### PR TITLE
Travis build docs

### DIFF
--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -123,9 +123,7 @@ Guidelines
 
 * All code should have tests (see `test coverage`_ below for more details).
 * All code should be documented, to the same
-  `standard
-<://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt#docstring-standard>`_
-  as NumPy and SciPy.
+  `standard <://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt#docstring-standard>`_ as NumPy and SciPy.
 * For new functionality, always add an example to the
   gallery.
 * No changes are ever committed without review.  Ask on the
@@ -195,8 +193,8 @@ successfully passes all tests. To do so,
 
    * Go to `Travis-CI <http://travis-ci.org/>`__ and follow the Sign In link at the top
 
-   * Go to your `profile page <https://travis-ci.org/profile>`__ and switch on your
-   scikit-image fork
+   * Go to your `profile page <https://travis-ci.org/profile>`__ and switch 
+     on your scikit-image fork
 
 It corresponds to steps one and two in
 `Travis-CI documentation <http://about.travis-ci.org/docs/user/getting-started/>`__

--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -45,12 +45,12 @@ functionality is only available with the following installed:
 
 * `Astropy <http://www.astropy.org>`__ provides FITS io capability.
 
-*`SimpleITK <http://www.simpleitk.org/>`
- Optional io plugin providing a wide variety of `formats <http://www.itk.org/Wiki/ITK_File_Formats>`__.
- including specialized formats using in medical imaging.
+* `SimpleITK <http://www.simpleitk.org/>`
+  Optional io plugin providing a wide variety of `formats <http://www.itk.org/Wiki/ITK_File_Formats>`__.
+  including specialized formats using in medical imaging.
 
-*`imread <http://pythonhosted.org/imread/>`
- Optional io plugin providing most standard `formats <http://pythonhosted.org//imread/formats.html>`__.
+* `imread <http://pythonhosted.org/imread/>`
+  Optional io plugin providing most standard `formats <http://pythonhosted.org//imread/formats.html>`__.
 
 
 Testing requirements

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ coverage:
 
 html:
 	pip install sphinx
-	make -C docs html
+	make -C doc html

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,7 @@ doctest:
 
 coverage:
 	nosetests skimage --with-coverage --cover-package=skimage
+
+html:
+	pip install sphinx
+	make -C docs html

--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,5 @@ coverage:
 	nosetests skimage --with-coverage --cover-package=skimage
 
 html:
-	pip install sphinx
-	make -C doc html
+	pip install -q sphinx
+	export SPHINXOPTS=-W; make -C doc html

--- a/doc/README.md
+++ b/doc/README.md
@@ -3,3 +3,16 @@ To build docs, run `make` in this directory. `make help` lists all targets.
 
 ## Requirements ##
 Sphinx is needed to build doc. Install with `pip install sphinx`.
+
+## Fixing Warnings ##
+
+- "citation not found: R###"
+  $ cd doc/build; grep -rin R### .
+  There is probably an underscore after the reference (e.g. [1]_)
+
+- "Duplicate citation R###, other instance in...""
+  There is probably a [2] without a [1] in one of
+  the docstrings
+
+- Make sure to use pre-sphinxification paths to images
+  (not the _images directory)

--- a/doc/ext/plot2rst.py
+++ b/doc/ext/plot2rst.py
@@ -258,7 +258,8 @@ def write_gallery(gallery_index, src_dir, rst_dir, cfg, depth=0):
     else:
         sub_dir_list = src_dir.psplit()[-depth:]
         sub_dir = Path('/'.join(sub_dir_list) + '/')
-    gallery_index.write(TOCTREE_TEMPLATE % (sub_dir + '\n   '.join(ex_names)))
+    joiner = '\n   %s' % sub_dir
+    gallery_index.write(TOCTREE_TEMPLATE % (sub_dir + joiner.join(ex_names)))
 
     for src_name in examples:
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -251,6 +251,7 @@ latex_use_modindex = False
 # Numpy extensions
 # -----------------------------------------------------------------------------
 numpydoc_show_class_members = False
+numpydoc_class_members_toctree = False
 
 # -----------------------------------------------------------------------------
 # Plots

