### PR TITLE
normalized cut and region adjacency graph additional options

### DIFF
--- a/skimage/future/graph/__init__.py
+++ b/skimage/future/graph/__init__.py
@@ -10,4 +10,5 @@ __all__ = ['rag_mean_color',
            'show_rag',
            'merge_hierarchical',
            'rag_boundary',
-           'RAG']
+           'RAG',
+           'rag_node_centroids']

--- a/skimage/future/graph/graph_cut.py
+++ b/skimage/future/graph/graph_cut.py
@@ -290,8 +290,8 @@ def _ncut_relabel(rag, thresh, num_cuts, max_rec):
             # Refer Shi & Malik 2001, Section 3.2.5, Page 893
             sub1, sub2 = partition_by_cut(cut_mask, rag)
 
-            _ncut_relabel(sub1, thresh, num_cuts, max_rec-1)
-            _ncut_relabel(sub2, thresh, num_cuts, max_rec-1)
+            _ncut_relabel(sub1, thresh, num_cuts, max_rec - 1)
+            _ncut_relabel(sub2, thresh, num_cuts, max_rec - 1)
             return
 
     # The N-cut wasn't small enough, or could not be computed.

--- a/skimage/future/graph/graph_cut.py
+++ b/skimage/future/graph/graph_cut.py
@@ -49,7 +49,7 @@ def cut_threshold(labels, rag, thresh, in_place=True):
     ----------
     .. [1] Alain Tremeau and Philippe Colantoni
            "Regions Adjacency Graph Applied To Color Image Segmentation"
-           http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.11.5274
+           DOI:10.1.1.11.5274
 
     """
     if not in_place:
@@ -121,9 +121,9 @@ def cut_normalized(labels, rag, thresh=0.001, num_cuts=10, in_place=True,
 
     References
     ----------
-    .. [1] Shi, J.; Malik, J., "Normalized cuts and image segmentation",
-           Pattern Analysis and Machine Intelligence,
-           IEEE Transactions on, vol. 22, no. 8, pp. 888-905, August 2000.
+    .. [1] Jianbo Shi, & Malik, J. (2000). Normalized cuts and image
+           segmentation. IEEE Transactions on Pattern Analysis and Machine
+           Intelligence, 22(8), 888-905. DOI:10.1109/34.868688
 
     """
     if not in_place:

--- a/skimage/future/graph/graph_cut.py
+++ b/skimage/future/graph/graph_cut.py
@@ -75,7 +75,7 @@ def cut_threshold(labels, rag, thresh, in_place=True):
 
 
 def cut_normalized(labels, rag, thresh=0.001, num_cuts=10, in_place=True,
-                   max_edge=1.0,  max_rec=float('Inf')):
+                   max_edge=1.0,  max_rec=np.inf):
     """Perform Normalized Graph cut on the Region Adjacency Graph.
 
     Given an image's labels and its similarity RAG, recursively perform
@@ -101,7 +101,7 @@ def cut_normalized(labels, rag, thresh=0.001, num_cuts=10, in_place=True,
         The maximum possible value of an edge in the RAG. This corresponds to
         an edge between identical regions. This is used to put self
         edges in the RAG.
-    max_rec : float
+    max_rec : float, optional
         The maximum number of recursions. A subgraph won't be further
         subdivided if the number of recursions exceeds `max_rec`.
 
@@ -239,7 +239,7 @@ def _label_all(rag, attr_name):
         d[attr_name] = new_label
 
 
-def _ncut_relabel(rag, thresh, num_cuts, max_rec, rec_count=0):
+def _ncut_relabel(rag, thresh, num_cuts, max_rec):
     """Perform Normalized Graph cut on the Region Adjacency Graph.
 
     Recursively partition the graph into 2, until further subdivision
@@ -261,15 +261,12 @@ def _ncut_relabel(rag, thresh, num_cuts, max_rec, rec_count=0):
     map_array : array
         The array which maps old labels to new ones. This is modified inside
         the function.
-    max_rec : float
+    max_rec : float, optional
         The maximum number of recursions. A subgraph won't be further
         subdivided if the number of recursions exceeds `max_rec`.
