### PR TITLE
NEW: add shannon entropy

### DIFF
--- a/skimage/measure/__init__.py
+++ b/skimage/measure/__init__.py
@@ -13,6 +13,7 @@ from .profile import profile_line
 from .fit import LineModel, LineModelND, CircleModel, EllipseModel, ransac
 from .block import block_reduce
 from ._label import label
+from .entropy import shannon_entropy
 
 
 __all__ = ['find_contours',
@@ -44,4 +45,5 @@ __all__ = ['find_contours',
            'compare_mse',
            'compare_nrmse',
            'compare_psnr',
+           'shannon_entropy',
            ]

--- a/skimage/measure/entropy.py
+++ b/skimage/measure/entropy.py
@@ -1,0 +1,37 @@
+from scipy.stats import entropy as scipy_entropy
+
+
+def shannon_entropy(image, base=2):
+    """Calculate the Shannon entropy of an image.
+
+    The Shannon entropy is defined as S = -sum(pk * log(pk)),
+    where pk are the number of pixels of value k.
+
+    Parameters
+    ----------
+    image : (N, M) ndarray
+        Grayscale input image.
+    base : float, optional
+        The logarithmic base to use.
+
+    Returns
+    -------
+    entropy : float
+
+    Notes
+    -----
+    The returned value is measured in bits or shannon (Sh) for base=2, natural
+    unit (nat) for base=np.e and hartley (Hart) for base=10.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Entropy_(information_theory)
+    .. [2] https://en.wiktionary.org/wiki/Shannon_entropy
+
+    Examples
+    --------
+    >>> from skimage import data
+    >>> shannon_entropy(data.camera())
+    17.732031303342747
+    """
+    return scipy_entropy(image.ravel(), base=base)

--- a/skimage/measure/tests/test_entropy.py
+++ b/skimage/measure/tests/test_entropy.py
@@ -1,0 +1,15 @@
+from numpy.testing import assert_almost_equal
+import numpy as np
+
+from skimage.measure import shannon_entropy
+
+
+def test_shannon_ones():
+    img = np.ones((10, 10))
+    res = shannon_entropy(img, base=np.e)
+    assert_almost_equal(res, np.log(10*10))
+
+
+if __name__ == "__main__":
+    from numpy.testing import run_module_suite
+    run_module_suite()


### PR DESCRIPTION
## Description

This PR implements a new feature, the shannon entropy. It's very simple, but we often miss simple features.
This also reflects a personal need for a library I'm writting.

* a request: https://stackoverflow.com/questions/40427172/getting-entropy-of-image-in-python-scikit-image
* wikipedia: https://en.wikipedia.org/wiki/Shannon_(unit)
* matlab page: http://fr.mathworks.com/help/images/ref/entropy.html

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example http://scikit-image.org/docs/dev/auto_examples/filters/plot_entropy.html
- [x] Unit tests


 

