### PR TITLE
Tidy up the deployment of dev docs

### DIFF
--- a/tools/deploy_docs.sh
+++ b/tools/deploy_docs.sh
@@ -8,15 +8,16 @@ then
     echo "-- pushing docs --"
 
     (
-    git clone --quiet --branch=gh-pages https://${GH_REF} doc_build
-    rm -r doc_build/dev
-    cp -r doc/build/html doc_build/dev
-
-    cd doc_build
     git config user.email "travis@travis-ci.com"
     git config user.name "Travis Bot"
 
+    git clone --quiet --branch=gh-pages https://${GH_REF} doc_build
+    cd doc_build
+
+    git rm -r dev
+    cp -r ../doc/build/html dev
     git add dev
+
     git commit -m "Deployed to GitHub Pages"
     git push --force --quiet "https://${GH_TOKEN}@${GH_REF}" gh-pages > /dev/null 2>&1
     )


### PR DESCRIPTION
## Description
In order not to accumulate old files in the folder with the documentation of `dev` version we should remove old files from git, not locally.

## References
Should close https://github.com/scikit-image/scikit-image/issues/2059.

