### PR TITLE
Docfix for `img_as_float()`; appended CONTRIBUTORS

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -110,3 +110,6 @@
 
 - Pavel Campr
   Fixes and tests for Histograms of Oriented Gradients.
+
+- Joshua Warner
+  Multichannel random walker segmentation.

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -265,8 +265,8 @@ def img_as_float(image, force_copy=False):
 
     Notes
     -----
-    The range of a floating point image is [0, 1].
-    Negative input values will be shifted to the positive domain.
+    The range of a floating point image is [0.0, 1.0] or [-1.0, 1.0] when
+    converting from unsigned or signed datatypes, respectively.
 
     """
     return convert(image, np.float64, force_copy)


### PR DESCRIPTION
The `img_as_float()` function in dtype.py had a legacy note stating 
conversion would force negative values to the positive domain; this 
no longer described its functionality. Note changed to reflect the 
retention of negative values when converting from signed datatypes.

When submitting my multichannel improvement to the random walker
segmentation algorithm, I neglected to append my name to the
CONTRIBUTORS file. Now fixed.
