### PR TITLE
Add new "thin" method based on Guo and Hall 1989

### DIFF
--- a/doc/examples/edges/plot_skeleton.py
+++ b/doc/examples/edges/plot_skeleton.py
@@ -131,7 +131,7 @@ ax[0].imshow(data, cmap=plt.cm.gray, interpolation='nearest')
 ax[0].set_title('original')
 ax[0].axis('off')
 
-ax[1].imshow(dist_on_skel, cmap=plt.cm.spectral, interpolation='nearest')
+ax[1].imshow(dist_on_skel, cmap=plt.cm.magma, interpolation='nearest')
 ax[1].contour(data, [0.5], colors='w')
 ax[1].set_title('medial_axis')
 ax[1].axis('off')

--- a/doc/examples/edges/plot_skeleton.py
+++ b/doc/examples/edges/plot_skeleton.py
@@ -123,6 +123,8 @@ skeleton3d = skeletonize_3d(data)
 # Distance to the background for pixels of the skeleton
 dist_on_skel = distance * skel
 
+from skimage.util.colormap import magma
+
 fig, axes = plt.subplots(2, 2, figsize=(8, 8), sharex=True, sharey=True,
                          subplot_kw={'adjustable': 'box-forced'})
 ax = axes.ravel()
@@ -131,7 +133,7 @@ ax[0].imshow(data, cmap=plt.cm.gray, interpolation='nearest')
 ax[0].set_title('original')
 ax[0].axis('off')
 
-ax[1].imshow(dist_on_skel, cmap=plt.cm.magma, interpolation='nearest')
+ax[1].imshow(dist_on_skel, cmap=magma, interpolation='nearest')
 ax[1].contour(data, [0.5], colors='w')
 ax[1].set_title('medial_axis')
 ax[1].axis('off')

--- a/doc/examples/edges/plot_skeleton.py
+++ b/doc/examples/edges/plot_skeleton.py
@@ -106,7 +106,7 @@ plt.show()
 # of the objects.
 #
 # For a skeleton with fewer branches, ``skeletonize`` or ``skeletonize_3d``
-# must be preferred.
+# should be preferred.
 
 from skimage.morphology import medial_axis, skeletonize, skeletonize_3d
 

--- a/doc/examples/edges/plot_skeleton.py
+++ b/doc/examples/edges/plot_skeleton.py
@@ -146,3 +146,46 @@ ax[3].axis('off')
 
 fig.tight_layout()
 plt.show()
+
+
+######################################################################
+# **Morphological thinning**
+#
+# Morphological thinning, implemented in the `thin` function, works on the
+# same principle as `skeletonize`: remove pixels from the borders at each
+# iteration until none can be removed without altering the connectivity. The
+# different rules of removal can speed up skeletonization and result in
+# different final skeletons.
+#
+# The `thin` function also takes an optional `max_iter` keyword argument to
+# limit the number of thinning iterations, and thus produce a relatively
+# thicker skeleton.
+
+from skimage.morphology import skeletonize, thin
+
+skeleton = skeletonize(image)
+thinned = thin(image)
+thinned_partial = thin(image, max_iter=25)
+
+fig, axes = plt.subplots(2, 2, figsize=(8, 8), sharex=True, sharey=True,
+                         subplot_kw={'adjustable': 'box-forced'})
+ax = axes.ravel()
+
+ax[0].imshow(image, cmap=plt.cm.gray, interpolation='nearest')
+ax[0].set_title('original')
+ax[0].axis('off')
+
+ax[1].imshow(skeleton, cmap=plt.cm.gray, interpolation='nearest')
+ax[1].set_title('skeleton')
+ax[1].axis('off')
+
+ax[2].imshow(thinned, cmap=plt.cm.gray, interpolation='nearest')
+ax[2].set_title('thinned')
+ax[2].axis('off')
+
+ax[3].imshow(thinned_partial, cmap=plt.cm.gray, interpolation='nearest')
+ax[3].set_title('partially thinned')
+ax[3].axis('off')
+
+fig.tight_layout()
+plt.show()

