### PR TITLE
Possible fix for #1548

### DIFF
--- a/skimage/external/tifffile/__init__.py
+++ b/skimage/external/tifffile/__init__.py
@@ -2,3 +2,6 @@ try:
     from tifffile import imread, imsave, TiffFile
 except ImportError:
     from .tifffile_local import imread, imsave, TiffFile
+    import tifffile_local, _tifffile
+    assert tifffile_local.decodelzw == _tifffile.decodelzw, \
+        "The _tifffile.so extension module could not be loaded."

--- a/skimage/external/tifffile/tifffile_local.py
+++ b/skimage/external/tifffile/tifffile_local.py
@@ -3109,7 +3109,9 @@ def _replace_by(module_function, package=None, warn=False):
         try:
             modname, function = module_function.split('.')
             if package is None:
-                full_name = modname
+                # No package given: 
+                # Assume the module is in the same package as this file.
+                full_name = '.'.join(__name__.split('.')[:-1] + [modname])
             else:
                 full_name = package + '.' + modname
             module = __import__(full_name, fromlist=[modname])


### PR DESCRIPTION
This PR offers a solution to #1548, but as I noted there, it has the disadvantage of making scikit-image's `tifffile_local.py` out-of-sync with the original text of `tifffile.py` as posted on @cgohlke's [website](http://www.lfd.uci.edu/~gohlke/code/tifffile.py.html).  Is that a problem?

@cgohlke, do you maintain an "official" git repository for `tifffile.py` and `tifffile.c`?  If so, I'd prefer to make a pull request there.  Downstream projects like scikit-image could pull fixes like this from there.