### PR TITLE
Detection of local extrema from morphology

### DIFF
--- a/doc/examples/segmentation/plot_extrema.py
+++ b/doc/examples/segmentation/plot_extrema.py
@@ -1,0 +1,84 @@
+"""
+===============================
+Extrema
+===============================
+
+We detect local maxima in a galaxy image. The image is corrupted by noise,
+generating many local maxima. To keep only those maxima with sufficient
+local contrast, we use h-maxima.
+"""
+import numpy as np
+
+import matplotlib.pyplot as plt
+
+from skimage.measure import label
+from skimage import data
+from skimage import color
+from skimage.morphology import extrema
+from skimage import exposure
+
+
+color_image = data.hubble_deep_field()
+img = color.rgb2grey(color_image)
+
+# the rescaling is done only for visualization purpose.
+# the algorithms would work identically in an unscaled version of the
+# image. However, the parameter h needs to be adapted to the scale.
+img = exposure.rescale_intensity(img)
+
+# for visualization, we work on a crop of the image.
+x_0 = 70
+y_0 = 354
+width = 100
+height = 100
+
+
+##############################################################
+# MAXIMA DETECTION
+
+# Maxima in the galaxy image are detected by mathematical morphology.
+# There is no a priori constraint on the density.
+
+# We find all local maxima
+local_maxima = extrema.local_maxima(img)
+label_maxima = label(local_maxima)
+overlay = color.label2rgb(label_maxima, img, alpha=0.7, bg_label=0,
+                          bg_color=None, colors=[(1, 0, 0)])
+
+# We observed in the previous image, that there are many local maxima
+# that are caused by the noise in the image.
+# For this, we find all local maxima with a height of h.
+# This height is the grey level value by which we need to descent
+# in order to reach a higher maximum and it can be seen as a local
+# contrast measurement.
+# The value of h scales with the dynamic range of the image, i.e.
+# if we multiply the image with a constant, we need to multiply
+# the value of h with the same constant in order to achieve the same result.
+h = 0.05
+h_maxima = extrema.h_maxima(img, h)
+label_h_maxima = label(h_maxima)
+overlay_h = color.label2rgb(label_h_maxima, img, alpha=0.7, bg_label=0,
+                            bg_color=None, colors=[(1, 0, 0)])
+
+
+##############################################################
+# GRAPHICAL OUTPUT
+
+# a new figure with 3 subplots
+fig, ax = plt.subplots(1, 3, figsize=(15, 5))
+
+ax[0].imshow(img[y_0:(y_0 + height), x_0:(x_0 + width)], cmap='gray',
+             interpolation='none')
+ax[0].set_title('Original image')
+ax[0].axis('off')
+
+ax[1].imshow(overlay[y_0:(y_0 + height), x_0:(x_0 + width)],
+             interpolation='none')
+ax[1].set_title('Local Maxima')
+ax[1].axis('off')
+
+ax[2].imshow(overlay_h[y_0:(y_0 + height), x_0:(x_0 + width)],
+             interpolation='none')
+ax[2].set_title('h maxima for h = %.2f' % h)
+ax[2].axis('off')
+plt.show()

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -1,0 +1,352 @@
+"""extrema.py - local minima and maxima
+
+This module provides functions to find local maxima and minima of an image.
+Here, local maxima (minima) are defined as connected sets of pixels with equal
+grey level which is strictly greater (smaller) than the grey level of all
+pixels in direct neighborhood of the connected set. In addition, the module
+provides the closely related functions h-maxima and h-minima.
+
+Soille, P. (2003). Morphological Image Analysis: Principles and Applications
+(2nd ed.), Chapter 6. Springer-Verlag New York, Inc.
+"""
+from __future__ import absolute_import
+
+import numpy as np
+
+from . import greyreconstruct
+from ..util import dtype_limits
+
+
+def _add_constant_clip(img, const_value):
+    """Add constant to the image while handling overflow issues gracefully.
+    """
+    min_dtype, max_dtype = dtype_limits(img, clip_negative=False)
+
+    if const_value > (max_dtype - min_dtype):
+        raise ValueError("The added constant is not compatible"
+                         "with the image data type.")
+
+    result = img + const_value
+    result[img > max_dtype-const_value] = max_dtype
+    return(result)
+
+
+def _subtract_constant_clip(img, const_value):
+    """Subtract constant from image while handling underflow issues.
+    """
+    min_dtype, max_dtype = dtype_limits(img, clip_negative=False)
+
+    if const_value > (max_dtype-min_dtype):
+        raise ValueError("The subtracted constant is not compatible"
+                         "with the image data type.")
+
+    result = img - const_value
+    result[img < (const_value + min_dtype)] = min_dtype
+    return(result)
+
+
+def h_maxima(img, h, selem=None):
+    """Determine all maxima of the image with height >= h.
+
+    The local maxima are defined as connected sets of pixels with equal
+    grey level strictly greater than the grey level of all pixels in direct
+    neighborhood of the set.
+
+    A local maximum M of height h is a local maximum for which
+    there is at least one path joining M with a higher maximum on which the
+    minimal value is f(M) - h (i.e. the values along the path are not
+    decreasing by more than h with respect to the maximum's value) and no
+    path for which the minimal value is greater.
+
+    Parameters
+    ----------
+    img : ndarray
+        The input image for which the maxima are to be calculated.
+    h : unsigned integer
+        The minimal height of all extracted maxima.
+    selem : ndarray, optional
+        The neighborhood expressed as an n-D array of 1's and 0's.
+        Default is the ball of radius 1 according to the maximum norm
+        (i.e. a 3x3 square for 2D images, a 3x3x3 cube for 3D images, etc.)
+
+    Returns
+    -------
+    h_max : ndarray
+       The maxima of height >= h. The result image is a binary image, where
+       pixels belonging to the selected maxima take value 1, the others
+       take value 0.
+
+    See also
+    --------
+    skimage.morphology.extrema.h_minima
+    skimage.morphology.extrema.local_maxima
+    skimage.morphology.extrema.local_minima
+
+    References
+    ----------
+    .. [1] Soille, P., "Morphological Image Analysis: Principles and
+           Applications" (Chapter 6), 2nd edition (2003), ISBN 3540429883.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skimage.morphology import extrema
+
+    We create an image (quadratic function with a maximum in the center and
+    4 additional constant maxima.
+    The heights of the maxima are: 1, 21, 41, 61, 81, 101
+
+    >>> w = 10
+    >>> x, y = np.mgrid[0:w,0:w]
+    >>> f = 20 - 0.2*((x - w/2)**2 + (y-w/2)**2)
+    >>> f[2:4,2:4] = 40; f[2:4,7:9] = 60; f[7:9,2:4] = 80; f[7:9,7:9] = 100
+    >>> f = f.astype(np.int)
+
+    We can calculate all maxima with a height of at least 40:
+
+    >>> maxima = extrema.h_maxima(f, 40)
+
+    The resulting image will contain 4 local maxima.
+    """
+    if np.issubdtype(img.dtype, 'half'):
+        resolution = 2 * np.finfo(img.dtype).resolution
+        if h < resolution:
+            h = resolution
+        h_corrected = h - resolution / 2.0
+        shifted_img = img - h
+    else:
+        shifted_img = _subtract_constant_clip(img, h)
+        h_corrected = h
+
+    rec_img = greyreconstruct.reconstruction(shifted_img, img,
+                                             method='dilation', selem=selem)
+    residue_img = img - rec_img
+    h_max = np.zeros(img.shape, dtype=np.uint8)
+    h_max[residue_img >= h_corrected] = 1
+    return h_max
+
+
+def h_minima(img, h, selem=None):
+    """Determine all minima of the image with depth >= h.
+
+    The local minima are defined as connected sets of pixels with equal
+    grey level strictly smaller than the grey levels of all pixels in direct
+    neighborhood of the set.
+
+    A local minimum M of depth h is a local minimum for which
+    there is at least one path joining M with a deeper minimum on which the
+    maximal value is f(M) + h (i.e. the values along the path are not
+    increasing by more than h with respect to the minimum's value) and no
+    path for which the maximal value is smaller.
+
+    Parameters
+    ----------
+    img : ndarray
+        The input image for which the minima are to be calculated.
+    h : unsigned integer
+        The minimal depth of all extracted minima.
+    selem : ndarray, optional
+        The neighborhood expressed as an n-D array of 1's and 0's.
+        Default is the ball of radius 1 according to the maximum norm
+        (i.e. a 3x3 square for 2D images, a 3x3x3 cube for 3D images, etc.)
+
+    Returns
+    -------
+    h_min : ndarray
+       The minima of depth >= h. The result image is a binary image, where
+       pixels belonging to the selected minima take value 1, the other pixels
+       take value 0.
+
+    See also
+    --------
+    skimage.morphology.extrema.h_maxima
+    skimage.morphology.extrema.local_maxima
+    skimage.morphology.extrema.local_minima
+
+    References
+    ----------
+    .. [1] Soille, P., "Morphological Image Analysis: Principles and
+           Applications" (Chapter 6), 2nd edition (2003), ISBN 3540429883.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skimage.morphology import extrema
+
+    We create an image (quadratic function with a minimum in the center and
+    4 additional constant maxima.
+    The depth of the minima are: 1, 21, 41, 61, 81, 101
+
+    >>> w = 10
+    >>> x, y = np.mgrid[0:w,0:w]
+    >>> f = 180 + 0.2*((x - w/2)**2 + (y-w/2)**2)
+    >>> f[2:4,2:4] = 160; f[2:4,7:9] = 140; f[7:9,2:4] = 120; f[7:9,7:9] = 100
+    >>> f = f.astype(np.int)
+
+    We can calculate all minima with a depth of at least 40:
+
+    >>> minima = extrema.h_minima(f, 40)
+
+    The resulting image will contain 4 local minima.
+    """
+    if np.issubdtype(img.dtype, 'half'):
+        resolution = 2 * np.finfo(img.dtype).resolution
+        if h < resolution:
+            h = resolution
+        h_corrected = h - resolution / 2.0
+        shifted_img = img + h
+    else:
+        shifted_img = _add_constant_clip(img, h)
+        h_corrected = h
+
+    rec_img = greyreconstruct.reconstruction(shifted_img, img,
+                                             method='erosion', selem=selem)
+    residue_img = rec_img - img
+    h_min = np.zeros(img.shape, dtype=np.uint8)
+    h_min[residue_img >= h_corrected] = 1
+    return h_min
+
+
+def _find_min_diff(img):
+    """
+    Find the minimal difference of grey levels inside the image.
+    """
+    img_vec = np.unique(img.flatten())
+    min_diff = np.min(img_vec[1:] - img_vec[:-1])
+    return min_diff
+
+
+def local_maxima(img, selem=None):
+    """Determine all local maxima of the image.
+
+    The local maxima are defined as connected sets of pixels with equal
+    grey level strictly greater than the grey levels of all pixels in direct
+    neighborhood of the set.
+
+    For integer typed images, this corresponds to the h-maxima with h=1.
+    For float typed images, h is determined as the smallest difference
+    between grey levels.
+
+    Parameters
+    ----------
+    img : ndarray
+        The input image for which the maxima are to be calculated.
+    selem : ndarray, optional
+        The neighborhood expressed as an n-D array of 1's and 0's.
+        Default is the ball of radius 1 according to the maximum norm
+        (i.e. a 3x3 square for 2D images, a 3x3x3 cube for 3D images, etc.)
+
+    Returns
+    -------
+    local_max : ndarray
+       All local maxima of the image. The result image is a binary image,
+       where pixels belonging to local maxima take value 1, the other pixels
+       take value 0.
+
+    See also
+    --------
+    skimage.morphology.extrema.h_minima
+    skimage.morphology.extrema.h_maxima
+    skimage.morphology.extrema.local_minima
+
+    References
+    ----------
+    .. [1] Soille, P., "Morphological Image Analysis: Principles and
+           Applications" (Chapter 6), 2nd edition (2003), ISBN 3540429883.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skimage.morphology import extrema
+
+    We create an image (quadratic function with a maximum in the center and
+    4 additional constant maxima.
+    The heights of the maxima are: 1, 21, 41, 61, 81, 101
+
+    >>> w = 10
+    >>> x, y = np.mgrid[0:w,0:w]
+    >>> f = 20 - 0.2*((x - w/2)**2 + (y-w/2)**2)
+    >>> f[2:4,2:4] = 40; f[2:4,7:9] = 60; f[7:9,2:4] = 80; f[7:9,7:9] = 100
+    >>> f = f.astype(np.int)
+
+    We can calculate all local maxima:
+
+    >>> maxima = extrema.local_maxima(f)
+
+    The resulting image will contain all 6 local maxima.
+    """
+    if np.issubdtype(img.dtype, 'half'):
+        # find the minimal grey level difference
+        h = _find_min_diff(img)
+    else:
+        h = 1
+    local_max = h_maxima(img, h, selem=selem)
+    return local_max
+
+
+def local_minima(img, selem=None):
+    """Determine all local minima of the image.
+
+    The local minima are defined as connected sets of pixels with equal
+    grey level strictly smaller than the grey levels of all pixels in direct
+    neighborhood of the set.
+
+    For integer typed images, this corresponds to the h-minima with h=1.
+    For float typed images, h is determined as the smallest difference
+    between grey levels.
+
+    Parameters
+    ----------
+    img : ndarray
+        The input image for which the minima are to be calculated.
+    selem : ndarray, optional
+        The neighborhood expressed as an n-D array of 1's and 0's.
+        Default is the ball of radius 1 according to the maximum norm
+        (i.e. a 3x3 square for 2D images, a 3x3x3 cube for 3D images, etc.)
+
+    Returns
+    -------
+    local_min : ndarray
+       All local minima of the image. The result image is a binary image,
+       where pixels belonging to local minima take value 1, the other pixels
+       take value 0.
+
+    See also
+    --------
+    skimage.morphology.extrema.h_minima
+    skimage.morphology.extrema.h_maxima
+    skimage.morphology.extrema.local_maxima
+
+    References
+    ----------
+    .. [1] Soille, P., "Morphological Image Analysis: Principles and
+           Applications" (Chapter 6), 2nd edition (2003), ISBN 3540429883.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skimage.morphology import extrema
+
+    We create an image (quadratic function with a minimum in the center and
+    4 additional constant maxima.
+    The depth of the minima are: 1, 21, 41, 61, 81, 101
+
+    >>> w = 10
+    >>> x, y = np.mgrid[0:w,0:w]
+    >>> f = 180 + 0.2*((x - w/2)**2 + (y-w/2)**2)
+    >>> f[2:4,2:4] = 160; f[2:4,7:9] = 140; f[7:9,2:4] = 120; f[7:9,7:9] = 100
+    >>> f = f.astype(np.int)
+
+    We can calculate all local minima:
+
+    >>> minima = extrema.local_minima(f)
+
+    The resulting image will contain all 6 local minima.
+    """
+    if np.issubdtype(img.dtype, 'half'):
+        # find the minimal grey level difference
+        h = _find_min_diff(img)
+    else:
+        h = 1
+    local_min = h_minima(img, h, selem=selem)
+    return local_min

--- a/skimage/morphology/greyreconstruct.py
+++ b/skimage/morphology/greyreconstruct.py
@@ -48,7 +48,9 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
         mask image. For dilation, each seed value must be less than or equal
         to the corresponding mask value; for erosion, the reverse is true.
     selem : ndarray
-        The neighborhood expressed as a 2-D array of 1's and 0's.
+        The neighborhood expressed as an n-D array of 1's and 0's.
+        Default is the ball of radius 1 according to the maximum norm
+        (i.e. a 3x3 square for 2D images, a 3x3x3 cube for 3D images, etc.)
 
     Returns
     -------

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -1,0 +1,298 @@
+import math
+import unittest
+
+import numpy as np
+
+from skimage.morphology import extrema
+from scipy import ndimage as ndi
+
+eps = 1e-12
+
+
+def diff(a, b):
+    a = np.asarray(a, dtype=np.float64)
+    b = np.asarray(b, dtype=np.float64)
+    t = ((a - b)**2).sum()
+    return math.sqrt(t)
+
+
+class TestExtrema(unittest.TestCase):
+
+    def test_saturated_arithmetic(self):
+        "Adding/subtracting a constant and clipping"
+        # Test for unsigned integer
+        data = np.array([[250, 251, 5, 5],
+                         [100, 200, 253, 252],
+                         [4, 10, 1, 3]],
+                        dtype=np.uint8)
+        # adding the constant
+        img_constant_added = extrema._add_constant_clip(data, 4)
+        expected = np.array([[254, 255, 9, 9],
+                             [104, 204, 255, 255],
+                             [8, 14, 5, 7]],
+                            dtype=np.uint8)
+        error = diff(img_constant_added, expected)
+        assert error < eps
+        img_constant_subtracted = extrema._subtract_constant_clip(data, 4)
+        expected = np.array([[246, 247, 1, 1],
+                             [96, 196, 249, 248],
+                             [0, 6, 0, 0]],
+                            dtype=np.uint8)
+        error = diff(img_constant_subtracted, expected)
+        assert error < eps
+
+        # Test for signed integer
+        data = np.array([[32767, 32766],
+                         [-32768, -32767]],
+                        dtype=np.int16)
+        img_constant_added = extrema._add_constant_clip(data, 1)
+        expected = np.array([[32767, 32767],
+                             [-32767, -32766]],
+                            dtype=np.int16)
+        error = diff(img_constant_added, expected)
+        assert error < eps
+        img_constant_subtracted = extrema._subtract_constant_clip(data, 1)
+        expected = np.array([[32766, 32765],
+                             [-32768, -32768]],
+                            dtype=np.int16)
+        error = diff(img_constant_subtracted, expected)
+        assert error < eps
+
+    def test_local_maxima(self):
+        "local maxima for various data types"
+        data = np.array([[10,  11,  13,  14,  14,  15,  14,  14,  13,  11],
+                         [11,  13,  15,  16,  16,  16,  16,  16,  15,  13],
+                         [13,  15,  40,  40,  18,  18,  18,  60,  60,  15],
+                         [14,  16,  40,  40,  19,  19,  19,  60,  60,  16],
+                         [14,  16,  18,  19,  19,  19,  19,  19,  18,  16],
+                         [15,  16,  18,  19,  19,  20,  19,  19,  18,  16],
+                         [14,  16,  18,  19,  19,  19,  19,  19,  18,  16],
+                         [14,  16,  80,  80,  19,  19,  19, 100, 100,  16],
+                         [13,  15,  80,  80,  18,  18,  18, 100, 100,  15],
+                         [11,  13,  15,  16,  16,  16,  16,  16,  15,  13]],
+                        dtype=np.uint8)
+        expected_result = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
+                                   dtype=np.uint8)
+        for dtype in [np.uint8, np.uint64, np.int8, np.int64]:
+
+            test_data = data.astype(dtype)
+            out = extrema.local_maxima(test_data)
+
+            error = diff(expected_result, out)
+            assert error < eps
+            assert out.dtype == expected_result.dtype
+
+    def test_local_minima(self):
+        "local minima for various data types"
+
+        data = np.array([[10,  11,  13,  14,  14,  15,  14,  14,  13,  11],
+                         [11,  13,  15,  16,  16,  16,  16,  16,  15,  13],
+                         [13,  15,  40,  40,  18,  18,  18,  60,  60,  15],
+                         [14,  16,  40,  40,  19,  19,  19,  60,  60,  16],
+                         [14,  16,  18,  19,  19,  19,  19,  19,  18,  16],
+                         [15,  16,  18,  19,  19,  20,  19,  19,  18,  16],
+                         [14,  16,  18,  19,  19,  19,  19,  19,  18,  16],
+                         [14,  16,  80,  80,  19,  19,  19, 100, 100,  16],
+                         [13,  15,  80,  80,  18,  18,  18, 100, 100,  15],
+                         [11,  13,  15,  16,  16,  16,  16,  16,  15,  13]],
+                        dtype=np.uint8)
+        data = 100 - data
+        expected_result = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
+                                   dtype=np.uint8)
+        for dtype in [np.uint8, np.uint64, np.int8, np.int64]:
+            data = data.astype(dtype)
+            out = extrema.local_minima(data)
+
+            error = diff(expected_result, out)
+            assert error < eps
+            assert out.dtype == expected_result.dtype
+
+    def test_h_maxima(self):
+        "h-maxima for various data types"
+
+        data = np.array([[10,  11,  13,  14,  14,  15,  14,  14,  13,  11],
+                         [11,  13,  15,  16,  16,  16,  16,  16,  15,  13],
+                         [13,  15,  40,  40,  18,  18,  18,  60,  60,  15],
+                         [14,  16,  40,  40,  19,  19,  19,  60,  60,  16],
+                         [14,  16,  18,  19,  19,  19,  19,  19,  18,  16],
+                         [15,  16,  18,  19,  19,  20,  19,  19,  18,  16],
+                         [14,  16,  18,  19,  19,  19,  19,  19,  18,  16],
+                         [14,  16,  80,  80,  19,  19,  19, 100, 100,  16],
+                         [13,  15,  80,  80,  18,  18,  18, 100, 100,  15],
+                         [11,  13,  15,  16,  16,  16,  16,  16,  15,  13]],
+                        dtype=np.uint8)
+
+        expected_result = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
+                                   dtype=np.uint8)
+        for dtype in [np.uint8, np.uint64, np.int8, np.int64]:
+            data = data.astype(dtype)
+            out = extrema.h_maxima(data, 40)
+
+            error = diff(expected_result, out)
+            assert error < eps
+
+    def test_h_minima(self):
+        "h-minima for various data types"
+
+        data = np.array([[10,  11,  13,  14,  14,  15,  14,  14,  13,  11],
+                         [11,  13,  15,  16,  16,  16,  16,  16,  15,  13],
+                         [13,  15,  40,  40,  18,  18,  18,  60,  60,  15],
+                         [14,  16,  40,  40,  19,  19,  19,  60,  60,  16],
+                         [14,  16,  18,  19,  19,  19,  19,  19,  18,  16],
+                         [15,  16,  18,  19,  19,  20,  19,  19,  18,  16],
+                         [14,  16,  18,  19,  19,  19,  19,  19,  18,  16],
+                         [14,  16,  80,  80,  19,  19,  19, 100, 100,  16],
+                         [13,  15,  80,  80,  18,  18,  18, 100, 100,  15],
+                         [11,  13,  15,  16,  16,  16,  16,  16,  15,  13]],
+                        dtype=np.uint8)
+        data = 100 - data
+        expected_result = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
+                                   dtype=np.uint8)
+        for dtype in [np.uint8, np.uint64, np.int8, np.int64]:
+            data = data.astype(dtype)
+            out = extrema.h_minima(data, 40)
+
+            error = diff(expected_result, out)
+            assert error < eps
+            assert out.dtype == expected_result.dtype
+
+    def test_extrema_float(self):
+        "specific tests for float type"
+        data = np.array([[0.10, 0.11, 0.13, 0.14, 0.14, 0.15, 0.14,
+                          0.14, 0.13, 0.11],
+                         [0.11, 0.13, 0.15, 0.16, 0.16, 0.16, 0.16,
+                          0.16, 0.15, 0.13],
+                         [0.13, 0.15, 0.40, 0.40, 0.18, 0.18, 0.18,
+                          0.60, 0.60, 0.15],
+                         [0.14, 0.16, 0.40, 0.40, 0.19, 0.19, 0.19,
+                          0.60, 0.60, 0.16],
+                         [0.14, 0.16, 0.18, 0.19, 0.19, 0.19, 0.19,
+                          0.19, 0.18, 0.16],
+                         [0.15, 0.182, 0.18, 0.19, 0.204, 0.20, 0.19,
+                          0.19, 0.18, 0.16],
+                         [0.14, 0.16, 0.18, 0.19, 0.19, 0.19, 0.19,
+                          0.19, 0.18, 0.16],
+                         [0.14, 0.16, 0.80, 0.80, 0.19, 0.19, 0.19,
+                          1.0,  1.0, 0.16],
+                         [0.13, 0.15, 0.80, 0.80, 0.18, 0.18, 0.18,
+                          1.0, 1.0, 0.15],
+                         [0.11, 0.13, 0.15, 0.16, 0.16, 0.16, 0.16,
+                          0.16, 0.15, 0.13]],
+                        dtype=np.float32)
+        inverted_data = 1.0 - data
+
+        expected_result = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 1, 0, 0, 1, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
+                                   dtype=np.uint8)
+
+        # test for local maxima with automatic step calculation
+        out = extrema.local_maxima(data)
+        error = diff(expected_result, out)
+        assert error < eps
+
+        # test for local minima with automatic step calculation
+        out = extrema.local_minima(inverted_data)
+        error = diff(expected_result, out)
+        assert error < eps
+
+        out = extrema.h_maxima(data, 0.003)
+        expected_result = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 1, 1, 0, 0, 0, 1, 1, 0],
+                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
+                                   dtype=np.uint8)
+
+        error = diff(expected_result, out)
+        assert error < eps
+
+        out = extrema.h_minima(inverted_data, 0.003)
+        error = diff(expected_result, out)
+        assert error < eps
+
+    def test_3d(self):
+        """tests the detection of maxima in 3D."""
+        img = np.zeros((8, 8, 8), dtype=np.uint8)
+        local_maxima = np.zeros((8, 8, 8), dtype=np.uint8)
+
+        # first maximum: only one pixel
+        img[1, 1:3, 1:3] = 100
+        img[2, 2, 2] = 200
+        img[3, 1:3, 1:3] = 100
+        local_maxima[2, 2, 2] = 1
+
+        # second maximum: three pixels in z-direction
+        img[5:8, 1, 1] = 200
+        local_maxima[5:8, 1, 1] = 1
+
+        # third: two maxima in 0 and 3.
+        img[0, 5:8, 5:8] = 200
+        img[1, 6, 6] = 100
+        img[2, 5:7, 5:7] = 200
+        img[0:3, 5:8, 5:8] += 50
+        local_maxima[0, 5:8, 5:8] = 1
+        local_maxima[2, 5:7, 5:7] = 1
+
+        # four : one maximum in the corner of the square
+        img[6:8, 6:8, 6:8] = 200
+        img[7, 7, 7] = 255
+        local_maxima[7, 7, 7] = 1
+
+        se = ndi.generate_binary_structure(3, 1)
+        out = extrema.local_maxima(img, se)
+
+        error = diff(local_maxima, out)
+        assert error < eps
+
+
+if __name__ == "__main__":
+    np.testing.run_module_suite()


### PR DESCRIPTION
## Description
Detection of local maxima and minima in an image. So far, skimage allows to detect local maxima with the function `peak_local_max `, but in some circumstances, this function is not optimal. For instance, it is impossible to retrieve all local maxima/minima of an image, irrespective of any distance or threshold consideration. Also, the definition of a local maximum as a set of pixels larger than any other pixel within a distance, does not suit all applications. Here, we use the morphological definition of a local maximum as a set of pixels strictly greater/lower than all surrounding pixels. We also define the h-minima and h-maxima, i.e. minima with a depth of at least h and maxima with a height of at least h. This is based on the morphological reconstruction in the morphology module implemented by Lee Kamentsky. All functions can be applied to all image types. The strategy was already mentioned in the help of the reconstruction algorithm, but I made this more formal and applicable to all data types. 

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]
I do not remember the first paper mentioning this, but it is based on a standard textbook: 

Soille, P. (2003). Morphological Image Analysis: Principles and Applications
(2nd ed.). Springer-Verlag New York, Inc.

