### PR TITLE
DOC : activate travis for a fork

### DIFF
--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -167,8 +167,6 @@ successfully passes all tests. To do so,
    * Go to your `profile page <https://travis-ci.org/profile>`__ and switch on your
    scikit-image fork
 
-   * Go to your scikit-image fork on github, and activate the travis-ci's hook in settings.
-
 It corresponds to steps one and two in
 `Travis-CI documentation <http://about.travis-ci.org/docs/user/getting-started/>`__
 (Step three is already done in scikit-image).


### PR DESCRIPTION
I think that some of our contributors may miss this functionality which is, IMHO, very interesting (especially because we have to check python 2 and 3 compat. and I don't check both locally).

Let me know if it's not clear/correctly said.
