### PR TITLE
Fixed threshold in example

### DIFF
--- a/doc/examples/plot_rag_mean_color.py
+++ b/doc/examples/plot_rag_mean_color.py
@@ -19,7 +19,7 @@ labels1 = segmentation.slic(img, compactness=30, n_segments=400)
 out1 = color.label2rgb(labels1, img, kind='avg')
 
 g = graph.rag_mean_color(img, labels1)
-labels2 = graph.cut_threshold(labels1, g, 30)
+labels2 = graph.cut_threshold(labels1, g, 29)
 out2 = color.label2rgb(labels2, img, kind='avg')
 
 plt.figure()


### PR DESCRIPTION
As @jni pointed out, the output image for `rag_mean_color.py`, as seen [here](http://vcansimplify.wordpress.com/2014/07/06/scikit-image-rag-introduction/) is different from the image in the original [Pull  Request](https://github.com/scikit-image/scikit-image/pull/1031), although the code is almost identical.

This change happened in [this](https://github.com/vighneshbirodkar/scikit-image/commit/410aecb354e5ce72c05979b088defcfeab5c131e) commit, when I switched from `int` to `double` ( I have never been more thankful for git in my life) .

I am guessing that one of the edges in the RAG ( as an example ) is taking a value like `360/12 = 29.99..`, due to floating point calculations. While using integers this value was `30` and the edge was cut, thus the cup's shadow and the dish were a separate component. 
### Initial PR

![Initial](https://cloud.githubusercontent.com/assets/3823490/3291723/7074b134-f587-11e3-8c73-d28222891a21.png)
### Current output of `doc/example/plot_rag_mean_color.py`

![figure_bad](https://cloud.githubusercontent.com/assets/3823490/3574563/6737f0a0-0b7f-11e4-9f80-52be5d085e05.png)
### Output in this branch

![figure_good](https://cloud.githubusercontent.com/assets/3823490/3574572/783f0b9a-0b7f-11e4-8dd4-a1a6d3592010.png)
