### PR TITLE
Equality of regionprops

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -336,8 +336,8 @@ class _RegionProperties(MutableMapping):
         for key in PROP_VALS:
             try:
                 #so that NaNs are equal
-                np.testing.assert_equal(
-                    getattr(self, key, None), getattr(other, key, None))
+                np.testing.assert_equal(getattr(self, key, None),
+                                        getattr(other, key, None))
             except AssertionError:
                 return False
 

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -383,8 +383,8 @@ def test_equals():
     r2 = regions[0]
     r3 = regions[1]
 
-    assert r1 == r2
-    assert r1 != r3
+    assert_equal(r1 == r2, True, "Same regionprops are not equal")
+    assert_equal(r1 != r3, True, "Different regionprops are equal")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #945
I've assumed two NaNs to be equal
Otherwise

``` python
regionprops(SAMPLE)[0] == regionprops(SAMPLE)[0] 
```

does not hold

Theoretically speaking two NaNs should not be equal though.
Are there better ways to handle this ?
