### PR TITLE
Separate out filter functions from peak finding in blob_dog, blob_log

### DIFF
--- a/skimage/feature/__init__.py
+++ b/skimage/feature/__init__.py
@@ -21,7 +21,8 @@ from .censure import CENSURE
 from .orb import ORB
 from .match import match_descriptors
 from .util import plot_matches
-from .blob import blob_dog, blob_log, blob_doh
+from .blob import (blob_dog, blob_log, blob_doh, 
+                   scale_space_dog, scale_space_log)
 
 
 __all__ = ['canny',
@@ -57,4 +58,6 @@ __all__ = ['canny',
            'plot_matches',
            'blob_dog',
            'blob_doh',
-           'blob_log']
+           'blob_log',
+           'scale_space_dog',
+           'scale_space_log']

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -186,7 +186,6 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
     # a geometric progression of standard deviations for gaussian kernels
     sigma_list = np.array([min_sigma * (sigma_ratio ** i)
                            for i in range(k + 1)])
-
     image_cube = scale_space_dog(image, min_sigma, max_sigma, sigma_ratio)
 
     # local_maxima = get_local_maxima(image_cube, threshold)

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -288,7 +288,6 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
 
     image_cube = scale_space_log(image, min_sigma, max_sigma, num_sigma, 
                                  log_scale)
