### PR TITLE
FIX: Specify field index for Python 2.6 compatible use of str.format()

### DIFF
--- a/skimage/novice/_novice.py
+++ b/skimage/novice/_novice.py
@@ -25,7 +25,7 @@ def open(path):
 def _verify_picture_index(index):
     """Raise error if picture index is not a 2D index/slice."""
     if not (isinstance(index, tuple) and len(index) == 2):
-        raise IndexError("Expected 2D index but got {!r}".format(index))
+        raise IndexError("Expected 2D index but got {0!r}".format(index))
 
     if all(isinstance(i, int) for i in index):
         return index

--- a/skimage/novice/tests/test_novice.py
+++ b/skimage/novice/tests/test_novice.py
@@ -268,5 +268,4 @@ def test_pixel_blue_raises():
 
 
 if __name__ == '__main__':
-    from numpy import testing
-    testing.run_module_suite()
+    np.testing.run_module_suite()


### PR DESCRIPTION
For people who may be stuck with production systems running Python 2.6.x, the `skimage.novice` module was regularly failing four tests because the formatting of the string when going to `raise IndexError` in `_verify_picture_index` was itself raising a `ValueError: zero length field name in format`.

This PR fixes the problem - which was the only current Python 2.6.x anomaly I'm aware of. The solution is to explicitly specify the index when using `str.format()` - this is required in Python 2.6 but optional in all future versions.

However, 2.7+ happily runs with the explicit field name, so this fix is fully compatible.
