### PR TITLE
Update join_segmentation example for float images

### DIFF
--- a/doc/examples/plot_join_segmentations.py
+++ b/doc/examples/plot_join_segmentations.py
@@ -18,16 +18,16 @@ from skimage.filter import sobel
 from skimage.segmentation import slic, join_segmentations
 from skimage.morphology import watershed
 from skimage.color import label2rgb
-from skimage import data
+from skimage import data, img_as_float
 
-coins = data.coins()
+coins = img_as_float(data.coins())
 
 # make segmentation using edge-detection and watershed
 edges = sobel(coins)
 markers = np.zeros_like(coins)
 foreground, background = 1, 2
-markers[coins < 30] = background
-markers[coins > 150] = foreground
+markers[coins < 30.0 / 255] = background
+markers[coins > 150.0 / 255] = foreground
 
 ws = watershed(edges, markers)
 seg1 = nd.label(ws == foreground)[0]
@@ -60,3 +60,4 @@ for ax in axes:
     ax.axis('off')
 plt.subplots_adjust(hspace=0.01, wspace=0.01, top=1, bottom=0, left=0, right=1)
 plt.show()
+


### PR DESCRIPTION
As noted by @kemaleren in #761, in Python 3.x, `data.coins()` is read as a `float32` image, leading the watershed segmentation to fail trivially in this example because no foreground markers are found. This PR fixes that.
