### PR TITLE
binary_perimeter

### DIFF
--- a/skimage/morphology/binary.py
+++ b/skimage/morphology/binary.py
@@ -144,3 +144,35 @@ def binary_closing(image, selem=None, out=None):
     dilated = binary_dilation(image, selem)
     out = binary_erosion(dilated, selem, out=out)
     return out
+
+@default_selem
+def binary_perimeter(image, selem=None):
+    """Return perimeter mask of objects in a binary image
+
+    Find the perimeters of objects in a provided binary image for a given
+    connectivity
+    Uses padding and binary erosion
+
+
+    Parameters
+    ----------
+    image : ndarray
+        Binary input image.
+    selem : ndarray, optional
+        The neighborhood expressed as a N-D array of 1's and 0's
+        where N is the dimensionality of image.
+        If None, use cross-shaped structuring element (connectivity=1).
+
+    Returns
+    -------
+    perim : binary image of perimeters of objects in bw
+
+    """
+
+    bw_pad = np.pad(image, pad_width=1, mode='constant', constant_values=0)
+    bw_eroded = binary_erosion(bw_pad, selem=selem)
+    bw_eroded = bw_eroded[1:-1,1:-1] # unpad output
+
+    perim = np.logical_and(image, ~bw_eroded)
+
+    return perim

--- a/skimage/morphology/tests/test_binary.py
+++ b/skimage/morphology/tests/test_binary.py
@@ -45,6 +45,14 @@ def test_binary_opening():
     grey_res = img_as_bool(grey.opening(bw_img, strel))
     testing.assert_array_equal(binary_res, grey_res)
 
+def test_binary_perimeter():
+    bw = np.zeros([10,10])
+    bw[3:7,3:7] = 1
+    perim = bw
+    perim[4:6,4:6] = 0
+    strel = selem.square(3)
+    binary_res = binary.binary_perimeter(bw, strel)
+    testing.assert_array_equal(binary_res, perim)
 
 def test_selem_overflow():
     strel = np.ones((17, 17), dtype=np.uint8)

--- a/skimage/morphology/tests/test_binary.py
+++ b/skimage/morphology/tests/test_binary.py
@@ -48,7 +48,7 @@ def test_binary_opening():
 def test_binary_perimeter():
     bw = np.zeros([10,10])
     bw[3:7,3:7] = 1
-    perim = bw
+    perim = np.copy(bw)
     perim[4:6,4:6] = 0
     strel = selem.square(3)
     binary_res = binary.binary_perimeter(bw, strel)


### PR DESCRIPTION
## Description
[Tell us about your new feature, improvement, or fix! If relevant, please supplement the PR with images.]

Added a function binary_perimeter() to find the perimeter of objects in a binary input image in the morphology.binary module.
Takes a binary image and selem neighborhood as inputs. Outputs a binary image of perimeters.
Added a unit test for this function in morphology.binary.test_binary()

This function is useful for many image segmentation tasks.

While I realize it is somewhat simple to script up, I believe having a function in place is beneficial for those migrating from commercial toolboxes, where even simple combinations of morphological operators like this are included as standalone functions. 

**Example output:**

![cellmask](https://cloud.githubusercontent.com/assets/2465221/21069858/f2aa79e2-be32-11e6-8df7-3aaba5d156a0.png)
![cellmask_perim](https://cloud.githubusercontent.com/assets/2465221/21069859/f49e1d80-be32-11e6-8389-46f63c88af1c.png)

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

