### PR TITLE
Fix test when tifffile plugin is not available.

### DIFF
--- a/skimage/io/tests/test_tifffile.py
+++ b/skimage/io/tests/test_tifffile.py
@@ -12,7 +12,7 @@ try:
     _plugins = sio.plugin_order()
     TF_available = True
     sio.use_plugin('tifffile')
-except OSError:
+except ImportError:
     TF_available = False
 
 


### PR DESCRIPTION
`tifffile_plugin` raises `ImportError` not `OSError`.
