### PR TITLE
add simple metrics (PSNR, NRMSE)

### DIFF
--- a/skimage/measure/__init__.py
+++ b/skimage/measure/__init__.py
@@ -2,7 +2,7 @@ from ._find_contours import find_contours
 from ._marching_cubes import (marching_cubes, mesh_surface_area,
                               correct_mesh_orientation)
 from ._regionprops import regionprops, perimeter
-from ._simple_metrics import mse, nrmse, psnr
+from .simple_metrics import mse, nrmse, psnr
 from ._structural_similarity import structural_similarity
 from ._polygon import approximate_polygon, subdivide_polygon
 from ._pnpoly import points_in_poly, grid_points_in_poly

--- a/skimage/measure/__init__.py
+++ b/skimage/measure/__init__.py
@@ -2,6 +2,7 @@ from ._find_contours import find_contours
 from ._marching_cubes import (marching_cubes, mesh_surface_area,
                               correct_mesh_orientation)
 from ._regionprops import regionprops, perimeter
+from ._simple_metrics import mse, nrmse, psnr
 from ._structural_similarity import structural_similarity
 from ._polygon import approximate_polygon, subdivide_polygon
 from ._pnpoly import points_in_poly, grid_points_in_poly
@@ -34,4 +35,7 @@ __all__ = ['find_contours',
            'profile_line',
            'label',
            'points_in_poly',
-           'grid_points_in_poly']
+           'grid_points_in_poly',
+           'mse',
+           'nrmse',
+           'psnr']

--- a/skimage/measure/__init__.py
+++ b/skimage/measure/__init__.py
@@ -2,7 +2,7 @@ from ._find_contours import find_contours
 from ._marching_cubes import (marching_cubes, mesh_surface_area,
                               correct_mesh_orientation)
 from ._regionprops import regionprops, perimeter
-from .simple_metrics import mse, nrmse, psnr
+from .simple_metrics import mean_squared_error, normalized_root_mse, psnr
 from ._structural_similarity import structural_similarity
 from ._polygon import approximate_polygon, subdivide_polygon
 from ._pnpoly import points_in_poly, grid_points_in_poly
@@ -36,6 +36,6 @@ __all__ = ['find_contours',
            'label',
            'points_in_poly',
            'grid_points_in_poly',
-           'mse',
-           'nrmse',
+           'mean_squared_error',
+           'normalized_root_mse',
            'psnr']

--- a/skimage/measure/_simple_metrics.py
+++ b/skimage/measure/_simple_metrics.py
@@ -113,5 +113,4 @@ def psnr(im_true, im, dynamic_range=None):
     im = im.astype(np.float64)
 
     err = mse(im_true, im)
-    psnr = 10 * np.log10((dynamic_range ** 2) / err)
-    return psnr
+    return 10 * np.log10((dynamic_range ** 2) / err)

