### PR TITLE
Updated docs for `regionprops`

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -332,7 +332,7 @@ def regionprops(label_image, intensity_image=None, cache=True):
     Parameters
     ----------
     label_image : (N, M) ndarray
-        Labeled input image.
+        Labeled input image. Labels with value 0 are ignored.
     intensity_image : (N, M) ndarray, optional
         Intensity image with same size as labeled image. Default is None.
     cache : bool, optional


### PR DESCRIPTION
The current implementation of `regionprops` calls out to `scipy.ndimage.find_objects` which ignores regions labelled with 0.

The fact is currently not reflected in `scikit-image` documentation which is what the current pull request fixes.
