### PR TITLE
Affine transform xy

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -423,7 +423,6 @@ class AffineTransform(ProjectiveTransform):
                         [                      0,                                0, 1]
                 ])
             self.params[0:2, 2] = translation
-
         else:
             # default to an identity transform
             self.params = np.eye(3)

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -406,12 +406,24 @@ class AffineTransform(ProjectiveTransform):
                 translation = (0, 0)
 
             sx, sy = scale
-            self.params = np.array([
-                [sx * math.cos(rotation), -sy * math.sin(rotation + shear), 0],
-                [sx * math.sin(rotation),  sy * math.cos(rotation + shear), 0],
-                [                      0,                                0, 1]
-            ])
+            if hasattr(shear, '__len__'):
+                if len(shear) != 2:
+                    raise ValueError("Shear value must be an integer or an iterable"
+                                     " of length 2")
+                shx, shy = shear
+                self.params = np.array([
+                    [sx * math.cos(rotation), -sy * math.sin(rotation) + shx, 0],
+                    [sx * math.sin(rotation) + shy,  sy * math.cos(rotation), 0],
+                    [                      0,                        0, 1]
+                ])
+            else:
+                self.params = np.array([
+                        [sx * math.cos(rotation), -sy * math.sin(rotation + shear), 0],
+                        [sx * math.sin(rotation),  sy * math.cos(rotation + shear), 0],
+                        [                      0,                                0, 1]
+                ])
             self.params[0:2, 2] = translation
+
         else:
             # default to an identity transform
             self.params = np.eye(3)

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -414,7 +414,7 @@ class AffineTransform(ProjectiveTransform):
                 self.params = np.array([
                     [sx * math.cos(rotation), -sy * math.sin(rotation) + shx, 0],
                     [sx * math.sin(rotation) + shy,  sy * math.cos(rotation), 0],
-                    [                      0,                        0, 1]
+                    [                      0,                              0, 1]
                 ])
             else:
                 self.params = np.array([

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -49,9 +49,8 @@ def test_estimate_transform():
 
 
 def test_matrix_transform():
-    tform = AffineTransform(scale=(0.1, 0.5), rotation=2)
+    tform = AffineTransform(scale=(0.1, 0.5), rotation=2, shear=(0.5, 2))
     assert_equal(tform(SRC), matrix_transform(SRC, tform.params))
-
 
 def test_similarity_estimation():
     # exact solution
@@ -245,6 +244,9 @@ def test_invalid_input():
                   matrix=np.zeros((2, 3)), scale=1)
     assert_raises(ValueError, SimilarityTransform,
                   matrix=np.zeros((2, 3)), scale=1)
+
+    assert_raises(ValueError, AffineTransform,
+                  shear=(1, 2, 3))
 
     assert_raises(ValueError, PolynomialTransform, np.zeros((3, 3)))
 


### PR DESCRIPTION
In efforts to address https://github.com/scikit-image/scikit-image/issues/1779

Here's a demo:

```
import numpy as np
import matplotlib.pyplot as plt
import matplotlib.cm as cm

from skimage import transform

# Generating a square
im = np.zeros((128, 128))
im[32:-32, 32:-32] = 1

# Creating Affine Transform instances with different shearing factors
t1 = transform.AffineTransform(shear=(0, 0.25))
t2 = transform.AffineTransform(shear=(0.75, 0))
t3 = transform.AffineTransform(shear=(0.5, 0.25))

# Transform image with transform objects above
im1 = transform.warp(im, t1)
im2 = transform.warp(im, t2)
im3 = transform.warp(im, t3)

# Display results
fig, (ax1, ax2, ax3, ax4) = plt.subplots(nrows=1, ncols=4, figsize=(12, 3), sharex=True, sharey=True)

ax1.imshow(im, cmap=plt.cm.jet)
ax1.axis('off')
ax1.set_title('Original Image', fontsize=20)

ax2.imshow(im1, cmap=plt.cm.gray)
ax2.axis('off')
ax2.set_title('Shear $y=0.25$', fontsize=20)

ax3.imshow(im2, cmap=plt.cm.gray)
ax3.axis('off')
ax3.set_title('Shear $x=0.75$', fontsize=20)

ax4.imshow(im3, cmap=plt.cm.gray)
ax4.axis('off')
ax4.set_title('Shear $x=0.5 y=0.25$', fontsize=20)

fig.subplots_adjust(wspace=0.02, hspace=0.02, top=0.9,
                    bottom=0.02, left=0.02, right=0.98)

plt.show()
```

![figure_1](https://cloud.githubusercontent.com/assets/5162104/13478207/d3fc51be-e084-11e5-9fcc-275a60d9756a.png)

There seems to be some unwanted extra translation occurring though. Any ideas how to tackle this?
