### PR TITLE
[MRG] MAINT: Replaced gaussian_filter with filters.gaussian

### DIFF
--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -63,14 +63,14 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
     Examples
     --------
     >>> from skimage.draw import circle_perimeter
-    >>> from skimage.filters import gaussian_filter
+    >>> from skimage.filters import gaussian
 
     Create and smooth image:
 
     >>> img = np.zeros((100, 100))
     >>> rr, cc = circle_perimeter(35, 45, 25)
     >>> img[rr, cc] = 1
-    >>> img = gaussian_filter(img, 2)
+    >>> img = gaussian(img, 2)
 
     Initiliaze spline:
 

--- a/skimage/segmentation/tests/test_active_contour_model.py
+++ b/skimage/segmentation/tests/test_active_contour_model.py
@@ -1,7 +1,7 @@
 import numpy as np
 from skimage import data
 from skimage.color import rgb2gray
-from skimage.filters import gaussian_filter
+from skimage.filters import gaussian
 from skimage.segmentation import active_contour
 from numpy.testing import assert_equal, assert_allclose, assert_raises
 from numpy.testing.decorators import skipif
@@ -19,7 +19,7 @@ def test_periodic_reference():
     x = 220 + 100*np.cos(s)
     y = 100 + 100*np.sin(s)
     init = np.array([x, y]).T
-    snake = active_contour(gaussian_filter(img, 3), init,
+    snake = active_contour(gaussian(img, 3), init,
             alpha=0.015, beta=10, w_line=0, w_edge=1, gamma=0.001)
     refx = [299, 298, 298, 298, 298, 297, 297, 296, 296, 295]
     refy = [98, 99, 100, 101, 102, 103, 104, 105, 106, 108]
@@ -32,7 +32,7 @@ def test_fixed_reference():
     x = np.linspace(5, 424, 100)
     y = np.linspace(136, 50, 100)
     init = np.array([x, y]).T
-    snake = active_contour(gaussian_filter(img, 1), init, bc='fixed',
+    snake = active_contour(gaussian(img, 1), init, bc='fixed',
             alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1)
     refx = [5, 9, 13, 17, 21, 25, 30, 34, 38, 42]
     refy = [136, 135, 134, 133, 132, 131, 129, 128, 127, 125]
@@ -45,7 +45,7 @@ def test_free_reference():
     x = np.linspace(5, 424, 100)
     y = np.linspace(70, 40, 100)
     init = np.array([x, y]).T
-    snake = active_contour(gaussian_filter(img, 3), init, bc='free',
+    snake = active_contour(gaussian(img, 3), init, bc='free',
             alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1)
     refx = [10, 13, 16, 19, 23, 26, 29, 32, 36, 39]
     refy = [76, 76, 75, 74, 73, 72, 71, 70, 69, 69]
@@ -54,7 +54,7 @@ def test_free_reference():
 
 @skipif(not new_scipy)
 def test_RGB():
-    img = gaussian_filter(data.text(), 1)
+    img = gaussian(data.text(), 1)
     imgR = np.zeros((img.shape[0], img.shape[1], 3))
     imgG = np.zeros((img.shape[0], img.shape[1], 3))
     imgRGB = np.zeros((img.shape[0], img.shape[1], 3))
@@ -87,15 +87,15 @@ def test_end_points():
     x = 220 + 100*np.cos(s)
     y = 100 + 100*np.sin(s)
     init = np.array([x, y]).T
-    snake = active_contour(gaussian_filter(img, 3), init,
+    snake = active_contour(gaussian(img, 3), init,
              bc='periodic', alpha=0.015, beta=10, w_line=0, w_edge=1,
              gamma=0.001, max_iterations=100)
     assert np.sum(np.abs(snake[0, :]-snake[-1, :])) < 2
-    snake = active_contour(gaussian_filter(img, 3), init,
+    snake = active_contour(gaussian(img, 3), init,
             bc='free', alpha=0.015, beta=10, w_line=0, w_edge=1,
             gamma=0.001, max_iterations=100)
     assert np.sum(np.abs(snake[0, :]-snake[-1, :])) > 2
-    snake = active_contour(gaussian_filter(img, 3), init,
+    snake = active_contour(gaussian(img, 3), init,
             bc='fixed', alpha=0.015, beta=10, w_line=0, w_edge=1,
             gamma=0.001, max_iterations=100)
     assert_allclose(snake[0, :], [x[0], y[0]], atol=1e-5)


### PR DESCRIPTION
## Description
Replaced instances of deprecated `skimage.filters.gaussian_filter` with `skimage.filters.gaussian`.

## References
This fix addresses issue #2206 



