### PR TITLE
BUG: Fix slicing error revealed by numpy 1.9.0.

### DIFF
--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -124,7 +124,7 @@ def relabel_sequential(label_field, offset=1):
     if m == len(labels0):  # nothing to do, already 1...n labels
         return label_field, labels, labels
     forward_map = np.zeros(m + 1, int)
-    forward_map[labels0] = np.arange(offset, offset + len(labels0) + 1)
+    forward_map[labels0] = np.arange(offset, offset + len(labels0))
     if not (labels == 0).any():
         labels = np.concatenate(([0], labels))
     inverse_map = np.zeros(offset - 1 + len(labels), dtype=np.intp)


### PR DESCRIPTION
Numpy 1.9.0 no longer allows oversize data to be assigned to a
boolean indexed 1-d array by discarding excess elements.

Closes #1050.
