### PR TITLE
Speed up bilateral filter tests

### DIFF
--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -153,15 +153,15 @@ def test_denoise_tv_bregman_3d():
 
 
 def test_denoise_bilateral_2d():
-    img = checkerboard_gray.copy()
+    img = checkerboard_gray.copy()[:50,:50]
     # add some random noise
     img += 0.5 * img.std() * np.random.rand(*img.shape)
     img = np.clip(img, 0, 1)
 
     out1 = restoration.denoise_bilateral(img, sigma_color=0.1,
-                                         sigma_spatial=20, multichannel=False)
+                                         sigma_spatial=10, multichannel=False)
     out2 = restoration.denoise_bilateral(img, sigma_color=0.2,
-                                         sigma_spatial=30, multichannel=False)
+                                         sigma_spatial=20, multichannel=False)
 
     # make sure noise is reduced in the checkerboard cells
     assert img[30:45, 5:15].std() > out1[30:45, 5:15].std()
@@ -169,13 +169,13 @@ def test_denoise_bilateral_2d():
 
 
 def test_denoise_bilateral_color():
-    img = checkerboard.copy()
+    img = checkerboard.copy()[:50,:50]
     # add some random noise
     img += 0.5 * img.std() * np.random.rand(*img.shape)
     img = np.clip(img, 0, 1)
 
-    out1 = restoration.denoise_bilateral(img, sigma_color=0.1, sigma_spatial=20)
-    out2 = restoration.denoise_bilateral(img, sigma_color=0.2, sigma_spatial=30)
+    out1 = restoration.denoise_bilateral(img, sigma_color=0.1, sigma_spatial=10)
+    out2 = restoration.denoise_bilateral(img, sigma_color=0.2, sigma_spatial=20)
 
     # make sure noise is reduced in the checkerboard cells
     assert img[30:45, 5:15].std() > out1[30:45, 5:15].std()
@@ -212,29 +212,29 @@ def test_denoise_bilateral_nan():
     assert_equal(img, out)
 
 def test_denoise_sigma_range():
-    img = checkerboard_gray.copy()
+    img = checkerboard_gray.copy()[:50,:50]
     # add some random noise
     img += 0.5 * img.std() * np.random.rand(*img.shape)
     img = np.clip(img, 0, 1)
     out1 = restoration.denoise_bilateral(img, sigma_color=0.1,
-                                         sigma_spatial=20, multichannel=False)
+                                         sigma_spatial=10, multichannel=False)
     with expected_warnings('`sigma_range` has been deprecated in favor of `sigma_color`. '
                            'The `sigma_range` keyword argument will be removed in v0.14'):
         out2 = restoration.denoise_bilateral(img, sigma_range=0.1,
-                                             sigma_spatial=20, multichannel=False)
+                                             sigma_spatial=10, multichannel=False)
     assert_equal(out1, out2)
 
 def test_denoise_sigma_range_and_sigma_color():
-    img = checkerboard_gray.copy()
+    img = checkerboard_gray.copy()[:50,:50]
     # add some random noise
     img += 0.5 * img.std() * np.random.rand(*img.shape)
     img = np.clip(img, 0, 1)
     out1 = restoration.denoise_bilateral(img, sigma_color=0.1,
-                                         sigma_spatial=20, multichannel=False)
+                                         sigma_spatial=10, multichannel=False)
     with expected_warnings('`sigma_range` has been deprecated in favor of `sigma_color`. '
                            'The `sigma_range` keyword argument will be removed in v0.14'):
         out2 = restoration.denoise_bilateral(img, sigma_color=0.2, sigma_range=0.1,
-                                             sigma_spatial=20, multichannel=False)
+                                             sigma_spatial=10, multichannel=False)
     assert_equal(out1, out2)
 
 def test_nl_means_denoising_2d():


### PR DESCRIPTION
## Description
Speed up bilateral filter tests by making them work on a 50x50 image instead of 200x200, and use smaller sigma_spatial

```
$ time PYTHONPATH=. python ./skimage/restoration/tests/test_denoise.py --verbose

(original)
real    1m59.317s
user    1m47.788s
sys 0m0.563s

(this version)
real    0m5.100s
user    0m5.008s
sys 0m0.341s
```

## Checklist

- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py) (Not applicable)
- [x] Gallery example in `./doc/examples` (new features only) (Not applicable)
- [x] Unit tests (Not applicable)



## References
Closes #1993


