### PR TITLE
TST: fix ValueError with scipy-0.19.0rc2

### DIFF
--- a/skimage/segmentation/tests/test_active_contour_model.py
+++ b/skimage/segmentation/tests/test_active_contour_model.py
@@ -4,14 +4,8 @@ from skimage.color import rgb2gray
 from skimage.filters import gaussian
 from skimage.segmentation import active_contour
 from numpy.testing import assert_equal, assert_allclose, assert_raises
-from numpy.testing.decorators import skipif
-import scipy
 
-scipy_version = list(map(int, scipy.__version__.split('.')))
-new_scipy = scipy_version[0] > 0 or \
-            (scipy_version[0] == 0 and scipy_version[1] >= 14)
 
-@skipif(not new_scipy)
 def test_periodic_reference():
     img = data.astronaut()
     img = rgb2gray(img)
@@ -26,7 +20,7 @@ def test_periodic_reference():
     assert_equal(np.array(snake[:10, 0], dtype=np.int32), refx)
     assert_equal(np.array(snake[:10, 1], dtype=np.int32), refy)
 
-@skipif(not new_scipy)
+
 def test_fixed_reference():
     img = data.text()
     x = np.linspace(5, 424, 100)
@@ -39,7 +33,7 @@ def test_fixed_reference():
     assert_equal(np.array(snake[:10, 0], dtype=np.int32), refx)
     assert_equal(np.array(snake[:10, 1], dtype=np.int32), refy)
 
-@skipif(not new_scipy)
+
 def test_free_reference():
     img = data.text()
     x = np.linspace(5, 424, 100)
@@ -52,7 +46,7 @@ def test_free_reference():
     assert_equal(np.array(snake[:10, 0], dtype=np.int32), refx)
     assert_equal(np.array(snake[:10, 1], dtype=np.int32), refy)
 
-@skipif(not new_scipy)
+
 def test_RGB():
     img = gaussian(data.text(), 1)
     imgR = np.zeros((img.shape[0], img.shape[1], 3))
@@ -79,7 +73,7 @@ def test_RGB():
     assert_equal(np.array(snake[:10, 0], dtype=np.int32), refx)
     assert_equal(np.array(snake[:10, 1], dtype=np.int32), refy)
 
-@skipif(not new_scipy)
+
 def test_end_points():
     img = data.astronaut()
     img = rgb2gray(img)
@@ -100,7 +94,7 @@ def test_end_points():
             gamma=0.001, max_iterations=100)
     assert_allclose(snake[0, :], [x[0], y[0]], atol=1e-5)
 
-@skipif(not new_scipy)
+
 def test_bad_input():
     img = np.zeros((10, 10))
     x = np.linspace(5, 424, 100)


### PR DESCRIPTION
Remove superfluous scipy>=0.14 version test. [Scipy>=0.17.0 is a required package dependency.](https://github.com/scikit-image/scikit-image/blob/master/requirements.txt#L3)

Fixes one test error:
```
======================================================================
ERROR: Failure: ValueError (invalid literal for int() with base 10: '0rc2')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python35-x32\lib\site-packages\nose\failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "X:\Python35-x32\lib\site-packages\nose\loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "X:\Python35-x32\lib\site-packages\nose\importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "X:\Python35-x32\lib\site-packages\nose\importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "X:\Python35-x32\lib\imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "X:\Python35-x32\lib\imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 693, in _load
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 673, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "X:\Python35-x32\lib\site-packages\skimage\segmentation\tests\test_active_contour_model.py", line 10, in <module>
    scipy_version = list(map(int, scipy.__version__.split('.')))
ValueError: invalid literal for int() with base 10: '0rc2'

----------------------------------------------------------------------
Ran 1496 tests in 79.540s

FAILED (errors=1)
```