### PR TITLE
Fix crash on import if byte-compiled level 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,9 @@ matrix:
     - os: linux
       python: 3.5
       env: PIP_FLAGS="--pre"
+    - os: linux
+      python: 3.5
+      env: PYTHONOPTIMIZE=2
     - os: osx
       osx_image: xcode7.3
       language: objective-c

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -597,10 +597,14 @@ def perimeter(image, neighbourhood=4):
 
 
 def _parse_docs():
+    doc = regionprops.__doc__
+    if doc is None:
+        # __doc__ is None if byte-compilation optimized level 2
+        return None
+
     import re
     import textwrap
 
-    doc = regionprops.__doc__
     matches = re.finditer('\*\*(\w+)\*\* \:.*?\n(.*?)(?=\n    [\*\S]+)',
                           doc, flags=re.DOTALL)
     prop_doc = dict((m.group(1), textwrap.dedent(m.group(2))) for m in matches)
@@ -613,11 +617,12 @@ def _install_properties_docs():
 
     for p in [member for member in dir(_RegionProperties)
               if not member.startswith('_')]:
-        try:
-            getattr(_RegionProperties, p).__doc__ = prop_doc[p]
-        except AttributeError:
-            # For Python 2.x
-            getattr(_RegionProperties, p).im_func.__doc__ = prop_doc[p]
+        if prop_doc is not None:
+            try:
+                getattr(_RegionProperties, p).__doc__ = prop_doc[p]
+            except AttributeError:
+                # For Python 2.x
+                getattr(_RegionProperties, p).im_func.__doc__ = prop_doc[p]
 
         setattr(_RegionProperties, p, property(getattr(_RegionProperties, p)))
 

--- a/skimage/measure/_structural_similarity.py
+++ b/skimage/measure/_structural_similarity.py
@@ -226,7 +226,7 @@ def compare_ssim(X, Y, win_size=None, gradient=False,
 def structural_similarity(X, Y, win_size=None, gradient=False,
                           dynamic_range=None, multichannel=False,
                           gaussian_weights=False, full=False, **kwargs):
-    """""" + compare_ssim.__doc__
+    """""" + compare_ssim.__doc__ if compare_ssim.__doc__ is not None else ""
     return compare_ssim(X, Y, win_size=win_size, gradient=gradient,
                         dynamic_range=dynamic_range,
                         multichannel=multichannel,

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -2,6 +2,7 @@ from numpy.testing import assert_array_equal, assert_almost_equal, \
     assert_array_almost_equal, assert_raises, assert_equal
 import numpy as np
 import math
+import sys
 
 from skimage.measure._regionprops import (regionprops, PROPS, perimeter,
                                           _parse_docs)
@@ -447,16 +448,19 @@ def test_cache():
 def test_docstrings_and_props():
     region = regionprops(SAMPLE)[0]
 
-    docs = _parse_docs()
-    props = [m for m in dir(region) if not m.startswith('_')]
-
-    nr_docs_parsed = len(docs)
-    nr_props = len(props)
-    assert_equal(nr_docs_parsed, nr_props)
-
-    ds = docs['weighted_moments_normalized']
-    assert 'iteration' not in ds
-    assert len(ds.split('\n')) > 3
+    docs = _parse_docs() # None if byte-compilation optimization 2
+    if sys.flags.optimize < 2:
+        props = [m for m in dir(region) if not m.startswith('_')]
+    
+        nr_docs_parsed = len(docs)
+        nr_props = len(props)
+        assert_equal(nr_docs_parsed, nr_props)
+    
+        ds = docs['weighted_moments_normalized']
+        assert 'iteration' not in ds
+        assert len(ds.split('\n')) > 3
+    else:
+        assert docs is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Fix crash on import if byte-compiled level 2 (Python -OO command line argument)
## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests
## References

No related issue.
