### PR TITLE
Use `image.astype(dtype)` instead of `dtype(image)`

### DIFF
--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -176,7 +176,7 @@ def convert(image, dtype, force_copy=False, uniform=False):
 
     if kind_in == 'b':
         # from binary image, to float and to integer
-        result = dtype(image)
+        result = image.astype(dtype)
         if kind != 'f':
             result *= dtype(dtype_range[dtype][1])
         return result
@@ -195,7 +195,7 @@ def convert(image, dtype, force_copy=False, uniform=False):
             # floating point -> floating point
             if itemsize_in > itemsize:
                 prec_loss()
-            return dtype(image)
+            return image.astype(dtype)
 
         # floating point -> integer
         prec_loss()
@@ -218,7 +218,7 @@ def convert(image, dtype, force_copy=False, uniform=False):
             image *= (imax - imin + 1.0) / 2.0
             np.floor(image, out=image)
             np.clip(image, imin, imax, out=image)
-        return dtype(image)
+        return image.astype(dtype)
 
     if kind == 'f':
         # integer -> floating point
@@ -236,7 +236,7 @@ def convert(image, dtype, force_copy=False, uniform=False):
             image *= 2.0
             image += 1.0
             image /= imax_in - imin_in
-        return dtype(image)
+        return image.astype(dtype)
 
     if kind_in == 'u':
         if kind == 'i':
@@ -262,7 +262,7 @@ def convert(image, dtype, force_copy=False, uniform=False):
     image -= imin_in
     image = _scale(image, 8 * itemsize_in, 8 * itemsize, copy=False)
     image += imin
-    return dtype(image)
+    return image.astype(dtype)
 
 
 def img_as_float(image, force_copy=False):


### PR DESCRIPTION
This PR addresses Issue #476, which is actually a NumPy bug but we can work around it with a trivial syntax change.

Passes all tests on my Mac, and the two versions profile no differently.

Someone familiar with this algorithm should look at line 181; that's the only remaining `dtype()` call, which reads `result *= dtype(dtype_range[dtype][1])`.  I'm not confident in naively dropping that argument into `.astype()`, and because it merely scales `result` I don't think it would matter even if it did drop back to a float.
