### PR TITLE
Update URL for data.coins()

### DIFF
--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -138,7 +138,7 @@ def coins():
     -----
     This image was downloaded from the
     `Brooklyn Museum Collection
-    <http://www.brooklynmuseum.org/opencollection/archives/image/617/image>`__.
+    <http://www.brooklynmuseum.org/opencollection/archives/image/33814>`__.
 
     No known copyright restrictions.
 


### PR DESCRIPTION
## Description

The URL http://www.brooklynmuseum.org/opencollection/archives/image/617/image now returns a 404 error message. 

The image is now located at  http://www.brooklynmuseum.org/opencollection/archives/image/33814


## Checklist

- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)

N/A

- [ ] Gallery example in `./doc/examples` (new features only)

N/A

- [ ] Unit tests

N/A
