### PR TITLE
Implemented Modified Connected Component Algorithm

### DIFF
--- a/skimage/measure/_ccomp.pyx
+++ b/skimage/measure/_ccomp.pyx
@@ -165,9 +165,9 @@ cdef void get_shape_info(inarr_shape, shape_info *res) except *:
 cdef inline bint close(DTYPE_t* data_p, DTYPE_t rindex, INTS_t idxdiff, INTS_t ratio):
     cdef DTYPE_t bigger, smaller;
     if data_p[rindex] > data_p[rindex + idxdiff]:
-        return data_p[rindex] < 3*data_p[rindex + idxdiff]
+        return data_p[rindex] < ratio * data_p[rindex + idxdiff]
     else:
-        return data_p[rindex + idxdiff] < 3*data_p[rindex]
+        return data_p[rindex + idxdiff] < ratio * data_p[rindex]
 
 cdef inline void join_trees_wrapper(DTYPE_t *data_p, DTYPE_t *forest_p,
                                     DTYPE_t rindex, INTS_t idxdiff, INTS_t ratio):

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -2,7 +2,7 @@ from ._ccomp import label_cython as clabel
 
 
 def label(input, neighbors=None, background=None, return_num=False,
-          connectivity=None):
+          connectivity=None, ratio=None):
     r"""Label connected regions of an integer array.
 
     Two pixels are connected when they are neighbors and have the same value.
@@ -38,6 +38,10 @@ def label(input, neighbors=None, background=None, return_num=False,
         as a neighbor.
         Accepted values are ranging from  1 to input.ndim. If ``None``, a full
         connectivity of ``input.ndim`` is used.
+    ratio : int, optional
+        Check if pixel a is "close enough" to pixel b based on a given ratio
+        rather than checking for equality (e.g. for ratio=3, Check if
+        a/3 < b < a*3).  If not defined, or set to 1, simply check for equality
 
     Returns
     -------
@@ -90,4 +94,4 @@ def label(input, neighbors=None, background=None, return_num=False,
      [1 1 2]
      [0 0 0]]
     """
-    return clabel(input, neighbors, background, return_num, connectivity)
+    return clabel(input, neighbors, background, return_num, connectivity, ratio)

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -39,9 +39,11 @@ def label(input, neighbors=None, background=None, return_num=False,
         Accepted values are ranging from  1 to input.ndim. If ``None``, a full
         connectivity of ``input.ndim`` is used.
     ratio : int, optional
-        Check if pixel a is "close enough" to pixel b based on a given ratio
-        rather than checking for equality (e.g. for ratio=3, Check if
-        a/3 < b < a*3).  If not defined, or set to 1, simply check for equality
+        Rather than connecting only pixels with equal values, connect pixels
+        that have a similar value, within the ratio specified by this argument.
+        For example, if R is the ratio, a is the value of one pixel, and b is
+        the value of one of its neighbors, those two pixels will be considered
+        connected if a/R < b < a*R is true.
 
     Returns
     -------

--- a/skimage/morphology/tests/test_ccomp.py
+++ b/skimage/morphology/tests/test_ccomp.py
@@ -96,6 +96,17 @@ class TestConnectedComponents:
 
         assert_array_equal(label(x, background=-1, return_num=True)[1], 4)
 
+    def test_ratio(self):
+        x = np.array([[0,  1,  2,  3],
+                      [0, 10, 20, 30],
+                      [3,  0,  1,  1],
+                      [2,  0,  1,  2]])
+        result = np.array([[0,  1,  1,  1],
+                           [0,  2,  2,  2],
+                           [3,  0,  4,  4],
+                           [3,  0,  4,  4]])
+        assert_array_equal(label(x, ratio=3), result)
+
 
 class TestConnectedComponents3d:
     def setup(self):


### PR DESCRIPTION
## Description

I've modified `skimage.morphology.label` so that it can perform the modified connected component algorithm described as a post-processing step for the Stroke Width Transform (second paragraph of Section 3.2 in the linked paper).

I would also like to contribute a SWT implementation down the road, but my current implementation is pure python and not very efficient.
## Todo
- [ ] add an example for the gallery of examples to show the new possibilities offered by the ratio keyword
- [x] provide a benchmark to know if for the default case (ratio=1), adding the ratio parameter does not result in a significant performance loss (benchmark is in a gist [here](https://gist.github.com/TheNeuralBit/aa988bf56f53b37bdb28f60e5e965330))
- [x] add unit tests in test_ccomp.py which use the ratio parameter.
## References

This implements the modified connected component algorithm described here:

[Epshtein, Boris, Eyal Ofek, and Yonatan Wexler. "Detecting text in natural scenes with stroke width transform." Computer Vision and Pattern Recognition (CVPR), 2010 IEEE Conference on. IEEE, 2010.](https://www.microsoft.com/en-us/research/publication/stroke-width-transform/)
