### PR TITLE
DOC ENH + API fix on houghline transform

### DIFF
--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -229,7 +229,7 @@ def hough_ellipse(cnp.ndarray img, int threshold=4, double accuracy=1,
 
 
 def hough_line(cnp.ndarray img,
-               cnp.ndarray[ndim=1, dtype=cnp.double_t] theta=None):
+               cnp.ndarray[ndim=1, dtype=cnp.double_t] theta):
     """Perform a straight line Hough transform.
 
     Parameters

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -17,14 +17,14 @@ def hough_line(img, theta=None):
         Input image with nonzero values representing edges.
     theta : 1D ndarray of double
         Angles at which to compute the transform, in radians.
-        Defaults to -pi/2 .. pi/2
+        Defaults to a vector of 180 angles evenly spaced from -pi/2 to pi/2.
 
     Returns
     -------
-    H : 2-D ndarray of uint64
+    hspace : 2-D ndarray of uint64
         Hough transform accumulator.
-    theta : ndarray
-        Angles at which the transform was computed, in radians.
+    angles : ndarray
+        Angles at which the transform is computed, in radians.
     distances : ndarray
         Distance values.
 
@@ -34,6 +34,8 @@ def hough_line(img, theta=None):
     X and Y axis are horizontal and vertical edges respectively.
     The distance is the minimal algebraic distance from the origin
     to the detected line.
+    The angle accuracy can be improved by decreasing the step size in
+    the `theta` array.
 
     Examples
     --------
@@ -66,7 +68,7 @@ def hough_line(img, theta=None):
 
 def hough_line_peaks(hspace, angles, dists, min_distance=9, min_angle=10,
                      threshold=None, num_peaks=np.inf):
-    """Return peaks in hough transform.
+    """Return peaks in a straight line Hough transform.
 
     Identifies most prominent lines separated by a certain angle and distance
     in a hough transform. Non-maximum suppression with different sizes is
@@ -96,7 +98,7 @@ def hough_line_peaks(hspace, angles, dists, min_distance=9, min_angle=10,
 
     Returns
     -------
-    hspace, angles, dists : tuple of array
+    hspace, angles, distances : tuple of array
         Peak values in hough space, angles and distances.
 
     Examples


### PR DESCRIPTION
Hi,

Long story short, I got some discrepancies from the Hough line transform. For instance, if you look carefully at the gallery, it doesn't superimpose perfectly. Based on that, I started a code analysis.

The hough line peak detection has a pixel resolution. I wrote a code to make it subpixel. Once I finished a first version of it, I figured out something else.

The default theta value in hough_line() specifies not only a range, but also a bin size. That was not clearly stated in  the doc. Reducing the bin size helps to improve the accuracy of the detection. Quick code that shows that:

```python
for i in range(1, 11):
    print(i*90)
    h, theta, d = hough_line(image, theta=np.linspace(-np.pi / 2, np.pi / 2, 90*i))
    angles = np.array([angle for _, angle, dist in zip(*hough_line_peaks(h, theta, d))])
    print((np.abs(angles) * 180 / np.pi - 45) / 45. * 100)
```

```
90
[ 1.12359551  1.12359551]
180
[-0.55865922 -0.55865922]
270
[ 0.37174721  0.37174721]
360
[-0.27855153 -0.27855153]
450
[-0.66815145  0.22271715]
540
[ 0.55658627 -0.18552876]
630
[-0.47694754  0.15898251]
720
[ 0.41724618 -0.13908206]
810
[ 0.12360939  0.12360939]
900
[-0.55617353 -0.11123471]
```
*Modification 1* So, I modified the docstring to hightlight that point.
It's trivial at the end, but took me a while to figure that out.

*Modification 2* I changed the "returned values" in the docstring to be consistent with the notations for the peak detection.

*Modification 3* I noticed that the cython function had a None default value. This is not handled by the code (Didn't try, but I think it would crash). The None case is handled by the python wrapper function. So I removed that. It's an API modification, but it's an internal function, I guess we are fine with that.

To come back on the subpixel algo, at the end, it shows a better result than the actual algorithm.
I just did a local peak fit with a gaussian curve. The idea here is to use the information from neighbouring pixels. If you think it's worth it, I can work on a separate PR to add this feature.
I may try with a lorenzian instead. usually, I have good results with lorenzian functions for data that fades out quickly with a good baseline.

I ping @stefanv @emmanuelle  for comments, others are welcome to comment too ;)
