### PR TITLE
Use specific structuring element in Canny function

### DIFF
--- a/skimage/filter/_canny.py
+++ b/skimage/filter/_canny.py
@@ -254,7 +254,8 @@ def canny(image, sigma=1., low_threshold=.1, high_threshold=.2, mask=None):
     # Segment the low-mask, then only keep low-segments that have
     # some high_mask component in them
     #
-    labels, count = label(low_mask, np.ndarray((3, 3), bool))
+    strel = np.ones((3, 3), bool)
+    labels, count = label(low_mask, strel)
     if count == 0:
         return low_mask
 


### PR DESCRIPTION
This PR specifies an 8-connected neighborhood structuring element used in the `scipy.ndimage.label` call within the Canny function.  The previous version `np.ndarray((3, 3), bool)` was not platform independent and in some cases random and nonsymmetric.

This fixes 5 of the errors in #495.

Also, if there is interest it would be simple to add a kwarg (and test) to toggle between 4- or 8-connected neighborhoods, probably with the default being 8-connected.
