### PR TITLE
HOG: ensure visualisation is in dtype_limits + maint.

### DIFF
--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -36,6 +36,7 @@ Version 0.11
 - The ``skimage.filter`` subpackage has been renamed to ``skimage.filters``.
 - Some edge detectors returned values greater than 1--their results are now
   appropriately scaled with a factor of ``sqrt(2)``.
+- The `normalise` parameter of `skimage.features.hog` is deprecated.
 
 Version 0.10
 ------------

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -50,11 +50,11 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
 
     References
     ----------
-    * http://en.wikipedia.org/wiki/Histogram_of_oriented_gradients
-
-    * Dalal, N and Triggs, B, Histograms of Oriented Gradients for
-      Human Detection, IEEE Computer Society Conference on Computer
-      Vision and Pattern Recognition 2005 San Diego, CA, USA
+    .. [1] http://en.wikipedia.org/wiki/Histogram_of_oriented_gradients
+    .. [2] Dalal, N and Triggs, B, Histograms of Oriented Gradients for
+           Human Detection, IEEE Computer Society Conference on Computer
+           Vision and Pattern Recognition 2005 San Diego, CA, USA
+           DOI:10.1109/CVPR.2005.177
 
     Notes
     -----

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -118,6 +118,8 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
                                        int(centre[0] + dx),
                                        int(centre[1] - dy))
                     hog_image[rr, cc] += orientation_histogram[y, x, o]
+        # Normalize to ensure that values fit in dtype_limits
+        hog_image /= hog_image.max()
 
     # The fourth stage computes normalisation, which takes local groups of
 

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -121,7 +121,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
         # Normalize to ensure that values fit in dtype_limits
         hog_image /= hog_image.max()
 
-    # The fourth stage computes normalisation, which takes local groups of
+    # The fourth stage computes normalisation
 
     n_blocksx = (n_cellsx - bx) + 1
     n_blocksy = (n_cellsy - by) + 1
@@ -134,7 +134,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
             eps = 1e-5
             normalised_blocks[y, x, :] = block / np.sqrt(block.sum() ** 2 + eps)
 
-    # The final step collects the HOG descriptors from all blocks of a dense
+    # The final step collects the HOG descriptors from all blocks of a dense
     # overlapping grid of blocks covering the detection window into a combined
     # feature vector for use in the window classifier.
 

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -7,7 +7,7 @@ import warnings
 
 def hog(image, orientations=9, pixels_per_cell=(8, 8),
         cells_per_block=(3, 3), visualise=False, transform_sqrt=False,
-        feature_vector=True, normalise=None):
+        feature_vector=True):
     """Extract Histogram of Oriented Gradients (HOG) for a given image.
 
     Compute a Histogram of Oriented Gradients (HOG) by
@@ -37,9 +37,6 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
     feature_vector : bool, optional
         Return the data as a feature vector by calling .ravel() on the result
         just before returning.
-    normalise : bool, deprecated
-        The parameter is deprecated. Use `transform_sqrt` for power law
-        compression. `normalise` has been deprecated.
 
     Returns
     -------
@@ -77,12 +74,6 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
     """
 
     assert_nD(image, 2)
-
-    if normalise is not None:
-        raise ValueError("The normalise parameter was removed due to incorrect "
-                         "behavior; it only applied a square root instead of a "
-                         "true normalization. If you wish to duplicate the old "
-                         "behavior, set ``transform_sqrt=True``.")
 
     if transform_sqrt:
         image = np.sqrt(image)

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -1,6 +1,7 @@
 from __future__ import division
 import numpy as np
 from .._shared.utils import assert_nD
+from .. import draw
 from . import _hoghistogram
 import warnings
 
