### PR TITLE
FIX: Require integer array indexing for future NumPy compatibility

### DIFF
--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -315,7 +315,8 @@ def interpolate(image, xslice, yslice,
                                  np.arange(yslice.size))
     x_inv_coef, y_inv_coef = x_coef[:, ::-1] + 1, y_coef[::-1] + 1
 
-    view = image[yslice[0]: yslice[-1] + 1, xslice[0]: xslice[-1] + 1]
+    view = image[int(yslice[0]): int(yslice[-1]) + 1,
+                 int(xslice[0]): int(xslice[-1]) + 1]
     im_slice = aLUT[view]
     new = ((y_inv_coef * (x_inv_coef * mapLU[im_slice]
                           + x_coef * mapRU[im_slice])

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -112,9 +112,10 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
 
     # compute orientations integral images
     orientation_histogram = np.zeros((n_cellsy, n_cellsx, orientations))
-    subsample = np.index_exp[cy / 2:cy * n_cellsy:cy, cx / 2:cx * n_cellsx:cx]
+    subsample = np.index_exp[cy // 2:cy * n_cellsy:cy,
+                             cx // 2:cx * n_cellsx:cx]
     for i in range(orientations):
-        #create new integral image for this orientation
+        # create new integral image for this orientation
         # isolate orientations in this range
 
         temp_ori = np.where(orientation < 180.0 / orientations * (i + 1),

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -73,7 +73,7 @@ def corner_kitchen_rosenfeld(image):
         ------------------------------------------------------
                         (imx**2 + imy**2)
 
-    Where imx and imy are the first and imxx, imxy, imyy the second derivatives.
+    Where imx and imy are first and imxx, imxy, imyy are second derivatives.
 
     Parameters
     ----------
@@ -110,7 +110,7 @@ def corner_harris(image, method='k', k=0.05, eps=1e-6, sigma=1):
         A = [(imx**2)   (imx*imy)] = [Axx Axy]
             [(imx*imy)   (imy**2)]   [Axy Ayy]
 
-    Where imx and imy are the first derivatives averaged with a gaussian filter.
+    Where imx and imy are first derivatives averaged with a gaussian filter.
     The corner measure is then defined as::
 
         det(A) - k * trace(A)**2
@@ -191,7 +191,7 @@ def corner_shi_tomasi(image, sigma=1):
         A = [(imx**2)   (imx*imy)] = [Axx Axy]
             [(imx*imy)   (imy**2)]   [Axy Ayy]
 
-    Where imx and imy are the first derivatives averaged with a gaussian filter.
+    Where imx and imy are first derivatives averaged with a gaussian filter.
     The corner measure is then defined as the smaller eigenvalue of A::
 
         ((Axx + Ayy) - sqrt((Axx - Ayy)**2 + 4 * Axy**2)) / 2
@@ -254,7 +254,7 @@ def corner_foerstner(image, sigma=1):
         A = [(imx**2)   (imx*imy)] = [Axx Axy]
             [(imx*imy)   (imy**2)]   [Axy Ayy]
 
-    Where imx and imy are the first derivatives averaged with a gaussian filter.
+    Where imx and imy are first derivatives averaged with a gaussian filter.
     The corner measure is then defined as::
 
         w = det(A) / trace(A)           (size of error ellipse)
@@ -354,7 +354,7 @@ def corner_subpix(image, corners, window_size=11, alpha=0.99):
     """
 
     # window extent in one direction
-    wext = (window_size - 1) / 2
+    wext = (window_size - 1) // 2
 
     # normal equation arrays
     N_dot = np.zeros((2, 2), dtype=np.double)
@@ -372,7 +372,7 @@ def corner_subpix(image, corners, window_size=11, alpha=0.99):
 
     corners_subpix = np.zeros_like(corners, dtype=np.double)
 
-    for i, (y0, x0) in enumerate(corners):
+    for i, (y0, x0) in enumerate(corners.astype(np.int64)):
 
         # crop window around corner + border for sobel operator
         miny = y0 - wext - 1

--- a/skimage/feature/template.py
+++ b/skimage/feature/template.py
@@ -73,8 +73,8 @@ def match_template(image, template, pad_input=False):
         pad_image = np.mean(image) * np.ones(pad_size, dtype=np.float32)
         h, w = image.shape
         i0, j0 = template.shape
-        i0 /= 2
-        j0 /= 2
+        i0 //= 2
+        j0 //= 2
         pad_image[i0:i0 + h, j0:j0 + w] = image
         image = pad_image
     result = _template.match_template(image, template)

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -4,9 +4,7 @@ from skimage import data
 from skimage import feature
 from skimage import img_as_float
 from skimage import draw
-from numpy.testing import (assert_raises,
-                           assert_almost_equal,
-                           )
+from numpy.testing import assert_raises, assert_almost_equal, run_module_suite
 
 
 def test_histogram_of_oriented_gradients():
@@ -32,9 +30,11 @@ def test_hog_color_image_unsupported_error():
 
 def test_hog_basic_orientations_and_data_types():
     # scenario:
-    #  1) create image (with float values) where upper half is filled by zeros, bottom half by 100
+    #  1) create image (with float values) where upper half is filled by zeros,
+    #     bottom half by 100
     #  2) create unsigned integer version of this image
-    #  3) calculate feature.hog() for both images, both with 'normalise' option enabled and disabled
+    #  3) calculate feature.hog() for both images, both with 'normalise' option
+    #     enabled and disabled
     #  4) verify that all results are equal where expected
     #  5) verify that computed feature vector is as expected
     #  6) repeat the scenario for 90, 180 and 270 degrees rotated images
@@ -43,7 +43,7 @@ def test_hog_basic_orientations_and_data_types():
     width = height = 35
 
     image0 = np.zeros((height, width), dtype='float')
-    image0[height / 2:] = 100
+    image0[height // 2:] = 100
 
     for rot in range(4):
         # rotate by 0, 90, 180 and 270 degrees
@@ -52,13 +52,17 @@ def test_hog_basic_orientations_and_data_types():
         # create uint8 image from image_float
         image_uint8 = image_float.astype('uint8')
 
-        (hog_float, hog_img_float) = feature.hog(image_float, orientations=4, pixels_per_cell=(8, 8),
+        (hog_float, hog_img_float) = feature.hog(
+            image_float, orientations=4, pixels_per_cell=(8, 8),
             cells_per_block=(1, 1), visualise=True, normalise=False)
-        (hog_uint8, hog_img_uint8) = feature.hog(image_uint8, orientations=4, pixels_per_cell=(8, 8),
+        (hog_uint8, hog_img_uint8) = feature.hog(
+            image_uint8, orientations=4, pixels_per_cell=(8, 8),
             cells_per_block=(1, 1), visualise=True, normalise=False)
-        (hog_float_norm, hog_img_float_norm) = feature.hog(image_float, orientations=4, pixels_per_cell=(8, 8),
+        (hog_float_norm, hog_img_float_norm) = feature.hog(
+            image_float, orientations=4, pixels_per_cell=(8, 8),
             cells_per_block=(1, 1), visualise=True, normalise=True)
-        (hog_uint8_norm, hog_img_uint8_norm) = feature.hog(image_uint8, orientations=4, pixels_per_cell=(8, 8),
+        (hog_uint8_norm, hog_img_uint8_norm) = feature.hog(
+            image_uint8, orientations=4, pixels_per_cell=(8, 8),
             cells_per_block=(1, 1), visualise=True, normalise=True)
 
         # set to True to enable manual debugging with graphical output,
@@ -73,16 +77,20 @@ def test_hog_basic_orientations_and_data_types():
             plt.subplot(2, 3, 6); plt.imshow(hog_img_uint8_norm); plt.colorbar(); plt.title('HOG result (normalise) visualisation (uint8 img)')
             plt.show()
 
-        # results (features and visualisation) for float and uint8 images must be almost equal
+        # results (features and visualisation) for float and uint8 images must
+        # be almost equal
         assert_almost_equal(hog_float, hog_uint8)
         assert_almost_equal(hog_img_float, hog_img_uint8)
 
-        # resulting features should be almost equal when 'normalise' is enabled or disabled (for current simple testing image)
+        # resulting features should be almost equal when 'normalise' is enabled
+        # or disabled (for current simple testing image)
         assert_almost_equal(hog_float, hog_float_norm, decimal=4)
         assert_almost_equal(hog_float, hog_uint8_norm, decimal=4)
 
-        # reshape resulting feature vector to matrix with 4 columns (each corresponding to one of 4 directions),
-        # only one direction should contain nonzero values (this is manually determined for testing image)
+        # reshape resulting feature vector to matrix with 4 columns (each
+        # corresponding to one of 4 directions), only one direction should
+        # contain nonzero values (this is manually determined for testing
+        # image)
         actual = np.max(hog_float.reshape(-1, 4), axis=0)
 
         if rot in [0, 2]:
@@ -101,8 +109,9 @@ def test_hog_orientations_circle():
     # scenario:
     #  1) create image with blurred circle in the middle
     #  2) calculate feature.hog()
-    #  3) verify that the resulting feature vector contains uniformly distributed values for all orientations,
-    #     i.e. no orientation is lost or emphasized
+    #  3) verify that the resulting feature vector contains uniformly
+    #     distributed values for all orientations, i.e. no orientation is lost
+    #     or emphasized.
     #  4) repeat the scenario for other 'orientations' option
 
     # size of testing image
@@ -114,8 +123,10 @@ def test_hog_orientations_circle():
     image = ndimage.gaussian_filter(image, 2)
 
     for orientations in range(2, 15):
-        (hog, hog_img) = feature.hog(image, orientations=orientations, pixels_per_cell=(8, 8),
-            cells_per_block=(1, 1), visualise=True, normalise=False)
+        (hog, hog_img) = feature.hog(image, orientations=orientations,
+                                     pixels_per_cell=(8, 8),
+                                     cells_per_block=(1, 1),
+                                     visualise=True, normalise=False)
 
         # set to True to enable manual debugging with graphical output,
         # must be False for automatic testing
@@ -126,17 +137,18 @@ def test_hog_orientations_circle():
             plt.subplot(1, 2, 2); plt.imshow(hog_img); plt.colorbar(); plt.title('HOG result visualisation, orientations=%d' % (orientations))
             plt.show()
 
-        # reshape resulting feature vector to matrix with N columns (each column corresponds to one direction),
+        # reshape resulting feature vector to matrix with N columns (each
+        # column corresponds to one direction)
         hog_matrix = hog.reshape(-1, orientations)
 
-        # compute mean values in the resulting feature vector for each direction,
-        # these values should be almost equal to the global mean value (since the image contains a circle),
-        # i.e. all directions have same contribution to the result
+        # compute mean values in the resulting feature vector for each
+        # direction, these values should be almost equal to the global mean
+        # value (since the image contains a circle), i.e. all directions
+        # contribute equally to the result
         actual = np.mean(hog_matrix, axis=0)
         desired = np.mean(hog_matrix)
         assert_almost_equal(actual, desired, decimal=1)
 
 
 if __name__ == '__main__':
-    from numpy.testing import run_module_suite
     run_module_suite()

--- a/skimage/filter/lpi_filter.py
+++ b/skimage/filter/lpi_filter.py
@@ -18,7 +18,7 @@ def _centre(x, oshape):
     """Return an array of oshape from the centre of x.
 
     """
-    start = (np.array(x.shape) - np.array(oshape)) / 2. + 1
+    start = (np.array(x.shape) - np.array(oshape)) // 2 + 1
     out = x[[slice(s, s + n) for s, n in zip(start, oshape)]]
     return out
 

--- a/skimage/filter/tests/test_ctmf.py
+++ b/skimage/filter/tests/test_ctmf.py
@@ -49,10 +49,10 @@ def test_02_02_median_bigger():
     np.random.seed(0)
     img = np.random.uniform(size=(20, 20))
     result = median_filter(img, 40, np.ones((20, 20), bool))
-    sorted = np.ravel(img)
-    sorted.sort()
-    min_acceptable = sorted[198]
-    max_acceptable = sorted[202]
+    sort_img = np.ravel(img)
+    sort_img.sort()
+    min_acceptable = sort_img[198]
+    max_acceptable = sort_img[202]
     assert (np.all(result >= min_acceptable))
     assert (np.all(result <= max_acceptable))
 
@@ -79,10 +79,10 @@ def test_03_01_shape():
     np.random.seed(0)
     img = np.random.uniform(size=(21, 21))
     result = median_filter(img, radius, np.ones((21, 21), bool))
-    sorted = img[octagon]
-    sorted.sort()
-    min_acceptable = sorted[len(sorted) / 2 - 1]
-    max_acceptable = sorted[len(sorted) / 2 + 1]
+    sort_img = img[octagon]
+    sort_img.sort()
+    min_acceptable = sort_img[len(sort_img) // 2 - 1]
+    max_acceptable = sort_img[len(sort_img) // 2 + 1]
     assert (result[10, 10] >= min_acceptable)
     assert (result[10, 10] <= max_acceptable)
 

--- a/skimage/morphology/greyreconstruct.py
+++ b/skimage/morphology/greyreconstruct.py
@@ -158,7 +158,7 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
 
     # Create a list of strides across the array to get the neighbors within
     # a flattened array
-    value_stride = np.array(images.strides[1:]) / images.dtype.itemsize
+    value_stride = np.array(images.strides[1:]) // images.dtype.itemsize
     image_stride = images.strides[0] // images.dtype.itemsize
     selem_mgrid = np.mgrid[[slice(-o, d - o)
                             for d, o in zip(selem.shape, offset)]]
@@ -187,7 +187,8 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
         value_map = -value_map
 
     start = index_sorted[0]
-    reconstruction_loop(value_rank, prev, next, nb_strides, start, image_stride)
+    reconstruction_loop(value_rank, prev, next, nb_strides, start,
+                        image_stride)
 
     # Reshape reconstructed image to original image shape and remove padding.
     rec_img = value_map[value_rank[:image_stride]]

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -7,16 +7,16 @@ def make_2d_syntheticdata(lx, ly=None):
         ly = lx
     np.random.seed(1234)
     data = np.zeros((lx, ly)) + 0.1 * np.random.randn(lx, ly)
-    small_l = int(lx / 5)
-    data[lx / 2 - small_l:lx / 2 + small_l,
-         ly / 2 - small_l:ly / 2 + small_l] = 1
-    data[lx / 2 - small_l + 1:lx / 2 + small_l - 1,
-         ly / 2 - small_l + 1:ly / 2 + small_l - 1] = \
-                        0.1 * np.random.randn(2 * small_l - 2, 2 * small_l - 2)
-    data[lx / 2 - small_l, ly / 2 - small_l / 8:ly / 2 + small_l / 8] = 0
+    small_l = int(lx // 5)
+    data[lx // 2 - small_l:lx // 2 + small_l,
+         ly // 2 - small_l:ly // 2 + small_l] = 1
+    data[lx // 2 - small_l + 1:lx // 2 + small_l - 1,
+         ly // 2 - small_l + 1:ly // 2 + small_l - 1] = (
+             0.1 * np.random.randn(2 * small_l - 2, 2 * small_l - 2))
+    data[lx // 2 - small_l, ly // 2 - small_l // 8:ly // 2 + small_l // 8] = 0
     seeds = np.zeros_like(data)
-    seeds[lx / 5, ly / 5] = 1
-    seeds[lx / 2 + small_l / 4, ly / 2 - small_l / 4] = 2
+    seeds[lx // 5, ly // 5] = 1
+    seeds[lx // 2 + small_l // 4, ly // 2 - small_l // 4] = 2
     return data, seeds
 
 
@@ -27,21 +27,23 @@ def make_3d_syntheticdata(lx, ly=None, lz=None):
         lz = lx
     np.random.seed(1234)
     data = np.zeros((lx, ly, lz)) + 0.1 * np.random.randn(lx, ly, lz)
-    small_l = int(lx / 5)
-    data[lx / 2 - small_l:lx / 2 + small_l,
-         ly / 2 - small_l:ly / 2 + small_l,
-         lz / 2 - small_l:lz / 2 + small_l] = 1
-    data[lx / 2 - small_l + 1:lx / 2 + small_l - 1,
-         ly / 2 - small_l + 1:ly / 2 + small_l - 1,
-         lz / 2 - small_l + 1:lz / 2 + small_l - 1] = 0
+    small_l = int(lx // 5)
+    data[lx // 2 - small_l:lx // 2 + small_l,
+         ly // 2 - small_l:ly // 2 + small_l,
+         lz // 2 - small_l:lz // 2 + small_l] = 1
+    data[lx // 2 - small_l + 1:lx // 2 + small_l - 1,
+         ly // 2 - small_l + 1:ly // 2 + small_l - 1,
+         lz // 2 - small_l + 1:lz // 2 + small_l - 1] = 0
     # make a hole
-    hole_size = np.max([1, small_l / 8])
-    data[lx / 2 - small_l,
-         ly / 2 - hole_size:ly / 2 + hole_size,
-         lz / 2 - hole_size:lz / 2 + hole_size] = 0
+    hole_size = np.max([1, small_l // 8])
+    data[lx // 2 - small_l,
+         ly // 2 - hole_size:ly // 2 + hole_size,
+         lz // 2 - hole_size:lz // 2 + hole_size] = 0
     seeds = np.zeros_like(data)
-    seeds[lx / 5, ly / 5, lz / 5] = 1
-    seeds[lx / 2 + small_l / 4, ly / 2 - small_l / 4, lz / 2 - small_l / 4] = 2
+    seeds[lx // 5, ly // 5, lz // 5] = 1
+    seeds[lx // 2 + small_l // 4,
+          ly // 2 - small_l // 4,
+          lz // 2 - small_l // 4] = 2
     return data, seeds
 
 
@@ -101,7 +103,7 @@ def test_types():
     lx = 70
     ly = 100
     data, labels = make_2d_syntheticdata(lx, ly)
-    data = 255 * (data - data.min()) / (data.max() - data.min())
+    data = 255 * (data - data.min()) // (data.max() - data.min())
     data = data.astype(np.uint8)
     labels_cg_mg = random_walker(data, labels, beta=90, mode='cg_mg')
     assert (labels_cg_mg[25:45, 40:60] == 2).all()

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -674,6 +674,7 @@ class PolynomialTransform(GeometricTransform):
             Polynomial order (number of coefficients is order + 1).
 
         """
+        order = int(order)
         xs = src[:, 0]
         ys = src[:, 1]
         xd = dst[:, 0]
@@ -688,7 +689,7 @@ class PolynomialTransform(GeometricTransform):
         for j in range(order + 1):
             for i in range(j + 1):
                 A[:rows, pidx] = xs ** (j - i) * ys ** i
-                A[rows:, pidx + u / 2] = xs ** (j - i) * ys ** i
+                A[rows:, pidx + u // 2] = xs ** (j - i) * ys ** i
                 pidx += 1
 
         A[:rows, -1] = xd
@@ -700,7 +701,7 @@ class PolynomialTransform(GeometricTransform):
         # singular value
         params = - V[-1, :-1] / V[-1, -1]
 
-        self._params = params.reshape((2, u / 2))
+        self._params = params.reshape((2, u // 2))
 
     def __call__(self, coords):
         """Apply forward transformation.
@@ -915,7 +916,7 @@ def warp_coords(coord_map, shape, dtype=np.float64):
     >>> warped_image = map_coordinates(image, coords)
 
     """
-    rows, cols = shape[0], shape[1]
+    rows, cols = int(shape[0]), int(shape[1])
     coords_shape = [len(shape), rows, cols]
     if len(shape) == 3:
         coords_shape.append(shape[2])

--- a/skimage/util/shape.py
+++ b/skimage/util/shape.py
@@ -90,7 +90,7 @@ def view_as_blocks(arr_in, block_shape):
     # -- restride the array to build the block view
     arr_in = np.ascontiguousarray(arr_in)
 
-    new_shape = tuple(arr_shape / block_shape) + tuple(block_shape)
+    new_shape = tuple(arr_shape // block_shape) + tuple(block_shape)
     new_strides = tuple(arr_in.strides * block_shape) + arr_in.strides
 
     arr_out = as_strided(arr_in, shape=new_shape, strides=new_strides)


### PR DESCRIPTION
This PR addresses #623. Various single `/` operations were returning floats in Python 3, so the fix was to convert them to floor division `//` to harmonize behavior and dtype with Python 2.

There are also a few PEP8 and style fixes.

@juliantaylor I'd appreciate it if you re-ran the test from #623 after pulling in these revisions, in case there's something I missed. Also, these seven deprecation warnings were from `numpy/core/numeric.py` after integer arguments were passed to NumPy functions. scikit-image may not the source of them:
- test_shape.test_view_as_blocks_1D_array ... /tmp/local/lib/python3.3/site-packages/numpy/core/numeric.py:341: DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
- test_shape.test_view_as_blocks_2D_array ... /tmp/local/lib/python3.3/site-packages/numpy/core/numeric.py:341: DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
- test_shape.test_view_as_blocks_3D_array ... /tmp/local/lib/python3.3/site-packages/numpy/core/numeric.py:341: DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
- /tmp/local/lib/python3.3/site-packages/numpy/core/numeric.py:1627: DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
- /tmp/local/lib/python3.3/site-packages/numpy/core/numeric.py:1630: DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
- /tmp/local/lib/python3.3/site-packages/numpy/core/numeric.py:1632: DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
- /tmp/local/lib/python3.3/site-packages/numpy/core/numeric.py:341: DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
