### PR TITLE
n-dimensional rescale, resize, and pyramid transforms

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -40,3 +40,16 @@ Version 0.15
   ``'reflect'``.
 * In ``skimage.transform.rescale``, set default value of ``mode`` to
   ``'reflect'``.
+
+Version 0.16
+------------
+* In ``skimage.transform.resize``, ``skimage.transform.pyramid_reduce``,
+  ``skimage.transform.pyramid_laplacian``,
+  ``skimage.transform.pyramid_gaussian``,
+  ``skimage.transform.pyramid_expandset``, set default value of
+  ``multichannel`` to False
+* Remove ``_multichannel_default`` from ``skimage.transform._warps.py``, and no
+  longer call it from within the ``resize`` or ``pyramid_*`` transforms.
+* Remove checks for the ``multichannel`` deprecation warnings in several tests
+  in ``skimage.transform.tests.test_pyramids.py`` and
+  ``skimage.transform.tests.test_warps.py``.

--- a/doc/examples/transform/plot_pyramid.py
+++ b/doc/examples/transform/plot_pyramid.py
@@ -5,8 +5,8 @@ Build image pyramids
 
 The ``pyramid_gaussian`` function takes an image and yields successive images
 shrunk by a constant scale factor. Image pyramids are often used, e.g., to
-implement algorithms for denoising, texture discrimination, and scale-
-invariant detection.
+implement algorithms for denoising, texture discrimination, and scale-invariant
+detection.
 
 """
 import numpy as np
@@ -18,7 +18,7 @@ from skimage.transform import pyramid_gaussian
 
 image = data.astronaut()
 rows, cols, dim = image.shape
-pyramid = tuple(pyramid_gaussian(image, downscale=2))
+pyramid = tuple(pyramid_gaussian(image, downscale=2, multichannel=True))
 
 composite_image = np.zeros((rows, cols + cols // 2, 3), dtype=np.double)
 

--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -68,7 +68,7 @@ from skimage import data_dir
 from skimage.transform import radon, rescale
 
 image = imread(data_dir + "/phantom.png", as_grey=True)
-image = rescale(image, scale=0.4, mode='reflect')
+image = rescale(image, scale=0.4, mode='reflect', multichannel=False)
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4.5))
 

--- a/skimage/feature/orb.py
+++ b/skimage/feature/orb.py
@@ -132,7 +132,8 @@ class ORB(FeatureDetector, DescriptorExtractor):
 
     def _build_pyramid(self, image):
         image = _prepare_grayscale_input_2D(image)
-        return list(pyramid_gaussian(image, self.n_scales - 1, self.downscale))
+        return list(pyramid_gaussian(image, self.n_scales - 1,
+                                     self.downscale, multichannel=False))
 
     def _detect_octave(self, octave_image):
         # Extract keypoints for current octave

--- a/skimage/feature/orb.py
+++ b/skimage/feature/orb.py
@@ -5,7 +5,7 @@ from ..feature.util import (FeatureDetector, DescriptorExtractor,
                             _prepare_grayscale_input_2D)
 
 from ..feature import (corner_fast, corner_orientations, corner_peaks,
-                             corner_harris)
+                       corner_harris)
 from ..transform import pyramid_gaussian
 from .._shared.utils import assert_nD
 
@@ -315,14 +315,14 @@ class ORB(FeatureDetector, DescriptorExtractor):
             keypoints_list.append(keypoints[mask] * self.downscale ** octave)
             responses_list.append(responses[mask])
             orientations_list.append(orientations[mask])
-            scales_list.append(self.downscale ** octave
-                               * np.ones(keypoints.shape[0], dtype=np.intp))
+            scales_list.append(self.downscale ** octave *
+                               np.ones(keypoints.shape[0], dtype=np.intp))
             descriptors_list.append(descriptors)
 
         if len(scales_list) == 0:
-            raise RuntimeError("ORB found no features. Try passing in an image "
-                               "containing greater intensity contrasts between "
-                               "adjacent pixels.")
+            raise RuntimeError(
+                "ORB found no features. Try passing in an image containing "
+                "greater intensity contrasts between adjacent pixels.")
 
         keypoints = np.vstack(keypoints_list)
         responses = np.hstack(responses_list)

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -17,6 +17,14 @@ HOMOGRAPHY_TRANSFORMS = (
 )
 
 
+def _multichannel_default(multichannel, ndim):
+    # utility for maintaining previous color image default behavior
+    if ndim == 3:
+        return True
+    else:
+        return False
+
+
 def resize(image, output_shape, order=1, mode='constant', cval=0, clip=True,
            preserve_range=False):
     """Resize image to match a certain size.
@@ -184,7 +192,8 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
     multichannel : bool, optional
-        If True, last axis will not be rescaled.
+        If True, last axis will not be rescaled.  The default is True for 3D
+        (2D+color) inputs, False otherwise.
 
     Examples
     --------
@@ -198,7 +207,7 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
 
     """
     if multichannel is None:
-        multichannel = False  # maintain previous default behavior
+        multichannel = _multichannel_default(multichannel, image.ndim)
     scale = np.atleast_1d(scale)
     if len(scale) > 1 and len(scale) != image.ndim:
         raise ValueError("must supply a single scale or one value per axis.")

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -7,8 +7,8 @@ from ._geometric import (SimilarityTransform, AffineTransform,
 from ._warps_cy import _warp_fast
 from ..measure import block_reduce
 
-from ..util import img_as_float
-from .._shared.utils import get_bound_method_class, safe_as_int, warn, convert_to_float
+from .._shared.utils import (get_bound_method_class, safe_as_int, warn,
+                             convert_to_float)
 
 HOMOGRAPHY_TRANSFORMS = (
     SimilarityTransform,
@@ -36,8 +36,8 @@ def resize(image, output_shape, order=1, mode=None, cval=0, clip=True,
 
     Performs interpolation to up-size or down-size images. For down-sampling
     N-dimensional images by applying a function or the arithmetic mean, see
-    `skimage.measure.block_reduce` and `skimage.transform.downscale_local_mean`,
-    respectively.
+    `skimage.measure.block_reduce` and
+    `skimage.transform.downscale_local_mean`, respectively.
 
     Parameters
     ----------
@@ -585,8 +585,8 @@ def _clip_warp_output(input_image, output_image, order, mode, cval, clip):
         min_val = input_image.min()
         max_val = input_image.max()
 
-        preserve_cval = mode == 'constant' and not \
-                        (min_val <= cval <= max_val)
+        preserve_cval = (mode == 'constant' and not
+                         (min_val <= cval <= max_val))
 
         if preserve_cval:
             cval_mask = output_image == cval
@@ -769,10 +769,9 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=1,
             # inverse_map is a homography
             matrix = inverse_map.params
 
-        elif (hasattr(inverse_map, '__name__')
-              and inverse_map.__name__ == 'inverse'
-              and get_bound_method_class(inverse_map) \
-                  in HOMOGRAPHY_TRANSFORMS):
+        elif (hasattr(inverse_map, '__name__') and
+              inverse_map.__name__ == 'inverse' and
+              get_bound_method_class(inverse_map) in HOMOGRAPHY_TRANSFORMS):
             # inverse_map is the inverse of a homography
             matrix = np.linalg.inv(six.get_method_self(inverse_map).params)
 
@@ -780,8 +779,8 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=1,
             matrix = matrix.astype(np.double)
             if image.ndim == 2:
                 warped = _warp_fast(image, matrix,
-                                 output_shape=output_shape,
-                                 order=order, mode=mode, cval=cval)
+                                    output_shape=output_shape,
+                                    order=order, mode=mode, cval=cval)
             elif image.ndim == 3:
                 dims = []
                 for dim in range(image.shape[2]):
@@ -793,8 +792,8 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=1,
     if warped is None:
         # use ndi.map_coordinates
 
-        if (isinstance(inverse_map, np.ndarray)
-                and inverse_map.shape == (3, 3)):
+        if (isinstance(inverse_map, np.ndarray) and
+                inverse_map.shape == (3, 3)):
             # inverse_map is a transformation matrix as numpy array,
             # this is only used for order >= 4.
             inverse_map = ProjectiveTransform(matrix=inverse_map)

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -200,8 +200,10 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
     multichannel : bool, optional
-        By default, is set to True for 3D (2D+color) inputs, and False for
-        others.  Starting in release 0.16, this will always default to False.
+        hether the last axis of the image is to be interpreted as multiple
+        channels or another spatial dimension.  By default, is set to True for
+        3D (2D+color) inputs, and False for others.  Starting in release 0.16,
+        this will always default to False.
 
     Examples
     --------

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -105,8 +105,12 @@ def resize(image, output_shape, order=1, mode='constant', cval=0, clip=True,
                                          sparse=False,
                                          indexing='ij'))
 
+        for i in range(len(output_shape) - image.ndim):
+            image = image[..., np.newaxis]
+
         image = convert_to_float(image, preserve_range)
 
+        ndi_mode = _to_ndimage_mode(mode)
         out = ndi.map_coordinates(image, coord_map, order=order,
                                   mode=ndi_mode, cval=cval)
 
@@ -523,15 +527,6 @@ def warp_coords(coord_map, shape, dtype=np.float64):
     return coords
 
 
-def _convert_warp_input(image, preserve_range):
-    """Convert input image to double image with the appropriate range."""
-    if preserve_range:
-        image = image.astype(np.double)
-    else:
-        image = img_as_float(image)
-    return image
-
-
 def _clip_warp_output(input_image, output_image, order, mode, cval, clip):
     """Clip output image to range of values of input image.
 
