### PR TITLE
Fix test_freeimage.test_metadata error on Python 3

### DIFF
--- a/skimage/io/_plugins/freeimage_plugin.py
+++ b/skimage/io/_plugins/freeimage_plugin.py
@@ -3,7 +3,7 @@ import numpy
 import sys
 import os
 import os.path
-from numpy.compat import asbytes
+from numpy.compat import asbytes, asstr
 
 
 def _generate_candidate_libs():
@@ -505,13 +505,13 @@ def _read_metadata(bitmap):
         if mdhandle:
             more = True
             while more:
-                tag_name = str(_FI.FreeImage_GetTagKey(tag))
+                tag_name = asstr(_FI.FreeImage_GetTagKey(tag))
                 tag_type = _FI.FreeImage_GetTagType(tag)
                 byte_size = _FI.FreeImage_GetTagLength(tag)
                 char_ptr = ctypes.c_char * byte_size
                 tag_str = char_ptr.from_address(_FI.FreeImage_GetTagValue(tag))
                 if tag_type == METADATA_DATATYPE.FIDT_ASCII:
-                    tag_val = str(tag_str.value)
+                    tag_val = asstr(tag_str.value)
                 else:
                     tag_val = numpy.fromstring(tag_str,
                             dtype=METADATA_DATATYPE.dtypes[tag_type])


### PR DESCRIPTION
```
======================================================================
ERROR: test_freeimage.test_metadata
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python31\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "X:\Python31\lib\site-packages\numpy\testing\decorators.py", line 147, in skipper_func
    return f(*args, **kwargs)
  File "X:\Python31\lib\site-packages\skimage\io\tests\test_freeimage.py", line 66, in test_metadata
    assert meta[('EXIF_MAIN', 'Orientation')] == 1
KeyError: ('EXIF_MAIN', 'Orientation')
```
