### PR TITLE
Change show_rag back to draw_rag

### DIFF
--- a/doc/examples/segmentation/plot_boundary_merge.py
+++ b/doc/examples/segmentation/plot_boundary_merge.py
@@ -63,7 +63,7 @@ edges = filters.sobel(color.rgb2gray(img))
 labels = segmentation.slic(img, compactness=30, n_segments=400)
 g = graph.rag_boundary(labels, edges)
 
-graph.show_rag(labels, g, img)
+graph.draw_rag(labels, g, img)
 plt.title('Initial RAG')
 
 labels2 = graph.merge_hierarchical(labels, g, thresh=0.08, rag_copy=False,
@@ -71,7 +71,7 @@ labels2 = graph.merge_hierarchical(labels, g, thresh=0.08, rag_copy=False,
                                    merge_func=merge_boundary,
                                    weight_func=weight_boundary)
 
-graph.show_rag(labels, g, img)
+graph.draw_rag(labels, g, img)
 plt.title('RAG after hierarchical merging')
 
 plt.figure()

--- a/doc/examples/segmentation/plot_rag_boundary.py
+++ b/doc/examples/segmentation/plot_rag_boundary.py
@@ -19,7 +19,7 @@ edges = filters.sobel(gimg)
 edges_rgb = color.gray2rgb(edges)
 
 g = graph.rag_boundary(labels, edges)
-lc = graph.show_rag(labels, g, edges_rgb, img_cmap=None, edge_cmap='viridis',
+lc = graph.draw_rag(labels, g, edges_rgb, img_cmap=None, edge_cmap='viridis',
                     edge_width=1.2)
 
 plt.colorbar(lc, fraction=0.03)

--- a/doc/examples/segmentation/plot_rag_draw.py
+++ b/doc/examples/segmentation/plot_rag_draw.py
@@ -18,14 +18,14 @@ g = graph.rag_mean_color(img, labels)
 
 fig, ax = plt.subplots()
 ax.set_title('RAG drawn with default settings')
-lc = graph.show_rag(labels, g, img, ax=ax)
+lc = graph.draw_rag(labels, g, img, ax=ax)
 # fraction specifies the fraction of the area of the plot that will be used to
 # draw the colorbar
 plt.colorbar(lc, fraction=0.03)
 
 fig, ax = plt.subplots()
 ax.set_title('RAG drawn with grayscale image and viridis colormap')
-lc = graph.show_rag(labels, g, img, img_cmap='gray', edge_cmap='viridis',
+lc = graph.draw_rag(labels, g, img, img_cmap='gray', edge_cmap='viridis',
                     ax=ax)
 plt.colorbar(lc, fraction=0.03)
 

--- a/skimage/future/graph/__init__.py
+++ b/skimage/future/graph/__init__.py
@@ -1,5 +1,5 @@
 from .graph_cut import cut_threshold, cut_normalized
-from .rag import rag_mean_color, RAG, show_rag, rag_boundary
+from .rag import rag_mean_color, RAG, draw_rag, rag_boundary
 from .graph_merge import merge_hierarchical
 ncut = cut_normalized
 
@@ -7,7 +7,7 @@ __all__ = ['rag_mean_color',
            'cut_threshold',
            'cut_normalized',
            'ncut',
-           'show_rag',
+           'draw_rag',
            'merge_hierarchical',
            'rag_boundary',
            'RAG']

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -420,7 +420,7 @@ def rag_boundary(labels, edge_map, connectivity=2):
     return rag
 
 
-def show_rag(labels, rag, img, border_color='black', edge_width=1.5,
+def draw_rag(labels, rag, img, border_color='black', edge_width=1.5,
              edge_cmap='magma', img_cmap='bone', in_place=True, ax=None):
     """Draw a Region Adjacency Graph on an image.
 
@@ -466,7 +466,7 @@ def show_rag(labels, rag, img, border_color='black', edge_width=1.5,
     >>> img = data.coffee()
     >>> labels = segmentation.slic(img)
     >>> g =  graph.rag_mean_color(img, labels)
-    >>> lc = graph.show_rag(labels, g, img)
+    >>> lc = graph.draw_rag(labels, g, img)
     >>> cbar = plt.colorbar(lc)
     """
 

--- a/skimage/graph/__init__.py
+++ b/skimage/graph/__init__.py
@@ -7,11 +7,4 @@ __all__ = ['shortest_path',
            'MCP_Geometric',
            'MCP_Connect',
            'MCP_Flexible',
-           'route_through_array',
-           'rag_mean_color',
-           'cut_threshold',
-           'cut_normalized',
-           'ncut',
-           'draw_rag',
-           'merge_hierarchical',
-           'RAG']
+           'route_through_array']


### PR DESCRIPTION
I suggest we revert the renaming of ``draw_rag``.

This commits also cleans up some leftovers from the `skimage.graph` init file.

/cc @jni @vighneshbirodkar 
