### PR TITLE
Add VisuShrink method for `denoise_wavelet`

### DIFF
--- a/doc/examples/filters/plot_denoise_wavelet.py
+++ b/doc/examples/filters/plot_denoise_wavelet.py
@@ -1,0 +1,104 @@
+"""
+=================
+Wavelet denoising
+=================
+
+Wavelet denoising relies on the wavelet representation of the image.
+Gaussian noise tends to be represented by small values in the wavelet domain
+and can be removed by setting coefficients below a given threshold to zero
+(hard thresholding) or shrinking all coefficients toward zero by a given amount
+(soft thresholding).
+
+In this example, we illustrate two different methods for wavelet coefficient
+threshold selection:  BayesShrink and VisuShrink.
+
+VisuShrink
+----------
+The VisuShrink approach employs a single, universal threshold to all wavelet
+detail coefficients.  This thershold is designed to remove additive Gaussian
+noise with high probability, which tends to result in overly smooth image
+appearance.  By specfying a sigma that is smaller than the true noise standard
+deviation, a more visually agreeable result can be obtained.
+
+BayesShrink
+-----------
+The BayesShrink algorithm is an adaptive approach to wavelet soft thresholding
+where a unique threshold is estimated for each wavelet subband.  This generally
+results in an improvement over what can be obtained with a single threshold.
+
+"""
+import matplotlib.pyplot as plt
+
+from skimage.restoration import (denoise_wavelet, estimate_sigma)
+from skimage import data, img_as_float
+from skimage.util import random_noise
+from skimage.measure import compare_psnr
+
+
+original = img_as_float(data.chelsea()[100:250, 50:300])
+
+sigma = 0.12
+noisy = random_noise(original, var=sigma**2)
+
+fig, ax = plt.subplots(nrows=2, ncols=3, figsize=(8, 5), sharex=True,
+                       sharey=True, subplot_kw={'adjustable': 'box-forced'})
+
+plt.gray()
+
+# Estimate the average noise standard deviation across color channels.
+sigma_est = estimate_sigma(noisy, multichannel=True, average_sigmas=True)
+# Due to clipping in random_noise, the estimate will be a bit smaller than the
+# specified sigma.
+print("Estimated Gaussian noise standard deviation = {}".format(sigma_est))
+
+im_bayes = denoise_wavelet(noisy, multichannel=True, convert2ycbcr=True,
+                           method='BayesShrink', mode='soft')
+im_visushrink = denoise_wavelet(noisy, multichannel=True, convert2ycbcr=True,
+                                method='VisuShrink', mode='soft',
+                                sigma=sigma_est)
+
+# VisuShrink is designed to eliminate noise with high probability, but this
+# results in a visually over-smooth appearance.  Repeat, specifying a reduction
+# in the threshold by factors of 2 and 4.
+im_visushrink2 = denoise_wavelet(noisy, multichannel=True, convert2ycbcr=True,
+                                 method='VisuShrink', mode='soft',
+                                 sigma=sigma_est/2)
+im_visushrink4 = denoise_wavelet(noisy, multichannel=True, convert2ycbcr=True,
+                                 method='VisuShrink', mode='soft',
+                                 sigma=sigma_est/4)
+
+# Compute PSNR as an indication of image quality
+psnr_noisy = compare_psnr(original, noisy)
+psnr_bayes = compare_psnr(original, im_bayes)
+psnr_visushrink = compare_psnr(original, im_visushrink)
+psnr_visushrink2 = compare_psnr(original, im_visushrink2)
+psnr_visushrink4 = compare_psnr(original, im_visushrink4)
+
+ax[0, 0].imshow(noisy)
+ax[0, 0].axis('off')
+ax[0, 0].set_title('Noisy\nPSNR={:0.4g}'.format(psnr_noisy))
+ax[0, 1].imshow(im_bayes)
+ax[0, 1].axis('off')
+ax[0, 1].set_title(
+    'Wavelet denoising\n(BayesShrink)\nPSNR={:0.4g}'.format(psnr_bayes))
+ax[0, 2].imshow(im_visushrink)
+ax[0, 2].axis('off')
+ax[0, 2].set_title(
+    ('Wavelet denoising\n(VisuShrink, $\sigma=\sigma_{est}$)\n'
+     'PSNR=%0.4g' % psnr_visushrink))
+ax[1, 0].imshow(original)
+ax[1, 0].axis('off')
+ax[1, 0].set_title('Original')
+ax[1, 1].imshow(im_visushrink2)
+ax[1, 1].axis('off')
+ax[1, 1].set_title(
+    ('Wavelet denoising\n(VisuShrink, $\sigma=\sigma_{est}/2$)\n'
+     'PSNR=%0.4g' % psnr_visushrink2))
+ax[1, 2].imshow(im_visushrink4)
+ax[1, 2].axis('off')
+ax[1, 2].set_title(
+    ('Wavelet denoising\n(VisuShrink, $\sigma=\sigma_{est}/4$)\n'
+     'PSNR=%0.4g' % psnr_visushrink4))
+fig.tight_layout()
+
+plt.show()

