### PR TITLE
Defer matplotlib imports

### DIFF
--- a/skimage/_shared/_geometry.py
+++ b/skimage/_shared/_geometry.py
@@ -1,7 +1,6 @@
 __all__ = ['polygon_clip', 'polygon_area']
 
 import numpy as np
-from matplotlib import _path, path, transforms
 
 
 def polygon_clip(rp, cp, r0, c0, r1, c1):
@@ -25,6 +24,8 @@ def polygon_clip(rp, cp, r0, c0, r1, c1):
     AGG 2.4 and exposed in Matplotlib.
 
     """
+    from matplotlib import _path, path, transforms
+
     poly = path.Path(np.vstack((rp, cp)).T, closed=True)
     clip_rect = transforms.Bbox([[r0, c0], [r1, c1]])
     poly_clipped = poly.clip_to_bbox(clip_rect).to_polygons()[0]

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -5,9 +5,6 @@ from scipy import ndimage as ndi
 from scipy import sparse
 import math
 from ... import measure, segmentation, util, color
-from matplotlib import colors, cm
-from matplotlib import pyplot as plt
-from matplotlib.collections import LineCollection
 
 
 def _edge_generator_from_csr(csr_matrix):
@@ -469,6 +466,9 @@ def show_rag(labels, rag, img, border_color='black', edge_width=1.5,
     >>> lc = graph.show_rag(labels, g, img)
     >>> cbar = plt.colorbar(lc)
     """
+    from matplotlib import colors, cm
+    from matplotlib import pyplot as plt
+    from matplotlib.collections import LineCollection
 
     if not in_place:
         rag = rag.copy()


### PR DESCRIPTION
## Description

I have a new project that for various reasons I won't get into must be delivered as a standalone PyInstaller .exe.

With skimage importing matplotlib at the top level, all of matplotlib, and thus all of Qt and a bunch of other stuff gets pulled in.

Maybe it's weird getting a PR to reduce the use of matplotlib from me of all people... ;)  But this particular app doesn't use matplotlib at all.
## Checklist
- [ ] Unit tests

I'm a little unsure about how to write a unit test for this -- the test suite still rightly and understandably imports matplotlib, so we can't just assert that it wasn't imported.
