### PR TITLE
Fix handling of ImageCollection indexing and add test

### DIFF
--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -254,13 +254,16 @@ class ImageCollection(object):
 
             if ((self.conserve_memory and n != self._cached) or
                     (self.data[idx] is None)):
+                kwargs = self.load_func_kwargs
                 if self._frame_index:
                     fname, img_num = self._frame_index[n]
-                    self.data[idx] = self.load_func(fname, img_num=img_num,
-                                                    **self.load_func_kwargs)
+                    if img_num > 0:
+                        self.data[idx] = self.load_func(fname, img_num=img_num,
+                                                        **kwargs)
+                    else:
+                        self.data[idx] = self.load_func(fname, **kwargs)
                 else:
-                    self.data[idx] = self.load_func(self.files[n],
-                                                    **self.load_func_kwargs)
+                    self.data[idx] = self.load_func(self.files[n], **kwargs)
                 self._cached = n
 
             return self.data[idx]

--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -163,11 +163,10 @@ class ImageCollection(object):
             for pattern in load_pattern:
                 self._files.extend(glob(pattern))
             self._files = sorted(self._files, key=alphanumeric_key)
-            self._numframes = self._find_images()
         else:
             self._files = load_pattern
-            self._numframes = len(load_pattern)
-            self._frame_index = None
+
+        self._numframes = self._find_images()
 
         if conserve_memory:
             memory_slots = 1

--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -163,10 +163,11 @@ class ImageCollection(object):
             for pattern in load_pattern:
                 self._files.extend(glob(pattern))
             self._files = sorted(self._files, key=alphanumeric_key)
+            self._numframes = self._find_images()
         else:
             self._files = load_pattern
-
-        self._numframes = self._find_images()
+            self._numframes = len(self._files)
+            self._frame_index = None
 
         if conserve_memory:
             memory_slots = 1

--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -135,7 +135,8 @@ class ImageCollection(object):
       ic = ImageCollection('/tmp/*.png', load_func=imread_convert)
 
     For files with multiple images, the images will be flattened into a list
-    and added to the list of available images.
+    and added to the list of available images.  In this case, ``load_func`` 
+    should accept the keyword argument ``img_num``.
 
     Examples
     --------

--- a/skimage/io/tests/test_freeimage.py
+++ b/skimage/io/tests/test_freeimage.py
@@ -13,7 +13,6 @@ try:
     FI_available = True
     sio.use_plugin('freeimage')
 except RuntimeError:
-    raise
     FI_available = False
 
 np.random.seed(0)

--- a/skimage/io/tests/test_freeimage.py
+++ b/skimage/io/tests/test_freeimage.py
@@ -1,6 +1,7 @@
 import os
 import skimage as si
 import skimage.io as sio
+from skimage import data_dir
 import numpy as np
 
 from numpy.testing import *
@@ -12,6 +13,7 @@ try:
     FI_available = True
     sio.use_plugin('freeimage')
 except RuntimeError:
+    raise
     FI_available = False
 
 np.random.seed(0)
@@ -111,6 +113,14 @@ def test_metadata():
     assert meta[0][('EXIF_MAIN', 'Orientation')] == 1
     assert meta[1][('EXIF_MAIN', 'Software')].startswith('I')
 
+
+@skipif(not FI_available)
+def test_collection():
+    pattern = [os.path.join(data_dir, pic)
+               for pic in ['camera.png', 'color.png']]
+    images = sio.ImageCollection(pattern)
+    assert len(images) == 2
+    assert len(images[:]) == 2
 
 if __name__ == "__main__":
     run_module_suite()

--- a/skimage/io/tests/test_freeimage.py
+++ b/skimage/io/tests/test_freeimage.py
@@ -116,10 +116,12 @@ def test_metadata():
 @skipif(not FI_available)
 def test_collection():
     pattern = [os.path.join(data_dir, pic)
-               for pic in ['camera.png', 'color.png']]
+               for pic in ['camera.png', 'color.png', 'multipage.tif']]
     images = sio.ImageCollection(pattern)
-    assert len(images) == 2
-    assert len(images[:]) == 2
+    assert len(images) == 4
+    assert len(images[:]) == 4
+    # this will fail as freeimage cannot load multi-image tifs
+    assert_raises(TypeError, images.__getitem__, 3)
 
 if __name__ == "__main__":
     run_module_suite()

--- a/skimage/io/tests/test_freeimage.py
+++ b/skimage/io/tests/test_freeimage.py
@@ -117,11 +117,13 @@ def test_metadata():
 def test_collection():
     pattern = [os.path.join(data_dir, pic)
                for pic in ['camera.png', 'color.png', 'multipage.tif']]
+    images = sio.ImageCollection(pattern[:-1])
+    assert len(images) == 2
+    assert len(images[:]) == 2
+
     images = sio.ImageCollection(pattern)
-    assert len(images) == 4
-    assert len(images[:]) == 4
-    # this will fail as freeimage cannot load multi-image tifs
-    assert_raises(TypeError, images.__getitem__, 3)
+    assert len(images) == 3
+    assert len(images[:]) == 3
 
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
Fixes #1439.  We previously introduced the assumption that `load_func` would take the keyword argument `img_num`, but did not document this fact.  

We now only use `img_num` if we are indexing past the first image, and this fact is now documented.  Added another test where the load function does not take the kwarg (in the freeimage plugin).