### PR TITLE
Add scattering transform

### DIFF
--- a/doc/examples/features_detection/plot_scattering.py
+++ b/doc/examples/features_detection/plot_scattering.py
@@ -1,0 +1,129 @@
+"""
+===================
+Scattering Features
+===================
+
+This example shows how to use the scattering transform on images. It explains how to access easily different scattering
+coefficients stored in the output vector. For more information on how to use scattering coefficients for image classification,
+please check the example *Scattering features for supervised learning*.
+
+We call the scattering features (or coefficients) the output of the scattering transform applied to an image. These features
+have shown to outperform any other 'non-learned' image representations for image classification tasks [2]_.
+Structurally, they are very similar to deep learning representations, with fixed filters which are Morlet filters, in this
+implementation.
+Since the scattering transform is based on the Discrete Wavelet transform (DWT), it is stable to deformations.
+It is also invariant to small translations. For more details on its mathematical properties, see [1]_.
+
+**Definition of the scattering coefficients**
+
+Given an image :math:`x`, the scattering transform computes (generally) three layers of cascaded convolutions
+and non-linear operators:
+
+-*Zero-order coefficients:*  :math:`Sx[0] = x * \phi`
+
+-*First-order coefficients:*   :math:`Sx[1][(i,l)] = | x * \psi_{(i,l)} | * \phi`
+
+-*Second-order coefficients:*  :math:`Sx[2][(i,l)][(j,l_2)] = || x * \psi_{(i,l)} | * \psi_{(j,l_2)}| * \phi`
+
+where :math:`\psi` is a band-pass filter, :math:`\phi` is a low-pass filter (normally a Gaussian), operator :math:`*` is a
+2D convolution, and :math:`|\cdot|` is the complex modulus. If :math:`x` is of size :math:`(px,px)`, the maximum number of scales
+is :math:`J=\log_2(px)` and :math:`i \in [0,J-1]`. For every scale :math:`i`, we have :math:`L` angles, thus :math:`l \in (0,L)`. For second-order coefficients, we compute coefficients with :math:`j>i`, since other
+coefficients do not have enough energy to be significant.
+
+
+**Implementation: Dictionary access to the scattering coefficients**
+
+Let's see how to access the different layers of the scattering transform. The scattering function outputs a python
+dictionary structure that allows an easy access to the scattering coefficients (first output of the function). The *keys*
+for this dictionary structure are the following:
+
+-*Zero-order coefficients*:  we only have one key for the only coefficient:
+                scat_tree[0]
+
+
+-*First-order coefficients*:   the keys are tuples with the scale :math:`i` and angle :math:`l`:
+                            scat_tree[(i,l)]
+
+-*Second-order coefficients*:  the keys are tuple of two tuples, with the scale :math:`i` and angle :math:`l` of the first layer and then the scale :math:`j` and angle :math:`l_2` of the second layer:
+                            scat_tree[( (i,l)  , (j,l_2) )]
+
+Note that the output of any layer is a matrix of size (Num_images, spatial_dimensions, spatial_dimensions).
+
+.. [1] Bruna, J., Mallat, S. 'Invariant Scattering Convolutional Networks'.IEEE TPAMI, 2012.
+.. [2] Oyallon, E. et Mallat, S. 'Deep Roto-translation Scattering for Object Classification'. CVPR 2015
+
+"""
+
+
+import numpy as np
+import skimage.data as d
+from skimage.transform import resize
+import matplotlib.pylab as plt
+from skimage.filters.filter_bank import multiresolution_filter_bank_morlet2d
+from skimage.feature.scattering import scattering
+
+# Load an image
+px = 32 # size of the image (squared)
+im= resize(d.camera(), (px, px))
+
+plt.figure(figsize=(6,3))
+plt.imshow(abs(im))
+plt.show()
+
+# Compute the scattering
+J=3 #number of scales
+L=8 #number of angles
+m=2 # compute up to the second order scattering coeffs.
+
+#get filters
+wavelet_filters, lw = multiresolution_filter_bank_morlet2d(px, J=J, L=L)
+
+#scattering coefficients (S) and the access tree (scat_tree)
+S,u,scat_tree = scattering(im[np.newaxis,:,:], wavelet_filters, m=m)
+num_images, coef_index, spatial, spatial = S.shape
+
+###############################
+# Zero order scattering coefficients
+zero_order_coef_index = 0
+#We can find the zero-order scattering coefficients in the S vector:
+S_zero_order = S[0, zero_order_coef_index, ]
+
+plt.figure(figsize=(8,4))
+plt.suptitle('Zero order scattering coefficients')
+plt.subplot(1,2,1)
+plt.title('Using the vector structure')
+plt.imshow(S_zero_order)
+# or we can access them using the scat_tree structure, which is a view of the S structure.
+plt.subplot(1,2,2)
+plt.title('Using the dictionary structure')
+plt.imshow(scat_tree[0][0, :, :])
+plt.show()
+
+
+###############################
+# First order scattering coefficients
+
+# we want to access one of the coefficients
+i = 0
+l = 3
+S_first_order = S[0, i*L+l+1, :, :]
+
+plt.figure(figsize=(8, 3))
+plt.suptitle('First order scattering coeff. (i,l)=(' + str(i) + ',' + str(l) + ')')
+plt.subplot(1, 2, 1)
+plt.imshow(S_first_order)
+# using the stree structure
+plt.subplot(1, 2, 2)
+plt.imshow(scat_tree[(i,l)][0, :, :])
+plt.show()
+
+#########################
+# Second order coefficients:
+# :math:`||x * \psi_{(i,l)}| * \psi_{(j,l_2)}| * \phi`
+# The complete number of coefficients second order coefficients is: :math:`\frac{J (J-1) L^2}{2}`
+# We will just access the coefficient using the scat tree structure:
+j = 1
+l_2 = 5
+plt.figure(figsize=(8,4))
+plt.suptitle('Second order scattering coefficients: (i,l)=(' + str(i) + ',' + str(l) + '),(j,l_2)=(' + str(i) + ',' + str(l) + ')')
+plt.imshow(scat_tree[((i, l), (j, l_2))][0, :, :])

--- a/doc/examples/features_detection/plot_scattering.py
+++ b/doc/examples/features_detection/plot_scattering.py
@@ -33,11 +33,11 @@ and non-linear operators:
 -*First-order coefficients:*
 :math:`Sx[1][(i,l)] = | x * \psi_{(i,l)} | * \phi`
 
--*Second-order coefficients:* :math:`Sx[2][(i,l)][(j,l_2)]=|| x * \psi_{(i,l)}|*\psi_{(j,l_2)}|*\phi`,
+-*Second-order coefficients:*
+:math:`Sx[2][(i,l)][(j,l_2)]=|| x * \psi_{(i,l)}|*\psi_{(j,l_2)}|*\phi`,
  where :math:`\psi` is a band-pass filter, :math:`\phi` is a low-pass filter
  (normally a Gaussian), operator :math:`*` is a 2D convolution,
- and :math:`|\cdot|` is
- the complex modulus. If :math:`x` is of size
+ and :math:`|\cdot|` is the complex modulus. If :math:`x` is of size
  :math:`(px,px)`, the maximum number of scales
  is :math:`J=\log_2(px)` and :math:`i \in [0,J-1]`. For every scale
  :math:`i`, we have :math:`L` angles, thus
@@ -70,8 +70,8 @@ coefficients (first output of the function). The
 Note that the output of any layer is a matrix of size
 (Num_images, spatial_dimensions, spatial_dimensions).
 
-.. [1] Bruna, J., Mallat, S. 'Invariant Scattering Convolutional Networks'. IEEE
- TPAMI, 2012.
+.. [1] Bruna, J., Mallat, S. 'Invariant Scattering Convolutional Networks'.
+ IEEE TPAMI, 2012.
 
 .. [2] Oyallon, E. et Mallat, S. 'Deep Roto-translation Scattering
  for Object Classification'. CVPR 2015

--- a/doc/examples/features_detection/plot_scattering.py
+++ b/doc/examples/features_detection/plot_scattering.py
@@ -3,127 +3,141 @@
 Scattering Features
 ===================
 
-This example shows how to use the scattering transform on images. It explains how to access easily different scattering
-coefficients stored in the output vector. For more information on how to use scattering coefficients for image classification,
-please check the example *Scattering features for supervised learning*.
-
-We call the scattering features (or coefficients) the output of the scattering transform applied to an image. These features
-have been shown to outperform any other 'non-learned' image representations for image classification tasks [2]_.
-Structurally, they are very similar to deep learning representations, with fixed filters (here Morlet filters).
-
-Since the scattering transform is based on the Discrete Wavelet transform (DWT), it is stable to deformations.
-It is also invariant to small translations. For more details on its mathematical properties, see [1]_.
+This example shows how to use the scattering transform on images.
+It explains how to access easily different scattering
+coefficients stored in the output vector. For more information on
+how to use scattering coefficients for image
+classification, please check the example *Scattering features
+for supervised learning*.
+We call the scattering features (or coefficients) the output of the
+scattering transform applied to an image.
+These features have been shown to outperform any other 'non-learned'
+image representations for image
+classification tasks [2]_. Structurally, they are very similar to
+deep learning representations, with fixed filters
+(here Morlet filters).
+Since the scattering transform is based on the
+Discrete Wavelet transform (DWT), it is stable to deformations.
+It is also invariant to small translations. For more details on
+its mathematical properties, see [1]_.
 
 **Definition of the scattering coefficients**
 
-Given an image :math:`x`, the scattering transform computes (generally) three layers of cascaded convolutions
+Given an image :math:`x`, the scattering transform computes
+(generally) three layers of cascaded convolutions
 and non-linear operators:
 
--*Zero-order coefficients:*  :math:`Sx[0] = x * \phi`
+-*Zero-order coefficients:*
+:math:`Sx[0] = x * \phi`
 
--*First-order coefficients:*   :math:`Sx[1][(i,l)] = | x * \psi_{(i,l)} | * \phi`
+-*First-order coefficients:*
+:math:`Sx[1][(i,l)] = | x * \psi_{(i,l)} | * \phi`
 
--*Second-order coefficients:*  :math:`Sx[2][(i,l)][(j,l_2)] = || x * \psi_{(i,l)} | * \psi_{(j,l_2)}| * \phi`
+-*Second-order coefficients:* :math:`Sx[2][(i,l)][(j,l_2)]=|| x * \psi_{(i,l)}|*\psi_{(j,l_2)}|*\phi`,
+ where :math:`\psi` is a band-pass filter, :math:`\phi` is a low-pass filter
+ (normally a Gaussian), operator :math:`*` is a 2D convolution,
+ and :math:`|\cdot|` is
+ the complex modulus. If :math:`x` is of size
+ :math:`(px,px)`, the maximum number of scales
+ is :math:`J=\log_2(px)` and :math:`i \in [0,J-1]`. For every scale
+ :math:`i`, we have :math:`L` angles, thus
+ :math:`l \in (0,L)`. For second-order coefficients, we compute coefficients
+ with :math:`j>i`, since other
+ coefficients do not have enough energy to be significant.
 
-where :math:`\psi` is a band-pass filter, :math:`\phi` is a low-pass filter (normally a Gaussian), operator :math:`*` is a
-2D convolution, and :math:`|\cdot|` is the complex modulus. If :math:`x` is of size :math:`(px,px)`, the maximum number of scales
-is :math:`J=\log_2(px)` and :math:`i \in [0,J-1]`. For every scale :math:`i`, we have :math:`L` angles, thus :math:`l \in (0,L)`. For second-order coefficients, we compute coefficients with :math:`j>i`, since other
-coefficients do not have enough energy to be significant.
-
+Note that we have one zero-order, :math:`JL` first order,
+and :math:`J L^2 (J-1) /2` second order coefficients.
 
 **Implementation: Dictionary access to the scattering coefficients**
 
-Let's see how to access the different layers of the scattering transform. The scattering function outputs a python
-dictionary structure that allows an easy access to the scattering coefficients (first output of the function). The *keys*
-for this dictionary structure are the following:
+Let's see how to access the different layers of the scattering transform.
+The scattering function outputs a python
+dictionary structure that allows an easy access to the scattering
+coefficients (first output of the function). The
+*keys* for this dictionary structure are the following:
 
--*Zero-order coefficients*:  we only have one key for the only coefficient:
-                scat_tree[0]
+-Zero-order coefficients: scat_tree[0]
+ we only have one key for the only coefficient.
 
+-First-order coefficients: scat_tree[(i,l)]
+ the keys are tuples with the scale :math:`i` and angle :math:`l`.
 
--*First-order coefficients*:   the keys are tuples with the scale :math:`i` and angle :math:`l`:
-                            scat_tree[(i,l)]
+-Second-order coefficients: scat_tree[( (i,l)  , (j,l_2) )]
+ the key is a tuple of two tuples, with the
+ scale :math:`i` and angle :math:`l` of the first order and
+ scale :math:`j` and angle :math:`l_2` of the second order.
 
--*Second-order coefficients*:  the keys are tuple of two tuples, with the scale :math:`i` and angle :math:`l` of the first layer and then the scale :math:`j` and angle :math:`l_2` of the second layer:
-                            scat_tree[( (i,l)  , (j,l_2) )]
+Note that the output of any layer is a matrix of size
+(Num_images, spatial_dimensions, spatial_dimensions).
 
-Note that the output of any layer is a matrix of size (Num_images, spatial_dimensions, spatial_dimensions).
+.. [1] Bruna, J., Mallat, S. 'Invariant Scattering Convolutional Networks'. IEEE
+ TPAMI, 2012.
 