--- a/doc/examples/filters/plot_denoise_wavelet.py
+++ b/doc/examples/filters/plot_denoise_wavelet.py
@@ -15,9 +15,9 @@ threshold selection:  BayesShrink and VisuShrink.
 VisuShrink
 ----------
 The VisuShrink approach employs a single, universal threshold to all wavelet
-detail coefficients.  This thershold is designed to remove additive Gaussian
+detail coefficients.  This threshold is designed to remove additive Gaussian
 noise with high probability, which tends to result in overly smooth image
-appearance.  By specfying a sigma that is smaller than the true noise standard
+appearance.  By specifying a sigma that is smaller than the true noise standard
 deviation, a more visually agreeable result can be obtained.
 
 BayesShrink

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -21,7 +21,7 @@ New Features
 
 Improvements
 ------------
-
+- VisuShrink method for wavelet denoising (#2470)
 
 
 

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -395,17 +395,16 @@ def _wavelet_threshold(image, wavelet, method=None, threshold=None,
         The type of wavelet to perform. Can be any of the options
         pywt.wavelist outputs. For example, this may be any of ``{db1, db2,
         db3, db4, haar}``.
-    method: string or None
-        The thresholding method to be used. Currently supported are
-        "BayesShrink" and "VisuShrink".  If it is set to None, a user-specified
-        ``threshold`` must be supplied instead.
-    sigma : float, optional
-        The standard deviation of the noise. The noise is estimated when sigma
-        is None (the default) by the method in [2]_.
+    method : {'BayesShrink', 'VisuShrink'}, optional
+        Thresholding method to be used. The currently supported methods are
+        "BayesShrink" [1]_ and "VisuShrink" [2]_. Defaults to "BayesShrink".
     threshold : float, optional
         The thresholding value to apply during wavelet coefficient
         thresholding. The default value (None) uses the selected ``method`` to
         estimate appropriate threshold(s) for noise removal.
+    sigma : float, optional
+        The standard deviation of the noise. The noise is estimated when sigma
+        is None (the default) by the method in [2]_.
     mode : {'soft', 'hard'}, optional
         An optional argument to choose the type of denoising performed. It
         noted that choosing soft thresholding given additive noise finds the
@@ -506,9 +505,6 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
         The noise standard deviation used when computing the wavelet detail
         coefficient threshold(s). When None (default), the noise standard
         deviation is estimated via the method in [2]_.
-    method : {'BayesShrink', 'VisuShrink'}, optional
-        Thresholding method to be used. The currently supported methods are
-        "BayesShrink" [1]_ and "VisuShrink" [2]_. Defaults to "BayesShrink".
     wavelet : string, optional
         The type of wavelet to perform and can be any of the options
         ``pywt.wavelist`` outputs. The default is `'db1'`. For example,
@@ -527,6 +523,9 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
         If True and multichannel True, do the wavelet denoising in the YCbCr
         colorspace instead of the RGB color space. This typically results in
         better performance for RGB images.
+    method : {'BayesShrink', 'VisuShrink'}, optional
+        Thresholding method to be used. The currently supported methods are
+        "BayesShrink" [1]_ and "VisuShrink" [2]_. Defaults to "BayesShrink".
 
     Returns
     -------
@@ -554,7 +553,7 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
     thresholding method that computes separate thresholds for each wavelet
     sub-band as described in [1]_.
 
-    If ``mode == "VisuShrink"``, a single "universal threshold" is applied to
+    If ``method == "VisuShrink"``, a single "universal threshold" is applied to
     all wavelet detail coefficients as described in [2]_.  This threshold
     is designed to remove all Gaussian noise at a given ``sigma`` with high
     probability, but tends to produce images that appear overly smooth.

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -381,8 +381,8 @@ def _sigma_est_dwt(detail_coeffs, distribution='Gaussian'):
     return sigma
 
 
-def _wavelet_threshold(image, wavelet, method, threshold=None, sigma=None, mode='soft',
-                       wavelet_levels=None):
+def _wavelet_threshold(image, wavelet, method, threshold=None, sigma=None,
+                       mode='soft', wavelet_levels=None):
     """Perform wavelet thresholding.
 
     Parameters

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -550,7 +550,7 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
     and 1, and `sigma` values are applied to these scaled color channels.
 
     Many wavelet coefficient thresholding approaches have been proposed.  By
-    default, ``denoise_wavelet`` applies BayesShrink, which is an adapative
+    default, ``denoise_wavelet`` applies BayesShrink, which is an adaptive
     thresholding method that computes separate thresholds for each wavelet
     sub-band as described in [1]_.
 

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -397,7 +397,8 @@ def _wavelet_threshold(image, wavelet, method=None, threshold=None,
         db3, db4, haar}``.
     method : {'BayesShrink', 'VisuShrink'}, optional
         Thresholding method to be used. The currently supported methods are
-        "BayesShrink" [1]_ and "VisuShrink" [2]_. Defaults to "BayesShrink".
+        "BayesShrink" [1]_ and "VisuShrink" [2]_. If it is set to None, a
+        user-specified ``threshold`` must be supplied instead.
     threshold : float, optional
         The thresholding value to apply during wavelet coefficient
         thresholding. The default value (None) uses the selected ``method`` to
@@ -580,7 +581,7 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
     """
     if method not in ["BayesShrink", "VisuShrink"]:
         raise ValueError(
-            ('Invalid method: {}. Currently supported methods are '
+            ('Invalid method: {}. The currently supported methods are '
              '"BayesShrink" and "VisuShrink"').format(method))
 
     image = img_as_float(image)

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -457,7 +457,7 @@ def _wavelet_threshold(image, wavelet, method=None, threshold=None,
         sigma = _sigma_est_dwt(detail_coeffs, distribution='Gaussian')
 
     if method is not None and threshold is not None:
-        warn(("Threshold method {} selected.  The user-specified threshold "
+        warn(("Thresholding method {} selected.  The user-specified threshold "
               "will be ignored.").format(method))
 
     if threshold is None:

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -370,20 +370,29 @@ def test_wavelet_threshold():
 
 def test_wavelet_denoising_nd():
     rstate = np.random.RandomState(1234)
-    for ndim in range(1, 5):
-        # Generate a very simple test image
-        img = 0.2*np.ones((16, )*ndim)
-        img[[slice(5, 13), ] * ndim] = 0.8
+    for method in ['VisuShrink', 'BayesShrink']:
+        for ndim in range(1, 5):
+            # Generate a very simple test image
+            if ndim < 3:
+                img = 0.2*np.ones((128, )*ndim)
+            else:
+                img = 0.2*np.ones((16, )*ndim)
+            img[[slice(5, 13), ] * ndim] = 0.8
 
-        sigma = 0.1
-        noisy = img + sigma * rstate.randn(*(img.shape))
-        noisy = np.clip(noisy, 0, 1)
+            sigma = 0.1
+            noisy = img + sigma * rstate.randn(*(img.shape))
+            noisy = np.clip(noisy, 0, 1)
 
-        # Verify that SNR is improved with internally estimated sigma
-        denoised = restoration.denoise_wavelet(noisy)
-        psnr_noisy = compare_psnr(img, noisy)
-        psnr_denoised = compare_psnr(img, denoised)
-        assert_(psnr_denoised > psnr_noisy)
+            # Verify that SNR is improved with internally estimated sigma
+            denoised = restoration.denoise_wavelet(noisy, method=method)
+            psnr_noisy = compare_psnr(img, noisy)
+            psnr_denoised = compare_psnr(img, denoised)
+            assert_(psnr_denoised > psnr_noisy)
+
+
+def test_wavelet_invalid_method():
+    with pytest.raises(ValueError):
+        restoration.denoise_wavelet(np.ones(16), method='Unimplemented')
 
 
 def test_wavelet_denoising_levels():

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -373,7 +373,7 @@ def test_wavelet_threshold():
         _wavelet_threshold(noisy, wavelet='db1', method=None, threshold=None)
 
     # warns if a threshold is provided in a case where it would be ignored
-    with expected_warnings(["Threshold method "]):
+    with expected_warnings(["Thresholding method "]):
         _wavelet_threshold(noisy, wavelet='db1', method='BayesShrink',
                            threshold=sigma)
 

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -361,11 +361,21 @@ def test_wavelet_threshold():
     noisy = img + sigma * rstate.randn(*(img.shape))
     noisy = np.clip(noisy, 0, 1)
 
-    # employ a single, uniform threshold instead of BayesShrink sigmas
-    denoised = _wavelet_threshold(noisy, wavelet='db1', threshold=sigma)
+    # employ a single, user-specified threshold instead of BayesShrink sigmas
+    denoised = _wavelet_threshold(noisy, wavelet='db1', method=None,
+                                  threshold=sigma)
     psnr_noisy = compare_psnr(img, noisy)
     psnr_denoised = compare_psnr(img, denoised)
     assert_(psnr_denoised > psnr_noisy)
+
+    # either method or threshold must be defined
+    with pytest.raises(ValueError):
+        _wavelet_threshold(noisy, wavelet='db1', method=None, threshold=None)
+
+    # warns if a threshold is provided in a case where it would be ignored
+    with expected_warnings(["Threshold method "]):
+        _wavelet_threshold(noisy, wavelet='db1', method='BayesShrink',
+                           threshold=sigma)
 
 
 def test_wavelet_denoising_nd():


### PR DESCRIPTION
## Description

This PR extends `denoise_wavelet` with the VisuShrink thresholding method [1].

## Checklist

- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

## References

[1] DL Donoho and JM Johnstone, Ideal spatial adaptation by wavelet shrinkage, Biometrika, 1994, vol. 81, no. 3, pp. 425-455.