### PR TITLE
Integer division incorrect for match_template

### DIFF
--- a/skimage/feature/template.py
+++ b/skimage/feature/template.py
@@ -131,8 +131,9 @@ def match_template(image, template, pad_input=False, mode='constant',
         image_window_sum = _window_sum_3d(image, template.shape)
         image_window_sum2 = _window_sum_3d(image ** 2, template.shape)
 
-    template_volume = np.prod(template.shape)
-    template_ssd = np.sum((template - template.mean()) ** 2)
+    template_volume = float(np.prod(template.shape))
+    template_ssd = float(np.sum((template - template.mean()) ** 2))
+    template_sum = float(template.sum())
 
     if image.ndim == 2:
         xcorr = fftconvolve(image, template[::-1, ::-1],
@@ -141,7 +142,7 @@ def match_template(image, template, pad_input=False, mode='constant',
         xcorr = fftconvolve(image, template[::-1, ::-1, ::-1],
                             mode="valid")[1:-1, 1:-1, 1:-1]
 
-    nom = xcorr - image_window_sum * (template.sum() / template_volume)
+    nom = xcorr - image_window_sum * (template_sum / template_volume)
 
     denom = image_window_sum2
     np.multiply(image_window_sum, image_window_sum, out=image_window_sum)

--- a/skimage/feature/template.py
+++ b/skimage/feature/template.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import numpy as np
 from scipy.signal import fftconvolve
 
@@ -131,9 +132,9 @@ def match_template(image, template, pad_input=False, mode='constant',
         image_window_sum = _window_sum_3d(image, template.shape)
         image_window_sum2 = _window_sum_3d(image ** 2, template.shape)
 
-    template_volume = float(np.prod(template.shape))
-    template_ssd = float(np.sum((template - template.mean()) ** 2))
-    template_sum = float(template.sum())
+    template_volume = np.prod(template.shape)
+    template_ssd = np.sum((template - template.mean()) ** 2)
+    template_sum = template.sum()
 
     if image.ndim == 2:
         xcorr = fftconvolve(image, template[::-1, ::-1],


### PR DESCRIPTION
Corrected a problem in match_template where integer division was
used when computing a scale factor in match_template.  This problem
caused large differences in match_template results between the Linux
and Windows platforms.