### PR TITLE
Replace cubehelix with the viridis colormap in the RAG drawing example

### DIFF
--- a/doc/examples/plot_rag_draw.py
+++ b/doc/examples/plot_rag_draw.py
@@ -31,8 +31,8 @@ plt.title("RAG with edge weights less than 30, color "
 plt.imshow(out)
 
 plt.figure()
-plt.title("All edges drawn with cubehelix colormap")
-cmap = plt.get_cmap('cubehelix')
+plt.title("All edges drawn with viridis colormap")
+cmap = plt.get_cmap('viridis')
 out = graph.draw_rag(labels, g, img, colormap=cmap,
                      desaturate=True)
 

--- a/doc/examples/plot_rag_draw.py
+++ b/doc/examples/plot_rag_draw.py
@@ -8,6 +8,7 @@ the `rag_draw` method.
 """
 from skimage import data, segmentation
 from skimage.future import graph
+from skimage.util.colormap import viridis
 from matplotlib import pyplot as plt, colors
 
 
@@ -32,8 +33,7 @@ plt.imshow(out)
 
 plt.figure()
 plt.title("All edges drawn with viridis colormap")
-cmap = plt.get_cmap('viridis')
-out = graph.draw_rag(labels, g, img, colormap=cmap,
+out = graph.draw_rag(labels, g, img, colormap=viridis,
                      desaturate=True)
 
 plt.imshow(out)


### PR DESCRIPTION
This is a lingering bit of #1661 that wasn't covered by #1599.
~~**NOTE:** I haven't tested this since I'm not running the very latest matplotlib.~~