### PR TITLE
Fix skimage.io.imread returns incorrect dimensions

### DIFF
--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -59,7 +59,7 @@ def imread(fname, as_grey=False, plugin=None, flatten=None,
     if img.ndim > 2:
         if img.shape[-1] not in (3, 4) and img.shape[-3] in (3, 4):
             img = np.swapaxes(img, -1, -3)
-            img = np.swapaxes(img, -1, -2)
+            img = np.swapaxes(img, -2, -3)
 
         if as_grey:
             img = rgb2grey(img)

--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -53,8 +53,16 @@ def imread(fname, as_grey=False, plugin=None, flatten=None,
     with file_or_url_context(fname) as fname:
         img = call_plugin('imread', fname, plugin=plugin, **plugin_args)
 
-    if as_grey and getattr(img, 'ndim', 0) >= 3:
-        img = rgb2grey(img)
+    if not hasattr(img, 'ndim'):
+        return img
+
+    if img.ndim > 2:
+        if img.shape[-1] not in (3, 4) and img.shape[-3] in (3, 4):
+            img = np.swapaxes(img, -1, -3)
+            img = np.swapaxes(img, -1, -2)
+
+        if as_grey:
+            img = rgb2grey(img)
 
     return img
 

--- a/skimage/io/tests/test_imread.py
+++ b/skimage/io/tests/test_imread.py
@@ -65,12 +65,12 @@ def test_bilevel():
 def test_imread_separate_channels():
     # Test that imread returns RGBA values contiguously even when they are
     # stored in separate planes.
-    x = np.zeros((3, 16, 8), np.uint8)
+    x = np.random.rand(3, 16, 8)
     f = NamedTemporaryFile(suffix='.tif')
     fname = f.name
     f.close()
     imsave(fname, x, plugin='tifffile')
-    img = imread(fname)
+    img = imread(fname, plugin='tifffile')
     os.remove(fname)
     assert img.shape == (16, 8, 3), img.shape
 

--- a/skimage/io/tests/test_imread.py
+++ b/skimage/io/tests/test_imread.py
@@ -1,3 +1,4 @@
+import os
 import os.path
 import numpy as np
 from numpy.testing import *
@@ -58,6 +59,20 @@ def test_bilevel():
 
     img = imread(os.path.join(data_dir, 'checker_bilevel.png'))
     assert_array_equal(img.astype(bool), expected)
+
+
+@skipif(not imread_available)
+def test_imread_separate_channels():
+    # Test that imread returns RGBA values contiguously even when they are
+    # stored in separate planes.
+    x = np.zeros((3, 16, 8), np.uint8)
+    f = NamedTemporaryFile(suffix='.tif')
+    fname = f.name
+    f.close()
+    imsave(fname, x, plugin='tifffile')
+    img = imread(fname)
+    os.remove(fname)
+    assert img.shape == (16, 8, 3), img.shape
 
 
 class TestSave:


### PR DESCRIPTION
Fixes #1496

Note that since imread does not have access to metadata, such as the TIFF PlanarConfiguration tag, this patch uses a heuristic approach based on the image shape. Also, the returned ndimage array might be non-contiguous.