### PR TITLE
Removed deprecated label function from morphology module in preparation for 0.12 release

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -38,8 +38,6 @@ Version 0.12
 ------------
 * Change `label` to mark background as 0, not -1, which is consistent with
   SciPy's labelling.
-* Remove `skimage.morphology.label` from `skimage.morphology.__init__`--it now
-  lives in `skimage.measure.label`.
 * Remove deprecated `reverse_map` parameter of `skimage.transform.warp`
 * Change deprecated `enforce_connectivity=False` on skimage.segmentation.slic
   and set it to True as default

--- a/skimage/morphology/__init__.py
+++ b/skimage/morphology/__init__.py
@@ -11,8 +11,6 @@ from .greyreconstruct import reconstruction
 from .misc import remove_small_objects, remove_small_holes
 
 from ..measure._label import label
-from .._shared.utils import deprecated as _deprecated
-label = _deprecated('skimage.measure.label')(label)
 
 
 __all__ = ['binary_erosion',


### PR DESCRIPTION
(as mentioned in TODO.txt, which I updated accordingly).