### PR TITLE
Remove build status until Travis-CI yields stable builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 Image Processing SciKit
 =======================
 
-[![Build Status](https://travis-ci.org/scikit-image/scikit-image.svg)](https://travis-ci.org/scikit-image/scikit-image)
 [![Coverage Status](https://img.shields.io/coveralls/scikit-image/scikit-image.svg)](https://coveralls.io/r/scikit-image/scikit-image?branch=master)
 
 Source


### PR DESCRIPTION
I tried multiple times today to restart the master build--it broke each time (without a valid error).  We can't have a banner saying broken in the README when that's not true.
