### PR TITLE
Fixed crashing bug in slic.

### DIFF
--- a/skimage/segmentation/_slic.pyx
+++ b/skimage/segmentation/_slic.pyx
@@ -255,7 +255,7 @@ def _enforce_label_connectivity_cython(Py_ssize_t[:, :, ::1] segments,
 
                 #perform a breadth first search to find
                 # the size of the connected component
-                while bfs_visited != current_segment_size:
+                while bfs_visited < current_segment_size < max_size:
                     for i in range(6):
                         zz = coord_list[bfs_visited, 0] + ddz[i]
                         yy = coord_list[bfs_visited, 1] + ddy[i]
@@ -271,6 +271,8 @@ def _enforce_label_connectivity_cython(Py_ssize_t[:, :, ::1] segments,
                                 coord_list[current_segment_size, 1] = yy
                                 coord_list[current_segment_size, 2] = xx
                                 current_segment_size += 1
+                                if current_segment_size >= max_size:
+                                    break
                             elif (connected_segments[zz, yy, xx] >= 0 and
                                   connected_segments[zz, yy, xx] != current_new_label):
                                 adjacent = connected_segments[zz, yy, xx]

--- a/skimage/segmentation/tests/test_slic.py
+++ b/skimage/segmentation/tests/test_slic.py
@@ -153,6 +153,12 @@ def test_enforce_connectivity():
                                  enforce_connectivity=False,
                                  convert2lab=False)
 
+    # Make sure nothing fatal occurs (e.g. buffer overflow) at low values of
+    # max_size_factor
+    segments_connected_low_max = slic(img, 2, compactness=0.0001,
+                                      enforce_connectivity=True,
+                                      convert2lab=False, max_size_factor=0.8)
+
     result_connected = np.array([[0, 0, 0, 1, 1, 1],
                                  [0, 0, 0, 1, 1, 1],
                                  [0, 0, 0, 1, 1, 1]], np.float)
@@ -163,6 +169,7 @@ def test_enforce_connectivity():
 
     assert_equal(segments_connected, result_connected)
     assert_equal(segments_disconnected, result_disconnected)
+    assert_equal(segments_connected_low_max, result_connected)
 
 
 def test_slic_zero():


### PR DESCRIPTION
The enforce connectivity step of slic runs a BFS and puts the
results in `coord_list`. This `coord_list` has room for `max_size` elements,
which is easily overrun if there is a large connected element. This
change limits the BFS to `max_size`, so that if a connected area is bigger
than `max_size`, it will be split up instead of causing the program to crash.

I'll add that this crash happens a lot for me with natural images and the default 
`max_size_factor` of 3. The easiest way to reproduce this bug though is to 
reduce `max_size_factor`:

    from skimage.segmentation import slic
    import numpy as np
    rs = np.random.RandomState(0)
    x = rs.uniform(size=(32, 32))
    slic(x, n_segments=100, enforce_connectivity=True, max_size_factor=1)

Random noise does not generate large connected elements, which is why 
`max_size_factor` needs to be set so low to reproduce the error.