### PR TITLE
Add mask option to exposure.equalize_hist with test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ script:
     #   The solution was suggested here
     #   https://groups.google.com/a/continuum.io/forum/#!topic/anaconda/-DLG2ZdTkw0
     - if [[ $ENV == python=3.2 ]]; then
-        sudo apt-get install python3-pyqt4;
+        travis_retry sudo apt-get install python3-pyqt4;
         travis_retry pip install matplotlib==1.3.1;
         travis_retry pip install networkx;
       else

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -5,7 +5,7 @@ from skimage import img_as_float
 from skimage.util.dtype import dtype_range, dtype_limits
 
 
-__all__ = ['histogram', 'cumulative_distribution', 'equalize',
+__all__ = ['histogram', 'cumulative_distribution', 'equalize_hist',
            'rescale_intensity', 'adjust_gamma', 'adjust_log', 'adjust_sigmoid']
 
 
@@ -104,7 +104,7 @@ def cumulative_distribution(image, nbins=256):
     return img_cdf, bin_centers
 
 
-def equalize_hist(image, nbins=256):
+def equalize_hist(image, nbins=256, mask=None):
     """Return image after histogram equalization.
 
     Parameters
@@ -113,6 +113,9 @@ def equalize_hist(image, nbins=256):
         Image array.
     nbins : int
         Number of bins for image histogram.
+    mask: ndarray of bools or 0s and 1s, optional
+        Array of same shape as `image`. Only points at which mask == True
+        are used for the equalization, which is applied to the whole image.
 
     Returns
     -------
@@ -130,7 +133,11 @@ def equalize_hist(image, nbins=256):
 
     """
     image = img_as_float(image)
-    cdf, bin_centers = cumulative_distribution(image, nbins)
+    if mask is not None:
+        mask = np.array(mask, dtype=bool)
+        cdf, bin_centers = cumulative_distribution(image[mask], nbins)
+    else:
+        cdf, bin_centers = cumulative_distribution(image, nbins)
     out = np.interp(image.flat, bin_centers, cdf)
     return out.reshape(image.shape)
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -38,6 +38,19 @@ def test_equalize_float():
     check_cdf_slope(cdf)
 
 
+def test_equalize_masked():
+    img = skimage.img_as_float(test_img)
+    mask = np.zeros(test_img.shape)
+    mask[50:150, 50:250] = 1
+    img_mask_eq = exposure.equalize_hist(img, mask=mask)
+    img_eq = exposure.equalize_hist(img)
+
+    cdf, bin_edges = exposure.cumulative_distribution(img_mask_eq)
+    check_cdf_slope(cdf)
+
+    assert not (img_eq == img_mask_eq).all()
+
+
 def check_cdf_slope(cdf):
     """Slope of cdf which should equal 1 for an equalized histogram."""
     norm_intensity = np.linspace(0, 1, len(cdf))


### PR DESCRIPTION
Adds an optional `mask` argument to `exposure.equalize_hist`.  If given, the equalization is calculated based on the unmasked region, and applied to the whole image.  A test is included.  Addresses #1107.
