### PR TITLE
Update the default boundary mode in transform.swirl

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -24,3 +24,4 @@ Version 0.15
 * In ``skimage.util.dtype_limits``, set default behavior of `clip_negative` to `False`.
 * In ``skimage.transform.radon``, set default behavior of `circle` to `True`.
 * In ``skimage.transform.iradon``, set default behavior of `circle` to `True`.
+* In ``skimage.transform.warp``, set default behavior of `mode` to `reflect`.

--- a/TODO.txt
+++ b/TODO.txt
@@ -24,4 +24,4 @@ Version 0.15
 * In ``skimage.util.dtype_limits``, set default behavior of `clip_negative` to `False`.
 * In ``skimage.transform.radon``, set default behavior of `circle` to `True`.
 * In ``skimage.transform.iradon``, set default behavior of `circle` to `True`.
-* In ``skimage.transform.warp``, set default behavior of `mode` to `reflect`.
+* In ``skimage.transform.swirl``, set default behavior of `mode` to `reflect`.

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -344,7 +344,7 @@ def _swirl_mapping(xy, center, rotation, strength, radius):
 
 
 def swirl(image, center=None, strength=1, radius=100, rotation=0,
-          output_shape=None, order=1, mode='None', cval=0, clip=True,
+          output_shape=None, order=1, mode=None, cval=0, clip=True,
           preserve_range=False):
     """Perform a swirl transformation.
 

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -378,7 +378,8 @@ def swirl(image, center=None, strength=1, radius=100, rotation=0,
         be in the range 0-5. See `skimage.transform.warp` for detail.
     mode : {'constant', 'edge', 'symmetric', 'reflect', 'wrap'}, optional
         Points outside the boundaries of the input are filled according
-        to the given mode.  Modes match the behaviour of `numpy.pad`.
+        to the given mode, with 'constant' used as the default. Modes match 
+        the behaviour of `numpy.pad`.
     cval : float, optional
         Used in conjunction with mode 'constant', the value outside
         the image boundaries.

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -1,4 +1,5 @@
 import numpy as np
+from warnings import warn
 from scipy import ndimage as ndi
 
 from ..measure import block_reduce
@@ -391,7 +392,7 @@ def swirl(image, center=None, strength=1, radius=100, rotation=0,
 
     """
     if mode is None:
-        warn('The default of `mode` in `skimage.transform.warp` '
+        warn('The default of `mode` in `skimage.transform.swirl` '
              'will change to `reflect` in version 0.15.')
         mode = 'constant'     
 

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -344,7 +344,7 @@ def _swirl_mapping(xy, center, rotation, strength, radius):
 
 
 def swirl(image, center=None, strength=1, radius=100, rotation=0,
-          output_shape=None, order=1, mode='constant', cval=0, clip=True,
+          output_shape=None, order=1, mode='None', cval=0, clip=True,
           preserve_range=False):
     """Perform a swirl transformation.
 
@@ -390,6 +390,10 @@ def swirl(image, center=None, strength=1, radius=100, rotation=0,
         image is converted according to the conventions of `img_as_float`.
 
     """
+    if mode is None:
+        warn('The default of `mode` in `skimage.transform.warp` '
+             'will change to `reflect` in version 0.15.')
+        mode = 'constant'     
 
     if center is None:
         center = np.array(image.shape)[:2] / 2

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -228,9 +228,7 @@ def test_swirl():
         swirled = tf.swirl(image, strength=10, **swirl_params)
         unswirled = tf.swirl(swirled, strength=-10, **swirl_params)
 
-
     assert np.mean(np.abs(image - unswirled)) < 0.01
-  
 
     swirl_params.pop('mode')
 
@@ -238,8 +236,7 @@ def test_swirl():
         swirled = tf.swirl(image, strength=10, **swirl_params)
         unswirled = tf.swirl(swirled, strength=-10, **swirl_params)
 
-
-    assert np.mean(np.abs(image - unswirled)) < 0.01
+    assert np.mean(np.abs(image[1:-1,1:-1] - unswirled[1:-1,1:-1])) < 0.01
 
 
 def test_const_cval_out_of_range():

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -224,7 +224,7 @@ def test_swirl():
 
     swirl_params = {'radius': 80, 'rotation': 0, 'order': 2, 'mode': 'reflect'}
 
-    with expected_warnings(['Bi-quadratic.*bug']):
+    with expected_warnings(['Bi-quadratic.*bug', 'default']):
         swirled = tf.swirl(image, strength=10, **swirl_params)
         unswirled = tf.swirl(swirled, strength=-10, **swirl_params)
 

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -224,9 +224,20 @@ def test_swirl():
 
     swirl_params = {'radius': 80, 'rotation': 0, 'order': 2, 'mode': 'reflect'}
 
+    with expected_warnings(['Bi-quadratic.*bug']):
+        swirled = tf.swirl(image, strength=10, **swirl_params)
+        unswirled = tf.swirl(swirled, strength=-10, **swirl_params)
+
+
+    assert np.mean(np.abs(image - unswirled)) < 0.01
+  
+
+    swirl_params.pop('mode')
+
     with expected_warnings(['Bi-quadratic.*bug', 'default']):
         swirled = tf.swirl(image, strength=10, **swirl_params)
         unswirled = tf.swirl(swirled, strength=-10, **swirl_params)
+
 
     assert np.mean(np.abs(image - unswirled)) < 0.01
 


### PR DESCRIPTION
## Description
Updating the default value of the boundary mode in transform.swirl as suggested in #1669


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Unit tests

## References
closes issue #1669


