### PR TITLE
Add line_nd to draw module

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -67,3 +67,5 @@ Other
   build to use Python 3.8 instead of 3.7.
 * When Python 3.8 is released, add entries to the build matrix in appveyor.
 * When Python 3.8 is released, add entries to the build matrix in azure.
+* When ``numpy`` is set to >= 1.16, simplify ``draw.line_nd`` by using the
+  vectorized version of ``np.linspace``.

--- a/skimage/draw/__init__.py
+++ b/skimage/draw/__init__.py
@@ -7,9 +7,11 @@ from ._draw import _bezier_segment
 from ._random_shapes import random_shapes
 from ._polygon2mask import polygon2mask
 
+from .draw_nd import line_nd
 
 __all__ = ['line',
            'line_aa',
+           'line_nd',
            'bezier_curve',
            'polygon',
            'polygon_perimeter',

--- a/skimage/draw/draw_nd.py
+++ b/skimage/draw/draw_nd.py
@@ -1,0 +1,57 @@
+import numpy as np
+
+
+def ndline(start, stop, endpoint=False, round=True):
+    """Draw a single-pixel thick line in n dimensions.
+
+    The line produced will be ndim-connected. That is, two subsequent
+    pixels in the line will be either direct or diagonal neighbours in
+    n dimensions.
+
+    Parameters
+    ----------
+    start : array-like, shape (N,)
+        The start coordinates of the line.
+    stop : array-like, shape (N,)
+        The end coordinates of the line.
+    endpoint : bool, optional
+        Whether to include the endpoint in the returned line. Defaults
+        to False, which allows for easy drawing of multi-point paths.
+    round : bool, optional
+        Whether to round the coordinates to integer. If True (default),
+        the returned coordinates can be used to directly index into an
+        array. `False` could be used for e.g. vector drawing.
+
+    Returns
+    -------
+    coords : tuple of arrays
+        The coordinates of points on the line.
+
+    Examples
+    --------
+    >>> lin = ndline((1, 1), (5, 2.5), endpoint=False)
+    >>> lin
+    [array([1, 2, 3, 4]), array([1, 1, 2, 2])]
+    >>> im = np.zeros((6, 5), dtype=int)
+    array([[0, 0, 0, 0, 0],
+           [0, 1, 0, 0, 0],
+           [0, 1, 0, 0, 0],
+           [0, 0, 1, 0, 0],
+           [0, 0, 1, 0, 0],
+           [0, 0, 0, 0, 0]])
+    >>> geom.ndline([2, 1, 1], [5, 5, 2.5], endpoint=True)
+    [array([2, 3, 4, 4, 5]), array([1, 2, 3, 4, 5]), array([1, 1, 2, 2, 2])]
+    """
+    start = np.asarray(start)
+    stop = np.asarray(stop)
+    npoints = np.max(np.abs(stop - start))
+    if endpoint:
+        npoints += 1
+    npoints = int(np.ceil(npoints))
+    coords = []
+    for dim in range(len(start)):
+        dimcoords = np.linspace(start[dim], stop[dim], npoints, endpoint)
+        if round:
+            dimcoords = np.round(dimcoords).astype(int)
+        coords.append(dimcoords)
+    return coords

--- a/skimage/draw/draw_nd.py
+++ b/skimage/draw/draw_nd.py
@@ -42,7 +42,9 @@ def _round_safe(coords):
     >>> _round_safe(coords1)
     array([0, 1, 2, 3, 4, 5, 6, 7])
     """
-    if coords[0] % 1 == 0.5 and coords[1] - coords[0] == 1:
+    if (len(coords) > 1
+            and coords[0] % 1 == 0.5
+            and coords[1] - coords[0] == 1):
         _round_function = np.floor
     else:
         _round_function = np.round

--- a/skimage/draw/draw_nd.py
+++ b/skimage/draw/draw_nd.py
@@ -51,7 +51,7 @@ def _round_safe(coords):
     return _round_function(coords).astype(int)
 
 
-def line_nd(start, stop, *, endpoint=False, round=True):
+def line_nd(start, stop, *, endpoint=False, integer=True):
     """Draw a single-pixel thick line in n dimensions.
 
     The line produced will be ndim-connected. That is, two subsequent
@@ -67,7 +67,7 @@ def line_nd(start, stop, *, endpoint=False, round=True):
     endpoint : bool, optional
         Whether to include the endpoint in the returned line. Defaults
         to False, which allows for easy drawing of multi-point paths.
-    round : bool, optional
+    integer : bool, optional
         Whether to round the coordinates to integer. If True (default),
         the returned coordinates can be used to directly index into an
         array. `False` could be used for e.g. vector drawing.
@@ -102,7 +102,7 @@ def line_nd(start, stop, *, endpoint=False, round=True):
     coords = []
     for dim in range(len(start)):
         dimcoords = np.linspace(start[dim], stop[dim], npoints, endpoint)
-        if round:
+        if integer:
             dimcoords = _round_safe(dimcoords).astype(int)
         coords.append(dimcoords)
     return coords

--- a/skimage/draw/draw_nd.py
+++ b/skimage/draw/draw_nd.py
@@ -51,7 +51,7 @@ def _round_safe(coords):
     return _round_function(coords).astype(int)
 
 
-def line_nd(start, stop, endpoint=False, round=True):
+def line_nd(start, stop, *, endpoint=False, round=True):
     """Draw a single-pixel thick line in n dimensions.
 
     The line produced will be ndim-connected. That is, two subsequent

--- a/skimage/draw/draw_nd.py
+++ b/skimage/draw/draw_nd.py
@@ -33,6 +33,8 @@ def line_nd(start, stop, endpoint=False, round=True):
     >>> lin
     [array([1, 2, 3, 4]), array([1, 1, 2, 2])]
     >>> im = np.zeros((6, 5), dtype=int)
+    >>> im[lin] = 1
+    >>> im
     array([[0, 0, 0, 0, 0],
            [0, 1, 0, 0, 0],
            [0, 1, 0, 0, 0],

--- a/skimage/draw/draw_nd.py
+++ b/skimage/draw/draw_nd.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def ndline(start, stop, endpoint=False, round=True):
+def line_nd(start, stop, endpoint=False, round=True):
     """Draw a single-pixel thick line in n dimensions.
 
     The line produced will be ndim-connected. That is, two subsequent
@@ -29,7 +29,7 @@ def ndline(start, stop, endpoint=False, round=True):
 
     Examples
     --------
-    >>> lin = ndline((1, 1), (5, 2.5), endpoint=False)
+    >>> lin = line_nd((1, 1), (5, 2.5), endpoint=False)
     >>> lin
     [array([1, 2, 3, 4]), array([1, 1, 2, 2])]
     >>> im = np.zeros((6, 5), dtype=int)
@@ -39,7 +39,7 @@ def ndline(start, stop, endpoint=False, round=True):
            [0, 0, 1, 0, 0],
            [0, 0, 1, 0, 0],
            [0, 0, 0, 0, 0]])