@@ -715,7 +710,7 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=1,
     >>> warped = warp(cube, coords)
 
     """
-    image = _convert_warp_input(image, preserve_range)
+    image = convert_to_float(image, preserve_range)
 
     input_shape = np.array(image.shape)
 

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -1,5 +1,4 @@
 import six
-import warnings
 import numpy as np
 from scipy import ndimage as ndi
 
@@ -22,8 +21,8 @@ def _multichannel_default(multichannel, ndim):
     if multichannel is not None:
         return multichannel
     else:
-        warnings.warn('default multichannel argument (None) is deprecated. '
-                      'Specifiy True or False explicitly.')
+        warn('The default multichannel argument (None) is deprecated. '
+             'Specifiy True or False explicitly.')
         # utility for maintaining previous color image default behavior
         if ndim == 3:
             return True
@@ -31,7 +30,7 @@ def _multichannel_default(multichannel, ndim):
             return False
 
 
-def resize(image, output_shape, order=1, mode='constant', cval=0, clip=True,
+def resize(image, output_shape, order=1, mode=None, cval=0, clip=True,
            preserve_range=False):
     """Resize image to match a certain size.
 
@@ -103,6 +102,7 @@ def resize(image, output_shape, order=1, mode='constant', cval=0, clip=True,
     if ndim_out > image.ndim:
         # append dimensions to input_shape
         input_shape = input_shape + (1, ) * (ndim_out - image.ndim)
+        image = np.reshape(image, input_shape)
     elif ndim_out == image.ndim - 1:
         # multichannel case: append shape of last axis
         output_shape = np.concatenate((output_shape, [image.shape[-1], ]))

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -18,7 +18,7 @@ HOMOGRAPHY_TRANSFORMS = (
 
 
 def resize(image, output_shape, order=1, mode='constant', cval=0, clip=True,
-           preserve_range=False, multichannel=True):
+           preserve_range=False):
     """Resize image to match a certain size.
 
     Performs interpolation to up-size or down-size images. For down-sampling
@@ -60,8 +60,6 @@ def resize(image, output_shape, order=1, mode='constant', cval=0, clip=True,
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
-    multichannel : bool, optional
-        If True and ``image.ndim > 2``, treat last axis as channels.
 
     Notes
     -----
@@ -145,7 +143,7 @@ def resize(image, output_shape, order=1, mode='constant', cval=0, clip=True,
 
 
 def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
-            preserve_range=False):
+            preserve_range=False, multichannel=None):
     """Scale image by a certain factor.
 
     Performs interpolation to upscale or down-scale images. For down-sampling
@@ -185,6 +183,8 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
+    multichannel : bool, optional
+        If True, last axis will not be rescaled.
 
     Examples
     --------
@@ -197,11 +197,15 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
     (256, 256)
 
     """
+    if multichannel is None:
+        multichannel = False  # maintain previous default behavior
     scale = np.atleast_1d(scale)
     if len(scale) > 1 and len(scale) != image.ndim:
         raise ValueError("must supply a single scale or one value per axis.")
     orig_shape = np.asarray(image.shape)
     output_shape = np.round(scale * orig_shape).astype('i8')
+    if multichannel:  # don't scale channel dimension
+        output_shape[-1] = orig_shape[-1]
 
     return resize(image, output_shape, order=order, mode=mode, cval=cval,
                   clip=clip, preserve_range=preserve_range)

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -91,7 +91,7 @@ def resize(image, output_shape, order=1, mode='constant', cval=0, clip=True,
         orig_shape = orig_shape[:-1]
     orig_shape = np.asarray(orig_shape)
 
-    dim_scales = orig_shape / output_shape
+    dim_scales = orig_shape.astype('f8') / output_shape
 
     ndim_out = len(output_shape)
     # 2-dimensional interpolation

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -201,8 +201,8 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
         image is converted according to the conventions of `img_as_float`.
     multichannel : bool, optional
         Whether the last axis of the image is to be interpreted as multiple
-        channels or another spatial dimension.  By default, is set to True for
-        3D (2D+color) inputs, and False for others.  Starting in release 0.16,
+        channels or another spatial dimension. By default, is set to True for
+        3D (2D+color) inputs, and False for others. Starting in release 0.16,
         this will always default to False.
 
     Examples

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -173,7 +173,7 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
         Input image.
     scale : {float, tuple of floats}
         Scale factors. Separate scale factors can be defined as
-        `(row_scale, col_scale)`.
+        `(rows, cols[, ...][, dim])`.
 
     Returns
     -------
@@ -200,7 +200,7 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
     multichannel : bool, optional
-        hether the last axis of the image is to be interpreted as multiple
+        Whether the last axis of the image is to be interpreted as multiple
         channels or another spatial dimension.  By default, is set to True for
         3D (2D+color) inputs, and False for others.  Starting in release 0.16,
         this will always default to False.

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -47,8 +47,10 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
     cval : float, optional
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
-        By default, is set to True for 3D (2D+color) inputs, and False for
-        others.  Starting in release 0.16, this will always default to False.
+        hether the last axis of the image is to be interpreted as multiple
+        channels or another spatial dimension.  By default, is set to True for
+        3D (2D+color) inputs, and False for others.  Starting in release 0.16,
+        this will always default to False.
 
     Returns
     -------
@@ -102,8 +104,11 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
     cval : float, optional
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
-        By default, is set to True for 3D (2D+color) inputs, and False for
-        others.  Starting in release 0.16, this will always default to False.
+        hether the last axis of the image is to be interpreted as multiple
+        channels or another spatial dimension.  By default, is set to True for
+        3D (2D+color) inputs, and False for others.  Starting in release 0.16,
+        this will always default to False.
+
 
     Returns
     -------
@@ -169,8 +174,11 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
     cval : float, optional
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
-        By default, is set to True for 3D (2D+color) inputs, and False for
-        others.  Starting in release 0.16, this will always default to False.
+        hether the last axis of the image is to be interpreted as multiple
+        channels or another spatial dimension.  By default, is set to True for
+        3D (2D+color) inputs, and False for others.  Starting in release 0.16,
+        this will always default to False.
+
 
     Returns
     -------
@@ -249,8 +257,11 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
     cval : float, optional
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
-        By default, is set to True for 3D (2D+color) inputs, and False for
-        others.  Starting in release 0.16, this will always default to False.
+        hether the last axis of the image is to be interpreted as multiple
+        channels or another spatial dimension.  By default, is set to True for
+        3D (2D+color) inputs, and False for others.  Starting in release 0.16,
+        this will always default to False.
+
 
     Returns
     -------

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -273,6 +273,7 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
         # automatically determine sigma which covers > 99% of distribution
         sigma = 2 * downscale / 6.0
 
+    layer = 0
     current_shape = image.shape
 
     smoothed_image = _smooth(image, sigma, mode, cval, multichannel)
@@ -280,7 +281,8 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
 
     # build downsampled images until max_layer is reached or downscale process
     # does not change image size
-    for layer in range(max_layer):
+    while layer != max_layer:
+        layer += 1
 
         out_shape = tuple(
             [math.ceil(d / float(downscale)) for d in current_shape])

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -8,8 +8,7 @@ from ._warps import _multichannel_default
 
 def _smooth(image, sigma, mode, cval, multichannel=None):
     """Return image with each channel smoothed by the Gaussian filter."""
-    if multichannel is None:
-        multichannel = _multichannel_default(multichannel, image.ndim)
+    multichannel = _multichannel_default(multichannel, image.ndim)
     smoothed = np.empty(image.shape, dtype=np.double)
 
     # apply Gaussian filter to all channels independently
@@ -52,6 +51,7 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
         cval is the value when mode is equal to 'constant'.
     cval : float, optional
         Value to fill past edges of input if mode is 'constant'.
+    multichannel : bool, optional
         If True, last axis will not be rescaled.  The default is True for 3D
         (2D+color) inputs, False otherwise.
 
@@ -65,8 +65,7 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
     .. [1] http://web.mit.edu/persci/people/adelson/pub_pdfs/pyramid83.pdf
 
     """
-    if multichannel is None:
-        multichannel = _multichannel_default(multichannel, image.ndim)
+    multichannel = _multichannel_default(multichannel, image.ndim)
     _check_factor(downscale)
 
     image = img_as_float(image)
@@ -121,8 +120,7 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
     .. [1] http://web.mit.edu/persci/people/adelson/pub_pdfs/pyramid83.pdf
 
     """
-    if multichannel is None:
-        multichannel = _multichannel_default(multichannel, image.ndim)
+    multichannel = _multichannel_default(multichannel, image.ndim)
     _check_factor(upscale)
 
     image = img_as_float(image)
@@ -270,8 +268,7 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
     .. [2] http://sepwww.stanford.edu/data/media/public/sep/morgan/texturematch/paper_html/node3.html
 
     """
-    if multichannel is None:
-        multichannel = _multichannel_default(multichannel, image.ndim)
+    multichannel = _multichannel_default(multichannel, image.ndim)
     _check_factor(downscale)
 
     # cast to float for consistent data type in pyramid

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -30,7 +30,7 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
 
     Parameters
     ----------
-    image : array
+    image : ndarray
         Input image.
     downscale : float, optional
         Downscale factor.
@@ -87,7 +87,7 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
 
     Parameters
     ----------
-    image : array
+    image : ndarray
         Input image.
     upscale : float, optional
         Upscale factor.
@@ -154,7 +154,7 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
 
     Parameters
     ----------
-    image : array
+    image : ndarray
         Input image.
     max_layer : int
         Number of layers for the pyramid. 0th layer is the original image.
@@ -237,7 +237,7 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
 
     Parameters
     ----------
-    image : array
+    image : ndarray
         Input image.
     max_layer : int
         Number of layers for the pyramid. 0th layer is the original image.

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -13,14 +13,9 @@ def _smooth(image, sigma, mode, cval, multichannel=None):
 
     # apply Gaussian filter to all channels independently
     if multichannel:
-        for dim in range(image.shape[-1]):
-            ndi.gaussian_filter(image[..., dim], sigma,
-                                output=smoothed[..., dim],
-                                mode=mode, cval=cval)
-    else:
-        ndi.gaussian_filter(image, sigma, output=smoothed,
-                            mode=mode, cval=cval)
-
+        sigma = (sigma, )*(image.ndim - 1) + (0, )
+    ndi.gaussian_filter(image, sigma, output=smoothed,
+                        mode=mode, cval=cval)
     return smoothed
 
 
@@ -52,8 +47,8 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
     cval : float, optional
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
-        If True, last axis will not be rescaled.  The default is True for 3D
-        (2D+color) inputs, False otherwise.
+        By default, is set to True for 3D (2D+color) inputs, and False for
+        others.  Starting in release 0.16, this will always default to False.
 
     Returns
     -------
@@ -107,8 +102,8 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
     cval : float, optional
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
-        If True, last axis will not be rescaled.  The default is True for 3D
-        (2D+color) inputs, False otherwise.
+        By default, is set to True for 3D (2D+color) inputs, and False for
+        others.  Starting in release 0.16, this will always default to False.
 
     Returns
     -------
@@ -174,8 +169,8 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
     cval : float, optional
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
-        If True, last axis will not be rescaled.  The default is True for 3D
-        (2D+color) inputs, False otherwise.
+        By default, is set to True for 3D (2D+color) inputs, and False for
+        others.  Starting in release 0.16, this will always default to False.
 
     Returns
     -------
@@ -254,8 +249,8 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
     cval : float, optional
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
-        If True, last axis will not be rescaled.  The default is True for 3D
-        (2D+color) inputs, False otherwise.
+        By default, is set to True for 3D (2D+color) inputs, and False for
+        others.  Starting in release 0.16, this will always default to False.
 
     Returns
     -------
@@ -278,7 +273,6 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
         # automatically determine sigma which covers > 99% of distribution
         sigma = 2 * downscale / 6.0
 
-    layer = 0
     current_shape = image.shape
 
     smoothed_image = _smooth(image, sigma, mode, cval, multichannel)
@@ -286,8 +280,7 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
 
     # build downsampled images until max_layer is reached or downscale process
     # does not change image size
-    while layer != max_layer:
-        layer += 1
+    for layer in range(max_layer):
 
         out_shape = tuple(
             [math.ceil(d / float(downscale)) for d in current_shape])

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -273,7 +273,6 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
         # automatically determine sigma which covers > 99% of distribution
         sigma = 2 * downscale / 6.0
 
-    layer = 0
     current_shape = image.shape
 
     smoothed_image = _smooth(image, sigma, mode, cval, multichannel)
@@ -281,8 +280,10 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
 
     # build downsampled images until max_layer is reached or downscale process
     # does not change image size
-    while layer != max_layer:
-        layer += 1
+    if max_layer == -1:
+        max_layer = int(np.ceil(math.log(np.max(current_shape), downscale)))
+
+    for layer in range(max_layer):
 
         out_shape = tuple(
             [math.ceil(d / float(downscale)) for d in current_shape])
@@ -294,12 +295,6 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
                                order=order, mode=mode, cval=cval)
         smoothed_image = _smooth(resized_image, sigma, mode, cval,
                                  multichannel)
