### PR TITLE
Random Walker improvements and checks for trivial cases

### DIFF
--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -9,7 +9,6 @@ significantly the performance.
 """
 
 import warnings
-from numbers import Number
 import numpy as np
 from scipy import sparse, ndimage
 
@@ -396,10 +395,6 @@ def random_walker(data, labels, beta=130, mode='bf', tol=1.e-3, copy=True,
     if spacing is None:
         spacing = np.asarray((1.,) * 3)
     elif len(spacing) == len(dims):
-        for i in spacing:
-            if not isinstance(i, Number):
-                raise ValueError('Input `spacing` contained %s, which is not '
-                                 'a number.' % (i))
         if len(spacing) == 2:  # Need a dummy spacing for singleton 3rd dim
             spacing = np.r_[spacing, 1.]
         else:                  # Convert to array

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -305,10 +305,6 @@ def test_bad_inputs():
     np.testing.assert_raises(ValueError,
                              random_walker, img, labels, spacing=(1,))
 
-    # Spacing contains unacceptable information
-    np.testing.assert_raises(
-        ValueError, random_walker, img, labels, spacing=(1, 'chickens'))
-
 
 if __name__ == '__main__':
     np.testing.run_module_suite()


### PR DESCRIPTION
In response to #983

If a fully labeled volume (i.e., no zero-valued regions) is passed as `labels`, `random_walker` now shortcuts and returns the user's data to them with an informative message. This also works if `return_full_prob=True`.

**Documentation fixes**
- Part of the docstring was incorrect; we implemented the solver fallback scheme last release but `'bf'` was still listed as the default solver. This was clarified. 
- The example is now PEP8 compliant.
- Warnings to the user (particularly the UMFPACK warning) were clarified.

**Style**
- This PR improves input checking, converting `assert` statements (who did those, I wonder...) to `if bad_thing: raise exception`.
- The `spacing` kwarg functionality now match the docstring. It also checks to ensure all items in the iterable are numbers (against duck typing philosophy, but if you let this pass the errors are very uninformative).
- Added some whitespace to `random_walker` function to break up code blocks. It's much more readable to me now.

**Tests**
- New features / checks are fully covered.
- Now with more `'chickens'`
