### PR TITLE
Canny filter: You can pass an image of any dtype!

### DIFF
--- a/skimage/filter/_canny.py
+++ b/skimage/filter/_canny.py
@@ -54,22 +54,22 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None, mask=None):
 
     Parameters
     -----------
-    image : two-dimensional array
+    image : 2D array
         Greyscale input image to detect edges on; can be of any dtype.
     sigma : float
         Standard deviation of the Gaussian filter.
     low_threshold : float
         Lower bound for hysteresis thresholding (linking edges).
-        If None, low_threshold is set to 10%.
+        If None, low_threshold is set to 10% of dtype's max.
     high_threshold : float
         Upper bound for hysteresis thresholding (linking edges).
-        If None, high_threshold is set to 20%.
+        If None, high_threshold is set to 20% of dtype's max.
     mask : array, dtype=bool, optional
         Mask to limit the application of Canny to a certain area.
 
     Returns
     -------
-    output : array (image)
+    output : 2D array (image)
         The binary edge map.
 
     See also


### PR DESCRIPTION
Took a closer look at the Canny edge detector when I decided to work on https://github.com/scikit-image/scikit-image/issues/466
It turns out `filter.canny` can be used on images of dtype int, not only float, unlike what the doc and docstring say (said).  This is great, so we want to make sure users know!
Users should/could pass low and high thresholds of their choice.  If they don't specify it, we default to 10 and 20 % (as the intention seemed to be, but now we're making sure we're talking about relative thresholds).
As per testing this new version, I did the following:

> > > from skimage import filter
> > > from skimage import data
> > > lena = data.lena()
> > > lena = lena[:, :, 1]
> > > filter.canny(lena)
> > > eNone = filter.canny(lena)
> > > eWith = filter.canny(lena, 1., 25.5, 51.0)
> > > eNone == eWith
> > > # True everywhere
> > > 
> > > np.where(eNone != eWith)
> > > # This is empty
