### PR TITLE
Fix link to Python XY

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -23,7 +23,7 @@ distributions, including Anaconda_, `Enthought Canopy`_,
 
 .. _Anaconda: https://store.continuum.io/cshop/anaconda/
 .. _Enthought Canopy: https://www.enthought.com/products/canopy/
-.. _Python(x,y): http://code.google.com/p/pythonxy/wiki/Welcome
+.. _Python(x,y): http://python-xy.github.io/
 .. _WinPython: https://winpython.github.io/
 
 If you are using the distribution from python.org_, you'll need to


### PR DESCRIPTION
## Description
Installation notes state that scikit-image comes pre-installed with several Python distributions, including Python(X,Y). Link to Python(X,Y) was https://code.google.com/p/pythonxy/  but project has moved to http://python-xy.github.io/ 

Just fixed the doc to contain updated link.