### PR TITLE
Fix Cython 0.19 build error on Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     - sudo apt-get install $PYTHON-setuptools
     - sudo apt-get install $PYTHON-nose
     - sudo easy_install$PYSUF pip
-    - sudo pip-$PYVER install cython==0.18.0
+    - sudo pip-$PYVER install cython
     - sudo apt-get install libfreeimage3
     - $PYTHON setup.py build
     - sudo $PYTHON setup.py install


### PR DESCRIPTION
This PR addresses #534 and reverts `.travis.yml` to use most recent version of Cython. Many thanks to Nikita Nemkin on the cython-devel mailing list for identifying the problem.

Wraparound indexing and bounds checks were turned off for the entire file, yet reverse index slicing (e.g. `arr[::-1]`) was used in several pure Python functions. It's amazing this worked at all, let alone consistently for so long.

The quick fix was to use decorators for those two Cython options, turning them on where necessary. If this ends up being too significant of a performance decrease, we can re-implement where necessary so reverse indexing isn't required.
