### PR TITLE
add optional + default in pyx docstring

### DIFF
--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -178,7 +178,7 @@ def circle_perimeter(Py_ssize_t cy, Py_ssize_t cx, Py_ssize_t radius,
     radius: int
         Radius of circle.
     method : {'bresenham', 'andres'}, optional
-        bresenham : Bresenham method
+        bresenham : Bresenham method (default)
         andres : Andres method
 
     Returns
@@ -274,7 +274,7 @@ def ellipse_perimeter(Py_ssize_t cy, Py_ssize_t cx, Py_ssize_t yradius,
         Centre coordinate of ellipse.
     yradius, xradius: int
         Minor and major semi-axes. ``(x/xradius)**2 + (y/yradius)**2 = 1``.
-    orientation: double, optional
+    orientation: double, optional (default 0)
         Major axis orientation in clockwise direction as radians.
 
     Returns

--- a/skimage/feature/corner_cy.pyx
+++ b/skimage/feature/corner_cy.pyx
@@ -20,7 +20,7 @@ def corner_moravec(image, Py_ssize_t window_size=1):
     ----------
     image : ndarray
         Input image.
-    window_size : int, optional
+    window_size : int, optional (default 1)
         Window size.
 
     Returns

--- a/skimage/segmentation/_felzenszwalb_cy.pyx
+++ b/skimage/segmentation/_felzenszwalb_cy.pyx
@@ -25,12 +25,12 @@ def _felzenszwalb_grey(image, double scale=1, sigma=0.8, Py_ssize_t min_size=20)
     ----------
     image: ndarray
         Input image.
-    scale: float
+    scale: float, optional (default 1)
         Sets the obervation level. Higher means larger clusters.
-    sigma: float
+    sigma: float, optional (default 0.8)
         Width of Gaussian smoothing kernel used in preprocessing.
         Larger sigma gives smother segment boundaries.
-    min_size: int
+    min_size: int, optional (default 20)
         Minimum component size. Enforced using postprocessing.
 
     Returns

--- a/skimage/segmentation/_quickshift.pyx
+++ b/skimage/segmentation/_quickshift.pyx
@@ -24,23 +24,23 @@ def quickshift(image, ratio=1., float kernel_size=5, max_dist=10,
     ----------
     image : (width, height, channels) ndarray
         Input image.
-    ratio : float, between 0 and 1.
+    ratio : float, optional, between 0 and 1 (default 1).
         Balances color-space proximity and image-space proximity.
         Higher values give more weight to color-space.
-    kernel_size : float
+    kernel_size : float, optional (default 5)
         Width of Gaussian kernel used in smoothing the
         sample density. Higher means fewer clusters.
-    max_dist : float
+    max_dist : float, optional (default 10)
         Cut-off point for data distances.
         Higher means fewer clusters.
-    return_tree : bool
+    return_tree : bool, optional (default False)
         Whether to return the full segmentation hierarchy tree and distances.
-    sigma : float
+    sigma : float, optional (default 0)
         Width for Gaussian smoothing as preprocessing. Zero means no smoothing.
-    convert2lab : bool
+    convert2lab : bool, optional (default True)
         Whether the input should be converted to Lab colorspace prior to
         segmentation. For this purpose, the input is assumed to be RGB.
-    random_seed : None or int
+    random_seed : None (default) or int, optional
         Random seed used for breaking ties.
 
     Returns

--- a/skimage/segmentation/_slic.pyx
+++ b/skimage/segmentation/_slic.pyx
@@ -20,17 +20,17 @@ def slic(image, n_segments=100, ratio=10., max_iter=10, sigma=1,
     ----------
     image : (width, height [, 3]) ndarray
         Input image.
-    n_segments : int
+    n_segments : int, optional (default 100)
         The (approximate) number of labels in the segmented output image.
-    ratio: float
+    ratio: float, optional (default 10)
         Balances color-space proximity and image-space proximity.
         Higher values give more weight to color-space.
-    max_iter : int
+    max_iter : int, optional (default 10)
         Maximum number of iterations of k-means.
-    sigma : float
+    sigma : float, optional (default 1)
         Width of Gaussian smoothing kernel for preprocessing. Zero means no
         smoothing.
-    convert2lab : bool
+    convert2lab : bool, optional (default True)
         Whether the input should be converted to Lab colorspace prior to
         segmentation.  For this purpose, the input is assumed to be RGB. Highly
         recommended.

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -31,10 +31,10 @@ def hough_circle(cnp.ndarray img,
         Input image with nonzero values representing edges.
     radius : ndarray
         Radii at which to compute the Hough transform.
-    normalize : boolean, optional
+    normalize : boolean, optional (default True)
         Normalize the accumulator with the number
-        of pixels used to draw the radius
-    full_output : boolean, optional
+        of pixels used to draw the radius.
+    full_output : boolean, optional (default False)
         Extend the output size by twice the largest
         radius in order to detect centers outside the
         input picture.

--- a/skimage/transform/_warps_cy.pyx
+++ b/skimage/transform/_warps_cy.pyx
@@ -67,17 +67,17 @@ def _warp_fast(cnp.ndarray image, cnp.ndarray H, output_shape=None,
         Input image.
     H : array of shape ``(3, 3)``
         Transformation matrix H that defines the homography.
-    output_shape : tuple (rows, cols)
-        Shape of the output image generated.
-    order : {0, 1}
+    output_shape : tuple (rows, cols), optional
+        Shape of the output image generated (default None).
+    order : {0, 1}, optional
         Order of interpolation::
         * 0: Nearest-neighbour interpolation.
         * 1: Bilinear interpolation (default).
-        * 2: Biquadratic interpolation (default).
+        * 2: Biquadratic interpolation.
         * 3: Bicubic interpolation.
-    mode : {'constant', 'reflect', 'wrap', 'nearest'}
-        How to handle values outside the image borders.
-    cval : string
+    mode : {'constant', 'reflect', 'wrap', 'nearest'}, optional
+        How to handle values outside the image borders (default is constant).
+    cval : string, optional (default 0)
         Used in conjunction with mode 'C' (constant), the value
         outside the image boundaries.
 


### PR DESCRIPTION
@stefanv I felt guilty :)

Comment:
In skimage/transform/_warps_cy.pyx, two values were marked as default. I fixed the docstring.
