### PR TITLE
Update measure.regionprops.weighted_moments_central doc

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -445,7 +445,8 @@ def regionprops(label_image, intensity_image=None, cache=True):
             wmu_ji = sum{ array(x, y) * (x - x_c)^j * (y - y_c)^i }
 
         where the sum is over the `x`, `y` coordinates of the region,
-        and `x_c` and `y_c` are the coordinates of the region's centroid.
+        and `x_c` and `y_c` are the coordinates of the region's weighted
+        centroid.
     **weighted_moments_hu** : tuple
         Hu moments (translation, scale and rotation invariant) of intensity
         image.


### PR DESCRIPTION
The documentation is misleading. In fact, the code does do what a user would expect: use the weighted centroid coordinates, not the centroid coordinates. It's one word, but it's an important one!

https://github.com/scikit-image/scikit-image/blob/master/skimage/measure/_regionprops.py#L291