### PR TITLE
FIX: configure just skimage logger on import

### DIFF
--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -136,6 +136,7 @@ def _setup_log():
     log = get_log()
     log.addHandler(handler)
     log.setLevel(logging.WARNING)
+    log.propagate = False
 
 _setup_log()
 


### PR DESCRIPTION
Previously importing skimage would add and configure a global logger... that wasn't the intent right?
