### PR TITLE
TST: Fix ValueError: Buffer dtype mismatch, expected 'intp_t' but got...

### DIFF
--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -122,7 +122,7 @@ def test_hough_circle():
     y, x = circle_perimeter(y_0, x_0, radius)
     img[x, y] = 1
 
-    out = tf.hough_circle(img, np.array([radius]))
+    out = tf.hough_circle(img, np.array([radius], dtype=np.intp))
 
     x, y = np.where(out[0] == out[0].max())
     assert_equal(x[0], x_0)
@@ -138,7 +138,8 @@ def test_hough_circle_extended():
     y, x = circle_perimeter(y_0, x_0, radius)
     img[x[np.where(x > 0)], y[np.where(x > 0)]] = 1
 
-    out = tf.hough_circle(img, np.array([radius]), full_output=True)
+    out = tf.hough_circle(img, np.array([radius], dtype=np.intp),
+                          full_output=True)
 
     x, y = np.where(out[0] == out[0].max())
     # Offset for x_0, y_0


### PR DESCRIPTION
...'long'

```
======================================================================
ERROR: test_hough_transform.test_hough_circle
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python33\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "X:\Python33\lib\site-packages\skimage\transform\tests\test_hough_transform.py", line 125, in test_hough_circle
    out = tf.hough_circle(img, np.array([radius]))
  File "_hough_transform.pyx", line 23, in skimage.transform._hough_transform.hough_circle (skimage\transform\_hough_transform.c:2286)
ValueError: Buffer dtype mismatch, expected 'intp_t' but got 'long'

======================================================================
ERROR: test_hough_transform.test_hough_circle_extended
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python33\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "X:\Python33\lib\site-packages\skimage\transform\tests\test_hough_transform.py", line 141, in test_hough_circle_extended
    out = tf.hough_circle(img, np.array([radius]), full_output=True)
  File "_hough_transform.pyx", line 23, in skimage.transform._hough_transform.hough_circle (skimage\transform\_hough_transform.c:2286)
ValueError: Buffer dtype mismatch, expected 'intp_t' but got 'long'
```
