### PR TITLE
Fix edge detection output dtypes / ranges.

### DIFF
--- a/skimage/filter/edges.py
+++ b/skimage/filter/edges.py
@@ -9,6 +9,7 @@ Original author: Lee Kamentsky
 
 """
 import numpy as np
+from skimage import img_as_float
 from scipy.ndimage import convolve, binary_erosion, generate_binary_structure
 
 def sobel(image, mask=None):
@@ -62,12 +63,13 @@ def hsobel(image, mask=None):
      -1  -2  -1
 
     """
+    image = img_as_float(image)
     if mask is None:
         mask = np.ones(image.shape, bool)
     big_mask = binary_erosion(mask,
                               generate_binary_structure(2, 2),
                               border_value = 0)
-    result = np.abs(convolve(image.astype(float),
+    result = np.abs(convolve(image,
                              np.array([[ 1, 2, 1],
                                        [ 0, 0, 0],
                                        [-1,-2,-1]]).astype(float) / 4.0))
@@ -99,12 +101,13 @@ def vsobel(image, mask=None):
       1   0  -1
 
     """
+    image = img_as_float(image)
     if mask is None:
         mask = np.ones(image.shape, bool)
     big_mask = binary_erosion(mask,
                               generate_binary_structure(2, 2),
                               border_value=0)
-    result = np.abs(convolve(image.astype(float),
+    result = np.abs(convolve(image,
                              np.array([[1, 0, -1],
                                        [2, 0, -2],
                                        [1, 0, -1]]).astype(float) / 4.0))
@@ -158,12 +161,13 @@ def hprewitt(image, mask=None):
      -1  -1  -1
 
     """
+    image = img_as_float(image)
     if mask is None:
         mask = np.ones(image.shape, bool)
     big_mask = binary_erosion(mask,
                               generate_binary_structure(2, 2),
                               border_value=0)
-    result = np.abs(convolve(image.astype(float),
+    result = np.abs(convolve(image,
                              np.array([[ 1, 1, 1],
                                        [ 0, 0, 0],
                                        [-1,-1,-1]]).astype(float) / 3.0))
@@ -195,12 +199,13 @@ def vprewitt(image, mask=None):
       1   0  -1
 
     """
+    image = img_as_float(image)
     if mask is None:
         mask = np.ones(image.shape, bool)
     big_mask = binary_erosion(mask,
                               generate_binary_structure(2, 2),
                               border_value=0)
-    result = np.abs(convolve(image.astype(float),
+    result = np.abs(convolve(image,
                              np.array([[1, 0, -1],
                                        [1, 0, -1],
                                        [1, 0, -1]]).astype(float) / 3.0))

--- a/skimage/filter/tests/test_edges.py
+++ b/skimage/filter/tests/test_edges.py
@@ -5,7 +5,7 @@ import numpy as np
 from scipy.ndimage import binary_dilation, binary_erosion
 
 import skimage.filter as F
-from skimage import data_dir
+from skimage import data_dir, img_as_float
 
 class TestSobel():
     def test_00_00_zeros(self):
@@ -39,15 +39,6 @@ class TestSobel():
         assert (np.all(result[j == 0] == 1))
         assert (np.all(result[np.abs(j) > 1] == 0))
 
-    def test_convolution_upcast(self):
-        i, j = np.mgrid[-5:6, -5:6]
-        image = np.load(os.path.join(data_dir, 'lena_GRAY_U8.npy'))
-
-        result1 = F.sobel(image)
-        image = image.astype(float)
-        result2 = F.sobel(image)
-
-        assert_array_equal(result1, result2)
 
 class TestHSobel():
     def test_00_00_zeros(self):


### PR DESCRIPTION
BUG: Edge detection routines returned images with invalid ranges [0-255] but dtype float.
