### PR TITLE
HOG Visualisation bugfix

### DIFF
--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -142,8 +142,8 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
                     centre = tuple([y * cy + cy // 2, x * cx + cx // 2])
                     dx = radius * cos(float(o) / orientations * np.pi)
                     dy = radius * sin(float(o) / orientations * np.pi)
-                    rr, cc = draw.bresenham(centre[0] - dy, centre[1] - dx,
-                                            centre[0] + dy, centre[1] + dx)
+                    rr, cc = draw.bresenham(centre[0] - dx, centre[1] - dy,
+                                            centre[0] + dx, centre[1] + dy)
                     hog_image[rr, cc] += orientation_histogram[y, x, o]
 
     """


### PR DESCRIPTION
I swapped the direction that the histograms point in the hog visualisation so that it matches the literature. Now, the lines are pointed perpendicular to gradients instead of parallel.
