### PR TITLE
DOC: Use CSS to style versions sidebar.

### DIFF
--- a/doc/source/_templates/versions.html
+++ b/doc/source/_templates/versions.html
@@ -2,7 +2,6 @@
 
   <h3>Version</h3>
 
-    <script type="text/javascript" src="/docs/dev/_static/docversions.js"></script>
     <script type="text/javascript">
       insert_version_links();
     </script>

--- a/doc/source/themes/agogo/layout.html
+++ b/doc/source/themes/agogo/layout.html
@@ -9,7 +9,7 @@
     :license: BSD, see LICENSE for details.
 #}
 {% extends "basic/layout.html" %}
-
+{% set script_files = script_files + ['_static/docversions.js'] %}
 
 {% block header %}
     <div class="header-wrapper">

--- a/doc/source/themes/agogo/static/agogo.css_t
+++ b/doc/source/themes/agogo/static/agogo.css_t
@@ -337,6 +337,14 @@ div.sidebarblock {
   margin-bottom: .8em;
 }
 
+ul.versions li {
+  color: gray;
+  list-style: circle inside;
+}
+
+ul.versions li#current {
+  list-style: disc inside;
+}
 
 /* Footer */
 

--- a/doc/source/themes/agogo/static/docversions.js
+++ b/doc/source/themes/agogo/static/docversions.js
@@ -4,13 +4,14 @@ function insert_version_links() {
     document.write('<ul class="versions">\n');
 
     for (i = 0; i < labels.length; i++){
-        document.write('<li>');
+        open_list = '<li>'
         if (typeof(DOCUMENTATION_OPTIONS) !== 'undefined') {
             if ((DOCUMENTATION_OPTIONS['VERSION'] == labels[i]) ||
                 (DOCUMENTATION_OPTIONS['VERSION'].match(/dev$/) && (i == 0))) {
-                document.write('&#9656;&nbsp;');
+                open_list = '<li id="current">'
             }
         }
+        document.write(open_list);
         document.write('<a href="URL">skimage VERSION</a> </li>\n'
                         .replace('VERSION', labels[i])
                         .replace('URL', 'http://scikits-image.org/docs/' + labels[i]));


### PR DESCRIPTION
Summary:
- Label current version with an html id so it can be highlighted in CSS.
- Note: Switched out arrow indicator for a disc b/c it's easier (unicode bullets are not well-supported).
- Move script file to theme and use standard Sphinx theming to include javascript file.
