### PR TITLE
Reinstate PyQt4 test on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@
 
 language: python
 sudo: false
-cache: pip
+cache:
+  directories:
+    - $HOME/.cache/pip
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
     - texlive 
     - texlive-latex-extra 
     - dvipng
+    - python-qt4
 
 notifications:
   webhooks:

--- a/tools/travis_script.sh
+++ b/tools/travis_script.sh
@@ -21,8 +21,25 @@ section_end "Flake8.test"
 section "Install.optional.dependencies"
 
 # Install Qt and then update the Matplotlib settings
-retry pip install -q PySide $WHEELHOUSE
-python ~/venv/bin/pyside_postinstall.py -install
+if [[ $PY == 2.7* ]]; then
+    # http://stackoverflow.com/a/9716100
+    LIBS=( PyQt4 sip.so )
+
+    VAR=( $(which -a python$PY) )
+
+    GET_PYTHON_LIB_CMD="from distutils.sysconfig import get_python_lib; print (get_python_lib())"
+    LIB_VIRTUALENV_PATH=$(python -c "$GET_PYTHON_LIB_CMD")
+    LIB_SYSTEM_PATH=$(${VAR[-1]} -c "$GET_PYTHON_LIB_CMD")
+
+    for LIB in ${LIBS[@]}
+    do
+        ln -sf $LIB_SYSTEM_PATH/$LIB $LIB_VIRTUALENV_PATH/$LIB
+    done
+
+else
+    retry pip install -q PySide $WHEELHOUSE
+    python ~/venv/bin/pyside_postinstall.py -install
+fi 
 
 # Install imread from wheelhouse if available (not 3.2)
 if [[ $PY != 3.2 ]]; then


### PR DESCRIPTION
Also explicitly use the `pip cache`, since we override the `install` script in `.travis.yml.`

http://docs.travis-ci.com/user/caching/#With-a-custom-install-step 