### PR TITLE
skimage.draw.ellipse speedups

### DIFF
--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -55,24 +55,26 @@ def ellipse(cy, cx, yradius, xradius, shape=None):
 
     center = np.array([cy, cx])
     radiuses = np.array([yradius, xradius])
+
+    # The upper_left and lower_right corners of the
+    # smallest rectangle containing the ellipse.
+    upper_left = np.ceil(center - radiuses)
+    lower_right = np.floor(center + radiuses)
+
     if shape is not None:
-        return _ellipse_in_shape(shape, center, radiuses)
-    else:
-        # rounding here is necessary to avoid rounding issues later
-        upper_left = np.floor(center - radiuses).astype(int)
+        # Constrain upper_left and lower_right by shape boundary.
+        upper_left = np.maximum(upper_left, np.array([0, 0]))
+        lower_right = np.minimum(lower_right, np.array(shape) - 1)
 
-        shifted_center = center - upper_left
+    shifted_center = center - upper_left
+    bounding_shape = lower_right - upper_left + 1
 
-        # Shifted center is in interval [radiuses, radiuses + 1], so
-        # the ellipse must fit in [0, 2*radiuses + 1].
-        bounding_shape = np.ceil(2 * radiuses + 1)
-
-        rr, cc = _ellipse_in_shape(bounding_shape, shifted_center, radiuses)
-        rr.flags.writeable = True
-        cc.flags.writeable = True
-        rr += upper_left[0]
-        cc += upper_left[1]
-        return rr, cc
+    rr, cc = _ellipse_in_shape(bounding_shape, shifted_center, radiuses)
+    rr.flags.writeable = True
+    cc.flags.writeable = True
+    rr += upper_left[0]
+    cc += upper_left[1]
+    return rr, cc
 
 
 def circle(cy, cx, radius, shape=None):

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -64,7 +64,7 @@ def ellipse(cy, cx, yradius, xradius, shape=None):
     if shape is not None:
         # Constrain upper_left and lower_right by shape boundary.
         upper_left = np.maximum(upper_left, np.array([0, 0]))
-        lower_right = np.minimum(lower_right, np.array(shape) - 1)
+        lower_right = np.minimum(lower_right, np.array(shape[:2]) - 1)
 
     shifted_center = center - upper_left
     bounding_shape = lower_right - upper_left + 1

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -58,8 +58,8 @@ def ellipse(cy, cx, yradius, xradius, shape=None):
 
     # The upper_left and lower_right corners of the
     # smallest rectangle containing the ellipse.
-    upper_left = np.ceil(center - radiuses)
-    lower_right = np.floor(center + radiuses)
+    upper_left = np.ceil(center - radiuses).astype(int)
+    lower_right = np.floor(center + radiuses).astype(int)
 
     if shape is not None:
         # Constrain upper_left and lower_right by shape boundary.


### PR DESCRIPTION
 `_ellipse_in_shape` is slow when passed large `shape` parameters because it creates a large `ogrid` mesh. This PR finds the smallest bounding box that fits the ellipse, and constrains the `shape` parameter before calling `_ellipse_in_shape`.

On my macbook pro, the old version took about 0.01s for a `shape` of `[744, 863]`. The new version takes on the order of 0.00001s (1000x faster!).