### PR TITLE
Fasthog

### DIFF
--- a/bento.info
+++ b/bento.info
@@ -98,6 +98,9 @@ Library:
     Extension: skimage.feature.corner_cy
         Sources:
             skimage/feature/corner_cy.pyx
+    Extension: skimage.feature._hoghistogram
+        Sources:
+            skimage/feature/_hoghistogram.pyx
     Extension: skimage.feature._texture
         Sources:
             skimage/feature/_texture.pyx

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy import sqrt, pi, arctan2, cos, sin
 from scipy.ndimage import uniform_filter
 from .._shared.utils import assert_nD
-
+import _hoghistogram
 
 def hog(image, orientations=9, pixels_per_cell=(8, 8),
         cells_per_block=(3, 3), visualise=False, normalise=False):
@@ -114,24 +114,10 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
     n_cellsx = int(np.floor(sx // cx))  # number of cells in x
     n_cellsy = int(np.floor(sy // cy))  # number of cells in y
 
-    # compute orientations integral images
     orientation_histogram = np.zeros((n_cellsy, n_cellsx, orientations))
-    subsample = np.index_exp[cy // 2:cy * n_cellsy:cy,
-                             cx // 2:cx * n_cellsx:cx]
-    for i in range(orientations):
-        # create new integral image for this orientation
-        # isolate orientations in this range
 
-        temp_ori = np.where(orientation < 180.0 / orientations * (i + 1),
-                            orientation, -1)
-        temp_ori = np.where(orientation >= 180.0 / orientations * i,
-                            temp_ori, -1)
-        # select magnitudes for those orientations
-        cond2 = temp_ori > -1
-        temp_mag = np.where(cond2, magnitude, 0)
-
-        temp_filt = uniform_filter(temp_mag, size=(cy, cx))
-        orientation_histogram[:, :, i] = temp_filt[subsample]
+    _hoghistogram.HogHistograms(gx, gy, cx, cy, sx, sy, n_cellsx, n_cellsy, visualise, orientations, 
+        orientation_histogram)
 
     # now for each cell, compute the histogram
     hog_image = None

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -114,6 +114,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
     n_cellsx = int(np.floor(sx // cx))  # number of cells in x
     n_cellsy = int(np.floor(sy // cy))  # number of cells in y
 
+    # compute orientations integral images
     orientation_histogram = np.zeros((n_cellsy, n_cellsx, orientations))
 
     _hoghistogram.HogHistograms(gx, gy, cx, cy, sx, sy, n_cellsx, n_cellsy, visualise, orientations, 

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy import sqrt, pi, arctan2, cos, sin
 from scipy.ndimage import uniform_filter
 from .._shared.utils import assert_nD
-import _hoghistogram
+from . import _hoghistogram
 
 def hog(image, orientations=9, pixels_per_cell=(8, 8),
         cells_per_block=(3, 3), visualise=False, normalise=False):

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -1,5 +1,4 @@
 import numpy as np
-from scipy import sqrt, pi, arctan2, cos, sin
 from scipy.ndimage import uniform_filter
 from .._shared.utils import assert_nD
 from . import _hoghistogram
@@ -63,7 +62,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
     assert_nD(image, 2)
 
     if normalise:
-        image = sqrt(image)
+        image = np.sqrt(image)
 
     """
     The second stage computes first order image gradients. These capture
@@ -104,8 +103,8 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
     cell are used to vote into the orientation histogram.
     """
 
-    magnitude = sqrt(gx ** 2 + gy ** 2)
-    orientation = arctan2(gy, gx) * (180 / pi) % 180
+    magnitude = np.hypot(gx, gy)
+    orientation = np.arctan2(gy, gx) * (180 / np.pi) % 180
 
     sy, sx = image.shape
     cx, cy = pixels_per_cell
@@ -132,8 +131,8 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
             for y in range(n_cellsy):
                 for o in range(orientations):
                     centre = tuple([y * cy + cy // 2, x * cx + cx // 2])
-                    dx = radius * cos(float(o) / orientations * np.pi)
-                    dy = radius * sin(float(o) / orientations * np.pi)
+                    dx = radius * np.cos(float(o) / orientations * np.pi)
+                    dy = radius * np.sin(float(o) / orientations * np.pi)
                     rr, cc = draw.line(int(centre[0] - dx),
                                        int(centre[1] + dy),
                                        int(centre[0] + dx),
@@ -164,7 +163,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
         for y in range(n_blocksy):
             block = orientation_histogram[y:y + by, x:x + bx, :]
             eps = 1e-5
-            normalised_blocks[y, x, :] = block / sqrt(block.sum() ** 2 + eps)
+            normalised_blocks[y, x, :] = block / np.sqrt(block.sum() ** 2 + eps)
 
     """
     The final step collects the HOG descriptors from all blocks of a dense

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -117,8 +117,8 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
     # compute orientations integral images
     orientation_histogram = np.zeros((n_cellsy, n_cellsx, orientations))
 
-    _hoghistogram.HogHistograms(gx, gy, cx, cy, sx, sy, n_cellsx, n_cellsy, visualise, orientations, 
-        orientation_histogram)
+    _hoghistogram.HogHistograms(gx, gy, cx, cy, sx, sy, n_cellsx, n_cellsy, 
+        visualise, orientations, orientation_histogram)
 
     # now for each cell, compute the histogram
     hog_image = None

--- a/skimage/feature/_hoghistogram.pyx
+++ b/skimage/feature/_hoghistogram.pyx
@@ -9,62 +9,62 @@ import numpy as np
 from scipy import pi, arctan2, cos, sin
 
 cdef float CellHog(np.ndarray[np.float64_t, ndim=2] magnitude, 
-	np.ndarray[np.float64_t, ndim=2] orientation,
-	float ori1, float ori2,
-	int cx, int cy, int xi, int yi, int sx, int sy):
-	cdef int cx1, cy1
+    np.ndarray[np.float64_t, ndim=2] orientation,
+    float ori1, float ori2,
+    int cx, int cy, int xi, int yi, int sx, int sy):
+    cdef int cx1, cy1
 
-	cdef float total = 0.
-	for cy1 in range(-cy/2, cy/2):
-		for cx1 in range(-cx/2, cx/2):
-			if yi + cy1 < 0: continue
-			if yi + cy1 >= sy: continue
-			if xi + cx1 < 0: continue
-			if xi + cx1 >= sx: continue
-			if orientation[yi + cy1, xi + cx1] >= ori1: continue
-			if orientation[yi + cy1, xi + cx1] < ori2: continue
+    cdef float total = 0.
+    for cy1 in range(-cy/2, cy/2):
+        for cx1 in range(-cx/2, cx/2):
+            if yi + cy1 < 0: continue
+            if yi + cy1 >= sy: continue
+            if xi + cx1 < 0: continue
+            if xi + cx1 >= sx: continue
+            if orientation[yi + cy1, xi + cx1] >= ori1: continue
+            if orientation[yi + cy1, xi + cx1] < ori2: continue
 
-			total += magnitude[yi + cy1, xi + cx1]
+            total += magnitude[yi + cy1, xi + cx1]
 
-	return total
+    return total
 
 def HogHistograms(np.ndarray[np.float64_t, ndim=2] gx, \
-	np.ndarray[np.float64_t, ndim=2] gy, 
-	int cx, int cy, #Pixels per cell
-	int sx, int sy, #Image size
-	int n_cellsx, int n_cellsy, 
-	int visualise, int orientations, 
-	np.ndarray[np.float64_t, ndim=3] orientation_histogram):
+    np.ndarray[np.float64_t, ndim=2] gy, 
+    int cx, int cy, #Pixels per cell
+    int sx, int sy, #Image size
+    int n_cellsx, int n_cellsy, 
+    int visualise, int orientations, 
+    np.ndarray[np.float64_t, ndim=3] orientation_histogram):
 
-	cdef np.ndarray[np.float64_t, ndim=2] magnitude = np.sqrt(gx**2 + gy**2)
-	cdef np.ndarray[np.float64_t, ndim=2] orientation = arctan2(gy, gx) * (180 / pi) % 180
-	cdef int i, x, y, o, yi, xi, cy1, cy2, cx1, cx2
-	cdef float ori1, ori2
+    cdef np.ndarray[np.float64_t, ndim=2] magnitude = np.sqrt(gx**2 + gy**2)
+    cdef np.ndarray[np.float64_t, ndim=2] orientation = arctan2(gy, gx) * (180 / pi) % 180
+    cdef int i, x, y, o, yi, xi, cy1, cy2, cx1, cx2
+    cdef float ori1, ori2
 
-	# compute orientations integral images
+    # compute orientations integral images
 
-	for i in range(orientations):
-		# isolate orientations in this range
+    for i in range(orientations):
+        # isolate orientations in this range
 
-		ori1 = 180. / orientations * (i + 1)
-		ori2 = 180. / orientations * i
+        ori1 = 180. / orientations * (i + 1)
+        ori2 = 180. / orientations * i
 
-		y = cy / 2
-		cy2 = cy * n_cellsy
-		x = cx / 2
-		cx2 = cx * n_cellsx
-		yi = 0
-		xi = 0
+        y = cy / 2
+        cy2 = cy * n_cellsy
+        x = cx / 2
+        cx2 = cx * n_cellsx
+        yi = 0
+        xi = 0
 
-		while y < cy2:
-			xi = 0
-			x = cx / 2
+        while y < cy2:
+            xi = 0
+            x = cx / 2
 
-			while x < cx2:
-				orientation_histogram[yi, xi, i] = CellHog(magnitude, orientation, ori1, ori2, cx, cy, x, y, sx, sy)
-				xi += 1
-				x += cx
+            while x < cx2:
+                orientation_histogram[yi, xi, i] = CellHog(magnitude, orientation, ori1, ori2, cx, cy, x, y, sx, sy)
+                xi += 1
+                x += cx
 
-			yi += 1
-			y += cy
+            yi += 1
+            y += cy
 

--- a/skimage/feature/_hoghistogram.pyx
+++ b/skimage/feature/_hoghistogram.pyx
@@ -1,43 +1,99 @@
-# cython: profile=True
 # cython: cdivision=True
 # cython: boundscheck=False
 # cython: wraparound=False
 
-import cmath, math
-cimport numpy as np
 import numpy as np
-from scipy import pi, arctan2, cos, sin
+cimport numpy as np
 
+# cnp.float64_t[:, :] magnitude
 cdef float CellHog(np.ndarray[np.float64_t, ndim=2] magnitude, 
     np.ndarray[np.float64_t, ndim=2] orientation,
     float ori1, float ori2,
     int cx, int cy, int xi, int yi, int sx, int sy):
+    """CellHog
+
+    Parameters
+    ----------
+    magnitude : ndarray
+        Coordinate to be clipped.
+    orientation : ndarray
+        The lower bound.
+    ori1 : float
+        The higher bound.
+    ori2 : float
+        The higher bound.
+    cx : int
+        The higher bound.
+    cy : int
+        The higher bound.
+    xi : int
+        The higher bound.
+    yi : int
+        The higher bound.
+    sx : int
+        The higher bound.
+    sy : int
+        The higher bound.
+
+    Returns
+    -------
+    total : float
+        The total HOG value.
+    """
     cdef int cx1, cy1
 
     cdef float total = 0.
     for cy1 in range(-cy/2, cy/2):
         for cx1 in range(-cx/2, cx/2):
-            if yi + cy1 < 0: continue
-            if yi + cy1 >= sy: continue
-            if xi + cx1 < 0: continue
-            if xi + cx1 >= sx: continue
-            if orientation[yi + cy1, xi + cx1] >= ori1: continue
-            if orientation[yi + cy1, xi + cx1] < ori2: continue
+            if (yi + cy1 < 0 
+                or yi + cy1 >= sy 
+                or xi + cx1 < 0
+                or xi + cx1 >= sx 
+                or orientation[yi + cy1, xi + cx1] >= ori1
+                or orientation[yi + cy1, xi + cx1] < ori2): continue
 
             total += magnitude[yi + cy1, xi + cx1]
 
     return total
 
-def HogHistograms(np.ndarray[np.float64_t, ndim=2] gx, \
+def HogHistograms(np.ndarray[np.float64_t, ndim=2] gx, 
     np.ndarray[np.float64_t, ndim=2] gy, 
     int cx, int cy, #Pixels per cell
     int sx, int sy, #Image size
     int n_cellsx, int n_cellsy, 
     int visualise, int orientations, 
     np.ndarray[np.float64_t, ndim=3] orientation_histogram):
+    """HogHistograms
 
-    cdef np.ndarray[np.float64_t, ndim=2] magnitude = np.sqrt(gx**2 + gy**2)
-    cdef np.ndarray[np.float64_t, ndim=2] orientation = arctan2(gy, gx) * (180 / pi) % 180
+    Parameters
+    ----------
+    gx : ndarray
+        Coordinate to be clipped.
+    gy : ndarray
+        The lower bound.
+    cx : int
+        The higher bound.
+    cy : int
+        The higher bound.
+    sx : int
+        The higher bound.
+    sy : int
+        The higher bound.
+    n_cellsx : int
+        The higher bound.
+    n_cellsy : int
+        The higher bound.
+    visualise : int
+        The higher bound.
+    orientations : int
+        The higher bound.
+    orientation_histogram : ndarray
+        The histogram to fill.
+    """
+
+    cdef np.ndarray[np.float64_t, ndim=2] magnitude = np.hypot(gx, gy)
+    cdef np.ndarray[np.float64_t, ndim=2] orientation = (
+        np.arctan2(gy, gx) * (180 / np.pi) % 180)
     cdef int i, x, y, o, yi, xi, cy1, cy2, cx1, cx2
     cdef float ori1, ori2
 
@@ -61,7 +117,8 @@ def HogHistograms(np.ndarray[np.float64_t, ndim=2] gx, \
             x = cx / 2
 
             while x < cx2:
-                orientation_histogram[yi, xi, i] = CellHog(magnitude, orientation, ori1, ori2, cx, cy, x, y, sx, sy)
+                orientation_histogram[yi, xi, i] = CellHog(magnitude, 
+                    orientation, ori1, ori2, cx, cy, x, y, sx, sy)
                 xi += 1
                 x += cx
 

--- a/skimage/feature/_hoghistogram.pyx
+++ b/skimage/feature/_hoghistogram.pyx
@@ -15,25 +15,25 @@ cdef float CellHog(np.ndarray[np.float64_t, ndim=2] magnitude,
     Parameters
     ----------
     magnitude : ndarray
-        Coordinate to be clipped.
+        The gradient magnitudes of the pixels.
     orientation : ndarray
-        The lower bound.
+        Lookup table for orientations.
     ori1 : float
-        The higher bound.
+        Orientation range start.
     ori2 : float
-        The higher bound.
+        Orientation range end.
     cx : int
-        The higher bound.
+        Pixels per cell (x).
     cy : int
-        The higher bound.
+        Pixels per cell (y).
     xi : int
-        The higher bound.
+        Block index (x).
     yi : int
-        The higher bound.
+        Block index (y).
     sx : int
-        The higher bound.
+        Image size (x).
     sy : int
-        The higher bound.
+        Image size (y).
 
     Returns
     -------
@@ -58,35 +58,35 @@ cdef float CellHog(np.ndarray[np.float64_t, ndim=2] magnitude,
 
 def HogHistograms(np.ndarray[np.float64_t, ndim=2] gx, 
     np.ndarray[np.float64_t, ndim=2] gy, 
-    int cx, int cy, #Pixels per cell
-    int sx, int sy, #Image size
+    int cx, int cy, 
+    int sx, int sy, 
     int n_cellsx, int n_cellsy, 
     int visualise, int orientations, 
     np.ndarray[np.float64_t, ndim=3] orientation_histogram):
-    """HogHistograms
+    """Extract Histogram of Oriented Gradients (HOG) for a given image.
 
     Parameters
     ----------
     gx : ndarray
-        Coordinate to be clipped.
+        First order image gradients (x).
     gy : ndarray
-        The lower bound.
+        First order image gradients (y).
     cx : int
-        The higher bound.
+        Pixels per cell (x).
     cy : int
-        The higher bound.
+        Pixels per cell (y).
     sx : int
-        The higher bound.
+        Image size (x).
     sy : int
-        The higher bound.
+        Image size (y).
     n_cellsx : int
-        The higher bound.
+        Number of cells (x).
     n_cellsy : int
-        The higher bound.
+        Number of cells (y).
     visualise : int
-        The higher bound.
+        Also return an image of the HOG.
     orientations : int
-        The higher bound.
+        Number of orientation bins.
     orientation_histogram : ndarray
         The histogram to fill.
     """

--- a/skimage/feature/_hoghistogram.pyx
+++ b/skimage/feature/_hoghistogram.pyx
@@ -1,0 +1,70 @@
+# cython: profile=True
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: wraparound=False
+
+import cmath, math
+cimport numpy as np
+import numpy as np
+from scipy import pi, arctan2, cos, sin
+
+cdef float CellHog(np.ndarray[np.float64_t, ndim=2] magnitude, 
+	np.ndarray[np.float64_t, ndim=2] orientation,
+	float ori1, float ori2,
+	int cx, int cy, int xi, int yi, int sx, int sy):
+	cdef int cx1, cy1
+
+	cdef float total = 0.
+	for cy1 in range(-cy/2, cy/2):
+		for cx1 in range(-cx/2, cx/2):
+			if yi + cy1 < 0: continue
+			if yi + cy1 >= sy: continue
+			if xi + cx1 < 0: continue
+			if xi + cx1 >= sx: continue
+			if orientation[yi + cy1, xi + cx1] >= ori1: continue
+			if orientation[yi + cy1, xi + cx1] < ori2: continue
+
+			total += magnitude[yi + cy1, xi + cx1]
+
+	return total
+
+def HogHistograms(np.ndarray[np.float64_t, ndim=2] gx, \
+	np.ndarray[np.float64_t, ndim=2] gy, 
+	int cx, int cy, #Pixels per cell
+	int sx, int sy, #Image size
+	int n_cellsx, int n_cellsy, 
+	int visualise, int orientations, 
+	np.ndarray[np.float64_t, ndim=3] orientation_histogram):
+
+	cdef np.ndarray[np.float64_t, ndim=2] magnitude = np.sqrt(gx**2 + gy**2)
+	cdef np.ndarray[np.float64_t, ndim=2] orientation = arctan2(gy, gx) * (180 / pi) % 180
+	cdef int i, x, y, o, yi, xi, cy1, cy2, cx1, cx2
+	cdef float ori1, ori2
+
+	# compute orientations integral images
+
+	for i in range(orientations):
+		# isolate orientations in this range
+
+		ori1 = 180. / orientations * (i + 1)
+		ori2 = 180. / orientations * i
+
+		y = cy / 2
+		cy2 = cy * n_cellsy
+		x = cx / 2
+		cx2 = cx * n_cellsx
+		yi = 0
+		xi = 0
+
+		while y < cy2:
+			xi = 0
+			x = cx / 2
+
+			while x < cx2:
+				orientation_histogram[yi, xi, i] = CellHog(magnitude, orientation, ori1, ori2, cx, cy, x, y, sx, sy)
+				xi += 1
+				x += cx
+
+			yi += 1
+			y += cy
+

--- a/skimage/feature/setup.py
+++ b/skimage/feature/setup.py
@@ -18,6 +18,7 @@ def configuration(parent_package='', top_path=None):
     cython(['brief_cy.pyx'], working_path=base_path)
     cython(['_texture.pyx'], working_path=base_path)
     cython(['_hessian_det_appx.pyx'], working_path=base_path)
+    cython(['_hoghistogram.pyx'], working_path=base_path)
 
     config.add_extension('corner_cy', sources=['corner_cy.c'],
                          include_dirs=[get_numpy_include_dirs()])
@@ -31,6 +32,8 @@ def configuration(parent_package='', top_path=None):
                          include_dirs=[get_numpy_include_dirs(), '../_shared'])
     config.add_extension('_hessian_det_appx', sources=['_hessian_det_appx.c'],
                          include_dirs=[get_numpy_include_dirs()])
+    config.add_extension('_hoghistogram', sources=['_hoghistogram.c'],
+                         include_dirs=[get_numpy_include_dirs(), '../_shared'])
 
     return config
 


### PR DESCRIPTION
This increases the speed to compute HOG features on an image. The histogram calculation has been moved to use cython. On the Lena test image, the computation time drops from 0.8 sec to 0.31 sec. This addresses issue #594.

```python
import skimage.color as col
import skimage.feature as feature
import skimage.data as data
import time

if __name__=="__main__":
	lena = data.lena()
	lenaG = col.rgb2grey(lena)

	st = time.clock()
	feature.hog(lenaG)
	print time.clock() - st
```

There are two practical issues that I know of:

The original implementation used scipy's uniform_filter to do the "averaging" step in step 3 in _hog.py. This causes the average to act slightly differently on the cell's boundaries because uniform_filter "reflects" the filter at the edges of the patch (I think). Instead of this, I just take the weighted average of the available pixels. I am not sure which is preferable. However, the result is approximately the same.

The built in visualisation (when enabled) appears to be different. I am not sure of the cause.
