### PR TITLE
BUG: Problem importing imread

### DIFF
--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -5,10 +5,9 @@ from __future__ import with_statement
 __all__ = ['MultiImage', 'ImageCollection', 'imread']
 
 from glob import glob
-import os.path
 
 import numpy as np
-from io import imread
+from ._io import imread
 
 
 class MultiImage(object):


### PR DESCRIPTION
I'm not sure why this problem just came up now (9 unit tests started failing out of the blue). I think the cause is that there is an `io` module in the Python Standard Library, leading to a conflict with `skimage.io` under certain conditions. This fixes it for me, but it doesn't really address to root of the problem.
