### PR TITLE
cast range to list for python3

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -222,14 +222,14 @@ class ProjectiveTransform(GeometricTransform):
         A[rows:, 8] = yd
 
         # Select relevant columns, depending on params
-        A = A[:, self._coeffs + [8]]
+        A = A[:, list(self._coeffs) + [8]]
 
         _, _, V = np.linalg.svd(A)
 
         H = np.zeros((3, 3))
         # solution is right singular vector that corresponds to smallest
         # singular value
-        H.flat[self._coeffs + [8]] = - V[-1, :-1] / V[-1, -1]
+        H.flat[list(self._coeffs) + [8]] = - V[-1, :-1] / V[-1, -1]
         H[2, 2] = 1
 
         self._matrix = H


### PR DESCRIPTION
Running unittests, I got this error (python 3):
unsupported operand type(s) for +: 'range' and 'list'
# python2

type(range(2)) returns list
# python3

type(range(2)) returns builtins.range

I solved it by casting the range into a list.
