### PR TITLE
arraypad: allow padding with zero entries (i.e. no padding).

### DIFF
--- a/skimage/util/arraypad.py
+++ b/skimage/util/arraypad.py
@@ -1085,7 +1085,7 @@ def _validate_lengths(narray, number_elements):
     normshp = _normalize_shape(narray, number_elements)
     for i in normshp:
         chk = [1 if x is None else x for x in i]
-        chk = [1 if x > 0 else -1 for x in chk]
+        chk = [1 if x >= 0 else -1 for x in chk]
         if (chk[0] < 0) or (chk[1] < 0):
             fmt = "%s cannot contain negative values."
             raise ValueError(fmt % (number_elements,))

--- a/skimage/util/tests/test_arraypad.py
+++ b/skimage/util/tests/test_arraypad.py
@@ -518,5 +518,12 @@ def test_pad_one_axis_three_ways():
                   **kwargs)
 
 
+def test_zero_pad_width():
+    arr = np.arange(30)
+    arr = np.reshape(arr, (6, 5))
+    for pad_width in (0, (0, 0), ((0, 0), (0, 0))):
+        assert np.all(arr == pad(arr, pad_width, mode='constant'))
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
@JDWarner To me this looks like a straightforward fix, which allows the user not to pad certain axes (certainly useful in some cases). If this fix does not work, and zeros should be avoided for some reason I'm not aware of, then the error message on arraypad.py:1090 should be changed to "non-positive" from "negative".
