### PR TITLE
BUG: Adjust pixel limits based on image data type

### DIFF
--- a/skimage/viewer/viewers/core.py
+++ b/skimage/viewer/viewers/core.py
@@ -5,6 +5,7 @@ import sys
 
 from PyQt4 import QtGui, QtCore
 
+from skimage.util.dtype import dtype_range
 from ..utils import figimage, MatplotlibCanvas
 
 
@@ -139,6 +140,8 @@ class ImageViewer(QtGui.QMainWindow):
     def image(self, image):
         self._img = image
         self._image_plot.set_array(image)
+        clim = dtype_range[image.dtype.type]
+        self._image_plot.set_clim(clim)
         self.redraw()
 
     def reset_image(self):


### PR DESCRIPTION
Before, the viewer used color limits based on the original image. So, for example, if the original image is uint8, but then later replaced by a binary image, the viewer displays a black image because the viewer expects white to be 255, not 1 (or True).

Example demonstrating the issue (all black before PR, correctly displayed after PR):

``` python
from skimage.viewer import ImageViewer
from skimage import data

image = data.coins()

viewer = ImageViewer(image) # initialize with uint8 image
viewer.image = image > 100  # replace with bool image
viewer.show()
```
