### PR TITLE
Apply plugins to all images in a CollectionViewer.

### DIFF
--- a/skimage/viewer/viewers/core.py
+++ b/skimage/viewer/viewers/core.py
@@ -297,6 +297,9 @@ class CollectionViewer(ImageViewer):
         react to image changes.
         """
         self.image = image
+        for plugin in self.plugins:
+            plugin.arguments[0] = self.image
+            plugin.filter_image()              # updates self.image
 
     def keyPressEvent(self, event):
         if type(event) == QtGui.QKeyEvent:


### PR DESCRIPTION
Currently, a CollectionViewer will only apply plugins to the first image of the sequence the first time that image is displayed. In all other cases, no plugins seem to be applied. This is an attempt at resolving this problem.