--- a/skimage/morphology/__init__.py
+++ b/skimage/morphology/__init__.py
@@ -5,7 +5,7 @@ from .grey import (erosion, dilation, opening, closing, white_tophat,
 from .selem import (square, rectangle, diamond, disk, cube, octahedron, ball,
                     octagon, star)
 from .watershed import watershed
-from ._skeletonize import skeletonize, medial_axis
+from ._skeletonize import skeletonize, medial_axis, thin
 from ._skeletonize_3d import skeletonize_3d
 from .convex_hull import convex_hull_image, convex_hull_object
 from .greyreconstruct import reconstruction
@@ -36,6 +36,7 @@ __all__ = ['binary_erosion',
            'watershed',
            'skeletonize',
            'skeletonize_3d',
+           'thin',
            'medial_axis',
            'convex_hull_image',
            'convex_hull_object',

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -144,7 +144,7 @@ def thin(image, max_iter=None):
     
     See also
     --------
-    skeletonize
+    skeletonize, skeletonize_3d, medial_axis
     
     Notes
     -----
@@ -170,7 +170,7 @@ def thin(image, max_iter=None):
     --------
     >>> square = np.zeros((7, 7), dtype=np.uint8)
     >>> square[1:-1, 2:-2] = 1
-    >>> square[0,1] =  1
+    >>> square[0, 1] =  1
     >>> square
     array([[0, 1, 0, 0, 0, 0, 0],
            [0, 0, 1, 1, 1, 0, 0],
@@ -209,7 +209,7 @@ def thin(image, max_iter=None):
     # neighborhood mask
     mask = np.array([[ 8,  4,  2],
                      [16,  0,  1],
-                     [32, 64,128]],dtype=np.uint8)
+                     [32, 64,128]], dtype=np.uint8)
 
     # iterate either 1) indefinitely or 2) up to iteration limit
     while n != 0:

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -264,7 +264,7 @@ def thin(image, max_iter=None):
     # iterate until convergence, up to the iteration limit
     for i in range(max_iter):
         before = np.sum(skel)  # count points before thinning
-
+        # perform the two "subiterations" described in the paper
         for lut in [G123_LUT, G123P_LUT]:
             # correlate image with neighborhood mask
             N = ndi.correlate(skel, mask, mode='constant')

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -9,6 +9,7 @@ from ._skeletonize_cy import _fast_skeletonize, _skeletonize_loop, _table_lookup
 
 # --------- Skeletonization by morphological thinning ---------
 
+
 def skeletonize(image):
     """Return the skeleton of a binary image.
 
@@ -99,7 +100,7 @@ def skeletonize(image):
 
 def _generate_thin_luts():
     """generate LUTs for thinning algorithm (for reference)"""
-    
+
     def nabe(n):
         return np.array([n >> i & 1 for i in range(0, 9)]).astype(np.bool)
 
@@ -144,57 +145,61 @@ def _generate_thin_luts():
     return g123_lut, g123p_lut
 
 
-G123_LUT = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1,
-       0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0,
-       1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
-       0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-       0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 1,
-       0, 0, 0], dtype=np.bool)
+G123_LUT = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+                     0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1,
+                     0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                     0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1,
+                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+                     0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0,
+                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                     0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+                     1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0,
+                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0,
+                     0, 1, 1, 0, 0, 1, 0, 0, 0], dtype=np.bool)
 
-G123P_LUT = np.array([0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0,
-       1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0,
-       0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0,
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0,
-       1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 1,
-       0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-       0, 0, 0], dtype=np.bool)
+G123P_LUT = np.array([0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0,
+                      0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+                      1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1,
+                      0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=np.bool)
 
 
 def thin(image, max_iter=None):
     """
     Perform morphological thinning of a binary image.
-    
+
     Parameters
     ----------
     image : binary (M, N) ndarray
         The image to be thinned.
-    
+
     max_iter : int, number of iterations, optional
         Regardless of the value of this parameter, the thinned image
         is returned immediately if an iteration produces no change.
         If this parameter is specified it thus sets an upper bound on
         the number of iterations performed.
-    
+
     Returns
     -------
     out : ndarray of bools
         Thinned image.
-    
+
     See also
     --------
     skeletonize, skeletonize_3d, medial_axis
-    
+
     Notes
     -----
     This algorithm [1]_ works by making multiple passes over the image,
@@ -204,7 +209,7 @@ def thin(image, max_iter=None):
     correlates the intermediate skeleton image with a neighborhood mask,
     then looks up each neighborhood in a lookup table indicating whether
     the central pixel should be deleted in that sub-iteration.
-    
+
     References
     ----------
     .. [1] Z. Guo and R. W. Hall, "Parallel thinning with
@@ -214,7 +219,7 @@ def thin(image, max_iter=None):
            Methodologies-A Comprehensive Survey," IEEE Transactions on
            Pattern Analysis and Machine Intelligence, Vol 14, No. 9,
            September 1992, p. 879
-    
+
     Examples
     --------
     >>> square = np.zeros((7, 7), dtype=np.uint8)
@@ -238,6 +243,7 @@ def thin(image, max_iter=None):
            [0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0]], dtype=uint8)
     """
+
     # check parameters
     if max_iter is None:
         n = -1
@@ -245,14 +251,16 @@ def thin(image, max_iter=None):
         raise ValueError('max_iter must be > 0')
     else:
         n = max_iter
-    
-    # check that we have a 2d binary image, and convert it
-    # to uint8
+
+    # convert image to uint8
     skel = np.array(image).astype(np.uint8)
-    
+
+    # check that image is 2d
     if skel.ndim != 2:
         raise ValueError('2D array required')
-    if not np.all(np.in1d(image.flat,(0,1))):
+
+    # check that image contains only 0s and 1s
+    if not np.all(np.in1d(image.flat, (0, 1))):
         raise ValueError('Image contains values other than 0 and 1')
 
     # neighborhood mask
@@ -262,8 +270,8 @@ def thin(image, max_iter=None):
 
     # iterate either 1) indefinitely or 2) up to iteration limit
     while n != 0:
-        before = np.sum(skel) # count points before thinning
-        
+        before = np.sum(skel)  # count points before thinning
+
         # for each subiteration
         for lut in [G123_LUT, G123P_LUT]:
             # correlate image with neighborhood mask
@@ -272,18 +280,18 @@ def thin(image, max_iter=None):
             D = np.take(lut, N)
             # perform deletion
             skel[D] = 0
-            
-        after = np.sum(skel) # coint points after thinning
-        
+
+        after = np.sum(skel)  # coint points after thinning
+
         if before == after:
             # iteration had no effect: finish
             break
-            
+
         # count down to iteration limit (or endlessly negative)
         n -= 1
-    
+
     return skel.astype(np.bool)
-    
+
 
 # --------- Skeletonization by medial axis transform --------
 

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -248,16 +248,12 @@ def thin(image, max_iter=None):
     # check parameters
     max_iter = max_iter or sys.maxsize
 
-    # convert image to uint8
-    skel = np.array(image).astype(np.uint8)
+    # convert image to uint8 with values in {0, 1}
+    skel = np.asanyarray(image, dtype=bool).astype(np.uint8)
 
     # check that image is 2d
     if skel.ndim != 2:
         raise ValueError('2D array required')
-
-    # check that image contains only 0s and 1s
-    if not np.all(np.in1d(image.flat, (0, 1))):
-        raise ValueError('Image contains values other than 0 and 1')
 
     # neighborhood mask
     mask = np.array([[ 8,  4,  2],

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -122,7 +122,7 @@ G123P_LUT = np.array([0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0
        0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 0], dtype=np.bool)
 
-def thin(image, n_iter=None):
+def thin(image, max_iter=None):
     """
     Perform morphological thinning of a binary image.
     
