### PR TITLE
Line integral convolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ?? WE KEEP THE WEAPONS WE BUILT TO KILL YOU! ??
 
+
 # scikit-image: Image processing in Python
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/scikit-image/scikit-image?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-!!! BEWARE: THIS GETS NIGGER-HACKED !!!
+!!! BEWARE: THIS REPO GETS NIGGER-HACKED !!!
+
 ?? WE KEEP THE WEAPONS WE BUILT TO KILL YOU! ??
 
 # scikit-image: Image processing in Python

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+!!! BEWARE: THIS GETS NIGGER-HACKED !!!
+
 # scikit-image: Image processing in Python
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/scikit-image/scikit-image?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 !!! BEWARE: THIS GETS NIGGER-HACKED !!!
+?? WE KEEP THE WEAPONS WE BUILT TO KILL YOU! ??
 
 # scikit-image: Image processing in Python
 

--- a/doc/source/plots/lic.py
+++ b/doc/source/plots/lic.py
@@ -1,0 +1,151 @@
+from __future__ import division
+
+# We will visualize a 2-D vortex with different configurations of the
+# ``line_integral_convolution`` algorithm, and we will use the 2-D vortex to
+# add motion blur to a sample image. First the necessary modules and functions
+# need to be imported.
+
+import numpy as np
+from skimage.filters import line_integral_convolution
+from scipy.stats import norm
+import matplotlib.pyplot as plt
+from matplotlib import rcParams
+from skimage.data import camera
+
+if rcParams['savefig.dpi'] == 'figure':
+    dpi = rcParams['figure.dpi']
+else:
+    dpi = rcParams['savefig.dpi']
+
+# The 2-D vortex that we want to visualize is described by the ``velocity``
+# array.
+
+position = np.mgrid[:150, :180].astype(float)
+velocity = np.tensordot((position -
+                         np.array(position.shape[1:])[:, None, None] / 2),
+                        [[0, 1], [-1, 0]], axes=(0, 0))
+# squared length of the velocity
+velocity_ssq = np.sum(np.square(velocity), axis=-1)
+
+# The following lines create three random boolean images. ``image5`` contains
+# an equal amount of black an white pixels. ``image01`` is mostly black and
+# contains only a few white pixels. ``image004`` is darker at pixels with
+# higher velocity, with a minimum brightness defined by the ``0.004``
+# constant and a maximum brightness controlled by the ``0.2`` constant.
+
+np.random.seed(0)
+image5 = (np.random.random(position.shape[1:]) < 0.5)
+np.random.seed(0)
+image01 = (np.random.random(position.shape[1:]) < 0.01)
+np.random.seed(0)
+image004 = (np.maximum(np.sqrt(velocity_ssq / np.max(velocity_ssq)),
+                       0.2) *
+            np.random.random(position.shape[1:])) < 0.004
+
+# A symmetric Gaussian kernel (``gauss_kernel``) and an asymmetric exponential
+# kernel (``exp_kernel``) are created.
+
+gauss_kernel = norm.pdf(np.linspace(-3, 3, 25))
+exp_kernel = np.exp(-np.linspace(0, 3, 25))
+
+# The symmetric kernel in combination with the ``image5`` input
+# image can be used to visualize the flow, ignoring velocity magnitude and
+# direction.
+
+fig = plt.figure(figsize=(np.array(image5.T.shape) / dpi))
+ax = plt.Axes(fig, [0., 0., 1., 1.])
+ax.set_axis_off()
+fig.add_axes(ax)
+ax.imshow(np.clip(line_integral_convolution(image5, velocity,
+                                            gauss_kernel), 0, 1),
+          cmap='Greys_r', interpolation='nearest')
+plt.figtext(0.5, 0.05, 'Standard LIC', fontsize=1000 // dpi,
+            color='w', backgroundcolor='k', ha='center')
+
+# The asymmetric kernel can be used to visualize the flow direction. The
+# ``image01`` array is used instead of the ``image5`` image, and the origin is
+# set to ``None``. Also, ``weighted`` is set to ``'integral'`` to treat the
+# white pixels in the input image as single particles.
+
+fig = plt.figure(figsize=(np.array(image01.T.shape) / dpi))
+ax = plt.Axes(fig, [0., 0., 1., 1.])
+ax.set_axis_off()
+fig.add_axes(ax)
+ax.imshow(np.clip(line_integral_convolution(image01, velocity,
+                                            exp_kernel,
+                                            origin=None,
+                                            weighted='integral'),
+                  0, 1),
+          cmap='Greys_r', interpolation='nearest')
+plt.figtext(0.5, 0.05, 'Direction', fontsize=1000 // dpi,
+            color='w', backgroundcolor='k', ha='center')
+
+# The symmetric kernel in combination with ``step_size='unit_time'`` and
+# ``maximum_velocity=2.`` visualizes the velocity magnitude and ignores the
+# direction. The largest element in the kernel is set to 1 in this case
+# (using ``gauss_kernel / np.max(gauss_kernel)``). To ensure that the resulting
+# image has the same line density everywhere, we adjust the number of white
+# pixels to the velocity by using ``image004``.
+
+fig = plt.figure(figsize=(np.array(image004.T.shape) / dpi))
+ax = plt.Axes(fig, [0., 0., 1., 1.])
+ax.set_axis_off()
+fig.add_axes(ax)
+ax.imshow(np.clip(line_integral_convolution(image004, velocity,
+                                            (gauss_kernel /
+                                             np.max(gauss_kernel)),
+                                            weighted='integral',
+                                            step_size='unit_time',
+                                            maximum_velocity=2.),
+                  0, 1),
+          cmap='Greys_r', interpolation='nearest')
+plt.figtext(0.5, 0.05, 'Magnitude', fontsize=1000 // dpi,
+            color='w', backgroundcolor='k', ha='center')
+
+# Velocity direction and magnitude can be visualized by using the same
+# configuration with the asymmetric kernel.
+
+fig = plt.figure(figsize=(np.array(image004.T.shape) / dpi))
+ax = plt.Axes(fig, [0., 0., 1., 1.])
+ax.set_axis_off()
+fig.add_axes(ax)
+ax.imshow(np.clip(line_integral_convolution(image004, velocity,
+                                            exp_kernel,
+                                            origin=None,
+                                            weighted='integral',
+                                            step_size='unit_time',
+                                            maximum_velocity=2.),
+                  0, 1),
+          cmap='Greys_r', interpolation='nearest')
+plt.figtext(0.5, 0.05, 'Direction and magnitude', fontsize=1000 // dpi,
+            color='w', backgroundcolor='k', ha='center')
+
+# If we replace ``weighted='integral'`` with ``weighted='average'``
+# (the default), we can add motion blur to an image.
+
+imageC = camera()
+try:
+    from scipy.misc import imresize
+    imageC = imresize(imageC, 150 / np.max(imageC.shape))
+    position = np.mgrid[[slice(None, s)
+                         for s in imageC.shape]].astype(float)
+    velocity = np.tensordot((position -
+                             np.array(imageC.shape)[:, None, None] / 2),
+                            [[0, 1], [-1, 0]], axes=(0, 0))
+    fig = plt.figure(figsize=(np.array(imageC.T.shape) / dpi))
+    ax = plt.Axes(fig, [0., 0., 1., 1.])
+    ax.set_axis_off()
+    fig.add_axes(ax)
+    ax.imshow(np.clip(line_integral_convolution(imageC, velocity,
+                                                exp_kernel,
+                                                origin=None,
+                                                step_size='unit_time',
+                                                maximum_velocity=2.),
+                      0, 255),
+              cmap='Greys_r', interpolation='nearest')
+    plt.figtext(0.5, 0.05, 'Motion blur', fontsize=1000 // dpi,
+                color='w', backgroundcolor='k', ha='center')
+except ImportError as e:
+    import sys
+    sys.stderr.write('WARNING: skipping motion blur test: %s\n' % e)
+plt.show()

