### PR TITLE
Raise a warning when attempting to save boolean images

### DIFF
--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -131,8 +131,7 @@ def imsave(fname, arr, plugin=None, **plugin_args):
     if is_low_contrast(arr):
         warn('%s is a low contrast image' % fname)
     if arr.dtype == bool:
-        warn('%s is a boolean image; converting True to white and False to black.' % fname)
-        arr = arr.astype(np.uint8)*255
+        warn('%s is a boolean image; setting True to 1 and False to 0.' % fname)
     return call_plugin('imsave', fname, arr, plugin=plugin, **plugin_args)
 
 

--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -130,6 +130,9 @@ def imsave(fname, arr, plugin=None, **plugin_args):
             plugin = 'tifffile'
     if is_low_contrast(arr):
         warn('%s is a low contrast image' % fname)
+    if arr.dtype == bool:
+        warn('%s is a boolean image; converting True to white and False to black.' % fname)
+        arr = arr.astype(np.uint8)*255
     return call_plugin('imsave', fname, arr, plugin=plugin, **plugin_args)
 
 


### PR DESCRIPTION
## Description
When imsave receives an ndarray with boolean entries, raise a warning that the True values will be set to 1 and the False to 0.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in the spirit of PEP8
- [x] Docstrings for all functions
- [ ] Unit tests

## References
Closes issue #1623 