### PR TITLE
Adds PyWavelets as required dependency

### DIFF
--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -16,7 +16,6 @@ Runtime requirements
 * `Six >=1.4 <https://pypi.python.org/pypi/six>`__
 * `Pillow >= 1.7.8 <https://pypi.python.org/pypi/Pillow>`__
     (or `PIL <http://www.pythonware.com/products/pil/>`__)
-* `PyWavelets >= 0.4.0 <http://pywavelets.readthedocs.org/en/latest/>`
 
 You can use pip to automatically install the runtime dependencies as follows::
 
@@ -49,6 +48,11 @@ functionality is only available with the following installed:
 
 * `imread <http://pythonhosted.org/imread/>`__
   Optional io plugin providing most standard `formats <http://pythonhosted.org//imread/formats.html>`__.
+
+* `PyWavelets >= 0.4.0 <http://pywavelets.readthedocs.org/en/latest/>`
+  Provides wavelet capabilities, useful in wavelet denoising and noise variance
+  estimation.
+  
 
 
 Testing requirements

--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -16,6 +16,7 @@ Runtime requirements
 * `Six >=1.4 <https://pypi.python.org/pypi/six>`__
 * `Pillow >= 1.7.8 <https://pypi.python.org/pypi/Pillow>`__
     (or `PIL <http://www.pythonware.com/products/pil/>`__)
+* `PyWavelets >= 0.4.0 <http://pywavelets.readthedocs.org/en/latest/>`
 
 You can use pip to automatically install the runtime dependencies as follows::
 

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -4,3 +4,4 @@ SimpleITK; python_version != '3.4' and python_version != '3.5'
 astropy
 tifffile
 imageio; python_version != '2.6'
+PyWavelets>=0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ six>=1.7.3
 networkx>=1.8
 pillow>=2.1.0
 dask[array]>=0.5.0
-PyWavelets>=0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ six>=1.7.3
 networkx>=1.8
 pillow>=2.1.0
 dask[array]>=0.5.0
+PyWavelets>=0.4.0


### PR DESCRIPTION
## Description
This PR adds PyWavelets as a required dependency. PyWavelets is pip installable, making for quick changes to `requirements.txt`

## References
* This issue will close issue #1838, which proposes making PyWavelets a required dependency
* As mentioned in #1838, this will be useful in algorithms that require it (including #1833, #1837).