### PR TITLE
2 unexpected lines removed

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -217,8 +217,6 @@ def rescale_intensity(image, in_range=None, out_range=None):
 
     if out_range is None or out_range in DTYPE_RANGE:
         out_range = dtype if out_range is None else out_range
-        if out_range is None:
-            out_range
         omin, omax = DTYPE_RANGE[out_range]
         if imin >= 0:
             omin = 0


### PR DESCRIPTION
Hi, 

I found two weird lines. It seems that the case is handled by the line before (excepted if the image dtype is None, but I don't think it happens, am I wrong ? Otherwise, we can take care of the case after the first line of this function)
