### PR TITLE
BUGFIX: inverse_map should not be None

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1147,7 +1147,7 @@ def _clip_warp_output(input_image, output_image, order, mode, cval, clip):
             output_image[cval_mask] = cval
 
 
-def warp(image, inverse_map=None, map_args={}, output_shape=None, order=1,
+def warp(image, inverse_map, map_args={}, output_shape=None, order=1,
          mode='constant', cval=0., clip=True, preserve_range=False):
     """Warp an image according to a given coordinate transformation.
 


### PR DESCRIPTION
Hi,

I just discovered that the signature of the `warp()` function in transform is not correct.
Way to reproduce:
```
from skimage import transform as tf
img = np.zeros((30, 30))
tf.warp(img)
```
raises: TypeError: 'NoneType' object is not callable

By default, a transformation must be pass, and that makes sense. So, I removed the optional value None to inverse_map.

Any comment?