### PR TITLE
updated local_binary_pattern documentation

### DIFF
--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -273,8 +273,7 @@ def local_binary_pattern(image, P, R, method='default'):
     .. [1] Multiresolution Gray-Scale and Rotation Invariant Texture
            Classification with Local Binary Patterns.
            Timo Ojala, Matti Pietikainen, Topi Maenpaa.
-           http://www.rafbis.it/biplab15/images/stories/docenti/Danielriccio/\
-           Articoliriferimento/LBP.pdf, 2002.
+           http://www.rafbis.it/biplab15/images/stories/docenti/Danielriccio/Articoliriferimento/LBP.pdf, 2002.
     .. [2] Face recognition with local binary patterns.
            Timo Ahonen, Abdenour Hadid, Matti Pietikainen,
            http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.214.6851,


### PR DESCRIPTION
The reference link was divided into two lines thereby linking to only half the url
