### PR TITLE
Use io.BytesIO instead of StringIO

### DIFF
--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -1,14 +1,12 @@
 __all__ = ['Image', 'imread', 'imread_collection', 'imsave', 'imshow', 'show',
            'push', 'pop']
 
-from skimage.io._plugins import call as call_plugin
-from skimage.color import rgb2grey
+from io import BytesIO
+
 import numpy as np
 
-try:
-    import cStringIO as StringIO
-except ImportError:
-    import StringIO
+from skimage.io._plugins import call as call_plugin
+from skimage.color import rgb2grey
 
 
 # Shared image queue
@@ -49,7 +47,7 @@ class Image(np.ndarray):
         return self._repr_image_format('jpeg')
 
     def _repr_image_format(self, format_str):
-        str_buffer = StringIO.StringIO()
+        str_buffer = BytesIO()
         imsave(str_buffer, self, format_str=format_str)
         return_str = str_buffer.getvalue()
         str_buffer.close()


### PR DESCRIPTION
Fixes NameError: global name 'io' is not defined on Python 3:

```
ERROR: test_pil.test_repr_png
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python32\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "X:\Python32\lib\site-packages\numpy\testing\decorators.py", line 147, in skipper_func
    return f(*args, **kwargs)
  File "X:\Python32\lib\site-packages\skimage\io\tests\test_pil.py", line 86, in test_repr_png
    original_img_str = original_img._repr_png_()
  File "X:\Python32\lib\site-packages\skimage\io\_io.py", line 46, in _repr_png_
    return self._repr_image_format('png')
  File "X:\Python32\lib\site-packages\skimage\io\_io.py", line 52, in _repr_image_format
    str_buffer = io.StringIO()
NameError: global name 'io' is not defined
```

This is because the following code breaks when run through the 2to3 tool:

```
try:
    import cStringIO as StringIO
except ImportError:
    import StringIO
# snip
str_buffer = StringIO.StringIO()    
```

After 2to3:

```
try:
    import io as StringIO
except ImportError:
    import io
# snip
str_buffer = io.StringIO()
```
