### PR TITLE
Fix ValueError: Buffer dtype mismatch, expected 'Py_ssize_t' but got 'lo...

### DIFF
--- a/skimage/segmentation/_slic.pyx
+++ b/skimage/segmentation/_slic.pyx
@@ -217,9 +217,9 @@ def _enforce_label_connectivity_cython(Py_ssize_t[:, :, ::1] segments,
     width = segments.shape[2]
 
     # neighborhood arrays
-    cdef Py_ssize_t[::1] ddx = np.array((1, -1, 0, 0, 0, 0))
-    cdef Py_ssize_t[::1] ddy = np.array((0, 0, 1, -1, 0, 0))
-    cdef Py_ssize_t[::1] ddz = np.array((0, 0, 0, 0, 1, -1))
+    cdef Py_ssize_t[::1] ddx = np.array((1, -1, 0, 0, 0, 0), dtype=np.intp)
+    cdef Py_ssize_t[::1] ddy = np.array((0, 0, 1, -1, 0, 0), dtype=np.intp)
+    cdef Py_ssize_t[::1] ddz = np.array((0, 0, 0, 0, 1, -1), dtype=np.intp)
 
     # new object with connected segments initialized to -1
     cdef Py_ssize_t[:, :, ::1] connected_segments \


### PR DESCRIPTION
...ng' on win-amd64

E.g. on win-amd64-py3.4:

```
======================================================================
ERROR: test_slic.test_enforce_connectivity
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "X:\Python34\lib\site-packages\skimage\segmentation\tests\test_slic.py", line 134, in test_enforce_connectivity
    convert2lab=False)
  File "X:\Python34\lib\site-packages\skimage\segmentation\slic_superpixels.py", line 193, in slic
    max_size)
  File "_slic.pyx", line 220, in skimage.segmentation._slic._enforce_label_connectivity_cython (skimage\segmentation\_sl
ic.c:3771)
ValueError: Buffer dtype mismatch, expected 'Py_ssize_t' but got 'long'
```
