### PR TITLE
Add handling of CMYK images

### DIFF
--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -73,7 +73,7 @@ def pil_to_ndarray(im, dtype=None, img_num=None):
 
         frame = im
 
-        if not img_num is None and img_num != i:
+        if img_num is not None and img_num != i:
             im.getdata()[0]
             i += 1
             continue
@@ -90,9 +90,8 @@ def pil_to_ndarray(im, dtype=None, img_num=None):
         elif im.mode == '1':
             frame = im.convert('L')
 
-        elif 'A' in im.mode:
+        elif 'A' in im.mode or im.mode == 'CMYK':
             frame = im.convert('RGBA')
-
 
         if im.mode.startswith('I;16'):
             shape = im.size

--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -90,8 +90,11 @@ def pil_to_ndarray(im, dtype=None, img_num=None):
         elif im.mode == '1':
             frame = im.convert('L')
 
-        elif 'A' in im.mode or im.mode == 'CMYK':
+        elif 'A' in im.mode:
             frame = im.convert('RGBA')
+
+        elif im.mode == 'CMYK':
+            frame = im.convert('RGB')
 
         if im.mode.startswith('I;16'):
             shape = im.size

--- a/skimage/io/tests/test_pil.py
+++ b/skimage/io/tests/test_pil.py
@@ -227,5 +227,4 @@ class TestSaveTIF:
                 yield self.roundtrip, dtype, x
 
 if __name__ == "__main__":
-    #run_module_suite()
-    test_cmyk()
+    run_module_suite()

--- a/skimage/io/tests/test_pil.py
+++ b/skimage/io/tests/test_pil.py
@@ -6,18 +6,18 @@ from numpy.testing import (
 
 from tempfile import NamedTemporaryFile
 
-from skimage import data_dir
-from skimage.io import (imread, imsave, use_plugin, reset_plugins,
+from ... import data_dir
+from .. import (imread, imsave, use_plugin, reset_plugins,
                         Image as ioImage)
-from skimage._shared.testing import mono_check, color_check
-from skimage._shared._warnings import expected_warnings
+from ..._shared.testing import mono_check, color_check
+from ..._shared._warnings import expected_warnings
 
 from six import BytesIO
 
 from PIL import Image
-from skimage.io._plugins.pil_plugin import (
+from .._plugins.pil_plugin import (
     pil_to_ndarray, ndarray_to_pil, _palette_is_grayscale)
-
+from ...measure import structural_similarity as ssim
 
 
 def setup():
@@ -183,6 +183,28 @@ def test_multi_page_gif():
     assert img2.shape == (280, 500, 3)
     assert_allclose(img[5], img2)
 
+
+def test_cmyk():
+    ref = imread(os.path.join(data_dir, 'color.png'))
+
+    img = Image.open(os.path.join(data_dir, 'color.png'))
+    img = img.convert('CMYK')
+
+    f = NamedTemporaryFile(suffix='.jpg')
+    fname = f.name
+    f.close()
+    img.save(fname)
+    img.close()
+
+    new = imread(fname)[:, :, :3]
+
+    for i in range(3):
+        newi = np.ascontiguousarray(new[:, :, i])
+        refi = np.ascontiguousarray(ref[:, :, i])
+        sim = ssim(refi, newi, dynamic_range=refi.max() - refi.min())
+        assert sim > 0.85
+
+
 class TestSaveTIF:
     def roundtrip(self, dtype, x):
         f = NamedTemporaryFile(suffix='.tif')
@@ -205,4 +227,5 @@ class TestSaveTIF:
                 yield self.roundtrip, dtype, x
 
 if __name__ == "__main__":
-    run_module_suite()
+    #run_module_suite()
+    test_cmyk()

--- a/skimage/io/tests/test_pil.py
+++ b/skimage/io/tests/test_pil.py
@@ -18,6 +18,7 @@ from PIL import Image
 from .._plugins.pil_plugin import (
     pil_to_ndarray, ndarray_to_pil, _palette_is_grayscale)
 from ...measure import structural_similarity as ssim
+from ...color import rgb2lab
 
 
 def setup():
@@ -196,13 +197,16 @@ def test_cmyk():
     img.save(fname)
     img.close()
 
-    new = imread(fname)[:, :, :3]
+    new = imread(fname)
+
+    ref_lab = rgb2lab(ref)
+    new_lab = rgb2lab(new)
 
     for i in range(3):
-        newi = np.ascontiguousarray(new[:, :, i])
-        refi = np.ascontiguousarray(ref[:, :, i])
+        newi = np.ascontiguousarray(new_lab[:, :, i])
+        refi = np.ascontiguousarray(ref_lab[:, :, i])
         sim = ssim(refi, newi, dynamic_range=refi.max() - refi.min())
-        assert sim > 0.85
+        assert sim > 0.99
 
 
 class TestSaveTIF:


### PR DESCRIPTION
Closes #1358.   Adds explicit handling of CMYK images.  Now looks like this:

![figure_4](https://cloud.githubusercontent.com/assets/2096628/5986340/1013b40c-a8ba-11e4-99a3-2037a12e7f59.png)


Using code:

```python
In [1]: from skimage import io

In [2]: import matplotlib.pyplot as plt

In [3]: im = io.imread('ant.jpg')

In [4]: plt.imshow(im)
Out[4]: <matplotlib.image.AxesImage at 0x7f5b3f00e860>

In [5]: plt.show()
```

or 

```python
In [1]: from skimage import novice
In [2]: p1 = novice.open('ant.jpg')
In [3]: p1.show()
```

and this:

```python
In [4]: p1.size
Out[4]: (120, 121)
In [5]: p1[0:60, 0:60] = (0, 255, 0)
In [6]: p1.show()
```

produces this:

![figure_5](https://cloud.githubusercontent.com/assets/2096628/5986360/8ea92806-a8ba-11e4-9dc8-c57cebe80fc5.png)
