### PR TITLE
TST: Fix RuntimeError: data type not supported on Python 2.6

### DIFF
--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -31,7 +31,8 @@ def test_all_props():
 def test_dtype():
     regionprops(np.zeros((10, 10), dtype=np.int))
     regionprops(np.zeros((10, 10), dtype=np.uint))
-    assert_raises(TypeError, regionprops, np.zeros((10, 10), dtype=np.double))
+    assert_raises((TypeError, RuntimeError), regionprops,
+                  np.zeros((10, 10), dtype=np.double))
 
 
 def test_ndim():


### PR DESCRIPTION
On Python >=2.7, C extensions that use integer format codes with the PyArg_Parse\* family of functions will raise a TypeError exception instead of triggering a DeprecationWarning (Python 2.6). The RuntimeError is raised by ndimage for unsupported array data types.

Fixes part of issue #785
