### PR TITLE
Add `dask[array]` to optional requirements

### DIFF
--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -4,3 +4,4 @@ SimpleITK; python_version != '3.4' and python_version != '3.5'
 astropy
 tifffile
 imageio
+dask[array]>=0.5.0


### PR DESCRIPTION
## References
Closes https://github.com/scikit-image/scikit-image/issues/2330. See also https://github.com/scikit-image/scikit-image/pull/2238 .

P.S. @sciunto I don't know what had actually happened when you tried to do the same, but it seems to be working now.