### PR TITLE
Fix setup to allow installing from PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ python:
 - 3.4
 
 before_install:
-    - sudo apt-get update
+    - sudo apt-get update; true
     - source tools/travis_before_install.sh
 
     - which python; python --version

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -15,7 +15,7 @@ How to make a new release of ``skimage``
   3. Copy ``doc/release/release_template.txt`` to
      ``doc/release/release_dev.txt`` for the next release.
 
-- Update the version number in ``setup.py`` and ``bento.info`` and commit
+- Update the version number in ``skimage/__init__.py`` and ``bento.info`` and commit
 
 - Update the docs:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,17 +13,18 @@ environment:
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python27_64"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "64"
+   # disable other builds until they can be run in parallel
+   #- PYTHON: "C:\\Python27_64"
+   #  PYTHON_VERSION: "2.7"
+   #  PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python34_32"
-      PYTHON_VERSION: "3.4.2"
-      PYTHON_ARCH: "32"
+    #- PYTHON: "C:\\Python34_32"
+    #  PYTHON_VERSION: "3.4.2"
+    #  PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python24_64"
-      PYTHON_VERSION: "3.4.2"
-      PYTHON_ARCH: "64"
+    #- PYTHON: "C:\\Python24_64"
+    #  PYTHON_VERSION: "3.4.2"
+    #  PYTHON_ARCH: "64"
 
 install:
   # Install Python (from the official .msi of http://python.org) and pip when

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -68,10 +68,10 @@ copyright = '2013, the scikit-image team'
 #
 # The short X.Y version.
 
-setup_lines = open('../../setup.py').readlines()
+setup_lines = open('../../skimage/__init__.py').readlines()
 version = 'vUndefined'
 for l in setup_lines:
-    if l.startswith('VERSION'):
+    if l.startswith('__version__'):
         version = l.split("'")[1]
         break
 

--- a/doc/tools/build_modref_templates.py
+++ b/doc/tools/build_modref_templates.py
@@ -37,10 +37,10 @@ if __name__ == '__main__':
 
     installed_version = V(module.__version__)
 
-    setup_lines = open('../setup.py').readlines()
+    source_lines = open('../skimage/__init__.py').readlines()
     version = 'vUndefined'
-    for l in setup_lines:
-        if l.startswith('VERSION'):
+    for l in source_lines:
+        if l.startswith('__version__'):
             source_version = V(l.split("'")[1])
             break
 

--- a/setup.py
+++ b/setup.py
@@ -17,28 +17,41 @@ MAINTAINER_EMAIL    = 'stefan@sun.ac.za'
 URL                 = 'http://scikit-image.org'
 LICENSE             = 'Modified BSD'
 DOWNLOAD_URL        = 'http://github.com/scikit-image/scikit-image'
-VERSION             = '0.12dev'
-PYTHON_VERSION      = (2, 6)
 
 import os
 import sys
 
 import setuptools
 from distutils.command.build_py import build_py
-from distutils.version import LooseVersion
 
 
-# These are manually checked.
-# These packages are sometimes installed outside of the setuptools scope
-DEPENDENCIES = {}
-with open('requirements.txt', 'rb') as fid:
-    data = fid.read().decode('utf-8', 'replace')
-for line in data.splitlines():
-    pkg, _, version_info = line.replace('==', '>=').partition('>=')
-    # Only require Cython if we have a developer checkout
-    if pkg.lower() == 'cython' and not VERSION.endswith('dev'):
-        continue
-    DEPENDENCIES[str(pkg).lower()] = str(version_info)
+with open('skimage/__init__.py') as fid:
+    for line in fid:
+        if line.startswith('__version__'):
+            VERSION = line.strip().split()[-1][1:-1]
+            break
+
+with open('requirements.txt') as fid:
+    INSTALL_REQUIRES = [l.strip() for l in fid.readlines() if l]
+
+# development versions do not have the cythonized files
+if VERSION.endswith('dev'):
+    SETUP_REQUIRES = [r for r in INSTALL_REQUIRES if r.startswith('cython')]
+else:
+    INSTALL_REQUIRES = [r for r in INSTALL_REQUIRES
+                                         if not r.startswith('cython')]
+    SETUP_REQUIRES = []
+
+
+# list requirements for PyPI
+REQUIRES = [r.replace('>=', ' (>= ') + ')'
+                      for r in INSTALL_REQUIRES + SETUP_REQUIRES]
+REQUIRES = [r.replace('==', ' (== ') for r in REQUIRES]
+
+
+# do not attempt to install numpy and scipy until they have eggs available
+INSTALL_REQUIRES = [r for r in INSTALL_REQUIRES
+                                     if not r.startswith(('scipy', 'numpy'))]
 
 
 def configuration(parent_package='', top_path=None):
@@ -59,72 +72,11 @@ def configuration(parent_package='', top_path=None):
     return config
 
 
