### PR TITLE
Default edge mode change for resize and rescale

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -18,7 +18,7 @@ Version 0.14
 * Remove deprecation error on the usage of ``ntiles_x``, ``ntiles_y`` in
   ``skimage.exposure.equalize_adapthist`` and the corresponding test.
 * Remove the freeimage plugin shim to imageio.
-* Remove deprecated `normalise` and corresponding test for ``skimage.feature.hog``. 
+* Remove deprecated `normalise` and corresponding test for ``skimage.feature.hog``.
 
 
 Version 0.15
@@ -35,3 +35,7 @@ Version 0.15
   update the reference .npy in ``skimage.data`` and `skimage/feature/tests/test_hog.py`.
 * Remove deprecated function ``threshold_adaptive`` in
   ``skimage/filters/thresholding.py``.
+* In ``skimage.transform.resize``, set default value of ``mode`` to
+  ``'reflect'``.
+* In ``skimage.transform.rescale``, set default value of ``mode`` to
+  ``'reflect'``.

--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -68,7 +68,7 @@ from skimage import data_dir
 from skimage.transform import radon, rescale
 
 image = imread(data_dir + "/phantom.png", as_grey=True)
-image = rescale(image, scale=0.4)
+image = rescale(image, scale=0.4, mode='reflect')
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4.5))
 

--- a/doc/examples/transform/plot_seam_carving.py
+++ b/doc/examples/transform/plot_seam_carving.py
@@ -32,7 +32,8 @@ plt.imshow(img)
 
 ######################################################################
 
-resized = transform.resize(img, (img.shape[0], img.shape[1] - 200))
+resized = transform.resize(img, (img.shape[0], img.shape[1] - 200),
+                           mode='reflect')
 plt.figure()
 plt.title('Resized Image')
 plt.imshow(resized)
@@ -77,7 +78,7 @@ eimg[rr, cc] -= 1000
 plt.figure()
 plt.title('Object Removed')
 out = transform.seam_carve(img, eimg, 'vertical', 90)
