### PR TITLE
Make font-size of documentation smaller

### DIFF
--- a/doc/source/themes/agogo/static/agogo.css_t
+++ b/doc/source/themes/agogo/static/agogo.css_t
@@ -23,6 +23,7 @@ div.header-wrapper {
 
 body {
   font-family: {{ theme_bodyfont }};
+  font-size: 10pt;
   line-height: 1.4em;
   color: black;
   background-color: {{ theme_bgcolor }};


### PR DESCRIPTION
Imho the font size is much too big at the moment and thus I reduced the font size. This makes it much more readable and should, of course, also be changed in the scikits-image-web repository, if you are also in favor of it.
