### PR TITLE
Replace local_sum by block_reduce in docstrings.

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -23,8 +23,8 @@ def resize(image, output_shape, order=1, mode=None, cval=0, clip=True,
     """Resize image to match a certain size.
 
     Performs interpolation to up-size or down-size images. For down-sampling
-    N-dimensional images by applying the arithmetic sum or mean, see
-    `skimage.measure.local_sum` and `skimage.transform.downscale_local_mean`,
+    N-dimensional images by applying a function or the arithmetic mean, see
+    `skimage.measure.block_reduce` and `skimage.transform.downscale_local_mean`,
     respectively.
 
     Parameters
@@ -142,8 +142,8 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
     """Scale image by a certain factor.
 
     Performs interpolation to upscale or down-scale images. For down-sampling
-    N-dimensional images with integer factors by applying the arithmetic sum or
-    mean, see `skimage.measure.local_sum` and
+    N-dimensional images with integer factors by applying a function or the
+    arithmetic mean, see `skimage.measure.block_reduce` and
     `skimage.transform.downscale_local_mean`, respectively.
 
     Parameters


### PR DESCRIPTION
## Description

Replace deprecated ``local_sum`` with ``block_reduce`` in docstrings.


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

