### PR TITLE
Fix travis build for python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ virtualenv:
 
 before_install:
     - export DISPLAY=:99.0
-    - export SPACER = "\n\n\n\n\n\n\n\n\n\n*************************\n\n"
+    - export SPACER="\n\n\n\n\n\n\n\n\n\n*************************\n\n"
     - sh -e /etc/init.d/xvfb start
     - sudo apt-get update
 


### PR DESCRIPTION
Matplotlib 1.4 does not work on Python 3.2, so specify 1.3.1.  I submitted an issue with mpl.

Also, make installs verbose so we are not left wondering when something fails.
