### PR TITLE
Bug fix for development version of scipy

### DIFF
--- a/doc/examples/edges/plot_active_contours.py
+++ b/doc/examples/edges/plot_active_contours.py
@@ -34,7 +34,10 @@ from skimage.segmentation import active_contour
 # Test scipy version, since active contour is only possible
 # with recent scipy version
 import scipy
-scipy_version = list(map(int, scipy.__version__.split('.')))
+split_version = scipy.__version__.split('.')
+if not(split_version[-1].isdigit()): # Remove dev string if present
+        split_version.pop()
+scipy_version = list(map(int, split_version))
 new_scipy = scipy_version[0] > 0 or \
             (scipy_version[0] == 0 and scipy_version[1] >= 14)
 

--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -85,7 +85,10 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
     25
 
     """
-    scipy_version = list(map(int, scipy.__version__.split('.')))
+    split_version = scipy.__version__.split('.')
+    if not(split_version[-1].isdigit()):
+        split_version.pop()
+    scipy_version = list(map(int, split_version))
     new_scipy = scipy_version[0] > 0 or \
                 (scipy_version[0] == 0 and scipy_version[1] >= 14)
     if not new_scipy:


### PR DESCRIPTION
This is a fix for handling the use of development versions of scipy.
Without this fix the active_contour function crashes as it expects the last part of the version number to be a number

