### PR TITLE
Fixed trivial tests for morphology.binary

### DIFF
--- a/skimage/morphology/binary.py
+++ b/skimage/morphology/binary.py
@@ -12,8 +12,9 @@ from .misc import default_selem
 def binary_erosion(image, selem=None, out=None):
     """Return fast binary morphological erosion of an image.
 
-    This function returns the same result as greyscale erosion but performs
-    faster for binary images.
+    This function returns a similar result to that of greyscale erosion,
+    but uses a constant value of 1 at the edges. It also
+    performs faster for binary images.
 
     Morphological erosion sets a pixel at ``(i,j)`` to the minimum over all
     pixels in the neighborhood centered at ``(i,j)``. Erosion shrinks bright
@@ -39,7 +40,7 @@ def binary_erosion(image, selem=None, out=None):
     """
     if out is None:
         out = np.empty(image.shape, dtype=np.bool)
-    nd.binary_erosion(image, structure=selem, output=out)
+    nd.binary_erosion(image, structure=selem, output=out, border_value=1)
     return out
 
 

--- a/skimage/morphology/grey.py
+++ b/skimage/morphology/grey.py
@@ -183,7 +183,7 @@ def erosion(image, selem=None, out=None, shift_x=False, shift_y=False):
     selem = _shift_selem(selem, shift_x, shift_y)
     if out is None:
         out = np.empty_like(image)
-    nd.grey_erosion(image, footprint=selem, mode='constant', output=out)
+    nd.grey_erosion(image, footprint=selem, output=out)
     return out
 
 

--- a/skimage/morphology/grey.py
+++ b/skimage/morphology/grey.py
@@ -159,6 +159,7 @@ def erosion(image, selem=None, out=None, shift_x=False, shift_y=False):
     For ``uint8`` (and ``uint16`` up to a certain bit-depth) data, the
     lower algorithm complexity makes the `skimage.filter.rank.minimum`
     function more efficient for larger images and structuring elements.
+    Also note that edge pixels are automatically set to 0.
 
     Examples
     --------
@@ -182,7 +183,7 @@ def erosion(image, selem=None, out=None, shift_x=False, shift_y=False):
     selem = _shift_selem(selem, shift_x, shift_y)
     if out is None:
         out = np.empty_like(image)
-    nd.grey_erosion(image, footprint=selem, output=out)
+    nd.grey_erosion(image, footprint=selem, mode='constant', output=out)
     return out
 
 

--- a/skimage/morphology/tests/test_binary.py
+++ b/skimage/morphology/tests/test_binary.py
@@ -10,7 +10,7 @@ from scipy import ndimage
 img = color.rgb2gray(data.astronaut())
 bw_img = img > 100./255
 
-def assert_internally_equal(a, b, border=1):
+def _assert_internally_equal(a, b, border=1):
     testing.assert_array_equal(a[border:-border, border:-border],
                                b[border:-border, border:-border])
 
@@ -18,14 +18,14 @@ def test_non_square_image():
     strel = selem.square(3)
     binary_res = binary.binary_erosion(bw_img[:100, :200], strel)
     grey_res = img_as_bool(grey.erosion(bw_img[:100, :200], strel))
-    assert_internally_equal(binary_res, grey_res)
+    _assert_internally_equal(binary_res, grey_res)
 
 
 def test_binary_erosion():
     strel = selem.square(3)
     binary_res = binary.binary_erosion(bw_img, strel)
     grey_res = img_as_bool(grey.erosion(bw_img, strel))
-    assert_internally_equal(binary_res, grey_res)
+    _assert_internally_equal(binary_res, grey_res)
 
 
 def test_binary_dilation():
@@ -39,14 +39,14 @@ def test_binary_closing():
     strel = selem.square(3)
     binary_res = binary.binary_closing(bw_img, strel)
     grey_res = img_as_bool(grey.closing(bw_img, strel))
-    assert_internally_equal(binary_res, grey_res)
+    _assert_internally_equal(binary_res, grey_res)
 
 
 def test_binary_opening():
     strel = selem.square(3)
     binary_res = binary.binary_opening(bw_img, strel)
     grey_res = img_as_bool(grey.opening(bw_img, strel))
-    assert_internally_equal(binary_res, grey_res, border=2)
+    _assert_internally_equal(binary_res, grey_res, border=2)
 
 
 def test_selem_overflow():

--- a/skimage/morphology/tests/test_binary.py
+++ b/skimage/morphology/tests/test_binary.py
@@ -10,22 +10,18 @@ from scipy import ndimage
 img = color.rgb2gray(data.astronaut())
 bw_img = img > 100./255
 
-def assert_internally_equal(a, b, border=1):
-    testing.assert_array_equal(a[border:-border, border:-border],
-                               b[border:-border, border:-border])
-
 def test_non_square_image():
     strel = selem.square(3)
     binary_res = binary.binary_erosion(bw_img[:100, :200], strel)
     grey_res = img_as_bool(grey.erosion(bw_img[:100, :200], strel))
-    assert_internally_equal(binary_res, grey_res)
+    testing.assert_array_equal(binary_res, grey_res)
 
 
 def test_binary_erosion():
     strel = selem.square(3)
     binary_res = binary.binary_erosion(bw_img, strel)
     grey_res = img_as_bool(grey.erosion(bw_img, strel))
