### PR TITLE
MAINT: removes _wavelet_threshold docstring

### DIFF
--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -383,7 +383,7 @@ def _sigma_est_dwt(detail_coeffs, distribution='Gaussian'):
 
 def _wavelet_threshold(img, wavelet, threshold=None, sigma=None, mode='soft',
                        wavelet_levels=None):
-    """Perform wavelet denoising.
+    """Perform wavelet thresholding.
 
     Parameters
     ----------
@@ -415,17 +415,6 @@ def _wavelet_threshold(img, wavelet, threshold=None, sigma=None, mode='soft',
     -------
     out : ndarray
         Denoised image.
-
-    Notes
-    -----
-    Reference [1]_ used four levels of wavelet decomposition.  To be more
-    flexible for a range of input sizes, the implementation here stops 3 levels
-    prior to the maximum level of decomposition for `img` (the exact # of
-    levels thus depends on `img.shape` and the chosen wavelet). BayesShrink
-    variance estimation doesn't work well on levels with extremely small
-    coefficient arrays.  This is the rationale for skipping a few of the
-    coarsest levels.  The user can override the automated setting by explicitly
-    specifying `wavelet_levels`.
 
     References
     ----------


### PR DESCRIPTION
## Description
Removes the docstring of a private function (`_wavelet_threshold`). This docstring is (nearly) a duplicate of `denoise_wavelet`. The only difference between these two docstrings is 

>    threshold : float, optional
>        The thresholding value. All wavelet coefficients less than this value
>        are set to 0. The default value (None) uses the BayesShrink method
>        found in [1]_ to remove noise.

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)

## References
This docstring was added by me in #2190.