### PR TITLE
[DOC] add link to guide

### DIFF
--- a/doc/examples/README.txt
+++ b/doc/examples/README.txt
@@ -3,5 +3,6 @@
 General examples
 -------------------
 
-General-purpose and introductory examples for the scikit.
+General-purpose and introductory examples for scikit-image.
 
+The `narrative documentation <../user_guide.html>`_ introduces conventions and basic image manipulations.


### PR DESCRIPTION
From the mailing list, I thought useful to put a link from the gallery to the user guide.

Please correct the rst syntax if it's not correct (this syntax makes me allergic). It looks good locally.