### PR TITLE
Do not try and upgrade other large dependencies on pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,14 @@ if __name__ == "__main__":
     try:
         from numpy.distutils.core import setup
         extra = {'configuration': configuration}
-        # do not risk updating numpy
+        # do not risk updating numpy or scipy
         INSTALL_REQUIRES = [r for r in INSTALL_REQUIRES if 'numpy' not in r]
+        try:
+            import scipy
+            INSTALL_REQUIRES = [r for r in INSTALL_REQUIRES if 'scipy'
+                                not in r]
+        except ImportError:
+            pass
     except ImportError:
         if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or
                                    sys.argv[1] in ('--help-commands',

--- a/setup.py
+++ b/setup.py
@@ -63,14 +63,14 @@ if __name__ == "__main__":
     try:
         from numpy.distutils.core import setup
         extra = {'configuration': configuration}
-        # do not risk updating numpy or scipy
-        INSTALL_REQUIRES = [r for r in INSTALL_REQUIRES if 'numpy' not in r]
-        try:
-            import scipy
-            INSTALL_REQUIRES = [r for r in INSTALL_REQUIRES if 'scipy'
-                                not in r]
-        except ImportError:
-            pass
+        # Do not try and upgrade larger dependencies
+        for lib in ['scipy', 'numpy', 'matplotlib', 'pillow']:
+            try:
+                __import__(lib)
+                INSTALL_REQUIRES = [i for i in INSTALL_REQUIRES
+                                    if lib not in i]
+            except ImportError:
+                pass
     except ImportError:
         if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or
                                    sys.argv[1] in ('--help-commands',


### PR DESCRIPTION
Installing or upgrading scikit-image should not try to upgrade libraries with large external dependencies.
Scipy takes the same stance with numpy.