### PR TITLE
Fix broken `test_ncut_stable_subgraph` for Python 3.6, enable Python 3.6 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,8 @@ matrix:
     - os: linux
       python: 3.5
       env: PIP_FLAGS="--pre"
-    # This entry waiting for resolution of issue 2450
-    # - os: linux
-    #  python: 3.6
+    - os: linux
+      python: 3.6
     - os: osx
       osx_image: xcode7.3
       language: objective-c

--- a/TODO.txt
+++ b/TODO.txt
@@ -19,6 +19,7 @@ Version 0.14
   ``skimage.exposure.equalize_adapthist`` and the corresponding test.
 * Remove the freeimage plugin shim to imageio.
 * Remove deprecated `normalise` and corresponding test for ``skimage.feature.hog``.
+* Remove deprecated ``marching_cubes`` from ``skimage.measure``.
 
 
 Version 0.15

--- a/skimage/future/graph/graph_cut.py
+++ b/skimage/future/graph/graph_cut.py
@@ -230,7 +230,7 @@ def _label_all(rag, attr_name):
     attr_name : string
         The attribute to which a unique integer is assigned.
     """
-    node = sorted(rag.nodes())[0]
+    node = min(rag.nodes())
     new_label = rag.node[node]['labels'][0]
     for n, d in rag.nodes_iter(data=True):
         d[attr_name] = new_label

--- a/skimage/future/graph/graph_cut.py
+++ b/skimage/future/graph/graph_cut.py
@@ -230,7 +230,7 @@ def _label_all(rag, attr_name):
     attr_name : string
         The attribute to which a unique integer is assigned.
     """
-    node = rag.nodes()[0]
+    node = sorted(rag.nodes())[0]
     new_label = rag.node[node]['labels'][0]
     for n, d in rag.nodes_iter(data=True):
         d[attr_name] = new_label

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -279,7 +279,7 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
     ----------
     image : ndarray, shape(M, N, [..., P,] 3)
         Input image.
-    labels : ndarray, shape(M, N, [..., P,])
+    labels : ndarray, shape(M, N, [..., P])
         The labelled image. This should have one dimension less than
         `image`. If `image` has dimensions `(M, N, 3)` `labels` should have
         dimensions `(M, N)`.
@@ -287,7 +287,7 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
         Pixels with a squared distance less than `connectivity` from each other
         are considered adjacent. It can range from 1 to `labels.ndim`. Its
         behavior is the same as `connectivity` parameter in
-        `scipy.ndimage.generate_binary_structure`.
+        ``scipy.ndimage.generate_binary_structure``.
     mode : {'distance', 'similarity'}, optional
         The strategy to assign edge weights.
 

--- a/skimage/future/graph/tests/test_rag.py
+++ b/skimage/future/graph/tests/test_rag.py
@@ -168,12 +168,10 @@ def test_ncut_stable_subgraph():
     img = np.zeros((100, 100, 3), dtype='uint8')
 
     labels = np.zeros((100, 100), dtype='uint8')
-    labels[...] = 0
     labels[:50, :50] = 1
     labels[:50, 50:] = 2
 
     rag = graph.rag_mean_color(img, labels, mode='similarity')
-
     new_labels = graph.cut_normalized(labels, rag, in_place=False)
     new_labels, _, _ = segmentation.relabel_sequential(new_labels)
 

