### PR TITLE
Address PendingDeprecationWarnings in watershed tests

### DIFF
--- a/skimage/morphology/tests/test_watershed.py
+++ b/skimage/morphology/tests/test_watershed.py
@@ -154,7 +154,7 @@ class TestWatershed(unittest.TestCase):
                       [-1, -1,  1,  1,  1, -1, -1],
                       [-1, -1, -1, -1, -1, -1, -1],
                       [-1, -1, -1, -1, -1, -1, -1]], out)
-        self.failUnless(error < eps)
+        self.assertTrue(error < eps)
 
     def test_watershed03(self):
         "watershed 3"
@@ -189,7 +189,7 @@ class TestWatershed(unittest.TestCase):
                       [-1, -1, -1, -1, -1, -1, -1],
                       [-1, -1, -1, -1, -1, -1, -1],
                       [-1, -1, -1, -1, -1, -1, -1]], out)
-        self.failUnless(error < eps)
+        self.assertTrue(error < eps)
 
     def test_watershed04(self):
         "watershed 4"
@@ -224,7 +224,7 @@ class TestWatershed(unittest.TestCase):
                       [-1, -1, -1, -1, -1, -1, -1],
                       [-1, -1, -1, -1, -1, -1, -1],
                       [-1, -1, -1, -1, -1, -1, -1]], out)
-        self.failUnless(error < eps)
+        self.assertTrue(error < eps)
 
     def test_watershed05(self):
         "watershed 5"
@@ -259,7 +259,7 @@ class TestWatershed(unittest.TestCase):
                       [-1, -1, -1, -1, -1, -1, -1],
                       [-1, -1, -1, -1, -1, -1, -1],
                       [-1, -1, -1, -1, -1, -1, -1]], out)
-        self.failUnless(error < eps)
+        self.assertTrue(error < eps)
 
     def test_watershed06(self):
         "watershed 6"
@@ -291,7 +291,7 @@ class TestWatershed(unittest.TestCase):
                       [-1, -1, -1, -1, -1, -1, -1],
                       [-1, -1, -1, -1, -1, -1, -1],
                       [-1, -1, -1, -1, -1, -1, -1]], out)
-        self.failUnless(error < eps)
+        self.assertTrue(error < eps)
 
     def test_watershed07(self):
         "A regression test of a competitive case that failed"


### PR DESCRIPTION
Resolves the following warnings raised from the watershed algorithm test suite:

```
./scikit-image/skimage/morphology/tests/test_watershed.py:157: PendingDeprecationWarning: Please use assertTrue instead.
  self.failUnless(error < eps)
./scikit-image/skimage/morphology/tests/test_watershed.py:192: PendingDeprecationWarning: Please use assertTrue instead.
  self.failUnless(error < eps)
./scikit-image/skimage/morphology/tests/test_watershed.py:227: PendingDeprecationWarning: Please use assertTrue instead.
  self.failUnless(error < eps)
./scikit-image/skimage/morphology/tests/test_watershed.py:262: PendingDeprecationWarning: Please use assertTrue instead.
  self.failUnless(error < eps)
./scikit-image/skimage/morphology/tests/test_watershed.py:294: PendingDeprecationWarning: Please use assertTrue instead.
  self.failUnless(error < eps)
```
