### PR TITLE
Fix ValueError: Buffer dtype mismatch on 64 bit platforms

### DIFF
--- a/skimage/segmentation/_felzenszwalb_cy.pyx
+++ b/skimage/segmentation/_felzenszwalb_cy.pyx
@@ -55,7 +55,7 @@ def _felzenszwalb_grey(image, double scale=1, sigma=0.8, int min_size=20):
     # compute edges between pixels:
     height, width = image.shape[:2]
     cdef np.ndarray[np.int_t, ndim=2] segments \
-            = np.arange(width * height).reshape(height, width)
+            = np.arange(width * height, dtype=np.int).reshape(height, width)
     right_edges = np.c_[segments[1:, :].ravel(), segments[:-1, :].ravel()]
     down_edges = np.c_[segments[:, 1:].ravel(), segments[:, :-1].ravel()]
     dright_edges = np.c_[segments[1:, 1:].ravel(), segments[:-1, :-1].ravel()]


### PR DESCRIPTION
Fixes two test failures:

```
======================================================================
ERROR: test_felzenszwalb.test_grey
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python26-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python26-x64\lib\site-packages\skimage\segmentation\tests\test_felzenszwalb.py", line 13, in test_grey
    seg = felzenszwalb(img, sigma=0)
  File "X:\Python26-x64\lib\site-packages\skimage\segmentation\_felzenszwalb.py", line 49, in felzenszwalb
    return _felzenszwalb_grey(image, scale=scale, sigma=sigma)
  File "_felzenszwalb_cy.pyx", line 57, in skimage.segmentation._felzenszwalb_cy._felzenszwalb_grey (skimage\segmentation\_felzenszwalb_cy.c:1949)
ValueError: Buffer dtype mismatch, expected 'int_t' but got 'long long'

======================================================================
ERROR: test_felzenszwalb.test_color
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python26-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python26-x64\lib\site-packages\skimage\segmentation\tests\test_felzenszwalb.py", line 28, in test_color
    seg = felzenszwalb(img, sigma=0)
  File "X:\Python26-x64\lib\site-packages\skimage\segmentation\_felzenszwalb.py", line 66, in felzenszwalb
    min_size=min_size)
  File "_felzenszwalb_cy.pyx", line 57, in skimage.segmentation._felzenszwalb_cy._felzenszwalb_grey (skimage\segmentation\_felzenszwalb_cy.c:1949)
ValueError: Buffer dtype mismatch, expected 'int_t' but got 'long long'

----------------------------------------------------------------------
```
