### PR TITLE
Bugfix unbounded correlation -- Dhyams fix for match template

### DIFF
--- a/skimage/feature/template.py
+++ b/skimage/feature/template.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import numpy as np
 from scipy.signal import fftconvolve
 

--- a/skimage/feature/template.py
+++ b/skimage/feature/template.py
@@ -102,7 +102,7 @@ def match_template(image, template, pad_input=False, mode='constant',
     array([[ 1.   , -0.125,  0.   ,  0.   ],
            [-0.125, -0.125,  0.   ,  0.   ],
            [ 0.   ,  0.   ,  0.125,  0.125],
-           [ 0.   ,  0.   ,  0.125, -1.   ]], dtype=float32)
+           [ 0.   ,  0.   ,  0.125, -1.   ]])
     >>> result = match_template(image, template, pad_input=True)
     >>> np.round(result, 3)
     array([[-0.125, -0.125, -0.125,  0.   ,  0.   ,  0.   ],
@@ -110,7 +110,7 @@ def match_template(image, template, pad_input=False, mode='constant',
            [-0.125, -0.125, -0.125,  0.   ,  0.   ,  0.   ],
            [ 0.   ,  0.   ,  0.   ,  0.125,  0.125,  0.125],
            [ 0.   ,  0.   ,  0.   ,  0.125, -1.   ,  0.125],
-           [ 0.   ,  0.   ,  0.   ,  0.125,  0.125,  0.125]], dtype=float32)
+           [ 0.   ,  0.   ,  0.   ,  0.125,  0.125,  0.125]])
     """
     assert_nD(image, (2, 3))
 

--- a/skimage/feature/template.py
+++ b/skimage/feature/template.py
@@ -122,7 +122,7 @@ def match_template(image, template, pad_input=False, mode='constant',
 
     image_shape = image.shape
 
-    image = np.array(image, dtype=np.float32, copy=False)
+    image = np.array(image, dtype=np.float64, copy=False)
 
     pad_width = tuple((width, width) for width in template.shape)
     if mode == 'constant':
@@ -161,10 +161,10 @@ def match_template(image, template, pad_input=False, mode='constant',
     np.maximum(denominator, 0, out=denominator)  # sqrt of negative number not allowed
     np.sqrt(denominator, out=denominator)
 
-    response = np.zeros_like(xcorr, dtype=np.float32)
+    response = np.zeros_like(xcorr, dtype=np.float64)
 
     # avoid zero-division
-    mask = denominator > np.finfo(np.float32).eps
+    mask = denominator > np.finfo(np.float64).eps
 
     response[mask] = numerator[mask] / denominator[mask]
 

--- a/skimage/feature/tests/test_template.py
+++ b/skimage/feature/tests/test_template.py
@@ -1,6 +1,7 @@
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal, assert_raises
 
+from skimage import data, img_as_float
 from skimage.morphology import diamond
 from skimage.feature import match_template, peak_local_max
 
@@ -168,6 +169,16 @@ def test_wrong_input():
     image = np.ones((5, 5, 3, 3))
     template = np.ones((3, 3, 2))
     assert_raises(ValueError, match_template, template, image)
+
+
+def test_bounding_values():
+    image = img_as_float(data.page())
+    template = np.zeros((3, 3))
+    template[1, 1] = 1
+    result = match_template(img_as_float(data.page()), template)
+    print(result.max())
+    assert result.max() < 1 + 1e-7
+    assert result.min() > -1 - 1e-7
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR is based on #1331 by @dhyams I open a new one because the other one is quite old and the contributor said that she/he didn't have enough time. (@dhyams are you fine with that?)

I rebased the PR and I investigated the second issue that was not fixed at that time.

Summary:
This is about `match_template`

* [x] in #1331 there was a division issue and fixed.
* [x] it was also noticed that, contrary to the docstring, values are not always in [-1,1]. I reproduced the problem. In particular, with the image provided by @dhyams (the plot), the min value is far below -1. After looking carefully to the code, I noticed that numbers are quite large in this example and there is an overflow. I switched to `np.float64` at it solved the problem.

The minimal code to check the last point is:
```
image = skimage.io.imread('/tmp/sample_scan.png')
coin = image[814:831, 256:272]
result = match_template(image, coin)
result.min() # returns -1.9822552
```


With the patch, it returns -0.53164628156574956

I didn't add a unittest because I don't know how to reproduce this excepted with that specific example.
