### PR TITLE
[MRG+1] Add felzenszwalb shape validation

### DIFF
--- a/skimage/segmentation/_felzenszwalb.py
+++ b/skimage/segmentation/_felzenszwalb.py
@@ -52,6 +52,10 @@ def felzenszwalb(image, scale=1, sigma=0.8, min_size=20, multichannel=True):
     >>> segments = felzenszwalb(img, scale=3.0, sigma=0.95, min_size=5)
     """
 
+    if not multichannel:
+        raise ValueError("This algorithm works only on single or "
+                         "multi-channel 2d images. ")
+
     image = np.atleast_3d(image)
     return _felzenszwalb_cython(image, scale=scale, sigma=sigma,
-                                min_size=min_size, multichannel=multichannel)
+                                min_size=min_size)

--- a/skimage/segmentation/_felzenszwalb.py
+++ b/skimage/segmentation/_felzenszwalb.py
@@ -52,7 +52,7 @@ def felzenszwalb(image, scale=1, sigma=0.8, min_size=20, multichannel=True):
     >>> segments = felzenszwalb(img, scale=3.0, sigma=0.95, min_size=5)
     """
 
-    if not multichannel:
+    if not multichannel and image.ndim > 2:
         raise ValueError("This algorithm works only on single or "
                          "multi-channel 2d images. ")
 

--- a/skimage/segmentation/_felzenszwalb.py
+++ b/skimage/segmentation/_felzenszwalb.py
@@ -4,7 +4,7 @@ from .._shared.utils import warn
 from ._felzenszwalb_cy import _felzenszwalb_cython
 
 
-def felzenszwalb(image, scale=1, sigma=0.8, min_size=20):
+def felzenszwalb(image, scale=1, sigma=0.8, min_size=20, multichannel=True):
     """Computes Felsenszwalb's efficient graph based image segmentation.
 
     Produces an oversegmentation of a multichannel (i.e. RGB) image
@@ -30,6 +30,9 @@ def felzenszwalb(image, scale=1, sigma=0.8, min_size=20):
         Width of Gaussian kernel used in preprocessing.
     min_size : int
         Minimum component size. Enforced using postprocessing.
+    multichannel : bool, optional (default: True)
+        Whether the last axis of the image is to be interpreted as multiple
+        channels. A value of False, for a 3D image, is not currently supported.
 
     Returns
     -------
@@ -51,4 +54,4 @@ def felzenszwalb(image, scale=1, sigma=0.8, min_size=20):
 
     image = np.atleast_3d(image)
     return _felzenszwalb_cython(image, scale=scale, sigma=sigma,
-                                min_size=min_size)
+                                min_size=min_size, multichannel=multichannel)

--- a/skimage/segmentation/_felzenszwalb_cy.pyx
+++ b/skimage/segmentation/_felzenszwalb_cy.pyx
@@ -14,7 +14,7 @@ from .._shared.utils import warn
 
 
 def _felzenszwalb_cython(image, double scale=1, sigma=0.8,
-                         Py_ssize_t min_size=20, multichannel=True):
+                         Py_ssize_t min_size=20):
     """Felzenszwalb's efficient graph based segmentation for
     single or multiple channels.
 
