### PR TITLE
maximum Feret diameter in regionprops

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -420,6 +420,12 @@ def regionprops(label_image, intensity_image=None, cache=True):
     **extent** : float
         Ratio of pixels in the region to pixels in the total bounding box.
         Computed as ``area / (rows * cols)``
+    **feret_diameter** : list
+        Maximum Feret's diameter computed as the longest distance between
+        points around a region's convex hull contour as determined by
+        ``find_contours``. Return list contains the maximum Feret 
+        diameter and the coordinates of the line of maximum diameter as
+        [float, [float, float], [float, float]].
     **filled_area** : int
         Number of pixels of filled region.
     **filled_image** : (H, J) ndarray

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -192,7 +192,7 @@ class _RegionProperties(object):
                     i1 = a
                     i2 = b
         
-        return (max_feret, tuple(coordinates[i1]), tuple(coordinates[i2]))
+        return max_feret
 
     @property
     def filled_area(self):
@@ -420,12 +420,10 @@ def regionprops(label_image, intensity_image=None, cache=True):
     **extent** : float
         Ratio of pixels in the region to pixels in the total bounding box.
         Computed as ``area / (rows * cols)``
-    **feret_diameter** : tuple
+    **feret_diameter** : float
         Maximum Feret's diameter computed as the longest distance between
         points around a region's convex hull contour as determined by
