### PR TITLE
Force `novice.Picture.from_size` to return a uint8 image

### DIFF
--- a/skimage/novice/_novice.py
+++ b/skimage/novice/_novice.py
@@ -282,6 +282,7 @@ class Picture(object):
             color = color_dict[color]
         rgb_size = tuple(size) + (len(color),)
         array = np.ones(rgb_size, dtype=np.uint8) * color
+        array = array.astype(np.uint8)
 
         # Force RGBA internally (use max alpha)
         if array.shape[-1] == 3:

--- a/skimage/novice/_novice.py
+++ b/skimage/novice/_novice.py
@@ -281,8 +281,8 @@ class Picture(object):
         if isinstance(color, six.string_types):
             color = color_dict[color]
         rgb_size = tuple(size) + (len(color),)
+        color = np.array(color, dtype=np.uint8)
         array = np.ones(rgb_size, dtype=np.uint8) * color
-        array = array.astype(np.uint8)
 
         # Force RGBA internally (use max alpha)
         if array.shape[-1] == 3:

--- a/skimage/novice/tests/test_novice.py
+++ b/skimage/novice/tests/test_novice.py
@@ -86,6 +86,8 @@ def test_pixel_rgb():
     pixel.rgb = np.arange(4)
     assert_equal(pixel.rgb, np.arange(3))
 
+    assert pic.array.dtype == np.uint8
+
 
 def test_pixel_rgba():
     pic = novice.Picture.from_size((3, 3), color=(10, 10, 10))


### PR DESCRIPTION
Partial fix for #1358.  Multiplying the array by a another array resulted in an `int64` array, which did not display properly.