### PR TITLE
TST: Test for selem.cube

### DIFF
--- a/skimage/morphology/tests/test_selem.py
+++ b/skimage/morphology/tests/test_selem.py
@@ -30,6 +30,13 @@ class TestSElem():
                 expected_mask = np.ones((i, j), dtype='uint8')
                 assert_equal(expected_mask, actual_mask)
 
+    def test_cube_selem(self):
+        """Test cube structuring elements"""
+        for k in range(0, 5):
+            actual_mask = selem.cube(k)
+            expected_mask = np.ones((k, k, k), dtype='uint8')
+            assert_equal(expected_mask, actual_mask)
+
     def strel_worker(self, fn, func):
         matlab_masks = np.load(os.path.join(data_dir, fn))
         k = 0


### PR DESCRIPTION
Add test case for selem.cube

Also begs a minor question -  for organizing test cases while tracking. Would it be better to write test cases/functions in same order as they are in module? 
Like if the order of functions in selem.py is 

```
selem.square()
selem.rectangle()
selem.disk()
```

should the test cases for each of these also be in same order? This is just a personal preference but can be ignored depending upon what others think..
