### PR TITLE
examples: Avoid python3-specific syntax.

### DIFF
--- a/doc/examples/plot_local_binary_pattern.py
+++ b/doc/examples/plot_local_binary_pattern.py
@@ -194,12 +194,12 @@ refs = {
 
 # classify rotated textures
 print('Rotated images matched against references using LBP:')
-print('original: brick, rotated: 30deg, match result: ', end='')
-print(match(refs, rotate(brick, angle=30, resize=False)))
-print('original: brick, rotated: 70deg, match result: ', end='')
-print(match(refs, rotate(brick, angle=70, resize=False)))
-print('original: grass, rotated: 145deg, match result: ', end='')
-print(match(refs, rotate(grass, angle=145, resize=False)))
+print('original: brick, rotated: 30deg, match result: ',
+      match(refs, rotate(brick, angle=30, resize=False)))
+print('original: brick, rotated: 70deg, match result: ',
+      match(refs, rotate(brick, angle=70, resize=False)))
+print('original: grass, rotated: 145deg, match result: ',
+      match(refs, rotate(grass, angle=145, resize=False)))
 
 # plot histograms of LBP of textures
 fig, ((ax1, ax2, ax3), (ax4, ax5, ax6)) = plt.subplots(nrows=2, ncols=3,


### PR DESCRIPTION
`from __future__ import ...` is ineffective when the example script is
exec-ed by sphinx, resulting in a SyntaxError when running under
python2.

Fixes gh-649.

There is no test included with this fix. The ideal solution is to build the docs using sphinx as part of travis' work, and have sphinx fail on failed execution of an example.
