### PR TITLE
Add pywavelets to runtime requirements in DEPENDS.txt

### DIFF
--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -17,6 +17,7 @@ Runtime requirements
 * `Six >=1.4 <https://pypi.python.org/pypi/six>`__
 * `Pillow >= 1.7.8 <https://pypi.python.org/pypi/Pillow>`__
     (or `PIL <http://www.pythonware.com/products/pil/>`__)
+* `PyWavelets>=0.4.0 <https://pypi.python.org/pypi/PyWavelets/>`__
 
 You can use pip to automatically install the runtime dependencies as follows::
 


### PR DESCRIPTION
Can somebody explain me why dask is in requirements.txt? and in Optional Requirements in DEPENDS.txt?