### PR TITLE
Turn `dask` into an optional dependency

### DIFF
--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -16,18 +16,18 @@ Runtime requirements
 * `Six >=1.4 <https://pypi.python.org/pypi/six>`__
 * `Pillow >= 1.7.8 <https://pypi.python.org/pypi/Pillow>`__
     (or `PIL <http://www.pythonware.com/products/pil/>`__)
-* `dask[array] >= 0.5.0 <http://dask.pydata.org/en/latest/>`__
-
 
 You can use pip to automatically install the runtime dependencies as follows::
 
     $ pip install -r requirements.txt
 
-
 Optional Requirements
 ---------------------
 You can use this scikit with the basic requirements listed above, but some
 functionality is only available with the following installed:
+
+* `dask[array] >= 0.5.0 <http://dask.pydata.org/en/latest/>`__.
+   For parallel computation using `skimage.util.apply_parallel`.
 
 * `PyQt4 <http://wiki.python.org/moin/PyQt>`__
    The ``qt`` plugin that provides ``imshow(x, fancy=True)`` and `skivi`.

--- a/skimage/util/apply_parallel.py
+++ b/skimage/util/apply_parallel.py
@@ -4,6 +4,13 @@ from multiprocessing import cpu_count
 __all__ = ['apply_parallel']
 
 
+try:
+    import dask.array as da
+    dask_available = True
+except ImportError:
+    dask_available = False
+
+
 def _get_chunks(shape, ncpu):
     """Split the array into equal sized chunks based on the number of
     available processors. The last chunk in each dimension absorbs the
@@ -82,7 +89,9 @@ def apply_parallel(function, array, chunks=None, depth=0, mode=None,
     equivalent `dask` boundary modes 'reflect', 'periodic' and 'nearest',
     respectively.
     """
-    import dask.array as da
+    if not dask_available:
+        raise RuntimeError("Could not import 'dask'.  Please install "
+                           "using 'pip install dask'")
 
     if chunks is None:
         shape = array.shape

--- a/skimage/util/tests/test_apply_parallel.py
+++ b/skimage/util/tests/test_apply_parallel.py
@@ -2,11 +2,13 @@ from __future__ import absolute_import
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal
+from numpy.testing.decorators import skipif
 
 from skimage.filters import threshold_adaptive, gaussian
-from skimage.util.apply_parallel import apply_parallel
+from skimage.util.apply_parallel import apply_parallel, dask_available
 
 
+@skipif(not dask_available)
 def test_apply_parallel():
     # data
     a = np.arange(144).reshape(12, 12).astype(float)
@@ -28,6 +30,7 @@ def test_apply_parallel():
     assert_array_almost_equal(result2, expected2)
 
 
+@skipif(not dask_available)
 def test_no_chunks():
     a = np.ones(1 * 4 * 8 * 9).reshape(1, 4, 8, 9)
 
@@ -40,6 +43,7 @@ def test_no_chunks():
     assert_array_almost_equal(result, expected)
 
 
+@skipif(not dask_available)
 def test_apply_parallel_wrap():
     def wrapped(arr):
         return gaussian(arr, 1, mode='wrap')
@@ -50,6 +54,7 @@ def test_apply_parallel_wrap():
     assert_array_almost_equal(result, expected)
 
 
+@skipif(not dask_available)
 def test_apply_parallel_nearest():
     def wrapped(arr):
         return gaussian(arr, 1, mode='nearest')


### PR DESCRIPTION
Dask is not yet packaged on all platforms, so make it optional for now.