### PR TITLE
Speedup rgb2gray and return congiguous array

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -707,10 +707,17 @@ def rgb2gray(rgb):
     >>> img = data.astronaut()
     >>> img_gray = rgb2gray(img)
     """
+
     if rgb.ndim == 2:
         return rgb
 
-    return _convert(gray_from_rgb, rgb[:, :, :3])[..., 0]
+    rgb = _prepare_colorarray(rgb)
+
+    gray = 0.2125 * rgb[..., 0]
+    gray[:] += 0.7154 * rgb[..., 1]
+    gray[:] += 0.0721 * rgb[..., 2]
+
+    return gray
 
 rgb2grey = rgb2gray
 

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -711,7 +711,7 @@ def rgb2gray(rgb):
     if rgb.ndim == 2:
         return np.ascontiguousarray(rgb)
 
-    rgb = _prepare_colorarray(rgb)
+    rgb = _prepare_colorarray(rgb[..., :3])
 
     gray = 0.2125 * rgb[..., 0]
     gray[:] += 0.7154 * rgb[..., 1]

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -709,7 +709,7 @@ def rgb2gray(rgb):
     """
 
     if rgb.ndim == 2:
-        return rgb
+        return np.ascontiguousarray(rgb)
 
     rgb = _prepare_colorarray(rgb)
 
@@ -718,6 +718,7 @@ def rgb2gray(rgb):
     gray[:] += 0.0721 * rgb[..., 2]
 
     return gray
+
 
 rgb2grey = rgb2gray
 

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -226,6 +226,11 @@ class TestColorconv(TestCase):
 
         assert_equal(g.shape, (1, 1))
 
+    def test_rgb2grey_contiguous(self):
+        x = np.random.rand(10, 10, 3)
+        assert rgb2grey(x).flags["C_CONTIGUOUS"]
+        assert rgb2grey(x[:5, :5]).flags["C_CONTIGUOUS"]
+
     def test_rgb2grey_on_grey(self):
         rgb2grey(np.random.rand(5, 5))
 

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -231,6 +231,10 @@ class TestColorconv(TestCase):
         assert rgb2grey(x).flags["C_CONTIGUOUS"]
         assert rgb2grey(x[:5, :5]).flags["C_CONTIGUOUS"]
 
+    def test_rgb2grey_alpha(self):
+        x = np.random.rand(10, 10, 4)
+        assert rgb2grey(x).ndim == 2
+
     def test_rgb2grey_on_grey(self):
         rgb2grey(np.random.rand(5, 5))
 


### PR DESCRIPTION
I argue, that this is the most commonly used color conversion function, i.e. it should be fast and the output contiguous for better performance in subsequent operations. The previous code was more general, but slower and did not return a contiguous array.