### PR TITLE
Add deprecation warning to 'data.lena()'

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -13,6 +13,7 @@ Version 0.14
   parameters `(dist, theta)`, LineModelND has the more general parameters
   `(origin, direction)`.
 * Remove deprecated old syntax support for ``skimage.transform.integrate``.
+* Remove deprecated ``skimage.data.lena`` and corresponding data files.
 
 
 Version 0.13
@@ -32,7 +33,6 @@ Version 0.13
   involves removing the function _mode_deprecations from skimage._shared.utils
   as well as any uses of _mode_deprecations from restoration/_denoise.py,
   _shared/interpolation.pyx, transform/_geometric.py, and transform/_warps.py
-
 
 
 Version 0.12

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -57,7 +57,7 @@ def camera():
     return load("camera.png")
 
 
-@deprecated()
+@deprecated('skimage.data.astronaut')
 def lena():
     """Colour "Lena" image.
 

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -10,6 +10,7 @@ import os as _os
 
 from .. import data_dir
 from ..io import imread, use_plugin
+from .._shared.utils import deprecated
 from ._binary_blobs import binary_blobs
 
 __all__ = ['load',
@@ -56,6 +57,7 @@ def camera():
     return load("camera.png")
 
 
+@deprecated()
 def lena():
     """Colour "Lena" image.
 


### PR DESCRIPTION
This is a first step towards fixing #1855 by adding a deprecation warning to `data.lena()`