### PR TITLE
Fixed some github links in the development docs

### DIFF
--- a/doc/source/gitwash/following_latest.txt
+++ b/doc/source/gitwash/following_latest.txt
@@ -18,7 +18,7 @@ Get the local copy of the code
 
 From the command line::
 
-   git clone git://github.com/scikits.image/scikits.image.git
+   git clone git://github.com/scikits-image/scikits.image.git
 
 You now have a copy of the code tree in the new ``scikits.image`` directory.
 

--- a/doc/source/gitwash/maintainer_workflow.txt
+++ b/doc/source/gitwash/maintainer_workflow.txt
@@ -16,7 +16,7 @@ access to the upstream repo.  Being a maintainer, you've got read-write access.
 It's good to have your upstream remote have a scary name, to remind you that
 it's a read-write remote::
 
-    git remote add upstream-rw git@github.com:scikits.image/scikits.image.git
+    git remote add upstream-rw git@github.com:scikits-image/scikits.image.git
     git fetch upstream-rw
 
 *******************

--- a/doc/source/gitwash/patching.txt
+++ b/doc/source/gitwash/patching.txt
@@ -29,7 +29,7 @@ Overview
    git config --global user.email you@yourdomain.example.com
    git config --global user.name "Your Name Comes Here"
    # get the repository if you don't have it
-   git clone git://github.com/scikits.image/scikits.image.git
+   git clone git://github.com/scikits-image/scikits.image.git
    # make a branch for your patching
    cd scikits.image
    git branch the-fix-im-thinking-of
@@ -59,7 +59,7 @@ In detail
 #. If you don't already have one, clone a copy of the
    scikits.image_ repository::
 
-      git clone git://github.com/scikits.image/scikits.image.git
+      git clone git://github.com/scikits-image/scikits.image.git
       cd scikits.image
 
 #. Make a 'feature branch'.  This will be where you work on

--- a/doc/source/gitwash/set_up_fork.txt
+++ b/doc/source/gitwash/set_up_fork.txt
@@ -13,7 +13,7 @@ Overview
 
    git clone git@github.com:your-user-name/scikits.image.git
    cd scikits.image
-   git remote add upstream git://github.com/scikits.image/scikits.image.git
+   git remote add upstream git://github.com/scikits-image/scikits.image.git
 
 In detail
 =========
@@ -46,7 +46,7 @@ Linking your repository to the upstream repo
 ::
 
    cd scikits.image
-   git remote add upstream git://github.com/scikits.image/scikits.image.git
+   git remote add upstream git://github.com/scikits-image/scikits.image.git
 
 ``upstream`` here is just the arbitrary name we're using to refer to the
 main scikits.image_ repository at `scikits.image github`_.
@@ -59,8 +59,8 @@ use it to merge into our own code.
 Just for your own satisfaction, show yourself that you now have a new
 'remote', with ``git remote -v show``, giving you something like::
 
-   upstream	git://github.com/scikits.image/scikits.image.git (fetch)
-   upstream	git://github.com/scikits.image/scikits.image.git (push)
+   upstream	git://github.com/scikits-image/scikits.image.git (fetch)
+   upstream	git://github.com/scikits-image/scikits.image.git (push)
    origin	git@github.com:your-user-name/scikits.image.git (fetch)
    origin	git@github.com:your-user-name/scikits.image.git (push)
 


### PR DESCRIPTION
Hello - I just signed up for github yesterday, so my apologies if I'm doing something incorrectly. This is my first attempt at a pull request.

Some of the links in the development documentation seem to point to an old location for scikits.image. These minor differences can cause major confusion for someone (like me) who is trying to set up and use git for the first time. I've tried to correct these links, but I could be way off. 

I hope to make some more interesting additions to the library soon (I'll likely send a message to the discussion group over the next few days).

Cheers,
Neil
