### PR TITLE
Fix circular mask example in the user_guide

### DIFF
--- a/doc/source/user_guide/numpy_images.txt
+++ b/doc/source/user_guide/numpy_images.txt
@@ -77,7 +77,7 @@ disk: ::
     >>> nrows, ncols = camera.shape
     >>> row, col = np.ogrid[:nrows, :ncols]
     >>> cnt_row, cnt_col = nrows / 2, ncols / 2
-    >>> outer_disk_mask = ((row - cnt_row)**2 + (col - cnt_col)**2 <
+    >>> outer_disk_mask = ((row - cnt_row)**2 + (col - cnt_col)**2 >
     ...                    (nrows / 2)**2)
     >>> camera[outer_disk_mask] = 0
 


### PR DESCRIPTION
With the current example, inner side of the circular region gets masked which does not match with the image shown in the user guide. The problem is in the comparison operator used while masking.

| **Image being generated right now** |  **Image, after the change** |
|---|---|---|---|---|
| <img src="https://cloud.githubusercontent.com/assets/8065913/12370670/a15ee212-bc3f-11e5-8622-b17408fecd97.png" width="250"><img>  | <img src="https://cloud.githubusercontent.com/assets/8065913/12370669/a15673e8-bc3f-11e5-8ea3-f7c8d16ba670.png" width="250"> |