--- a/doc/source/contents.txt
+++ b/doc/source/contents.txt
@@ -1,7 +1,0 @@
-Table of Contents
-=================
-
-.. toctree::
-
-   /api/api
-

--- a/doc/source/index.txt
+++ b/doc/source/index.txt
@@ -15,7 +15,7 @@ Sections
    :hidden:
 
    overview
-   api
+   api/api
    api_changes
    install
    user_guide

--- a/doc/source/user_guide.txt
+++ b/doc/source/user_guide.txt
@@ -12,3 +12,5 @@ User Guide
    user_guide/tutorials
    user_guide/getting_help
    user_guide/viewer
+   user_guide/tutorial_parallelization
+   user_guide/tutorial_segmentation

--- a/doc/source/user_guide/numpy_images.txt
+++ b/doc/source/user_guide/numpy_images.txt
@@ -81,7 +81,7 @@ disk: ::
     ...                    (nrows / 2)**2)
     >>> camera[outer_disk_mask] = 0
 
-.. image:: ../../_images/plot_camera_numpy_1.png
+.. image:: ../auto_examples/images/plot_camera_numpy_1.png
     :width: 45%
     :target: ../auto_examples/plot_camera_numpy.html
 
@@ -123,6 +123,8 @@ the grayscale image above:
 
     Using a 2D mask on a 2D color image
 
+    >>> from skimage import data
+    >>> cat = data.chelsea()
     >>> reddish = cat[:, :, 0] > 160
     >>> cat[reddish] = [0, 255, 0]
     >>> plt.imshow(cat)
@@ -153,14 +155,14 @@ These conventions are summarized below:
 
 .. table:: Dimension name and order conventions in scikit-image
 
-========================   ========================================
-Image type                 coordinates
-========================   ========================================
-2D grayscale               (row, col)
-2D multichannel (eg. RGB)  (row, col, ch)
-3D grayscale               (pln, row, col)
-3D multichannel            (pln, row, col, ch)
-========================   ========================================
+  =========================   ========================================
+  Image type                  coordinates
+  =========================   ========================================
+  2D grayscale                (row, col)
+  2D multichannel (eg. RGB)   (row, col, ch)
+  3D grayscale                (pln, row, col)
+  3D multichannel             (pln, row, col, ch)
+  =========================   ========================================
 
 
 Many functions in scikit-image operate on 3D images directly:
@@ -248,9 +250,9 @@ We can then supplement the above table as follows:
 
 .. table:: Addendum to dimension names and orders in scikit-image
 
-========================   ========================================
-Image type                 coordinates
-========================   ========================================
-2D color video             (t, row, col, ch)
-3D multichannel video      (t, pln, row, col, ch)
-========================   ========================================
+  ========================   ========================================
+  Image type                 coordinates
+  ========================   ========================================
+  2D color video             (t, row, col, ch)
+  3D multichannel video      (t, pln, row, col, ch)
+  ========================   ========================================

--- a/doc/source/user_guide/transforming_image_data.txt
+++ b/doc/source/user_guide/transforming_image_data.txt
@@ -67,7 +67,7 @@ from RGB to grayscale::
     array([[ 0.7154]])
 
 