--- a/skimage/measure/_simple_metrics.py
+++ b/skimage/measure/_simple_metrics.py
@@ -1,0 +1,117 @@
+from __future__ import division
+
+import numpy as np
+from ..util.dtype import dtype_range
+
+__all__ = ['mse', 'nrmse', 'psnr']
+
+
+def mse(X, Y):
+    """ compute mean-squared error between two images.
+
+    Parameters
+    ----------
+    X, Y : ndarray
+        Image.  Any dimensionality.
+
+    Returns
+    -------
+    mse : float
+        The MSE metric.
+
+    """
+    if not X.shape == Y.shape:
+        raise ValueError('Input images must have the same dimensions.')
+    if not X.dtype == Y.dtype:
+        raise ValueError('Input images must have the same dtype.')
+    return np.square(X - Y).mean()
+
+
+def nrmse(im_true, im, norm_type='Euclidean'):
+    """ compute the normalized root mean-squared error between two images.
+
+    Parameters
+    ----------
+    im_true : ndarray
+        Ground-truth image.
+    im : ndarray
+        Test image.
+    norm_type : {'Euclidean', 'min-max', 'mean'}
+        Controls the normalization method to use in the denominator of the
+        NRMSE.
+
+    Returns
+    -------
+    nrmse : float
+        The NRMSE metric.
+
+    Notes
+    -----
+    There is no standard method of normalization across the literature [1]_.
+    The methods available here are as follows:
+
+    - 'Euclidean' : normalize by the Euclidean norm of ``im_true``.
+    - 'min-max'   : normalize by the intensity range of ``im_true``.
+    - 'mean'      : normalize by the mean of ``im_true``.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Root-mean-square_deviation
+
+    """
+    if not im_true.dtype == im.dtype:
+        raise ValueError('Input images must have the same dtype.')
+
+    if not im_true.shape == im.shape:
+        raise ValueError('Input images must have the same dimensions.')
+
+    norm_type = norm_type.lower()
+    if norm_type == 'euclidean':
+        denom = np.sqrt((im_true*im_true).mean())
+    elif norm_type == 'min-max':
+        denom = im_true.max() - im_true.min()
+    elif norm_type == 'mean':
+        denom = im_true.mean()
+    return np.sqrt(mse(im_true, im)) / denom
+
+
+def psnr(im_true, im, dynamic_range=None):
+    """ Compute the peak signal to noise ratio (PSNR) for an image.
+
+    Parameters
+    ----------
+    im_true : ndarray
+        Ground-truth image.
+    im : ndarray
+        Test image.
+    dynamic_range : int
+        The dynamic range of the input image (distance between minimum and
+        maximum possible values).  By default, this is estimated from the image
+        data-type.
+
+    Returns
+    -------
+    psnr : float
+        The PSNR metric.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio
+
+    """
+    if not im_true.dtype == im.dtype:
+        raise ValueError('Input images must have the same dtype.')
+
+    if not im_true.shape == im.shape:
+        raise ValueError('Input images must have the same dimensions.')
+
+    if dynamic_range is None:
+        dmin, dmax = dtype_range[im_true.dtype.type]
+        dynamic_range = dmax - dmin
+
+    im_true = im_true.astype(np.float64)
+    im = im.astype(np.float64)
+
+    err = mse(im_true, im)
+    psnr = 10 * np.log10((dynamic_range ** 2) / err)
+    return psnr

--- a/skimage/measure/simple_metrics.py
+++ b/skimage/measure/simple_metrics.py
@@ -16,11 +16,12 @@ def _assert_compatible(im1, im2):
 
 
 def _as_floats(im1, im2):
-    """Promote im1, im2 to floating point precision."""
-    if im1.dtype != np.float64:
-        im1 = im1.astype(np.float64)
-    if im2.dtype != np.float64:
-        im2 = im2.astype(np.float64)
+    """Promote im1, im2 to nearest appropriate floating point precision."""
+    float_type = np.result_type(im1.dtype, im2.dtype, np.float32)
+    if im1.dtype != float_type:
+        im1 = im1.astype(float_type)
+    if im2.dtype != float_type:
+        im2 = im2.astype(float_type)
     return im1, im2
 
 
