### PR TITLE
BUX: in _slic.pyx slice can has steps=None

### DIFF
--- a/skimage/segmentation/_slic.pyx
+++ b/skimage/segmentation/_slic.pyx
@@ -76,7 +76,8 @@ def _slic_cython(double[:, :, :, ::1] image_zyx,
     # approximate grid size for desired n_segments
     cdef Py_ssize_t step_z, step_y, step_x
     slices = regular_grid((depth, height, width), n_segments)
-    step_z, step_y, step_x = [int(s.step) for s in slices]
+    step_z, step_y, step_x = [int(s.step if s.step is not None else 1)
+                              for s in slices]
 
     cdef Py_ssize_t[:, :, ::1] nearest_segments \
         = np.empty((depth, height, width), dtype=np.intp)

--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -155,7 +155,8 @@ def slic(image, n_segments=100, compactness=10., max_iter=10, sigma=0,
     # initialize cluster centroids for desired number of segments
     grid_z, grid_y, grid_x = np.mgrid[:depth, :height, :width]
     slices = regular_grid(image.shape[:3], n_segments)
-    step_z, step_y, step_x = [int(s.step) for s in slices]
+    step_z, step_y, step_x = [int(s.step if s.step is not None else 1)
+                              for s in slices]
     segments_z = grid_z[slices]
     segments_y = grid_y[slices]
     segments_x = grid_x[slices]

--- a/skimage/segmentation/tests/test_slic.py
+++ b/skimage/segmentation/tests/test_slic.py
@@ -195,6 +195,20 @@ def test_slic_zero():
     assert_equal(seg[10:, 10:], 3)
 
 
+def test_more_segments_than_pixels():
+    rnd = np.random.RandomState(0)
+    img = np.zeros((20, 21))
+    img[:10, :10] = 0.33
+    img[10:, :10] = 0.67
+    img[10:, 10:] = 1.00
+    img += 0.0033 * rnd.normal(size=img.shape)
+    img[img > 1] = 1
+    img[img < 0] = 0
+    seg = slic(img, sigma=0, n_segments=500, compactness=1,
+               multichannel=False, convert2lab=False)
+    assert np.all(seg.ravel() == np.arange(seg.size))
+
+
 if __name__ == '__main__':
     from numpy import testing
 


### PR DESCRIPTION
int(None) fails, and slice.steps == None is valid. It is equivalent to 1.

We hit this with a student in a fairly involved brain-imaging situation. It doesn't happen in most cases. I did a quick fix for him, and I am pushing the fix upstream.

I am sorry, I don't have a test case. I didn't have the time to inspect what specific situation caused steps to be None. I thought that it was still useful to push the fix upstream.