### PR TITLE
add iradon_workspace to allow caching of iradon work arrays

### DIFF
--- a/skimage/transform/__init__.py
+++ b/skimage/transform/__init__.py
@@ -1,7 +1,7 @@
 from ._hough_transform import (hough_ellipse, hough_line,
                                probabilistic_hough_line)
 from .hough_transform import hough_circle, hough_line_peaks
-from .radon_transform import radon, iradon, iradon_sart
+from .radon_transform import radon, iradon, iradon_sart, iradon_workspace
 from .finite_radon_transform import frt2, ifrt2
 from .integral import integral_image, integrate
 from ._geometric import (warp, warp_coords, estimate_transform,

--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -147,7 +147,7 @@ def iradon_workspace(theta, output_size, circle=False, full=True):
         grid data (for older behavior, smaller memory usage).
     Returns
     -------
-    xpr, ypr, thw : tuple of ndarrays
+    workspace: 
         The workspace
     """
     if not circle:

--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -128,9 +128,8 @@ def iradon_workspace(theta, output_size, circle=False, full=True):
     """
     Generate workspace needed for iradon().
 
-    This allows expensive work arrays to be calculated once for an output size
-    and set of angles, useful when doing multiple calls to iradon() for the
-    same geometry
+    This allows work arrays to be calculated once for an output size and set
+    of angles, useful for multiple calls to iradon() for the same geometry.
 
     Parameters
     ----------
@@ -145,11 +144,11 @@ def iradon_workspace(theta, output_size, circle=False, full=True):
         ``radon`` called with ``circle=True``.
     full : boolean, optional
         Whether to generate full workspace (default) or only the
-        grid data (for older behavior, smaller memory usage)
+        grid data (for older behavior, smaller memory usage).
     Returns
     -------
-    workspace : a tuple of ndarrays (xpr, ypr, twork)
-
+    xpr, ypr, thw : tuple of ndarrays
+        The workspace
     """
     if not circle:
         output_size = int(np.floor(np.sqrt((output_size)**2 / 2.0)))
@@ -188,9 +187,9 @@ def iradon(radon_image, theta=None, output_size=None, workspace=None,
     output_size : int
         Number of rows and columns in the reconstruction.
     workspace : ``None`` or result of ``iradon_workspace()``
-        workspace is a tuple of arrayy with values needed for iradon
-        transform, as calculated by ``iradon_workspace(output_size, theta)``.
-        If ``None`` (default), the needed work arrays are generated as neeeded.
+        Workspace is a tuple of arrays with values needed for iradon
+        transform, as calculated by ``iradon_workspace(theta, output_size)``.
+        If ``None`` (default), the work arrays are generated as needed.
     filter : str, optional (default ramp)
         Filter used in frequency domain filtering. Ramp filter used by default.
         Filters available: ramp, shepp-logan, cosine, hamming, hann.
@@ -276,12 +275,14 @@ def iradon(radon_image, theta=None, output_size=None, workspace=None,
     # Determine the center of the projections (= center of sinogram)
     mid_index = radon_image.shape[0] // 2
 
+    # notes on workspace:
+    # 1. if thwork[i] is None, the calculation will be done per row.
+    # 2. since output_size may have already been rescaled above, use
+    #    circle=True when calling iradon_workspace() here.
     if workspace is None:
-        workspace = iradon_workspace(theta, output_size, circle=True, full=False)
+        workspace = iradon_workspace(theta, output_size,
+                                     circle=True, full=False)
     xpr, ypr, thwork = workspace
-    # note: if workspace = False, the large thw array will not be
-    # calculated, and thw will be an array of `None` -- this will
-    # cause t to be calculated per row
 
     # Reconstruct image by interpolation
     for i in range(len(theta)):

--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -22,7 +22,7 @@ from ._radon_transform import sart_projection_update
 from .. import util
 
 
-__all__ = ["radon", "iradon", "iradon_sart"]
+__all__ = ["radon", "iradon", "iradon_sart", "iradon_workspace"]
 
 
 def radon(image, theta=None, circle=False):
@@ -124,8 +124,49 @@ def _sinogram_circle_to_square(sinogram):
     pad_width = ((pad_before, pad - pad_before), (0, 0))
     return util.pad(sinogram, pad_width, mode='constant', constant_values=0)
 
+def iradon_workspace(theta, output_size, circle=False, full=True):
+    """
+    Generate workspace needed for iradon().
 
-def iradon(radon_image, theta=None, output_size=None,
+    This allows expensive work arrays to be calculated once for an output size
+    and set of angles, useful when doing multiple calls to iradon() for the
+    same geometry
+
+    Parameters
+    ----------
+    theta : array_like, dtype=float, optional
+        Reconstruction angles (in degrees). Default: m angles evenly spaced
+        between 0 and 180 (if the shape of `radon_image` is (N, M)).
+    output_size : int
+        Number of rows and columns in the reconstruction.
+    circle : boolean, optional
+        Assume the reconstructed image is zero outside the inscribed circle.
+        Also changes the default output_size to match the behaviour of
+        ``radon`` called with ``circle=True``.
+    full : boolean, optional
+        Whether to generate full workspace (default) or only the
+        grid data (for older behavior, smaller memory usage)
+    Returns
+    -------
+    workspace : a tuple of ndarrays (xpr, ypr, twork)
+
+    """
+    if not circle:
+        output_size = int(np.floor(np.sqrt((output_size)**2 / 2.0)))
+
+    [_x, _y] = np.mgrid[0:output_size, 0:output_size]
+    xpr = _x - int(output_size) // 2
+    ypr = _y - int(output_size) // 2
+    thw = [None]*len(theta)
+    if full:
+        th  = np.deg2rad(theta)
+        thw = np.zeros((len(th), output_size, output_size),
+                       dtype=np.float64)
+        for i in range(len(th)):
+            thw[i] = ypr * np.cos(th[i]) - xpr * np.sin(th[i])
+    return (xpr, ypr, thw)
+
+def iradon(radon_image, theta=None, output_size=None, workspace=None,
            filter="ramp", interpolation="linear", circle=False):
     """
     Inverse radon transform.
@@ -146,6 +187,10 @@ def iradon(radon_image, theta=None, output_size=None,
         between 0 and 180 (if the shape of `radon_image` is (N, M)).
     output_size : int
         Number of rows and columns in the reconstruction.
+    workspace : ``None`` or result of ``iradon_workspace()``
+        workspace is a tuple of arrayy with values needed for iradon
+        transform, as calculated by ``iradon_workspace(output_size, theta)``.
+        If ``None`` (default), the needed work arrays are generated as neeeded.
     filter : str, optional (default ramp)
         Filter used in frequency domain filtering. Ramp filter used by default.
         Filters available: ramp, shepp-logan, cosine, hamming, hann.
@@ -194,8 +239,7 @@ def iradon(radon_image, theta=None, output_size=None,
                                                / 2.0)))
     if circle:
         radon_image = _sinogram_circle_to_square(radon_image)
-
-    th = (np.pi / 180.0) * theta
+    th = np.deg2rad(theta)
     # resize image to next power of two (but no less than 64) for
     # Fourier analysis; speeds up Fourier and lessens artifacts
     projection_size_padded = \
@@ -232,13 +276,19 @@ def iradon(radon_image, theta=None, output_size=None,
     # Determine the center of the projections (= center of sinogram)
     mid_index = radon_image.shape[0] // 2
 
-    [X, Y] = np.mgrid[0:output_size, 0:output_size]
-    xpr = X - int(output_size) // 2
-    ypr = Y - int(output_size) // 2
+    if workspace is None:
+        workspace = iradon_workspace(theta, output_size, circle=True, full=False)
+    xpr, ypr, thwork = workspace
+    # note: if workspace = False, the large thw array will not be
+    # calculated, and thw will be an array of `None` -- this will
+    # cause t to be calculated per row
 
     # Reconstruct image by interpolation
     for i in range(len(theta)):
-        t = ypr * np.cos(th[i]) - xpr * np.sin(th[i])
+        t = thwork[i]
+        if t is None:
+            t = ypr * np.cos(th[i]) - xpr * np.sin(th[i])
+
         x = np.arange(radon_filtered.shape[0]) - mid_index
         if interpolation == 'linear':
             backprojected = np.interp(t, x, radon_filtered[:, i],


### PR DESCRIPTION
This PR partially addresses #929, and is part of attempts to speed up `iradon`.  

Here, a new function `iradon_workspace` is added to pre-calculate and cache many of the the trigonometric values for the transform, and adds an optional `workspace`  argument to the `iradon` function.   Using a workspace can give noticeable (somewhat less than 2x in preliminary tests) speed-ups for repeated calls to `iradon` with the same geometry. 
