### PR TITLE
BUG: wrong search for pivot in `quicker_sort`

### DIFF
--- a/skimage/exposure/unwrap_2d_ljmu.c
+++ b/skimage/exposure/unwrap_2d_ljmu.c
@@ -77,64 +77,64 @@ typedef enum {yes, no} yes_no;
 
 yes_no find_pivot(EDGE *left, EDGE *right, double *pivot_ptr)
 {
-  EDGE a, b, c, *p;
+    EDGE a, b, c, *p;
 
-  a = *left;
-  b = *(left + (right - left) /2 );
-  c = *right;
-  o3(a,b,c);
+    a = *left;
+    b = *(left + (right - left) / 2);
+    c = *right;
+    o3(a, b, c);
 
-  if (a.reliab < b.reliab)
+    if (a.reliab < b.reliab)
     {
-      *pivot_ptr = b.reliab;
-      return yes;
+        *pivot_ptr = b.reliab;
+        return yes;
     }
 
-  if (b.reliab < c.reliab)
+    if (b.reliab < c.reliab)
     {
-      *pivot_ptr = c.reliab;
-      return yes;
+        *pivot_ptr = c.reliab;
+        return yes;
     }
 
-  for (p = left + 1; p <= right; ++p)
+    for (p = left + 1; p <= right; ++p)
     {
-      if (p->reliab != left->reliab)
-	{
-	  *pivot_ptr = (p->reliab < left->reliab) ? left->reliab : p->reliab;
-	  return yes;
-	}
-      return no;
+        if (p->reliab != left->reliab)
+        {
+            *pivot_ptr = (p->reliab < left->reliab) ? left->reliab : p->reliab;
+            return yes;
+        }
     }
+    return no;
 }
 
 EDGE *partition(EDGE *left, EDGE *right, double pivot)
 {
-  while (left <= right)
+    while (left <= right)
     {
-      while (left->reliab < pivot)
-	++left;
-      while (right->reliab >= pivot)
-	--right;
-      if (left < right)
-	{
-	  swap (*left, *right);
-	  ++left;
-	  --right;
-	}
+        while (left->reliab < pivot)
+            ++left;
+        while (right->reliab >= pivot)
+            --right;
+        if (left < right)
+        {
+            swap (*left, *right);
+            ++left;
+            --right;
+        }
     }
-  return left;
+    return left;
 }
 
 void quicker_sort(EDGE *left, EDGE *right)
 {
-  EDGE *p;
-  double pivot;
+    EDGE *p;
+    double pivot;
 
-  if (find_pivot(left, right, &pivot) == yes)
+    if (find_pivot(left, right, &pivot) == yes)
     {
-      p = partition(left, right, pivot);
-      quicker_sort(left, p - 1);
-      quicker_sort(p, right);
+        p = partition(left, right, pivot);
+        quicker_sort(left, p - 1);
+        quicker_sort(p, right);
     }
 }
 //--------------end quicker_sort algorithm -----------------------------------

--- a/skimage/exposure/unwrap_3d_ljmu.c
+++ b/skimage/exposure/unwrap_3d_ljmu.c
@@ -104,8 +104,8 @@ yes_no find_pivot(EDGE *left, EDGE *right, double *pivot_ptr)
 			*pivot_ptr = (p->reliab < left->reliab) ? left->reliab : p->reliab;
 			return yes;
 		}
-		return no;
 	}
+    return no;
 }
 
 EDGE *partition(EDGE *left, EDGE *right, double pivot)


### PR DESCRIPTION
This PR corrects an error in the search for the existence of a distinct
pivot for sorting in the `quicker_sort` routines. This could lead to
`quicker_sort` wrongly believing that all items in a subsequence are equal and
hence require no sorting, when only the first, second, middle and last items
are the same.

It also fixes the indentation in the `quicker_sort` part of `unwrap_2d_ljmu.c`

While this doesn't explain #835 and #902 on its own, it may be related.
