### PR TITLE
Added function to generate binary image with rounded (blob-like) objects...

### DIFF
--- a/doc/examples/plot_random_walker_segmentation.py
+++ b/doc/examples/plot_random_walker_segmentation.py
@@ -25,30 +25,11 @@ from scipy import ndimage
 import matplotlib.pyplot as plt
 
 from skimage.segmentation import random_walker
-
-
-def microstructure(l=256):
-    """
-    Synthetic binary data: binary microstructure with blobs.
-
-    Parameters
-    ----------
-
-    l: int, optional
-        linear size of the returned image
-    """
-    n = 5
-    x, y = np.ogrid[0:l, 0:l]
-    mask = np.zeros((l, l))
-    generator = np.random.RandomState(1)
-    points = l * generator.rand(2, n ** 2)
-    mask[(points[0]).astype(np.int), (points[1]).astype(np.int)] = 1
-    mask = ndimage.gaussian_filter(mask, sigma=l / (4. * n))
-    return (mask > mask.mean()).astype(np.float)
-
+from skimage.data import binary_blobs
+import skimage
 
 # Generate noisy synthetic data
-data = microstructure(l=128)
+data = skimage.img_as_float(binary_blobs(length=128, seed=1))
 data += 0.35 * np.random.randn(*data.shape)
 markers = np.zeros(data.shape, dtype=np.uint)
 markers[data < -0.3] = 1

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -10,7 +10,7 @@ import os as _os
 
 from .. import data_dir
 from ..io import imread, use_plugin