-        ``find_contours``. Return list contains the maximum Feret 
-        diameter and the coordinates of the line of maximum diameter as
-        (float, (float, float), (float, float)).
+        ``find_contours``.
     **filled_area** : int
         Number of pixels of filled region.
     **filled_image** : (H, J) ndarray

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -28,6 +28,7 @@ PROPS = {
     'EulerNumber': 'euler_number',
     'Extent': 'extent',
 #    'Extrema',
+    'FeretDiameter': 'feret_diameter',
     'FilledArea': 'filled_area',
     'FilledImage': 'filled_image',
     'HuMoments': 'moments_hu',
@@ -167,6 +168,31 @@ class _RegionProperties(object):
     def extent(self):
         rows, cols = self.image.shape
         return self.moments[0, 0] / (rows * cols)
+
+    @property
+    def feret_diameter(self):
+        from ..morphology.convex_hull import convex_hull_image
+        from ._find_contours import find_contours
+        
+        label_image = self._label_image
+        label = self.label
+        
+        max_feret = 0.0
+        identity_convex_hull = convex_hull_image(label_image == label)
+        coordinates = np.vstack(find_contours(identity_convex_hull, 0.5, fully_connected = 'high'))
+    
+        n = len(coordinates)
+        for a in range(0, n):
+            for b in range(0, n):
+                dx = coordinates[a][0] - coordinates[b][0]
+                dy = coordinates[a][1] - coordinates[b][1]
+                d = sqrt(dx ** 2 + dy ** 2)
+                if d > max_feret:
+                    max_feret = d
+                    i1 = a
+                    i2 = b
+        
+        return [max_feret, coordinates[i1], coordinates[i2]]
 
     @property
     def filled_area(self):

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -2,9 +2,13 @@
 from math import sqrt, atan2, pi as PI
 import numpy as np
 from scipy import ndimage as ndi
+from scipy.spatial.distance import pdist
 
 from ._label import label
 from . import _moments
+from ._find_contours import find_contours
+
+
 
 
 __all__ = ['regionprops', 'perimeter']
@@ -172,19 +176,13 @@ class _RegionProperties(object):
     @property
     def feret_diameter(self):
         from ..morphology.convex_hull import convex_hull_image
-        from ._find_contours import find_contours
-        from scipy.spatial.distance import pdist
-        
         label_image = self._label_image
         label = self.label
-        
-        max_feret = 0.0
         identity_convex_hull = convex_hull_image(label_image == label)
         coordinates = np.vstack(find_contours(identity_convex_hull, 0.5, 
                                               fully_connected = 'high'))
-        distances = pdist(coordinates, 'euclidean')
-
-        return np.max(distances)
+        distances = pdist(coordinates, 'sqeuclidean')
+        return sqrt(np.max(distances))
 
     @property
     def filled_area(self):
@@ -415,7 +413,7 @@ def regionprops(label_image, intensity_image=None, cache=True):
     **feret_diameter** : float
         Maximum Feret's diameter computed as the longest distance between
         points around a region's convex hull contour as determined by
-        ``find_contours``.
+        ``find_contours``. [5]_
     **filled_area** : int
         Number of pixels of filled region.
     **filled_image** : (H, J) ndarray
@@ -515,6 +513,9 @@ def regionprops(label_image, intensity_image=None, cache=True):
            Features, from Lecture notes in computer science, p. 676. Springer,
            Berlin, 1993.
     .. [4] http://en.wikipedia.org/wiki/Image_moment
+    .. [5] W. Pabst, E. Gregorová. Characterization of particles and particle
+           systems, pp. 27-28. ICT Prague, 2007.
+           http://old.vscht.cz/sil/keramika/Characterization_of_particles/CPPS%20_English%20version_.pdf
 
     Examples
     --------

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -173,26 +173,18 @@ class _RegionProperties(object):
     def feret_diameter(self):
         from ..morphology.convex_hull import convex_hull_image
         from ._find_contours import find_contours
+        from scipy.spatial.distance import pdist
         
         label_image = self._label_image
         label = self.label
         
         max_feret = 0.0
         identity_convex_hull = convex_hull_image(label_image == label)
-        coordinates = np.vstack(find_contours(identity_convex_hull, 0.5, fully_connected = 'high'))
-        
-        n = len(coordinates)
-        for a in range(0, n):
-            for b in range(0, n):
-                dx = coordinates[a][0] - coordinates[b][0]
-                dy = coordinates[a][1] - coordinates[b][1]
-                d = sqrt(dx ** 2 + dy ** 2)
-                if d > max_feret:
-                    max_feret = d
-                    i1 = a
-                    i2 = b
-        
-        return max_feret
+        coordinates = np.vstack(find_contours(identity_convex_hull, 0.5, 
+                                              fully_connected = 'high'))
+        distances = pdist(coordinates, 'euclidean')
+
+        return np.max(distances)
 
     @property
     def filled_area(self):

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -192,7 +192,7 @@ class _RegionProperties(object):
                     i1 = a
                     i2 = b
         
-        return [max_feret, coordinates[i1], coordinates[i2]]
+        return (max_feret, tuple(coordinates[i1]), tuple(coordinates[i2]))
 
     @property
     def filled_area(self):
@@ -420,12 +420,12 @@ def regionprops(label_image, intensity_image=None, cache=True):
     **extent** : float
         Ratio of pixels in the region to pixels in the total bounding box.
         Computed as ``area / (rows * cols)``
-    **feret_diameter** : list
+    **feret_diameter** : tuple
         Maximum Feret's diameter computed as the longest distance between
         points around a region's convex hull contour as determined by
         ``find_contours``. Return list contains the maximum Feret 
         diameter and the coordinates of the line of maximum diameter as
-        [float, [float, float], [float, float]].
+        (float, (float, float), (float, float)).
     **filled_area** : int
         Number of pixels of filled region.
     **filled_image** : (H, J) ndarray

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -180,7 +180,7 @@ class _RegionProperties(object):
         max_feret = 0.0
         identity_convex_hull = convex_hull_image(label_image == label)
         coordinates = np.vstack(find_contours(identity_convex_hull, 0.5, fully_connected = 'high'))
-    
+        
         n = len(coordinates)
         for a in range(0, n):
             for b in range(0, n):

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -45,6 +45,13 @@ def test_ndim():
     assert_raises(TypeError, regionprops, np.zeros((10, 10, 2), dtype=np.int))
 
 
+def test_feret_diameter():
+    # comparator result is based on SAMPLE from manually-inspected computations
+    comparator_result = 17.029386365926403
+    test_result = regionprops(SAMPLE)[0].feret_diameter
+    assert_almost_equal(comparator_result, test_result)
+
+
 def test_area():
     area = regionprops(SAMPLE)[0].area
     assert area == np.sum(SAMPLE)
@@ -140,13 +147,6 @@ def test_euler_number():
 def test_extent():
     extent = regionprops(SAMPLE)[0].extent
     assert_almost_equal(extent, 0.4)
-
-
-def test_feret_diameter():
-    # comparator result is based on SAMPLE from manually-inspected computations
-    comparator_result = 17.029386365926403
-    test_result = regionprops(SAMPLE)[0].feret_diameter
-    assert_almost_equal(comparator_result, test_result)
 
 
 def test_moments_hu():

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -142,6 +142,13 @@ def test_extent():
     assert_almost_equal(extent, 0.4)
 
 
+def test_feret_diameter():
+    # comparator result is based on SAMPLE from manually-inspected computations
+    comparator_result = 17.029386365926403
+    test_result = regionprops(SAMPLE)[0].feret_diameter
+    assert_almost_equal(comparator_result, test_result)
+
+
 def test_moments_hu():
     hu = regionprops(SAMPLE)[0].moments_hu
     ref = np.array([
@@ -166,14 +173,6 @@ def test_label():
     label = regionprops(SAMPLE)[0].label
     assert_array_equal(label, 1)
 
-
-def test_feret_diameter():
-    # comparator result is based on SAMPLE from manually-inspected computations
-    comparator_result = (17.029386365926403, (6.5, 17.0), (7.5, 0.0))
-    test_result = regionprops(SAMPLE)[0].feret_diameter
-    assert_almost_equal(comparator_result[0], test_result[0])
-    assert_array_almost_equal(comparator_result[0], test_result[0])
-    assert_array_almost_equal(comparator_result[1], test_result[1])
 
 def test_filled_area():
     area = regionprops(SAMPLE)[0].filled_area

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -167,6 +167,14 @@ def test_label():
     assert_array_equal(label, 1)
 
 
+def test_feret_diameter():
+    # comparator result is based on SAMPLE from manually-inspected computations
+    comparator_result = (17.029386365926403, (6.5, 17.0), (7.5, 0.0))
+    test_result = regionprops(SAMPLE)[0].feret_diameter
+    assert_almost_equal(comparator_result[0], test_result[0])
+    assert_array_almost_equal(comparator_result[0], test_result[0])
+    assert_array_almost_equal(comparator_result[1], test_result[1])
+
 def test_filled_area():
     area = regionprops(SAMPLE)[0].filled_area
     assert area == np.sum(SAMPLE)


### PR DESCRIPTION
Added maximum Feret diameter of a region's convex hull. There is an alternative implementation in which only lines passing through the center of mass are considered, but my understanding is that the Feret diameter has only been evaluated in the context of convex objects. Here's hoping that someone here knows more than me on this subject!
