### PR TITLE
install_requires from requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -153,9 +153,7 @@ if __name__ == "__main__":
         ],
 
         configuration=configuration,
-        install_requires=[
-            "six>=%s" % DEPENDENCIES['six']
-        ],
+        install_requires=[dep for dep in DEPENDENCIES],
         packages=setuptools.find_packages(exclude=['doc']),
         include_package_data=True,
         zip_safe=False,  # the package can run out of an .egg file

--- a/tools/travis_before_install.sh
+++ b/tools/travis_before_install.sh
@@ -46,6 +46,8 @@ retry pip install wheel flake8 coveralls nose sphinx
 # install system tk for matplotlib
 sudo apt-get install python-tk
 
+# try to solve #1426
+sudo apt-get install --reinstall python-pkg-resources
 
 # on Python 3.2, use matplotlib 1.3.1
 if [[ $TRAVIS_PYTHON_VERSION == 3.2 ]]; then

--- a/tools/travis_before_install.sh
+++ b/tools/travis_before_install.sh
@@ -41,7 +41,7 @@ else
 fi
 
 source ~/venv/bin/activate
-retry pip install wheel flake8 coveralls nose
+retry pip install wheel flake8 coveralls nose sphinx
 
 # install system tk for matplotlib
 sudo apt-get install python-tk


### PR DESCRIPTION
Include requirements in setup.py, so that new users can install easily with `pip install`. This is especially for those on mac (might be wheel for windows in the future also?), that get the wheel package, does not run `setup.py` and does not get the error messages about missing libraries.