@@ -35,22 +35,17 @@ def _felzenszwalb_cython(image, double scale=1, sigma=0.8,
         Larger sigma gives smother segment boundaries.
     min_size : int, optional (default 20)
         Minimum component size. Enforced using postprocessing.
-    multichannel : bool, optional (default: True)
-        Whether the last axis of the image is to be interpreted as multiple
-        channels. A value of False, for a 3D image, is not currently supported.
 
     Returns
     -------
     segment_mask : (N, M) ndarray
         Integer mask indicating segment labels.
     """
-    if multichannel and image.shape[2] not in [1, 3]:
+
+    if image.shape[2] > 3:
         warn(RuntimeWarning("Got image with third dimension of %s. This image "
                             "will be interpreted as a multichannel 2d image, "
                             "which may not be intended." % str(image.shape[2])))
-    elif not multichannel:
-        raise ValueError("This algorithm works only on single or "
-                         "multi-channel 2d images. ")
 
     image = img_as_float(image)
 

--- a/skimage/segmentation/_felzenszwalb_cy.pyx
+++ b/skimage/segmentation/_felzenszwalb_cy.pyx
@@ -47,7 +47,7 @@ def _felzenszwalb_cython(image, double scale=1, sigma=0.8,
     if multichannel and image.shape[2] not in [1, 3]:
         warn(RuntimeWarning("Got image with third dimension of %s. This image "
                             "will be interpreted as a multichannel 2d image, "
-                            "which may not be intended." % str(image.shape[2]))
+                            "which may not be intended." % str(image.shape[2])))
     elif not multichannel:
         raise ValueError("This algorithm works only on single or "
                          "multi-channel 2d images. ")

--- a/skimage/segmentation/_felzenszwalb_cy.pyx
+++ b/skimage/segmentation/_felzenszwalb_cy.pyx
@@ -50,8 +50,7 @@ def _felzenszwalb_cython(image, double scale=1, sigma=0.8,
                             "which may not be intended." % str(image.shape[2]))
     elif not multichannel:
         raise ValueError("This algorithm works only on single or "
-                         "multi-channel 2d images. "
-                         "Got image of shape %s" % str(image.shape))
+                         "multi-channel 2d images. ")
 
     image = img_as_float(image)
 

--- a/skimage/segmentation/_felzenszwalb_cy.pyx
+++ b/skimage/segmentation/_felzenszwalb_cy.pyx
@@ -14,10 +14,10 @@ from ..util import img_as_float
 
 def _felzenszwalb_cython(image, double scale=1, sigma=0.8,
                          Py_ssize_t min_size=20):
-    """Felzenszwalb's efficient graph based segmentation for 
+    """Felzenszwalb's efficient graph based segmentation for
     single or multiple channels.
 
-    Produces an oversegmentation of a single or multi-channel image 
+    Produces an oversegmentation of a single or multi-channel image
     using a fast, minimum spanning tree based clustering on the image grid.
     The number of produced segments as well as their size can only be
     controlled indirectly through ``scale``. Segment size within an image can
@@ -40,8 +40,8 @@ def _felzenszwalb_cython(image, double scale=1, sigma=0.8,
     segment_mask : (N, M) ndarray
         Integer mask indicating segment labels.
     """
-    if image.ndim != 3:
-        raise ValueError("This algorithm works only on single or " 
+    if image.ndim != 3 or image.shape[2] not in [1, 3]:
+        raise ValueError("This algorithm works only on single or "
                          "multi-channel 2d images. "
                          "Got image of shape %s" % str(image.shape))
 

--- a/skimage/segmentation/tests/test_felzenszwalb.py
+++ b/skimage/segmentation/tests/test_felzenszwalb.py
@@ -1,5 +1,6 @@
 import numpy as np
-from numpy.testing import assert_equal, assert_array_equal, assert_raises
+from numpy.testing import (assert_equal, assert_array_equal, assert_raises,
+    assert_warns, assert_no_warnings)
 
 from skimage._shared.testing import assert_greater, test_parallel
 from skimage.segmentation import felzenszwalb
@@ -37,8 +38,18 @@ def test_minsize():
         assert_greater(counts.min() + 1, min_size)
 
 def test_3D():
-    img = np.zeros((10, 10, 10))
-    assert_raises(ValueError, felzenszwalb, img, multichannel=False)
+    grey_img = np.zeros((10, 10))
+    rgb_img = np.zeros((10, 10, 3))
+    three_d_img = np.zeros((10, 10, 10))
+    with assert_no_warnings():
+        felzenszwalb(grey_img, multichannel=True)
+        felzenszwalb(grey_img, multichannel=False)
+        felzenszwalb(rgb_img, multichannel=True)
+    with assert_warns(RuntimeWarning):
+        felzenszwalb(three_d_img, multichannel=True)
+    with assert_raises(ValueError):
+        felzenszwalb(rgb_img, multichannel=False)
+        felzenszwalb(three_d_img, multichannel=False)
 
 def test_color():
     # very weak tests.

--- a/skimage/segmentation/tests/test_felzenszwalb.py
+++ b/skimage/segmentation/tests/test_felzenszwalb.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_equal, assert_array_equal
+from numpy.testing import assert_equal, assert_array_equal, assert_raises
 
 from skimage._shared.testing import assert_greater, test_parallel
 from skimage.segmentation import felzenszwalb
@@ -36,6 +36,9 @@ def test_minsize():
         # actually want to test greater or equal.
         assert_greater(counts.min() + 1, min_size)
 
+def test_shape():
+    img = np.arange(100).reshape(4,5,5)
+    assert_raises(ValueError, felzenszwalb, img)
 
 def test_color():
     # very weak tests.

--- a/skimage/segmentation/tests/test_felzenszwalb.py
+++ b/skimage/segmentation/tests/test_felzenszwalb.py
@@ -36,8 +36,8 @@ def test_minsize():
         # actually want to test greater or equal.
         assert_greater(counts.min() + 1, min_size)
 
-def test_shape():
-    img = np.arange(100).reshape(4,5,5)
+def test_3D():
+    img = np.zeros((10, 10, 10))
     assert_raises(ValueError, felzenszwalb, img)
 
 def test_color():

--- a/skimage/segmentation/tests/test_felzenszwalb.py
+++ b/skimage/segmentation/tests/test_felzenszwalb.py
@@ -38,7 +38,7 @@ def test_minsize():
 
 def test_3D():
     img = np.zeros((10, 10, 10))
-    assert_raises(ValueError, felzenszwalb, img)
+    assert_raises(ValueError, felzenszwalb, img, multichannel=False)
 
 def test_color():
     # very weak tests.


### PR DESCRIPTION
## Description
A simple check to ensure the image passed to felzenszwalb is a 2d grayscale or RGB image. I also considered adding a `multichannel` flag as in `skimage.filters.gaussian` to be more robust. Please let me know which approach is preferable.

## References
Short-term fix for issue  #2267