### PR TITLE
Work around `AttributeError: 'module' object has no attribute 'BufferedIO

### DIFF
--- a/scikits/image/__init__.py
+++ b/scikits/image/__init__.py
@@ -8,6 +8,7 @@ data_dir = _osp.abspath(_osp.join(_osp.dirname(__file__), 'data'))
 from version import version as __version__
 
 def _setup_test():
+    import gzip
     import functools
 
     basedir = _osp.dirname(_osp.join(__file__, '../'))


### PR DESCRIPTION
Work around `AttributeError: 'module' object has no attribute 'BufferedIOBase'` on Python 2.7+, Windows
