### PR TITLE
the output of hough_ellipse needs to be rounded before being truncated

### DIFF
--- a/doc/examples/plot_circular_elliptical_hough_transform.py
+++ b/doc/examples/plot_circular_elliptical_hough_transform.py
@@ -128,10 +128,10 @@ result.sort(order='accumulator')
 
 # Estimated parameters for the ellipse
 best = result[-1]
-yc = int(best[1])
-xc = int(best[2])
-a = int(best[3])
-b = int(best[4])
+yc = int(round(best[1]))
+xc = int(round(best[2]))
+a = int(round(best[3]))
+b = int(round(best[4]))
 orientation = best[5]
 
 # Draw the ellipse on the original image

--- a/doc/examples/plot_circular_elliptical_hough_transform.py
+++ b/doc/examples/plot_circular_elliptical_hough_transform.py
@@ -127,11 +127,8 @@ result = hough_ellipse(edges, accuracy=20, threshold=250,
 result.sort(order='accumulator')
 
 # Estimated parameters for the ellipse
-best = result[-1]
-yc = int(round(best[1]))
-xc = int(round(best[2]))
-a = int(round(best[3]))
-b = int(round(best[4]))
+best = list(result[-1])
+yc, xc, a, b = [int(round(x)) for x in best[1:5]]
 orientation = best[5]
 
 # Draw the ellipse on the original image


### PR DESCRIPTION
This fix is motivated by the following post on the mailing list:
https://groups.google.com/d/msg/scikit-image/eLsRO38BrJs/4RIrQWch5HoJ

It improves the output of the example, as can be seen below:

**int():**
![figure_2](https://cloud.githubusercontent.com/assets/802153/7899071/b1334d14-070d-11e5-9128-ee06112c2ca6.png)

**int(round()):**
![figure_2_bis](https://cloud.githubusercontent.com/assets/802153/7899073/b89fdc0c-070d-11e5-8b90-9f4331e1b434.png)

The explanation is that *int(x)* returns the nearest integer which is smaller than x while *round(x)* returns the nearest integer, but as a float. For instance, *int(3.8) = 3* and *round(3.8) = 4.0*.
