### PR TITLE
Add coordinate conversion routines to `skimage.util`

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -222,7 +222,8 @@
   Structuring elements in morphology module.
 
 - Egor Panfilov
-  Inpainting with biharmonic equation
+  Inpainting with biharmonic equation.
+  Coordinate convertion utilities.
 
 - Evgeni Burovski
   Adaptation of ImageJ 3D skeletonization algorithm.

--- a/skimage/util/__init__.py
+++ b/skimage/util/__init__.py
@@ -8,6 +8,9 @@ from .arraycrop import crop
 from ._regular_grid import regular_grid, regular_seeds
 from .unique import unique_rows
 from ._invert import invert
+from ._coord_conv import (xy_to_rc, rc_to_xy,
+                          cart_to_rc, rc_to_cart,
+                          cart_to_xy, xy_to_cart)
 
 from .._shared.utils import copy_func
 
@@ -30,4 +33,11 @@ __all__ = ['img_as_float',
            'regular_seeds',
            'apply_parallel',
            'invert',
-           'unique_rows']
+           'unique_rows',
+           'xy_to_rc',
+           'rc_to_xy',
+           'cart_to_rc',
+           'rc_to_cart',
+           'cart_to_xy',
+           'xy_to_cart',
+]

--- a/skimage/util/_coord_conv.py
+++ b/skimage/util/_coord_conv.py
@@ -1,0 +1,236 @@
+import numpy as np
+
+
+def xy_to_rc(points=None, image=None):
+    """Convert points' coordinates and/or image from `x, y` to `r, c` convention.
+
+        o--->....       o--->....
+        |   x   .       |   c   .
+        |       .  ==>  |       .
+        v y     .       v r     .
+        .........       .........
+
+    Parameters
+    ----------
+    points : (K, 2) ndarray, optional
+        Array of points' `x, y` coordinates.
+    image : (M, N[, C]) ndarray, optional
+        Image stored in `x, y` axes convention.
+
+    Returns
+    -------
+    points_out : (K, 2) ndarray
+        Array of `points` `r, c` coordinates.
+    image_out : (M, N[, C]) ndarray
+        Same data as `image`, but in `r, c` convention.
+    """
+    if points is not None:
+        points_out = np.fliplr(points)
+    else:
+        points_out = None
+
+    if image is not None:
+        image_out = np.swapaxes(image, 0, 1)
+    else:
+        image_out = None
+
+    return points_out, image_out
+
+
+def rc_to_xy(points=None, image=None):
+    """Convert points' coordinates and/or image from `r, c` to `x, y` convention.
+
+        o--->....       o--->....
+        |   c   .       |   x   .
+        |       .  ==>  |       .
+        v r     .       v y     .
+        .........       .........
+
+    Parameters
+    ----------
+image : (M, N[, C]) ndarray, optional
+        Image stored in `r, c` axes convention.
+    points : (K, 2) ndarray, optional
+        Array of points' `r, c` coordinates.
+    copy : bool, optional
+        If True, returns copy(s) of array(s) instead of view(s).
+
+    Returns
+    -------
+    image_out : (M, N[, C]) ndarray
+        Same as `image`, but in `x, y` convention.
+    points_out : (K, 2) ndarray
+        Array of `points` `x, y` coordinates.
+    """
+    if points is not None:
+        points_out = np.fliplr(points)
+    else:
+        points_out = None
+
+    if image is not None:
+        image_out = np.swapaxes(image, 0, 1)
+    else:
+        image_out = None
+
+    return points_out, image_out
+
+
+def cart_to_rc(points=None, deltao=None, image=None):
+    """Convert image and/or points' coordinates from `x_c, y_c` to `r, c` convention.
+
+        .........       o--->....
+        ^ y_c   .       |   c   .
+        |       .  ==>  |       .
+        |   x_c .       v r     .
+        o--->....       .........
+
+    Parameters
+    ----------
+    points : (K, 2) ndarray, optional
+        Array of points' `x_c, y_c` Cartesian coordinates.
+    deltao : int, optional
+        Distance between `y_c` and `r` vectors' origins.
+        Optional for `points` convertion if `image` is specified.
+    image : (M, N[, C]) ndarray, optional
+        Image stored in `r, c` axes convention.
+
+    Returns
+    -------
+    points_out : (K, 2) ndarray
+        Array of `points` `r, c` coordinates.
+    image_out : (M, N[, C]) ndarray
+        Same data as `image`, but in `r, c` convention.
+    """
+    if points is not None:
+        if deltao is None:
+            if image is None:
+                msg = ('When converting coordinates, either `deltao` or `image` '
+                       'have to be specified.')
+                raise ValueError(msg)
+            else:
+                deltao = image.shape[1] - 1
+        r = deltao - points[:, 1]
+        c = points[:, 0]
+        points_out = np.stack((r, c)).T
+    else:
+        points_out = None
+
+    if image is not None:
+        image_out = np.swapaxes(np.flipud(image), 0, 1)
+    else:
+        image_out = None
+
+    return points_out, image_out
+
+
+def rc_to_cart(points=None, deltao=None, image=None):
+    """Convert image and/or points' coordinates from `r, c` to `x_c, y_c` convention.
+
+        o--->....       .........
+        |   c   .       ^ y_c   .
+        |       .  ==>  |       .
+        v r     .       |   x_c .
+        .........       o--->....
+
+    Parameters
+    ----------
+    points : (K, 2) ndarray, optional
+        Array of points' `r, c` coordinates.
+    deltao : int, optional
+        Distance between `r` and `y_c` vectors' origins.
+        Optional for `points` convertion if `image` is specified.
+    image : (M, N[, C]) ndarray, optional
+        Image stored in `x_c, y_c` axes convention.
+
+    Returns
+    -------
+    points_out : (K, 2) ndarray
+        Array of `points` `r, c` coordinates.
+    image_out : (M, N[, C]) ndarray
+        Same data as `image`, but in `r, c` convention.
+    """
+    if points is not None:
+        if deltao is None:
+            if image is None:
+                msg = ('When converting coordinates, either `deltao` or `image` '
+                       'have to be specified.')
+                raise ValueError(msg)
+            else:
+                deltao = image.shape[0] - 1
+        x_c = points[:, 1]
+        y_c = deltao - points[:, 0]
+        points_out = np.stack((x_c, y_c)).T
+    else:
+        points_out = None
+
+    if image is not None:
+        image_out = np.flipud(np.swapaxes(image, 0, 1))
+    else:
+        image_out = None
+
+    return points_out, image_out
+
+
+def xy_to_cart(points=None, deltao=None, image=None):
+    """Convert image and/or points' coordinates from `x, y` to `x_c, y_c` convention.
+
+        o--->....       .........
+        |   x   .       ^ y_c   .
+        |       .  ==>  |       .
+        v y     .       |   x_c .
+        .........       o--->....
+
+    Parameters
+    ----------
+    points : (K, 2) ndarray, optional
+        Array of points' `x, y` coordinates.
+    deltao : int, optional
+        Distance between `y` and `y_c` vectors' origins.
+        Optional for `points` convertion if `image` is specified.
+    image : (M, N[, C]) ndarray, optional
+        Image stored in `x, y` axes convention.
+
+    Returns
+    -------
+    points_out : (K, 2) ndarray
+        Array of `points` `x_c, y_c` Cartesian coordinates.
+    image_out : (M, N[, C]) ndarray
+        Same data as `image`, but in `x_c, y_c` convention.
+    """
+    p, i = xy_to_rc(points, image)
+    points_out, image_out = rc_to_cart(p, deltao, i)
+
+    return points_out, image_out
+
+
+def cart_to_xy(points=None, deltao=None, image=None):
+    """Convert image and/or points' coordinates from `x_c, y_c` to `x, y` convention.
+
+        .........       o--->....
+        ^ y_c   .       |   x   .
+        |       .  ==>  |       .
+        |   x_c .       v y     .
+        o--->....       .........
+
+    Parameters
+    ----------
+    points : (K, 2) ndarray, optional
+        Array of points' `x_c, y_c` Cartesian coordinates.
+    deltao : int, optional
+        Distance between `y_c` and `y` vectors' origins.
+        Optional for `points` convertion if `image` is specified.
+    image : (M, N[, C]) ndarray, optional
+        Image stored in `x_c, y_y` axes convention.
+
+    Returns
+    -------
+    points_out : (K, 2) ndarray
+        Array of `points` `x, y` coordinates.
+    image_out : (M, N[, C]) ndarray
+        Same data as `image`, but in `x, y` convention.
+    """
+    p, i = cart_to_rc(points, deltao, image)
+    points_out, image_out = rc_to_xy(p, i)
+
+    return points_out, image_out
+

