### PR TITLE
Have detect/extract/detect_and_extract methods return underlying object

### DIFF
--- a/skimage/feature/brief.py
+++ b/skimage/feature/brief.py
@@ -182,3 +182,5 @@ class BRIEF(DescriptorExtractor):
 
         _brief_loop(image, self.descriptors.view(np.uint8), keypoints,
                     pos1, pos2)
+                    
+        return self

--- a/skimage/feature/brief.py
+++ b/skimage/feature/brief.py
@@ -88,9 +88,11 @@ class BRIEF(DescriptorExtractor):
     >>> keypoints1 = corner_peaks(corner_harris(square1), min_distance=1)
     >>> keypoints2 = corner_peaks(corner_harris(square2), min_distance=1)
     >>> extractor = BRIEF(patch_size=5)
-    >>> extractor.extract(square1, keypoints1)
+    >>> extractor.extract(square1, keypoints1) #doctest: +ELLIPSIS
+    <skimage.feature.brief.BRIEF object at 0x...>
     >>> descriptors1 = extractor.descriptors
-    >>> extractor.extract(square2, keypoints2)
+    >>> extractor.extract(square2, keypoints2) #doctest: +ELLIPSIS
+    <skimage.feature.brief.BRIEF object at 0x...>
     >>> descriptors2 = extractor.descriptors
     >>> matches = match_descriptors(descriptors1, descriptors2)
     >>> matches

--- a/skimage/feature/censure.py
+++ b/skimage/feature/censure.py
@@ -291,3 +291,5 @@ class CENSURE(FeatureDetector):
 
         self.keypoints = keypoints[cumulative_mask]
         self.scales = scales[cumulative_mask]
+        
+        return self

--- a/skimage/feature/orb.py
+++ b/skimage/feature/orb.py
@@ -89,8 +89,10 @@ class ORB(FeatureDetector, DescriptorExtractor):
     >>> img2[53:73, 53:73] = square
     >>> detector_extractor1 = ORB(n_keypoints=5)
     >>> detector_extractor2 = ORB(n_keypoints=5)
-    >>> detector_extractor1.detect_and_extract(img1)
-    >>> detector_extractor2.detect_and_extract(img2)
+    >>> detector_extractor1.detect_and_extract(img1) #doctest: +ELLIPSIS
+    <skimage.feature.orb.ORB object at 0x...>
+    >>> detector_extractor2.detect_and_extract(img2) #doctest: +ELLIPSIS
+    <skimage.feature.orb.ORB object at 0x...>
     >>> matches = match_descriptors(detector_extractor1.descriptors,
     ...                             detector_extractor2.descriptors)
     >>> matches

--- a/skimage/feature/orb.py
+++ b/skimage/feature/orb.py
@@ -206,6 +206,8 @@ class ORB(FeatureDetector, DescriptorExtractor):
             self.scales = scales[best_indices]
             self.orientations = orientations[best_indices]
             self.responses = responses[best_indices]
+            
+        return self
 
     def _extract_octave(self, octave_image, keypoints, orientations):
         mask = _mask_border_keypoints(octave_image.shape, keypoints,
@@ -272,6 +274,8 @@ class ORB(FeatureDetector, DescriptorExtractor):
 
         self.descriptors = np.vstack(descriptors_list).view(np.bool)
         self.mask_ = np.hstack(mask_list)
+        
+        return self
 
     def detect_and_extract(self, image):
         """Detect oriented FAST keypoints and extract rBRIEF descriptors.
@@ -338,3 +342,5 @@ class ORB(FeatureDetector, DescriptorExtractor):
             self.orientations = orientations[best_indices]
             self.responses = responses[best_indices]
             self.descriptors = descriptors[best_indices]
+            
+        return self


### PR DESCRIPTION
Pull request for issue #1962 
This is the most straightforward solution where I've simply added return self to the end of the appropriate functions. However, I believe as @vighneshbirodkar alluded to in the issue thread there may be a better solution where instead the FeatureDetector and DescriptorExtractor base classes are modified to return the underlying object instead. In this case, these methods would call something like self._detect and self._extract (and throwing not implemented exceptions there if necessary) before returning self. However, as is the FeatureDetector and DesciptorExtract base classes don't really do anything besides throw not implemented exceptions so it wasn't clear that the refactoring would be worth it.
