### PR TITLE
FIX: prepend `np.testing.` to assert_* statements

### DIFF
--- a/skimage/io/tests/test_simpleitk.py
+++ b/skimage/io/tests/test_simpleitk.py
@@ -48,7 +48,7 @@ def test_bilevel():
     expected[::2] = 255
 
     img = imread(os.path.join(data_dir, 'checker_bilevel.png'))
-    assert_array_equal(img, expected)
+    np.testing.assert_array_equal(img, expected)
 
 
 @skipif(not sitk_available)
@@ -56,14 +56,14 @@ def test_imread_uint16():
     expected = np.load(os.path.join(data_dir, 'chessboard_GRAY_U8.npy'))
     img = imread(os.path.join(data_dir, 'chessboard_GRAY_U16.tif'))
     assert np.issubdtype(img.dtype, np.uint16)
-    assert_array_almost_equal(img, expected)
+    np.testing.assert_array_almost_equal(img, expected)
 
 
 @skipif(not sitk_available)
 def test_imread_uint16_big_endian():
     expected = np.load(os.path.join(data_dir, 'chessboard_GRAY_U8.npy'))
     img = imread(os.path.join(data_dir, 'chessboard_GRAY_U16B.tif'))
-    assert_array_almost_equal(img, expected)
+    np.testing.assert_array_almost_equal(img, expected)
 
 
 class TestSave:
@@ -74,7 +74,7 @@ class TestSave:
         imsave(fname, x)
         y = imread(fname)
 
-        assert_array_almost_equal(x, y)
+        np.testing.assert_array_almost_equal(x, y)
 
     @skipif(not sitk_available)
     def test_imsave_roundtrip(self):


### PR DESCRIPTION
Resolve a simple namespace problem, eliminating 15 errors in
tests Travis skips because Travis doesn't build SimpleITK.
