### PR TITLE
Uses fftconvolve instead of convolve2d for speedups

### DIFF
--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -7,7 +7,7 @@ from __future__ import division
 
 import numpy as np
 import numpy.random as npr
-from scipy.signal import convolve2d
+from scipy.signal import fftconvolve
 
 from . import uft
 
@@ -370,8 +370,8 @@ def richardson_lucy(image, psf, iterations=50, clip=True):
     im_deconv = 0.5 * np.ones(image.shape)
     psf_mirror = psf[::-1, ::-1]
     for _ in range(iterations):
-        relative_blur = image / convolve2d(im_deconv, psf, 'same')
-        im_deconv *= convolve2d(relative_blur, psf_mirror, 'same')
+        relative_blur = image / fftconvolve(im_deconv, psf, 'same')
+        im_deconv *= fftconvolve(relative_blur, psf_mirror, 'same')
 
     if clip:
         im_deconv[im_deconv > 1] = 1

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -369,6 +369,8 @@ def richardson_lucy(image, psf, iterations=50, clip=True):
     def fft_time(m, n, k, l):
         return m*np.log(m) + n*np.log(n) + k*np.log(k) + l*np.log(l)
 
+    # see whether the fourier transform convolution method or the direct
+    # convolution method is faster (discussed in scikit-image PR #1792)
     time_ratio = 71.468 * fft_time(*(image.shape + psf.shape))
     time_ratio /= direct_time(*(image.shape + psf.shape))
     convolve_method = fftconvolve if time_ratio <= 1 else convolve2d

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -7,7 +7,7 @@ from __future__ import division
 
 import numpy as np
 import numpy.random as npr
-from scipy.signal import fftconvolve
+from scipy.signal import fftconvolve, convolve2d
 
 from . import uft
 
@@ -369,8 +369,8 @@ def richardson_lucy(image, psf, iterations=50, clip=True):
     def fft_time(m, n, k, l):
         return m*np.log(m) + n*np.log(n) + k*np.log(k) + l*np.log(l)
 
-    time_ratio = 71.468 * fft_time(*image.shape, *psf.shape)
-    time_ratio /= direct_time(*image.shape, *psf.shape)
+    time_ratio = 71.468 * fft_time(*(image.shape + psf.shape))
+    time_ratio /= direct_time(*(image.shape + psf.shape))
     convolve_method = fftconvolve if time_ratio <= 1 else convolve2d
 
     image = image.astype(np.float)

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -375,7 +375,7 @@ def richardson_lucy(image, psf, iterations=50, clip=True):
 
     # see whether the fourier transform convolution method or the direct
     # convolution method is faster (discussed in scikit-image PR #1792)
-    time_ratio = 40.032 * fft_time(image.shape, psf.shape))
+    time_ratio = 40.032 * fft_time(image.shape, psf.shape)
     time_ratio /= direct_time(image.shape, psf.shape)
 
     if time_ratio <= 1 or len(image.shape) > 2:


### PR DESCRIPTION
This pull request uses [`scipy.signal.fftconvolve`] instead of [`scipy.signal.convolve2d`] in skimage/restoration/deconvolution.py. These are equivalent functions, as noted in [this StackOverflow answer] but `fftconvolve` is much faster. Quoting the documentation page for fftconvolve,

> This is generally much faster than convolve for large arrays (n > ~500)

This function change gives equivalent results (up a to a machine epsilon) as indicated by the test below:

[this StackOverflow answer]:http://stackoverflow.com/a/1768140/1141256

```python
from scipy.signal import convolve2d, fftconvolve
import numpy as np

N, m = 1e3, 10
np.random.seed(42)
x = np.random.randn(int(N), int(N))
h = np.ones((m, m)) / m**2

y1 = convolve2d(x, h, mode='same')
y2 = fftconvolve(x, h, mode='same')

assert np.allclose(y1, y2)

print("{:0.4e}".format(np.max(np.abs(y1 - y2)))) # prints 1.7876e-15
```

When I use `N = 1e3`, I see speedups of roughly 6x.

[`scipy.signal.fftconvolve`]:http://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.fftconvolve.html#scipy.signal.fftconvolve
[`scipy.signal.convolve2d`]:http://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.convolve2d.html#scipy.signal.convolve2d