### PR TITLE
Removed Python 2.6 support and related checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,6 @@ notifications:
 
 matrix:
   include:
-    - python: 2.6
-      env: WITH_PYAMG=1 NO_SPHINX=1
     - python: 2.7
       env: PIP_FLAGS="--pre"
     - python: 2.7

--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -1,6 +1,6 @@
 Build Requirements
 ------------------
-* `Python >= 2.6 <http://python.org>`__
+* `Python >= 2.7 <http://python.org>`__
 * `Numpy >= 1.7.2 <http://numpy.scipy.org/>`__
 * `Cython >= 0.23 <http://www.cython.org/>`__
 * `Six >=1.4 <https://pypi.python.org/pypi/six>`__
@@ -8,7 +8,7 @@ Build Requirements
 
 Runtime requirements
 --------------------
-* `Python >= 2.6 <http://python.org>`__
+* `Python >= 2.7 <http://python.org>`__
 * `Numpy >= 1.7.2 <http://numpy.scipy.org/>`__
 * `SciPy >= 0.9 <http://scipy.org>`__
 * `Matplotlib >= 1.1.0 <http://matplotlib.sf.net>`__

--- a/TODO.txt
+++ b/TODO.txt
@@ -21,8 +21,6 @@ Version 0.14
 
 Version 0.13
 ------------
-* Require Python 2.7+, remove warning in `__init__.py` and 2.6 hack in
-  `doc/release/contribs.py`.
 * Remove deprecated `None` defaults for `skimage.exposure.rescale_intensity`
 * Remove deprecated edge filters `hsobel`, `vsobel`, `hscharr`, `vscharr`,
   `hprewitt`, `vprewitt`, `roberts_positive_diagonal`,

--- a/doc/release/release_dev.txt
+++ b/doc/release/release_dev.txt
@@ -33,6 +33,8 @@ API Changes
 Deprecations
 ------------
 
+- Python 2.6 support has been dropped. Minimal required Python version is 2.7.
+
 
 Contributors to this release
 ----------------------------

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -3,4 +3,4 @@ imread; python_version != '2.7'
 SimpleITK; python_version != '3.4' and python_version != '3.5'
 astropy
 tifffile
-imageio; python_version != '2.6'
+imageio

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -157,10 +157,4 @@ else:
     from .util.dtype import *
 
 
-if sys.version.startswith('2.6'):
-    msg = ("Python 2.6 is deprecated and will not be supported in "
-           "scikit-image 0.13+")
-    warnings.warn(msg, stacklevel=2)
-
-
 del warnings, functools, osp, imp, sys

--- a/skimage/_shared/tests/test_version_requirements.py
+++ b/skimage/_shared/tests/test_version_requirements.py
@@ -15,14 +15,13 @@ def test_get_module_version():
 
 
 def test_is_installed():
-    assert version_req.is_installed('python', '>=2.6')
+    assert version_req.is_installed('python', '>=2.7')
     assert not version_req.is_installed('numpy', '<1.0')
 
 
 def test_require():
-
-    # A function that only runs on Python >2.6 and numpy > 1.5 (should pass)
-    @version_req.require('python', '>2.6')
+    # A function that only runs on Python >2.7 and numpy > 1.5 (should pass)
+    @version_req.require('python', '>2.7')
     @version_req.require('numpy', '>1.5')
     def foo():
         return 1

--- a/tools/travis_before_install.sh
+++ b/tools/travis_before_install.sh
@@ -32,13 +32,6 @@ retry () {
 # add build dependencies
 echo "cython>=0.23.4" >> requirements.txt
 
-# require networkx 1.9.1 on 2.6, as 2.6 support was dropped in 1.10
-# require matplotlib 1.4.3 on 2.6, as 2.6 support was dropped in 1.5
-if [[ $TRAVIS_PYTHON_VERSION == 2.6* ]]; then
-    sed -i 's/networkx.*/networkx==1.9.1/g' requirements.txt
-    sed -i 's/matplotlib.*/matplotlib==1.4.3/g' requirements.txt
-fi
-
 if [[ $MINIMUM_REQUIREMENTS == 1 ]]; then
     sed -i 's/>=/==/g' requirements.txt
 fi


### PR DESCRIPTION
## Description
Python 2.6 development and support have stopped in [late 2013](https://docs.python.org/devguide/index.html#branchstatus). This PR claims to drop the support of Python 2.6 branch from `skimage` codebase.

## References
Addresses https://github.com/scikit-image/scikit-image/issues/1854 .


