### PR TITLE
ENH: ImageCollection now supports slicing

### DIFF
--- a/skimage/io/tests/test_collection.py
+++ b/skimage/io/tests/test_collection.py
@@ -44,10 +44,14 @@ class TestImageCollection():
         assert_raises(IndexError, return_img, -num - 1)
 
     def test_slicing(self):
-        assert type(self.collection[:] is ImageCollection)
+        assert type(self.collection[:]) is ImageCollection
         assert len(self.collection[:]) == 2
-        assert_array_almost_equal(self.collection[0], self.collection[:1])
-        assert_array_almost_equal(self.collection[1], self.collection[1:])
+        assert len(self.collection[:1]) == 1
+        assert len(self.collection[1:]) == 1
+        assert_array_almost_equal(self.collection[0], self.collection[:1][0])
+        assert_array_almost_equal(self.collection[1], self.collection[1:][0])
+        assert_array_almost_equal(self.collection[1], self.collection[::-1][0])
+        assert_array_almost_equal(self.collection[0], self.collection[::-1][1])
 
     def test_files_property(self):
         assert isinstance(self.collection.files, list)


### PR DESCRIPTION
When the more than one image is selected a new ImageCollection object is created. When a single image is selected the image is returned.

Any images which have already been loaded will be be included in the new ImageCollection.  One issue is that after creation if new image data is loaded into either ImageCollection the other object does not get this new data. 
