### PR TITLE
option to read tiff metadata

### DIFF
--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -10,7 +10,8 @@ from ..exposure import is_low_contrast
 from .._shared.utils import all_warnings, warn
 
 
-__all__ = ['imread', 'imread_collection', 'imsave', 'imshow', 'show']
+__all__ = ['imread', 'imsave', 'imshow', 'show',
+           'imread_collection', 'imread_with_metadata']
 
 
 def imread(fname, as_grey=False, plugin=None, flatten=None,
@@ -71,6 +72,68 @@ def imread(fname, as_grey=False, plugin=None, flatten=None,
             img = rgb2grey(img)
 
     return img
+
+
+def imread_with_metadata(fname, as_grey=False, plugin=None, flatten=None,
+           **plugin_args):
+    """Load an image from file along with its metadata.
+
+    Parameters
+    ----------
+    fname : string
+        Image file name, e.g. ``test.jpg`` or URL.
+    as_grey : bool
+        If True, convert color images to grey-scale (32-bit floats).
+        Images that are already in grey-scale format are not converted.
+    plugin : str
+        Name of plugin to use.  By default, the different plugins are
+        tried (starting with the Python Imaging Library) until a suitable
+        candidate is found.  If not given and fname is a tiff file, the
+        tifffile plugin will be used.
+
+    Other Parameters
+    ----------------
+    flatten : bool
+        Backward compatible keyword, superseded by `as_grey`.
+
+    Returns
+    -------
+    img_array : ndarray
+        The different colour bands/channels are stored in the
+        third dimension, such that a grey-image is MxN, an
+        RGB-image MxNx3 and an RGBA-image MxNx4.
+    metadata : list
+        A list containing TIFF pages' metadata dictionaries.
+
+    Other parameters
+    ----------------
+    plugin_args : keywords
+        Passed to the given plugin.
+
+    """
+    # Backward compatibility
+    if flatten is not None:
+        as_grey = flatten
+
+    if plugin is None and hasattr(fname, 'lower'):
+        if fname.lower().endswith(('.tiff', '.tif')):
+            plugin = 'tifffile'
+
+    with file_or_url_context(fname) as fname:
+        (img, metadata) = call_plugin('imread_with_metadata', fname, plugin=plugin, **plugin_args)
+
+    if not hasattr(img, 'ndim'):
+        return (img, metadata)
+
+    if img.ndim > 2:
+        if img.shape[-1] not in (3, 4) and img.shape[-3] in (3, 4):
+            img = np.swapaxes(img, -1, -3)
+            img = np.swapaxes(img, -2, -3)
+
+        if as_grey:
+            img = rgb2grey(img)
+
+    return (img, metadata)
 
 
 def imread_collection(load_pattern, conserve_memory=True,

--- a/skimage/io/_plugins/tifffile_plugin.ini
+++ b/skimage/io/_plugins/tifffile_plugin.ini
@@ -1,3 +1,3 @@
 [tifffile]
 description = Load and save TIFF and TIFF-based images using tifffile.py
-provides = imread, imsave
+provides = imread, imsave, imread_metadata, imread_with_metadata

--- a/skimage/io/_plugins/tifffile_plugin.py
+++ b/skimage/io/_plugins/tifffile_plugin.py
@@ -1,8 +1,41 @@
 from ...external.tifffile import TiffFile, imsave
 
 
-def imread(fname, dtype=None, **kwargs):
-    """Load a tiff image from file.
+def imread(fname, dtype=None, incl_metadata=False, **kwargs):
+    """Load a tiff image from file. 
+
+    Parameters
+    ----------
+    fname : str or file
+       File name or file-like-object.
+    dtype : numpy dtype object or string specifier
+       Specifies data type of array elements (Not currently used).
+    incl_metadata : boolean
+        Specifies whether or not to return metadata in addition to image array.
+        If true, returns a tuple (image array, metadata). Else, returns image array.
+    kwargs : keyword pairs, optional
+        Additional keyword arguments to pass through (see ``tifffile``'s
+        ``imread`` function).
+    
+    Notes
+    -----
+    Provided by Christophe Golhke's tifffile.py [1]_, and supports many
+    advanced image types including multi-page and floating point.
+
+    References
+    ----------
+    .. [1] http://www.lfd.uci.edu/~gohlke/code/tifffile.py
+
+    """
+    img_and_metadata = imread_with_metadata(fname, dtype, **kwargs)
+    if incl_metadata:
+        return img_and_metadata
+    else:
+        return img_and_metadata[0]
+
+def imread_metadata(fname, dtype=None, **kwargs):
+    """Retrieve a tiff image metadata from file, as a list
+    of metadata dictionaries, one metadata dictionary for each page.
 
     Parameters
     ----------
@@ -14,18 +47,36 @@ def imread(fname, dtype=None, **kwargs):
         Additional keyword arguments to pass through (see ``tifffile``'s
         ``imread`` function).
 
-    Notes
-    -----
-    Provided by Christophe Golhke's tifffile.py [1]_, and supports many
-    advanced image types including multi-page and floating point.
-
-    References
-    ----------
-    .. [1] http://www.lfd.uci.edu/~gohlke/code/tifffile.py
-
     """
     if 'img_num' in kwargs:
         kwargs['key'] = kwargs.pop('img_num')
     with open(fname, 'rb') as f:
         tif = TiffFile(f)
-        return tif.asarray(**kwargs)
+        if 'key' not in kwargs:
+            metadata = tif.asarray_with_metadata(**kwargs)[1]
+        else:
+            page = tif.pages[kwargs['key']]
+            metadata = [{t: k.value for (t, k) in page.tags.items()}]
+        return metadata
+
+def imread_with_metadata(fname, dtype=None, **kwargs):
+    """Load a tiff image and its metadata from file. 
+    Return (image array, list of metadata dictionaries for each page).
+
+    Parameters
+    ----------
+    fname : str or file
+       File name or file-like-object.
+    dtype : numpy dtype object or string specifier
+       Specifies data type of array elements (Not currently used).
+    kwargs : keyword pairs, optional
+        Additional keyword arguments to pass through (see ``tifffile``'s
+        ``imread`` function).
+    
+    """
+    if 'img_num' in kwargs:
+        kwargs['key'] = kwargs.pop('img_num')
+    with open(fname, 'rb') as f:
+        tif = TiffFile(f)
+        metadata = imread_metadata(fname, dtype, **kwargs)
+        return (tif.asarray(**kwargs), metadata)

--- a/skimage/io/manage_plugins.py
+++ b/skimage/io/manage_plugins.py
@@ -56,6 +56,8 @@ def _clear_plugins():
     """
     global plugin_store
     plugin_store = {'imread': [],
+                    'imread_with_metadata': [],
+                    'imread_metadata': [],
                     'imsave': [],
                     'imshow': [],
                     'imread_collection': [],
@@ -65,7 +67,9 @@ _clear_plugins()
 
 def _load_preferred_plugins():
     # Load preferred plugin for each io function.
-    io_types = ['imsave', 'imshow', 'imread_collection', 'imread']
+    io_types = ['imsave', 'imshow', 'imread_collection',
+                'imread', 'imread_with_metadata']
+
     for p_type in io_types:
         _set_plugin(p_type, preferred_plugins['all'])
 
@@ -190,8 +194,8 @@ def call_plugin(kind, *args, **kwargs):
     if len(plugin_funcs) == 0:
         msg = ("No suitable plugin registered for %s.\n\n"
                "You may load I/O plugins with the `skimage.io.use_plugin` "
-               "command.  A list of all available plugins can be found using "
-               "`skimage.io.plugins()`.")
+               "command.  A list of all available plugins are shown in the "
+               "`skimage.io` docstring.")
         raise RuntimeError(msg % kind)
 
     plugin = kwargs.pop('plugin', None)

--- a/skimage/io/tests/test_tifffile.py
+++ b/skimage/io/tests/test_tifffile.py
@@ -1,6 +1,6 @@
 import os
 from ... import data_dir
-from .. import imread, imsave, use_plugin, reset_plugins
+from .. import imread, imsave, use_plugin, reset_plugins, imread_with_metadata
 import numpy as np
 
 from numpy.testing import (
@@ -31,6 +31,13 @@ def test_imread_uint16_big_endian():
     assert img.dtype == np.uint16
     assert_array_almost_equal(img, expected)
 
+def test_imread_with_metadata():
+    expected = np.load(os.path.join(data_dir, 'chessboard_GRAY_U8.npy'))
+    (img, metadata) = imread_with_metadata(os.path.join(data_dir, 'chessboard_GRAY_U16.tif'))
+    assert img.dtype == np.uint16
+    assert isinstance(metadata,list)
+    assert 'photometric' in metadata[0]
+    assert_array_almost_equal(img, expected)
 
 def test_imread_multipage_rgb_tif():
     img = imread(os.path.join(data_dir, 'multipage_rgb.tif'))


### PR DESCRIPTION
addressing issue #1940
Automatic inversion of binary image stored as TIFFILE

created imread_metadata, imread_with_metadata, and imread(include_metadata = False) methods in tifffile_plugin.py,  as suggested in a comment in the issue thread

added a new method, asarray_with_metadata, in tifffile.py that returns the image array along with a list of metadata dictionaries for each page. 
Returns metadata dictionary for first page by default, like how tifffile returns the first image series by default.
