### PR TITLE
peak_local_max: num_peaks param is ignored if labels param is also used

### DIFF
--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -112,6 +112,13 @@ def peak_local_max(image, min_distance=10, threshold_abs=0, threshold_rel=0.1,
                                   indices=False, num_peaks=np.inf,
                                   footprint=footprint, labels=None)
 
+        out = out.astype(np.bool)
+        if np.count_nonzero(out) > num_peaks:
+            original_inds = np.argwhere(out)
+            sort_inds = np.argsort(image[out])
+            subset_inds = original_inds[sort_inds][::-1][num_peaks:]
+            out[ subset_inds.T[0], subset_inds.T[1] ] = False
+
         if indices is True:
             return np.transpose(out.nonzero())
         else:


### PR DESCRIPTION
In skimage.feature.peak_local_max(), when using the labels param, the function is called recursively for each unique label. After this, however, there is no step in which the result is culled down to match the num_peaks param.

Changed it to only return the highest peaks, across all labels.