### PR TITLE
BUG: Pass package directory as positional argument to nose.run

### DIFF
--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -65,7 +65,7 @@ except ImportError:
 def _setup_test(verbose=False):
     import functools
 
-    args = ['', '--exe', '-w', pkg_dir]
+    args = ['', pkg_dir, '--exe']
     if verbose:
         args.extend(['-v', '-s'])
 


### PR DESCRIPTION
When the package directory is passed to nosetest via the "where" argument (-w), that directory becomes the working directory. This causes problems because `skimage.io` will take precedence over the builtin `io` package.

This PR should fix #344
