### PR TITLE
Allow axes to be provided to imshow and fix colorbar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,7 @@ before_install:
 install:
     - python setup.py develop
 
-script:
-   - tools/travis_script.sh
-   - grep -irn "R385" doc/build
+script: tools/travis_script.sh
 
 after_success:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ addons:
     packages:
     - ccache
     - libfreeimage3
-    - texlive 
-    - texlive-latex-extra 
+    - texlive
+    - texlive-latex-extra
     - dvipng
     - python-qt4
 env:
@@ -53,7 +53,9 @@ before_install:
 install:
     - python setup.py develop
 
-script: tools/travis_script.sh
+script:
+   - tools/travis_script.sh
+   - grep -irn "R385" doc/build
 
 after_success:
     - coveralls

--- a/skimage/io/_plugins/matplotlib_plugin.py
+++ b/skimage/io/_plugins/matplotlib_plugin.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 import numpy as np
 import warnings
 import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 from ...util import dtype as dtypes
 from ...exposure import is_low_contrast
 from ...util.colormap import viridis
@@ -110,7 +111,7 @@ def _get_display_range(image):
     return lo, hi, cmap
 
 
-def imshow(im, *args, **kwargs):
+def imshow(im, ax=None, show_cbar=None, **kwargs):
     """Show the input image and return the current axes.
 
     By default, the image is displayed in greyscale, rather than
@@ -131,8 +132,11 @@ def imshow(im, *args, **kwargs):
     ----------
     im : array, shape (M, N[, 3])
         The image to display.
-
-    *args, **kwargs : positional and keyword arguments
+    ax: `matplotlib.axes.Axes`, optional
+        The axis to use for the image, defaults to plt.gca().
+    show_cbar: boolean, optional.
+        Whether to show the colorbar (used to override default behavior).
+    **kwargs : Keyword arguments
         These are passed directly to `matplotlib.pyplot.imshow`.
 
     Returns
@@ -147,9 +151,15 @@ def imshow(im, *args, **kwargs):
     kwargs.setdefault('cmap', cmap)
     kwargs.setdefault('vmin', lo)
     kwargs.setdefault('vmax', hi)
-    ax_im = plt.imshow(im, *args, **kwargs)
-    if cmap != _default_colormap:
-        plt.colorbar()
+
+    ax = ax or plt.gca()
+    ax_im = ax.imshow(im, **kwargs)
+    if (cmap != _default_colormap and show_cbar is not False) or show_cbar:
+        divider = make_axes_locatable(ax)
+        cax = divider.append_axes("right", size="5%", pad=0.05)
+        plt.colorbar(ax_im, cax=cax)
+    ax.set_adjustable('box-forced')
+    ax.get_figure().tight_layout()
     return ax_im
 
 imread = plt.imread

--- a/skimage/io/tests/test_mpl_imshow.py
+++ b/skimage/io/tests/test_mpl_imshow.py
@@ -78,7 +78,7 @@ def test_low_dynamic_range():
 
 def test_outside_standard_range():
     plt.figure()
-    with expected_warnings(["out of standard range"]):
+    with expected_warnings(["out of standard range|CObject type is marked"]):
         ax_im = io.imshow(im_hi)
     assert ax_im.get_clim() == (im_hi.min(), im_hi.max())
     assert n_subplots(ax_im) == 2
@@ -87,7 +87,8 @@ def test_outside_standard_range():
 
 def test_nonstandard_type():
     plt.figure()
-    with expected_warnings(["Low image dynamic range"]):
+
+    with expected_warnings(["Low image dynamic range|CObject type is marked"]):
         ax_im = io.imshow(im64)
     assert ax_im.get_clim() == (im64.min(), im64.max())
     assert n_subplots(ax_im) == 2

--- a/skimage/io/tests/test_mpl_imshow.py
+++ b/skimage/io/tests/test_mpl_imshow.py
@@ -81,6 +81,7 @@ def test_outside_standard_range():
     # Warning raised by matplotlib on Windows:
     # "The CObject type is marked Pending Deprecation in Python 2.7.
     #  Please use capsule objects instead."
+    # Ref: https://docs.python.org/2/c-api/cobject.html
     with expected_warnings(["out of standard range|CObject type is marked"]):
         ax_im = io.imshow(im_hi)
     assert ax_im.get_clim() == (im_hi.min(), im_hi.max())
@@ -93,6 +94,7 @@ def test_nonstandard_type():
     # Warning raised by matplotlib on Windows:
     # "The CObject type is marked Pending Deprecation in Python 2.7.
     #  Please use capsule objects instead."
+    # Ref: https://docs.python.org/2/c-api/cobject.html
     with expected_warnings(["Low image dynamic range|CObject type is marked"]):
         ax_im = io.imshow(im64)
     assert ax_im.get_clim() == (im64.min(), im64.max())

--- a/skimage/io/tests/test_mpl_imshow.py
+++ b/skimage/io/tests/test_mpl_imshow.py
@@ -78,7 +78,7 @@ def test_low_dynamic_range():
 
 def test_outside_standard_range():
     plt.figure()
-    with expected_warnings(["out of standard range|CObject type is marked"]):
+    with expected_warnings(["out of standard range"]):
         ax_im = io.imshow(im_hi)
     assert ax_im.get_clim() == (im_hi.min(), im_hi.max())
     assert n_subplots(ax_im) == 2
@@ -88,7 +88,7 @@ def test_outside_standard_range():
 def test_nonstandard_type():
     plt.figure()
 
-    with expected_warnings(["Low image dynamic range|CObject type is marked"]):
+    with expected_warnings(["Low image dynamic range"]):
         ax_im = io.imshow(im64)
     assert ax_im.get_clim() == (im64.min(), im64.max())
     assert n_subplots(ax_im) == 2

--- a/skimage/io/tests/test_mpl_imshow.py
+++ b/skimage/io/tests/test_mpl_imshow.py
@@ -78,7 +78,10 @@ def test_low_dynamic_range():
 
 def test_outside_standard_range():
     plt.figure()
-    with expected_warnings(["out of standard range"]):
+    # Warning raised by matplotlib on Windows:
+    # "The CObject type is marked Pending Deprecation in Python 2.7.
+    #  Please use capsule objects instead."
+    with expected_warnings(["out of standard range|CObject type is marked"]):
         ax_im = io.imshow(im_hi)
     assert ax_im.get_clim() == (im_hi.min(), im_hi.max())
     assert n_subplots(ax_im) == 2
@@ -87,8 +90,10 @@ def test_outside_standard_range():
 
 def test_nonstandard_type():
     plt.figure()
-
-    with expected_warnings(["Low image dynamic range"]):
+    # Warning raised by matplotlib on Windows:
+    # "The CObject type is marked Pending Deprecation in Python 2.7.
+    #  Please use capsule objects instead."
+    with expected_warnings(["Low image dynamic range|CObject type is marked"]):
         ax_im = io.imshow(im64)
     assert ax_im.get_clim() == (im64.min(), im64.max())
     assert n_subplots(ax_im) == 2


### PR DESCRIPTION
- Allows an axis to be provided
- Fixes the colorbar to be more aesthetically pleasing
- Uses tight_layout

With this change, our examples could be written like the one below.
The downside is that adding a colorbar interferes with sharey=True.

```python
import numpy as np
import matplotlib.pyplot as plt
from scipy import ndimage as ndi

from skimage import feature, io


# Generate noisy image of a square
im = np.zeros((128, 128))
im[32:-32, 32:-32] = 1

im = ndi.rotate(im, 15, mode='constant')
im = ndi.gaussian_filter(im, 4)
im += 0.2 * np.random.random(im.shape)

# Compute the Canny filter for two values of sigma
edges1 = feature.canny(im)
edges2 = feature.canny(im, sigma=3)

# display results
fig, (ax1, ax2, ax3) = plt.subplots(nrows=1, ncols=3, figsize=(8, 3), sharex=True, sharey=True)

io.imshow(im, ax=ax1)
ax1.axis('off')
ax1.set_title('noisy image', fontsize=20)

io.imshow(edges1, ax=ax2)
ax2.axis('off')
ax2.set_title('Canny filter, $\sigma=1$', fontsize=20)

io.imshow(edges2, ax=ax3)
ax3.axis('off')
ax3.set_title('Canny filter, $\sigma=3$', fontsize=20)

plt.show()
```

<img width="743" alt="screen shot 2015-12-12 at 1 58 10 pm" src="https://cloud.githubusercontent.com/assets/2096628/11763637/755ab68c-a0d8-11e5-853f-2768ec3c47d4.png">

