### PR TITLE
colorconv: Add rgba2rgb()

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -234,3 +234,6 @@
 
 - Kirill Malev
   Frangi and Hessian filters implementation
+
+- Abdeali Kothari
+  Alpha blending to convert from rgba to rgb

--- a/doc/source/user_guide/transforming_image_data.rst
+++ b/doc/source/user_guide/transforming_image_data.rst
@@ -42,6 +42,17 @@ transformed to floating-point type by the conversion operation::
 
 
 
+Conversion from RGBA to RGB - Removing alpha channel through alpha blending
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Converting an RGBA image to an RGB image by alpha blending it with a
+background is realized with :func:`rgba2rgb` :: 
+
+    >>> from skimage.color import rgba2rgb
+    >>> from skimage import data
+    >>> img_rgba = data.horse()
+    >>> img_rgb = rgba2rgb(img_rgba)
+
 Conversion between color and gray values
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/skimage/color/__init__.py
+++ b/skimage/color/__init__.py
@@ -1,5 +1,6 @@
 from .colorconv import (convert_colorspace,
                         guess_spatial_dimensions,
+                        rgba2rgb,
                         rgb2hsv,
                         hsv2rgb,
                         rgb2xyz,

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -41,6 +41,7 @@ from skimage.color import (rgb2hsv, hsv2rgb,
                            rgb2yiq, yiq2rgb,
                            rgb2ypbpr, ypbpr2rgb,
                            rgb2ycbcr, ycbcr2rgb,
+                           rgba2rgb,
                            guess_spatial_dimensions
                            )
 
@@ -67,6 +68,9 @@ class TestColorconv(TestCase):
 
     img_rgb = imread(os.path.join(data_dir, 'color.png'))
     img_grayscale = imread(os.path.join(data_dir, 'camera.png'))
+    img_rgba = np.array([[[0, 0.5, 1, 0],
+                          [0, 0.5, 1, 1],
+                          [0, 0.5, 1, 0.5]]]).astype(np.float)
 
     colbars = np.array([[1, 1, 0, 0, 1, 1, 0, 0],
                         [1, 1, 1, 1, 0, 0, 0, 0],
@@ -94,6 +98,22 @@ class TestColorconv(TestCase):
                           [[32.303, -9.400, -130.358]],   # blue
                           [[46.228, -43.774, 56.589]],   # green
                           ])
+
+    # RGBA to RGB
+    def test_rgba2rgb_conversion(self):
+        rgba = self.img_rgba
+        rgb = rgba2rgb(rgba)
+        expected = np.array([[[1, 1, 1],
+                              [0, 0.5, 1],
+                              [0.5, 0.75, 1]]]).astype(np.float)
+        self.assertEqual(rgb.shape, expected.shape)
+        assert_almost_equal(rgb, expected)
+
+    def test_rgba2rgb_error_grayscale(self):
+        self.assertRaises(ValueError, rgba2rgb, self.img_grayscale)
+
+    def test_rgba2rgb_error_rgb(self):
+        self.assertRaises(ValueError, rgba2rgb, self.img_rgb)
 
     # RGB to HSV
     def test_rgb2hsv_conversion(self):


### PR DESCRIPTION
## Description
rgba2rgb() is a conversion function which takes in a background RGB
color which is used to alpha blend with an RGBA image in the foreground.
The default value for this background is white (255, 255, 255).

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

## References
Closes https://github.com/scikit-image/scikit-image/issues/2174