### PR TITLE
JPEG quality argument in imsave

### DIFF
--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -124,6 +124,13 @@ def imsave(fname, arr, plugin=None, **plugin_args):
     plugin_args : keywords
         Passed to the given plugin.
 
+    Notes
+    -----
+    When saving a JPEG, the compression ratio may be controlled using the
+    ``quality`` keyword argument which is an integer with values in [1, 100]
+    where 1 is worst quality and smallest file size, and 100 is best quality and
+    largest file size (default 75).  This is only available when using the PIL
+    and imageio plugins.
     """
     if plugin is None and hasattr(fname, 'lower'):
         if fname.lower().endswith(('.tiff', '.tif')):

--- a/skimage/io/_plugins/freeimage_plugin.py
+++ b/skimage/io/_plugins/freeimage_plugin.py
@@ -751,7 +751,7 @@ def imread(filename):
     return img
 
 
-def imsave(filename, img):
+def imsave(filename, img, **kwargs):
     '''
     imsave(filename, img)
 
@@ -763,5 +763,26 @@ def imsave(filename, img):
     ----------
       filename : file name
       img : image to be saved as nd array
+
+    Other parameters
+    ----------------
+    kwargs : keywords
+        When saving as JPEG, supports the ``quality`` keyword argument which is
+        an integer with values in [1, 100]
     '''
-    write(img, filename)
+
+    flags = 0
+    if 'quality' in kwargs:
+        quality = kwargs['quality']
+        if quality > 75:
+            flags |= IoFlags.JPEG_QUALITYSUPERB
+        elif quality > 50:
+            flags |= IoFlags.JPEG_QUALITYGOOD
+        elif quality > 25:
+            flags |= IoFlags.JPEG_QUALITYNORMAL
+        elif quality > 10:
+            flags |= IoFlags.JPEG_QUALITYAVERAGE
+        elif quality >= 0:
+            flags |= IoFlags.JPEG_QUALITYBAD
+
+    write(img, filename, flags=flags)


### PR DESCRIPTION
## Description

Add documentation on how to set the JPEG quality (and control file size).  This is a very useful feature in imsave but it is highly non-obvious at the moment (hidden in PIL docs, not documented at all for imageio or the top level imsave).  The default quality=75 is too low for many uses, and sometimes explicit control of file size/quality tradeoff is needed.

Both PIL and imageio plugins already support this.  

Also adds support for quality in freeimage plugin (okay to not include this part, the doc change stands alone)
## Checklist

[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests
