### PR TITLE
[MRG+1] Remove unused imports in `transform.{pyx/pxd}`

### DIFF
--- a/skimage/_shared/transform.pxd
+++ b/skimage/_shared/transform.pxd
@@ -1,5 +1,2 @@
-cimport numpy as cnp
-
-
 cdef float integrate(float[:, ::1] sat, Py_ssize_t r0, Py_ssize_t c0,
                      Py_ssize_t r1, Py_ssize_t c1) nogil

--- a/skimage/_shared/transform.pyx
+++ b/skimage/_shared/transform.pyx
@@ -2,7 +2,6 @@
 #cython: boundscheck=False
 #cython: nonecheck=False
 #cython: wraparound=False
-cimport numpy as cnp
 
 
 cdef float integrate(float[:, ::1] sat, Py_ssize_t r0, Py_ssize_t c0,


### PR DESCRIPTION
## References
Closes https://github.com/scikit-image/scikit-image/issues/1571.

Although our tests from `_shared` don't start, I've verified that `python setup.py build_ext -i` works without any problems.