### PR TITLE
color.colorconv: Fix documentation of rgb2gray()

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -694,19 +694,21 @@ def rgb2gray(rgb):
     Parameters
     ----------
     rgb : array_like
-        The image in RGB format, in a 3-D array of shape ``(.., .., 3)``,
-        or in RGBA format with shape ``(.., .., 4)``.
+        The image in RGB format, in a 3-D or 4-D array of shape
+        ``(.., ..,[ ..,] 3)``, or in RGBA format with shape
+        ``(.., ..,[ ..,] 4)``.
 
     Returns
     -------
     out : ndarray
-        The luminance image, a 2-D array.
+        The luminance image - an array which is the same size as the input
+        array, but with the channel dimension removed.
 
     Raises
     ------
     ValueError
-        If `rgb2gray` is not a 3-D array of shape ``(.., .., 3)`` or
-        ``(.., .., 4)``.
+        If `rgb2gray` is not a 3-D or 4-D arrays of shape
+        ``(.., ..,[ ..,] 3)`` or ``(.., ..,[ ..,] 4)``.
 
     References
     ----------


### PR DESCRIPTION
## Description
The working of rgb2gray() has been modified, and it now works
with both 3D and 4D arrays and appropriately finds the luminance
image of the given image. The documentation does not mention the
4D array support and this commit modifies the documentation to
mention this.

## Checklist
As this is a documentation modification, these are not required.
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

## References
Closes https://github.com/scikit-image/scikit-image/issues/2167