### PR TITLE
STY: Fix formatting and use tight_layout in doc examples.

### DIFF
--- a/doc/examples/color_exposure/plot_equalize.py
+++ b/doc/examples/color_exposure/plot_equalize.py
@@ -99,5 +99,5 @@ ax_cdf.set_ylabel('Fraction of total intensity')
 ax_cdf.set_yticks(np.linspace(0, 1, 5))
 
 # prevent overlap of y-axis labels
-fig.subplots_adjust(wspace=0.4)
+fig.tight_layout()
 plt.show()

--- a/doc/examples/color_exposure/plot_ihc_color_separation.py
+++ b/doc/examples/color_exposure/plot_ihc_color_separation.py
@@ -26,7 +26,8 @@ from skimage.color import rgb2hed
 ihc_rgb = data.immunohistochemistry()
 ihc_hed = rgb2hed(ihc_rgb)
 
-fig, axes = plt.subplots(2, 2, figsize=(7, 6), sharex=True, sharey=True, subplot_kw={'adjustable':'box-forced'})
+fig, axes = plt.subplots(2, 2, figsize=(7, 6), sharex=True, sharey=True,
+                         subplot_kw={'adjustable': 'box-forced'})
 ax0, ax1, ax2, ax3 = axes.ravel()
 
 ax0.imshow(ihc_rgb)
@@ -44,7 +45,7 @@ ax3.set_title("DAB")
 for ax in axes.ravel():
     ax.axis('off')
 