-Converting a grayscale image to RGB with :func:`gray2rgb``simply
+Converting a grayscale image to RGB with :func:`gray2rgb` simply
 duplicates the gray values over the three color channels.
 
 Painting images with labels
@@ -78,7 +78,7 @@ using an array of labels to encode the regions to be represented with the
 same color. 
 
 
-.. image:: ../../_images/plot_join_segmentations_1.png
+.. image: ../auto_examples/images/plot_join_segmentations_1.png
    :target: ../auto_examples/plot_join_segmentations.html
    :align: center
    :width: 80%
@@ -159,7 +159,7 @@ image with :func:`equalize_adapthist`, in order to correct for exposure
 gradients across the image. See the example
 :ref:`example_plot_equalize.py`.
 
-.. image:: ../../_images/plot_equalize_1.png
+.. image:: ../auto_examples/images/plot_equalize_1.png
    :target: ../auto_examples/plot_equalize.html
    :align: center
    :width: 90%

--- a/doc/source/user_guide/tutorial_segmentation.txt
+++ b/doc/source/user_guide/tutorial_segmentation.txt
@@ -11,7 +11,7 @@ the coins cannot be done directly from the histogram of grey values,
 because the background shares enough grey levels with the coins that a
 thresholding segmentation is not sufficient.
 
-.. image:: ../../_images/plot_coins_segmentation_1.png
+.. image:: ../auto_examples/applications/images/plot_coins_segmentation_1.png
    :target: ../auto_examples/applications/plot_coins_segmentation.html
    :align: center
 
@@ -26,7 +26,7 @@ Simply thresholding the image leads either to missing significant parts
 of the coins, or to merging parts of the background with the
 coins. This is due to the inhomogeneous lighting of the image. 
 
-.. image:: ../../_images/plot_coins_segmentation_2.png
+.. image:: ../auto_examples/applications/images/plot_coins_segmentation_2.png
    :target: ../auto_examples/applications/plot_coins_segmentation.html
    :align: center
 
@@ -53,7 +53,7 @@ boundary of the coins, or inside the coins.
     >>> from scipy import ndimage
     >>> fill_coins = ndimage.binary_fill_holes(edges)
 
-.. image:: ../../_images/plot_coins_segmentation_3.png
+.. image:: ../auto_examples/applications/images/plot_coins_segmentation_3.png
    :target: ../auto_examples/applications/plot_coins_segmentation.html
    :align: center
 
@@ -62,7 +62,7 @@ we fill the inner part of the coins using the
 ``ndimage.binary_fill_holes`` function, which uses mathematical morphology
 to fill the holes.
 
-.. image:: ../../_images/plot_coins_segmentation_4.png
+.. image:: ../auto_examples/applications/images/plot_coins_segmentation_4.png
    :target: ../auto_examples/applications/plot_coins_segmentation.html
    :align: center
 
@@ -83,7 +83,7 @@ has not been segmented correctly at all. The reason is that the contour
 that we got from the Canny detector was not completely closed, therefore
 the filling function did not fill the inner part of the coin. 
 
-.. image:: ../../_images/plot_coins_segmentation_5.png
+.. image:: ../auto_examples/applications/images/plot_coins_segmentation_5.png
    :target: ../auto_examples/applications/plot_coins_segmentation.html
    :align: center
 
@@ -128,7 +128,7 @@ separate the coins from the background.
 
 and here is the corresponding 2-D plot:
 
-.. image:: ../../_images/plot_coins_segmentation_6.png
+.. image:: ../auto_examples/applications/images/plot_coins_segmentation_6.png
    :target: ../auto_examples/applications/plot_coins_segmentation.html
    :align: center
 
@@ -139,7 +139,7 @@ extreme parts of the histogram of grey values::
     >>> markers[coins < 30] = 1
     >>> markers[coins > 150] = 2
 
-.. image:: ../../_images/plot_coins_segmentation_7.png
+.. image:: ../auto_examples/applications/images/plot_coins_segmentation_7.png
    :target: ../auto_examples/applications/plot_coins_segmentation.html
    :align: center
 
@@ -148,7 +148,7 @@ Let us now compute the watershed transform::
     >>> from skimage.morphology import watershed
     >>> segmentation = watershed(elevation_map, markers)
 
-.. image:: ../../_images/plot_coins_segmentation_8.png
+.. image:: ../auto_examples/applications/images/plot_coins_segmentation_8.png
    :target: ../auto_examples/applications/plot_coins_segmentation.html
    :align: center
 
@@ -165,7 +165,7 @@ We can now label all the coins one by one using ``ndimage.label``::
 
     >>> labeled_coins, _ = ndimage.label(segmentation)
 
-.. image:: ../../_images/plot_coins_segmentation_9.png
+.. image:: ../auto_examples/applications/images/plot_coins_segmentation_9.png
    :target: ../auto_examples/applications/plot_coins_segmentation.html
    :align: center
 

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -95,6 +95,7 @@ def circle(cy, cx, radius, shape=None):
         Pixel coordinates of circle.
         May be used to directly index into an array, e.g.
         ``img[rr, cc] = 1``.
+
     Notes
     -----
         This function is a wrapper for skimage.draw.ellipse()

--- a/skimage/feature/__init__.py
+++ b/skimage/feature/__init__.py
@@ -18,7 +18,7 @@ from .util import plot_matches
 from .blob import blob_dog, blob_log, blob_doh
 
 
-__all__ = ['canny'
+__all__ = ['canny',
            'daisy',
            'hog',
            'greycomatrix',

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -1,5 +1,5 @@
 """The local histogram is computed using a sliding window similar to the method
-described in [1]_.
+described in [1].
 
 Input image can be 8-bit or 16-bit, for 16-bit input images, the number of
 histogram bins is determined from the maximum value present in the image.
@@ -749,7 +749,7 @@ def tophat(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
 def noise_filter(image, selem, out=None, mask=None, shift_x=False,
                  shift_y=False):
-    """Noise feature as described in [1]_.
+    """Noise feature as described in [1].
 
     Parameters
     ----------
@@ -800,7 +800,7 @@ def noise_filter(image, selem, out=None, mask=None, shift_x=False,
 
 
 def entropy(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
-    """Local entropy [1]_.
+    """Local entropy [1].
 
     The entropy is computed using base 2 logarithm i.e. the filter returns the
     minimum number of bits needed to encode the local greylevel distribution.

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -749,7 +749,7 @@ def tophat(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
 def noise_filter(image, selem, out=None, mask=None, shift_x=False,
                  shift_y=False):
-    """Noise feature as described in [Hashimoto12]_.
+    """Noise feature as described in [1]_.
 
     Parameters
     ----------
@@ -769,7 +769,7 @@ def noise_filter(image, selem, out=None, mask=None, shift_x=False,
 
     References
     ----------
-    .. [Hashimoto12] N. Hashimoto et al. Referenceless image quality evaluation
+    .. [1] N. Hashimoto et al. Referenceless image quality evaluation
                      for whole slide imaging. J Pathol Inform 2012;3:9.
 
     Returns
@@ -872,7 +872,7 @@ def otsu(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     References
     ----------
-    .. [otsu] http://en.wikipedia.org/wiki/Otsu's_method
+    .. [1] http://en.wikipedia.org/wiki/Otsu's_method
 
     Examples
     --------

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -201,8 +201,8 @@ def threshold_isodata(image, nbins=256, return_all=False):
     Histogram-based threshold, known as Ridler-Calvard method or inter-means.
     Threshold values returned satisfy the following equality:
 
-    ``threshold = (image[image <= threshold].mean() +``
-                 ``image[image > threshold].mean()) / 2.0``
+    `threshold = (image[image <= threshold].mean() +`
+                 `image[image > threshold].mean()) / 2.0`
 
     That is, returned thresholds are intensities that separate the image into
     two groups of pixels, where the threshold intensity is midway between the

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -200,8 +200,10 @@ def threshold_isodata(image, nbins=256, return_all=False):
 
     Histogram-based threshold, known as Ridler-Calvard method or inter-means.
     Threshold values returned satisfy the following equality:
-    threshold = (image[image <= threshold].mean() +
-                 image[image > threshold].mean()) / 2.0
+
+    ``threshold = (image[image <= threshold].mean() +``
+                 ``image[image > threshold].mean()) / 2.0``
+
     That is, returned thresholds are intensities that separate the image into
     two groups of pixels, where the threshold intensity is midway between the
     mean intensities of these groups.

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -220,7 +220,7 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
     labels : ndarray, shape(M, N, [..., P,])
         The labelled image. This should have one dimension less than
         `image`. If `image` has dimensions `(M, N, 3)` `labels` should have
-         dimensions `(M, N)`.
+        dimensions `(M, N)`.
     connectivity : int, optional
         Pixels with a squared distance less than `connectivity` from each other
         are considered adjacent. It can range from 1 to `labels.ndim`. Its

--- a/skimage/io/_plugins/pil_plugin.ini
+++ b/skimage/io/_plugins/pil_plugin.ini
@@ -1,3 +1,3 @@
 [pil]
 description = Image reading via the Python Imaging Library
-provides = imread, imsave, imshow, _app_show
+provides = imread, imsave

--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -260,20 +260,3 @@ def imsave(fname, arr, format_str=None):
 
     img = ndarray_to_pil(arr, format_str=format_str)
     img.save(fname, format=format_str)
-
-
-def imshow(arr):
-    """Display an image, using PIL's default display command.
-
-    Parameters
-    ----------
-    arr : ndarray
-       Image to display.  Images of dtype float are assumed to be in
-       [0, 1].  Images of dtype uint8 are in [0, 255].
-
-    """
-    Image.fromarray(img_as_ubyte(arr)).show()
-
-
-def _app_show():
-    pass

--- a/skimage/io/tests/test_plugin.py
+++ b/skimage/io/tests/test_plugin.py
@@ -93,15 +93,18 @@ def test_available():
 
 
 def test_load_preferred_plugins_all():
-    from skimage.io._plugins import pil_plugin
+    from skimage.io._plugins import pil_plugin, matplotlib_plugin
 
     with protect_preferred_plugins():
-        manage_plugins.preferred_plugins = {'all': ['pil']}
+        manage_plugins.preferred_plugins = {'all': ['pil'],
+                                            'imshow': ['matplotlib']}
         manage_plugins.reset_plugins()
 
-        for plugin_type in ('imread', 'imsave', 'imshow'):
+        for plugin_type in ('imread', 'imsave'):
             plug, func = manage_plugins.plugin_store[plugin_type][0]
             assert func == getattr(pil_plugin, plugin_type)
+        plug, func = manage_plugins.plugin_store['imshow'][0]
+        assert func == getattr(matplotlib_plugin, 'imshow')
 
 
 def test_load_preferred_plugins_imread():

--- a/skimage/measure/_ccomp.pyx
+++ b/skimage/measure/_ccomp.pyx
@@ -368,7 +368,7 @@ def label(input, neighbors=None, background=None, return_num=False,
     Two pixels are connected when they are neighbors and have the same value.
     In 2D, they can be neighbors either in a 1- or 2-connected sense.
     The value refers to the maximum number of orthogonal hops to consider a
-    pixel/voxel a neighbor.
+    pixel/voxel a neighbor::
 
       1-connectivity      2-connectivity     diagonal connection close-up
 

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -363,7 +363,7 @@ def richardson_lucy(image, psf, iterations=50, clip=True):
 
     References
     ----------
-    .. [2] http://en.wikipedia.org/wiki/Richardson%E2%80%93Lucy_deconvolution
+    .. [1] http://en.wikipedia.org/wiki/Richardson%E2%80%93Lucy_deconvolution
     """
     image = image.astype(np.float)
     psf = psf.astype(np.float)

--- a/skimage/segmentation/boundaries.py
+++ b/skimage/segmentation/boundaries.py
@@ -65,15 +65,15 @@ def find_boundaries(label_img, connectivity=1, mode='thick', background=0):
         How to mark the boundaries:
 
         - thick: any pixel not completely surrounded by pixels of the
-        same label (defined by `connectivity`) is marked as a boundary.
-        This results in boundaries that are 2 pixels thick.
+          same label (defined by `connectivity`) is marked as a boundary.
+          This results in boundaries that are 2 pixels thick.
         - inner: outline the pixels *just inside* of objects, leaving
-        background pixels untouched.
+          background pixels untouched.
         - outer: outline pixels in the background around object
-        boundaries. When two objects touch, their boundary is also
-        marked.
+          boundaries. When two objects touch, their boundary is also
+          marked.
         - subpixel: return a doubled image, with pixels *between* the
-        original pixels marked as boundary where appropriate.
+          original pixels marked as boundary where appropriate.
     background: int, optional
         For modes 'inner' and 'outer', a definition of a background
         label is required. See `mode` for descriptions of these two.
@@ -197,7 +197,7 @@ def mark_boundaries(image, label_img, color=(1, 1, 0),
 
     See Also
     --------
-    ``find_boundaries``.
+    find_boundaries
     """
     marked = img_as_float(image, force_copy=True)
     if marked.ndim == 2:

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -332,7 +332,9 @@ class ProjectiveTransform(GeometricTransform):
 
 class AffineTransform(ProjectiveTransform):
 
-    """2D affine transformation of the form::
+    """2D affine transformation of the form:
+
+    ..:math:
 
         X = a0*x + a1*y + a2 =
           = sx*x*cos(rotation) - sy*y*sin(rotation + shear) + a2
@@ -551,7 +553,9 @@ class PiecewiseAffineTransform(GeometricTransform):
 
 
 class SimilarityTransform(ProjectiveTransform):
-    """2D similarity transformation of the form::
+    """2D similarity transformation of the form:
+
+    ..:math:
 
         X = a0 * x - b0 * y + a1 =
           = m * x * cos(rotation) - m * y * sin(rotation) + a1
@@ -715,7 +719,9 @@ class SimilarityTransform(ProjectiveTransform):
 
 
 class PolynomialTransform(GeometricTransform):
-    """2D transformation of the form::
+    """2D transformation of the form:
+
+    ..:math:
 
         X = sum[j=0:order]( sum[i=0:j]( a_ji * x**(j - i) * y**i ))
         Y = sum[j=0:order]( sum[i=0:j]( b_ji * x**(j - i) * y**i ))

--- a/skimage/util/noise.py
+++ b/skimage/util/noise.py
@@ -16,15 +16,15 @@ def random_noise(image, mode='gaussian', seed=None, clip=True, **kwargs):
     mode : str
         One of the following strings, selecting the type of noise to add:
 
-        'gaussian'  Gaussian-distributed additive noise.
-        'localvar'  Gaussian-distributed additive noise, with specified
-                    local variance at each point of `image`
-        'poisson'   Poisson-distributed noise generated from the data.
-        'salt'      Replaces random pixels with 1.
-        'pepper'    Replaces random pixels with 0.
-        's&p'       Replaces random pixels with 0 or 1.
-        'speckle'   Multiplicative noise using out = image + n*image, where
-                    n is uniform noise with specified mean & variance.
+        - 'gaussian'  Gaussian-distributed additive noise.
+        - 'localvar'  Gaussian-distributed additive noise, with specified
+                      local variance at each point of `image`
+        - 'poisson'   Poisson-distributed noise generated from the data.
+        - 'salt'      Replaces random pixels with 1.
+        - 'pepper'    Replaces random pixels with 0.
+        - 's&p'       Replaces random pixels with 0 or 1.
+        - 'speckle'   Multiplicative noise using out = image + n*image, where
+                      n is uniform noise with specified mean & variance.
     seed : int
         If provided, this will set the random seed before generating noise,
         for valid pseudo-random comparisons.

--- a/tools/travis_script.sh
+++ b/tools/travis_script.sh
@@ -5,6 +5,9 @@ section "Test.with.min.requirements"
 nosetests $TEST_ARGS skimage
 section_end "Test.with.min.requirements"
 
+section "Build.docs"
+make html
+section_end "Build.docs"
 
 section "Flake8.test"
 flake8 --exit-zero --exclude=test_*,six.py skimage doc/examples viewer_examples

--- a/tools/travis_script.sh
+++ b/tools/travis_script.sh
@@ -7,6 +7,7 @@ section_end "Test.with.min.requirements"
 
 section "Build.docs"
 if [[ $TRAVIS_PYTHON_VERSION != 3.2 ]]; then
+    sudo apt-get install -qq texlive
     make html
 fi
 section_end "Build.docs"

--- a/tools/travis_script.sh
+++ b/tools/travis_script.sh
@@ -6,7 +6,9 @@ nosetests $TEST_ARGS skimage
 section_end "Test.with.min.requirements"
 
 section "Build.docs"
-make html
+if [[ $TRAVIS_PYTHON_VERSION != 3.2 ]]; then
+    make html
+fi
 section_end "Build.docs"
 
 section "Flake8.test"


### PR DESCRIPTION
Fixes #681.  Boom.

Also fixed a problem where the `pil_plugin` overrides `imshow`.  Since we require matplotlib now, I removed `imshow` from the `pil_plugin`.

Could not build on 3.2 due to `u''` literals.  Could not build on 2.6 due to missing `flags` kwarg in `re.sub`.  