### PR TITLE
1477 - Regionprops doesn't check shape equivalence between label_imag…

### DIFF
--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -360,6 +360,11 @@ def test_invalid():
     assert_raises(AttributeError, get_intensity_image)
 
 
+def test_invalid_size():
+    wrong_intensity_sample = np.array([[1], [1]])
+    assert_raises(ValueError, regionprops, SAMPLE, wrong_intensity_sample)
+
+
 def test_equals():
     arr = np.zeros((100, 100), dtype=np.int)
     arr[0:25, 0:25] = 1


### PR DESCRIPTION
…e and intensity_image

#1477 