### PR TITLE
restoration.denoise_bilateral and negative value image

### DIFF
--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -63,8 +63,8 @@ def denoise_bilateral(image, win_size=5, sigma_range=None, sigma_spatial=1,
         # if all value identical, returns the same image
         return image
     else:
-        return _denoise_bilateral(offset_img+1, win_size, sigma_range, sigma_spatial,
-                              bins, mode, cval) + offset - 1
+        return _denoise_bilateral(offset_img, win_size, sigma_range, sigma_spatial,
+                              bins, mode, cval) + offset
 
 
 def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True):

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -23,7 +23,7 @@ def denoise_bilateral(image, win_size=5, sigma_range=None, sigma_spatial=1,
     Parameters
     ----------
     image : ndarray
-        Input image (image must be >= 0 with at least one > 0 value).
+        Input image (whose minimum value is greater than 0).
     win_size : int
         Window size for filtering.
     sigma_range : float

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -23,7 +23,7 @@ def denoise_bilateral(image, win_size=5, sigma_range=None, sigma_spatial=1,
     Parameters
     ----------
     image : ndarray
-        Input image (whose minimum value is greater than 0).
+        Input image.
     win_size : int
         Window size for filtering.
     sigma_range : float

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -64,8 +64,7 @@ def denoise_bilateral(image, win_size=5, sigma_range=None, sigma_spatial=1,
         return image
     else:
         return _denoise_bilateral(offset_img+1, win_size, sigma_range, sigma_spatial,
-                              bins, mode, cval) + offset -1
-
+                              bins, mode, cval) + offset - 1
 
 
 def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True):

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -56,8 +56,16 @@ def denoise_bilateral(image, win_size=5, sigma_range=None, sigma_spatial=1,
 
     """
     mode = _mode_deprecations(mode)
-    return _denoise_bilateral(image, win_size, sigma_range, sigma_spatial,
-                              bins, mode, cval)
+
+    offset = np.min(image)
+    offset_img = image - offset
+    if not offset_img.any():
+        # if all value identical, returns the same image
+        return image
+    else:
+        return _denoise_bilateral(offset_img+1, win_size, sigma_range, sigma_spatial,
+                              bins, mode, cval) + offset -1
+
 
 
 def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True):

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -23,7 +23,7 @@ def denoise_bilateral(image, win_size=5, sigma_range=None, sigma_spatial=1,
     Parameters
     ----------
     image : ndarray
-        Input image (image minimum must be >0).
+        Input image (image must be >= 0 with at least one > 0 value).
     win_size : int
         Window size for filtering.
     sigma_range : float

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -23,7 +23,7 @@ def denoise_bilateral(image, win_size=5, sigma_range=None, sigma_spatial=1,
     Parameters
     ----------
     image : ndarray
-        Input image.
+        Input image (image minimum must be >0).
     win_size : int
         Window size for filtering.
     sigma_range : float

--- a/skimage/restoration/_denoise_cy.pyx
+++ b/skimage/restoration/_denoise_cy.pyx
@@ -59,7 +59,7 @@ def _denoise_bilateral(image, Py_ssize_t win_size, sigma_range,
     # if image.max() is 0, then dist_scale can have an unverified value
     # and color_lut[<int>(dist * dist_scale)] may cause a segmentation fault
     # so we verify we have a positive image and that the max is not 0.0.
-    if image.min() <= 0.0:
+    if image.min() < 0.0:
         raise ValueError("Image must contain only positive values")
 
     cdef:

--- a/skimage/restoration/_denoise_cy.pyx
+++ b/skimage/restoration/_denoise_cy.pyx
@@ -59,7 +59,7 @@ def _denoise_bilateral(image, Py_ssize_t win_size, sigma_range,
     # if image.max() is 0, then dist_scale can have an unverified value
     # and color_lut[<int>(dist * dist_scale)] may cause a segmentation fault
     # so we verify we have a positive image and that the max is not 0.0.
-    if image.min() < 0.0:
+    if image.min() <= 0.0:
         raise ValueError("Image must contain only positive values")
 
     cdef:

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -110,12 +110,14 @@ def test_denoise_tv_bregman_3d():
     assert img[30:45, 5:15].std() > out1[30:45, 5:15].std()
     assert out1[30:45, 5:15].std() > out2[30:45, 5:15].std()
 
+
 def test_denoise_bilateral_null():
     img = np.zeros((50, 50))
     out = restoration.denoise_bilateral(img)
 
     # image full of zeros should return identity
     assert_equal(out, img)
+
 
 def test_denoise_bilateral_negative():
     img = -np.ones((50, 50))
@@ -124,15 +126,18 @@ def test_denoise_bilateral_negative():
     # image with only negative values should be ok
     assert_equal(out, img)
 
+
 def test_denoise_bilateral_negative2():
     img = np.ones((50, 50))
-    img[2,2] = 2
+    img[2, 2] = 2
 
     out1 = restoration.denoise_bilateral(img)
-    out2 = restoration.denoise_bilateral(img-10) #contains negative values
+    out2 = restoration.denoise_bilateral(img - 10)  # contains negative values
 
-    # 2 images with a given offset should give the same result (with the same offset)
-    assert_equal(out1, out2+10)
+    # 2 images with a given offset should give the same result (with the same
+    # offset)
+    assert_equal(out1, out2 + 10)
+
 
 def test_denoise_bilateral_2d():
     img = checkerboard_gray.copy()
@@ -172,11 +177,10 @@ def test_denoise_bilateral_nan():
     assert_equal(img, out)
 
 
-
 def test_nl_means_denoising_2d():
     img = np.zeros((40, 40))
     img[10:-10, 10:-10] = 1.
-    img += 0.3*np.random.randn(*img.shape)
+    img += 0.3 * np.random.randn(*img.shape)
     denoised = restoration.nl_means_denoising(img, 7, 5, 0.2, fast_mode=True)
     # make sure noise is reduced
     assert img.std() > denoised.std()
@@ -202,7 +206,7 @@ def test_nl_means_denoising_2drgb():
 def test_nl_means_denoising_3d():
     img = np.zeros((20, 20, 10))
     img[5:-5, 5:-5, 3:-3] = 1.
-    img += 0.3*np.random.randn(*img.shape)
+    img += 0.3 * np.random.randn(*img.shape)
     denoised = restoration.nl_means_denoising(img, 5, 4, 0.2, fast_mode=True,
                                               multichannel=False)
     # make sure noise is reduced
@@ -216,15 +220,15 @@ def test_nl_means_denoising_3d():
 def test_nl_means_denoising_multichannel():
     img = np.zeros((21, 20, 10))
     img[10, 9:11, 2:-2] = 1.
-    img += 0.3*np.random.randn(*img.shape)
+    img += 0.3 * np.random.randn(*img.shape)
     denoised_wrong_multichannel = restoration.nl_means_denoising(img,
-                    5, 4, 0.1, fast_mode=True, multichannel=True)
+                                                                 5, 4, 0.1, fast_mode=True, multichannel=True)
     denoised_ok_multichannel = restoration.nl_means_denoising(img,
-                    5, 4, 0.1, fast_mode=True, multichannel=False)
+                                                              5, 4, 0.1, fast_mode=True, multichannel=False)
     snr_wrong = 10 * np.log10(1. /
-                            ((denoised_wrong_multichannel - img)**2).mean())
+                              ((denoised_wrong_multichannel - img)**2).mean())
     snr_ok = 10 * np.log10(1. /
-                            ((denoised_ok_multichannel - img)**2).mean())
+                           ((denoised_ok_multichannel - img)**2).mean())
     assert snr_ok > snr_wrong
 
 
@@ -236,7 +240,7 @@ def test_nl_means_denoising_wrong_dimension():
 def test_no_denoising_for_small_h():
     img = np.zeros((40, 40))
     img[10:-10, 10:-10] = 1.
-    img += 0.3*np.random.randn(*img.shape)
+    img += 0.3 * np.random.randn(*img.shape)
     # very small h should result in no averaging with other patches
     denoised = restoration.nl_means_denoising(img, 7, 5, 0.01, fast_mode=True)
     assert np.allclose(denoised, img)

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -221,14 +221,13 @@ def test_nl_means_denoising_multichannel():
     img = np.zeros((21, 20, 10))
     img[10, 9:11, 2:-2] = 1.
     img += 0.3 * np.random.randn(*img.shape)
-    denoised_wrong_multichannel = restoration.nl_means_denoising(img,
-                                                                 5, 4, 0.1, fast_mode=True, multichannel=True)
-    denoised_ok_multichannel = restoration.nl_means_denoising(img,
-                                                              5, 4, 0.1, fast_mode=True, multichannel=False)
-    snr_wrong = 10 * np.log10(1. /
-                              ((denoised_wrong_multichannel - img)**2).mean())
-    snr_ok = 10 * np.log10(1. /
-                           ((denoised_ok_multichannel - img)**2).mean())
+    denoised_wrong_multichannel = restoration.nl_means_denoising(
+        img, 5, 4, 0.1, fast_mode=True, multichannel=True)
+    denoised_ok_multichannel = restoration.nl_means_denoising(
+        img, 5, 4, 0.1, fast_mode=True, multichannel=False)
+    snr_wrong = 10 * \
+        np.log10(1. / ((denoised_wrong_multichannel - img)**2).mean())
+    snr_ok = 10 * np.log10(1. / ((denoised_ok_multichannel - img)**2).mean())
     assert snr_ok > snr_wrong
 
 

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -110,6 +110,19 @@ def test_denoise_tv_bregman_3d():
     assert img[30:45, 5:15].std() > out1[30:45, 5:15].std()
     assert out1[30:45, 5:15].std() > out2[30:45, 5:15].std()
 
+def test_denoise_bilateral_null():
+    img = np.zeros((50, 50))
+    out = restoration.denoise_bilateral(img)
+
+    # image full of zeros should return identity
+    assert_equal(out, img)
+
+def test_denoise_bilateral_negative():
+    img = -np.ones((50, 50))
+    out = restoration.denoise_bilateral(img)
+
+    # image with negative value should be filtered as well using an offset
+    assert_equal(out, img)
 
 def test_denoise_bilateral_2d():
     img = checkerboard_gray.copy()
@@ -147,6 +160,7 @@ def test_denoise_bilateral_nan():
     img = np.NaN + np.empty((50, 50))
     out = restoration.denoise_bilateral(img)
     assert_equal(img, out)
+
 
 
 def test_nl_means_denoising_2d():

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -121,8 +121,18 @@ def test_denoise_bilateral_negative():
     img = -np.ones((50, 50))
     out = restoration.denoise_bilateral(img)
 
-    # image with negative value should be filtered as well using an offset
+    # image with only negative values should be ok
     assert_equal(out, img)
+
+def test_denoise_bilateral_negative2():
+    img = np.ones((50, 50))
+    img[2,2] = 2
+
+    out1 = restoration.denoise_bilateral(img)
+    out2 = restoration.denoise_bilateral(img-10) #contains negative values
+
+    # 2 images with a given offset should give the same result (with the same offset)
+    assert_equal(out1, out2+10)
 
 def test_denoise_bilateral_2d():
     img = checkerboard_gray.copy()


### PR DESCRIPTION
Here is a fix for #1677 regarding  the case of negative-valued images, not fixed in  #2533
basically change the test inside .pyx and adjusted docstring
