### PR TITLE
Clip output in denoise_tv_bregman

### DIFF
--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -189,7 +189,7 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True,
         Relative difference of the value of the cost function that determines
         the stop criterion. The algorithm stops when::
 
-            SUM((u(n) - u(n-1))**2) < eps
+            SUM((out(n) - out(n-1))**2) < eps
 
     max_iter : int, optional
         Maximal number of iterations used for the optimization.

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -220,10 +220,15 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True):
     dims = image.shape[2]
 
     shape_ext = (rows + 2, cols + 2, dims)
-
+    
     out = np.zeros(shape_ext, image.dtype)
     _denoise_tv_bregman(image, image.dtype.type(weight), max_iter, eps,
                         isotropic, out)
+
+    minvalue = -1 if np.any(image < 0) else 0
+    maxvalue = 1
+    np.clip(out, minvalue, maxvalue, out=out)
+
     return np.squeeze(out[1:-1, 1:-1])
 
 

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -168,7 +168,8 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
                               range_lut, empty_dims, out)
 
 
-def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True):
+def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True,
+                       clip=True):
     """Perform total-variation denoising using split-Bregman optimization.
 
     Total-variation denoising (also know as total-variation regularization)
@@ -194,6 +195,9 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True):
         Maximal number of iterations used for the optimization.
     isotropic : boolean, optional
         Switch between isotropic and anisotropic TV denoising.
+    clip : boolean, optional
+        Ensure that the output values are in the range [0, 1] for a
+        non-negative input image, or [-1, 1] for a signed input image.
 
     Returns
     -------
@@ -225,9 +229,10 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True):
     _denoise_tv_bregman(image, image.dtype.type(weight), max_iter, eps,
                         isotropic, out)
 
-    minvalue = -1. if np.any(image < 0) else 0.
-    maxvalue = 1.
-    np.clip(out, minvalue, maxvalue, out=out)
+    if clip:
+        minvalue = -1. if np.any(image < 0) else 0.
+        maxvalue = 1.
+        np.clip(out, minvalue, maxvalue, out=out)
 
     return np.squeeze(out[1:-1, 1:-1])
 

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -197,7 +197,7 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True):
 
     Returns
     -------
-    u : ndarray
+    out : ndarray
         Denoised image.
 
     References
@@ -225,8 +225,8 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True):
     _denoise_tv_bregman(image, image.dtype.type(weight), max_iter, eps,
                         isotropic, out)
 
-    minvalue = -1 if np.any(image < 0) else 0
-    maxvalue = 1
+    minvalue = -1. if np.any(image < 0) else 0.
+    maxvalue = 1.
     np.clip(out, minvalue, maxvalue, out=out)
 
     return np.squeeze(out[1:-1, 1:-1])

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -224,7 +224,7 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True,
     dims = image.shape[2]
 
     shape_ext = (rows + 2, cols + 2, dims)
-    
+
     out = np.zeros(shape_ext, image.dtype)
     _denoise_tv_bregman(image, image.dtype.type(weight), max_iter, eps,
                         isotropic, out)

--- a/skimage/restoration/_denoise_cy.pyx
+++ b/skimage/restoration/_denoise_cy.pyx
@@ -136,9 +136,9 @@ def _denoise_tv_bregman(np_floats[:, :, ::1] image, np_floats weight,
 
         rmse = 0
 
-        for r in range(1, rows + 1):
-            for c in range(1, cols + 1):
-                for k in range(dims):
+        for k in range(dims):
+            for r in range(1, rows):
+                for c in range(1, cols):
 
                     uprev = out[r, c, k]
 

--- a/skimage/restoration/_denoise_cy.pyx
+++ b/skimage/restoration/_denoise_cy.pyx
@@ -3,7 +3,6 @@
 #cython: nonecheck=False
 #cython: wraparound=False
 
-cimport numpy as cnp
 import numpy as np
 from libc.math cimport exp, fabs, sqrt
 from libc.float cimport DBL_MAX
@@ -111,6 +110,7 @@ def _denoise_tv_bregman(np_floats[:, :, ::1] image, np_floats weight,
     shape_ext = (rows2, cols2, dims)
 
     cdef:
+        np_floats[:, :, ::1] cu = u
         np_floats[:, :, ::1] dx = out.copy()
         np_floats[:, :, ::1] dy = out.copy()
         np_floats[:, :, ::1] bx = out.copy()

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -174,6 +174,24 @@ def test_denoise_tv_bregman_3d():
     assert_(out1[30:45, 5:15].std() > out2[30:45, 5:15].std())
 
 
+def test_denoise_tv_bregman_approx_errors():
+    '''Ensure output is valid image when valid input image is given.
+
+    The test image was shown to give invalid output (>1) in #1939.
+    '''
+    image = np.array([[[254, 255, 254, 255, 255, 255, 255],
+                       [254, 255, 255, 255, 255, 255, 255]],
+
+                      [[248, 255, 255, 255, 255, 255, 255],
+                       [255, 255, 255, 255, 255, 255, 255]],
+
+                      [[250, 255, 255, 255, 255, 255, 255],
+                       [255, 255, 255, 255, 255, 255, 255]]], dtype=np.uint8).T
+    image = img_as_float(image).astype(np.float32)
+    out = restoration.denoise_tv_bregman(image, weight=50)
+    assert np.max(out) <= 1
+
+
 def test_denoise_bilateral_2d():
     img = checkerboard_gray.copy()[:50, :50]
     # add some random noise

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -188,7 +188,7 @@ def test_denoise_tv_bregman_approx_errors():
                       [[250, 255, 255, 255, 255, 255, 255],
                        [255, 255, 255, 255, 255, 255, 255]]], dtype=np.uint8).T
     image = img_as_float(image).astype(np.float32)
-    out = restoration.denoise_tv_bregman(image, weight=50)
+    out = restoration.denoise_tv_bregman(image, weight=200)
     assert np.max(out) <= 1
 
 
@@ -206,7 +206,7 @@ def test_denoise_tv_bregman_noclip():
                       [[250, 255, 255, 255, 255, 255, 255],
                        [255, 255, 255, 255, 255, 255, 255]]], dtype=np.uint8).T
     image = img_as_float(image).astype(np.float32)
-    out = restoration.denoise_tv_bregman(image, weight=50, clip=False)
+    out = restoration.denoise_tv_bregman(image, weight=200, clip=False)
     assert np.max(out) > 1
 
 

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -175,10 +175,10 @@ def test_denoise_tv_bregman_3d():
 
 
 def test_denoise_tv_bregman_approx_errors():
-    '''Ensure output is valid image when valid input image is given.
+    """Ensure output is valid image when valid input image is given.
 
     The test image was shown to give invalid output (>1) in #1939.
