### PR TITLE
Polygon approximation

### DIFF
--- a/skimage/measure/_polygon.py
+++ b/skimage/measure/_polygon.py
@@ -3,7 +3,7 @@ from scipy import signal
 import pdb
 
 
-def approximate_polygon(coords, tolerance):
+def approximate_polygon(coords, tolerance, closed=True):
     """Approximate a polygonal chain with the specified tolerance.
 
     It is based on the Douglas-Peucker algorithm.
@@ -19,6 +19,9 @@ def approximate_polygon(coords, tolerance):
         Maximum distance from original points of polygon to approximated
         polygonal chain. If tolerance is 0, the original coordinate array
         is returned.
+    closed : boolean
+        If true, the approximated curve is closed (the first and last
+        vertices are connected). Default is True.
 
     Returns
     -------
@@ -51,7 +54,7 @@ def approximate_polygon(coords, tolerance):
     i, j = furthest_points
     chain[i] = True
     chain[j] = True
-    pos_stack = [(0, i), (i, j), (j, coords.shape[0] - 1)]
+    pos_stack = [(j, coords.shape[0] - 1), (i, j), (0, i)]
     end_of_chain = False
 
     while not end_of_chain:
@@ -101,6 +104,11 @@ def approximate_polygon(coords, tolerance):
 
         if len(pos_stack) == 0:
             end_of_chain = True
+
+    if closed:
+        for i, p in enumerate(coords):
+            if chain[i]:
+                return np.vstack([coords[chain, :], p])
 
     return coords[chain, :]
 

--- a/skimage/measure/_polygon.py
+++ b/skimage/measure/_polygon.py
@@ -29,6 +29,7 @@ def approximate_polygon(coords, tolerance):
     ----------
     .. [1] http://en.wikipedia.org/wiki/Ramer-Douglas-Peucker_algorithm
     """
+    """
     if tolerance <= 0:
         return coords
 
@@ -48,6 +49,70 @@ def approximate_polygon(coords, tolerance):
             chain[index] = True
 
     return coords[chain, :]
+    """
+    if tolerance <= 0:
+        return coords
+
+    chain = np.zeros(coords.shape[0], 'bool')
+    # pre-allocate distance array for all points
+    dists = np.zeros(coords.shape[0])
+    chain[0] = True
+    chain[-1] = True
+    pos_stack = [(0, chain.shape[0] - 1)]
+    end_of_chain = False
+
+    while not end_of_chain:
+        start, end = pos_stack.pop()
+        # determine properties of current line segment
+        r0, c0 = coords[start, :]
+        r1, c1 = coords[end, :]
+        dr = r1 - r0
+        dc = c1 - c0
+        segment_angle = - np.arctan2(dr, dc)
+        segment_dist = c0 * np.sin(segment_angle) + r0 * np.cos(segment_angle)
+
+        # select points in-between line segment
+        segment_coords = coords[start + 1:end, :]
+        segment_dists = dists[start + 1:end]
+
+        # check whether to take perpendicular or euclidean distance with
+        # inner product of vectors
+
+        # vectors from points -> start and end
+        dr0 = segment_coords[:, 0] - r0
+        dc0 = segment_coords[:, 1] - c0
+        dr1 = segment_coords[:, 0] - r1
+        dc1 = segment_coords[:, 1] - c1
+        # vectors points -> start and end projected on start -> end vector
+        projected_lengths0 = dr0 * dr + dc0 * dc
+        projected_lengths1 = - dr1 * dr - dc1 * dc
+        perp = np.logical_and(projected_lengths0 > 0,
+                              projected_lengths1 > 0)
+        eucl = np.logical_not(perp)
+        segment_dists[perp] = np.abs(
+            (segment_coords[perp, 0] * dc - segment_coords[perp, 1] * dr \
+            + (r1 * c0) - (c1 * r0)) \
+            / float(((dr ** 2 + dc ** 2) ** 0.5))
+        )
+        segment_dists[eucl] = np.minimum(
+            # distance to start point
+            np.sqrt(dc0[eucl] ** 2 + dr0[eucl] ** 2),
+            # distance to end point
+            np.sqrt(dc1[eucl] ** 2 + dr1[eucl] ** 2)
+        )
+
+        if np.any(segment_dists > tolerance):
+            # select point with maximum distance to line
+            new_end = start + np.argmax(segment_dists) + 1
+            pos_stack.append((new_end, end))
+            pos_stack.append((start, new_end))
+            chain[new_end] = True
+
+        if len(pos_stack) == 0:
+            end_of_chain = True
+
+    return coords[chain, :]
+
 
 def _max_perp_dist(coords, start, end):
     """Helper function for approximate_polygon.

--- a/skimage/measure/_polygon.py
+++ b/skimage/measure/_polygon.py
@@ -2,7 +2,6 @@ import numpy as np
 from scipy import signal
 from scipy.spatial import distance_matrix
 from numpy import unravel_index
-import pdb
 
 
 def approximate_polygon(coords, tolerance, closed=True):

--- a/skimage/measure/_polygon.py
+++ b/skimage/measure/_polygon.py
@@ -35,12 +35,23 @@ def approximate_polygon(coords, tolerance):
     if coords.shape[0] <= 2:
         return coords
 
+    # calculate the furthest two points
+    max_dist = 0
+    furthest_points = None
+    for i in range(coords.shape[0]):
+        for j in range(i + 1, coords.shape[0]):
+            dist = np.sum((coords[j, :] - coords[i, :]) ** 2)
+            if dist > max_dist:
+                max_dist = dist
+                furthest_points = (i, j)
+
     chain = np.zeros(coords.shape[0], 'bool')
     # pre-allocate distance array for all points
     dists = np.zeros(coords.shape[0])
-    chain[0] = True
-    chain[-1] = True
-    pos_stack = [(0, chain.shape[0] - 1)]
+    i, j = furthest_points
+    chain[i] = True
+    chain[j] = True
+    pos_stack = [(0, i), (i, j), (j, coords.shape[0] - 1)]
     end_of_chain = False
 
     while not end_of_chain:

--- a/skimage/measure/_polygon.py
+++ b/skimage/measure/_polygon.py
@@ -29,28 +29,10 @@ def approximate_polygon(coords, tolerance):
     ----------
     .. [1] http://en.wikipedia.org/wiki/Ramer-Douglas-Peucker_algorithm
     """
