### PR TITLE
Fix test_novice.test_update_on_save failure on Windows

### DIFF
--- a/skimage/novice/tests/test_novice.py
+++ b/skimage/novice/tests/test_novice.py
@@ -111,12 +111,16 @@ def test_update_on_save():
     assert pic.modified
     assert pic.path is None
 
-    with tempfile.NamedTemporaryFile(suffix=".jpg") as tmp:
-        pic.save(tmp.name)
+    fd, filename = tempfile.mkstemp(suffix=".jpg")
+    os.close(fd)
+    try:
+        pic.save(filename)
 
         assert not pic.modified
-        assert_equal(pic.path, os.path.abspath(tmp.name))
+        assert_equal(pic.path, os.path.abspath(filename))
         assert_equal(pic.format, "jpeg")
+    finally:
+        os.unlink(filename)
 
 
 def test_indexing():


### PR DESCRIPTION
On Windows, tempfile.NamedTemporaryFile() can not be opened a second time. See http://docs.python.org/2/library/tempfile.html#tempfile.NamedTemporaryFile

```
======================================================================
ERROR: test_novice.test_update_on_save
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "X:\Python34\lib\site-packages\skimage\novice\tests\test_novice.py", line 115, in test_update_on_save
    pic.save(tmp.name)
  File "X:\Python34\lib\site-packages\skimage\novice\_novice.py", line 267, in save
    io.imsave(path, self._rescale(self.array))
  File "X:\Python34\lib\site-packages\skimage\io\_io.py", line 155, in imsave
    return call_plugin('imsave', fname, arr, plugin=plugin, **plugin_args)
  File "X:\Python34\lib\site-packages\skimage\io\manage_plugins.py", line 209, in call_plugin
    return func(*args, **kwargs)
  File "X:\Python34\lib\site-packages\skimage\io\_plugins\pil_plugin.py", line 119, in imsave
    img.save(fname, format=format_str)
  File "X:\Python34\lib\site-packages\PIL\Image.py", line 1459, in save
    fp = builtins.open(fp, "wb")
PermissionError: [Errno 13] Permission denied: 'C:\\Users\\gohlke\\AppData\\Local\\Temp\\tmpyvdigal3.jpg'
```