@@ -40,7 +41,7 @@ def mean_squared_error(im1, im2):
     """
     _assert_compatible(im1, im2)
     im1, im2 = _as_floats(im1, im2)
-    return np.mean(np.square(im1 - im2))
+    return np.mean(np.square(im1 - im2), dtype=np.float64)
 
 
 def normalized_root_mse(im_true, im_test, norm_type='Euclidean'):
@@ -77,7 +78,7 @@ def normalized_root_mse(im_true, im_test, norm_type='Euclidean'):
 
     norm_type = norm_type.lower()
     if norm_type == 'euclidean':
-        denom = np.sqrt(np.mean((im_true*im_true)))
+        denom = np.sqrt(np.mean((im_true*im_true), dtype=np.float64))
     elif norm_type == 'min-max':
         denom = im_true.max() - im_true.min()
     elif norm_type == 'mean':

--- a/skimage/measure/simple_metrics.py
+++ b/skimage/measure/simple_metrics.py
@@ -16,12 +16,11 @@ def _assert_compatible(X, Y):
 
 
 def _as_floats(X, Y):
-    """Promote X, Y to nearest appropriate floating point precision."""
-    float_type = np.result_type(X.dtype, Y.dtype, np.float32)
-    if X.dtype != float_type:
-        X = X.astype(float_type)
-    if Y.dtype != float_type:
-        Y = Y.astype(float_type)
+    """Promote X, Y to floating point precision."""
+    if X.dtype != np.float64:
+        X = X.astype(np.float64)
+    if Y.dtype != np.float64:
+        Y = Y.astype(np.float64)
     return X, Y
 
 

--- a/skimage/measure/simple_metrics.py
+++ b/skimage/measure/simple_metrics.py
@@ -119,7 +119,15 @@ def psnr(im_true, im_test, dynamic_range=None):
 
     if dynamic_range is None:
         dmin, dmax = dtype_range[im_true.dtype.type]
-        dynamic_range = dmax - dmin
+        dynamic_range = dmax  # assume non-negative inputs
+        if im_true.min() < 0:
+            raise ValueError(
+                "im_true contains negative values.  Please manually specify "
+                "the dynamic range.")
+        if im_true.max() > dmax:
+            raise ValueError(
+                "im_true has a larger maximum intensity than expected for its "
+                "data type.  Please manually specify the dynamic_range")
 
     im_true, im_test = _as_floats(im_true, im_test)
 

--- a/skimage/measure/simple_metrics.py
+++ b/skimage/measure/simple_metrics.py
@@ -7,7 +7,7 @@ __all__ = ['mse', 'nrmse', 'psnr']
 
 
 def mse(X, Y):
-    """ compute mean-squared error between two images.
+    """Compute the mean-squared error between two images.
 
     Parameters
     ----------
@@ -27,42 +27,38 @@ def mse(X, Y):
     return np.square(X - Y).mean()
 
 
-def nrmse(im_true, im, norm_type='Euclidean'):
-    """ compute the normalized root mean-squared error between two images.
+def nrmse(im_true, im_test, norm_type='Euclidean'):
+    """Compute the normalized root mean-squared error between two images.
 
     Parameters
     ----------
     im_true : ndarray
         Ground-truth image.
-    im : ndarray
+    im_test : ndarray
         Test image.
     norm_type : {'Euclidean', 'min-max', 'mean'}
         Controls the normalization method to use in the denominator of the
-        NRMSE.
+        NRMSE.  There is no standard method of normalization across the
+        literature [1]_.  The methods available here are as follows:
+
+        - 'Euclidean' : normalize by the Euclidean norm of ``im_true``.
+        - 'min-max'   : normalize by the intensity range of ``im_true``.
+        - 'mean'      : normalize by the mean of ``im_true``.
 
     Returns
     -------
     nrmse : float
         The NRMSE metric.
 
-    Notes
-    -----
-    There is no standard method of normalization across the literature [1]_.
-    The methods available here are as follows:
-
-    - 'Euclidean' : normalize by the Euclidean norm of ``im_true``.
-    - 'min-max'   : normalize by the intensity range of ``im_true``.
-    - 'mean'      : normalize by the mean of ``im_true``.
-
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Root-mean-square_deviation
 
     """
-    if not im_true.dtype == im.dtype:
+    if not im_true.dtype == im_test.dtype:
         raise ValueError('Input images must have the same dtype.')
 
-    if not im_true.shape == im.shape:
+    if not im_true.shape == im_test.shape:
         raise ValueError('Input images must have the same dimensions.')
 
     norm_type = norm_type.lower()
@@ -72,17 +68,19 @@ def nrmse(im_true, im, norm_type='Euclidean'):
         denom = im_true.max() - im_true.min()
     elif norm_type == 'mean':
         denom = im_true.mean()
-    return np.sqrt(mse(im_true, im)) / denom
+    else:
+        raise ValueError("Unsupported norm_type")
+    return np.sqrt(mse(im_true, im_test)) / denom
 
 
-def psnr(im_true, im, dynamic_range=None):
+def psnr(im_true, im_test, dynamic_range=None):
     """ Compute the peak signal to noise ratio (PSNR) for an image.
 
     Parameters
     ----------
     im_true : ndarray
         Ground-truth image.
-    im : ndarray
+    im_test : ndarray
         Test image.
     dynamic_range : int
         The dynamic range of the input image (distance between minimum and
@@ -99,10 +97,10 @@ def psnr(im_true, im, dynamic_range=None):
     .. [1] https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio
 
     """
-    if not im_true.dtype == im.dtype:
+    if not im_true.dtype == im_test.dtype:
         raise ValueError('Input images must have the same dtype.')
 
-    if not im_true.shape == im.shape:
+    if not im_true.shape == im_test.shape:
         raise ValueError('Input images must have the same dimensions.')
 
     if dynamic_range is None:
@@ -110,7 +108,7 @@ def psnr(im_true, im, dynamic_range=None):
         dynamic_range = dmax - dmin
 
     im_true = im_true.astype(np.float64)
-    im = im.astype(np.float64)
+    im_test = im_test.astype(np.float64)
 
