### PR TITLE
Add a plugin and test for imageio

### DIFF
--- a/doc/release/release_dev.txt
+++ b/doc/release/release_dev.txt
@@ -16,7 +16,7 @@ New Features
 ------------
 
 - ``skimage.util.apply_parallel`` (#1493)
-
+- Plugin for ``imageio`` library (#1575)
 
 
 Improvements

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -3,3 +3,4 @@ imread; python_version != '2.7' and python_version != '3.2'
 SimpleITK; python_version != '3.2' and python_version != '3.4'
 astropy
 tifffile
+imageio

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -3,4 +3,4 @@ imread; python_version != '2.7'
 SimpleITK; python_version != '3.4'
 astropy
 tifffile
-imageio
+imageio; python_version != '2.6'

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -1,6 +1,6 @@
 PySide; python_version != '2.7'
-imread; python_version != '2.7' and python_version != '3.2'
-SimpleITK; python_version != '3.2' and python_version != '3.4'
+imread; python_version != '2.7'
+SimpleITK; python_version != '3.4'
 astropy
 tifffile
 imageio

--- a/skimage/io/_plugins/imageio_plugin.ini
+++ b/skimage/io/_plugins/imageio_plugin.ini
@@ -1,0 +1,3 @@
+[imageio]
+description = Image reading via the ImageIO Library
+provides = imread, imsave

--- a/skimage/io/_plugins/imageio_plugin.py
+++ b/skimage/io/_plugins/imageio_plugin.py
@@ -1,0 +1,3 @@
+__all__ = ['imread', 'imsave']
+
+from imageio import imread, imsave

--- a/skimage/io/tests/test_imageio.py
+++ b/skimage/io/tests/test_imageio.py
@@ -1,0 +1,78 @@
+import os
+import os.path
+import numpy as np
+from numpy.testing import *
+from numpy.testing.decorators import skipif
+
+from tempfile import NamedTemporaryFile
+
+from skimage import data_dir
+from skimage.io import imread, imsave, use_plugin, reset_plugins
+import skimage.io as sio
+
+try:
+    import imageio as _imageio
+except ImportError:
+    imageio_available = False
+else:
+    imageio_available = True
+
+
+def setup():
+    if imageio_available:
+        np.random.seed(0)
+        use_plugin('imageio')
+
+
+def teardown():
+    reset_plugins()
+
+
+@skipif(not imageio_available)
+def test_imageio_flatten():
+    # a color image is flattened
+    img = imread(os.path.join(data_dir, 'color.png'), flatten=True)
+    assert img.ndim == 2
+    assert img.dtype == np.float64
+    img = imread(os.path.join(data_dir, 'camera.png'), flatten=True)
+    # check that flattening does not occur for an image that is grey already.
+    assert np.sctype2char(img.dtype) in np.typecodes['AllInteger']
+
+
+@skipif(not imageio_available)
+def test_imageio_palette():
+    img = imread(os.path.join(data_dir, 'palette_color.png'))
+    assert img.ndim == 3
+
+
+@skipif(not imageio_available)
+def test_imageio_truncated_jpg():
+    assert_raises((RuntimeError, ValueError),
+                  sio.imread,
+                  os.path.join(data_dir, 'truncated.jpg'))
+
+
+class TestSave:
+    def roundtrip(self, x, scaling=1):
+        f = NamedTemporaryFile(suffix='.png')
+        fname = f.name
+        f.close()
+        imsave(fname, x)
+        y = imread(fname)
+
+        assert_array_almost_equal((x * scaling).astype(np.int32), y)
+
+    @skipif(not imageio_available)
+    def test_imsave_roundtrip(self):
+        dtype = np.uint8
+        for shape in [(10, 10), (10, 10, 3), (10, 10, 4)]:
+            x = np.ones(shape, dtype=dtype) * np.random.rand(*shape)
+
+            if np.issubdtype(dtype, float):
+                yield self.roundtrip, x, 255
+            else:
+                x = (x * 255).astype(dtype)
+                yield self.roundtrip, x
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/skimage/io/tests/test_imageio.py
+++ b/skimage/io/tests/test_imageio.py
@@ -8,7 +8,6 @@ from tempfile import NamedTemporaryFile
 
 from skimage import data_dir
 from skimage.io import imread, imsave, use_plugin, reset_plugins
-import skimage.io as sio
 
 try:
     import imageio as _imageio
@@ -48,11 +47,12 @@ def test_imageio_palette():
 @skipif(not imageio_available)
 def test_imageio_truncated_jpg():
     assert_raises((RuntimeError, ValueError),
-                  sio.imread,
+                  imread,
                   os.path.join(data_dir, 'truncated.jpg'))
 
 
 class TestSave:
+
     def roundtrip(self, x, scaling=1):
         f = NamedTemporaryFile(suffix='.png')
         fname = f.name

--- a/tools/travis_script.sh
+++ b/tools/travis_script.sh
@@ -41,7 +41,7 @@ if [[ $PY == 2.7* ]]; then
         ln -sf $LIB_SYSTEM_PATH/$LIB $LIB_VIRTUALENV_PATH/$LIB
     done
 
-else
+else if [[ $PY != 3.2* ]]; then
     python ~/venv/bin/pyside_postinstall.py -install
 fi
 

--- a/tools/travis_script.sh
+++ b/tools/travis_script.sh
@@ -21,7 +21,9 @@ section_end "Flake8.test"
 section "Install.optional.dependencies"
 
 # Install most of the optional packages
-pip install --retries 3 -q -r ./optional_requirements.txt $WHEELHOUSE
+if [[ $PY != 3.2* ]]; then
+    pip install --retries 3 -q -r ./optional_requirements.txt $WHEELHOUSE
+fi
 
 # Install Qt and then update the Matplotlib settings
 if [[ $PY == 2.7* ]]; then

--- a/tools/travis_script.sh
+++ b/tools/travis_script.sh
@@ -41,7 +41,7 @@ if [[ $PY == 2.7* ]]; then
         ln -sf $LIB_SYSTEM_PATH/$LIB $LIB_VIRTUALENV_PATH/$LIB
     done
 
-else if [[ $PY != 3.2* ]]; then
+elif [[ $PY != 3.2* ]]; then
     python ~/venv/bin/pyside_postinstall.py -install
 fi
 


### PR DESCRIPTION
From the test with optional dependencies (it installed and is passing tests):

```
skimage.io.tests.test_imageio.TestSave.test_imsave_roundtrip(array([[139, 182, 153, 138, 108, 164, 111, 227, 245,  97], ... ok
skimage.io.tests.test_imageio.TestSave.test_imsave_roundtrip(array([[[172,  68, 187], ... ok
skimage.io.tests.test_imageio.TestSave.test_imsave_roundtrip(array([[[102, 236,  25, 241], ... ok
skimage.io.tests.test_imageio.test_imageio_flatten ... ok
skimage.io.tests.test_imageio.test_imageio_palette ... ok
skimage.io.tests.test_imageio.test_imageio_truncated_jpg ... ok
```

cc @almarklein.