-    '''
+    """
     image = np.array([[[254, 255, 254, 255, 255, 255, 255],
                        [254, 255, 255, 255, 255, 255, 255]],
 
@@ -190,6 +190,24 @@ def test_denoise_tv_bregman_approx_errors():
     image = img_as_float(image).astype(np.float32)
     out = restoration.denoise_tv_bregman(image, weight=50)
     assert np.max(out) <= 1
+
+
+def test_denoise_tv_bregman_noclip():
+    """Ensure output is not clipped when the `clip=False` kwarg is used.
+
+    The test image was shown to give output >1 in #1939.
+    """
+    image = np.array([[[254, 255, 254, 255, 255, 255, 255],
+                       [254, 255, 255, 255, 255, 255, 255]],
+
+                      [[248, 255, 255, 255, 255, 255, 255],
+                       [255, 255, 255, 255, 255, 255, 255]],
+
+                      [[250, 255, 255, 255, 255, 255, 255],
+                       [255, 255, 255, 255, 255, 255, 255]]], dtype=np.uint8).T
+    image = img_as_float(image).astype(np.float32)
+    out = restoration.denoise_tv_bregman(image, weight=50, clip=False)
+    assert np.max(out) > 1
 
 
 def test_denoise_bilateral_2d():


### PR DESCRIPTION
This is pretty simple: always clip the output of denoise_tv_bregman in order to prevent invalid output due to numerical errors. Fixes #1939. However, the tests are failing in 2.7 and 3.5. Anyone got any idea why???