@@ -131,7 +131,7 @@ def thin(image, n_iter=None):
     image : binary (M, N) ndarray
         The image to be thinned.
     
-    n_iter : int, number of iterations, optional
+    max_iter : int, number of iterations, optional
         Regardless of the value of this parameter, the thinned image
         is returned immediately if an iteration produces no change.
         If this parameter is specified it thus sets an upper bound on
@@ -190,12 +190,12 @@ def thin(image, n_iter=None):
            [0, 0, 0, 0, 0, 0, 0]], dtype=uint8)
     """
     # check parameters
-    if n_iter is None:
+    if max_iter is None:
         n = -1
-    elif n_iter <= 0:
-        raise ValueError('n_iter must be > 0')
+    elif max_iter <= 0:
+        raise ValueError('max_iter must be > 0')
     else:
-        n = n_iter
+        n = max_iter
     
     # check that we have a 2d binary image, and convert it
     # to uint8

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -3,6 +3,7 @@ Algorithms for computing the skeleton of a binary image
 """
 
 import sys
+from six.moves import range
 import numpy as np
 from scipy import ndimage as ndi
 

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -2,6 +2,7 @@
 Algorithms for computing the skeleton of a binary image
 """
 
+import sys
 import numpy as np
 from scipy import ndimage as ndi
 
@@ -245,12 +246,7 @@ def thin(image, max_iter=None):
     """
 
     # check parameters
