### PR TITLE
BUG: Fix ValueError: Buffer dtype mismatch, expected 'long' but got...

### DIFF
--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -149,7 +149,7 @@ def hough_ellipse(cnp.ndarray img, int threshold=4, double accuracy=1,
     if img.ndim != 2:
             raise ValueError('The input image must be 2D.')
 
-    cdef long[:, :] pixels = np.transpose(np.nonzero(img))
+    cdef Py_ssize_t[:, :] pixels = np.transpose(np.nonzero(img))
     cdef Py_ssize_t num_pixels = pixels.shape[0]
     cdef list acc = list()
     cdef list results = list()


### PR DESCRIPTION
... 'long long' on win-amd64

```
======================================================================
ERROR: test_hough_transform.test_hough_ellipse_zero_angle
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python33\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "X:\Python33\lib\site-packages\skimage\transform\tests\test_hough_transform.py", line 158, in test_hough_ellipse_zero_angle
    result = tf.hough_ellipse(img, threshold=9)
  File "_hough_transform.pyx", line 152, in skimage.transform._hough_transform.hough_ellipse (skimage\transform\_hough_transform.c:3293)
ValueError: Buffer dtype mismatch, expected 'long' but got 'long long'

======================================================================
ERROR: test_hough_transform.test_hough_ellipse_non_zero_angle
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python33\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "X:\Python33\lib\site-packages\skimage\transform\tests\test_hough_transform.py", line 175, in test_hough_ellipse_non_zero_angle
    result = tf.hough_ellipse(img, threshold=15, accuracy=3)
  File "_hough_transform.pyx", line 152, in skimage.transform._hough_transform.hough_ellipse (skimage\transform\_hough_transform.c:3293)
ValueError: Buffer dtype mismatch, expected 'long' but got 'long long'

```