-    """
     if tolerance <= 0:
         return coords
 
     if coords.shape[0] <= 2:
-        return coords
-
-    chain = np.zeros(coords.shape[0], 'bool')
-    chain[0] = True
-    chain[coords.shape[0] - 1] = True
-    pos_stack = [(0, coords.shape[0] - 1)]
-    while len(pos_stack) != 0:
-        start, end = pos_stack.pop()
-        index, dmax = _max_perp_dist(coords, start, end)
-        if dmax > tolerance:
-            pos_stack.append((start, index))
-            pos_stack.append((index, end))
-            chain[index] = True
-
-    return coords[chain, :]
-    """
-    if tolerance <= 0:
         return coords
 
     chain = np.zeros(coords.shape[0], 'bool')
@@ -68,8 +50,6 @@ def approximate_polygon(coords, tolerance):
         r1, c1 = coords[end, :]
         dr = r1 - r0
         dc = c1 - c0
-        segment_angle = - np.arctan2(dr, dc)
-        segment_dist = c0 * np.sin(segment_angle) + r0 * np.cos(segment_angle)
 
         # select points in-between line segment
         segment_coords = coords[start + 1:end, :]
@@ -112,44 +92,6 @@ def approximate_polygon(coords, tolerance):
             end_of_chain = True
 
     return coords[chain, :]
