### PR TITLE
Writing, style, and PEP8 fixes for greycomatrix

### DIFF
--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -31,7 +31,7 @@ def _glcm_loop(any_int[:, ::1] image, double[:] distances,
     Parameters
     ----------
     image : ndarray
-        Integer typed input image. Only positive valued images are supported. 
+        Integer typed input image. Only positive valued images are supported.
         If type is other than uint8, the argument `levels` needs to be set.
     distances : ndarray
         List of pixel pair distance offsets.
@@ -40,11 +40,7 @@ def _glcm_loop(any_int[:, ::1] image, double[:] distances,
     levels : int
         The input image should contain integers in [0, `levels`-1],
         where levels indicate the number of grey-levels counted
-        (typically 256 for an 8-bit image). This argument is required for
-        16-bit images or higher and is typically the maximum of the image. 
-        As the output matrix is at least `levels` x `levels`, it might
-        be preferable to use binning of the input image rather than 
-        large values for `levels`. 
+        (typically 256 for an 8-bit image).
     out : ndarray
         On input a 4D array of zeros, and on output it contains
         the results of the GLCM computation.

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -116,8 +116,7 @@ def greycomatrix(image, distances, angles, levels=None, symmetric=False,
                          "other than uint8. The resulting matrix will be at "
                          "least levels ** 2 in size.")
 
-    if (image.dtype in (np.int8, np.int16, np.int32, np.int64) and
-                                                        np.any(image < 0)):
+    if np.issubdtype(image.dtype, np.signedinteger) and np.any(image < 0):
         raise ValueError("Negative-valued images are not supported.")
 
     if levels is None:

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -21,7 +21,7 @@ def greycomatrix(image, distances, angles, levels=None, symmetric=False,
     Parameters
     ----------
     image : array_like
-        Integer typed input image. Only positive valued images are supported. 
+        Integer typed input image. Only positive valued images are supported.
         If type is other than uint8, the argument `levels` needs to be set.
     distances : array_like
         List of pixel pair distance offsets.
@@ -31,10 +31,10 @@ def greycomatrix(image, distances, angles, levels=None, symmetric=False,
         The input image should contain integers in [0, `levels`-1],
         where levels indicate the number of grey-levels counted
         (typically 256 for an 8-bit image). This argument is required for
-        16-bit images or higher and is typically the maximum of the image. 
+        16-bit images or higher and is typically the maximum of the image.
         As the output matrix is at least `levels` x `levels`, it might
-        be preferable to use binning of the input image rather than 
-        large values for `levels`. 
+        be preferable to use binning of the input image rather than
+        large values for `levels`.
     symmetric : bool, optional
         If True, the output matrix `P[:, :, d, theta]` is symmetric. This
         is accomplished by ignoring the order of value pairs, so both
@@ -74,7 +74,8 @@ def greycomatrix(image, distances, angles, levels=None, symmetric=False,
     ...                   [0, 0, 1, 1],
     ...                   [0, 2, 2, 2],
     ...                   [2, 2, 3, 3]], dtype=np.uint8)
-    >>> result = greycomatrix(image, [1], [0, np.pi/4, np.pi/2, 3*np.pi/4], levels=4)
+    >>> result = greycomatrix(image, [1], [0, np.pi/4, np.pi/2, 3*np.pi/4],
+    ...                       levels=4)
     >>> result[:, :, 0, 0]
     array([[2, 2, 1, 0],
            [0, 2, 0, 0],
@@ -107,21 +108,24 @@ def greycomatrix(image, distances, angles, levels=None, symmetric=False,
 
     if np.issubdtype(image.dtype, np.float):
         raise ValueError("Float images are not supported by greycomatrix. "
-                         "The image needs to be cast to an unsigned integer type.")
-    
-    # for image type > 8bit, levels must be set.
-    if image.dtype not in (np.uint8, np.int8) and levels is None:         
-        raise ValueError("The levels argument is required for data types other than uint8. "
-                         "The resulting matrix will be at least levels ** 2 in size.")
-                             
-    if image.dtype in (np.int8, np.int16, np.int32, np.int64) and np.any(image < 0):
-        raise ValueError("Negative valued images are not supported.")
+                         "Convert the image to an unsigned integer type.")
 
-    if levels is None:    
+    # for image type > 8bit, levels must be set.
+    if image.dtype not in (np.uint8, np.int8) and levels is None:
+        raise ValueError("The levels argument is required for data types "
+                         "other than uint8. The resulting matrix will be at "
+                         "least levels ** 2 in size.")
+
+    if (image.dtype in (np.int8, np.int16, np.int32, np.int64) and
+                                                        np.any(image < 0)):
+        raise ValueError("Negative-valued images are not supported.")
+
+    if levels is None:
         levels = 256
 
     if image_max >= levels:
-        raise ValueError("The image maximum needs to be smaller than `levels`.")
+        raise ValueError("The maximum grayscale value in the image should be "
+                         "smaller than the number of levels.")
 
     distances = np.ascontiguousarray(distances, dtype=np.float64)
     angles = np.ascontiguousarray(angles, dtype=np.float64)
@@ -461,12 +465,14 @@ def draw_multiblock_lbp(img, r, c, width, height,
 
         # Mix-in the visualization colors.
         if has_greater_value:
-            new_value = ((1-alpha) * output[curr_r:curr_r+height, curr_c:curr_c+width]
-                         + alpha * color_greater_block)
+            new_value = ((1-alpha) *
+                         output[curr_r:curr_r+height, curr_c:curr_c+width] +
+                         alpha * color_greater_block)
             output[curr_r:curr_r+height, curr_c:curr_c+width] = new_value
         else:
-            new_value = ((1-alpha) * output[curr_r:curr_r+height, curr_c:curr_c+width]
-                         + alpha * color_less_block)
+            new_value = ((1-alpha) *
+                         output[curr_r:curr_r+height, curr_c:curr_c+width] +
+                         alpha * color_less_block)
             output[curr_r:curr_r+height, curr_c:curr_c+width] = new_value
 
     return output


### PR DESCRIPTION
- Reword some error messages
- Wrap lines to 80 char
- Remove trailing whitespace characters
- Fix misleading docstring in private function

See #2095.