### PR TITLE
FIX: Remove unnecessary .transpose introduced in PR #984

### DIFF
--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -389,7 +389,7 @@ def random_walker(data, labels, beta=130, mode='bf', tol=1.e-3, copy=True,
         dims = data[..., 0].shape  # To reshape final labeled result
         data = img_as_float(data)
         if data.ndim == 3:  # 2D multispectral, needs singleton in 3rd axis
-            data = data[:, :, np.newaxis, :].transpose((0, 1, 3, 2))
+            data = data[:, :, np.newaxis, :]
 
     # Spacing kwarg checks
     if spacing is None:


### PR DESCRIPTION
After the merge of #984, @jni correctly pointed out that moving the `np.newaxis` obviates the need for the `.transpose`. This PR removes the incorrect `.transpose` operation.
