### PR TITLE
Corrected the formulae to calculate the location of offset pixels

### DIFF
--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -4,8 +4,8 @@
 #cython: wraparound=False
 import numpy as np
 cimport numpy as cnp
-from libc.math cimport sin, cos, abs, floor
-from skimage._shared.interpolation cimport bilinear_interpolation
+from libc.math cimport sin, cos, abs
+from skimage._shared.interpolation cimport bilinear_interpolation, round
 
 
 def _glcm_loop(cnp.uint8_t[:, ::1] image, double[:] distances,
@@ -48,8 +48,8 @@ def _glcm_loop(cnp.uint8_t[:, ::1] image, double[:] distances,
                     i = image[r, c]
 
                     # compute the location of the offset pixel
-                    row = r + <int>floor(sin(angle) * distance + 0.5)
-                    col = c + <int>floor(cos(angle) * distance + 0.5)
+                    row = r + <int>round(sin(angle) * distance)
+                    col = c + <int>round(cos(angle) * distance)
 
                     # make sure the offset is within bounds
                     if row >= 0 and row < rows and \


### PR DESCRIPTION
This is regarding #899 issue.

In existing code, following formulae is used to calculate row and column offset:
`row = r + <int>(sin(angle) * distance + 0.5)`
`col = c + <int>(cos(angle) * distance + 0.5)`
that give offset of (1, 0) for both `pi/2` and `3pi/4`. It should give offset of (1, 0) for `pi/2` and that of (1, -1) for `3pi/4`.

I modified the formulae as:
`row = r + <int>floor(sin(angle) * distance + 0.5)`
`col = c + <int>floor(cos(angle) * distance + 0.5)`
Now it's giving the correct offset.

In offset (x, y), x corresponds to row offset and y corresponds to column offset.
