### PR TITLE
allowing to pass a np.random.RandomState to ransac

### DIFF
--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -201,6 +201,7 @@ def check_random_state(seed):
     If seed is already a RandomState instance, return it.
     Otherwise raise ValueError.
     """
+    # Function originally from scikit-learn's module sklearn.utils.validation
     if seed is None or seed is np.random:
         return np.random.mtrand._rand
     if isinstance(seed, (numbers.Integral, np.integer)):

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -195,11 +195,20 @@ def copy_func(f, name=None):
 
 
 def check_random_state(seed):
-    """Turn seed into a np.random.RandomState instance
-    If seed is None, return the RandomState singleton used by np.random.
-    If seed is an int, return a new RandomState instance seeded with seed.
-    If seed is already a RandomState instance, return it.
-    Otherwise raise ValueError.
+    """Turn seed into a `np.random.RandomState` instance.
+
+    Parameters
+    ----------
+    seed : None, int or np.random.RandomState
+           If `seed` is None, return the RandomState singleton used by `np.random`.
+           If `seed` is an int, return a new RandomState instance seeded with `seed`.
+           If `seed` is already a RandomState instance, return it.
+
+    Raises
+    ------
+    ValueError
+        If `seed` is of the wrong type.
+
     """
     # Function originally from scikit-learn's module sklearn.utils.validation
     if seed is None or seed is np.random:

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -3,6 +3,7 @@ import functools
 import sys
 import numpy as np
 import types
+import numbers
 
 import six
 
@@ -191,3 +192,20 @@ def copy_func(f, name=None):
     return types.FunctionType(six.get_function_code(f),
                               six.get_function_globals(f), name or f.__name__,
                               six.get_function_defaults(f), six.get_function_closure(f))
+
+
+def check_random_state(seed):
+    """Turn seed into a np.random.RandomState instance
+    If seed is None, return the RandomState singleton used by np.random.
+    If seed is an int, return a new RandomState instance seeded with seed.
+    If seed is already a RandomState instance, return it.
+    Otherwise raise ValueError.
+    """
+    if seed is None or seed is np.random:
+        return np.random.mtrand._rand
+    if isinstance(seed, (numbers.Integral, np.integer)):
+        return np.random.RandomState(seed)
+    if isinstance(seed, np.random.RandomState):
+        return seed
+    raise ValueError('%r cannot be used to seed a numpy.random.RandomState'
+                     ' instance' % seed)

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -765,7 +765,7 @@ def ransac(data, model_class, min_samples, residual_threshold,
         where the probability (confidence) is typically set to a high value
         such as 0.99, and e is the current fraction of inliers w.r.t. the
         total number of samples.
-    random_state : int, RandomState instance or None, optional (default=None)
+    random_state : int, RandomState instance or None, optional
         If int, random_state is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -1,8 +1,7 @@
 import math
-import numbers
 import numpy as np
 from scipy import optimize
-from .._shared.utils import skimage_deprecation, warn
+from .._shared.utils import check_random_state, skimage_deprecation, warn
 
 
 def _check_data_dim(data, dim):
@@ -688,23 +687,6 @@ def _dynamic_max_trials(n_inliers, n_samples, min_samples, probability):
         return 0
 
     return int(np.ceil(nom / denom))
-    
-    
-def check_random_state(seed):
-    """Turn seed into a np.random.RandomState instance
-    If seed is None, return the RandomState singleton used by np.random.
-    If seed is an int, return a new RandomState instance seeded with seed.
-    If seed is already a RandomState instance, return it.
-    Otherwise raise ValueError.
-    """
-    if seed is None or seed is np.random:
-        return np.random.mtrand._rand
-    if isinstance(seed, (numbers.Integral, np.integer)):
-        return np.random.RandomState(seed)
-    if isinstance(seed, np.random.RandomState):
-        return seed
-    raise ValueError('%r cannot be used to seed a numpy.random.RandomState'
-                     ' instance' % seed)
 
 
 def ransac(data, model_class, min_samples, residual_threshold,

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -32,7 +32,8 @@ def test_line_model_estimate():
     model_est.estimate(data)
 
     # test whether estimated parameters almost equal original parameters
-    x = np.random.rand(100, 2)
+    random_state = np.random.RandomState(1234)
+    x = random_state.rand(100, 2)
     assert_almost_equal(model0.predict(x), model_est.predict(x), 1)
 
 
@@ -75,8 +76,8 @@ def test_line_modelND_estimate():
              10 * np.arange(-100,100)[...,np.newaxis] * model0.params[1])
 
     # add gaussian noise to data
-    np.random.seed(1234)
-    data = data0 + np.random.normal(size=data0.shape)
+    random_state = np.random.RandomState(1234)
+    data = data0 + random_state.normal(size=data0.shape)
 
     # estimate parameters of noisy data
     model_est = LineModelND()
@@ -130,8 +131,8 @@ def test_circle_model_estimate():
     data0 = model0.predict_xy(t)
 
     # add gaussian noise to data
-    np.random.seed(1234)
-    data = data0 + np.random.normal(size=data0.shape)
+    random_state = np.random.RandomState(1234)
+    data = data0 + random_state.normal(size=data0.shape)
 
     # estimate parameters of noisy data
     model_est = CircleModel()
@@ -172,8 +173,8 @@ def test_ellipse_model_estimate():
     data0 = model0.predict_xy(t)
 
     # add gaussian noise to data
-    np.random.seed(1234)
-    data = data0 + np.random.normal(size=data0.shape)
+    random_state = np.random.RandomState(1234)
+    data = data0 + random_state.normal(size=data0.shape)
 
     # estimate parameters of noisy data
     model_est = EllipseModel()
@@ -206,7 +207,8 @@ def test_ransac_shape():
     data0[outliers[2], :] = (-100, -10)
 
     # estimate parameters of corrupted data
-    model_est, inliers = ransac(data0, CircleModel, 3, 5, random_state=np.random.RandomState(1))
+    model_est, inliers = ransac(data0, CircleModel, 3, 5,
+                                random_state=1)
 
     # test whether estimated parameters equal original parameters
     assert_equal(model0.params, model_est.params)
@@ -230,7 +232,8 @@ def test_ransac_geometric():
     dst[outliers[2]] = (50, 50)
 
     # estimate parameters of corrupted data
-    model_est, inliers = ransac((src, dst), AffineTransform, 2, 20, random_state=random_state)
+    model_est, inliers = ransac((src, dst), AffineTransform, 2, 20,
+                                random_state=random_state)
 
     # test whether estimated parameters equal original parameters
     assert_almost_equal(model0.params, model_est.params)
@@ -238,22 +241,20 @@ def test_ransac_geometric():
 
 
 def test_ransac_is_data_valid():
-    np.random.seed(1)
 
     is_data_valid = lambda data: data.shape[0] > 2
     model, inliers = ransac(np.empty((10, 2)), LineModelND, 2, np.inf,
-                            is_data_valid=is_data_valid)
+                            is_data_valid=is_data_valid, random_state=1)
     assert_equal(model, None)
     assert_equal(inliers, None)
 
 
 def test_ransac_is_model_valid():
