### PR TITLE
Fixed typo in docs README

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -4,7 +4,7 @@ To build docs, run `make` in this directory. `make help` lists all targets.
 ## Requirements ##
 Sphinx and Latex is needed to build doc.
 
-**Spinx:**
+**Sphinx:**
 ```sh
 pip install sphinx
 ```


### PR DESCRIPTION
Very simple fix to a typo in the README file in the docs folder.