### PR TITLE
Cleans up richardson-lucy deconvolution function

### DIFF
--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -368,15 +368,12 @@ def richardson_lucy(image, psf, iterations=50, clip=True):
     # compute the times for direct convolution and the fft method. The fft is of
     # complexity O(N log(N)) for each dimension and the direct method does
     # straight arithmetic (and is O(n*k) to add n elements k times)
-    def direct_time(img_shape, kernel_shape):
-        return np.prod(img_shape + kernel_shape)
-    def fft_time(img_shape, kernel_shape):
-        return np.sum([n*np.log(n) for n in img_shape+kernel_shape])
+    direct_time = np.prod(image.shape + psf.shape)
+    fft_time =  np.sum([n*np.log(n) for n in image.shape + psf.shape])
 
     # see whether the fourier transform convolution method or the direct
     # convolution method is faster (discussed in scikit-image PR #1792)
-    time_ratio = 40.032 * fft_time(image.shape, psf.shape)
-    time_ratio /= direct_time(image.shape, psf.shape)
+    time_ratio = 40.032 * fft_time / direct_time
 
     if time_ratio <= 1 or len(image.shape) > 2:
         convolve_method = fftconvolve


### PR DESCRIPTION
In PR #1792, I made changes to the Richardson-Lucy deconvolution function in [deconvolution.py]. However, these changes were not styled the way I would have liked: I defined functions within functions when I should have used clear variable names.

While pushing these changes upstream in SciPy PR [#5608], I realized that I could format these changes more nicely. I used clear variable names instead of defining functions within functions and got rid of 3 lines.

I performed a simple test on my machine to make sure I named all variables correctly.

[#5608]:https://github.com/scipy/scipy/pull/5608