### PR TITLE
Add array coords and Cython-Python wrapping to new contributors guide

### DIFF
--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -166,6 +166,10 @@ Stylistic Guidelines
 * Use ``Py_ssize_t`` as data type for all indexing, shape and size variables
   in C/C++ and Cython code.
 
+* Wrap Cython code in a pure Python function, which defines the API. This
+  improves compatibility with code introspection tools, which are often not
+  aware of Cython code.
+
 Test coverage
 -------------
 

--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -152,6 +152,10 @@ Stylistic Guidelines
 * When documenting array parameters, use ``image : (M, N) ndarray``
   and then refer to ``M`` and ``N`` in the docstring, if necessary.
 
+* Refer to array dimensions as (plane), row, column, not as x, y, z. See
+  `Coordinate conventions <http://scikit-image.org/docs/dev/user_guide/numpy_images.html#coordinate-conventions>`__
+  in the user guide for more information.
+
 * Functions should support all input image dtypes.  Use utility functions such
   as ``img_as_float`` to help convert to an appropriate type.  The output
   format can be whatever is most efficient.  This allows us to string together

--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -153,7 +153,7 @@ Stylistic Guidelines
   and then refer to ``M`` and ``N`` in the docstring, if necessary.
 
 * Refer to array dimensions as (plane), row, column, not as x, y, z. See
-  `Coordinate conventions <http://scikit-image.org/docs/dev/user_guide/numpy_images.html#coordinate-conventions>`__
+  :ref:`Coordinate conventions <numpy-images-coordinate-conventions>`
   in the user guide for more information.
 
 * Functions should support all input image dtypes.  Use utility functions such

--- a/doc/source/user_guide/numpy_images.txt
+++ b/doc/source/user_guide/numpy_images.txt
@@ -130,6 +130,7 @@ the grayscale image above:
     >>> plt.imshow(cat)
 
 
+.. _numpy-images-coordinate-conventions:
 Coordinate conventions
 ----------------------
 

--- a/doc/source/user_guide/numpy_images.txt
+++ b/doc/source/user_guide/numpy_images.txt
@@ -131,6 +131,7 @@ the grayscale image above:
 
 
 .. _numpy-images-coordinate-conventions:
+
 Coordinate conventions
 ----------------------
 


### PR DESCRIPTION
As pointed out by @csachs, we don't currently specify our array conventions to new contributors, nor the requirement that Cython functions be wrapped in Python. This PR adds both of those points to the contributing guidelines.

I didn't know how to create a relative link (within Sphinx) to the coordinate conventions; happy to change that link if someone points me to the Right Way to do this!