### PR TITLE
MAINT: around label and regionprops functions.

### DIFF
--- a/skimage/measure/_ccomp.pyx
+++ b/skimage/measure/_ccomp.pyx
@@ -405,6 +405,10 @@ def label(input, neighbors=None, background=0, return_num=False,
         Number of labels, which equals the maximum label index and is only
         returned if return_num is `True`.
 
+    See Also
+    --------
+    regionprops
+
     Examples
     --------
     >>> import numpy as np

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -1,8 +1,97 @@
-from ._ccomp import label as _label
+from ._ccomp import label_cython as clabel
 
+
+"""
+    References
+    ----------
+    .. [1] Christophe Fiorio and Jens Gustedt, "Two linear time Union-Find
+           strategies for image processing", Theoretical Computer Science
+           154 (1996), pp. 165-181.
+
+    .. [2] Kensheng Wu, Ekow Otoo and Arie Shoshani, "Optimizing connected
+           component labeling algorithms", Paper LBNL-56864, 2005,
+           Lawrence Berkeley National Laboratory (University of California),
+           http://repositories.cdlib.org/lbnl/LBNL-56864
+"""
 
 def label(input, neighbors=None, background=None, return_num=False,
           connectivity=None):
-    return _label(input, neighbors, background, return_num, connectivity)
+    r"""Label connected regions of an integer array.
 
-label.__doc__ = _label.__doc__
+    Two pixels are connected when they are neighbors and have the same value.
+    In 2D, they can be neighbors either in a 1- or 2-connected sense.
+    The value refers to the maximum number of orthogonal hops to consider a
+    pixel/voxel a neighbor::
+
+      1-connectivity      2-connectivity     diagonal connection close-up
+
+           [ ]           [ ]  [ ]  [ ]         [ ]
+            |               \  |  /             |  <- hop 2
+      [ ]--[x]--[ ]      [ ]--[x]--[ ]    [x]--[ ]
+            |               /  |  \         hop 1
+           [ ]           [ ]  [ ]  [ ]
+
+    Parameters
+    ----------
+    input : ndarray of dtype int
+        Image to label.
+    neighbors : {4, 8}, int, optional
+        Whether to use 4- or 8-"connectivity".
+        In 3D, 4-"connectivity" means connected pixels have to share face,
+        whereas with 8-"connectivity", they have to share only edge or vertex.
+        **Deprecated, use ``connectivity`` instead.**
+    background : int, optional
+        Consider all pixels with this value as background pixels, and label
+        them as 0. By default, 0-valued pixels are considered as background
+        pixels.
+    return_num : bool, optional
+        Whether to return the number of assigned labels.
+    connectivity : int, optional
+        Maximum number of orthogonal hops to consider a pixel/voxel
+        as a neighbor.
+        Accepted values are ranging from  1 to input.ndim. If ``None``, a full
+        connectivity of ``input.ndim`` is used.
+
+    Returns
+    -------
+    labels : ndarray of dtype int
+        Labeled array, where all connected regions are assigned the
+        same integer value.
+    num : int, optional
+        Number of labels, which equals the maximum label index and is only
+        returned if return_num is `True`.
+
+    See Also
+    --------
+    regionprops
+
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> x = np.eye(3).astype(int)
+    >>> print(x)
+    [[1 0 0]
+     [0 1 0]
+     [0 0 1]]
+    >>> print(label(x, connectivity=1))
+    [[1 0 0]
+     [0 2 0]
+     [0 0 3]]
+    >>> print(label(x, connectivity=2))
+    [[1 0 0]
+     [0 1 0]
+     [0 0 1]]
+    >>> print(label(x, background=-1))
+    [[1 2 2]
+     [2 1 2]
+     [2 2 1]]
+    >>> x = np.array([[1, 0, 0],
+    ...               [1, 1, 5],
+    ...               [0, 0, 0]])
+    >>> print(label(x))
+    [[1 0 0]
+     [1 1 2]
+     [0 0 0]]
+    """
+    return clabel(input, neighbors, background, return_num, connectivity)

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -1,5 +1,6 @@
 from ._ccomp import label as _label
 
+
 def label(input, neighbors=None, background=None, return_num=False,
           connectivity=None):
     return _label(input, neighbors, background, return_num, connectivity)

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -371,7 +371,9 @@ def regionprops(label_image, intensity_image=None, cache=True):
     **area** : int
         Number of pixels of region.
     **bbox** : tuple
-        Bounding box ``(min_row, min_col, max_row, max_col)``
+        Bounding box ``(min_row, min_col, max_row, max_col)``.
+        Pixels belonging to the bounding box are in the half-open interval
+        ``[min_row; max_row)`` and ``[min_col; max_col)``.
     **centroid** : array
         Centroid coordinate tuple ``(row, col)``.
     **convex_area** : int

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -94,7 +94,8 @@ class _RegionProperties(object):
 
         if intensity_image is not None:
             if not intensity_image.shape == label_image.shape:
-                raise ValueError('Label and intensity image must have the same shape.')
+                raise ValueError('Label and intensity image must have the'
+                                 'same shape.')
 
         self.label = label
 
@@ -282,7 +283,8 @@ class _RegionProperties(object):
     @_cached
     @only2d
     def weighted_moments(self):
-        return _moments.moments_central(self._intensity_image_double(), 0, 0, 3)
+        return _moments.moments_central(self._intensity_image_double(),
+                                        0, 0, 3)
 
     @_cached
     @only2d

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -9,7 +9,6 @@ from . import _moments
 
 
 from functools import wraps
-from collections import defaultdict
 
 __all__ = ['regionprops', 'perimeter']
 

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -490,6 +490,10 @@ def regionprops(label_image, intensity_image=None, cache=True):
       for prop in region:
           print(prop, region[prop])
 
+    See Also
+    --------
+    label
+
     References
     ----------
     .. [1] Wilhelm Burger, Mark Burge. Principles of Digital Image Processing:


### PR DESCRIPTION
CHANGELOG


* [x] move docstring from pyx to py
* [x] move references from header to docstring
* [x] merge two cython functions (label, a wrapper of _label, and _label)
* [x] add cross ref between these functions (label and regionprops)
* [x] PEP8
* [ ] fix #2116 