### PR TITLE
Use new Travis containers for faster builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,15 @@
 # See doc/travis_notes.txt for some guidelines
 
 language: python
+sudo: false
+cache: pip
+addons:
+  apt:
+    packages:
+    - libfreeimage3
+    - texlive 
+    - texlive-latex-extra 
+    - dvipng
 
 notifications:
   webhooks:

--- a/skimage/novice/__init__.py
+++ b/skimage/novice/__init__.py
@@ -29,7 +29,7 @@ We can create a Picture object open opening an image file:
 
 We can display pictures (after running this command, close the window to access the prompt again):
 
->>> picture.show()
+>>> picture.show()  # doctest: +SKIP
 
 Pictures know their format:
 
@@ -50,7 +50,7 @@ True
 
 As a reminder, we can preview the picture with our earlier command:
 
->>> picture.show()
+>>> picture.show()  # doctest: +SKIP
 
 Changing `size` resizes the picture.
 
@@ -58,7 +58,7 @@ Changing `size` resizes the picture.
 
 We can preview the changes we made to the picture with our earlier command:
 
->>> picture.show()
+>>> picture.show()  # doctest: +SKIP
 
 You can iterate over pixels, which have RGB values between 0 and 255,
 and know their location in the picture.

--- a/tools/travis_before_install.sh
+++ b/tools/travis_before_install.sh
@@ -46,10 +46,6 @@ source ~/venv/bin/activate
 
 retry pip install wheel flake8 coveralls nose
 
-# install system tk for matplotlib
-sudo apt-get install python-tk
-
-
 # on Python 3.2, use matplotlib 1.3.1
 if [[ $TRAVIS_PYTHON_VERSION == 3.2 ]]; then
     sed -i 's/matplotlib>=.*/matplotlib==1.3.1/g' requirements.txt
@@ -62,10 +58,6 @@ done
 retry pip install $WHEELHOUSE $WHEELS
 
 retry pip install -r requirements.txt
-
-# clean up disk space
-sudo apt-get clean
-sudo rm -rf /tmp/*
 
 
 section () {

--- a/tools/travis_script.sh
+++ b/tools/travis_script.sh
@@ -9,7 +9,6 @@ section_end "Test.with.min.requirements"
 
 section "Build.docs"
 if [[ ($PY != 2.6) && ($PY != 3.2) ]]; then
-    sudo apt-get install -qq texlive texlive-latex-extra dvipng
     make html
 fi
 section_end "Build.docs"
@@ -22,33 +21,12 @@ section_end "Flake8.test"
 section "Install.optional.dependencies"
 
 # Install Qt and then update the Matplotlib settings
-if [[ $PY == 2.7* ]]; then
-    sudo apt-get install -q python-qt4
+retry pip install -q PySide $WHEELHOUSE
+python ~/venv/bin/pyside_postinstall.py -install
 
-    # http://stackoverflow.com/a/9716100
-    LIBS=( PyQt4 sip.so )
-
-    VAR=( $(which -a python$PY) )
-
-    GET_PYTHON_LIB_CMD="from distutils.sysconfig import get_python_lib; print (get_python_lib())"
-    LIB_VIRTUALENV_PATH=$(python -c "$GET_PYTHON_LIB_CMD")
-    LIB_SYSTEM_PATH=$(${VAR[-1]} -c "$GET_PYTHON_LIB_CMD")
-
-    for LIB in ${LIBS[@]}
-    do
-        sudo ln -sf $LIB_SYSTEM_PATH/$LIB $LIB_VIRTUALENV_PATH/$LIB
-    done
-
-else
-    sudo apt-get install -q libqt4-dev
-    retry pip install -q PySide $WHEELHOUSE
-    python ~/venv/bin/pyside_postinstall.py -install
-fi
-
-# imread does NOT support py3.2
+# Install imread from wheelhouse if available (not 3.2)
 if [[ $PY != 3.2 ]]; then
-    sudo apt-get install -q libtiff4-dev libwebp-dev libpng12-dev xcftools
-    retry pip  install -q imread
+    retry pip install -q $WHEELHOUSE
 fi
 
 # Install SimpleITK from wheelhouse if available (not 3.2 or 3.4)
@@ -58,7 +36,6 @@ else
     retry pip  install -q SimpleITK $WHEELHOUSE
 fi
 
-sudo apt-get install -q libfreeimage3
 retry pip install -q astropy $WHEELHOUSE
 
 if [[ $PY == 2.* ]]; then


### PR DESCRIPTION
The latest sprint drove home the fact that the old Travis method is broken.

This switches us over to the new containerized method, and uses a pip cache as well.

http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade

The only thing I had to sacrifice was testing against `PyQt4` specifically, all builds now use `PySide`.