### PR TITLE
don't use np.empty_like with dtype argument to be numpy 1.5 compatible.

### DIFF
--- a/scikits/image/util/dtype.py
+++ b/scikits/image/util/dtype.py
@@ -75,9 +75,7 @@ def _convert(image, dtype, prec_loss):
 
     # Do scaling/shifting calculations in floating point
     image = image.astype(np.float64)
-    out = np.empty_like(image, dtype=dtype)
-    
-    out[:] = round_fn((image - imin) * scale + shift)
+    out = round_fn((image - imin) * scale + shift).astype(dtype)
 
     return out
 


### PR DESCRIPTION
as I said in the dtype pull request...
