### PR TITLE
BUG: Buffer dtype mismatch, expected 'Py_ssize_t' but got 'long'

### DIFF
--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -271,8 +271,8 @@ def _local_binary_pattern(double[:, ::1] image,
 # Values represent offsets of neighbour rectangles relative to central one.
 # It has order starting from top left and going clockwise.
 cdef:
-    Py_ssize_t[::1] mlbp_r_offsets = np.asarray([-1, -1, -1, 0, 1, 1, 1, 0])
-    Py_ssize_t[::1] mlbp_c_offsets = np.asarray([-1, 0, 1, 1, 1, 0, -1, -1])
+    Py_ssize_t[::1] mlbp_r_offsets = np.asarray([-1, -1, -1, 0, 1, 1, 1, 0], dtype=np.intp)
+    Py_ssize_t[::1] mlbp_c_offsets = np.asarray([-1, 0, 1, 1, 1, 0, -1, -1], dtype=np.intp)
 
 
 def _multiblock_lbp(float[:, ::1] int_image,

--- a/skimage/transform/_seam_carving.pyx
+++ b/skimage/transform/_seam_carving.pyx
@@ -180,7 +180,7 @@ def _seam_carve_v(img, energy_map, iters, border):
     cdef Py_ssize_t seams_left = iters
     cdef Py_ssize_t seams_removed
     cdef Py_ssize_t seam_idx
-    cdef Py_ssize_t[::1] seam_buffer = np.zeros(rows, dtype=np.int)
+    cdef Py_ssize_t[::1] seam_buffer = np.zeros(rows, dtype=np.intp)
 
     cdef cnp.double_t[:, :, ::1] image = img
     cdef cnp.int8_t[:, ::1] track_img = np.zeros(img.shape[0:2], dtype=np.int8)


### PR DESCRIPTION
On Python 2.7.7 |Anaconda 2.0.1 (64-bit)| [MSC v.1500 64 bit (AMD64)]

nosetests fails on windows due to certain cython implemetations.

```bash
$ nosetests skimage/transform/tests/test_finite_radon_transform.py
E
======================================================================
ERROR: test suite for <module 'skimage.transform.tests.test_finite_radon_transform' from 'd:\githubme\scikit-image\skimage\transform\tests\test_finite_radon_transform.pyc'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\Anaconda\lib\site-packages\nose\suite.py", line 209, in run
    self.setUp()
  File "c:\Anaconda\lib\site-packages\nose\suite.py", line 292, in setUp
    self.setupContext(ancestor)
  File "c:\Anaconda\lib\site-packages\nose\suite.py", line 315, in setupContext
    try_run(context, names)
  File "c:\Anaconda\lib\site-packages\nose\util.py", line 470, in try_run
    return func()
  File "d:\githubme\scikit-image\skimage\transform\tests\__init__.py", line 5, in setup
    setup_test()
  File "d:\githubme\scikit-image\skimage\_shared\testing.py", line 195, in setup_test
    from skimage import viewer, filter
  File "d:\githubme\scikit-image\skimage\viewer\__init__.py", line 2, in <module>
    from .viewers import ImageViewer, CollectionViewer
  File "d:\githubme\scikit-image\skimage\viewer\viewers\__init__.py", line 1, in <module>
    from .core import ImageViewer, CollectionViewer
  File "d:\githubme\scikit-image\skimage\viewer\viewers\core.py", line 14, in <module>
    from ..plugins.base import Plugin
  File "d:\githubme\scikit-image\skimage\viewer\plugins\__init__.py", line 2, in <module>
    from .canny import CannyPlugin
  File "d:\githubme\scikit-image\skimage\viewer\plugins\canny.py", line 4, in <module>
    from ...feature import canny
  File "d:\githubme\scikit-image\skimage\feature\__init__.py", line 4, in <module>
    from .texture import (greycomatrix, greycoprops,
  File "d:\githubme\scikit-image\skimage\feature\texture.py", line 9, in <module>
    from ._texture import (_glcm_loop,
  File "skimage\feature\_texture.pyx", line 274, in init skimage.feature._texture (skimage\feature\_texture.c:19310)
    Py_ssize_t[::1] mlbp_r_offsets = np.asarray([-1, -1, -1, 0, 1, 1, 1, 0])
ValueError: Buffer dtype mismatch, expected 'Py_ssize_t' but got 'long'

----------------------------------------------------------------------
Ran 0 tests in 0.021s

FAILED (errors=1)
```

After adding `dtype`

```cython
cdef:
    Py_ssize_t[::1] mlbp_r_offsets = np.asarray([-1, -1, -1, 0, 1, 1, 1, 0], dtype=np.intp)
    Py_ssize_t[::1] mlbp_c_offsets = np.asarray([-1, 0, 1, 1, 1, 0, -1, -1], dtype=np.intp)
```

```bash
$ nosetests skimage/transform/tests/test_finite_radon_transform.py
d:\githubme\scikit-image\skimage\filter\__init__.py:6: skimage_deprecation: The `skimage.filter` module has been renamed to `skimage.filters`.  This placeholder module will be removed in v0.13.
  warn(skimage_deprecation('The `skimage.filter` module has been renamed '
.
----------------------------------------------------------------------
Ran 1 test in 0.399s

OK
```

**EDIT**

```bash
$ nosetests skimage/transform/tests/                                                  
d:\githubme\scikit-image\skimage\filter\__init__.py:6: skimage_deprecation: The       
` module has been renamed to `skimage.filters`.  This placeholder module will be      
13.                                                                                   
  warn(skimage_deprecation('The `skimage.filter` module has been renamed '            
................................................................................      
...............................E.........................                             
======================================================================                
ERROR: skimage.transform.tests.test_seam_carving.test_seam_carving                    
----------------------------------------------------------------------                
Traceback (most recent call last):                                                    
  File "c:\Anaconda\lib\site-packages\nose\case.py", line 197, in runTest             
    self.test(*self.arg)                                                              
  File "d:\githubme\scikit-image\skimage\transform\tests\test_seam_carving.py",       
t_seam_carving                                                                        
    out = transform.seam_carve(img, energy, 'vertical', 1, border=0)                  
  File "d:\githubme\scikit-image\skimage\transform\seam_carving.py", line 61, in      
    out = _seam_carve_v(image, energy_map, num, border)                               
  File "skimage\transform\_seam_carving.pyx", line 183, in skimage.transform._se      
m_carve_v (skimage\transform\_seam_carving.c:2712)                                    
    cdef Py_ssize_t[::1] seam_buffer = np.zeros(rows, dtype=np.int)                   
ValueError: Buffer dtype mismatch, expected 'Py_ssize_t' but got 'long'               
                                                                                      
----------------------------------------------------------------------                
Ran 152 tests in 12.285s                                                              
                                                                                      
FAILED (errors=1)                                                                     
```

Updated dtype to `_seam_carving.pyx`

Now,

```bash
$ nosetests skimage/transform/tests/
...............................................................................................
.........................................................
----------------------------------------------------------------------
Ran 152 tests in 12.079s

OK
```

I can only get skimage up and runnning fully on windows after this change.