### PR TITLE
Fix display problem when printing error messages

### DIFF
--- a/skimage/io/_plugins/freeimage_plugin.py
+++ b/skimage/io/_plugins/freeimage_plugin.py
@@ -93,10 +93,12 @@ def load_freeimage():
             err_txt = ['%s:\n%s' % (l, str(e)) for l, e in errors]
             raise RuntimeError('One or more FreeImage libraries were found, '
                                'but could not be loaded due to the following '
-                               'errors:\n\n\n'.join(err_txt))
+                               'errors:\n',
+                               '\n\n'.join(err_txt))
         else:
             # No errors, because no potential libraries found at all!
             raise RuntimeError('Could not find a FreeImage library in any of:'
+                               '\n', 
                                '\n\n'.join(lib_dirs))
 
     # FreeImage found

--- a/skimage/io/_plugins/freeimage_plugin.py
+++ b/skimage/io/_plugins/freeimage_plugin.py
@@ -93,12 +93,12 @@ def load_freeimage():
             err_txt = ['%s:\n%s' % (l, str(e)) for l, e in errors]
             raise RuntimeError('One or more FreeImage libraries were found, '
                                'but could not be loaded due to the following '
-                               'errors:\n',
+                               'errors:\n' +
                                '\n'.join(err_txt))
         else:
             # No errors, because no potential libraries found at all!
             raise RuntimeError('Could not find a FreeImage library in any of:'
-                               '\n', 
+                               '\n' +
                                '\n'.join(lib_dirs))
 
     # FreeImage found

--- a/skimage/io/_plugins/freeimage_plugin.py
+++ b/skimage/io/_plugins/freeimage_plugin.py
@@ -94,12 +94,12 @@ def load_freeimage():
             raise RuntimeError('One or more FreeImage libraries were found, '
                                'but could not be loaded due to the following '
                                'errors:\n',
-                               '\n'.join(err_txt), sep='')
+                               '\n'.join(err_txt))
         else:
             # No errors, because no potential libraries found at all!
             raise RuntimeError('Could not find a FreeImage library in any of:'
                                '\n', 
-                               '\n'.join(lib_dirs), sep='')
+                               '\n'.join(lib_dirs))
 
     # FreeImage found
     freeimage.FreeImage_SetOutputMessage(c_error_handler)

--- a/skimage/io/_plugins/freeimage_plugin.py
+++ b/skimage/io/_plugins/freeimage_plugin.py
@@ -94,12 +94,12 @@ def load_freeimage():
             raise RuntimeError('One or more FreeImage libraries were found, '
                                'but could not be loaded due to the following '
                                'errors:\n',
-                               '\n\n'.join(err_txt))
+                               '\n'.join(err_txt), sep='')
         else:
             # No errors, because no potential libraries found at all!
             raise RuntimeError('Could not find a FreeImage library in any of:'
                                '\n', 
-                               '\n\n'.join(lib_dirs))
+                               '\n'.join(lib_dirs), sep='')
 
     # FreeImage found
     freeimage.FreeImage_SetOutputMessage(c_error_handler)


### PR DESCRIPTION
## Description
Platform: Win64  Anaconda3
Python Version: 3.5.2

This PR is about freeimage plugin in the io module.
Bug fix when printing error message. Try to solve the display problem when not finding a proper freeimage library.



