### PR TITLE
skimage.transform.hough_line: new parameter to set bin size in the rho dimension

### DIFF
--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -232,7 +232,8 @@ def hough_ellipse(cnp.ndarray img, int threshold=4, double accuracy=1,
 
 
 def hough_line(cnp.ndarray img,
-               cnp.ndarray[ndim=1, dtype=cnp.double_t] theta=None):
+               cnp.ndarray[ndim=1, dtype=cnp.double_t] theta=None,
+               int num_rho=None):
     """Perform a straight line Hough transform.
 
     Parameters
@@ -298,8 +299,12 @@ def hough_line(cnp.ndarray img,
 
     max_distance = 2 * <Py_ssize_t>ceil(sqrt(img.shape[0] * img.shape[0] +
                                              img.shape[1] * img.shape[1]))
-    accum = np.zeros((max_distance, theta.shape[0]), dtype=np.uint64)
-    bins = np.linspace(-max_distance / 2.0, max_distance / 2.0, max_distance)
+
+    if ((num_rho is None) or (num_rho > max_distance)):
+        num_rho = max_distance
+
+    accum = np.zeros((num_rho, theta.shape[0]), dtype=np.uint64)
+    bins = np.linspace(-max_distance / 2.0, max_distance / 2.0, num_rho)
     offset = max_distance / 2
 
     # compute the nonzero indexes
@@ -317,6 +322,7 @@ def hough_line(cnp.ndarray img,
             y = y_idxs[i]
             for j in range(nthetas):
                 accum_idx = <int>round((ctheta[j] * x + stheta[j] * y)) + offset
+                accum_idx = np.searchsorted(bins, accum_idx, 'right') - 1
                 accum[accum_idx, j] += 1
 
     return accum, theta, bins


### PR DESCRIPTION
From https://github.com/scikit-image/scikit-image/issues/1433:

> it is possible to specify a custom angle range, but not a custom distance range. Is there a good reason why one can't stipulate a distance range.

Other implementations of the hough transform seem to use a "rho_resolution" parameter that represents how many bins to use in the rho dimension of the accumulator, so I thought I'd give that a try.

I'm new to Cython and C, and discovered that I can't use `np.searchsorted` in the `with nogil` block. Any suggestions for how I would go about doing something similar in C? I'm just trying to determine what bin index of the accumulator to increment (I think it should be pretty obvious if you take a look at my changes).