-
-        prev_shape = np.asarray(current_shape)
         current_shape = np.asarray(resized_image.shape)
-
-        # no change to previous pyramid layer
-        if np.all(current_shape == prev_shape):
-            break
 
         yield resized_image - smoothed_image

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -138,7 +138,7 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
 
 
 def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
-                     mode='reflect', cval=0):
+                     mode='reflect', cval=0, multichannel=True):
     """Yield images of the Gaussian pyramid formed by the input image.
 
     Recursively applies the `pyramid_reduce` function to the image, and yields
@@ -201,7 +201,7 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
         layer += 1
 
         layer_image = pyramid_reduce(prev_layer_image, downscale, sigma, order,
-                                     mode, cval)
+                                     mode, cval, multichannel=multichannel)
 
         prev_shape = np.asarray(current_shape)
         prev_layer_image = layer_image
@@ -292,7 +292,8 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
             out_shape = out_shape[:-1]
 
         resized_image = resize(smoothed_image, out_shape,
-                               order=order, mode=mode, cval=cval)
+                               order=order, mode=mode, cval=cval,
+                               multichannel=multichannel)
         smoothed_image = _smooth(resized_image, sigma, mode, cval,
                                  multichannel)
 

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -3,22 +3,13 @@ import numpy as np
 from scipy import ndimage as ndi
 from ..transform import resize
 from ..util import img_as_float
-
-
-def _previous_multichannel_default(multichannel, ndim):
-    if multichannel is None:
-        # needed to maintain previous default behavior
-        if ndim == 3:
-            return True
-        else:
-            return False
-    else:
-        return multichannel
+from ._warps import _multichannel_default
 
 
 def _smooth(image, sigma, mode, cval, multichannel=None):
     """Return image with each channel smoothed by the Gaussian filter."""
-    multichannel = _previous_multichannel_default(multichannel, image.ndim)
+    if multichannel is None:
+        multichannel = _multichannel_default(multichannel, image.ndim)
     smoothed = np.empty(image.shape, dtype=np.double)
 
     # apply Gaussian filter to all channels independently
@@ -61,8 +52,8 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
         cval is the value when mode is equal to 'constant'.
     cval : float, optional
         Value to fill past edges of input if mode is 'constant'.
-    multichannel : bool, optional
-        If True and ``image.ndim > 2``, treat last axis as channels.
+        If True, last axis will not be rescaled.  The default is True for 3D
+        (2D+color) inputs, False otherwise.
 
     Returns
     -------
@@ -74,7 +65,8 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
     .. [1] http://web.mit.edu/persci/people/adelson/pub_pdfs/pyramid83.pdf
 
     """