-    rec_count : int
-        The recursion count.
     """
     d, w = _ncut.DW_matrices(rag)
     m = w.shape[0]
-    rec_count += 1
 
     if m > 2:
         d2 = d.copy()
@@ -288,13 +285,13 @@ def _ncut_relabel(rag, thresh, num_cuts, max_rec, rec_count=0):
         ev = vectors[:, index2]
 
         cut_mask, mcut = get_min_ncut(ev, d, w, num_cuts)
-        if (mcut < thresh) and (rec_count <= max_rec):
+        if (mcut < thresh) and (max_rec > 0):
             # Sub divide and perform N-cut again
             # Refer Shi & Malik 2001, Section 3.2.5, Page 893
             sub1, sub2 = partition_by_cut(cut_mask, rag)
 
-            _ncut_relabel(sub1, thresh, num_cuts, max_rec, rec_count)
-            _ncut_relabel(sub2, thresh, num_cuts, max_rec, rec_count)
+            _ncut_relabel(sub1, thresh, num_cuts, max_rec-1)
+            _ncut_relabel(sub2, thresh, num_cuts, max_rec-1)
             return
 
     # The N-cut wasn't small enough, or could not be computed.

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -71,7 +71,6 @@ def min_weight(graph, src, dst, n):
         both exist.
 
     """
-
     # cover the cases where n only has edge to either `src` or `dst`
     default = {'weight': np.inf}
     w1 = graph[n].get(src, default)['weight']
@@ -108,7 +107,6 @@ def _add_edge_filter(values, graph):
 
 
 class RAG(nx.Graph):
-
     """
     The Region Adjacency Graph (RAG) of an image, subclasses
     `networx.Graph <http://networkx.github.io/documentation/latest/reference/classes.graph.html>`_
@@ -225,27 +223,30 @@ class RAG(nx.Graph):
     def add_node(self, n, attr_dict=None, **attr):
         """Add node `n` while updating the maximum node id.
 
-        .. seealso:: :func:`networkx.Graph.add_node`."""
+        .. seealso:: :func:`networkx.Graph.add_node`.
+        """
         super(RAG, self).add_node(n, attr_dict, **attr)
         self.max_id = max(n, self.max_id)
 
     def add_edge(self, u, v, attr_dict=None, **attr):
         """Add an edge between `u` and `v` while updating max node id.
 
-        .. seealso:: :func:`networkx.Graph.add_edge`."""
+        .. seealso:: :func:`networkx.Graph.add_edge`.
+        """
         super(RAG, self).add_edge(u, v, attr_dict, **attr)
         self.max_id = max(u, v, self.max_id)
 
     def copy(self):
         """Copy the graph with its max node id.
 
-        .. seealso:: :func:`networkx.Graph.copy`."""
+        .. seealso:: :func:`networkx.Graph.copy`.
+        """
         g = super(RAG, self).copy()
         g.max_id = self.max_id
         return g
 
     def next_id(self):
-        """Returns the `id` for the new node to be inserted.
+        """Return the `id` for the new node to be inserted.
 
         The current implementation returns one more than the maximum `id`.
 
@@ -261,7 +262,8 @@ class RAG(nx.Graph):
 
         This is a convenience method used internally.
 
-        .. seealso:: :func:`networkx.Graph.add_node`."""
+        .. seealso:: :func:`networkx.Graph.add_node`.
+        """
         super(RAG, self).add_node(n)
 
 
@@ -381,7 +383,7 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
 
 
 def rag_boundary(labels, edge_map, connectivity=2):
-    """ Comouter RAG based on region boundaries
+    """Comouter RAG based on region boundaries.
 
     Given an image's initial segmentation and its edge map this method
     constructs the corresponding Region Adjacency Graph (RAG). Each node in the
