### PR TITLE
Cannot use bare deprecated decorators

### DIFF
--- a/skimage/filter/__init__.py
+++ b/skimage/filter/__init__.py
@@ -36,7 +36,7 @@ denoise_tv_chambolle = deprecated('skimage.restoration.denoise_tv_chambolle')\
                         (restoration.denoise_tv_chambolle)
 
 # Backward compatibility v<0.11
-@deprecated
+@deprecated()
 def canny(*args, **kwargs):
     # Hack to avoid circular import
     from skimage.feature._canny import canny as canny_

--- a/skimage/filter/__init__.py
+++ b/skimage/filter/__init__.py
@@ -36,7 +36,7 @@ denoise_tv_chambolle = deprecated('skimage.restoration.denoise_tv_chambolle')\
                         (restoration.denoise_tv_chambolle)
 
 # Backward compatibility v<0.11
-@deprecated()
+@deprecated('skimage.feature.canny')
 def canny(*args, **kwargs):
     # Hack to avoid circular import
     from skimage.feature._canny import canny as canny_

--- a/skimage/filters/__init__.py
+++ b/skimage/filters/__init__.py
@@ -23,7 +23,7 @@ denoise_tv_chambolle = deprecated('skimage.restoration.denoise_tv_chambolle')\
                         (restoration.denoise_tv_chambolle)
 
 # Backward compatibility v<0.11
-@deprecated
+@deprecated()
 def canny(*args, **kwargs):
     # Hack to avoid circular import
     from ..feature._canny import canny as canny_

--- a/skimage/filters/__init__.py
+++ b/skimage/filters/__init__.py
@@ -23,7 +23,7 @@ denoise_tv_chambolle = deprecated('skimage.restoration.denoise_tv_chambolle')\
                         (restoration.denoise_tv_chambolle)
 
 # Backward compatibility v<0.11
-@deprecated()
+@deprecated('skimage.feature.canny')
 def canny(*args, **kwargs):
     # Hack to avoid circular import
     from ..feature._canny import canny as canny_

--- a/skimage/filters/tests/test_deprecated_imports.py
+++ b/skimage/filters/tests/test_deprecated_imports.py
@@ -1,4 +1,6 @@
 from warnings import catch_warnings, simplefilter
+from ..._shared._warnings import expected_warnings
+from ...data import moon
 
 
 def test_filter_import():
@@ -11,9 +13,7 @@ def test_filter_import():
 
 
 def test_canny_import():
-    with catch_warnings():
-        simplefilter('ignore')
+    data = moon()
+    with expected_warnings(['skimage.feature.canny']):
         from skimage.filters import canny
-
-    assert('canny' in dir(F))
-    assert F._import_warned
+        canny(data)

--- a/skimage/filters/tests/test_deprecated_imports.py
+++ b/skimage/filters/tests/test_deprecated_imports.py
@@ -8,3 +8,12 @@ def test_filter_import():
 
     assert('sobel' in dir(F))
     assert F._import_warned
+
+
+def test_canny_import():
+    with catch_warnings():
+        simplefilter('ignore')
+        from skimage.filters import canny
+
+    assert('canny' in dir(F))
+    assert F._import_warned


### PR DESCRIPTION
Closes #1363.  The `deprecated` decorator is a class, and so must be instantiated.  I used `grep -irn "@deprecated" .` to make sure there were no other instances.