-    assert_internally_equal(binary_res, grey_res)
+    testing.assert_array_equal(binary_res, grey_res)
 
 
 def test_binary_dilation():
@@ -39,14 +35,14 @@ def test_binary_closing():
     strel = selem.square(3)
     binary_res = binary.binary_closing(bw_img, strel)
     grey_res = img_as_bool(grey.closing(bw_img, strel))
-    assert_internally_equal(binary_res, grey_res)
+    testing.assert_array_equal(binary_res, grey_res)
 
 
 def test_binary_opening():
     strel = selem.square(3)
     binary_res = binary.binary_opening(bw_img, strel)
     grey_res = img_as_bool(grey.opening(bw_img, strel))
-    assert_internally_equal(binary_res, grey_res, border=2)
+    testing.assert_array_equal(binary_res, grey_res)
 
 
 def test_selem_overflow():

--- a/skimage/morphology/tests/test_binary.py
+++ b/skimage/morphology/tests/test_binary.py
@@ -10,18 +10,22 @@ from scipy import ndimage
 img = color.rgb2gray(data.astronaut())
 bw_img = img > 100./255
 
+def assert_internally_equal(a, b, border=1):
+    testing.assert_array_equal(a[border:-border, border:-border],
+                               b[border:-border, border:-border])
+
 def test_non_square_image():
     strel = selem.square(3)
     binary_res = binary.binary_erosion(bw_img[:100, :200], strel)
     grey_res = img_as_bool(grey.erosion(bw_img[:100, :200], strel))
-    testing.assert_array_equal(binary_res, grey_res)
+    assert_internally_equal(binary_res, grey_res)
 
 
 def test_binary_erosion():
     strel = selem.square(3)
     binary_res = binary.binary_erosion(bw_img, strel)
     grey_res = img_as_bool(grey.erosion(bw_img, strel))
-    testing.assert_array_equal(binary_res, grey_res)
+    assert_internally_equal(binary_res, grey_res)
 
 
 def test_binary_dilation():
@@ -35,14 +39,14 @@ def test_binary_closing():
     strel = selem.square(3)
     binary_res = binary.binary_closing(bw_img, strel)
     grey_res = img_as_bool(grey.closing(bw_img, strel))
-    testing.assert_array_equal(binary_res, grey_res)
+    assert_internally_equal(binary_res, grey_res)
 
 
 def test_binary_opening():
     strel = selem.square(3)
     binary_res = binary.binary_opening(bw_img, strel)
     grey_res = img_as_bool(grey.opening(bw_img, strel))
-    testing.assert_array_equal(binary_res, grey_res)
+    assert_internally_equal(binary_res, grey_res, border=2)
 
 
 def test_selem_overflow():

--- a/skimage/morphology/tests/test_binary.py
+++ b/skimage/morphology/tests/test_binary.py
@@ -8,21 +8,24 @@ from scipy import ndimage
 
 
 img = color.rgb2gray(data.astronaut())
-bw_img = img > 100
+bw_img = img > 100./255
 
+def assert_internally_equal(a, b, border=1):
+    testing.assert_array_equal(a[border:-border, border:-border],
+                               b[border:-border, border:-border])
 
 def test_non_square_image():
     strel = selem.square(3)
     binary_res = binary.binary_erosion(bw_img[:100, :200], strel)
     grey_res = img_as_bool(grey.erosion(bw_img[:100, :200], strel))
-    testing.assert_array_equal(binary_res, grey_res)
+    assert_internally_equal(binary_res, grey_res)
 
 
 def test_binary_erosion():
     strel = selem.square(3)
     binary_res = binary.binary_erosion(bw_img, strel)
     grey_res = img_as_bool(grey.erosion(bw_img, strel))
-    testing.assert_array_equal(binary_res, grey_res)
+    assert_internally_equal(binary_res, grey_res)
 
 
 def test_binary_dilation():
@@ -36,14 +39,14 @@ def test_binary_closing():
     strel = selem.square(3)
     binary_res = binary.binary_closing(bw_img, strel)
     grey_res = img_as_bool(grey.closing(bw_img, strel))
-    testing.assert_array_equal(binary_res, grey_res)
+    assert_internally_equal(binary_res, grey_res)
 
 
 def test_binary_opening():
     strel = selem.square(3)
     binary_res = binary.binary_opening(bw_img, strel)
     grey_res = img_as_bool(grey.opening(bw_img, strel))
-    testing.assert_array_equal(binary_res, grey_res)
+    assert_internally_equal(binary_res, grey_res, border=2)
 
 
 def test_selem_overflow():


### PR DESCRIPTION
This addresses #1418. I figured out that the failure of the tests (noted by @emmanuelle) was due to a discrepancy in how `binary.binary_erosion` and `grey.erosion` deal with the border of the 2D input array, and so at least for now I just changed the assertions to make sure everything agrees except at the border. However, it seems that either the functionality should be changed to make these functions agree at the borders (by changing `grey.erosion` to assign a constant value at the borders, setting `mode="constant"` and `cval=0.0`), or else the difference should be documented, as the `binary_erosion` docstring incorrectly states that "This function returns the same result as greyscale erosion but performs
    faster for binary images.". I can quickly add either change to this PR, but I was wondering which route would make more sense.
