### PR TITLE
HOG enhancement to accept color images

### DIFF
--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -131,24 +131,20 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
         image = image.astype('float')
 
     if len(image.shape) == 3:
-
-        channel_gradients = []
-        gradient = np.zeros(image.shape)
+        #If image is a color image
+        x_gradient = np.zeros(image.shape)
+        y_gradient = np.zeros(image.shape)
+        gradient_magnitude = np.zeros(image.shape)
 
         for dimension in range(image.shape[2]):
-            gx, gy = compute_image_gradients(image[:, :, dimension])
-            gradient[:, :, dimension] = np.hypot(gx, gy)
-            channel_gradients.append((gx, gy))
+            x_gradient[:, :, dimension], y_gradient[:, :, dimension] = compute_image_gradients(image[:, :, dimension])
+            gradient_magnitude[:, :, dimension] = np.hypot(x_gradient[:, :, dimension], y_gradient[:, :, dimension])
 
-        gx = np.empty(image.shape[0:2], dtype=np.double)
-        gy = np.empty(image.shape[0:2], dtype=np.double)
+        max_index_array = gradient_magnitude.argmax(axis=2)
+        rr, cc = np.meshgrid(np.arange(image.shape[0]), np.arange(image.shape[1]))
 
-        max_index_array = gradient.argmax(axis = 2)
-
-        for row_index, row in enumerate(max_index_array):
-            for col_index, value in enumerate(row):
-                gx[row_index][col_index] = channel_gradients[value][0][row_index][col_index]
-                gy[row_index][col_index] = channel_gradients[value][1][row_index][col_index]
+        gx = x_gradient[rr, cc, max_index_array]
+        gy = y_gradient[rr, cc, max_index_array]
 
     else:
         gx, gy = compute_image_gradients(image)

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -39,10 +39,6 @@ def test_hog_image_size_cell_size_mismatch():
     assert len(fd) == 9 * (150 // 8) * (200 // 8)
 
 
-def test_hog_color_image_unsupported_error():
-    image = np.zeros((20, 20, 3))
-    assert_raises(ValueError, feature.hog, image)
-
 
 def test_hog_basic_orientations_and_data_types():
     # scenario:


### PR DESCRIPTION
I implemented the HOG for color images based on the excerpt from the original paper "For colour images, we calculate separate gradients for each colour channel, and take the one with the largest norm
as the pixel’s gradient vector"[Dalal and Triggs] and the CVPR presentation "For color image, pick the color channel with the highest gradient magnitude for each pixel"[Dalal and Triggs].

To allow this change, I refactored the code so that image gradients are computed in a separate method. If the image has more than 1 channels, this method is called on each channel. Gradient magnitude is calculated for each channel and for each pixel, the gradient vector with maximum magnitude is considered. 

This is my first open source contribution and I implemented the change based on my understanding. Please review my code and let me know if I implemented the functionality correctly. Please comment on coding style too.
