### PR TITLE
regionprops: a very simple 'Perimeter' property

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -36,7 +36,7 @@ PROPS = (
     'Moments',
     'NormalizedMoments',
     'Orientation',
-#    'Perimeter',
+    'Perimeter',
 #    'PixelIdxList',
 #    'PixelList',
     'Solidity',
@@ -122,6 +122,9 @@ def regionprops(label_image, properties=['Area', 'Centroid'],
             Angle between the X-axis and the major axis of the ellipse that has
             the same second-moments as the region. Ranging from `-pi/2` to
             `-pi/2` in counter-clockwise direction.
+        * Perimeter : float
+            A simple approximation of the region boundary. It is not the same as 
+            the value returned by the 'regionprops' function in MATLAB.
         * Solidity : float
             Ratio of pixels in the region to pixels of the convex hull image.
         * WeightedCentralMoments : 3 x 3 ndarray
@@ -296,7 +299,10 @@ def regionprops(label_image, properties=['Area', 'Centroid'],
                 obj_props['Orientation'] = PI / 2
             else:
                 obj_props['Orientation'] = - 0.5 * atan(2 * b / (a - c))
-
+        
+        if 'Perimeter' in properties:
+            obj_props['Perimeter'] = np.sum(np.abs(np.diff(array,1,0))) + np.sum(np.abs(np.diff(array,1,1)))
+        
         if 'Solidity' in properties:
             if _convex_image is None:
                 _convex_image = convex_hull_image(array)

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -178,6 +178,11 @@ def test_orientation():
     # determined with MATLAB
     assert_almost_equal(orientation, 0.10446844651921)
 
+def test_perimeter():
+    perimeter = regionprops(SAMPLE, ['Perimeter'])[0]['Perimeter']
+    # determined by simple calculation
+    assert_almost_equal(perimeter, 69)
+    
 def test_solidity():
     solidity = regionprops(SAMPLE, ['Solidity'])[0]['Solidity']
     # determined with MATLAB


### PR DESCRIPTION
This is a very simple implementation of a 'Perimeter' property for the regionprops function. 

I was a bit surprised that the regionprops function lacked a 'Perimeter' property. I suspect there is a good reason for this which I don't know, though. Still, I found this very simple solution useful for image classification.
