### PR TITLE
DOC: add a note on warning treatment

### DIFF
--- a/doc/source/user_guide/data_types.rst
+++ b/doc/source/user_guide/data_types.rst
@@ -73,6 +73,14 @@ issued::
    float64 to uint8
    array([  0, 128, 255], dtype=uint8)
 
+Warnings can be locally ignored with a context manager::
+
+   >>> import warnings
+   >>> image = np.array([0, 0.5, 1], dtype=float)
+   >>> with warnings.catch_warnings():
+   ...     warnings.simplefilter("ignore")
+   ...     img_as_ubyte(image)
+   array([  0, 128, 255], dtype=uint8)
 
 Additionally, some functions take a ``preserve_range`` argument where a range
 conversion is convenient but not necessary. For example, interpolation in


### PR DESCRIPTION
It's not necessarily straightforward to treat warnings and from https://github.com/scikit-image/scikit-image/issues/543#issuecomment-208202228 it seems that a note in the doc would be welcome. 

Warnings on dtype conversion happen very often...