### PR TITLE
Fixing Error and documentation on Otsu Threshold

### DIFF
--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -167,7 +167,7 @@ def test_otsu_astro_image():
 
 def test_otsu_one_color_image():
     img = np.ones((10, 10), dtype=np.uint8)
-    assert_raises(TypeError, threshold_otsu, img)
+    assert_raises(ValueError, threshold_otsu, img)
 
 def test_li_camera_image():
     camera = skimage.img_as_ubyte(data.camera())

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -113,7 +113,6 @@ def threshold_otsu(image, nbins=256):
         
     Raises
     ------
-    
     ValueError
          If `image` only contains a single grayscale value.
 

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -133,7 +133,7 @@ def threshold_otsu(image, nbins=256):
 
     # Check if the image is multi-colored or not
     if image.min() == image.max():
-        raise TypeError("threshold_otsu is expected to work with images " \
+        raise ValueError("threshold_otsu is expected to work with images " \
                         "having more than one color. The input image seems " \
                         "to have just one color {0}.".format(image.min()))
 

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -110,6 +110,12 @@ def threshold_otsu(image, nbins=256):
     threshold : float
         Upper threshold value. All pixels intensities that less or equal of
         this value assumed as foreground.
+        
+    Raises
+    ------
+    
+    ValueError
+         If `image` only contains a single grayscale value.
 
     References
     ----------

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -134,8 +134,8 @@ def threshold_otsu(image, nbins=256):
     # Check if the image is multi-colored or not
     if image.min() == image.max():
         raise ValueError("threshold_otsu is expected to work with images " \
-                        "having more than one color. The input image seems " \
-                        "to have just one color {0}.".format(image.min()))
+                         "having more than one color. The input image seems " \
+                         "to have just one color {0}.".format(image.min()))
 
     hist, bin_centers = histogram(image.ravel(), nbins)
     hist = hist.astype(float)


### PR DESCRIPTION
## Description
The previous error, `TypeError` did not reflect the test done and would typically be raised while `image` indeed had the correct type. Proposing to switch to `ValueError`.

Including previously missing section in docstring about the raised error.

## Checklist

- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References

