### PR TITLE
WIP: Proof of concept for Dask/NumPy shared codebase

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ six>=1.4
 networkx>=1.8
 pillow>=1.7.8
 dask[array]>=0.5.0
+psutil>=2.0.0

--- a/skimage/util/dask_compatibility.py
+++ b/skimage/util/dask_compatibility.py
@@ -1,0 +1,493 @@
+from __future__ import division
+import numpy as np
+import dask.array as da
+import operator
+import collections
+import functools
+import six
+import psutil      # New dependency
+
+"""
+Provides compatibility to use Dask and NumPy arrays on a shared codebase.
+
+The goal of this module is to provide transparent compatibility functions
+with the same names, signatures, and behavior from the base NumPy (``np``)
+and Dask (``da``) namespaces. Ideally this module would be imported and used
+as follows::
+
+>>> import dask_compatibility as dc
+>>> dc.rint(arr)  # Identical behavior if arr is from Dask or NumPy
+"""
+
+__all__ = ['asanyarray',
+           'asarray',
+           'clip',
+           'dtype_conversion_inplace',
+           'eager_min',
+           'eager_max',
+           'empty',
+           'est_best_chunk',
+           'floor',
+           'maximum',
+           'rint',
+           ]
+
+
+def _graceful_compute(variable):
+    """
+    Attempts to call .compute() on every item in variable.
+    """
+    # Shortcut on NumPy arrays first
+    if isinstance(variable, np.ndarray):
+        # Return the NumPy array
+        return variable
+
+    # Dask arrays are not iterable, but NumPy arrays are.
+    elif not isinstance(variable, collections.Iterable):
+        # Could be a Dask array, try to compute it
+        try:
+            return variable.compute()
+        except AttributeError:
+            # Not a Dask array, return the variable.
+            return variable
+
+    # Might be multiple values in a container
+    else:
+        # TODO: graceful computing of items in dicts
+        try:
+            # Attempt to gracefully compute each item
+            return tuple(_graceful_compute(x) for x in variable)
+        except TypeError:
+            # If neither of these work it isn't a Dask array; return as-is
+            return variable
+
+
+def _dask_input(*args, **kwargs):
+    """
+    Determines if any inputs contain Dask arrays.
+
+    Parameters
+    ----------
+    *args, **kwargs
+        All arguments from the enclosing function should be passed.
+
+    Returns
+    -------
+    dask_present : bool
+        True if at least one input was a Dask array.
+    """
+    return (any(isinstance(x, da.core.Array) for x in args) or
+            any(isinstance(x, da.core.Array)
+                for _, x in six.iteritems(kwargs)))
+
+
+def dask_decorator(compute=True):
+    """
+    Decorator to control conversion of outputs from Dask to NumPy arrays
+
+    Parameters
+    ----------
+    compute : bool
+        Decorator argument allows the default behavior (True, do the
+        conversion) to be overridden so Dask arrays can be passed along
+        to another function.
+
+    Returns
+    -------
+    decorator : function
+        Decorated function, ready for use.
+    """
+    def real_decorator(function):
+        def wrapper(*args, **kwargs):
+            if _dask_input(*args, **kwargs) or not compute:
+                return function(*args, **kwargs)
+            else:
+                return _graceful_compute(function(*args, **kwargs))
+        return wrapper
+    return real_decorator
+
+
+def _total_elements(shape):
+    """
+    Efficiently determine the number of elements in an array, given its shape.
+    """
+    return functools.reduce(operator.mul, shape, 1)
+
+
+def est_best_chunk(shape, dtype, mem_frac=0.25, preserve_dims_under=50):
+    """
+    Find optimal dask.array chunks given shape and dtype of an array.
+
+    Parameters
+    ----------
+    shape : iterable of ints
+        Formatted like the ``numpy_array.shape`` attribute.
+    dtype : NumPy dtype
+        Actual NumPy dtype, e.g., ``np.float64`` or ``np.uint8``.
+    frac_of_phys_mem : float
+        Floating point value on interval (0, 1]. The chunk size found
+        will fit in your total memory multiplied by this value.
+    preserve_dims_under : int
+        Integer value, must be >= 1. Dimensions with lengths below this value
+        will not be broken down further.
+
+    Returns
+    -------
+    smaller_chunk : iterable of ints
+        Same length as ``shape``, this corresponds to an appropriate value for
+        ``dask.array.from_array(..., chunks=smaller_chunk)``.
+    """
+    ram = psutil.virtual_memory().total * mem_frac
+
+    # Size of each array element
+    bytes_per_entry = np.dtype(dtype).itemsize
+
+    # Start with current shape, decrease iteratively as necessary
+    smaller_chunk = shape
+    preserve_dims_under *= 2
+
+    while (bytes_per_entry * _total_elements(smaller_chunk)) > ram:
+        smaller_chunk = tuple(dim // 2
+                              if dim > preserve_dims_under
+                              else dim
+                              for dim in smaller_chunk)
+
+    return smaller_chunk
+
+
+def asanyarray(arr_like):
+    """
+    Convert array-like input to array, passing dask arrays through.
+
+    Parameters
+    ----------
+    arr_like : array-like
+        Array-like input object to be converted to an array. Can be a NumPy
+        array, a ``dask.array``, or any other array-like object.
+
+    Returns
+    -------
+    arr : array
+        If ``arr_like`` was a ``dask.array`` object it is passed unmodified,
+        otherwise a NumPy array is returned.
+
+    Notes
+    -----
+    This function is intended to replace ``np.asanyarray`` in the package so
+    Dask arrays can be passed without conversion back into NumPy objects.
+    """
+    if isinstance(arr_like, da.core.Array):
+        return arr_like
+    else:
+        return np.asanyarray(arr_like)
+
+
+def asarray(arr_like):
+    """
+    Convert array-like input to array, passing dask arrays through.
+
+    Parameters
+    ----------
+    arr_like : array-like
+        Array-like input object to be converted to an array. Can be a NumPy
+        array, a ``dask.array``, or any other array-like object.
+
+    Returns
+    -------
+    arr : array
+        If ``arr_like`` was a ``dask.array`` object it is passed unmodified,
+        otherwise a NumPy array is returned.
+
+    Notes
+    -----
+    This function is intended to replace ``np.asarray`` in the package so
+    Dask arrays can be passed without conversion back into NumPy objects.
+    """
+    if isinstance(arr_like, da.core.Array):
+        return arr_like
+    else:
+        return np.asarray(arr_like)
+
+
+def dtype_conversion_inplace(arr, new_dtype):
+    """
+    Convert dtype of NumPy or dask array inplace.
+
+    Parameters
+    ----------
+    arr : dask or NumPy array
+        Input array, NumPy or Dask arrays supported.
+    new_dtype : NumPy dtype object
+        Valid destination dtype for ``arr``.
+
+    Returns
+    -------
+    arr : dask or NumPy array
+        Output array, converted to dtype ``new_dtype``.
+
+    Notes
+    -----
+    This function is intended to replace ``np.array(..., copy=False)`` as
+    Dask has no equivalent functionality.
+    """
+    # There is no `array` method in dask, so the code must branch
+    if isinstance(arr, np.ndarray):
+        return np.array(arr, new_dtype, copy=False)
+    else:
+        return arr.astype(new_dtype)
+
+
+def eager_min(arr, *args, **kwargs):
+    """
+    Calculate the minimum of a NumPy or Dask array.
+
+    Parameters
+    ----------
+    arr : Dask or NumPy array
+        Input array, NumPy or Dask arrays supported.
+    axis : int, optional
+        Axis along which to operate. By default, flattened input is used.
+    out : ndarray, optional
+        Alternative output array in which to place the result. Must
+        be of the same shape and buffer length as the expected output.
+        See ``doc.ufuncs`` (Section "Output arguments") for more details.
+    keepdims : bool, optional
+        If this is set to True, the axes which are reduced are left
+        in the result as dimensions with size one. With this option,
+        the result will broadcast correctly against the original ``arr``.
+
+    Returns
+    -------
+    amax : ndarray or scalar
+        Maximum of `a`. If `axis` is None, the result is a scalar value.
+        If `axis` is given, the result is an array of dimension
+        ``a.ndim - 1``.
+    """
+    amin = arr.min(*args, **kwargs)
+
+    if isinstance(arr, da.core.Array):
+        amin = amin.compute()
+
+    return amin
+
+
+def eager_max(arr, *args, **kwargs):
+    """
+    Calculate the maximum of a NumPy or Dask array.
+
+    Parameters
+    ----------
+    arr : Dask or NumPy array
+        Input array, NumPy or Dask arrays supported.
+    axis : int, optional
+        Axis along which to operate. By default, flattened input is used.
+    out : ndarray, optional
+        Alternative output array in which to place the result. Must
+        be of the same shape and buffer length as the expected output.
+        See ``doc.ufuncs`` (Section "Output arguments") for more details.
+    keepdims : bool, optional
+        If this is set to True, the axes which are reduced are left
+        in the result as dimensions with size one. With this option,
+        the result will broadcast correctly against the original ``arr``.
+
+    Returns
+    -------
+    amax : ndarray or scalar
+        Maximum of `a`. If `axis` is None, the result is a scalar value.
+        If `axis` is given, the result is an array of dimension
+        ``a.ndim - 1``.
+
+    Notes
+    -----
+    Use this function instead of ``np.max`` or ``arr.max()`` when the result
+    must be known immediately within a function for other purposes. The
+    result is calculated and returned from Dask.
+
+    In all other cases simply use the ``arr.max()`` attribute which is shared
+    between NumPy and Dask (but will remain lazy in Dask).
+    """
+    amin = arr.min(*args, **kwargs)
+
+    if isinstance(arr, da.core.Array):
+        amin = amin.compute()
+
+    return amin
+
+
+def rint(arr, out=None):
+    """
+    Calculate the maximum of a NumPy or Dask array.
+
+    Parameters
+    ----------
+    arr : Dask or NumPy array
+        Input array, NumPy or Dask arrays supported.
+    out : ndarray, optional
+        Alternative output array in which to place the result. Must
+        be of the same shape and buffer length as the expected output.
+        See ``doc.ufuncs`` (Section "Output arguments") for more details.
+
+    Returns
+    -------
+    arr_rounded : Dask or NumPy array
+        Rounded output array.
+    """
+    if isinstance(arr, da.core.Array):
+        return da.rint(arr)
+    else:
+        return np.rint(arr, out=out)
+
+
+def clip(arr, a_min, a_max, out=None):
+    """
+    Clip (limit) the values in an array.
+
+    Given an interval, values outside the interval are clipped to
+    the interval edges.  For example, if an interval of ``[0, 1]``
+    is specified, values smaller than 0 become 0, and values larger
+    than 1 become 1.
+
+    Parameters
+    ----------
+    a : array_like
+        Array containing elements to clip.
+    a_min : scalar or array_like
+        Minimum value.
+    a_max : scalar or array_like
+        Maximum value.  If ``a_min`` or ``a_max`` are array_like, then they
+        will be broadcasted to the shape of ``a``.
+    out : ndarray, optional
+        The results will be placed in this array. It may be the input
+        array for in-place clipping.  ``out`` must be of the right shape
+        to hold the output.  Its type is preserved.
+
+    Returns
+    -------
+    clipped_array : ndarray
+        An array with the elements of ``a``, but where values
+        < ``a_min`` are replaced with ``a_min``, and those > ``a_max``
+        with ``a_max``.
+    """
+    if isinstance(arr, da.core.Array):
+        return da.clip(arr, a_min, a_max)
+    else:
+        return np.clip(arr, a_min, a_max, out=out)
+
+
+def floor(arr, out=None):
+    """
+    Return the floor of the input, element-wise.
+
+    The floor of the scalar ``x`` is the largest integer ``i``, such that
+    ``i <= x``.  It is often denoted as :math:`\lfloor x \rfloor`.
+
+    Parameters
+    ----------
+    arr : array_like
+        Input data.
+
+    Returns
+    -------
+    arr_floored : {ndarray, scalar}
+        The floor of each element in ``x``.
+    """
+    if isinstance(arr, da.core.Array):
+        return da.floor(arr)
+    else:
+        return np.floor(arr, out=out)
+
+
+def maximum(x1, x2, out=None, dtype=None, casting='safe'):
+    """
+    Element-wise maximum of array elements.
+
+    Compare two arrays and returns a new array containing the element-wise
+    maxima. If one of the elements being compared is a NaN, then that
+    element is returned. If both elements are NaNs then the first is
+    returned. The latter distinction is important for complex NaNs, which
+    are defined as at least one of the real or imaginary parts being a NaN.
+    The net effect is that NaNs are propagated.
+
+    Parameters
+    ----------
+    x1, x2 : array_like
+        The arrays holding the elements to be compared. They must have
+        the same shape, or shapes that can be broadcast to a single shape.
+
+    Returns
+    -------
+    y : {ndarray, scalar}
+        The maximum of `x1` and `x2`, element-wise.  Returns scalar if
+        both  `x1` and `x2` are scalars.
+    """
+    if isinstance(x1, da.core.Array) and isinstance(x2, da.core.Array):
+        return da.maximum(x1, x2, dtype=dtype, casting=casting)
+    else:
+        if out is not None:
+            if isinstance(out, da.core.Array):
+                out = out.compute()
+            return np.maximum(x1, x2, out=out, dtype=dtype, casting=casting)
+        else:
+            return np.maximum(x1, x2, dtype=dtype, casting=casting)
+
+
+def minimum(x1, x2, out=None, dtype=None, casting='safe'):
+    """
+    Element-wise minimum of array elements.
+
+    Compare two arrays and returns a new array containing the element-wise
+    minima. If one of the elements being compared is a NaN, then that
+    element is returned. If both elements are NaNs then the first is
+    returned. The latter distinction is important for complex NaNs, which
+    are defined as at least one of the real or imaginary parts being a NaN.
+    The net effect is that NaNs are propagated.
+
+    Parameters
+    ----------
+    x1, x2 : array_like
+        The arrays holding the elements to be compared. They must have
+        the same shape, or shapes that can be broadcast to a single shape.
+
+    Returns
+    -------
+    y : {ndarray, scalar}
+        The minimum of `x1` and `x2`, element-wise.  Returns scalar if
+        both  `x1` and `x2` are scalars.
+    """
+    if isinstance(x1, da.core.Array) and isinstance(x2, da.core.Array):
+        return da.minimum(x1, x2, dtype=dtype, casting=casting)
+    else:
+        if out is not None:
+            if isinstance(out, da.core.Array):
+                out = out.compute()
+            return np.minimum(x1, x2, out=out, dtype=dtype, casting=casting)
+        else:
+            return np.minimum(x1, x2, dtype=dtype, casting=casting)
+
+
+def empty(shape, dtype=np.float64, order='C', chunks=None):
+    """
+    Return a new array of given shape and type, without initializing entries.
+
+    Parameters
+    ----------
+    shape : int or tuple of int
+        Shape of the empty array
+    dtype : data-type, optional
+        Desired output data-type.
+    order : {'C', 'F'}, optional
+        Whether to store multi-dimensional data in C (row-major) or
+        Fortran (column-major) order in memory.
+    chunks : int or tuple of int, optional
+        Chunks for Dask. Will be approximated if not set.
+
+    Returns
+    -------
+    out : dask array
+        Array of uninitialized (arbitrary) data with the given
+        shape, dtype, and order.
+    """
+    if chunks is None:
+        chunks = est_best_chunk(shape, dtype)
+
+    return da.empty(shape, dtype=dtype, order=order, chunks=chunks)

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -1,6 +1,7 @@
 from __future__ import division
 import numpy as np
 from warnings import warn
