### PR TITLE
FIX: Correct typo in local version of tifffile _replace_by

### DIFF
--- a/skimage/external/tifffile/tifffile_local.py
+++ b/skimage/external/tifffile/tifffile_local.py
@@ -153,7 +153,7 @@ import numpy
 
 from . import _tifffile
 
-__version__ = '0.3.3'
+__version__ = '0.3.4'
 __docformat__ = 'restructuredtext en'
 __all__ = ('imsave', 'imread', 'imshow', 'TiffFile', 'TiffWriter',
            'TiffSequence')
@@ -3114,7 +3114,7 @@ def _replace_by(module_function, package=None, warn=False):
                 full_name = modname
             else:
                 full_name = package + '.' + modname
-            module = __import__(full_name, romlist=[modname])
+            module = __import__(full_name, fromlist=[modname])
             func, oldfunc = getattr(module, function), func
             globals()['__old_' + func.__name__] = oldfunc
         except Exception:

--- a/skimage/external/tifffile/tifffile_local.py
+++ b/skimage/external/tifffile/tifffile_local.py
@@ -1,5 +1,3 @@
-
-
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # tifffile.py
@@ -153,7 +151,7 @@ import numpy
 
 from . import _tifffile
 
-__version__ = '0.3.4'
+__version__ = '0.4.1'
 __docformat__ = 'restructuredtext en'
 __all__ = ('imsave', 'imread', 'imshow', 'TiffFile', 'TiffWriter',
            'TiffSequence')
@@ -4858,4 +4856,3 @@ if sys.version_info[0] > 2:
 
 if __name__ == "__main__":
     sys.exit(main())
-


### PR DESCRIPTION
Should fix the error reported in #1548. Also added a minor point to our local __version__ for this file.