### PR TITLE
[MRG+1] more closesly match the BayesShrink paper in _wavelet_threshold

### DIFF
--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -389,8 +389,7 @@ def _wavelet_threshold(img, wavelet, threshold=None, sigma=None, mode='soft'):
 
     denoised_detail = [{key: pywt.threshold(level[key], value=threshold,
                        mode=mode) for key in level} for level in coeffs[1:]]
-    denoised_root = pywt.threshold(coeffs[0], value=threshold, mode=mode)
-    denoised_coeffs = [denoised_root] + [d for d in denoised_detail]
+    denoised_coeffs = [coeffs[0]] + [d for d in denoised_detail]
     return pywt.waverecn(denoised_coeffs, wavelet)
 
 

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -353,8 +353,8 @@ def _wavelet_threshold(img, wavelet, threshold=None, sigma=None, mode='soft'):
         is None (the default) by the method in [2]_.
     threshold : float, optional
         The thresholding value. All wavelet coefficients less than this value
-        are set to 0. The default value (None) uses the SureShrink method found
-        in [1]_ to remove noise.
+        are set to 0. The default value (None) uses the BayesShrink method
+        found in [1]_ to remove noise.
     mode : {'soft', 'hard'}, optional
         An optional argument to choose the type of denoising performed. It
         noted that choosing soft thresholding given additive noise finds the

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -501,12 +501,12 @@ def denoise_wavelet(img, sigma=None, wavelet='db1', mode='soft',
         An optional argument to choose the type of denoising performed. It
         noted that choosing soft thresholding given additive noise finds the
         best approximation of the original image.
-    multichannel : bool, optional
-        Apply wavelet denoising separately for each channel (where channels
-        correspond to the final axis of the array).
     wavelet_levels : int or None, optional
         The number of wavelet decomposition levels to use.  The default is
         three less than the maximum number of possible decomposition levels.
+    multichannel : bool, optional
+        Apply wavelet denoising separately for each channel (where channels
+        correspond to the final axis of the array).
 
     Returns
     -------

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -445,7 +445,7 @@ def _wavelet_threshold(img, wavelet, threshold=None, sigma=None, mode='soft',
 
 
 def denoise_wavelet(img, sigma=None, wavelet='db1', mode='soft',
-                    multichannel=False, wavelet_levels=None):
+                    wavelet_levels=None, multichannel=False):
     """Perform wavelet denoising on an image.
 
     Parameters

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -562,7 +562,7 @@ def denoise_wavelet(img, sigma=None, wavelet='db1', mode='soft',
     return np.clip(out, *clip_range)
 
 
-def estimate_sigma(im, multichannel=False, average_sigmas=False):
+def estimate_sigma(im, average_sigmas=False, multichannel=False):
     """
     Robust wavelet-based estimator of the (Gaussian) noise standard deviation.
 
@@ -570,11 +570,11 @@ def estimate_sigma(im, multichannel=False, average_sigmas=False):
     ----------
     im : ndarray
         Image for which to estimate the noise standard deviation.
-    multichannel : bool
-        Estimate sigma separately for each channel.
     average_sigmas : bool, optional
         If true, average the channel estimates of `sigma`.  Otherwise return
         a list of sigmas corresponding to each channel.
+    multichannel : bool
+        Estimate sigma separately for each channel.
 
     Returns
     -------

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -418,7 +418,7 @@ def _wavelet_threshold(img, wavelet, threshold=None, sigma=None, mode='soft',
     dcoeffs = coeffs[1:]
 
     if sigma is None:
-        # Estimates via the noise via method in [2]
+        # Estimate the noise via the method in [2]_
         detail_coeffs = dcoeffs[-1]['d' * img.ndim]
         sigma = np.median(np.abs(detail_coeffs)) / 0.67448975019608171
 

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -346,7 +346,7 @@ def _bayes_thresh(details, var):
 
 def _wavelet_threshold(img, wavelet, threshold=None, sigma=None, mode='soft',
                        wavelet_levels=None):
-    """Performs wavelet denoising.
+    """Perform wavelet denoising.
 
     Parameters
     ----------
@@ -445,8 +445,8 @@ def _wavelet_threshold(img, wavelet, threshold=None, sigma=None, mode='soft',
 
 
 def denoise_wavelet(img, sigma=None, wavelet='db1', mode='soft',
-                    multichannel=False):
-    """Performs wavelet denoising on an image.
+                    multichannel=False, wavelet_levels=None):
+    """Perform wavelet denoising on an image.
 
     Parameters
     ----------
@@ -469,6 +469,9 @@ def denoise_wavelet(img, sigma=None, wavelet='db1', mode='soft',
     multichannel : bool, optional
         Apply wavelet denoising separately for each channel (where channels
         correspond to the final axis of the array).
+    wavelet_levels : int or None, optional
+        The number of wavelet decomposition levels to use.  The default is
+        three less than the maximum number of possible decomposition levels.
 
     Returns
     -------
@@ -508,17 +511,17 @@ def denoise_wavelet(img, sigma=None, wavelet='db1', mode='soft',
     >>> denoised_img = denoise_wavelet(img, sigma=0.1)
 
     """
-
     img = img_as_float(img)
 
     if multichannel:
         out = np.empty_like(img)
         for c in range(img.shape[-1]):
             out[..., c] = _wavelet_threshold(img[..., c], wavelet=wavelet,
-                                             mode=mode, sigma=sigma)
+                                             mode=mode, sigma=sigma,
+                                             wavelet_levels=wavelet_levels)
     else:
         out = _wavelet_threshold(img, wavelet=wavelet, mode=mode,
-                                 sigma=sigma)
+                                 sigma=sigma, wavelet_levels=wavelet_levels)
 
     clip_range = (-1, 1) if img.min() < 0 else (0, 1)
     return np.clip(out, *clip_range)

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -311,9 +311,10 @@ def test_no_denoising_for_small_h():
 
 
 def test_wavelet_denoising():
+    rstate = np.random.RandomState(1234)
     for img, multichannel in [(astro_gray, False), (astro, True)]:
         sigma = 0.1
-        noisy = img + sigma * np.random.randn(*(img.shape))
+        noisy = img + sigma * rstate.randn(*(img.shape))
         noisy = np.clip(noisy, 0, 1)
 
         # Verify that SNR is improved when true sigma is used
@@ -335,17 +336,18 @@ def test_wavelet_denoising():
                                            multichannel=multichannel)
         res2 = restoration.denoise_wavelet(noisy, sigma=sigma,
                                            multichannel=multichannel)
-        assert (res1.sum()**2 <= res2.sum()**2)
+        assert np.sum(res1**2) <= np.sum(res2**2)
 
 
 def test_wavelet_denoising_nd():
+    rstate = np.random.RandomState(1234)
     for ndim in range(1, 5):
         # Generate a very simple test image
         img = 0.2*np.ones((16, )*ndim)
         img[[slice(5, 13), ] * ndim] = 0.8
 
         sigma = 0.1
-        noisy = img + sigma * np.random.randn(*(img.shape))
+        noisy = img + sigma * rstate.randn(*(img.shape))
         noisy = np.clip(noisy, 0, 1)
 
         # Verify that SNR is improved with internally estimated sigma

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -7,6 +7,8 @@ from skimage._shared._warnings import expected_warnings
 from skimage.measure import compare_psnr
 from skimage.restoration._denoise import _wavelet_threshold
 
+import pywt
+
 np.random.seed(1234)
 
 
@@ -371,6 +373,38 @@ def test_wavelet_denoising_nd():
         psnr_noisy = compare_psnr(img, noisy)
         psnr_denoised = compare_psnr(img, denoised)
         assert psnr_denoised > psnr_noisy
+
+
+def test_wavelet_denoising_levels():
+    rstate = np.random.RandomState(1234)
+    ndim = 2
+    N = 256
+    wavelet = 'db1'
+    # Generate a very simple test image
+    img = 0.2*np.ones((N, )*ndim)
+    img[[slice(5, 13), ] * ndim] = 0.8
+
+    sigma = 0.1
+    noisy = img + sigma * rstate.randn(*(img.shape))
+    noisy = np.clip(noisy, 0, 1)
+
+    denoised = restoration.denoise_wavelet(noisy, wavelet=wavelet)
+    denoised_1 = restoration.denoise_wavelet(noisy, wavelet=wavelet,
+                                             wavelet_levels=1)
+    psnr_noisy = compare_psnr(img, noisy)
+    psnr_denoised = compare_psnr(img, denoised)
+    psnr_denoised_1 = compare_psnr(img, denoised_1)
+
+    # multi-level case should outperform single level case
+    assert psnr_denoised > psnr_denoised_1 > psnr_noisy
+
+    # invalid number of wavelet levels results in a ValueError
+    max_level = pywt.dwt_max_level(np.min(img.shape),
+                                   pywt.Wavelet(wavelet).dec_len)
+    assert_raises(ValueError, restoration.denoise_wavelet, noisy,
+                  wavelet=wavelet, wavelet_levels=max_level+1)
+    assert_raises(ValueError, restoration.denoise_wavelet, noisy,
+                  wavelet=wavelet, wavelet_levels=-1)
 
 
 def test_estimate_sigma_gray():

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -339,6 +339,21 @@ def test_wavelet_denoising():
         assert np.sum(res1**2) <= np.sum(res2**2)
 
 
+def test_wavelet_threshold():
+    rstate = np.random.RandomState(1234)
+
+    img = astro_gray
+    sigma = 0.1
+    noisy = img + sigma * rstate.randn(*(img.shape))
+    noisy = np.clip(noisy, 0, 1)
+
+    # employ a single, uniform threshold instead of BayesShrink sigmas
+    denoised = _wavelet_threshold(noisy, wavelet='db1', threshold=sigma)
+    psnr_noisy = compare_psnr(img, noisy)
+    psnr_denoised = compare_psnr(img, denoised)
+    assert psnr_denoised > psnr_noisy
+
+
 def test_wavelet_denoising_nd():
     rstate = np.random.RandomState(1234)
     for ndim in range(1, 5):

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -5,6 +5,7 @@ from numpy.testing import (run_module_suite, assert_raises, assert_equal,
 from skimage import restoration, data, color, img_as_float, measure
 from skimage._shared._warnings import expected_warnings
 from skimage.measure import compare_psnr
+from skimage.restoration._denoise import _wavelet_threshold
 
 np.random.seed(1234)
 


### PR DESCRIPTION
## Description

pinging @stsievert, @JDWarner, @sciunto, @soupault from the discussion in #2190 for feedback on this one.

This small PR modifies the recently merged #2190 to more closely match the implementation of the Chang et. al. IEEE paper mentioned in the docstring.  I apologize for not being more active in reviewing that PR before it was merged.  I think either we need to make these changes to match the reference, or we need to change the docstring to match what is currently implemented.

I realize there is also ongoing work in #2240 related to color denoising.

There are no API changes proposed, but the resulting denoised images look much different than before.

The primary changes made to match the referenced article are:
-  approximation coefficients are not soft thresholded
-  BayesShrink thresholds are computed individually for each individual detail coefficient sub-band
- the wavelet decomposition is not performed to the full possible number of levels (although I did not fix at 4 levels as in the reference as we should support any size of input images)

I have not tested extensively whether using separate thresholds per sub-band is truly better, but if we cite the BayesShrink paper in the References we should more closely match the implementation in the citation.

## Demonstration

Here is a quick demo for which I have pasted the image for current master as opposed to this PR.
```python
import numpy as np
from matplotlib import pyplot as plt

from skimage import img_as_float
import skimage.data
from skimage.restoration._denoise import _wavelet_threshold

x = img_as_float(skimage.data.camera())
sigma = 0.1
y = x + sigma*np.random.randn(*x.shape)
ydn = _wavelet_threshold(y, 'db1')

fig, axes = plt.subplots(1, 2)
axes[0].imshow(y, interpolation='nearest')
axes[0].set_title('noisy')
axes[0].set_xticks([])
axes[0].set_yticks([])
axes[1].imshow(ydn, interpolation='nearest')
axes[1].set_title('with proposed changes')
axes[1].set_xticks([])
axes[1].set_yticks([])
plt.tight_layout()
```

Result with code in this PR:
![_dn_current_pr](https://cloud.githubusercontent.com/assets/6528957/17570334/f40be866-5f19-11e6-9d87-a310838cb63b.png)

or when providing `sigma=0.9*sigma` as anargument to `_wavelet_threshold:
```python
ydn_fixed_thresh = _wavelet_threshold(y, 'db1', sigma=0.9*sigma)
```
![_dn_current_pr_0 9sigma](https://cloud.githubusercontent.com/assets/6528957/17572617/74434c82-5f23-11e6-9b67-ac19ced44534.png)



It is still possible to supply `threshold` to get a single threshold used at all levels:
```python
ydn_fixed_thresh = _wavelet_threshold(y, 'db1', threshold=sigma)
```
![_dn_current_pr_fixedthresh](https://cloud.githubusercontent.com/assets/6528957/17571586/ddd59eb6-5f1e-11e6-9b7c-6ed1b603fa16.png)


The default level of denoising produced by the master branch is much lower:
![_dn_current_master](https://cloud.githubusercontent.com/assets/6528957/17570414/46bc4498-5f1a-11e6-960b-327370202c76.png)

