### PR TITLE
Make library-loading more robust and provide better errors

### DIFF
--- a/skimage/io/_plugins/freeimage_plugin.py
+++ b/skimage/io/_plugins/freeimage_plugin.py
@@ -65,7 +65,7 @@ def load_freeimage():
                         'libfreeimage', 'libFreeImage'):
             freeimage, new_errors = _load_library(libname, d)
             if freeimage:
-              break
+                break
             errors.update(new_errors)
         if freeimage:
             break


### PR DESCRIPTION
Apropos of the recent discussion on the email list, this commit:
(a) Adds better search-paths for windows (sort of -- could be enhanced)
(b) Provides simpler-to-understand error reporting
and most importantly, 
(c) Differentiates in the error messages between absent libraries, and libraries that could not be loaded due to errors.
