### PR TITLE
Miscellaneous tidying in HOG code

### DIFF
--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -57,7 +57,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
         ``L2-Hys``
            Normalization using L2-norm, followed by limiting the
            maximum values to 0.2 (`Hys` stands for `hysteresis`) and
-           renormalization using L2-norm.           
+           renormalization using L2-norm.
            For details, see [3]_, [4]_.
 
     visualise : bool, optional

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -11,11 +11,11 @@ def _hog_normalize_block(block, method, eps):
     elif method == 'L1-sqrt':
         out = np.sqrt(block / (np.sum(np.abs(block)) + eps))
     elif method == 'L2':
-        out = block / np.sqrt(np.sqrt(np.sum(block ** 2)) ** 2 + eps ** 2)
+        out = block / np.sqrt(np.sum(block ** 2) + eps ** 2)
     elif method == 'L2-Hys':
-        out = block / np.sqrt(np.sqrt(np.sum(block ** 2)) ** 2 + eps ** 2)
+        out = block / np.sqrt(np.sum(block ** 2) + eps ** 2)
         out = np.minimum(out, 0.2)
-        out = out / np.sqrt(np.sqrt(np.sum(block ** 2)) ** 2 + eps ** 2)
+        out = out / np.sqrt(np.sum(block ** 2) + eps ** 2)
     else:
         raise ValueError('Selected block normalization method is invalid.')
 

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -5,7 +5,7 @@ from .._shared.utils import skimage_deprecation, warn
 from . import _hoghistogram
 
 
-def _hog_normalize_block(block, method, eps):
+def _hog_normalize_block(block, method, eps=1e-5):
     if method == 'L1':
         out = block / (np.sum(np.abs(block)) + eps)
     elif method == 'L1-sqrt':
@@ -234,7 +234,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
         for y in range(n_blocksy):
             block = orientation_histogram[y:y + by, x:x + bx, :]
             normalized_blocks[y, x, :] = \
-                _hog_normalize_block(block, method=block_norm, eps=1e-5)
+                _hog_normalize_block(block, method=block_norm)
 
     """
     The final step collects the HOG descriptors from all blocks of a dense

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -5,7 +5,7 @@ from .._shared.utils import skimage_deprecation, warn
 from . import _hoghistogram
 
 
-def _hog_normalize_block(block, method, eps=1e-5):
+def _hog_normalize_block(block, method, eps):
     if method == 'L1':
         out = block / (np.sum(np.abs(block)) + eps)
     elif method == 'L1-sqrt':
@@ -230,12 +230,11 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
     normalized_blocks = np.zeros((n_blocksy, n_blocksx,
                                   by, bx, orientations))
 
-    eps = 1e-8
     for x in range(n_blocksx):
         for y in range(n_blocksy):
             block = orientation_histogram[y:y + by, x:x + bx, :]
             normalized_blocks[y, x, :] = \
-                _hog_normalize_block(block, method=block_norm)
+                _hog_normalize_block(block, method=block_norm, eps=1e-5)
 
     """
     The final step collects the HOG descriptors from all blocks of a dense


### PR DESCRIPTION
## Description
Here are a few changes to make the HOG code cleaner.  This is not expected to change its behavior.
* Remove some trailing whitespace
* Remove unused local variable `eps`
* Remove sequential square root and square

@soupault perhaps you could be one of the reviewers for this?  It looks like you might be most familiar with this code.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

