### PR TITLE
FIX: Check plugin is loaded before checking its functions.

### DIFF
--- a/skimage/io/_plugins/plugin.py
+++ b/skimage/io/_plugins/plugin.py
@@ -79,6 +79,7 @@ command.  A list of all available plugins can be found using
     if plugin is None:
         _, func = plugin_funcs[0]
     else:
+        _load(plugin)
         try:
             func = [f for (p,f) in plugin_funcs if p == plugin][0]
         except IndexError:
@@ -124,8 +125,7 @@ def use(name, kind=None):
         else:
             kind = [kind]
 
-    if not name in available(loaded=True):
-        _load(name)
+    _load(name)
 
     for k in kind:
         if not k in plugin_store:
@@ -182,6 +182,8 @@ def _load(plugin):
     plugins : List of available plugins
 
     """
+    if plugin in available(loaded=True):
+        return
     if not plugin in plugin_module_name:
         raise ValueError("Plugin %s not found." % plugin)
     else:


### PR DESCRIPTION
When `io` functions (e.g. `io.imread`) are called with a non-default (i.e. not loaded by default) plugin, they would fail.

For example, the following fails on my system:

``` python
from skimage import data_dir
img_name = data_dir + '/camera.png'
import skimage.io as io
img = io.imread(img_name, plugin='freeimage')
```

But this works:

``` python
io.use_plugin('freeimage')
img = io.imread(img_name)
```
