### PR TITLE
Added comment + isotropic denoising 

### DIFF
--- a/skimage/filter/_denoise_cy.pyx
+++ b/skimage/filter/_denoise_cy.pyx
@@ -224,7 +224,6 @@ def denoise_tv_bregman(image, double weight, int max_iter=100, double eps=1e-3, 
 
     max_iter: int, optional
         Maximal number of iterations used for the optimization.
-
     isotropic: boolean, optimal
         Switch between isotropic and anisotropic tv denoising
 


### PR DESCRIPTION
'''
Short test of plausibility:
Result
![lena_test](https://f.cloud.github.com/assets/416808/792382/8cf038ec-eb92-11e2-8794-09b20f180b36.png)
'''

import numpy as np
import matplotlib.pyplot as plt
from skimage import data, color, img_as_float
from skimage.filter import denoise_tv_bregman

lena = img_as_float(data.lena())
lena = lena[220:300, 220:320]
noisy = lena + 0.6 \* lena.std() \* np.random.random(lena.shape)
noisy = np.clip(noisy, 0, 1)

fig, ax = plt.subplots(nrows=2, ncols=3, figsize=(8, 5))
plt.gray()

ax[0, 0].imshow(noisy)
ax[0, 0].axis('off')
ax[0, 0].set_title('noisy')

ax[0, 1].imshow(denoise_tv_bregman(lena, weight=0.05, anisotropic=True))
ax[0, 1].axis('off')
ax[0, 1].set_title('TV Anistopic')

ax[0, 2].imshow(denoise_tv_bregman(lena, weight=0.05))
ax[0, 2].axis('off')
ax[0, 2].set_title('TV Isotropical')
