### PR TITLE
Ordered the paramaters in the equalize_adapthist docstring according …

### DIFF
--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -37,19 +37,20 @@ def equalize_adapthist(image, ntiles_x=None, ntiles_y=None, clip_limit=0.01,
     ----------
     image : array-like
         Input image.
-    kernel_size: integer or 2-tuple
-        Defines the shape of contextual regions used in the algorithm.
-        If an integer is given, the shape will be a square of
-        sidelength given by this value.
     ntiles_x : int, optional (deprecated in favor of ``kernel_size``)
         Number of tile regions in the X direction (horizontal).
     ntiles_y : int, optional (deprecated in favor of ``kernel_size``)
         Number of tile regions in the Y direction (vertical).
     clip_limit : float: optional
         Clipping limit, normalized between 0 and 1 (higher values give more
-        contrast).
+        contrast). Value of the clip_limit is dependent on the normalization 
+        of the histogram and the size of the neighbourhood region.
     nbins : int, optional
         Number of gray bins for histogram ("dynamic range").
+    kernel_size: integer or 2-tuple
+        Defines the shape of contextual regions used in the algorithm.
+        If an integer is given, the shape will be a square of
+        sidelength given by this value.
 
     Returns
     -------


### PR DESCRIPTION
## Description
[Tell us about your new feature, improvement, or fix! If relevant, please supplement the PR with images.]


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]


…to the order that they appear in the function equalize_adapthist. Clarified how the clip_limit is calculated.