### PR TITLE
replace separate 2D and 3D Chambolle TV denoising functions with a single nD function

### DIFF
--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -276,7 +276,7 @@ def denoise_tv_chambolle(im, weight=0.1, eps=2.e-4, n_iter_max=200,
 
     if multichannel:
         out = np.zeros_like(im)
-        for c in range(im.shape[2]):
+        for c in range(im.shape[-1]):
             out[..., c] = _denoise_tv_chambolle_nd(im[..., c], weight, eps,
                                                    n_iter_max)
     else:

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -116,7 +116,7 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True):
     return _denoise_tv_bregman(image, weight, max_iter, eps, isotropic)
 
 
-def _denoise_tv_chambolle_nd(im, weight=0.2, eps=2.e-4, n_iter_max=200):
+def _denoise_tv_chambolle_nd(im, weight=0.1, eps=2.e-4, n_iter_max=200):
     """Perform total-variation denoising on n-dimensional images.
 
     Parameters
@@ -198,7 +198,7 @@ def _denoise_tv_chambolle_nd(im, weight=0.2, eps=2.e-4, n_iter_max=200):
     return out
 
 
-def denoise_tv_chambolle(im, weight=0.2, eps=2.e-4, n_iter_max=200,
+def denoise_tv_chambolle(im, weight=0.1, eps=2.e-4, n_iter_max=200,
                          multichannel=False):
     """Perform total-variation denoising on n-dimensional images.
 

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -175,7 +175,12 @@ def _denoise_tv_chambolle_nd(im, weight=0.2, eps=2.e-4, n_iter_max=200):
             g[slices_g] = np.diff(out, axis=ax)
             slices_g[ax] = slice(None)
 
-        norm = np.sqrt((g*g).sum(-1, keepdims=True))
+        try:
+            norm = np.sqrt((g*g).sum(-1, keepdims=True))
+        except:
+            # no keepdims argument available prior to numpy 1.7
+            norm = np.sqrt((g*g).sum(-1))[..., np.newaxis]
+
         E += weight * norm.sum()
         norm *= 0.5 / weight
         norm += 1.

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -147,7 +147,7 @@ def _denoise_tv_chambolle_nd(im, weight=0.2, eps=2.e-4, n_iter_max=200):
     """
 
     ndim = im.ndim
-    p = np.zeros(im.shape + (im.ndim, ), dtype=im.dtype)
+    p = np.zeros(im.shape + (im.ndim, ), dtype=im.dtype, order='F')
     g = np.zeros_like(p)
     d = np.zeros_like(im)
     i = 0

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -175,12 +175,7 @@ def _denoise_tv_chambolle_nd(im, weight=0.2, eps=2.e-4, n_iter_max=200):
             g[slices_g] = np.diff(out, axis=ax)
             slices_g[ax] = slice(None)
 
-        try:
-            norm = np.sqrt((g*g).sum(-1, keepdims=True))
-        except:
-            # no keepdims argument available prior to numpy 1.7
-            norm = np.sqrt((g*g).sum(-1))[..., np.newaxis]
-
+        norm = np.sqrt((g*g).sum(-1))[..., np.newaxis]
         E += weight * norm.sum()
         norm *= 0.5 / weight
         norm += 1.

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -116,7 +116,7 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True):
     return _denoise_tv_bregman(image, weight, max_iter, eps, isotropic)
 
 
-def _denoise_tv_chambolle_3d(im, weight=0.2, eps=2.e-4, n_iter_max=200):
+def _denoise_tv_chambolle_nd(im, weight=0.2, eps=2.e-4, n_iter_max=200):
     """Perform total-variation denoising on 3D images.
 
     Parameters
