### PR TITLE
Gallery: Use Horse to illustrate Convex Hull

### DIFF
--- a/doc/examples/edges/plot_convex_hull.py
+++ b/doc/examples/edges/plot_convex_hull.py
@@ -6,9 +6,6 @@ Convex Hull
 The convex hull of a binary image is the set of pixels included in the
 smallest convex polygon that surround all white pixels in the input.
 
-In this example, we show how the input pixels (white) get filled in by the
-convex hull (white and grey).
-
 A good overview of the algorithm is given on `Steve Eddin's blog
 <http://blogs.mathworks.com/steve/2011/10/04/binary-image-convex-hull-algorithm-notes/>`__.
 
@@ -18,38 +15,23 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from skimage.morphology import convex_hull_image
+from skimage import data
+from skimage.util import invert
 
-
-image = np.array(
-    [[0, 0, 0, 0, 0, 0, 0, 0, 0],
-     [0, 0, 0, 0, 1, 0, 0, 0, 0],
-     [0, 0, 0, 1, 0, 1, 0, 0, 0],
-     [0, 0, 1, 0, 0, 0, 1, 0, 0],
-     [0, 1, 0, 0, 0, 0, 0, 1, 0],
-     [0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=float)
-
-original_image = np.copy(image)
+# The original image is inverted as the object must be white.
+image = invert(data.horse())
 
 chull = convex_hull_image(image)
-image[chull] += 1
 
-# image is now:
-# [[ 0.  0.  0.  0.  0.  0.  0.  0.  0.]
-#  [ 0.  0.  0.  0.  2.  0.  0.  0.  0.]
-#  [ 0.  0.  0.  2.  1.  2.  0.  0.  0.]
-#  [ 0.  0.  2.  1.  1.  1.  2.  0.  0.]
-#  [ 0.  2.  1.  1.  1.  1.  1.  2.  0.]
-#  [ 0.  0.  0.  0.  0.  0.  0.  0.  0.]]
-
-fig, axes = plt.subplots(1, 2, figsize=(9, 3))
+fig, axes = plt.subplots(1, 2, figsize=(8, 4))
 ax = axes.ravel()
 
 ax[0].set_title('Original picture')
-ax[0].imshow(original_image, cmap=plt.cm.gray, interpolation='nearest')
+ax[0].imshow(image, cmap=plt.cm.gray, interpolation='nearest')
 ax[0].set_axis_off()
 
 ax[1].set_title('Transformed picture')
-ax[1].imshow(image, cmap=plt.cm.gray, interpolation='nearest')
+ax[1].imshow(chull, cmap=plt.cm.gray, interpolation='nearest')
 ax[1].set_axis_off()
 
 plt.tight_layout()

--- a/doc/examples/edges/plot_convex_hull.py
+++ b/doc/examples/edges/plot_convex_hull.py
@@ -11,11 +11,10 @@ A good overview of the algorithm is given on `Steve Eddin's blog
 
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
 
 from skimage.morphology import convex_hull_image
-from skimage import data
+from skimage import data, img_as_float
 from skimage.util import invert
 
 # The original image is inverted as the object must be white.
@@ -35,4 +34,16 @@ ax[1].imshow(chull, cmap=plt.cm.gray, interpolation='nearest')
 ax[1].set_axis_off()
 
 plt.tight_layout()
+plt.show()
+
+######################################################################
+# We prepare a second plot to show the difference.
+#
+
+chull_diff = img_as_float(chull.copy())
+chull_diff[image] = 2
+
+fig, ax = plt.subplots()
+ax.imshow(chull_diff, cmap=plt.cm.gray, interpolation='nearest')
+ax.set_title('Difference')
 plt.show()


### PR DESCRIPTION
## Description

These modifications are on my disk for a while. I had to push the invert() function and a fix on the horse picture and I forgot in the mean time this patch.

Here, I propose to use the horse to illustrate the convex hull transformation. To me, this illustration is much more straightforward than the previous one. In the original version, getting a int picture with additional gray pixels from a binary image as an input is visually puzzling  to me. 
This new version also has the advantage to show the use of invert().

The idea is to improve again our examples for the next release.

![sphx_glr_plot_convex_hull_001](https://cloud.githubusercontent.com/assets/335370/21693546/99197d10-d381-11e6-98f4-e047f25728ef.png)