### PR TITLE
Blob detection supports for non-integer sigmas

### DIFF
--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -200,7 +200,7 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
                                   footprint=np.ones((3, 3, 3)),
                                   threshold_rel=0.0,
                                   exclude_border=False)
-    # Convert array to float64
+    # Convert local_maxima to float64
     lm = local_maxima.astype('float64')
     # Convert the last index to its corresponding scale value
     lm[:,2] = sigma_list[local_maxima[:,2]]
@@ -302,7 +302,7 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
                                   threshold_rel=0.0,
                                   exclude_border=False)
 
-    # Convert array to float64
+    # Convert local_maxima to float64
     lm = local_maxima.astype('float64')
     # Convert the last index to its corresponding scale value
     lm[:,2] = sigma_list[local_maxima[:,2]]
@@ -413,7 +413,7 @@ def blob_doh(image, min_sigma=1, max_sigma=30, num_sigma=10, threshold=0.01,
                                   threshold_rel=0.0,
                                   exclude_border=False)
 
-    # Convert array to float64
+    # Convert local_maxima to float64
     lm = local_maxima.astype('float64')
     # Convert the last index to its corresponding scale value
     lm[:,2] = sigma_list[local_maxima[:,2]]

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -200,8 +200,8 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
                                   footprint=np.ones((3, 3, 3)),
                                   threshold_rel=0.0,
                                   exclude_border=False)
-    # Convert array to float32
-    lm = local_maxima.astype('float32')
+    # Convert array to float64
+    lm = local_maxima.astype('float64')
     # Convert the last index to its corresponding scale value
     lm[:,2] = sigma_list[local_maxima[:,2]]
     local_maxima = lm
@@ -302,8 +302,8 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
                                   threshold_rel=0.0,
                                   exclude_border=False)
 
-    # Convert array to float32
-    lm = local_maxima.astype('float32')
+    # Convert array to float64
+    lm = local_maxima.astype('float64')
     # Convert the last index to its corresponding scale value
     lm[:,2] = sigma_list[local_maxima[:,2]]
     local_maxima = lm
@@ -413,8 +413,8 @@ def blob_doh(image, min_sigma=1, max_sigma=30, num_sigma=10, threshold=0.01,
                                   threshold_rel=0.0,
                                   exclude_border=False)
 
-    # Convert array to float32
-    lm = local_maxima.astype('float32')
+    # Convert array to float64
+    lm = local_maxima.astype('float64')
     # Convert the last index to its corresponding scale value
     lm[:,2] = sigma_list[local_maxima[:,2]]
     local_maxima = lm

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -200,9 +200,11 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
                                   footprint=np.ones((3, 3, 3)),
                                   threshold_rel=0.0,
                                   exclude_border=False)
-
+    # Convert array to float32
+    lm = local_maxima.astype('float32')
     # Convert the last index to its corresponding scale value
-    local_maxima[:, 2] = sigma_list[local_maxima[:, 2]]
+    lm[:,2] = sigma_list[local_maxima[:,2]]
+    local_maxima = lm
     return _prune_blobs(local_maxima, overlap)
 
 
@@ -300,8 +302,11 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
                                   threshold_rel=0.0,
                                   exclude_border=False)
 
+    # Convert array to float32
+    lm = local_maxima.astype('float32')
     # Convert the last index to its corresponding scale value
-    local_maxima[:, 2] = sigma_list[local_maxima[:, 2]]
+    lm[:,2] = sigma_list[local_maxima[:,2]]
+    local_maxima = lm
     return _prune_blobs(local_maxima, overlap)
 
 
@@ -408,6 +413,9 @@ def blob_doh(image, min_sigma=1, max_sigma=30, num_sigma=10, threshold=0.01,
                                   threshold_rel=0.0,
                                   exclude_border=False)
 
+    # Convert array to float32
+    lm = local_maxima.astype('float32')
     # Convert the last index to its corresponding scale value
-    local_maxima[:, 2] = sigma_list[local_maxima[:, 2]]
+    lm[:,2] = sigma_list[local_maxima[:,2]]
+    local_maxima = lm
     return _prune_blobs(local_maxima, overlap)


### PR DESCRIPTION
Hello,
I noticed that in all the blob detectors peaks are found like this:

    local_maxima = peak_local_max(image_cube, threshold_abs=threshold,
                                  footprint=np.ones((3, 3, 3)),
                                  threshold_rel=0.0,
                                  exclude_border=False)

    # Convert the last index to its corresponding scale value
    local_maxima[:, 2] = sigma_list[local_maxima[:, 2]]
    
My sigma list contains floats in it that a re converted to int64 when the sigma list is copied back into local_maxima.  I had to modify the code so local_maxima[:,2] still contained a list of integers but the results are now stored as a float32.

I've made a quick change to fix this issue:

    # Convert array to float32
    lm = local_maxima.astype('float32')
    lm[:,2] = sigma_list[local_maxima[:,2]]
    local_maxima = lm