### PR TITLE
stable ellipse fitting

### DIFF
--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -1,5 +1,6 @@
 import numpy as np
-from numpy.testing import assert_equal, assert_raises, assert_almost_equal
+from numpy.testing import assert_equal, assert_almost_equal, assert_array_less
+from numpy.testing import assert_raises
 from skimage.measure import LineModelND, CircleModel, EllipseModel, ransac
 from skimage.transform import AffineTransform
 from skimage.measure.fit import _dynamic_max_trials
@@ -181,7 +182,40 @@ def test_ellipse_model_estimate():
     model_est.estimate(data)
 
     # test whether estimated parameters almost equal original parameters
-    assert_almost_equal(model0.params, model_est.params, 0)
+    assert_almost_equal(model0.params[:4], model_est.params[:4], 0)
+
+def test_ellipse_model_estimate_from_data():
+    data = np.array([
+        [264, 854], [265, 875], [268, 863], [270, 857], [275, 905], [285, 915],
+        [305, 925], [324, 934], [335, 764], [336, 915], [345, 925], [345, 945],
+        [354, 933], [355, 745], [364, 936], [365, 754], [375, 745], [375, 735],
+        [385, 736], [395, 735], [394, 935], [405, 727], [415, 736], [415, 727],
+        [425, 727], [426, 929], [435, 735], [444, 933], [445, 735], [455, 724],
+        [465, 934], [465, 735], [475, 908], [475, 726], [485, 753], [485, 728],
+        [492, 762], [495, 745], [491, 910], [493, 909], [499, 904], [505, 905],
+        [504, 747], [515, 743], [516, 752], [524, 855], [525, 844], [525, 885],
+        [533, 845], [533, 873], [535, 883], [545, 874], [543, 864], [553, 865],
+        [553, 845], [554, 825], [554, 835], [563, 845], [565, 826], [563, 855],
+        [563, 795], [565, 735], [573, 778], [572, 815], [574, 804], [575, 665],
+        [575, 685], [574, 705], [574, 745], [575, 875], [572, 732], [582, 795],
+        [579, 709], [583, 805], [583, 854], [586, 755], [584, 824], [585, 655],
+        [581, 718], [586, 844], [585, 915], [587, 905], [594, 824], [593, 855],
+        [590, 891], [594, 776], [596, 767], [593, 763], [603, 785], [604, 775],
+        [603, 885], [605, 753], [605, 655], [606, 935], [603, 761], [613, 802],
+        [613, 945], [613, 965], [615, 693], [617, 665], [623, 962], [624, 972],
+        [625, 995], [633, 673], [633, 965], [633, 683], [633, 692], [633, 954],
+        [634, 1016], [635, 664], [641, 804], [637, 999], [641, 956], [643, 946],
+        [643, 926], [644, 975], [643, 655], [646, 705], [651, 664], [651, 984],
+        [647, 665], [651, 715], [651, 725], [651, 734], [647, 809], [651, 825],
+        [651, 873], [647, 900], [652, 917], [651, 944], [652, 742], [648, 811],
+        [651, 994], [652, 783], [650, 911], [654, 879]])
+
+    # estimate parameters of real data
+    model = EllipseModel()
+    model.estimate(data)
+
+    # test whether estimated parameters are smaller then 1000, so means stable
+    assert_array_less(np.abs(model.params[:4]), np.array([2e3] * 4))
 
 
 def test_ellipse_model_residuals():


### PR DESCRIPTION
## Description
Fix for ellipse fitting is not stable #2379

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
This method of least Squares fitting for Ellipses is taken from the paper by Halir, R., and Flusser, J. [Numerically Stable Direct Least Squares Fitting of Ellipses](http://autotrace.sourceforge.net/WSCG98.pdf)


