### PR TITLE
Speed up colorconv._convert

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -502,14 +502,8 @@ def _convert(matrix, arr):
         The converted array.
     """
     arr = _prepare_colorarray(arr)
-    arr = np.swapaxes(arr, 0, -1)
-    oldshape = arr.shape
-    arr = np.reshape(arr, (3, -1))
-    out = np.dot(matrix, arr)
-    out.shape = oldshape
-    out = np.swapaxes(out, -1, 0)
 
-    return np.ascontiguousarray(out)
+    return np.dot(arr, matrix.T.copy())
 
 
 def xyz2rgb(xyz):


### PR DESCRIPTION
## Description

`colorconv._convert(matrix, arr)` does a pretty complicated rearrangement of the source image, then `np.dot(matrix, arr)`, then another rearrangement. This replaces with the equivalent and simpler `np.dot(arr, matrix.T)`

Benchmarking script (ipython):

```
import skimage.color.colorconv as colorconv
import skimage
import skimage.transform
import skimage.data
import numpy as np
from memory_profiler import memory_usage

img = skimage.data.hubble_deep_field()
img = skimage.transform.resize(img, (4096,4096))
img = skimage.img_as_float(img)
img.shape

def test():
    colorconv._convert(colorconv.xyz_from_rgb, img)

memory_usage(test)

%timeit test()
```

Results:
```
(original)
memory in MB:
[486.21484375,
 486.2265625,
 538.8828125,
 592.8828125,
 646.8828125,
 702.8828125,
 758.8828125,
 814.8828125,
 869.49609375,
 1254.09375,
 1254.09375,
 1285.08984375,
 1329.08984375,
 1375.1640625,
 1421.1640625,
 1467.1640625,
 1513.1640625,
 1557.1640625,
 1603.1640625,
 486.2421875]

time:
1 loops, best of 3: 1.77 s per loop

(new)
memory in MB:
[483.3671875,
 483.37109375,
 521.828125,
 559.83984375,
 597.90625,
 635.90625,
 673.90625,
 711.90625,
 749.90625,
 789.90625,
 827.90625,
 865.90625,
 483.38671875]

time:
1 loops, best of 3: 1.01 s per loop
```

The peak memory usage is ~2x the size of the source image, compared to 4x the size of the source image in the original version.  

The speedup is significant for images which are too big to fit in CPU cache, but also depends a lot on stride and memory alignment issues, so it is not consistenly as good as shown here. 