-    multichannel = _previous_multichannel_default(multichannel, image.ndim)
+    if multichannel is None:
+        multichannel = _multichannel_default(multichannel, image.ndim)
     _check_factor(downscale)
 
     image = img_as_float(image)
@@ -116,7 +108,8 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
     cval : float, optional
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
-        If True and ``image.ndim > 2``, treat last axis as channels.
+        If True, last axis will not be rescaled.  The default is True for 3D
+        (2D+color) inputs, False otherwise.
 
     Returns
     -------
@@ -128,7 +121,8 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
     .. [1] http://web.mit.edu/persci/people/adelson/pub_pdfs/pyramid83.pdf
 
     """
-    multichannel = _previous_multichannel_default(multichannel, image.ndim)
+    if multichannel is None:
+        multichannel = _multichannel_default(multichannel, image.ndim)
     _check_factor(upscale)
 
     image = img_as_float(image)
@@ -182,7 +176,8 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
     cval : float, optional
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
-        If True and ``image.ndim > 2``, treat last axis as channels.
+        If True, last axis will not be rescaled.  The default is True for 3D
+        (2D+color) inputs, False otherwise.
 
     Returns
     -------
@@ -261,7 +256,8 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
     cval : float, optional
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
-        If True and ``image.ndim > 2``, treat last axis as channels.
+        If True, last axis will not be rescaled.  The default is True for 3D
+        (2D+color) inputs, False otherwise.
 
     Returns
     -------
@@ -274,7 +270,8 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
     .. [2] http://sepwww.stanford.edu/data/media/public/sep/morgan/texturematch/paper_html/node3.html
 
     """
-    multichannel = _previous_multichannel_default(multichannel, image.ndim)
+    if multichannel is None:
+        multichannel = _multichannel_default(multichannel, image.ndim)
     _check_factor(downscale)
 
     # cast to float for consistent data type in pyramid

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -47,9 +47,9 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
     cval : float, optional
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
-        hether the last axis of the image is to be interpreted as multiple
-        channels or another spatial dimension.  By default, is set to True for
-        3D (2D+color) inputs, and False for others.  Starting in release 0.16,
+        Whether the last axis of the image is to be interpreted as multiple
+        channels or another spatial dimension. By default, is set to True for
+        3D (2D+color) inputs, and False for others. Starting in release 0.16,
         this will always default to False.
 
     Returns
@@ -104,9 +104,9 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
     cval : float, optional
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
-        hether the last axis of the image is to be interpreted as multiple
-        channels or another spatial dimension.  By default, is set to True for
-        3D (2D+color) inputs, and False for others.  Starting in release 0.16,
+        Whether the last axis of the image is to be interpreted as multiple
+        channels or another spatial dimension. By default, is set to True for
+        3D (2D+color) inputs, and False for others. Starting in release 0.16,
         this will always default to False.
 
 
@@ -174,9 +174,9 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
     cval : float, optional
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
-        hether the last axis of the image is to be interpreted as multiple
-        channels or another spatial dimension.  By default, is set to True for
-        3D (2D+color) inputs, and False for others.  Starting in release 0.16,
+        Whether the last axis of the image is to be interpreted as multiple
+        channels or another spatial dimension. By default, is set to True for
+        3D (2D+color) inputs, and False for others. Starting in release 0.16,
         this will always default to False.
 
 
@@ -257,9 +257,9 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
     cval : float, optional
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
-        hether the last axis of the image is to be interpreted as multiple
-        channels or another spatial dimension.  By default, is set to True for
-        3D (2D+color) inputs, and False for others.  Starting in release 0.16,
+        Whether the last axis of the image is to be interpreted as multiple
+        channels or another spatial dimension. By default, is set to True for
+        3D (2D+color) inputs, and False for others. Starting in release 0.16,
         this will always default to False.
 
 

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -4,18 +4,21 @@ import pytest
 import numpy as np
 from skimage import data
 from skimage.transform import pyramids
+from skimage._shared._warnings import expected_warnings
 
 
 image = data.astronaut()
 image_gray = image[..., 0]
 
 
+@expected_warnings(['default multichannel'])
 def test_pyramid_reduce_rgb():
     rows, cols, dim = image.shape
     out = pyramids.pyramid_reduce(image, downscale=2)
     assert_array_equal(out.shape, (rows / 2, cols / 2, dim))
 
 
+@expected_warnings(['default multichannel'])
 def test_pyramid_reduce_gray():
     rows, cols = image_gray.shape
     out = pyramids.pyramid_reduce(image_gray, downscale=2)
@@ -31,12 +34,14 @@ def test_pyramid_reduce_nd():
         assert_array_equal(out.shape, expected_shape)
 
 
+@expected_warnings(['default multichannel'])
 def test_pyramid_expand_rgb():
     rows, cols, dim = image.shape
     out = pyramids.pyramid_expand(image, upscale=2)
     assert_array_equal(out.shape, (rows * 2, cols * 2, dim))
 
 
+@expected_warnings(['default multichannel'])
 def test_pyramid_expand_gray():
     rows, cols = image_gray.shape
     out = pyramids.pyramid_expand(image_gray, upscale=2)
