### PR TITLE
Improve py3k compatibility for Viewer core widget and OverlayPlugin.

### DIFF
--- a/skimage/viewer/plugins/overlayplugin.py
+++ b/skimage/viewer/plugins/overlayplugin.py
@@ -45,7 +45,7 @@ class OverlayPlugin(Plugin):
         self._overlay_plot = None
         self._overlay = None
         self.cmap = None
-        self.color_names = [c for c in self.colors.keys()]
+        self.color_names = list(self.colors.keys())
 
     def attach(self, image_viewer):
         super(OverlayPlugin, self).attach(image_viewer)

--- a/skimage/viewer/widgets/core.py
+++ b/skimage/viewer/widgets/core.py
@@ -232,7 +232,7 @@ class ComboBox(BaseWidget):
         self.name_label.setAlignment(QtCore.Qt.AlignLeft)
 
         self._combo_box = QtGui.QComboBox()
-        self._combo_box.addItems([i for i in items])
+        self._combo_box.addItems(list(items))
 
         self.layout = QtGui.QHBoxLayout(self)
         self.layout.addWidget(self.name_label)


### PR DESCRIPTION
Dictionary keys are treated differently in py3k, causing the Canny plugin to not work on py3k.  This addresses two such errors, allowing the Canny plugin to work on Python 3.2 (tested with Ubuntu 12.04 32-bit).

This addresses #892.
