### PR TITLE
FIX: Use direct, secure link to wheelhouse to fix AppVeyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ install:
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
   # Install the build and runtime dependencies of the project.
-  - "%CMD_IN_ENV% pip install -v %WHEELHOUSE% -r tools/appveyor/requirements.txt"
+  - "%CMD_IN_ENV% pip install -v --trusted-host 28daf2247a33ed269873-7b1aad3fab3cc330e1fd9d109892382a.r6.cf2.rackcdn.com %WHEELHOUSE% -r tools/appveyor/requirements.txt"
   - "%CMD_IN_ENV% pip install -v -r requirements.txt"
   - "%CMD_IN_ENV% python setup.py bdist_wheel bdist_wininst"
   - ps: "ls dist"


### PR DESCRIPTION
@arve0 is doing great work over in #1526 to simplify the CI builds. This is just a one-liner fix to AppVeyor  so the builds work for other contributions until #1526 provides a more definitive solution.