### PR TITLE
Docstring: typo

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -615,8 +615,8 @@ class SimilarityTransform(ProjectiveTransform):
         a0, a1, b0, b1 = - V[-1, :-1] / V[-1, -1]
 
         self.params = np.array([[a0, -b0, a1],
-                                 [b0,  a0, b1],
-                                 [ 0,   0,  1]])
+                                [b0,  a0, b1],
+                                [ 0,   0,  1]])
 
     @property
     def scale(self):


### PR DESCRIPTION
Hi,

According to #813, there is a typo in a docstring. I suggest to fix it before 0.10 with this PR.
