### PR TITLE
Remove `skimage.filters.canny` links

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -24,10 +24,6 @@ Version 0.13
 * Require Python 2.7+, remove warning in `__init__.py` and 2.6 hack in
   `doc/release/contribs.py`.
 * Remove deprecated `None` defaults for `skimage.exposure.rescale_intensity`
-* Remove deprecated `skimage.filters.canny` import in `filters/__init__.py`
-  file (canny is now in `skimage.feature.canny`).
-    * Don't forget to complete api_changes.txt.
-     (`GitHub discuss <https://github.com/scikit-image/scikit-image/pull/1113>`__ )
 * Remove deprecated edge filters `hsobel`, `vsobel`, `hscharr`, `vscharr`,
   `hprewitt`, `vprewitt`, `roberts_positive_diagonal`,
   `roberts_negative_diagonal` in `skimage/filters/edges.py`

--- a/doc/source/api_changes.txt
+++ b/doc/source/api_changes.txt
@@ -1,6 +1,8 @@
 Version 0.13
 ------------
 - `skimage.filter` has been removed. Use `skimage.filters` instead.
+- `skimage.filters.canny` has been removed.
+  `canny` is available only from `skimage.feature` now.
 
 Version 0.12
 ------------

--- a/skimage/filters/__init__.py
+++ b/skimage/filters/__init__.py
@@ -14,29 +14,18 @@ from . import rank
 from .rank import median
 
 from .._shared.utils import deprecated, copy_func
-from .. import restoration
+
 
 gaussian_filter = copy_func(gaussian, name='gaussian_filter')
 gaussian_filter = deprecated('skimage.filters.gaussian')(gaussian_filter)
 gabor_filter = copy_func(gabor, name='gabor_filter')
 gabor_filter = deprecated('skimage.filters.gabor')(gabor_filter)
 
-# Backward compatibility v<0.11
-
-
-@deprecated('skimage.feature.canny')
-def canny(*args, **kwargs):
-    # Hack to avoid circular import
-    from ..feature._canny import canny as canny_
-    return canny_(*args, **kwargs)
-
-
 __all__ = ['inverse',
            'wiener',
            'LPIFilter2D',
            'gaussian',
            'median',
-           'canny',
            'sobel',
            'hsobel',
            'vsobel',

--- a/skimage/filters/tests/test_deprecated_imports.py
+++ b/skimage/filters/tests/test_deprecated_imports.py
@@ -1,9 +1,0 @@
-from ..._shared._warnings import expected_warnings
-from ...data import moon
-
-
-def test_canny_import():
-    data = moon()
-    with expected_warnings(['skimage.feature.canny']):
-        from skimage.filters import canny
-        canny(data)


### PR DESCRIPTION
## Description
`filters.canny` to be removed, `feature.canny` to be used instead.

## References
Related PR: https://github.com/scikit-image/scikit-image/pull/1113

