### PR TITLE
document default behavior of kernel_size

### DIFF
--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -37,10 +37,11 @@ def equalize_adapthist(image, ntiles_x=None, ntiles_y=None, clip_limit=0.01,
     ----------
     image : array-like
         Input image.
-    kernel_size: integer or 2-tuple
+    kernel_size: integer or 2-tuple, optional
         Defines the shape of contextual regions used in the algorithm.
         If an integer is given, the shape will be a square of
         sidelength given by this value.
+        By default, ``kernel_size`` is chosen so as to have 8x8 tile regions.
     ntiles_x : int, optional (deprecated in favor of ``kernel_size``)
         Number of tile regions in the X direction (horizontal).
     ntiles_y : int, optional (deprecated in favor of ``kernel_size``)


### PR DESCRIPTION
a tiny enhancement of the docstring of `exposure.equalize_adapthist`: the default behavior of the function when `kernel_size` is `None` is not documented.

Only odd thing, I quickly browsed the closed PR #1547 where it is mentionned that tiles are somehow problematic. As such, `ntiles_x/y` arguments are getting deprecated. However, the default behavior when `kernel_size` is `None` is to set these to 8. So what will be the default once these arguments are removed in a future  release ?