-.. [1] Bruna, J., Mallat, S. 'Invariant Scattering Convolutional Networks'.IEEE TPAMI, 2012.
-.. [2] Oyallon, E. et Mallat, S. 'Deep Roto-translation Scattering for Object Classification'. CVPR 2015
-
+.. [2] Oyallon, E. et Mallat, S. 'Deep Roto-translation Scattering
+ for Object Classification'. CVPR 2015
 """
-
-
 import numpy as np
 import skimage.data as d
 from skimage.transform import resize
 import matplotlib.pylab as plt
 from skimage.filters.filter_bank import multiresolution_filter_bank_morlet2d
 from skimage.feature.scattering import scattering
-
 # Load an image
-px = 32 # size of the image (squared)
-im= resize(d.camera(), (px, px))
-
-plt.figure(figsize=(6,3))
+px = 32  # size of the image (squared)
+im = resize(d.camera(), (px, px))
+plt.figure(figsize=(6, 3))
 plt.imshow(abs(im))
 plt.show()
-
 # Compute the scattering
-J=3 #number of scales
-L=8 #number of angles
-m=2 # compute up to the second order scattering coeffs.
-
-#get filters
+J = 3  # number of scales
+L = 8  # number of angles
+m = 2  # compute up to the second order scattering coeffs.
+# get filters
 wavelet_filters, lw = multiresolution_filter_bank_morlet2d(px, J=J, L=L)
-
-#scattering coefficients (S) and the access tree (scat_tree)
-S,u,scat_tree = scattering(im[np.newaxis,:,:], wavelet_filters, m=m)
+# scattering coefficients (S) and the access tree (scat_tree)
+S, u, scat_tree = scattering(im[np.newaxis, :, :], wavelet_filters, m=m)
 num_images, coef_index, spatial, spatial = S.shape
-
 ###############################
 # Zero order scattering coefficients
 zero_order_coef_index = 0
-#We can find the zero-order scattering coefficients in the S vector:
+# We can find the zero-order scattering coefficients in the S vector:
 S_zero_order = S[0, zero_order_coef_index, ]
-
-plt.figure(figsize=(8,4))
+plt.figure(figsize=(8, 4))
 plt.suptitle('Zero order scattering coefficients')
-plt.subplot(1,2,1)
+plt.subplot(1, 2, 1)
 plt.title('Using the vector structure')
 plt.imshow(S_zero_order)
-# or we can access them using the scat_tree structure, which is a view of the S structure.
-plt.subplot(1,2,2)
+# or we can access them using the scat_tree structure,
+#  which is a view of the S structure.
+plt.subplot(1, 2, 2)
 plt.title('Using the dictionary structure')
 plt.imshow(scat_tree[0][0, :, :])
 plt.show()
-
-
 ###############################
 # First order scattering coefficients
-
 # we want to access one of the coefficients
 i = 0
 l = 3
 S_first_order = S[0, i*L+l+1, :, :]
-
 plt.figure(figsize=(8, 3))
-plt.suptitle('First order scattering coeff. (i,l)=(' + str(i) + ',' + str(l) + ')')
+plt.suptitle('First order scattering coeff. (i,l)=(' +
+             str(i) + ',' + str(l) + ')')
 plt.subplot(1, 2, 1)
 plt.imshow(S_first_order)
 # using the stree structure
 plt.subplot(1, 2, 2)
-plt.imshow(scat_tree[(i,l)][0, :, :])
+plt.imshow(scat_tree[(i, l)][0, :, :])
 plt.show()
-
 #########################
 # Second order coefficients:
 # :math:`||x * \psi_{(i,l)}| * \psi_{(j,l_2)}| * \phi`
-# The complete number of coefficients second order coefficients is: :math:`\frac{J (J-1) L^2}{2}`
+# The complete number of coefficients second order
+# coefficients is: :math:`\frac{J (J-1) L^2}{2}`
 # We will just access the coefficient using the scat tree structure:
 j = 1
 l_2 = 5
-plt.figure(figsize=(8,4))
-plt.suptitle('Second order scattering coefficients: (i,l)=(' + str(i) + ',' + str(l) + '),(j,l_2)=(' + str(i) + ',' + str(l) + ')')
+plt.figure(figsize=(8, 4))
+plt.suptitle('Second order scattering coefficients: (i,l)=(' +
+             str(i) + ',' + str(l) + '),(j,l_2)=(' +
+             str(i) + ',' + str(l) + ')')
 plt.imshow(scat_tree[((i, l), (j, l_2))][0, :, :])

--- a/doc/examples/features_detection/plot_scattering.py
+++ b/doc/examples/features_detection/plot_scattering.py
@@ -8,9 +8,9 @@ coefficients stored in the output vector. For more information on how to use sca
 please check the example *Scattering features for supervised learning*.
 
 We call the scattering features (or coefficients) the output of the scattering transform applied to an image. These features
-have shown to outperform any other 'non-learned' image representations for image classification tasks [2]_.
-Structurally, they are very similar to deep learning representations, with fixed filters which are Morlet filters, in this
-implementation.
+have been shown to outperform any other 'non-learned' image representations for image classification tasks [2]_.
+Structurally, they are very similar to deep learning representations, with fixed filters (here Morlet filters).
+
 Since the scattering transform is based on the Discrete Wavelet transform (DWT), it is stable to deformations.
 It is also invariant to small translations. For more details on its mathematical properties, see [1]_.
 

--- a/doc/examples/features_detection/plot_scattering_classification.py
+++ b/doc/examples/features_detection/plot_scattering_classification.py
@@ -1,0 +1,237 @@
+"""
+===========================================
+Scattering features for supervised learning
+===========================================
+
+This example shows how to use the scattering features for image classification. More specifically, we compute
+the scattering vectors from the MNIST and CIFAR10 databases and show how to successfully
+classify their images using Support Vector Machine (SVM) with Gaussian kernels. These two
+databases are widely used in research to compare the quality of image representations and
+classification methods. We provide the parameters obtained by crossvalidation to reproduce the results obtained
+in [1]_ and [2]_.
+
+Scattering features have shown to outperform any other 'non-learned' image representations for image classification
+tasks [2]_.
+Structurally, they are very similar to deep learning representations, with fixed filters, Morlet filters in this implementation.
+Since the scattering transform is based on the Discrete Wavelet transform (DWT), it is stable to deformations.
+It is also invariant to small translations. For more details on its mathematical properties and exact definition,
+see the example *Scattering Features* or check [1]_ and [2]_.
+
+**Supervised Learning: Image Classification**
+
+The first task in supervised image classification is to collect a set of images tagged with a class. In case of the MNIST
+database we have pictures of digits, and the class is the corresponding number. Then, for every image
+we compute a feature vector which, in our case, is the scattering vector. Once we have the complete
+database, we 'train' a classifier, meaning, we find the best parameters that allow to correctly classify the images.
+
+A widely used classifier is Support Vector Machine (SVM), which searches the high dimensional plane
+that allows to better separate each pair of classes, see [3]_ for more information.
+Here, we show how to reproduce the results obtained with the scattering transform, using SVM (with Gaussian kernels)
+first presented in the following papers:
+
+- **MNIST database** : The results were first presented in [1]_ Table 4. Using this implementation and a 10000 image test set, we were able to obtain, the following error results :
+
+            +-------------------------+---------+
+            |num images training set  | % error |
+            +-------------------------+---------+
+            |                    300  |  5.92   |
+            +-------------------------+---------+
+            |                  1000   |  2.7    |
+            +-------------------------+---------+
+            |                  2000   |  2      |
+            +-------------------------+---------+
+            |                  5000   |  1.32   |
+            +-------------------------+---------+
+            |                 10000   |  0.96   |
+            +-------------------------+---------+
+            |                 20000   |  0.82   |
+            +-------------------------+---------+
+            |                 40000   |  0.56   |
+            +-------------------------+---------+
+            |                 60000   |  0.51   |
+            +-------------------------+---------+
+
+- **CIFAR10 database**: This is a very challenging database with 10 classes and 32x32 color images. The code presented here can reproduce the results obtained in Table 1 (Trans., order 1) of [2]_, more specifically it can obtain 73.6% success for m=1 and 40000 images in the training set.
+
+**Warning: For integration reasons, the code uses very few images in the datasets. To obtain full performance, you need
+to change the variable num_images to 10000 at least**
+
+.. [1] Bruna, J., Mallat, S. 'Invariant Scattering Convolutional Networks'.IEEE TPAMI, 2012.
+.. [2] Oyallon, E. et Mallat, S. 'Deep Roto-translation Scattering for Object Classification'. CVPR 2015
+.. [3] https://en.wikipedia.org/wiki/Support_vector_machine
+"""
+
+
+#######################
+# MNIST Classification
+
+#Modules, MNIST database and functions for scattering feature generation
+import time as time
+from keras.datasets import mnist
+import numpy as np
+from skimage.filters.filter_bank import multiresolution_filter_bank_morlet2d
+from skimage.feature.scattering import scattering
+from sklearn.svm import SVC
+from sklearn.pipeline import make_pipeline
+from sklearn.metrics import accuracy_score
+from sklearn.preprocessing import MinMaxScaler, Normalizer,StandardScaler
+
+def load_images_mnist(px=32, num_images=500000):
+    (X_train_sm, y_train), (X_test_sm, y_test) = mnist.load_data()
+    X_train_sm = X_train_sm[0:num_images, :, :]
+    y_train = y_train[0:num_images]
+    X_test_sm = X_test_sm[0:num_images, :, :]
+    y_test = y_train[0:num_images]
+
+    num_images_ta = X_train_sm.shape[0]
+    num_images_te = X_test_sm.shape[0]
+    #set size to a power of 2 (32) with a zero pad border
+    X_train = np.zeros((num_images_ta, px, px))
+    X_train[:, 3:31, 3:31] = X_train_sm
+
+    X_test = np.zeros((num_images_te, px, px))
+    X_test[:, 3:31, 3:31] = X_test_sm
+
+    X_train = X_train.astype('float32')
+    X_test = X_test.astype('float32')
+
+    return X_train, y_train, X_test, y_test
+
+def load_scattering(X_train, X_test, px=32, J=3, L=8, m=2,sigma_phi=0.6957, sigma_xi=0.8506):
+    i = -1
+    #Create filters
+    Filters,lw = multiresolution_filter_bank_morlet2d(px, J=J, L=L, sigma_phi=sigma_phi, sigma_xi=sigma_xi)
+
+    ### Generate Training set
+    scatterings_train, u, scat_tree = scattering(X_train, Filters, m=m)
+
+    ### Generate Testing set
+    t_scats = time.time()
+    scatterings_test, u, scat_tree = scattering(X_test, Filters, m=m)
+    time_per_image = (time.time() - t_scats) / scatterings_test.shape[0]
+    print('Scattering coefficients computed as ', str(time_per_image), ' secs. per image')
+
+    return scatterings_train, scatterings_test
+
+def gethomogeneus_datast(X, y, d, n):
+    num_per_class = np.int(np.amin([n, X.shape[0]]) / d)
+    ytrain = np.reshape(y, (y.shape[0],))
+
+    X_out = []
+    y_out = []
+    for i_d in np.arange(d):
+        indx = np.where(ytrain.ravel() == i_d)
+
+        X_out.append(X[indx[0][0:num_per_class], :])
+        y_out.append(ytrain[indx[0][0:num_per_class], ])
+
+    X_out = np.concatenate(X_out, axis=0)
+    y_out = np.concatenate(y_out, axis=0)
+    return X_out, y_out
+
+
+#######################
+# Classification of MNIST Database following the results presented in Bruna et al. paper.
+
+
+# Get dataset
+num_classes = 10
+px=32  # number of pixels
+num_images = 50  # for full data set set to 50000
+n = np.amin([10000, num_images])
+
+im_train, ytrain, im_test, ytest = load_images_mnist(px=px, num_images=num_images)
+Xtrain, Xtest = load_scattering(im_train, im_test, px=px, J=3, L=6, m=2, sigma_phi=0.6957, sigma_xi=0.8506)
+
+Xtrain_1d = Xtrain.reshape((len(Xtrain), -1)) #colapse spatial components
+Xtest_1d = Xtest.reshape((len(Xtest), -1))
+
+
+# Classification using SVM with RBF Gaussian kernels
+bestC = 4.3 # parameters obtained by crossvalidation with 10000 images
+bestgamma = 10**0.1
+
+ns = [300, 1000, 2000, 5000, 10000, 20000, 40000, 60000]
+score_gaussian = np.zeros((len(ns), 1))
+
+for i,n in enumerate(ns):
+    # resample the dataset to have a uniform distribution on the classes
+    Xa, ya = gethomogeneus_datast(Xtrain_1d, ytrain, num_classes, n)
+    #define pipeline for SVM classif.
+    gs_gaussian = SVC(kernel='rbf', C=bestC, gamma=bestgamma)
+    pip_gaussian = make_pipeline(MinMaxScaler((-1, 1)), Normalizer(), gs_gaussian)
+    pip_gaussian.fit(Xa, ya)
+    out = pip_gaussian.predict(Xtest_1d)
+    score_gaussian[i] = 1.0-accuracy_score(ytest, out)
+    #print('num training images:' + str(n) + ' err:' + str(score_gaussian[i]*100) + '%')
+print('Warning: For exact error performance, we need at least num_images=10000.')
+
+
+############################
+#  CIFAR10 classification
+
+################
+# Load CIFAR10
+from skimage.color.colorconv import rgb2yuv
+from keras.datasets import cifar10
+
+def DB_rgb2yuv(X):
+    num_samples, c, px, px = X.shape
+    Xta = X.transpose((3, 2, 0, 1)).astype('float32')/255
+    Iyuv = rgb2yuv(Xta).transpose((2, 3, 1, 0)).copy()
+
+    # stack the color channels as 3 images
+    Iyuv.shape = (num_samples*3, px, px)
+    return Iyuv
+
+def load_images_cifar(num_images):
+    # the data, shuffled and split between train and test sets
+    (X_train_sm, y_train), (X_test_sm, y_test) = cifar10.load_data()
+
+    # need to change to YUV
+    X_train = DB_rgb2yuv(X_train_sm[0:num_images, :, :, :])
+    X_test = DB_rgb2yuv(X_test_sm[0:num_images, :, :, :])
+
+    return X_train, y_train[0:num_images], X_test,  y_test[0:num_images]
+
+
+
+
+
+############################
+# Load data, training and testing
+num_images = 50 # For accurate error result we need to train with 10000 images (not 10!)
+im_train, ytrain, im_test, ytest = load_images_cifar(num_images)
+#We are computing just the first order scattering transform
+Xtrain, Xtest = load_scattering(im_train, im_test, px=px, J=3, L=8, m=1, sigma_phi=0.8, sigma_xi=0.8)
+# note that it works better in the log domain!
+epsilon = 1e-6
+Xtrain = np.log(np.abs(Xtrain)+epsilon)
+Xtest = np.log(np.abs(Xtest)+epsilon)
+
+# putting color channels together
+num_files, scat_coefs, spatial, spatial = Xtrain.shape
+Xtrain.shape = (num_files / 3, 3 * scat_coefs, spatial, spatial)
+Xtrain_1d = Xtrain.reshape((len(Xtrain), -1))
+#Testing
+num_files, scat_coefs, spatial, spatial = Xtest.shape
+Xtest.shape = (num_files/3, 3*scat_coefs, spatial, spatial)
+Xtest_1d = Xtest.reshape((len(Xtest), -1))
+
+# Train model for CIFAR10
+num_classes = 10
+n = 10000  # number of samples for training
+Xa, ya = gethomogeneus_datast(Xtrain_1d, ytrain, num_classes, n)
+
+#parameters obtain with cross-validation
+bestC = 4.4
+bestgamma = 10**-3.55
+#Define SVM pipeline
+gs_gaussian = SVC(kernel='rbf',C=bestC,gamma=bestgamma)
+pip_gaussian = make_pipeline(MinMaxScaler((-1,1)), StandardScaler(), gs_gaussian)
+
+pip_gaussian.fit(Xa, ya)
+out = pip_gaussian.predict(Xtest_1d)
+accuracy = accuracy_score(ytest, out)
+#print('Training set: ' + str(num_images) + ' % correctly classified:', str(accuracy*100)+'%')
+#print('should be should be 73.6% success for m=1 and 40000 images')

--- a/doc/examples/features_detection/plot_scattering_classification.py
+++ b/doc/examples/features_detection/plot_scattering_classification.py
@@ -44,8 +44,8 @@ first presented in the following papers:
 
 - **MNIST database** :
  The results were first presented in [1]_ Table 4. Using this
- implementation and a 10000 image test set, we were able to obtain, the following
- error results :
+ implementation and a 10000 image test set, we were able to obtain, 
+ the following error results :
             +-------------------------+---------+
             |num images training set  | % error |
             +-------------------------+---------+
@@ -117,9 +117,10 @@ def load_images_mnist(px=32, num_images=500000):
     return X_train, y_train, X_test, y_test
 
 
-def load_scattering(X_train, X_test, px=32, J=3, L=8, m=2,
+def load_scattering(X_train, X_test, J=3, L=8, m=2,
                     sigma_phi=0.6957, sigma_xi=0.8506):
     # Create filters
+    px = X_train.shape[-1] # squared images
     Filters, lw = multiresolution_filter_bank_morlet2d(px, J=J, L=L,
                                                        sigma_phi=sigma_phi,
                                                        sigma_xi=sigma_xi)
@@ -172,7 +173,7 @@ Xtest_1d = Xtest.reshape((len(Xtest), -1))
 bestC = 4.3   # parameters obtained by crossvalidation with 10000 images
 bestgamma = 10**0.1
 ns = [300, 1000, 2000, 5000, 10000, 20000, 40000, 60000]
-score_gaussian = np.zeros((len(ns), 1))
+score_gaussian = np.zeros(len(ns))
 for i, n in enumerate(ns):
     # resample the dataset to have a uniform distribution on the classes
     Xa, ya = gethomogeneus_datast(Xtrain_1d, ytrain, num_classes, n)
@@ -199,6 +200,20 @@ from keras.datasets import cifar10
 
 
 def DB_rgb2yuv(X):
+ """Change the database of images in RGB space into YUV, 
+ maintaining the input format (num_images,color,pixels,pixels)
+    Parameters
+    ----------
+    X: 4D nd array 
+       Group of color images in the range [0,255] stacked in a 
+       4D matrix.
+    Returns
+    -------
+    Iyuv: 4D nd array
+       Group of images in the YUV color space, with shape
+       (num_images,color,pixels,pixels).
+ """
+ 
     num_samples, c, px, px = X.shape
     Xta = X.transpose((3, 2, 0, 1)).astype('float32')/255
     Iyuv = rgb2yuv(Xta).transpose((2, 3, 1, 0)).copy()

--- a/doc/examples/features_detection/plot_scattering_classification.py
+++ b/doc/examples/features_detection/plot_scattering_classification.py
@@ -99,7 +99,7 @@ from sklearn.metrics import accuracy_score
 from sklearn.preprocessing import MinMaxScaler, Normalizer, StandardScaler
 
 
-def load_images_mnist(px=32, num_images=500000):
+def load_images_mnist(px=32, num_images=60000):
     (X_train_sm, y_train), (X_test_sm, y_test) = mnist.load_data()
     X_train_sm = X_train_sm[0:num_images, :, :]
     y_train = y_train[0:num_images]

--- a/doc/examples/features_detection/plot_scattering_classification.py
+++ b/doc/examples/features_detection/plot_scattering_classification.py
@@ -3,34 +3,49 @@
 Scattering features for supervised learning
 ===========================================
 
-This example shows how to use the scattering features for image classification. More specifically, we compute
-the scattering vectors from the MNIST and CIFAR10 databases and show how to successfully
-classify their images using Support Vector Machine (SVM) with Gaussian kernels. These two
-databases are widely used in research to compare the quality of image representations and
-classification methods. We provide the parameters obtained by crossvalidation to reproduce the results obtained
+This example shows how to use the scattering features
+for image classification. More specifically, we compute
+the scattering vectors from the MNIST and CIFAR10 databases
+and show how to successfully
+classify their images using Support Vector Machine (SVM)
+with Gaussian kernels. These two
+databases are widely used in research to compare the quality
+of image representations and
+classification methods. We provide the parameters obtained by
+crossvalidation to reproduce the results obtained
 in [1]_ and [2]_.
-
-Scattering features have shown to outperform any other 'non-learned' image representations for image classification
+Scattering features have shown to outperform any other 'non-learned'
+image representations for image classification
 tasks [2]_.
-Structurally, they are very similar to deep learning representations, with fixed filters, Morlet filters in this implementation.
-Since the scattering transform is based on the Discrete Wavelet transform (DWT), it is stable to deformations.
-It is also invariant to small translations. For more details on its mathematical properties and exact definition,
+Structurally, they are very similar to deep learning representations,
+with fixed filters, Morlet filters in this implementation.
+Since the scattering transform is based on the
+Discrete Wavelet transform (DWT), it is stable to deformations.
+It is also invariant to small translations. For more details on
+its mathematical properties and exact definition,
 see the example *Scattering Features* or check [1]_ and [2]_.
 
-**Supervised Learning: Image Classification**
-
-The first task in supervised image classification is to collect a set of images tagged with a class. In case of the MNIST
-database we have pictures of digits, and the class is the corresponding number. Then, for every image
-we compute a feature vector which, in our case, is the scattering vector. Once we have the complete
-database, we 'train' a classifier, meaning, we find the best parameters that allow to correctly classify the images.
-
-A widely used classifier is Support Vector Machine (SVM), which searches the high dimensional plane
-that allows to better separate each pair of classes, see [3]_ for more information.
-Here, we show how to reproduce the results obtained with the scattering transform, using SVM (with Gaussian kernels)
+ **Supervised Learning: Image Classification**
+The first task in supervised image classification is to collect a
+set of images tagged with a class. In case of the MNIST
+database we have pictures of digits, and the class is the
+corresponding number. Then, for every image
+we compute a feature vector which, in our case, is the
+scattering vector. Once we have the complete
+database, we 'train' a classifier, meaning, we find the
+best parameters that allow to correctly classify the images.
+A widely used classifier is Support Vector Machine (SVM),
+which searches the high dimensional plane
+that allows to better separate each pair of classes,
+see [3]_ for more information.
+Here, we show how to reproduce the results obtained
+with the scattering transform, using SVM (with Gaussian kernels)
 first presented in the following papers:
 
-- **MNIST database** : The results were first presented in [1]_ Table 4. Using this implementation and a 10000 image test set, we were able to obtain, the following error results :
-
+- **MNIST database** :
+ The results were first presented in [1]_ Table 4. Using this
+ implementation and a 10000 image test set, we were able to obtain, the following
+ error results :
             +-------------------------+---------+
             |num images training set  | % error |
             +-------------------------+---------+
@@ -51,21 +66,28 @@ first presented in the following papers:
             |                 60000   |  0.51   |
             +-------------------------+---------+
 
-- **CIFAR10 database**: This is a very challenging database with 10 classes and 32x32 color images. The code presented here can reproduce the results obtained in Table 1 (Trans., order 1) of [2]_, more specifically it can obtain 73.6% success for m=1 and 40000 images in the training set.
+- **CIFAR10 database**:
+ This is a very challenging database with
+ 10 classes and 32x32 color images. The code presented here can
+ reproduce the results obtained in Table 1 (Trans., order 1)
+ of [2]_, more specifically it can obtain 73.6% success for m=1
+ and 40000 images in the training set.
 
-**Warning: For integration reasons, the code uses very few images in the datasets. To obtain full performance, you need
-to change the variable num_images to 10000 at least**
+**Warning**: For integration reasons, the code uses very few images
+in the datasets. To obtain full performance, you need
+to change the variable num_images to 10000 at least.
 
-.. [1] Bruna, J., Mallat, S. 'Invariant Scattering Convolutional Networks'.IEEE TPAMI, 2012.
-.. [2] Oyallon, E. et Mallat, S. 'Deep Roto-translation Scattering for Object Classification'. CVPR 2015
+.. [1] Bruna, J., Mallat, S. 'Invariant Scattering Convolutional Networks'.
+IEEE TPAMI, 2012.
+
+.. [2] Oyallon, E. et Mallat, S. 'Deep Roto-translation Scattering
+ for Object Classification'. CVPR 2015
+
 .. [3] https://en.wikipedia.org/wiki/Support_vector_machine
 """