-    if max_iter is None:
-        n = -1
-    elif max_iter <= 0:
-        raise ValueError('max_iter must be > 0')
-    else:
-        n = max_iter
+    max_iter = max_iter or sys.maxsize
 
     # convert image to uint8
     skel = np.array(image).astype(np.uint8)
@@ -269,7 +265,7 @@ def thin(image, max_iter=None):
                      [32, 64,128]], dtype=np.uint8)
 
     # iterate either 1) indefinitely or 2) up to iteration limit
-    while n != 0:
+    for i in range(max_iter):
         before = np.sum(skel)  # count points before thinning
 
         # for each subiteration
@@ -286,9 +282,6 @@ def thin(image, max_iter=None):
         if before == after:
             # iteration had no effect: finish
             break
-
-        # count down to iteration limit (or endlessly negative)
-        n -= 1
 
     return skel.astype(np.bool)
 

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -199,7 +199,7 @@ def thin(image, max_iter=None):
 
     Returns
     -------
-    out : ndarray of bools
+    out : ndarray of bool
         Thinned image.
 
     See also
@@ -220,11 +220,11 @@ def thin(image, max_iter=None):
     ----------
     .. [1] Z. Guo and R. W. Hall, "Parallel thinning with
            two-subiteration algorithms," Comm. ACM, vol. 32, no. 3,
-           pp. 359-373, 1989.
+           pp. 359-373, 1989. DOI:10.1145/62065.62074
     .. [2] Lam, L., Seong-Whan Lee, and Ching Y. Suen, "Thinning
            Methodologies-A Comprehensive Survey," IEEE Transactions on
            Pattern Analysis and Machine Intelligence, Vol 14, No. 9,
-           September 1992, p. 879
+           p. 879, 1992. DOI:10.1109/34.161346
 
     Examples
     --------

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -94,7 +94,55 @@ def skeletonize(image):
 
     return _fast_skeletonize(image)
 
-# Alternate skeletonization by thinning algorithm
+# --------- Skeletonization and thinning based on Guo and Hall 1989 ---------
+
+
+def _generate_thin_luts():
+    """generate LUTs for thinning algorithm (for reference)"""
+    
+    def nabe(n):
+        return np.array([n >> i & 1 for i in range(0, 9)]).astype(np.bool)
+
+    def G1(n):
+        s = 0
+        bits = nabe(n)
+        for i in (0, 2, 4, 6):
+            if not(bits[i]) and (bits[i + 1] or bits[(i + 2) % 8]):
+                s += 1
+        return s == 1
+
+    g1_lut = np.array([G1(n) for n in range(256)])
+
+    def G2(n):
+        n1, n2 = 0, 0
+        bits = nabe(n)
+        for k in (1, 3, 5, 7):
+            if bits[k] or bits[k - 1]:
+                n1 += 1
+            if bits[k] or bits[(k + 1) % 8]:
+                n2 += 1
+        return min(n1, n2) in [2, 3]
+
+    g2_lut = np.array([G2(n) for n in range(256)])
+
+    g12_lut = g1_lut & g2_lut
+
+    def G3(n):
+        bits = nabe(n)
+        return not((bits[1] or bits[2] or not(bits[7])) and bits[0])
+
+    def G3p(n):
+        bits = nabe(n)
+        return not((bits[5] or bits[6] or not(bits[3])) and bits[4])
+
+    g3_lut = np.array([G3(n) for n in range(256)])
+    g3p_lut = np.array([G3p(n) for n in range(256)])
+
+    g123_lut = g12_lut & g3_lut
+    g123p_lut = g12_lut & g3p_lut
+
+    return g123_lut, g123p_lut
+
 
 G123_LUT = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1,
        0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -121,6 +169,7 @@ G123P_LUT = np.array([0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0
        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 1,
        0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
        0, 0, 0], dtype=np.bool)
