### PR TITLE
[MRG+1] By default, clear_border is not inplace

### DIFF
--- a/doc/examples/segmentation/plot_label.py
+++ b/doc/examples/segmentation/plot_label.py
@@ -32,8 +32,7 @@ thresh = threshold_otsu(image)
 bw = closing(image > thresh, square(3))
 
 # remove artifacts connected to image border
-cleared = bw.copy()
-clear_border(cleared)
+cleared = clear_border(bw)
 
 # label image regions
 label_image = label(cleared)


### PR DESCRIPTION
While reviewing another PR, I noticed that `clear_border` was not properly used in an example. Probably due to an evolution of the API.