### PR TITLE
Allow running `setup.py egg_info` without numpy installed.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,10 @@ if __name__ == "__main__":
         if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or
                                    sys.argv[1] in ('--help-commands',
                                                    '--version',
-                                                   'clean')):
+                                                   'clean',
+                                                   'egg_info',
+                                                   'install_egg_info',
+                                                   'rotate')):
             # For these actions, NumPy is not required.
             #
             # They are required to succeed without Numpy for example when


### PR DESCRIPTION
## Description
`pip` first tries to run `python setup.py egg_info` to read the metadata before the build, but `setup.py` does not deal with it, which eventually leads to installation failure if numpy is not installed prior to the execution of `pip install`.

Note that [numba](https://github.com/numba/numba) pretty much does [the same thing](https://github.com/numba/numba/commit/9e750374e9f66657f82a2fc2d651855d577a009a).