### PR TITLE
DOC: reference broken,  protect last character in URL

### DIFF
--- a/skimage/filter/rank/generic.py
+++ b/skimage/filter/rank/generic.py
@@ -677,7 +677,7 @@ def entropy(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Entropy_(information_theory)
+    .. [1] http://en.wikipedia.org/wiki/Entropy_(information_theory)>
 
     Examples
     --------


### PR DESCRIPTION
See ref in http://scikit-image.org/docs/dev/api/skimage.filter.rank.html#entropy

According to
http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#id76
the addition of a '>' character at the end is a solution. (I checked, it works).
