### PR TITLE
Added an import of `median` from the `filters` module

### DIFF
--- a/skimage/filters/tests/test_filter_import.py
+++ b/skimage/filters/tests/test_filter_import.py
@@ -1,6 +1,5 @@
 from warnings import catch_warnings, simplefilter
 
-from skimage.filters import median
 
 def test_filter_import():
     with catch_warnings():

--- a/skimage/filters/tests/test_median.py
+++ b/skimage/filters/tests/test_median.py
@@ -1,0 +1,2 @@
+def test_median_in_filters():
+    from skimage.filters import median


### PR DESCRIPTION
(it's `filters.rank.median`, but it is convenient to have the very common
median filter in `filters` as well)

Following Issue #1236 
