### PR TITLE
Added missing numpy as np import

### DIFF
--- a/skimage/viewer/canvastools/recttool.py
+++ b/skimage/viewer/canvastools/recttool.py
@@ -36,6 +36,7 @@ class RectangleTool(CanvasToolBase, RectangleSelector):
 
     Examples
     ----------
+    >>> import numpy as np
     >>> from skimage import data
     >>> from skimage.viewer import ImageViewer
     >>> from skimage.viewer.canvastools import RectangleTool


### PR DESCRIPTION
The example for RectangleTool calls np.int64() but fails to import
numpy as np.  This commit resolves that.