@@ -411,7 +413,6 @@ def rag_boundary(labels, edge_map, connectivity=2):
     >>> rag = graph.rag_boundary(labels, edge_map)
 
     """
-
     conn = ndi.generate_binary_structure(labels.ndim, connectivity)
     eroded = ndi.grey_erosion(labels, footprint=conn)
     dilated = ndi.grey_dilation(labels, footprint=conn)
@@ -493,7 +494,6 @@ def show_rag(labels, rag, img, border_color='black', edge_width=1.5,
     >>> lc = graph.show_rag(labels, g, img)
     >>> cbar = plt.colorbar(lc)
     """
-
     if not in_place:
         rag = rag.copy()
 
@@ -541,7 +541,7 @@ def show_rag(labels, rag, img, border_color='black', edge_width=1.5,
 
 
 def rag_node_centroids(labels, rag):
-    """Get centroids of the region adjacency graph nodes
+    """Get centroids of the region adjacency graph nodes.
 
     Parameters
     ----------

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -300,6 +300,14 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
             :math:`e^{-d^2/sigma}` where :math:`d=|c_1 - c_2|`, where
             :math:`c_1` and :math:`c_2` are the mean colors of the two regions.
             It represents how similar two regions are.
+
+            'similarity_and_centroid_proximity' : The weight between two
+            adjacent is :math:`e^{-d^2/sigma} * e^{-x^2/sigma}`
+            where :math:`d=|c_1 - c_2|`, where :math:`c_1` and :math:`c_2` are
+            the mean colors of the two regions and where :math:`x=|x_1 - x_2|`,
+            where :math:`x_1` and :math:`x_2` are the centroid coordinates of
+            the two regions. It represents how similar and spatially close two
+            regions are [see reference 2 section 3.1 equation 11].
     sigma : float, optional
         Used for computation when `mode` is "similarity". It governs how
         close to each other two colors should be, for their corresponding edge
@@ -325,6 +333,10 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
            "Regions Adjacency Graph Applied To Color Image Segmentation"
            http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.11.5274
 
+    .. [2] Jianbo Shi, & Malik, J. (2000). Normalized cuts and image
+           segmentation. IEEE Transactions on Pattern Analysis and Machine
+           Intelligence, 22(8), 888-905. http://doi.org/10.1109/34.868688
+
     """
     graph = RAG(labels, connectivity=connectivity)
 
@@ -339,6 +351,12 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
         graph.node[current]['pixel count'] += 1
         graph.node[current]['total color'] += image[index]
 
+    regions, _ = rag_node_centroids(labels, graph)
+
+    for n in graph:
+        graph.node[n].update({'centroid': np.array((regions[n]['centroid']),
+                                                   dtype=np.double)})
+
     for n in graph:
         graph.node[n]['mean color'] = (graph.node[n]['total color'] /
                                        graph.node[n]['pixel count'])
@@ -346,10 +364,15 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
     for x, y, d in graph.edges_iter(data=True):
         diff = graph.node[x]['mean color'] - graph.node[y]['mean color']
         diff = np.linalg.norm(diff)
+        prox = graph.node[x]['centroid'] - graph.node[y]['centroid']
+        prox = np.linalg.norm(prox)
         if mode == 'similarity':
             d['weight'] = math.e ** (-(diff ** 2) / sigma)
         elif mode == 'distance':
             d['weight'] = diff
+        elif mode == 'similarity_and_centroid_proximity':
+            d['weight'] = ((math.e ** (-(diff ** 2) / sigma)) *
+                           (math.e ** (-(prox ** 2) / sigma)))
         else:
             raise ValueError("The mode '%s' is not recognised" % mode)
 
@@ -490,18 +513,7 @@ def show_rag(labels, rag, img, border_color='black', edge_width=1.5,
         out = img_cmap(out)[:, :, :3]
 
     edge_cmap = cm.get_cmap(edge_cmap)
-
-    # Handling the case where one node has multiple labels
-    # offset is 1 so that regionprops does not ignore 0
-    offset = 1
-    map_array = np.arange(labels.max() + 1)
-    for n, d in rag.nodes_iter(data=True):
-        for label in d['labels']:
-            map_array[label] = offset
-        offset += 1
-
-    rag_labels = map_array[labels]
-    regions = measure.regionprops(rag_labels)
+    regions, rag_labels = rag_node_centroids(labels, rag)
 
     for (n, data), region in zip(rag.nodes_iter(data=True), regions):
         data['centroid'] = tuple(map(int, region['centroid']))
@@ -525,3 +537,29 @@ def show_rag(labels, rag, img, border_color='black', edge_width=1.5,
     ax.add_collection(lc)
 
     return lc
+
+
+def rag_node_centroids(labels, rag):
+    """ Get centroids of the region adjacency graph nodes
+
+     Parameters
+     ----------
+     labels : ndarray, shape (M, N)
+         The labelled image.
+     rag : RAG
+         The Region Adjacency Graph.
+
+     """
+    # Handling the case where one node has multiple labels
+    # offset is 1 so that regionprops does not ignore 0
+    offset = 1
+    map_array = np.arange(labels.max() + 1)
+    for n, d in rag.nodes_iter(data=True):
+        for label in d['labels']:
+            map_array[label] = offset
+        offset += 1
+
+    rag_labels = map_array[labels]
+    regions = measure.regionprops(rag_labels)
+
+    return regions, rag_labels

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -288,7 +288,7 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
         are considered adjacent. It can range from 1 to `labels.ndim`. Its
         behavior is the same as `connectivity` parameter in
         `scipy.ndimage.generate_binary_structure`.
-    mode : {'distance', 'similarity'}, optional
+    mode : {'distance', 'similarity', 'similarity_and_proximity'}, optional
         The strategy to assign edge weights.
 
             'distance' : The weight between two adjacent regions is the
@@ -301,8 +301,8 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
             :math:`c_1` and :math:`c_2` are the mean colors of the two regions.
             It represents how similar two regions are.
 
-            'similarity_and_centroid_proximity' : The weight between two
-            adjacent is :math:`e^{-d^2/sigma} * e^{-x^2/sigma}`
+            'similarity_and_proximity' : The weight between two
+            adjacent is :math:`e^{-d^2/sigma} * e^{-x^2/sigma_x}`
             where :math:`d=|c_1 - c_2|`, where :math:`c_1` and :math:`c_2` are
             the mean colors of the two regions and where :math:`x=|x_1 - x_2|`,
             where :math:`x_1` and :math:`x_2` are the centroid coordinates of
@@ -370,9 +370,10 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
             d['weight'] = math.e ** (-(diff ** 2) / sigma)
         elif mode == 'distance':
             d['weight'] = diff
-        elif mode == 'similarity_and_centroid_proximity':
+        elif mode == 'similarity_and_proximity':
+            sigma_x = np.linalg.norm(labels.shape)
             d['weight'] = ((math.e ** (-(diff ** 2) / sigma)) *
-                           (math.e ** (-(prox ** 2) / sigma)))
+                           (math.e ** (-(prox ** 2) / sigma_x)))
         else:
             raise ValueError("The mode '%s' is not recognised" % mode)
 

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -333,11 +333,11 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
     ----------
     .. [1] Alain Tremeau and Philippe Colantoni
            "Regions Adjacency Graph Applied To Color Image Segmentation"
-           http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.11.5274
+           DOI:10.1.1.11.5274
 
     .. [2] Jianbo Shi, & Malik, J. (2000). Normalized cuts and image
            segmentation. IEEE Transactions on Pattern Analysis and Machine
-           Intelligence, 22(8), 888-905. http://doi.org/10.1109/34.868688
+           Intelligence, 22(8), 888-905. DOI:10.1109/34.868688
 
     """
     graph = RAG(labels, connectivity=connectivity)


### PR DESCRIPTION
## Description

I have made some minor changes to fulfill two needs:

1- being able to put a limit on number of recursions
2- an additional option for edge weights which considers not only color similarity but also centroid proximity. I think this is similar to Shi and Malik (2000)[section 3.1 equation 11]
## References

Jianbo Shi, & Malik, J. (2000). Normalized cuts and image segmentation. IEEE Transactions on Pattern Analysis and Machine Intelligence, 22(8), 888–905. http://doi.org/10.1109/34.868688
