### PR TITLE
Correcting a bug in SimialarityTransform

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -515,7 +515,7 @@ class SimilarityTransform(ProjectiveTransform):
                 [math.sin(rotation),   math.cos(rotation), 0],
                 [                 0,                    0, 1]
             ])
-            self._matrix *= scale
+            self._matrix[0:2, 0:2] *= scale
             self._matrix[0:2, 2] = translation
         else:
             # default to an identity transform


### PR DESCRIPTION
The current version does not allow scaling as it also multiplies the homogenous factor i.e. the `(-1, -1)`th element of the transformation matrix with the argument `scale`.
