### PR TITLE
Skip viewer tests if no Qt API is available

### DIFF
--- a/skimage/viewer/tests/test_viewer.py
+++ b/skimage/viewer/tests/test_viewer.py
@@ -1,7 +1,9 @@
 import skimage
 import skimage.data as data
 from skimage.viewer import ImageViewer
+from skimage.viewer.qt import qt_api
 from numpy.testing import assert_equal, assert_allclose
+from numpy.testing.decorators import skipif
 
 
 def setup_line_profile(image):
@@ -12,6 +14,7 @@ def setup_line_profile(image):
     return plugin
 
 
+@skipif(qt_api is None)
 def test_line_profile():
     """ Test a line profile using an ndim=2 image"""
     plugin = setup_line_profile(data.camera())
@@ -25,6 +28,7 @@ def test_line_profile():
     assert_allclose(scan_data.mean(), 0.2828, rtol=1e-3)
 
 
+@skipif(qt_api is None)
 def test_line_profile_rgb():
     """ Test a line profile using an ndim=3 image"""
     plugin = setup_line_profile(data.chelsea())


### PR DESCRIPTION
Fixes two test errors when PyQt/PySide are not installed:

```
======================================================================
ERROR: Test a line profile using an ndim=2 image
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "X:\Python34\lib\site-packages\skimage\viewer\tests\test_viewer.py", line 17, in test_line_profile
    plugin = setup_line_profile(data.camera())
  File "X:\Python34\lib\site-packages\skimage\viewer\tests\test_viewer.py", line 9, in setup_line_profile
    viewer = ImageViewer(skimage.img_as_float(image))
  File "X:\Python34\lib\site-packages\skimage\viewer\viewers\core.py", line 97, in __init__
    utils.init_qtapp()
  File "X:\Python34\lib\site-packages\skimage\viewer\utils\core.py", line 39, in init_qtapp
    QApp = QtGui.QApplication.instance()
AttributeError: 'module' object has no attribute 'QApplication'

======================================================================
ERROR: Test a line profile using an ndim=3 image
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\nose\case.py", line 198, in runTest
    self.test(*self.arg)
  File "X:\Python34\lib\site-packages\skimage\viewer\tests\test_viewer.py", line 30, in test_line_profile_rgb
    plugin = setup_line_profile(data.chelsea())
  File "X:\Python34\lib\site-packages\skimage\viewer\tests\test_viewer.py", line 9, in setup_line_profile
    viewer = ImageViewer(skimage.img_as_float(image))
  File "X:\Python34\lib\site-packages\skimage\viewer\viewers\core.py", line 97, in __init__
    utils.init_qtapp()
  File "X:\Python34\lib\site-packages\skimage\viewer\utils\core.py", line 39, in init_qtapp
    QApp = QtGui.QApplication.instance()
AttributeError: 'module' object has no attribute 'QApplication'
```
