### PR TITLE
Multispectral random walker

### DIFF
--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -86,6 +86,7 @@ def test_2d_cg_mg():
                         full_prob[0, 25:45, 40:60]).all()
     return data, labels_cg_mg
 
+
 def test_types():
     lx = 70
     ly = 100
@@ -96,6 +97,7 @@ def test_types():
     assert (labels_cg_mg[25:45, 40:60] == 2).all()
     return data, labels_cg_mg
 
+
 def test_reorder_labels():
     lx = 70
     ly = 100
@@ -104,7 +106,6 @@ def test_reorder_labels():
     labels_bf = random_walker(data, labels, beta=90, mode='bf')
     assert (labels_bf[25:45, 40:60] == 2).all()
     return data, labels_bf
-
 
 
 def test_2d_inactive():
@@ -139,14 +140,26 @@ def test_3d_inactive():
     return data, labels, old_labels, after_labels
 
 
-def test_multispectral():
+def test_multispectral_2d():
+    lx, ly = 70, 100
+    data, labels = make_2d_syntheticdata(lx, ly)
+    data2 = data.copy()
+    data.shape += (1,)
+    data = data.repeat(2, axis=2)   # Result should be identical
+    multi_labels = random_walker(data, labels, mode='cg', multichannel=True)
+    single_labels = random_walker(data2, labels, mode='cg')
+    assert (multi_labels.reshape(labels.shape)[25:45, 40:60] == 2).all()
+    return data, multi_labels, single_labels, labels
+
+
+def test_multispectral_3d():
     n = 30
     lx, ly, lz = n, n, n
-    data, labels = make_3d_syntheticdata( lx, ly, lz )
+    data, labels = make_3d_syntheticdata(lx, ly, lz)
     data.shape += (1,)
-    data = data.repeat(2, axis=3) # Result should be identical
+    data = data.repeat(2, axis=3)   # Result should be identical
     multi_labels = random_walker(data, labels, mode='cg', multichannel=True)
-    single_labels = random_walker(data[:,:,:,0], labels, mode='cg')
+    single_labels = random_walker(data[..., 0], labels, mode='cg')
     assert (multi_labels.reshape(labels.shape)[13:17, 13:17, 13:17] == 2).all()
     assert (single_labels.reshape(labels.shape)[13:17, 13:17, 13:17] == 2).all()
     return data, multi_labels, single_labels, labels


### PR DESCRIPTION
This pull request implements multispectral capability to the random_walker() algorithm, and an optional depth=float kwarg which permits scaling for non-isotropic voxel depths in 3-D volumes.  The implementation is fully backwards-compatible with prior usage and tests.  I have also added a test to test_random_walker.py covering the trivial multispectral case (identical spectra passed).

I also fixed a minor bug which would cause a crash if pyamg was not installed but mode='cg_mg' was requested; the fallback _solve_cg() call did not have the new "return_full_prob" kwarg added.
