### PR TITLE
Allow for type of hdu.size changing in PyFITS 3.1

### DIFF
--- a/skimage/io/_plugins/fits_plugin.py
+++ b/skimage/io/_plugins/fits_plugin.py
@@ -96,11 +96,11 @@ def imread_collection(load_pattern, conserve_memory=True):
                 # Ignore (primary) header units with no data (use '.size'
                 # rather than '.data' to avoid actually loading the image):
                 try:
-                    if hdu.size() > 0:
-                        ext_list.append((filename, n))
+                    data_size = hdu.size()
                 except TypeError:  # (size changed to int in PyFITS 3.1)
-                    if hdu.size > 0:
-                        ext_list.append((filename, n))
+                    data_size = hdu.size
+                if data_size > 0:
+                    ext_list.append((filename, n))
         hdulist.close()
 
     return io.ImageCollection(ext_list, load_func=FITSFactory,


### PR DESCRIPTION
This is a fix for the problem reported to Stefan by Christoph Deil on 13 April, due to an API change in the unreleased development version 3.1 of PyFITS (hope I got all the git commands right!). None of my other changes are included. BTW, is there any more concise way to write this try...except without repeating a line? Thanks.
