### PR TITLE
Minor fix for bugs in HOG implementation

### DIFF
--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -80,11 +80,11 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
         # to avoid problems with subtracting unsigned numbers in np.diff()
         image = image.astype('float')
     
-    gx = np.empty(image.shape)
+    gx = np.empty(image.shape, dtype=np.double)
     gx[:, 0] = 0
     gx[:, -1] = 0
     gx[:, 1:-1] = image[:, 2:] - image[:, :-2]
-    gy = np.empty(image.shape)
+    gy = np.empty(image.shape, dtype=np.double)
     gy[0, :] = 0
     gy[-1, :] = 0
     gy[1:-1, :] = image[2:, :] - image[:-2, :]


### PR DESCRIPTION
There are some problems with the current implementation of the HOG features:
- The code for the visualisation of the features has the coordinate Y flipped upside down, i.e., the representation of the gradients is mirrored in the vertical direction.
- The gradients are computed calling to `np.diff` for each axis. `np.diff` uses an even length filter [-1, 1] that causes problems when applied in image edges with diagonal orientations.

This [IPython notebook](http://nbviewer.ipython.org/gist/pmneila/832aa665680f54e99937) contains two example images where the current HOG implementation fails and the fixed code provides proper results.