-
-
-def _max_perp_dist(coords, start, end):
-    """Helper function for approximate_polygon.
-
-    For each point in COORDS, it calculates the perpendicular distance from the
-    line connecting START and END.
-
-    It returns the index and the distance of the point that has the maximum
-    distance.
-
-    Parameters
-    ----------
-    coords : (N, 2) array
-        Coordinate array.
-
-    Returns
-    -------
-    index : integer
-        Index of the point with maximum distance.
-    dmax : float
-        The maximum perpendicular distance.
-    """
-    dmax = 0
-    index = 0
-    p1_x, p1_y = coords[start, :]
-    p2_x, p2_y = coords[end, :]
-
-    for i in range(start + 1, end):
-        x, y = coords[i, :]
-        perp_dist = abs(float((p2_y - p1_y) * x - (p2_x - p1_x) * y + \
-                        (p2_x * p1_y) - (p2_y * p1_x))) / \
-                        (((p2_y - p1_y) ** 2 + (p2_x - p1_x) ** 2) ** 0.5)
-        if perp_dist > dmax:
-            index = i
-            dmax = perp_dist
-
-    return index, dmax
 
 # B-Spline subdivision
 _SUBDIVISION_MASKS = {

--- a/skimage/measure/tests/test_polygon.py
+++ b/skimage/measure/tests/test_polygon.py
@@ -11,18 +11,30 @@ square = np.array([
 
 
 def test_approximate_polygon():
-    out = approximate_polygon(square, 0.1)
+    out = approximate_polygon(square, 0.1, closed=True)
     np.testing.assert_array_equal(out, square[(0, 3, 6, 9, 12), :])
+    out = approximate_polygon(square, 0.1, closed=False)
+    np.testing.assert_array_equal(out, square[(0, 3, 6, 9), :])
 
-    out = approximate_polygon(square, 2.2)
+    out = approximate_polygon(square, 2.2, closed=True)
     np.testing.assert_array_equal(out, square[(0, 6, 12), :])
+    out = approximate_polygon(square, 2.2, closed=False)
+    np.testing.assert_array_equal(out, square[(0, 6), :])
 
-    out = approximate_polygon(square[(0, 1, 3, 4, 5, 6, 7, 9, 11, 12), :], 0.1)
+    out = approximate_polygon(square[(0, 1, 3, 4, 5, 6, 7, 9, 11, 12), :],
+                              0.1, closed=True)
     np.testing.assert_array_equal(out, square[(0, 3, 6, 9, 12), :])
+    out = approximate_polygon(square[(0, 1, 3, 4, 5, 6, 7, 9, 11, 12), :],
+                              0.1, closed=False)
+    np.testing.assert_array_equal(out, square[(0, 3, 6, 9), :])
 
-    out = approximate_polygon(square, -1)
+    out = approximate_polygon(square, -1, closed=True)
     np.testing.assert_array_equal(out, square)
-    out = approximate_polygon(square, 0)
+    out = approximate_polygon(square, -1, closed=False)
+    np.testing.assert_array_equal(out, square)
+    out = approximate_polygon(square, 0, closed=True)
+    np.testing.assert_array_equal(out, square)
+    out = approximate_polygon(square, 0, closed=False)
     np.testing.assert_array_equal(out, square)
 
 

--- a/skimage/measure/tests/test_polygon.py
+++ b/skimage/measure/tests/test_polygon.py
@@ -14,19 +14,19 @@ def test_approximate_polygon():
     out = approximate_polygon(square, 0.1, closed=True)
     np.testing.assert_array_equal(out, square[(0, 3, 6, 9, 12), :])
     out = approximate_polygon(square, 0.1, closed=False)
-    np.testing.assert_array_equal(out, square[(0, 3, 6, 9), :])
+    np.testing.assert_array_equal(out, square[(0, 3, 6, 9, 12), :])
 
     out = approximate_polygon(square, 2.2, closed=True)
     np.testing.assert_array_equal(out, square[(0, 6, 12), :])
     out = approximate_polygon(square, 2.2, closed=False)
-    np.testing.assert_array_equal(out, square[(0, 6), :])
+    np.testing.assert_array_equal(out, square[(0, 6, 12), :])
 
     out = approximate_polygon(square[(0, 1, 3, 4, 5, 6, 7, 9, 11, 12), :],
                               0.1, closed=True)
     np.testing.assert_array_equal(out, square[(0, 3, 6, 9, 12), :])
     out = approximate_polygon(square[(0, 1, 3, 4, 5, 6, 7, 9, 11, 12), :],
                               0.1, closed=False)
-    np.testing.assert_array_equal(out, square[(0, 3, 6, 9), :])
+    np.testing.assert_array_equal(out, square[(0, 3, 6, 9, 12), :])
 
     out = approximate_polygon(square, -1, closed=True)
     np.testing.assert_array_equal(out, square)


### PR DESCRIPTION
addressing issue #1552 

Some of the issues in the previous implementation:
1) The previous implementation always included the starting and end points of the input, which resulted in a suboptimal behavior mentioned in issue #1552. This also means that if the starting and end points change, the algorithm will give different results although the shape of the polygon itself stays the same, which is also a suboptimal behavior. 
2) Usage of arctan2() to calculate perpendicular distance might introduce unnecessary bugs if unexpected degree/radian values are given. 

Possible Fix:
1) Instead of always having the algorithm include the starting point and the end point, users can use a flag called "closed" to choose how the algorithm approximates the polygon. If closed=True, the algorithm assumes that the given polygon is closed and thus starts approximating by first finding the furthest two points. If closed=False, it assumes the polygon to be open and simply applies the previous implementation.
In the following examples, the top plots in each figure are the results when setting closed=True while the bottom plots are the results when setting closed=False.

![tolerance4](https://cloud.githubusercontent.com/assets/9913159/13763112/00878048-ea01-11e5-8c17-19e01235509e.png)
![tolerance8](https://cloud.githubusercontent.com/assets/9913159/13763111/0084f080-ea01-11e5-9fd0-9d4184b5bb5e.png)

2) Replace with a code that calculates the perpendicular distance using an equation that does not involve any trig functions.

Open to many feedbacks! Thank you :)
