### PR TITLE
Expanded on Hessian eigenvalue test

### DIFF
--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -90,6 +90,22 @@ def test_hessian_matrix_eigvals():
                                      [0, 0, 1, 0, 0],
                                      [0, 0, 0, 0, 0],
                                      [0, 0, 0, 0, 0]]))
+    np.random.seed(1) # make sure the test is repeatable
+    N = 100 # number of random images to try
+    for i in range(N):
+        mat = np.random.rand(5, 5)
+        Hxx, Hxy, Hyy = hessian_matrix(mat, sigma=0.1)
+        l1, l2 = hessian_matrix_eigvals(Hxx, Hxy, Hyy)
+        for j in range(5):
+            for k in range(5):
+                hessian = [[Hxx[j][k], Hxy[j][k]], [Hxy[j][k], Hyy[j][k]]]
+                for l in (l1[j][k], l2[j][k]): # test each eigenvalue
+                    # The matrix H - lI should have determinant zero
+                    h = [x[:] for x in hessian] # deep copy
+                    h[0][0] -= l
+                    h[1][1] -= l
+                    det = h[0][0]*h[1][1] - h[0][1]*h[1][0]
+                    assert_almost_equal(det, 0, decimal=3)
 
 
 def test_hessian_matrix_det():


### PR DESCRIPTION
This is a start on addressing #1393. Unfortunately I'm not familiar with computing the Hessian via convolution for an image, so I can't think of a good way to test the `hessian_matrix` function in more detail. I did try testing the `hessian_matrix_det` function by matching against the determinant of the matrix returned by `hessian_matrix`, but the values weren't even close, and varied considerably based on `sigma`. For example,

```
In [3]: im = np.random.rand(5, 5)

In [4]: im
Out[4]: 
array([[ 0.29763742,  0.05449981,  0.71780469,  0.51500638,  0.63904432],
       [ 0.67701664,  0.00113305,  0.05631246,  0.004884  ,  0.03438824],
       [ 0.03267068,  0.26552206,  0.31953294,  0.8475709 ,  0.14632559],
       [ 0.18858282,  0.44127783,  0.7114495 ,  0.45750935,  0.89106171],
       [ 0.52487659,  0.74190839,  0.49202619,  0.30676331,  0.61698863]])

In [5]: Hxx, Hxy, Hyy = hessian_matrix(im, sigma=5)

In [6]: det = hessian_matrix_det(im, sigma=5)

In [7]: h0 = [[Hxx[0][0], Hxy[0][0]], [Hxy[0][0], Hyy[0][0]]]

In [8]: h0
Out[8]: 
[[1.8388767163921964, 0.00033013261040972804],
 [0.00033013261040972804, 1.7744890649800114]]

In [9]: det[0][0], h0[0][0]*h0[1][1] - h0[0][1]*h0[1][0]
Out[9]: (0.0031705952509722057, 3.263066516096762)
```

I'm probably missing something here, so if anyone could clear that up I'd be happy to write tests for `hessian_matrix_det` and `hessian_matrix`.
