### PR TITLE
DOC: Add sidebar section listing package versions.

### DIFF
--- a/doc/source/_static/docversions.js
+++ b/doc/source/_static/docversions.js
@@ -1,0 +1,17 @@
+
+function insert_version_links() {
+    var labels = ['0.5dev', '0.4', '0.3'];
+    var links = ['http://scikits-image.org/docs/dev/index.html',
+                 'http://scikits-image.org/docs/0.4/index.html',
+                 'http://scikits-image.org/docs/0.3/index.html'];
+
+    document.write('<ul class="versions">\n');
+
+    for (i = 0; i < labels.length; i++){
+        document.write('<li> <a href="URL">skimage VERSION</a> </li>\n'
+                        .replace('VERSION', labels[i])
+                        .replace('URL', links[i]));
+    }
+    document.write('</ul>\n');
+}
+

--- a/doc/source/_templates/versions.html
+++ b/doc/source/_templates/versions.html
@@ -1,0 +1,10 @@
+{%- block versions %}
+
+  <h3>Version</h3>
+
+    <script type="text/javascript" src="_static/docversions.js"></script>
+    <script type="text/javascript">
+      insert_version_links();
+    </script>
+
+{%- endblock %}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -150,7 +150,13 @@ html_static_path = ['_static']
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+html_sidebars = {
+   '**': ['localtoc.html',
+          'relations.html',
+          'sourcelink.html',
+          'versions.html',
+          'searchbox.html'],
+}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.


### PR DESCRIPTION
- The listing is implemented in javascript so that all versions can simply import the script from the dev url and have a listing of all the packages (i.e. older versions will list newer versions in the sidebar). 
- The js file should probably be included in the header, but I couldn't figure out how sphinx builds the header.
- It'd be nice to highlight the currently-viewed version (maybe you could figure out the current version by parsing the document url), but I didn't want to dig into it.
