### PR TITLE
Update plot_edge_filter.py to remove large whitespace

### DIFF
--- a/doc/examples/edges/plot_edge_filter.py
+++ b/doc/examples/edges/plot_edge_filter.py
@@ -19,15 +19,15 @@ image = camera()
 edge_roberts = roberts(image)
 edge_sobel = sobel(image)
 
-fig, (ax0, ax1) = plt.subplots(ncols=2, sharex=True, sharey=True, subplot_kw={'adjustable':'box-forced'})
+fig, ax = plt.subplots(nrows=1, ncols=2, figsize=(12, 6))
 
-ax0.imshow(edge_roberts, cmap=plt.cm.gray)
-ax0.set_title('Roberts Edge Detection')
-ax0.axis('off')
+ax[0].imshow(edge_roberts, cmap=plt.cm.gray)
+ax[0].set_title('Roberts Edge Detection')
+ax[0].axis('off')
 
-ax1.imshow(edge_sobel, cmap=plt.cm.gray)
-ax1.set_title('Sobel Edge Detection')
-ax1.axis('off')
+ax[1].imshow(edge_sobel, cmap=plt.cm.gray)
+ax[1].set_title('Sobel Edge Detection')
+ax[1].axis('off')
 
 plt.tight_layout()
 
@@ -64,23 +64,24 @@ diff_scharr_prewitt = edge_scharr - edge_prewitt
 diff_scharr_sobel = edge_scharr - edge_sobel
 max_diff = np.max(np.maximum(diff_scharr_prewitt, diff_scharr_sobel))
 
-fig, ((ax0, ax1), (ax2, ax3)) = plt.subplots(nrows=2, ncols=2, sharex=True, sharey=True, subplot_kw={'adjustable':'box-forced'})
+#fig, ((ax0, ax1), (ax2, ax3)) = plt.subplots(nrows=2, ncols=2, sharex=True, sharey=True, subplot_kw={'adjustable':'box-forced'})
+fig, ax = plt.subplots(nrows=2, ncols=2, sharex=True, sharey=True, subplot_kw={'adjustable':'box-forced'})
 
-ax0.imshow(img, cmap=plt.cm.gray)
-ax0.set_title('Original image')
-ax0.axis('off')
+ax[0, 0].imshow(img, cmap=plt.cm.gray)
+ax[0, 0].set_title('Original image')
+ax[0, 0].axis('off')
 
-ax1.imshow(edge_scharr, cmap=plt.cm.gray)
-ax1.set_title('Scharr Edge Detection')
-ax1.axis('off')
+ax[0, 1].imshow(edge_scharr, cmap=plt.cm.gray)
+ax[0, 1].set_title('Scharr Edge Detection')
+ax[0, 1].axis('off')
 
-ax2.imshow(diff_scharr_prewitt, cmap=plt.cm.gray, vmax=max_diff)
-ax2.set_title('Scharr - Prewitt')
-ax2.axis('off')
+ax[1, 0].imshow(diff_scharr_prewitt, cmap=plt.cm.gray, vmax=max_diff)
+ax[1, 0].set_title('Scharr - Prewitt')
+ax[1, 0].axis('off')
 
-ax3.imshow(diff_scharr_sobel, cmap=plt.cm.gray, vmax=max_diff)
-ax3.set_title('Scharr - Sobel')
-ax3.axis('off')
+ax[1, 1].imshow(diff_scharr_sobel, cmap=plt.cm.gray, vmax=max_diff)
+ax[1, 1].set_title('Scharr - Sobel')
+ax[1, 1].axis('off')
 
 plt.tight_layout()
 plt.show()


### PR DESCRIPTION
## Description
Updated plot_edge_filter.py to remove large whitespace in the figure with the imshow of camera.  Additionally made the ax an array or matrix to be more consistent with the other examples.  


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ x  ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ x  ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ x  ] Gallery example in `./doc/examples` (new features only)
- [ x  ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
Issue #1773 


Issue #1773 removed large whitespace from imshow figure.  Additionally made the ax an array or matrix to be more consistent with other examples.