### PR TITLE
Concatenate image collection

### DIFF
--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -2,12 +2,41 @@
 
 from __future__ import with_statement
 
-__all__ = ['MultiImage', 'ImageCollection', 'imread']
+__all__ = ['MultiImage', 'ImageCollection', 'imread', 'concatenate_images']
 
 from glob import glob
 
 import numpy as np
 from ._io import imread
+
+def concatenate_images(ic):
+    """Concatenate all images in the image collection into an array.
+
+    Parameters
+    ----------
+    ic: an iterable of images (including ImageCollection and MultiImage)
+        The images to be concatenated.
+
+    Returns
+    -------
+    ar : np.ndarray
+        An array having one more dimension than the images in `ic`.
+
+    See Also
+    --------
+    `ImageCollection.concatenate`, `MultiImage.concatenate`
+
+    Raises
+    ------
+    ValueError
+        If images in `ic` don't have identical shapes.
+    """
+    all_images = [img[np.newaxis, ...] for img in ic]
+    try:
+        ar = np.concatenate(all_images)
+    except ValueError:
+        raise ValueError('Image dimensions must agree.')
+    return ar
 
 
 class MultiImage(object):
@@ -142,6 +171,24 @@ class MultiImage(object):
     def __str__(self):
         return str(self.filename) + ' [%s frames]' % self._numframes
 
+    def concatenate(self):
+        """Concatenate all images in the multi-image into an array.
+
+        Returns
+        -------
+        ar : np.ndarray
+            An array having one more dimension than the images in `self`.
+
+        See Also
+        --------
+        `concatenate_images`
+
+        Raises
+        ------
+        ValueError
+            If images in the `MultiImage` don't have identical shapes.
+        """
+        return concatenate_images(self)
 
 class ImageCollection(object):
     """Load and manage a collection of image files.
@@ -309,21 +356,21 @@ class ImageCollection(object):
         self.data = np.empty_like(self.data)
 
     def concatenate(self):
-        """Concatenate all images in the collection on a new axis.
+        """Concatenate all images in the collection into an array.
 
         Returns
         -------
         ar : np.ndarray
             An array having one more dimension than the images in `self`.
 
+        See Also
+        --------
+        `concatenate_images`
+
         Raises
         ------
         ValueError
-            If images in the collection don't have identical shapes.
+            If images in the `ImageCollection` don't have identical shapes.
         """
-        all_images = [img[np.newaxis, ...] for img in self]
-        try:
-            ar = np.concatenate(all_images)
-        except ValueError:
-            raise ValueError('Image dimensions must agree.')
-        return ar
+        return concatenate_images(self)
+

--- a/skimage/io/tests/test_collection.py
+++ b/skimage/io/tests/test_collection.py
@@ -111,6 +111,12 @@ class TestMultiImage():
             self.img.conserve_memory = val
         assert_raises(AttributeError, set_mem, True)
 
+    @skipif(not PIL_available)
+    def test_concatenate(self):
+        ar = self.img.concatenate()
+        assert_equal(ar.shape, (len(self.img),) + 
+                                self.img[0].shape)
+
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
In a few contexts (stacks of microscopy images, video frames) it is desirable to operate on a `numpy.ndarray` containing _all_ images in a collection. The new `skimage.io.ImageCollection.concatenate` function converts a collection to such an `ndarray`. 

This operation only makes sense when all images have the same shape, so the function raises a `ValueError` when this is not the case (and np.concatenate fails with such a ValueError).
