### PR TITLE
Have `threshold_minimum` return identical results on i686 and x86_64

### DIFF
--- a/doc/examples/xx_applications/plot_thresholding.py
+++ b/doc/examples/xx_applications/plot_thresholding.py
@@ -75,51 +75,31 @@ plt.show()
 #
 # For pictures with a bimodal histogram, more specific algorithms can be used.
 # For instance, the minimum algorithm takes a histogram of the image and smooths it
-# repeatedly until there are only two peaks in the histogram. Then it
-# finds the minimum value between the two peaks. After smoothing the
-# histogram, there can be multiple pixel values with the minimum histogram
-# count, so you can pick the 'min', 'mid', or 'max' of these values.
-#
+# repeatedly until there are only two peaks in the histogram.
 
 from skimage.filters import threshold_minimum
 
 
 image = data.camera()
 
-thresh_min = threshold_minimum(image, bias='min')
+thresh_min = threshold_minimum(image)
 binary_min = image > thresh_min
-thresh_mid = threshold_minimum(image, bias='mid')
-binary_mid = image > thresh_mid
-thresh_max = threshold_minimum(image, bias='max')
-binary_max = image > thresh_max
 
-fig, axes = plt.subplots(4, 2, figsize=(10, 10))
-ax = axes.ravel()
+fig, ax = plt.subplots(2, 2, figsize=(10, 10))
 
-ax[0].imshow(image, cmap=plt.cm.gray)
-ax[0].set_title('Original')
-ax[0].axis('off')
+ax[0, 0].imshow(image, cmap=plt.cm.gray)
+ax[0, 0].set_title('Original')
 
-ax[1].hist(image.ravel(), bins=256)
-ax[1].set_title('Histogram')
+ax[0, 1].hist(image.ravel(), bins=256)
+ax[0, 1].set_title('Histogram')
 
-ax[2].imshow(binary_min, cmap=plt.cm.gray)
-ax[2].set_title('Thresholded (min)')
+ax[1, 0].imshow(binary_min, cmap=plt.cm.gray)
+ax[1, 0].set_title('Thresholded (min)')
 
-ax[3].hist(image.ravel(), bins=256)
-ax[3].axvline(thresh_min, color='r')
+ax[1, 1].hist(image.ravel(), bins=256)
+ax[1, 1].axvline(thresh_min, color='r')
 
-ax[4].imshow(binary_mid, cmap=plt.cm.gray)
-ax[4].set_title('Thresholded (mid)')
-ax[5].hist(image.ravel(), bins=256)
-ax[5].axvline(thresh_mid, color='r')
-
-ax[6].imshow(binary_max, cmap=plt.cm.gray)
-ax[6].set_title('Thresholded (max)')
-ax[7].hist(image.ravel(), bins=256)
-ax[7].axvline(thresh_max, color='r')
-
-for a in ax[::2]:
+for a in ax[:, 0]:
     a.axis('off')
 plt.show()
 

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -328,14 +328,11 @@ def test_threshold_minimum():
     camera = skimage.img_as_ubyte(data.camera())
 
     threshold = threshold_minimum(camera)
-    assert threshold == 78
-
-    threshold = threshold_minimum(camera, bias='max')
-    assert threshold == 79
+    assert_equal(threshold, 76)
 
     astronaut = skimage.img_as_ubyte(data.astronaut())
     threshold = threshold_minimum(astronaut)
-    assert threshold == 131
+    assert_equal(threshold, 114)
 
 
 def test_threshold_minimum_synthetic():
@@ -343,15 +340,8 @@ def test_threshold_minimum_synthetic():
     img[0:9, :] = 50
     img[14:25, :] = 250
 
-    threshold = threshold_minimum(img, bias='min')
-    assert threshold == 93
-
-    threshold = threshold_minimum(img, bias='mid')
-    assert threshold == 159
-
-    threshold = threshold_minimum(img, bias='max')
-    assert threshold == 225
-
+    threshold = threshold_minimum(img)
+    assert_equal(threshold, 95)
 
 def test_threshold_minimum_failure():
     img = np.zeros((16*16), dtype=np.uint8)

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -328,14 +328,14 @@ def test_threshold_minimum():
     camera = skimage.img_as_ubyte(data.camera())
 
     threshold = threshold_minimum(camera)
-    assert threshold == 76
+    assert threshold == 78
 
     threshold = threshold_minimum(camera, bias='max')
-    assert threshold == 77
+    assert threshold == 79
 
     astronaut = skimage.img_as_ubyte(data.astronaut())
     threshold = threshold_minimum(astronaut)
-    assert threshold == 117
+    assert threshold == 131
 
 
 def test_threshold_minimum_synthetic():

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -533,7 +533,7 @@ def threshold_li(image):
     return threshold + immin
 
 
