### PR TITLE
FIX: Ignore exception if attempted deletion fails (fixes #817)

### DIFF
--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -167,7 +167,10 @@ def _assemble_contours(points_iterator):
                     head.extend(tail)
                     # remove all traces of tail:
                     del starts[to_point]
-                    del ends[tail[-1]]
+                    try:
+                        del ends[tail[-1]]
+                    except KeyError:
+                        pass
                     del contours[tail_num]
                     # remove the old end of head and add the new end.
                     del ends[from_point]


### PR DESCRIPTION
Pragmatic, empirical fix to #817. See my comment in #817 for justification.

I considered raising a warning instead of silently passing, but there is *literally nothing wrong* if only this line fails. If anything problematic happens other lines will fail, and they are not ignored.