### PR TITLE
3D test for register_translation, as required by TODO.txt

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -41,5 +41,3 @@ Version 0.12
 ------------
 * Change `label` to mark background as 0, not -1, which is consistent with
   SciPy's labelling.
-* Add 3D phantom in `skimage.data`
-* Add 3D test case of `skimage.feature.phase_correlate`


### PR DESCRIPTION
The 3D phantom data was added a while ago as ``data.binary_blobs``