### PR TITLE
Update `exposure.equalize_adapthist` args and docstring

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -17,7 +17,8 @@ Version 0.14
   deprecation warning test for this alias.
 * Remove deprecated ``sigma_range`` kwargs in ``skimage.restoration.denoise_bilateral``
   and corresponding tests.
-
+* Remove deprecation error on the usage of ``ntiles_x``, ``ntiles_y``
+  ``skimage.exposure.equalize_adapthist``.
 
 Version 0.15
 ------------

--- a/TODO.txt
+++ b/TODO.txt
@@ -18,7 +18,7 @@ Version 0.14
 * Remove deprecated ``sigma_range`` kwargs in ``skimage.restoration.denoise_bilateral``
   and corresponding tests.
 * Remove deprecation error on the usage of ``ntiles_x``, ``ntiles_y`` in
-  ``skimage.exposure.equalize_adapthist``.
+  ``skimage.exposure.equalize_adapthist`` and the corresponding test.
 
 Version 0.15
 ------------

--- a/TODO.txt
+++ b/TODO.txt
@@ -17,7 +17,7 @@ Version 0.14
   deprecation warning test for this alias.
 * Remove deprecated ``sigma_range`` kwargs in ``skimage.restoration.denoise_bilateral``
   and corresponding tests.
-* Remove deprecation error on the usage of ``ntiles_x``, ``ntiles_y``
+* Remove deprecation error on the usage of ``ntiles_x``, ``ntiles_y`` in
   ``skimage.exposure.equalize_adapthist``.
 
 Version 0.15

--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -15,6 +15,8 @@ Version 0.13
 - The `circle` parameter of `skimage.transform.radon` and `skimage.transform.iradon`
   are now set to `None` by default, equivalent to `False`, the former value. In version
   0.15, will be set to `True`.
+- Parameters ``ntiles_x``, ``ntiles_y`` has been removed from
+  ``skimage.exposure.equalize_adapthist``.
 
 Version 0.12
 ------------

--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -15,7 +15,7 @@ Version 0.13
 - The `circle` parameter of `skimage.transform.radon` and `skimage.transform.iradon`
   are now set to `None` by default, equivalent to `False`, the former value. In version
   0.15, will be set to `True`.
-- Parameters ``ntiles_x``, ``ntiles_y`` has been removed from
+- Parameters ``ntiles_x``, ``ntiles_y`` have been removed from
   ``skimage.exposure.equalize_adapthist``.
 
 Version 0.12

