### PR TITLE
Update docs for img_as_ubyte

### DIFF
--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -304,7 +304,8 @@ def img_as_uint(image, force_copy=False):
 
     Notes
     -----
-    Negative input values will be clipped.
+    Negative input values will be clipped. 
+    Positive values are scaled between 0 and 65535.
 
     """
     return convert(image, np.uint16, force_copy)
@@ -327,6 +328,7 @@ def img_as_int(image, force_copy=False):
 
     Notes
     -----
+    The values are scaled between -32768 and 32767.
     If the input data-type is positive-only (e.g., uint8), then
     the output image will still only have positive values.
 
@@ -351,7 +353,8 @@ def img_as_ubyte(image, force_copy=False):
 
     Notes
     -----
-    Negative input values will be clipped.
+    Negative input values will be clipped. 
+    Positive values are scaled between 0 and 255.
 
     """
     return convert(image, np.uint8, force_copy)


### PR DESCRIPTION
The line in `img_as_ubyte` needs correction; ubyte cannot hold negative data. From a quick experiment it seems like both `img_as_uint` and `img_as_ubyte` clip negative values (and not shift them to the positive domain).