-    np.random.seed(1)
 
     def is_model_valid(model, data):
         return False
     model, inliers = ransac(np.empty((10, 2)), LineModelND, 2, np.inf,
-                            is_model_valid=is_model_valid)
+                            is_model_valid=is_model_valid, random_state=1)
     assert_equal(model, None)
     assert_equal(inliers, None)
 

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -193,8 +193,6 @@ def test_ellipse_model_residuals():
 
 
 def test_ransac_shape():
-    np.random.seed(1)
-
     # generate original data without noise
     model0 = CircleModel()
     model0.params = (10, 12, 3)
@@ -208,7 +206,7 @@ def test_ransac_shape():
     data0[outliers[2], :] = (-100, -10)
 
     # estimate parameters of corrupted data
-    model_est, inliers = ransac(data0, CircleModel, 3, 5)
+    model_est, inliers = ransac(data0, CircleModel, 3, 5, random_state=np.random.RandomState(1))
 
     # test whether estimated parameters equal original parameters
     assert_equal(model0.params, model_est.params)
@@ -217,10 +215,10 @@ def test_ransac_shape():
 
 
 def test_ransac_geometric():
-    np.random.seed(1)
+    random_state = np.random.RandomState(1)
 
     # generate original data without noise
-    src = 100 * np.random.random((50, 2))
+    src = 100 * random_state.random_sample((50, 2))
     model0 = AffineTransform(scale=(0.5, 0.3), rotation=1,
                              translation=(10, 20))
     dst = model0(src)
@@ -232,7 +230,7 @@ def test_ransac_geometric():
     dst[outliers[2]] = (50, 50)
 
     # estimate parameters of corrupted data
-    model_est, inliers = ransac((src, dst), AffineTransform, 2, 20)
+    model_est, inliers = ransac((src, dst), AffineTransform, 2, 20, random_state=random_state)
 
     # test whether estimated parameters equal original parameters
     assert_almost_equal(model0.params, model_est.params)


### PR DESCRIPTION
## Description
This PR is to allow passing a random_state to `ransac`. Using `np.random.seed()` to freeze the random state is generally a bad idea as it sets a seed for all subsequent `np.random` calls, even outside of `ransac`. For certain reasons, we might want to freeze some seeds while allowing others to be free.

My personal interest in allowing to freeze the random seed of `ransac` are:
 - for unit testing, where `np.random.RandomState` is cleaner than `np.random.seed()` 
 - for running experiments: I have a pipeline where `ransac` is called at the beginning, I want to experiment with different parameters that influence later stages of the pipeline, but I do not want to see in my results the influence of the randomness of ransac (or at least I want to be able to switch between a deterministic `ransac` for a fixed input or a non-deterministic `ransac`).

Additionally, `np.random` has been reported not to be thread-safe, while `np.random.RandomState` is: 
 - https://github.com/scikit-image/scikit-image/issues/1521

## Comments

 - the `check_random_state` function is from scikit-learn: https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/utils/validation.py#L564 as well as the docstring line. Please let me know if you would prefer a simpler version that only allows passing a `np.random.RandomState` object. If you think this function is good to use, shall we mention in its docstring that it has been copied from scikit-learn?

 - I updated two of the tests as an example, I can update the remaining ones if you are happy with it.

 - `np.random.RandomState.random` does not exist and `np.random.RandomState.random_sample` should be used instead. Indeed, `np.random.random` is only an alias for `np.random.random_sample` https://github.com/numpy/numpy/blob/master/numpy/random/__init__.py#L102




