### PR TITLE
Update _texture.pyx

### DIFF
--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -48,8 +48,8 @@ def _glcm_loop(cnp.uint8_t[:, ::1] image, double[:] distances,
                     i = image[r, c]
 
                     # compute the location of the offset pixel
-                    row = r + <int>(sin(angle) * distance + 0.5)
-                    col = c + <int>(cos(angle) * distance + 0.5)
+                    row = r + np.round(sin(angle)) * distance 
+                    col = c + np.round(cos(angle)) * distance
 
                     # make sure the offset is within bounds
                     if row >= 0 and row < rows and \


### PR DESCRIPTION
In function skimage.feature.texture.greycomatrix, I think I detected a bug. For instance, when using the angle 3*pi/4, and distance 1 in line 58, the expected answer would be col = c-1. But the code answer is col = c,

since (cos(3_pi/4)_1+0.5) = (-0.7+0.5) = (-0.2) = 0

So, the computed matrix using angle 3*pi/4 or pi/2 achieves the same results.

Besides, when using larger distances, such as distance = 4 and angle = PI/4
row = r + round(sin(angle) \* distance + 0.5) = round(0.7_4+0.5) = 3 (should be 4)
col = c + round(cos(angle) \* distance + 0.5) = round(0.7_4+0.5) = 3 (should be 4)

A possible solution would be:
row = r + round(sin(angle)) \* distance
col = c + round(cos(angle)) \* distance
