### PR TITLE
Add morlet filters

### DIFF
--- a/doc/examples/filters/plot_gabor_vs_morlet.py
+++ b/doc/examples/filters/plot_gabor_vs_morlet.py
@@ -1,7 +1,7 @@
 """
-=====================
+==========================================================
 Apply a set of "Gabor" and "Morlet" filters to an picture
-=====================
+==========================================================
 
 In this example, we show the difference between filtering an image with the
 Gabor filter and the Morlet filter.

--- a/doc/examples/filters/plot_gabor_vs_morlet.py
+++ b/doc/examples/filters/plot_gabor_vs_morlet.py
@@ -94,6 +94,3 @@ im_filtered = np.abs(ndi.convolve(image, gabor, mode='wrap'))
 print('[Gabor] energy:',im_filtered.sum())
 im_filtered100 = np.abs(ndi.convolve(image+100, gabor, mode='wrap'))
 print('[Gabor] energy (im+100):',im_filtered100.sum())
-
-
-

--- a/doc/examples/filters/plot_gabor_vs_morlet.py
+++ b/doc/examples/filters/plot_gabor_vs_morlet.py
@@ -1,0 +1,84 @@
+"""
+====================
+Apply a set of Gabor and Morlet filters to an picture
+====================
+
+In this example, we show the difference between filtering an image with the
+gabor filter and the morlet filter.
+
+
+Morlet Filter
+----------------------
+
+Zero sum version of the Gabor filter
+
+"""
+import numpy as np
+import skimage
+from skimage.filters import gabor_kernel
+import matplotlib.pylab as plt
+from skimage import data
+from skimage.util import img_as_float
+from scipy import ndimage as ndi
+
+image = img_as_float(data.load('brick.png'))
+image = image[0:64,0:64]
+
+
+J = 4
+L = 8
+xi_psi = 3. / 4 * np.pi  # for Q=1
+sigma_xi = .8
+slant = 4. / L
+
+#show image
+plt.figure(figsize=(16, 8))
+plt.imshow(image)
+plt.title('Original image')
+
+# Generate a group of gabor filters and apply it to the brick image
+
+plt.figure(figsize=(16, 8))
+for j, scale in enumerate(2 ** np.arange(J)):
+    for l, theta in enumerate(np.arange(L) / float(L) * np.pi):
+        sigma = sigma_xi * scale
+        xi = xi_psi / scale
+
+        sigma_x = sigma
+        sigma_y = sigma / slant
+        freq = xi / (np.pi * 2)
+
+        gabor = gabor_kernel(freq, theta=theta, sigma_x=sigma_x, sigma_y=sigma_y)
+
+        im_filtered = np.abs(ndi.convolve(image, gabor, mode='wrap'))
+
+        plt.subplot(J, L, j * L + l + 1)
+        plt.imshow(np.real(im_filtered), interpolation='nearest')
+
+        plt.viridis()
+
+plt.suptitle('Gabor (different scales and orientations)')
+# Generate a group of morlet filters and apply it to the brick image
+
+plt.figure(figsize=(16, 8))
+for j, scale in enumerate(2 ** np.arange(J)):
+    for l, theta in enumerate(np.arange(L) / float(L) * np.pi):
+        sigma = sigma_xi * scale
+        xi = xi_psi / scale
+
+        sigma_x = sigma
+        sigma_y = sigma / slant
+        freq = xi / (np.pi * 2)
+
+        morlet = gabor_kernel(freq, theta=theta, sigma_x=sigma_x, sigma_y=sigma_y, no_DC_offset=True)
+
+        im_filtered = np.abs(ndi.convolve(image, morlet, mode='wrap'))
+
+        plt.subplot(J, L, j * L + l + 1)
+        plt.imshow(np.real(im_filtered), interpolation='nearest')
+
+        plt.viridis()
+
+plt.suptitle('Morlet (different scales and orientations)')
+
+plt.show()

--- a/doc/examples/filters/plot_gabor_vs_morlet.py
+++ b/doc/examples/filters/plot_gabor_vs_morlet.py
@@ -1,21 +1,22 @@
 """
-====================
-Apply a set of Gabor and Morlet filters to an picture
-====================
+=====================
+Apply a set of "Gabor" and "Morlet" filters to an picture
+=====================
 
 In this example, we show the difference between filtering an image with the
