### PR TITLE
Allow images with singleton dimensions for regionprops

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -517,10 +517,13 @@ def regionprops(label_image, intensity_image=None, cache=True):
 
     """
 
-    label_image = np.squeeze(label_image)
+    squeezed_label_image = np.squeeze(label_image)
 
-    if label_image.ndim not in (2, 3):
-        raise TypeError('Only 2-D and 3-D images supported.')
+    if squeezed_label_image.ndim not in (2, 3):
+        if label_image.ndim not in (2, 3):
+            raise TypeError('Only 2-D and 3-D images supported.')
+    else:
+        label_image = squeezed_label_image
 
     if not np.issubdtype(label_image.dtype, np.integer):
         raise TypeError('Label image must be of integral type.')

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -459,6 +459,12 @@ def test_docstrings_and_props():
     assert len(ds.split('\n')) > 3
 
 
+def test_tiny_image_dims():
+    image = np.ones((1, 1), dtype=np.uint8)
+    p = regionprops(image)
+    assert_equal(p[0].area, 1)
+
+
 if __name__ == "__main__":
     from numpy.testing import run_module_suite
     run_module_suite()


### PR DESCRIPTION
Fixes #2105.

I think the ultimate goal should be to not use squeeze, because it will result in unpredictable behaviour in the future. But the deprecation path is tricky, so help is appreciated here.
