### PR TITLE
MNT: Remove redundant return from gray2rgb  

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -768,8 +768,6 @@ def gray2rgb(image, alpha=None):
         else:
             return np.concatenate(3 * (image,), axis=-1)
 
-        return image
-
     else:
         raise ValueError("Input image expected to be RGB, RGBA or gray.")
 

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -439,6 +439,8 @@ def test_gray2rgb():
 
     assert_equal(y.shape, (3, 1, 3))
     assert_equal(y.dtype, x.dtype)
+    assert_equal(y[..., 0], x)
+    assert_equal(y[0, 0, :], [0, 0, 0])
 
     x = np.array([[0, 128, 255]], dtype=np.uint8)
     z = gray2rgb(x)


### PR DESCRIPTION
PR is with reference to the discussion over [here](https://github.com/scikit-image/scikit-image/pull/1639/files#r44875388).

1. Remove redundant return from gray2rgb  
2. Updated a test case to check values returned in test_gray2rgb