### PR TITLE
Example of see also hyperlinks between gallery examples

### DIFF
--- a/doc/examples/segmentation/plot_otsu.py
+++ b/doc/examples/segmentation/plot_otsu.py
@@ -3,8 +3,6 @@
 Thresholding
 ============
 
-.. _otsu:
-
 Thresholding is used to create a binary image. This example uses Otsu's method
 to calculate the threshold value.
 
@@ -15,7 +13,7 @@ the intra-class variance.
 
 .. [1] http://en.wikipedia.org/wiki/Otsu's_method
 
-See also: :ref:`Adaptive thresholding <threshold_adaptive>`
+.. seealso:: :ref:`example_segmentation_plot_local_otsu.py`
 """
 import matplotlib
 import matplotlib.pyplot as plt

--- a/doc/examples/segmentation/plot_otsu.py
+++ b/doc/examples/segmentation/plot_otsu.py
@@ -3,6 +3,8 @@
 Thresholding
 ============
 
+.. _otsu:
+
 Thresholding is used to create a binary image. This example uses Otsu's method
 to calculate the threshold value.
 
@@ -13,6 +15,7 @@ the intra-class variance.
 
 .. [1] http://en.wikipedia.org/wiki/Otsu's_method
 
+See also: :ref:`Adaptive thresholding <threshold_adaptive>`
 """
 import matplotlib
 import matplotlib.pyplot as plt

--- a/doc/examples/segmentation/plot_threshold_adaptive.py
+++ b/doc/examples/segmentation/plot_threshold_adaptive.py
@@ -1,5 +1,6 @@
 """
 .. _threshold_adaptive:
+
 =====================
 Adaptive Thresholding
 =====================

--- a/doc/examples/segmentation/plot_threshold_adaptive.py
+++ b/doc/examples/segmentation/plot_threshold_adaptive.py
@@ -1,6 +1,4 @@
 """
-.. _threshold_adaptive:
-
 =====================
 Adaptive Thresholding
 =====================

--- a/doc/examples/segmentation/plot_threshold_adaptive.py
+++ b/doc/examples/segmentation/plot_threshold_adaptive.py
@@ -1,7 +1,9 @@
 """
+.. _threshold_adaptive:
 =====================
 Adaptive Thresholding
 =====================
+
 
 Thresholding is the simplest way to segment objects from a background. If that
 background is relatively uniform, then you can use a global threshold value to


### PR DESCRIPTION
It would be a nice addition to have see-also-like links between examples of the gallery. Recently I browsed through the statistics of visits of the gallery, and I found out some pages were often visited together (links between those pages would be convenient for users), whereas pages that I would have expected to be visited together were not, maybe because a method was less known than others: suggestions of other pages to visit could also increase the visibility of some pages. 

This PR is a minimal example of how to create links between pages by putting sphinx codes in comment blocks. It works well for html pages. However, it causes problems for the ipython notebook that is created, with the following error

```
<string>:35: (ERROR/3) Unknown interpreted text role "ref"
```

Therefore, I would welcome comments and suggestions for improvements, especially regarding the generation of the ipython notebook.
