### PR TITLE
Peak local max n darrays issue1354

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -203,3 +203,6 @@
 
 - Salvatore Scaramuzzino
   RectTool example
+
+- Kevin Keraudren
+  Fix and test for feature.peak_local_max

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -149,7 +149,7 @@ def peak_local_max(image, min_distance=10, threshold_abs=0, threshold_rel=0.1,
     coordinates = np.transpose((image > peak_threshold).nonzero())
 
     if coordinates.shape[0] > num_peaks:
-        intensities = image[coordinates[:, 0], coordinates[:, 1]]
+        intensities = image.flat[np.ravel_multi_index(coordinates.transpose(),image.shape)]
         idx_maxsort = np.argsort(intensities)[::-1]
         coordinates = coordinates[idx_maxsort][:num_peaks]
 

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -146,7 +146,7 @@ def peak_local_max(image, min_distance=10, threshold_abs=0, threshold_rel=0.1,
     peak_threshold = max(np.max(image.ravel()) * threshold_rel, threshold_abs)
 
     # get coordinates of peaks
-    coordinates = np.transpose((image > peak_threshold).nonzero())
+    coordinates = np.argwhere(image > peak_threshold)
 
     if coordinates.shape[0] > num_peaks:
         intensities = image.flat[np.ravel_multi_index(coordinates.transpose(),image.shape)]

--- a/skimage/feature/tests/test_peak.py
+++ b/skimage/feature/tests/test_peak.py
@@ -82,6 +82,15 @@ def test_num_peaks():
     assert (3, 5) in peaks_limited
 
 
+def test_num_peaks3D():
+    # Issue 1354: the old code only hold for 2D arrays
+    # and this code would die with IndexError
+    image = np.zeros((10, 10, 100))
+    image[5,5,::5] = np.arange(20)
+    peaks_limited = peak.peak_local_max(image, min_distance=1, num_peaks=2)
+    assert len(peaks_limited) == 2
+    
+
 def test_reorder_labels():
     image = np.random.uniform(size=(40, 60))
     i, j = np.mgrid[0:40, 0:60]


### PR DESCRIPTION
These are the changes proposed in:
https://github.com/scikit-image/scikit-image/issues/1354

The changes are as follows:
 - a test which fails with the old code and succeeds witht the proposed fix
 - the fix in question enables the use of `num_peaks` for ND arrays, N!=2. The old code assumed a 2D array.
 - Additionally `np.transpose(np.nonzero(a))` has been replaced by `np.argwhere(a)` to improve code readability (http://docs.scipy.org/doc/numpy/reference/generated/numpy.argwhere.html).