### PR TITLE
Fix a broken link to daisy code

### DIFF
--- a/skimage/feature/_daisy.py
+++ b/skimage/feature/_daisy.py
@@ -91,7 +91,7 @@ def daisy(img, step=4, radius=15, rings=3, histograms=8, orientations=8,
     .. [1] Tola et al. "Daisy: An efficient dense descriptor applied to wide-
            baseline stereo." Pattern Analysis and Machine Intelligence, IEEE
            Transactions on 32.5 (2010): 815-830.
-    .. [2] http://cvlab.epfl.ch/alumni/tola/daisy.html
+    .. [2] http://cvlab.epfl.ch/software/daisy
     '''
 
     assert_nD(img, 2, 'img')


### PR DESCRIPTION
In the document of Daisy feature extractor, current citation link returns 404. I found another page which contains a link to the original implementation.