### PR TITLE
Replace GRIN URL with Flickr URL

### DIFF
--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -78,7 +78,7 @@ def astronaut():
     and 10 minutes in outer space.
 
     This image was downloaded from the NASA Great Images database
-    <https://www.flickr.com/photos/nasacommons/16504233985/in/photolist-r9qvLn-wiHFSH-r9pLdR-8PHqki-qRX5GZ-r8qWwg-fpTA99-p4qDRQ-oYGs51-oUgKd4-pfewQe-D3hL45-vQNk7L-qUEKkd-eERobk>`__.
+    <https://flic.kr/p/r9qvLn>`__.
 
     No known copyright restrictions, released into the public domain.
 

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -78,7 +78,7 @@ def astronaut():
     and 10 minutes in outer space.
 
     This image was downloaded from the NASA Great Images database
-    <http://grin.hq.nasa.gov/ABSTRACTS/GPN-2000-001177.html>`__.
+    <https://www.flickr.com/photos/nasacommons/16504233985/in/photolist-r9qvLn-wiHFSH-r9pLdR-8PHqki-qRX5GZ-r8qWwg-fpTA99-p4qDRQ-oYGs51-oUgKd4-pfewQe-D3hL45-vQNk7L-qUEKkd-eERobk>`__.
 
     No known copyright restrictions, released into the public domain.
 


### PR DESCRIPTION
## Description

The URL http://grin.hq.nasa.gov/ABSTRACTS/GPN-2000-001177.html now redirects to https://grin.hq.nasa.gov/ which shows the message:

> GRIN Site Relocated

> The GReat Images in NASA (GRIN) site has been retired in favor of the improved NASA Commons site on Flickr (https://www.flickr.com/photos/nasacommons) so please go there for your NASA historical still imagery needs. 

The image of Eileen M. Collins can now be found on Flickr at the URL: 
https://www.flickr.com/photos/nasacommons/16504233985/in/photolist-r9qvLn-wiHFSH-r9pLdR-8PHqki-qRX5GZ-r8qWwg-fpTA99-p4qDRQ-oYGs51-oUgKd4-pfewQe-D3hL45-vQNk7L-qUEKkd-eERobk


## Checklist

- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

The URL is longer than 79 characters, but I think this is [an acceptable exception](http://stackoverflow.com/questions/10739843/how-should-i-format-a-long-url-in-a-python-comment-and-still-be-pep8-compliant).

- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)

N/A

- [ ] Gallery example in `./doc/examples` (new features only)

N/A

- [ ] Unit tests

N/A