@@ -63,30 +64,14 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
     """
     image = np.atleast_2d(image)
 
-    """
-    The first stage applies an optional global image normalisation
-    equalisation that is designed to reduce the influence of illumination
-    effects. In practice we use gamma (power law) compression, either
-    computing the square root or the log of each colour channel.
-    Image texture strength is typically proportional to the local surface
-    illumination so this compression helps to reduce the effects of local
-    shadowing and illumination variations.
-    """
 
     assert_nD(image, 2)
 
+    # The first stage applies an optional global image normalisation
     if transform_sqrt:
         image = np.sqrt(image)
 
-    """
-    The second stage computes first order image gradients. These capture
-    contour, silhouette and some texture information, while providing
-    further resistance to illumination variations. The locally dominant
-    colour channel is used, which provides colour invariance to a large
-    extent. Variant methods may also include second order image derivatives,
-    which act as primitive bar detectors - a useful feature for capturing,
-    e.g. bar like structures in bicycles and limbs in humans.
-    """
+    # The second stage computes first order image gradients
 
     if image.dtype.kind == 'u':
         # convert uint image to float
@@ -102,20 +87,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
     gy[-1, :] = 0
     gy[1:-1, :] = image[2:, :] - image[:-2, :]
 
-    """
-    The third stage aims to produce an encoding that is sensitive to
-    local image content while remaining resistant to small changes in
-    pose or appearance. The adopted method pools gradient orientation
-    information locally in the same way as the SIFT [Lowe 2004]
-    feature. The image window is divided into small spatial regions,
-    called "cells". For each cell we accumulate a local 1-D histogram
-    of gradient or edge orientations over all the pixels in the
-    cell. This combined cell-level 1-D histogram forms the basic
-    "orientation histogram" representation. Each orientation histogram
-    divides the gradient angle range into a fixed number of
-    predetermined bins. The gradient magnitudes of the pixels in the
-    cell are used to vote into the orientation histogram.
-    """
+    # The third stage computes the orientation histogram
 
     sy, sx = image.shape
     cx, cy = pixels_per_cell
@@ -130,12 +102,8 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
     _hoghistogram.hog_histograms(gx, gy, cx, cy, sx, sy, n_cellsx, n_cellsy,
                                  orientations, orientation_histogram)
 
-    # now for each cell, compute the histogram
-    hog_image = None
-
     if visualise:
-        from .. import draw
-
+        # For each cell, compute the histogram
         radius = min(cx, cy) // 2 - 1
         orientations_arr = np.arange(orientations)
         dx_arr = radius * np.cos(orientations_arr / orientations * np.pi)
@@ -151,20 +119,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
                                        int(centre[1] - dy))
                     hog_image[rr, cc] += orientation_histogram[y, x, o]
 
-    """
-    The fourth stage computes normalisation, which takes local groups of
-    cells and contrast normalises their overall responses before passing
-    to next stage. Normalisation introduces better invariance to illumination,
-    shadowing, and edge contrast. It is performed by accumulating a measure
-    of local histogram "energy" over local groups of cells that we call
-    "blocks". The result is used to normalise each cell in the block.
-    Typically each individual cell is shared between several blocks, but
-    its normalisations are block dependent and thus different. The cell
-    thus appears several times in the final output vector with different
-    normalisations. This may seem redundant but it improves the performance.
-    We refer to the normalised block descriptors as Histogram of Oriented
-    Gradient (HOG) descriptors.
-    """
+    # The fourth stage computes normalisation, which takes local groups of
 
     n_blocksx = (n_cellsx - bx) + 1
     n_blocksy = (n_cellsy - by) + 1
@@ -177,11 +132,9 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8),
             eps = 1e-5
             normalised_blocks[y, x, :] = block / np.sqrt(block.sum() ** 2 + eps)
 
-    """
-    The final step collects the HOG descriptors from all blocks of a dense
-    overlapping grid of blocks covering the detection window into a combined
-    feature vector for use in the window classifier.
-    """
+    # The final step collects the HOG descriptors from all blocks of a dense
+    # overlapping grid of blocks covering the detection window into a combined
+    # feature vector for use in the window classifier.
 
     if feature_vector:
         normalised_blocks = normalised_blocks.ravel()

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -188,9 +188,5 @@ def test_hog_orientations_circle():
         assert_almost_equal(actual, desired, decimal=1)
 
 
-def test_hog_normalise_none_error_raised():
-    img = np.array([1, 2, 3])
-    assert_raises(ValueError, feature.hog, img, normalise=True)
-
 if __name__ == '__main__':
     np.testing.run_module_suite()


### PR DESCRIPTION
This PR partially fixes #1334.

* [x] if `visualise` is True, ensure that the output is in [0, 1]. -> bugfix.
* [x] clean up inline comments
* [x] retrospective note added about that deprecation (was not in api_changes)
* [x] remove option that is deprecated since 0.11 (was not in TODO list)
* [x] fix docstring (references)