### PR TITLE
Make HOG visualization use midpoints of orientation bins

### DIFF
--- a/doc/examples/features_detection/plot_hog.py
+++ b/doc/examples/features_detection/plot_hog.py
@@ -87,7 +87,7 @@ from skimage import data, color, exposure
 
 image = color.rgb2gray(data.astronaut())
 
-fd, hog_image = hog(image, orientations=8, pixels_per_cell=(16, 16),
+fd, hog_image = hog(image, orientations=8, pixels_per_cell=(32, 32),
                     cells_per_block=(1, 1), visualize=True)
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4), sharex=True, sharey=True)

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -63,8 +63,9 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
     visualize : bool, optional
         Also return an image of the HOG.  For each cell and orientation bin,
         the image contains a line segment that is centered at the cell center,
-        is perpendicular to the bisector of the orientation bin, and has
-        intensity proportional to the corresponding histogram value.
+        is perpendicular to the midpoint of the range of angles spanned by the
+        orientation bin, and has intensity proportional to the corresponding
+        histogram value.
     transform_sqrt : bool, optional
         Apply power law compression to normalize the image before
         processing. DO NOT use this if the image contains negative

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -203,7 +203,8 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
         radius = min(cx, cy) // 2 - 1
         orientations_arr = np.arange(orientations)
         # set dx_arr, dy_arr to correspond to midpoints of orientation bins
-        orientation_bin_midpoints = (orientations_arr + .5) / orientations * np.pi
+        orientation_bin_midpoints = (
+            np.pi * (orientations_arr + .5) / orientations)
         dx_arr = radius * np.cos(orientation_bin_midpoints)
         dy_arr = radius * np.sin(orientation_bin_midpoints)
         hog_image = np.zeros((sy, sx), dtype=float)

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -61,7 +61,10 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
            For details, see [3]_, [4]_.
 
     visualize : bool, optional
-        Also return an image of the HOG.
+        Also return an image of the HOG.  For each cell and orientation bin,
+        the image contains a line segment that is centered at the cell center,
+        is perpendicular to the bisector of the orientation bin, and has
+        intensity proportional to the corresponding histogram value.
     transform_sqrt : bool, optional
         Apply power law compression to normalize the image before
         processing. DO NOT use this if the image contains negative
@@ -199,8 +202,10 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
 
         radius = min(cx, cy) // 2 - 1
         orientations_arr = np.arange(orientations)
-        dx_arr = radius * np.cos(orientations_arr / orientations * np.pi)
-        dy_arr = radius * np.sin(orientations_arr / orientations * np.pi)
+        # set dx_arr, dy_arr to correspond to midpoints of orientation bins
+        orientation_bin_midpoints = (orientations_arr + .5) / orientations * np.pi
+        dx_arr = radius * np.cos(orientation_bin_midpoints)
+        dy_arr = radius * np.sin(orientation_bin_midpoints)
         hog_image = np.zeros((sy, sx), dtype=float)
         for x in range(n_cellsx):
             for y in range(n_cellsy):

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -201,6 +201,35 @@ def test_hog_orientations_circle():
         assert_almost_equal(actual, desired, decimal=1)
 
 
+def test_hog_visualization_orientation():
+    """Test that the visualization produces a line with correct orientation
+
+    The hog visualization is expected to draw line segments perpendicular to
+    the midpoints of orientation bins.  This example verifies that when
+    orientations=3 and the gradient is entirely in the middle bin (bisected
+    by the y-axis), the line segment drawn by the visualization is horizontal.
+    """
+
+    width = height = 11
+
+    image = np.zeros((height, width), dtype='float')
+    image[height // 2:] = 1
+
+    _, hog_image = feature.hog(
+        image,
+        orientations=3,
+        pixels_per_cell=(width, height),
+        cells_per_block=(1, 1),
+        visualize=True
+    )
+
+    middle_index = height // 2
+    indices_excluding_middle = [x for x in range(height) if x != middle_index]
+
+    assert (hog_image[indices_excluding_middle, :] == 0).all()
+    assert (hog_image[middle_index, 1:-1] > 0).all()
+
+
 def test_hog_block_normalization_incorrect_error():
     img = np.eye(4)
     with testing.raises(ValueError):


### PR DESCRIPTION
## Description
The HOG visualization currently draws lines perpendicular to the edges of orientation bins.  I propose that it instead draw lines perpendicular to the bisectors of orientation bins.  This would make the visualization more closely represent the distribution of gradient directions captured by the histogram.  See #2453 for more details.

Here are the changes:
* change the visualization implementation to use midpoints of orientation bins
* indicate in the `hog` docstring exactly what the visualization depicts
* add a test case checking the orientation of a line drawn by the visualization
* decrease the cell resolution of the [image in the HOG documentation](http://scikit-image.org/docs/dev/auto_examples/features_detection/plot_hog.html).  Now that the visualization does not draw horizontal and vertical lines, the example in the documentation is a bit unclear at the original resolution.  The new visualization will look like this:
![new_doc_image](https://cloud.githubusercontent.com/assets/5924638/23138473/88bac268-f75c-11e6-8d37-7f11231daa0b.png)


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
Closes #2453

