### PR TITLE
ENH:  routine to estimate the noise standard deviation from an image

### DIFF
--- a/doc/examples/filters/plot_denoise.py
+++ b/doc/examples/filters/plot_denoise.py
@@ -29,19 +29,27 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from skimage import data, img_as_float
-from skimage.restoration import denoise_tv_chambolle, denoise_bilateral, denoise_wavelet
+from skimage.restoration import (denoise_tv_chambolle, denoise_bilateral,
+                                 denoise_wavelet, estimate_sigma)
 from skimage.util import random_noise
 
 
 astro = img_as_float(data.astronaut())
 astro = astro[220:300, 220:320]
 
-noisy = random_noise(astro, var=(0.6 * astro.std())**2)
+sigma = 0.155
+noisy = random_noise(astro, var=sigma**2)
 
 fig, ax = plt.subplots(nrows=2, ncols=4, figsize=(8, 5), sharex=True,
                        sharey=True, subplot_kw={'adjustable': 'box-forced'})
 
 plt.gray()
+
+# Estimate the average noise standard deviation across color channels.
+sigma_est = estimate_sigma(noisy, multichannel=True, average_sigmas=True)
+# Due to clipping in random_noise, the estimate will be a bit smaller than the
+# specified sigma.
+print("Estimated Gaussian noise standard deviation = {}".format(sigma_est))
 
 ax[0, 0].imshow(noisy)
 ax[0, 0].axis('off')
@@ -52,7 +60,7 @@ ax[0, 1].set_title('TV')
 ax[0, 2].imshow(denoise_bilateral(noisy, sigma_color=0.05, sigma_spatial=15))
 ax[0, 2].axis('off')
 ax[0, 2].set_title('Bilateral')
