### PR TITLE
load correct _frame_index

### DIFF
--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -254,7 +254,7 @@ class ImageCollection(object):
             if ((self.conserve_memory and n != self._cached) or
                     (self.data[idx] is None)):
                 if self._frame_index:
-                    fname, img_num = self._frame_index[idx]
+                    fname, img_num = self._frame_index[n]
                     self.data[idx] = self.load_func(fname, img_num=img_num,
                                                     **self.load_func_kwargs)
                 else:

--- a/skimage/io/tests/test_multi_image.py
+++ b/skimage/io/tests/test_multi_image.py
@@ -50,6 +50,10 @@ class TestMultiImage():
                 assert type(img[i]) is np.ndarray
             assert_allclose(img[0], img[-num])
 
+            assert_raises(AssertionError,
+                          assert_allclose,
+                          img[0], img[1])
+
             # assert_raises expects a callable, hence this thin wrapper function.
             def return_img(n):
                 return img[n]
@@ -77,6 +81,9 @@ class TestMultiImage():
 
     def test_concatenate(self):
         for img in self.imgs:
+            if img[0].shape != img[-1].shape:
+                assert_raises(ValueError, img.concatenate)
+                continue
             array = img.concatenate()
             assert_equal(array.shape, (len(img),) + img[0].shape)
 


### PR DESCRIPTION
Fixes #1368 
idx is always 0 when conserve_memory=True so the first image always gets loaded. Using n as an index fixes this issue.