### PR TITLE
Use appropriate weights in tv_denoise_chambolle

### DIFF
--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -31,7 +31,7 @@ def denoise_bilateral(image, win_size=5, sigma_range=None, sigma_spatial=1,
         similarity). A larger value results in averaging of pixels with larger
         radiometric differences. Note, that the image will be converted using
         the `img_as_float` function and thus the standard deviation is in
-        respect to the range ``[0, 1]``. If the value is ``None`` the standard 
+        respect to the range ``[0, 1]``. If the value is ``None`` the standard
         deviation of the ``image`` will be used.
     sigma_spatial : float
         Standard deviation for range distance. A larger value results in
@@ -116,7 +116,7 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True):
     return _denoise_tv_bregman(image, weight, max_iter, eps, isotropic)
 
 
-def _denoise_tv_chambolle_3d(im, weight=100, eps=2.e-4, n_iter_max=200):
+def _denoise_tv_chambolle_3d(im, weight=0.2, eps=2.e-4, n_iter_max=200):
     """Perform total-variation denoising on 3D images.
 
     Parameters
@@ -189,7 +189,7 @@ def _denoise_tv_chambolle_3d(im, weight=100, eps=2.e-4, n_iter_max=200):
     return out
 
 
-def _denoise_tv_chambolle_2d(im, weight=50, eps=2.e-4, n_iter_max=200):
+def _denoise_tv_chambolle_2d(im, weight=0.2, eps=2.e-4, n_iter_max=200):
     """Perform total-variation denoising on 2D images.
 
     Parameters
@@ -265,7 +265,7 @@ def _denoise_tv_chambolle_2d(im, weight=50, eps=2.e-4, n_iter_max=200):
     return out
 
 
-def denoise_tv_chambolle(im, weight=50, eps=2.e-4, n_iter_max=200,
+def denoise_tv_chambolle(im, weight=0.2, eps=2.e-4, n_iter_max=200,
                          multichannel=False):
     """Perform total-variation denoising on 2D and 3D images.
 

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -21,7 +21,7 @@ def test_denoise_tv_chambolle_2d():
     # clip noise so that it does not exceed allowed range for float images.
     img = np.clip(img, 0, 1)
     # denoise
-    denoised_astro = restoration.denoise_tv_chambolle(img, weight=60.0)
+    denoised_astro = restoration.denoise_tv_chambolle(img, weight=0.25)
     # which dtype?
     assert denoised_astro.dtype in [np.float, np.float32, np.float64]
     from scipy import ndimage as ndi
@@ -30,12 +30,12 @@ def test_denoise_tv_chambolle_2d():
     # test if the total variation has decreased
     assert grad_denoised.dtype == np.float
     assert (np.sqrt((grad_denoised**2).sum())
-            < np.sqrt((grad**2).sum()) / 2)
+            < np.sqrt((grad**2).sum()))
 
 
 def test_denoise_tv_chambolle_multichannel():
-    denoised0 = restoration.denoise_tv_chambolle(astro[..., 0], weight=60.0)
-    denoised = restoration.denoise_tv_chambolle(astro, weight=60.0,
+    denoised0 = restoration.denoise_tv_chambolle(astro[..., 0], weight=0.25)
+    denoised = restoration.denoise_tv_chambolle(astro, weight=0.25,
                                                 multichannel=True)
     assert_equal(denoised[..., 0], denoised0)
 
@@ -46,7 +46,7 @@ def test_denoise_tv_chambolle_float_result_range():
     int_astro = np.multiply(img, 255).astype(np.uint8)
     assert np.max(int_astro) > 1
     denoised_int_astro = restoration.denoise_tv_chambolle(int_astro,
-                                                          weight=60.0)
+                                                          weight=0.25)
     # test if the value range of output float data is within [0.0:1.0]
     assert denoised_int_astro.dtype == np.float
     assert np.max(denoised_int_astro) <= 1.0
@@ -62,7 +62,7 @@ def test_denoise_tv_chambolle_3d():
     mask += 20 * np.random.rand(*mask.shape)
     mask[mask < 0] = 0
     mask[mask > 255] = 255
-    res = restoration.denoise_tv_chambolle(mask.astype(np.uint8), weight=100)
+    res = restoration.denoise_tv_chambolle(mask.astype(np.uint8), weight=0.4)
     assert res.dtype == np.float
     assert res.std() * 255 < mask.std()
 


### PR DESCRIPTION
As discussed in #1839, this PR just changes the default weights for TV-based denoising to values that are appropriate for images scaled to [0, 1].  It seems the current values are appropriate for images scaled [0, 255], so using the defaults results in extreme levels of blurring.

Here is a quick example using `test_denoise_tv_chambolle_2d`:

the noisy input:
![test1_noisy](https://cloud.githubusercontent.com/assets/6528957/11981523/7488033a-a971-11e5-84d1-11035e7c9d2e.png)

denoised output with the currently set weight of 60:
![test1_dn60](https://cloud.githubusercontent.com/assets/6528957/11981525/7916d962-a971-11e5-84a4-70969bf22f28.png)

denoised output with weight=0.25;
![test1_dn0 25](https://cloud.githubusercontent.com/assets/6528957/11981528/7cfd0222-a971-11e5-8faf-0a09f87d002b.png)
