### PR TITLE
Remove plotting from docstring examples

### DIFF
--- a/skimage/transform/finite_radon_transform.py
+++ b/skimage/transform/finite_radon_transform.py
@@ -46,14 +46,6 @@ def frt2(a):
 
     >>> f = frt2(img)
 
-    Plot the results::
-
-        import matplotlib.pyplot as plt
-        plt.imshow(f, interpolation='nearest', cmap=plt.cm.gray)
-        plt.xlabel('Angle')
-        plt.ylabel('Translation')
-        plt.show()
-
     References
     ----------
     .. [FRT] A. Kingston and I. Svalbe, "Projective transforms on periodic

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -131,14 +131,6 @@ def hough(img, theta=None):
 
     >>> out, angles, d = hough(img)
 
-    Plot the results::
-
-        import matplotlib.pyplot as plt
-        plt.imshow(out, cmap=plt.cm.bone)
-        plt.xlabel('Angle (degree)')
-        plt.ylabel('Distance %d (pixel)' % d[0])
-        plt.show()
-
     .. plot:: hough_tf.py
 
     """


### PR DESCRIPTION
Plot commands return objects that we don't want to save, but not doing so will raise doctest errors. Just avoid doctest for the plotting part of the example. (See PR #314.)
