### PR TITLE
Corrections proposed + improvements.

### DIFF
--- a/doc/examples/segmentation/plot_multiotsu.py
+++ b/doc/examples/segmentation/plot_multiotsu.py
@@ -1,0 +1,76 @@
+"""
+=======================
+Multi-Otsu Thresholding
+=======================
+
+In this example we use multi-Otsu threshold to separate the pixels of an
+input image into three different classes, each one obtained according to
+the intensity of the gray levels within the image.
+
+Multi-Otsu calculates several thresholds, determined by the number of desired
+classes. The default number of classes is 3: for obtaining three classes, the
+algorithm returns two threshold values. They are represented by a red line in
+the histogram below.
+
+.. [1] Liao, P-S. and Chung, P-C., "A fast algorithm for multilevel
+thresholding", Journal of Information Science and Engineering 17 (5):
+713-727, 2001.
+"""
+
+from skimage.data import camera
+from skimage.filters import threshold_multiotsu
+
+import matplotlib
+import matplotlib.pyplot as plt
+
+
+# Stablishing the font size for all plots.
+matplotlib.rcParams['font.size'] = 9
+
+# The input image.
+image = camera()
+
+# Applying multi-Otsu threshold for the default value, generating
+# three classes.
+thresh = threshold_multiotsu(image)
+
+# Using the values on thresh, we generate the three regions.
+region1 = image <= thresh[0]
+region2 = (image > thresh[0]) & (image <= thresh[1])
+region3 = image > thresh[1]
+
+# Plotting the original image.
+plt.figure(figsize=(8, 2.5))
+
+plt.subplot(1, 2, 1)
+plt.imshow(image, cmap='gray')
+plt.title('Original')
+plt.axis('off')
+
+# Plotting the histogram and the two thresholds obtained from
+# multi-Otsu.
+plt.subplot(1, 2, 2)
+plt.hist(image)
+plt.title('Histogram')
+for i in enumerate(thresh):
+    plt.axvline(i[1], color='r')
+
+# Plotting the three resulting regions.
+plt.figure(figsize=(9, 2.5))
+
+plt.subplot(1, 3, 1)
+plt.imshow(region1, cmap='gray')
+plt.title('Multi-Otsu result, Region #1')
+plt.axis('off')
+
+plt.subplot(1, 3, 2)
+plt.imshow(region2, cmap='gray')
+plt.title('Multi-Otsu result, Region #2')
+plt.axis('off')
+
+plt.subplot(1, 3, 3)
+plt.imshow(region3, cmap='gray')
+plt.title('Multi-Otsu result, Region #3')
+plt.axis('off')
+
+plt.show()

--- a/skimage/filters/__init__.py
+++ b/skimage/filters/__init__.py
@@ -11,7 +11,7 @@ from ._frangi import frangi, hessian
 from .thresholding import (threshold_adaptive, threshold_otsu, threshold_yen,
                            threshold_isodata, threshold_li, threshold_minimum,
                            threshold_mean, threshold_triangle,
-                           try_all_threshold)
+                           threshold_multiotsu, try_all_threshold)
 from . import rank
 from .rank import median
 

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -5,6 +5,7 @@ from scipy.ndimage import filters as ndif
 from collections import OrderedDict
 from ..exposure import histogram
 from .._shared.utils import assert_nD, warn
+from ..util.dtype import img_as_ubyte
 
 __all__ = ['try_all_threshold',
            'threshold_adaptive',
@@ -14,7 +15,8 @@ __all__ = ['try_all_threshold',
            'threshold_li',
            'threshold_minimum',
            'threshold_mean',
-           'threshold_triangle']
+           'threshold_triangle',
+           'threshold_multiotsu']
 
 
 def _try_all(image, methods=None, figsize=None, num_cols=2, verbose=True):
@@ -679,7 +681,7 @@ def threshold_triangle(image, nbins=256):
     # Find peak, lowest and highest gray levels.
     arg_peak_height = np.argmax(hist)
     peak_height = hist[arg_peak_height]
-    arg_low_level, arg_high_level = np.where(hist>0)[0][[0, -1]]
+    arg_low_level, arg_high_level = np.where(hist > 0)[0][[0, -1]]
 
     # Flip is True if left tail is shorter.
     flip = arg_peak_height - arg_low_level < arg_high_level - arg_peak_height
@@ -713,3 +715,142 @@ def threshold_triangle(image, nbins=256):
         arg_level = nbins - arg_level - 1
 
     return bin_centers[arg_level]
