### PR TITLE
[MRG+2] MAINT: Fix numpy deprecation

### DIFF
--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -98,7 +98,7 @@ class TestRank():
         # make sure the size is not a problem
 
         elem = np.array([[1, 1, 1], [1, 1, 1], [1, 1, 1]], dtype=np.uint8)
-        for m, n in np.random.random_integers(1, 100, size=(10, 2)):
+        for m, n in np.random.randint(1, 101, size=(10, 2)):
             mask = np.ones((m, n), dtype=np.uint8)
 
             image8 = np.ones((m, n), dtype=np.uint8)


### PR DESCRIPTION
Fixes 
```
skimage.filters.rank.tests.test_rank.TestRank.test_random_sizes ... /home/travis/build/scikit-image/scikit-image/skimage/filters/rank/tests/test_rank.py:101: DeprecationWarning: This function is deprecated. Please call randint(1, 100 + 1) instead

  for m, n in np.random.random_integers(1, 100, size=(10, 2)):

```