-    err = mse(im_true, im)
+    err = mse(im_true, im_test)
     return 10 * np.log10((dynamic_range ** 2) / err)

--- a/skimage/measure/simple_metrics.py
+++ b/skimage/measure/simple_metrics.py
@@ -6,6 +6,16 @@ from ..util.dtype import dtype_range
 __all__ = ['mse', 'nrmse', 'psnr']
 
 
+def _as_floats(X, Y):
+    """Promote X, Y to nearest appropriate floating point precision."""
+    float_type = np.result_type(X.dtype, Y.dtype, np.float32)
+    if X.dtype != float_type:
+        X = X.astype(float_type)
+    if Y.dtype != float_type:
+        Y = Y.astype(float_type)
+    return X, Y
+
+
 def mse(X, Y):
     """Compute the mean-squared error between two images.
 
@@ -20,6 +30,8 @@ def mse(X, Y):
         The MSE metric.
 
     """
+    X, Y = _as_floats(X, Y)
+
     if not X.shape == Y.shape:
         raise ValueError('Input images must have the same dimensions.')
     if not X.dtype == Y.dtype:
@@ -60,6 +72,8 @@ def nrmse(im_true, im_test, norm_type='Euclidean'):
 
     if not im_true.shape == im_test.shape:
         raise ValueError('Input images must have the same dimensions.')
+
+    im_true, im_test = _as_floats(im_true, im_test)
 
     norm_type = norm_type.lower()
     if norm_type == 'euclidean':
@@ -107,8 +121,7 @@ def psnr(im_true, im_test, dynamic_range=None):
         dmin, dmax = dtype_range[im_true.dtype.type]
         dynamic_range = dmax - dmin
 
-    im_true = im_true.astype(np.float64)
-    im_test = im_test.astype(np.float64)
+    im_true, im_test = _as_floats(im_true, im_test)
 
     err = mse(im_true, im_test)
     return 10 * np.log10((dynamic_range ** 2) / err)

--- a/skimage/measure/tests/test_simple_metrics.py
+++ b/skimage/measure/tests/test_simple_metrics.py
@@ -1,5 +1,6 @@
 import numpy as np
-from numpy.testing import assert_equal, assert_raises, assert_almost_equal
+from numpy.testing import (run_module_suite, assert_equal, assert_raises,
+                           assert_almost_equal)
 
 from skimage.measure import psnr, nrmse
 import skimage.data
@@ -41,3 +42,7 @@ def test_NRMSE():
 
     assert_raises(ValueError, nrmse, x.astype(np.uint8), y)
     assert_raises(ValueError, nrmse, x[:-1], y)
+
+
+if __name__ == "__main__":
+    run_module_suite()

--- a/skimage/measure/tests/test_simple_metrics.py
+++ b/skimage/measure/tests/test_simple_metrics.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.testing import (run_module_suite, assert_equal, assert_raises,
                            assert_almost_equal)
 
-from skimage.measure import psnr, nrmse
+from skimage.measure import psnr, nrmse, mse
 import skimage.data
 
 np.random.seed(5)
@@ -23,7 +23,7 @@ def test_PSNR_vs_IPOL():
 def test_PSNR_float():
     p_uint8 = psnr(cam, cam_noisy)
     p_float64 = psnr(cam/255., cam_noisy/255., dynamic_range=1)
-    assert_almost_equal(p_uint8, p_float64)
+    assert_almost_equal(p_uint8, p_float64, decimal=5)
 
 
 def test_PSNR_errors():
@@ -38,7 +38,14 @@ def test_NRMSE():
     assert_equal(nrmse(y, x, 'Euclidean'), 1/np.sqrt(3))
     assert_equal(nrmse(y, x, 'min-max'), 1/(y.max()-y.min()))
 
-    assert_equal(nrmse(x, x), 0)
+
+def test_NRMSE_no_int_overflow():
+    camf = cam.astype(np.float32)
+    cam_noisyf = cam_noisy.astype(np.float32)
+    assert_almost_equal(mse(cam, cam_noisy),
+                        mse(camf, cam_noisyf))
+    assert_almost_equal(nrmse(cam, cam_noisy),
+                        nrmse(camf, cam_noisyf))
 
 
 def test_NRMSE_errors():

