### PR TITLE
Temporarily use Cython 0.18 to restore normal Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     - sudo apt-get install $PYTHON-setuptools
     - sudo apt-get install $PYTHON-nose
     - sudo easy_install$PYSUF pip
-    - sudo pip-$PYVER install cython
+    - sudo pip-$PYVER install cython==0.18.0
     - sudo apt-get install libfreeimage3
     - $PYTHON setup.py build
     - sudo $PYTHON setup.py install


### PR DESCRIPTION
This is a workaround/hack to temporarily restore the normal Travis workflow. It doesn't fix the problem, but gets it out of everyone else's way.

We still need to address (fix bug or determine if the problem is on Cython's side) the Cython 0.19 issue with `_mcp.pyx` or `_mcp.pxd` that has been throwing these Travis errors at us on Python 2.7. Once we do, this would be reverted.
