### PR TITLE
fix-2551: prevented NaN in convoluted matrix

### DIFF
--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -387,6 +387,7 @@ def richardson_lucy(image, psf, iterations=50, clip=True):
 
     for _ in range(iterations):
         relative_blur = image / convolve_method(im_deconv, psf, 'same')
+        relative_blur[np.isnan(relative_blur)] = 0  # to prevent NaN from propogating throughout convulated matrix
         im_deconv *= convolve_method(relative_blur, psf_mirror, 'same')
 
     if clip:


### PR DESCRIPTION
## Description
[Tell us about your new feature, improvement, or fix! If relevant, please supplement the PR with images.]


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

