### PR TITLE
Update hessian matrix code to include order kwarg

### DIFF
--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -367,7 +367,7 @@ def shape_index(image, sigma=1, mode='constant', cval=0):
            [ nan,  nan, -0.5,  nan,  nan]])
     """
 
-    Hxx, Hxy, Hyy = hessian_matrix(image, sigma=sigma, mode=mode, cval=cval)
+    Hxx, Hxy, Hyy = hessian_matrix(image, sigma=sigma, mode=mode, cval=cval, order='rc')
     l1, l2 = hessian_matrix_eigvals(Hxx, Hxy, Hyy)
 
     return (2.0 / np.pi) * np.arctan((l2 + l1) / (l2 - l1))

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -102,7 +102,7 @@ def structure_tensor(image, sigma=1, mode='constant', cval=0):
     return Axx, Axy, Ayy
 
 
-def hessian_matrix(image, sigma=1, mode='constant', cval=0):
+def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
     """Compute Hessian matrix.
 
     The Hessian matrix is defined as::
@@ -122,9 +122,13 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0):
         weighting function for the auto-correlation matrix.
     mode : {'constant', 'reflect', 'wrap', 'nearest', 'mirror'}, optional
         How to handle values outside the image borders.
-    cval : float, optional
+    cval : float, 'F'
+        else:optional
         Used in conjunction with mode 'constant', the value outside
         the image boundaries.
+    order : {'C', 'F'}, optional
+        this parameter allows for the use of reverse or forward order of
+        returned matrix values
 
     Returns
     -------
@@ -159,10 +163,18 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0):
     H_elems = [np.gradient(gradients[ax0], axis=ax1)
                for ax0, ax1 in combinations_with_replacement(axes, 2)]
 
-    if image.ndim == 2:
-        # The legacy 2D code followed (x, y) convention, so we swap the axis
-        # order to maintain compatibility with old code
+
+    if order is None:
+        if image.ndim ==2:
+            # The legacy 2D code followed (x, y) convention, so we swap the axis
+            # order to maintain compatibility with old code
+            order = 'F'
+        else:
+            order = 'C'
+
+    if order == 'F':
         H_elems.reverse()
+
     return H_elems
 
 
@@ -249,7 +261,7 @@ def structure_tensor_eigvals(Axx, Axy, Ayy):
 
 
 def hessian_matrix_eigvals(Hxx, Hxy, Hyy):
-    """Compute Eigen values of Hessian matrix.
+    """Compute Eigenvalues of Hessian matrix.
 
     Parameters
     ----------

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -126,8 +126,10 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
         Used in conjunction with mode 'constant', the value outside
         the image boundaries.
     order : {'xy', 'rc'}, optional
-        this parameter allows for the use of reverse or forward order of
-        returned matrix values
+        This parameter allows for the use of reverse or forward order of
+        the image axes in gradient computation. 'xy' indicates the usage
+        of the last axis initially (Hxx, Hxy, Hyy), whilst 'rc' indicates
+        the use of the first axis initially (Hrr, Hrc, Hcc).
 
     Returns
     -------

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -164,8 +164,8 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
             # The legacy 2D code followed (x, y) convention, so we swap the axis
             # order to maintain compatibility with old code
             warn('deprecation warning: the default order of the hessian matrix values '
-            'will be "row-column" instead of "xy" starting in skimage version 0.15'
-             'Use order="rc" or order="xy" to set this explicitly')
+            'will be "row-column" instead of "xy" starting in skimage version 0.15. '
+            'Use order="rc" or order="xy" to set this explicitly')
             order = 'xy'
         else:
             order = 'rc'

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -164,8 +164,8 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
             # The legacy 2D code followed (x, y) convention, so we swap the axis
             # order to maintain compatibility with old code
             warn('deprecation warning: the default order of the hessian matrix values '
-            'will be "row-column" instead of "xy" starting in skimage version 0.15. '
-            'Use order="rc" or order="xy" to set this explicitly')
+                 'will be "row-column" instead of "xy" starting in skimage version 0.15. '
+                 'Use order="rc" or order="xy" to set this explicitly')
             order = 'xy'
         else:
             order = 'rc'

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -162,7 +162,7 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
         if image.ndim ==2:
             # The legacy 2D code followed (x, y) convention, so we swap the axis
             # order to maintain compatibility with old code
