### PR TITLE
Shape Index

### DIFF
--- a/doc/examples/features_detection/plot_shape_index.py
+++ b/doc/examples/features_detection/plot_shape_index.py
@@ -8,38 +8,119 @@ derived from the eigen values of the Hessian, defined by Koenderink & van Doorn 
 
 It can be used to find structures based on their apparent local shape.
 
-Within this example, e.g. try to spot the guy-wires on the original image.
-While only minutely visible in the input image, they become clearly recognizable
-after calculating the shape index of the image.
+The shape index maps to values from -1 to 1,
+representing different kind of shapes (see the documentation for details).
+
+In this example, a random image with spots is generated, which should be detected.
+
+A shape index of 1 represents 'spherical caps', the shape of the spots we want to detect.
+
+The leftmost plot shows the generated image, the center shows a 3D render of the image,
+taking intensity values as height of a 3D surface, and the right one shows the shape index (s).
+
+As visible, the shape index readily amplifies the local shape of noise as well, however is insusceptible
+global phenomena like uneven illumination.
+
+The blue and green marks are points which deviate no more than 0.05 from the desired shape.
+To attenuate noise in the signal, the green marks are taken from the shape index (s)
+ after another Gaussian blur pass (yielding s').
+
+Note how spots interjoined too closely are *not* detected, as they do not posses the desired shape.
 
 .. [1] Koenderink, J. J. & van Doorn, A. J., "Surface shape and curvature scales",
        Image and Vision Computing, 1992, 10, 557-564. DOI:10.1016/0262-8856(92)90076-F
 """
+
+import numpy as np
 import matplotlib.pyplot as plt
-
-from skimage.data import rocket
+from mpl_toolkits.mplot3d import Axes3D
+from scipy import ndimage as ndi
 from skimage.feature import shape_index
+from skimage.draw import circle
 
 
-image = rocket().mean(axis=2)
-s_1 = shape_index(image, sigma=1.0)
-s_3 = shape_index(image, sigma=3.0)
+def create_test_image(image_size=256, spot_count=30, spot_radius=5, cloud_noise_size=4):
+    """Generate a test image with random noise, uneven illumination and spots."""
+    state = np.random.get_state()
+    np.random.seed(314159265)  # some digits of pi
+
+    image = np.random.normal(loc=0.25, scale=0.25, size=(image_size, image_size))
+
+    for _ in range(spot_count):
+        rr, cc = circle(
+            np.random.randint(image.shape[0]),
+            np.random.randint(image.shape[1]),
+            spot_radius,
+            shape=image.shape
+        )
+        image[rr, cc] = 1
+
+    image *= np.random.normal(loc=1.0, scale=0.1, size=image.shape)
+
+    image *= ndi.zoom(
+        np.random.normal(1.0, scale=0.5, size=(cloud_noise_size, cloud_noise_size)),
+        image_size / cloud_noise_size
+    )
+
+    np.random.set_state(state)
+
+    return ndi.gaussian_filter(image, sigma=2.0)
+
+# First create the test image and its shape index
+
+image = create_test_image()
+
+s = shape_index(image)
+
+# In this example we want to detect 'spherical caps', so we threshold the shape index map
+# to find points which are 'spherical caps' (~1)
+
+target = 1
+delta = 0.05
+
+point_y, point_x = np.where(np.abs(s - target) < delta)
+point_z = image[point_y, point_x]
+
+# The shape index map relentlessly produces the shape, even that of noise.
+# In order to reduce the impact of noise, we apply a Gaussian filter to it,
+# and show the results once in
+
+s_smooth = ndi.gaussian_filter(s, sigma=0.5)
+
+point_y_s, point_x_s = np.where(np.abs(s_smooth - target) < delta)
+point_z_s = image[point_y_s, point_x_s]
 
 
-fig, (ax1, ax2, ax3) = plt.subplots(nrows=3, ncols=1, figsize=(5, 15),
-                                    sharex=True, sharey=True)
+fig = plt.figure(figsize=(24, 8))
+ax1 = fig.add_subplot(1, 3, 1)
 
 ax1.imshow(image, cmap=plt.cm.gray)
 ax1.axis('off')
 ax1.set_title('Input image', fontsize=18)
 
-ax2.imshow(s_1, cmap=plt.cm.gray)
-ax2.axis('off')
-ax2.set_title('Shape index, $\sigma=1$', fontsize=18)
+scatter_settings = dict(alpha=0.75, s=10, linewidths=0)
 
-ax3.imshow(s_3, cmap=plt.cm.gray)
+ax1.scatter(point_x, point_y, color='blue', **scatter_settings)
+ax1.scatter(point_x_s, point_y_s, color='green', **scatter_settings)
+
+ax2 = fig.add_subplot(1, 3, 2, projection='3d', sharex=ax1, sharey=ax1)
+
+x, y = np.meshgrid(np.arange(0, image.shape[0], 1), np.arange(0, image.shape[1], 1))
+ax2.plot_surface(x, y, image, linewidth=0, alpha=0.5)
+
+ax2.scatter(point_x, point_y, point_z, color='blue', label='$|s - 1|<0.05$', **scatter_settings)
+ax2.scatter(point_x_s, point_y_s, point_z_s, color='green', label='$|s\' - 1|<0.05$', **scatter_settings)
+
+ax2.legend()
+
+ax2.axis('off')
+ax2.set_title('3D visualization')
+
+ax3 = fig.add_subplot(1, 3, 3, sharex=ax1, sharey=ax1)
+
+ax3.imshow(s, cmap=plt.cm.gray)
 ax3.axis('off')
-ax3.set_title('Shape index, $\sigma=3$', fontsize=18)
+ax3.set_title('Shape index, $\sigma=1$', fontsize=18)
 
 fig.tight_layout()
 

--- a/doc/examples/features_detection/plot_shape_index.py
+++ b/doc/examples/features_detection/plot_shape_index.py
@@ -1,0 +1,46 @@
+"""
+===========
+Shape Index
+===========
+
+The shape index is a single valued measure of local curvature,
+derived from the eigen values of the Hessian, defined by Koenderink & van Doorn [1]_.
+
+It can be used to find structures based on their apparent local shape.
+
+Within this example, e.g. try to spot the guy-wires on the original image.
+While only minutely visible in the input image, they become clearly recognizable
+after calculating the shape index of the image.
+
+.. [1] Koenderink, J. J. & van Doorn, A. J., "Surface shape and curvature scales",
+       Image and Vision Computing, 1992, 10, 557-564. DOI:10.1016/0262-8856(92)90076-F
+"""
+import matplotlib.pyplot as plt
+
+from skimage.data import rocket
+from skimage.feature import shape_index
+
+
+image = rocket().mean(axis=2)
+s_1 = shape_index(image, sigma=1.0)
+s_3 = shape_index(image, sigma=3.0)
+
+
+fig, (ax1, ax2, ax3) = plt.subplots(nrows=3, ncols=1, figsize=(5, 15),
+                                    sharex=True, sharey=True)
+
+ax1.imshow(image, cmap=plt.cm.gray)
+ax1.axis('off')
+ax1.set_title('Input image', fontsize=18)
+
+ax2.imshow(s_1, cmap=plt.cm.gray)
+ax2.axis('off')
+ax2.set_title('Shape index, $\sigma=1$', fontsize=18)
+
+ax3.imshow(s_3, cmap=plt.cm.gray)
+ax3.axis('off')
+ax3.set_title('Shape index, $\sigma=3$', fontsize=18)
+
+fig.tight_layout()
+
+plt.show()

--- a/doc/examples/features_detection/plot_shape_index.py
+++ b/doc/examples/features_detection/plot_shape_index.py
@@ -23,7 +23,7 @@ global phenomena like uneven illumination.
 
 The blue and green marks are points which deviate no more than 0.05 from the desired shape.
 To attenuate noise in the signal, the green marks are taken from the shape index (s)
- after another Gaussian blur pass (yielding s').
+after another Gaussian blur pass (yielding s').
 
 Note how spots interjoined too closely are *not* detected, as they do not posses the desired shape.
 

--- a/doc/examples/features_detection/plot_shape_index.py
+++ b/doc/examples/features_detection/plot_shape_index.py
@@ -4,31 +4,39 @@ Shape Index
 ===========
 
 The shape index is a single valued measure of local curvature,
-derived from the eigen values of the Hessian, defined by Koenderink & van Doorn [1]_.
+derived from the eigen values of the Hessian,
+defined by Koenderink & van Doorn [1]_.
 
 It can be used to find structures based on their apparent local shape.
 
 The shape index maps to values from -1 to 1,
 representing different kind of shapes (see the documentation for details).
 
-In this example, a random image with spots is generated, which should be detected.
+In this example, a random image with spots is generated,
+which should be detected.
 
-A shape index of 1 represents 'spherical caps', the shape of the spots we want to detect.
+A shape index of 1 represents 'spherical caps',
+the shape of the spots we want to detect.
 
-The leftmost plot shows the generated image, the center shows a 3D render of the image,
-taking intensity values as height of a 3D surface, and the right one shows the shape index (s).
+The leftmost plot shows the generated image, the center shows a 3D render
+of the image, taking intensity values as height of a 3D surface,
+and the right one shows the shape index (s).
 
-As visible, the shape index readily amplifies the local shape of noise as well, however is insusceptible
-global phenomena like uneven illumination.
+As visible, the shape index readily amplifies the local shape of noise as well,
+but is insusceptible to global phenomena (e.g. uneven illumination).
 
-The blue and green marks are points which deviate no more than 0.05 from the desired shape.
-To attenuate noise in the signal, the green marks are taken from the shape index (s)
+The blue and green marks are points which deviate no more than 0.05
+from the desired shape. To attenuate noise in the signal, the
+green marks are taken from the shape index (s)
 after another Gaussian blur pass (yielding s').
 
-Note how spots interjoined too closely are *not* detected, as they do not posses the desired shape.
+Note how spots interjoined too closely are *not* detected,
+as they do not posses the desired shape.
 
-.. [1] Koenderink, J. J. & van Doorn, A. J., "Surface shape and curvature scales",
-       Image and Vision Computing, 1992, 10, 557-564. DOI:10.1016/0262-8856(92)90076-F
+.. [1] Koenderink, J. J. & van Doorn, A. J.,
+       "Surface shape and curvature scales",
+       Image and Vision Computing, 1992, 10, 557-564.
+       DOI:10.1016/0262-8856(92)90076-F
 """
 
 import numpy as np
@@ -39,12 +47,19 @@ from skimage.feature import shape_index
 from skimage.draw import circle
 
 
-def create_test_image(image_size=256, spot_count=30, spot_radius=5, cloud_noise_size=4):
-    """Generate a test image with random noise, uneven illumination and spots."""
+def create_test_image(
+        image_size=256, spot_count=30, spot_radius=5, cloud_noise_size=4):
+    """
+    Generate a test image with random noise, uneven illumination and spots.
+    """
     state = np.random.get_state()
     np.random.seed(314159265)  # some digits of pi
 
-    image = np.random.normal(loc=0.25, scale=0.25, size=(image_size, image_size))
+    image = np.random.normal(
+        loc=0.25,
+        scale=0.25,
+        size=(image_size, image_size)
+    )
 
     for _ in range(spot_count):
         rr, cc = circle(
@@ -58,7 +73,11 @@ def create_test_image(image_size=256, spot_count=30, spot_radius=5, cloud_noise_
     image *= np.random.normal(loc=1.0, scale=0.1, size=image.shape)
 
     image *= ndi.zoom(
-        np.random.normal(1.0, scale=0.5, size=(cloud_noise_size, cloud_noise_size)),
+        np.random.normal(
+            loc=1.0,
+            scale=0.5,
+            size=(cloud_noise_size, cloud_noise_size)
+        ),
         image_size / cloud_noise_size
     )
 
@@ -72,8 +91,9 @@ image = create_test_image()
 
 s = shape_index(image)
 
-# In this example we want to detect 'spherical caps', so we threshold the shape index map
-# to find points which are 'spherical caps' (~1)
+# In this example we want to detect 'spherical caps',
+# so we threshold the shape index map to
+# find points which are 'spherical caps' (~1)
 
 target = 1
 delta = 0.05
@@ -105,11 +125,30 @@ ax1.scatter(point_x_s, point_y_s, color='green', **scatter_settings)
 
 ax2 = fig.add_subplot(1, 3, 2, projection='3d', sharex=ax1, sharey=ax1)
 
-x, y = np.meshgrid(np.arange(0, image.shape[0], 1), np.arange(0, image.shape[1], 1))
+x, y = np.meshgrid(
+    np.arange(0, image.shape[0], 1),
+    np.arange(0, image.shape[1], 1)
+)
+
 ax2.plot_surface(x, y, image, linewidth=0, alpha=0.5)
 
-ax2.scatter(point_x, point_y, point_z, color='blue', label='$|s - 1|<0.05$', **scatter_settings)
-ax2.scatter(point_x_s, point_y_s, point_z_s, color='green', label='$|s\' - 1|<0.05$', **scatter_settings)
+ax2.scatter(
+    point_x,
+    point_y,
+    point_z,
+    color='blue',
+    label='$|s - 1|<0.05$',
+    **scatter_settings
+)
+
+ax2.scatter(
+    point_x_s,
+    point_y_s,
+    point_z_s,
+    color='green',
+    label='$|s\' - 1|<0.05$',
+    **scatter_settings
+)
 
 ax2.legend()
 

--- a/skimage/feature/__init__.py
+++ b/skimage/feature/__init__.py
@@ -12,7 +12,8 @@ from .corner import (corner_kitchen_rosenfeld, corner_harris,
                      corner_peaks, corner_fast, structure_tensor,
                      structure_tensor_eigvals, hessian_matrix,
                      hessian_matrix_eigvals, hessian_matrix_det,
-                     corner_moravec, corner_orientations)
+                     corner_moravec, corner_orientations,
+                     shape_index)
 from .template import match_template
 from .register_translation import register_translation
 from .brief import BRIEF
@@ -37,6 +38,7 @@ __all__ = ['canny',
            'hessian_matrix',
            'hessian_matrix_det',
            'hessian_matrix_eigvals',
+           'shape_index',
            'corner_kitchen_rosenfeld',
            'corner_harris',
            'corner_shi_tomasi',

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -288,8 +288,8 @@ def hessian_matrix_eigvals(Hxx, Hxy, Hyy):
 def shape_index(image, sigma=1, mode='constant', cval=0):
     """Compute the shape index.
 
-    The shape index, as defined by defined by Koenderink & van Doorn [1]_,
-    is a single valued measure of local curvature, assuming the image as a 3D plane
+    The shape index, as defined by Koenderink & van Doorn [1]_, is a
+    single valued measure of local curvature, assuming the image as a 3D plane
     with intensities representing heights.
 
     It is derived from the eigen values of the Hessian, and its
@@ -332,8 +332,10 @@ def shape_index(image, sigma=1, mode='constant', cval=0):
 
     References
     ----------
-    .. [1] Koenderink, J. J. & van Doorn, A. J., "Surface shape and curvature scales",
-           Image and Vision Computing, 1992, 10, 557-564. DOI:10.1016/0262-8856(92)90076-F
+    .. [1] Koenderink, J. J. & van Doorn, A. J.,
+           "Surface shape and curvature scales",
+           Image and Vision Computing, 1992, 10, 557-564.
+           DOI:10.1016/0262-8856(92)90076-F
 
     Examples
     --------

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -288,8 +288,9 @@ def hessian_matrix_eigvals(Hxx, Hxy, Hyy):
 def shape_index(image, sigma=1, mode='constant', cval=0):
     """Compute the shape index.
 
-    The shape index is a single valued measure
-    of local curvature, defined by Koenderink & van Doorn [1]_.
+    The shape index, as defined by defined by Koenderink & van Doorn [1]_,
+    is a single valued measure of local curvature, assuming the image as a 3D plane
+    with intensities representing heights.
 
     It is derived from the eigen values of the Hessian, and its
     value ranges from -1 to 1 (and is undefined (=NaN) in *flat* regions),

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -286,29 +286,38 @@ def hessian_matrix_eigvals(Hxx, Hxy, Hyy):
 
 
 def shape_index(image, sigma=1, mode='constant', cval=0):
-    """Compute the shape index. The shape index is a single valued measure
-    of local curvature, defined by Koenderink & van Doorn [1].
+    """Compute the shape index.
 
-    Its values range from -1 to 1 (and may be nan), with following ranges
-    representing following shapes:
+    The shape index is a single valued measure
+    of local curvature, defined by Koenderink & van Doorn [1]_.
 
-    * s in [  -1, -7/8): Spherical cup
-    * s in [-7/8, -5/8): Through
-    * s in [-5/8, -3/8): Rut
-    * s in [-3/8, -1/8): Saddle rut
-    * s in [-1/8, +1/8): Saddle
-    * s in [+1/8, +3/8): Saddle ridge
-    * s in [+3/8, +5/8): Ridge
-    * s in [+5/8, +7/8): Dome
-    * s in [+7/8,   +1]: Spherical cap
+    It is derived from the eigen values of the Hessian, and its
+    value ranges from -1 to 1 (and is undefined (=NaN) in *flat* regions),
+    with following ranges representing following shapes:
+
+    .. table:: Ranges of the shape index and corresponding shapes.
+
+      ===================  =============
+      Interval (s in ...)  Shape
+      ===================  =============
+      [  -1, -7/8)         Spherical cup
+      [-7/8, -5/8)         Through
+      [-5/8, -3/8)         Rut
+      [-3/8, -1/8)         Saddle rut
+      [-1/8, +1/8)         Saddle
+      [+1/8, +3/8)         Saddle ridge
+      [+3/8, +5/8)         Ridge
+      [+5/8, +7/8)         Dome
+      [+7/8,   +1]         Spherical cap
+      ===================  =============
 
     Parameters
     ----------
     image : ndarray
         Input image.
-    sigma : float
-        Standard deviation used for the Gaussian kernel, which is used as
-        weighting function for the auto-correlation matrix.
+    sigma : float, optional
+        Standard deviation used for the Gaussian kernel, which is used for
+        smoothing the input data before Hessian eigen value calculation.
     mode : {'constant', 'reflect', 'wrap', 'nearest', 'mirror'}, optional
         How to handle values outside the image borders.
     cval : float, optional
@@ -323,8 +332,7 @@ def shape_index(image, sigma=1, mode='constant', cval=0):
     References
     ----------
     .. [1] Koenderink, J. J. & van Doorn, A. J., "Surface shape and curvature scales",
-           Image and Vision Computing, 1992, 10, 557-564.
-
+           Image and Vision Computing, 1992, 10, 557-564. DOI:10.1016/0262-8856(92)90076-F
 
     Examples
     --------

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -285,6 +285,67 @@ def hessian_matrix_eigvals(Hxx, Hxy, Hyy):
     return _image_orthogonal_matrix22_eigvals(Hxx, Hxy, Hyy)
 
 
+def shape_index(image, sigma=1, mode='constant', cval=0):
+    """Compute the shape index. The shape index is a single valued measure
+    of local curvature, defined by Koenderink & van Doorn [1].
+
+    Its values range from -1 to 1 (and may be nan), with following ranges
+    representing following shapes:
+
+    * s in [  -1, -7/8): Spherical cup
+    * s in [-7/8, -5/8): Through
+    * s in [-5/8, -3/8): Rut
+    * s in [-3/8, -1/8): Saddle rut
+    * s in [-1/8, +1/8): Saddle
+    * s in [+1/8, +3/8): Saddle ridge
+    * s in [+3/8, +5/8): Ridge
+    * s in [+5/8, +7/8): Dome
+    * s in [+7/8,   +1]: Spherical cap
+
+    Parameters
+    ----------
+    image : ndarray
+        Input image.
+    sigma : float
+        Standard deviation used for the Gaussian kernel, which is used as
+        weighting function for the auto-correlation matrix.
+    mode : {'constant', 'reflect', 'wrap', 'nearest', 'mirror'}, optional
+        How to handle values outside the image borders.
+    cval : float, optional
+        Used in conjunction with mode 'constant', the value outside
+        the image boundaries.
+
+    Returns
+    -------
+    s : ndarray
+        Shape index
+
+    References
+    ----------
+    .. [1] Koenderink, J. J. & van Doorn, A. J., "Surface shape and curvature scales",
+           Image and Vision Computing, 1992, 10, 557-564.
+
+
+    Examples
+    --------
+    >>> from skimage.feature import shape_index
+    >>> square = np.zeros((5, 5))
+    >>> square[2, 2] = 4
+    >>> s = shape_index(square, sigma=0.1)
+    >>> s
+    array([[ nan,  nan, -0.5,  nan,  nan],
+           [ nan, -0. ,  nan, -0. ,  nan],
+           [-0.5,  nan, -1. ,  nan, -0.5],
+           [ nan, -0. ,  nan, -0. ,  nan],
+           [ nan,  nan, -0.5,  nan,  nan]])
+    """
+
+    Hxx, Hxy, Hyy = hessian_matrix(image, sigma=sigma, mode=mode, cval=cval)
+    l1, l2 = hessian_matrix_eigvals(Hxx, Hxy, Hyy)
+
+    return (2.0 / np.pi) * np.arctan((l2 + l1) / (l2 - l1))
+
+
 def corner_kitchen_rosenfeld(image, mode='constant', cval=0):
     """Compute Kitchen and Rosenfeld corner measure response image.
 

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -120,11 +120,13 @@ def test_shape_index():
     square = np.zeros((5, 5))
     square[2, 2] = 4
     s = shape_index(square, sigma=0.1)
-    assert_almost_equal(s, np.array([[ np.nan, np.nan,   -0.5, np.nan, np.nan],
-                                     [ np.nan,      0, np.nan,      0, np.nan],
-                                     [   -0.5, np.nan,     -1, np.nan,   -0.5],
-                                     [ np.nan,      0, np.nan,      0, np.nan],
-                                     [ np.nan, np.nan,   -0.5, np.nan, np.nan]]))
+    assert_almost_equal(
+        s, np.array([[ np.nan, np.nan,   -0.5, np.nan, np.nan],
+                     [ np.nan,      0, np.nan,      0, np.nan],
+                     [   -0.5, np.nan,     -1, np.nan,   -0.5],
+                     [ np.nan,      0, np.nan,      0, np.nan],
+                     [ np.nan, np.nan,   -0.5, np.nan, np.nan]])
+    )
 
 
 @test_parallel()

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -120,12 +120,11 @@ def test_shape_index():
     square = np.zeros((5, 5))
     square[2, 2] = 4
     s = shape_index(square, sigma=0.1)
-    nan = float('nan')
-    assert_almost_equal(s,  np.array([[ nan,  nan, -0.5,  nan,  nan],
-                                      [ nan,    0,  nan,   0,   nan],
-                                      [-0.5,  nan,  -1,   nan, -0.5],
-                                      [ nan,   0,   nan,   0,   nan],
-                                      [ nan,  nan, -0.5,  nan,  nan]]))
+    assert_almost_equal(s, np.array([[ np.nan, np.nan,   -0.5, np.nan, np.nan],
+                                     [ np.nan,      0, np.nan,      0, np.nan],
+                                     [   -0.5, np.nan,     -1, np.nan,   -0.5],
+                                     [ np.nan,      0, np.nan,      0, np.nan],
+                                     [ np.nan, np.nan,   -0.5, np.nan, np.nan]]))
 
 
 @test_parallel()

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -14,7 +14,7 @@ from skimage.feature import (corner_moravec, corner_harris, corner_shi_tomasi,
                              corner_fast, corner_orientations,
                              structure_tensor, structure_tensor_eigvals,
                              hessian_matrix, hessian_matrix_eigvals,
-                             hessian_matrix_det)
+                             hessian_matrix_det, shape_index)
 
 
 def test_structure_tensor():
@@ -114,6 +114,18 @@ def test_hessian_matrix_det():
     image[2, 2] = 1
     det = hessian_matrix_det(image, 5)
     assert_almost_equal(det, 0, decimal = 3)
+
+
+def test_shape_index():
+    square = np.zeros((5, 5))
+    square[2, 2] = 4
+    s = shape_index(square, sigma=0.1)
+    nan = float('nan')
+    assert_almost_equal(s,  np.array([[ nan,  nan, -0.5,  nan,  nan],
+                                      [ nan,    0,  nan,   0,   nan],
+                                      [-0.5,  nan,  -1,   nan, -0.5],
+                                      [ nan,   0,   nan,   0,   nan],
+                                      [ nan,  nan, -0.5,  nan,  nan]]))
 
 
 @test_parallel()


### PR DESCRIPTION
## Description
This PR adds a function for shape index calculation, the shape index being a single valued measure of local curvature, derived from the Hessian of the image. I've found this method to be a valuable feature in segmenting objects based on their apparent shape (roundness, that is), but there do not seem many readily available functions around. However, with the paper [1] having 813 citations according to Google Scholar [2], I do think that it must be a more known technique in certain communities. An ImageJ plugin for its calculation is bundled with Fiji [3].

The function is rather small, but largely depends on existing Hessian code. I do not think that a Gallery example is useful for this. Code should be adherent to PEP8 and has a (rather simple) test case.
Not sure if `corner.py` is the best place for this, however, it's close to the other Hessian-related functions that way.

What do you think, would this be a useful addition to scikit-image?

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

## References
[1] Koenderink, J. J. & van Doorn, A. J., "Surface shape and curvature scales", Image and Vision Computing, 1992, 10, 557-564.
[2] https://scholar.google.de/scholar?cites=12619217473602495580
[3] http://imagej.net/Shape_Index_Map