### PR TITLE
Modify mpl_image_to_rgba to allow RGB input image

### DIFF
--- a/skimage/viewer/viewers/core.py
+++ b/skimage/viewer/viewers/core.py
@@ -20,12 +20,28 @@ __all__ = ['ImageViewer', 'CollectionViewer']
 def mpl_image_to_rgba(mpl_image):
     """Return RGB image from the given matplotlib image object.
 
-    Each image in a matplotlib figure has it's own colormap and normalization
+    Each image in a matplotlib figure has its own colormap and normalization
     function. Return RGBA (RGB + alpha channel) image with float dtype.
+
+    Parameters
+    ----------
+    mpl_image : matplotlib.image.AxesImage object
+        The image being converted.
+
+    Returns
+    -------
+    img : array of float, shape (M, N, 4)
+        An image of float values in [0, 1].
     """
-    input_range = (mpl_image.norm.vmin, mpl_image.norm.vmax)
-    image = rescale_intensity(mpl_image.get_array(), in_range=input_range)
-    image = mpl_image.cmap(img_as_float(image)) # cmap complains on bool arrays
+    image = mpl_image.get_array()
+    if image.ndim == 2:
+        input_range = (mpl_image.norm.vmin, mpl_image.norm.vmax)
+        image = rescale_intensity(image, in_range=input_range)
+        # cmap complains on bool arrays
+        image = mpl_image.cmap(img_as_float(image))
+    elif image.ndim == 3 and image.shape[2] == 3:
+        # add alpha channel if it's missing
+        image = np.dstack((image, np.ones_like(image)))
     return img_as_float(image)
 
 


### PR DESCRIPTION
mpl_image_to_rgba produces a image of shape (M, N, 3, 4) when the input
image is already RGB. This is understandably confusing for downstream
processes, and this commit fixes it.

Calling "File > save as" in the viewer when the input image was RGB produced the following error:

``` python
In [4]: v = viewer.ImageViewer(rgbs[0])
v += CentroPlugin()
v.show()
   ...:
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
/Users/nuneziglesiasj/venv/cafe/lib/python2.7/site-packages/scikit_image-0.10dev-py2.7-macosx-10.5-x86_64.egg/skimage/viewer/viewers/core.pyc in save_to_file(self)
    191             alpha = alpha[:, :, np.newaxis]
    192             composite = (overlay[:, :, :3] * alpha +
--> 193                          underlay[:, :, :3] * (1 - alpha))
    194             io.imsave(filename, composite)
    195

ValueError: operands could not be broadcast together with shapes (669,649,3,4) (669,649,1)
> /Users/nuneziglesiasj/venv/cafe/lib/python2.7/site-packages/scikit_image-0.10dev-py2.7-macosx-10.5-x86_64.egg/skimage/viewer/viewers/core.py(193)save_to_file()
    192             composite = (overlay[:, :, :3] * alpha +
--> 193                          underlay[:, :, :3] * (1 - alpha))
    194             io.imsave(filename, composite)
```
