### PR TITLE
The edge filter example contains all implemented filters apart from t…

### DIFF
--- a/doc/examples/plot_edge_filter.py
+++ b/doc/examples/plot_edge_filter.py
@@ -12,7 +12,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from skimage.data import camera
-from skimage.filters import roberts, sobel, scharr
+from skimage.filters import roberts, sobel, scharr, prewitt
 
 
 image = camera()
@@ -36,17 +36,21 @@ plt.tight_layout()
 
 Different operators compute different finite-difference approximations of the
 gradient. For example, the Scharr filter results in a better rotational
-variance than other filters such as the Sobel filter [1]_ [2]_. The difference
-between the two filters is illustrated below on an image that is the
-discretization of a rotation-invariant continuous function. The discrepancy
-between the two filters is stronger for regions of the image where the
-direction of the gradient is close to diagonal, and for regions with high
-spatial frequencies.
+variance than the Sobel filter that is in turn better than the Prewitt filter
+[1]_ [2]_ [3]_. The difference between the Prewitt and Sobel filters and the
+Scharr filter is illustrated below on an image that is the discretization of a
+rotation-invariant continuous function. The discrepancy between the Prewitt and
+Sobel filters, and the Scharr filter is stronger for regions of the image where
+the direction of the gradient is close to diagonal, and for regions with high
+spatial frequencies. The Sobel filter is less rotationally invariant than the
+Sobel filter.
 
-.. [1] http://en.wikipedia.org/wiki/Sobel_operator#Alternative_operators
+.. [1] https://en.wikipedia.org/wiki/Sobel_operator#Alternative_operators
 
 .. [2] B. Jaehne, H. Scharr, and S. Koerkel. Principles of filter design. In
        Handbook of Computer Vision and Applications. Academic Press, 1999.
