### PR TITLE
Remove unnecessary `measure.label` shim

### DIFF
--- a/skimage/measure/__init__.py
+++ b/skimage/measure/__init__.py
@@ -9,7 +9,7 @@ from ._moments import moments, moments_central, moments_normalized, moments_hu
 from .profile import profile_line
 from .fit import LineModel, CircleModel, EllipseModel, ransac
 from .block import block_reduce
-from ._label import label
+from ._ccomp import label
 
 
 __all__ = ['find_contours',


### PR DESCRIPTION
`measure._label` was unnecessary and has already gotten out of date once.  Moves the import from `_ccomp` up to the package level.
