### PR TITLE
Bump min scipy version

### DIFF
--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -3,19 +3,19 @@ Build Requirements
 * `Python >= 2.7 <http://python.org>`__
 * `Numpy >= 1.11 <http://numpy.scipy.org/>`__
 * `Cython >= 0.23 <http://www.cython.org/>`__
-* `Six >=1.4 <https://pypi.python.org/pypi/six>`__
-* `SciPy >=0.9 <http://scipy.org>`__
+* `Six >=1.7.3 <https://pypi.python.org/pypi/six>`__
+* `SciPy >=0.17.0 <http://scipy.org>`__
 * `numpydoc >=0.6 <https://github.com/numpy/numpydoc>`__
 
 Runtime requirements
 --------------------
 * `Python >= 2.7 <http://python.org>`__
-* `Numpy >= 1.7.2 <http://numpy.scipy.org/>`__
-* `SciPy >= 0.9 <http://scipy.org>`__
-* `Matplotlib >= 1.1.0 <http://matplotlib.sf.net>`__
+* `Numpy >= 1.11 <http://numpy.scipy.org/>`__
+* `SciPy >= 0.17.0 <http://scipy.org>`__
+* `Matplotlib >= 1.3.1 <http://matplotlib.sf.net>`__
 * `NetworkX >= 1.8 <https://networkx.github.io>`__
-* `Six >=1.4 <https://pypi.python.org/pypi/six>`__
-* `Pillow >= 1.7.8 <https://pypi.python.org/pypi/Pillow>`__
+* `Six >=1.7.3 <https://pypi.python.org/pypi/six>`__
+* `Pillow >= 2.1.0 <https://pypi.python.org/pypi/Pillow>`__
     (or `PIL <http://www.pythonware.com/products/pil/>`__)
 * `PyWavelets>=0.4.0 <https://pypi.python.org/pypi/PyWavelets/>`__
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 matplotlib>=1.3.1
 numpy>=1.11
-scipy>=0.10.0
+scipy>=0.17.0
 six>=1.7.3
 networkx>=1.8
 pillow>=2.1.0


### PR DESCRIPTION
Closes #2250
- I update scipy to 0.17.0. I based by judgement on debian version of numpy and scipy in testing. Numpy corresponds already to our min requirement. I guess it doesn't hurt for scipy as well, as these versions have been released almost at the same time.
- I noticed that DEPENDS.txt had outdated requirements. Updated according to requirements.txt. 