--- a/skimage/filters/__init__.py
+++ b/skimage/filters/__init__.py
@@ -8,6 +8,7 @@ from .edges import (sobel, sobel_h, sobel_v,
 from ._rank_order import rank_order
 from ._gabor import gabor_kernel, gabor
 from ._frangi import frangi, hessian
+from ._lic import line_integral_convolution
 from .thresholding import (threshold_local,
                            threshold_adaptive, threshold_otsu, threshold_yen,
                            threshold_isodata, threshold_li, threshold_minimum,
@@ -41,6 +42,7 @@ __all__ = ['inverse',
            'try_all_threshold',
            'frangi',
            'hessian',
+           'line_integral_convolution',
            'threshold_adaptive',
            'threshold_otsu',
            'threshold_yen',

--- a/skimage/filters/_lic.py
+++ b/skimage/filters/_lic.py
@@ -1,0 +1,163 @@
+import numpy as np
+
+
+def _astype_nocopy(a, dtype):
+    """
+    Workaround to enable "a.astype(dtype, copy=False) under Python 2.6
+    """
+    if a.dtype != dtype:
+        return a.astype(dtype)
+    else:
+        return a
+
+
+def line_integral_convolution(input, velocity, kernel, origin=0, order=3,
+                              weighted='average', step_size='unit_length',
+                              maximum_velocity=None):
+    """
+    Line integral convolution of an input image with an arbitrary kernel.
+    Lines are defined by a velocity field.
+
+    Parameters
+    ----------
+    input : array_like
+        Random image to be convolved (can be created for instance with
+        ``1. * (np.random.random(shape) > 0.5)``).
+    velocity: array_like
+        One velocity vector for each pixel. Must have shape
+        ``input.shape + (input.ndim,)``.
+        First dimensions are identical to the shape of the random input
+        image, the last dimension defines the coordinate of the velocity.
+    kernel: array_like
+        1-D array with at least on element. Defines the convolution kernel
+        (e.g. a Gaussian kernel constructed with
+        scipy.stats.norm.norm.pdf(np.linspace(-3,3,50))).
+        The flow direction can be visualized by using an asymmetric kernel
+        in combination with an ``origin`` parameter equal to ``None`` or
+        equivalently ``-(len(kernel) // 2)``.
+    origin: int, optional
+        Placement of the filter, by default 0 (which is correct for
+        symmetric kernels). The flow direction can be visualized by using an
+        asymmetric kernel in combination with an ``origin`` parameter equal to
+        ``None`` or equivalently ``-(len(kernel) // 2)``.
+    order: int, optional
+        The order of the spline interpolation used for interpolating the input
+        image and the velocity field, by default 3.
+        See the documentation of
+        ``scipy.ndimage.interpolation.map_coordinates`` for more details.
+    weighted: string, optional
+        Can be either ``'average'`` or ``'integral'``, by default
+        ``'average'``. If set to ``'average'``, the weighted average is
+        computed. If set to ``'integral'``, the weighted integral is computed.
+        See the examples to see which parameter is appropriate each use case.
+    step_size: str, optional
+        Can be either ``'unit_length'`` or ``'unit_time'``, by default
+        ``'unit_length'``. If set to ``'unit_length'``, the integration step is
+        the velocity scaled to unit length. If set to ``'unit_time'``, the step
+        equals the velocity.
+    maximum_velocity: float, optional
+        Is ``None`` by default. If it is not ``None``, the velocity field is
+        mutiplied with a scalar variable s.t. the maximum velocity after
+        multiplication equals ``maximum_velocity``.
+
+    Returns
+    -------
+    line_integral_convolution : ndarray
+        Returned array of same shape as `input`.
+
+    See Also
+    --------
+    scipy.ndimage.filters.convolve1d : Calculate a one-dimensional convolution
+                                       with a kernel.
+    scipy.integrate.ode : Integrate an ordinary differential equation.
+
+    References
+    ----------
+    .. [1] http://dl.acm.org/citation.cfm?id=166151
+
+    Examples
+    --------
+    .. plot:: lic.py
+
+    """
+    from scipy.ndimage.interpolation import map_coordinates
+    input = np.asarray(input)
+    kernel = np.asarray(kernel)
+    velocity = np.asarray(velocity)
+    if (kernel.ndim != 1) or (len(kernel) < 1):
+        raise ValueError('Kernel must be 1-D array of length at least 1')
+    if velocity.shape != (input.shape + (input.ndim,)):
+        raise ValueError('Shape of velocity not compatible with shape of '
+                         'input image')
+    float_type = np.result_type(velocity.dtype, kernel.dtype, input.dtype,
+                                np.float32)
+    if origin is None:
+        center = 0
+    else:
+        center = (len(kernel) // 2) + origin
+    if center < 0:
+        raise ValueError('Origin parameter is too low for the chosen kernel '
+                         'length')
+    if center >= len(kernel):
+        raise ValueError('Origin paremeter is too large for the kernel length')
+    if maximum_velocity is not None:
+        velocity = maximum_velocity * velocity / np.sqrt(np.max(
+            np.sum(np.square(_astype_nocopy(velocity, float_type)), axis=-1)))
+    if weighted not in ('integral', 'average'):
+        raise ValueError("Weighted must be either 'intergral' or 'average'")
+    if step_size not in ('unit_length', 'unit_time'):
+        raise ValueError("Step_size must be either 'unit_length' "
+                         "or 'unit_time'")
+    if weighted == 'average':
+        weight = np.zeros(input.shape, float_type)
+    result = np.zeros(input.shape, float_type)
+    # the kernel is divided into a part left of "center" and a part right of
+    # "center".
+    # The part on the "right" lies in positive flow direction (sign=1),
+    # the part on the "left" lies in negative flow direction (sign=-1)
+    for sign, ids in [(+1, range(center, len(kernel))),
+                      (-1, reversed(range(0, center + 1)))]:
+        # workaround to prevent pyflakes from complaining about undefined
+        # variables
+        v2, m1, v2l2 = None, None, None
+        for i in ids:
+            if i == center:
+                # initialize position and mask
+                pos = np.mgrid[[slice(None, s)
+                                for s in input.shape]].astype(float_type)
+                m = np.ones(input.shape, dtype=bool)
+            else:
+                # advance position using velocity
+                if step_size == 'unit_length':
+                    denominator = v2l2[m1][None, :]
+                elif step_size == 'unit_time':
+                    denominator = 1
+                pos[:, m] += (sign * v2[:, m1] / denominator)
+            # velocity at current position
+            v2 = np.array([map_coordinates(velocity[..., axis], pos[:, m],
+                                           order=order,
+                                           output=float_type)
+                           for axis in range(input.ndim)])
+            # l2-norm of velocity
+            v2l2 = np.sqrt(np.sum(np.square(v2), axis=0))
+            # update mask
+            m1 = (v2l2 > 0)
+            m[m] = m1
+            # update result
+            if (sign == 1) or (i != center):
+                if step_size == 'unit_length':
+                    ki = kernel[i]
+                elif step_size == 'unit_time':
+                    ki = kernel[i] * v2l2[m1]
+                if i == center:
+                    result[m] += ki * input[m]
+                else:
+                    result[m] += ki * map_coordinates(input, pos[:, m],
+                                                      order=order,
+                                                      output=float_type)
+                if weighted == 'average':
+                    weight[m] += ki
+    if weighted == 'average':
+        return result / weight
+    else:
+        return result

--- a/skimage/filters/tests/test_lic.py
+++ b/skimage/filters/tests/test_lic.py
@@ -1,0 +1,97 @@
+import numpy as np
+from numpy.testing import assert_raises, assert_allclose, assert_equal
+from skimage.filters._lic import line_integral_convolution as lic
+from skimage._shared._warnings import expected_warnings
+
+
+def test_lic_1D():
+    image = np.zeros((5,))
+    image[3] = 2
+    ones_ = np.ones_like(image)
+    velocity = 10 * ones_[:, None]
+    kernel = np.array([1, 0.5, 0.1])
+    assert_allclose(lic(image, velocity, kernel, order=1, origin=-1,
+                        weighted='integral'), [0, 0.2, 1, 2, 0])
+    assert_allclose(lic(image, velocity, kernel, order=1, origin=None,
+                        weighted='integral'), [0, 0.2, 1, 2, 0])
+    assert_allclose(lic(ones_, velocity, kernel, order=1, weighted='average'),
+                    ones_)
+
+    assert_allclose(lic(image, velocity, kernel, order=1, weighted='integral'),
+                    [0, 0, 0.2, 1, 2])
+
+    assert_allclose(lic(image.astype(bool), velocity, kernel, order=1,
+                        weighted='integral'), [0, 0, 0.1, 0.5, 1])
+
+    assert_equal(lic(image.astype(bool), velocity, kernel, order=1,
+                     weighted='integral').dtype.type,
+                 np.float64)
+
+    assert_equal(lic(image.astype(bool), velocity.astype(np.float32),
+                     kernel.astype(np.float32),
+                     order=1, weighted='integral').dtype.type,
+                 np.float32)
+
+    assert_equal(lic(image.astype(bool), velocity,
+                     kernel.astype(np.float32),
+                     order=1, weighted='integral').dtype.type,
+                 np.float64)
+
+    assert_allclose(lic(image, velocity, kernel, order=1, origin=None,
+                        weighted='integral', step_size='unit_time',
+                        maximum_velocity=1.), [0, 0.2, 1, 2, 0])
+
+    assert_allclose(lic(image, velocity, kernel, order=1, origin=None,
+                        weighted='integral', step_size='unit_time',
+                        maximum_velocity=0.5), [0, 0, 0.35, 1.25, 0])
+
+
+def test_lic_2D():
+    # was used to generate results for test cases
+    # np.set_printoptions(
+    #     formatter={'float':lambda x:'%.15e' % x},
+    #     threshold=np.nan,
+    #     linewidth=200)
+    image = np.zeros((4, 5))
+    image[1, 3] = 2
+    ones_ = np.ones_like(image)
+    velocity = ones_[:, :, None] * [[[0, 2]]]
+    kernel = [1, 0.5, 0.1]
+    assert_allclose(lic(image, velocity, kernel, order=1, origin=-1,
+                        weighted='integral'),
+                    [[0, 0, 0, 0, 0],
+                     [0, 0.2, 1, 2, 0],
+                     [0, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0]])
+
+    velocity = ones_[:, :, None] * [[[2, 0]]]
+    assert_allclose(lic(image, velocity, kernel, order=1, origin=-1,
+                        weighted='integral'),
+                    [[0, 0, 0, 1, 0],
+                     [0, 0, 0, 2, 0],
+                     [0, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0]])
+
+    velocity = (ones_[:, :, None] * [[[2, 7]]])
+    assert_allclose(lic(image, velocity, kernel, order=1, origin=-1,
+                        weighted='integral'),
+                    [[0, 1.014323035580300e-01, 2.726070909971477e-01,
+                      1.057018450115160e-02, 0],
+                     [0, 8.317727549829940e-02, 7.043072775873462e-01,
+                        2.027905867858025e+00, 0],
+                     [0, 0, 0, 0, 0],
+                     [0, 0, 0, 0, 0]])
+    assert_allclose(lic(image, velocity, kernel, order=3, origin=-1,
+                        weighted='integral'),
+                    [[-4.946647656636081e-03, 1.041909046074850e-01,
+                      1.765005843082361e-01, 6.998764796487109e-04, 0],
+                     [3.736874054193710e-04, 8.431107873364971e-02,
+                        8.935011111472939e-01, 2.003570754474494e+00, 0],
+                     [1.425762748747135e-04, -1.431941717202221e-02,
+                        -1.164110107604186e-01, -4.650116996736128e-04, 0],
+                     [0, 0, 0, 0, 0]])
+
+
+if __name__ == "__main__":
+    from numpy import testing
+    testing.run_module_suite()


### PR DESCRIPTION
This PR implements the [line integral convolution (LIC)](https://en.wikipedia.org/wiki/Line_integral_convolution) algorithm. The implementation works in arbitrary image dimensions and does not require C or Cython code. It is an skimage-version of the PR https://github.com/scipy/scipy/pull/5658.

An example image of an alternative Python implementation of LIC (from another author) is available [in the SciPy Cookbook](http://scipy-cookbook.readthedocs.org/items/LineIntegralConvolution.html).