-gabor filter and the morlet filter.
+Gabor filter and the Morlet filter.
 
 
 Morlet Filter
-----------------------
+---------------------
 
-Zero sum version of the Gabor filter
+Zero sum version of the Gabor filter.
 
 """
 import numpy as np
 import skimage
 from skimage.filters import gabor_kernel
+from skimage.filters import morlet_kernel
 import matplotlib.pylab as plt
 from skimage import data
 from skimage.util import img_as_float
@@ -27,7 +28,7 @@ image = image[0:64,0:64]
 
 J = 4
 L = 8
-xi_psi = 3. / 4 * np.pi  # for Q=1
+xi_psi = 3. / 4 * np.pi
 sigma_xi = .8
 slant = 4. / L
 
@@ -70,7 +71,7 @@ for j, scale in enumerate(2 ** np.arange(J)):
         sigma_y = sigma / slant
         freq = xi / (np.pi * 2)
 
-        morlet = gabor_kernel(freq, theta=theta, sigma_x=sigma_x, sigma_y=sigma_y, no_DC_offset=True)
+        morlet = morlet_kernel(freq, theta=theta, sigma_x=sigma_x, sigma_y=sigma_y)
 
         im_filtered = np.abs(ndi.convolve(image, morlet, mode='wrap'))
 
@@ -82,3 +83,17 @@ for j, scale in enumerate(2 ** np.arange(J)):
 plt.suptitle('Morlet (different scales and orientations)')
 
 plt.show()
+
+print('The energy of the filtered image changes with the gabor fiter but not with the Gabor:')
+im_filtered = np.abs(ndi.convolve(image, morlet, mode='wrap'))
+print('[Morlet] energy:',im_filtered.sum())
+im_filtered100 = np.abs(ndi.convolve(image+100, morlet, mode='wrap'))
+print('[Morlet] energy (im+100):',im_filtered100.sum())
+
+im_filtered = np.abs(ndi.convolve(image, gabor, mode='wrap'))
+print('[Gabor] energy:',im_filtered.sum())
+im_filtered100 = np.abs(ndi.convolve(image+100, gabor, mode='wrap'))
+print('[Gabor] energy (im+100):',im_filtered100.sum())
+
+
+

--- a/skimage/filters/__init__.py
+++ b/skimage/filters/__init__.py
@@ -6,7 +6,7 @@ from .edges import (sobel, sobel_h, sobel_v,
                     roberts, roberts_pos_diag, roberts_neg_diag,
                     laplace)
 from ._rank_order import rank_order
-from ._gabor import gabor_kernel, gabor
+from ._gabor import gabor_kernel, gabor, morlet_kernel
 from ._frangi import frangi, hessian
 from .thresholding import (threshold_adaptive, threshold_otsu, threshold_yen,
                            threshold_isodata, threshold_li, threshold_minimum,
@@ -46,6 +46,7 @@ __all__ = ['inverse',
            'denoise_tv_bregman',
            'rank_order',
            'gabor_kernel',
+           'morlet_kernel',
            'gabor',
            'try_all_threshold',
            'frangi',

--- a/skimage/filters/_gabor.py
+++ b/skimage/filters/_gabor.py
@@ -99,7 +99,9 @@ def morlet_kernel(frequency, theta=0, bandwidth=1,
                       sigma_x=None, sigma_y=None, n_stds=3, offset=0):
     """Return complex 2D morlet filter kernel.
 
-       Morlet kernel is a Gabor kernel with no DC offset.
+       Morlet kernel is a Gabor kernel with no DC offset. This means that not only
+       the imaginary part (sin component), but also the real part (cos component)
+       have zero sum. The filter response to a constant image is zero.
        Harmonic function consists of a complex exponential (carrier) multiplied
        by a Gaussian window (envelope). Spatial frequency is inversely proportional
        to the wavelength of the harmonic and to the standard deviation of a Gaussian

