### PR TITLE
Remove unnecessary mirror option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
     - sudo apt-get install libfreeimage3
     - if [[ $PYVER == '2.7' ]]; then sudo apt-get install $PYTHON-matplotlib; fi
     - if [[ $PYVER == '3.2' ]]; then sudo pip-$PYVER install git+git://github.com/matplotlib/matplotlib.git@v1.2.x; fi
-    - sudo pip-$PYVER install flake8 --use-mirrors
+    - sudo pip-$PYVER install flake8
     - $PYTHON setup.py build
     - sudo $PYTHON setup.py install
 script:


### PR DESCRIPTION
This should not be necessary after PyPI has been migrated to a new backend.