-
-
 #######################
-# MNIST Classification
-
-#Modules, MNIST database and functions for scattering feature generation
+# MNIST database
+# Modules, MNIST database and functions for scattering feature generation
 import time as time
 from keras.datasets import mnist
 import numpy as np
@@ -74,7 +96,8 @@ from skimage.feature.scattering import scattering
 from sklearn.svm import SVC
 from sklearn.pipeline import make_pipeline
 from sklearn.metrics import accuracy_score
-from sklearn.preprocessing import MinMaxScaler, Normalizer,StandardScaler
+from sklearn.preprocessing import MinMaxScaler, Normalizer, StandardScaler
+
 
 def load_images_mnist(px=32, num_images=500000):
     (X_train_sm, y_train), (X_test_sm, y_test) = mnist.load_data()
@@ -82,156 +105,155 @@ def load_images_mnist(px=32, num_images=500000):
     y_train = y_train[0:num_images]
     X_test_sm = X_test_sm[0:num_images, :, :]
     y_test = y_train[0:num_images]
-
     num_images_ta = X_train_sm.shape[0]
     num_images_te = X_test_sm.shape[0]
-    #set size to a power of 2 (32) with a zero pad border
+    # set size to a power of 2 (32) with a zero pad border
     X_train = np.zeros((num_images_ta, px, px))
     X_train[:, 3:31, 3:31] = X_train_sm
-
     X_test = np.zeros((num_images_te, px, px))
     X_test[:, 3:31, 3:31] = X_test_sm
-
     X_train = X_train.astype('float32')
     X_test = X_test.astype('float32')
-
     return X_train, y_train, X_test, y_test
 
-def load_scattering(X_train, X_test, px=32, J=3, L=8, m=2,sigma_phi=0.6957, sigma_xi=0.8506):
-    i = -1
-    #Create filters
-    Filters,lw = multiresolution_filter_bank_morlet2d(px, J=J, L=L, sigma_phi=sigma_phi, sigma_xi=sigma_xi)
 
-    ### Generate Training set
+def load_scattering(X_train, X_test, px=32, J=3, L=8, m=2,
+                    sigma_phi=0.6957, sigma_xi=0.8506):
+    # Create filters
+    Filters, lw = multiresolution_filter_bank_morlet2d(px, J=J, L=L,
+                                                       sigma_phi=sigma_phi,
+                                                       sigma_xi=sigma_xi)
+    # Generate Training set
     scatterings_train, u, scat_tree = scattering(X_train, Filters, m=m)
-
-    ### Generate Testing set
+    # Generate Testing set
     t_scats = time.time()
     scatterings_test, u, scat_tree = scattering(X_test, Filters, m=m)
     time_per_image = (time.time() - t_scats) / scatterings_test.shape[0]
-    print('Scattering coefficients computed as ', str(time_per_image), ' secs. per image')
-
+    print('Scattering coefficients computed as ',
+          str(time_per_image), ' secs. per image')
     return scatterings_train, scatterings_test
+
 
 def gethomogeneus_datast(X, y, d, n):
     num_per_class = np.int(np.amin([n, X.shape[0]]) / d)
     ytrain = np.reshape(y, (y.shape[0],))
-
     X_out = []
     y_out = []
     for i_d in np.arange(d):
         indx = np.where(ytrain.ravel() == i_d)
-
         X_out.append(X[indx[0][0:num_per_class], :])
         y_out.append(ytrain[indx[0][0:num_per_class], ])
-
     X_out = np.concatenate(X_out, axis=0)
     y_out = np.concatenate(y_out, axis=0)
     return X_out, y_out
 
 
-#######################
-# Classification of MNIST Database following the results presented in Bruna et al. paper.
+##########################
+#  Classification of MNIST
+# ########################
+# Database following the results
+# presented in Bruna et al. paper.
 
 
 # Get dataset
 num_classes = 10
-px=32  # number of pixels
+px = 32  # number of pixels
 num_images = 50  # for full data set set to 50000
 n = np.amin([10000, num_images])
 
-im_train, ytrain, im_test, ytest = load_images_mnist(px=px, num_images=num_images)
-Xtrain, Xtest = load_scattering(im_train, im_test, px=px, J=3, L=6, m=2, sigma_phi=0.6957, sigma_xi=0.8506)
-
-Xtrain_1d = Xtrain.reshape((len(Xtrain), -1)) #colapse spatial components
+im_train, ytrain, im_test, ytest = load_images_mnist(px=px,
+                                                     num_images=num_images)
+Xtrain, Xtest = load_scattering(im_train, im_test, px=px,
+                                J=3, L=6, m=2,
+                                sigma_phi=0.6957, sigma_xi=0.8506)
+Xtrain_1d = Xtrain.reshape((len(Xtrain), -1))  # colapse spatial components
 Xtest_1d = Xtest.reshape((len(Xtest), -1))
-
-
 # Classification using SVM with RBF Gaussian kernels
-bestC = 4.3 # parameters obtained by crossvalidation with 10000 images
+bestC = 4.3   # parameters obtained by crossvalidation with 10000 images
 bestgamma = 10**0.1
-
 ns = [300, 1000, 2000, 5000, 10000, 20000, 40000, 60000]
 score_gaussian = np.zeros((len(ns), 1))
-
-for i,n in enumerate(ns):
+for i, n in enumerate(ns):
     # resample the dataset to have a uniform distribution on the classes
     Xa, ya = gethomogeneus_datast(Xtrain_1d, ytrain, num_classes, n)
-    #define pipeline for SVM classif.
+    # define pipeline for SVM classif.
     gs_gaussian = SVC(kernel='rbf', C=bestC, gamma=bestgamma)
-    pip_gaussian = make_pipeline(MinMaxScaler((-1, 1)), Normalizer(), gs_gaussian)
+    pip_gaussian = make_pipeline(MinMaxScaler((-1, 1)),
+                                 Normalizer(), gs_gaussian)
     pip_gaussian.fit(Xa, ya)
     out = pip_gaussian.predict(Xtest_1d)
     score_gaussian[i] = 1.0-accuracy_score(ytest, out)
-    #print('num training images:' + str(n) + ' err:' + str(score_gaussian[i]*100) + '%')
-print('Warning: For exact error performance, we need at least num_images=10000.')
+    # print('num training images:' + str(n) +
+    #          ' err:' + str(score_gaussian[i]*100) + '%')
+print('Warning: For exact error performance, we '
+      'need at least num_images=10000.')
+#########################
+#  Classification CIFAR10
+#########################
+# Database following the results
+# presented in Oyallon et al. paper.
 
-
-############################
-#  CIFAR10 classification
-
-################
 # Load CIFAR10
 from skimage.color.colorconv import rgb2yuv
 from keras.datasets import cifar10
+
 
 def DB_rgb2yuv(X):
     num_samples, c, px, px = X.shape
     Xta = X.transpose((3, 2, 0, 1)).astype('float32')/255
     Iyuv = rgb2yuv(Xta).transpose((2, 3, 1, 0)).copy()
-
     # stack the color channels as 3 images
     Iyuv.shape = (num_samples*3, px, px)
     return Iyuv
 
+
 def load_images_cifar(num_images):
     # the data, shuffled and split between train and test sets
-    (X_train_sm, y_train), (X_test_sm, y_test) = cifar10.load_data()
-
+    (X_train_sm, y_train), (X_test_sm, y_test) = \
+        cifar10.load_data()
     # need to change to YUV
     X_train = DB_rgb2yuv(X_train_sm[0:num_images, :, :, :])
     X_test = DB_rgb2yuv(X_test_sm[0:num_images, :, :, :])
-
     return X_train, y_train[0:num_images], X_test,  y_test[0:num_images]
-
-
-
 
 
 ############################
 # Load data, training and testing
-num_images = 50 # For accurate error result we need to train with 10000 images (not 10!)
+
+
+num_images = 50  # For accurate error result we need to
+#                 train with 10000 images (not 10!)
 im_train, ytrain, im_test, ytest = load_images_cifar(num_images)
-#We are computing just the first order scattering transform
-Xtrain, Xtest = load_scattering(im_train, im_test, px=px, J=3, L=8, m=1, sigma_phi=0.8, sigma_xi=0.8)
+# We are computing just the first order scattering transform
+Xtrain, Xtest = load_scattering(im_train, im_test, px=px,
+                                J=3, L=8, m=1,
+                                sigma_phi=0.8, sigma_xi=0.8)
 # note that it works better in the log domain!
 epsilon = 1e-6
 Xtrain = np.log(np.abs(Xtrain)+epsilon)
 Xtest = np.log(np.abs(Xtest)+epsilon)
-
 # putting color channels together
 num_files, scat_coefs, spatial, spatial = Xtrain.shape
 Xtrain.shape = (num_files / 3, 3 * scat_coefs, spatial, spatial)
 Xtrain_1d = Xtrain.reshape((len(Xtrain), -1))
-#Testing
+# Testing
 num_files, scat_coefs, spatial, spatial = Xtest.shape
 Xtest.shape = (num_files/3, 3*scat_coefs, spatial, spatial)
 Xtest_1d = Xtest.reshape((len(Xtest), -1))
-
 # Train model for CIFAR10
 num_classes = 10
 n = 10000  # number of samples for training
 Xa, ya = gethomogeneus_datast(Xtrain_1d, ytrain, num_classes, n)
-
-#parameters obtain with cross-validation
+# parameters obtain with cross-validation
 bestC = 4.4
 bestgamma = 10**-3.55
-#Define SVM pipeline
-gs_gaussian = SVC(kernel='rbf',C=bestC,gamma=bestgamma)
-pip_gaussian = make_pipeline(MinMaxScaler((-1,1)), StandardScaler(), gs_gaussian)
-
+# Define SVM pipeline
+gs_gaussian = SVC(kernel='rbf', C=bestC, gamma=bestgamma)
+pip_gaussian = make_pipeline(MinMaxScaler((-1, 1)),
+                             StandardScaler(), gs_gaussian)
 pip_gaussian.fit(Xa, ya)
 out = pip_gaussian.predict(Xtest_1d)
 accuracy = accuracy_score(ytest, out)
-#print('Training set: ' + str(num_images) + ' % correctly classified:', str(accuracy*100)+'%')
-#print('should be should be 73.6% success for m=1 and 40000 images')
+# print('Training set: ' + str(num_images) +
+# ' % correctly classified:', str(accuracy*100)+'%')
+# print('should be should be 73.6% success for m=1 and 40000 images')