-fig.subplots_adjust(hspace=0.3)
+fig.tight_layout()
 
 
 """

--- a/doc/examples/color_exposure/plot_local_equalize.py
+++ b/doc/examples/color_exposure/plot_local_equalize.py
@@ -74,12 +74,14 @@ img_eq = rank.equalize(img, selem=selem)
 # Display results
 fig = plt.figure(figsize=(8, 5))
 axes = np.zeros((2, 3), dtype=np.object)
-axes[0,0] = plt.subplot(2, 3, 1, adjustable='box-forced')
-axes[0,1] = plt.subplot(2, 3, 2, sharex=axes[0,0], sharey=axes[0,0], adjustable='box-forced')
-axes[0,2] = plt.subplot(2, 3, 3, sharex=axes[0,0], sharey=axes[0,0], adjustable='box-forced')
-axes[1,0] = plt.subplot(2, 3, 4)
-axes[1,1] = plt.subplot(2, 3, 5)
-axes[1,2] = plt.subplot(2, 3, 6)
+axes[0, 0] = plt.subplot(2, 3, 1, adjustable='box-forced')
+axes[0, 1] = plt.subplot(2, 3, 2, sharex=axes[0, 0], sharey=axes[0, 0],
+                         adjustable='box-forced')
+axes[0, 2] = plt.subplot(2, 3, 3, sharex=axes[0, 0], sharey=axes[0, 0],
+                         adjustable='box-forced')
+axes[1, 0] = plt.subplot(2, 3, 4)
+axes[1, 1] = plt.subplot(2, 3, 5)
+axes[1, 2] = plt.subplot(2, 3, 6)
 
 ax_img, ax_hist, ax_cdf = plot_img_and_hist(img, axes[:, 0])
 ax_img.set_title('Low contrast image')
@@ -94,5 +96,5 @@ ax_cdf.set_ylabel('Fraction of total intensity')
 
 
 # prevent overlap of y-axis labels
-fig.subplots_adjust(wspace=0.4)
+fig.tight_layout()
 plt.show()

--- a/doc/examples/color_exposure/plot_log_gamma.py
+++ b/doc/examples/color_exposure/plot_log_gamma.py
@@ -55,10 +55,12 @@ logarithmic_corrected = exposure.adjust_log(img, 1)
 
 # Display results
 fig = plt.figure(figsize=(8, 5))
-axes = np.zeros((2,3), dtype=np.object)
+axes = np.zeros((2, 3), dtype=np.object)
 axes[0, 0] = plt.subplot(2, 3, 1, adjustable='box-forced')
-axes[0, 1] = plt.subplot(2, 3, 2, sharex=axes[0, 0], sharey=axes[0, 0], adjustable='box-forced')
-axes[0, 2] = plt.subplot(2, 3, 3, sharex=axes[0, 0], sharey=axes[0, 0], adjustable='box-forced')
+axes[0, 1] = plt.subplot(2, 3, 2, sharex=axes[0, 0], sharey=axes[0, 0],
+                         adjustable='box-forced')
+axes[0, 2] = plt.subplot(2, 3, 3, sharex=axes[0, 0], sharey=axes[0, 0],
+                         adjustable='box-forced')
 axes[1, 0] = plt.subplot(2, 3, 4)
 axes[1, 1] = plt.subplot(2, 3, 5)
 axes[1, 2] = plt.subplot(2, 3, 6)
@@ -80,5 +82,5 @@ ax_cdf.set_ylabel('Fraction of total intensity')
 ax_cdf.set_yticks(np.linspace(0, 1, 5))
 
 # prevent overlap of y-axis labels
-fig.subplots_adjust(wspace=0.4)
+fig.tight_layout()
 plt.show()

--- a/doc/examples/edges/plot_canny.py
+++ b/doc/examples/edges/plot_canny.py
@@ -35,7 +35,8 @@ edges1 = feature.canny(im)
 edges2 = feature.canny(im, sigma=3)
 
 # display results
-fig, (ax1, ax2, ax3) = plt.subplots(nrows=1, ncols=3, figsize=(8, 3), sharex=True, sharey=True)
+fig, (ax1, ax2, ax3) = plt.subplots(nrows=1, ncols=3, figsize=(8, 3),
+                                    sharex=True, sharey=True)
 
 ax1.imshow(im, cmap=plt.cm.jet)
 ax1.axis('off')
@@ -49,7 +50,6 @@ ax3.imshow(edges2, cmap=plt.cm.gray)
 ax3.axis('off')
 ax3.set_title('Canny filter, $\sigma=3$', fontsize=20)
 
-fig.subplots_adjust(wspace=0.02, hspace=0.02, top=0.9,
-                    bottom=0.02, left=0.02, right=0.98)
+fig.tight_layout()
 
 plt.show()

--- a/doc/examples/edges/plot_medial_transform.py
+++ b/doc/examples/edges/plot_medial_transform.py
@@ -54,12 +54,13 @@ skel, distance = medial_axis(data, return_distance=True)
 # Distance to the background for pixels of the skeleton
 dist_on_skel = distance * skel
 
-fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4), sharex=True, sharey=True, subplot_kw={'adjustable':'box-forced'})
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4), sharex=True, sharey=True,
+                               subplot_kw={'adjustable': 'box-forced'})
 ax1.imshow(data, cmap=plt.cm.gray, interpolation='nearest')
 ax1.axis('off')
 ax2.imshow(dist_on_skel, cmap=plt.cm.spectral, interpolation='nearest')
 ax2.contour(data, [0.5], colors='w')
 ax2.axis('off')
 
-fig.subplots_adjust(hspace=0.01, wspace=0.01, top=1, bottom=0, left=0, right=1)
+fig.tight_layout()
 plt.show()

--- a/doc/examples/edges/plot_shapes.py
+++ b/doc/examples/edges/plot_shapes.py
@@ -5,16 +5,16 @@ Shapes
 
 This example shows how to draw several different shapes:
 
- - line
- - Bezier curve
- - polygon
- - circle
- - ellipse
+- line
+- Bezier curve
+- polygon
+- circle
+- ellipse
 
 Anti-aliased drawing for:
 
- - line
- - circle
+- line
+- circle
 
 """
 import math

--- a/doc/examples/edges/plot_skeleton.py
+++ b/doc/examples/edges/plot_skeleton.py
@@ -47,7 +47,9 @@ image[circle2] = 0
 skeleton = skeletonize(image)
 
 # display results
-fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4.5), sharex=True, sharey=True, subplot_kw={'adjustable':'box-forced'})
+fig, (ax1, ax2) = plt.subplots(nrows=1, ncols=2, figsize=(8, 4.5),
+                               sharex=True, sharey=True,
+                               subplot_kw={'adjustable': 'box-forced'})
 
 ax1.imshow(image, cmap=plt.cm.gray)
 ax1.axis('off')
@@ -57,7 +59,6 @@ ax2.imshow(skeleton, cmap=plt.cm.gray)
 ax2.axis('off')
 ax2.set_title('skeleton', fontsize=20)
 
-fig.subplots_adjust(wspace=0.02, hspace=0.02, top=0.98,
-                    bottom=0.02, left=0.02, right=0.98)
+fig.tight_layout()
 
 plt.show()

--- a/doc/examples/features_detection/plot_gabors_from_astronaut.py
+++ b/doc/examples/features_detection/plot_gabors_from_astronaut.py
@@ -87,5 +87,5 @@ ax3.set_title("K-means filterbank (codebook)\non LGN-like DoG image")
 for ax in axes.ravel():
     ax.axis('off')
 
-fig.subplots_adjust(hspace=0.3)
+fig.tight_layout()
 plt.show()

--- a/doc/examples/features_detection/plot_hog.py
+++ b/doc/examples/features_detection/plot_hog.py
@@ -15,11 +15,11 @@ Algorithm overview
 
 Compute a Histogram of Oriented Gradients (HOG) by
 
-    1. (optional) global image normalisation
-    2. computing the gradient image in x and y
-    3. computing gradient histograms
-    4. normalising across blocks
-    5. flattening into a feature vector
+1. (optional) global image normalisation
+2. computing the gradient image in x and y
+3. computing gradient histograms
+4. normalising across blocks
+5. flattening into a feature vector
 
 The first stage applies an optional global image normalisation
 equalisation that is designed to reduce the influence of illumination

--- a/doc/examples/filters/plot_denoise.py
+++ b/doc/examples/filters/plot_denoise.py
@@ -38,7 +38,8 @@ astro = astro[220:300, 220:320]
 noisy = astro + 0.6 * astro.std() * np.random.random(astro.shape)
 noisy = np.clip(noisy, 0, 1)
 
-fig, ax = plt.subplots(nrows=2, ncols=3, figsize=(8, 5), sharex=True, sharey=True, subplot_kw={'adjustable':'box-forced'})
+fig, ax = plt.subplots(nrows=2, ncols=3, figsize=(8, 5), sharex=True,
+                       sharey=True, subplot_kw={'adjustable': 'box-forced'})
 
 plt.gray()
 
@@ -62,7 +63,6 @@ ax[1, 2].imshow(astro)
 ax[1, 2].axis('off')
 ax[1, 2].set_title('original')
 
-fig.subplots_adjust(wspace=0.02, hspace=0.2,
-                    top=0.9, bottom=0.05, left=0, right=1)
+fig.tight_layout()
 
 plt.show()

--- a/doc/examples/filters/plot_nonlocal_means.py
+++ b/doc/examples/filters/plot_nonlocal_means.py
@@ -26,7 +26,8 @@ noisy = np.clip(noisy, 0, 1)
 
 denoise = denoise_nl_means(noisy, 7, 9, 0.08)
 
-fig, ax = plt.subplots(ncols=2, figsize=(8, 4), sharex=True, sharey=True, subplot_kw={'adjustable':'box-forced'})
+fig, ax = plt.subplots(ncols=2, figsize=(8, 4), sharex=True, sharey=True,
+                       subplot_kw={'adjustable': 'box-forced'})
 
 ax[0].imshow(noisy)
 ax[0].axis('off')
@@ -35,7 +36,6 @@ ax[1].imshow(denoise)
 ax[1].axis('off')
 ax[1].set_title('non-local means')
 
-fig.subplots_adjust(wspace=0.02, hspace=0.2,
-                    top=0.9, bottom=0.05, left=0, right=1)
+fig.tight_layout()
 
 plt.show()

