### PR TITLE
BUG: Fix testing failures when FreeImage not installed.

### DIFF
--- a/skimage/io/__init__.py
+++ b/skimage/io/__init__.py
@@ -31,7 +31,7 @@ def _load_preferred_plugins():
             try:
                 use_plugin(plugin, kind=func)
                 break
-            except (ImportError, RuntimeError):
+            except (ImportError, RuntimeError, OSError):
                 pass
 
     # Use PIL as the default imread plugin, since matplotlib (1.2.x)


### PR DESCRIPTION
FreeImage throws an OSError, which must be caught when attempting
to load the IO plugins for tests to pass without FreeImage installed.
