### PR TITLE
improve performance of equalize example

### DIFF
--- a/doc/examples/plot_equalize.py
+++ b/doc/examples/plot_equalize.py
@@ -60,8 +60,7 @@ def plot_img_and_hist(img, axes, bins=256):
 img = data.moon()
 
 # Contrast stretching
-p2 = np.percentile(img, 2)
-p98 = np.percentile(img, 98)
+p2, p98 = np.percentile(img, (2, 98))
 img_rescale = exposure.rescale_intensity(img, in_range=(p2, p98))
 
 # Equalization

--- a/doc/examples/plot_local_equalize.py
+++ b/doc/examples/plot_local_equalize.py
@@ -63,9 +63,7 @@ def plot_img_and_hist(img, axes, bins=256):
 # Load an example image
 img = img_as_ubyte(data.moon())
 
-# Contrast stretching
-p2 = np.percentile(img, 2)
-p98 = np.percentile(img, 98)
+# Global equalize
 img_rescale = exposure.equalize_hist(img)
 
 # Equalization


### PR DESCRIPTION
percentile can compute multiple ranks in one go which in the case of the
example halves the required time.