--- a/skimage/measure/tests/test_simple_metrics.py
+++ b/skimage/measure/tests/test_simple_metrics.py
@@ -40,8 +40,13 @@ def test_NRMSE():
 
     assert_equal(nrmse(x, x), 0)
 
-    assert_raises(ValueError, nrmse, x.astype(np.uint8), y)
-    assert_raises(ValueError, nrmse, x[:-1], y)
+
+def test_NRMSE_errors():
+    x = np.ones(4)
+    assert_raises(ValueError, nrmse, x.astype(np.uint8), x.astype(np.float32))
+    assert_raises(ValueError, nrmse, x[:-1], x)
+    # invalid normalization name
+    assert_raises(ValueError, nrmse, x, x, 'foo')
 
 
 if __name__ == "__main__":

--- a/skimage/measure/tests/test_simple_metrics.py
+++ b/skimage/measure/tests/test_simple_metrics.py
@@ -34,8 +34,8 @@ def test_NRMSE():
     x = np.ones(4)
     y = np.asarray([0., 2., 2., 2.])
     assert_equal(nrmse(y, x, 'mean'), 1/np.mean(y))
-    assert_equal(nrmse(y, x, 'Euclidean'), 0.5)
-    assert_equal(nrmse(y, x, 'min-max'), 0.5)
+    assert_equal(nrmse(y, x, 'Euclidean'), 1/np.sqrt(3))
+    assert_equal(nrmse(y, x, 'min-max'), 1/(y.max()-y.min()))
 
     assert_equal(nrmse(x, x), 0)
 

--- a/skimage/measure/tests/test_simple_metrics.py
+++ b/skimage/measure/tests/test_simple_metrics.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.testing import (run_module_suite, assert_equal, assert_raises,
                            assert_almost_equal)
 
-from skimage.measure import psnr, nrmse, mse
+from skimage.measure import psnr, normalized_root_mse, mean_squared_error
 import skimage.data
 
 np.random.seed(5)
@@ -34,26 +34,27 @@ def test_PSNR_errors():
 def test_NRMSE():
     x = np.ones(4)
     y = np.asarray([0., 2., 2., 2.])
-    assert_equal(nrmse(y, x, 'mean'), 1/np.mean(y))
-    assert_equal(nrmse(y, x, 'Euclidean'), 1/np.sqrt(3))
-    assert_equal(nrmse(y, x, 'min-max'), 1/(y.max()-y.min()))
+    assert_equal(normalized_root_mse(y, x, 'mean'), 1/np.mean(y))
+    assert_equal(normalized_root_mse(y, x, 'Euclidean'), 1/np.sqrt(3))
+    assert_equal(normalized_root_mse(y, x, 'min-max'), 1/(y.max()-y.min()))
 
 
 def test_NRMSE_no_int_overflow():
     camf = cam.astype(np.float32)
     cam_noisyf = cam_noisy.astype(np.float32)
-    assert_almost_equal(mse(cam, cam_noisy),
-                        mse(camf, cam_noisyf))
-    assert_almost_equal(nrmse(cam, cam_noisy),
-                        nrmse(camf, cam_noisyf))
+    assert_almost_equal(mean_squared_error(cam, cam_noisy),
+                        mean_squared_error(camf, cam_noisyf))
+    assert_almost_equal(normalized_root_mse(cam, cam_noisy),
+                        normalized_root_mse(camf, cam_noisyf))
 
 
 def test_NRMSE_errors():
     x = np.ones(4)
-    assert_raises(ValueError, nrmse, x.astype(np.uint8), x.astype(np.float32))
-    assert_raises(ValueError, nrmse, x[:-1], x)
+    assert_raises(ValueError, normalized_root_mse,
+                  x.astype(np.uint8), x.astype(np.float32))
+    assert_raises(ValueError, normalized_root_mse, x[:-1], x)
     # invalid normalization name
-    assert_raises(ValueError, nrmse, x, x, 'foo')
+    assert_raises(ValueError, normalized_root_mse, x, x, 'foo')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds simple metrics:  `mse`, normalized root mean square error (`nrmse`) and peak signal to noise ratio (`psnr`).

These are all pretty trivial to implement, but are still useful to have on hand.  PSNR in particular is widely used as a comparison metric in image denoising/compression papers.  

I realize that the existing `skimage.measure.structural_similarity` (SSIM) metric is generally superior to these in terms of making image comparisons, but I would argue these are still useful to have around, if only for comparing to results from the literature.