### PR TITLE
Inverse Radon transform: Expand functionality

### DIFF
--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -160,7 +160,7 @@ def iradon(radon_image, theta=None, output_size=None,
         Assume the reconstructed image is zero outside the inscribed circle.
         Also changes the default output_size to match the behaviour of
         ``radon`` called with ``circle=True``.
-    projection_shifts : 1D array, dtype=float
+    projection_shifts : 1D array, dtype=float, optional
         Shift the projections contained in ``radon_image`` (the sinogram) by
         this many pixels before reconstructing the image. The i'th value
         defines the shift of the i'th column of ``radon_image``.

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -8,6 +8,7 @@ import os.path
 from skimage.transform import radon, iradon
 from skimage.io import imread
 from skimage import data_dir
+from skimage.util import pad
 
 
 __PHANTOM = imread(os.path.join(data_dir, "phantom.png"),
@@ -414,7 +415,7 @@ def test_iradon_shifted():
 
 
 def _sinogram_derivative(sinogram):
-    sinogram_padded = np.pad(sinogram, ((1, 1), (0, 0)), mode='constant',
+    sinogram_padded = pad(sinogram, ((1, 1), (0, 0)), mode='constant',
                              constant_values=0)
     central = (sinogram_padded[:-1, :] + sinogram_padded[1:, :]) / 2.
     derivative = central[1:, :] - central[:-1, :]

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -358,30 +358,50 @@ def test_iradon_sart():
         print('delta (1 iteration, clip) =', delta)
         assert delta < 0.015 * error_factor
 
-        np.random.seed(1239867)
-        shifts = np.random.uniform(-3, 3, sinogram.shape[1])
-        x = np.arange(sinogram.shape[0])
-        sinogram_shifted = np.vstack(np.interp(x + shifts[i], x,
-                                               sinogram[:, i])
-                                     for i in range(sinogram.shape[1])).T
-        reconstructed = iradon_sart(sinogram_shifted, theta,
-                                    projection_shifts=shifts)
-        if debug:
-            from matplotlib import pyplot as plt
-            plt.figure()
-            plt.subplot(221)
-            plt.imshow(image, interpolation='nearest')
-            plt.subplot(222)
-            plt.imshow(sinogram_shifted, interpolation='nearest')
-            plt.subplot(223)
-            plt.imshow(reconstructed, interpolation='nearest')
-            plt.subplot(224)
-            plt.imshow(reconstructed - image, interpolation='nearest')
-            plt.show()
-
         delta = np.mean(np.abs(reconstructed - image))
         print('delta (1 iteration, shifted sinogram) =', delta)
         assert delta < 0.018 * error_factor
+
+
+def check_iradon_shifted(image):
+    from skimage.transform import radon, iradon_sart
+    debug = False
+
+    theta = np.linspace(0., 180., image.shape[0], endpoint=False)
+    sinogram = radon(image, theta, circle=True)
+
+    np.random.seed(1239867)
+    shifts = np.random.uniform(-3, 3, sinogram.shape[1])
+    x = np.arange(sinogram.shape[0])
+    sinogram_shifted = np.vstack(np.interp(x + shifts[i], x,
+                                            sinogram[:, i])
+                                    for i in range(sinogram.shape[1])).T
+
+    reconstructed = iradon_sart(sinogram_shifted, theta,
+                                projection_shifts=shifts)
+
+    if debug:
+        from matplotlib import pyplot as plt
+        plt.figure()
+        plt.subplot(221)
+        plt.imshow(image, interpolation='nearest')
+        plt.subplot(222)
+        plt.imshow(sinogram_shifted, interpolation='nearest')
+        plt.subplot(223)
+        plt.imshow(reconstructed, interpolation='nearest')
+        plt.subplot(224)
+        plt.imshow(reconstructed - image, interpolation='nearest')
+        plt.show()
+
+    delta = np.mean(np.abs(reconstructed - image))
+    print('delta (1 iteration, shifted sinogram) =', delta)
+    assert delta < 0.018
+
+
+def test_iradon_shifted():
+    image = _load_shepp_logan()
+    yield check_iradon_shifted, image
+
 
 if __name__ == "__main__":
     from numpy.testing import run_module_suite

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -313,15 +313,19 @@ def test_order_angles_golden_ratio():
             assert len(indices) == len(set(indices))
 
 
-def test_iradon_sart():
+def _load_shepp_logan():
     from skimage.io import imread
     from skimage import data_dir
-    from skimage.transform import rescale, radon, iradon_sart
+    from skimage.transform import rescale
+    shepp_logan = imread(os.path.join(data_dir, "phantom.png"), as_grey=True)
+    return rescale(shepp_logan, scale=0.4)
 
+
+def test_iradon_sart():
+    from skimage.transform import radon, iradon_sart
     debug = False
 
-    shepp_logan = imread(os.path.join(data_dir, "phantom.png"), as_grey=True)
-    image = rescale(shepp_logan, scale=0.4)
+    image = _load_shepp_logan()
     theta_ordered = np.linspace(0., 180., image.shape[0], endpoint=False)
     theta_missing_wedge = np.linspace(0., 150., image.shape[0], endpoint=True)
     for theta, error_factor in ((theta_ordered, 1.),


### PR DESCRIPTION
This PR does two things:
- Adds a `projection_shifts` argument to `iradon`, with identical functionality as for `iradon_sart`
- Enables using user-defined filters for the filtered back projection by supplying a callable

Both changes are intended to be backwards compatible.

From my side, this is ready for merge.