--- a/doc/examples/features_detection/plot_scattering_classification.py
+++ b/doc/examples/features_detection/plot_scattering_classification.py
@@ -136,27 +136,27 @@ def load_scattering(X_train, X_test, J=3, L=8, m=2,
 
 
 def gethomogeneus_datast(X, y, d, n):
- """Extract from the data set of images the same number
- of samples per class.
+    """ Extract from the data set of images the same number
+    of samples per class.
      Parameters
      ----------
      X: nd array
        matrix of features times samples (exemplars)
      y: 1d array
-       class of each sample, ordered as X. 
-     d: int 
+       class of each sample, ordered as X.
+     d: int
        number of classes
-     n: int 
+     n: int
        number of samples per class in the output set
      Returns
      -------
      X_out: nd array
-       matrix of features times samples, with the same 
+       matrix of features times samples, with the same
        number of samples per class.
      y_out: 1d array
-       class of each sample, ordered as X_out, with the 
+       class of each sample, ordered as X_out, with the
        same number of samples per class.
- """
+    """
     num_per_class = np.int(np.amin([n, X.shape[0]]) / d)
     ytrain = np.reshape(y, (y.shape[0],))
     X_out = []
@@ -185,7 +185,7 @@ n = np.amin([10000, num_images])
 
 im_train, ytrain, im_test, ytest = load_images_mnist(px=px,
                                                      num_images=num_images)
-Xtrain, Xtest = load_scattering(im_train, im_test, px=px,
+Xtrain, Xtest = load_scattering(im_train, im_test,
                                 J=3, L=6, m=2,
                                 sigma_phi=0.6957, sigma_xi=0.8506)
 Xtrain_1d = Xtrain.reshape((len(Xtrain), -1))  # colapse spatial components
@@ -221,19 +221,19 @@ from keras.datasets import cifar10
 
 
 def DB_rgb2yuv(X):
- """Change the database of images from RGB space to YUV, 
- maintaining the input format (num_images,color,pixels,pixels)
+    """Change the database of images from RGB space to YUV,
+    maintaining the input format (num_images,color,pixels,pixels)
     Parameters
     ----------
-    X: 4D nd array 
-       Group of color images in the range [0,255] stacked in a 
+    X: 4D nd array
+       Group of color images in the range [0,255] stacked in a
        4D matrix.
     Returns
     -------
     Iyuv: 4D nd array
        Group of images in the YUV color space, with shape
        (num_images,color,pixels,pixels).
- """
+    """
  
     num_samples, c, px, px = X.shape
     Xta = X.transpose((3, 2, 0, 1)).astype('float32')/255
@@ -261,7 +261,7 @@ num_images = 50  # For accurate error result we need to
 #                 train with 10000 images (not 10!)
 im_train, ytrain, im_test, ytest = load_images_cifar(num_images)
 # We are computing just the first order scattering transform
-Xtrain, Xtest = load_scattering(im_train, im_test, px=px,
+Xtrain, Xtest = load_scattering(im_train, im_test,
                                 J=3, L=8, m=1,
                                 sigma_phi=0.8, sigma_xi=0.8)
 # note that it works better in the log domain!

--- a/doc/examples/features_detection/plot_scattering_classification.py
+++ b/doc/examples/features_detection/plot_scattering_classification.py
@@ -136,6 +136,27 @@ def load_scattering(X_train, X_test, J=3, L=8, m=2,
 
 
 def gethomogeneus_datast(X, y, d, n):
+ """Extract from the data set of images the same number
+ of samples per class.
+     Parameters
+     ----------
+     X: nd array
+       matrix of features times samples (exemplars)
+     y: 1d array
+       class of each sample, ordered as X. 
+     d: int 
+       number of classes
+     n: int 
+       number of samples per class in the output set
+     Returns
+     -------
+     X_out: nd array
+       matrix of features times samples, with the same 
+       number of samples per class.
+     y_out: 1d array
+       class of each sample, ordered as X_out, with the 
+       same number of samples per class.
+ """
     num_per_class = np.int(np.amin([n, X.shape[0]]) / d)
     ytrain = np.reshape(y, (y.shape[0],))
     X_out = []
@@ -200,7 +221,7 @@ from keras.datasets import cifar10
 
 
 def DB_rgb2yuv(X):
- """Change the database of images in RGB space into YUV, 
+ """Change the database of images from RGB space to YUV, 
  maintaining the input format (num_images,color,pixels,pixels)
     Parameters
     ----------

--- a/doc/examples/filters/plot_multiresolution_filterbank.py
+++ b/doc/examples/filters/plot_multiresolution_filterbank.py
@@ -3,38 +3,40 @@
 Multiresolution Filterbank
 ==========================
 
-Here, we show how to create and access a multiresolution wavelet filter bank
+Here, we show how to create and access a multiresolution
+wavelet filter bank
 with Morlet filters in 2D, using the functions in filter_bank.py.
-We need to define the number of scales (J), angles (L), and the number of pixels (px).
-There are two optional parameters: the standard deviation of the low pass filter (sigma_phi)
+We need to define the number of scales (J), angles (L), and
+the number of pixels (px).
+There are two optional parameters: the standard deviation
+of the low pass filter (sigma_phi)
 and the band pass filter (sigma_xi).
-
-We show, for a certain scale (j) and angle (l), the same filter at different resolutions.
+We show, for a certain scale (j) and angle (l), the
+same filter at different resolutions.
 """
+
 
 import matplotlib.pylab as plt
 import numpy as np
 from skimage.filters.filter_bank import multiresolution_filter_bank_morlet2d
-
 J = 5  # number of scales
 L = 8  # number of angles
 px = 128  # size of the filters
 sigma_phi = 0.6957  # std_0 of the low pass filter
 sigma_xi = 0.8506  # std_0 of the band pass filters
-
 j = 3
 l = 5
-
 # Get the multiresolution filterbank:
-wavelet_bnk, littlewood_p = multiresolution_filter_bank_morlet2d(px, J=J, L=L, sigma_phi=sigma_phi, sigma_xi= sigma_xi)
+wavelet_bnk, lp = multiresolution_filter_bank_morlet2d(px, J=J, L=L,
+                                                       sigma_phi=sigma_phi,
+                                                       sigma_xi=sigma_xi)
 num_resolutions = len(wavelet_bnk['psi'])
-
-plt.figure(figsize=(18,6))
-plt.suptitle("All resolutions of filter" + "(" + str(j) + "," + str(l) + ")", fontsize=20)
-for r in np.arange(0,num_resolutions):
-    plt.subplot(1,num_resolutions,r+1)
+plt.figure(figsize=(18, 6))
+plt.suptitle("All resolutions of filter" + "(" +
+             str(j) + "," + str(l) + ")", fontsize=20)
+for r in np.arange(0, num_resolutions):
+    plt.subplot(1, num_resolutions, r+1)
     plt.title("resolution:"+str(r))
     f = wavelet_bnk['psi'][r][j][l, :, :]
     plt.imshow(np.abs(np.fft.fftshift(f)))
 plt.show()
-

--- a/doc/examples/filters/plot_multiresolution_filterbank.py
+++ b/doc/examples/filters/plot_multiresolution_filterbank.py
@@ -1,0 +1,40 @@
+"""
+==========================
+Multiresolution Filterbank
+==========================
+
+Here, we show how to create and access a multiresolution wavelet filter bank
+with Morlet filters in 2D, using the functions in filter_bank.py.
+We need to define the number of scales (J), angles (L), and the number of pixels (px).
+There are two optional parameters: the standard deviation of the low pass filter (sigma_phi)
+and the band pass filter (sigma_xi).
+
+We show, for a certain scale (j) and angle (l), the same filter at different resolutions.
+"""
+
+import matplotlib.pylab as plt
+import numpy as np
+from skimage.filters.filter_bank import multiresolution_filter_bank_morlet2d
+
+J = 5  # number of scales
+L = 8  # number of angles
+px = 128  # size of the filters
+sigma_phi = 0.6957  # std_0 of the low pass filter
+sigma_xi = 0.8506  # std_0 of the band pass filters
+
+j = 3
+l = 5
+
+# Get the multiresolution filterbank:
+wavelet_bnk, littlewood_p = multiresolution_filter_bank_morlet2d(px, J=J, L=L, sigma_phi=sigma_phi, sigma_xi= sigma_xi)
+num_resolutions = len(wavelet_bnk['psi'])
+
+plt.figure(figsize=(18,6))
+plt.suptitle("All resolutions of filter" + "(" + str(j) + "," + str(l) + ")", fontsize=20)
+for r in np.arange(0,num_resolutions):
+    plt.subplot(1,num_resolutions,r+1)
+    plt.title("resolution:"+str(r))
+    f = wavelet_bnk['psi'][r][j][l, :, :]
+    plt.imshow(np.abs(np.fft.fftshift(f)))
+plt.show()
+

--- a/skimage/feature/scattering.py
+++ b/skimage/feature/scattering.py
@@ -1,0 +1,290 @@
+"""
+    Scattering transform code licensed under
+    BSD licenses.
+    
+    Original author: Sira Ferradans, based on a code developed by Ivan Dokmanic and Michael Eickenberg
+"""
+
+import numpy as np
+import skimage
+from skimage._shared.utils import assert_nD
+from scipy import ndimage as ndi
+from skimage.filters.filter_bank import multiresolution_filter_bank_morlet2d
+import warnings
+
+def _apply_fourier_mult(signals,filters):
+    """Spatial subsampling on the last two dimensions of X at a rate that depends on 2**j.
+        
+        Parameters
+        ----------
+        signals: ndarray (3D)
+            Signals in the Fourier domain stacked as (num_signals, N,N). Note that color images can be stacked as 'num_signals'.
+        filters: ndarray (3D)
+            Filters in the Fourier domain, stacked as (L,N,N) where L is the num. of filters to apply
+        
+        Returns
+        -------
+        filtered_signals : ndarray
+            Filtered signals in the Fourier domain, stacked as (num_signals,L,N,N)
+        """
+
+    N = filters.shape[1]
+    Nj= signals.shape[1]
+
+    filtered_signals=signals[:,np.newaxis,:,:] * filters[np.newaxis,:,:,:]
+    return filtered_signals
+
+
+def _subsample(X,j):
+    """Spatial subsampling on the last two dimensions of X at a rate that depends on 2**j.
+
+    Parameters
+    ----------
+    X : array like variable.
+        3D dnarray with shape (N,L,n,n) or (N,n,n). The subsampling is produced in the last two
+        dimensions (n,n)
+    j : int
+        Rate of subsampling is 2**j
+
+    Returns
+    -------
+    XX : ndarray
+        Subsampled images
+    """
+
+    dsf = 2**j
+    
+    return dsf*X[..., ::dsf, ::dsf]
+
+
+def _apply_lowpass(img, phi, J, n_scat):
+    """Applies a low pass filter on the 'img' set of 2D arrays and subsamples.
+
+    Convolution the filter phi (in the Fourier domain) on the set of images defined by img. The convolution is done in
+    the Fourier domain, thus it is a pointwise multiplication of the filter phi and the images, stored in
+    the last 2 dimensions of img. Then, the images are subsampled at the appropiate rate to have 'n_scat'
+    spatial coefficients
+
+    Parameters
+    ----------
+    img : ndarray of (N,L,n,n) or (N,n,n) shape.
+        Input images in the spatial domain, stacked along the first dimensions.
+    phi : Low pass filter as a 2D ndarray
+        Low pass filter in the Fourier domain, stored as (n,n) matrix
+    J : int
+        Rate of subsampling 2**J
+    n_scat : int
+        number of spatial coefficients of the scattering vector
+
+    Returns
+    -------
+    XX : ndarray
+        stacked images after being filtered and subsampled
+    """
+
+    img_filtered = np.real(np.fft.ifft2(np.fft.fft2(img)*phi))
+
+    n_nolp = img.shape[-1]
+
+    ds = int(n_nolp / n_scat)
+    
+    return 2 ** (J - 1) * img_filtered[..., ::ds, ::ds]
+
+
+def scattering(x,wavelet_filters=None,m=2):
+    """Compute the scattering transform of a signal (or set of signals).
+
+    Given 'x', a set of 2D signals, this function computes the scattering transform
+    of these signals using the filter bank 'wavelet_filters'.
+
+    Notes
+    -----
+    **Bondary values: The scattering transform applies a set of convolutions to the input signals.
+    These convolutions are computed as the point-wise multiplication in the Fourier domain, thus
+    the boundary values of the image are circular or cyclic. In case you need other kind of boundary
+    values, for instance zero-padded, you should edit the images before calling this function.
+
+    **Shape of x: The signals x must be squared shaped, thus (N,px,px) and not (N,px,py) for py != px. In case
+    the images are rectangular they will be cropped to the smallest dimension, px or py.
+
+    Parameters
+    ----------
+    x : array_like
+        3D dnarray with N images (2D arrays) of size (px,px), thus x has size (N,px,px)
+        In case the array is rectangular (N,px,py) for px not equal to py, the images will be cropped.
+    wavelet_filters : Dictionary with the multiresolution wavelet filter bank
+        Dictionary of vectors obtained after calling:
+            >>>> px = 32 #number of pixels of the images
+            >>>> J = np.log2(px) #number of scales
+            >>>> wavelet_filters = multiresolution_filter_bank_morlet2d(px,J=J)
+    m : int
+        Order of the scattering transform, which can be 0, 1 or 2.
+
+
+    Returns
+    -------
+    S : 4D array_like
+        Scattering transform of the x signals, of size (N,num_coeffs,spatial_coefs,spatial_coefs). For more information
+        see _[1] _[2]
+    U : array_like
+        Result before applying the lowpass filter and subsampling.
+
+    S_tree : dictionary
+        Dictionary that allows to access the scattering coefficients (S) according to the layer and indices. More
+        specifically:
+            Zero-order layer: The only available key is 0:
+            S_tree[0] : returns all the coefficients of the 0-order scattering transform
+
+            First-order layer: The keys are tuples with (j,l) indexing
+            S_tree[(j,l)] : returns the first order coefficients for scale 'j' and angle 'l'
+            S_tree[((j1,l1),(j2,l2))] : the second order for scale 'j1', angle 'l1' on the first layer,
+                        and 'j2', 'l2' in the second layer.
+
+        The number of coefficients for each entry is (N,spatial_coefs,spatial_coefs)
+
+    Raises
+    ------
+    UserWarning
+        If the size of x is not (N,px,px) and informs that the images with be cropped to (N,px,px)
+    UserWarning
+        If no wavelet filters, the function creates a multiresolution set of filters with predefined
+        settings, but warns about the parameters and suggests precomputing the filters.
+    UserWarning
+        If the value of m is not 0,1, or 2.
+
+    References
+    ----------
+    .. [1] Bruna, J., Mallat, S. 'Invariant Scattering Convolutional Networks'. IEEE Transactions on PAMI, 2012.
+    .. [2] Oyallon, E. et Mallat, S. 'Deep Roto-translation Scattering for Object Classification'. CVPR 2015.
+    
+    Examples
+    --------
+    Processing a set of 3 (randomly generated) images:
+
+            >>>> import numpy as np
+            >>>> from scattering.filter_bank import multiresolution_filter_bank_morlet2d
+            >>>> from scattering.scattering import scattering
+
+            >>>> px = 32 #number of pixels of the images
+            >>>> images = np.arange(0,3*px*px).reshape(3,px,px) #create images
+            >>>> wavelet_filters,littlewoodpaley = multiresolution_filter_bank_morlet2d(px,J=np.log2(px))
+            >>>> S,U = scattering(images,m=2)
+    """
+
+    ## Check that the input data is correct:
+    ## 1.- Signals are squared, otherwise, crop
+    assert_nD(x, 3, 'x')  # check that the images are correctly stacked
+    num_signals, px, py = x.shape
+
+    if (px != py):
+        warning_string = "Variable x has shape {0}, which is not in format (N,px,px). We crop to the smallest dimension."
+        warnings.warn(warning_string.format(x.shape))
+        px = min(px,py)
+        x = x[:, 0:px, 0:px]
+
+    ## 2.- If we dont have filters, get them with the default values, J=3, L=8
+    if wavelet_filters is None:
+        J = int(min(np.log2(px),3))
+        L = 8
+        warning_string = "No filter input, we create a Morlet filter bank with J= {0} and L={1}. " \
+                         "Strongly suggest creating " \
+                         "the filters before hand and pass them as a parameter."
+        warnings.warn(warning_string.format(J,L))
+        wavelet_filters, littlewood=multiresolution_filter_bank_morlet2d(px, J=J, L=L)
+    else:
+        J = len(wavelet_filters['psi'][0])  # number of scales
+        L = len(wavelet_filters['psi'][0][0])  # number of orientations
+
+    num_signals = x.shape[0]
+
+    ## 3.- Check the Order (m) of the scattering transform, can only be 0,1,2, and that gives us different
+    # number of scattering coefficients
+    num_coefs = {
+        0: int(1),
+        1: int(1 + J * L),
+        2: int(1 + J * L + J * (J - 1) * L ** 2 / 2)
+    }.get(m, -1)
+
+    if num_coefs == -1:
+        warning_string = "Parameter m out of bounds, valid values are 0,1,2 not {0}"
+        warnings.warn(warning_string.format(m))
+        return
+
+    #constants
+    spatial_coefs = int(x.shape[1]/2**(J-1))
+    oversample = 1  # subsample at a rate a bit lower than the critic frequency
+
+    U = []
+    V = []
+    v_resolution = []
+    current_resolution = 0
+
+    #vars to return (where we save the scattering and its accessing tree-structure (a dictionary)
+    S = np.ndarray((num_signals,num_coefs,spatial_coefs,spatial_coefs))
+    S_tree = {} #allows access to the coefficients (S) using the tree structure
+
+    ### Start computing the scattering coefficients
+    #Zero order scattering coeffs
+    S[:, 0, :, :] = _apply_lowpass(x, wavelet_filters['phi'][current_resolution], J,  spatial_coefs)
+    S_tree[0] = S[:, 0, :, :]
+    l_indexing = np.arange(0,L)
+
+    #First order scattering coeffs
+    if m > 0:
+        Sview = S[:,1:J*L+1,:,:].view()
+        Sview.shape=(num_signals,J,L,spatial_coefs,spatial_coefs)
+
+        X = np.fft.fft2(x) # precompute the fourier transform of the images
+        for j in np.arange(J):
+            filtersj = wavelet_filters['psi'][current_resolution][j].view()
+
+            resolution = max(j-oversample, 0)# resolution for the next layer
+            v_resolution.append(resolution)
+
+            # fft2(| x conv Psi_j |): X is full resolution, as well as the filters
+            aux = _subsample(np.fft.ifft2(_apply_fourier_mult(X,filtersj)), resolution )
+
+            V.append(aux)
+            U.append(np.abs(aux))
+
+            Sview[:, j, :, :, :] = _apply_lowpass(U[j], wavelet_filters['phi'][resolution], J,  spatial_coefs)
+            j_indexing = np.ones((L))*int(j)
+            for i_l, first_order_label in enumerate(zip(j_indexing, l_indexing)):
+                S_tree[first_order_label] = Sview[:, j, i_l, :, :]
+
+
+
+    #Second order scattering coeffs
+    if m > 1:
+        sec_order_coefs = int(J*(J-1)*L**2/2)
+        
+        S2norder = S[:, J*L+1:num_coefs, :, :]  # view of the data
+        S2norder.shape = (num_signals, int(sec_order_coefs/L), L, spatial_coefs, spatial_coefs)
+        
+        indx = 0
+        for j1 in np.arange(J):
+            Uj1 = np.fft.fft2(U[j1].view())  # U is in the spatial domain
+            current_resolution = v_resolution[j1]
+
+            for l1 in np.arange(Uj1.shape[1]):
+                Ujl1 = Uj1[:, l1, ].view()  # all images single angle, all spatial coefficients
+
+                layer1_indexing = [(int(j1), int(l1))] * L  # for S_tree
+
+                for j2 in np.arange(j1+1,J):
+                    # | U_lambda1 conv Psi_lambda2 | conv phi
+                    aux = np.abs(np.fft.ifft2(_apply_fourier_mult(Ujl1, wavelet_filters['psi'][current_resolution][j2])))
+                    # computing all angles at once
+                    S2norder[:, indx, :, :, :] = \
+                        _apply_lowpass(aux, wavelet_filters['phi'][current_resolution], J,  spatial_coefs)
+
+                    # save tree structure
+                    j2_indexing = np.ones((L)) * int(j2)
+                    for i_l, second_order_label in enumerate(zip(layer1_indexing, zip(j2_indexing, l_indexing))):
+                        S_tree[second_order_label] = S2norder[:, indx, i_l, :, :]
+                        
+
+                    indx = indx+1
+    
+    return S, U, S_tree
+

--- a/skimage/feature/scattering.py
+++ b/skimage/feature/scattering.py
@@ -217,7 +217,6 @@ def scattering(x, wavelet_filters=None, m=2):
     # vars to return (where we save the scattering and its accessing
     # tree-structure (a dictionary)
     S = np.ndarray((num_signals, num_coefs, spatial_coefs, spatial_coefs))
-    print()
     # allows access to the coefficients (S) using the tree structure
     S_tree = {}
     # Start computing the scattering coefficients

--- a/skimage/feature/scattering.py
+++ b/skimage/feature/scattering.py
@@ -30,7 +30,7 @@ def _apply_fourier_mult(signals, filters):
             Filtered signals in the Fourier domain,
             stacked as (num_signals,L,N,N)
         """
-    filtered_s = signals[:, np.newaxis, :, :]*filters[np.newaxis, :, :, :]
+    filtered_s = signals[:, np.newaxis, :, :] * filters[np.newaxis, :, :, :]
     return filtered_s
 
 
@@ -49,8 +49,8 @@ def _subsample(X, j):
     XX : ndarray
         Subsampled images
     """
-    dsf = 2**j
-    return dsf*X[..., ::dsf, ::dsf]
+    dsf = 2 ** j
+    return dsf * X[..., ::dsf, ::dsf]
 
 
 def _apply_lowpass(img, phi, J, n_scat):
@@ -205,7 +205,7 @@ def scattering(x, wavelet_filters=None, m=2):
         raise ValueError(error_string.format(m))
         return
     # constants
-    spatial_coefs = int(x.shape[1]/2**(J-1))
+    spatial_coefs = int(x.shape[1] // 2 ** (J - 1))
     # subsample at a rate a bit lower than the critic frequency
     oversample = 1
     U = []
@@ -225,7 +225,7 @@ def scattering(x, wavelet_filters=None, m=2):
     l_indexing = np.arange(0, L)
     # First order scattering coeffs
     if m > 0:
-        Sview = S[:, 1:J*L+1, :, :].view()
+        Sview = S[:, 1:J * L + 1, :, :].view()
         Sview.shape = (num_signals, J, L, spatial_coefs, spatial_coefs)
         # precompute the fourier transform of the images
         X = np.fft.fft2(x)
@@ -250,8 +250,8 @@ def scattering(x, wavelet_filters=None, m=2):
                 S_tree[first_order_label] = Sview[:, j, i_l, :, :]
     # Second order scattering coeffs
     if m > 1:
-        sec_order_coefs = int(J*(J-1)*L**2/2)
-        S2norder = S[:, J*L+1:num_coefs, :, :]  # view of the data
+        sec_order_coefs = int(J * (J - 1) * L ** 2 / 2)
+        S2norder = S[:, J * L + 1 :num_coefs, :, :]  # view of the data
         S2norder.shape = (num_signals, int(sec_order_coefs/L),
                           L, spatial_coefs, spatial_coefs)
         indx = 0
@@ -286,5 +286,5 @@ def scattering(x, wavelet_filters=None, m=2):
                         S_tree[second_order_label] = \
                             S2norder[:, indx, i_l, :, :]
 
-                    indx = indx+1
+                    indx = indx + 1
     return S, U, S_tree

--- a/skimage/feature/scattering.py
+++ b/skimage/feature/scattering.py
@@ -1,70 +1,61 @@
-"""
-    Scattering transform code licensed under
+""" Scattering transform code licensed under
     BSD licenses.
-    
-    Original author: Sira Ferradans, based on a code developed by Ivan Dokmanic and Michael Eickenberg
+    Original author: Sira Ferradans, based on a code developed by
+    Ivan Dokmanic and Michael Eickenberg
 """
-
 import numpy as np
-import skimage
 from skimage._shared.utils import assert_nD
-from scipy import ndimage as ndi
 from skimage.filters.filter_bank import multiresolution_filter_bank_morlet2d
 import warnings
 
-def _apply_fourier_mult(signals,filters):
-    """Spatial subsampling on the last two dimensions of X at a rate that depends on 2**j.
-        
+
+def _apply_fourier_mult(signals, filters):
+    """Spatial subsampling on the last two dimensions of X at a
+    rate that depends on 2**j.
         Parameters
         ----------
         signals: ndarray (3D)
-            Signals in the Fourier domain stacked as (num_signals, N,N). Note that color images can be stacked as 'num_signals'.
+            Signals in the Fourier domain stacked as (num_signals, N,N).
+            Note that color images can be stacked as 'num_signals'.
         filters: ndarray (3D)
-            Filters in the Fourier domain, stacked as (L,N,N) where L is the num. of filters to apply
-        
+            Filters in the Fourier domain, stacked as (L,N,N) where
+            L is the num. of filters to apply
         Returns
         -------
         filtered_signals : ndarray
-            Filtered signals in the Fourier domain, stacked as (num_signals,L,N,N)
+            Filtered signals in the Fourier domain,
+            stacked as (num_signals,L,N,N)
         """
-
-    N = filters.shape[1]
-    Nj= signals.shape[1]
-
-    filtered_signals=signals[:,np.newaxis,:,:] * filters[np.newaxis,:,:,:]
-    return filtered_signals
+    filtered_s = signals[:, np.newaxis, :, :]*filters[np.newaxis, :, :, :]
+    return filtered_s
 
 
-def _subsample(X,j):
-    """Spatial subsampling on the last two dimensions of X at a rate that depends on 2**j.
-
+def _subsample(X, j):
+    """Spatial subsampling on the last two dimensions of X at a rate that
+    depends on 2**j.
     Parameters
     ----------
     X : array like variable.
-        3D dnarray with shape (N,L,n,n) or (N,n,n). The subsampling is produced in the last two
-        dimensions (n,n)
+        3D dnarray with shape (N,L,n,n) or (N,n,n). The subsampling is produced
+         in the last two dimensions (n,n)
     j : int
         Rate of subsampling is 2**j
-
     Returns
     -------
     XX : ndarray
         Subsampled images
     """
-
     dsf = 2**j
-    
     return dsf*X[..., ::dsf, ::dsf]
 
 
 def _apply_lowpass(img, phi, J, n_scat):
     """Applies a low pass filter on the 'img' set of 2D arrays and subsamples.
-
-    Convolution the filter phi (in the Fourier domain) on the set of images defined by img. The convolution is done in
-    the Fourier domain, thus it is a pointwise multiplication of the filter phi and the images, stored in
-    the last 2 dimensions of img. Then, the images are subsampled at the appropiate rate to have 'n_scat'
-    spatial coefficients
-
+    Convolution the filter phi (in the Fourier domain) on the set of images
+    defined by img. The convolution is done in the Fourier domain, thus it is
+    a pointwise multiplication of the filter phi and the images, stored in the
+    last 2 dimensions of img. Then, the images are subsampled at the appropiate
+    rate to have 'n_scat' spatial coefficients
     Parameters
     ----------
     img : ndarray of (N,L,n,n) or (N,n,n) shape.
@@ -75,43 +66,40 @@ def _apply_lowpass(img, phi, J, n_scat):
         Rate of subsampling 2**J
     n_scat : int
         number of spatial coefficients of the scattering vector
-
     Returns
     -------
     XX : ndarray
         stacked images after being filtered and subsampled
     """
-
     img_filtered = np.real(np.fft.ifft2(np.fft.fft2(img)*phi))
-
     n_nolp = img.shape[-1]
-
     ds = int(n_nolp / n_scat)
-    
     return 2 ** (J - 1) * img_filtered[..., ::ds, ::ds]
 
 
-def scattering(x,wavelet_filters=None,m=2):
+def scattering(x, wavelet_filters=None, m=2):
     """Compute the scattering transform of a signal (or set of signals).
-
-    Given 'x', a set of 2D signals, this function computes the scattering transform
-    of these signals using the filter bank 'wavelet_filters'.
-
+    Given 'x', a set of 2D signals, this function computes the
+    scattering transform of these signals using the filter bank
+    'wavelet_filters'.
     Notes
     -----
-    **Bondary values: The scattering transform applies a set of convolutions to the input signals.
-    These convolutions are computed as the point-wise multiplication in the Fourier domain, thus
-    the boundary values of the image are circular or cyclic. In case you need other kind of boundary
-    values, for instance zero-padded, you should edit the images before calling this function.
-
-    **Shape of x: The signals x must be squared shaped, thus (N,px,px) and not (N,px,py) for py != px. In case
-    the images are rectangular they will be cropped to the smallest dimension, px or py.
-
+    **Bondary values: The scattering transform applies a set of convolutions
+    to the input signals. These convolutions are computed as the point-wise
+    multiplication in the Fourier domain, thus the boundary values of the
+    image are circular or cyclic. In case you need other
+    kind of boundary values, for instance zero-padded, you should
+    edit the images before calling this function.
+    **Shape of x: The signals x must be squared shaped, thus (N,px,px)
+    and not (N,px,py) for py != px. In case the images are rectangular,
+    they will be cropped to the smallest dimension, px or py.
     Parameters
     ----------
     x : array_like
-        3D dnarray with N images (2D arrays) of size (px,px), thus x has size (N,px,px)
-        In case the array is rectangular (N,px,py) for px not equal to py, the images will be cropped.
+        3D dnarray with N images (2D arrays) of size (px,px), thus x has size
+         (N,px,px)
+        In case the array is rectangular (N,px,py) for px not equal to py, t
+        he images will be cropped.
     wavelet_filters : Dictionary with the multiresolution wavelet filter bank
         Dictionary of vectors obtained after calling:
             >>>> px = 32 #number of pixels of the images
@@ -119,172 +107,180 @@ def scattering(x,wavelet_filters=None,m=2):
             >>>> wavelet_filters = multiresolution_filter_bank_morlet2d(px,J=J)
     m : int
         Order of the scattering transform, which can be 0, 1 or 2.
-
-
     Returns
     -------
     S : 4D array_like
-        Scattering transform of the x signals, of size (N,num_coeffs,spatial_coefs,spatial_coefs). For more information
+        Scattering transform of the x signals, of size
+        (N,num_coeffs,spatial_coefs,spatial_coefs). For more information
         see _[1] _[2]
     U : array_like
         Result before applying the lowpass filter and subsampling.
-
     S_tree : dictionary
-        Dictionary that allows to access the scattering coefficients (S) according to the layer and indices. More
-        specifically:
+        Dictionary that allows to access the scattering coefficients (S)
+        according to the layer and indices. More specifically:
             Zero-order layer: The only available key is 0:
-            S_tree[0] : returns all the coefficients of the 0-order scattering transform
+            S_tree[0] : returns all the coefficients of the 0-order scattering
+             transform
 
             First-order layer: The keys are tuples with (j,l) indexing
-            S_tree[(j,l)] : returns the first order coefficients for scale 'j' and angle 'l'
-            S_tree[((j1,l1),(j2,l2))] : the second order for scale 'j1', angle 'l1' on the first layer,
-                        and 'j2', 'l2' in the second layer.
+            S_tree[(j,l)] : returns the first order coefficients for scale 'j'
+             and angle 'l'
+            S_tree[((j1,l1),(j2,l2))] : the second order for scale 'j1',
+            angle 'l1' on the first layer, and 'j2', 'l2' in the second layer.
 
-        The number of coefficients for each entry is (N,spatial_coefs,spatial_coefs)
-
+        The number of coefficients for each entry is
+        (N,spatial_coefs,spatial_coefs)
     Raises
     ------
     UserWarning
-        If the size of x is not (N,px,px) and informs that the images with be cropped to (N,px,px)
+        If the size of x is not (N,px,px) and informs that the images with be
+        cropped to (N,px,px)
     UserWarning
-        If no wavelet filters, the function creates a multiresolution set of filters with predefined
-        settings, but warns about the parameters and suggests precomputing the filters.
+        If no wavelet filters, the function creates a multiresolution set of
+        filters with predefined settings, but warns about the parameters and
+        suggests precomputing the filters.
     UserWarning
         If the value of m is not 0,1, or 2.
-
     References
     ----------
-    .. [1] Bruna, J., Mallat, S. 'Invariant Scattering Convolutional Networks'. IEEE Transactions on PAMI, 2012.
-    .. [2] Oyallon, E. et Mallat, S. 'Deep Roto-translation Scattering for Object Classification'. CVPR 2015.
-    
+    .. [1] Bruna, J., Mallat, S. 'Invariant Scattering Convolutional Networks'.
+    IEEE Transactions on PAMI, 2012.
+    .. [2] Oyallon, E. et Mallat, S. 'Deep Roto-translation Scattering for
+    Object Classification'. CVPR 2015.
     Examples
     --------
     Processing a set of 3 (randomly generated) images:
-
-            >>>> import numpy as np
-            >>>> from scattering.filter_bank import multiresolution_filter_bank_morlet2d
-            >>>> from scattering.scattering import scattering
-
-            >>>> px = 32 #number of pixels of the images
-            >>>> images = np.arange(0,3*px*px).reshape(3,px,px) #create images
-            >>>> wavelet_filters,littlewoodpaley = multiresolution_filter_bank_morlet2d(px,J=np.log2(px))
-            >>>> S,U = scattering(images,m=2)
+       >>>> import numpy as np
+       >>>> from scattering.filter_bank \
+                import multiresolution_filter_bank_morlet2d
+       >>>> from scattering.scattering import scattering
+       >>>> px = 32 #number of pixels of the images
+       >>>> images = np.arange(0,3*px*px).reshape(3,px,px) #create images
+       >>>> wavelet_filters,lp = \
+                multiresolution_filter_bank_morlet2d(px,J=np.log2(px))
+       >>>> S,U = scattering(images,m=2)
     """
-
-    ## Check that the input data is correct:
-    ## 1.- Signals are squared, otherwise, crop
+    # Check that the input data is correct:
+    # 1.- Signals are squared, otherwise, crop
     assert_nD(x, 3, 'x')  # check that the images are correctly stacked
     num_signals, px, py = x.shape
-
-    if (px != py):
-        warning_string = "Variable x has shape {0}, which is not in format (N,px,px). We crop to the smallest dimension."
+    if px != py:
+        warning_string = "Variable x has shape {0}, " \
+                         "which is not in format (N,px,px). " \
+                         "We crop to the smallest dimension."
         warnings.warn(warning_string.format(x.shape))
-        px = min(px,py)
+        px = min(px, py)
         x = x[:, 0:px, 0:px]
-
-    ## 2.- If we dont have filters, get them with the default values, J=3, L=8
+    # 2.- If we dont have filters, get them with the default values, J=3, L=8
     if wavelet_filters is None:
-        J = int(min(np.log2(px),3))
+        J = int(min(np.log2(px), 3))
         L = 8
-        warning_string = "No filter input, we create a Morlet filter bank with J= {0} and L={1}. " \
+        warning_string = "No filter input, we create a " \
+                         "Morlet filter bank with " \
+                         "J= {0} and L={1}. " \
                          "Strongly suggest creating " \
-                         "the filters before hand and pass them as a parameter."
-        warnings.warn(warning_string.format(J,L))
-        wavelet_filters, littlewood=multiresolution_filter_bank_morlet2d(px, J=J, L=L)
+                         "the filters before hand and" \
+                         " pass them as a parameter."
+        warnings.warn(warning_string.format(J, L))
+        wavelet_filters, lp = multiresolution_filter_bank_morlet2d(px,
+                                                                   J=J, L=L)
     else:
         J = len(wavelet_filters['psi'][0])  # number of scales
         L = len(wavelet_filters['psi'][0][0])  # number of orientations
-
     num_signals = x.shape[0]
-
-    ## 3.- Check the Order (m) of the scattering transform, can only be 0,1,2, and that gives us different
-    # number of scattering coefficients
+    # 3.- Check the Order (m) of the scattering transform, can only be 0,1,2,
+    # and that gives us different number of scattering coefficients
     num_coefs = {
         0: int(1),
         1: int(1 + J * L),
         2: int(1 + J * L + J * (J - 1) * L ** 2 / 2)
     }.get(m, -1)
-
     if num_coefs == -1:
-        warning_string = "Parameter m out of bounds, valid values are 0,1,2 not {0}"
+        warning_string = "Parameter m out of bounds, " \
+                         "valid values are 0,1,2 not {0}"
         warnings.warn(warning_string.format(m))
         return
-
-    #constants
+    # constants
     spatial_coefs = int(x.shape[1]/2**(J-1))
-    oversample = 1  # subsample at a rate a bit lower than the critic frequency
-
+    # subsample at a rate a bit lower than the critic frequency
+    oversample = 1
     U = []
     V = []
     v_resolution = []
-    current_resolution = 0
-
-    #vars to return (where we save the scattering and its accessing tree-structure (a dictionary)
-    S = np.ndarray((num_signals,num_coefs,spatial_coefs,spatial_coefs))
-    S_tree = {} #allows access to the coefficients (S) using the tree structure
-
-    ### Start computing the scattering coefficients
-    #Zero order scattering coeffs
-    S[:, 0, :, :] = _apply_lowpass(x, wavelet_filters['phi'][current_resolution], J,  spatial_coefs)
+    current_res = 0
+    # vars to return (where we save the scattering and its accessing
+    # tree-structure (a dictionary)
+    S = np.ndarray((num_signals, num_coefs, spatial_coefs, spatial_coefs))
+    # allows access to the coefficients (S) using the tree structure
+    S_tree = {}
+    # Start computing the scattering coefficients
+    # Zero order scattering coeffs
+    S[:, 0, :, :] = _apply_lowpass(x, wavelet_filters['phi'][current_res],
+                                   J,  spatial_coefs)
     S_tree[0] = S[:, 0, :, :]
-    l_indexing = np.arange(0,L)
-
-    #First order scattering coeffs
+    l_indexing = np.arange(0, L)
+    # First order scattering coeffs
     if m > 0:
-        Sview = S[:,1:J*L+1,:,:].view()
-        Sview.shape=(num_signals,J,L,spatial_coefs,spatial_coefs)
-
-        X = np.fft.fft2(x) # precompute the fourier transform of the images
+        Sview = S[:, 1:J*L+1, :, :].view()
+        Sview.shape = (num_signals, J, L, spatial_coefs, spatial_coefs)
+        # precompute the fourier transform of the images
+        X = np.fft.fft2(x)
         for j in np.arange(J):
-            filtersj = wavelet_filters['psi'][current_resolution][j].view()
-
-            resolution = max(j-oversample, 0)# resolution for the next layer
+            filtersj = wavelet_filters['psi'][current_res][j].view()
+            # resolution for the next layer
+            resolution = max(j-oversample, 0)
             v_resolution.append(resolution)
-
-            # fft2(| x conv Psi_j |): X is full resolution, as well as the filters
-            aux = _subsample(np.fft.ifft2(_apply_fourier_mult(X,filtersj)), resolution )
-
+            # fft2(| x conv Psi_j |): X is full resolution,
+            # as well as the filters
+            aux = _subsample(np.fft.ifft2(_apply_fourier_mult(X, filtersj)),
+                             resolution)
             V.append(aux)
             U.append(np.abs(aux))
-
-            Sview[:, j, :, :, :] = _apply_lowpass(U[j], wavelet_filters['phi'][resolution], J,  spatial_coefs)
+            filter = wavelet_filters['phi'][resolution]
+            Sview[:, j, :, :, :] = _apply_lowpass(U[j],
+                                                  filter, J,
+                                                  spatial_coefs)
             j_indexing = np.ones((L))*int(j)
-            for i_l, first_order_label in enumerate(zip(j_indexing, l_indexing)):
+            for i_l, first_order_label in \
+                    enumerate(zip(j_indexing, l_indexing)):
                 S_tree[first_order_label] = Sview[:, j, i_l, :, :]
-
-
-
-    #Second order scattering coeffs
+    # Second order scattering coeffs
     if m > 1:
         sec_order_coefs = int(J*(J-1)*L**2/2)
-        
         S2norder = S[:, J*L+1:num_coefs, :, :]  # view of the data
-        S2norder.shape = (num_signals, int(sec_order_coefs/L), L, spatial_coefs, spatial_coefs)
-        
+        S2norder.shape = (num_signals, int(sec_order_coefs/L),
+                          L, spatial_coefs, spatial_coefs)
         indx = 0
         for j1 in np.arange(J):
-            Uj1 = np.fft.fft2(U[j1].view())  # U is in the spatial domain
-            current_resolution = v_resolution[j1]
+            # U is in the spatial domain
+            Uj1 = np.fft.fft2(U[j1].view())
+            current_res = v_resolution[j1]
 
             for l1 in np.arange(Uj1.shape[1]):
-                Ujl1 = Uj1[:, l1, ].view()  # all images single angle, all spatial coefficients
+                # all images single angle, all spatial coefficients
+                Ujl1 = Uj1[:, l1, ].view()
 
                 layer1_indexing = [(int(j1), int(l1))] * L  # for S_tree
 
-                for j2 in np.arange(j1+1,J):
+                for j2 in np.arange(j1+1, J):
                     # | U_lambda1 conv Psi_lambda2 | conv phi
-                    aux = np.abs(np.fft.ifft2(_apply_fourier_mult(Ujl1, wavelet_filters['psi'][current_resolution][j2])))
+                    filter = wavelet_filters['psi'][current_res][j2]
+                    aux = np.abs(np.fft.ifft2(
+                        _apply_fourier_mult(Ujl1, filter)
+                    ))
                     # computing all angles at once
                     S2norder[:, indx, :, :, :] = \
-                        _apply_lowpass(aux, wavelet_filters['phi'][current_resolution], J,  spatial_coefs)
+                        _apply_lowpass(aux,
+                                       wavelet_filters['phi'][current_res],
+                                       J, spatial_coefs)
 
                     # save tree structure
                     j2_indexing = np.ones((L)) * int(j2)
-                    for i_l, second_order_label in enumerate(zip(layer1_indexing, zip(j2_indexing, l_indexing))):
-                        S_tree[second_order_label] = S2norder[:, indx, i_l, :, :]
-                        
+                    for i_l, second_order_label in \
+                            enumerate(zip(layer1_indexing,
+                                          zip(j2_indexing, l_indexing))):
+                        S_tree[second_order_label] = \
+                            S2norder[:, indx, i_l, :, :]
 
                     indx = indx+1
-    
     return S, U, S_tree
-

--- a/skimage/feature/scattering.py
+++ b/skimage/feature/scattering.py
@@ -205,7 +205,6 @@ def scattering(x, wavelet_filters=None, m=2):
         error_string = "Parameter m out of bounds, " \
                        "valid values are 0,1,2 not {0}"
         raise ValueError(error_string.format(m))
-        return
     # constants
     spatial_coefs = int(x.shape[1] / 2 ** (J - 1))
     # subsample at a rate a bit lower than the critical frequency

--- a/skimage/feature/scattering.py
+++ b/skimage/feature/scattering.py
@@ -1,5 +1,5 @@
 """ Scattering transform code licensed under
-    BSD licenses.
+    BSD license.
     Original author: Sira Ferradans, based on a code developed by
     Ivan Dokmanic and Michael Eickenberg
 """

--- a/skimage/filters/__init__.py
+++ b/skimage/filters/__init__.py
@@ -6,7 +6,7 @@ from .edges import (sobel, sobel_h, sobel_v,
                     roberts, roberts_pos_diag, roberts_neg_diag,
                     laplace)
 from ._rank_order import rank_order
-from ._gabor import gabor_kernel, gabor
+from ._gabor import gabor_kernel, gabor, morlet_kernel
 from ._frangi import frangi, hessian
 from .thresholding import (threshold_adaptive, threshold_otsu, threshold_yen,
                            threshold_isodata, threshold_li, threshold_minimum,
@@ -14,6 +14,9 @@ from .thresholding import (threshold_adaptive, threshold_otsu, threshold_yen,
                            try_all_threshold)
 from . import rank
 from .rank import median
+from .filter_bank import (multiresolution_filter_bank_morlet2d,
+                          filter_bank_morlet2d,
+                          filterbank_to_multiresolutionfilterbank)
 
 from .._shared.utils import deprecated, copy_func
 
@@ -46,6 +49,7 @@ __all__ = ['inverse',
            'denoise_tv_bregman',
            'rank_order',
            'gabor_kernel',
+           'morlet_kernel',
            'gabor',
            'try_all_threshold',
            'frangi',
@@ -58,4 +62,7 @@ __all__ = ['inverse',
            'threshold_minimum',
            'threshold_mean',
            'threshold_triangle',
-           'rank']
+           'rank',
+           'multiresolution_filter_bank_morlet2d,'
+           'filter_bank_morlet2d',
+           'filterbank_to_multiresolutionfilterbank']

--- a/skimage/filters/filter_bank.py
+++ b/skimage/filters/filter_bank.py
@@ -1,0 +1,310 @@
+"""
+    Multiresolution Morlet filterbank filters
+    
+    Original author: Sira Ferradans, based on code developed by Ivan Dokmanic and Michael Eickenberg
+"""
+
+import numpy as np
+from skimage.filters import morlet_kernel, gabor_kernel
+
+
+def _ispow2(N):
+    return 0 == (N & (N - 1))
+
+
+def _get_filter_at_resolution(filt,j):
+    """Computes the filter 'filt' at resolution 'j'
+        
+        Parameters
+        ----------
+        filt : ndarray
+        Filter in the Fourier domain.
+        j : int
+        Resolution to be computed
+        Returns
+        -------
+        filt_multires : ndarray
+        Filter 'filt' at the resolution j, in the Fourier domain
+        """
+    
+    cast = np.complex64
+    N = filt.shape[0]  # filter is square
+    
+    assert _ispow2(N), 'Filter size must be an integer power of 2.'
+    
+    J = int(np.log2(N))
+    
+    # NTM: 0.5 is a cute trick for higher dimensions!
+    mask = np.hstack((np.ones(int(N / 2 ** (1 + j))), 0.5, np.zeros(int(N - N / 2 ** (j + 1) - 1)))) \
+        + np.hstack((np.zeros(int(N - N / 2 ** (j + 1))), 0.5, np.ones(int(N / 2 ** (1 + j) - 1))))
+
+    mask.shape = N, 1
+    
+    filt_lp = filt * mask * mask.T
+    if 'cast' in locals():
+        filt_lp = cast(filt_lp)
+
+    # Remember: C contiguous, last index varies "fastest" (contiguous in
+    # memory) (unlike Matlab)
+    fold_size = (int(2 ** j), int(N / 2 ** j), int(2 ** j), int(N / 2 ** j))
+    filt_multires = filt_lp.reshape(fold_size).sum(axis=(0, 2))
+
+    return filt_multires
+
+def _zero_pad_filter(filter, N):
+    """ Zero pad filter to (N,N)
+    Zero pads 'filter' so it has a NxN size instead of its original size (n,n)
+
+    Parameters
+    ----------
+    filter : (n,n) ndarray
+        Filter in the Fourier domain of size (n,n)
+    N : int
+        Goal size of the filter, assumed to be squared (N,N)
+
+    Returns
+    -------
+    padded_filter : (N,N) ndarray
+        input filter 'filter' padded with zeros to the size (N,N)
+    """
+
+    if filter.shape[0] > N :
+        M = np.array(filter.shape[0])
+        init = np.int(np.floor(M / 2 - N / 2))
+        filter = filter[init:init + N,:]
+
+    if filter.shape[1] > N:
+        M = np.array(filter.shape[1])
+        init = np.int(np.floor(M / 2 - N / 2))
+        filter = filter[:, init:init + N]
+
+    left_pad = np.int64((np.array((N, N)) - np.array(filter.shape)) / 2)
+    right_pad = np.int64(np.array((N, N)) - (left_pad + np.array(filter.shape)))
+
+    padded_filter = np.lib.pad(filter, ((left_pad[0], right_pad[0]), (left_pad[1], right_pad[1])),
+                               'constant', constant_values=(0, 0))
+    return padded_filter
+
+
+def multiresolution_filter_bank_morlet2d(N, J, L=8, sigma_phi = 0.8, sigma_xi = 0.8):
+    """ Generates the multiresolution filter bank of 2D Morlet filters in the Fourier domain.
+       Computes a set of 2D Morlet filters at different scales and angles, plus a low pass filter. All of them at
+        at different resolutions.
+
+    Parameters
+    ----------
+    N : int
+        Size of the  filters, which are square (N,N)
+    J : int
+        Total number of scales of the filters located in the frequency domain as powers of 2.
+    L : int
+        Total number of angles per scale
+    sigma_phi : float
+        Standard deviation needed as a parameter for the low-pass filter (Gaussian), normally set to 0.8
+    sigma_xi  : float
+        Standard deviation needed as a parameter for every band-pass filter (Morlet), normally set to 0.8
+
+    Returns
+    -------
+    Filters : Dictionary structure with the filters saved in the Fourier domain organized in the following way
+            - Filters['phi'] : Low pass filter (Gaussian) in a 2D vector of size NxN
+            - Filters['psi'][resolution] : Band pass filter (Morlet) saved as 4D complex array of size [J,L,N,N]
+              where 'J' indexes the scale, 'L; the angles and NxN is the size of a single filter. The variable
+              'resolution' goes from 0 to J.
+
+    Examples
+    --------
+    Generate a multiresolution filterbank and plot all the bank pass filters at a given scale j, and angle l. They
+    will be shown in the Fourier domain.
+
+    >>>> N=128
+    >>>> J=5
+    >>>> L=8
+    >>>> j=3
+    >>>> l=5
+    >>>> wavelet_bnk,littlewood_p = multiresolution_filter_bank_morlet2d(px, J=J, L=L)
+    >>>> plt.figure(figsize=(18,6))
+    >>>> for r in np.arange(0,num_resolutions):
+            plt.subplot(1,num_resolutions,r+1)
+            f = wavelet_bnk['psi'][r][j][l,:,:]
+            plt.imshow(np.abs(np.fft.fftshift(f)))
+
+     """
+
+    wf, littlewood = filter_bank_morlet2d(N, J=J, L=L, sigma_phi=sigma_phi, sigma_xi=sigma_xi)
+
+    multiresolution_wavelet_filters = filterbank_to_multiresolutionfilterbank(wf, J)
+
+    return multiresolution_wavelet_filters, littlewood
+
+
+def filter_bank_morlet2d(N, J=4, L=8, sigma_phi=0.8, sigma_xi=0.8):
+    """ Compute a 2D complex Morlet filter bank in the Fourier domain.
+
+    Creates a filter bank of 1+JxL number of filters in the Fourier domain, where each filter has size NxN, and differ in
+    the activation frequency. All these filters are complex 2D morlet filters [1]_ , [2]_ .
+
+    Parameters
+    ----------
+    N : int
+        Size of the  filters, which are square (N,N)
+    J : int
+        Total number of scales of the filters located in the frequency domain as powers of 2.
+    L : int
+        Total number of angles per scale
+    sigma_phi : float
+        Standard deviation needed as a parameter for the low-pass filter (Gaussian), normally set to 0.8
+    sigma_xi  : float
+        Standard deviation needed as a parameter for every band-pass filter (Morlet), normally set to 0.8
+
+    Returns
+    -------
+    Filters : Dictionary structure with the filters saved in the Fourier domain organized in the following way
+            - Filters['phi'] : Low pass filter (Gaussian) in a 2D vector of size NxN
+            - Filters['psi'] : Band pass filter (Morlet) saved as 4D complex array of size [J,L,N,N]
+              where 'J' indexes the scale, 'L; the angles and NxN is the size of a single filter.
+
+
+    littlewood_paley : (N,N) ndarray
+        Measure of quality of the filter bank for image representation, it should be as close as possible to 1.
+        For more information see eq. 8 in [3]_
+
+    References
+    ----------
+
+    .. [1] https://en.wikipedia.org/wiki/Filter_bank
+    .. [2] https://en.wikipedia.org/wiki/Discrete_wavelet_transform
+    .. [3] Bruna, J., Mallat, S. 'Invariant Scattering Convolutional Networks'. IEEE Transactions on PAMI, 2012.
+
+
+    Examples
+    --------
+
+    Generate a filter bank and show all the band pass filters in the Fourier domain.
+
+    >>>>J = 3
+    >>>>L=8
+    >>>>px = 32
+    >>>>wavelet_filters, littlewood = filter_bank_morlet2d(px, J=J, L=L, sigma_phi=0.6957,sigma_xi=0.8506 )
+    >>>>print('params consistent? J2=',J2,' L2=',L2,' N2=', N2)
+        print('Show low pass filter in the Fourier domain')
+        plt.imshow(np.abs(np.fft.fftshift(filters['phi'])))
+        plt.show()
+        print('.. and the band pass filters in the Fourier domain:')
+
+        for j in np.arange(0,J):
+            print('j=',j)
+            plt.figure(figsize=(18,6))
+            for l in np.arange(0,L):
+                plt.subplot(1, L, l+1)
+                plt.imshow(np.abs(np.fft.fftshift(filters['psi'][j][l, :, :])))
+
+            plt.show()
+
+    """
+    max_scale = 2 ** (float(J - 1))
+
+    sigma = sigma_phi * max_scale
+    freq = 0.
+
+    filter_phi = np.ndarray((N,N), dtype='complex')
+    littlewood_paley = np.zeros((N, N), dtype='single')
+
+    # Low pass
+    filter_phi = np.fft.fft2(np.fft.fftshift(_zero_pad_filter(gabor_kernel(freq, theta=0., sigma_x=sigma, sigma_y=sigma),N)))
+
+    ## Band pass filters:
+    ## psi: Create band-pass filters
+    # constant values for psi
+    xi_psi = 3. /4 * np.pi
+    slant = 4. / L
+
+    filters_psi = []
+
+    for j, scale in enumerate(2. ** np.arange(J)):
+        angles = np.zeros((L, N, N), dtype='complex')
+        for l, theta in enumerate(np.pi * np.arange(L) / float(L)):
+            sigma = sigma_xi * scale
+            xi = xi_psi / scale
+
+            sigma_x = sigma
+            sigma_y = sigma / slant
+            freq = xi / (np.pi * 2)
+
+            psi = morlet_kernel(freq, theta=theta, sigma_x=sigma_x, sigma_y=sigma_y,n_stds=12)
+      
+            #needs a small shift for odd sizes
+            if (psi.shape[0] % 2 > 0):
+                if (psi.shape[1] % 2 > 0):
+                    Psi = _zero_pad_filter(psi[:-1, :-1], N)
+                else:
+                    Psi = _zero_pad_filter(psi[:-1, :], N)
+            else:
+                if (psi.shape[1] % 2 > 0):
+                    Psi = _zero_pad_filter(psi[:, :-1], N)
+                else:
+                    Psi = _zero_pad_filter(psi, N)
+
+            angles[l, :, :] = np.fft.fft2(np.fft.fftshift(0.5*Psi))
+
+        littlewood_paley += np.sum(np.abs(angles) ** 2, axis=0)
+        filters_psi.append(angles)
+
+    lwp_max = littlewood_paley.max()
+
+    for filt in filters_psi:
+        filt /= np.sqrt(lwp_max/2)
+
+    Filters = dict(phi=filter_phi, psi=filters_psi)
+
+    return Filters, littlewood_paley*2
+
+
+def filterbank_to_multiresolutionfilterbank(filters, max_resolution):
+    """ Converts a filter bank into a multiresolution filterbank
+    For every filter of a filter bank, compute this same filter at different resolutions (differnt sizes). The filters
+    are assumed to be in the Fourier domain, as well as the output multiresolution filters.
+
+    Parameters
+    ----------
+    filters : dictionary
+        Set of filters stored in a dictionary in the following way:
+         - filters['phi'] : Low pass filter (Gaussian) in a 2D vector of size NxN
+         - filters['psi'] : Band pass filter (Morlet) saved as 4D complex array of size [J,L,N,N]
+              where 'J' indexes the scale, 'L; the angles and NxN is the size of a single filter.
+
+    max_resolution : int
+        number of resolutions to compute for every filter (thus for every scale and angle)
+
+    Returns
+    -------
+    filters_multires : dictionary
+        Set of filters in the Fourier domain, at different scales, angles and resolutions.
+        See multiresolution_filter_bank_morlet2d for more details on the Filters_multires structure.
+
+    """
+    J = len(filters['psi']) #scales
+    L = len(filters['psi'][0]) #angles
+    N = filters['psi'][0].shape[-1] #size at max scale
+
+    Phi_multires = []
+    Psi_multires = []
+    for res in np.arange(0,max_resolution):
+        Phi_multires.append(_get_filter_at_resolution(filters['phi'],res))
+
+        aux_filt_psi = np.ndarray((J,L,int(N/2**res),int(N/2**res)), dtype='complex64')
+        for j in np.arange(0,J):
+            for l in np.arange(0,L):
+                aux_filt_psi[j,l,:,:] = _get_filter_at_resolution(filters['psi'][j][l,:,:],res)
+
+        Psi_multires.append(aux_filt_psi)
+
+    filters_multires = dict(phi=Phi_multires, psi=Psi_multires)
+    return filters_multires
+
+
+
+
+
+
+

--- a/skimage/filters/filter_bank.py
+++ b/skimage/filters/filter_bank.py
@@ -1,7 +1,7 @@
 """
-    Multiresolution Morlet filterbank filters
-    
-    Original author: Sira Ferradans, based on code developed by Ivan Dokmanic and Michael Eickenberg
+Multiresolution Morlet filterbank filters
+Original author: Sira Ferradans, based on code
+developed by Ivan Dokmanic and Michael Eickenberg
 """
 
 import numpy as np
@@ -12,9 +12,8 @@ def _ispow2(N):
     return 0 == (N & (N - 1))
 
 
-def _get_filter_at_resolution(filt,j):
+def _get_filter_at_resolution(filt, j):
     """Computes the filter 'filt' at resolution 'j'
-        
         Parameters
         ----------
         filt : ndarray
@@ -26,69 +25,65 @@ def _get_filter_at_resolution(filt,j):
         filt_multires : ndarray
         Filter 'filt' at the resolution j, in the Fourier domain
         """
-    
     cast = np.complex64
     N = filt.shape[0]  # filter is square
-    
     assert _ispow2(N), 'Filter size must be an integer power of 2.'
-    
     J = int(np.log2(N))
-    
     # NTM: 0.5 is a cute trick for higher dimensions!
-    mask = np.hstack((np.ones(int(N / 2 ** (1 + j))), 0.5, np.zeros(int(N - N / 2 ** (j + 1) - 1)))) \
-        + np.hstack((np.zeros(int(N - N / 2 ** (j + 1))), 0.5, np.ones(int(N / 2 ** (1 + j) - 1))))
-
+    mask = np.hstack((np.ones(int(N / 2 ** (1 + j))), 0.5,
+                      np.zeros(int(N - N / 2 ** (j + 1) - 1)))) \
+        + np.hstack((np.zeros(int(N - N / 2 ** (j + 1))),
+                     0.5, np.ones(int(N / 2 ** (1 + j) - 1))))
     mask.shape = N, 1
-    
     filt_lp = filt * mask * mask.T
     if 'cast' in locals():
         filt_lp = cast(filt_lp)
-
     # Remember: C contiguous, last index varies "fastest" (contiguous in
     # memory) (unlike Matlab)
     fold_size = (int(2 ** j), int(N / 2 ** j), int(2 ** j), int(N / 2 ** j))
     filt_multires = filt_lp.reshape(fold_size).sum(axis=(0, 2))
-
     return filt_multires
+
 
 def _zero_pad_filter(filter, N):
     """ Zero pad filter to (N,N)
-    Zero pads 'filter' so it has a NxN size instead of its original size (n,n)
-
+    Zero pads 'filter' so it has a NxN size instead of
+    its original size (n,n)
     Parameters
     ----------
     filter : (n,n) ndarray
         Filter in the Fourier domain of size (n,n)
     N : int
         Goal size of the filter, assumed to be squared (N,N)
-
     Returns
     -------
     padded_filter : (N,N) ndarray
         input filter 'filter' padded with zeros to the size (N,N)
     """
-
-    if filter.shape[0] > N :
+    if filter.shape[0] > N:
         M = np.array(filter.shape[0])
         init = np.int(np.floor(M / 2 - N / 2))
-        filter = filter[init:init + N,:]
-
+        filter = filter[init:init + N, :]
     if filter.shape[1] > N:
         M = np.array(filter.shape[1])
         init = np.int(np.floor(M / 2 - N / 2))
         filter = filter[:, init:init + N]
-
     left_pad = np.int64((np.array((N, N)) - np.array(filter.shape)) / 2)
-    right_pad = np.int64(np.array((N, N)) - (left_pad + np.array(filter.shape)))
-
-    padded_filter = np.lib.pad(filter, ((left_pad[0], right_pad[0]), (left_pad[1], right_pad[1])),
+    right_pad = np.int64(np.array((N, N)) -
+                         (left_pad + np.array(filter.shape)))
+    padded_filter = np.lib.pad(filter, ((left_pad[0], right_pad[0]),
+                                        (left_pad[1], right_pad[1])),
                                'constant', constant_values=(0, 0))
     return padded_filter
 
 
-def multiresolution_filter_bank_morlet2d(N, J, L=8, sigma_phi = 0.8, sigma_xi = 0.8):
-    """ Generates the multiresolution filter bank of 2D Morlet filters in the Fourier domain.
-       Computes a set of 2D Morlet filters at different scales and angles, plus a low pass filter. All of them at
+def multiresolution_filter_bank_morlet2d(N, J, L=8,
+                                         sigma_phi=0.8,
+                                         sigma_xi=0.8):
+    """ Generates the multiresolution filter bank of
+    2D Morlet filters in the Fourier domain.
+       Computes a set of 2D Morlet filters at different
+       scales and angles, plus a low pass filter. All of them at
         at different resolutions.
 
     Parameters
@@ -96,146 +91,137 @@ def multiresolution_filter_bank_morlet2d(N, J, L=8, sigma_phi = 0.8, sigma_xi = 
     N : int
         Size of the  filters, which are square (N,N)
     J : int
-        Total number of scales of the filters located in the frequency domain as powers of 2.
+        Total number of scales of the filters located in the
+        frequency domain as powers of 2.
     L : int
         Total number of angles per scale
     sigma_phi : float
-        Standard deviation needed as a parameter for the low-pass filter (Gaussian), normally set to 0.8
+        Standard deviation needed as a parameter for the
+        low-pass filter (Gaussian), normally set to 0.8
     sigma_xi  : float
-        Standard deviation needed as a parameter for every band-pass filter (Morlet), normally set to 0.8
-
+        Standard deviation needed as a parameter for every
+        band-pass filter (Morlet), normally set to 0.8
     Returns
     -------
-    Filters : Dictionary structure with the filters saved in the Fourier domain organized in the following way
-            - Filters['phi'] : Low pass filter (Gaussian) in a 2D vector of size NxN
-            - Filters['psi'][resolution] : Band pass filter (Morlet) saved as 4D complex array of size [J,L,N,N]
-              where 'J' indexes the scale, 'L; the angles and NxN is the size of a single filter. The variable
-              'resolution' goes from 0 to J.
-
+    Filters : Dictionary structure with the filters saved in the Fourier
+    domain organized in the following way
+            - Filters['phi'] : Low pass filter (Gaussian)
+                in a 2D vector of size NxN
+            - Filters['psi'][resolution] : Band pass filter (Morlet)
+                saved as 4D complex array of size [J,L,N,N] where
+                'J' indexes the scale, 'L; the angles and NxN is
+                 the size of a single filter. The variable 'resolution'
+                 goes from 0 to J.
     Examples
     --------
-    Generate a multiresolution filterbank and plot all the bank pass filters at a given scale j, and angle l. They
+    Generate a multiresolution filterbank and plot all the bank pass
+    filters at a given scale j, and angle l. They
     will be shown in the Fourier domain.
-
     >>>> N=128
     >>>> J=5
     >>>> L=8
     >>>> j=3
     >>>> l=5
-    >>>> wavelet_bnk,littlewood_p = multiresolution_filter_bank_morlet2d(px, J=J, L=L)
+    >>>> wavelet_bnk,lp = multiresolution_filter_bank_morlet2d(px, J=J, L=L)
     >>>> plt.figure(figsize=(18,6))
-    >>>> for r in np.arange(0,num_resolutions):
-            plt.subplot(1,num_resolutions,r+1)
-            f = wavelet_bnk['psi'][r][j][l,:,:]
-            plt.imshow(np.abs(np.fft.fftshift(f)))
-
-     """
-
-    wf, littlewood = filter_bank_morlet2d(N, J=J, L=L, sigma_phi=sigma_phi, sigma_xi=sigma_xi)
-
-    multiresolution_wavelet_filters = filterbank_to_multiresolutionfilterbank(wf, J)
-
+    >>>> r = 2 # resolution to check
+    >>>> f = wavelet_bnk['psi'][r][j][l,:,:]
+    >>>> plt.imshow(np.abs(np.fft.fftshift(f)))
+    """
+    wf, littlewood = filter_bank_morlet2d(N, J=J, L=L,
+                                          sigma_phi=sigma_phi,
+                                          sigma_xi=sigma_xi)
+    multiresolution_wavelet_filters = \
+        filterbank_to_multiresolutionfilterbank(wf, J)
     return multiresolution_wavelet_filters, littlewood
 
 
 def filter_bank_morlet2d(N, J=4, L=8, sigma_phi=0.8, sigma_xi=0.8):
     """ Compute a 2D complex Morlet filter bank in the Fourier domain.
-
-    Creates a filter bank of 1+JxL number of filters in the Fourier domain, where each filter has size NxN, and differ in
-    the activation frequency. All these filters are complex 2D morlet filters [1]_ , [2]_ .
-
+    Creates a filter bank of 1+JxL number of filters in the Fourier domain,
+    where each filter has size NxN, and differ
+    in the activation frequency. All these filters are complex
+    2D morlet filters [1]_ , [2]_ .
     Parameters
     ----------
     N : int
         Size of the  filters, which are square (N,N)
     J : int
-        Total number of scales of the filters located in the frequency domain as powers of 2.
+        Total number of scales of the filters located in the
+        frequency domain as powers of 2.
     L : int
         Total number of angles per scale
     sigma_phi : float
-        Standard deviation needed as a parameter for the low-pass filter (Gaussian), normally set to 0.8
+        Standard deviation needed as a parameter for the low-pass
+         filter (Gaussian), normally set to 0.8
     sigma_xi  : float
-        Standard deviation needed as a parameter for every band-pass filter (Morlet), normally set to 0.8
-
+        Standard deviation needed as a parameter for every band-pass
+         filter (Morlet), normally set to 0.8
     Returns
     -------
-    Filters : Dictionary structure with the filters saved in the Fourier domain organized in the following way
-            - Filters['phi'] : Low pass filter (Gaussian) in a 2D vector of size NxN
-            - Filters['psi'] : Band pass filter (Morlet) saved as 4D complex array of size [J,L,N,N]
-              where 'J' indexes the scale, 'L; the angles and NxN is the size of a single filter.
-
-
+    Filters : Dictionary structure with the filters saved in the Fourier
+        domain organized in the following way
+            - Filters['phi'] : Low pass filter (Gaussian) in a 2D vector
+                    of size NxN
+            - Filters['psi'] : Band pass filter (Morlet) saved as 4D
+                    complex array of size [J,L,N,N] where 'J' indexes
+                    the scale, 'L' the angles and NxN is the size
+                    of a single filter.
     littlewood_paley : (N,N) ndarray
-        Measure of quality of the filter bank for image representation, it should be as close as possible to 1.
-        For more information see eq. 8 in [3]_
-
+        Measure of quality of the filter bank for image representation,
+        it should be as close as possible to 1. For more information
+        see eq. 8 in [3]_
     References
     ----------
-
     .. [1] https://en.wikipedia.org/wiki/Filter_bank
     .. [2] https://en.wikipedia.org/wiki/Discrete_wavelet_transform
-    .. [3] Bruna, J., Mallat, S. 'Invariant Scattering Convolutional Networks'. IEEE Transactions on PAMI, 2012.
-
-
+    .. [3] Bruna, J., Mallat, S. 'Invariant Scattering Convolutional Networks'.
+    IEEE Transactions on PAMI, 2012.
     Examples
     --------
-
-    Generate a filter bank and show all the band pass filters in the Fourier domain.
-
+    Generate a filter bank and show all the band pass filters in
+    the Fourier domain.
     >>>>J = 3
     >>>>L=8
     >>>>px = 32
-    >>>>wavelet_filters, littlewood = filter_bank_morlet2d(px, J=J, L=L, sigma_phi=0.6957,sigma_xi=0.8506 )
+    >>>>filters, littlewood = filter_bank_morlet2d(px, J=J, L=L, \
+                                            sigma_phi=0.6957,sigma_xi=0.8506 )
     >>>>print('params consistent? J2=',J2,' L2=',L2,' N2=', N2)
-        print('Show low pass filter in the Fourier domain')
-        plt.imshow(np.abs(np.fft.fftshift(filters['phi'])))
-        plt.show()
-        print('.. and the band pass filters in the Fourier domain:')
-
-        for j in np.arange(0,J):
-            print('j=',j)
-            plt.figure(figsize=(18,6))
-            for l in np.arange(0,L):
-                plt.subplot(1, L, l+1)
-                plt.imshow(np.abs(np.fft.fftshift(filters['psi'][j][l, :, :])))
-
-            plt.show()
-
+    >>>>print('Show low pass filter in the Fourier domain')
+    >>>>plt.imshow(np.abs(np.fft.fftshift(filters['phi'])))
+    >>>>plt.show()
+    >>>>print('.. and a band pass filters in the Fourier domain:')
+    >>>>f = filters['psi'][j][l,:,:]
+    >>>>plt.imshow(np.abs(np.fft.fftshift(f)))
+    >>>>plt.show()
     """
-    max_scale = 2 ** (float(J - 1))
 
+    max_scale = 2 ** (float(J - 1))
     sigma = sigma_phi * max_scale
     freq = 0.
-
-    filter_phi = np.ndarray((N,N), dtype='complex')
     littlewood_paley = np.zeros((N, N), dtype='single')
-
     # Low pass
-    filter_phi = np.fft.fft2(np.fft.fftshift(_zero_pad_filter(gabor_kernel(freq, theta=0., sigma_x=sigma, sigma_y=sigma),N)))
-
-    ## Band pass filters:
-    ## psi: Create band-pass filters
+    filter_phi = np.fft.fft2(np.fft.fftshift(_zero_pad_filter(
+        gabor_kernel(freq, theta=0., sigma_x=sigma, sigma_y=sigma), N)))
+    # Band pass filters:
+    # psi: Create band-pass filters
     # constant values for psi
-    xi_psi = 3. /4 * np.pi
+    xi_psi = 3. / 4 * np.pi
     slant = 4. / L
-
     filters_psi = []
-
     for j, scale in enumerate(2. ** np.arange(J)):
         angles = np.zeros((L, N, N), dtype='complex')
         for l, theta in enumerate(np.pi * np.arange(L) / float(L)):
             sigma = sigma_xi * scale
             xi = xi_psi / scale
-
             sigma_x = sigma
             sigma_y = sigma / slant
             freq = xi / (np.pi * 2)
-
-            psi = morlet_kernel(freq, theta=theta, sigma_x=sigma_x, sigma_y=sigma_y,n_stds=12)
-      
-            #needs a small shift for odd sizes
-            if (psi.shape[0] % 2 > 0):
-                if (psi.shape[1] % 2 > 0):
+            psi = morlet_kernel(freq, theta=theta, sigma_x=sigma_x,
+                                sigma_y=sigma_y, n_stds=12)
+            # needs a small shift for odd sizes
+            if psi.shape[0] % 2 > 0:
+                if psi.shape[1] % 2 > 0:
                     Psi = _zero_pad_filter(psi[:-1, :-1], N)
                 else:
                     Psi = _zero_pad_filter(psi[:-1, :], N)
@@ -244,67 +230,56 @@ def filter_bank_morlet2d(N, J=4, L=8, sigma_phi=0.8, sigma_xi=0.8):
                     Psi = _zero_pad_filter(psi[:, :-1], N)
                 else:
                     Psi = _zero_pad_filter(psi, N)
-
             angles[l, :, :] = np.fft.fft2(np.fft.fftshift(0.5*Psi))
-
         littlewood_paley += np.sum(np.abs(angles) ** 2, axis=0)
         filters_psi.append(angles)
-
     lwp_max = littlewood_paley.max()
-
     for filt in filters_psi:
         filt /= np.sqrt(lwp_max/2)
-
     Filters = dict(phi=filter_phi, psi=filters_psi)
-
     return Filters, littlewood_paley*2
 
 
 def filterbank_to_multiresolutionfilterbank(filters, max_resolution):
     """ Converts a filter bank into a multiresolution filterbank
-    For every filter of a filter bank, compute this same filter at different resolutions (differnt sizes). The filters
-    are assumed to be in the Fourier domain, as well as the output multiresolution filters.
-
+    For every filter of a filter bank, compute this same filter at different
+    resolutions (differnt sizes). The filters are assumed to be in the
+    Fourier domain, as well as the output multiresolution filters.
     Parameters
     ----------
     filters : dictionary
         Set of filters stored in a dictionary in the following way:
-         - filters['phi'] : Low pass filter (Gaussian) in a 2D vector of size NxN
-         - filters['psi'] : Band pass filter (Morlet) saved as 4D complex array of size [J,L,N,N]
-              where 'J' indexes the scale, 'L; the angles and NxN is the size of a single filter.
-
+         - filters['phi'] : Low pass filter (Gaussian) in a
+               2D vector of size NxN
+         - filters['psi'] : Band pass filter (Morlet) saved as 4D
+              complex array of size [J,L,N,N] where 'J' indexes the scale,
+               'L; the angles and NxN is the size of a single filter.
     max_resolution : int
-        number of resolutions to compute for every filter (thus for every scale and angle)
-
+        number of resolutions to compute for every filter (thus for every
+        scale and angle)
     Returns
     -------
     filters_multires : dictionary
-        Set of filters in the Fourier domain, at different scales, angles and resolutions.
-        See multiresolution_filter_bank_morlet2d for more details on the Filters_multires structure.
-
+        Set of filters in the Fourier domain, at different scales,
+        angles and resolutions.
+        See multiresolution_filter_bank_morlet2d for more details
+        on the Filters_multires structure.
     """
-    J = len(filters['psi']) #scales
-    L = len(filters['psi'][0]) #angles
-    N = filters['psi'][0].shape[-1] #size at max scale
-
+    J = len(filters['psi'])  # scales
+    L = len(filters['psi'][0])  # angles
+    N = filters['psi'][0].shape[-1]  # size at max scale
     Phi_multires = []
     Psi_multires = []
-    for res in np.arange(0,max_resolution):
-        Phi_multires.append(_get_filter_at_resolution(filters['phi'],res))
-
-        aux_filt_psi = np.ndarray((J,L,int(N/2**res),int(N/2**res)), dtype='complex64')
-        for j in np.arange(0,J):
-            for l in np.arange(0,L):
-                aux_filt_psi[j,l,:,:] = _get_filter_at_resolution(filters['psi'][j][l,:,:],res)
-
+    for res in np.arange(0, max_resolution):
+        Phi_multires.append(_get_filter_at_resolution(filters['phi'], res))
+        aux_filt_psi = np.ndarray((J, L, int(N/2**res),
+                                   int(N/2**res)),
+                                  dtype='complex64')
+        for j in np.arange(0, J):
+            for l in np.arange(0, L):
+                aux_filt_psi[j, l, :, :] = _get_filter_at_resolution(
+                    filters['psi'][j][l, :, :],
+                    res)
         Psi_multires.append(aux_filt_psi)
-
     filters_multires = dict(phi=Phi_multires, psi=Psi_multires)
     return filters_multires
-
-
-
-
-
-
-

--- a/skimage/filters/tests/test_gabor.py
+++ b/skimage/filters/tests/test_gabor.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.testing import (assert_equal, assert_almost_equal,
                            assert_array_almost_equal)
 
-from skimage.filters._gabor import gabor_kernel, gabor, _sigma_prefactor
+from skimage.filters._gabor import gabor_kernel, gabor, _sigma_prefactor, morlet_kernel
 
 
 def test_gabor_kernel_size():
@@ -36,9 +36,9 @@ def test_sigma_prefactor():
 
 
 def test_gabor_kernel_sum():
-    for sigma_x in range(1, 10, 2):
-        for sigma_y in range(1, 10, 2):
-            for frequency in range(0, 10, 2):
+    for sigma_x in range(1, 6, 2):
+        for sigma_y in range(1, 6, 2):
+            for frequency in range(0, 6, 2):
                 kernel = gabor_kernel(frequency + 0.1, theta=0,
                                       sigma_x=sigma_x, sigma_y=sigma_y)
                 # make sure gaussian distribution is covered nearly 100%
@@ -46,10 +46,10 @@ def test_gabor_kernel_sum():
 
 
 def test_gabor_kernel_theta():
-    for sigma_x in range(1, 10, 2):
-        for sigma_y in range(1, 10, 2):
-            for frequency in range(0, 10, 2):
-                for theta in range(0, 10, 2):
+    for sigma_x in range(1, 6, 2):
+        for sigma_y in range(1, 6, 2):
+            for frequency in range(0, 6, 2):
+                for theta in range(0, 6, 2):
                     kernel0 = gabor_kernel(frequency + 0.1, theta=theta,
                                            sigma_x=sigma_x, sigma_y=sigma_y)
                     kernel180 = gabor_kernel(frequency, theta=theta + np.pi,
@@ -75,6 +75,17 @@ def test_gabor():
     assert responses[1, 1] > responses[0, 1]
     assert responses[0, 0] > responses[1, 0]
     assert responses[1, 1] > responses[1, 0]
+
+
+def test_morlet_zero_sum():
+    for sigma_x in range(1, 6, 2):
+        for sigma_y in range(1, 6, 2):
+            for frequency in range(0, 6, 2):
+                for theta in range(0, 6, 2):
+                    kernel = morlet_kernel(frequency + 0.1, theta=theta,
+                                           sigma_x=sigma_x, sigma_y=sigma_y)
+
+                    assert_array_almost_equal(np.sum(kernel), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This is a re-pull request for the scattering transform, that I did 4 days ago (#2295). Following the indications of @sciunto (as far as I could), I am re-summiting the code with just the new files (scattering.py, filter_bank.py) and its examples (plot_scattering_classification.py, plot_scattering.py, plot_multiresolution_filterbank.py). For completeness, I am copying the text I put in the previous pull request:  

I have implemented the scattering transform to be applied to images. This scattering transform needs a multiresolution wavelet filter, thus you can also find this new functionality. There are three new examples that show how to use the scattering transform (how to create it and access it), how to use it for classification, and how to use the multiresolution filters implemented.
## Checklist

[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [X] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [X] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [X] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

I am not sure how to provide unitary tests for the proposed code, since there are no mathematical constraints on the output scattering features. Any suggestions here are appreciated. 

@eickenberg
## References

This pull-request is 'improving' the #2295 pull request.

For an explanation on the scattering transform, you can check the examples:
- plot_scattering
- plot_scattering_classification
- papers:

[1] Bruna, J., Mallat, S. 'Invariant Scattering Convolutional Networks'.IEEE TPAMI, 2012.
[2] Oyallon, E. et Mallat, S. 'Deep Roto-translation Scattering for Object Classification'. CVPR 2015
