### PR TITLE
Show warnings for input image type in threshold_otsu

### DIFF
--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -3,6 +3,7 @@ from numpy.testing import assert_equal, assert_almost_equal
 
 import skimage
 from skimage import data
+from skimage._shared._warnings import expected_warnings
 from skimage.filters.thresholding import (threshold_adaptive,
                                           threshold_otsu,
                                           threshold_li,
@@ -158,11 +159,13 @@ def test_otsu_coins_image_as_float():
 
 def test_otsu_lena_image():
     img = skimage.img_as_ubyte(data.lena())
-    assert 140 < threshold_otsu(img) < 142
+    with expected_warnings(['grayscale']):
+        assert 140 < threshold_otsu(img) < 142
 
 def test_otsu_astro_image():
     img = skimage.img_as_ubyte(data.astronaut())
-    assert 109 < threshold_otsu(img) < 111
+    with expected_warnings(['grayscale']):
+        assert 109 < threshold_otsu(img) < 111
 
 def test_li_camera_image():
     camera = skimage.img_as_ubyte(data.camera())

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -122,11 +122,11 @@ def threshold_otsu(image, nbins=256):
 
     Notes
     -----
-    The input image must be Grayscale.
+    The input image must be grayscale.
     """
     if image.shape[-1] in (3, 4):
         msg = "threshold_otsu is expected to work correctly only for " \
-              "grayscale images; image shape {} looks like an RGB image"
+              "grayscale images; image shape {0} looks like an RGB image"
         warnings.warn(msg.format(image.shape))
 
     hist, bin_centers = histogram(image.ravel(), nbins)

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -97,7 +97,7 @@ def threshold_otsu(image, nbins=256):
     Parameters
     ----------
     image : array
-        Input image.
+        Grayscale input image.
     nbins : int, optional
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
@@ -118,6 +118,10 @@ def threshold_otsu(image, nbins=256):
     >>> image = camera()
     >>> thresh = threshold_otsu(image)
     >>> binary = image <= thresh
+
+    Notes
+    -----
+    The input image must be Grayscale.
     """
     hist, bin_centers = histogram(image.ravel(), nbins)
     hist = hist.astype(float)

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -8,6 +8,7 @@ import numpy as np
 from scipy import ndimage as ndi
 from ..exposure import histogram
 from .._shared.utils import assert_nD
+import warnings
 
 
 def threshold_adaptive(image, block_size, method='gaussian', offset=0,
@@ -123,6 +124,11 @@ def threshold_otsu(image, nbins=256):
     -----
     The input image must be Grayscale.
     """
+    if image.shape[-1] in (3, 4):
+        msg = "threshold_otsu is expected to work correctly only for " \
+              "grayscale images; image shape {} looks like an RGB image"
+        warnings.warn(msg.format(image.shape))
+
     hist, bin_centers = histogram(image.ravel(), nbins)
     hist = hist.astype(float)
 


### PR DESCRIPTION
Address #1867 

The `threshold_otsu` function only supports grayscale image as input and results in unexpected behavior when used with an RGB image.
This PR tries to improve the documentation of the function and raise a temporary warning for the usage with an RGB image.

Question : Should we convert the image into grayscale as @JDWarner suggested by using `rgb2gray` and return the result for it? Or should we let the user use the faulty output? If we go with `rgb2gray` solution, we can probably add a line about it in the warning.