### PR TITLE
viewer: add button widget

### DIFF
--- a/skimage/viewer/widgets/core.py
+++ b/skimage/viewer/widgets/core.py
@@ -1,8 +1,8 @@
-from ..qt import QtWidgets, QtCore, Qt
+from ..qt import QtWidgets, QtCore, Qt, QtGui
 from ..utils import RequiredAttr
 
 
-__all__ = ['BaseWidget', 'Slider', 'ComboBox', 'CheckBox', 'Text']
+__all__ = ['BaseWidget', 'Slider', 'ComboBox', 'CheckBox', 'Text', 'Button']
 
 
 
@@ -287,3 +287,22 @@ class CheckBox(BaseWidget):
     @val.setter
     def val(self, i):
         self._check_box.setChecked(i)
+
+
+class Button(BaseWidget):
+    """Button which calls callback upon click.
+
+    Parameters
+    ----------
+    name : str
+        Name of button.
+    callback : callable f()
+        Function to call when button is clicked.
+    """
+    def __init__(self, name, callback):
+        super(Button, self).__init__(self)
+        self._button = QtGui.QPushButton(name)
+        self._button.clicked.connect(callback)
+
+        self.layout = QtGui.QHBoxLayout(self)
+        self.layout.addWidget(self._button)


### PR DESCRIPTION
This is useful for stuff like resetting plugins, resetting canvas, fire off expensive filters upon user interaction, etc.

Example usage:

```python
from skimage.viewer.plugins import Plugin
from skimage.viewer.widgets import Button
from skimage.viewer.canvastools import RectangleTool

class Zoom(Plugin):
    name = 'Zoom'
    def attach(self, iv):
        super(Offset, self).attach(iv)
        self.ax = iv.ax
        self.canvas = iv.canvas
        self.orig_shape = iv.original_image.shape
        self._reset_btn = Button('Reset', self.reset)
        self.add_widget(self._reset_btn)
        self.zoom_artist = RectangleTool(iv, on_enter=self.zoom)
        self.artists.append(self.zoom_artist)

    def zoom(self, extents):
        xmin, xmax, ymin, ymax = extents
        self.ax.set_xlim(xmin, xmax)
        self.ax.set_ylim(ymax, ymin)
        self.canvas.draw()

    def reset(self):
        ymax, xmax = self.orig_shape
        self.ax.set_xlim(0, xmax)
        self.ax.set_ylim(ymax, 0)
        self.canvas.draw()
```