### PR TITLE
Fix `AttributeError: 'function' object has no attribute 'func_name'`

### DIFF
--- a/scikits/image/transform/tests/test_hough_transform.py
+++ b/scikits/image/transform/tests/test_hough_transform.py
@@ -9,7 +9,7 @@ def append_desc(func, description):
     """Append the test function ``func`` and append
     ``description`` to its name.
     """
-    func.description = func.__module__ + '.' + func.func_name + description
+    func.description = func.__module__ + '.' + func.__name__ + description
 
     return func
 


### PR DESCRIPTION
Fix `AttributeError: 'function' object has no attribute 'func_name'` on Python 3
