### PR TITLE
Do not require cython for normal builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,8 +131,6 @@ if __name__ == "__main__":
             'Operating System :: MacOS',
         ],
         install_requires=INSTALL_REQUIRES,
-        # install cython when running setup.py (source install)
-        setup_requires=['cython>=0.21'],
         requires=REQUIRES,
         packages=setuptools.find_packages(exclude=['doc']),
         include_package_data=True,

--- a/skimage/_build.py
+++ b/skimage/_build.py
@@ -36,7 +36,7 @@ def cython(pyx_files, working_path=''):
         c_files = [f.replace('.pyx.in', '.c').replace('.pyx', '.c') for f in pyx_files]
         for cfile in [os.path.join(working_path, f) for f in c_files]:
             if not os.path.isfile(cfile):
-                raise RuntimeError('Cython >= 0.23 is required to build scikit-image from SCM checkout')
+                raise RuntimeError('Cython >= 0.23 is required to build scikit-image from git checkout')
 
         print("Cython >= 0.23 not found; falling back to pre-built %s" \
               % " ".join(c_files))

--- a/skimage/_build.py
+++ b/skimage/_build.py
@@ -27,15 +27,19 @@ def cython(pyx_files, working_path=''):
     try:
         from Cython import __version__
         if LooseVersion(__version__) < '0.23':
-            raise RuntimeError('Cython >= 0.23 needed to build scikit-image')
+            raise ImportError
 
         from Cython.Build import cythonize
     except ImportError:
-        # If cython is not found, we do nothing -- the build will make use of
-        # the distributed .c files
-        print("Cython not found; falling back to pre-built %s" \
-              % " ".join([f.replace('.pyx.in', 'c').replace('.pyx', '.c')
-                          for f in pyx_files]))
+        # If cython is not found, the build will make use of
+        # the distributed .c files if present
+        c_files = [f.replace('.pyx.in', '.c').replace('.pyx', '.c') for f in pyx_files]
+        for cfile in [os.path.join(working_path, f) for f in c_files]:
+            if not os.path.isfile(cfile):
+                raise RuntimeError('Cython >= 0.23 is required to build scikit-image from SCM checkout')
+
+        print("Cython >= 0.23 not found; falling back to pre-built %s" \
+              % " ".join(c_files))
     else:
         for pyxfile in [os.path.join(working_path, f) for f in pyx_files]:
 


### PR DESCRIPTION
## Description

We can build without cython when using pypi source tarballs.  Let people do that.
## Checklist

[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]
## References

Closes issue #2035
