### PR TITLE
Fix tests for matplotlib warnings generated by Template backend

### DIFF
--- a/skimage/io/tests/test_mpl_imshow.py
+++ b/skimage/io/tests/test_mpl_imshow.py
@@ -43,7 +43,9 @@ def n_subplots(ax_im):
 
 def test_uint8():
     plt.figure()
-    ax_im = io.imshow(im8)
+    with expected_warnings(["tight_layout : Falling back to Agg|\A\Z",
+                            "CObject type is marked|\A\Z"]):
+        ax_im = io.imshow(im8)
     assert ax_im.cmap.name == 'gray'
     assert ax_im.get_clim() == (0, 255)
     assert n_subplots(ax_im) == 1
@@ -52,7 +54,9 @@ def test_uint8():
 
 def test_uint16():
     plt.figure()
-    ax_im = io.imshow(im16)
+    with expected_warnings(["tight_layout : Falling back to Agg|\A\Z",
+                            "CObject type is marked|\A\Z"]):
+        ax_im = io.imshow(im16)
     assert ax_im.cmap.name == 'gray'
     assert ax_im.get_clim() == (0, 65535)
     assert n_subplots(ax_im) == 1
@@ -61,7 +65,9 @@ def test_uint16():
 
 def test_float():
     plt.figure()
-    ax_im = io.imshow(imf)
+    with expected_warnings(["tight_layout : Falling back to Agg|\A\Z",
+                            "CObject type is marked|\A\Z"]):
+        ax_im = io.imshow(imf)
     assert ax_im.cmap.name == 'gray'
     assert ax_im.get_clim() == (0, 1)
     assert n_subplots(ax_im) == 1
@@ -69,7 +75,8 @@ def test_float():
 
 
 def test_low_dynamic_range():
-    with expected_warnings(["Low image dynamic range"]):
+    with expected_warnings(["Low image dynamic range|CObject type is marked",
+                            "tight_layout : Falling back to Agg|\A\Z"]):
         ax_im = io.imshow(im_lo)
     assert ax_im.get_clim() == (im_lo.min(), im_lo.max())
     # check that a colorbar was created
@@ -82,7 +89,8 @@ def test_outside_standard_range():
     # "The CObject type is marked Pending Deprecation in Python 2.7.
     #  Please use capsule objects instead."
     # Ref: https://docs.python.org/2/c-api/cobject.html
-    with expected_warnings(["out of standard range|CObject type is marked"]):
+    with expected_warnings(["out of standard range|CObject type is marked",
+                            "tight_layout : Falling back to Agg|\A\Z"]):
         ax_im = io.imshow(im_hi)
     assert ax_im.get_clim() == (im_hi.min(), im_hi.max())
     assert n_subplots(ax_im) == 2
@@ -95,7 +103,8 @@ def test_nonstandard_type():
     # "The CObject type is marked Pending Deprecation in Python 2.7.
     #  Please use capsule objects instead."
     # Ref: https://docs.python.org/2/c-api/cobject.html
-    with expected_warnings(["Low image dynamic range|CObject type is marked"]):
+    with expected_warnings(["Low image dynamic range|CObject type is marked",
+                            "tight_layout : Falling back to Agg|\A\Z"]):
         ax_im = io.imshow(im64)
     assert ax_im.get_clim() == (im64.min(), im64.max())
     assert n_subplots(ax_im) == 2
@@ -105,7 +114,10 @@ def test_nonstandard_type():
 def test_signed_image():
     plt.figure()
     im_signed = np.array([[-0.5, -0.2], [0.1, 0.4]])
-    ax_im = io.imshow(im_signed)
+
+    with expected_warnings(["tight_layout : Falling back to Agg|\A\Z",
+                            "CObject type is marked|\A\Z"]):
+        ax_im = io.imshow(im_signed)
     assert ax_im.get_clim() == (-0.5, 0.5)
     assert n_subplots(ax_im) == 2
     assert ax_im.colorbar is not None


### PR DESCRIPTION
Addresses test failures seen in https://github.com/scikit-image/scikit-image/pull/1938