### PR TITLE
Escape `\` in `label` docstring

### DIFF
--- a/skimage/morphology/ccomp.pyx
+++ b/skimage/morphology/ccomp.pyx
@@ -93,7 +93,7 @@ def label(input, DTYPE_t neighbors=8, DTYPE_t background=-1, return_num=False):
            [ ]           [ ]  [ ]  [ ]
             |               \  |  /
       [ ]--[ ]--[ ]      [ ]--[ ]--[ ]
-            |               /  |  \
+            |               /  |  \\
            [ ]           [ ]  [ ]  [ ]
 
     Parameters


### PR DESCRIPTION
There was an un-escaped `\` ending a line in the `skimage.morphology.label` docstring, leading to [formatting issues like this](http://scikit-image.org/docs/dev/api/skimage.morphology.html?highlight=label#skimage.morphology.label).
