### PR TITLE
MRG: update build matrix for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,11 @@ matrix:
       env: OPTIONAL_DEPS=1 WITH_PYSIDE=1
     - os: linux
       python: 3.5
+    - os: linux
+      python: 3.5
       env: PIP_FLAGS="--pre"
+    - os: linux
+      python: 3.6
     - os: osx
       osx_image: xcode7.3
       language: objective-c
@@ -58,6 +62,9 @@ before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source tools/travis_osx_install.sh ; fi
     - ccache -s
     - export PATH=/usr/lib/ccache:${PATH}
+    # Attempt to fix bug making virtualenvs for Python 3.6
+    - python -m pip install -U pip
+    - pip install -U virtualenv
     - source tools/travis_before_install.sh
     - which python; python --version
     - python check_bento_build.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,9 @@ matrix:
     - os: linux
       python: 3.5
       env: PIP_FLAGS="--pre"
-    - os: linux
-      python: 3.6
+    # This entry waiting for resolution of issue 2450
+    # - os: linux
+    #  python: 3.6
     - os: osx
       osx_image: xcode7.3
       language: objective-c

--- a/doc/examples/edges/plot_circular_elliptical_hough_transform.py
+++ b/doc/examples/edges/plot_circular_elliptical_hough_transform.py
@@ -131,8 +131,9 @@ orientation = best[5]
 # Draw the ellipse on the original image
 cy, cx = ellipse_perimeter(yc, xc, a, b, orientation)
 image_rgb[cy, cx] = (0, 0, 255)
