### PR TITLE
Use MD5 hashes of .pyx files to determine whether they need to be recompiled.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 *.bak
 *.c
 *.new
+*.md5
+*.old
 doc/source/api
 doc/build
 source/api

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,7 @@ include setup*.py
 include MANIFEST.in
 include *.txt
 include Makefile
-recursive-include skimage *.pyx *.pxd *.pxi *.py *.c *.h *.ini
+recursive-include skimage *.pyx *.pxd *.pxi *.py *.c *.h *.ini *.md5
 recursive-include skimage/data *
 
 include doc/Makefile


### PR DESCRIPTION
Previously, we'd recompile all Cython files on each rebuild, and then compare the generated C files against one another.  This was slow and unnecessary.  The new approach compares the MD5sum of `abc.pyx` and compares it against `abs.pyx.md5`.  If that file does not exist, a recompile is triggered.

The .md5 files are added to the `setup.py` generated source tarball (see `MANIFEST.in`), to ensure that the downloaded package can be built without having Cython installed.
