### PR TITLE
Gallery example improvement

### DIFF
--- a/doc/examples/plot_adapt_rgb.py
+++ b/doc/examples/plot_adapt_rgb.py
@@ -3,9 +3,9 @@
 Adapting gray-scale filters to RGB images
 =========================================
 
-There are many filters that are designed work with gray-scale images but not
-color images. To simplify the process of creating functions that can adapt to
-RGB images, scikit-image provides the ``adapt_rgb`` decorator.
+There are many filters that are designed to work with gray-scale images but not
+with color images. To simplify the process of creating functions that can adapt
+to RGB images, scikit-image provides the ``adapt_rgb`` decorator.
 
 To actually use the ``adapt_rgb`` decorator, you have to decide how you want to
 adapt the RGB image for use with the gray-scale filter. There are two
@@ -46,9 +46,19 @@ import matplotlib.pyplot as plt
 
 image = data.lena()
 
-fig, (ax_each, ax_hsv) = plt.subplots(ncols=2)
-ax_each.imshow(sobel_each(image))
-ax_hsv.imshow(sobel_hsv(image))
+fig = plt.figure( figsize=(14,7) )
+ax_each = fig.add_subplot(121)
+ax_hsv  = fig.add_subplot(122)
+
+# We use 1 - sobel_each(image) but this will not work if image is not normalized
+ax_each.imshow(1-sobel_each(image))
+ax_each.set_xticks([]), ax_each.set_yticks([])
+ax_each.set_title("Sobel filter computed\n on individual RGB channels")
+
+# We use 1 - sobel_hsv(image) but this will not work if image is not normalized
+ax_hsv.imshow(1-sobel_hsv(image))
+ax_hsv.set_xticks([]), ax_hsv.set_yticks([])
+ax_hsv.set_title("Sobel filter computed\n on (V)alue converted image (HSV)")
 
 """
 .. image:: PLOT2RST.current_figure
@@ -94,8 +104,13 @@ Finally, we can use this handler with ``adapt_rgb`` just as before:
 def sobel_gray(image):
     return filters.sobel(image)
 
-fig, ax = plt.subplots()
-ax.imshow(sobel_gray(image), cmap=plt.cm.gray)
+fig = plt.figure( figsize=(7,7) )
+ax = fig.add_subplot(111)
+
+# We use 1 - sobel_gray(image) but this will not work if image is not normalized 
+ax.imshow(1-sobel_gray(image), cmap=plt.cm.gray)
+ax.set_xticks([]), ax.set_yticks([])
+ax.set_title("Sobel filter computed\n on the converted grayscale image")
 
 plt.show()
 

--- a/doc/examples/plot_adapt_rgb.py
+++ b/doc/examples/plot_adapt_rgb.py
@@ -47,7 +47,7 @@ import matplotlib.pyplot as plt
 
 image = data.astronaut()
 
-fig = plt.figure( figsize=(14,7) )
+fig = plt.figure(figsize=(14, 7))
 ax_each = fig.add_subplot(121)
 ax_hsv  = fig.add_subplot(122)
 
@@ -57,7 +57,7 @@ ax_each.set_xticks([]), ax_each.set_yticks([])
 ax_each.set_title("Sobel filter computed\n on individual RGB channels")
 
 # We use 1 - sobel_hsv(image) but this will not work if image is not normalized
-ax_hsv.imshow( rescale_intensity((1-sobel_hsv(image))))
+ax_hsv.imshow(rescale_intensity(1 - sobel_hsv(image)))
 ax_hsv.set_xticks([]), ax_hsv.set_yticks([])
 ax_hsv.set_title("Sobel filter computed\n on (V)alue converted image (HSV)")
 
@@ -105,11 +105,11 @@ Finally, we can use this handler with ``adapt_rgb`` just as before:
 def sobel_gray(image):
     return filters.sobel(image)
 
-fig = plt.figure( figsize=(7,7) )
+fig = plt.figure(figsize=(7, 7))
 ax = fig.add_subplot(111)
 
 # We use 1 - sobel_gray(image) but this will not work if image is not normalized 
-ax.imshow( rescale_intensity(1-sobel_gray(image)), cmap=plt.cm.gray)
+ax.imshow( rescale_intensity(1 - sobel_gray(image)), cmap=plt.cm.gray)
 ax.set_xticks([]), ax.set_yticks([])
 ax.set_title("Sobel filter computed\n on the converted grayscale image")
 

--- a/doc/examples/plot_adapt_rgb.py
+++ b/doc/examples/plot_adapt_rgb.py
@@ -42,6 +42,7 @@ image:
 """
 
 from skimage import data
+from skimage.exposure import rescale_intensity
 import matplotlib.pyplot as plt
 
 image = data.astronaut()
@@ -51,12 +52,12 @@ ax_each = fig.add_subplot(121)
 ax_hsv  = fig.add_subplot(122)
 
 # We use 1 - sobel_each(image) but this will not work if image is not normalized
-ax_each.imshow(1-sobel_each(image))
+ax_each.imshow( rescale_intensity(1-sobel_each(image)))
 ax_each.set_xticks([]), ax_each.set_yticks([])
 ax_each.set_title("Sobel filter computed\n on individual RGB channels")
 
 # We use 1 - sobel_hsv(image) but this will not work if image is not normalized
-ax_hsv.imshow(1-sobel_hsv(image))
+ax_hsv.imshow( rescale_intensity((1-sobel_hsv(image))))
 ax_hsv.set_xticks([]), ax_hsv.set_yticks([])
 ax_hsv.set_title("Sobel filter computed\n on (V)alue converted image (HSV)")
 
@@ -108,7 +109,7 @@ fig = plt.figure( figsize=(7,7) )
 ax = fig.add_subplot(111)
 
 # We use 1 - sobel_gray(image) but this will not work if image is not normalized 
-ax.imshow(1-sobel_gray(image), cmap=plt.cm.gray)
+ax.imshow( rescale_intensity(1-sobel_gray(image)), cmap=plt.cm.gray)
 ax.set_xticks([]), ax.set_yticks([])
 ax.set_title("Sobel filter computed\n on the converted grayscale image")
 

--- a/doc/examples/plot_adapt_rgb.py
+++ b/doc/examples/plot_adapt_rgb.py
@@ -44,7 +44,7 @@ image:
 from skimage import data
 import matplotlib.pyplot as plt
 
-image = data.lena()
+image = data.astronaut()
 
 fig = plt.figure( figsize=(14,7) )
 ax_each = fig.add_subplot(121)


### PR DESCRIPTION
The very first example in the gallery is barely visible. I tried to reverse colors and add some titles to make it more explicit what the images are representing.

Here is a screenshot:

![figure_1](https://cloud.githubusercontent.com/assets/327203/9553883/4b07b5ce-4dc2-11e5-99c8-ab394b9b2cc6.png)


**Note**: I did not find the "official" way of reversing color in an aimage so I used 1-image. This works only if image channels are normalized.
