### PR TITLE
Fix TypeError: __class__ assignment: 'TestFlexibleMCP' object layout differs from 'UnboundSelf'

### DIFF
--- a/skimage/graph/tests/test_flexible.py
+++ b/skimage/graph/tests/test_flexible.py
@@ -9,7 +9,7 @@ a = np.ones((8, 8), dtype=np.float32)
 a[1::2] *= 2.0
 
 
-class TestFlexibleMCP(mcp.MCP_Flexible):
+class FlexibleMCP(mcp.MCP_Flexible):
     """ Simple MCP subclass that allows the front to travel 
     a certain distance from the seed point, and uses a constant
     cost factor that is independant of the cost array.
@@ -38,7 +38,7 @@ class TestFlexibleMCP(mcp.MCP_Flexible):
 def test_flexible():
     
     # Create MCP and do a traceback
-    mcp = TestFlexibleMCP(a)
+    mcp = FlexibleMCP(a)
     costs, traceback = mcp.find_costs([(0, 0)])
     
     # Check that inner part is correct. This basically


### PR DESCRIPTION
On win-amd64-py3.4 with numpy 1.8.1rc1 and nose 1.3.1 I get the following error. Simply renaming the `TestFlexibleMCP` class to `FlexibleMCP` fixes this.

```
======================================================================
ERROR: Failure: TypeError (__class__ assignment: 'TestFlexibleMCP' object layout differs from 'UnboundSelf')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python34\lib\site-packages\nose\failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "X:\Python34\lib\site-packages\nose\loader.py", line 516, in makeTest
    return self._makeTest(obj, parent)
  File "X:\Python34\lib\site-packages\nose\loader.py", line 565, in _makeTest
    return self.loadTestsFromTestClass(obj)
  File "X:\Python34\lib\site-packages\nose\loader.py", line 509, in loadTestsFromTestClass
    for case in filter(wanted, dir(cls))]
  File "X:\Python34\lib\site-packages\nose\loader.py", line 508, in <listcomp>
    cases = [self.makeTest(getattr(cls, case), cls)
  File "X:\Python34\lib\site-packages\nose\loader.py", line 504, in wanted
    item = unbound_method(cls, item)
  File "X:\Python34\lib\site-packages\nose\pyversion.py", line 131, in unbound_method
    return UnboundMethod(cls, func)
  File "X:\Python34\lib\site-packages\nose\pyversion.py", line 92, in __init__
    self.__self__.__class__ = cls
TypeError: __class__ assignment: 'TestFlexibleMCP' object layout differs from 'UnboundSelf'
```