--- a/doc/examples/filters/plot_rank_mean.py
+++ b/doc/examples/filters/plot_rank_mean.py
@@ -5,12 +5,12 @@ Mean filters
 
 This example compares the following mean filters of the rank filter package:
 
- * **local mean**: all pixels belonging to the structuring element to compute
-   average gray level.
- * **percentile mean**: only use values between percentiles p0 and p1
-   (here 10% and 90%).
- * **bilateral mean**: only use pixels of the structuring element having a gray
-   level situated inside g-s0 and g+s1 (here g-500 and g+500)
+* **local mean**: all pixels belonging to the structuring element to compute
+  average gray level.
+* **percentile mean**: only use values between percentiles p0 and p1
+  (here 10% and 90%).
+* **bilateral mean**: only use pixels of the structuring element having a gray
+  level situated inside g-s0 and g+s1 (here g-500 and g+500)
 
 Percentile and usual mean give here similar results, these filters smooth the
 complete image (background and details). Bilateral mean exhibits a high
@@ -34,7 +34,8 @@ bilateral_result = rank.mean_bilateral(image, selem=selem, s0=500, s1=500)
 normal_result = rank.mean(image, selem=selem)
 
 
-fig, axes = plt.subplots(nrows=2, ncols=2, figsize=(8, 10), sharex=True, sharey=True)
+fig, axes = plt.subplots(nrows=2, ncols=2, figsize=(8, 10),
+                         sharex=True, sharey=True)
 ax = axes.ravel()
 
 titles = ['Original', 'Percentile mean', 'Bilateral mean', 'Local mean']

--- a/doc/examples/filters/plot_restoration.py
+++ b/doc/examples/filters/plot_restoration.py
@@ -42,7 +42,9 @@ astro += 0.1 * astro.std() * np.random.standard_normal(astro.shape)
 
 deconvolved, _ = restoration.unsupervised_wiener(astro, psf)
 
-fig, ax = plt.subplots(nrows=1, ncols=2, figsize=(8, 5), sharex=True, sharey=True, subplot_kw={'adjustable':'box-forced'})
+fig, ax = plt.subplots(nrows=1, ncols=2, figsize=(8, 5),
+                       sharex=True, sharey=True,
+                       subplot_kw={'adjustable': 'box-forced'})
 
 plt.gray()
 
@@ -54,7 +56,6 @@ ax[1].imshow(deconvolved)
 ax[1].axis('off')
 ax[1].set_title('Self tuned restoration')
 
-fig.subplots_adjust(wspace=0.02, hspace=0.2,
-                    top=0.9, bottom=0.05, left=0, right=1)
+fig.tight_layout()
 
 plt.show()

--- a/doc/examples/numpy_operations/plot_view_as_blocks.py
+++ b/doc/examples/numpy_operations/plot_view_as_blocks.py
@@ -49,8 +49,9 @@ ax0, ax1, ax2, ax3 = axes.ravel()
 
 ax0.set_title("Original rescaled with\n spline interpolation (order=3)")
 l_resized = ndi.zoom(l, 2, order=3)
-#ax0.imshow(l_resized, cmap=cm.Greys_r)
-ax0.imshow(l_resized, extent=(0, 128, 128, 0), interpolation='nearest', cmap=cm.Greys_r)
+
+ax0.imshow(l_resized, extent=(0, 128, 128, 0), interpolation='nearest',
+           cmap=cm.Greys_r)
 ax0.set_axis_off()
 
 ax1.set_title("Block view with\n local mean pooling")
@@ -65,5 +66,5 @@ ax3.set_title("Block view with\n local median pooling")
 ax3.imshow(median_view, interpolation='nearest', cmap=cm.Greys_r)
 ax3.set_axis_off()
 
-fig.subplots_adjust(hspace=0.4, wspace=0.4)
+fig.tight_layout()
 plt.show()

