### PR TITLE
Added more specific check for image shape in threshold_otsu warning

### DIFF
--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -246,7 +246,7 @@ def threshold_otsu(image, nbins=256):
     -----
     The input image must be grayscale.
     """
-    if image.shape[-1] in (3, 4):
+    if len(image.shape) > 2 and image.shape[-1] in (3, 4):
         msg = "threshold_otsu is expected to work correctly only for " \
               "grayscale images; image shape {0} looks like an RGB image"
         warn(msg.format(image.shape))


### PR DESCRIPTION
## Description
Currently a warning is emitted from threshold_otsu if image.shape[-1]
is 3 or 4, as this suggests the image may be a RGB or RGBA image. However,
this warning is often raised unnecessarily. For example, the following
shapes of array raise this warning even though they are unlikely to be a RGB
image:

(500, 4)
(4, 3)
(3,)
(4,)

Modifying the code to check whether len(image.shape) > 2 means that none
of these are caught, but all images that may potentially be RGB are still caught.

I'm aware that the logic may be to raise warnings liberally, but it can cause problems,
particularly for people running with 'warnings as errors' - and I think this alteration
still catches all genuine RGB(A) images.

I tried to add a test for this, but couldn't find a way to assert that a piece of code _doesn't_ raise a warning. Do you know if this is possible? If not, is it ok to not have an extra test for this change?

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests