### PR TITLE
Contrast check function

### DIFF
--- a/skimage/exposure/__init__.py
+++ b/skimage/exposure/__init__.py
@@ -1,6 +1,7 @@
 from .exposure import histogram, equalize_hist, \
                       rescale_intensity, cumulative_distribution, \
-                      adjust_gamma, adjust_sigmoid, adjust_log
+                      adjust_gamma, adjust_sigmoid, adjust_log, \
+                      is_low_contrast
 
 from ._adapthist import equalize_adapthist
 
@@ -12,4 +13,5 @@ __all__ = ['histogram',
            'cumulative_distribution',
            'adjust_gamma',
            'adjust_sigmoid',
-           'adjust_log']
+           'adjust_log',
+           'is_low_contrast']

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -472,6 +472,22 @@ def test_negative():
     assert_raises(ValueError, exposure.adjust_gamma, image)
 
 
+def test_is_low_contrast():
+    image = np.linspace(0, 0.04, 100)
+    assert exposure.is_low_contrast(image)
+    image[-1] = 1
+    assert exposure.is_low_contrast(image)
+    assert not exposure.is_low_contrast(image, upper_percentile=100)
+
+    image = (image * 255).astype(np.uint8)
+    assert exposure.is_low_contrast(image)
+    assert not exposure.is_low_contrast(image, upper_percentile=100)
+
+    image = (image.astype(np.uint16)) * 2**8
+    assert exposure.is_low_contrast(image)
+    assert not exposure.is_low_contrast(image, upper_percentile=100)
+
+
 if __name__ == '__main__':
     from numpy import testing
     testing.run_module_suite()

--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+import warnings
 
 import numpy as np
 import six
@@ -6,6 +7,8 @@ import six
 from ..io.manage_plugins import call_plugin
 from ..color import rgb2grey
 from .util import file_or_url_context
+from ..exposure import is_low_contrast
+from .._shared._warnings import all_warnings
 
 
 __all__ = ['Image', 'imread', 'imread_collection', 'imsave', 'imshow', 'show']
@@ -152,6 +155,8 @@ def imsave(fname, arr, plugin=None, **plugin_args):
         Passed to the given plugin.
 
     """
+    if is_low_contrast(arr):
+        warnings.warn('%s is a low contrast image' % fname)
     return call_plugin('imsave', fname, arr, plugin=plugin, **plugin_args)
 
 

--- a/skimage/io/_plugins/matplotlib_plugin.py
+++ b/skimage/io/_plugins/matplotlib_plugin.py
@@ -2,7 +2,9 @@ from collections import namedtuple
 import numpy as np
 import warnings
 import matplotlib.pyplot as plt
-from skimage.util import dtype as dtypes
+from ...util import dtype as dtypes
+from ...exposure import is_low_contrast
+from ..._shared._warnings import all_warnings
 
 
 _default_colormap = 'gray'
@@ -49,7 +51,7 @@ def _get_image_properties(image):
     out_of_range_float = (np.issubdtype(image.dtype, np.float) and
                           (immin < lo or immax > hi))
     low_dynamic_range = (immin != immax and
-                         (float(immax - immin) / (hi - lo)) < (1. / 255))
+                         is_low_contrast(image))
     unsupported_dtype = image.dtype not in dtypes._supported_types
 
     return ImageProperties(signed, out_of_range_float,
@@ -72,8 +74,8 @@ def _raise_warnings(image_properties):
         warnings.warn("Low image dynamic range; displaying image with "
                       "stretched contrast.")
     if ip.out_of_range_float:
-        warnings.warn("Float image out of standard range; displaying image "
-                      "with stretched contrast.")
+        warnings.warn("Float image out of standard range; displaying "
+                      "image with stretched contrast.")
 
 
 def _get_display_range(image):

--- a/skimage/io/tests/test_mpl_imshow.py
+++ b/skimage/io/tests/test_mpl_imshow.py
@@ -87,7 +87,8 @@ def test_outside_standard_range():
 
 def test_nonstandard_type():
     plt.figure()
-    with expected_warnings(["Non-standard image type"]):
+    with expected_warnings(["Non-standard image type",
+                            "Low image dynamic range"]):
         ax_im = io.imshow(im64)
     assert ax_im.get_clim() == (im64.min(), im64.max())
     assert n_subplots(ax_im) == 2

--- a/skimage/io/tests/test_pil.py
+++ b/skimage/io/tests/test_pil.py
@@ -147,7 +147,8 @@ def test_imsave_filelike():
     s = BytesIO()
 
     # save to file-like object
-    with expected_warnings(['precision loss|unclosed file']):
+    with expected_warnings(['precision loss|unclosed file',
+                            'is a low contrast image']):
         imsave(s, image)
 
     # read from file-like object

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -26,7 +26,7 @@ INTENSITY_SAMPLE[1, 9:11] = 2
 def test_all_props():
     region = regionprops(SAMPLE, INTENSITY_SAMPLE)[0]
     for prop in PROPS:
-        assert_equal(region[prop], getattr(region, PROPS[prop]))
+        assert_almost_equal(region[prop], getattr(region, PROPS[prop]))
 
 
 def test_dtype():

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -11,6 +11,10 @@ dtype_range = {np.bool_: (False, True),
                np.uint16: (0, 65535),
                np.int8: (-128, 127),
                np.int16: (-32768, 32767),
+               np.int64: (-2**63, 2**63 - 1),
+               np.uint64: (0, 2**64 - 1),
+               np.int32: (-2**31, 2**31 - 1),
+               np.uint32: (0, 2**32 - 1),
                np.float32: (-1, 1),
                np.float64: (-1, 1)}
 


### PR DESCRIPTION
Fix for #1403.  Adds function in `exposure` to check for a low contrast image, and uses the function in `imsave` and matplotlib's `imshow`.