### PR TITLE
DOC: change colormap away from "jet" in examples

### DIFF
--- a/doc/examples/edges/plot_canny.py
+++ b/doc/examples/edges/plot_canny.py
@@ -38,7 +38,7 @@ edges2 = feature.canny(im, sigma=3)
 fig, (ax1, ax2, ax3) = plt.subplots(nrows=1, ncols=3, figsize=(8, 3),
                                     sharex=True, sharey=True)
 
-ax1.imshow(im, cmap=plt.cm.jet)
+ax1.imshow(im, cmap=plt.cm.gray)
 ax1.axis('off')
 ax1.set_title('noisy image', fontsize=20)
 

--- a/doc/examples/edges/plot_edge_filter.py
+++ b/doc/examples/edges/plot_edge_filter.py
@@ -76,11 +76,11 @@ ax1.imshow(edge_scharr, cmap=plt.cm.gray)
 ax1.set_title('Scharr Edge Detection')
 ax1.axis('off')
 
-ax2.imshow(diff_scharr_prewitt, cmap=plt.cm.jet, vmax=max_diff)
+ax2.imshow(diff_scharr_prewitt, cmap=plt.cm.gray, vmax=max_diff)
 ax2.set_title('Scharr - Prewitt')
 ax2.axis('off')
 
-ax3.imshow(diff_scharr_sobel, cmap=plt.cm.jet, vmax=max_diff)
+ax3.imshow(diff_scharr_sobel, cmap=plt.cm.gray, vmax=max_diff)
 ax3.set_title('Scharr - Sobel')
 ax3.axis('off')
 

--- a/doc/examples/filters/plot_entropy.py
+++ b/doc/examples/filters/plot_entropy.py
@@ -63,7 +63,7 @@ ax0.set_title("Image")
 ax0.axis("off")
 fig.colorbar(img0, ax=ax0)
 
-img1 = ax1.imshow(entropy(image, disk(5)), cmap=plt.cm.jet)
+img1 = ax1.imshow(entropy(image, disk(5)), cmap=plt.cm.gray)
 ax1.set_title("Entropy")
 ax1.axis("off")
 fig.colorbar(img1, ax=ax1)

--- a/doc/examples/filters/plot_phase_unwrap.py
+++ b/doc/examples/filters/plot_phase_unwrap.py
@@ -68,18 +68,18 @@ image_unwrapped_wrap_around = unwrap_phase(image_wrapped,
 fig, ax = plt.subplots(2, 2)
 ax1, ax2, ax3, ax4 = ax.ravel()
 
-fig.colorbar(ax1.imshow(np.ma.array(image, mask=mask), cmap='jet'), ax=ax1)
+fig.colorbar(ax1.imshow(np.ma.array(image, mask=mask), cmap='rainbow'), ax=ax1)
 ax1.set_title('Original')
 
-fig.colorbar(ax2.imshow(image_wrapped, cmap='jet', vmin=-np.pi, vmax=np.pi),
+fig.colorbar(ax2.imshow(image_wrapped, cmap='rainbow', vmin=-np.pi, vmax=np.pi),
              ax=ax2)
 ax2.set_title('Wrapped phase')
 
-fig.colorbar(ax3.imshow(image_unwrapped_no_wrap_around, cmap='jet'),
+fig.colorbar(ax3.imshow(image_unwrapped_no_wrap_around, cmap='rainbow'),
              ax=ax3)
 ax3.set_title('Unwrapped without wrap_around')
 
-fig.colorbar(ax4.imshow(image_unwrapped_wrap_around, cmap='jet'), ax=ax4)
+fig.colorbar(ax4.imshow(image_unwrapped_wrap_around, cmap='rainbow'), ax=ax4)
 ax4.set_title('Unwrapped with wrap_around')
 
 plt.show()

--- a/doc/examples/segmentation/plot_watershed.py
+++ b/doc/examples/segmentation/plot_watershed.py
@@ -54,7 +54,7 @@ ax0, ax1, ax2 = axes
 
 ax0.imshow(image, cmap=plt.cm.gray, interpolation='nearest')
 ax0.set_title('Overlapping objects')
-ax1.imshow(-distance, cmap=plt.cm.jet, interpolation='nearest')
+ax1.imshow(-distance, cmap=plt.cm.gray, interpolation='nearest')
 ax1.set_title('Distances')
 ax2.imshow(labels, cmap=plt.cm.spectral, interpolation='nearest')
 ax2.set_title('Separated objects')

--- a/doc/examples/xx_applications/plot_coins_segmentation.py
+++ b/doc/examples/xx_applications/plot_coins_segmentation.py
@@ -116,7 +116,7 @@ from skimage.filters import sobel
 elevation_map = sobel(coins)
 
 fig, ax = plt.subplots(figsize=(4, 3))
-ax.imshow(elevation_map, cmap=plt.cm.jet, interpolation='nearest')
+ax.imshow(elevation_map, cmap=plt.cm.gray, interpolation='nearest')
 ax.axis('off')
 ax.set_title('elevation_map')
 

--- a/doc/examples/xx_applications/plot_rank_filters.py
+++ b/doc/examples/xx_applications/plot_rank_filters.py
@@ -552,7 +552,7 @@ ax1.set_title('Image')
 ax1.axis('off')
 ax1.set_adjustable('box-forced')
 
-fig.colorbar(ax2.imshow(entropy(image, disk(5)), cmap=plt.cm.jet), ax=ax2)
+fig.colorbar(ax2.imshow(entropy(image, disk(5)), cmap=plt.cm.gray), ax=ax2)
 ax2.set_title('Entropy')
 ax2.axis('off')
 ax2.set_adjustable('box-forced')


### PR DESCRIPTION
1. `jet` is generally discouraged as perceptually misleading: https://github.com/matplotlib/matplotlib/issues/875#issue-4616667
2. I think it's more clear when all 3 images use the same colormap, to show how an edge detector converts a solid block of brightness into bright lines on just the edges:

```
          ______
    _____/      \_____  -->  _____/\____/\_____
```