-    print("hello")
 
     local_maxima = peak_local_max(image_cube, threshold_abs=threshold,
                                   footprint=np.ones((3, 3, 3)),

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -301,91 +301,6 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
     return _prune_blobs(local_maxima, overlap)
 
 
-def scale_space_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6):
-    """Finds the difference of Gaussians of the given image.
-
-    Parameters
-    ----------
-    image : ndarray
-        Input grayscale image.
-    min_sigma : float, optional
-        The minimum standard deviation for Gaussian Kernel.
-    max_sigma : float, optional
-        The maximum standard deviation for Gaussian Kernel. 
-    sigma_ratio : float, optional
-        The ratio between the standard deviation of Gaussian Kernels used for
-        computing the Difference of Gaussians. 
-
-    Returns
-    -------
-    image_cube : 3D ndarray
-        The Difference of Gaussians of the image.
-    """
-    assert_nD(image, 2)
-
-    image = img_as_float(image)
-
-    # k such that min_sigma*(sigma_ratio**k) > max_sigma
-    k = int(log(float(max_sigma) / min_sigma, sigma_ratio)) + 1
-
-    # a geometric progression of standard deviations for gaussian kernels
-    sigma_list = np.array([min_sigma * (sigma_ratio ** i)
-                           for i in range(k + 1)])
-
-    gaussian_images = [gaussian_filter(image, s) for s in sigma_list]
-
-    # computing difference between two successive Gaussian blurred images
-    # multiplying with standard deviation provides scale invariance
-    dog_images = [(gaussian_images[i] - gaussian_images[i + 1])
-                  * sigma_list[i] for i in range(k)]
-    image_cube = np.dstack(dog_images)
-
-    return image_cube
-
-
-def scale_space_log(image, min_sigma=1, max_sigma=50, num_sigma=10, 
-                    log_scale=False):
-    """Finds the Laplacian of Gaussian of the given image. 
-
-    Parameters
-    ----------
-    image : ndarray
-        Input grayscale image.
-    min_sigma : float, optional
-        The minimum standard deviation for Gaussian Kernel.
-    max_sigma : float, optional
-        The maximum standard deviation for Gaussian Kernel. 
-    num_sigma : int, optional
-        The number of intermediate values of standard deviations to consider
-        between `min_sigma` and `max_sigma`.
-    log_scale : bool, optional
-        If set intermediate values of standard deviations are interpolated
-        using a logarithmic scale to the base `10`. If not, linear
-        interpolation is used.
-
-    Returns
-    -------
-    image_cube : 3D ndarray
-        The Laplacian of Gaussians of the image.
-    """
-    assert_nD(image, 2)
-
-    image = img_as_float(image)
-
-    if log_scale:
-        start, stop = log(min_sigma, 10), log(max_sigma, 10)
-        sigma_list = np.logspace(start, stop, num_sigma)
-    else:
-        sigma_list = np.linspace(min_sigma, max_sigma, num_sigma)
-
-    # computing gaussian laplace
-    # s**2 provides scale invariance
-    gl_images = [-gaussian_laplace(image, s) * s ** 2 for s in sigma_list]
-    image_cube = np.dstack(gl_images)
-
-    return image_cube
-
-
 def blob_doh(image, min_sigma=1, max_sigma=30, num_sigma=10, threshold=0.01,
              overlap=.5, log_scale=False):
     """Finds blobs in the given grayscale image.
@@ -494,3 +409,88 @@ def blob_doh(image, min_sigma=1, max_sigma=30, num_sigma=10, threshold=0.01,
     lm[:, 2] = sigma_list[local_maxima[:, 2]]
     local_maxima = lm
     return _prune_blobs(local_maxima, overlap)
+
+
+def scale_space_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6):
+    """Finds the difference of Gaussians of the given image.
+
+    Parameters
+    ----------
+    image : ndarray
+        Input grayscale image.
+    min_sigma : float, optional
+        The minimum standard deviation for Gaussian Kernel.
+    max_sigma : float, optional
+        The maximum standard deviation for Gaussian Kernel. 
+    sigma_ratio : float, optional
+        The ratio between the standard deviation of Gaussian Kernels used for
+        computing the Difference of Gaussians. 
+
+    Returns
+    -------
+    image_cube : 3D ndarray
+        The Difference of Gaussians of the image.
+    """
+    assert_nD(image, 2)
+
+    image = img_as_float(image)
+
+    # k such that min_sigma*(sigma_ratio**k) > max_sigma
+    k = int(log(float(max_sigma) / min_sigma, sigma_ratio)) + 1
+
+    # a geometric progression of standard deviations for gaussian kernels
+    sigma_list = np.array([min_sigma * (sigma_ratio ** i)
+                           for i in range(k + 1)])
+
+    gaussian_images = [gaussian_filter(image, s) for s in sigma_list]
+
+    # computing difference between two successive Gaussian blurred images
+    # multiplying with standard deviation provides scale invariance
+    dog_images = [(gaussian_images[i] - gaussian_images[i + 1])
+                  * sigma_list[i] for i in range(k)]
+    image_cube = np.dstack(dog_images)
+
+    return image_cube
+
+
+def scale_space_log(image, min_sigma=1, max_sigma=50, num_sigma=10, 
+                    log_scale=False):
+    """Finds the Laplacian of Gaussian of the given image. 
+
+    Parameters
+    ----------
+    image : ndarray
+        Input grayscale image.
+    min_sigma : float, optional
+        The minimum standard deviation for Gaussian Kernel.
+    max_sigma : float, optional
+        The maximum standard deviation for Gaussian Kernel. 
+    num_sigma : int, optional
+        The number of intermediate values of standard deviations to consider
+        between `min_sigma` and `max_sigma`.
+    log_scale : bool, optional
+        If set intermediate values of standard deviations are interpolated
+        using a logarithmic scale to the base `10`. If not, linear
+        interpolation is used.
+
+    Returns
+    -------
+    image_cube : 3D ndarray
+        The Laplacian of Gaussians of the image.
+    """
+    assert_nD(image, 2)
+
+    image = img_as_float(image)
+
+    if log_scale:
+        start, stop = log(min_sigma, 10), log(max_sigma, 10)
+        sigma_list = np.logspace(start, stop, num_sigma)
+    else:
+        sigma_list = np.linspace(min_sigma, max_sigma, num_sigma)
+
+    # computing gaussian laplace
+    # s**2 provides scale invariance
+    gl_images = [-gaussian_laplace(image, s) * s ** 2 for s in sigma_list]
+    image_cube = np.dstack(gl_images)
+
+    return image_cube

--- a/skimage/feature/tests/test_blob.py
+++ b/skimage/feature/tests/test_blob.py
@@ -217,9 +217,10 @@ def test_blob_overlap():
 
 def test_scale_space_dog():
     img = np.ones((512, 512))
-    dog = scale_space_dog(img)
+    image_cube = scale_space_dog(img)
     for i in range(4):
-        assert_almost_equal(dog[:,:,i], dog[:,:,i+1])
+        assert_almost_equal(image_cube[:, :, i], 
+                            image_cube[:, :, i + 1])
 
     xs, ys = circle(400, 130, 20)
     img[xs, ys] = 255
@@ -231,22 +232,23 @@ def test_scale_space_dog():
     img[xs, ys] = 255
     
     thresh = 2
-    dog = scale_space_dog(img, 5, 50)
-    d = blob_dog(dog[:,:,1], min_sigma=5, max_sigma=50)
+    image_cube = scale_space_dog(img, 5, 50)
+    dog = image_cube[:, :, 1]
     blobs = blob_dog(img, min_sigma=5, max_sigma=50)
-    for i in blobs:
-        assert min([np.linalg.norm(i[:2] - d[j][:2]) 
-            for j in range(d.shape[0])]) <= thresh
+    dog_blobs = blob_dog(dog, min_sigma=5, max_sigma=50)
+    for blob in blobs:
+        assert min([np.linalg.norm(blob[:2] - dog_blobs[i][:2]) 
+            for i in range(dog_blobs.shape[0])]) <= thresh
 
 
 def test_scale_space_log():
     img = np.ones((256, 256)) * 255
-    log = scale_space_log(img, min_sigma=5, max_sigma=20)
+    image_cube = scale_space_log(img, min_sigma=5, max_sigma=20)
+    zero = np.zeros((256, 256))
     for i in range(10):
-        l = log[:,:,i] - log[:,:,i].mean()
-        zero = np.zeros((256, 256))
-        print(l)
-        assert_almost_equal(l, zero)
+        log = image_cube[:, :, i]
+        demeaned_log = log - log.mean()
+        assert_almost_equal(demeaned_log, zero)
 
     xs, ys = circle(200, 65, 5)
     img[xs, ys] = 255
@@ -261,8 +263,7 @@ def test_scale_space_log():
     img[xs, ys] = 255
 
     blobs = blob_log(img, min_sigma=5, max_sigma=20, threshold=1)
-    d = blob_log(log[:,:,2], min_sigma=5, max_sigma=20, threshold=1)
+    log_blobs = blob_log(image_cube[:,:,2], min_sigma=5, max_sigma=20, 
+                         threshold=1)
     thresh = 5
-    for i in blobs:
-        assert min([np.linalg.norm(i[:2] - d[j][:2]) 
-                    for j in range(d.shape[0])]) <= thresh
+    assert min([np.linalg.norm(blobs - log_blobs)]) <= thresh

--- a/skimage/feature/tests/test_blob.py
+++ b/skimage/feature/tests/test_blob.py
@@ -1,6 +1,5 @@
 import numpy as np
 from skimage.draw import circle
-from scipy.ndimage import gaussian_filter, gaussian_laplace
 from skimage.feature import (blob_dog, blob_log, blob_doh, 
                             scale_space_dog, scale_space_log)
 import math


### PR DESCRIPTION
## Description
This addresses #2315. 
As mentioned by @jmetz these functions should be in a `scale_space.py` file in filters, but for now they reside in `blob.py` in the features module. 


## Checklist
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue #2315  ]

