### PR TITLE
Kahan summation

### DIFF
--- a/skimage/_shared/kahan.pyx
+++ b/skimage/_shared/kahan.pyx
@@ -1,0 +1,85 @@
+# -*- python -*-
+#cython: cdivision=True
+#cython: boundscheck=False
+#cython: nonecheck=False
+#cython: wraparound=False
+
+import numpy as np
+
+
+cpdef fsum_vector(double[:] v, int calc_cumsum=0):
+    """Apply Kahan summation to a vector.
+
+    Parameters
+    ----------
+    v : ndarray of double
+        Array to sum.
+    calc_cumsum : int
+        Whether or not to calculate the cumulative sum as well.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Kahan_summation_algorithm
+    """
+    cdef:
+        double s = 0
+        double y, t
+        double c = 0
+        Py_ssize_t i
+        double[:] cumsum
+
+    if calc_cumsum:
+        cumsum = np.zeros_like(v)
+
+    for i in range(v.size):
+        y = v[i] - c
+        t = s + y
+        c = (t - s) - y
+        s = t
+
+        if calc_cumsum:
+            cumsum[i] = s
+
+    if calc_cumsum:
+        return s, np.asarray(cumsum)
+    else:
+        return s
+
+
+def kahan_sum(arr, axis=None):
+    """Calculate array sum using Kahan algorithm.
+
+    Parameters
+    ----------
+    arr : ndarray
+        Input array.
+    axis : int
+        Axis along which to sum.
+    """
+    if axis is None:
+        return fsum_vector(arr.ravel())
+
+    out = np.apply_along_axis(fsum_vector, axis, arr)
+
+    shape = list(arr.shape)
+    shape.pop(axis)
+
+    return out.reshape(shape)
+
+
+def kahan_cumsum(arr, axis=None):
+    """Calculate cumulative array sum using Kahan algorithm.
+
+    Parameters
+    ----------
+    arr : ndarray
+        Input array.
+    axis : int
+        Axis along which to sum.
+    """
+    if axis is None:
+        return fsum_vector(arr.ravel(), calc_cumsum=1)[1]
+    else:
+        out = np.apply_along_axis(lambda v: fsum_vector(v, calc_cumsum=1)[1],
+                                  axis, arr)
+        return out

--- a/skimage/_shared/setup.py
+++ b/skimage/_shared/setup.py
@@ -16,11 +16,13 @@ def configuration(parent_package='', top_path=None):
     cython(['geometry.pyx'], working_path=base_path)
     cython(['transform.pyx'], working_path=base_path)
     cython(['interpolation.pyx'], working_path=base_path)
+    cython(['kahan.pyx'], working_path=base_path)
 
     config.add_extension('geometry', sources=['geometry.c'])
     config.add_extension('transform', sources=['transform.c'],
                          include_dirs=[get_numpy_include_dirs()])
     config.add_extension('interpolation', sources=['interpolation.c'])
+    config.add_extension('kahan', sources=['kahan.c'])
     return config
 
 

--- a/skimage/_shared/tests/test_kahan.py
+++ b/skimage/_shared/tests/test_kahan.py
@@ -1,0 +1,31 @@
+from skimage._shared.kahan import kahan_sum, kahan_cumsum
+
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+
+
+def test_sum():
+    rnd = np.random.RandomState(0)
+    z = rnd.random_sample((50, 50, 3))
+
+    assert_array_almost_equal(kahan_sum(z), np.sum(z))
+    assert_array_almost_equal(kahan_sum(z, axis=1),
+                              np.sum(z, axis=1))
+    assert_array_almost_equal(kahan_sum(z, axis=0),
+                              np.sum(z, axis=0))
+
+
+def test_cumsum():
+    rnd = np.random.RandomState(0)
+    z = rnd.random_sample((50, 50, 3))
+
+    assert_array_almost_equal(kahan_cumsum(z), np.cumsum(z))
+    assert_array_almost_equal(kahan_cumsum(z, axis=1),
+                              np.cumsum(z, axis=1))
+    assert_array_almost_equal(kahan_cumsum(z, axis=0),
+                              np.cumsum(z, axis=0))
+
+
+if __name__ == "__main__":
+    from numpy.testing import run_module_suite
+    run_module_suite()

--- a/skimage/transform/integral.py
+++ b/skimage/transform/integral.py
@@ -1,6 +1,8 @@
 import numpy as np
 import collections
 import warnings
+from .._shared.kahan import kahan_cumsum
+
 
 def integral_image(img):
     """Integral image / summed area table.
@@ -29,8 +31,13 @@ def integral_image(img):
 
     """
     S = img
+    if np.issubdtype(img.dtype, np.integer):
+        cumsum = np.cumsum
+    else:
+        cumsum = kahan_cumsum
+
     for i in range(img.ndim):
-        S = S.cumsum(axis=i)
+        S = cumsum(S, axis=i)
     return S
 
 

--- a/skimage/transform/tests/test_integral.py
+++ b/skimage/transform/tests/test_integral.py
@@ -2,6 +2,7 @@ import numpy as np
 from numpy.testing import assert_equal
 
 from skimage.transform import integral_image, integrate
+from skimage._shared._warnings import expected_warnings
 
 np.random.seed(0)
 x = (np.random.rand(50, 50) * 255).astype(np.uint8)
@@ -43,7 +44,10 @@ def test_vectorized_integrate():
                          x[30:, 31:].sum()])
     start_pts = [(r0[i], c0[i]) for i in range(len(r0))]
     end_pts = [(r1[i], c1[i]) for i in range(len(r0))]
-    assert_equal(expected, integrate(s, r0, c0, r1, c1))  # test deprecated
+
+    with expected_warnings(['deprecated']):
+        assert_equal(expected, integrate(s, r0, c0, r1, c1))
+
     assert_equal(expected, integrate(s, start_pts, end_pts))
 
 


### PR DESCRIPTION
Implement Kahan summation to improve the accuracy of summed area tables at some computational cost (see https://github.com/scikit-image/scikit-image/issues/1712).  Note that NumPy already uses paired summation, so the improvement is not that big.

An even better algorithm would perhaps be the one by Shewchuk, but that will take more time to figure out.

See also:

- Python C implementation of Shewchuk's method (msum): http://svn.python.org/projects/python/trunk/Modules/mathmodule.c
- Shewchuk's paper: http://www-2.cs.cmu.edu/afs/cs/project/quake/public/papers/robust-arithmetic.ps
- Wikipedia talk page with another few improved alternatives: https://en.wikipedia.org/wiki/Talk:Kahan_summation_algorithm

If we can, we should look at implementing one of the above.