### PR TITLE
[WIP] RAG Merging

### DIFF
--- a/skimage/future/graph/__init__.py
+++ b/skimage/future/graph/__init__.py
@@ -1,9 +1,10 @@
 from .graph_cut import cut_threshold, cut_normalized
-from .rag import rag_mean_color, RAG, draw_rag
+from .rag import rag_mean_color, RAG, draw_rag, rag_generic
 from .graph_merge import merge_hierarchical
 ncut = cut_normalized
 
 __all__ = ['rag_mean_color',
+           'rag_generic',
            'cut_threshold',
            'cut_normalized',
            'ncut',

--- a/skimage/future/graph/graph_merge.py
+++ b/skimage/future/graph/graph_merge.py
@@ -57,7 +57,7 @@ def _invalidate_edge(graph, n1, n2):
 
 
 def merge_hierarchical(labels, rag, thresh, rag_copy, in_place_merge,
-                       merge_func, weight_func):
+                       merge_func, weight_func, merge_trace = False):
     """Perform hierarchical merging of a RAG.
 
     Greedily merges the most similar pair of nodes until no edges lower than
@@ -77,6 +77,8 @@ def merge_hierarchical(labels, rag, thresh, rag_copy, in_place_merge,
     in_place_merge : bool
         If set, the nodes are merged in place. Otherwise, a new node is
         created for each merge..
+    merge_trace : bool
+        If set, the intermediate merge steps are returned.
     merge_func : callable
         This function is called before merging two nodes. For the RAG `graph`
         while merging `src` and `dst`, it is called as follows
@@ -90,8 +92,12 @@ def merge_hierarchical(labels, rag, thresh, rag_copy, in_place_merge,
     -------
     out : ndarray
         The new labeled array.
-
+    trace: list of labeled arrays
+        If `merge_trace` set, then intermediate merge steps are returned. A
+        labeled array for each merge is recorded. Otherwise an empty list is
+        returned.
     """
+    trace = [] #store intermediate merges
     if rag_copy:
         rag = rag.copy()
 
@@ -128,10 +134,16 @@ def merge_hierarchical(labels, rag, thresh, rag_copy, in_place_merge,
             merge_func(rag, src, dst)
             new_id = rag.merge_nodes(src, dst, weight_func)
             _revalidate_node_edges(rag, new_id, edge_heap)
+            if merge_trace:
+                label_map = np.arange(labels.max() + 1)
+                for ix, (n, d) in enumerate(rag.nodes_iter(data=True)):
+                    for label in d['labels']:
+                        label_map[label] = ix
+                trace.append(label_map[labels])
 
     label_map = np.arange(labels.max() + 1)
     for ix, (n, d) in enumerate(rag.nodes_iter(data=True)):
         for label in d['labels']:
             label_map[label] = ix
 
-    return label_map[labels]
+    return label_map[labels], trace

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -67,7 +67,6 @@ def mean_color(graph, extra_arguments=[], extra_keywords={}):
         sigma = 255
         mode = 'distance'
     """
-    print "Extra Keywords: ", extra_keywords
     sigma = extra_keywords['sigma']
     mode = extra_keywords['mode']
     for x, y, d in graph.edges_iter(data=True):
@@ -381,7 +380,6 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
             raise ValueError("The mode '%s' is not recognised" % mode)
 
     return graph
-
 
 
 def rag_generic(image, labels, connectivity=2, describe_func=describe_node,


### PR DESCRIPTION
If anyone think these modification are useful, let me know I don't mind to continue working on this, or just as happy for someone else can takeover.  (My first pull-request ever, so be gentle)

rag.py
---------
Abstracted rag creation method to take two functions, one to describe the nodes (parameters: graph, image, labels), the other to calculate the edge weights(parameters: graph).   I provide two example methods which duplicate functionality of rag_mean_color().  Since rag_mean_color() has 'sigma' and 'mode' parameters have also use *args, and **kwargs to allow the additional parameters to be provided to the callbacks.  It is a little ugly but works.  

Not sure if a generic version is needed.   Assuming I understand the NetworkX graph object.  The attributes of a node are a python dictionary.  As such attributes can be added by the user, not forced/required at creation time.  Similarly, edge weights can be updated/modified by iterating over the nodes and updating the 'weight' attribute.

graph_merge.py
----------------------
Added a flag to merge_hierachical so as to include a trace of each merger.  After the merger of the two most similar nodes a label_map is reconstructed.  This is appended to a list.  In addition to the final  segmentation, the list of labeled maps is returned.  

Currently at each merger, I iterate over the nodes and build a complete label map of all regions.  Although this will allow a reconstruction of the merge process (is that useful to anyone?) I only need a simplified label map that make it easy to distinguish the new merger form the rest of the image.  I sure there is a better/more efficient way to create a simpler label map (that contains only the merger/node)