### PR TITLE
Fix shape type for histogram

### DIFF
--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -1040,7 +1040,7 @@ def windowed_histogram(image, selem, out=None, mask=None,
     """
 
     if n_bins is None:
-        n_bins = image.max() + 1
+        n_bins = int(image.max()) + 1
 
     return _apply_vector_per_pixel(generic_cy._windowed_hist, image, selem,
                                    out=out, mask=mask,


### PR DESCRIPTION
## Description
The number of bins is always an integer, independently of the image data type. This fixes a build problem with numpy 1.12, [in Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=848112#40):
```
======================================================================
ERROR: skimage.filters.rank.tests.test_rank.test_all
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/build/skimage-0.12.3/debian/tmp/usr/lib/python2.7/dist-packages/skimage/filters/rank/tests/test_rank.py", line 16, in test_all
    check_all()
  File "/build/skimage-0.12.3/debian/tmp/usr/lib/python2.7/dist-packages/skimage/_shared/testing.py", line 232, in inner
    result = func(*args, **kwargs)
  File "/build/skimage-0.12.3/debian/tmp/usr/lib/python2.7/dist-packages/skimage/filters/rank/tests/test_rank.py", line 89, in check_all
    rank.windowed_histogram(image, selem))
  File "/build/skimage-0.12.3/debian/tmp/usr/lib/python2.7/dist-packages/skimage/filters/rank/generic.py", line 986, in windowed_histogram
    pixel_size=n_bins)
  File "/build/skimage-0.12.3/debian/tmp/usr/lib/python2.7/dist-packages/skimage/filters/rank/generic.py", line 90, in _apply_vector_per_pixel
    pixel_size=pixel_size)
  File "/build/skimage-0.12.3/debian/tmp/usr/lib/python2.7/dist-packages/skimage/filters/rank/generic.py", line 53, in _handle_input
    out = np.empty(image.shape+(pixel_size,), dtype=out_dtype)
TypeError: 'numpy.float64' object cannot be interpreted as an index

----------------------------------------------------------------------
Ran 1383 tests in 181.697s

FAILED (SKIP=54, errors=1)
```
## Checklist
(not needed -- trivial change)
## References
See above
