### PR TITLE
BUG: Ignore colorconv RuntimeWarning:invalid value encountered in true_d...

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -164,8 +164,10 @@ def rgb2hsv(rgb):
 
     # -- S channel
     delta = arr.ptp(-1)
+    # Ignore warning for zero divided by zero
+    old_settings = np.seterr(invalid='ignore')
     out_s = delta / out_v
-    out_s[delta == 0] = 0
+    out_s[delta == 0.] = 0.
 
     # -- H channel
     # red is max
@@ -180,6 +182,9 @@ def rgb2hsv(rgb):
     idx = (arr[:, :, 2] == out_v)
     out[idx, 0] = 4. + (arr[idx, 0] - arr[idx, 1]) / delta[idx]
     out_h = (out[:, :, 0] / 6.) % 1.
+    out_h[delta == 0.] = 0.
+
+    np.seterr(**old_settings)
 
     # -- output
     out[:, :, 0] = out_h


### PR DESCRIPTION
...ivide.

Sometimes zero divided by zero can occur in this code.  Saturation was already
explicitly set to zero when 'delta' is zero.  According to Wikipedia, hue is
undefined when 'delta' here is zero, so explicitly set to zero.
