### PR TITLE
DOC: img_as_float add note about range if input dtype is float

### DIFF
--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -329,6 +329,8 @@ def img_as_float(image, force_copy=False):
     -----
     The range of a floating point image is [0.0, 1.0] or [-1.0, 1.0] when
     converting from unsigned or signed datatypes, respectively.
+    If the input image has a float type, intensity values are not modified
+    and can be outside the ranges [0.0, 1.0] or [-1.0, 1.0].
 
     """
     return convert(image, np.float64, force_copy)


### PR DESCRIPTION
## Description

From https://stackoverflow.com/questions/41339633/the-conversion-issue-for-using-img-as-float it seems that this behaviour deserves a comment.