@@ -146,112 +146,41 @@ def _denoise_tv_chambolle_3d(im, weight=0.2, eps=2.e-4, n_iter_max=200):
 
     """
 
-    px = np.zeros_like(im)
-    py = np.zeros_like(im)
-    pz = np.zeros_like(im)
-    gx = np.zeros_like(im)
-    gy = np.zeros_like(im)
-    gz = np.zeros_like(im)
+    ndim = im.ndim
+    p = np.zeros(im.shape + (im.ndim, ), dtype=im.dtype)
+    g = np.zeros_like(p)
     d = np.zeros_like(im)
     i = 0
     while i < n_iter_max:
-        d = - px - py - pz
-        d[1:] += px[:-1]
-        d[:, 1:] += py[:, :-1]
-        d[:, :, 1:] += pz[:, :, :-1]
-
-        out = im + d
+        if i > 0:
+            d = -p.sum(-1)
+            slices_d = [slice(None), ] * ndim
+            slices_p = [slice(None), ] * (ndim + 1)
+            for ax in range(ndim):
+                slices_d[ax] = slice(1, None)
+                slices_p[ax] = slice(0, -1)
+                slices_p[-1] = ax
+                d[slices_d] += p[slices_p]
+                slices_d[ax] = slice(None)
+                slices_p[ax] = slice(None)
+            out = im + d
+        else:
+            out = im
         E = (d ** 2).sum()
 
-        gx[:-1] = np.diff(out, axis=0)
-        gy[:, :-1] = np.diff(out, axis=1)
-        gz[:, :, :-1] = np.diff(out, axis=2)
-        norm = np.sqrt(gx ** 2 + gy ** 2 + gz ** 2)
+        slices_g = [slice(None), ] * (ndim + 1)
+        for ax in range(ndim):
+            slices_g[ax] = slice(0, -1)
+            slices_g[-1] = ax
+            g[slices_g] = np.diff(out, axis=ax)
+            slices_g[ax] = slice(None)
+
+        norm = np.sqrt((g*g).sum(-1, keepdims=True))
         E += weight * norm.sum()
         norm *= 0.5 / weight
         norm += 1.
-        px -= 1. / 6. * gx
-        px /= norm
-        py -= 1. / 6. * gy
-        py /= norm
-        pz -= 1 / 6. * gz
-        pz /= norm
-        E /= float(im.size)
-        if i == 0:
-            E_init = E
-            E_previous = E
-        else:
-            if np.abs(E_previous - E) < eps * E_init:
-                break
-            else:
-                E_previous = E
-        i += 1
-    return out
-
-
-def _denoise_tv_chambolle_2d(im, weight=0.2, eps=2.e-4, n_iter_max=200):
-    """Perform total-variation denoising on 2D images.
-
-    Parameters
-    ----------
-    im : ndarray
-        Input data to be denoised.
-    weight : float, optional
-        Denoising weight. The greater `weight`, the more denoising (at
-        the expense of fidelity to `input`)
-    eps : float, optional
-        Relative difference of the value of the cost function that determines
-        the stop criterion. The algorithm stops when:
-
-            (E_(n-1) - E_n) < eps * E_0
-
-    n_iter_max : int, optional
-        Maximal number of iterations used for the optimization.
-
-    Returns
-    -------
-    out : ndarray
-        Denoised array of floats.
-
-    Notes
-    -----
-    The principle of total variation denoising is explained in
-    http://en.wikipedia.org/wiki/Total_variation_denoising.
-
-    This code is an implementation of the algorithm of Rudin, Fatemi and Osher
-    that was proposed by Chambolle in [1]_.
-
-    References
-    ----------
-    .. [1] A. Chambolle, An algorithm for total variation minimization and
-           applications, Journal of Mathematical Imaging and Vision,
-           Springer, 2004, 20, 89-97.
-
-    """
-
-    px = np.zeros_like(im)
-    py = np.zeros_like(im)
-    gx = np.zeros_like(im)
-    gy = np.zeros_like(im)
-    d = np.zeros_like(im)
-    i = 0
-    while i < n_iter_max:
-        d = -px - py
-        d[1:] += px[:-1]
-        d[:, 1:] += py[:, :-1]
-
-        out = im + d
-        E = (d ** 2).sum()
-        gx[:-1] = np.diff(out, axis=0)
-        gy[:, :-1] = np.diff(out, axis=1)
-        norm = np.sqrt(gx ** 2 + gy ** 2)
-        E += weight * norm.sum()
-        norm *= 0.5 / weight
-        norm += 1
-        px -= 0.25 * gx
-        px /= norm
-        py -= 0.25 * gy
-        py /= norm
+        p -= 1. / (2.*ndim) * g
+        p /= norm
         E /= float(im.size)
         if i == 0:
             E_init = E
@@ -271,7 +200,7 @@ def denoise_tv_chambolle(im, weight=0.2, eps=2.e-4, n_iter_max=200,
 
     Parameters
     ----------
-    im : ndarray (2d or 3d) of ints, uints or floats
+    im : ndarray of ints, uints or floats
         Input data to be denoised. `im` can be of any numeric type,
         but it is cast into an ndarray of floats for the computation
         of the denoised image.
@@ -289,7 +218,7 @@ def denoise_tv_chambolle(im, weight=0.2, eps=2.e-4, n_iter_max=200,
     multichannel : bool, optional
         Apply total-variation denoising separately for each channel. This
         option should be true for color images, otherwise the denoising is
-        also applied in the 3rd dimension.
+        also applied in the channels dimension.
 
     Returns
     -------
@@ -341,17 +270,11 @@ def denoise_tv_chambolle(im, weight=0.2, eps=2.e-4, n_iter_max=200,
     if not im_type.kind == 'f':
         im = img_as_float(im)
 
-    if im.ndim == 2:
-        out = _denoise_tv_chambolle_2d(im, weight, eps, n_iter_max)
-    elif im.ndim == 3:
-        if multichannel:
-            out = np.zeros_like(im)
-            for c in range(im.shape[2]):
-                out[..., c] = _denoise_tv_chambolle_2d(im[..., c], weight, eps,
-                                                       n_iter_max)
-        else:
-            out = _denoise_tv_chambolle_3d(im, weight, eps, n_iter_max)
+    if multichannel:
+        out = np.zeros_like(im)
+        for c in range(im.shape[2]):
+            out[..., c] = _denoise_tv_chambolle_nd(im[..., c], weight, eps,
+                                                   n_iter_max)
     else:
-        raise ValueError('only 2-d and 3-d images may be denoised with this '
-                         'function')
+        out = _denoise_tv_chambolle_nd(im, weight, eps, n_iter_max)
     return out

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -178,7 +178,7 @@ def _denoise_tv_chambolle_nd(im, weight=0.1, eps=2.e-4, n_iter_max=200):
             g[slices_g] = np.diff(out, axis=ax)
             slices_g[ax+1] = slice(None)
 
-        norm = np.sqrt((g ** 2).sum(0))[np.newaxis, ...]
+        norm = np.sqrt((g ** 2).sum(axis=0))[np.newaxis, ...]
         E += weight * norm.sum()
         tau = 1. / (2.*ndim)
         norm *= tau / weight

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -39,6 +39,15 @@ def test_denoise_tv_chambolle_multichannel():
                                                 multichannel=True)
     assert_equal(denoised[..., 0], denoised0)
 
+    # tile astronaut subset to generate 3D+channels data
+    astro3 = np.tile(astro[:64, :64, np.newaxis, :], [1, 1, 2, 1])
+    # modify along tiled dimension to give non-zero gradient on 3rd axis
+    astro3[:, :, 0, :] = 2*astro3[:, :, 0, :]
+    denoised0 = restoration.denoise_tv_chambolle(astro3[..., 0], weight=0.1)
+    denoised = restoration.denoise_tv_chambolle(astro3, weight=0.1,
+                                                multichannel=True)
+    assert_equal(denoised[..., 0], denoised0)
+
 
 def test_denoise_tv_chambolle_float_result_range():
     # astronaut image

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -66,9 +66,23 @@ def test_denoise_tv_chambolle_3d():
     assert res.dtype == np.float
     assert res.std() * 255 < mask.std()
 
-    # test wrong number of dimensions
-    assert_raises(ValueError, restoration.denoise_tv_chambolle,
-                  np.random.rand(8, 8, 8, 8))
+
+def test_denoise_tv_chambolle_1d():
+    """Apply the TV denoising algorithm on a 1D sinusoid."""
+    x = 125 + 100*np.sin(np.linspace(0, 8*np.pi, 1000))
+    x += 20 * np.random.rand(x.size)
+    x = np.clip(x, 0, 255)
+    res = restoration.denoise_tv_chambolle(x.astype(np.uint8), weight=0.5)
+    assert res.dtype == np.float
+    assert res.std() * 255 < x.std()
+
+
+def test_denoise_tv_chambolle_4d():
+    """ TV denoising for a 4D input."""
+    im = 255 * np.random.rand(8, 8, 8, 8)
+    res = restoration.denoise_tv_chambolle(im.astype(np.uint8), weight=0.5)
+    assert res.dtype == np.float
+    assert res.std() * 255 < im.std()
 
 
 def test_denoise_tv_bregman_2d():

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -21,7 +21,7 @@ def test_denoise_tv_chambolle_2d():
     # clip noise so that it does not exceed allowed range for float images.
     img = np.clip(img, 0, 1)
     # denoise
-    denoised_astro = restoration.denoise_tv_chambolle(img, weight=0.25)
+    denoised_astro = restoration.denoise_tv_chambolle(img, weight=0.1)
     # which dtype?
     assert denoised_astro.dtype in [np.float, np.float32, np.float64]
     from scipy import ndimage as ndi
@@ -34,8 +34,8 @@ def test_denoise_tv_chambolle_2d():
 
 
 def test_denoise_tv_chambolle_multichannel():
-    denoised0 = restoration.denoise_tv_chambolle(astro[..., 0], weight=0.25)
-    denoised = restoration.denoise_tv_chambolle(astro, weight=0.25,
+    denoised0 = restoration.denoise_tv_chambolle(astro[..., 0], weight=0.1)
+    denoised = restoration.denoise_tv_chambolle(astro, weight=0.1,
                                                 multichannel=True)
     assert_equal(denoised[..., 0], denoised0)
 
@@ -46,7 +46,7 @@ def test_denoise_tv_chambolle_float_result_range():
     int_astro = np.multiply(img, 255).astype(np.uint8)
     assert np.max(int_astro) > 1
     denoised_int_astro = restoration.denoise_tv_chambolle(int_astro,
-                                                          weight=0.25)
+                                                          weight=0.1)
     # test if the value range of output float data is within [0.0:1.0]
     assert denoised_int_astro.dtype == np.float
     assert np.max(denoised_int_astro) <= 1.0
@@ -62,7 +62,7 @@ def test_denoise_tv_chambolle_3d():
     mask += 20 * np.random.rand(*mask.shape)
     mask[mask < 0] = 0
     mask[mask > 255] = 255
-    res = restoration.denoise_tv_chambolle(mask.astype(np.uint8), weight=0.4)
+    res = restoration.denoise_tv_chambolle(mask.astype(np.uint8), weight=0.1)
     assert res.dtype == np.float
     assert res.std() * 255 < mask.std()
 
@@ -72,7 +72,7 @@ def test_denoise_tv_chambolle_1d():
     x = 125 + 100*np.sin(np.linspace(0, 8*np.pi, 1000))
     x += 20 * np.random.rand(x.size)
     x = np.clip(x, 0, 255)
-    res = restoration.denoise_tv_chambolle(x.astype(np.uint8), weight=0.5)
+    res = restoration.denoise_tv_chambolle(x.astype(np.uint8), weight=0.1)
     assert res.dtype == np.float
     assert res.std() * 255 < x.std()
 
@@ -80,7 +80,7 @@ def test_denoise_tv_chambolle_1d():
 def test_denoise_tv_chambolle_4d():
     """ TV denoising for a 4D input."""
     im = 255 * np.random.rand(8, 8, 8, 8)
-    res = restoration.denoise_tv_chambolle(im.astype(np.uint8), weight=0.5)
+    res = restoration.denoise_tv_chambolle(im.astype(np.uint8), weight=0.1)
     assert res.dtype == np.float
     assert res.std() * 255 < im.std()
 


### PR DESCRIPTION
This is a refactor of the existing Chambolle TV denoising algorithm, replacing the separate 2D and 3D implementations with a single nD equivalent.  The output should be identical to the previous implementation for the 2D and 3D cases.

I debated leaving the 2D code in place because it is a bit simpler to read, but ended up removing it because it was redundant.

A 1D example that would not have run previously:

```python
import numpy as np
from skimage import restoration
from matplotlib import pyplot as plt
x = 0.9 * np.ones(400)
x[100:200] = 0
x[300:] = 0
x += 0.1 * np.random.rand(x.size)
x = np.clip(x, 0, 1)
res = restoration.denoise_tv_chambolle(x, weight=0.5)

# plot it
t = np.arange(x.size)
plt.figure(); plt.plot(t, x, 'r', t, res, 'k')
```
![tvexample1d](https://cloud.githubusercontent.com/assets/6528957/11967736/5245c8fa-a8d3-11e5-92c2-643a11825e41.png)

