### PR TITLE
Make black the default boundary color for mark_boundaries.

### DIFF
--- a/skimage/segmentation/boundaries.py
+++ b/skimage/segmentation/boundaries.py
@@ -13,7 +13,7 @@ def find_boundaries(label_img):
     return boundaries
 
 
-def mark_boundaries(image, label_img, color=(1, 1, 0), outline_color=None):
+def mark_boundaries(image, label_img, color=(1, 1, 0), outline_color=(0, 0, 0)):
     """Return image with boundaries between labeled regions highlighted.
 
     Parameters


### PR DESCRIPTION
This improves visibility in light-colored image regions. Note also that the new behavior matches the behavior from the 0.7 release.
