### PR TITLE
BUG: fix denoise_wavelet for odd-length input

### DIFF
--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -429,6 +429,10 @@ def _wavelet_threshold(img, wavelet, threshold=None, sigma=None, mode='soft',
     """
     wavelet = pywt.Wavelet(wavelet)
 
+    # original_extent is used to workaround PyWavelets issue #80
+    # odd-sized input results in an image with 1 extra sample after waverecn
+    original_extent = [slice(s) for s in img.shape]
+
     # Determine the number of wavelet decomposition levels
     if wavelet_levels is None:
         # Determine the maximum number of possible levels for img
@@ -467,7 +471,7 @@ def _wavelet_threshold(img, wavelet, threshold=None, sigma=None, mode='soft',
                                                 mode=mode) for key in level}
                            for thresh, level in zip(threshold, dcoeffs)]
     denoised_coeffs = [coeffs[0]] + denoised_detail
-    return pywt.waverecn(denoised_coeffs, wavelet)
+    return pywt.waverecn(denoised_coeffs, wavelet)[original_extent]
 
 
 def denoise_wavelet(img, sigma=None, wavelet='db1', mode='soft',

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -323,7 +323,13 @@ def test_no_denoising_for_small_h():
 
 def test_wavelet_denoising():
     rstate = np.random.RandomState(1234)
-    for img, multichannel in [(astro_gray, False), (astro, True)]:
+
+    # version with one odd-sized dimension
+    astro_gray_odd = astro_gray[:, :-1]
+    astro_odd = astro[:, :-1]
+
+    for img, multichannel in [(astro_gray, False), (astro_gray_odd, False),
+                              (astro_odd, True)]:
         sigma = 0.1
         noisy = img + sigma * rstate.randn(*(img.shape))
         noisy = np.clip(noisy, 0, 1)


### PR DESCRIPTION
## Description

This is a fix for `denoise_wavelet` when the input has odd shape.

## References
This fixes the shape mismatch error encountered for odd-sized inputs in #2461.  This is due to a known issue in PyWavelets (PyWavelets/pywt#80) where the reconstructed signal has size 1 sample larger than the input when the input size is odd.  

The wavelet denoising tests were updated to use 128x127  and  128x127x3 inputs for validation of the approach.

