### PR TITLE
FIX: Address non-int DeprecationWarning from NumPy

### DIFF
--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -118,7 +118,7 @@ def relabel_sequential(label_field, offset=1):
     if not np.issubdtype(label_field.dtype, np.int):
         new_type = np.min_scalar_type(int(m))
         label_field = label_field.astype(new_type)
-        m = np.round(m).astype(new_type)  # Ensures m is an integer
+        m = m.astype(new_type)  # Ensures m is an integer
     labels = np.unique(label_field)
     labels0 = labels[labels != 0]
     if m == len(labels0):  # nothing to do, already 1...n labels


### PR DESCRIPTION
This PR fixes the following warning being raised by NumPy from `relabel_sequential`, due to `m` not being the proper type if `label_field` was input as floating point. This was raised by the final test case in the suite.

```
skimage/segmentation/_join.py:125: DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  forward_map = np.zeros(m+1, int)
```

I also fixed a discrepancy in the documentation.

Submitting this separately from the non-integer indexing fixes, as this is a different DeprecationWarning.