-def write_version_py(filename='skimage/version.py'):
-    template = """# THIS FILE IS GENERATED FROM THE SKIMAGE SETUP.PY
-version='%s'
-"""
-
-    try:
-        vfile = open(os.path.join(os.path.dirname(__file__),
-                                  filename), 'w')
-        vfile.write(template % VERSION)
-
-    except IOError:
-        raise IOError("Could not open/write to skimage/version.py - did you "
-                      "install using sudo in the past? If so, run\n"
-                      "sudo chown -R your_username ./*\n"
-                      "from package root to fix permissions, and try again.")
-
-    finally:
-        vfile.close()
-
-
-def get_package_version(package):
-    for version_attr in ('__version__', 'VERSION', 'version'):
-        version_info = getattr(package, version_attr, None)
-        if version_info and str(version_attr) == version_attr:
-            return str(version_info)
-
-
-def check_requirements():
-    if sys.version_info < PYTHON_VERSION:
-        raise SystemExit('You need Python version %d.%d or later.' \
-                         % PYTHON_VERSION)
-    for (package_name, min_version) in DEPENDENCIES.items():
-        if package_name == 'cython':
-            package_name = 'Cython'
-        dep_error = ''
-        if package_name.lower() == 'pillow':
-            package_name = 'PIL.Image'
-            min_version = '1.1.7'
-        try:
-            package = __import__(package_name,
-                fromlist=[package_name.rpartition('.')[0]])
-        except ImportError:
-            dep_error = ('You need `%s` version %s or later.'
-                         % (package_name, min_version))
-        else:
-            if package_name == 'PIL':
-                package_version = package.PILLOW_VERSION
-            else:
-                package_version = get_package_version(package)
-
-            if LooseVersion(min_version) > LooseVersion(package_version):
-                dep_error = ('You need `%s` version %s or later,'
-                             'found version %s.'
-                             % (package_name, min_version,
-                                package_version))
-        if dep_error:
-            raise ImportError(dep_error)
-
-
 if __name__ == "__main__":
-
-    check_requirements()
-
-    write_version_py()
-
+    # purposely fail loudly if numpy or scipy are not available
     from numpy.distutils.core import setup
+    import scipy
+
     setup(
         name=DISTNAME,
         description=DESCRIPTION,
@@ -153,7 +105,9 @@ if __name__ == "__main__":
         ],
 
         configuration=configuration,
-        install_requires=[dep for dep in DEPENDENCIES],
+        setup_requires=SETUP_REQUIRES,
+        install_requires=INSTALL_REQUIRES,
+        requires=REQUIRES,
         packages=setuptools.find_packages(exclude=['doc']),
         include_package_data=True,
         zip_safe=False,  # the package can run out of an .egg file

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -64,13 +64,7 @@ import warnings as _warnings
 pkg_dir = _osp.abspath(_osp.dirname(__file__))
 data_dir = _osp.join(pkg_dir, 'data')
 
-try:
-    from .version import version as __version__
-except ImportError:
-    __version__ = "unbuilt-dev"
-else:
-    del version
-
+__version__ = '0.12dev'
 
 try:
     _imp.find_module('nose')

--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -161,7 +161,7 @@ def mono_check(plugin, fmt='png'):
     else:
         testing.assert_allclose(r3, img_as_uint(img))
 
-    with expected_warnings(['precision loss']):
+    with expected_warnings(['precision loss|unclosed file']):
         img4 = img_as_int(img)
     if fmt.lower() in (('tif', 'tiff')):
         img4 -= 100
@@ -182,7 +182,7 @@ def setup_test():
     """Default package level setup routine for skimage tests.
 
     Import packages known to raise errors, and then
-    force warnings to raise errors.  
+    force warnings to raise errors.
     Set a random seed
     """
     warnings.simplefilter('default')
@@ -190,7 +190,7 @@ def setup_test():
     from scipy.io import loadmat
     from skimage import viewer, filter
     np.random.seed(0)
-    warnings.simplefilter('error') 
+    warnings.simplefilter('error')
 
 
 def teardown_test():

--- a/tools/travis_before_install.sh
+++ b/tools/travis_before_install.sh
@@ -36,19 +36,16 @@ if [[ $TRAVIS_PYTHON_VERSION == 2.7* ]]; then
     sed -i 's/cython>=/cython==/g' requirements.txt
     sed -i 's/networkx>=/networkx==/g' requirements.txt
     sed -i '/pillow/d' requirements.txt
-    sudo apt-get install --reinstall python-pkg-resources
 else
     virtualenv -p python --system-site-packages ~/venv
 fi
 
 source ~/venv/bin/activate
-retry pip install wheel flake8 coveralls nose sphinx
+retry pip install wheel flake8 coveralls nose
 
 # install system tk for matplotlib
 sudo apt-get install python-tk
 
-# try to solve #1426
-sudo apt-get install --reinstall python-pkg-resources
 
 # on Python 3.2, use matplotlib 1.3.1
 if [[ $TRAVIS_PYTHON_VERSION == 3.2 ]]; then


### PR DESCRIPTION
Allows scikit-image to be installed from PyPI and puts required library info on PyPI.

Puts the `__version__` information in `skimage/__init__.py` so we don't have to worry about file permissions associated with `version.py` (`matplotlib` does the same thing).

We now require `pillow` explicitly when installing, but we still support `PIL` in the library itself (so packagers can still link against `PIL`).

We can't use `numpy` and `scipy` in `install_requires` because it breaks `setuptools` in our 2.7 build and there are no official wheels for them anyway.

Limits our Appveyor build to just the 32bit Python 2.7 for now.

Fixes #1456.  Fixes #1427.  Fixes #1400.