### PR TITLE
Tool for checking completeness of sdist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ before_install:
     - pip install -U virtualenv
     - source tools/travis_before_install.sh
     - which python; python --version
-    - python check_bento_build.py
+    - tools/check_bento_build.py
     - tools/build_versions.py
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ before_install:
     - which python; python --version
     - tools/check_bento_build.py
     - tools/build_versions.py
+    - tools/check_sdist.py
 
 install:
     - section build

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include *.txt
 include Makefile
 include bento.info
 include skimage/scripts/skivi
-recursive-include skimage *.pyx *.pxd *.pxi *.py *.c *.h *.ini *.md5 *.npy *.txt *.in
+recursive-include skimage *.pyx *.pxd *.pxi *.py *.c *.h *.ini *.md5 *.npy *.txt *.in *.cpp *.md
 recursive-include skimage/data *
 
 include doc/Makefile

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,8 @@ include setup*.py
 include MANIFEST.in
 include *.txt
 include Makefile
+include bento.info
+include skimage/scripts/skivi
 recursive-include skimage *.pyx *.pxd *.pxi *.py *.c *.h *.ini *.md5 *.npy *.txt *.in
 recursive-include skimage/data *
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ import sys
 
 import setuptools
 from distutils.command.build_py import build_py
+from distutils.command.sdist import sdist
 
 if sys.version_info[0] < 3:
     import __builtin__ as builtins
@@ -145,6 +146,7 @@ if __name__ == "__main__":
             'console_scripts': ['skivi = skimage.scripts.skivi:main'],
         },
 
-        cmdclass={'build_py': build_py},
+        cmdclass={'build_py': build_py,
+                  'sdist': sdist},
         **extra
     )

--- a/tools/check_bento_build.py
+++ b/tools/check_bento_build.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 Check that Cython extensions in setup.py files match those in bento.info.
 """

--- a/tools/check_sdist.py
+++ b/tools/check_sdist.py
@@ -20,8 +20,8 @@ data = ['./' + l.split(' ->')[0] for l in data]
 
 ignore_exts = ['.pyc', '.so', '.o', '#', '~', '.gitignore']
 ignore_dirs = ['./dist', './tools', './doc', './viewer_examples',
-               './downloads']
-ignore_files = ['./TODO.md', './README.md',
+               './downloads', './scikit_image.egg-info']
+ignore_files = ['./TODO.md', './README.md', './MANIFEST',
                 './.gitignore', './.travis.yml', './.gitmodules',
                 './.mailmap', './.coveragerc', './appveyor.yml',
                 './tools/check_bento_build.py',

--- a/tools/check_sdist.py
+++ b/tools/check_sdist.py
@@ -19,8 +19,9 @@ data = [l.replace('hard linking ', '') for l in data]
 data = ['./' + l.split(' ->')[0] for l in data]
 
 ignore_exts = ['.pyc', '.so', '.o', '#', '~', '.gitignore']
-ignore_dirs = ['./dist', './tools', './doc', './viewer_examples']
-ignore_files = ['./TODO.md', './README.md', 
+ignore_dirs = ['./dist', './tools', './doc', './viewer_examples',
+               './downloads']
+ignore_files = ['./TODO.md', './README.md',
                 './.gitignore', './.travis.yml', './.gitmodules',
                 './.mailmap', './.coveragerc', './appveyor.yml',
                 './tools/check_bento_build.py',

--- a/tools/check_sdist.py
+++ b/tools/check_sdist.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import os
+import subprocess
+import sys
+
+base_dir = os.path.join(os.path.dirname(__file__), '..')
+os.chdir(base_dir)
+
+p = subprocess.Popen("python setup.py sdist".split(),
+                     stdout=subprocess.PIPE)
+out, err = p.communicate()
+
+data = out.decode('utf-8').split('\n')
+data = [l for l in data if l.startswith('hard linking')]
+data = [l.replace('hard linking ', '') for l in data]
+data = ['./' + l.split(' ->')[0] for l in data]
+
+ignore_exts = ['.pyc', '.so', '.o', '#', '~', '.gitignore']
+ignore_dirs = ['./dist', './tools', './doc', './viewer_examples']
+ignore_files = ['./TODO.md', './README.md', 
+                './.gitignore', './.travis.yml', './.gitmodules',
+                './.mailmap', './.coveragerc', './appveyor.yml',
+                './tools/check_bento_build.py',
+                './skimage/filters/rank/README.rst']
+
+
+missing = []
+for root, dirs, files in os.walk('./'):
+    for d in ignore_dirs:
+        if root.startswith(d):
+            break
+    else:
+
+        if root.startswith('./.'):
+            continue
+
+        for fn in files:
+            for ext in ignore_exts:
+                if fn.endswith(ext):
+                    break
+            else:
+                fn = os.path.join(root, fn)
+
+                if not (fn in data or fn in ignore_files):
+                    missing.append(fn)
+
+if missing:
+    print('Missing from source distribution:\n')
+    for m in missing:
+        print('  ', m)
+
+    print('\nPlease update MANIFEST.in')
+
+    sys.exit(1)
+else:
+    print('All expected source files accounted for in sdist')


### PR DESCRIPTION
Files easily get left out of the MANIFEST.in file, which means that sdists uploaded to PyPi can be incomplete.  This script runs as part of the Travis-CI build to prevent that.
