### PR TITLE
FIX: Rename variables in draw

### DIFF
--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -909,4 +909,4 @@ def bezier_curve(Py_ssize_t y0, Py_ssize_t x0,
     if shape is not None:
         return _coords_inside_image(np.array(px, dtype=np.intp),
                                     np.array(py, dtype=np.intp), shape)
-    return np.array(px, dtype=np.intp), np.array(py, dtype=np.intp)
+    return np.array(py, dtype=np.intp), np.array(px, dtype=np.intp)

--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -894,8 +894,8 @@ def bezier_curve(Py_ssize_t y0, Py_ssize_t x0,
         xx = (x1 - x0) * (yy - y0) / (y1 - y0) + x0
 
         rr, cc = _bezier_segment(y0, x0, y, <int>(xx + 0.5), y, x, ww)
-        px.extend(rr)
-        py.extend(cc)
+        py.extend(rr)
+        px.extend(cc)
 
         xx = (x1 - x2) * (yy - y2) / (y1 - y2) + x2
         x1 = <int>(xx + 0.5)
@@ -903,8 +903,8 @@ def bezier_curve(Py_ssize_t y0, Py_ssize_t x0,
         y0 = y1 = y
 
     rr, cc = _bezier_segment(y0, x0, y1, x1, y2, x2, weight * weight)
-    px.extend(rr)
-    py.extend(cc)
+    py.extend(rr)
+    px.extend(cc)
 
     if shape is not None:
         return _coords_inside_image(np.array(px, dtype=np.intp),

--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -767,8 +767,8 @@ def _bezier_segment(Py_ssize_t y0, Py_ssize_t x0,
 
     # Plot line
     rr, cc = line(x0, y0, x2, y2)
-    py.extend(rr)
-    px.extend(cc)
+    px.extend(rr)
+    py.extend(cc)
 
     return np.array(py, dtype=np.intp), np.array(px, dtype=np.intp)
 

--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -907,6 +907,6 @@ def bezier_curve(Py_ssize_t y0, Py_ssize_t x0,
     px.extend(cc)
 
     if shape is not None:
-        return _coords_inside_image(np.array(px, dtype=np.intp),
-                                    np.array(py, dtype=np.intp), shape)
+        return _coords_inside_image(np.array(py, dtype=np.intp),
+                                    np.array(px, dtype=np.intp), shape)
     return np.array(py, dtype=np.intp), np.array(px, dtype=np.intp)

--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -767,8 +767,8 @@ def _bezier_segment(Py_ssize_t y0, Py_ssize_t x0,
 
     # Plot line
     rr, cc = line(x0, y0, x2, y2)
-    px.extend(rr)
-    py.extend(cc)
+    py.extend(rr)
+    px.extend(cc)
 
     return np.array(py, dtype=np.intp), np.array(px, dtype=np.intp)
 


### PR DESCRIPTION
## Description
The issue fixes #2305 by renaming variables in _draw.pyx for better understanding.





