### PR TITLE
Fix holes in lab conversions and add tests

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -811,7 +811,7 @@ def xyz2lab(xyz, illuminant="D65", observer="2"):
     return np.concatenate([x[..., np.newaxis] for x in [L, a, b]], axis=-1)
 
 
-def lab2xyz(lab, illuminant="D65", observer="2", error_on_invalid=False):
+def lab2xyz(lab, illuminant="D65", observer="2"):
     """CIE-LAB to XYZcolor space conversion.
 
     Parameters
@@ -822,9 +822,6 @@ def lab2xyz(lab, illuminant="D65", observer="2", error_on_invalid=False):
         The name of the illuminant (the function is NOT case sensitive).
     observer : {"2", "10"}, optional
         The aperture angle of the observer.
-     error_on_invalid: optional, bool
-        If true, raise ValueError when pixels are outside the valid gamut.
-        Otherwise, raise a warning.
 
     Returns
     -------
@@ -838,6 +835,8 @@ def lab2xyz(lab, illuminant="D65", observer="2", error_on_invalid=False):
     ValueError
         If either the illuminant or the observer angle are not supported or
         unknown.
+    UserWarning
+        If any of the pixels are invalid (Z < 0).
 
 
     Notes
@@ -862,12 +861,8 @@ def lab2xyz(lab, illuminant="D65", observer="2", error_on_invalid=False):
 
     if np.any(z < 0):
         invalid = np.nonzero(z < 0)
-        msg = 'Color data out of range: Z < 0 in %s pixels' % invalid[0].size
-        if error_on_invalid:
-            raise ValueError(msg)
-        else:
-            warn(msg)
-            z[invalid] = 0
+        warn('Color data out of range: Z < 0 in %s pixels' % invalid[0].size)
+        z[invalid] = 0
 
     out = np.dstack([x, y, z])
 

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -11,6 +11,7 @@ Authors
 :license: modified BSD
 """
 
+from __future__ import division
 import os.path
 
 import numpy as np
@@ -371,6 +372,29 @@ class TestColorconv(TestCase):
     def test_luv_rgb_roundtrip(self):
         img_rgb = img_as_float(self.img_rgb)
         assert_array_almost_equal(luv2rgb(rgb2luv(img_rgb)), img_rgb)
+
+    def test_lab_rgb_outlier(self):
+        lab_array = np.ones((3, 1, 3))
+        lab_array[0] = [50, -12, 85]
+        lab_array[1] = [50, 12, -85]
+        lab_array[2] = [90, -4, -47]
+        rgb_array = np.array([[[0.501, 0.481, 0]],
+                              [[0, 0.482, 1.]],
+                              [[0.578, 0.914, 1.]],
+                              ])
+        assert_almost_equal(lab2rgb(lab_array), rgb_array, decimal=3)
+
+    def test_lab_full_gamut(self):
+        a, b = np.meshgrid(np.arange(-100, 100), np.arange(-100, 100))
+        L = np.ones(a.shape)
+        lab = np.dstack((L, a, b))
+        assert_raises(ValueError, lambda: lab2xyz(lab))
+        multipliers = [0, 10, 50, 100]
+        nan_percents = [12, 9, 0, 0]
+        for (l, perc) in zip(multipliers, nan_percents):
+            lab[:, :, 0] = l
+            out = lab2xyz(lab)
+            assert_equal(int(np.isnan(out).sum() / out.size * 100), perc)
 
     def test_lab_lch_roundtrip(self):
         rgb = img_as_float(self.img_rgb)

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -388,13 +388,11 @@ class TestColorconv(TestCase):
         a, b = np.meshgrid(np.arange(-100, 100), np.arange(-100, 100))
         L = np.ones(a.shape)
         lab = np.dstack((L, a, b))
-        assert_raises(ValueError, lambda: lab2xyz(lab))
-        multipliers = [0, 10, 50, 100]
-        nan_percents = [12, 9, 0, 0]
-        for (l, perc) in zip(multipliers, nan_percents):
-            lab[:, :, 0] = l
-            out = lab2xyz(lab)
-            assert_equal(int(np.isnan(out).sum() / out.size * 100), perc)
+        assert_raises(ValueError, lambda: lab2xyz(lab, error_on_invalid=True))
+        for value in [0, 10, 20]:
+            lab[:, :, 0] = value
+            with expected_warnings(['Color data out of range']):
+                lab2xyz(lab)
 
     def test_lab_lch_roundtrip(self):
         rgb = img_as_float(self.img_rgb)

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -388,7 +388,6 @@ class TestColorconv(TestCase):
         a, b = np.meshgrid(np.arange(-100, 100), np.arange(-100, 100))
         L = np.ones(a.shape)
         lab = np.dstack((L, a, b))
-        assert_raises(ValueError, lambda: lab2xyz(lab, error_on_invalid=True))
         for value in [0, 10, 20]:
             lab[:, :, 0] = value
             with expected_warnings(['Color data out of range']):


### PR DESCRIPTION
While working on the M&M color segmentation gallery example, we noticed that Lab conversion was not working as expected.  Turns out, there are some Lab (and correspondingly XYZ) values that yield a negative RGB channel.  An example is Lab (50, -12, 85).  There are also some values that saturate an RGB channel (e.g. Lab 90, -4, -47).  Also, there are some Lab values that have no corresponding XYZ value, as they result in a Z < 0.  An example is Lab (10, -12, 85).  

This PR mimics the behavior at [EasyRGB](http://www.easyrgb.com/index.php?X=CALC#Result), which is to limit RGB values to [0, 1], and to refuse to convert invalid Lab values.  Invalid values by default raise a `ValueError`, but can set to  result in a warning with those pixels being set to NaN.  I added two tests to cover the new behavior.