### PR TITLE
Hough transform ellipse: bugfix

### DIFF
--- a/doc/examples/plot_circular_elliptical_hough_transform.py
+++ b/doc/examples/plot_circular_elliptical_hough_transform.py
@@ -74,7 +74,6 @@ for idx in np.argsort(accums)[::-1][:5]:
     image[cy, cx] = (220, 20, 20)
 
 ax.imshow(image, cmap=plt.cm.gray)
-plt.show()
 
 
 """
@@ -96,13 +95,13 @@ an ellipse passes to them. A good match corresponds to high accumulator values.
 
 A full description of the algorithm can be found in reference [1]_.
 
-
 References
 ----------
 .. [1] Xie, Yonghong, and Qiang Ji. "A new efficient ellipse detection
        method." Pattern Recognition, 2002. Proceedings. 16th International
        Conference on. Vol. 2. IEEE, 2002
 """
+
 import matplotlib.pyplot as plt
 
 from skimage import data, filter, color
@@ -110,7 +109,7 @@ from skimage.transform import hough_ellipse
 from skimage.draw import ellipse_perimeter
 
 # Load picture, convert to grayscale and detect edges
-image_rgb = data.load('coffee.png')[0:220, 100:450]
+image_rgb = data.coffee()[0:220, 160:420]
 image_gray = color.rgb2gray(image_rgb)
 edges = filter.canny(image_gray, sigma=2.0,
                      low_threshold=0.55, high_threshold=0.8)
