### PR TITLE
Warn about matplotlib backend in skimage.viewer

### DIFF
--- a/skimage/viewer/utils/core.py
+++ b/skimage/viewer/utils/core.py
@@ -14,6 +14,9 @@ try:
     else:
         from matplotlib.backends.backend_qt4 import FigureManagerQT
         from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg
+    if 'agg' not in mpl.get_backend().lower():
+        print("Recommended matplotlib backend is `Agg` for full "
+              "skimage.viewer functionality.")
 except ImportError:
     FigureCanvasQTAgg = object  # hack to prevent nosetest and autodoc errors
     LinearSegmentedColormap = object


### PR DESCRIPTION
Addresses https://github.com/scikit-image/scikit-image/issues/884.

@tonysyu Could you please review this, as I was not sure if you intended to print the warning only for OSX?