-            warn('deprecation warning: the order will be changed in' 'v0.15')
+            warn('deprecation warning: the default value will be changed to ''xy'' in version 0.15')
 
             order = 'F'
         else:

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -123,7 +123,6 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
     mode : {'constant', 'reflect', 'wrap', 'nearest', 'mirror'}, optional
         How to handle values outside the image borders.
     cval : float, optional
-        else:optional
         Used in conjunction with mode 'constant', the value outside
         the image boundaries.
     order : {'xy', 'rc'}, optional

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -158,12 +158,6 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
     gaussian_filtered = ndi.gaussian_filter(image, sigma=sigma,
                                             mode=mode, cval=cval)
 
-    gradients = np.gradient(gaussian_filtered)
-    axes = range(image.ndim)
-    H_elems = [np.gradient(gradients[ax0], axis=ax1)
-               for ax0, ax1 in combinations_with_replacement(axes, 2)]
-
-
     if order is None:
         if image.ndim ==2:
             # The legacy 2D code followed (x, y) convention, so we swap the axis
@@ -172,8 +166,13 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
         else:
             order = 'C'
 
+    gradients = np.gradient(gaussian_filtered)
+    axes = range(image.ndim)
+    H_elems = [np.gradient(gradients[ax0], axis=ax1)
+               for ax0, ax1 in combinations_with_replacement(axes, 2)]
+
     if order == 'F':
-        H_elems.reverse()
+        H_elems = reversed(H_elems);
 
     return H_elems
 

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -166,9 +166,9 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
             warn('deprecation warning: the default order of the hessian matrix values '
             'will be "row-column" instead of "xy" starting in skimage version 0.15'
              'Use order="rc" or order="xy" to set this explicitly')
-            order = 'rc'
-        else:
             order = 'xy'
+        else:
+            order = 'rc'
 
 
     gradients = np.gradient(gaussian_filtered)

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -336,8 +336,7 @@ def shape_index(image, sigma=1, mode='constant', cval=0):
         Standard deviation used for the Gaussian kernel, which is used for
         smoothing the input data before Hessian eigen value calculation.
     mode : {'constant', 'reflect', 'wrap', 'nearest', 'mirror'}, optional
-        How to handle values outside the image borders.from .._shared.utils import skimage_deprecation, warn
-
+        How to handle values outside the image borders
     cval : float, optional
         Used in conjunction with mode 'constant', the value outside
         the image boundaries.

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -12,7 +12,7 @@ from ._hessian_det_appx import _hessian_matrix_det
 from ..transform import integral_image
 from .._shared.utils import safe_as_int
 from .corner_cy import _corner_moravec, _corner_orientations
-
+from warnings import warn
 
 def _compute_derivatives(image, mode='constant', cval=0):
     """Compute derivatives in x and y direction using the Sobel operator.
@@ -122,7 +122,7 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
         weighting function for the auto-correlation matrix.
     mode : {'constant', 'reflect', 'wrap', 'nearest', 'mirror'}, optional
         How to handle values outside the image borders.
-    cval : float, 'F'
+    cval : float, optional
         else:optional
         Used in conjunction with mode 'constant', the value outside
         the image boundaries.
@@ -162,9 +162,12 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
         if image.ndim ==2:
             # The legacy 2D code followed (x, y) convention, so we swap the axis
             # order to maintain compatibility with old code
+            warn('deprecation warning: the order will be changed in' 'v0.15')
+
             order = 'F'
         else:
             order = 'C'
+
 
     gradients = np.gradient(gaussian_filtered)
     axes = range(image.ndim)
@@ -331,7 +334,8 @@ def shape_index(image, sigma=1, mode='constant', cval=0):
         Standard deviation used for the Gaussian kernel, which is used for
         smoothing the input data before Hessian eigen value calculation.
     mode : {'constant', 'reflect', 'wrap', 'nearest', 'mirror'}, optional
-        How to handle values outside the image borders.
+        How to handle values outside the image borders.from .._shared.utils import skimage_deprecation, warn
+
     cval : float, optional
         Used in conjunction with mode 'constant', the value outside
         the image boundaries.

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -170,14 +170,14 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
 
     gradients = np.gradient(gaussian_filtered)
     axes = range(image.ndim)
+
+    if order == 'rc':
+        axes = reversed(axes)
+
     H_elems = [np.gradient(gradients[ax0], axis=ax1)
                for ax0, ax1 in combinations_with_replacement(axes, 2)]
 
-    if order == 'rc':
-        H_elems = reversed(H_elems);
-
     return H_elems
-
 
 def hessian_matrix_det(image, sigma=1):
     """Computes the approximate Hessian Determinant over an image.

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -145,7 +145,7 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
     >>> from skimage.feature import hessian_matrix
     >>> square = np.zeros((5, 5))
     >>> square[2, 2] = 4
