### PR TITLE
Fix circular import

### DIFF
--- a/skimage/morphology/watershed.py
+++ b/skimage/morphology/watershed.py
@@ -28,7 +28,6 @@ from _heapq import heappush, heappop
 import numpy as np
 import scipy.ndimage
 from ..filter import rank_order
-from ..feature import peak_local_max
 from .._shared.utils import deprecated
 
 from . import _watershed
@@ -293,6 +292,8 @@ def is_local_maximum(image, labels=None, footprint=None):
            [False,  True, False,  True]], dtype=bool)
 
     """
+    # call import here to prevent circular imports
+    from ..feature import peak_local_max
     return peak_local_max(image, labels=labels, min_distance=1,
                           threshold_rel=0, footprint=footprint,
                           indices=False, exclude_border=False)


### PR DESCRIPTION
Running

```
$ python -c 'from skimage import morphology'
```

gave the following traceback:

> Traceback (most recent call last):
>   File "<string>", line 1, in <module>
>   File "/Users/Tony/python/devel/skimage/skimage/morphology/**init**.py", line 6, in <module>
>     from .watershed import watershed, is_local_maximum
>   File "skimage/morphology/watershed.py", line 31, in <module>
>     from ..feature import peak_local_max
>   File "/Users/Tony/python/devel/skimage/skimage/feature/**init**.py", line 5, in <module>
>     from .template import match_template
>   File "skimage/feature/template.py", line 4, in <module>
>     from . import _template
>   File "_template.pyx", line 37, in init skimage.feature._template (../skimage/feature/_template.c:4073)
>   File "skimage/transform/__init__.py", line 1, in <module>
>     from .hough_transform import *
>   File "skimage/transform/hough_transform.py", line 8, in <module>
>     from skimage import measure, morphology
>   File "/Users/Tony/python/devel/skimage/skimage/measure/**init**.py", line 2, in <module>
>     from ._regionprops import regionprops, perimeter
>   File "skimage/measure/_regionprops.py", line 6, in <module>
>     from skimage.morphology import convex_hull_image
> ImportError: cannot import name convex_hull_image

The `is_local_maximum` function (in the `morphology` package) was reimplemented in PR #376 to reuse `peak_local` (in the `feature` package). This ended up creating a circular import, as the traceback above shows.
