### PR TITLE
Use frombytes instead of fromstring on PIL images

### DIFF
--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -109,7 +109,13 @@ def imsave(fname, arr, format_str=None):
     if not isinstance(fname, string_types) and format_str is None:
         format_str = "PNG"
 
-    img = Image.frombytes(mode, (arr.shape[1], arr.shape[0]), arr.tostring())
+    try:
+        img = Image.frombytes(mode, (arr.shape[1], arr.shape[0]),
+                              arr.tostring())
+    except AttributeError:
+        img = Image.fromstring(mode, (arr.shape[1], arr.shape[0]),
+                               arr.tostring())
+
     img.save(fname, format=format_str)
 
 


### PR DESCRIPTION
(Since the latter is now deprecated)