@@ -52,6 +57,7 @@ def test_pyramid_expand_nd():
         assert_array_equal(out.shape, expected_shape)
 
 
+@expected_warnings(['default multichannel'])
 def test_build_gaussian_pyramid_rgb():
     rows, cols, dim = image.shape
     pyramid = pyramids.pyramid_gaussian(image, downscale=2)
@@ -60,6 +66,7 @@ def test_build_gaussian_pyramid_rgb():
         assert_array_equal(out.shape, layer_shape)
 
 
+@expected_warnings(['default multichannel'])
 def test_build_gaussian_pyramid_gray():
     rows, cols = image_gray.shape
     pyramid = pyramids.pyramid_gaussian(image_gray, downscale=2)
@@ -79,6 +86,7 @@ def test_build_gaussian_pyramid_nd():
             assert_array_equal(out.shape, layer_shape)
 
 
+@expected_warnings(['default multichannel'])
 def test_build_laplacian_pyramid_rgb():
     rows, cols, dim = image.shape
     pyramid = pyramids.pyramid_laplacian(image, downscale=2)

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -11,17 +11,17 @@ image = data.astronaut()
 image_gray = image[..., 0]
 
 
-@expected_warnings(['default multichannel'])
 def test_pyramid_reduce_rgb():
     rows, cols, dim = image.shape
-    out = pyramids.pyramid_reduce(image, downscale=2)
+    with expected_warnings(['default multichannel']):
+        out = pyramids.pyramid_reduce(image, downscale=2)
     assert_array_equal(out.shape, (rows / 2, cols / 2, dim))
 
 
-@expected_warnings(['default multichannel'])
 def test_pyramid_reduce_gray():
     rows, cols = image_gray.shape
-    out = pyramids.pyramid_reduce(image_gray, downscale=2)
+    with expected_warnings(['default multichannel']):
+        out = pyramids.pyramid_reduce(image_gray, downscale=2)
     assert_array_equal(out.shape, (rows / 2, cols / 2))
 
 
@@ -34,17 +34,17 @@ def test_pyramid_reduce_nd():
         assert_array_equal(out.shape, expected_shape)
 
 
-@expected_warnings(['default multichannel'])
 def test_pyramid_expand_rgb():
     rows, cols, dim = image.shape
-    out = pyramids.pyramid_expand(image, upscale=2)
+    with expected_warnings(['default multichannel']):
+        out = pyramids.pyramid_expand(image, upscale=2)
     assert_array_equal(out.shape, (rows * 2, cols * 2, dim))
 
 
-@expected_warnings(['default multichannel'])
 def test_pyramid_expand_gray():
     rows, cols = image_gray.shape
-    out = pyramids.pyramid_expand(image_gray, upscale=2)
+    with expected_warnings(['default multichannel']):
+        out = pyramids.pyramid_expand(image_gray, upscale=2)
     assert_array_equal(out.shape, (rows * 2, cols * 2))
 
 
@@ -57,22 +57,22 @@ def test_pyramid_expand_nd():
         assert_array_equal(out.shape, expected_shape)
 
 
-@expected_warnings(['default multichannel'])
 def test_build_gaussian_pyramid_rgb():
     rows, cols, dim = image.shape
-    pyramid = pyramids.pyramid_gaussian(image, downscale=2)
-    for layer, out in enumerate(pyramid):
-        layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
-        assert_array_equal(out.shape, layer_shape)
+    with expected_warnings(['default multichannel']):
+        pyramid = pyramids.pyramid_gaussian(image, downscale=2)
+        for layer, out in enumerate(pyramid):
+            layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
+            assert_array_equal(out.shape, layer_shape)
 
 
-@expected_warnings(['default multichannel'])
 def test_build_gaussian_pyramid_gray():
     rows, cols = image_gray.shape
-    pyramid = pyramids.pyramid_gaussian(image_gray, downscale=2)
-    for layer, out in enumerate(pyramid):
-        layer_shape = (rows / 2 ** layer, cols / 2 ** layer)
-        assert_array_equal(out.shape, layer_shape)
+    with expected_warnings(['default multichannel']):
+        pyramid = pyramids.pyramid_gaussian(image_gray, downscale=2)
+        for layer, out in enumerate(pyramid):
+            layer_shape = (rows / 2 ** layer, cols / 2 ** layer)
+            assert_array_equal(out.shape, layer_shape)
 
 
 def test_build_gaussian_pyramid_nd():
@@ -86,13 +86,13 @@ def test_build_gaussian_pyramid_nd():
             assert_array_equal(out.shape, layer_shape)
 
 
-@expected_warnings(['default multichannel'])
 def test_build_laplacian_pyramid_rgb():
     rows, cols, dim = image.shape
-    pyramid = pyramids.pyramid_laplacian(image, downscale=2)
-    for layer, out in enumerate(pyramid):
-        layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
-        assert_array_equal(out.shape, layer_shape)
+    with expected_warnings(['default multichannel']):
+        pyramid = pyramids.pyramid_laplacian(image, downscale=2)
+        for layer, out in enumerate(pyramid):
+            layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
+            assert_array_equal(out.shape, layer_shape)
 
 
 def test_build_laplacian_pyramid_nd():

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -13,14 +13,14 @@ image_gray = image[..., 0]
 
 def test_pyramid_reduce_rgb():
     rows, cols, dim = image.shape
-    with expected_warnings(['default multichannel']):
+    with expected_warnings(['The default multichannel']):
         out = pyramids.pyramid_reduce(image, downscale=2)
     assert_array_equal(out.shape, (rows / 2, cols / 2, dim))
 
 
 def test_pyramid_reduce_gray():
     rows, cols = image_gray.shape
-    with expected_warnings(['default multichannel']):
+    with expected_warnings(['The default multichannel']):
         out = pyramids.pyramid_reduce(image_gray, downscale=2)
     assert_array_equal(out.shape, (rows / 2, cols / 2))
 
@@ -36,14 +36,14 @@ def test_pyramid_reduce_nd():
 
 def test_pyramid_expand_rgb():
     rows, cols, dim = image.shape
-    with expected_warnings(['default multichannel']):
+    with expected_warnings(['The default multichannel']):
         out = pyramids.pyramid_expand(image, upscale=2)
     assert_array_equal(out.shape, (rows * 2, cols * 2, dim))
 
 
 def test_pyramid_expand_gray():
     rows, cols = image_gray.shape
-    with expected_warnings(['default multichannel']):
+    with expected_warnings(['The default multichannel']):
         out = pyramids.pyramid_expand(image_gray, upscale=2)
     assert_array_equal(out.shape, (rows * 2, cols * 2))
 
@@ -59,7 +59,7 @@ def test_pyramid_expand_nd():
 
 def test_build_gaussian_pyramid_rgb():
     rows, cols, dim = image.shape
-    with expected_warnings(['default multichannel']):
+    with expected_warnings(['The default multichannel']):
         pyramid = pyramids.pyramid_gaussian(image, downscale=2)
         for layer, out in enumerate(pyramid):
             layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
@@ -68,7 +68,7 @@ def test_build_gaussian_pyramid_rgb():
 
 def test_build_gaussian_pyramid_gray():
     rows, cols = image_gray.shape
-    with expected_warnings(['default multichannel']):
+    with expected_warnings(['The default multichannel']):
         pyramid = pyramids.pyramid_gaussian(image_gray, downscale=2)
         for layer, out in enumerate(pyramid):
             layer_shape = (rows / 2 ** layer, cols / 2 ** layer)
@@ -88,7 +88,7 @@ def test_build_gaussian_pyramid_nd():
 
 def test_build_laplacian_pyramid_rgb():
     rows, cols, dim = image.shape