-# Draw the edge (white) and the resulting ellipse (red)
-edges = color.gray2rgb(edges)
+# The edge in white
+edges = color.gray2rgb(edges).astype('uint8') * 255
+# The resulting ellipse in red
 edges[cy, cx] = (250, 0, 0)
 
 fig2, (ax1, ax2) = plt.subplots(ncols=2, nrows=1, figsize=(8, 4), sharex=True,

--- a/doc/examples/features_detection/plot_local_binary_pattern.py
+++ b/doc/examples/features_detection/plot_local_binary_pattern.py
@@ -107,7 +107,7 @@ lbp = local_binary_pattern(image, n_points, radius, METHOD)
 
 
 def hist(ax, lbp):
-    n_bins = lbp.max() + 1
+    n_bins = int(lbp.max() + 1)
     return ax.hist(lbp.ravel(), normed=True, bins=n_bins, range=(0, n_bins),
                    facecolor='0.5')
 
@@ -166,7 +166,7 @@ def match(refs, img):
     best_score = 10
     best_name = None
     lbp = local_binary_pattern(img, n_points, radius, METHOD)
-    n_bins = lbp.max() + 1
+    n_bins = int(lbp.max() + 1)
     hist, _ = np.histogram(lbp, normed=True, bins=n_bins, range=(0, n_bins))
     for name, ref in refs.items():
         ref_hist, _ = np.histogram(ref, normed=True, bins=n_bins,

--- a/doc/examples/transform/plot_pyramid.py
+++ b/doc/examples/transform/plot_pyramid.py
@@ -20,7 +20,7 @@ image = data.astronaut()
 rows, cols, dim = image.shape
 pyramid = tuple(pyramid_gaussian(image, downscale=2))
 
-composite_image = np.zeros((rows, cols + cols / 2, 3), dtype=np.double)
+composite_image = np.zeros((rows, cols + cols // 2, 3), dtype=np.double)
 
 composite_image[:rows, :cols, :] = pyramid[0]
 

--- a/skimage/io/tests/test_imageio.py
+++ b/skimage/io/tests/test_imageio.py
@@ -46,7 +46,9 @@ def test_imageio_palette():
 
 @skipif(not imageio_available)
 def test_imageio_truncated_jpg():
-    assert_raises((RuntimeError, ValueError),
+    # imageio>2.0 uses Pillow / PIL to try and load the file.
+    # Oddly, PIL explicitly raises a SyntaxError when the file read fails.
+    assert_raises((RuntimeError, ValueError, SyntaxError),
                   imread,
                   os.path.join(data_dir, 'truncated.jpg'))
 

--- a/tools/travis_before_install.sh
+++ b/tools/travis_before_install.sh
@@ -7,9 +7,9 @@ export PIP_DEFAULT_TIMEOUT=60
 
 # This URL is for any extra wheels that are not available on pypi.  As of 14
 # Jan 2017, the major packages such as numpy and matplotlib are up for all
-# platforms.  The URL comes points ot a Rackspace CDN belonging to the
-# scikit-learn team.  Please contact Olivier Grisel or Matthew Brett if you
-# need permissions for this folder.
+# platforms.  The URL points to a Rackspace CDN belonging to the scikit-learn
+# team.  Please contact Olivier Grisel or Matthew Brett if you need
+# permissions for this folder.
 EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
 WHEELHOUSE="--find-links=$EXTRA_WHEELS"
 

--- a/tools/travis_before_install.sh
+++ b/tools/travis_before_install.sh
@@ -5,10 +5,16 @@ set -ex
 export COVERALLS_REPO_TOKEN=7LdFN9232ZbSY3oaXHbQIzLazrSf6w2pQ
 export PIP_DEFAULT_TIMEOUT=60
 
+# This URL is for any extra wheels that are not available on pypi.  As of 14
+# Jan 2017, the major packages such as numpy and matplotlib are up for all
+# platforms.  The URL comes points ot a Rackspace CDN belonging to the
+# scikit-learn team.  Please contact Olivier Grisel or Matthew Brett if you
+# need permissions for this folder.
+EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
+export WHEELHOUSE="--find-links=$EXTRA_WHEELS"
+
 if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
     sh -e /etc/init.d/xvfb start
-    export WHEELHOUSE="--no-index --trusted-host travis-wheels.scikit-image.org \
-                       --find-links=http://travis-wheels.scikit-image.org/"
 fi
 
 export DISPLAY=:99.0
@@ -46,7 +52,7 @@ fi
 virtualenv -p python ~/venv
 source ~/venv/bin/activate
 
-pip install --upgrade pip
+python -m pip install --upgrade pip
 pip install --retries 3 -q wheel flake8 codecov nose
 # install numpy from PyPI instead of our wheelhouse
 pip install --retries 3 -q wheel numpy

--- a/tools/travis_before_install.sh
+++ b/tools/travis_before_install.sh
@@ -11,11 +11,22 @@ export PIP_DEFAULT_TIMEOUT=60
 # scikit-learn team.  Please contact Olivier Grisel or Matthew Brett if you
 # need permissions for this folder.
 EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
-export WHEELHOUSE="--find-links=$EXTRA_WHEELS"
+WHEELHOUSE="--find-links=$EXTRA_WHEELS"
 
 if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
     sh -e /etc/init.d/xvfb start
+    # This one is for wheels we can only build on the travis precise container.
+    # As of 14 Jan 2017, this is only pyside.  Also on Rackspace, see above.
+    # To build new wheels for this container, consider using:
+    # https://github.com/matthew-brett/travis-wheel-builder . The wheels from
+    # that building repo upload to the container "travis-wheels" available at
+    # https://8167b5c3a2af93a0a9fb-13c6eee0d707a05fa610c311eec04c66.ssl.cf2.rackcdn.com
+    # You then need to transfer them to the container pointed to by the URL
+    # below (called "precise-wheels" on the Rackspace interface).
+    PRECISE_WHEELS="https://7d8d0debcc2964ae0517-cec8b1780d3c0de237cc726d565607b4.ssl.cf2.rackcdn.com"
+    WHEELHOUSE="--find-links=$PRECISE_WHEELS $WHEELHOUSE"
 fi
+export WHEELHOUSE
 
 export DISPLAY=:99.0
 export PYTHONWARNINGS="d,all:::skimage"

--- a/tools/travis_script.sh
+++ b/tools/travis_script.sh
@@ -55,7 +55,7 @@ if [[ $WITH_QT == 1 ]]; then
         ln -sf $LIB_SYSTEM_PATH/$LIB $LIB_VIRTUALENV_PATH/$LIB
     done
 
-elif [[ $WITH_PYSIDE == 1 ]]; then
+elif [ "$WITH_PYSIDE" == 1 ] && [ -e ~/venv/bin/pyside_postinstall.py ]; then
     python ~/venv/bin/pyside_postinstall.py -install
 fi
 


### PR DESCRIPTION
* Add Python 3.6 tests;
* Switch away from un-maintained travis-wheels wheelhouse to pypi + nipy server
  (for Python 3.6 matplotlib wheels).

Reveals test failures for Python 3.6 and with --pre flag.