### PR TITLE
Remove dask from `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ scipy>=0.17.0
 six>=1.7.3
 networkx>=1.8
 pillow>=2.1.0
-dask[array]>=0.5.0
 PyWavelets>=0.4.0


### PR DESCRIPTION
## Description
Dask is marked as an optional dependency since https://github.com/scikit-image/scikit-image/pull/2494.

## References
Closes https://github.com/scikit-image/scikit-image/issues/2571.
