### PR TITLE
Add ndim checks in filter.edges

### DIFF
--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -8,7 +8,7 @@ import six
 from ._warnings import all_warnings
 
 __all__ = ['deprecated', 'get_bound_method_class', 'all_warnings',
-           'safe_as_int']
+           'safe_as_int', 'assert_nD']
 
 
 class skimage_deprecation(Warning):
@@ -141,3 +141,10 @@ def safe_as_int(val, atol=1e-3):
                          "{0}, check inputs.".format(val))
 
     return np.round(val).astype(np.int64)
+
+
+def assert_nD(array, arg_name='image', ndim=2):
+    array = np.asanyarray(array)
+    if array.ndim != ndim:
+        msg = "The parameter `%s` must be a %s-dimensional array"
+        raise ValueError(msg % (arg_name, ndim))

--- a/skimage/filter/edges.py
+++ b/skimage/filter/edges.py
@@ -11,6 +11,7 @@ Original author: Lee Kamentsky
 """
 import numpy as np
 from skimage import img_as_float
+from skimage._shared.utils import assert_nD
 from scipy.ndimage import convolve, binary_erosion, generate_binary_structure
 
 
@@ -80,6 +81,7 @@ def sobel(image, mask=None):
     Note that ``scipy.ndimage.sobel`` returns a directional Sobel which
     has to be further processed to perform edge detection.
     """
+    assert_nD(image)
     return np.sqrt(hsobel(image, mask)**2 + vsobel(image, mask)**2)
 
 
@@ -110,8 +112,7 @@ def hsobel(image, mask=None):
      -1  -2  -1
 
     """
-    if image.ndim != 2:
-        raise TypeError("The input 'image' must be a two-dimensional array.")
+    assert_nD(image)
     image = img_as_float(image)
     result = np.abs(convolve(image, HSOBEL_WEIGHTS))
     return _mask_filter_result(result, mask)
@@ -144,8 +145,7 @@ def vsobel(image, mask=None):
       1   0  -1
 
     """
-    if image.ndim != 2:
-        raise TypeError("The input 'image' must be a two-dimensional array.")
+    assert_nD(image)
     image = img_as_float(image)
     result = np.abs(convolve(image, VSOBEL_WEIGHTS))
     return _mask_filter_result(result, mask)
@@ -215,8 +215,7 @@ def hscharr(image, mask=None):
            of Kernel Based Image Derivatives.
 
     """
-    if image.ndim != 2:
-        raise TypeError("The input 'image' must be a two-dimensional array.")
+    assert_nD(image)
     image = img_as_float(image)
     result = np.abs(convolve(image, HSCHARR_WEIGHTS))
     return _mask_filter_result(result, mask)
@@ -254,8 +253,7 @@ def vscharr(image, mask=None):
            of Kernel Based Image Derivatives.
 
     """
-    if image.ndim != 2:
-        raise TypeError("The input 'image' must be a two-dimensional array.")
+    assert_nD(image)
     image = img_as_float(image)
     result = np.abs(convolve(image, VSCHARR_WEIGHTS))
     return _mask_filter_result(result, mask)
@@ -283,6 +281,7 @@ def prewitt(image, mask=None):
     Return the square root of the sum of squares of the horizontal
     and vertical Prewitt transforms.
     """
+    assert_nD(image)
     return np.sqrt(hprewitt(image, mask)**2 + vprewitt(image, mask)**2)
 
 
@@ -313,8 +312,7 @@ def hprewitt(image, mask=None):
      -1  -1  -1
 
     """
-    if image.ndim != 2:
-        raise TypeError("The input 'image' must be a two-dimensional array.")
+    assert_nD(image)
     image = img_as_float(image)
     result = np.abs(convolve(image, HPREWITT_WEIGHTS))
     return _mask_filter_result(result, mask)
@@ -347,8 +345,7 @@ def vprewitt(image, mask=None):
       1   0  -1
 
     """
-    if image.ndim != 2:
-        raise TypeError("The input 'image' must be a two-dimensional array.")
+    assert_nD(image)
     image = img_as_float(image)
     result = np.abs(convolve(image, VPREWITT_WEIGHTS))
     return _mask_filter_result(result, mask)
@@ -371,6 +368,7 @@ def roberts(image, mask=None):
     output : 2-D array
         The Roberts' Cross edge map.
     """
+    assert_nD(image)
     return np.sqrt(roberts_positive_diagonal(image, mask)**2 +
                    roberts_negative_diagonal(image, mask)**2)
 
@@ -404,8 +402,7 @@ def roberts_positive_diagonal(image, mask=None):
       0  -1
 
     """
-    if image.ndim != 2:
-        raise TypeError("The input 'image' must be a two-dimensional array.")
+    assert_nD(image)
     image = img_as_float(image)
     result = np.abs(convolve(image, ROBERTS_PD_WEIGHTS))
     return _mask_filter_result(result, mask)
@@ -440,8 +437,7 @@ def roberts_negative_diagonal(image, mask=None):
      -1   0
 
     """
-    if image.ndim != 2:
-        raise TypeError("The input 'image' must be a two-dimensional array.")
+    assert_nD(image)
     image = img_as_float(image)
     result = np.abs(convolve(image, ROBERTS_ND_WEIGHTS))
     return _mask_filter_result(result, mask)


### PR DESCRIPTION
This addresses #1147, treating it the same way `feature.canny` does:

``` python
    if image.ndim != 2:
        raise TypeError("The input 'image' must be a two-dimensional array.")
```
