### PR TITLE
fix the gaussian impulse function definition example

### DIFF
--- a/skimage/filter/lpi_filter.py
+++ b/skimage/filter/lpi_filter.py
@@ -66,7 +66,8 @@ class LPIFilter2D(object):
         --------
 
         Gaussian filter:
-	Use a 1-D gaussian in each direction without normalization coefficients:
+	    Use a 1-D gaussian in each direction without normalization
+	    coefficients.
         >>> def filt_func(r, c, sigma = 1):
         ...     return np.exp(-np.hypot(r, c)/sigma)
         >>> filter = LPIFilter2D(filt_func)


### PR DESCRIPTION
the gaussian impulse function incorrectly takes the euclidean distance of the x,y instead of considering them as separate gaussians.
