### PR TITLE
Harris threshold

### DIFF
--- a/skimage/feature/_harris.py
+++ b/skimage/feature/_harris.py
@@ -103,7 +103,7 @@ def harris(image, min_distance=10, threshold=0.1, eps=1e-6,
     """
 
     harrisim = _compute_harris_response(image, eps=eps,
-                    gaussian_deviation=gaussian_deviation)
+                                        gaussian_deviation=gaussian_deviation)
     coordinates = peak.peak_local_max(harrisim, min_distance=min_distance,
-                                        threshold_rel=threshold)
+                                      threshold_rel=threshold)
     return coordinates


### PR DESCRIPTION
Hello,

It seems clear that the "threshold" argument in function peak_local_max was meant to be "threshold_rel", as expressed line 67 of _harris.py!  I noticed because calling function harris was giving a deprecated warning from function peak_local_max.

Best,
Marianne
