### PR TITLE
DOC: Remove confusing paragraph about dtype range.

### DIFF
--- a/doc/source/user_guide/data_types.txt
+++ b/doc/source/user_guide/data_types.txt
@@ -71,11 +71,6 @@ issued::
    float64 to uint8
    array([  0, 128, 255], dtype=uint8)
 
-Wherever possible, functions should try to handle input without explicit
-conversion. For example, there is no need to force values to a specific type
-for doing a convolution; a plotting function, on the other hand, needs to know
-the range of the input.
-
 
 Output types
 ============


### PR DESCRIPTION
I originally wrote this paragraph, but now think it should be removed.  There are very few situations in which data-types should not be taken into consideration.