-    >>> geom.ndline([2, 1, 1], [5, 5, 2.5], endpoint=True)
+    >>> geom.line_nd([2, 1, 1], [5, 5, 2.5], endpoint=True)
     [array([2, 3, 4, 4, 5]), array([1, 2, 3, 4, 5]), array([1, 1, 2, 2, 2])]
     """
     start = np.asarray(start)

--- a/skimage/draw/draw_nd.py
+++ b/skimage/draw/draw_nd.py
@@ -81,7 +81,7 @@ def line_nd(start, stop, *, endpoint=False, integer=True):
     --------
     >>> lin = line_nd((1, 1), (5, 2.5), endpoint=False)
     >>> lin
-    [array([1, 2, 3, 4]), array([1, 1, 2, 2])]
+    (array([1, 2, 3, 4]), array([1, 1, 2, 2]))
     >>> im = np.zeros((6, 5), dtype=int)
     >>> im[lin] = 1
     >>> im
@@ -92,7 +92,7 @@ def line_nd(start, stop, *, endpoint=False, integer=True):
            [0, 0, 1, 0, 0],
            [0, 0, 0, 0, 0]])
     >>> line_nd([2, 1, 1], [5, 5, 2.5], endpoint=True)
-    [array([2, 3, 4, 4, 5]), array([1, 2, 3, 4, 5]), array([1, 1, 2, 2, 2])]
+    (array([2, 3, 4, 4, 5]), array([1, 2, 3, 4, 5]), array([1, 1, 2, 2, 2]))
     """
     start = np.asarray(start)
     stop = np.asarray(stop)

