### PR TITLE
Fix euler

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -125,7 +125,7 @@ class _RegionProperties(object):
     def euler_number(self):
         euler_array = self.filled_image != self.image
         _, num = label(euler_array, neighbors=8, return_num=True,
-                       background=-1)
+                       background=0)
         return -num + 1
 
     def extent(self):

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -340,7 +340,7 @@ def regionprops(label_image, intensity_image=None, cache=True):
     **equivalent_diameter** : float
         The diameter of a circle with the same area as the region.
     **euler_number** : int
-        Euler number of region. Computed as number of objects (= 1)
+        Euler characteristic of region. Computed as number of objects (= 1)
         subtracted by number of holes (8-connectivity).
     **extent** : float
         Ratio of pixels in the region to pixels in the total bounding box.

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -129,12 +129,12 @@ def test_equiv_diameter():
 
 def test_euler_number():
     en = regionprops(SAMPLE)[0].euler_number
-    assert en == 0
+    assert en == 1
 
     SAMPLE_mod = SAMPLE.copy()
     SAMPLE_mod[7, -3] = 0
     en = regionprops(SAMPLE_mod)[0].euler_number
-    assert en == -1
+    assert en == 0
 
 
 def test_extent():


### PR DESCRIPTION
This PR fixes #1503. There was a bug in the computation of the Euler characteristic (``background=-1`` instead of ``background=0``).

Also, Euler number is ``e`` (2.72), what is computed is the Euler characteristic. I changed the docstring accordingly.