### PR TITLE
Add gitignore for *.pyd Windows libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *#
 *egg-info
 *.so
+*.pyd
 *.bak
 *.c
 *.new


### PR DESCRIPTION
*.pyd files are compiled libraries in Windows and should be ignored in version control.