+
+
+def threshold_multiotsu(image, nclass=3):
+    """Generates multiple thresholds for an input image. Based on the
+    Multi-Otsu approach by Liao, Chen and Chung.
+
+    Parameters
+    ----------
+    image : (N, M) ndarray
+        Grayscale input image.
+    nclass : int, optional
+        Number of classes to be thresholded, i.e. the number of resulting
+        regions. Accepts an integer from 2 to 5.
+    nbins : int, optional
+        Number of bins used to calculate the histogram. This value is
+        ignored for integer arrays.
+
+    Returns
+    -------
+    idx_thresh : array
+        Array containing the threshold values for the desired classes.
+
+    References
+    ----------
+    .. [1] Liao, P-S., Chen, T-S. and Chung, P-C., "A fast algorithm for
+    multilevel thresholding", Journal of Information Science and
+    Engineering 17 (5): 713-727, 2001.
+    .. [2] Tosa, Y., "Multi-Otsu Threshold", a java plugin for ImageJ.
+    Available at:
+    http://imagej.net/plugins/download/Multi_OtsuThreshold.java
+
+    Examples
+    --------
+    >>> from skimage.data import camera
+    >>> image = camera()
+    >>> thresh = threshold_multiotsu(image)
+    >>> region1 = image <= thresh[0]
+    >>> region2 = (image > thresh[0]) & (image <= thresh[1])
+    >>> region3 = image > thresh[1]
+    """
+
+    if image.shape[-1] in (3, 4):
+        raise TypeError("The input image seems to be RGB (shape: {0}. Please"
+                        "use a grayscale image.".format(image.shape))
+
+    if image.min() == image.max():
+        raise TypeError("The input image seems to have only one color: {0}."
+                        "Please use a grayscale image.".format(image.min()))
+
+    # check if nclass is between 2 and 5.
+    if nclass not in np.array((2, 3, 4, 5)):
+        raise ValueError("Please choose a number of classes between"
+                         "2 and 5.")
+
+    # image needs to be between [0, 255].
+    nbins = 256
+    image = img_as_ubyte(image)
+
+    # calculating the histogram and the probability of each gray level.
+    hist, _ = np.histogram(image.ravel(), bins=nbins, range=(0, nbins))
+    prob = hist / image.size
+
+    max_sigma = 0
+    momP, momS, var_btwcls = [np.zeros((nbins, nbins)) for n in range(3)]
+
+    # building the lookup tables.
+    # step 1: calculating the diagonal.
+    for u in range(1, nbins):
+        momP[u, u] = prob[u]
+        momS[u, u] = u * prob[u]
+
+    # step 2: calculating the first row.
+    for u in range(1, nbins-1):
+        momP[1, u+1] = momP[1, u] + prob[u+1]
+        momS[1, u+1] = momS[1, u] + (u+1)*prob[u+1]
+
+    # step 3: calculating the other rows recursively.
+    for u in range(2, nbins):
+        for v in range(u+1, nbins):
+            momP[u, v] = momP[1, v] - momP[1, u-1]
+            momS[u, v] = momS[1, v] - momS[1, u-1]
+
+    # step 4: calculating the between class variance.
+    for u in range(1, nbins):
+        for v in range(u+1, nbins):
+            if (momP[u, v] != 0):
+                var_btwcls[u, v] = momS[u, v]**2 / momP[u, v]
+            else:
+                var_btwcls[u, v] = 0
+
+    # finding max threshold candidates, depending on nclass.
+    # number of thresholds is equal to number of classes - 1.
+    if nclass == 2:
+        for idx in range(1, nbins - nclass):
+            part_sigma = var_btwcls[1, idx] + var_btwcls[idx+1, nbins-1]
+            if max_sigma < part_sigma:
+                idx_thresh = idx
+                max_sigma = part_sigma
+
+    elif nclass == 3:
+        for idx1 in range(1, nbins - nclass):
+            for idx2 in range(idx1+1, nbins - nclass+1):
+                part_sigma = var_btwcls[1, idx1] + \
+                            var_btwcls[idx1+1, idx2] + \
+                            var_btwcls[idx2+1, nbins-1]
+
+                if max_sigma < part_sigma:
+                    idx_thresh = idx1, idx2
+                    max_sigma = part_sigma
+
+    elif nclass == 4:
+        for idx1 in range(1, nbins - nclass):
+            for idx2 in range(idx1+1, nbins - nclass+1):
+                for idx3 in range(idx2+1, nbins - nclass+2):
+                    part_sigma = var_btwcls[1, idx1] + \
+                                var_btwcls[idx1+1, idx2] + \
+                                var_btwcls[idx2+1, idx3] + \
+                                var_btwcls[idx3+1, nbins-1]
+
+                    if max_sigma < part_sigma:
+                        idx_thresh = idx1, idx2, idx3
+                        max_sigma = part_sigma
+
+    elif nclass == 5:
+        for idx1 in range(1, nbins - nclass):
+            for idx2 in range(idx1+1, nbins - nclass+1):
+                for idx3 in range(idx2+1, nbins - nclass+2):
+                    for idx4 in range(idx3+1, nbins - nclass+3):
+                        part_sigma = var_btwcls[1, idx1] + \
+                            var_btwcls[idx1+1, idx2] + \
+                            var_btwcls[idx2+1, idx3] + \
+                            var_btwcls[idx3+1, idx4] + \
+                            var_btwcls[idx4+1, nbins-1]
+
+                        if max_sigma < part_sigma:
+                            idx_thresh = idx1, idx2, idx3, idx4
+                            max_sigma = part_sigma
+
+    return np.array(idx_thresh)


### PR DESCRIPTION
## Description
Adding the function `threshold_multiotsu()`. This generates multiple thresholds for an input image, based on the Multi-Otsu implementation by Liao and Chung.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [X] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [X] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [X] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

## References
[1] Liao, P-S., Chen, T-S. and Chung, P-C., "A fast algorithm for multilevel thresholding", Journal of Information Science and Engineering 17 (5): 713-727, 2001.
[2] Tosa, Y., "Multi-Otsu Threshold", a java plugin for ImageJ. Available at: http://imagej.net/plugins/download/Multi_OtsuThreshold.java