### PR TITLE
ENH: `make clean` now removes compiled .c and .pyd files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all:
 	python setup.py build_ext --inplace
 
 clean:
-	find . -name "*.so" -o -name "*.pyc" -o -name "*.pyx.md5" | xargs rm -f
+	find . -name "*.so" -o -name "*.pyc" -o -name "*.pyx.md5" -o -name "*.c" -o -name "*.pyd" | xargs rm -f
 
 test:
 	python -c "import skimage, sys, io; sys.exit(skimage.test_verbose())"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ all:
 	python setup.py build_ext --inplace
 
 clean:
-	find . -name "*.so" -o -name "*.pyc" -o -name "*.pyx.md5" -o -name "*.c" -o -name "*.pyd" | xargs rm -f
+	find . -name "*.so" -o -name "*.pyc" -o -name "*.pyx.md5" -o -name "*.pyd" | xargs rm -f
+	find . -name "*.pyx" -exec ./tools/rm_pyx_c_file.sh {} \;
 
 test:
 	python -c "import skimage, sys, io; sys.exit(skimage.test_verbose())"

--- a/tools/rm_pyx_c_file.sh
+++ b/tools/rm_pyx_c_file.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Accepts a .pyx file path and deletes an associated .c file, if present.
+filename="${1%.*}".c
+if [ -e "$filename" ]; then
+	rm -f "$filename";
+fi


### PR DESCRIPTION
As reported by @grlee77 as a sidenote in #1583, `make clean` previously did not remove all compiled files.

Now the `clean` target removes Cythonized `.c` files as well as `.pyd` files, which are the Windows equivalent of `.so`, for those using Cygwin or similar to have `Makefile` support on Windows.