### PR TITLE
optimized label2rgb()

### DIFF
--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -101,6 +101,9 @@ def label2rgb(label, image=None, colors=None, alpha=0.3,
             bg_color = _rgb_vector(bg_color)
             color_cycle = itertools.chain(bg_color, color_cycle)
 
+    if len(labels) == 0:
+        return img_layer
+
     label_to_color = np.zeros((max(labels) + 1, 3))
     for lab, c in zip(labels, color_cycle):
         label_to_color[lab] = c


### PR DESCRIPTION
The current implementation of `label2rgb()` loops over all labels, creating a mask for each. This approach is far too slow for large images with lots of labels. I have rewritten it to instead create an index array which maps labels to colors. Then the final image can be created in one go, using NumPy indexing and array operations.

Here is a simple benchmark:

```
import numpy as np
from skimage.color import label2rgb

test_image = np.zeros(10000).reshape(100, 100)
test_labels = np.arange(10000).reshape(100, 100)
timeit label2rgb(test_labels, test_image)
```

The old version takes 1.04 seconds. The new version takes 0.034 seconds, for a speedup of about 30.6.
