### PR TITLE
Fix errors in relabel_from_one docs; PEP8

### DIFF
--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -72,8 +72,8 @@ def relabel_from_one(label_field):
     -----
     The forward map can be extremely big for some inputs, since its
     length is given by the maximum of the label field. However, in most
-    situations, `label_field.max()` is much smaller than
-    `label_field.size`, and in these cases the forward map is
+    situations, ``label_field.max()`` is much smaller than
+    ``label_field.size``, and in these cases the forward map is
     guaranteed to be smaller than either the input or output images.
 
     Examples


### PR DESCRIPTION
Hi guys,

So, um, funny story! My good friend @DocSavage recently pointed out that the documentation in my `relabel_from_one` function (in `skimage/segmentation/_join.py`) is _dramatically_ wrong about the length of the forward map array returned. (Though the example is correct.) This PR fixes the docstring. It additionally fixes a couple of PEP8 gaffes (spacing between functions, newline before EOF).

In the longer term, @DocSavage and I discussed that a relabeling based on iterating through the array will be faster in some situations. (e.g. if I want to relabel `array([0, 1, 2e9])`). However, returning the forward map would be problematic. Possible solutions:
- add a new function, e.g. `relabel_from_one_lowmem`, for these situations. Let users choose the one they want.
- keep the one function, and add some logic inside it to determine if the input is pathological, like the array above. If so, use the iterating approach. (And return a dummy forward map?) Otherwise, use the current approach.
- as above, but _never_ return the forward map.

Finally, it would be trivial to allow arbitrary start indices and default the offset to 1, but that would require renaming the function to `relabel_from_offset`. Perhaps deprecation would be a good idea, _or_ keep both, _or_ ignore that function.

Looking forward to hearing your thoughts!
