### PR TITLE
DOC : add ref to nlmeans

### DIFF
--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -359,6 +359,11 @@ cdef inline float _integral_to_distance_2d(IMGDTYPE [:, ::] integral,
     """
     References
     ----------
+    J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
+    nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
+    International Symposium on Biomedical Imaging: From Nano to Macro,
+    2008, pp. 1331–1334.
+
     Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
     Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.
 
@@ -381,6 +386,11 @@ cdef inline float _integral_to_distance_3d(IMGDTYPE [:, :, ::] integral,
     """
     References
     ----------
+    J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
+    nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
+    International Symposium on Biomedical Imaging: From Nano to Macro,
+    2008, pp. 1331–1334.
+
     Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
     Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.
 
@@ -523,6 +533,16 @@ def _fast_nl_means_denoising_2d(image, int s=7, int d=13, float h=0.1):
     -------
     result : ndarray
         Denoised image, of same shape as input image.
+
+    References
+    ----------
+    J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
+    nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
+    International Symposium on Biomedical Imaging: From Nano to Macro,
+    2008, pp. 1331–1334.
+
+    Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
+    Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.
     """
     if s % 2 == 0:
         s += 1  # odd value for symmetric patch
@@ -623,6 +643,16 @@ def _fast_nl_means_denoising_3d(image, int s=5, int d=7, float h=0.1):
     -------
     result : ndarray
         Denoised image, of same shape as input image.
+
+    References
+    ----------
+    J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
+    nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
+    International Symposium on Biomedical Imaging: From Nano to Macro,
+    2008, pp. 1331–1334.
+
+    Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
+    Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.
     """
     if s % 2 == 0:
         s += 1  # odd value for symmetric patch

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -362,7 +362,7 @@ cdef inline float _integral_to_distance_2d(IMGDTYPE [:, ::] integral,
     J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
     nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
     International Symposium on Biomedical Imaging: From Nano to Macro,
-    2008, pp. 1331–1334.
+    2008, pp. 1331-1334.
 
     Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
     Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.
@@ -389,7 +389,7 @@ cdef inline float _integral_to_distance_3d(IMGDTYPE [:, :, ::] integral,
     J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
     nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
     International Symposium on Biomedical Imaging: From Nano to Macro,
-    2008, pp. 1331–1334.
+    2008, pp. 1331-1334.
 
     Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
     Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.
@@ -539,7 +539,7 @@ def _fast_nl_means_denoising_2d(image, int s=7, int d=13, float h=0.1):
     J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
     nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
     International Symposium on Biomedical Imaging: From Nano to Macro,
-    2008, pp. 1331–1334.
+    2008, pp. 1331-1334.
 
     Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
     Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.
@@ -649,7 +649,7 @@ def _fast_nl_means_denoising_3d(image, int s=5, int d=7, float h=0.1):
     J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
     nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
     International Symposium on Biomedical Imaging: From Nano to Macro,
-    2008, pp. 1331–1334.
+    2008, pp. 1331-1334.
 
     Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
     Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.

--- a/skimage/restoration/non_local_means.py
+++ b/skimage/restoration/non_local_means.py
@@ -91,7 +91,7 @@ def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
     .. [2] J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
            nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
            International Symposium on Biomedical Imaging: From Nano to Macro,
-           2008, pp. 1331–1334.
+           2008, pp. 1331-1334.
 
     .. [3] Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
            Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.

--- a/skimage/restoration/non_local_means.py
+++ b/skimage/restoration/non_local_means.py
@@ -69,6 +69,8 @@ def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
     shift, that reduces the number of operations [1]_. Therefore, this
     algorithm executes faster than the classic algorith
     (``fast_mode=False``), at the expense of using twice as much memory.
+    This implementation has been proven to be more efficient compared to
+    other alternatives, see e.g. [3]_.
 
     Compared to the classic algorithm, all pixels of a patch contribute
     to the distance to another patch with the same weight, no matter
@@ -84,9 +86,14 @@ def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
     References
     ----------
     .. [1] Buades, A., Coll, B., & Morel, J. M. (2005, June). A non-local
-        algorithm for image denoising. In CVPR 2005, Vol. 2, pp. 60-65, IEEE.
+           algorithm for image denoising. In CVPR 2005, Vol. 2, pp. 60-65, IEEE.
 
-    .. [2] Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
+    .. [2] J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
+           nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
+           International Symposium on Biomedical Imaging: From Nano to Macro,
+           2008, pp. 1331–1334.
+
+    .. [3] Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
            Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.
 
     Examples


### PR DESCRIPTION
The right reference for the fast nlmeans with integrable tables is the one of Darbon (2008) as mentioned by Froment (2014) himself. Also these two papers should be refered at the beginning of the functions _fast_nl_means_denoising_*d and not only in _fast_nl_means_denoising_*d.