--- a/skimage/measure/_marching_cubes_classic.py
+++ b/skimage/measure/_marching_cubes_classic.py
@@ -11,7 +11,7 @@ def marching_cubes_classic(volume, level=None, spacing=(1., 1., 1.),
 
     Note that the ``marching_cubes()`` algorithm is recommended over
     this algorithm, because it's faster and produces better results.
-    
+
     Parameters
     ----------
     volume : (M, N, P) array of doubles
@@ -92,7 +92,7 @@ def marching_cubes_classic(volume, level=None, spacing=(1., 1., 1.),
            Resolution 3D Surface Construction Algorithm. Computer Graphics
            (SIGGRAPH 87 Proceedings) 21(4) July 1987, p. 163-170).
            DOI: 10.1145/37401.37422
-    
+
     See Also
     --------
     skimage.measure.marching_cubes


### PR DESCRIPTION
## Description


CURRENT 2.7-3.5
---------------
```
for node in rag.nodes_iter():
    print(node)
```
Returns: `[0, 1, 2]`.

Graph returned by `_ncut_relabel` during the test:
```
{'adj': {0: {0: {'weight': 1.0}, 1: {'weight': 1.0}, 2: {'weight': 1.0}},
         1: {0: {'weight': 1.0}, 1: {'weight': 1.0}, 2: {'weight': 1.0}},
         2: {0: {'weight': 1.0}, 1: {'weight': 1.0}, 2: {'weight': 1.0}}},
 'adjlist_dict_factory': <type 'dict'>,
 'edge': {0: {0: {'weight': 1.0}, 1: {'weight': 1.0}, 2: {'weight': 1.0}},
          1: {0: {'weight': 1.0}, 1: {'weight': 1.0}, 2: {'weight': 1.0}},
          2: {0: {'weight': 1.0}, 1: {'weight': 1.0}, 2: {'weight': 1.0}}},
 'edge_attr_dict_factory': <type 'dict'>,
 'graph': {},
 'max_id': 2,
 'node': {0: {'labels': [0],
              'mean color': array([ 0.,  0.,  0.]),
              'ncut label': 0,
              'pixel count': 5000,
              'total color': array([ 0.,  0.,  0.])},
          1: {'labels': [1],
              'mean color': array([ 0.,  0.,  0.]),
              'ncut label': 0,
              'pixel count': 2500,
              'total color': array([ 0.,  0.,  0.])},
          2: {'labels': [2],
              'mean color': array([ 0.,  0.,  0.]),
              'ncut label': 0,
              'pixel count': 2500,
              'total color': array([ 0.,  0.,  0.])}},
 'node_dict_factory': <type 'dict'>}
```

Python 3.6 [before the fix]
-----------------------
```
for node in rag.nodes_iter():
    print(node)
```
Returns: `[1, 2, 0]`.

Graph returned by `_ncut_relabel` during the test:
```
{'adj': {0: {0: {'weight': 1.0}, 1: {'weight': 1.0}, 2: {'weight': 1.0}},
         1: {0: {'weight': 1.0}, 1: {'weight': 1.0}, 2: {'weight': 1.0}},
         2: {0: {'weight': 1.0}, 1: {'weight': 1.0}, 2: {'weight': 1.0}}},
 'adjlist_dict_factory': <class 'dict'>,
 'edge': {0: {0: {'weight': 1.0}, 1: {'weight': 1.0}, 2: {'weight': 1.0}},
          1: {0: {'weight': 1.0}, 1: {'weight': 1.0}, 2: {'weight': 1.0}},
          2: {0: {'weight': 1.0}, 1: {'weight': 1.0}, 2: {'weight': 1.0}}},
 'edge_attr_dict_factory': <class 'dict'>,
 'graph': {},
 'max_id': 2,
 'node': {0: {'labels': [0],
              'mean color': array([ 0.,  0.,  0.]),
              'ncut label': 1,
              'pixel count': 5000.0,
              'total color': array([ 0.,  0.,  0.])},
          1: {'labels': [1],
              'mean color': array([ 0.,  0.,  0.]),
              'ncut label': 1,
              'pixel count': 2500.0,
              'total color': array([ 0.,  0.,  0.])},
          2: {'labels': [2],
              'mean color': array([ 0.,  0.,  0.]),
              'ncut label': 1,
              'pixel count': 2500.0,
              'total color': array([ 0.,  0.,  0.])}},
 'node_dict_factory': <class 'dict'>}
```

## References
Closes https://github.com/scikit-image/scikit-image/issues/2450.

