### PR TITLE
BUG: Fix greycoprops correlation always returning 1

### DIFF
--- a/skimage/feature/tests/test_texture.py
+++ b/skimage/feature/tests/test_texture.py
@@ -138,21 +138,26 @@ class TestGLCM():
                               normed=True, symmetric=True)
         result = np.round(result, 3)
         contrast = greycoprops(result, 'contrast')
-        np.testing.assert_almost_equal(contrast[0, 0], 0.586)
+        np.testing.assert_almost_equal(contrast[0, 0], 0.585, decimal=3)
 
     def test_dissimilarity(self):
         result = greycomatrix(self.image, [1], [0, np.pi / 2], 4,
                               normed=True, symmetric=True)
         result = np.round(result, 3)
         dissimilarity = greycoprops(result, 'dissimilarity')
-        np.testing.assert_almost_equal(dissimilarity[0, 0], 0.418)
+        np.testing.assert_almost_equal(dissimilarity[0, 0], 0.418, decimal=3)
 
     def test_dissimilarity_2(self):
         result = greycomatrix(self.image, [1, 3], [np.pi / 2], 4,
                               normed=True, symmetric=True)
         result = np.round(result, 3)
         dissimilarity = greycoprops(result, 'dissimilarity')[0, 0]
-        np.testing.assert_almost_equal(dissimilarity, 0.664)
+        np.testing.assert_almost_equal(dissimilarity, 0.665, decimal=3)
+
+    def test_non_normalized_glcm(self):
+        img = (np.random.random((100, 100)) * 8).astype(np.uint8)
+        p = greycomatrix(img, [1, 2, 4, 5], [0, 0.25, 1, 1.5], levels=8)
+        np.testing.assert_(np.max(greycoprops(p, 'correlation')) < 1.0)
 
     def test_invalid_property(self):
         result = greycomatrix(self.image, [1], [0], 4)

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -3,6 +3,7 @@ Methods to characterize image textures.
 """
 
 import numpy as np
+import warnings
 from .._shared.utils import assert_nD
 from ..util import img_as_float
 from ..color import gray2rgb
@@ -140,7 +141,7 @@ def greycomatrix(image, distances, angles, levels=None, symmetric=False,
         Pt = np.transpose(P, (1, 0, 2, 3))
         P = P + Pt
 
-    # normalize each GLMC
+    # normalize each GLCM
     if normed:
         P = P.astype(np.float64)
         glcm_sums = np.apply_over_axes(np.sum, P, axes=(0, 1))
@@ -166,6 +167,8 @@ def greycoprops(P, prop='contrast'):
         .. math:: \\sum_{i,j=0}^{levels-1} P_{i,j}\\left[\\frac{(i-\\mu_i) \\
                   (j-\\mu_j)}{\\sqrt{(\\sigma_i^2)(\\sigma_j^2)}}\\right]
 
+    Each GLCM is normalized to have a sum of 1 before the computation of texture
+    properties.
 
     Parameters
     ----------
@@ -213,6 +216,12 @@ def greycoprops(P, prop='contrast'):
     assert num_level == num_level2
     assert num_dist > 0
     assert num_angle > 0
+
+    # normalize each GLCM
+    P = P.astype(np.float64)
+    glcm_sums = np.apply_over_axes(np.sum, P, axes=(0, 1))
+    glcm_sums[glcm_sums == 0] = 1
+    P /= glcm_sums
 
     # create weights for specified property
     I, J = np.ogrid[0:num_level, 0:num_level]


### PR DESCRIPTION
Fixes issue #2012 by always normalizing the Gray-level Co-occurrence Matrices to a sum of 1.