### PR TITLE
Make the img_num argument optional

### DIFF
--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -161,8 +161,10 @@ class ImageCollection(object):
             load_pattern = load_pattern.split(':')
             self._files = []
             for pattern in load_pattern:
+                print(pattern, glob(pattern))
                 self._files.extend(glob(pattern))
             self._files = sorted(self._files, key=alphanumeric_key)
+            print(self._files, load_pattern)
             self._numframes = self._find_images()
         else:
             self._files = load_pattern
@@ -207,7 +209,6 @@ class ImageCollection(object):
                     im = Image.open(fname)
                     im.seek(0)
                 except (IOError, OSError):
-                    index.append([fname, i])
                     continue
                 i = 0
                 while True:
@@ -256,10 +257,15 @@ class ImageCollection(object):
                 if self._frame_index:
                     fname, img_num = self._frame_index[n]
                     if img_num is not None:
-                        self.data[idx] = self.load_func(fname, img_num=img_num,
-                                                        **kwargs)
-                    else:
+                        kwargs['img_num'] = img_num
+                    try:
                         self.data[idx] = self.load_func(fname, **kwargs)
+                    except TypeError as e:
+                        if "unexpected keyword argument 'img_num'" in str(e):
+                            del kwargs['img_num']
+                            self.data[idx] = self.load_func(fname, **kwargs)
+                        else:
+                            raise
                 else:
                     self.data[idx] = self.load_func(self.files[n], **kwargs)
                 self._cached = n

--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -258,6 +258,7 @@ class ImageCollection(object):
                         kwargs['img_num'] = img_num
                     try:
                         self.data[idx] = self.load_func(fname, **kwargs)
+                    # Account for functions that do not accept an img_num kwarg
                     except TypeError as e:
                         if "unexpected keyword argument 'img_num'" in str(e):
                             del kwargs['img_num']

--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -157,8 +157,7 @@ class ImageCollection(object):
                  **load_func_kwargs):
         """Load and manage a collection of images."""
         if isinstance(load_pattern, six.string_types):
-            load_pattern = load_pattern.replace(os.pathsep, ':')
-            load_pattern = load_pattern.split(':')
+            load_pattern = load_pattern.split(os.pathsep)
             self._files = []
             for pattern in load_pattern:
                 self._files.extend(glob(pattern))

--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -161,10 +161,8 @@ class ImageCollection(object):
             load_pattern = load_pattern.split(':')
             self._files = []
             for pattern in load_pattern:
-                print(pattern, glob(pattern))
                 self._files.extend(glob(pattern))
             self._files = sorted(self._files, key=alphanumeric_key)
-            print(self._files, load_pattern)
             self._numframes = self._find_images()
         else:
             self._files = load_pattern

--- a/skimage/io/tests/test_collection.py
+++ b/skimage/io/tests/test_collection.py
@@ -80,6 +80,14 @@ class TestImageCollection():
         ic = ImageCollection(load_pattern, load_func=load_fn)
         assert_equal(ic[1], (2, 'two'))
 
+    def test_custom_load_func(self):
+
+        def load_fn(x):
+            return x
+
+        ic = ImageCollection(':'.join(self.pattern), load_func=load_fn)
+        assert_equal(ic[0], self.pattern[0])
+
     def test_concatenate(self):
         array = self.images_matched.concatenate()
         expected_shape = (len(self.images_matched),) + self.images[0].shape

--- a/skimage/io/tests/test_collection.py
+++ b/skimage/io/tests/test_collection.py
@@ -85,7 +85,7 @@ class TestImageCollection():
         def load_fn(x):
             return x
 
-        ic = ImageCollection(':'.join(self.pattern), load_func=load_fn)
+        ic = ImageCollection(os.pathsep.join(self.pattern), load_func=load_fn)
         assert_equal(ic[0], self.pattern[0])
 
     def test_concatenate(self):

--- a/skimage/io/tests/test_multi_image.py
+++ b/skimage/io/tests/test_multi_image.py
@@ -24,7 +24,7 @@ class TestMultiImage():
                      MultiImage(paths[1], conserve_memory=False),
                      ImageCollection(paths[0]),
                      ImageCollection(paths[1], conserve_memory=False),
-                     ImageCollection('%s:%s' % (paths[0], paths[1]))]
+                     ImageCollection(os.pathsep.join(paths))]
 
     def test_shapes(self):
         img = self.imgs[-1]


### PR DESCRIPTION
Fixes #2050, do not require the `load_func` to accept an `img_num` argument.