-    with expected_warnings(['default multichannel']):
+    with expected_warnings(['The default multichannel']):
         pyramid = pyramids.pyramid_laplacian(image, downscale=2)
         for layer, out in enumerate(pyramid):
             layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -1,5 +1,7 @@
 from numpy.testing import assert_array_equal, run_module_suite
 import pytest
+
+import numpy as np
 from skimage import data
 from skimage.transform import pyramids
 
@@ -20,6 +22,15 @@ def test_pyramid_reduce_gray():
     assert_array_equal(out.shape, (rows / 2, cols / 2))
 
 
+def test_pyramid_reduce_nd():
+    for ndim in [1, 2, 3, 4]:
+        img = np.random.randn(*((8, ) * ndim))
+        out = pyramids.pyramid_reduce(img, downscale=2,
+                                      multichannel=False)
+        expected_shape = np.asarray(img.shape) / 2
+        assert_array_equal(out.shape, expected_shape)
+
+
 def test_pyramid_expand_rgb():
     rows, cols, dim = image.shape
     out = pyramids.pyramid_expand(image, upscale=2)
@@ -30,6 +41,15 @@ def test_pyramid_expand_gray():
     rows, cols = image_gray.shape
     out = pyramids.pyramid_expand(image_gray, upscale=2)
     assert_array_equal(out.shape, (rows * 2, cols * 2))
+
+
+def test_pyramid_expand_nd():
+    for ndim in [1, 2, 3, 4]:
+        img = np.random.randn(*((4, ) * ndim))
+        out = pyramids.pyramid_expand(img, upscale=2,
+                                      multichannel=False)
+        expected_shape = np.asarray(img.shape) * 2
+        assert_array_equal(out.shape, expected_shape)
 
 
 def test_build_gaussian_pyramid_rgb():
@@ -48,6 +68,17 @@ def test_build_gaussian_pyramid_gray():
         assert_array_equal(out.shape, layer_shape)
 
 
+def test_build_gaussian_pyramid_nd():
+    for ndim in [1, 2, 3, 4]:
+        img = np.random.randn(*((8, ) * ndim))
+        original_shape = np.asarray(img.shape)
+        pyramid = pyramids.pyramid_gaussian(img, downscale=2,
+                                            multichannel=False)
+        for layer, out in enumerate(pyramid):
+            layer_shape = original_shape / 2 ** layer
+            assert_array_equal(out.shape, layer_shape)
+
+
 def test_build_laplacian_pyramid_rgb():
     rows, cols, dim = image.shape
     pyramid = pyramids.pyramid_laplacian(image, downscale=2)
@@ -56,12 +87,15 @@ def test_build_laplacian_pyramid_rgb():
         assert_array_equal(out.shape, layer_shape)
 
 
-def test_build_laplacian_pyramid_gray():
-    rows, cols = image_gray.shape
-    pyramid = pyramids.pyramid_laplacian(image_gray, downscale=2)
-    for layer, out in enumerate(pyramid):
-        layer_shape = (rows / 2 ** layer, cols / 2 ** layer)
-        assert_array_equal(out.shape, layer_shape)
+def test_build_laplacian_pyramid_nd():
+    for ndim in [1, 2, 3, 4]:
+        img = np.random.randn(*((8, ) * ndim))
+        original_shape = np.asarray(img.shape)
+        pyramid = pyramids.pyramid_laplacian(img, downscale=2,
+                                             multichannel=False)
+        for layer, out in enumerate(pyramid):
+            layer_shape = original_shape / 2 ** layer
+            assert_array_equal(out.shape, layer_shape)
 
 
 def test_check_factor():

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -154,7 +154,8 @@ def test_iradon_angles():
     theta = np.linspace(0, 180, nb_angles, endpoint=False)
     radon_image_200 = radon(image, theta=theta, circle=False)
     reconstructed = iradon(radon_image_200, circle=False)
-    delta_200 = np.mean(abs(_rescale_intensity(image) - _rescale_intensity(reconstructed)))
+    delta_200 = np.mean(abs(_rescale_intensity(image) -
+                            _rescale_intensity(reconstructed)))
     assert delta_200 < 0.03
     # Lower number of projections
     nb_angles = 80
@@ -244,7 +245,10 @@ def check_sinogram_circle_to_square(size):
     image = _random_circle((size, size))
     theta = np.linspace(0., 180., size, False)
     sinogram_circle = radon(image, theta, circle=True)
-    argmax_shape = lambda a: np.unravel_index(np.argmax(a), a.shape)
+
+    def argmax_shape(a):
+        return np.unravel_index(np.argmax(a), a.shape)
+
     print('\n\targmax of circle:', argmax_shape(sinogram_circle))
     sinogram_square = radon(image, theta, circle=False)
     print('\targmax of square:', argmax_shape(sinogram_square))
@@ -253,8 +257,8 @@ def check_sinogram_circle_to_square(size):
           argmax_shape(sinogram_circle_to_square))
     error = abs(sinogram_square - sinogram_circle_to_square)
     print(np.mean(error), np.max(error))
-    assert (argmax_shape(sinogram_square)
-            == argmax_shape(sinogram_circle_to_square))
+    assert (argmax_shape(sinogram_square) ==
+            argmax_shape(sinogram_circle_to_square))
 
 
 def test_sinogram_circle_to_square():

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -12,8 +12,8 @@ from skimage._shared.testing import test_parallel
 from skimage._shared._warnings import expected_warnings
 
 PHANTOM = imread(os.path.join(data_dir, "phantom.png"),
-                   as_grey=True)[::2, ::2]
-PHANTOM = rescale(PHANTOM, 0.5, order=1, mode='reflect')
+                 as_grey=True)[::2, ::2]
+PHANTOM = rescale(PHANTOM, 0.5, order=1, multichannel=False)
 
 
 def _debug_plot(original, result, sinogram=None):

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -179,6 +179,35 @@ def test_rescale():
     assert_almost_equal(scaled, ref)
 
 
+def test_rescale_multichannel():
+    # 1D + channels
+    x = np.zeros((8, 3), dtype=np.double)
+    scaled = rescale(x, 2, order=0, multichannel=True)
+    assert_equal(scaled.shape, (16, 3))
+    # 2D
+    scaled = rescale(x, 2, order=0, multichannel=False)
+    assert_equal(scaled.shape, (16, 6))
+    # multichannel defaults to False
+    scaled = rescale(x, 2, order=0)
+    assert_equal(scaled.shape, (16, 6))
+
+    # 2D + channels
+    x = np.zeros((8, 8, 3), dtype=np.double)
+    scaled = rescale(x, 2, order=0, multichannel=True)
+    assert_equal(scaled.shape, (16, 16, 3))
+    # 3D
+    scaled = rescale(x, 2, order=0, multichannel=False)
+    assert_equal(scaled.shape, (16, 16, 6))
+
+    # 3D + channels
+    x = np.zeros((8, 8, 8, 3), dtype=np.double)
+    scaled = rescale(x, 2, order=0, multichannel=True)
+    assert_equal(scaled.shape, (16, 16, 16, 3))
+    # 4D
+    scaled = rescale(x, 2, order=0, multichannel=False)
+    assert_equal(scaled.shape, (16, 16, 16, 6))
+
+
 def test_resize2d():
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
@@ -234,6 +263,17 @@ def test_resize2d_4d():
     ref = np.zeros(out_shape)
     ref[2:4, 2:4, ...] = 1
     assert_almost_equal(resized, ref)
+
+
+def test_resize_nd():
+    for dim in range(1, 6):
+        shape = 2 + np.arange(dim) * 2
+        x = np.ones(shape)
+        out_shape = np.asarray(shape) * 1.5
+        resized = resize(x, out_shape, order=0, mode='reflect')
+        expected_shape = 1.5 * shape
+        assert_equal(resized.shape, expected_shape)
+        assert np.all(resized == 1)
 
 
 def test_resize3d_bilinear():

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -88,6 +88,7 @@ def test_warp_nd():
         assert_almost_equal(outx, refx)
 
 
+@expected_warnings(['default multichannel'])
 def test_warp_clip():
     x = np.zeros((5, 5), dtype=np.double)
     x[2, 2] = 1
@@ -159,6 +160,7 @@ def test_rotate_resize_center():
     assert_equal(x45, ref_x45)
 
 
+@expected_warnings(['default multichannel'])
 def test_rescale():
     # same scale factor
     x = np.zeros((5, 5), dtype=np.double)
@@ -187,9 +189,6 @@ def test_rescale_multichannel():
     # 2D
     scaled = rescale(x, 2, order=0, multichannel=False)
     assert_equal(scaled.shape, (16, 6))
-    # multichannel defaults to False
-    scaled = rescale(x, 2, order=0)
-    assert_equal(scaled.shape, (16, 6))
 
     # 2D + channels
     x = np.zeros((8, 8, 3), dtype=np.double)
@@ -206,6 +205,21 @@ def test_rescale_multichannel():
     # 4D
     scaled = rescale(x, 2, order=0, multichannel=False)
     assert_equal(scaled.shape, (16, 16, 16, 6))
+
+
+@expected_warnings(['default multichannel'])
+def test_rescale_multichannel_defaults():
+    # Tests to ensure multichannel=None matches the previous default behaviour
+
+    # 2D: multichannel should default to False
+    x = np.zeros((8, 3), dtype=np.double)
+    scaled = rescale(x, 2, order=0)
+    assert_equal(scaled.shape, (16, 6))
+
+    # 3D: multichannel should default to True
+    x = np.zeros((8, 8, 3), dtype=np.double)
+    scaled = rescale(x, 2, order=0,)
+    assert_equal(scaled.shape, (16, 16, 3))
 
 
 def test_resize2d():
@@ -323,7 +337,7 @@ def test_warp_identity():
     assert np.allclose(img, warp(img, AffineTransform(rotation=0)))
     assert not np.allclose(img, warp(img, AffineTransform(rotation=0.1)))
     rgb_img = np.transpose(np.asarray([img, np.zeros_like(img), img]),
-                            (1, 2, 0))
+                           (1, 2, 0))
     warped_rgb_img = warp(rgb_img, AffineTransform(rotation=0.1))
     assert np.allclose(rgb_img, warp(rgb_img, AffineTransform(rotation=0)))
     assert not np.allclose(rgb_img, warped_rgb_img)
@@ -342,14 +356,14 @@ def test_warp_coords_example():
 def test_downscale_local_mean():
     image1 = np.arange(4 * 6).reshape(4, 6)
     out1 = downscale_local_mean(image1, (2, 3))
-    expected1 = np.array([[  4.,   7.],
-                          [ 16.,  19.]])
+    expected1 = np.array([[ 4.,   7.],
+                          [16.,  19.]])
     assert_equal(expected1, out1)
 
     image2 = np.arange(5 * 8).reshape(5, 8)
     out2 = downscale_local_mean(image2, (4, 5))
-    expected2 = np.array([[ 14. ,  10.8],
-                          [  8.5,   5.7]])
+    expected2 = np.array([[14. ,  10.8],
+                          [ 8.5,   5.7]])
     assert_equal(expected2, out2)
 
 
@@ -376,6 +390,7 @@ def test_slow_warp_nonint_oshape():
     warp(image, lambda xy: xy, output_shape=(13.0001, 19.9999))
 
 
+@expected_warnings(['default multichannel'])
 def test_keep_range():
     image = np.linspace(0, 2, 25).reshape(5, 5)
 
@@ -394,7 +409,6 @@ def test_keep_range():
                       clip=True, order=0)
     assert out.min() == 0
     assert out.max() == 2 / 255.0
-
 
 
 if __name__ == "__main__":

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -47,7 +47,8 @@ def test_warp_callable():
     refx = np.zeros((5, 5), dtype=np.double)
     refx[1, 1] = 1
 
-    shift = lambda xy: xy + 1
+    def shift(xy):
+        return xy + 1
 
     outx = warp(x, shift, order=1)
     assert_almost_equal(outx, refx)
@@ -320,7 +321,7 @@ def test_swirl():
         swirled = tf.swirl(image, strength=10, **swirl_params)
         unswirled = tf.swirl(swirled, strength=-10, **swirl_params)
 
-    assert np.mean(np.abs(image[1:-1,1:-1] - unswirled[1:-1,1:-1])) < 0.01
+    assert np.mean(np.abs(image[1:-1, 1:-1] - unswirled[1:-1, 1:-1])) < 0.01
 
 
 def test_const_cval_out_of_range():
@@ -355,14 +356,14 @@ def test_warp_coords_example():
 def test_downscale_local_mean():
     image1 = np.arange(4 * 6).reshape(4, 6)
     out1 = downscale_local_mean(image1, (2, 3))
-    expected1 = np.array([[ 4.,   7.],
-                          [16.,  19.]])
+    expected1 = np.array([[4., 7.],
+                          [16., 19.]])
     assert_equal(expected1, out1)
 
     image2 = np.arange(5 * 8).reshape(5, 8)
     out2 = downscale_local_mean(image2, (4, 5))
-    expected2 = np.array([[14. ,  10.8],
-                          [ 8.5,   5.7]])
+    expected2 = np.array([[14., 10.8],
+                          [8.5, 5.7]])
     assert_equal(expected2, out2)
 
 

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -92,11 +92,11 @@ def test_warp_clip():
     x = np.zeros((5, 5), dtype=np.double)
     x[2, 2] = 1
 
-    with expected_warnings(['The default mode', 'default multichannel']):
+    with expected_warnings(['The default mode', 'The default multichannel']):
         outx = rescale(x, 3, order=3, clip=False)
     assert outx.min() < 0
 
-    with expected_warnings(['The default mode', 'default multichannel']):
+    with expected_warnings(['The default mode', 'The default multichannel']):
         outx = rescale(x, 3, order=3, clip=True)
     assert_almost_equal(outx.min(), 0)
     assert_almost_equal(outx.max(), 1)
@@ -159,12 +159,11 @@ def test_rotate_resize_center():
     assert_equal(x45, ref_x45)
 
 
-@expected_warnings(['default multichannel'])
 def test_rescale():
     # same scale factor
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
-    with expected_warnings(['The default mode', 'default multichannel']):
+    with expected_warnings(['The default mode', 'The default multichannel']):
         scaled = rescale(x, 2, order=0)
     ref = np.zeros((10, 10))
     ref[2:4, 2:4] = 1
@@ -173,7 +172,7 @@ def test_rescale():
     # different scale factors
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
-    with expected_warnings(['The default mode', 'default multichannel']):
+    with expected_warnings(['The default mode', 'The default multichannel']):
         scaled = rescale(x, (2, 1), order=0)
     ref = np.zeros((10, 5))
     ref[2:4, 1] = 1
@@ -211,13 +210,13 @@ def test_rescale_multichannel_defaults():
 
     # 2D: multichannel should default to False
     x = np.zeros((8, 3), dtype=np.double)
-    with expected_warnings(['default multichannel']):
+    with expected_warnings(['The default mode', 'The default multichannel']):
         scaled = rescale(x, 2, order=0)
     assert_equal(scaled.shape, (16, 6))
 
     # 3D: multichannel should default to True
     x = np.zeros((8, 8, 3), dtype=np.double)
