### PR TITLE
Adding threshold_multiotsu.

### DIFF
--- a/doc/examples/segmentation/plot_multiotsu.py
+++ b/doc/examples/segmentation/plot_multiotsu.py
@@ -1,0 +1,79 @@
+"""
+=======================
+Multi-Otsu Thresholding
+=======================
+
+In this example we use multi-Otsu threshold to separate the pixels of an
+input image into three different classes, each one obtained according to
+the intensity of the gray levels within the image.
+
+Multi-Otsu calculates several thresholds, determined by the number of desired
+classes. The default number of classes is 3: for obtaining three classes, the
+algorithm returns two threshold values. They are represented by a red line in
+the histogram below.
+
+.. [1] Liao, P-S. and Chung, P-C., "A fast algorithm for multilevel
+thresholding", Journal of Information Science and Engineering 17 (5):
+713-727, 2001.
+"""
+
+from skimage.data import camera
+from skimage import img_as_float
+from skimage.filters import threshold_multiotsu
+
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+# Stablishing the font size for all plots.
+matplotlib.rcParams['font.size'] = 9
+
+# The input image.
+image = camera()
+
+# Applying multi-Otsu threshold for the default value, generating
+# three classes.
+thresh = threshold_multiotsu(image)
+print('Threshold values: ', thresh)
+
+# Using the values on thresh, we generate the three regions.
+region1 = image <= thresh[0]
+region2 = (image > thresh[0]) & (image <= thresh[1])
+region3 = image > thresh[1]
+
+# Plotting the original image.
+plt.figure(figsize=(8, 2.5))
+
+plt.subplot(1, 2, 1)
+plt.imshow(image, cmap='gray')
+plt.title('Original')
+plt.axis('off')
+
+# Plotting the histogram and the two thresholds obtained from
+# multi-Otsu.
+plt.subplot(1, 2, 2)
+plt.hist(image)
+plt.title('Histogram')
+for i in range(len(thresh)):
+    plt.axvline(thresh[i], color='r')
+
+# Plotting the three resulting regions.
+plt.figure(figsize=(9, 2.5))
+
+plt.subplot(1, 3, 1)
+plt.imshow(region1, cmap='gray')
+plt.title('Multi-Otsu result, Region #1')
+plt.axis('off')
+
+plt.subplot(1, 3, 2)
+plt.imshow(region2, cmap='gray')
+plt.title('Multi-Otsu result, Region #2')
+plt.axis('off')
+
+plt.subplot(1, 3, 3)
+plt.imshow(region3, cmap='gray')
+plt.title('Multi-Otsu result, Region #3')
+plt.axis('off')
+
+plt.show()

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -395,11 +395,11 @@ def threshold_multiotsu(image, nclass=3, nbins=256):
     image : array
         Grayscale input image.
     nclass : int, optional
-        Number of classes to be thresholded, i.e. the number of
-        resulting regions. Accepts an integer from 2 to 5.
+        Number of classes to be thresholded, i.e. the number of resulting
+        regions. Accepts an integer from 2 to 5.
     nbins : int, optional
-        Number of bins used to calculate histogram. This value is
-        ignored for integer arrays.
+        Number of bins used to calculate histogram. This value is ignored for
+        integer arrays.
 
     Returns
     -------
@@ -421,15 +421,19 @@ def threshold_multiotsu(image, nclass=3, nbins=256):
     >>> region2 = (image > thresh[0]) & (image <= thresh[1])
     >>> region3 = image > thresh[1]
     """
+
     # check if the image is RGB.
     if image.shape[-1] in (3, 4):
-        raise TypeError("Your image seems to be RGB (shape: {0}. Please "
-                        "use a grayscale image.".format(image.shape))
+        raise TypeError("Your image seems to be RGB (shape: {0}. Please use a"
+                        "grayscale image.".format(image.shape))
 
     # check if the image has more than one color.
     if image.min() == image.max():
         raise TypeError("The input image seems to have just one color: {0}."
                         "Please use a grayscale image.".format(image.min()))
+
+    # image needs to be treated as float.
+    image = img_as_float(image)
 
     # calculating the histogram and the probability of each gray level.
     hist, _ = histogram(image.ravel(), nbins)

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -2,7 +2,8 @@ __all__ = ['threshold_adaptive',
            'threshold_otsu',
            'threshold_yen',
            'threshold_isodata',
-           'threshold_li', ]
+           'threshold_li',
+           'threshold_multiotsu']
 
 import numpy as np
 from scipy import ndimage as ndi
@@ -517,4 +518,4 @@ def threshold_multiotsu(image, nclass=3, nbins=256):
                             idx_thresh[3] = idx4
                             max_sigma = part_sigma
 
-    return idx_thresh
+    return idx_thresh.astype(int)


### PR DESCRIPTION
## Description
Adding the function `threshold_multiotsu()`. This generates multiple thresholds for an input image, based on the Multi-Otsu implementation by Liao and Chung.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [X] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [X] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]

## References
[1] Liao, P-S. and Chung, P-C., "A fast algorithm for multilevel thresholding", Journal of Information Science and Engineering 17 (5): 713-727, 2001.