### PR TITLE
import configparser for python3

### DIFF
--- a/skimage/io/_plugins/plugin.py
+++ b/skimage/io/_plugins/plugin.py
@@ -4,7 +4,11 @@
 
 __all__ = ['use', 'available', 'call', 'info', 'configuration', 'reset_plugins']
 
-from ConfigParser import ConfigParser
+try:
+    from configparser import ConfigParser
+except ImportError:
+    from ConfigParser import ConfigParser
+
 import os.path
 from glob import glob
 


### PR DESCRIPTION
ConfigParser has been renamed configparser to satisfy pep8 under python3.

This is my last PR for today. :) 