--- a/doc/examples/segmentation/plot_join_segmentations.py
+++ b/doc/examples/segmentation/plot_join_segmentations.py
@@ -40,7 +40,8 @@ seg2 = slic(coins, n_segments=117, max_iter=160, sigma=1, compactness=0.75,
 segj = join_segmentations(seg1, seg2)
 
 # show the segmentations
-fig, axes = plt.subplots(ncols=4, figsize=(9, 2.5), sharex=True, sharey=True, subplot_kw={'adjustable':'box-forced'})
+fig, axes = plt.subplots(ncols=4, figsize=(9, 2.5), sharex=True, sharey=True,
+                         subplot_kw={'adjustable': 'box-forced'})
 axes[0].imshow(coins, cmap=plt.cm.gray, interpolation='nearest')
 axes[0].set_title('Image')
 
@@ -58,5 +59,5 @@ axes[3].set_title('Join')
 
 for ax in axes:
     ax.axis('off')
-fig.subplots_adjust(hspace=0.01, wspace=0.01, top=1, bottom=0, left=0, right=1)
+fig.tight_layout()
 plt.show()

--- a/doc/examples/segmentation/plot_peak_local_max.py
+++ b/doc/examples/segmentation/plot_peak_local_max.py
@@ -25,7 +25,8 @@ image_max = ndi.maximum_filter(im, size=20, mode='constant')
 coordinates = peak_local_max(im, min_distance=20)
 
 # display results
-fig, ax = plt.subplots(1, 3, figsize=(8, 3), sharex=True, sharey=True, subplot_kw={'adjustable':'box-forced'})
+fig, ax = plt.subplots(1, 3, figsize=(8, 3), sharex=True, sharey=True,
+                       subplot_kw={'adjustable': 'box-forced'})
 ax1, ax2, ax3 = ax.ravel()
 ax1.imshow(im, cmap=plt.cm.gray)
 ax1.axis('off')
@@ -41,7 +42,6 @@ ax3.plot(coordinates[:, 1], coordinates[:, 0], 'r.')
 ax3.axis('off')
 ax3.set_title('Peak local max')
 
-fig.subplots_adjust(wspace=0.02, hspace=0.02, top=0.9,
-                    bottom=0.02, left=0.02, right=0.98)
+fig.tight_layout()
 
 plt.show()

--- a/doc/examples/segmentation/plot_random_walker_segmentation.py
+++ b/doc/examples/segmentation/plot_random_walker_segmentation.py
@@ -38,7 +38,8 @@ markers[data > 1.3] = 2
 labels = random_walker(data, markers, beta=10, mode='bf')
 
 # Plot results
-fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(8, 3.2), sharex=True, sharey=True)
+fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(8, 3.2),
+                                    sharex=True, sharey=True)
 ax1.imshow(data, cmap='gray', interpolation='nearest')
 ax1.axis('off')
 ax1.set_adjustable('box-forced')
@@ -52,6 +53,5 @@ ax3.axis('off')
 ax3.set_adjustable('box-forced')
 ax3.set_title('Segmentation')
 
-fig.subplots_adjust(hspace=0.01, wspace=0.01, top=1, bottom=0, left=0,
-                    right=1)
+fig.tight_layout()
 plt.show()

--- a/doc/examples/segmentation/plot_segmentations.py
+++ b/doc/examples/segmentation/plot_segmentations.py
@@ -79,9 +79,10 @@ print("Felzenszwalb's number of segments: %d" % len(np.unique(segments_fz)))
 print("Slic number of segments: %d" % len(np.unique(segments_slic)))
 print("Quickshift number of segments: %d" % len(np.unique(segments_quick)))
 
-fig, ax = plt.subplots(1, 3, sharex=True, sharey=True, subplot_kw={'adjustable':'box-forced'})
+fig, ax = plt.subplots(1, 3, sharex=True, sharey=True,
+                       subplot_kw={'adjustable': 'box-forced'})
 fig.set_size_inches(8, 3, forward=True)
