### PR TITLE
Bug fix for Sauvola and Niblack thresholding

### DIFF
--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -403,5 +403,17 @@ def test_mean_std_2d():
     np.testing.assert_allclose(s, expected_s)
 
 
+def test_mean_std_3d():
+    image = np.random.rand(40, 40, 40)
+    window_size = 5
+    mean_kernel = np.ones((window_size,) * 3) / window_size**3
+    m, s = _mean_std(image, w=window_size)
+    expected_m = ndi.convolve(image, mean_kernel, mode='mirror')
+    np.testing.assert_allclose(m, expected_m)
+    expected_s = ndi.generic_filter(image, np.std, size=window_size,
+                                    mode='mirror')
+    np.testing.assert_allclose(s, expected_s)
+
+
 if __name__ == '__main__':
     np.testing.run_module_suite()

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy import ndimage as ndi
 from numpy.testing import (assert_equal,
                            assert_almost_equal,
                            assert_raises)
@@ -15,7 +16,8 @@ from skimage.filters.thresholding import (threshold_adaptive,
                                           threshold_sauvola,
                                           threshold_mean,
                                           threshold_triangle,
-                                          threshold_minimum)
+                                          threshold_minimum,
+                                          _mean_std)
 
 
 class TestSimpleImage():
@@ -387,6 +389,18 @@ def test_triangle_flip():
     # See numpy #7685 for a future np.testing API
     unequal_pos = np.where(t_img.ravel() != t_inv_inv_img.ravel())
     assert(len(unequal_pos[0]) / t_img.size < 1e-2)
+
+
+def test_mean_std_2d():
+    image = np.random.rand(256, 256)
+    window_size = 11
+    m, s = _mean_std(image, w=window_size)
+    mean_kernel = np.ones((window_size,) * 2) / window_size**2
+    expected_m = ndi.convolve(image, mean_kernel, mode='mirror')
+    np.testing.assert_allclose(m, expected_m)
+    expected_s = ndi.generic_filter(image, np.std, size=window_size,
+                                    mode='mirror')
+    np.testing.assert_allclose(s, expected_s)
 
 
 if __name__ == '__main__':

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -772,9 +772,9 @@ def _mean_std(image, w):
         kern[indices] = (-1) ** (image.ndim % 2 != np.sum(indices) % 2)
 
     sum_full = ndi.correlate(integral, kern, mode='constant')
-    m = util.crop(sum_full, (left_pad, right_pad)) / (w * w)
+    m = util.crop(sum_full, (left_pad, right_pad)) / (w ** image.ndim)
     sum_sq_full = ndi.correlate(integral_sq, kern, mode='constant')
-    g2 = util.crop(sum_sq_full, (left_pad, right_pad)) / (w * w)
+    g2 = util.crop(sum_sq_full, (left_pad, right_pad)) / (w ** image.ndim)
     s = np.sqrt(g2 - m * m)
     return m, s
 

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -758,7 +758,10 @@ def _mean_std(image, w):
         raise ValueError(
             "Window size w = %s must be odd and greater than 1." % w)
 
-    padded = np.pad(image.astype('float'), (2, 1), mode='reflect')
+    left_pad = w // 2 + 1
+    right_pad = w // 2
+    padded = np.pad(image.astype('float'), (left_pad, right_pad),
+                    mode='reflect')
     padded_sq = padded * padded
 
     integral = integral_image(padded)
@@ -769,9 +772,9 @@ def _mean_std(image, w):
         kern[indices] = (-1) ** (image.ndim % 2 != np.sum(indices) % 2)
 
     sum_full = ndi.correlate(integral, kern, mode='constant')
-    m = util.crop(sum_full, (2, 1)) / (w * w)
+    m = util.crop(sum_full, (left_pad, right_pad)) / (w * w)
     sum_sq_full = ndi.correlate(integral_sq, kern, mode='constant')
-    g2 = util.crop(sum_sq_full, (2, 1)) / (w * w)
+    g2 = util.crop(sum_sq_full, (left_pad, right_pad)) / (w * w)
     s = np.sqrt(g2 - m * m)
     return m, s
 


### PR DESCRIPTION
## Description
My bad! As part of n-D-fying #2266, I introduced two bugs:

- the padding of the integral image was sufficient only for a (3, 3) window size (ie what I was using in my informal tests). This resulted in incorrect values along image borders. It is now updated to work on arbitrary window sizes.
- the denominator for computing means was valid only for 2D images. It is now updated to be valid for images of any dimension.

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests

