### PR TITLE
FIX: New versions of FreeImage report software as "I", not "ImageMagick ..."

### DIFF
--- a/skimage/io/tests/test_freeimage.py
+++ b/skimage/io/tests/test_freeimage.py
@@ -53,9 +53,10 @@ def test_imread_uint16_big_endian():
     assert img.dtype == np.uint16
     assert_array_almost_equal(img, expected)
 
+
 @skipif(not FI_available)
 def test_write_multipage():
-    shape = (64,64,64)
+    shape = (64, 64, 64)
     x = np.ones(shape, dtype=np.uint8) * np.random.random(shape) * 255
     x = x.astype(np.uint8)
     f = NamedTemporaryFile(suffix='.tif')
@@ -64,7 +65,8 @@ def test_write_multipage():
     fi.write_multipage(x, fname)
     y = fi.read_multipage(fname)
     assert_array_equal(x, y)
-    
+
+
 class TestSave:
     def roundtrip(self, dtype, x, suffix):
         f = NamedTemporaryFile(suffix='.' + suffix)
@@ -94,13 +96,13 @@ class TestSave:
 def test_metadata():
     meta = fi.read_metadata(os.path.join(si.data_dir, 'multipage.tif'))
     assert meta[('EXIF_MAIN', 'Orientation')] == 1
-    assert meta[('EXIF_MAIN', 'Software')].startswith('ImageMagick')
+    assert meta[('EXIF_MAIN', 'Software')].startswith('I')
 
     meta = fi.read_multipage_metadata(os.path.join(si.data_dir,
                                                    'multipage.tif'))
     assert len(meta) == 2
     assert meta[0][('EXIF_MAIN', 'Orientation')] == 1
-    assert meta[1][('EXIF_MAIN', 'Software')].startswith('ImageMagick')
+    assert meta[1][('EXIF_MAIN', 'Software')].startswith('I')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This should close both #820 and #730.

It was a bit interesting. It appears some versions of FreeImage - older ones, apparently - reported `('EXIF_MAIN', 'Software')` as `"ImageMagick [date] [version number] [other stuff]". The old version available through my Enterprise Linux derivative's package manager did this - though it was broken in other ways for being so out of date. Thus, we just checked for the string to start with`"ImageMagick"`.

After removing that version of FreeImage, I went and compiled an entirely fresh install from source. And now I can reproduce the errors reported in #820 and #730. New versions of FreeImage are reporting `('EXIF_MAIN', 'Software')` as the single character `'I'`.

The fix is simple and backwards compatible, just change the test to `.startswith('I')`, and should be credited to @rovitotv.

I also made a couple minor PEP8 improvements.
