### PR TITLE
added variables to Makefile for build time configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,22 @@
 .PHONY: all clean test
+PYTHON=python
+NOSETESTS=nosetests
 
 all:
-	python setup.py build_ext --inplace
+	$(PYTHON) setup.py build_ext --inplace
 
 clean:
 	find . -name "*.so" -o -name "*.pyc" -o -name "*.pyx.md5" -o -name "*.pyd" | xargs rm -f
 	find . -name "*.pyx" -exec ./tools/rm_pyx_c_file.sh {} \;
 
 test:
-	python -c "import skimage, sys, io; sys.exit(skimage.test_verbose())"
+	$(PYTHON) -c "import skimage, sys, io; sys.exit(skimage.test_verbose())"
 
 doctest:
-	python -c "import skimage, sys, io; sys.exit(skimage.doctest_verbose())"
+	$(PYTHON) -c "import skimage, sys, io; sys.exit(skimage.doctest_verbose())"
 
 coverage:
-	nosetests skimage --with-coverage --cover-package=skimage
+	$(NOSETESTS) skimage --with-coverage --cover-package=skimage
 
 html:
 	pip install -q sphinx


### PR DESCRIPTION
I use Fedora Linux and on the latest update I switched from python2.x to python3.x for my work. This caused I minor problem when using source version of scikit-image. The Makefile uses command "python" which links to python2.x on my system. To use python3.x i need to use python3 or python3.x. 

Instead of modifying the Makefile or building manually each time I pull, I decided to make a more permanent solution. I've added variables to the Makefile, so that the builder can configure it at runtime. While the fixes are very simple either way, this seems more convenient. I hope you will consider accepting the modification. 