-    with expected_warnings(['default multichannel']):
+    with expected_warnings(['The default mode', 'The default multichannel']):
         scaled = rescale(x, 2, order=0,)
     assert_equal(scaled.shape, (16, 16, 3))
 
@@ -393,17 +392,17 @@ def test_slow_warp_nonint_oshape():
 def test_keep_range():
     image = np.linspace(0, 2, 25).reshape(5, 5)
 
-    with expected_warnings(['The default mode', 'default multichannel']):
+    with expected_warnings(['The default mode', 'The default multichannel']):
         out = rescale(image, 2, preserve_range=False, clip=True, order=0)
     assert out.min() == 0
     assert out.max() == 2
 
-    with expected_warnings(['The default mode', 'default multichannel']):
+    with expected_warnings(['The default mode', 'The default multichannel']):
         out = rescale(image, 2, preserve_range=True, clip=True, order=0)
     assert out.min() == 0
     assert out.max() == 2
 
-    with expected_warnings(['The default mode', 'default multichannel']):
+    with expected_warnings(['The default mode', 'The default multichannel']):
         out = rescale(image.astype(np.uint8), 2, preserve_range=False,
                       clip=True, order=0)
     assert out.min() == 0

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -225,6 +225,17 @@ def test_resize3d_2din_3dout():
     assert_almost_equal(resized, ref)
 
 
+def test_resize2d_4d():
+    # resize with extra output dimensions
+    x = np.zeros((5, 5), dtype=np.double)
+    x[1, 1] = 1
+    out_shape = (10, 10, 1, 1)
+    resized = resize(x, out_shape, order=0)
+    ref = np.zeros(out_shape)
+    ref[2:4, 2:4, ...] = 1
+    assert_almost_equal(resized, ref)
+
+
 def test_resize3d_bilinear():
     # bilinear 3rd dimension
     x = np.zeros((5, 5, 2), dtype=np.double)

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -88,16 +88,15 @@ def test_warp_nd():
         assert_almost_equal(outx, refx)
 
 
-@expected_warnings(['default multichannel'])
 def test_warp_clip():
     x = np.zeros((5, 5), dtype=np.double)
     x[2, 2] = 1
 
-    with expected_warnings(['The default mode']):
+    with expected_warnings(['The default mode', 'default multichannel']):
         outx = rescale(x, 3, order=3, clip=False)
     assert outx.min() < 0
 
-    with expected_warnings(['The default mode']):
+    with expected_warnings(['The default mode', 'default multichannel']):
         outx = rescale(x, 3, order=3, clip=True)
     assert_almost_equal(outx.min(), 0)
     assert_almost_equal(outx.max(), 1)
@@ -165,7 +164,7 @@ def test_rescale():
     # same scale factor
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
-    with expected_warnings(['The default mode']):
+    with expected_warnings(['The default mode', 'default multichannel']):
         scaled = rescale(x, 2, order=0)
     ref = np.zeros((10, 10))
     ref[2:4, 2:4] = 1
@@ -174,7 +173,7 @@ def test_rescale():
     # different scale factors
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
-    with expected_warnings(['The default mode']):
+    with expected_warnings(['The default mode', 'default multichannel']):
         scaled = rescale(x, (2, 1), order=0)
     ref = np.zeros((10, 5))
     ref[2:4, 1] = 1
@@ -207,18 +206,19 @@ def test_rescale_multichannel():
     assert_equal(scaled.shape, (16, 16, 16, 6))
 
 
-@expected_warnings(['default multichannel'])
 def test_rescale_multichannel_defaults():
-    # Tests to ensure multichannel=None matches the previous default behaviour
+    # ensure multichannel=None matches the previous default behaviour
 
     # 2D: multichannel should default to False
     x = np.zeros((8, 3), dtype=np.double)
-    scaled = rescale(x, 2, order=0)
+    with expected_warnings(['default multichannel']):
+        scaled = rescale(x, 2, order=0)
     assert_equal(scaled.shape, (16, 6))
 
     # 3D: multichannel should default to True
     x = np.zeros((8, 8, 3), dtype=np.double)
-    scaled = rescale(x, 2, order=0,)
+    with expected_warnings(['default multichannel']):
+        scaled = rescale(x, 2, order=0,)
     assert_equal(scaled.shape, (16, 16, 3))
 
 
@@ -390,21 +390,20 @@ def test_slow_warp_nonint_oshape():
     warp(image, lambda xy: xy, output_shape=(13.0001, 19.9999))
 
 
-@expected_warnings(['default multichannel'])
 def test_keep_range():
     image = np.linspace(0, 2, 25).reshape(5, 5)
 
-    with expected_warnings(['The default mode']):
+    with expected_warnings(['The default mode', 'default multichannel']):
         out = rescale(image, 2, preserve_range=False, clip=True, order=0)
     assert out.min() == 0
     assert out.max() == 2
 
-    with expected_warnings(['The default mode']):
+    with expected_warnings(['The default mode', 'default multichannel']):
         out = rescale(image, 2, preserve_range=True, clip=True, order=0)
     assert out.min() == 0
     assert out.max() == 2
 
-    with expected_warnings(['The default mode']):
+    with expected_warnings(['The default mode', 'default multichannel']):
         out = rescale(image.astype(np.uint8), 2, preserve_range=False,
                       clip=True, order=0)
     assert out.min() == 0

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -238,6 +238,9 @@ def test_resize3d_keep():
     x[1, 1, :] = 1
     with expected_warnings(['The default mode']):
         resized = resize(x, (10, 10), order=0)
+        with pytest.raises(ValueError):
+            # output_shape too short
+            resize(x, (10, ), order=0)
     ref = np.zeros((10, 10, 3))
     ref[2:4, 2:4, :] = 1
     assert_almost_equal(resized, ref)

--- a/skimage/viewer/tests/test_viewer.py
+++ b/skimage/viewer/tests/test_viewer.py
@@ -44,7 +44,7 @@ def make_key_event(key):
 def test_collection_viewer():
 
     img = data.astronaut()
-    img_collection = tuple(pyramid_gaussian(img))
+    img_collection = tuple(pyramid_gaussian(img, multichannel=True))
 
     view = CollectionViewer(img_collection)
     make_key_event(48)


### PR DESCRIPTION
This is a pretty simple pull request extending n-dimensional support to the following transforms:
- `skimage.transform.rescale`
- `skimage.transform.resize`
- `skimage.transform.pyramid_*`

This is useful for me as I work primarily in medical imaging where data is often either 3D volumetric or 3D+time.

As was previously the case, resize still calls the two-dimensional interpolations implemented in `_shared/interpolation.pyx` for 2D or 2D+color images, while all other cases use `scipy.ndimage.map_coordinates`.  Previously `map_coordinates` was set up explicitly for 3D only.

The changes to `resize` are substantially smaller than the diff would indicate at first glance, because I switched the order of the  if / else statement calling the 2D or n-D interpolation code.  (The logic for when to call 2D seemed slightly simpler to express)

A multichannel argument was added to `rescale` to indicate that the last axis should not be reshaped.  This defaults to True for 3D inputs to replicate the previous behaviour for 2D+color images.  To do a true 3D rescale, the user must explicitly specify `multichannel=False`.

Similarly in `pyramids.py`:
The `_smooth` function previously always looped 2D smoothing operations over the last axis if the input was 3D.  Now there is a new `multichannel` argument that explicitly controls this behavior of looping over the last axis, regardless of image dimension.  As for `rescale` above, `multichannel` defaults to None which will result in a call to a small function to replicate the old behaviour of True for 3D inputs and False otherwise.
