### PR TITLE
Add task update version on wikipedia

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -77,6 +77,8 @@ How to make a new release of ``skimage``
   - scikit-learn-general@lists.sourceforge.net
   - pythonvision@googlegroups.com
 
+- Update the version and the release date on wikipedia
+  https://en.wikipedia.org/wiki/Scikit-image
 
 Debian
 ------


### PR DESCRIPTION
I discovered that the scikit-image wikipedia page was not up-to-date. This PR adds a step to the release procedure to do not forget.