### PR TITLE
Updated centroid to use coords - works in 3d

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -115,17 +115,14 @@ class _RegionProperties(object):
         """
         Returns
         -------
-        A tuple of the bounding box's start coordinates for each dimension, 
+        A tuple of the bounding box's start coordinates for each dimension,
         followed by the end coordinates for each dimension
         """
         return tuple([self._slice[i].start for i in range(self._ndim)] +
                      [self._slice[i].stop for i in range(self._ndim)])
 
     def centroid(self):
-        centroid_coords = self.local_centroid
-        return tuple(centroid_coords +
-                     np.array([self._slice[i].start
-                               for i in range(self._ndim)]))
+        return tuple(self.coords.mean(axis=0))
 
     @only2d
     def convex_area(self):

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -24,7 +24,7 @@ INTENSITY_SAMPLE[1, 9:11] = 2
 
 SAMPLE_3D = np.zeros((6, 6, 6), dtype=np.uint8)
 SAMPLE_3D[1:3, 1:3, 1:3] = 1
-SAMPLE_3D[3, 2, 2] = 1 
+SAMPLE_3D[3, 2, 2] = 1
 INTENSITY_SAMPLE_3D = SAMPLE_3D.copy()
 
 def test_all_props():
@@ -95,6 +95,12 @@ def test_centroid():
     centroid = regionprops(SAMPLE)[0].centroid
     # determined with MATLAB
     assert_array_almost_equal(centroid, (5.66666666666666, 9.444444444444444))
+
+
+def test_centroid_3d():
+    centroid = regionprops(SAMPLE_3D)[0].centroid
+    # determined by mean along axis 1 of SAMPLE_3D.nonzero()
+    assert_array_almost_equal(centroid, (1.66666667, 1.55555556, 1.55555556))
 
 
 def test_convex_area():


### PR DESCRIPTION
## Description
 Really quick pull request to add 3d `centroid` prop (#1489) by replacing dependency on `moments` with `coords`. 



