### PR TITLE
Bump Cython version to 0.23 in DEPENDS.txt

### DIFF
--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -2,7 +2,7 @@ Build Requirements
 ------------------
 * `Python >= 2.6 <http://python.org>`__
 * `Numpy >= 1.7.2 <http://numpy.scipy.org/>`__
-* `Cython >= 0.21 <http://www.cython.org/>`__
+* `Cython >= 0.23 <http://www.cython.org/>`__
 * `Six >=1.4 <https://pypi.python.org/pypi/six>`__
 * `SciPy >=0.9 <http://scipy.org>`__
 


### PR DESCRIPTION
This matches what was already implicit in our testing, and might have avoided #1971. 