--- a/skimage/draw/draw_nd.py
+++ b/skimage/draw/draw_nd.py
@@ -1,6 +1,54 @@
 import numpy as np
 
 
+def _round_safe(coords):
+    """Round coords while ensuring successive values are less than 1 apart.
+
+    When rounding coordinates for `line_nd`, we want coordinates that are less
+    than 1 apart (always the case, by design) to remain less than one apart.
+    However, NumPy rounds values to the nearest *even* integer, so:
+
+    >>> np.round([0.5, 1.5, 2.5, 3.5, 4.5])
+    array([ 0.,  2.,  2.,  4.,  4.])
+
+    So, for our application, we detect whether the above case occurs, and use
+    ``np.floor`` if so. It is sufficient to detect that the first coordinate
+    falls on 0.5 and that the second coordinate is 1.0 apart, since we assume
+    by construction that the inter-point distance is less than or equal to 1
+    and that all successive points are equidistant.
+
+    Parameters
+    ----------
+    coords : 1D array of float
+        The coordinates array. We assume that all successive values are
+        equidistant (``np.all(np.diff(coords) = coords[1] - coords[0])``)
+        and that this distance is no more than 1
+        (``np.abs(coords[1] - coords[0]) <= 1``).
+
+    Returns
+    -------
+    rounded : 1D array of int
+        The array correctly rounded for an indexing operation, such that no
+        successive indices will be more than 1 apart.
+
+    Examples
+    --------
+    >>> coords0 = np.array([0.5, 1.25, 2., 2.75, 3.5])
+    >>> _round_safe(coords0)
+    array([0, 1, 2, 3, 4])
+    >>> coords1 = np.arange(0.5, 8, 1)
+    >>> coords1
+    array([ 0.5,  1.5,  2.5,  3.5,  4.5,  5.5,  6.5,  7.5])
+    >>> _round_safe(coords1)
+    array([0, 1, 2, 3, 4, 5, 6, 7])
+    """
+    if coords[0] % 1 == 0.5 and coords[1] - coords[0] == 1:
+        _round_function = np.floor
+    else:
+        _round_function = np.round
+    return _round_function(coords).astype(int)
+
+
 def line_nd(start, stop, endpoint=False, round=True):
     """Draw a single-pixel thick line in n dimensions.
 
@@ -53,6 +101,6 @@ def line_nd(start, stop, endpoint=False, round=True):
     for dim in range(len(start)):
         dimcoords = np.linspace(start[dim], stop[dim], npoints, endpoint)
         if round:
-            dimcoords = np.round(dimcoords).astype(int)
+            dimcoords = _round_safe(dimcoords).astype(int)
         coords.append(dimcoords)
     return coords

--- a/skimage/draw/draw_nd.py
+++ b/skimage/draw/draw_nd.py
@@ -39,7 +39,7 @@ def line_nd(start, stop, endpoint=False, round=True):
            [0, 0, 1, 0, 0],
            [0, 0, 1, 0, 0],
            [0, 0, 0, 0, 0]])
-    >>> geom.line_nd([2, 1, 1], [5, 5, 2.5], endpoint=True)
+    >>> line_nd([2, 1, 1], [5, 5, 2.5], endpoint=True)
     [array([2, 3, 4, 4, 5]), array([1, 2, 3, 4, 5]), array([1, 1, 2, 2, 2])]
     """
     start = np.asarray(start)

