### PR TITLE
Fix typo in ylabel of GLCM demo

### DIFF
--- a/doc/examples/features_detection/plot_glcm.py
+++ b/doc/examples/features_detection/plot_glcm.py
@@ -74,7 +74,7 @@ ax.plot(xs[:len(grass_patches)], ys[:len(grass_patches)], 'go',
 ax.plot(xs[len(grass_patches):], ys[len(grass_patches):], 'bo',
         label='Sky')
 ax.set_xlabel('GLCM Dissimilarity')
-ax.set_ylabel('GLVM Correlation')
+ax.set_ylabel('GLCM Correlation')
 ax.legend()
 
 # display the image patches


### PR DESCRIPTION
## Description
Fix typo in ylabel. GLVM -> GLCM.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