+
 
 def thin(image, max_iter=None):
     """

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -94,6 +94,147 @@ def skeletonize(image):
 
     return _fast_skeletonize(image)
 
+# Alternate skeletonization by thinning algorithm
+
+G123_LUT = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1,
+       0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+       0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0,
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0,
+       1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
+       0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+       0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0,
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 1,
+       0, 0, 0], dtype=np.bool)
+
+G123P_LUT = np.array([0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0,
+       0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0,
+       1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+       0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0,
+       0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0,
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+       0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0,
+       1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 1,
+       0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+       0, 0, 0], dtype=np.bool)
+
+def thin(image, n_iter=None):
+    """
+    Perform morphological thinning of a binary image.
+    
+    Parameters
+    ----------
+    image : binary (M, N) ndarray
+        The image to be thinned.
+    
+    n_iter : int, number of iterations, optional
+        Regardless of the value of this parameter, the thinned image
+        is returned immediately if an iteration produces no change.
+        If this parameter is specified it thus sets an upper bound on
+        the number of iterations performed.
+    
+    Returns
+    -------
+    out : ndarray of bools
+        Thinned image.
+    
+    See also
+    --------
+    skeletonize
+    
+    Notes
+    -----
+    This algorithm [1]_ works by making multiple passes over the image,
+    removing pixels matching a set of criteria designed to thin
+    connected regions while preserving eight-connected components and
+    2 x 2 squares [2]_. In each of the two sub-iterations the algorithm
+    correlates the intermediate skeleton image with a neighborhood mask,
+    then looks up each neighborhood in a lookup table indicating whether
+    the central pixel should be deleted in that sub-iteration.
+    
+    References
+    ----------
+    .. [1] Z. Guo and R. W. Hall, "Parallel thinning with
+           two-subiteration algorithms," Comm. ACM, vol. 32, no. 3,
+           pp. 359-373, 1989.
+    .. [2] Lam, L., Seong-Whan Lee, and Ching Y. Suen, "Thinning
+           Methodologies-A Comprehensive Survey," IEEE Transactions on
+           Pattern Analysis and Machine Intelligence, Vol 14, No. 9,
+           September 1992, p. 879
+    
+    Examples
+    --------
+    >>> square = np.zeros((7, 7), dtype=np.uint8)
+    >>> square[1:-1, 2:-2] = 1
+    >>> square[0,1] =  1
+    >>> square
+    array([[0, 1, 0, 0, 0, 0, 0],
+           [0, 0, 1, 1, 1, 0, 0],
+           [0, 0, 1, 1, 1, 0, 0],
+           [0, 0, 1, 1, 1, 0, 0],
+           [0, 0, 1, 1, 1, 0, 0],
+           [0, 0, 1, 1, 1, 0, 0],
+           [0, 0, 0, 0, 0, 0, 0]], dtype=uint8)
+    >>> skel = thin(square)
+    >>> skel.astype(np.uint8)
+    array([[0, 1, 0, 0, 0, 0, 0],
+           [0, 0, 1, 0, 0, 0, 0],
+           [0, 0, 0, 1, 0, 0, 0],
+           [0, 0, 0, 1, 0, 0, 0],
+           [0, 0, 0, 1, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0, 0]], dtype=uint8)
+    """
+    # check parameters
+    if n_iter is None:
+        n = -1
+    elif n_iter <= 0:
+        raise ValueError('n_iter must be > 0')
+    else:
+        n = n_iter
+    
+    # check that we have a 2d binary image, and convert it
+    # to uint8
+    skel = np.array(image).astype(np.uint8)
+    
+    if skel.ndim != 2:
+        raise ValueError('2D array required')
+    if not np.all(np.in1d(image.flat,(0,1))):
+        raise ValueError('Image contains values other than 0 and 1')
+
+    # neighborhood mask
+    mask = np.array([[ 8,  4,  2],
+                     [16,  0,  1],
+                     [32, 64,128]],dtype=np.uint8)
+
+    # iterate either 1) indefinitely or 2) up to iteration limit
+    while n != 0:
+        before = np.sum(skel) # count points before thinning
+        
+        # for each subiteration
+        for lut in [G123_LUT, G123P_LUT]:
+            # correlate image with neighborhood mask
+            N = ndi.correlate(skel, mask, mode='constant')
+            # take deletion decision from this subiteration's LUT
+            D = np.take(lut, N)
+            # perform deletion
+            skel[D] = 0
+            
+        after = np.sum(skel) # coint points after thinning
+        
+        if before == after:
+            # iteration had no effect: finish
+            break
+            
+        # count down to iteration limit (or endlessly negative)
+        n -= 1
+    
+    return skel.astype(np.bool)
+    
 
 # --------- Skeletonization by medial axis transform --------
 

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -7,6 +7,8 @@ import numpy as np
 from scipy import ndimage as ndi
 
 from ._skeletonize_cy import _fast_skeletonize, _skeletonize_loop, _table_lookup_index
+from .._shared.utils import assert_nD
+
 
 # --------- Skeletonization by morphological thinning ---------
 
@@ -244,16 +246,13 @@ def thin(image, max_iter=None):
            [0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0]], dtype=uint8)
     """
