### PR TITLE
Apparent bug in blob pruning code

### DIFF
--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -92,6 +92,13 @@ def _prune_blobs(blobs_array, overlap):
     # iterating again might eliminate more blobs, but one iteration suffices
     # for most cases
     for blob1, blob2 in itt.combinations(blobs_array, 2):
+
+        # Ignore if we have removed either blob during an earlier iteration.
+        if blob1[3] == -1:
+          continue
+        if blob2[3] == -1:
+          continue
+
         if _blob_overlap(blob1, blob2) > overlap:
             if blob1[2] > blob2[2]:
                 blob2[2] = -1

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -94,9 +94,9 @@ def _prune_blobs(blobs_array, overlap):
     for blob1, blob2 in itt.combinations(blobs_array, 2):
 
         # Ignore if we have removed either blob during an earlier iteration.
-        if blob1[3] == -1:
+        if blob1[2] == -1:
           continue
-        if blob2[3] == -1:
+        if blob2[2] == -1:
           continue
 
         if _blob_overlap(blob1, blob2) > overlap:


### PR DESCRIPTION
When pruning blobs that have overlap, some blobs can be removed when comparing with a blob that has previously been removed. Also, blobs with a negative radius, set in an earlier iteration are not passed to the overlap calculation function.
