### PR TITLE
MAINT: fixes #1652 (Temporary file from file_or_url_context is not removed on error)

### DIFF
--- a/skimage/io/util.py
+++ b/skimage/io/util.py
@@ -24,10 +24,12 @@ def file_or_url_context(resource_name):
     """Yield name of file from the given resource (i.e. file or url)."""
     if is_url(resource_name):
         _, ext = os.path.splitext(resource_name)
-        with tempfile.NamedTemporaryFile(delete=False, suffix=ext) as f:
+        # Here, we need to handle the file destruction by ourself
+        try:
+            f = tempfile.NamedTemporaryFile(delete=False, suffix=ext)
             u = urlopen(resource_name)
             f.write(u.read())
-        try:
+            f.close()
             yield f.name
         finally:
             os.remove(f.name)


### PR DESCRIPTION
Here the with statement was contradictory with the keyword delete=False. We should handle the temp file destruction ourself.