### PR TITLE
Another solution for rounding in greycomatrix

### DIFF
--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -7,6 +7,8 @@ cimport numpy as cnp
 from libc.math cimport sin, cos, abs
 from skimage._shared.interpolation cimport bilinear_interpolation
 
+cdef inline int _round_towards_zero(double r):
+    return <int>((r + 0.5) if (r > 0.0) else (r - 0.5))
 
 def _glcm_loop(cnp.uint8_t[:, ::1] image, double[:] distances,
                double[:] angles, Py_ssize_t levels,
@@ -48,8 +50,8 @@ def _glcm_loop(cnp.uint8_t[:, ::1] image, double[:] distances,
                     i = image[r, c]
 
                     # compute the location of the offset pixel
-                    row = r + <int>(sin(angle) * distance + 0.5)
-                    col = c + <int>(cos(angle) * distance + 0.5)
+                    row = r + _round_towards_zero(sin(angle) * distance)
+                    col = c + _round_towards_zero(cos(angle) * distance)
 
                     # make sure the offset is within bounds
                     if row >= 0 and row < rows and \


### PR DESCRIPTION
Hi guys,

This is also related to the #899 issue. I just did some code to handle negative numbers based on http://stackoverflow.com/questions/485525/round-for-float-in-c.

I think it makes more sense that always rounding up, as the case with angle=3pi/4 and radius=1 pointed out.
