### PR TITLE
FIX: Require networkx 1.9.1 for the 2.6 build

### DIFF
--- a/tools/travis_before_install.sh
+++ b/tools/travis_before_install.sh
@@ -32,6 +32,11 @@ retry () {
 # add build dependencies
 echo "cython>=0.21" >> requirements.txt
 
+# require networkx 1.9.1 on 2.6, as 2.6 support was dropped in 1.10
+if [[ $TRAVIS_PYTHON_VERSION == 2.6* ]]; then
+    sed -i 's/networkx.*/networkx==1.9.1/g' requirements.txt
+fi
+
 # test minimum requirements on 2.7
 if [[ $TRAVIS_PYTHON_VERSION == 2.7* ]]; then
     sed -i 's/>=/==/g' requirements.txt


### PR DESCRIPTION
This is a (hopefully temporary) workaround which patches our 2.6 build to require networkx 1.9.1 (see #1629)