### PR TITLE
Change to Javascript loading of search index (patch by Julian Taylor)

### DIFF
--- a/doc/source/themes/scikit-image/search.html
+++ b/doc/source/themes/scikit-image/search.html
@@ -10,7 +10,15 @@
 {% extends "layout.html" %}
 {% set title = _('Search') %}
 {% set script_files = script_files + ['_static/searchtools.js'] %}
-{% set script_files = script_files + ['searchindex.js'] %}
+{% block extrahead %}
+  <script type="text/javascript">
+    jQuery(function() { Search.loadIndex("{{ pathto('searchindex.js', 1) }}"); });
+  </script>
+  {# this is used when loading the search index using $.ajax fails,
+     such as on Chrome for documents on localhost #}
+  <script type="text/javascript" id="searchindexloader"></script>
+  {{ super() }}
+{% endblock %}
 {% block body %}
   <h1 id="search-documentation">{{ _('Search') }}</h1>
   <div id="fallback" class="admonition warning">


### PR DESCRIPTION
Required so dh_sphinx (used in Debian packaging) recognises it as a
search.html
