### PR TITLE
[MRG] DOC: corrected mssim docstring to return float

### DIFF
--- a/skimage/measure/_structural_similarity.py
+++ b/skimage/measure/_structural_similarity.py
@@ -54,7 +54,7 @@ def compare_ssim(X, Y, win_size=None, gradient=False,
 
     Returns
     -------
-    mssim : float or ndarray
+    mssim : float
         The mean structural similarity over the image.
     grad : ndarray
         The gradient of the structural similarity index between X and Y [2]_.


### PR DESCRIPTION
## Description
Corrected docstring to say that `mssim` is returned as float as opposed to float and ndarray. 

## References
Closes issue #2201 


