### PR TITLE
Fix hough_circle regression on windows

### DIFF
--- a/skimage/transform/__init__.py
+++ b/skimage/transform/__init__.py
@@ -1,6 +1,6 @@
-from ._hough_transform import (hough_circle, hough_ellipse, hough_line,
+from ._hough_transform import (hough_ellipse, hough_line,
                                probabilistic_hough_line)
-from .hough_transform import hough_line_peaks
+from .hough_transform import hough_circle, hough_line_peaks
 from .radon_transform import radon, iradon, iradon_sart
 from .finite_radon_transform import frt2, ifrt2
 from .integral import integral_image, integrate

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -20,9 +20,9 @@ cdef inline Py_ssize_t round(double r):
     return <Py_ssize_t>((r + 0.5) if (r > 0.0) else (r - 0.5))
 
 
-def hough_circle(cnp.ndarray img,
-                 cnp.ndarray[ndim=1, dtype=cnp.intp_t] radius,
-                 char normalize=True, char full_output=False):
+def _hough_circle(cnp.ndarray img,
+                  cnp.ndarray[ndim=1, dtype=cnp.intp_t] radius,
+                  char normalize=True, char full_output=False):
     """Perform a circular Hough transform.
 
     Parameters

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -1,6 +1,7 @@
 import numpy as np
 from scipy import ndimage
 from skimage import measure, morphology
+from ._hough_transform import _hough_circle
 
 
 def hough_line_peaks(hspace, angles, dists, min_distance=9, min_angle=10,
@@ -125,3 +126,31 @@ def hough_line_peaks(hspace, angles, dists, min_distance=9, min_angle=10,
         angle_peaks = angle_peaks[idx_maxsort]
 
     return hspace_peaks, angle_peaks, dist_peaks
+
+
+def hough_circle(image, radius, normalize=True, full_output=False):
+    """Perform a circular Hough transform.
+
+    Parameters
+    ----------
+    image : (M, N) ndarray
+        Input image with nonzero values representing edges.
+    radius : ndarray
+        Radii at which to compute the Hough transform.
+    normalize : boolean, optional (default True)
+        Normalize the accumulator with the number
+        of pixels used to draw the radius.
+    full_output : boolean, optional (default False)
+        Extend the output size by twice the largest
+        radius in order to detect centers outside the
+        input picture.
+
+    Returns
+    -------
+    H : 3D ndarray (radius index, (M + 2R, N + 2R) ndarray)
+        Hough transform accumulator for each radius.
+        R designates the larger radius if full_output is True.
+        Otherwise, R = 0.
+    """
+    return _hough_circle(image, radius.astype(np.intp),
+                         normalize=normalize, full_output=full_output)


### PR DESCRIPTION
This adds back the pure Python interface for `hough_circle` so that the radius argument can be cast to `np.intp_t`.

This issue was fixed in https://github.com/scikit-image/scikit-image/commit/7ca08cf7630787201636da4ea4409741b558d613 (which essentially has the same fix deployed here) and then broken in https://github.com/scikit-image/scikit-image/pull/480 (which I reviewed, apparently).
