### PR TITLE
removing obsolete (or not found?) link

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -245,7 +245,7 @@ def rescale_intensity(image, in_range='image', out_range='dtype'):
 
     See Also
     --------
-    intensity_range, equalize_hist
+    equalize_hist
 
     Examples
     --------


### PR DESCRIPTION
`intensity_range` does not seem to exist or is not found. Removing obsolete reference in doctext.