--- a/skimage/draw/draw_nd.py
+++ b/skimage/draw/draw_nd.py
@@ -46,10 +46,9 @@ def line_nd(start, stop, endpoint=False, round=True):
     """
     start = np.asarray(start)
     stop = np.asarray(stop)
-    npoints = np.max(np.abs(stop - start))
+    npoints = int(np.ceil(np.max(np.abs(stop - start))))
     if endpoint:
         npoints += 1
-    npoints = int(np.ceil(npoints))
     coords = []
     for dim in range(len(start)):
         dimcoords = np.linspace(start[dim], stop[dim], npoints, endpoint)

--- a/skimage/draw/draw_nd.py
+++ b/skimage/draw/draw_nd.py
@@ -105,4 +105,4 @@ def line_nd(start, stop, *, endpoint=False, integer=True):
         if integer:
             dimcoords = _round_safe(dimcoords).astype(int)
         coords.append(dimcoords)
-    return coords
+    return tuple(coords)

--- a/skimage/draw/tests/test_draw_nd.py
+++ b/skimage/draw/tests/test_draw_nd.py
@@ -1,0 +1,7 @@
+from skimage.draw import line_nd
+
+
+def test_empty_line():
+    coords = line_nd((1, 1, 1), (1, 1, 1))
+    assert len(coords) == 3
+    assert all(len(c) == 0 for c in coords)

--- a/skimage/draw/tests/test_draw_nd.py
+++ b/skimage/draw/tests/test_draw_nd.py
@@ -1,7 +1,13 @@
 from skimage.draw import line_nd
+from skimage._shared.testing import assert_equal
 
 
 def test_empty_line():
     coords = line_nd((1, 1, 1), (1, 1, 1))
     assert len(coords) == 3
     assert all(len(c) == 0 for c in coords)
+
+
+def test_zero_line():
+    coords = line_nd((-1, -1), (2, 2))
+    assert_equal(coords, [[-1, 0, 1], [-1, 0, 1]])

--- a/skimage/draw/tests/test_draw_nd.py
+++ b/skimage/draw/tests/test_draw_nd.py
@@ -11,3 +11,8 @@ def test_empty_line():
 def test_zero_line():
     coords = line_nd((-1, -1), (2, 2))
     assert_equal(coords, [[-1, 0, 1], [-1, 0, 1]])
+
+
+def test_no_round():
+    coords = line_nd((0.5, 0), (2.5, 0), integer=False, endpoint=True)
+    assert_equal(coords, [[0.5, 1.5, 2.5], [0, 0, 0]])


### PR DESCRIPTION
Add a function drawing a line in n-dimensional space.

There is one failure edge case to the function, which is numpy's rounding behaviour to the nearest even number:

``` python
In [1]: import numpy as np
In [2]: arr = np.arange(0.5, 8, 1)
In [3]: arr
Out[3]: array([ 0.5,  1.5,  2.5,  3.5,  4.5,  5.5,  6.5,  7.5])
In [4]: np.round(arr)
Out[4]: array([ 0.,  2.,  2.,  4.,  4.,  6.,  6.,  8.])
```

This would result in broken lines. This can be detected, though. The question is what to do when detected. My preference would be to replace round with floor (ie rounding towards 0) when this happens:

``` python
In [5]: np.all(arr % 1 == 0.5)
Out[5]: True
In [6]: np.floor(arr)
Out[6]: array([ 0.,  1.,  2.,  3.,  4.,  5.,  6.,  7.])
```

Should I just add that in?
## Checklist

[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests
