### PR TITLE
FIX: Fix and improve Poisson random noise generator

### DIFF
--- a/skimage/util/tests/test_random_noise.py
+++ b/skimage/util/tests/test_random_noise.py
@@ -83,6 +83,31 @@ def test_gaussian():
     assert 0.012 < data_gaussian.var() < 0.018
 
 
+def test_localvar():
+    seed = 42
+    data = np.zeros((128, 128)) + 0.5
+    local_vars = np.zeros((128, 128)) + 0.001
+    local_vars[:64, 64:] = 0.1
+    local_vars[64:, :64] = 0.25
+    local_vars[64:, 64:] = 0.45
+
+    data_gaussian = random_noise(data, mode='localvar', seed=seed,
+                                 local_vars=local_vars, clip=False)
+    assert 0. < data_gaussian[:64, :64].var() < 0.002
+    assert 0.095 < data_gaussian[:64, 64:].var() < 0.105
+    assert 0.245 < data_gaussian[64:, :64].var() < 0.255
+    assert 0.445 < data_gaussian[64:, 64:].var() < 0.455
+
+    # Ensure local variance bounds checking works properly
+    bad_local_vars = np.zeros_like(data)
+    assert_raises(ValueError, random_noise, data, mode='localvar', seed=seed,
+                  local_vars=bad_local_vars)
+    bad_local_vars += 0.1
+    bad_local_vars[0, 0] = -1
+    assert_raises(ValueError, random_noise, data, mode='localvar', seed=seed,
+                  local_vars=bad_local_vars)
+
+
 def test_speckle():
     seed = 42
     data = np.zeros((128, 128)) + 0.1


### PR DESCRIPTION
The Poissson generator now works. This should resolve recent comments on merged #625

The Poisson generator is also considerably improved. It infers the bit depth of the image _after_ conversion to a floating point image, by analyzing the unique values present and finding the next power of two. This value is then used to scale the floating point image up, after which Poisson noise is generated, and finally the image is scaled back down.

In my opinion this is an improvement over Matlab's approach, which is rather erratic based on what you feed it.

**The below is kept for posterity. We elected to go with clipping using a boolean kwarg, `clip=True`**

Unfortunately, the Poisson distribution can result in overflows. These are gracefully handled and not aliased in the current implementation, consider:

``` python
import numpy as np
from skimage.data import camera
data = camera()  # 512x512 grayscale uint8
cam_noisy = random_noise(data, mode='poisson', seed=42)
print cam_noisy.max()
```

The result should be 1.152. The question is what to do in this case. I see two options.
- Clip the result back to the proper [0, 1] range
- Rescale the image to [0, 1], preserving the noisy overflows but potentially lowering overall brightness slightly

I'm conflicted on which is the superior path, so advice appreciated! With consensus either way, I'll implement and then it should be merge-ready.