-fig.subplots_adjust(0.05, 0.05, 0.95, 0.95, 0.05, 0.05)
+fig.tight_layout()
 
 ax[0].imshow(mark_boundaries(img, segments_fz))
 ax[0].set_title("Felzenszwalbs's method")

--- a/doc/examples/segmentation/plot_watershed.py
+++ b/doc/examples/segmentation/plot_watershed.py
@@ -48,7 +48,8 @@ local_maxi = peak_local_max(distance, indices=False, footprint=np.ones((3, 3)),
 markers = ndi.label(local_maxi)[0]
 labels = watershed(-distance, markers, mask=image)
 
-fig, axes = plt.subplots(ncols=3, figsize=(8, 2.7), sharex=True, sharey=True, subplot_kw={'adjustable':'box-forced'})
+fig, axes = plt.subplots(ncols=3, figsize=(8, 2.7), sharex=True, sharey=True,
+                         subplot_kw={'adjustable': 'box-forced'})
 ax0, ax1, ax2 = axes
 
 ax0.imshow(image, cmap=plt.cm.gray, interpolation='nearest')
@@ -61,6 +62,5 @@ ax2.set_title('Separated objects')
 for ax in axes:
     ax.axis('off')
 
-fig.subplots_adjust(hspace=0.01, wspace=0.01, top=0.9, bottom=0, left=0,
-                    right=1)
+fig.tight_layout()
 plt.show()

--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -31,9 +31,9 @@ Technique (SART).
 
 For further information on tomographic reconstruction, see
 
-    - AC Kak, M Slaney, "Principles of Computerized Tomographic Imaging",
-      http://www.slaney.org/pct/pct-toc.html
-    - http://en.wikipedia.org/wiki/Radon_transform
+- AC Kak, M Slaney, "Principles of Computerized Tomographic Imaging",
+  http://www.slaney.org/pct/pct-toc.html
+- http://en.wikipedia.org/wiki/Radon_transform
 
 The forward transform
 =====================
@@ -73,7 +73,7 @@ ax2.set_ylabel("Projection position (pixels)")
 ax2.imshow(sinogram, cmap=plt.cm.Greys_r,
            extent=(0, 180, 0, sinogram.shape[0]), aspect='auto')
 
-fig.subplots_adjust(hspace=0.4, wspace=0.5)
+fig.tight_layout()
 plt.show()
 
 """
@@ -101,7 +101,9 @@ error = reconstruction_fbp - image
 print('FBP rms reconstruction error: %.3g' % np.sqrt(np.mean(error**2)))
 
 imkwargs = dict(vmin=-0.2, vmax=0.2)
-fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4.5), sharex=True, sharey=True, subplot_kw={'adjustable':'box-forced'})
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4.5),
+                               sharex=True, sharey=True,
+                               subplot_kw={'adjustable': 'box-forced'})
 ax1.set_title("Reconstruction\nFiltered back projection")
 ax1.imshow(reconstruction_fbp, cmap=plt.cm.Greys_r)
 ax2.set_title("Reconstruction error\nFiltered back projection")
@@ -152,7 +154,8 @@ error = reconstruction_sart - image
 print('SART (1 iteration) rms reconstruction error: %.3g'
       % np.sqrt(np.mean(error**2)))
 
-fig, ax = plt.subplots(2, 2, figsize=(8, 8.5), sharex=True, sharey=True, subplot_kw={'adjustable':'box-forced'})
+fig, ax = plt.subplots(2, 2, figsize=(8, 8.5), sharex=True, sharey=True,
+                       subplot_kw={'adjustable': 'box-forced'})
 ax1, ax2, ax3, ax4 = ax.ravel()
 ax1.set_title("Reconstruction\nSART")
 ax1.imshow(reconstruction_sart, cmap=plt.cm.Greys_r)


### PR DESCRIPTION
Attempts to address #1774 and #1775.

Some lines may need to be reverted if the automatic `tight_layout()` is a step backward.

I attempted to enforce 80 char line limits wherever possible; many of the shared axes calls did not respect this. There are likely other instances beyond the scope of this PR (which was aimed specifically at the above Issues).