### PR TITLE
Added chapter title formatting for numpy_images.rst

### DIFF
--- a/doc/source/user_guide/numpy_images.rst
+++ b/doc/source/user_guide/numpy_images.rst
@@ -1,5 +1,6 @@
+==================================
 A crash course on NumPy for images
-----------------------------------
+==================================
 
 Images manipulated by ``scikit-image`` are simply NumPy arrays. Hence, a
 large fraction of operations on images will just consist in using NumPy::


### PR DESCRIPTION
The layout of the "crash course on numpy images" chapter in http://scikit-image.org/docs/stable/user_guide.html, because the title of the chapter had the same formatting as its sections. I corrected this, so that section titles now appear nested below the title of the chapter.