-
     # check parameters
     max_iter = max_iter or sys.maxsize
+    # check that image is 2d
+    assert_nD(image, 2)
 
     # convert image to uint8 with values in {0, 1}
     skel = np.asanyarray(image, dtype=bool).astype(np.uint8)
-
-    # check that image is 2d
-    if skel.ndim != 2:
-        raise ValueError('2D array required')
 
     # neighborhood mask
     mask = np.array([[ 8,  4,  2],

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -6,7 +6,9 @@ import sys
 import numpy as np
 from scipy import ndimage as ndi
 
-from ._skeletonize_cy import _fast_skeletonize, _skeletonize_loop, _table_lookup_index
+from ._skeletonize_cy import (_fast_skeletonize, _skeletonize_loop,
+                              _table_lookup_index)
+
 from .._shared.utils import assert_nD
 
 
@@ -98,8 +100,8 @@ def skeletonize(image):
 
     return _fast_skeletonize(image)
 
-# --------- Skeletonization and thinning based on Guo and Hall 1989 ---------
 
+# --------- Skeletonization and thinning based on Guo and Hall 1989 ---------
 
 def _generate_thin_luts():
     """generate LUTs for thinning algorithm (for reference)"""
@@ -259,11 +261,10 @@ def thin(image, max_iter=None):
                      [16,  0,  1],
                      [32, 64,128]], dtype=np.uint8)
 
-    # iterate either 1) indefinitely or 2) up to iteration limit
+    # iterate until convergence, up to the iteration limit
     for i in range(max_iter):
         before = np.sum(skel)  # count points before thinning
 
-        # for each subiteration
         for lut in [G123_LUT, G123P_LUT]:
             # correlate image with neighborhood mask
             N = ndi.correlate(skel, mask, mode='constant')
@@ -272,7 +273,7 @@ def thin(image, max_iter=None):
             # perform deletion
             skel[D] = 0
 
-        after = np.sum(skel)  # coint points after thinning
+        after = np.sum(skel)  # count points after thinning
 
         if before == after:
             # iteration had no effect: finish

--- a/skimage/morphology/tests/test_skeletonize.py
+++ b/skimage/morphology/tests/test_skeletonize.py
@@ -1,5 +1,7 @@
 import numpy as np
 from skimage.morphology import skeletonize, medial_axis, thin
+from skimage.morphology._skeletonize import (_generate_thin_luts,
+                                             G123_LUT, G123P_LUT)
 import numpy.testing
 from skimage import draw
 from scipy.ndimage import correlate
@@ -110,7 +112,7 @@ class TestSkeletonize():
                              [0, 0, 0, 0, 0, 0]], dtype=np.uint8)
         assert np.all(result == expected)
 
-        
+
 class TestThin():
     @property
     def input_image(self):
@@ -123,10 +125,10 @@ class TestThin():
                        [0, 1, 1, 1, 1, 1, 0],
                        [0, 0, 0, 0, 0, 0, 0]], dtype=np.uint8)
         return ii
-    
+
     def test_zeros(self):
         assert np.all(thin(np.zeros((10, 10))) == False)
-        
+
     def test_iter_1(self):
         result = thin(self.input_image, 1).astype(np.uint8)
         expected = np.array([[0, 0, 0, 0, 0, 0, 0],
@@ -137,7 +139,7 @@ class TestThin():
                              [0, 0, 0, 0, 0, 0, 0],
                              [0, 0, 0, 0, 0, 0, 0]], dtype=np.uint8)
         numpy.testing.assert_array_equal(result, expected)
-        
+
     def test_noiter(self):
         result = thin(self.input_image).astype(np.uint8)
         expected = np.array([[0, 0, 0, 0, 0, 0, 0],
@@ -148,19 +150,27 @@ class TestThin():
                              [0, 0, 0, 0, 0, 0, 0],
                              [0, 0, 0, 0, 0, 0, 0]], dtype=np.uint8)
         numpy.testing.assert_array_equal(result, expected)
-        
+
     def test_baditer(self):
         for n_iter in [-1, 0]:
