### PR TITLE
Only run coverage for Python 3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,8 @@ script:
     # Run all tests
     - if [[ $PYVER == '3.x' ]]; then
     -   nosetests --exe -v --with-doctest --with-cov --cov skimage --cov-config .coveragerc skimage
-    - else
+    - fi
+    - if [[ $PYVER == '2.x' ]]; then
     -   nosetests --exe -v --with-doctest skimage
     - fi
     # Run all doc examples
@@ -79,6 +80,5 @@ script:
 after_success:
      - if [[ $PYVER == '3.x' ]]; then
      -   coveralls
-     - else
-     -   exit 0
      - fi
+


### PR DESCRIPTION
I think we're confusing Coverage by running it consecutively on different Python versions.
