### PR TITLE
TST/STY: Hough transform regression test & Cython wrappers

### DIFF
--- a/skimage/transform/__init__.py
+++ b/skimage/transform/__init__.py
@@ -1,6 +1,6 @@
-from ._hough_transform import (hough_ellipse, hough_line,
-                               probabilistic_hough_line)
-from .hough_transform import hough_circle, hough_line_peaks
+from .hough_transform import (hough_line, hough_line_peaks,
+                              probabilistic_hough_line, hough_circle,
+                              hough_ellipse)
 from .radon_transform import radon, iradon, iradon_sart
 from .finite_radon_transform import frt2, ifrt2
 from .integral import integral_image, integrate

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -12,9 +12,6 @@ from libc.stdlib cimport rand
 
 from ..draw import circle_perimeter
 
-cdef double PI_2 = 1.5707963267948966
-cdef double NEG_PI_2 = -PI_2
-
 from .._shared.interpolation cimport round
 
 

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -278,15 +278,9 @@ def hough_line(cnp.ndarray img,
     .. plot:: hough_tf.py
 
     """
-    if img.ndim != 2:
-        raise ValueError('The input image must be 2D.')
-
     # Compute the array of angles and their sine and cosine
     cdef cnp.ndarray[ndim=1, dtype=cnp.double_t] ctheta
     cdef cnp.ndarray[ndim=1, dtype=cnp.double_t] stheta
-
-    if theta is None:
-        theta = np.linspace(NEG_PI_2, PI_2, 180)
 
     ctheta = np.cos(theta)
     stheta = np.sin(theta)
@@ -354,12 +348,6 @@ def probabilistic_hough_line(cnp.ndarray img, int threshold=10,
            Hough transform for line detection", in IEEE Computer Society
            Conference on Computer Vision and Pattern Recognition, 1999.
     """
-    if img.ndim != 2:
-        raise ValueError('The input image must be 2D.')
-
-    if theta is None:
-        theta = PI_2 - np.arange(180) / 180.0 * 2 * PI_2
-
     cdef Py_ssize_t height = img.shape[0]
     cdef Py_ssize_t width = img.shape[1]
 

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -59,7 +59,7 @@ def hough_line(img, theta=None):
 
     if theta is None:
         # These values are approximations of pi/2
-        theta = np.linspace(-1.5707963267948966, 1.5707963267948966, 180)
+        theta = np.linspace(-np.pi / 2, np.pi / 2, 180)
 
     return _hough_line(img, theta=theta)
 
@@ -225,7 +225,7 @@ def probabilistic_hough_line(img, threshold=10, line_length=50, line_gap=10,
         raise ValueError('The input image `img` must be 2D.')
 
     if theta is None:
-        theta = 1.5707963267948966 - np.arange(180) / 180.0 * np.pi
+        theta = np.pi / 2 - np.arange(180) / 180.0 * np.pi
 
     return _prob_hough_line(img, threshold=threshold, line_length=line_length,
                             line_gap=line_gap, theta=theta)
@@ -304,11 +304,14 @@ def hough_ellipse(img, threshold=4, accuracy=1, min_size=4, max_size=None):
 
     Examples
     --------
+    >>> from skimage.transform import hough_ellipse
+    >>> from skimage.draw import ellipse_perimeter
     >>> img = np.zeros((25, 25), dtype=np.uint8)
     >>> rr, cc = ellipse_perimeter(10, 10, 6, 8)
     >>> img[cc, rr] = 1
     >>> result = hough_ellipse(img, threshold=8)
-    [(10, 10.0, 8.0, 6.0, 0.0, 10.0)]
+    >>> result.tolist()
+    [(10, 10.0, 10.0, 8.0, 6.0, 0.0)]
 
     Notes
     -----

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -1,19 +1,10 @@
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_equal
+from numpy.testing import assert_almost_equal, assert_equal, assert_raises
 
 import skimage.transform as tf
 from skimage.draw import line, circle_perimeter, ellipse_perimeter
 from skimage._shared._warnings import expected_warnings
 from skimage._shared.testing import test_parallel
-
-
-def append_desc(func, description):
-    """Append the test function ``func`` and append
-    ``description`` to its name.
-    """
-    func.description = func.__module__ + '.' + func.__name__ + description
-
-    return func
 
 
 @test_parallel()
@@ -42,12 +33,21 @@ def test_hough_line_angles():
     assert_equal(len(angles), 10)
 
 
+def test_hough_line_bad_input():
+    img = np.zeros(100)
+    img[10] = 1
+
+    # Expected error, img must be 2D
+    assert_raises(ValueError, tf.hough_line, img, np.linspace(0, 360, 10))
+
+
 def test_probabilistic_hough():
     # Generate a test image
     img = np.zeros((100, 100), dtype=int)
     for i in range(25, 75):
         img[100 - i, i] = 100
         img[i, i] = 100
+
     # decrease default theta sampling because similar orientations may confuse
     # as mentioned in article of Galambos et al
     theta = np.linspace(0, np.pi, 45)
@@ -59,8 +59,20 @@ def test_probabilistic_hough():
         line = list(line)
         line.sort(key=lambda x: x[0])
         sorted_lines.append(line)
+
     assert([(25, 75), (74, 26)] in sorted_lines)
     assert([(25, 25), (74, 74)] in sorted_lines)
+
+    # Execute with default theta
+    tf.probabilistic_hough_line(img, line_length=10, line_gap=3)
+
+
+def test_probabilistic_hough_bad_input():
+    img = np.zeros(100)
+    img[10] = 1
+
+    # Expected error, img must be 2D
+    assert_raises(ValueError, tf.probabilistic_hough_line, img)
 
 
 def test_hough_line_peaks():

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -78,6 +78,22 @@ def test_hough_line_peaks():
     assert_almost_equal(theta[0], 1.41, 1)
 
 
+def test_hough_line_peaks_ordered():
+    # Regression test per PR #1421
+    testim = np.zeros((256, 64), dtype=np.bool)
+
+    testim[50:100, 20] = True
+    testim[85:200, 25] = True
+    testim[15:35, 50] = True
+    testim[1:-1, 58] = True
+
+    hough_space, angles, dists = tf.hough_line(testim)
+
+    with expected_warnings(['`background`']):
+        hspace, _, _ = tf.hough_line_peaks(hough_space, angles, dists)
+        assert hspace[0] > hspace[1]
+
+
 def test_hough_line_peaks_dist():
     img = np.zeros((100, 100), dtype=np.bool_)
     img[:, 30] = True


### PR DESCRIPTION
Adds a regression test for the behavior patched in #1421. 

Also, when testing this module I noted `hough_line`, `hough_ellipse`, and `probabilistic_hough_line` were missing function signatures because they were imported directly from Cython. These functions are now imported from pure Python wrappers. Along with this I moved some of the input checks into the new Python wrappers, which should make the generated C smaller and simpler.

Doctest imports now fixed in `hough_ellipse` - previously these doctests were not run, as they were exclusively in Cython.