### PR TITLE
TST: Barn-door testing of SaveButtons clicks

### DIFF
--- a/skimage/viewer/tests/test_widgets.py
+++ b/skimage/viewer/tests/test_widgets.py
@@ -101,6 +101,11 @@ def test_save_buttons():
     timer = QtCore.QTimer()
     timer.singleShot(100, QtGui.QApplication.quit)
 
+    # exercise the button clicks
+    sv.save_stack.click()
+    sv.save_file.click()
+
+    # call the save functions directly
     sv.save_to_stack()
     with expected_warnings(['precision loss']):
         sv.save_to_file(filename)

--- a/skimage/viewer/widgets/history.py
+++ b/skimage/viewer/widgets/history.py
@@ -80,9 +80,9 @@ class SaveButtons(BaseWidget):
         notify(msg)
 
     def save_to_file(self, filename=None):
-        if filename is None:
+        if not filename:
             filename = dialogs.save_file_dialog()
-        if filename is None:
+        if not filename:
             return
         image = self.plugin.filtered_image
         if image.dtype == np.bool:


### PR DESCRIPTION
Opening up `canny_simple.py` and clicking the `file` button produces the following stacktrace that this PR fixes.

```bash
(nikea2)edill@edill-810g:~/dev/python/scikit-image/viewer_examples/plugins (master $ u=)$ git describe --long --tags
v0.11.0-29-g6051ff2
(nikea2)edill@edill-810g:~/dev/python/scikit-image/viewer_examples/plugins (master $ u=)$ python canny_simple.py
Traceback (most recent call last):
  File "/home/edill/dev/python/scikit-image/skimage/viewer/widgets/history.py", line 91, in save_to_file
    io.imsave(filename, image)
  File "/home/edill/dev/python/scikit-image/skimage/io/_io.py", line 160, in imsave
    return call_plugin('imsave', fname, arr, plugin=plugin, **plugin_args)
  File "/home/edill/dev/python/scikit-image/skimage/io/manage_plugins.py", line 207, in call_plugin
    return func(*args, **kwargs)
  File "/home/edill/dev/python/scikit-image/skimage/io/_plugins/pil_plugin.py", line 265, in imsave
    img.save(fname, format=format_str)
  File "/home/edill/anaconda/envs/nikea2/lib/python2.7/site-packages/PIL/Image.py", line 1439, in save
    save_handler(self, fp, filename)
  File "/home/edill/anaconda/envs/nikea2/lib/python2.7/site-packages/PIL/PngImagePlugin.py", line 514, in _save
    fp.write(_MAGIC)
AttributeError: 'bool' object has no attribute 'write'
```
The canny_simple.py demo in viewer_examples/plugins has a save that raises an AttributeError in PIL because the button is passing 'False' to the `SaveButtons.save_to_file` function which expects a filename or None. The `False` comes from the `clicked` signal on the Qt PushButton object which is emitting a boolean value in its signal to state if the button is `checked`.  This boolean value is being passed to the `filename` input parameter to `SaveButtons.save_file()` which is causing havoc in pil.
