### PR TITLE
Install simpleitk from wheelhouse if available

### DIFF
--- a/tools/travis_install_optional.sh
+++ b/tools/travis_install_optional.sh
@@ -33,10 +33,8 @@ if [[ $TRAVIS_PYTHON_VERSION != 3.2 ]]; then
     pip install -q imread
 fi
 
-# TODO: update when SimpleITK become available on py34 or hopefully pip
-if [[ $TRAVIS_PYTHON_VERSION != 3.4 ]]; then
-    easy_install -q SimpleITK
-fi
+# Install SimpleITK from wheelhouse if available
+pip install -q SimpleITK $WHEELHOUSE; true
 
 sudo apt-get install -q libfreeimage3
 pip install -q astropy $WHEELHOUSE


### PR DESCRIPTION
No more being at the whims of their SourceForge hosting and having to use `easy_install`.
Only available for Py26, Py27, and Py33 at the moment.