-
+from ._binary_blobs import binary_blobs
 
 __all__ = ['load',
            'camera',

--- a/skimage/data/_binary_blobs.py
+++ b/skimage/data/_binary_blobs.py
@@ -29,17 +29,18 @@ def binary_blobs(length=512, blob_size_fraction=0.1, n_dim=2,
 
     Examples
     --------
+    >>> from skimage import data
     >>> data.binary_blobs(length=5, blob_size_fraction=0.2, seed=1)
     array([[ True, False,  True,  True,  True],
            [ True,  True,  True, False,  True],
            [False,  True, False,  True,  True],
            [ True, False, False,  True,  True],
            [ True, False, False, False,  True]], dtype=bool)
-    >>> blobs = binary_blobs(length=256, blob_size_fraction=0.1)
+    >>> blobs = data.binary_blobs(length=256, blob_size_fraction=0.1)
     >>> # Finer structures
-    >>> blobs = binary_blobs(length=256, blob_size_fraction=0.05)
+    >>> blobs = data.binary_blobs(length=256, blob_size_fraction=0.05)
     >>> # Blobs cover a smaller volume fraction of the image
-    >>> blobs = binary_blobs(length=256, volume_fraction=0.3)
+    >>> blobs = data.binary_blobs(length=256, volume_fraction=0.3)
     """
     rs = np.random.RandomState(seed)
     shape = tuple([length] * n_dim)

--- a/skimage/data/_binary_blobs.py
+++ b/skimage/data/_binary_blobs.py
@@ -5,21 +5,21 @@ from ..filters import gaussian_filter
 def binary_blobs(length=512, blob_size_fraction=0.1, n_dim=2,
                  volume_fraction=0.5, seed=None):
     """
-    Generate synthetic binary image with several blob-like rounded objects.
+    Generate synthetic binary image with several rounded blob-like objects.
 
     Parameters
     ----------
-    length : int, default 512
+    length : int, optional
         Linear size of output image.
-    blob_size_fraction : float, default 0.1
+    blob_size_fraction : float, optional
         Typical linear size of blob, as a fraction of ``length``, should be
         smaller than 1.
-    n_dim : int, default 2
+    n_dim : int, optional
         Number of dimensions of output image.
     volume_fraction : float, default 0.5
         Fraction of image pixels covered by the blobs (where the output is 1).
         Should be in [0, 1].
-    seed : int, default 0
+    seed : int, optional
         Seed to initialize the random number generator.
 
     Returns
@@ -29,15 +29,18 @@ def binary_blobs(length=512, blob_size_fraction=0.1, n_dim=2,
 
     Examples
     --------
+    >>> data.binary_blobs(length=5, blob_size_fraction=0.2, seed=1)
+    array([[ True, False,  True,  True,  True],
+           [ True,  True,  True, False,  True],
+           [False,  True, False,  True,  True],
+           [ True, False, False,  True,  True],
+           [ True, False, False, False,  True]], dtype=bool)
     >>> blobs = binary_blobs(length=256, blob_size_fraction=0.1)
     >>> # Finer structures
     >>> blobs = binary_blobs(length=256, blob_size_fraction=0.05)
     >>> # Blobs cover a smaller volume fraction of the image
     >>> blobs = binary_blobs(length=256, volume_fraction=0.3)
     """
-    if seed is None:
-        seed = 0
-    # Fix the seed for reproducible results
     rs = np.random.RandomState(seed)
     shape = tuple([length] * n_dim)
     mask = np.zeros(shape)

--- a/skimage/data/_binary_blobs.py
+++ b/skimage/data/_binary_blobs.py
@@ -1,0 +1,49 @@
+import numpy as np
+from ..filters import gaussian_filter
+
+
+def binary_blobs(length=512, blob_size_fraction=0.1, n_dim=2,
+                 volume_fraction=0.5, seed=None):
+    """
+    Generate synthetic binary image with several blob-like rounded objects.
+
+    Parameters
+    ----------
+    length : int, default 512
+        Linear size of output image.
+    blob_size_fraction : float, default 0.1
+        Typical linear size of blob, as a fraction of ``length``, should be
+        smaller than 1.
+    n_dim : int, default 2
+        Number of dimensions of output image.
+    volume_fraction : float, default 0.5
+        Fraction of image pixels covered by the blobs (where the output is 1).
+        Should be in [0, 1].
+    seed : int, default 0
+        Seed to initialize the random number generator.
+
+    Returns
+    -------
+    blobs : ndarray of bools
+        Output binary image
+
+    Examples
+    --------
+    >>> blobs = binary_blobs(length=256, blob_size_fraction=0.1)
+    >>> # Finer structures
+    >>> blobs = binary_blobs(length=256, blob_size_fraction=0.05)
+    >>> # Blobs cover a smaller volume fraction of the image
+    >>> blobs = binary_blobs(length=256, volume_fraction=0.3)
+    """
+    if seed is None:
+        seed = 0
+    # Fix the seed for reproducible results
+    rs = np.random.RandomState(seed)
+    shape = tuple([length] * n_dim)
+    mask = np.zeros(shape)
+    n_pts = max(int(1. / blob_size_fraction) ** n_dim, 1)
+    points = (length * rs.rand(n_dim, n_pts)).astype(np.int)
+    mask[[indices for indices in points]] = 1
+    mask = gaussian_filter(mask, sigma=0.25 * length * blob_size_fraction)
+    threshold = np.percentile(mask, 100 * (1 - volume_fraction))
+    return np.logical_not(mask < threshold)

--- a/skimage/data/tests/test_data.py
+++ b/skimage/data/tests/test_data.py
@@ -1,3 +1,4 @@
+import numpy as np
 import skimage.data as data
 from numpy.testing import assert_equal
 
@@ -6,6 +7,7 @@ def test_lena():
     """ Test that "Lena" image can be loaded. """
     lena = data.lena()
     assert_equal(lena.shape, (512, 512, 3))
+
 
 def test_astronaut():
     """ Test that "astronaut" image can be loaded. """
@@ -61,6 +63,10 @@ def test_binary_blobs():
     assert blobs.mean() == 0.25
     blobs = data.binary_blobs(length=32, volume_fraction=0.25, n_dim=3)
     assert blobs.mean() == 0.25
+    other_realization = data.binary_blobs(length=32, volume_fraction=0.25,
+                                          n_dim=3)
+    assert not np.all(blobs == other_realization)
+
 
 if __name__ == "__main__":
     from numpy.testing import run_module_suite

--- a/skimage/data/tests/test_data.py
+++ b/skimage/data/tests/test_data.py
@@ -1,6 +1,6 @@
 import numpy as np
 import skimage.data as data
-from numpy.testing import assert_equal
+from numpy.testing import assert_equal, assert_almost_equal
 
 
 def test_lena():
@@ -58,11 +58,11 @@ def test_coffee():
 
 def test_binary_blobs():
     blobs = data.binary_blobs(length=128)
-    assert blobs.mean() == 0.5
+    assert_almost_equal(blobs.mean(), 0.5, decimal=4)
     blobs = data.binary_blobs(length=128, volume_fraction=0.25)
-    assert blobs.mean() == 0.25
+    assert_almost_equal(blobs.mean(), 0.25, decimal=4)
     blobs = data.binary_blobs(length=32, volume_fraction=0.25, n_dim=3)
-    assert blobs.mean() == 0.25
+    assert_almost_equal(blobs.mean(), 0.25, decimal=4)
     other_realization = data.binary_blobs(length=32, volume_fraction=0.25,
                                           n_dim=3)
     assert not np.all(blobs == other_realization)

--- a/skimage/data/tests/test_data.py
+++ b/skimage/data/tests/test_data.py
@@ -54,6 +54,14 @@ def test_coffee():
     data.coffee()
 
 
+def test_binary_blobs():
+    blobs = data.binary_blobs(length=128)
+    assert blobs.mean() == 0.5
+    blobs = data.binary_blobs(length=128, volume_fraction=0.25)
+    assert blobs.mean() == 0.25
+    blobs = data.binary_blobs(length=32, volume_fraction=0.25, n_dim=3)
+    assert blobs.mean() == 0.25
+
 if __name__ == "__main__":
     from numpy.testing import run_module_suite
     run_module_suite()

--- a/skimage/data/tests/test_data.py
+++ b/skimage/data/tests/test_data.py
@@ -58,11 +58,11 @@ def test_coffee():
 
 def test_binary_blobs():
     blobs = data.binary_blobs(length=128)
-    assert_almost_equal(blobs.mean(), 0.5, decimal=4)
+    assert_almost_equal(blobs.mean(), 0.5, decimal=1)
     blobs = data.binary_blobs(length=128, volume_fraction=0.25)
-    assert_almost_equal(blobs.mean(), 0.25, decimal=4)
+    assert_almost_equal(blobs.mean(), 0.25, decimal=1)
     blobs = data.binary_blobs(length=32, volume_fraction=0.25, n_dim=3)
-    assert_almost_equal(blobs.mean(), 0.25, decimal=4)
+    assert_almost_equal(blobs.mean(), 0.25, decimal=1)
     other_realization = data.binary_blobs(length=32, volume_fraction=0.25,
                                           n_dim=3)
     assert not np.all(blobs == other_realization)


### PR DESCRIPTION
The function exposed in this PR is a utility function that I use very often for tests on binary images, in order to have several objects that can be labeled, measured, etc. 

I was not sure whether it was of a general enough interest to include it in scikit-image, but since I use it very often, others might find it useful as well!

If I receive positive feedback on the interest of merging such a feature, I'll modify as well an example of the gallery that uses a similar function (http://scikit-image.org/docs/dev/auto_examples/plot_random_walker_segmentation.html).