-def threshold_minimum(image, nbins=256, bias='min', max_iter=10000):
+def threshold_minimum(image, nbins=256, max_iter=10000):
     """Return threshold value based on minimum method.
 
     The histogram of the input `image` is computed and smoothed until there are
@@ -546,9 +546,6 @@ def threshold_minimum(image, nbins=256, bias='min', max_iter=10000):
     nbins : int, optional
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
-    bias : {'min', 'mid', 'max'}, optional
-        'min', 'mid', 'max' return lowest, middle, or highest pixel value
-        with minimum histogram value.
     max_iter: int, optional
         Maximum number of iterations to smooth the histogram.
 
@@ -566,8 +563,11 @@ def threshold_minimum(image, nbins=256, bias='min', max_iter=10000):
 
     References
     ----------
-    .. [1] Prewitt, JMS & Mendelsohn, ML (1966), "The analysis of cell images",
-           Annals of the New York Academy of Sciences 128: 1035-1053
+    .. [1] C. A. Glasbey, "An analysis of histogram-based thresholding
+           algorithms," CVGIP: Graphical Models and Image Processing,
+           vol. 55, pp. 532-537, 1993.
+    .. [2] Prewitt, JMS & Mendelsohn, ML (1966), "The analysis of cell
+           images", Annals of the New York Academy of Sciences 128: 1035-1053
            DOI:10.1111/j.1749-6632.1965.tb11715.x
 
     Examples
@@ -578,64 +578,43 @@ def threshold_minimum(image, nbins=256, bias='min', max_iter=10000):
     >>> binary = image > thresh
     """
 
-    def find_local_maxima(hist):
+    def find_local_maxima_idx(hist):
         # We can't use scipy.signal.argrelmax
         # as it fails on plateaus
-        maximums = list()
+        maximum_idxs = list()
         direction = 1
+
         for i in range(hist.shape[0] - 1):
             if direction > 0:
                 if hist[i + 1] < hist[i]:
                     direction = -1
-                    maximums.append(i)
+                    maximum_idxs.append(i)
             else:
                 if hist[i + 1] > hist[i]:
                     direction = 1
-        return maximums
 
-    if bias not in ('min', 'mid', 'max'):
-        raise ValueError("Unknown bias: {0}".format(bias))
+        return maximum_idxs
 
     hist, bin_centers = histogram(image.ravel(), nbins)
 
-    smooth_hist = np.copy(hist)
-
-    def uniform_filter(x):
-        # The type casting here is needed so that
-        # uniform_filter1d produces the same result on 32-bit
-        # and 64-bit platforms.
-        return ndif.uniform_filter1d(x.astype(np.float32), 3).astype(int)
+    smooth_hist = np.copy(hist).astype(np.float64)
 
     for counter in range(max_iter):
-        smooth_hist = uniform_filter(smooth_hist)
-        maximums = find_local_maxima(smooth_hist)
-        if len(maximums) < 3:
+        smooth_hist = ndif.uniform_filter1d(smooth_hist, 3)
+        maximum_idxs = find_local_maxima_idx(smooth_hist)
+        if len(maximum_idxs) < 3:
             break
-    if len(maximums) != 2:
+
+    if len(maximum_idxs) != 2:
         raise RuntimeError('Unable to find two maxima in histogram')
     elif counter == max_iter - 1:
         raise RuntimeError('Maximum iteration reached for histogram'
                            'smoothing')
 
-    # Find lowest point between the maxima, biased to the low end (min)
-    minimum = smooth_hist[maximums[0]]
-    threshold = maximums[0]
-    for i in range(maximums[0], maximums[1]+1):
-        if smooth_hist[i] < minimum:
-            minimum = smooth_hist[i]
-            threshold = i
+    # Find lowest point between the maxima
+    threshold_idx = np.argmin(smooth_hist[maximum_idxs[0]:maximum_idxs[1] + 1])
 
-    if bias == 'min':
-        return bin_centers[threshold]
-    else:
-        upper_bound = threshold
-        while smooth_hist[upper_bound] == smooth_hist[threshold]:
-            upper_bound += 1
-        upper_bound -= 1
-        if bias == 'max':
-            return bin_centers[upper_bound]
-        elif bias == 'mid':
-            return bin_centers[(threshold + upper_bound) // 2]
+    return bin_centers[maximum_idxs[0] + threshold_idx]
 
 
 def threshold_mean(image):

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -599,8 +599,15 @@ def threshold_minimum(image, nbins=256, bias='min', max_iter=10000):
     hist, bin_centers = histogram(image.ravel(), nbins)
 
     smooth_hist = np.copy(hist)
+
+    def uniform_filter(x):
+        # The type casting here is needed so that
+        # uniform_filter1d produces the same result on 32-bit
+        # and 64-bit platforms.
+        return ndif.uniform_filter1d(x.astype(np.float32), 3).astype(int)
+
     for counter in range(max_iter):
-        smooth_hist = ndif.uniform_filter1d(smooth_hist, 3)
+        smooth_hist = uniform_filter(smooth_hist)
         maximums = find_local_maxima(smooth_hist)
         if len(maximums) < 3:
             break

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -499,12 +499,12 @@ class EllipseModel(BaseModel):
             True, if model estimation succeeds.
 
 
-        References:
-        -----------
-        .. [1]  Halir, R.; Flusser, J. "Numerically stable direct least squares
-                fitting of ellipses". In Proc. 6th International Conference in
-                Central Europe on Computer Graphics and Visualization.
-                WSCG (Vol. 98, pp. 125-132).
+        References
+        ----------
+        .. [1] Halir, R.; Flusser, J. "Numerically stable direct least squares
+               fitting of ellipses". In Proc. 6th International Conference in
+               Central Europe on Computer Graphics and Visualization.
+               WSCG (Vol. 98, pp. 125-132).
 
         """
         # Original Implementation: Ben Hammel, Nick Sullivan-Molina


### PR DESCRIPTION
Due to a difference in behavior of `scipy.ndimage.filters.uniform_filter1d`,
the results also vary in `threshold_minimum`.  This PR modifies the filter to
operate on 32-bit floating point numbers (instead of integers),
and casting the output to int afterwards.