+from . import dask_compatibility as dc
 
 __all__ = ['img_as_float', 'img_as_int', 'img_as_uint', 'img_as_ubyte',
            'img_as_bool', 'dtype_limits']
@@ -47,6 +48,83 @@ def dtype_limits(image, clip_negative=True):
     return imin, imax
 
 
+def _sign_loss(dtypeobj_in, dtypeobj):
+    warn("Possible sign loss when converting negative image of type "
+         "%s to positive image of type %s." % (dtypeobj_in, dtypeobj))
+
+
+def _prec_loss(dtypeobj_in, dtypeobj):
+    warn("Possible precision loss when converting from "
+         "%s to %s" % (dtypeobj_in, dtypeobj))
+
+
+def _dtype(itemsize, *dtypes):
+    # Return first of `dtypes` with itemsize greater than `itemsize`
+    return next(dt for dt in dtypes if itemsize < np.dtype(dt).itemsize)
+
+
+def _dtype2(kind, bits, itemsize=1):
+    # Return dtype of `kind` that can store a `bits` wide unsigned int
+    c = lambda x, y: x <= y if kind == 'u' else x < y
+    s = next(i for i in (itemsize, ) + (2, 4, 8) if c(bits, i * 8))
+    return np.dtype(kind + str(s))
+
+
+def _scale(a, n, m, dtypeobj_in, dtypeobj, copy=True):
+    # Scale unsigned/positive integers from n to m bits
+    # Numbers can be represented exactly only if m is a multiple of n
+    # Output array is of same kind as input.
+    kind = a.dtype.kind
+    if n == m:
+        return a.copy() if copy else a
+
+    elif n > m:
+        # downscale with precision loss
+        _prec_loss(dtypeobj_in, dtypeobj)
+        if copy and isinstance(a, np.ndarray):
+            b = np.empty(a.shape, _dtype2(kind, m))
+            np.floor_divide(a, 2**(n - m), out=b, dtype=a.dtype,
+                            casting='unsafe')
+            return b
+
+        else:  # the dask code path
+            a //= 2**(n - m)
+            return a.astype(dtypeobj)
+
+    elif m % n == 0:
+        # exact upscale to a multiple of n bits
+        if copy and isinstance(a, np.ndarray):
+            b = np.empty(a.shape, _dtype2(kind, m))
+            np.multiply(a, (2**m - 1) // (2**n - 1), out=b, dtype=b.dtype)
+            return b
+
+        else:
+            new_dtype = _dtype2(kind, m, a.dtype.itemsize)
+            a = dc.dtype_conversion_inplace(a, new_dtype)
+            a *= (2**m - 1) // (2**n - 1)
+            return a
+
+    else:
+        # upscale to a multiple of n bits,
+        # then downscale with precision loss
+        _prec_loss(dtypeobj_in, dtypeobj)
+        o = (m // n + 1) * n
+
+        if copy and isinstance(a, np.ndarray):
+            b = np.empty(a.shape, _dtype2(kind, o))
+            np.multiply(a, (2**o - 1) // (2**n - 1), out=b, dtype=b.dtype)
+            b //= 2**(o - m)
+            return b
+
+        else:
+            new_dtype = _dtype2(kind, o, a.dtype.itemsize)
+            a = dc.dtype_conversion_inplace(a, new_dtype)
+            a *= (2**o - 1) // (2**n - 1)
+            a //= 2**(o - m)
+            return a
+
+
+@dc.dask_decorator(compute=True)
 def convert(image, dtype, force_copy=False, uniform=False):
     """
     Convert an image to the requested data-type.
@@ -88,7 +166,7 @@ def convert(image, dtype, force_copy=False, uniform=False):
         In "Jim Blinn's corner: Dirty Pixels", pp 47-57. Morgan Kaufmann, 1998.
 
     """
-    image = np.asarray(image)
+    image = dc.asarray(image)
     dtypeobj = np.dtype(dtype)
     dtypeobj_in = image.dtype
     dtype = dtypeobj.type
@@ -102,68 +180,6 @@ def convert(image, dtype, force_copy=False, uniform=False):
     if not (dtype_in in _supported_types and dtype in _supported_types):
         raise ValueError("can not convert %s to %s." % (dtypeobj_in, dtypeobj))
 
-    def sign_loss():
-        warn("Possible sign loss when converting negative image of type "
-             "%s to positive image of type %s." % (dtypeobj_in, dtypeobj))
-
-    def prec_loss():
-        warn("Possible precision loss when converting from "
-             "%s to %s" % (dtypeobj_in, dtypeobj))
-
-    def _dtype(itemsize, *dtypes):
-        # Return first of `dtypes` with itemsize greater than `itemsize`
-        return next(dt for dt in dtypes if itemsize < np.dtype(dt).itemsize)
-
-    def _dtype2(kind, bits, itemsize=1):
-        # Return dtype of `kind` that can store a `bits` wide unsigned int
-        c = lambda x, y: x <= y if kind == 'u' else x < y
-        s = next(i for i in (itemsize, ) + (2, 4, 8) if c(bits, i * 8))
-        return np.dtype(kind + str(s))
-
-    def _scale(a, n, m, copy=True):
-        # Scale unsigned/positive integers from n to m bits
-        # Numbers can be represented exactly only if m is a multiple of n
-        # Output array is of same kind as input.
-        kind = a.dtype.kind
-        if n == m:
-            return a.copy() if copy else a
-        elif n > m:
-            # downscale with precision loss
-            prec_loss()
-            if copy:
-                b = np.empty(a.shape, _dtype2(kind, m))
-                np.floor_divide(a, 2**(n - m), out=b, dtype=a.dtype,
-                                casting='unsafe')
-                return b
-            else:
-                a //= 2**(n - m)
-                return a
-        elif m % n == 0:
-            # exact upscale to a multiple of n bits
-            if copy:
-                b = np.empty(a.shape, _dtype2(kind, m))
-                np.multiply(a, (2**m - 1) // (2**n - 1), out=b, dtype=b.dtype)
-                return b
-            else:
-                a = np.array(a, _dtype2(kind, m, a.dtype.itemsize), copy=False)
-                a *= (2**m - 1) // (2**n - 1)
-                return a
-        else:
-            # upscale to a multiple of n bits,
-            # then downscale with precision loss
-            prec_loss()
-            o = (m // n + 1) * n
-            if copy:
-                b = np.empty(a.shape, _dtype2(kind, o))
-                np.multiply(a, (2**o - 1) // (2**n - 1), out=b, dtype=b.dtype)
-                b //= 2**(o - m)
-                return b
-            else:
-                a = np.array(a, _dtype2(kind, o, a.dtype.itemsize), copy=False)
-                a *= (2**o - 1) // (2**n - 1)
-                a //= 2**(o - m)
-                return a
-
     kind = dtypeobj.kind
     kind_in = dtypeobj_in.kind
     itemsize = dtypeobj.itemsize
@@ -172,8 +188,8 @@ def convert(image, dtype, force_copy=False, uniform=False):
     if kind == 'b':
         # to binary image
         if kind_in in "fi":
-            sign_loss()
-        prec_loss()
+            _sign_loss(dtypeobj_in, dtypeobj)
+        _prec_loss(dtypeobj_in, dtypeobj)
         return image > dtype_in(dtype_range[dtype_in][1] / 2)
 
     if kind_in == 'b':
@@ -191,19 +207,19 @@ def convert(image, dtype, force_copy=False, uniform=False):
         imax_in = np.iinfo(dtype_in).max
 
     if kind_in == 'f':
-        if np.min(image) < -1.0 or np.max(image) > 1.0:
+        if dc.eager_min(image) < -1.0 or dc.eager_min(image) > 1.0:
             raise ValueError("Images of type float must be between -1 and 1.")
         if kind == 'f':
             # floating point -> floating point
             if itemsize_in > itemsize:
-                prec_loss()
+                _prec_loss(dtypeobj_in, dtypeobj)
             return image.astype(dtype)
 
         # floating point -> integer
-        prec_loss()
+        _prec_loss(dtypeobj_in, dtypeobj)
         # use float type that can represent output integer type
-        image = np.array(image, _dtype(itemsize, dtype_in,
-                                       np.float32, np.float64))
+        image = image.astype(_dtype(itemsize, dtype_in, np.float32,
+                                    np.float64))
         if not uniform:
             if kind == 'u':
                 image *= imax
@@ -211,29 +227,29 @@ def convert(image, dtype, force_copy=False, uniform=False):
                 image *= imax - imin
                 image -= 1.0
                 image /= 2.0
-            np.rint(image, out=image)
-            np.clip(image, imin, imax, out=image)
+            image = dc.rint(image, out=image)
+            image = dc.clip(image, imin, imax, out=image)
         elif kind == 'u':
             image *= imax + 1
-            np.clip(image, 0, imax, out=image)
+            image = dc.clip(image, 0, imax, out=image)
         else:
             image *= (imax - imin + 1.0) / 2.0
-            np.floor(image, out=image)
-            np.clip(image, imin, imax, out=image)
+            image = dc.floor(image, out=image)
+            image = dc.clip(image, imin, imax, out=image)
         return image.astype(dtype)
 
     if kind == 'f':
         # integer -> floating point
         if itemsize_in >= itemsize:
-            prec_loss()
+            _prec_loss(dtypeobj_in, dtypeobj)
         # use float type that can exactly represent input integers
-        image = np.array(image, _dtype(itemsize_in, dtype,
-                                       np.float32, np.float64))
+        image = dc.dtype_conversion_inplace(
+            image, _dtype(itemsize_in, dtype, np.float32, np.float64))
         if kind_in == 'u':
             image /= imax_in
             # DirectX uses this conversion also for signed ints
-            #if imin_in:
-            #    np.maximum(image, -1.0, out=image)
+            # if imin_in:
+            #     np.maximum(image, -1.0, out=image)
         else:
             image *= 2.0
             image += 1.0
@@ -243,26 +259,32 @@ def convert(image, dtype, force_copy=False, uniform=False):
     if kind_in == 'u':
         if kind == 'i':
             # unsigned integer -> signed integer
-            image = _scale(image, 8 * itemsize_in, 8 * itemsize - 1)
-            return image.view(dtype)
+            image = _scale(image, 8 * itemsize_in, 8 * itemsize - 1,
+                           dtypeobj_in, dtypeobj)
+            return image.astype(dtype)
         else:
             # unsigned integer -> unsigned integer
-            return _scale(image, 8 * itemsize_in, 8 * itemsize)
+            return _scale(image, 8 * itemsize_in, 8 * itemsize,
+                          dtypeobj_in, dtypeobj)
 
     if kind == 'u':
         # signed integer -> unsigned integer
-        sign_loss()
-        image = _scale(image, 8 * itemsize_in - 1, 8 * itemsize)
-        result = np.empty(image.shape, dtype)
-        np.maximum(image, 0, out=result, dtype=image.dtype, casting='unsafe')
+        _sign_loss(dtypeobj_in, dtypeobj)
+        image = _scale(image, 8 * itemsize_in - 1, 8 * itemsize,
+                       dtypeobj_in, dtypeobj)
+        result = dc.empty(image.shape, dtype)
+        result = dc.maximum(image, 0, out=result, dtype=image.dtype,
+                            casting='unsafe')
         return result
 
     # signed integer -> signed integer
     if itemsize_in > itemsize:
-        return _scale(image, 8 * itemsize_in - 1, 8 * itemsize - 1)
+        return _scale(image, 8 * itemsize_in - 1, 8 * itemsize - 1,
+                      dtypeobj_in, dtypeobj)
     image = image.astype(_dtype2('i', itemsize * 8))
     image -= imin_in
-    image = _scale(image, 8 * itemsize_in, 8 * itemsize, copy=False)
+    image = _scale(image, 8 * itemsize_in, 8 * itemsize,
+                   dtypeobj_in, dtypeobj, copy=False)
     image += imin
     return image.astype(dtype)
 
@@ -327,7 +349,7 @@ def img_as_int(image, force_copy=False):
 
     Returns
     -------
-    out : ndarray of uint16
+    out : ndarray of int16
         Output image.
 
     Notes

--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_equal, assert_raises
-from skimage import img_as_int, img_as_float, \
-                    img_as_uint, img_as_ubyte
+from skimage import (img_as_int, img_as_float,
+                     img_as_uint, img_as_ubyte)
 from skimage.util.dtype import convert
 from skimage._shared._warnings import expected_warnings
 
@@ -23,13 +23,13 @@ def _verify_range(msg, x, vmin, vmax, dtype):
 def test_range():
     for dtype in dtype_range:
         imin, imax = dtype_range[dtype]
-        x = np.linspace(imin, imax, 10).astype(dtype)
 
         for (f, dt) in [(img_as_int, np.int16),
                         (img_as_float, np.float64),
                         (img_as_uint, np.uint16),
                         (img_as_ubyte, np.ubyte)]:
-            
+
+            x = np.linspace(imin, imax, 10).astype(dtype)
             with expected_warnings(['precision loss|sign loss|\A\Z']):
                 y = f(x)
 
@@ -62,7 +62,7 @@ def test_range_extra_dtypes():
     for dtype_in, dt in dtype_pairs:
         imin, imax = dtype_range_extra[dtype_in]
         x = np.linspace(imin, imax, 10).astype(dtype_in)
-        
+
         with expected_warnings(['precision loss|sign loss|\A\Z']):
             y = convert(x, dt)
 
@@ -99,9 +99,9 @@ def test_bool():
     img_[1, 1] = True
     img8[1, 1] = True
     for (func, dt) in [(img_as_int, np.int16),
-                    (img_as_float, np.float64),
-                    (img_as_uint, np.uint16),
-                    (img_as_ubyte, np.ubyte)]:
+                       (img_as_float, np.float64),
+                       (img_as_uint, np.uint16),
+                       (img_as_ubyte, np.ubyte)]:
         converted_ = func(img_)
         assert np.sum(converted_) == dtype_range[dt][1]
         converted8 = func(img8)


### PR DESCRIPTION
This is a work in progress showing Dask and NumPy supported on a shared codebase. It requires psutil as a new dependency.  Right now this only applies to `convert`, but widespread use of `img_as_*` made it the largest barrier for potential use in the package.

The design, in brief:

* Dask and NumPy arrays share most attributes, so most operations done with `arr.method()` need no modification
* The Dask compatibility layer substitutes `dc` for `np` for all operations that previously required `np.function_call()`
* Functions are wrapped with the Dask wrapper. It looks at the arguments and returns un-computed Dask arrays instead of NumPy arrays if Dask arrays were passed as inputs. 
* Those Dask arrays can then be passed to additional functions, enabling a pipeline which will be computed at the end, in memory, without intermediate arrays. 


TODO / comments appreciated: 

* The `_optimal_chunk` subroutine is anything but. It should make reasonable choices for image-like arrays, though.
* This started as a side project for skimage, but it's looking like something a bit more than that. Should this be located within the package, or spun off?
* **I'd like to make the Dask wrapper context-aware, so one could simply write `with dask:` for auto-pipelining. Ideas appreciated.**
* A lot of the NumPy `np.method()` API remains to be exposed, and their docstrings should be stripped for maintainability.
* The wrapper could use some enhancement, and instead of recursing it could require a couple of iterables designating position(s) of potential array(s) in inputs and outputs. Thoughts?

Coverage will fail, I need to write tests but wanted a few more eyes on this before the API settles.