### PR TITLE
fix: set random seed in `test_noisy_square_image`

### DIFF
--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -31,6 +31,7 @@ def test_square_image():
 def test_noisy_square_image():
     im = np.zeros((50, 50)).astype(float)
     im[:25, :25] = 1.
+    np.random.seed(seed=1234)
     im = im + np.random.uniform(size=im.shape) * .2
 
     # Moravec


### PR DESCRIPTION
This PR should address random failures of the `test_noisy_square_image` test (as described in #418).

Before this PR, I observed this test occasionally failing in both OSX and Windows.
