### PR TITLE
Bugs in filter.denoise_biltateral.

### DIFF
--- a/skimage/filter/_denoise_cy.pyx
+++ b/skimage/filter/_denoise_cy.pyx
@@ -137,11 +137,11 @@ def denoise_bilateral(image, Py_ssize_t win_size=5, sigma_range=None,
 
     max_value = image.max()
     
-    cimage = np.ascontiguousarray(image)
-    
     if max_value == 0.0:
         raise ValueError("The maximum value found in the image was 0.")
 
+    cimage = np.ascontiguousarray(image)
+    
     out = np.zeros((rows, cols, dims), dtype=np.double)
     image_data = <double*>cimage.data
     out_data = <double*>out.data


### PR DESCRIPTION
## Detected bugs

I detected two problems:
1. letting the default argument was raising an `TypeError` exception
2. passing an image with all values to zero was leading to a segmentation fault.

The diagnostic:
1. the value of `sigma_range` was checked, but the function using it (`_compute_color_lut`)  was called with the unchecked value.
2. the value `dist_scale` which is used during the indexing of `color_lut`, is computed  with `bins/ dims / max_value`. Hence if max_value is 0, `dist_scale` won't have a reasonable value, leading to a segmentation fault when indexing.

The solution:
1. Initialize `color_lut` after `sigma_range` has been checked.
2. check that `max_value` is not zero.
## Remarks:

The input values are never checked, which can lead to segmentation fault since their values are then used during indexing.

More generally, the index values are never checked before indexing, which can lead to some problems.
