### PR TITLE
Move the virtual framebuffer to top level yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ python:
 
 before_install:
     - export DISPLAY=:99.0
+    - sh -e /etc/init.d/xvfb start
     - export PYTHONWARNINGS="all"
     - export WHEELHOUSE="--no-index --find-links=http://travis-wheels.scikit-image.org/"
     - sudo apt-get update

--- a/tools/travis_setup.sh
+++ b/tools/travis_setup.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -ex
 
-sh -e /etc/init.d/xvfb start
-
 # on Python 2.7, use the system versions of numpy, scipy, and matplotlib
 # and the minimum version of cython and networkx
 if [[ $TRAVIS_PYTHON_VERSION == 2.7* ]]; then


### PR DESCRIPTION
See discussion from Google Groups: https://groups.google.com/forum/#!topic/scikit-image/hCKQU-PSasM.  Previously, `travis_retry` was not working for `travis_setup.py` because trying to start the virtual framebuffer caused an error.  
