### PR TITLE
Changed the 180 constant in bin calculation to avoid rounding errors

### DIFF
--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -117,9 +117,9 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
         #create new integral image for this orientation
         # isolate orientations in this range
 
-        temp_ori = np.where(orientation < 180 / orientations * (i + 1),
+        temp_ori = np.where(orientation < 180.0 / orientations * (i + 1),
                             orientation, -1)
-        temp_ori = np.where(orientation >= 180 / orientations * i,
+        temp_ori = np.where(orientation >= 180.0 / orientations * i,
                             temp_ori, -1)
         # select magnitudes for those orientations
         cond2 = temp_ori > -1


### PR DESCRIPTION
The code

```
   180 / orientations
```

performs integral division in python < 3, leading the HOG computation to ignore some orientations near the 180 maximum, as explained in the issue titled "HOG bin computation rounding off error". The solution adopted is to specify the constant as a float, i.e. `180.0`
