### PR TITLE
Move debug info into top level Travis for visibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,12 @@ before_install:
     - export WHEELHOUSE="--no-index --find-links=http://travis-wheels.scikit-image.org/"
     - travis_retry tools/travis_setup.sh
 
+    - python check_bento_build.py
+
+    - tools/header.py "Dependency versions"
+    - tools/build_versions.py
+
+
 install:
     - python setup.py build_ext --inplace
     - python setup.py install

--- a/tools/travis_setup.sh
+++ b/tools/travis_setup.sh
@@ -16,10 +16,6 @@ if [[ $TRAVIS_PYTHON_VERSION == 2.7* ]]; then
 fi
 
 pip install -r requirements.txt $WHEELHOUSE
-python check_bento_build.py
-
-tools/header.py "Dependency versions"
-tools/build_versions.py
 
 # clean up disk space
 sudo apt-get clean


### PR DESCRIPTION
This makes it easier to check output of `check_bento_build.py` and `tools/build_versions.py` without scrolling past hundreds of lines.
