### PR TITLE
Deprecating is_rgb()

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -43,22 +43,36 @@ References
 
 from __future__ import division
 
-__all__ = ['convert_colorspace', 'rgb2hsv', 'hsv2rgb', 'rgb2xyz', 'xyz2rgb',
-           'rgb2rgbcie', 'rgbcie2rgb', 'rgb2grey', 'rgb2gray', 'gray2rgb',
-           'xyz2lab', 'lab2xyz', 'lab2rgb', 'rgb2lab', 'rgb2hed', 'hed2rgb',
-           'separate_stains', 'combine_stains', 'rgb_from_hed', 'hed_from_rgb',
-           'rgb_from_hdx', 'hdx_from_rgb', 'rgb_from_fgx', 'fgx_from_rgb',
-           'rgb_from_bex', 'bex_from_rgb', 'rgb_from_rbd', 'rbd_from_rgb',
-           'rgb_from_gdx', 'gdx_from_rgb', 'rgb_from_hax', 'hax_from_rgb',
-           'rgb_from_bro', 'bro_from_rgb', 'rgb_from_bpx', 'bpx_from_rgb',
-           'rgb_from_ahx', 'ahx_from_rgb', 'rgb_from_hpx', 'hpx_from_rgb'
-           ]
-
-__docformat__ = "restructuredtext en"
-
 import numpy as np
 from scipy import linalg
 from ..util import dtype
+from skimage._shared.utils import deprecated
+
+
+@deprecated()
+def is_rgb(image):
+    """Test whether the image is RGB or RGBA.
+
+    Parameters
+    ----------
+    image : ndarray
+        Input image.
+
+    """
+    return (image.ndim == 3 and image.shape[2] in (3, 4))
+
+
+@deprecated()
+def is_gray(image):
+    """Test whether the image is gray (i.e. has only one color band).
+
+    Parameters
+    ----------
+    image : ndarray
+        Input image.
+
+    """
+    return np.squeeze(image).ndim == 2
 
 
 def convert_colorspace(arr, fromspace, tospace):
@@ -629,7 +643,7 @@ def gray2rgb(image):
     """
     if np.squeeze(image).ndim == 3 and image.shape[2] in (3, 4):
         return image
-    elif np.squeeze(image).ndim == 2:
+    elif image.ndim == 2 or np.squeeze(image).ndim == 2:
         return np.dstack((image, image, image))
     else:
         raise ValueError("Input image expected to be RGB, RGBA or gray.")

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -28,7 +28,8 @@ from skimage.color import (
     convert_colorspace,
     rgb2grey, gray2rgb,
     xyz2lab, lab2xyz,
-    lab2rgb, rgb2lab
+    lab2rgb, rgb2lab,
+    is_rgb, is_gray
     )
 
 from skimage import data_dir, data
@@ -231,16 +232,19 @@ class TestColorconv(TestCase):
         assert_array_almost_equal(lab2rgb(rgb2lab(img_rgb)), img_rgb)
 
 def test_gray2rgb():
-    x = np.array([[0, 0.5, 1], [0, 0.5, 1]])
+    x = np.array([0, 0.5, 1])
+    assert_raises(ValueError, gray2rgb, x)
+
+    x = x.reshape((3, 1))
     y = gray2rgb(x)
 
-    assert_equal(y.shape, (2, 3, 3))
+    assert_equal(y.shape, (3, 1, 3))
     assert_equal(y.dtype, x.dtype)
 
-    x = np.array([[0, 128], [128, 255], [255, 0]], dtype=np.uint8)
+    x = np.array([[0, 128, 255]], dtype=np.uint8)
     z = gray2rgb(x)
 
-    assert_equal(z.shape, (3, 2, 3))
+    assert_equal(z.shape, (1, 3, 3))
     assert_equal(z[..., 0], x)
     assert_equal(z[0, 1, :], [128, 128, 128])
 
@@ -249,6 +253,17 @@ def test_gray2rgb_rgb():
     x = np.random.random((5, 5, 4))
     y = gray2rgb(x)
     assert_equal(x, y)
+
+
+def test_is_rgb():
+    color = data.lena()
+    gray = data.camera()
+
+    assert is_rgb(color)
+    assert not is_gray(color)
+
+    assert is_gray(gray)
+    assert not is_gray(color)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I grepped for `is_rgb` and surprisingly didn't find it anywhere except `colorconv.py` and `test_colorconv.py`.
Currently, the condition for testing for an rgb image in `is_gray()` in this commit is the same as one used in `is_rgb()` which is a weak test in my opinion. Does anyone have better ideas for it?
