### PR TITLE
Fix type hierarchy check in remove_small_objects

### DIFF
--- a/skimage/morphology/misc.py
+++ b/skimage/morphology/misc.py
@@ -52,7 +52,7 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
     True
     """
     # Should use `issubdtype` for bool below, but there's a bug in numpy 1.7
-    if not (ar.dtype == bool or np.issubdtype(ar.dtype, int)):
+    if not (ar.dtype == bool or np.issubdtype(ar.dtype, np.integer)):
         raise TypeError("Only bool or integer image types are supported. "
                         "Got %s." % ar.dtype)
 

--- a/skimage/morphology/tests/test_misc.py
+++ b/skimage/morphology/tests/test_misc.py
@@ -42,6 +42,19 @@ def test_labeled_image():
     assert_array_equal(observed, expected)
 
 
+def test_uint_image():
+    labeled_image = np.array([[2, 2, 2, 0, 1],
+                              [2, 2, 2, 0, 1],
+                              [2, 0, 0, 0, 0],
+                              [0, 0, 3, 3, 3]], dtype=np.uint8)
+    expected = np.array([[2, 2, 2, 0, 0],
+                         [2, 2, 2, 0, 0],
+                         [2, 0, 0, 0, 0],
+                         [0, 0, 3, 3, 3]], dtype=np.uint8)
+    observed = remove_small_objects(labeled_image, min_size=3)
+    assert_array_equal(observed, expected)
+
+
 def test_float_input():
     float_test = np.random.rand(5, 5)
     assert_raises(TypeError, remove_small_objects, float_test)


### PR DESCRIPTION
Another whoopsies fix from me.

`skimage.morphology.remove_small_objects` is neat and useful but currently does _not_ accept unsigned integer input! That is because when I was checking for valid input types, I wrote:

``` python
    if not (ar.dtype == bool or np.issubdtype(ar.dtype, int)):
```

This results in the following error:

``` python
In [1]: x = np.array([1, 0, 2, 2], dtype=np.int8)

In [2]: from skimage.morphology import remove_small_objects

In [3]: remove_small_objects(x, 2)
Out[3]: array([0, 0, 2, 2], dtype=int8)

In [4]: remove_small_objects(x.astype(np.uint8), 2)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-74cd0cdfc2ec> in <module>()
----> 1 remove_small_objects(x.astype(np.uint8), 2)

/Users/nuneziglesiasj/venv/skimdev/lib/python2.7/site-packages/scikit_image-0.9dev-py2.7-macosx-10.5-x86_64.egg/skimage/morphology/misc.pyc in remove_small_objects(ar, min_size, connectivity, in_place)
     55     if not (ar.dtype == bool or np.issubdtype(ar.dtype, int)):
     56         raise TypeError("Only bool or integer image types are supported. "
---> 57                         "Got %s." % ar.dtype)
     58
     59     if in_place:

TypeError: Only bool or integer image types are supported. Got uint8.
```

It looks like the Python built-in type `int` resolves in numpy to `np.signedinteger` rather than `np.integer`, the latter of which [encompasses](http://docs.scipy.org/doc/numpy/reference/arrays.scalars.html) both signed and unsigned. The following line allows both signed and unsigned integer input (in addition to `bool`):

``` python
    if not (ar.dtype == bool or np.issubdtype(ar.dtype, np.integer)):
```

I've added a test with unsigned input to prevent regression of this bug.
