### PR TITLE
Move six into install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,11 @@ LICENSE             = 'Modified BSD'
 DOWNLOAD_URL        = 'http://github.com/scikit-image/scikit-image'
 VERSION             = '0.11dev'
 PYTHON_VERSION      = (2, 5)
+
+# These are manually checked.
+# These packages are sometimes installed outside of the setuptools scope
 DEPENDENCIES        = {
                         'numpy': (1, 6),
-                        'six': (1, 3),
                       }
 
 # Only require Cython if we have a developer checkout
@@ -139,7 +141,9 @@ if __name__ == "__main__":
         ],
 
         configuration=configuration,
-
+        install_requires=[
+            "six>=1.3"
+        ],
         packages=setuptools.find_packages(exclude=['doc']),
         include_package_data=True,
         zip_safe=False, # the package can run out of an .egg file


### PR DESCRIPTION
In relation to the topic: https://github.com/scikit-image/scikit-image/issues/1041
Moved the six dependency to install_requires. 
The other dependencies are left where they are, following this discussion:
http://mail.scipy.org/pipermail/numpy-discussion/2012-September/063969.html

Tested in empty virtualenv with py2.7.
