### PR TITLE
ENH: initialize AffineTransform to identity when no args are provided

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -105,7 +105,10 @@ class ProjectiveTransform(GeometricTransform):
     coeffs = range(8)
 
     def __init__(self, matrix=None):
-        if matrix is not None and matrix.shape != (3, 3):
+        if matrix is None:
+            # default to an identity transform
+            matrix = np.eye(3)
+        if matrix.shape != (3, 3):
             raise ValueError("invalid shape of transformation matrix")
         self._matrix = matrix
 
@@ -271,15 +274,16 @@ class AffineTransform(ProjectiveTransform):
 
     def __init__(self, matrix=None, scale=None, rotation=None, shear=None,
                  translation=None):
-        self._matrix = matrix
         params = any(param is not None
                      for param in (scale, rotation, shear, translation))
 
         if params and matrix is not None:
             raise ValueError("You cannot specify the transformation matrix and "
                              "the implicit parameters at the same time.")
-        elif matrix is not None and matrix.shape != (3, 3):
-            raise ValueError("Invalid shape of transformation matrix.")
+        elif matrix is not None:
+            if matrix.shape != (3, 3):
+                raise ValueError("Invalid shape of transformation matrix.")
+            self._matrix = matrix
         elif params:
             if scale is None:
                 scale = (1, 1)
@@ -298,7 +302,7 @@ class AffineTransform(ProjectiveTransform):
             ])
             self._matrix[0:2, 2] = translation
         else:
-            # Default to an identity transform
+            # default to an identity transform
             self._matrix = np.eye(3)
 
     @property
@@ -351,15 +355,16 @@ class SimilarityTransform(ProjectiveTransform):
 
     def __init__(self, matrix=None, scale=None, rotation=None,
                  translation=None):
-        self._matrix = matrix
         params = any(param is not None
                      for param in (scale, rotation, translation))
 
         if params and matrix is not None:
             raise ValueError("You cannot specify the transformation matrix and "
                              "the implicit parameters at the same time.")
-        elif matrix is not None and matrix.shape != (3, 3):
-            raise ValueError("Invalid shape of transformation matrix.")
+        elif matrix is not None:
+            if matrix.shape != (3, 3):
+                raise ValueError("Invalid shape of transformation matrix.")
+            self._matrix = matrix
         elif params:
             if scale is None:
                 scale = 1
@@ -376,7 +381,7 @@ class SimilarityTransform(ProjectiveTransform):
             self._matrix *= scale
             self._matrix[0:2, 2] = translation
         else:
-            # Default to an identity transform
+            # default to an identity transform
             self._matrix = np.eye(3)
 
     def estimate(self, src, dst):
@@ -480,7 +485,10 @@ class PolynomialTransform(GeometricTransform):
     """
 
     def __init__(self, params=None):
-        if params is not None and params.shape[0] != 2:
+        if params is None:
+            # default to transformation which preserves original coordinates
+            params = np.array([[0, 1, 0], [0, 0, 1]])
+        if params.shape[0] != 2:
             raise ValueError("invalid shape of transformation parameters")
         self._params = params
 

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -144,6 +144,13 @@ def test_polynomial_estimation():
     assert_array_almost_equal(tform2._params, tform._params)
 
 
+def test_polynomial_init():
+    tform = estimate_transform('polynomial', SRC, DST, order=10)
+    # init with transformation parameters
+    tform2 = PolynomialTransform(tform._params)
+    assert_array_almost_equal(tform2._params, tform._params)
+
+
 def test_union():
     tform1 = SimilarityTransform(scale=0.1, rotation=0.3)
     tform2 = SimilarityTransform(scale=0.1, rotation=0.9)


### PR DESCRIPTION
Previously, transform.AffineTransform() would not initialize the _matrix attribute of the transform, so none of the other methods would work properly. I propose to initialize the object with an identity transform in that case.
