### PR TITLE
Fix reference links

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -8,7 +8,8 @@ Sphinx is needed to build doc. Install with `pip install sphinx`.
 
 - "citation not found: R###"
   $ cd doc/build; grep -rin R### .
-  There is probably an underscore after the reference (e.g. [1]_)
+  There is probably an underscore after a reference 
+  in the first line of a docstring (e.g. [1]_)
 
 - "Duplicate citation R###, other instance in...""
   There is probably a [2] without a [1] in one of

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -259,7 +259,7 @@ def local_binary_pattern(image, P, R, method='default'):
             finer quantization of the angular space which is gray scale and
             rotation invariant.
         * 'nri_uniform': non rotation-invariant uniform patterns variant
-            which is only gray scale invariant [2].
+            which is only gray scale invariant [2]_.
         * 'var': rotation invariant variance measures of the contrast of local
             image texture which is rotation but not gray scale invariant.
 

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -1,5 +1,5 @@
 """The local histogram is computed using a sliding window similar to the method
-described in [1].
+described in [1]_.
 
 Input image can be 8-bit or 16-bit, for 16-bit input images, the number of
 histogram bins is determined from the maximum value present in the image.
@@ -749,7 +749,7 @@ def tophat(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
 def noise_filter(image, selem, out=None, mask=None, shift_x=False,
                  shift_y=False):
-    """Noise feature as described in [1].
+    """Noise feature.
 
     Parameters
     ----------
@@ -800,10 +800,11 @@ def noise_filter(image, selem, out=None, mask=None, shift_x=False,
 
 
 def entropy(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
-    """Local entropy [1].
+    """Local entropy.
 
     The entropy is computed using base 2 logarithm i.e. the filter returns the
-    minimum number of bits needed to encode the local greylevel distribution.
+    minimum number of bits needed to encode the local greylevel
+    distribution.
 
     Parameters
     ----------

--- a/skimage/morphology/grey.py
+++ b/skimage/morphology/grey.py
@@ -53,7 +53,7 @@ def _invert_selem(selem):
     """Change the order of the values in `selem`.
 
     This is a patch for the *weird* footprint inversion in
-    `nd.grey_morphology` [1].
+    `nd.grey_morphology` [1]_.
 
     Parameters
     ----------


### PR DESCRIPTION
We do need underscores after links, they just cannot be in the first line of a docstring.