### PR TITLE
Fixing greycomatrix swapped angles

### DIFF
--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -54,7 +54,7 @@ def _glcm_loop(cnp.uint8_t[:, ::1] image, double[:] distances,
                         i = image[r, c]
 
                         # compute the location of the offset pixel
-                        row = r + <int>round(sin(angle) * distance)
+                        row = r + <int>round(sin(-angle) * distance)
                         col = c + <int>round(cos(angle) * distance)
 
                         # make sure the offset is within bounds

--- a/skimage/feature/tests/test_texture.py
+++ b/skimage/feature/tests/test_texture.py
@@ -24,19 +24,19 @@ class TestGLCM():
                              [0, 0, 3, 1],
                              [0, 0, 0, 1]], dtype=np.uint32)
         np.testing.assert_array_equal(result[:, :, 0, 0], expected1)
-        expected2 = np.array([[1, 1, 3, 0],
-                             [0, 1, 1, 0],
-                             [0, 0, 0, 2],
+        expected2 = np.array([[2, 0, 0, 0],
+                             [1, 1, 2, 0],
+                             [0, 0, 2, 1],
                              [0, 0, 0, 0]], dtype=np.uint32)
         np.testing.assert_array_equal(result[:, :, 0, 1], expected2)
         expected3 = np.array([[3, 0, 2, 0],
                              [0, 2, 2, 0],
                              [0, 0, 1, 2],
                              [0, 0, 0, 0]], dtype=np.uint32)
-        np.testing.assert_array_equal(result[:, :, 0, 2], expected3)
-        expected4 = np.array([[2, 0, 0, 0],
-                             [1, 1, 2, 0],
-                             [0, 0, 2, 1],
+        np.testing.assert_array_equal(result[:, :, 0, 2], expected3)        
+        expected4 = np.array([[1, 1, 3, 0],
+                             [0, 1, 1, 0],
+                             [0, 0, 0, 2],
                              [0, 0, 0, 0]], dtype=np.uint32)
         np.testing.assert_array_equal(result[:, :, 0, 3], expected4)
 

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -77,9 +77,9 @@ def greycomatrix(image, distances, angles, levels=256, symmetric=False,
            [0, 0, 3, 1],
            [0, 0, 0, 1]], dtype=uint32)
     >>> result[:, :, 0, 1]
-    array([[1, 1, 3, 0],
-           [0, 1, 1, 0],
-           [0, 0, 0, 2],
+    array([[2, 0, 0, 0],
+           [1, 1, 2, 0],
+           [0, 0, 2, 1],
            [0, 0, 0, 0]], dtype=uint32)
     >>> result[:, :, 0, 2]
     array([[3, 0, 2, 0],
@@ -87,9 +87,9 @@ def greycomatrix(image, distances, angles, levels=256, symmetric=False,
            [0, 0, 1, 2],
            [0, 0, 0, 0]], dtype=uint32)
     >>> result[:, :, 0, 3]
-    array([[2, 0, 0, 0],
-           [1, 1, 2, 0],
-           [0, 0, 2, 1],
+    array([[1, 1, 3, 0],
+           [0, 1, 1, 0],
+           [0, 0, 0, 2],
            [0, 0, 0, 0]], dtype=uint32)
 
     """


### PR DESCRIPTION
I've changed just one line in feature/_texture.pyx to fix a bug that makes the angles pi/4 and 3*pi/4 appear swapped in the final matrix.

I've changed the docs in feature/texture.py and the tests in feature/tests/test_texture.py to reflect the change.

The bug can be verified if you compare the docs with the original paper: http://haralick.org/journals/TexturalFeatures.pdf : figure 3 on page 4 of the pdf