### PR TITLE
BUG: Not all plugins would pass the adapthist test

### DIFF
--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -11,8 +11,8 @@ from skimage.util.dtype import dtype_range
 # ===========================
 
 # squeeze image intensities to lower image contrast
-test_img = exposure.rescale_intensity(data.camera() / 5. + 100)
-test_img = skimage.img_as_float(test_img)
+test_img = skimage.img_as_float(data.camera())
+test_img = exposure.rescale_intensity(test_img / 5. + 100)
 
 
 def test_equalize_ubyte():


### PR DESCRIPTION
Using the freeimage plugin (as Travis does), produced a float64 test_img, while others produced a float32 test image.  I normalized to float64 and adjusted the expected results.