--- a/skimage/util/_coord_conv.py
+++ b/skimage/util/_coord_conv.py
@@ -48,19 +48,17 @@ def rc_to_xy(points=None, image=None):
 
     Parameters
     ----------
-image : (M, N[, C]) ndarray, optional
-        Image stored in `r, c` axes convention.
     points : (K, 2) ndarray, optional
         Array of points' `r, c` coordinates.
-    copy : bool, optional
-        If True, returns copy(s) of array(s) instead of view(s).
+    image : (M, N[, C]) ndarray, optional
+        Image stored in `r, c` axes convention.
 
     Returns
     -------
-    image_out : (M, N[, C]) ndarray
-        Same as `image`, but in `x, y` convention.
     points_out : (K, 2) ndarray
         Array of `points` `x, y` coordinates.
+    image_out : (M, N[, C]) ndarray
+        Same as `image`, but in `x, y` convention.
     """
     if points is not None:
         points_out = np.fliplr(points)

--- a/skimage/util/tests/test_coord_conv.py
+++ b/skimage/util/tests/test_coord_conv.py
@@ -1,0 +1,73 @@
+import numpy as np
+from numpy.testing import assert_array_equal
+from skimage.util import (xy_to_rc, rc_to_xy,
+                          cart_to_rc, rc_to_cart,
+                          cart_to_xy, xy_to_cart)
+
+
+def test_round_trip_xy_via_cart():
+    shape = (5, 10)
+    points = np.stack((np.random.randint(0, shape[0], 5),
+                       np.random.randint(0, shape[1], 5))).T
+    image = np.random.random(shape)
+    tmp_p, tmp_i = xy_to_cart(points=points, image=image)
+    result_points, result_image = cart_to_xy(points=tmp_p, image=tmp_i)
+    assert_array_equal(points, result_points)
+    assert_array_equal(image, result_image)
+
+
+def test_round_trip_xy_via_rc():
+    shape = (10, 5)
+    points = np.stack((np.random.randint(0, shape[0], 5),
+                       np.random.randint(0, shape[1], 5))).T
+    image = np.random.random(shape)
+    result_points, result_image = rc_to_xy(*xy_to_rc(points, image))
+    assert_array_equal(points, result_points)
+    assert_array_equal(image, result_image)
+
+
+def test_round_trip_rc_via_cart():
+    shape = (5, 10)
+    points = np.stack((np.random.randint(0, shape[0], 5),
+                       np.random.randint(0, shape[1], 5))).T
+    image = np.random.random(shape)
+    tmp_p, tmp_i = rc_to_cart(points=points, image=image)
+    result_points, result_image = cart_to_rc(points=tmp_p, image=tmp_i)
+    assert_array_equal(points, result_points)
+    assert_array_equal(image, result_image)
+
+
+def test_round_trip_rc_via_xy():
+    shape = (10, 5)
+    points = np.stack((np.random.randint(0, shape[0], 5),
+                       np.random.randint(0, shape[1], 5))).T
+    image = np.random.random(shape)
+    result_points, result_image = xy_to_rc(*rc_to_xy(points, image))
+    assert_array_equal(points, result_points)
+    assert_array_equal(image, result_image)
+
+
+def test_round_trip_cart_via_rc():
+    shape = (5, 10)
+    points = np.stack((np.random.randint(0, shape[0], 5),
+                       np.random.randint(0, shape[1], 5))).T
+    image = np.random.random(shape)
+    tmp_p, tmp_i = cart_to_rc(points=points, image=image)
+    result_points, result_image = rc_to_cart(points=tmp_p, image=tmp_i)
+    assert_array_equal(points, result_points)
+    assert_array_equal(image, result_image)
+
+
+def test_round_trip_cart_via_xy():
+    shape = (10, 5)
+    points = np.stack((np.random.randint(0, shape[0], 5),
+                       np.random.randint(0, shape[1], 5))).T
+    image = np.random.random(shape)
+    tmp_p, tmp_i = cart_to_xy(points=points, image=image)
+    result_points, result_image = xy_to_cart(points=tmp_p, image=tmp_i)
+    assert_array_equal(points, result_points)
+    assert_array_equal(image, result_image)
+
+
+if __name__ == '__main__':
+    np.testing.run_module_suite()


### PR DESCRIPTION
## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]
## References

Addresses https://github.com/scikit-image/scikit-image/issues/2275 .