-resized = transform.resize(img, out.shape)
+resized = transform.resize(img, out.shape, mode='reflect')
 plt.imshow(out)
 plt.show()
 

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -75,7 +75,7 @@ def resize(image, output_shape, order=1, mode=None, cval=0, clip=True,
     >>> from skimage import data
     >>> from skimage.transform import resize
     >>> image = data.camera()
-    >>> resize(image, (100, 100)).shape
+    >>> resize(image, (100, 100), mode='reflect').shape
     (100, 100)
 
     """
@@ -184,9 +184,9 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
     >>> from skimage import data
     >>> from skimage.transform import rescale
     >>> image = data.camera()
-    >>> rescale(image, 0.1).shape
+    >>> rescale(image, 0.1, mode='reflect').shape
     (51, 51)
-    >>> rescale(image, 0.5).shape
+    >>> rescale(image, 0.5, mode='reflect').shape
     (256, 256)
 
     """

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -18,7 +18,7 @@ HOMOGRAPHY_TRANSFORMS = (
 )
 
 
-def resize(image, output_shape, order=1, mode='constant', cval=0, clip=True,
+def resize(image, output_shape, order=1, mode=None, cval=0, clip=True,
            preserve_range=False):
     """Resize image to match a certain size.
 
@@ -49,7 +49,8 @@ def resize(image, output_shape, order=1, mode='constant', cval=0, clip=True,
         be in the range 0-5. See `skimage.transform.warp` for detail.
     mode : {'constant', 'edge', 'symmetric', 'reflect', 'wrap'}, optional
         Points outside the boundaries of the input are filled according
-        to the given mode.  Modes match the behaviour of `numpy.pad`.
+        to the given mode.  Modes match the behaviour of `numpy.pad`.  The
+        default mode is 'constant'.
     cval : float, optional
         Used in conjunction with mode 'constant', the value outside
         the image boundaries.
@@ -78,6 +79,10 @@ def resize(image, output_shape, order=1, mode='constant', cval=0, clip=True,
     (100, 100)
 
     """
+    if mode is None:
+        mode = 'constant'
+        warn("The default mode, 'constant', will be changed to 'reflect' in "
+             "skimage 0.15.")
 
     rows, cols = output_shape[0], output_shape[1]
     orig_rows, orig_cols = image.shape[0], image.shape[1]
@@ -132,7 +137,7 @@ def resize(image, output_shape, order=1, mode='constant', cval=0, clip=True,
     return out
 
 
-def rescale(image, scale, order=1, mode='constant', cval=0, clip=True,
+def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
             preserve_range=False):
     """Scale image by a certain factor.
 
@@ -161,7 +166,8 @@ def rescale(image, scale, order=1, mode='constant', cval=0, clip=True,
         be in the range 0-5. See `skimage.transform.warp` for detail.
     mode : {'constant', 'edge', 'symmetric', 'reflect', 'wrap'}, optional
         Points outside the boundaries of the input are filled according
-        to the given mode.  Modes match the behaviour of `numpy.pad`.
+        to the given mode.  Modes match the behaviour of `numpy.pad`.  The
+        default mode is 'constant'.
     cval : float, optional
         Used in conjunction with mode 'constant', the value outside
         the image boundaries.

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -13,7 +13,7 @@ from skimage._shared._warnings import expected_warnings
 
 PHANTOM = imread(os.path.join(data_dir, "phantom.png"),
                    as_grey=True)[::2, ::2]
-PHANTOM = rescale(PHANTOM, 0.5, order=1)
+PHANTOM = rescale(PHANTOM, 0.5, order=1, mode='reflect')
 
 
 def _debug_plot(original, result, sinogram=None):
@@ -315,7 +315,7 @@ def test_order_angles_golden_ratio():
 def test_iradon_sart():
     debug = False
 
-    image = rescale(PHANTOM, 0.8)
+    image = rescale(PHANTOM, 0.8, mode='reflect')
     theta_ordered = np.linspace(0., 180., image.shape[0], endpoint=False)
     theta_missing_wedge = np.linspace(0., 150., image.shape[0], endpoint=True)
     for theta, error_factor in ((theta_ordered, 1.),

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -91,10 +91,12 @@ def test_warp_clip():
     x = np.zeros((5, 5), dtype=np.double)
     x[2, 2] = 1
 
-    outx = rescale(x, 3, order=3, clip=False)
+    with expected_warnings(['The default mode']):
+        outx = rescale(x, 3, order=3, clip=False)
     assert outx.min() < 0
 
-    outx = rescale(x, 3, order=3, clip=True)
+    with expected_warnings(['The default mode']):
+        outx = rescale(x, 3, order=3, clip=True)
     assert_almost_equal(outx.min(), 0)
     assert_almost_equal(outx.max(), 1)
 
@@ -160,7 +162,8 @@ def test_rescale():
     # same scale factor
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
-    scaled = rescale(x, 2, order=0)
+    with expected_warnings(['The default mode']):
+        scaled = rescale(x, 2, order=0)
     ref = np.zeros((10, 10))
     ref[2:4, 2:4] = 1
     assert_almost_equal(scaled, ref)
@@ -168,7 +171,8 @@ def test_rescale():
     # different scale factors
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
-    scaled = rescale(x, (2, 1), order=0)
+    with expected_warnings(['The default mode']):
+        scaled = rescale(x, (2, 1), order=0)
     ref = np.zeros((10, 5))
     ref[2:4, 1] = 1
     assert_almost_equal(scaled, ref)
@@ -177,7 +181,8 @@ def test_rescale():
 def test_resize2d():
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
-    resized = resize(x, (10, 10), order=0)
+    with expected_warnings(['The default mode']):
+        resized = resize(x, (10, 10), order=0)
     ref = np.zeros((10, 10))
     ref[2:4, 2:4] = 1
     assert_almost_equal(resized, ref)
@@ -187,11 +192,13 @@ def test_resize3d_keep():
     # keep 3rd dimension
     x = np.zeros((5, 5, 3), dtype=np.double)
     x[1, 1, :] = 1
-    resized = resize(x, (10, 10), order=0)
+    with expected_warnings(['The default mode']):
+        resized = resize(x, (10, 10), order=0)
     ref = np.zeros((10, 10, 3))
     ref[2:4, 2:4, :] = 1
     assert_almost_equal(resized, ref)
-    resized = resize(x, (10, 10, 3), order=0)
+    with expected_warnings(['The default mode']):
+        resized = resize(x, (10, 10, 3), order=0)
     assert_almost_equal(resized, ref)
 
 
@@ -199,7 +206,8 @@ def test_resize3d_resize():
     # resize 3rd dimension
     x = np.zeros((5, 5, 3), dtype=np.double)
     x[1, 1, :] = 1
-    resized = resize(x, (10, 10, 1), order=0)
+    with expected_warnings(['The default mode']):
+        resized = resize(x, (10, 10, 1), order=0)
     ref = np.zeros((10, 10, 1))
     ref[2:4, 2:4] = 1
     assert_almost_equal(resized, ref)
@@ -209,7 +217,8 @@ def test_resize3d_2din_3dout():
     # 3D output with 2D input
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
-    resized = resize(x, (10, 10, 1), order=0)
+    with expected_warnings(['The default mode']):
+        resized = resize(x, (10, 10, 1), order=0)
     ref = np.zeros((10, 10, 1))
     ref[2:4, 2:4] = 1
     assert_almost_equal(resized, ref)
@@ -220,7 +229,7 @@ def test_resize3d_bilinear():
     x = np.zeros((5, 5, 2), dtype=np.double)
     x[1, 1, 0] = 0
     x[1, 1, 1] = 1
-    resized = resize(x, (10, 10, 1), order=1)
+    resized = resize(x, (10, 10, 1), order=1, mode='constant')
     ref = np.zeros((10, 10, 1))
     ref[1:5, 1:5, :] = 0.03125
     ref[1:5, 2:4, :] = 0.09375
@@ -316,16 +325,19 @@ def test_slow_warp_nonint_oshape():
 def test_keep_range():
     image = np.linspace(0, 2, 25).reshape(5, 5)
 
-    out = rescale(image, 2, preserve_range=False, clip=True, order=0)
+    with expected_warnings(['The default mode']):
+        out = rescale(image, 2, preserve_range=False, clip=True, order=0)
     assert out.min() == 0
     assert out.max() == 2
 
-    out = rescale(image, 2, preserve_range=True, clip=True, order=0)
+    with expected_warnings(['The default mode']):
+        out = rescale(image, 2, preserve_range=True, clip=True, order=0)
     assert out.min() == 0
     assert out.max() == 2
 
-    out = rescale(image.astype(np.uint8), 2, preserve_range=False,
-                  clip=True, order=0)
+    with expected_warnings(['The default mode']):
+        out = rescale(image.astype(np.uint8), 2, preserve_range=False,
+                      clip=True, order=0)
     assert out.min() == 0
     assert out.max() == 2 / 255.0
 


### PR DESCRIPTION
## Description
Perhaps a bit late to go in for 0.13, but this PR warns about a pending change in the default edge mode from 'constant' to 'reflect' for both `skimage.transform.resize` and `skimage.transform.reflect`.  This change was discussed in #1514 where the consensus was that this was preferable to the current default.

The only test that relies on the default edge mode being 'constant' to pass was `test_resize3d_bilinear`, so I have set `mode='constant'` explicitly in that case.   The remaining tests use `expected_warnings` to verify that the warning is raised.  

Examples and doctests were updated to explicitly use mode='reflect' to avoid warnings there.

not sure if 0.15 is the appropriate version to cite in the warning message

## References
closes #1514