### PR TITLE
fix github logo in navbar

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ scipy>=0.9
 six>=1.3
 networkx>=1.8
 pillow>=1.1.7
-Sphinx==1.2.3


### PR DESCRIPTION
Url to logo is static and relative, therefor at some pages (http://scikit-image.org/docs/dev/api/api.html) the github logo doesn't show up.

I'm unable to test this, as I'm unable to build doc (I'll create an issue), but I guess this is such a simple fix that someone with knowledge of the doc internals should easily see if this is the correct fix.
