### PR TITLE
[MRG] Fix broadcasting error (revised PR)

### DIFF
--- a/skimage/feature/hog.py
+++ b/skimage/feature/hog.py
@@ -107,6 +107,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
 
     # compute orientations integral images
     orientation_histogram = np.zeros((n_cellsy, n_cellsx, orientations))
+    subsample = np.index_exp[cy / 2:cy * n_cellsy:cy, cx / 2:cx * n_cellsx:cx]
     for i in range(orientations):
         #create new integral image for this orientation
         # isolate orientations in this range
@@ -119,19 +120,17 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
         cond2 = temp_ori > 0
         temp_mag = np.where(cond2, magnitude, 0)
 
-        orientation_histogram[:, :, i] = uniform_filter(temp_mag,
-             size=(cy, cx))[cy / 2::cy, cx / 2::cx]
+        temp_filt = uniform_filter(temp_mag, size=(cy, cx))
+        orientation_histogram[:, :, i] = temp_filt[subsample]
 
     # now for each cell, compute the histogram
-    #orientation_histogram = np.zeros((n_cellsx, n_cellsy, orientations))
-    radius = min(cx, cy) // 2 - 1
     hog_image = None
-    if visualise:
-        hog_image = np.zeros((sy, sx), dtype=float)
 
     if visualise:
         from skimage import draw
 
+        radius = min(cx, cy) // 2 - 1
+        hog_image = np.zeros((sy, sx), dtype=float)
         for x in range(n_cellsx):
             for y in range(n_cellsy):
                 for o in range(orientations):

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -1,17 +1,20 @@
-import numpy as np
-import scipy
-
-from skimage.feature import hog
-
+from skimage import data
+from skimage import feature
+from skimage import img_as_float
 
 def test_histogram_of_oriented_gradients():
-    # Replace with skimage.data.lena() after merge
-    img = scipy.misc.lena()[:256, :].astype(np.int8)
+    img = img_as_float(data.lena()[:256, :].mean(axis=2))
 
-    fd = hog(img, orientations=9, pixels_per_cell=(8, 8),
-             cells_per_block=(1, 1))
+    fd = feature.hog(img, orientations=9, pixels_per_cell=(8, 8),
+                     cells_per_block=(1, 1))
 
     assert len(fd) == 9 * (256 // 8) * (512 // 8)
+
+def test_hog_image_size_cell_size_mismatch():
+    image = data.camera()[:150, :200]
+    fd = feature.hog(image, orientations=9, pixels_per_cell=(8, 8),
+                     cells_per_block=(1, 1))
+    assert len(fd) == 9 * (150 // 8) * (200 // 8)
 
 if __name__ == '__main__':
     from numpy.testing import run_module_suite


### PR DESCRIPTION
This is a second PR to replace #213 after re-forking my repo to scikits-image.

In response to a bug submitted on the mailing list by Damian, this PR corrects the broadcasting error.

The problem stems from the fact that in his image (150,200) n_cellsx = 18
    n_cellsx = int(np.floor(150 // 8))  # number of cells in x

but 
    uniform_filter(temp_mag, size=(cy, cx))[cy / 2::cy, cx / 2::cx]
results in an object of (19, 25) which cannot be broadcast to one of (18,25).

The reason is that there are 19 steps from 4:150:8. This is easily resolved by restricting the upper range to ensure that the view is of the right shape.

This gist will test it

``` python
import skimage.color
import skimage.data
import skimage.feature

if __name__=="__main__":

    I=skimage.data.imread("motorbikes041.png")  # see attached
    I2=skimage.color.rgb2gray(I)
    print I2.shape, I2.dtype
    skimage.feature.hog(I2)
```
