### PR TITLE
Deprecate old threshold_adaptive API

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -33,3 +33,5 @@ Version 0.15
   `multichannel` to False
 * Change the default value of `block_norm` in ``skimage.feature.hog` to L2-Hys,
   update the reference .npy in ``skimage.data`` and `skimage/feature/tests/test_hog.py`.
+* Remove deprecated function ``threshold_adaptive`` in
+  ``skimage/filters/thresholding.py``.

--- a/doc/examples/xx_applications/plot_thresholding.py
+++ b/doc/examples/xx_applications/plot_thresholding.py
@@ -169,13 +169,13 @@ plt.show()
 # thresholding) may produce better results. Note that local is much slower than
 # global thresholding.
 #
-# Here, we binarize an image using the `threshold_adaptive` function, which
+# Here, we binarize an image using the `threshold_local` function, which
 # calculates thresholds in regions with a characteristic size `block_size` surrounding
 # each pixel (i.e. local neighborhoods). Each threshold value is the weighted mean
 # of the local neighborhood minus an offset value.
 #
 
-from skimage.filters import threshold_otsu, threshold_adaptive
+from skimage.filters import threshold_otsu, threshold_local
 
 
 image = data.page()
@@ -184,7 +184,8 @@ global_thresh = threshold_otsu(image)
 binary_global = image > global_thresh
 
 block_size = 35
-binary_adaptive = threshold_adaptive(image, block_size, offset=10)
+adaptive_thresh = threshold_local(image, block_size, offset=10)
+binary_adaptive = image > adaptive_thresh
 
 fig, axes = plt.subplots(nrows=3, figsize=(7, 8))
 ax = axes.ravel()

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -34,20 +34,27 @@ class deprecated(object):
     behavior : {'warn', 'raise'}
         Behavior during call to deprecated function: 'warn' = warn user that
         function is deprecated; 'raise' = raise error.
+    removed_version : str
+        The package version in which the deprecated function will be removed.
     """
 
-    def __init__(self, alt_func=None, behavior='warn'):
+    def __init__(self, alt_func=None, behavior='warn', removed_version=None):
         self.alt_func = alt_func
         self.behavior = behavior
+        self.removed_version = removed_version
 
     def __call__(self, func):
 
         alt_msg = ''
         if self.alt_func is not None:
             alt_msg = ' Use ``%s`` instead.' % self.alt_func
+        rmv_msg = ''
+        if self.removed_version is not None:
+            rmv_msg = (' and will be removed in version %s' %
+                       self.removed_version)
 
-        msg = 'Call to deprecated function ``%s``.' % func.__name__
-        msg += alt_msg
+        msg = ('Function ``%s`` is deprecated' % func.__name__ +
+               rmv_msg + '.' + alt_msg)
 
         @functools.wraps(func)
         def wrapped(*args, **kwargs):

--- a/skimage/filters/__init__.py
+++ b/skimage/filters/__init__.py
@@ -8,7 +8,8 @@ from .edges import (sobel, sobel_h, sobel_v,
 from ._rank_order import rank_order
 from ._gabor import gabor_kernel, gabor
 from ._frangi import frangi, hessian
-from .thresholding import (threshold_adaptive, threshold_otsu, threshold_yen,
+from .thresholding import (threshold_local,
+                           threshold_adaptive, threshold_otsu, threshold_yen,
                            threshold_isodata, threshold_li, threshold_minimum,
                            threshold_mean, threshold_triangle,
                            threshold_niblack, threshold_sauvola,

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -221,8 +221,8 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
 @deprecated('threshold_local')
 def threshold_adaptive(image, block_size, method='gaussian', offset=0,
                        mode='reflect', param=None):
-    warn('The return value of `threshold_local` is not the same as that '
-         'of `threshold_adaptive`.')
+    warn('The return value of `threshold_local` is a threshold image, while '
+         '`threshold_adaptive` returned the *thresholded* image.')
     return image > threshold_local(image, block_size=block_size,
                                    method=method, offset=offset, mode=mode,
                                    param=param)

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -217,8 +217,7 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
     return thresh_image - offset
 
 
-
-@deprecated('threshold_local')
+@deprecated('threshold_local', removed_version='0.15')
 def threshold_adaptive(image, block_size, method='gaussian', offset=0,
                        mode='reflect', param=None):
     warn('The return value of `threshold_local` is a threshold image, while '

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -185,9 +185,10 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
     --------
     >>> from skimage.data import camera
     >>> image = camera()[:50, :50]
-    >>> binary_image1 = threshold_adaptive(image, 15, 'mean')
+    >>> binary_image1 = image > threshold_local(image, 15, 'mean')
     >>> func = lambda arr: arr.mean()
-    >>> binary_image2 = threshold_adaptive(image, 15, 'generic', param=func)
+    >>> binary_image2 = image > threshold_local(image, 15, 'generic',
+    ...                                         param=func)
     """
     if block_size % 2 == 0:
         raise ValueError("The kwarg ``block_size`` must be odd! Given "

--- a/skimage/measure/_structural_similarity.py
+++ b/skimage/measure/_structural_similarity.py
@@ -230,7 +230,7 @@ def compare_ssim(X, Y, win_size=None, gradient=False,
             return mssim
 
 
-@deprecated('compare_ssim')
+@deprecated('compare_ssim', removed_version='0.14')
 def structural_similarity(X, Y, win_size=None, gradient=False,
                           dynamic_range=None, multichannel=False,
                           gaussian_weights=False, full=False, **kwargs):

--- a/skimage/measure/tests/test_structural_similarity.py
+++ b/skimage/measure/tests/test_structural_similarity.py
@@ -23,9 +23,7 @@ np.random.seed(1234)
 # for compare_ssim
 def test_old_name_deprecated():
     from skimage.measure import structural_similarity
-    with expected_warnings('Call to deprecated function '
-                           '``structural_similarity``. Use '
-                           '``compare_ssim`` instead.'):
+    with expected_warnings('deprecated'):
         ssim_result = structural_similarity(cam, cam_noisy, win_size=31)
 
 

--- a/skimage/util/tests/test_apply_parallel.py
+++ b/skimage/util/tests/test_apply_parallel.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal
 from numpy.testing.decorators import skipif
 
-from skimage.filters import threshold_adaptive, gaussian
+from skimage.filters import threshold_local, gaussian
 from skimage.util.apply_parallel import apply_parallel, dask_available
 
 
@@ -14,8 +14,8 @@ def test_apply_parallel():
     a = np.arange(144).reshape(12, 12).astype(float)
 
     # apply the filter
-    expected1 = threshold_adaptive(a, 3)
-    result1 = apply_parallel(threshold_adaptive, a, chunks=(6, 6), depth=5,
+    expected1 = threshold_local(a, 3)
+    result1 = apply_parallel(threshold_local, a, chunks=(6, 6), depth=5,
                              extra_arguments=(3,),
                              extra_keywords={'mode': 'reflect'})
 


### PR DESCRIPTION
## Description
This PR makes all thresholding functions consistent by returning (by default) a value `threshold` that can be used to threshold the original image with `thresholded = image > threshold`. The value may be a scalar or an array with the same shape as the input image.

See discussion in #2121 for alternate APIs. However, this API is consistent with the current API for almost all our thresholding functions, so I think it should be strongly preferred, *and* it should certainly be preferred for the purposes of the 0.13 release.

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

## References
Closes #2121 