### PR TITLE
Speedup `inpaint_biharmonic`

### DIFF
--- a/doc/examples/filters/plot_inpaint.py
+++ b/doc/examples/filters/plot_inpaint.py
@@ -23,7 +23,7 @@ inpainting algorithm based on 'biharmonic equation'-assumption [2]_ [3]_.
 import numpy as np
 import matplotlib.pyplot as plt
 
-from skimage import data, color
+from skimage import data
 from skimage.restoration import inpaint
 
 image_orig = data.astronaut()[0:200, 0:200]

--- a/skimage/restoration/inpaint.py
+++ b/skimage/restoration/inpaint.py
@@ -125,7 +125,6 @@ def inpaint_biharmonic(img, mask, multichannel=False):
 
     # Split inpainting mask into independent regions
     kernel = ndi.morphology.generate_binary_structure(mask.ndim, 1)
-    kernel = ndi.iterate_structure(kernel, 2)
     mask_dilated = ndi.morphology.binary_dilation(mask, structure=kernel)
     mask_labeled, num_labels = label(mask_dilated, return_num=True)
     mask_labeled *= mask


### PR DESCRIPTION
## Description
Added inpainting region pre-split to reduce the size of eq.system for `spsolve`.

"""Benchmarking""" on a gallery example:
```
*** BEFORE ***
[egor@host restoration]$ time python inpaint.py 
real	0m7.371s
user	0m7.267s
sys	0m0.313s

[egor@host restoration]$ time python inpaint.py 
real	0m7.291s
user	0m7.210s
sys	0m0.287s

*** AFTER***
[egor@host restoration]$ time python inpaint.py 
real	0m6.275s
user	0m6.210s
sys	0m0.273s

[egor@host restoration]$ time python inpaint.py 
real	0m6.320s
user	0m6.220s
sys	0m0.363s
```

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

## References
Partially addresses https://github.com/scikit-image/scikit-image/issues/2008.