@@ -119,30 +118,31 @@ edges = filter.canny(image_gray, sigma=2.0,
 # The accuracy corresponds to the bin size of a major axis.
 # The value is chosen in order to get a single high accumulator.
 # The threshold eliminates low accumulators
-accum = hough_ellipse(edges, accuracy=10, threshold=170, min_size=50)
-accum.sort(key=lambda x: x[0])
-best = accum[-1]
+result = hough_ellipse(edges, accuracy=20, threshold=250,
+                       min_size=100, max_size=120)
+result.sort(order='accumulator')
+
 # Estimated parameters for the ellipse
-center_y = int(best[1])
-center_x = int(best[2])
-yradius = int(best[3])
-xradius = int(best[4])
-angle = best[5]
+best = result[-1]
+yc = int(best[1])
+xc = int(best[2])
+a = int(best[3])
+b = int(best[4])
+orientation = best[5]
 
 # Draw the ellipse on the original image
-cy, cx = ellipse_perimeter(center_y, center_x,
-                           yradius, xradius, orientation=angle)
-image_rgb[cy, cx] = (0, 0, 1)
+cy, cx = ellipse_perimeter(yc, xc, a, b, orientation)
+image_rgb[cy, cx] = (0, 0, 255)
 # Draw the edge (white) and the resulting ellipse (red)
 edges = color.gray2rgb(edges)
 edges[cy, cx] = (250, 0, 0)
 
-fig = plt.subplots(figsize=(10, 6))
-plt.subplot(1, 2, 1)
-plt.title('Original picture')
-plt.imshow(image_rgb)
-plt.subplot(1, 2, 2)
-plt.title('Edge (white) and result (red)')
-plt.imshow(edges)
+fig2, (ax1, ax2) = plt.subplots(ncols=2, nrows=1, figsize=(10, 6))
+
+ax1.set_title('Original picture')
+ax1.imshow(image_rgb)
+
+ax2.set_title('Edge (white) and result (red)')
+ax2.imshow(edges)
 
 plt.show()

--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -449,9 +449,9 @@ def ellipse_perimeter(Py_ssize_t cy, Py_ssize_t cx, Py_ssize_t yradius,
     ----------
     cy, cx : int
         Centre coordinate of ellipse.
-    yradius, xradius: int
+    yradius, xradius : int
         Minor and major semi-axes. ``(x/xradius)**2 + (y/yradius)**2 = 1``.
-    orientation: double, optional (default 0)
+    orientation : double, optional (default 0)
         Major axis orientation in clockwise direction as radians.
 
     Returns

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -1,7 +1,5 @@
 import numpy as np
-from numpy.testing import (assert_almost_equal,
-                           assert_equal,
-                           )
+from numpy.testing import assert_almost_equal, assert_equal
 
 import skimage.transform as tf
 from skimage.draw import line, circle_perimeter, ellipse_perimeter
@@ -81,8 +79,10 @@ def test_hough_line_peaks_dist():
     img[:, 30] = True
     img[:, 40] = True
     hspace, angles, dists = tf.hough_line(img)
-    assert len(tf.hough_line_peaks(hspace, angles, dists, min_distance=5)[0]) == 2
-    assert len(tf.hough_line_peaks(hspace, angles, dists, min_distance=15)[0]) == 1
+    assert len(tf.hough_line_peaks(hspace, angles, dists,
+                                   min_distance=5)[0]) == 2
+    assert len(tf.hough_line_peaks(hspace, angles, dists,
+                                   min_distance=15)[0]) == 1
 
 
 def test_hough_line_peaks_angle():
@@ -91,18 +91,24 @@ def test_hough_line_peaks_angle():
     img[0, :] = True
 
     hspace, angles, dists = tf.hough_line(img)
-    assert len(tf.hough_line_peaks(hspace, angles, dists, min_angle=45)[0]) == 2
-    assert len(tf.hough_line_peaks(hspace, angles, dists, min_angle=90)[0]) == 1
+    assert len(tf.hough_line_peaks(hspace, angles, dists,
+                                   min_angle=45)[0]) == 2
+    assert len(tf.hough_line_peaks(hspace, angles, dists,
+                                   min_angle=90)[0]) == 1
 
     theta = np.linspace(0, np.pi, 100)
     hspace, angles, dists = tf.hough_line(img, theta)
-    assert len(tf.hough_line_peaks(hspace, angles, dists, min_angle=45)[0]) == 2
-    assert len(tf.hough_line_peaks(hspace, angles, dists, min_angle=90)[0]) == 1
+    assert len(tf.hough_line_peaks(hspace, angles, dists,
+                                   min_angle=45)[0]) == 2
+    assert len(tf.hough_line_peaks(hspace, angles, dists,
+                                   min_angle=90)[0]) == 1
 
     theta = np.linspace(np.pi / 3, 4. / 3 * np.pi, 100)
     hspace, angles, dists = tf.hough_line(img, theta)
-    assert len(tf.hough_line_peaks(hspace, angles, dists, min_angle=45)[0]) == 2
-    assert len(tf.hough_line_peaks(hspace, angles, dists, min_angle=90)[0]) == 1
+    assert len(tf.hough_line_peaks(hspace, angles, dists,
+                                   min_angle=45)[0]) == 2
+    assert len(tf.hough_line_peaks(hspace, angles, dists,
+                                   min_angle=90)[0]) == 1
 
 
 def test_hough_line_peaks_num():
@@ -165,7 +171,8 @@ def test_hough_ellipse_zero_angle():
     assert_equal(best[5], angle)
     # Check if I re-draw the ellipse, points are the same!
     # ie check API compatibility between hough_ellipse and ellipse_perimeter
-    rr2, cc2 = ellipse_perimeter(y0, x0, int(best[3]), int(best[4]), orientation=best[5])
+    rr2, cc2 = ellipse_perimeter(y0, x0, int(best[3]), int(best[4]),
+                                 orientation=best[5])
     assert_equal(rr, rr2)
     assert_equal(cc, cc2)
 
@@ -181,7 +188,7 @@ def test_hough_ellipse_non_zero_posangle1():
     rr, cc = ellipse_perimeter(y0, x0, ry, rx, orientation=angle)
     img[rr, cc] = 1
     result = tf.hough_ellipse(img, threshold=15, accuracy=3)
-    result.sort(key=lambda x:x[0])
+    result.sort(order='accumulator')
     best = result[-1]
     assert_almost_equal(best[1] / 100., y0 / 100., decimal=1)
     assert_almost_equal(best[2] / 100., x0 / 100., decimal=1)
@@ -190,7 +197,8 @@ def test_hough_ellipse_non_zero_posangle1():
     assert_almost_equal(best[5], angle, decimal=1)
     # Check if I re-draw the ellipse, points are the same!
     # ie check API compatibility between hough_ellipse and ellipse_perimeter
-    rr2, cc2 = ellipse_perimeter(y0, x0, int(best[3]), int(best[4]), orientation=best[5])
+    rr2, cc2 = ellipse_perimeter(y0, x0, int(best[3]), int(best[4]),
+                                 orientation=best[5])
     assert_equal(rr, rr2)
     assert_equal(cc, cc2)
 
@@ -206,7 +214,7 @@ def test_hough_ellipse_non_zero_posangle2():
     rr, cc = ellipse_perimeter(y0, x0, ry, rx, orientation=angle)
     img[rr, cc] = 1
     result = tf.hough_ellipse(img, threshold=15, accuracy=3)
-    result.sort(key=lambda x:x[0])
+    result.sort(order='accumulator')
     best = result[-1]
     assert_almost_equal(best[1] / 100., y0 / 100., decimal=1)
     assert_almost_equal(best[2] / 100., x0 / 100., decimal=1)
@@ -215,7 +223,8 @@ def test_hough_ellipse_non_zero_posangle2():
     assert_almost_equal(best[5], angle, decimal=1)
     # Check if I re-draw the ellipse, points are the same!
     # ie check API compatibility between hough_ellipse and ellipse_perimeter
-    rr2, cc2 = ellipse_perimeter(y0, x0, int(best[3]), int(best[4]), orientation=best[5])
+    rr2, cc2 = ellipse_perimeter(y0, x0, int(best[3]), int(best[4]),
+                                 orientation=best[5])
     assert_equal(rr, rr2)
     assert_equal(cc, cc2)
 
@@ -231,11 +240,12 @@ def test_hough_ellipse_non_zero_posangle3():
     rr, cc = ellipse_perimeter(y0, x0, ry, rx, orientation=angle)
     img[rr, cc] = 1
     result = tf.hough_ellipse(img, threshold=15, accuracy=3)
-    result.sort(key=lambda x:x[0])
+    result.sort(order='accumulator')
     best = result[-1]
     # Check if I re-draw the ellipse, points are the same!
     # ie check API compatibility between hough_ellipse and ellipse_perimeter
-    rr2, cc2 = ellipse_perimeter(y0, x0, int(best[3]), int(best[4]), orientation=best[5])
+    rr2, cc2 = ellipse_perimeter(y0, x0, int(best[3]), int(best[4]),
+                                 orientation=best[5])
     assert_equal(rr, rr2)
     assert_equal(cc, cc2)
 
@@ -251,11 +261,12 @@ def test_hough_ellipse_non_zero_posangle4():
     rr, cc = ellipse_perimeter(y0, x0, ry, rx, orientation=angle)
     img[rr, cc] = 1
     result = tf.hough_ellipse(img, threshold=15, accuracy=3)
-    result.sort(key=lambda x:x[0])
+    result.sort(order='accumulator')
     best = result[-1]
     # Check if I re-draw the ellipse, points are the same!
     # ie check API compatibility between hough_ellipse and ellipse_perimeter
-    rr2, cc2 = ellipse_perimeter(y0, x0, int(best[3]), int(best[4]), orientation=best[5])
+    rr2, cc2 = ellipse_perimeter(y0, x0, int(best[3]), int(best[4]),
+                                 orientation=best[5])
     assert_equal(rr, rr2)
     assert_equal(cc, cc2)
 
@@ -271,11 +282,12 @@ def test_hough_ellipse_non_zero_negangle1():
     rr, cc = ellipse_perimeter(y0, x0, ry, rx, orientation=angle)
     img[rr, cc] = 1
     result = tf.hough_ellipse(img, threshold=15, accuracy=3)
-    result.sort(key=lambda x:x[0])
+    result.sort(order='accumulator')
     best = result[-1]
     # Check if I re-draw the ellipse, points are the same!
     # ie check API compatibility between hough_ellipse and ellipse_perimeter
-    rr2, cc2 = ellipse_perimeter(y0, x0, int(best[3]), int(best[4]), orientation=best[5])
+    rr2, cc2 = ellipse_perimeter(y0, x0, int(best[3]), int(best[4]),
+                                 orientation=best[5])
     assert_equal(rr, rr2)
     assert_equal(cc, cc2)
 
@@ -291,11 +303,12 @@ def test_hough_ellipse_non_zero_negangle2():
     rr, cc = ellipse_perimeter(y0, x0, ry, rx, orientation=angle)
     img[rr, cc] = 1
     result = tf.hough_ellipse(img, threshold=15, accuracy=3)
-    result.sort(key=lambda x:x[0])
+    result.sort(order='accumulator')
     best = result[-1]
     # Check if I re-draw the ellipse, points are the same!
     # ie check API compatibility between hough_ellipse and ellipse_perimeter
-    rr2, cc2 = ellipse_perimeter(y0, x0, int(best[3]), int(best[4]), orientation=best[5])
+    rr2, cc2 = ellipse_perimeter(y0, x0, int(best[3]), int(best[4]),
+                                 orientation=best[5])
     assert_equal(rr, rr2)
     assert_equal(cc, cc2)
 
@@ -311,11 +324,12 @@ def test_hough_ellipse_non_zero_negangle3():
     rr, cc = ellipse_perimeter(y0, x0, ry, rx, orientation=angle)
     img[rr, cc] = 1
     result = tf.hough_ellipse(img, threshold=15, accuracy=3)
-    result.sort(key=lambda x:x[0])
+    result.sort(order='accumulator')
     best = result[-1]
     # Check if I re-draw the ellipse, points are the same!
     # ie check API compatibility between hough_ellipse and ellipse_perimeter
-    rr2, cc2 = ellipse_perimeter(y0, x0, int(best[3]), int(best[4]), orientation=best[5])
+    rr2, cc2 = ellipse_perimeter(y0, x0, int(best[3]), int(best[4]),
+                                 orientation=best[5])
     assert_equal(rr, rr2)
     assert_equal(cc, cc2)
 
@@ -331,11 +345,12 @@ def test_hough_ellipse_non_zero_negangle4():
     rr, cc = ellipse_perimeter(y0, x0, ry, rx, orientation=angle)
     img[rr, cc] = 1
     result = tf.hough_ellipse(img, threshold=15, accuracy=3)
-    result.sort(key=lambda x:x[0])
+    result.sort(order='accumulator')
     best = result[-1]
     # Check if I re-draw the ellipse, points are the same!
     # ie check API compatibility between hough_ellipse and ellipse_perimeter
-    rr2, cc2 = ellipse_perimeter(y0, x0, int(best[3]), int(best[4]), orientation=best[5])
+    rr2, cc2 = ellipse_perimeter(y0, x0, int(best[3]), int(best[4]),
+                                 orientation=best[5])
     assert_equal(rr, rr2)
     assert_equal(cc, cc2)
 


### PR DESCRIPTION
- fix a "bug". The docstring claims that angle (from HT) was compatible with `ellipse_perimeter` but it was not. I fixed it and added a large quantity of tests (to convince myself :) ) The example looks cleaner (no weird np.pi - ... ).

This is the last PR for this feature, I hope :)