-    >>> Hrr, Hrc, Hcc = hessian_matrix(square, sigma=0.1)
+    >>> Hrr, Hrc, Hcc = hessian_matrix(square, sigma=0.1, order = 'rc')
     >>> Hrc
     array([[ 0.,  0.,  0.,  0.,  0.],
            [ 0.,  1.,  0., -1.,  0.],

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -288,7 +288,7 @@ def hessian_matrix_eigvals(Hxx, Hxy, Hyy):
     >>> from skimage.feature import hessian_matrix, hessian_matrix_eigvals
     >>> square = np.zeros((5, 5))
     >>> square[2, 2] = 4
-    >>> Hxx, Hxy, Hyy = hessian_matrix(square, sigma=0.1)
+    >>> Hxx, Hxy, Hyy = hessian_matrix(square, sigma=0.1, order='rc')
     >>> hessian_matrix_eigvals(Hxx, Hxy, Hyy)[0]
     array([[ 0.,  0.,  2.,  0.,  0.],
            [ 0.,  1.,  0.,  1.,  0.],

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -164,8 +164,8 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
             # The legacy 2D code followed (x, y) convention, so we swap the axis
             # order to maintain compatibility with old code
             warn('deprecation warning: the default order of the hessian matrix values '
-            'will be ''row-column'' instead of ''xy'' starting in skimage version 0.15'
-             'Use order=''rc'' or order=''xy'' to set this explicitly')
+            'will be "row-column" instead of "xy" starting in skimage version 0.15'
+             'Use order="rc" or order="xy" to set this explicitly')
             order = 'rc'
         else:
             order = 'xy'

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -107,8 +107,8 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
 
     The Hessian matrix is defined as::
 
-        H = [Hxx Hxy]
-            [Hxy Hyy]
+        H = [Hrr Hrc]
+            [Hrc Hcc]
 
     which is computed by convolving the image with the second derivatives
     of the Gaussian kernel in the respective x- and y-directions.
@@ -126,17 +126,17 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
         else:optional
         Used in conjunction with mode 'constant', the value outside
         the image boundaries.
-    order : {'C', 'F'}, optional
+    order : {'xy', 'rc'}, optional
         this parameter allows for the use of reverse or forward order of
         returned matrix values
 
     Returns
     -------
-    Hxx : ndarray
+    Hrr : ndarray
         Element of the Hessian matrix for each pixel in the input image.
-    Hxy : ndarray
+    Hrc : ndarray
         Element of the Hessian matrix for each pixel in the input image.
-    Hyy : ndarray
+    Hcc : ndarray
         Element of the Hessian matrix for each pixel in the input image.
 
     Examples
@@ -144,8 +144,8 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
     >>> from skimage.feature import hessian_matrix
     >>> square = np.zeros((5, 5))
     >>> square[2, 2] = 4
-    >>> Hxx, Hxy, Hyy = hessian_matrix(square, sigma=0.1)
-    >>> Hxy
+    >>> Hrr, Hrc, Hcc = hessian_matrix(square, sigma=0.1)
+    >>> Hrc
     array([[ 0.,  0.,  0.,  0.,  0.],
            [ 0.,  1.,  0., -1.,  0.],
            [ 0.,  0.,  0.,  0.,  0.],
@@ -163,10 +163,9 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
             # The legacy 2D code followed (x, y) convention, so we swap the axis
             # order to maintain compatibility with old code
             warn('deprecation warning: the default value will be changed to ''xy'' in version 0.15')
-
-            order = 'F'
+            order = 'rc'
         else:
-            order = 'C'
+            order = 'xy'
 
 
     gradients = np.gradient(gaussian_filtered)
@@ -174,7 +173,7 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
     H_elems = [np.gradient(gradients[ax0], axis=ax1)
                for ax0, ax1 in combinations_with_replacement(axes, 2)]
 
-    if order == 'F':
+    if order == 'rc':
         H_elems = reversed(H_elems);
 
     return H_elems

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -159,7 +159,7 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
                                             mode=mode, cval=cval)
 
     if order is None:
-        if image.ndim ==2:
+        if image.ndim == 2:
             # The legacy 2D code followed (x, y) convention, so we swap the axis
             # order to maintain compatibility with old code
             warn('deprecation warning: the default value will be changed to ''xy'' in version 0.15')

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -162,7 +162,9 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order=None):
         if image.ndim == 2:
             # The legacy 2D code followed (x, y) convention, so we swap the axis
             # order to maintain compatibility with old code
-            warn('deprecation warning: the default value will be changed to ''xy'' in version 0.15')
+            warn('deprecation warning: the default order of the hessian matrix values '
+            'will be ''row-column'' instead of ''xy'' starting in skimage version 0.15'
+             'Use order=''rc'' or order=''xy'' to set this explicitly')
             order = 'rc'
         else:
             order = 'xy'

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -41,7 +41,7 @@ def test_structure_tensor():
 def test_hessian_matrix():
     square = np.zeros((5, 5))
     square[2, 2] = 4
-    Hxx, Hxy, Hyy = hessian_matrix(square, sigma=0.1)
+    Hyy, Hxy, Hxx = hessian_matrix(square, sigma=0.1, order='C')
     assert_almost_equal(Hxx, np.array([[0, 0,  0, 0, 0],
                                        [0, 0,  0, 0, 0],
                                        [2, 0, -2, 0, 2],
@@ -64,7 +64,7 @@ def test_hessian_matrix():
 def test_hessian_matrix_3d():
     cube = np.zeros((5, 5, 5))
     cube[2, 2, 2] = 4
-    Hs = hessian_matrix(cube, sigma=0.1)
+    Hs = hessian_matrix(cube, sigma=0.1, order=None)
     assert len(Hs) == 6, ("incorrect number of Hessian images (%i) for 3D" %
                           len(Hs))
     assert_almost_equal(Hs[2][:, 2, :], np.array([[0,  0,  0,  0,  0],
@@ -94,8 +94,8 @@ def test_structure_tensor_eigvals():
 def test_hessian_matrix_eigvals():
     square = np.zeros((5, 5))
     square[2, 2] = 4
-    Hxx, Hxy, Hyy = hessian_matrix(square, sigma=0.1)
-    l1, l2 = hessian_matrix_eigvals(Hxx, Hxy, Hyy)
+    Hyy, Hxy, Hxx = hessian_matrix(square, sigma=0.1, order='C')
+    l1, l2 = hessian_matrix_eigvals(Hyy, Hxy, Hxx)
     assert_almost_equal(l1, np.array([[0, 0,  2, 0, 0],
                                       [0, 1,  0, 1, 0],
                                       [2, 0, -2, 0, 2],

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -41,20 +41,20 @@ def test_structure_tensor():
 def test_hessian_matrix():
     square = np.zeros((5, 5))
     square[2, 2] = 4
-    Hyy, Hxy, Hxx = hessian_matrix(square, sigma=0.1, order='C')
-    assert_almost_equal(Hxx, np.array([[0, 0,  0, 0, 0],
+    Hrr, Hrc, Hcc = hessian_matrix(square, sigma=0.1, order='C')
+    assert_almost_equal(Hrr, np.array([[0, 0,  0, 0, 0],
                                        [0, 0,  0, 0, 0],
                                        [2, 0, -2, 0, 2],
                                        [0, 0,  0, 0, 0],
                                        [0, 0,  0, 0, 0]]))
 
-    assert_almost_equal(Hxy, np.array([[0,  0, 0,  0, 0],
+    assert_almost_equal(Hrc, np.array([[0,  0, 0,  0, 0],
                                        [0,  1, 0, -1, 0],
                                        [0,  0, 0,  0, 0],
                                        [0, -1, 0,  1, 0],
                                        [0,  0, 0,  0, 0]]))
 
-    assert_almost_equal(Hyy, np.array([[0, 0,  2, 0, 0],
+    assert_almost_equal(Hcc, np.array([[0, 0,  2, 0, 0],
                                        [0, 0,  0, 0, 0],
                                        [0, 0, -2, 0, 0],
                                        [0, 0,  0, 0, 0],
@@ -94,8 +94,8 @@ def test_structure_tensor_eigvals():
 def test_hessian_matrix_eigvals():
     square = np.zeros((5, 5))
     square[2, 2] = 4
-    Hyy, Hxy, Hxx = hessian_matrix(square, sigma=0.1, order='C')
-    l1, l2 = hessian_matrix_eigvals(Hyy, Hxy, Hxx)
+    Hrr, Hrc, Hcc = hessian_matrix(square, sigma=0.1, order='C')
+    l1, l2 = hessian_matrix_eigvals(Hrr, Hrc, Hcc)
     assert_almost_equal(l1, np.array([[0, 0,  2, 0, 0],
                                       [0, 1,  0, 1, 0],
                                       [2, 0, -2, 0, 2],

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -94,7 +94,7 @@ def test_structure_tensor_eigvals():
 def test_hessian_matrix_eigvals():
     square = np.zeros((5, 5))
     square[2, 2] = 4
-    Hrr, Hrc, Hcc = hessian_matrix(square, sigma=0.1, order='C')
+    Hrr, Hrc, Hcc = hessian_matrix(square, sigma=0.1, order='rc')
     l1, l2 = hessian_matrix_eigvals(Hrr, Hrc, Hcc)
     assert_almost_equal(l1, np.array([[0, 0,  2, 0, 0],
                                       [0, 1,  0, 1, 0],

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -60,7 +60,7 @@ def test_hessian_matrix():
                                        [0, 0,  0, 0, 0],
                                        [0, 0,  2, 0, 0]]))
 
-    matrix2d = np.random.rand((3,3))
+    matrix2d = np.random.rand(3,3)
     Arr, Arc, Acc = hessian_matrix(matrix2d, sigma=0.1)
     assert_warns(Warning, hessian_matrix, matrix2d, sigma=0.1)
 

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -70,7 +70,7 @@ def test_hessian_matrix():
 def test_hessian_matrix_3d():
     cube = np.zeros((5, 5, 5))
     cube[2, 2, 2] = 4
-    Hs = hessian_matrix(cube, sigma=0.1, order=None)
+    Hs = hessian_matrix(cube, sigma=0.1, order='rc')
     assert len(Hs) == 6, ("incorrect number of Hessian images (%i) for 3D" %
                           len(Hs))
     assert_almost_equal(Hs[2][:, 2, :], np.array([[0,  0,  0,  0,  0],

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.testing import (assert_array_equal, assert_raises,
-                           assert_almost_equal)
+                           assert_almost_equal, assert_warns)
 
 from skimage import data
 from skimage import img_as_float

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -41,7 +41,7 @@ def test_structure_tensor():
 def test_hessian_matrix():
     square = np.zeros((5, 5))
     square[2, 2] = 4
-    Hrr, Hrc, Hcc = hessian_matrix(square, sigma=0.1, order='C')
+    Hrr, Hrc, Hcc = hessian_matrix(square, sigma=0.1, order='rc')
     assert_almost_equal(Hrr, np.array([[0, 0,  0, 0, 0],
                                        [0, 0,  0, 0, 0],
                                        [2, 0, -2, 0, 2],

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -60,6 +60,14 @@ def test_hessian_matrix():
                                        [0, 0,  0, 0, 0],
                                        [0, 0,  2, 0, 0]]))
 
+    matrix2d = np.zeros((2,2))
+    matrix2d = np.diag([1,3])
+    Arr, Arc, Acc = hessian_matrix(matrix2d, sigma=0.1)
+    assert_warns(Warning, hessian_matrix, matrix2d, sigma=0.1)
+
+
+
+
 
 def test_hessian_matrix_3d():
     cube = np.zeros((5, 5, 5))

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -62,7 +62,7 @@ def test_hessian_matrix():
 
     matrix2d = np.random.rand(3,3)
     Arr, Arc, Acc = hessian_matrix(matrix2d, sigma=0.1)
-    assert_warns(Warning, hessian_matrix, matrix2d, sigma=0.1)
+    assert_warns(UserWarning, hessian_matrix, matrix2d, sigma=0.1)
 
 
 

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -60,8 +60,7 @@ def test_hessian_matrix():
                                        [0, 0,  0, 0, 0],
                                        [0, 0,  2, 0, 0]]))
 
-    matrix2d = np.zeros((2,2))
-    matrix2d = np.diag([1,3])
+    matrix2d = np.random.rand((3,3))
     Arr, Arc, Acc = hessian_matrix(matrix2d, sigma=0.1)
     assert_warns(Warning, hessian_matrix, matrix2d, sigma=0.1)
 

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -61,7 +61,6 @@ def test_hessian_matrix():
                                        [0, 0,  2, 0, 0]]))
 
     matrix2d = np.random.rand(3,3)
-    Arr, Arc, Acc = hessian_matrix(matrix2d, sigma=0.1)
     assert_warns(UserWarning, hessian_matrix, matrix2d, sigma=0.1)
 
 

--- a/skimage/filters/_frangi.py
+++ b/skimage/filters/_frangi.py
@@ -44,12 +44,12 @@ def _frangi_hessian_common_filter(image, scale_range, scale_step,
     # Filtering for all sigmas
     for i, sigma in enumerate(sigmas):
         # Make 2D hessian
-        (Dyy, Dxy, Dxx) = hessian_matrix(image, sigma, order='C')
+        (Drr, Drc, Dcc) = hessian_matrix(image, sigma, order='C')
 
         # Correct for scale
-        Dyy = (sigma ** 2) * Dyy
-        Dxy = (sigma ** 2) * Dxy
-        Dxx = (sigma ** 2) * Dxx
+        Drr = (sigma ** 2) * Drr
+        Drc = (sigma ** 2) * Drc
+        Dcc = (sigma ** 2) * Dcc
 
         # Calculate (abs sorted) eigenvalues and vectors
         (lambda1, lambda2) = hessian_matrix_eigvals(Dyy, Dxy, Dxx)

--- a/skimage/filters/_frangi.py
+++ b/skimage/filters/_frangi.py
@@ -44,7 +44,7 @@ def _frangi_hessian_common_filter(image, scale_range, scale_step,
     # Filtering for all sigmas
     for i, sigma in enumerate(sigmas):
         # Make 2D hessian
-        (Drr, Drc, Dcc) = hessian_matrix(image, sigma, order='C')
+        (Drr, Drc, Dcc) = hessian_matrix(image, sigma, order='rc')
 
         # Correct for scale
         Drr = (sigma ** 2) * Drr
@@ -52,7 +52,7 @@ def _frangi_hessian_common_filter(image, scale_range, scale_step,
         Dcc = (sigma ** 2) * Dcc
 
         # Calculate (abs sorted) eigenvalues and vectors
-        (lambda1, lambda2) = hessian_matrix_eigvals(Dyy, Dxy, Dxx)
+        (lambda1, lambda2) = hessian_matrix_eigvals(Drr, Drc, Dcc)
 
         # Compute some similarity measures
         lambda1[lambda1 == 0] = 1e-10

--- a/skimage/filters/_frangi.py
+++ b/skimage/filters/_frangi.py
@@ -44,15 +44,15 @@ def _frangi_hessian_common_filter(image, scale_range, scale_step,
     # Filtering for all sigmas
     for i, sigma in enumerate(sigmas):
         # Make 2D hessian
-        (Dxx, Dxy, Dyy) = hessian_matrix(image, sigma)
+        (Dyy, Dxy, Dxx) = hessian_matrix(image, sigma, order='C')
 
         # Correct for scale
-        Dxx = (sigma ** 2) * Dxx
-        Dxy = (sigma ** 2) * Dxy
         Dyy = (sigma ** 2) * Dyy
+        Dxy = (sigma ** 2) * Dxy
+        Dxx = (sigma ** 2) * Dxx
 
         # Calculate (abs sorted) eigenvalues and vectors
-        (lambda1, lambda2) = hessian_matrix_eigvals(Dxx, Dxy, Dyy)
+        (lambda1, lambda2) = hessian_matrix_eigvals(Dyy, Dxy, Dxx)
 
         # Compute some similarity measures
         lambda1[lambda1 == 0] = 1e-10


### PR DESCRIPTION
## Description

I've included an optional parameter into the Hessian matrix function in corner.py that allows for reverse and forward ordering of the Hessian matrix. This 'order' parameter defaults to Fortran order if the order isn't specificied, wherein, Hxx and Hyy will be reversed if the image dimensions are 2, and otherwise will default to C style.
I also changed the corresponding test function 'test_hessian_matrix_eigvals' in test_corner.py to 'force' the order to 'C', and likewise did the same in _frangi.py, line 47. 
The latter in _frangi.py:
# Make 2D hessian

(Dyy, Dxy, Dxx) = hessian_matrix(image, sigma, order='C')
This is my first pull request so please let me know what I can do if this is not sufficient.
Thanks!
## Checklist

[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]
## References

Closes issue #2301
