### PR TITLE
Doc push fix again

### DIFF
--- a/tools/deploy_docs.sh
+++ b/tools/deploy_docs.sh
@@ -17,7 +17,7 @@ then
 
     git add dev
     git commit -m "Deployed to GitHub Pages"
-    git push --force --quiet "https://${GHTOKEN}@${GH_REF}" master:gh-pages > /dev/null 2>&1
+    git push --force --quiet "https://${GHTOKEN}@${GH_REF}" gh-pages > /dev/null 2>&1
     )
 else
     echo "-- will only push docs from master --"


### PR DESCRIPTION
I actually ran it from the command line this time.  The problem was that it assumed the default branch was `master`, when it is `gh-pages` for our docs repo.

ping @stefanv 
cc @sciunto 