-            numpy.testing.assert_raises(ValueError, thin, self.input_image, n_iter)
-            
+            numpy.testing.assert_raises(ValueError, thin, self.input_image,
+                                        n_iter)
+
     def test_badtype(self):
         ii = self.input_image
-        ii[2,2] = 5
+        ii[2, 2] = 5
         numpy.testing.assert_raises(ValueError, thin, ii)
-        
+
     def test_baddim(self):
-        for ii in [np.zeros((3)), np.zeros((3,3,3))]:
+        for ii in [np.zeros((3)), np.zeros((3, 3, 3))]:
             numpy.testing.assert_raises(ValueError, thin, ii)
+
+    def test_lut_generation(self):
+        g123, g123p = _generate_thin_luts()
+
+        numpy.testing.assert_array_equal(g123, G123_LUT)
+        numpy.testing.assert_array_equal(g123p, G123P_LUT)
+
 
 class TestMedialAxis():
     def test_00_00_zeros(self):

--- a/skimage/morphology/tests/test_skeletonize.py
+++ b/skimage/morphology/tests/test_skeletonize.py
@@ -1,5 +1,5 @@
 import numpy as np
-from skimage.morphology import skeletonize, medial_axis
+from skimage.morphology import skeletonize, medial_axis, thin
 import numpy.testing
 from skimage import draw
 from scipy.ndimage import correlate
@@ -110,6 +110,62 @@ class TestSkeletonize():
                              [0, 0, 0, 0, 0, 0]], dtype=np.uint8)
         assert np.all(result == expected)
 
+class TestThin():
+    @property
+    def input_image(self):
+        """image to test thinning with"""
+        ii = np.array([[0, 0, 0, 0, 0, 0, 0],
+                       [0, 1, 1, 1, 1, 1, 0],
+                       [0, 1, 0, 1, 1, 1, 0],
+                       [0, 1, 1, 1, 1, 1, 0],
+                       [0, 1, 1, 1, 1, 1, 0],
+                       [0, 1, 1, 1, 1, 1, 0],
+                       [0, 0, 0, 0, 0, 0, 0]], dtype=np.uint8)
+        return ii
+    def test_zeros(self):
+        assert np.all(thin(np.zeros((10,10))) == False)
+    def test_iter_1(self):
+        result = thin(self.input_image,1).astype(np.uint8)
+        expected = np.array([[0, 0, 0, 0, 0, 0, 0],
+                             [0, 0, 1, 0, 0, 0, 0],
+                             [0, 1, 0, 1, 1, 0, 0],
+                             [0, 0, 1, 1, 1, 0, 0],
+                             [0, 0, 1, 1, 1, 0, 0],
+                             [0, 0, 0, 0, 0, 0, 0],
+                             [0, 0, 0, 0, 0, 0, 0]], dtype=np.uint8)
+        assert np.all(result == expected)
+    def test_noiter(self):
+        result = thin(self.input_image).astype(np.uint8)
+        expected = np.array([[0, 0, 0, 0, 0, 0, 0],
+                             [0, 0, 1, 0, 0, 0, 0],
+                             [0, 1, 0, 1, 0, 0, 0],
+                             [0, 0, 1, 0, 0, 0, 0],
+                             [0, 0, 0, 0, 0, 0, 0],
+                             [0, 0, 0, 0, 0, 0, 0],
+                             [0, 0, 0, 0, 0, 0, 0]], dtype=np.uint8)
+        assert np.all(result == expected)
+    def test_baditer(self):
+        for n_iter in [-1, 0]:
+            try:
+                result = thin(self.input_image,n_iter)
+                assert False
+            except ValueError:
+                pass
+    def test_badtype(self):
+        ii = self.input_image
+        ii[2,2] = 5
+        try:
+            result = thin(ii)
+            assert False
+        except ValueError:
+            pass
+    def test_baddim(self):
+        for ii in [np.zeros((3)), np.zeros((3,3,3))]:
+            try:
+                result = thin(ii)
+                assert False
+            except ValueError:
+                pass
 
 class TestMedialAxis():
     def test_00_00_zeros(self):

--- a/skimage/morphology/tests/test_skeletonize.py
+++ b/skimage/morphology/tests/test_skeletonize.py
@@ -122,10 +122,12 @@ class TestThin():
                        [0, 1, 1, 1, 1, 1, 0],
                        [0, 0, 0, 0, 0, 0, 0]], dtype=np.uint8)
         return ii
