### PR TITLE
Update find_contours docstring to use r/c notation

### DIFF
--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -35,7 +35,7 @@ def find_contours(array, level,
     -------
     contours : list of (n,2)-ndarrays
         Each contour is an ndarray of shape ``(n, 2)``,
-        consisting of n ``(x, y)`` coordinates along the contour.
+        consisting of n ``(row, column)`` coordinates along the contour.
 
     Notes
     -----


### PR DESCRIPTION
This update fixes #1140.

Other docstrings will probably need to be updated as well.
