### PR TITLE
Fix TypeError on 64 bit platforms

### DIFF
--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -286,7 +286,7 @@ def random_walker(data, labels, beta=130, mode='bf', tol=1.e-3, copy=True):
     data = np.atleast_3d(data)
     if copy:
         labels = np.copy(labels)
-    labels = labels.astype(np.int)
+    labels = labels.astype(np.intp)
     # If the array has pruned zones, be sure that no isolated pixels
     # exist between pruned zones (they could not be determined)
     if np.any(labels < 0):


### PR DESCRIPTION
Fixes multiple test errors on win-amd64, such as:

```
======================================================================
ERROR: test_random_walker.test_3d_inactive
----------------------------------------------------------------------
<snip>
  File "skimage\segmentation\random_walker_segmentation.py", line 101, in _clean_labels_ar
    labels[labels == 0] = X
TypeError: array cannot be safely cast to required type
```
