### PR TITLE
BUG: Fix NumPy error when no descriptors are returned by ORB

### DIFF
--- a/skimage/feature/orb.py
+++ b/skimage/feature/orb.py
@@ -318,6 +318,11 @@ class ORB(FeatureDetector, DescriptorExtractor):
                                * np.ones(keypoints.shape[0], dtype=np.intp))
             descriptors_list.append(descriptors)
 
+        if len(scales_list) == 0:
+            raise RuntimeError("ORB found no features. Try passing in an image "
+                               "containing greater intensity contrasts between "
+                               "adjacent pixels.")
+
         keypoints = np.vstack(keypoints_list)
         responses = np.hstack(responses_list)
         scales = np.hstack(scales_list)

--- a/skimage/feature/tests/test_orb.py
+++ b/skimage/feature/tests/test_orb.py
@@ -1,5 +1,6 @@
 import numpy as np
-from numpy.testing import assert_equal, assert_almost_equal, run_module_suite
+from numpy.testing import (assert_equal, assert_almost_equal, run_module_suite,
+                           assert_raises)
 from skimage.feature import ORB
 from skimage import data
 from skimage._shared.testing import test_parallel
@@ -101,6 +102,12 @@ def test_descriptor_orb():
     detector_extractor.detect_and_extract(img)
     assert_equal(exp_descriptors,
                  detector_extractor.descriptors[100:120, 10:20])
+
+
+def test_no_descriptors_extracted_orb():
+    img = np.ones((128, 128))
+    detector_extractor = ORB()
+    assert_raises(RuntimeError, detector_extractor.detect_and_extract, img)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix issue #2253 by simply checking if the length of scales_list is zero. Then raise a RuntimeError with a helpful error message.