### PR TITLE
Remove unused fopenmp compile args

### DIFF
--- a/skimage/transform/setup.py
+++ b/skimage/transform/setup.py
@@ -20,9 +20,7 @@ def configuration(parent_package='', top_path=None):
                          include_dirs=[get_numpy_include_dirs()])
 
     config.add_extension('_warps_cy', sources=['_warps_cy.c'],
-                         include_dirs=[get_numpy_include_dirs(), '../_shared'],
-                         extra_compile_args=['-fopenmp'],
-                         extra_link_args=['-fopenmp'])
+                         include_dirs=[get_numpy_include_dirs(), '../_shared'])
 
     return config
 


### PR DESCRIPTION
Fix for https://github.com/scikit-image/scikit-image/issues/341.
