### PR TITLE
fix: docstring in rank/percentile

### DIFF
--- a/skimage/filter/rank/_crank16_percentiles.pyx
+++ b/skimage/filter/rank/_crank16_percentiles.pyx
@@ -299,11 +299,11 @@ def percentile(cnp.ndarray[dtype_t, ndim=2] image,
                cnp.ndarray[cnp.uint8_t, ndim=2] mask=None,
                cnp.ndarray[dtype_t, ndim=2] out=None,
                char shift_x=0, char shift_y=0, int bitdepth=8,
-               float p0=0., float p1=0.):
+               float p0=0.):
     """return p0 percentile
     """
     _core16(kernel_percentile, image, selem, mask, out, shift_x, shift_y,
-            bitdepth, p0, p1, <Py_ssize_t>0, <Py_ssize_t>0)
+            bitdepth, p0, .0, <Py_ssize_t>0, <Py_ssize_t>0)
 
 
 def pop(cnp.ndarray[dtype_t, ndim=2] image,
@@ -323,8 +323,8 @@ def threshold(cnp.ndarray[dtype_t, ndim=2] image,
               cnp.ndarray[cnp.uint8_t, ndim=2] mask=None,
               cnp.ndarray[dtype_t, ndim=2] out=None,
               char shift_x=0, char shift_y=0, int bitdepth=8,
-              float p0=0., float p1=0.):
+              float p0=0.):
     """return (maxbin-1) if g > percentile p0
     """
     _core16(kernel_threshold, image, selem, mask, out, shift_x, shift_y,
-            bitdepth, p0, p1, <Py_ssize_t>0, <Py_ssize_t>0)
+            bitdepth, p0, 0., <Py_ssize_t>0, <Py_ssize_t>0)

--- a/skimage/filter/rank/_crank8_percentiles.pyx
+++ b/skimage/filter/rank/_crank8_percentiles.pyx
@@ -265,11 +265,11 @@ def percentile(cnp.ndarray[dtype_t, ndim=2] image,
                cnp.ndarray[dtype_t, ndim=2] selem,
                cnp.ndarray[dtype_t, ndim=2] mask=None,
                cnp.ndarray[dtype_t, ndim=2] out=None,
-               char shift_x=0, char shift_y=0, float p0=0., float p1=0.):
+               char shift_x=0, char shift_y=0, float p0=0.):
     """return p0 percentile
     """
     _core8(kernel_percentile, image, selem, mask, out, shift_x, shift_y,
-           p0, p1, <Py_ssize_t>0, <Py_ssize_t>0)
+           p0, 0., <Py_ssize_t>0, <Py_ssize_t>0)
 
 
 def pop(cnp.ndarray[dtype_t, ndim=2] image,
@@ -287,8 +287,8 @@ def threshold(cnp.ndarray[dtype_t, ndim=2] image,
               cnp.ndarray[dtype_t, ndim=2] selem,
               cnp.ndarray[dtype_t, ndim=2] mask=None,
               cnp.ndarray[dtype_t, ndim=2] out=None,
-              char shift_x=0, char shift_y=0, float p0=0., float p1=0.):
+              char shift_x=0, char shift_y=0, float p0=0.):
     """return 255 if g > percentile p0
     """
-    _core8(kernel_threshold, image, selem, mask, out, shift_x, shift_y, p0, p1,
+    _core8(kernel_threshold, image, selem, mask, out, shift_x, shift_y, p0, 0.,
            <Py_ssize_t>0, <Py_ssize_t>0)

--- a/skimage/filter/rank/percentile_rank.pyx
+++ b/skimage/filter/rank/percentile_rank.pyx
@@ -275,7 +275,7 @@ def percentile_morph_contr_enh(
 
 
 def percentile(image, selem, out=None, mask=None, shift_x=False, shift_y=False,
-               p0=.0, p1=1.):
+               p0=.0):
     """Return greyscale local percentile of an image.
 
     percentile is computed on the given structuring element. Returns the value
@@ -298,8 +298,8 @@ def percentile(image, selem, out=None, mask=None, shift_x=False, shift_y=False,
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
-    p0, p1 : float in [0, ..., 1]
-        Define the percentile p0. The p1 value is unused.
+    p0 : float in [0, ..., 1]
+        Set the percentile value.
 
     Returns
     -------
@@ -311,7 +311,7 @@ def percentile(image, selem, out=None, mask=None, shift_x=False, shift_y=False,
     return _apply(_crank8_percentiles.percentile,
                   _crank16_percentiles.percentile,
                   image, selem, out=out, mask=mask, shift_x=shift_x,
-                  shift_y=shift_y, p0=p0, p1=p1)
+                  shift_y=shift_y, p0=p0, p1=0.)
 
 
 def percentile_pop(image, selem, out=None, mask=None, shift_x=False,
@@ -355,7 +355,7 @@ def percentile_pop(image, selem, out=None, mask=None, shift_x=False,
 
 
 def percentile_threshold(image, selem, out=None, mask=None, shift_x=False,
-                         shift_y=False, p0=.0, p1=1.):
+                         shift_y=False, p0=.0):
     """Return greyscale local threshold of an image.
 
     threshold is computed on the given structuring element. Returns
@@ -380,8 +380,8 @@ def percentile_threshold(image, selem, out=None, mask=None, shift_x=False,
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
-    p0, p1 : float in [0, ..., 1]
-        Define the percentile p0. The p1 value is unused.
+    p0 : float in [0, ..., 1]
+        Set the percentile value.
 
     Returns
     -------
@@ -393,4 +393,4 @@ def percentile_threshold(image, selem, out=None, mask=None, shift_x=False,
     return _apply(
         _crank8_percentiles.threshold, _crank16_percentiles.threshold,
         image, selem, out=out, mask=mask, shift_x=shift_x,
-        shift_y=shift_y, p0=p0, p1=p1)
+        shift_y=shift_y, p0=p0, p1=0.)


### PR DESCRIPTION
Hi, here is a small modification in the docstring for `filter/rank/percentile` and `filter/rank/percentile_threshold` functions. Thanks @Juan for pointing that out.