--- a/skimage/filters/_gabor.py
+++ b/skimage/filters/_gabor.py
@@ -43,8 +43,6 @@ def gabor_kernel(frequency, theta=0, bandwidth=1, sigma_x=None, sigma_y=None,
         deviations
     offset : float, optional
         Phase offset of harmonic function in radians.
-    no_DC_offset: bool, optional, default False
-        Removes offset of cosine part of Gabor yielding a Morlet wavelet
 
     Returns
     -------
@@ -99,7 +97,62 @@ def gabor_kernel(frequency, theta=0, bandwidth=1, sigma_x=None, sigma_y=None,
 
 def morlet_kernel(frequency, theta=0, bandwidth=1,
                       sigma_x=None, sigma_y=None, n_stds=3, offset=0):
+    """Return complex 2D morlet filter kernel.
 
+       Morlet kernel is a Gabor kernel with no DC offset.
+       Harmonic function consists of a complex exponential (carrier) multiplied
+       by a Gaussian window (envelope). Spatial frequency is inversely proportional
+       to the wavelength of the harmonic and to the standard deviation of a Gaussian
+       kernel. The bandwidth is also inversely proportional to the standard
+       deviation.
+
+       Parameters
+       ----------
+       frequency : float
+           Spatial frequency of the harmonic function. Specified in pixels.
+       theta : float, optional
+           Orientation in radians. If 0, the harmonic is in the x-direction.
+       bandwidth : float, optional
+           The bandwidth captured by the filter. For fixed bandwidth, `sigma_x`
+           and `sigma_y` will decrease with increasing frequency. This value is
+           ignored if `sigma_x` and `sigma_y` are set by the user.
+       sigma_x, sigma_y : float, optional
+           Standard deviation in x- and y-directions. These directions apply to
+           the kernel *before* rotation. If `theta = pi/2`, then the kernel is
+           rotated 90 degrees so that `sigma_x` controls the *vertical* direction.
+       n_stds : scalar, optional
+           The linear size of the kernel is n_stds (3 by default) standard
+           deviations
+       offset : float, optional
+           Phase offset of harmonic function in radians.
+
+       Returns
+       -------
+       g : complex array
+           Complex filter kernel.
+
+       References
+       ----------
+       .. [1] https://en.wikipedia.org/wiki/Morlet_wavelet
+
+
+       Examples
+       --------
+       >>> from skimage.filters import morlet_kernel
+       >>> from skimage import io
+       >>> from matplotlib import pyplot as plt  # doctest: +SKIP
+       >>> import numpy as np
+       >>> gk = morlet_kernel(frequency=0.2)
+       >>> plt.figure()        # doctest: +SKIP
+       >>> io.imshow(gk.real)  # doctest: +SKIP
+       >>> io.show()           # doctest: +SKIP
+
+       >>> # change in angle to pi/4
+       >>> gk = morlet_kernel(frequency=0.2, theta=np.pi/4.)
+       >>> plt.figure()        # doctest: +SKIP
+       >>> io.imshow(gk.real)  # doctest: +SKIP
+       >>> io.show()           # doctest: +SKIP
+       """
 
     w = gabor_kernel(frequency, theta=theta, bandwidth=bandwidth,
                      sigma_x=sigma_x, sigma_y=sigma_y,

--- a/skimage/filters/_gabor.py
+++ b/skimage/filters/_gabor.py
@@ -14,7 +14,7 @@ def _sigma_prefactor(bandwidth):
 
 
 def gabor_kernel(frequency, theta=0, bandwidth=1, sigma_x=None, sigma_y=None,
-                 n_stds=3, offset=0):
+                 n_stds=3, offset=0, no_DC_offset=False):
     """Return complex 2D Gabor filter kernel.
 
     Gabor kernel is a Gaussian kernel modulated by a complex harmonic function.
@@ -43,6 +43,8 @@ def gabor_kernel(frequency, theta=0, bandwidth=1, sigma_x=None, sigma_y=None,
         deviations
     offset : float, optional
         Phase offset of harmonic function in radians.
+    no_DC_offset: bool, optional, default False
+        Removes offset of cosine part of Gabor yielding a Morlet wavelet
 
     Returns
     -------
@@ -89,9 +91,12 @@ def gabor_kernel(frequency, theta=0, bandwidth=1, sigma_x=None, sigma_y=None,
     g = np.zeros(y.shape, dtype=np.complex)
     g[:] = np.exp(-0.5 * (rotx ** 2 / sigma_x ** 2 + roty ** 2 / sigma_y ** 2))
     g /= 2 * np.pi * sigma_x * sigma_y
-    g *= np.exp(1j * (2 * np.pi * frequency * rotx + offset))
+    w = g * np.exp(1j * (2 * np.pi * frequency * rotx + offset))
 
-    return g
+    if no_DC_offset:
+        w = w - w.sum() / g.sum() * g
+
+    return w
 
 
 def gabor(image, frequency, theta=0, bandwidth=1, sigma_x=None,

--- a/skimage/filters/_gabor.py
+++ b/skimage/filters/_gabor.py
@@ -3,7 +3,7 @@ from scipy import ndimage as ndi
 from .._shared.utils import assert_nD
 
 
-__all__ = ['gabor_kernel', 'gabor']
+__all__ = ['gabor_kernel', 'gabor', 'morlet_kernel']
 
 
 def _sigma_prefactor(bandwidth):
@@ -14,7 +14,7 @@ def _sigma_prefactor(bandwidth):
 
 
 def gabor_kernel(frequency, theta=0, bandwidth=1, sigma_x=None, sigma_y=None,
-                 n_stds=3, offset=0, no_DC_offset=False):
+                 n_stds=3, offset=0):
     """Return complex 2D Gabor filter kernel.
 
     Gabor kernel is a Gaussian kernel modulated by a complex harmonic function.
@@ -74,6 +74,7 @@ def gabor_kernel(frequency, theta=0, bandwidth=1, sigma_x=None, sigma_y=None,
     >>> io.imshow(gk.real)  # doctest: +SKIP
     >>> io.show()           # doctest: +SKIP
     """
+
     if sigma_x is None:
         sigma_x = _sigma_prefactor(bandwidth) / frequency
     if sigma_y is None:
@@ -91,10 +92,20 @@ def gabor_kernel(frequency, theta=0, bandwidth=1, sigma_x=None, sigma_y=None,
     g = np.zeros(y.shape, dtype=np.complex)
     g[:] = np.exp(-0.5 * (rotx ** 2 / sigma_x ** 2 + roty ** 2 / sigma_y ** 2))
     g /= 2 * np.pi * sigma_x * sigma_y
-    w = g * np.exp(1j * (2 * np.pi * frequency * rotx + offset))
+    g *= np.exp(1j * (2 * np.pi * frequency * rotx + offset))
 
-    if no_DC_offset:
-        w = w - w.sum() / g.sum() * g
+    return g
+
+
+def morlet_kernel(frequency, theta=0, bandwidth=1,
+                      sigma_x=None, sigma_y=None, n_stds=3, offset=0):
+
+
+    w = gabor_kernel(frequency, theta=theta, bandwidth=bandwidth,
+                     sigma_x=sigma_x, sigma_y=sigma_y,
+                     n_stds=n_stds, offset=offset)
+    envelop = np.abs(w)
+    w -= w.sum() / envelop.sum() * envelop
 
     return w
 

--- a/skimage/filters/tests/test_gabor.py
+++ b/skimage/filters/tests/test_gabor.py
@@ -36,9 +36,9 @@ def test_sigma_prefactor():
 
 
 def test_gabor_kernel_sum():
-    for sigma_x in range(1, 10, 2):
-        for sigma_y in range(1, 10, 2):
-            for frequency in range(0, 10, 2):
+    for sigma_x in range(1, 6, 2):
+        for sigma_y in range(1, 6, 2):
+            for frequency in range(0, 6, 2):
                 kernel = gabor_kernel(frequency + 0.1, theta=0,
                                       sigma_x=sigma_x, sigma_y=sigma_y)
                 # make sure gaussian distribution is covered nearly 100%
@@ -46,10 +46,10 @@ def test_gabor_kernel_sum():
 
 
 def test_gabor_kernel_theta():
-    for sigma_x in range(1, 10, 2):
-        for sigma_y in range(1, 10, 2):
-            for frequency in range(0, 10, 2):
-                for theta in range(0, 10, 2):
+    for sigma_x in range(1, 6, 2):
+        for sigma_y in range(1, 6, 2):
+            for frequency in range(0, 6, 2):
+                for theta in range(0, 6, 2):
                     kernel0 = gabor_kernel(frequency + 0.1, theta=theta,
                                            sigma_x=sigma_x, sigma_y=sigma_y)
                     kernel180 = gabor_kernel(frequency, theta=theta + np.pi,
@@ -78,10 +78,10 @@ def test_gabor():
 
 
 def test_morlet_zero_sum():
-    for sigma_x in range(1, 10, 2):
-        for sigma_y in range(1, 10, 2):
-            for frequency in range(0, 10, 2):
-                for theta in range(0, 10, 2):
+    for sigma_x in range(1, 6, 2):
+        for sigma_y in range(1, 6, 2):
+            for frequency in range(0, 6, 2):
+                for theta in range(0, 6, 2):
                     kernel = morlet_kernel(frequency + 0.1, theta=theta,
                                            sigma_x=sigma_x, sigma_y=sigma_y)
 

--- a/skimage/filters/tests/test_gabor.py
+++ b/skimage/filters/tests/test_gabor.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.testing import (assert_equal, assert_almost_equal,
                            assert_array_almost_equal)
 
-from skimage.filters._gabor import gabor_kernel, gabor, _sigma_prefactor
+from skimage.filters._gabor import gabor_kernel, gabor, _sigma_prefactor, morlet_kernel
 
 
 def test_gabor_kernel_size():
@@ -82,9 +82,8 @@ def test_morlet_zero_sum():
         for sigma_y in range(1, 10, 2):
             for frequency in range(0, 10, 2):
                 for theta in range(0, 10, 2):
-                    kernel = gabor_kernel(frequency + 0.1, theta=theta,
-                                           sigma_x=sigma_x, sigma_y=sigma_y,
-                                           no_DC_offset=True)
+                    kernel = morlet_kernel(frequency + 0.1, theta=theta,
+                                           sigma_x=sigma_x, sigma_y=sigma_y)
 
                     assert_array_almost_equal(np.sum(kernel), 0)
 

--- a/skimage/filters/tests/test_gabor.py
+++ b/skimage/filters/tests/test_gabor.py
@@ -77,6 +77,18 @@ def test_gabor():
     assert responses[1, 1] > responses[1, 0]
 
 
+def test_morlet_zero_sum():
+    for sigma_x in range(1, 10, 2):
+        for sigma_y in range(1, 10, 2):
+            for frequency in range(0, 10, 2):
+                for theta in range(0, 10, 2):
+                    kernel = gabor_kernel(frequency + 0.1, theta=theta,
+                                           sigma_x=sigma_x, sigma_y=sigma_y,
+                                           no_DC_offset=True)
+
+                    assert_array_almost_equal(np.sum(kernel), 0)
+
+
 if __name__ == "__main__":
     from numpy import testing
     testing.run_module_suite()


### PR DESCRIPTION
We just added the option to the Gabor filter of taking out the DC. This is equivalent to the Morlet filter. In the code we uploaded, we just put the option `no_DC_offset=True` for generating the Morlet filter (`False` for Gabor). We were wondering if this is a good option or if you prefer to write a stand-alone function called Morlet that directly calls the Gabor function. 

We also added a small example that shows the difference between Morlet and Gabor, and a test to validate that the sum of the filter is zero, when the Morlet option is active. By the way, when executing the tests we get an error that doesnt seem to be related to our test:

```
======================================================================
ERROR: test suite for <module 'skimage.filters.tests.test_gabor' from '../scikit-image/skimage/filters/tests/test_gabor.py'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ferradans/anaconda3/lib/python3.5/site-packages/nose/suite.py", line 229, in run
    self.tearDown()
  File "/Users/ferradans/anaconda3/lib/python3.5/site-packages/nose/suite.py", line 352, in tearDown
    self.teardownContext(ancestor)
  File "/Users/ferradans/anaconda3/lib/python3.5/site-packages/nose/suite.py", line 368, in teardownContext
    try_run(context, names)
  File "/Users/ferradans/anaconda3/lib/python3.5/site-packages/nose/util.py", line 453, in try_run
    inspect.getargspec(func)
  File "/Users/ferradans/anaconda3/lib/python3.5/inspect.py", line 1041, in getargspec
    stacklevel=2)
DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead

----------------------------------------------------------------------
Ran 7 tests in 0.796s
```

Please let us know what you think about the code/options. 

CC @eickenberg
