### PR TITLE
Create a new figure for imshow if there is already data

### DIFF
--- a/skimage/io/_plugins/matplotlib_plugin.py
+++ b/skimage/io/_plugins/matplotlib_plugin.py
@@ -2,6 +2,8 @@ import matplotlib.pyplot as plt
 
 
 def imshow(*args, **kwargs):
+    if plt.gca().has_data():
+        plt.figure()
     kwargs.setdefault('interpolation', 'nearest')
     kwargs.setdefault('cmap', 'gray')
     plt.imshow(*args, **kwargs)


### PR DESCRIPTION
This closes #599.  When calling `imshow`, we create a new figure if the current axes has data on it.  The following code now results in exactly two figures regardless of whether we use the `plt.figure()` calls:

``` python
import matplotlib.pyplot as plt
from skimage import io, data

x = data.moon()
y = data.camera()

plt.figure()
io.imshow(x)

plt.figure()
io.imshow(y)

io.show()
```
