### PR TITLE
ENH: Strip doctest annotations before building docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.old
 doc/source/api
 doc/build
+doc/_prebuild
 source/api
 build
 dist

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -10,11 +10,11 @@ PAPER         ?=
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+ALLSPHINXOPTS   = -d build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) _prebuild
 DEST = build
-.PHONY: all help clean html dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest gitwash gh-pages coveragetable random_gallery
+.PHONY: all help clean html dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest gitwash gh-pages coveragetable random_gallery prebuild prebuild_docstrip
 
-all: html
+all: clean html
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -31,24 +31,38 @@ help:
 	@echo "  linkcheck to check all external links for integrity"
 	@echo "  doctest   to run all doctests embedded in the documentation (if enabled)"
 	@echo "  gitwash   to update the gitwash documentation"
+
+prebuild:
+	-rm -rf ./_prebuild
+	$(PYTHON) tools/doctest_strip.py --NOSTRIP
+	@echo Copying doc sources to ./_prebuild
+
+prebuild_docstrip:
+	-rm -rf ./_prebuild
+	$(PYTHON) tools/doctest_strip.py
+	@echo Removing doctest annotations from doc sources.
+	@echo Copying doc sources to ./_prebuild
+
 clean:
-	-rm -rf $(DEST)/*
-	-rm -rf source/api
+	-rm -rf ./$(DEST)/*
+	-rm -rf ./_prebuild/*
+	-rm -rf ./source/api
 	-find ./source/auto_examples/* -type f | grep -v blank | xargs rm -f
+
 api:
 	@mkdir -p source/api
 	$(PYTHON) tools/build_modref_templates.py
 	@echo "Build API docs...done."
 
 random_gallery:
-	@cd source && $(PYTHON) random_gallery.py
+	@cd _prebuild && $(PYTHON) random_gallery.py
 
 coveragetable:
-	@cd source && $(PYTHON) coverage_generator.py
+	@cd _prebuild && $(PYTHON) coverage_generator.py
 
-html: api coveragetable random_gallery
+html: api prebuild_docstrip coveragetable random_gallery
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(DEST)/html
-	cp -r source/plots $(DEST)/html
+	cp -r _prebuild/plots $(DEST)/html
 	@echo
 	@echo "Build finished. The HTML pages are in build/html."
 
@@ -91,7 +105,7 @@ devhelp:
 	@echo "# ln -s build/devhelp $$HOME/.local/share/devhelp/scikitimage"
 	@echo "# devhelp"
 
-latex: api
+latex: api prebuild_docstrip
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(DEST)/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in $(DEST)/latex."
@@ -124,7 +138,7 @@ gh-pages:
 	$(PYTHON) gh-pages.py
 
 gitwash:
-	$(PYTHON) tools/gitwash/gitwash_dumper.py source scikit-image \
+	$(PYTHON) tools/gitwash/gitwash_dumper.py _prebuild scikit-image \
 	--project-url=http://scikit-image.org \
 	--project-ml-url=http://groups.google.com/group/scikit-image \
 	--repo-name=scikit-image \

--- a/doc/examples/plot_ncut.py
+++ b/doc/examples/plot_ncut.py
@@ -12,7 +12,7 @@ References
        Pattern Analysis and Machine Intelligence,
        IEEE Transactions on, vol. 22, no. 8, pp. 888-905, August 2000.
 """
-from skimage import graph, data, io, segmentation, color
+from skimage import graph, data, segmentation, color
 from matplotlib import pyplot as plt
 
 
@@ -25,8 +25,10 @@ g = graph.rag_mean_color(img, labels1, mode='similarity')
 labels2 = graph.cut_normalized(labels1, g)
 out2 = color.label2rgb(labels2, img, kind='avg')
 
-plt.figure()
-io.imshow(out1)
-plt.figure()
-io.imshow(out2)
-io.show()
+fig, ax = plt.subplots()
+ax.imshow(out1)
+
+fig2, ax2 = plt.subplots()
+ax2.imshow(out2)
+
+plt.show()

--- a/doc/examples/plot_rag.py
+++ b/doc/examples/plot_rag.py
@@ -51,10 +51,10 @@ def max_edge(g, src, dst, n):
 def display(g, title):
     """Displays a graph with the given title."""
     pos = nx.circular_layout(g)
-    plt.figure()
-    plt.title(title)
-    nx.draw(g, pos)
-    nx.draw_networkx_edge_labels(g, pos, font_size=20)
+    fig, ax = plt.subplots()
+    ax.set_title(title)
+    nx.draw(g, pos, ax=ax)
+    nx.draw_networkx_edge_labels(g, pos, font_size=20, ax=ax)
 
 
 g = rag.RAG()

--- a/doc/examples/plot_rag_mean_color.py
+++ b/doc/examples/plot_rag_mean_color.py
@@ -9,7 +9,7 @@ difference in mean color. We then join regions with similar mean color.
 
 """
 
-from skimage import graph, data, io, segmentation, color
+from skimage import graph, data, segmentation, color
 from matplotlib import pyplot as plt
 
 
@@ -22,8 +22,10 @@ g = graph.rag_mean_color(img, labels1)
 labels2 = graph.cut_threshold(labels1, g, 29)
 out2 = color.label2rgb(labels2, img, kind='avg')
 
-plt.figure()
-io.imshow(out1)
-plt.figure()
-io.imshow(out2)
-io.show()
+fig, ax = plt.subplots()
+ax.imshow(out1)
+
+fig2, ax2 = plt.subplots()
+ax2.imshow(out2)
+
+plt.show()

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -3,7 +3,7 @@
 REM Command file for Sphinx documentation
 
 set SPHINXBUILD=sphinx-build
-set ALLSPHINXOPTS=-d build/doctrees %SPHINXOPTS% source
+set ALLSPHINXOPTS=-d build/doctrees %SPHINXOPTS% _prebuild
 if NOT "%PAPER%" == "" (
 	set ALLSPHINXOPTS=-D latex_paper_size=%PAPER% %ALLSPHINXOPTS%
 )
@@ -27,22 +27,27 @@ if "%1" == "help" (
 	goto end
 )
 
+rmdir /q /s _prebuild
+mkdir _prebuild
+python tools/doctest_strip.py
+
 for %%x in (html htmlhelp latex qthelp) do (
 	if "%1" == "%%x" (
-		md source\api 2>NUL
+		md _prebuild\api 2>NUL
 		python tools/build_modref_templates.py
 	)
 )
 
-
 if "%1" == "clean" (
 	for /d %%i in (build\*) do rmdir /q /s %%i
 	del /q /s build\*
+	for /d %%i in (_prebuild\*) do rmdir /q /s %%i
+	del /q /s _prebuild\*
 	goto end
 )
 
 if "%1" == "html" (
-	cd source && python random_gallery.py && python coverage_generator.py && cd ..
+	cd _prebuild && python random_gallery.py && python coverage_generator.py && cd ..
 	%SPHINXBUILD% -b html %ALLSPHINXOPTS% build/html
 	echo.
 	echo.Build finished. The HTML pages are in build/html.

--- a/doc/tools/build_modref_templates.py
+++ b/doc/tools/build_modref_templates.py
@@ -2,7 +2,7 @@
 """Script to auto-generate our API docs.
 """
 # stdlib imports
-import os, sys
+import sys
 
 # local imports
 from apigen import ApiDocWriter

--- a/doc/tools/doctest_strip.py
+++ b/doc/tools/doctest_strip.py
@@ -1,0 +1,55 @@
+"""
+Copy documentation files into new temp directory removing doctest annotations.
+
+"""
+
+# Stdlib imports
+import os
+import re
+import shutil
+
+find_doctest = re.compile(r"\s*?# doctest: \++")
+
+
+def strip_doctest_annotations(path):
+    """
+    Remove trailing ' # doctest +' annotations if present.
+    """
+    # Open file, read it line by line
+    temp = []
+    with open(path, 'r') as docfile:
+        for line in docfile:
+            temp.append(find_doctest.split(line)[0])
+
+    # Write back result
+    with open(path, 'w') as new_docfile:
+        new_docfile.writelines(temp)
+
+
+if __name__ == '__main__':
+    import sys
+
+    # Copy doc source to a new temp directory
+    shutil.copytree('./source/', './_prebuild/')
+
+    # Parse input flags, see if doctest stripping was requested
+    if len(sys.argv) < 2:
+        # Parse by default, with no additional flags
+
+        # Find text-like files in _prebuild which need this applied, currently
+        #   *.py
+        #   *.txt
+        files_to_strip = []
+        for root, dirnames, filenames in os.walk('./_prebuild/'):
+            for filename in filenames:
+                if filename.endswith(('.txt', '.py')):
+                    files_to_strip.append(os.path.join(root, filename))
+
+        # Strip out all lines matching find_doctest pattern
+        for text_file in files_to_strip:
+            strip_doctest_annotations(text_file)
+
+    else:
+        # If any additional argument(s) passed, doc sources are copied but
+        # doctest annotation removal is not done
+        pass

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -97,7 +97,7 @@ def circle(cy, cx, radius, shape=None):
         ``img[rr, cc] = 1``.
     Notes
     -----
-        This function is a wrapper for skimage.draw.ellipse()
+    This function is a wrapper for skimage.draw.ellipse()
 
     Examples
     --------

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -199,9 +199,10 @@ def threshold_isodata(image, nbins=256, return_all=False):
     """Return threshold value(s) based on ISODATA method.
 
     Histogram-based threshold, known as Ridler-Calvard method or inter-means.
-    Threshold values returned satisfy the following equality:
-    threshold = (image[image <= threshold].mean() +
-                 image[image > threshold].mean()) / 2.0
+    Threshold values returned satisfy the following equality::
+        threshold = (image[image <= threshold].mean() +
+                     image[image > threshold].mean()) / 2.0
+
     That is, returned thresholds are intensities that separate the image into
     two groups of pixels, where the threshold intensity is midway between the
     mean intensities of these groups.
@@ -216,7 +217,7 @@ def threshold_isodata(image, nbins=256, return_all=False):
     nbins : int, optional
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
-    return_all: bool, optional
+    return_all : bool, optional
         If False (default), return only the lowest threshold that satisfies
         the above equality. If True, return all valid thresholds.
 

--- a/skimage/measure/_ccomp.pyx
+++ b/skimage/measure/_ccomp.pyx
@@ -368,14 +368,14 @@ def label(input, neighbors=None, background=None, return_num=False,
     Two pixels are connected when they are neighbors and have the same value.
     In 2D, they can be neighbors either in a 1- or 2-connected sense.
     The value refers to the maximum number of orthogonal hops to consider a
-    pixel/voxel a neighbor.
+    pixel/voxel a neighbor. ::
 
       1-connectivity      2-connectivity     diagonal connection close-up
 
            [ ]           [ ]  [ ]  [ ]         [ ]
-            |               \  |  /             |  <- hop 2
+            |               \\  |  /             |  <- hop 2
       [ ]--[x]--[ ]      [ ]--[x]--[ ]    [x]--[ ]
-            |               /  |  \         hop 1
+            |               /  |  \\         hop 1
            [ ]           [ ]  [ ]  [ ]
 
     Parameters
@@ -416,7 +416,7 @@ def label(input, neighbors=None, background=None, return_num=False,
      [0 1 0]
      [0 0 1]]
     >>> from skimage.measure import label
-    >>> print(label(x, connectivity=1)) 
+    >>> print(label(x, connectivity=1))
     [[0 1 1]
      [2 3 1]
      [2 2 4]]

--- a/skimage/util/noise.py
+++ b/skimage/util/noise.py
@@ -16,15 +16,16 @@ def random_noise(image, mode='gaussian', seed=None, clip=True, **kwargs):
     mode : str
         One of the following strings, selecting the type of noise to add:
 
-        'gaussian'  Gaussian-distributed additive noise.
-        'localvar'  Gaussian-distributed additive noise, with specified
-                    local variance at each point of `image`
-        'poisson'   Poisson-distributed noise generated from the data.
-        'salt'      Replaces random pixels with 1.
-        'pepper'    Replaces random pixels with 0.
-        's&p'       Replaces random pixels with 0 or 1.
-        'speckle'   Multiplicative noise using out = image + n*image, where
-                    n is uniform noise with specified mean & variance.
+        'gaussian' : Gaussian-distributed additive noise.
+        'localvar' : Gaussian-distributed additive noise, with specified
+                     local variance at each point of `image`
+        'poisson'  : Poisson-distributed noise generated from the data.
+        'salt'     : Replaces random pixels with 1.
+        'pepper'   : Replaces random pixels with 0.
+        's&p'      : Replaces random pixels with 0 or 1.
+        'speckle'  : Multiplicative noise using out = image + n*image, where
+                     n is uniform noise with specified mean & variance.
+
     seed : int
         If provided, this will set the random seed before generating noise,
         for valid pseudo-random comparisons.


### PR DESCRIPTION
Per discussion in #1280, there was concern that if we began running doctests on the user guide and other documentation there would be inelegant `# doctest: +SKIP` annotations running around.

This PR adds an intermediate step where the entire `doc/source` directory is copied to `doc/_prebuild` and text-like files (currently just `*.txt` and `*.py`) are parsed, looking to match and remove all instances of `# doctest: +*`. I also fixed a few other minor style issues in the documentation, causing erroneous formatting in iPython or Sphinx warnings.

The result: `# doctest: +` annotations should be completely safe to use as necessary throughout the handwritten documentation source, but they are stripped out before Sphinx starts. Thus, users will never see them.