--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -35,12 +35,12 @@ def equalize_adapthist(image, kernel_size=None,
 
     Parameters
     ----------
-    image : array-like
+    image : ndarray
         Input image.
-    kernel_size: integer or 2-tuple
+    kernel_size: integer or list-like
         Defines the shape of contextual regions used in the algorithm. If an
-        iterable is passed, it should have the same length as the image
-        dimensionality.
+        iterable is passed, it must have the same number of elements as
+        `image.ndim`. If integer, it is broadcasted to each `image` dimension.
     clip_limit : float: optional
         Clipping limit, normalized between 0 and 1 (higher values give more
         contrast).
@@ -82,6 +82,8 @@ def equalize_adapthist(image, kernel_size=None,
                        np.round(image.shape[1] / 8))
     elif isinstance(kernel_size, numbers.Number):
         kernel_size = (kernel_size,) * image.ndim
+    elif len(kernel_size) != image.ndim:
+        ValueError('Incorrect value of `kernel_size`: {}'.format(kernel_size))
 
     kernel_size = [int(k) for k in kernel_size]
 

--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -25,8 +25,8 @@ NR_OF_GREY = 2 ** 14  # number of grayscale levels to use in CLAHE algorithm
 
 
 @adapt_rgb(hsv_value)
-def equalize_adapthist(image, ntiles_x=None, ntiles_y=None, clip_limit=0.01,
-                       nbins=256, kernel_size=None):
+def equalize_adapthist(image, kernel_size=None,
+                       clip_limit=0.01, nbins=256, **kwargs):
     """Contrast Limited Adaptive Histogram Equalization (CLAHE).
 
     An algorithm for local contrast enhancement, that uses histograms computed
@@ -38,13 +38,9 @@ def equalize_adapthist(image, ntiles_x=None, ntiles_y=None, clip_limit=0.01,
     image : array-like
         Input image.
     kernel_size: integer or 2-tuple
-        Defines the shape of contextual regions used in the algorithm.
-        If an integer is given, the shape will be a square of
-        sidelength given by this value.
-    ntiles_x : int, optional (deprecated in favor of ``kernel_size``)
-        Number of tile regions in the X direction (horizontal).
-    ntiles_y : int, optional (deprecated in favor of ``kernel_size``)
-        Number of tile regions in the Y direction (vertical).
+        Defines the shape of contextual regions used in the algorithm. If an
+        iterable is passed, it should have the same length as the image
+        dimensionality.
     clip_limit : float: optional
         Clipping limit, normalized between 0 and 1 (higher values give more
         contrast).
@@ -76,19 +72,15 @@ def equalize_adapthist(image, ntiles_x=None, ntiles_y=None, clip_limit=0.01,
     image = img_as_uint(image)
     image = rescale_intensity(image, out_range=(0, NR_OF_GREY - 1))
 
-    if ntiles_x is not None or ntiles_y is not None:
-        warn('`ntiles_*` have been deprecated in favor of '
-             '`kernel_size`.  The `ntiles_*` keyword arguments '
-             'will be removed in v0.14', skimage_deprecation)
+    if kwargs:
+        if 'ntiles_x' in kwargs or 'ntiles_y' in kwargs:
+            raise ValueError('`ntiles_*` have been deprecated in favor of `kernel_size`')
 
-    if kernel_size is None:
-        ntiles_x = ntiles_x or 8
-        ntiles_y = ntiles_y or 8
-        kernel_size = (np.round(image.shape[0] / ntiles_y),
-                       np.round(image.shape[1] / ntiles_x))
+    if kernel_size == None:
+        kernel_size = (np.round(image.shape[0] / 8), np.round(image.shape[1] / 8))
 
     if isinstance(kernel_size, numbers.Number):
-        kernel_size = (kernel_size, kernel_size)
+        kernel_size = (kernel_size,) * image.ndim
 
     kernel_size = [int(k) for k in kernel_size]
 

--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -19,7 +19,7 @@ import numpy as np
 from .. import img_as_float, img_as_uint
 from ..color.adapt_rgb import adapt_rgb, hsv_value
 from ..exposure import rescale_intensity
-from .._shared.utils import skimage_deprecation, warn
+
 
 NR_OF_GREY = 2 ** 14  # number of grayscale levels to use in CLAHE algorithm
 
@@ -74,12 +74,13 @@ def equalize_adapthist(image, kernel_size=None,
 
     if kwargs:
         if 'ntiles_x' in kwargs or 'ntiles_y' in kwargs:
-            raise ValueError('`ntiles_*` have been deprecated in favor of `kernel_size`')
+            msg = '`ntiles_*` have been deprecated in favor of `kernel_size`'
+            raise ValueError(msg)
 
-    if kernel_size == None:
-        kernel_size = (np.round(image.shape[0] / 8), np.round(image.shape[1] / 8))
-
-    if isinstance(kernel_size, numbers.Number):
+    if kernel_size is None:
+        kernel_size = (np.round(image.shape[0] / 8),
+                       np.round(image.shape[1] / 8))
+    elif isinstance(kernel_size, numbers.Number):
         kernel_size = (kernel_size,) * image.ndim
 
     kernel_size = [int(k) for k in kernel_size]

--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -35,13 +35,15 @@ def equalize_adapthist(image, kernel_size=None,
 
     Parameters
     ----------
-    image : ndarray
+    image : (M, N[, C]) ndarray
         Input image.
-    kernel_size: integer or list-like
-        Defines the shape of contextual regions used in the algorithm. If an
+    kernel_size: integer or list-like, optional
+        Defines the shape of contextual regions used in the algorithm. If
         iterable is passed, it must have the same number of elements as
-        `image.ndim`. If integer, it is broadcasted to each `image` dimension.
-    clip_limit : float: optional
+        ``image.ndim`` (without color channel). If integer, it is broadcasted
+        to each `image` dimension. By default, ``kernel_size`` is 1/8 of
+        ``image`` height by 1/8 of its width.
+    clip_limit : float, optional
         Clipping limit, normalized between 0 and 1 (higher values give more
         contrast).
     nbins : int, optional
@@ -49,7 +51,7 @@ def equalize_adapthist(image, kernel_size=None,
 
     Returns
     -------
-    out : ndarray
+    out : (M, N[, C]) ndarray
         Equalized image.
 
     See Also
@@ -78,8 +80,7 @@ def equalize_adapthist(image, kernel_size=None,
             raise ValueError(msg)
 
     if kernel_size is None:
-        kernel_size = (np.round(image.shape[0] / 8),
-                       np.round(image.shape[1] / 8))
+        kernel_size = (image.shape[0] // 8, image.shape[1] // 8)
     elif isinstance(kernel_size, numbers.Number):
         kernel_size = (kernel_size,) * image.ndim
     elif len(kernel_size) != image.ndim:
@@ -97,18 +98,18 @@ def _clahe(image, kernel_size, clip_limit, nbins=128):
 
     Parameters
     ----------
-    image : array-like
+    image : (M, N) ndarray
         Input image.
-    kernel_size: 2-tuple
+    kernel_size: 2-tuple of int
         Defines the shape of contextual regions used in the algorithm.
-    clip_limit : float, optional
+    clip_limit : float
         Normalized clipping limit (higher values give more contrast).
     nbins : int, optional
         Number of gray bins for histogram ("dynamic range").
 
     Returns
     -------
-    out : ndarray
+    out : (M, N) ndarray
         Equalized image.
 
     The number of "effective" greylevels in the output image is set by `nbins`;

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -211,10 +211,6 @@ def test_adapthist_grayscale():
     img = skimage.img_as_float(data.astronaut())
     img = rgb2gray(img)
     img = np.dstack((img, img, img))
-    with expected_warnings(['precision loss|non-contiguous input',
-                            'deprecated']):
-        adapted_old = exposure.equalize_adapthist(img, 10, 9, clip_limit=0.001,
-                                                  nbins=128)
     with expected_warnings(['precision loss|non-contiguous input']):
         adapted = exposure.equalize_adapthist(img, kernel_size=(57, 51),
                                               clip_limit=0.01, nbins=128)

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -45,6 +45,7 @@ test_img_int = data.camera()
 test_img = skimage.img_as_float(test_img_int)
 test_img = exposure.rescale_intensity(test_img / 5. + 100)
 
+
 def test_equalize_uint8_approx():
     """Check integer bins used for uint8 images."""
     img_eq0 = exposure.equalize_hist(test_img_int)
@@ -121,7 +122,6 @@ def test_intensity_range_clipped_float():
 
 # Test rescale intensity
 # ======================
-
 
 uint10_max = 2**10 - 1
 uint12_max = 2**12 - 1
@@ -300,9 +300,9 @@ def norm_brightness_err(img1, img2):
     return nbe
 
 
-
 # Test Gamma Correction
 # =====================
+
 
 def test_adjust_gamma_one():
     """Same image should be returned for gamma equal to one"""
@@ -322,8 +322,9 @@ def test_adjust_gamma_zero():
 def test_adjust_gamma_less_one():
     """Verifying the output with expected results for gamma
     correction with gamma equal to half"""
-    image = np.arange(0, 255, 4, np.uint8).reshape(8,8)
-    expected = np.array([[  0,  31,  45,  55,  63,  71,  78,  84],
+    image = np.arange(0, 255, 4, np.uint8).reshape((8, 8))
+    expected = np.array([
+        [  0,  31,  45,  55,  63,  71,  78,  84],
         [ 90,  95, 100, 105, 110, 115, 119, 123],
         [127, 131, 135, 139, 142, 146, 149, 153],
         [156, 159, 162, 165, 168, 171, 174, 177],
@@ -339,8 +340,9 @@ def test_adjust_gamma_less_one():
 def test_adjust_gamma_greater_one():
     """Verifying the output with expected results for gamma
     correction with gamma equal to two"""
-    image = np.arange(0, 255, 4, np.uint8).reshape(8,8)
-    expected = np.array([[  0,   0,   0,   0,   1,   1,   2,   3],
+    image = np.arange(0, 255, 4, np.uint8).reshape((8, 8))
+    expected = np.array([
+        [  0,   0,   0,   0,   1,   1,   2,   3],
         [  4,   5,   6,   7,   9,  10,  12,  14],
         [ 16,  18,  20,  22,  25,  27,  30,  33],
         [ 36,  39,  42,  45,  49,  52,  56,  60],
@@ -354,7 +356,7 @@ def test_adjust_gamma_greater_one():
 
 
 def test_adjust_gamma_neggative():
-    image = np.arange(0, 255, 4, np.uint8).reshape(8,8)
+    image = np.arange(0, 255, 4, np.uint8).reshape((8, 8))
     assert_raises(ValueError, exposure.adjust_gamma, image, -1)
 
 
@@ -364,8 +366,9 @@ def test_adjust_gamma_neggative():
 def test_adjust_log():
     """Verifying the output with expected results for logarithmic
     correction with multiplier constant multiplier equal to unity"""
-    image = np.arange(0, 255, 4, np.uint8).reshape(8,8)
-    expected = np.array([[  0,   5,  11,  16,  22,  27,  33,  38],
+    image = np.arange(0, 255, 4, np.uint8).reshape((8, 8))
+    expected = np.array([
+        [  0,   5,  11,  16,  22,  27,  33,  38],
         [ 43,  48,  53,  58,  63,  68,  73,  77],
         [ 82,  86,  91,  95, 100, 104, 109, 113],
         [117, 121, 125, 129, 133, 137, 141, 145],
@@ -381,8 +384,9 @@ def test_adjust_log():
 def test_adjust_inv_log():
     """Verifying the output with expected results for inverse logarithmic
     correction with multiplier constant multiplier equal to unity"""
-    image = np.arange(0, 255, 4, np.uint8).reshape(8,8)
-    expected = np.array([[  0,   2,   5,   8,  11,  14,  17,  20],
+    image = np.arange(0, 255, 4, np.uint8).reshape((8, 8))
+    expected = np.array([
+        [  0,   2,   5,   8,  11,  14,  17,  20],
         [ 23,  26,  29,  32,  35,  38,  41,  45],
         [ 48,  51,  55,  58,  61,  65,  68,  72],
         [ 76,  79,  83,  87,  90,  94,  98, 102],
@@ -401,8 +405,9 @@ def test_adjust_inv_log():
 def test_adjust_sigmoid_cutoff_one():
     """Verifying the output with expected results for sigmoid correction
     with cutoff equal to one and gain of 5"""
-    image = np.arange(0, 255, 4, np.uint8).reshape(8,8)
-    expected = np.array([[  1,   1,   1,   2,   2,   2,   2,   2],
+    image = np.arange(0, 255, 4, np.uint8).reshape((8, 8))
+    expected = np.array([
+        [  1,   1,   1,   2,   2,   2,   2,   2],
         [  3,   3,   3,   4,   4,   4,   5,   5],
         [  5,   6,   6,   7,   7,   8,   9,  10],
         [ 10,  11,  12,  13,  14,  15,  16,  18],
@@ -418,8 +423,9 @@ def test_adjust_sigmoid_cutoff_one():
 def test_adjust_sigmoid_cutoff_zero():
     """Verifying the output with expected results for sigmoid correction
     with cutoff equal to zero and gain of 10"""
-    image = np.arange(0, 255, 4, np.uint8).reshape(8,8)
-    expected = np.array([[127, 137, 147, 156, 166, 175, 183, 191],
+    image = np.arange(0, 255, 4, np.uint8).reshape((8, 8))
+    expected = np.array([
+        [127, 137, 147, 156, 166, 175, 183, 191],
         [198, 205, 211, 216, 221, 225, 229, 232],
         [235, 238, 240, 242, 244, 245, 247, 248],
         [249, 250, 250, 251, 251, 252, 252, 253],
@@ -435,8 +441,9 @@ def test_adjust_sigmoid_cutoff_zero():
 def test_adjust_sigmoid_cutoff_half():
     """Verifying the output with expected results for sigmoid correction
     with cutoff equal to half and gain of 10"""
-    image = np.arange(0, 255, 4, np.uint8).reshape(8,8)
-    expected = np.array([[  1,   1,   2,   2,   3,   3,   4,   5],
+    image = np.arange(0, 255, 4, np.uint8).reshape((8, 8))
+    expected = np.array([
+        [  1,   1,   2,   2,   3,   3,   4,   5],
         [  5,   6,   7,   9,  10,  12,  14,  16],
         [ 19,  22,  25,  29,  34,  39,  44,  50],
         [ 57,  64,  72,  80,  89,  99, 108, 118],
@@ -452,8 +459,9 @@ def test_adjust_sigmoid_cutoff_half():
 def test_adjust_inv_sigmoid_cutoff_half():
     """Verifying the output with expected results for inverse sigmoid
     correction with cutoff equal to half and gain of 10"""
-    image = np.arange(0, 255, 4, np.uint8).reshape(8,8)
-    expected = np.array([[253, 253, 252, 252, 251, 251, 250, 249],
+    image = np.arange(0, 255, 4, np.uint8).reshape((8, 8))
+    expected = np.array([
+        [253, 253, 252, 252, 251, 251, 250, 249],
         [249, 248, 247, 245, 244, 242, 240, 238],
         [235, 232, 229, 225, 220, 215, 210, 204],
         [197, 190, 182, 174, 165, 155, 146, 136],
@@ -467,7 +475,7 @@ def test_adjust_inv_sigmoid_cutoff_half():
 
 
 def test_negative():
-    image = np.arange(-10, 245, 4).reshape(8, 8).astype(np.double)
+    image = np.arange(-10, 245, 4).reshape((8, 8)).astype(np.double)
     assert_raises(ValueError, exposure.adjust_gamma, image)
 
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -1,9 +1,8 @@
 import warnings
 
 import numpy as np
-from numpy.testing import assert_array_almost_equal as assert_close
-from numpy.testing import (assert_array_equal, assert_raises,
-                           assert_almost_equal)
+from numpy.testing import (assert_array_equal, assert_array_almost_equal,
+                           assert_raises, assert_almost_equal)
 
 import skimage
 from skimage import data
@@ -133,56 +132,56 @@ def test_rescale_stretch():
     image = np.array([51, 102, 153], dtype=np.uint8)
     out = exposure.rescale_intensity(image)
     assert out.dtype == np.uint8
-    assert_close(out, [0, 127, 255])
+    assert_array_almost_equal(out, [0, 127, 255])
 
 
 def test_rescale_shrink():
     image = np.array([51., 102., 153.])
     out = exposure.rescale_intensity(image)
-    assert_close(out, [0, 0.5, 1])
+    assert_array_almost_equal(out, [0, 0.5, 1])
 
 
 def test_rescale_in_range():
     image = np.array([51., 102., 153.])
     out = exposure.rescale_intensity(image, in_range=(0, 255))
-    assert_close(out, [0.2, 0.4, 0.6])
+    assert_array_almost_equal(out, [0.2, 0.4, 0.6])
 
 
 def test_rescale_in_range_clip():
     image = np.array([51., 102., 153.])
     out = exposure.rescale_intensity(image, in_range=(0, 102))
-    assert_close(out, [0.5, 1, 1])
+    assert_array_almost_equal(out, [0.5, 1, 1])
 
 
 def test_rescale_out_range():
     image = np.array([-10, 0, 10], dtype=np.int8)
     out = exposure.rescale_intensity(image, out_range=(0, 127))
     assert out.dtype == np.int8
-    assert_close(out, [0, 63, 127])
+    assert_array_almost_equal(out, [0, 63, 127])
 
 
 def test_rescale_named_in_range():
     image = np.array([0, uint10_max, uint10_max + 100], dtype=np.uint16)
     out = exposure.rescale_intensity(image, in_range='uint10')
-    assert_close(out, [0, uint16_max, uint16_max])
+    assert_array_almost_equal(out, [0, uint16_max, uint16_max])
 
 
 def test_rescale_named_out_range():
     image = np.array([0, uint16_max], dtype=np.uint16)
     out = exposure.rescale_intensity(image, out_range='uint10')
-    assert_close(out, [0, uint10_max])
+    assert_array_almost_equal(out, [0, uint10_max])
 
 
 def test_rescale_uint12_limits():
     image = np.array([0, uint16_max], dtype=np.uint16)
     out = exposure.rescale_intensity(image, out_range='uint12')
-    assert_close(out, [0, uint12_max])
+    assert_array_almost_equal(out, [0, uint12_max])
 
 
 def test_rescale_uint14_limits():
     image = np.array([0, uint16_max], dtype=np.uint16)
     out = exposure.rescale_intensity(image, out_range='uint14')
-    assert_close(out, [0, uint14_max])
+    assert_array_almost_equal(out, [0, uint14_max])
 
 
 # Test adaptive histogram equalization
@@ -198,11 +197,9 @@ def test_adapthist_scalar():
     assert img.shape == adapted.shape
     full_scale = skimage.exposure.rescale_intensity(skimage.img_as_float(img))
 
-    assert_almost_equal = np.testing.assert_almost_equal
     assert_almost_equal(peak_snr(full_scale, adapted), 102.066, 3)
     assert_almost_equal(norm_brightness_err(full_scale, adapted),
                         0.038, 3)
-    return img, adapted
 
 
 def test_adapthist_grayscale():
@@ -215,9 +212,8 @@ def test_adapthist_grayscale():
         adapted = exposure.equalize_adapthist(img, kernel_size=(57, 51),
                                               clip_limit=0.01, nbins=128)
     assert img.shape == adapted.shape
-    assert_almost_equal(peak_snr(img, adapted),  102.078, 3)
+    assert_almost_equal(peak_snr(img, adapted), 102.078, 3)
     assert_almost_equal(norm_brightness_err(img, adapted), 0.0529, 3)
-    return data, adapted
 
 
 def test_adapthist_color():
@@ -231,7 +227,6 @@ def test_adapthist_color():
     with expected_warnings(['precision loss']):
         adapted = exposure.equalize_adapthist(img, clip_limit=0.01)
 
-    assert_almost_equal = np.testing.assert_almost_equal
     assert adapted.min() == 0
     assert adapted.max() == 1.0
     assert img.shape == adapted.shape
@@ -253,9 +248,16 @@ def test_adapthist_alpha():
     img = img[:, :, :3]
     full_scale = skimage.exposure.rescale_intensity(img)
     assert img.shape == adapted.shape
-    assert_almost_equal = np.testing.assert_almost_equal
     assert_almost_equal(peak_snr(full_scale, adapted), 109.393, 2)
     assert_almost_equal(norm_brightness_err(full_scale, adapted), 0.0248, 3)
+
+
+def test_adapthist_ntiles_raises():
+    img = skimage.img_as_ubyte(data.moon())
+    assert_raises(ValueError, exposure.equalize_adapthist, img, ntiles_x=8)
+    assert_raises(ValueError, exposure.equalize_adapthist, img, ntiles_y=8)
+    assert_raises(ValueError, exposure.equalize_adapthist, img,
+                  ntiles_x=8, ntiles_y=8)
 
 
 def peak_snr(img1, img2):


### PR DESCRIPTION
## Description

Re-ordered `equalize_adapthist()` parameters so that they match the docstring. Also added default values for `kernel_size`, `ntiles_y`, and `ntiles_x` to docstring.
## References

Issue #2214
