### PR TITLE
Added label vs. intensity shape checking to regionprops

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -111,7 +111,7 @@ class _RegionProperties(object):
                  
         if intensity_image is not None:
             if not intensity_image.shape == label_image.shape:
-                raise ValueError('Label and intensity image must be the same shape.')
+                raise ValueError('Label and intensity image must have the same shape.')
         
         self.label = label
         self._slice = slice

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -108,6 +108,11 @@ class _RegionProperties(object):
 
     def __init__(self, slice, label, label_image, intensity_image,
                  cache_active):
+                 
+        if not intensity_image is None:
+            if not intensity_image.shape == label_image.shape:
+                raise ValueError('Label and intensity image must be the same shape.')
+        
         self.label = label
         self._slice = slice
         self._label_image = label_image

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -109,7 +109,7 @@ class _RegionProperties(object):
     def __init__(self, slice, label, label_image, intensity_image,
                  cache_active):
                  
-        if not intensity_image is None:
+        if intensity_image is not None:
             if not intensity_image.shape == label_image.shape:
                 raise ValueError('Label and intensity image must be the same shape.')
         

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -362,6 +362,11 @@ def test_invalid():
     assert_raises(AttributeError, get_intensity_image)
 
 
+def test_invalid_size():
+    wrong_intensity_sample = np.array([[1], [1]])
+    assert_raises(ValueError, regionprops, SAMPLE, wrong_intensity_sample)
+
+
 def test_equals():
     arr = np.zeros((100, 100), dtype=np.int)
     arr[0:25, 0:25] = 1


### PR DESCRIPTION
#1477 addressed plus #1527 test.

I ran `measure/tests/test_regionprops.py` with the current scikit-image/master and with this PR's branch and I get the same DeprecationWarning for both:

    /usr/local/lib/python2.7/site-packages/scipy/io/matlab/mio4.py:18: RuntimeWarning: numpy.dtype size changed, may indicate binary incompatibility
      from .mio_utils import squeeze_element, chars_to_strings
    /usr/local/lib/python2.7/site-packages/scipy/io/matlab/mio4.py:18: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility
      from .mio_utils import squeeze_element, chars_to_strings
    /usr/local/lib/python2.7/site-packages/scipy/io/matlab/mio5.py:98: RuntimeWarning: numpy.dtype size changed, may indicate binary incompatibility
      from .mio5_utils import VarReader5
    /usr/local/lib/python2.7/site-packages/scipy/io/matlab/mio5.py:98: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility
      from .mio5_utils import VarReader5
    skimage/viewer/__init__.py:6: UserWarning: Viewer requires Qt
      warnings.warn('Viewer requires Qt')
    skimage/filter/__init__.py:6: skimage_deprecation: The `skimage.filter` module has been renamed to `skimage.filters`.  This placeholder module will be removed in v0.13
    .
      warn(skimage_deprecation('The `skimage.filter` module has been renamed '
    E.....................................
    ======================================================================
    ERROR: skimage.measure.tests.test_regionprops.test_all_props
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/usr/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
        self.test(*self.arg)
      File "skimage/measure/tests/test_regionprops.py", line 29, in test_all_props
        assert_almost_equal(region[prop], getattr(region, PROPS[prop]))
      File "skimage/measure/_regionprops.py", line 311, in __getitem__
        return getattr(self, PROPS[key])
      File "skimage/measure/_regionprops.py", line 160, in euler_number
        _, num = label(euler_array, neighbors=8, return_num=True)
      File "skimage/measure/_label.py", line 5, in label
        return _label(input, neighbors, background, return_num, connectivity)
      File "skimage/measure/_ccomp.pyx", line 444, in skimage.measure._ccomp.label (skimage/measure/_ccomp.c:3941)
        res, ctr = _label(input_corrected, neighbors, background, connectivity)
      File "skimage/measure/_ccomp.pyx", line 471, in skimage.measure._ccomp._label (skimage/measure/_ccomp.c:4458)
        get_bginfo(background, &bg)
      File "skimage/measure/_ccomp.pyx", line 50, in skimage.measure._ccomp.get_bginfo (skimage/measure/_ccomp.c:1556)
        warnings.warn(DeprecationWarning(
    DeprecationWarning: The default value for `background` will change to 0 in v0.12
    
    ----------------------------------------------------------------------
    Ran 38 tests in 0.126s
    
    FAILED (errors=1)
