### PR TITLE
Bugs fix-obtaining the wrong intensity profile using `profile_line`

### DIFF
--- a/skimage/measure/profile.py
+++ b/skimage/measure/profile.py
@@ -94,8 +94,8 @@ def _line_profile_coordinates(src, dst, linewidth=1):
     The destination point is included in the profile, in contrast to
     standard numpy indexing.
     """
-    src_row, src_col = src = np.asarray(src, dtype=float)
-    dst_row, dst_col = dst = np.asarray(dst, dtype=float)
+    src_col, src_row = src = np.asarray(src, dtype=float)
+    dst_col, dst_row = dst = np.asarray(dst, dtype=float)
     d_row, d_col = dst - src
     theta = np.arctan2(d_row, d_col)
 


### PR DESCRIPTION
## Description
Fix the problem of getting the wrong intensity profile.

Switch and position of src_col and src_row (dst_col and dst_row).

We use img[row, col] to access the pixel intensity of an image.  Corresponded to x-y coordinate, It should be img[y, x], therefore, a x and y in tuple (x,y) should be assigned to col and row respectively, not the other way around.