### PR TITLE
Added an example of use of CanvasTools.RectTool 

### DIFF
--- a/skimage/viewer/canvastools/recttool.py
+++ b/skimage/viewer/canvastools/recttool.py
@@ -37,8 +37,40 @@ class RectangleTool(CanvasToolBase, RectangleSelector):
     ----------
     extents : tuple
         Rectangle extents: (xmin, xmax, ymin, ymax).
-    """
+    
 
+     Examples
+    --------
+    >>>from skimage import data
+    >>>import matplotlib.pyplot as plt
+    >>>from skimage.viewer.canvastools import RectangleTool
+    >>>import numpy as np
+    >>>from skimage.draw import line
+    >>>from skimage.draw import set_color
+
+    >>>im = data.lena()
+    >>>[f, ax] = plt.subplots()
+    >>>ax.imshow(im)
+
+    >>>def stampa(extents):
+    >>>>>>global im,ax
+    >>>>>>coord = np.int64(extents)
+    >>>>>>[rr1, cc1] = line(coord[2],coord[0],coord[2],coord[1])
+    >>>>>>[rr2, cc2] = line(coord[2],coord[1],coord[3],coord[1])
+    >>>>>>[rr3, cc3] = line(coord[3],coord[1],coord[3],coord[0])
+    >>>>>>[rr4, cc4] = line(coord[3],coord[0],coord[2],coord[0])
+    >>>>>>set_color(im, (rr1, cc1), [255, 255, 0])
+    >>>>>>set_color(im, (rr2, cc2), [0, 255, 255])
+    >>>>>>set_color(im, (rr3, cc3), [255, 0, 255])
+    >>>>>>set_color(im, (rr4, cc4), [0, 0, 0])
+    >>>>>>ax.imshow(im)
+    >>>>>>plt.show()
+
+    >>>rect_tool = RectangleTool(ax, on_enter=stampa)
+    >>>plt.show()
+ 
+    """
+    
     def __init__(self, viewer, on_move=None, on_release=None, on_enter=None,
                  maxdist=10, rect_props=None):
         CanvasToolBase.__init__(self, viewer, on_move=on_move,


### PR DESCRIPTION
in order to allow generation of docs.

RectTool is used to write rectangles over an image (lena).
This example also can be useful for set_color explanation using both [RGB] and single value color setting
