### PR TITLE
BUG: greycomatrix, one of the tests was failing for symmetric case

### DIFF
--- a/skimage/feature/greycomatrix.py
+++ b/skimage/feature/greycomatrix.py
@@ -101,7 +101,9 @@ def greycomatrix(image, distances, angles, levels=256, symmetric=False,
 
     # make each GLMC symmetric
     if symmetric:
-        P += np.transpose(P, (1, 0, 2, 3))
+        Pt = np.transpose(P, (1, 0, 2, 3))
+        P = P + Pt
+ 
                 
     # normalize each GLMC
     if normed:


### PR DESCRIPTION
test_glcm.TestGLCM.test_output_symmetric_1 was failing on my computer.
I think this is because np.transpose returns a view when possible,
so P += np.transpose(P) must do weird things.
