### PR TITLE
fix region merging in `segmentation.felzenszwalb`

### DIFF
--- a/skimage/segmentation/_felzenszwalb_cy.pyx
+++ b/skimage/segmentation/_felzenszwalb_cy.pyx
@@ -52,9 +52,9 @@ def _felzenszwalb_cython(image, double scale=1, sigma=0.8,
     image = ndi.gaussian_filter(image, sigma=[sigma, sigma, 0])
 
     # compute edge weights in 8 connectivity:
-    right_cost = np.sqrt(np.sum((image[1:, :, :] - image[:-1, :, :])
+    down_cost = np.sqrt(np.sum((image[1:, :, :] - image[:-1, :, :])
     	*(image[1:, :, :] - image[:-1, :, :]), axis=-1))
-    down_cost = np.sqrt(np.sum((image[:, 1:, :] - image[:, :-1, :])
+    right_cost = np.sqrt(np.sum((image[:, 1:, :] - image[:, :-1, :])
     	*(image[:, 1:, :] - image[:, :-1, :]), axis=-1))
     dright_cost = np.sqrt(np.sum((image[1:, 1:, :] - image[:-1, :-1, :])
 	*(image[1:, 1:, :] - image[:-1, :-1, :]), axis=-1))
@@ -68,8 +68,8 @@ def _felzenszwalb_cython(image, double scale=1, sigma=0.8,
     height, width = image.shape[:2]
     cdef cnp.ndarray[cnp.intp_t, ndim=2] segments \
             = np.arange(width * height, dtype=np.intp).reshape(height, width)
-    right_edges = np.c_[segments[1:, :].ravel(), segments[:-1, :].ravel()]
-    down_edges = np.c_[segments[:, 1:].ravel(), segments[:, :-1].ravel()]
+    down_edges = np.c_[segments[1:, :].ravel(), segments[:-1, :].ravel()]
+    right_edges = np.c_[segments[:, 1:].ravel(), segments[:, :-1].ravel()]
     dright_edges = np.c_[segments[1:, 1:].ravel(), segments[:-1, :-1].ravel()]
     uright_edges = np.c_[segments[:-1, 1:].ravel(), segments[1:, :-1].ravel()]
     cdef cnp.ndarray[cnp.intp_t, ndim=2] edges \
@@ -122,6 +122,8 @@ def _felzenszwalb_cython(image, double scale=1, sigma=0.8,
                 continue
             if segment_size[seg0] < min_size or segment_size[seg1] < min_size:
                 join_trees(segments_p, seg0, seg1)
+                seg_new = find_root(segments_p, seg0)
+                segment_size[seg_new] = segment_size[seg0] + segment_size[seg1]
 
     # unravel the union find tree
     flat = segments.ravel()

--- a/skimage/segmentation/tests/test_felzenszwalb.py
+++ b/skimage/segmentation/tests/test_felzenszwalb.py
@@ -7,7 +7,7 @@ from skimage import data
 
 @test_parallel()
 def test_grey():
-    # very weak tests. This algorithm is pretty unstable.
+    # very weak tests.
     img = np.zeros((20, 21))
     img[:10, 10:] = 0.2
     img[10:, :10] = 0.4
@@ -38,7 +38,7 @@ def test_minsize():
 
 
 def test_color():
-    # very weak tests. This algorithm is pretty unstable.
+    # very weak tests.
     img = np.zeros((20, 21, 3))
     img[:10, :10, 0] = 1
     img[10:, :10, 1] = 1
@@ -50,6 +50,17 @@ def test_color():
     assert_array_equal(seg[10:, :10], 2)
     assert_array_equal(seg[:10, 10:], 1)
     assert_array_equal(seg[10:, 10:], 3)
+
+
+def test_merging():
+    # test region merging in the post-processing step
+    img = np.array([[0, 0.3], [0.7, 1]])
+    # With scale=0, only the post-processing is performed.
+    seg = felzenszwalb(img, scale=0, sigma=0, min_size=2)
+    # we expect 2 segments:
+    assert_equal(len(np.unique(seg)), 2)
+    assert_array_equal(seg[0, :], 0)
+    assert_array_equal(seg[1, :], 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
Old implementation does not update the sizes of merged regions which causes small regions to be merged into only a few large regions. Fixed.

## References
Fixes the issue discussed in #2134


