### PR TITLE
Fixing greycomatrix swapped angles and adding new texture features

### DIFF
--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -54,7 +54,7 @@ def _glcm_loop(cnp.uint8_t[:, ::1] image, double[:] distances,
                         i = image[r, c]
 
                         # compute the location of the offset pixel
-                        row = r + <int>round(sin(angle) * distance)
+                        row = r + <int>round(sin(-angle) * distance)
                         col = c + <int>round(cos(angle) * distance)
 
                         # make sure the offset is within bounds

--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -4,7 +4,7 @@
 #cython: wraparound=False
 import numpy as np
 cimport numpy as cnp
-from libc.math cimport sin, cos, tan, abs
+from libc.math cimport sin, cos, tan, fabs
 from .._shared.interpolation cimport bilinear_interpolation, round
 from .._shared.transform cimport integrate
 
@@ -58,7 +58,7 @@ def _glcm_loop(cnp.uint8_t[:, ::1] image, double[:] distances,
                         row = r + <int>round(sin(angle) * distance)
                         col = c + <int>round(cos(angle) * distance)
                         
-                        if (abs(abs(tan(angle))-1) < 1e-8): #if pi/4 or 3*pi/4, invert cosines
+                        if (fabs(fabs(tan(angle))-1) < 1e-8): #if pi/4 or 3*pi/4, invert cosines
                             col = c + <int>round(cos(angle+PI) * distance)
 
                         # make sure the offset is within bounds

--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -66,7 +66,7 @@ def _glcm_loop(cnp.uint8_t[:, ::1] image, double[:] distances,
                         row = r + <int>round(sin(angle) * distance)
                         col = c + <int>round(cos(angle) * distance)
                         
-                        if _clockwise == 1:
+                        if _clockwise == 0:
                             row = r + <int>round(sin(-angle) * distance)
 
                         # make sure the offset is within bounds

--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -11,6 +11,7 @@ from .._shared.transform cimport integrate
 
 cdef extern from "numpy/npy_math.h":
     double NAN "NPY_NAN"
+    double PI "NPY_PI"
 
 
 def _glcm_loop(cnp.uint8_t[:, ::1] image, double[:] distances,
@@ -57,8 +58,8 @@ def _glcm_loop(cnp.uint8_t[:, ::1] image, double[:] distances,
                         row = r + <int>round(sin(angle) * distance)
                         col = c + <int>round(cos(angle) * distance)
                         
-                        if (np.isclose(abs(tan(angle)), 1)): #if pi/4 or 3*pi/4, invert cosines
-                            col = c + <int>round(cos(angle+np.pi) * distance)
+                        if (abs(abs(tan(angle))-1) < 1e-8): #if pi/4 or 3*pi/4, invert cosines
+                            col = c + <int>round(cos(angle+PI) * distance)
 
                         # make sure the offset is within bounds
                         if row >= 0 and row < rows and \

--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -4,7 +4,7 @@
 #cython: wraparound=False
 import numpy as np
 cimport numpy as cnp
-from libcpp cimport bool
+from cpython cimport bool
 from libc.math cimport sin, cos
 from .._shared.interpolation cimport bilinear_interpolation, round
 from .._shared.transform cimport integrate
@@ -43,6 +43,12 @@ def _glcm_loop(cnp.uint8_t[:, ::1] image, double[:] distances,
         Py_ssize_t a_idx, d_idx, r, c, rows, cols, row, col
         cnp.uint8_t i, j
         cnp.float64_t angle, distance
+        cnp.uint8_t _clockwise
+        
+    if clockwise:
+        _clockwise = 1
+    else:
+        _clockwise = 0
 
     with nogil:
         rows = image.shape[0]
@@ -60,7 +66,7 @@ def _glcm_loop(cnp.uint8_t[:, ::1] image, double[:] distances,
                         row = r + <int>round(sin(angle) * distance)
                         col = c + <int>round(cos(angle) * distance)
                         
-                        if (not clockwise):
+                        if _clockwise == 1:
                             row = r + <int>round(sin(-angle) * distance)
 
                         # make sure the offset is within bounds

--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -4,7 +4,7 @@
 #cython: wraparound=False
 import numpy as np
 cimport numpy as cnp
-from libc.math cimport sin, cos, abs
+from libc.math cimport sin, cos, tan, abs
 from .._shared.interpolation cimport bilinear_interpolation, round
 from .._shared.transform cimport integrate
 
@@ -54,8 +54,11 @@ def _glcm_loop(cnp.uint8_t[:, ::1] image, double[:] distances,
                         i = image[r, c]
 
                         # compute the location of the offset pixel
-                        row = r + <int>round(sin(-angle) * distance)
+                        row = r + <int>round(sin(angle) * distance)
                         col = c + <int>round(cos(angle) * distance)
+                        
+                        if (np.isclose(abs(tan(angle)), 1)): #if pi/4 or 3*pi/4, invert cosines
+                            col = c + <int>round(cos(angle+np.pi) * distance)
 
                         # make sure the offset is within bounds
                         if row >= 0 and row < rows and \

--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -4,7 +4,7 @@
 #cython: wraparound=False
 import numpy as np
 cimport numpy as cnp
-from cpython cimport bool
+from libcpp cimport bool
 from libc.math cimport sin, cos
 from .._shared.interpolation cimport bilinear_interpolation, round
 from .._shared.transform cimport integrate

--- a/skimage/feature/tests/test_texture.py
+++ b/skimage/feature/tests/test_texture.py
@@ -156,6 +156,56 @@ class TestGLCM():
         for prop in ['contrast', 'dissimilarity', 'homogeneity',
                      'energy', 'correlation', 'ASM']:
             greycoprops(result, prop)
+            
+    def test_variance(self):
+
+        glcm = greycomatrix(self.image, [1], [0], 4, normed=True, symmetric=True)
+    
+        feature = greycoprops(glcm, "variance")
+    
+        np.testing.assert_almost_equal(feature[0,0], 1.03993055)
+        
+    def test_mean(self):
+
+        glcm = greycomatrix(self.image, [1], [0], 4, normed=True, symmetric=True)    
+        feature = greycoprops(glcm, "mean")    
+        np.testing.assert_almost_equal(feature[0,0], 1.29166666)
+        
+    def test_maximum_probability(self):
+
+        glcm = greycomatrix(self.image, [1], [0], 4, normed=True, symmetric=True)    
+        feature = greycoprops(glcm, "maxprob")    
+        np.testing.assert_almost_equal(feature[0,0], 0.25)
+        
+    def test_inverse_difference(self):
+
+        glcm = greycomatrix(self.image, [1], [0], 4, normed=True, symmetric=True)    
+        feature = greycoprops(glcm, "invdiff")    
+        np.testing.assert_almost_equal(feature[0,0], 0.81944444)
+
+    def test_autocorrelation(self):
+
+        glcm = greycomatrix(self.image, [1], [0], 4, normed=True, symmetric=True)    
+        feature = greycoprops(glcm, "autocorr")    
+        np.testing.assert_almost_equal(feature[0,0], 2.41666666)
+        
+    def test_entropy(self):
+
+        glcm = greycomatrix(self.image, [1], [0], 4, normed=True, symmetric=True)    
+        feature = greycoprops(glcm, "entropy")    
+        np.testing.assert_almost_equal(feature[0,0], 13649637258.817244)
+
+    def test_cluster_shade(self):
+
+        glcm = greycomatrix(self.image, [1], [0], 4, normed=True, symmetric=True)    
+        feature = greycoprops(glcm, "cshade")    
+        np.testing.assert_almost_equal(feature[0,0], 1.62615740)
+        
+    def test_cluster_prominence(self):
+
+        glcm = greycomatrix(self.image, [1], [0], 4, normed=True, symmetric=True)    
+        feature = greycoprops(glcm, "cprominence")    
+        np.testing.assert_almost_equal(feature[0,0], 23.70471643)
 
 
 class TestLBP():

--- a/skimage/feature/tests/test_texture.py
+++ b/skimage/feature/tests/test_texture.py
@@ -24,9 +24,9 @@ class TestGLCM():
                              [0, 0, 3, 1],
                              [0, 0, 0, 1]], dtype=np.uint32)
         np.testing.assert_array_equal(result[:, :, 0, 0], expected1)
-        expected2 = np.array([[2, 0, 0, 0],
-                             [1, 1, 2, 0],
-                             [0, 0, 2, 1],
+        expected2 = np.array([[1, 1, 3, 0],
+                             [0, 1, 1, 0],
+                             [0, 0, 0, 2],
                              [0, 0, 0, 0]], dtype=np.uint32)
         np.testing.assert_array_equal(result[:, :, 0, 1], expected2)
         expected3 = np.array([[3, 0, 2, 0],
@@ -34,10 +34,35 @@ class TestGLCM():
                              [0, 0, 1, 2],
                              [0, 0, 0, 0]], dtype=np.uint32)
         np.testing.assert_array_equal(result[:, :, 0, 2], expected3)        
-        expected4 = np.array([[1, 1, 3, 0],
-                             [0, 1, 1, 0],
-                             [0, 0, 0, 2],
-                             [0, 0, 0, 0]], dtype=np.uint32)
+        expected4 = np.array([[2, 0, 0, 0],
+                             [2, 2, 0, 0],
+                             [1, 0, 3, 0],
+                             [0, 0, 1, 1]], dtype=np.uint32)
+        np.testing.assert_array_equal(result[:, :, 0, 3], expected4)
+
+    @test_parallel()
+    def test_output_angles_anti_clockwise(self):
+        result = greycomatrix(self.image, [1], [0, np.pi / 4, np.pi / 2, 3 * np.pi / 4], 4, clockwise=False)
+        assert result.shape == (4, 4, 1, 4)
+        expected1 = np.array([[2, 2, 1, 0],
+                             [0, 2, 0, 0],
+                             [0, 0, 3, 1],
+                             [0, 0, 0, 1]], dtype=np.uint32)
+        np.testing.assert_array_equal(result[:, :, 0, 0], expected1)
+        expected2 = np.array([[2, 1, 0, 0],
+                             [0, 1, 0, 0],
+                             [0, 2, 2, 0],
+                             [0, 0, 1, 0]], dtype=np.uint32)
+        np.testing.assert_array_equal(result[:, :, 0, 1], expected2)
+        expected3 = np.array([[3, 0, 0, 0],
+                             [0, 2, 0, 0],
+                             [2, 2, 1, 0],
+                             [0, 0, 2, 0]], dtype=np.uint32)
+        np.testing.assert_array_equal(result[:, :, 0, 2], expected3)        
+        expected4 = np.array([[1, 0, 0, 0],
+                             [1, 1, 0, 0],
+                             [3, 1, 0, 0],
+                             [0, 0, 2, 0]], dtype=np.uint32)
         np.testing.assert_array_equal(result[:, :, 0, 3], expected4)
 
     def test_output_symmetric_1(self):

--- a/skimage/feature/tests/test_texture.py
+++ b/skimage/feature/tests/test_texture.py
@@ -35,9 +35,9 @@ class TestGLCM():
                              [0, 0, 0, 0]], dtype=np.uint32)
         np.testing.assert_array_equal(result[:, :, 0, 2], expected3)        
         expected4 = np.array([[2, 0, 0, 0],
-                             [2, 2, 0, 0],
-                             [1, 0, 3, 0],
-                             [0, 0, 1, 1]], dtype=np.uint32)
+                             [1, 1, 2, 0],
+                             [0, 0, 2, 1],
+                             [0, 0, 0, 0]], dtype=np.uint32)
         np.testing.assert_array_equal(result[:, :, 0, 3], expected4)
 
     @test_parallel()

--- a/skimage/feature/tests/test_texture.py
+++ b/skimage/feature/tests/test_texture.py
@@ -24,19 +24,19 @@ class TestGLCM():
                              [0, 0, 3, 1],
                              [0, 0, 0, 1]], dtype=np.uint32)
         np.testing.assert_array_equal(result[:, :, 0, 0], expected1)
-        expected2 = np.array([[1, 1, 3, 0],
-                             [0, 1, 1, 0],
-                             [0, 0, 0, 2],
+        expected2 = np.array([[2, 0, 0, 0],
+                             [1, 1, 2, 0],
+                             [0, 0, 2, 1],
                              [0, 0, 0, 0]], dtype=np.uint32)
         np.testing.assert_array_equal(result[:, :, 0, 1], expected2)
         expected3 = np.array([[3, 0, 2, 0],
                              [0, 2, 2, 0],
                              [0, 0, 1, 2],
                              [0, 0, 0, 0]], dtype=np.uint32)
-        np.testing.assert_array_equal(result[:, :, 0, 2], expected3)
-        expected4 = np.array([[2, 0, 0, 0],
-                             [1, 1, 2, 0],
-                             [0, 0, 2, 1],
+        np.testing.assert_array_equal(result[:, :, 0, 2], expected3)        
+        expected4 = np.array([[1, 1, 3, 0],
+                             [0, 1, 1, 0],
+                             [0, 0, 0, 2],
                              [0, 0, 0, 0]], dtype=np.uint32)
         np.testing.assert_array_equal(result[:, :, 0, 3], expected4)
 

--- a/skimage/feature/tests/test_texture.py
+++ b/skimage/feature/tests/test_texture.py
@@ -193,7 +193,7 @@ class TestGLCM():
 
         glcm = greycomatrix(self.image, [1], [0], 4, normed=True, symmetric=True)    
         feature = greycoprops(glcm, "entropy")    
-        np.testing.assert_almost_equal(feature[0,0], 13649637258.817244)
+        np.testing.assert_almost_equal(feature[0,0], 2.09472904)
 
     def test_cluster_shade(self):
 

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -133,15 +133,22 @@ def greycoprops(P, prop='contrast'):
     a compact summary of the matrix. The properties are computed as
     follows:
 
-    - 'contrast': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(i-j)^2`
-    - 'dissimilarity': :math:`\\sum_{i,j=0}^{levels-1}P_{i,j}|i-j|`
-    - 'homogeneity': :math:`\\sum_{i,j=0}^{levels-1}\\frac{P_{i,j}}{1+(i-j)^2}`
     - 'ASM': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}^2`
-    - 'energy': :math:`\\sqrt{ASM}`
+    - 'autocorr' :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(ij)`
+    - 'contrast': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(i-j)^2`
     - 'correlation':
         .. math:: \\sum_{i,j=0}^{levels-1} P_{i,j}\\left[\\frac{(i-\\mu_i) \\
                   (j-\\mu_j)}{\\sqrt{(\\sigma_i^2)(\\sigma_j^2)}}\\right]
-
+    - 'cprominence': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(i+j-\\mu_i-\\mu_j)^4`
+    - 'cshade': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(i+j-\\mu_i-\\mu_j)^3`
+    - 'dissimilarity': :math:`\\sum_{i,j=0}^{levels-1}P_{i,j}|i-j|`
+    - 'energy': :math:`\\sqrt{ASM}`
+    - 'entropy': :math:`\\sum_{i,j=0}^{levels-1}-P_{i,j}*\\log{P_{i,j}}`
+    - 'homogeneity': :math:`\\sum_{i,j=0}^{levels-1}\\frac{P_{i,j}}{1+(i-j)^2}`
+    - 'invdiff': :math:`\\sum_{i,j=0}^{levels-1}\\frac{P_{i,j}}{1+|i-j|}`
+    - 'maxprob': :math:`\\sum_{i,j=0}^{levels-1} \\max{P_{i,j}}`
+    - 'mean': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(i)`
+    - 'variance': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(i-\\mu_i)^2`
 
     Parameters
     ----------
@@ -151,8 +158,8 @@ def greycoprops(P, prop='contrast'):
         `P[i,j,d,theta]` is the number of times that grey-level j
         occurs at a distance d and at an angle theta from
         grey-level i.
-    prop : {'contrast', 'dissimilarity', 'homogeneity', 'energy', \
-            'correlation', 'ASM'}, optional
+    prop : {'ASM', 'autocorr', 'contrast', 'correlation', 'cprominence', 'cshade', 'dissimilarity', 'energy', 'entropy', 'homogeneity', \
+            'invdiff', 'maxprob', 'mean', 'variance'}, optional
         The property of the GLCM to compute. The default is 'contrast'.
 
     Returns
@@ -165,6 +172,22 @@ def greycoprops(P, prop='contrast'):
     ----------
     .. [1] The GLCM Tutorial Home Page,
            http://www.fp.ucalgary.ca/mhallbey/tutorial.htm
+           
+    .. [2] R. M. Haralick, K. Shanmugan, and I. H. Dinstein,
+    "Textural features for image classification,"
+    IEEE Trans. Syst., Man, Cybern., vol. SMC-3, pp. 610–621, May 1973.
+
+    .. [3] R. W. Conners, M. M. Trivedi, and C. A. Harlow,
+    "Segmentation of a high-resolution urban scene using texture operators,"
+    Comput. Vision, Graph., Image Processing, vol. 25, pp. 273–310, 1984.
+
+    .. [4] R. M. Haralick, "Statistical and structural approaches to texture,"
+    Proc. IEEE, vol. 67, pp. 786–804, May 1979.
+
+    .. [5] Soh, L.-K.; Tsatsoulis, C.,
+    "Texture analysis of SAR sea ice imagery using gray level co-occurrence matrices,"
+    in Geoscience and Remote Sensing, IEEE Transactions on , vol.37, no.2, pp.780-795, Mar 1999
+    doi: 10.1109/36.752194
 
     Examples
     --------
@@ -198,7 +221,11 @@ def greycoprops(P, prop='contrast'):
         weights = np.abs(I - J)
     elif prop == 'homogeneity':
         weights = 1. / (1. + (I - J) ** 2)
-    elif prop in ['ASM', 'energy', 'correlation']:
+    elif prop == 'invdiff':
+        weights = 1. / (1. + np.abs(I - J))
+    elif prop == 'autocorr':
+        weights = I * J
+    elif prop in ['ASM', 'energy', 'correlation', 'cshade', 'cprominence', 'mean', 'entropy', 'variance', 'maxprob']:
         pass
     else:
         raise ValueError('%s is an invalid property' % (prop))
@@ -209,6 +236,18 @@ def greycoprops(P, prop='contrast'):
         results = np.sqrt(asm)
     elif prop == 'ASM':
         results = np.apply_over_axes(np.sum, (P ** 2), axes=(0, 1))[0, 0]
+    elif prop == 'entropy':
+        results = np.apply_over_axes(np.sum, -P * np.log(P + np.finfo(np.float).eps), axes=(0, 1))[0, 0]
+    elif prop == 'mean':
+        I = np.array(range(num_level)).reshape((num_level, 1, 1, 1))
+        results = np.apply_over_axes(np.sum, (I * P), axes=(0, 1))[0, 0]
+    elif prop == 'variance':
+        I = np.array(range(num_level)).reshape((num_level, 1, 1, 1))
+        mean_i = np.apply_over_axes(np.sum, (I * P), axes=(0, 1))[0, 0]
+        weights = np.power(I - mean_i, 2)
+        results = np.apply_over_axes(np.sum, (P * weights), axes=(0, 1))[0, 0]
+    elif prop == 'maxprob':
+        results = np.apply_over_axes(np.max, P, axes=(0, 1))[0, 0]
     elif prop == 'correlation':
         results = np.zeros((num_dist, num_angle), dtype=np.float64)
         I = np.array(range(num_level)).reshape((num_level, 1, 1, 1))
@@ -231,7 +270,27 @@ def greycoprops(P, prop='contrast'):
         # handle the standard case
         mask_1 = mask_0 == False
         results[mask_1] = cov[mask_1] / (std_i[mask_1] * std_j[mask_1])
-    elif prop in ['contrast', 'dissimilarity', 'homogeneity']:
+    elif prop == 'cshade':
+        I = np.array(range(num_level)).reshape((num_level, 1, 1, 1))
+        J = np.array(range(num_level)).reshape((1, num_level, 1, 1))
+
+        mean_i = np.apply_over_axes(np.sum, (I * P), axes=(0, 1))[0, 0]
+        mean_j = np.apply_over_axes(np.sum, (J * P), axes=(0, 1))[0, 0]
+
+        weights = np.power(I + J - mean_i - mean_j, 3)
+
+        results = np.apply_over_axes(np.sum, (P * weights), axes=(0, 1))[0, 0]
+    elif prop == 'cprominence':
+        I = np.array(range(num_level)).reshape((num_level, 1, 1, 1))
+        J = np.array(range(num_level)).reshape((1, num_level, 1, 1))
+
+        mean_i = np.apply_over_axes(np.sum, (I * P), axes=(0, 1))[0, 0]
+        mean_j = np.apply_over_axes(np.sum, (J * P), axes=(0, 1))[0, 0]
+
+        weights = np.power(I + J - mean_i - mean_j, 4)
+
+        results = np.apply_over_axes(np.sum, (P * weights), axes=(0, 1))[0, 0]
+    elif prop in ['contrast', 'dissimilarity', 'homogeneity', 'invdiff', 'autocorr']:
         weights = weights.reshape((num_level, num_level, 1, 1))
         results = np.apply_over_axes(np.sum, (P * weights), axes=(0, 1))[0, 0]
 

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -138,19 +138,17 @@ def greycoprops(P, prop='contrast'):
     - 'contrast': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(i-j)^2`
     - 'correlation':
         .. math:: \\sum_{i,j=0}^{levels-1} P_{i,j}\\left[\\frac{(i-\\mu_i) \\
-                  (j-\\mu_j)}{\\sqrt{(\\sigma_i^2)(\\sigma_j^2)}}\\right]
-                  
+                  (j-\\mu_j)}{\\sqrt{(\\sigma_i^2)(\\sigma_j^2)}}\\right]        
     - 'cprominence': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(i+j-\\mu_i-\\mu_j)^4`
     - 'cshade': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(i+j-\\mu_i-\\mu_j)^3`
-    - 'dissimilarity': :math:`\\sum_{i,j=0}^{levels-1}P_{i,j}|i-j|`
+    - 'dissimilarity': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}|i-j|`
     - 'energy': :math:`\\sqrt{ASM}`
-    - 'entropy': :math:`\\sum_{i,j=0}^{levels-1}-P_{i,j}*\\log{P_{i,j}}`
+    - 'entropy': :math:`\\sum_{i,j=0}^{levels-1} -P_{i,j}*\\log{P_{i,j}}`
     - 'homogeneity': :math:`\\sum_{i,j=0}^{levels-1}\\frac{P_{i,j}}{1+(i-j)^2}`
-    - 'invdiff': :math:`\\sum_{i,j=0}^{levels-1}\\frac{P_{i,j}}{1+|i-j|}`
+    - 'invdiff': :math:`\\sum_{i,j=0}^{levels-1} \\frac{P_{i,j}}{1+|i-j|}`
     - 'maxprob': :math:`\\sum_{i,j=0}^{levels-1} \\max{P_{i,j}}`
     - 'mean': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(i)`
     - 'variance': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(i-\\mu_i)^2`
-
 
     Parameters
     ----------
@@ -176,20 +174,19 @@ def greycoprops(P, prop='contrast'):
            http://www.fp.ucalgary.ca/mhallbey/tutorial.htm
            
     .. [2] R. M. Haralick, K. Shanmugan, and I. H. Dinstein,
-    "Textural features for image classification,"
-    IEEE Trans. Syst., Man, Cybern., vol. SMC-3, pp. 610–621, May 1973.
+        "Textural features for image classification,"
+        IEEE Trans. Syst., Man, Cybern., vol. SMC-3, pp. 610–621, May 1973.
 
     .. [3] R. W. Conners, M. M. Trivedi, and C. A. Harlow,
-    "Segmentation of a high-resolution urban scene using texture operators,"
-    Comput. Vision, Graph., Image Processing, vol. 25, pp. 273–310, 1984.
+        "Segmentation of a high-resolution urban scene using texture operators,"
+        Comput. Vision, Graph., Image Processing, vol. 25, pp. 273–310, 1984.
 
     .. [4] R. M. Haralick, "Statistical and structural approaches to texture,"
-    Proc. IEEE, vol. 67, pp. 786–804, May 1979.
+        Proc. IEEE, vol. 67, pp. 786–804, May 1979.
 
     .. [5] Soh, L.-K.; Tsatsoulis, C.,
-    "Texture analysis of SAR sea ice imagery using gray level co-occurrence matrices,"
-    in Geoscience and Remote Sensing, IEEE Transactions on , vol.37, no.2, pp.780-795, Mar 1999
-    doi: 10.1109/36.752194
+        "Texture analysis of SAR sea ice imagery using gray level co-occurrence matrices,"
+        in Geoscience and Remote Sensing, IEEE Transactions on , vol.37, no.2, pp.780-795, Mar 1999
 
     Examples
     --------

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -77,9 +77,9 @@ def greycomatrix(image, distances, angles, levels=256, symmetric=False,
            [0, 0, 3, 1],
            [0, 0, 0, 1]], dtype=uint32)
     >>> result[:, :, 0, 1]
-    array([[1, 1, 3, 0],
-           [0, 1, 1, 0],
-           [0, 0, 0, 2],
+    array([[2, 0, 0, 0],
+           [1, 1, 2, 0],
+           [0, 0, 2, 1],
            [0, 0, 0, 0]], dtype=uint32)
     >>> result[:, :, 0, 2]
     array([[3, 0, 2, 0],
@@ -87,9 +87,9 @@ def greycomatrix(image, distances, angles, levels=256, symmetric=False,
            [0, 0, 1, 2],
            [0, 0, 0, 0]], dtype=uint32)
     >>> result[:, :, 0, 3]
-    array([[2, 0, 0, 0],
-           [1, 1, 2, 0],
-           [0, 0, 2, 1],
+    array([[1, 1, 3, 0],
+           [0, 1, 1, 0],
+           [0, 0, 0, 2],
            [0, 0, 0, 0]], dtype=uint32)
 
     """

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -134,11 +134,12 @@ def greycoprops(P, prop='contrast'):
     follows:
 
     - 'ASM': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}^2`
-    - 'autocorr' :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(ij)`
+    - 'autocorr': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(ij)`
     - 'contrast': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(i-j)^2`
     - 'correlation':
         .. math:: \\sum_{i,j=0}^{levels-1} P_{i,j}\\left[\\frac{(i-\\mu_i) \\
                   (j-\\mu_j)}{\\sqrt{(\\sigma_i^2)(\\sigma_j^2)}}\\right]
+                  
     - 'cprominence': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(i+j-\\mu_i-\\mu_j)^4`
     - 'cshade': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(i+j-\\mu_i-\\mu_j)^3`
     - 'dissimilarity': :math:`\\sum_{i,j=0}^{levels-1}P_{i,j}|i-j|`
@@ -149,6 +150,7 @@ def greycoprops(P, prop='contrast'):
     - 'maxprob': :math:`\\sum_{i,j=0}^{levels-1} \\max{P_{i,j}}`
     - 'mean': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(i)`
     - 'variance': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}(i-\\mu_i)^2`
+
 
     Parameters
     ----------

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -12,7 +12,7 @@ from ._texture import (_glcm_loop,
 
 
 def greycomatrix(image, distances, angles, levels=256, symmetric=False,
-                 normed=False):
+                 normed=False, clockwise=True):
     """Calculate the grey-level co-occurrence matrix.
 
     A grey level co-occurrence matrix is a histogram of co-occurring
@@ -42,6 +42,8 @@ def greycomatrix(image, distances, angles, levels=256, symmetric=False,
         by the total number of accumulated co-occurrences for the given
         offset. The elements of the resulting matrix sum to 1. The
         default is False.
+    clockwise : bool, optional
+        Defines if the angles will be considered clockwise or anti-clockwise. Default: True
 
     Returns
     -------
@@ -77,9 +79,9 @@ def greycomatrix(image, distances, angles, levels=256, symmetric=False,
            [0, 0, 3, 1],
            [0, 0, 0, 1]], dtype=uint32)
     >>> result[:, :, 0, 1]
-    array([[2, 0, 0, 0],
-           [1, 1, 2, 0],
-           [0, 0, 2, 1],
+    array([[1, 1, 3, 0],
+           [0, 1, 1, 0],
+           [0, 0, 0, 2],
            [0, 0, 0, 0]], dtype=uint32)
     >>> result[:, :, 0, 2]
     array([[3, 0, 2, 0],
@@ -87,10 +89,10 @@ def greycomatrix(image, distances, angles, levels=256, symmetric=False,
            [0, 0, 1, 2],
            [0, 0, 0, 0]], dtype=uint32)
     >>> result[:, :, 0, 3]
-    array([[1, 1, 3, 0],
-           [0, 1, 1, 0],
-           [0, 0, 0, 2],
-           [0, 0, 0, 0]], dtype=uint32)
+    array([[2, 0, 0, 0],
+           [2, 2, 0, 0],
+           [1, 0, 3, 0],
+           [0, 0, 1, 1]], dtype=uint32)
 
     """
     assert_nD(image, 2)
@@ -109,7 +111,7 @@ def greycomatrix(image, distances, angles, levels=256, symmetric=False,
                  dtype=np.uint32, order='C')
 
     # count co-occurences
-    _glcm_loop(image, distances, angles, levels, P)
+    _glcm_loop(image, distances, angles, levels, P, clockwise)
 
     # make each GLMC symmetric
     if symmetric:

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -90,9 +90,9 @@ def greycomatrix(image, distances, angles, levels=256, symmetric=False,
            [0, 0, 0, 0]], dtype=uint32)
     >>> result[:, :, 0, 3]
     array([[2, 0, 0, 0],
-           [2, 2, 0, 0],
-           [1, 0, 3, 0],
-           [0, 0, 1, 1]], dtype=uint32)
+           [1, 1, 2, 0],
+           [0, 0, 2, 1],
+           [0, 0, 0, 0]], dtype=uint32)
 
     """
     assert_nD(image, 2)


### PR DESCRIPTION
I've changed feature/_texture.pyx to fix a bug that makes the angles pi/4 and 3*pi/4 appear swapped in the final matrix.

I've changed the docs in feature/texture.py and the tests in feature/tests/test_texture.py to reflect the change.

The bug can be verified if you compare the docs with the original paper: http://haralick.org/journals/TexturalFeatures.pdf : figure 3 on page 4 of the pdf

New texture features:

Autocorrelation [5]
Cluster Shade [2]
Cluster Prominence [2]
Entropy [1]
Inverse Difference [3]
Maximum Probability [3]
Mean [4]
Variance [1]

[1] R. M. Haralick, K. Shanmugan, and I. H. Dinstein,
"Textural features for image classification,"
IEEE Trans. Syst., Man, Cybern., vol. SMC-3, pp. 610–621, May 1973.

[2] R. W. Conners, M. M. Trivedi, and C. A. Harlow,
"Segmentation of a high-resolution urban scene using texture operators,"
Comput. Vision, Graph., Image Processing, vol. 25, pp. 273–310, 1984.

[3] R. M. Haralick, "Statistical and structural approaches to texture,"
Proc. IEEE, vol. 67, pp. 786–804, May 1979.

[4] http://www.fp.ucalgary.ca/mhallbey/tutorial.htm

[5] Soh, L.-K.; Tsatsoulis, C.,
"Texture analysis of SAR sea ice imagery using gray level co-occurrence matrices,"
in Geoscience and Remote Sensing, IEEE Transactions on , vol.37, no.2, pp.780-795, Mar 1999
doi: 10.1109/36.752194

The equations can be found in the docs in the .py file.