-ax[0, 3].imshow(denoise_wavelet(noisy, sigma=0.4*astro.std(),
+ax[0, 3].imshow(denoise_wavelet(noisy, sigma=0.85*sigma_est,
                                 multichannel=True))
 ax[0, 3].axis('off')
 ax[0, 3].set_title('Wavelet')
@@ -63,7 +71,7 @@ ax[1, 1].set_title('(more) TV')
 ax[1, 2].imshow(denoise_bilateral(noisy, sigma_color=0.1, sigma_spatial=15))
 ax[1, 2].axis('off')
 ax[1, 2].set_title('(more) Bilateral')
-ax[1, 3].imshow(denoise_wavelet(noisy, sigma=0.6*astro.std(),
+ax[1, 3].imshow(denoise_wavelet(noisy, sigma=1.25*sigma_est,
                                 multichannel=True))
 ax[1, 3].axis('off')
 ax[1, 3].set_title('(more) Wavelet')

--- a/skimage/restoration/__init__.py
+++ b/skimage/restoration/__init__.py
@@ -21,7 +21,7 @@ References
 from .deconvolution import wiener, unsupervised_wiener, richardson_lucy
 from .unwrap import unwrap_phase
 from ._denoise import denoise_tv_chambolle, denoise_tv_bregman, \
-                      denoise_bilateral, denoise_wavelet
+                      denoise_bilateral, denoise_wavelet, estimate_sigma
 from .non_local_means import denoise_nl_means
 from .inpaint import inpaint_biharmonic
 from .._shared.utils import copy_func, deprecated

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-import warnings
 import scipy.stats
 import numpy as np
 from math import ceil
@@ -564,10 +563,10 @@ def estimate_sigma(im, multichannel=False, average_sigmas=False):
             sigmas = np.mean(sigmas)
         return sigmas
     elif im.shape[-1] <= 4:
-        warnings.warn(
-            "image is size {} on the last axis, but ".format(im.shape[-1]) +
-            "multichannel is False.  If this is a color image, please set "
-            "multchannel to True for proper noise estimation.")
+        msg = ("image is size {0} on the last axis, but multichannel is "
+               "False.  If this is a color image, please set multichannel "
+               "to True for proper noise estimation.")
+        warn(msg.format(im.shape[-1]))
     coeffs = pywt.dwtn(im, wavelet='db2')
     detail_coeffs = coeffs['d' * im.ndim]
     return _sigma_est_dwt(detail_coeffs, distribution='Gaussian')

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -496,11 +496,11 @@ def _sigma_est_dwt(detail_coeffs, distribution='Gaussian'):
     Returns
     -------
     sigma : float
-        estimated noise standard deviation.  See [1]_
+        The estimated noise standard deviation (see section 4.2 of [1]_).
 
     References
     ----------
-    .. [1] Donoho, David L., and Jain M. Johnstone. "Ideal spatial adaptation
+    .. [1] D. L. Donoho and I. M. Johnstone. "Ideal spatial adaptation
        by wavelet shrinkage." Biometrika 81.3 (1994): 425-455.
     """
     detail_coeffs = np.asarray(detail_coeffs)
@@ -524,7 +524,7 @@ def estimate_sigma(im, multichannel, average_sigmas=True):
     im : ndarray
         Image for which to estimate the noise standard deviation.
     multichannel : bool
-       Estimate sigma separately for each channel.
+        Estimate sigma separately for each channel.
     average_sigmas : bool, optional
         If true, average the channel estimates of `sigma`.  Otherwise return
         a list of sigmas corresponding to each channel.
@@ -539,12 +539,12 @@ def estimate_sigma(im, multichannel, average_sigmas=True):
 
     Notes
     -----
-    The estimation algorithm is based on the mean absolute deviation of the
-    wavelet detail coefficients as described in [1]_.
+    The estimation algorithm is based on the median absolute deviation of the
+    wavelet detail coefficients as described in section 4.2 of [1]_.
 
     References
     ----------
-    .. [1] Donoho, David L., and Jain M. Johnstone. "Ideal spatial adaptation
+    .. [1] D. L. Donoho and I. M. Johnstone. "Ideal spatial adaptation
        by wavelet shrinkage." Biometrika 81.3 (1994): 425-455.
 
     Examples

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -503,7 +503,6 @@ def _sigma_est_dwt(detail_coeffs, distribution='Gaussian'):
     .. [1] D. L. Donoho and I. M. Johnstone. "Ideal spatial adaptation
        by wavelet shrinkage." Biometrika 81.3 (1994): 425-455.
     """
-    detail_coeffs = np.asarray(detail_coeffs)
     if distribution.lower() == 'gaussian':
         # 75th quantile of the underlying, symmetric noise distribution:
         # denom = scipy.stats.norm.ppf(0.75)
@@ -558,8 +557,6 @@ def estimate_sigma(im, multichannel, average_sigmas=True):
     """
     if not pywt_available:
         raise ValueError("estimate_sigma requires PyWavelets to be installed.")
-
-    im = np.asarray(im)
 
     if multichannel:
         kwargs = dict(multichannel=False, distribution='Gaussian')

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -549,7 +549,7 @@ def estimate_sigma(im, multichannel, average_sigmas=True):
     >>> img = img_as_float(skimage.data.camera())
     >>> sigma = 0.1
     >>> img = img + sigma * np.random.standard_normal(img.shape)
-    >>> sigma_hat = estimate_sigma(img, multichannel=False)
+    >>> sigma_hat = estimate_sigma(img, multichannel=False)  # doctest: +SKIP
     """
     if not pywt_available:
         raise ValueError("estimate_sigma requires PyWavelets to be installed.")

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -5,7 +5,6 @@ from math import ceil
 from .. import img_as_float
 from ..restoration._denoise_cy import _denoise_bilateral, _denoise_tv_bregman
 from .._shared.utils import skimage_deprecation, warn
-import warnings
 import pywt
 
 
@@ -89,15 +88,15 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
                                  "".format(image.ndim))
         elif image.shape[2] not in (3, 4):
             if image.shape[2] > 4:
-                warnings.warn("The last axis of the input image is interpreted "
-                              "as channels. Input image with shape {0} has {1} "
-                              "channels in last axis. ``denoise_bilateral`` is "
-                              "implemented for 2D grayscale and color images "
-                              "only.".format(image.shape, image.shape[2]))
+                msg = ("The last axis of the input image is interpreted as "
+                       "channels. Input image with shape {0} has {1} channels "
+                       "in last axis. ``denoise_bilateral`` is implemented "
+                       "for 2D grayscale and color images only")
+                warn(msg.format(image.shape, image.shape[2]))
             else:
                 msg = "Input image must be grayscale, RGB, or RGBA; " \
                       "but has shape {0}."
-                warnings.warn(msg.format(image.shape))
+                warn(msg.format(image.shape))
     else:
         if image.ndim > 2:
             raise ValueError("Bilateral filter is not implemented for "
@@ -111,7 +110,7 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
              '`sigma_color`. The `sigma_range` keyword argument '
              'will be removed in v0.14', skimage_deprecation)
 
-        #If sigma_range is provided, assign it to sigma_color
+        # If sigma_range is provided, assign it to sigma_color
         sigma_color = sigma_range
 
     if win_size is None:

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -515,8 +515,7 @@ def _sigma_est_dwt(detail_coeffs, distribution='Gaussian'):
     return sigma
 
 
-def estimate_sigma(im, multichannel, average_sigmas=True,
-                   distribution='Gaussian'):
+def estimate_sigma(im, multichannel, average_sigmas=True):
     """
     Robust wavelet-based estimator of the noise standard deviation [1]_.
 
@@ -524,7 +523,7 @@ def estimate_sigma(im, multichannel, average_sigmas=True,
     ----------
     im : ndarray
         Image for which to estimate the noise standard deviation.
-    multichannel : bool, optional
+    multichannel : bool
        Estimate sigma separately for each channel.
     average_sigmas : bool, optional
         If true, average the channel estimates of `sigma`.  Otherwise return
@@ -557,7 +556,7 @@ def estimate_sigma(im, multichannel, average_sigmas=True,
     im = np.asarray(im)
 
     if multichannel:
-        kwargs = dict(multichannel=False, distribution=distribution)
+        kwargs = dict(multichannel=False, distribution='Gaussian')
         nchannels = im.shape[-1]
         sigmas = [estimate_sigma(
             im[..., c], **kwargs) for c in range(nchannels)]
@@ -567,4 +566,4 @@ def estimate_sigma(im, multichannel, average_sigmas=True,
 
     coeffs = pywt.dwtn(im, wavelet='db2')
     detail_coeffs = coeffs['d' * im.ndim]
-    return _sigma_est_dwt(detail_coeffs, distribution=distribution)
+    return _sigma_est_dwt(detail_coeffs, distribution='Gaussian')

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -545,13 +545,14 @@ def estimate_sigma(im, multichannel, average_sigmas=True):
     Examples
     --------
     >>> import skimage.data
-    >>> img = skimage.data.camera()
-    >>> sigma = 20
+    >>> from skimage import img_as_float
+    >>> img = img_as_float(skimage.data.camera())
+    >>> sigma = 0.1
     >>> img = img + sigma * np.random.standard_normal(img.shape)
-    >>> sigma_hat = sigma_est(img)
+    >>> sigma_hat = estimate_sigma(img, multichannel=False)
     """
     if not pywt_available:
-        raise ValueError("Estimate_sigma requires PyWavelets to be installed.")
+        raise ValueError("estimate_sigma requires PyWavelets to be installed.")
 
     im = np.asarray(im)
 

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -483,7 +483,7 @@ def denoise_wavelet(img, sigma=None, wavelet='db1', mode='soft',
 def _sigma_est_dwt(detail_coeffs, distribution='Gaussian'):
     """
     Calculation of the robust median estimator of the noise standard
-    deviation [1]_.
+    deviation.
 
     Parameters
     ----------
@@ -517,7 +517,7 @@ def _sigma_est_dwt(detail_coeffs, distribution='Gaussian'):
 
 def estimate_sigma(im, multichannel, average_sigmas=True):
     """
-    Robust wavelet-based estimator of the noise standard deviation [1]_.
+    Robust wavelet-based estimator of the noise standard deviation.
 
     Parameters
     ----------
@@ -536,6 +536,11 @@ def estimate_sigma(im, multichannel, average_sigmas=True):
         `average_sigmas` is False, a separate noise estimate for each channel
         is returned.  Otherwise, the average of the individual channel
         estimates is returned.
+
+    Notes
+    -----
+    The estimation algorithm is based on the mean absolute deviation of the
+    wavelet detail coefficients as described in [1]_.
 
     References
     ----------

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -559,10 +559,9 @@ def estimate_sigma(im, multichannel, average_sigmas=True):
         raise ValueError("estimate_sigma requires PyWavelets to be installed.")
 
     if multichannel:
-        kwargs = dict(multichannel=False, distribution='Gaussian')
         nchannels = im.shape[-1]
         sigmas = [estimate_sigma(
-            im[..., c], **kwargs) for c in range(nchannels)]
+            im[..., c], multichannel=False) for c in range(nchannels)]
         if average_sigmas:
             sigmas = np.mean(sigmas)
         return sigmas

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import warnings
 import scipy.stats
 import numpy as np
 from math import ceil
@@ -512,7 +513,7 @@ def _sigma_est_dwt(detail_coeffs, distribution='Gaussian'):
     return sigma
 
 
-def estimate_sigma(im, multichannel, average_sigmas=True):
+def estimate_sigma(im, multichannel=False, average_sigmas=False):
     """
     Robust wavelet-based estimator of the (Gaussian) noise standard deviation.
 
@@ -562,7 +563,11 @@ def estimate_sigma(im, multichannel, average_sigmas=True):
         if average_sigmas:
             sigmas = np.mean(sigmas)
         return sigmas
-
+    elif im.shape[-1] <= 4:
+        warnings.warn(
+            "image is size {} on the last axis, but ".format(im.shape[-1]) +
+            "multichannel is False.  If this is a color image, please set "
+            "multchannel to True for proper noise estimation.")
     coeffs = pywt.dwtn(im, wavelet='db2')
     detail_coeffs = coeffs['d' * im.ndim]
     return _sigma_est_dwt(detail_coeffs, distribution='Gaussian')

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import scipy.stats
 import numpy as np
 from math import ceil
 from .. import img_as_float
@@ -496,14 +497,14 @@ def _sigma_est_dwt(detail_coeffs, distribution='Gaussian'):
     ----------
     .. [1] D. L. Donoho and I. M. Johnstone. "Ideal spatial adaptation
        by wavelet shrinkage." Biometrika 81.3 (1994): 425-455.
+       DOI:10.1093/biomet/81.3.425
     """
     # consider regions with detail coefficients exactly zero to be masked out
     detail_coeffs = detail_coeffs[np.nonzero(detail_coeffs)]
 
     if distribution.lower() == 'gaussian':
         # 75th quantile of the underlying, symmetric noise distribution:
-        # denom = scipy.stats.norm.ppf(0.75)
-        denom = 0.67448975019608171
+        denom = scipy.stats.norm.ppf(0.75)
         sigma = np.median(np.abs(detail_coeffs)) / denom
     else:
         raise ValueError("Only Gaussian noise estimation is currently "
@@ -513,7 +514,7 @@ def _sigma_est_dwt(detail_coeffs, distribution='Gaussian'):
 
 def estimate_sigma(im, multichannel, average_sigmas=True):
     """
-    Robust wavelet-based estimator of the noise standard deviation.
+    Robust wavelet-based estimator of the (Gaussian) noise standard deviation.
 
     Parameters
     ----------
@@ -535,13 +536,15 @@ def estimate_sigma(im, multichannel, average_sigmas=True):
 
     Notes
     -----
-    The estimation algorithm is based on the median absolute deviation of the
+    This function assumes the noise follows a Gaussian distribution. The
+    estimation algorithm is based on the median absolute deviation of the
     wavelet detail coefficients as described in section 4.2 of [1]_.
 
     References
     ----------
     .. [1] D. L. Donoho and I. M. Johnstone. "Ideal spatial adaptation
        by wavelet shrinkage." Biometrika 81.3 (1994): 425-455.
+       DOI:10.1093/biomet/81.3.425
 
     Examples
     --------

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -503,6 +503,9 @@ def _sigma_est_dwt(detail_coeffs, distribution='Gaussian'):
     .. [1] D. L. Donoho and I. M. Johnstone. "Ideal spatial adaptation
        by wavelet shrinkage." Biometrika 81.3 (1994): 425-455.
     """
+    # consider regions with detail coefficients exactly zero to be masked out
+    detail_coeffs = detail_coeffs[np.nonzero(detail_coeffs)]
+
     if distribution.lower() == 'gaussian':
         # 75th quantile of the underlying, symmetric noise distribution:
         # denom = scipy.stats.norm.ppf(0.75)

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -7,12 +7,6 @@ from .._shared.utils import skimage_deprecation, warn
 import warnings
 import pywt
 
-try:
-    import pywt
-    pywt_available = True
-except ImportError:
-    pywt_available = False
-
 
 def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
                       bins=10000, mode='constant', cval=0, multichannel=True,
@@ -556,11 +550,8 @@ def estimate_sigma(im, multichannel, average_sigmas=True):
     >>> img = img_as_float(skimage.data.camera())
     >>> sigma = 0.1
     >>> img = img + sigma * np.random.standard_normal(img.shape)
-    >>> sigma_hat = estimate_sigma(img, multichannel=False)  # doctest: +SKIP
+    >>> sigma_hat = estimate_sigma(img, multichannel=False)
     """
-    if not pywt_available:
-        raise ValueError("estimate_sigma requires PyWavelets to be installed.")
-
     if multichannel:
         nchannels = im.shape[-1]
         sigmas = [estimate_sigma(

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.testing import (run_module_suite, assert_raises, assert_equal,
-                           assert_almost_equal, dec)
+                           assert_almost_equal, dec, assert_warns)
 
 from skimage import restoration, data, color, img_as_float, measure
 from skimage._shared._warnings import expected_warnings
@@ -400,6 +400,9 @@ def test_estimate_sigma_color():
                                             average_sigmas=False)
     assert_equal(len(sigma_list), img.shape[-1])
     assert_almost_equal(sigma_list[0], sigma_est, decimal=2)
+
+    # default multichannel=False should raise a warning about last axis size
+    assert_warns(UserWarning, restoration.estimate_sigma, img)
 
 
 if __name__ == "__main__":

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -364,8 +364,26 @@ def test_estimate_sigma_gray():
     # add noise to astronaut
     img += sigma * rstate.standard_normal(img.shape)
 
-    sigma_est = restoration.estimate_sigma(img, multichannel=False)
+    sigma_est = estimate_sigma(img, multichannel=False)
     assert_almost_equal(sigma, sigma_est, decimal=2)
+
+
+@dec.skipif(not restoration._denoise.pywt_available)
+def test_estimate_sigma_masked_image():
+    # Verify computation on an image with a large, noise-free border.
+    # (zero regions will be masked out by _sigma_est_dwt to avoid returning
+    #  sigma = 0)
+    rstate = np.random.RandomState(1234)
+    # uniform image
+    img = np.zeros((128, 128))
+    center_roi = [slice(32, 96), slice(32, 96)]
+    img[center_roi] = 0.8
+    sigma = 0.1
+
+    img[center_roi] = sigma * rstate.standard_normal(img[center_roi].shape)
+
+    sigma_est = estimate_sigma(img, multichannel=False)
+    assert_almost_equal(sigma, sigma_est, decimal=1)
 
 
 @dec.skipif(not restoration._denoise.pywt_available)

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -355,7 +355,6 @@ def test_wavelet_denoising_nd():
         assert psnr_denoised > psnr_noisy
 
 
-@dec.skipif(not restoration._denoise.pywt_available)
 def test_estimate_sigma_gray():
     rstate = np.random.RandomState(1234)
     # astronaut image
@@ -364,11 +363,10 @@ def test_estimate_sigma_gray():
     # add noise to astronaut
     img += sigma * rstate.standard_normal(img.shape)
 
-    sigma_est = estimate_sigma(img, multichannel=False)
+    sigma_est = restoration.estimate_sigma(img, multichannel=False)
     assert_almost_equal(sigma, sigma_est, decimal=2)
 
 
-@dec.skipif(not restoration._denoise.pywt_available)
 def test_estimate_sigma_masked_image():
     # Verify computation on an image with a large, noise-free border.
     # (zero regions will be masked out by _sigma_est_dwt to avoid returning
@@ -382,11 +380,10 @@ def test_estimate_sigma_masked_image():
 
     img[center_roi] = sigma * rstate.standard_normal(img[center_roi].shape)
 
-    sigma_est = estimate_sigma(img, multichannel=False)
+    sigma_est = restoration.estimate_sigma(img, multichannel=False)
     assert_almost_equal(sigma, sigma_est, decimal=1)
 
 
-@dec.skipif(not restoration._denoise.pywt_available)
 def test_estimate_sigma_color():
     rstate = np.random.RandomState(1234)
     # astronaut image


### PR DESCRIPTION
This PR adds a routine for estimating the (Gaussian) noise standard deviation from an image.  This should be of use with the various denoising routines in the usual case when the underlying noise standard deviation is unknown.

The algorithm implemented is based on the median absolute deviation of wavelet detail coefficients, so it requires `PyWavelets` to run.  

For example, this could be used by the method of #1833 to automate the threshold estimation.

A minimal example:
```python
import skimage.data
from skimage import img_as_float
from skimage.restoration import estimate_sigma
img = img_as_float(skimage.data.camera())
sigma = 0.1
img = img + sigma * np.random.standard_normal(img.shape)
sigma_hat = estimate_sigma(img, multichannel=False)
print("True sigma = {}".format(sigma))
print("Estimated sigma = {}".format(sigma_hat))
```
```
True sigma = 0.1
Estimated sigma = 0.09989763880477982
```

