### PR TITLE
Create dummy WindowsError that is an actual Exception instead of None. 

### DIFF
--- a/skimage/_build.py
+++ b/skimage/_build.py
@@ -8,7 +8,8 @@ import subprocess
 try:
     WindowsError
 except NameError:
-    WindowsError = None
+    class WindowsError(Exception):
+        pass
 
 
 def cython(pyx_files, working_path=''):


### PR DESCRIPTION
The solution in pull request #383 does not work when an error occurs: "TypeError: catching classes that do not inherit from BaseException is not allowed"

This prevented me from installing scikit image on Python 3.3 and Mac OS X 10.6.2.

(please let me know if this is not the correct way to do a PR)
