### PR TITLE
feature.hog() fails on non-square images

### DIFF
--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -5,12 +5,12 @@ from skimage.feature import hog
 
 def test_histogram_of_oriented_gradients():
     # Replace with skimage.data.lena() after merge
-    img = scipy.misc.lena().astype(np.int8) 
+    img = scipy.misc.lena()[:256,:].astype(np.int8) 
     
     fd = hog(img, orientations=9, pixels_per_cell=(8, 8), 
              cells_per_block=(1, 1))
 
-    assert len(fd) == 9 * (512//8) ** 2
+    assert len(fd) == 9 * (256//8) * (512//8)
     
 if __name__ == '__main__':
     from numpy.testing import run_module_suite


### PR DESCRIPTION
G'day,

The HoG code works very nicely for square images (thanks!) but there are a few [x,y] coordinate lookups throughout where they should be [y,x], which has hog() failing when width != height.
Commit #4d999c3 addresses this; I've also updated the test case to use just the top half of the Lena image!  It would be great if you have a chance to merge it in.

cheers
tfm