+
+.. [3] https://en.wikipedia.org/wiki/Prewitt_operator
 """
 
 x, y = np.ogrid[:100, :100]
@@ -55,24 +59,37 @@ img = np.exp(1j * np.hypot(x, y)**1.3 / 20.).real
 
 edge_sobel = sobel(img)
 edge_scharr = scharr(img)
+edge_prewitt = prewitt(img)
 
-fig, ((ax0, ax1), (ax2, ax3)) = plt.subplots(nrows=2, ncols=2)
+fig, ((ax0, ax1, ax2), (ax3, ax4, ax5)) = plt.subplots(nrows=2, ncols=3)
 
-ax0.imshow(edge_sobel, cmap=plt.cm.gray)
-ax0.set_title('Sobel Edge Detection')
+ax0.imshow(edge_prewitt, cmap=plt.cm.gray)
+ax0.set_title('Prewitt Edge Detection')
 ax0.axis('off')
 
-ax1.imshow(edge_scharr, cmap=plt.cm.gray)
-ax1.set_title('Scharr Edge Detection')
+ax1.imshow(edge_sobel, cmap=plt.cm.gray)
+ax1.set_title('Sobel Edge Detection')
 ax1.axis('off')
 
-ax2.imshow(img, cmap=plt.cm.gray)
-ax2.set_title('Original image')
+ax2.imshow(edge_scharr, cmap=plt.cm.gray)
+ax2.set_title('Scharr Edge Detection')
 ax2.axis('off')
 
-ax3.imshow(edge_scharr - edge_sobel, cmap=plt.cm.jet)
-ax3.set_title('difference (Scharr - Sobel)')
+ax3.imshow(img, cmap=plt.cm.gray)
+ax3.set_title('Original image')
 ax3.axis('off')
+
+diff_scharr_prewitt = edge_scharr - edge_prewitt
+diff_scharr_sobel = edge_scharr - edge_sobel
+max_diff = np.max(np.maximum(diff_scharr_prewitt, diff_scharr_sobel))
+
+ax4.imshow(diff_scharr_prewitt, cmap=plt.cm.jet, vmax=max_diff)
+ax4.set_title('difference (Scharr - Prewitt)')
+ax4.axis('off')
+
+ax5.imshow(diff_scharr_sobel, cmap=plt.cm.jet, vmax=max_diff)
+ax5.set_title('difference (Scharr - Sobel)')
+ax5.axis('off')
 
 plt.tight_layout()
 

--- a/doc/examples/plot_edge_filter.py
+++ b/doc/examples/plot_edge_filter.py
@@ -35,15 +35,16 @@ plt.tight_layout()
 .. image:: PLOT2RST.current_figure
 
 Different operators compute different finite-difference approximations of the
-gradient. For example, the Scharr filter results in a better rotational
-variance than the Sobel filter that is in turn better than the Prewitt filter
-[1]_ [2]_ [3]_. The difference between the Prewitt and Sobel filters and the
-Scharr filter is illustrated below on an image that is the discretization of a
-rotation-invariant continuous function. The discrepancy between the Prewitt and
-Sobel filters, and the Scharr filter is stronger for regions of the image where
-the direction of the gradient is close to diagonal, and for regions with high
-spatial frequencies. The Sobel filter is less rotationally invariant than the
-Sobel filter.
+gradient. For example, the Scharr filter results in a less rotational variance
+than the Sobel filter that is in turn better than the Prewitt filter [1]_ [2]_
+[3]_. The difference between the Prewitt and Sobel filters and the Scharr filter
+is illustrated below with an image that is the discretization of a rotation-
+invariant continuous function. The discrepancy between the Prewitt and Sobel
+filters, and the Scharr filter is stronger for regions of the image where the
+direction of the gradient is close to diagonal, and for regions with high
+spatial frequencies. For the example image the differences between the filter
+results are very small and the filter results are visually almost
+indistinguishable.
 
 .. [1] https://en.wikipedia.org/wiki/Sobel_operator#Alternative_operators
 
@@ -61,38 +62,29 @@ edge_sobel = sobel(img)
 edge_scharr = scharr(img)
 edge_prewitt = prewitt(img)
 
-fig, ((ax0, ax1, ax2), (ax3, ax4, ax5)) = plt.subplots(nrows=2, ncols=3)
-
-ax0.imshow(edge_prewitt, cmap=plt.cm.gray)
-ax0.set_title('Prewitt Edge Detection')
-ax0.axis('off')
-
-ax1.imshow(edge_sobel, cmap=plt.cm.gray)
-ax1.set_title('Sobel Edge Detection')
-ax1.axis('off')
-
-ax2.imshow(edge_scharr, cmap=plt.cm.gray)
-ax2.set_title('Scharr Edge Detection')
-ax2.axis('off')
-
-ax3.imshow(img, cmap=plt.cm.gray)
-ax3.set_title('Original image')
-ax3.axis('off')
-
 diff_scharr_prewitt = edge_scharr - edge_prewitt
 diff_scharr_sobel = edge_scharr - edge_sobel
 max_diff = np.max(np.maximum(diff_scharr_prewitt, diff_scharr_sobel))
 
-ax4.imshow(diff_scharr_prewitt, cmap=plt.cm.jet, vmax=max_diff)
-ax4.set_title('difference (Scharr - Prewitt)')
-ax4.axis('off')
+fig, ((ax0, ax1), (ax2, ax3)) = plt.subplots(nrows=2, ncols=2)
 
-ax5.imshow(diff_scharr_sobel, cmap=plt.cm.jet, vmax=max_diff)
-ax5.set_title('difference (Scharr - Sobel)')
-ax5.axis('off')
+ax0.imshow(img, cmap=plt.cm.gray)
+ax0.set_title('Original image')
+ax0.axis('off')
+
+ax1.imshow(edge_scharr, cmap=plt.cm.gray)
+ax1.set_title('Scharr Edge Detection')
+ax1.axis('off')
+
+ax2.imshow(diff_scharr_prewitt, cmap=plt.cm.jet, vmax=max_diff)
+ax2.set_title('Scharr - Prewitt')
+ax2.axis('off')
+
+ax3.imshow(diff_scharr_sobel, cmap=plt.cm.jet, vmax=max_diff)
+ax3.set_title('Scharr - Sobel')
+ax3.axis('off')
 
 plt.tight_layout()
-
 plt.show()
 
 """


### PR DESCRIPTION
…he Prewitt filter. Added the Prewitt filter to the example and compared it to the Scharr filter showing that Prewitt is even less rotationally invarient than the Sobel filter. Also added description.