### PR TITLE
Improve performance of disk and diamond selems

### DIFF
--- a/skimage/morphology/selem.py
+++ b/skimage/morphology/selem.py
@@ -115,7 +115,7 @@ def disk(radius, dtype=np.uint8):
     """
     L = np.arange(-radius, radius + 1)
     X, Y = np.meshgrid(L, L)
-    return np.array((X ** 2 + Y ** 2) <= radius ** 2, dtype=np.uint8)
+    return np.array((X ** 2 + Y ** 2) <= radius ** 2, dtype=dtype)
 
 
 def cube(width, dtype=np.uint8):


### PR DESCRIPTION
Replaced np.linspace, range with np.arange
Use less variables.
np.arange is faster than np.linspace in this case.
`diskslow`, `diamondslow` are existing functions.
`diskfast`, `diamondfast` are updated functions.

``` python
def diskslow(radius, dtype=np.uint8):
    L = np.linspace(-radius, radius, 2 * radius + 1)
    (X, Y) = np.meshgrid(L, L)
    s = X**2
    s += Y**2
    return np.array(s <= radius * radius, dtype=dtype)

def diskfast(radius, dtype=np.uint8):
    L = np.arange(-radius, radius + 1)
    X, Y = np.meshgrid(L, L)
    return np.array((X ** 2 + Y ** 2) <= radius ** 2, dtype=dtype)

def diamondslow(radius, dtype=np.uint8):
    half = radius
    (I, J) = np.meshgrid(range(0, radius * 2 + 1), range(0, radius * 2 + 1))
    s = np.abs(I - half) + np.abs(J - half)
    return np.array(s <= radius, dtype=dtype)

def diamondfast(radius, dtype=np.uint8):
    L = np.arange(0, radius * 2 + 1)
    I, J = np.meshgrid(L, L)
    return np.array(np.abs(I - radius) + np.abs(J - radius) <= radius,
                    dtype=dtype)
```

Speed tests:

``` python
%timeit diamondslow(5)
%timeit diamondfast(5)
%timeit diamondslow(50)
%timeit diamondfast(50)
1000 loops, best of 3: 141 µs per loop
10000 loops, best of 3: 108 µs per loop
1000 loops, best of 3: 559 µs per loop
1000 loops, best of 3: 439 µs per loop
```

``` python
%timeit diskslow(5)
%timeit diskfast(5)
%timeit diskslow(50)
%timeit diskfast(50)
1000 loops, best of 3: 162 µs per loop
10000 loops, best of 3: 110 µs per loop
1000 loops, best of 3: 457 µs per loop
1000 loops, best of 3: 350 µs per loop
```
