### PR TITLE
Clarify `mask` argument in `medial_axis` docstring

### DIFF
--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -163,22 +163,18 @@ def medial_axis(image, mask=None, return_distance=False):
 
     Parameters
     ----------
-
     image : binary ndarray, shape (M, N)
-
+        The image of the shape to be skeletonized.
     mask : binary ndarray, shape (M, N), optional
         If a mask is given, only those elements in `image` with a true
         value in `mask` are used for computing the medial axis.
-
     return_distance : bool, optional
         If true, the distance transform is returned as well as the skeleton.
 
     Returns
     -------
-
     out : ndarray of bools
         Medial axis transform of the image
-
     dist : ndarray of ints, optional
         Distance transform of the image (only returned if `return_distance`
         is True)


### PR DESCRIPTION
Addresses one of the points raised in [this thread](https://groups.google.com/d/msg/scikit-image/XRQy1arQ5E0/GDnYdHrtu4kJ) on the mailing list.