+    
     def test_zeros(self):
-        assert np.all(thin(np.zeros((10,10))) == False)
+        assert np.all(thin(np.zeros((10, 10))) == False)
+        
     def test_iter_1(self):
-        result = thin(self.input_image,1).astype(np.uint8)
+        result = thin(self.input_image, 1).astype(np.uint8)
         expected = np.array([[0, 0, 0, 0, 0, 0, 0],
                              [0, 0, 1, 0, 0, 0, 0],
                              [0, 1, 0, 1, 1, 0, 0],
@@ -134,6 +136,7 @@ class TestThin():
                              [0, 0, 0, 0, 0, 0, 0],
                              [0, 0, 0, 0, 0, 0, 0]], dtype=np.uint8)
         assert np.all(result == expected)
+        
     def test_noiter(self):
         result = thin(self.input_image).astype(np.uint8)
         expected = np.array([[0, 0, 0, 0, 0, 0, 0],
@@ -144,28 +147,19 @@ class TestThin():
                              [0, 0, 0, 0, 0, 0, 0],
                              [0, 0, 0, 0, 0, 0, 0]], dtype=np.uint8)
         assert np.all(result == expected)
+        
     def test_baditer(self):
         for n_iter in [-1, 0]:
-            try:
-                result = thin(self.input_image,n_iter)
-                assert False
-            except ValueError:
-                pass
+            numpy.testing.assert_raises(ValueError, thin, self.input_image, n_iter)
+            
     def test_badtype(self):
         ii = self.input_image
         ii[2,2] = 5
-        try:
-            result = thin(ii)
-            assert False
-        except ValueError:
-            pass
+        numpy.testing.assert_raises(ValueError, thin, ii)
+        
     def test_baddim(self):
         for ii in [np.zeros((3)), np.zeros((3,3,3))]:
-            try:
-                result = thin(ii)
-                assert False
-            except ValueError:
-                pass
+            numpy.testing.assert_raises(ValueError, thin, ii)
 
 class TestMedialAxis():
     def test_00_00_zeros(self):

--- a/skimage/morphology/tests/test_skeletonize.py
+++ b/skimage/morphology/tests/test_skeletonize.py
@@ -110,6 +110,7 @@ class TestSkeletonize():
                              [0, 0, 0, 0, 0, 0]], dtype=np.uint8)
         assert np.all(result == expected)
 
+        
 class TestThin():
     @property
     def input_image(self):
@@ -135,7 +136,7 @@ class TestThin():
                              [0, 0, 1, 1, 1, 0, 0],
                              [0, 0, 0, 0, 0, 0, 0],
                              [0, 0, 0, 0, 0, 0, 0]], dtype=np.uint8)
-        assert np.all(result == expected)
+        numpy.testing.assert_array_equal(result, expected)
         
     def test_noiter(self):
         result = thin(self.input_image).astype(np.uint8)
@@ -146,7 +147,7 @@ class TestThin():
                              [0, 0, 0, 0, 0, 0, 0],
                              [0, 0, 0, 0, 0, 0, 0],
                              [0, 0, 0, 0, 0, 0, 0]], dtype=np.uint8)
-        assert np.all(result == expected)
+        numpy.testing.assert_array_equal(result, expected)
         
     def test_baditer(self):
         for n_iter in [-1, 0]:

--- a/skimage/morphology/tests/test_skeletonize.py
+++ b/skimage/morphology/tests/test_skeletonize.py
@@ -151,16 +151,6 @@ class TestThin():
                              [0, 0, 0, 0, 0, 0, 0]], dtype=np.uint8)
         numpy.testing.assert_array_equal(result, expected)
 
-    def test_baditer(self):
-        for n_iter in [-1, 0]:
-            numpy.testing.assert_raises(ValueError, thin, self.input_image,
-                                        n_iter)
-
-    def test_badtype(self):
-        ii = self.input_image
-        ii[2, 2] = 5
-        numpy.testing.assert_raises(ValueError, thin, ii)
-
     def test_baddim(self):
         for ii in [np.zeros((3)), np.zeros((3, 3, 3))]:
             numpy.testing.assert_raises(ValueError, thin, ii)


### PR DESCRIPTION
## Description

Add new "thin" method replicating MATLAB's "bwmorph('thin',...)" (Guo and Hall 1989), along with inline docs and tests.

This replaces #1858, which somehow got messed up during a rebase.
