### PR TITLE
Fix display problem when printing error messages

### DIFF
--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -250,7 +250,7 @@ def imsave(fname, arr, format_str=None, **kwargs):
         arr = arr.astype(np.uint8)
 
     if arr.ndim not in (2, 3):
-        raise ValueError("Invalid shape for image array: %s" % arr.shape)
+        raise ValueError("Invalid shape for image array: %s" % (arr.shape, ))
 
     if arr.ndim == 3:
         if arr.shape[2] not in (3, 4):

--- a/skimage/io/tests/test_pil.py
+++ b/skimage/io/tests/test_pil.py
@@ -184,6 +184,10 @@ class TestSave:
     def test_imsave_roundtrip_pil_image(self):
         self.verify_imsave_roundtrip(self.roundtrip_pil_image)
 
+def test_imsave_incorrect_dimension():
+    with temporary_file(suffix='.png') as fname:
+        assert_raises(ValueError, imsave, fname, np.zeros((2, 3, 3, 1)))
+        assert_raises(ValueError, imsave, fname, np.zeros((2, 3, 2)))
 
 def test_imsave_filelike():
     shape = (2, 2)


### PR DESCRIPTION
I've fixed the problem with error messaging. There were the following code:
```python
raise ValueError('message: %s' % arr.shape)
```
String formatting here failed because arr.shape is tuple