### PR TITLE
doc: missing import numpy in watershed

### DIFF
--- a/skimage/morphology/watershed.py
+++ b/skimage/morphology/watershed.py
@@ -215,6 +215,7 @@ def watershed(image, markers, connectivity=1, offset=None, mask=None,
 
     We first generate an initial image with two overlapping circles:
 
+    >>> import numpy as np
     >>> x, y = np.indices((80, 80))
     >>> x1, y1, x2, y2 = 28, 28, 44, 52
     >>> r1, r2 = 16, 20


### PR DESCRIPTION
## Description
Watershed example starts as
```
    We first generate an initial image with two overlapping circles:

    >>> x, y = np.indices((80, 80))
    >>> x1, y1, x2, y2 = 28, 28, 44, 52
    >>> r1, r2 = 16, 20
    >>> mask_circle1 = (x - x1)**2 + (y - y1)**2 < r1**2
    >>> mask_circle2 = (x - x2)**2 + (y - y2)**2 < r2**2
    >>> image = np.logical_or(mask_circle1, mask_circle2)
```

But there is no reference to `numpy`. Then, this PR adds the first line of code as

```
    >>> import numpy as np
```