### PR TITLE
Use os.pathsep to sepatate multiple ImageCollection load_pattern

### DIFF
--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -2,6 +2,7 @@
 
 from __future__ import with_statement
 
+import os
 from glob import glob
 import re
 from copy import copy
@@ -229,7 +230,7 @@ class ImageCollection(object):
     ----------
     load_pattern : str or list
         Pattern glob or filenames to load. The path can be absolute or
-        relative.  Multiple patterns should be separated by a colon,
+        relative.  Multiple patterns should be separated by os.pathsep,
         e.g. '/tmp/work/*.png:/tmp/other/*.jpg'.  Also see
         implementation notes below.
     conserve_memory : bool, optional
@@ -295,7 +296,7 @@ class ImageCollection(object):
     def __init__(self, load_pattern, conserve_memory=True, load_func=None):
         """Load and manage a collection of images."""
         if isinstance(load_pattern, six.string_types):
-            load_pattern = load_pattern.split(':')
+            load_pattern = load_pattern.split(os.pathsep)
             self._files = []
             for pattern in load_pattern:
                 self._files.extend(glob(pattern))


### PR DESCRIPTION
The colon `:` does not work on Windows as it can be part of a path.

Fixes the following test error on Windows:

```
======================================================================
ERROR: test_null.test_null_imread_collection
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "X:\Python34\lib\site-packages\nose\tools\nontrivial.py", line 60, in newfunc
    func(*arg, **kw)
  File "X:\Python34\lib\site-packages\skimage\io\tests\test_null.py", line 45, in test_null_imread_collection
    collection[0]
  File "X:\Python34\lib\site-packages\skimage\io\collection.py", line 355, in __getitem__
    n = self._check_imgnum(n)
  File "X:\Python34\lib\site-packages\skimage\io\collection.py", line 389, in _check_imgnum
    % num)
IndexError: There are only 0 images in the collection
```
