### PR TITLE
explicitly suggest using multichannel in compute_ssim error message

### DIFF
--- a/skimage/measure/_structural_similarity.py
+++ b/skimage/measure/_structural_similarity.py
@@ -139,7 +139,9 @@ def compare_ssim(X, Y, win_size=None, gradient=False,
             win_size = 7   # backwards compatibility
 
     if np.any((np.asarray(X.shape) - win_size) < 0):
-        raise ValueError("win_size exceeds image extent")
+        raise ValueError(
+            "win_size exceeds image extent.  If the input is a multichannel "
+            "(color) image, set multichannel=True.")
 
     if not (win_size % 2 == 1):
         raise ValueError('Window size must be odd.')


### PR DESCRIPTION
The most common source for this `win_size` error is likely to be users calling `compute_ssim` on a color image (see #1998).  This modifies the error message to explicitly suggest setting multichannel=True.  
