### PR TITLE
add callback to active contour model

### DIFF
--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -9,7 +9,8 @@ from skimage.filters import sobel
 def active_contour(image, snake, alpha=0.01, beta=0.1,
                    w_line=0, w_edge=1, gamma=0.01,
                    bc='periodic', max_px_move=1.0,
-                   max_iterations=2500, convergence=0.1):
+                   max_iterations=2500, convergence=0.1,
+                   callback=None):
     """Active contour model.
 
     Active contours by fitting snakes to features of images. Supports single
@@ -51,6 +52,16 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
         Maximum iterations to optimize snake shape.
     convergence: float, optional
         Convergence criteria.
+    callback(snake, i, conv): function, optional
+        Called every 11 iterations with three args.
+        snake: (N, 2) ndarray -- the current snake.
+        i: int -- the total number of iterations completed.
+        conv: float -- convergence criterion. This value is computed by
+            looking over the previous 10 snakes to find the minimum distance
+            that each point has moved, and taking the maximum. If any
+            point is moving, the value will be high and the algorithm will
+            continue. If all points are stationary, the value will be low, and
+            the algorithm terminates when the value falls below 'convergence'.
 
     Returns
     -------
@@ -75,7 +86,7 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
     >>> img[rr, cc] = 1
     >>> img = gaussian(img, 2)
 
-    Initiliaze spline:
+    Initialize spline:
 
     >>> s = np.linspace(0, 2*np.pi,100)
     >>> init = 50*np.array([np.cos(s), np.sin(s)]).T+50
@@ -87,6 +98,17 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
     >>> int(np.mean(dist)) #doctest: +SKIP
     25
 
+    Watch the snake progress:
+
+    >>> import matplotlib.pyplot as plt
+    >>> def cb(snake, it, dist):
+    ...     pts = plt.scatter(snake[:, 0], snake[:, 1], figure=fig)
+    ...     plt.title('it = %i, dist=%f' % (it, dist))
+    ...     plt.pause(.05)
+    ...     pts.remove()
+    >>> plt.imshow(img, figure=fig)  #doctest: +SKIP
+    >>> snake = active_contour(img, init, callback=cb)  #doctest: +SKIP
+
     """
     split_version = scipy.__version__.split('.')
     if not(split_version[-1].isdigit()):
@@ -95,9 +117,11 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
     new_scipy = scipy_version[0] > 0 or \
                 (scipy_version[0] == 0 and scipy_version[1] >= 14)
     if not new_scipy:
-        raise NotImplementedError('You are using an old version of scipy. '
-                      'Active contours is implemented for scipy versions '
-                      '0.14.0 and above.')
+        raise NotImplementedError(
+            'You are using an old version of scipy. '
+            'Active contours is implemented for scipy versions '
+            '0.14.0 and above.'
+        )
 
     max_iterations = int(max_iterations)
     if max_iterations <= 0:
@@ -139,7 +163,8 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
                                    np.arange(img.shape[0]),
                                    img.T, kx=2, ky=2, s=0)
     else:
-        intp = np.vectorize(interp2d(np.arange(img.shape[1]),
+        intp = np.vectorize(interp2d(
+          np.arange(img.shape[1]),
                         np.arange(img.shape[0]), img, kind='cubic',
                         copy=False, bounds_error=False, fill_value=0))
 
@@ -236,5 +261,7 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
                    np.abs(ysave-y[None, :]), 1))
             if dist < convergence:
                 break
+            elif callback:
+                callback(np.array([x, y]).T, i, dist)
 
     return np.array([x, y]).T

--- a/skimage/segmentation/tests/test_active_contour_model.py
+++ b/skimage/segmentation/tests/test_active_contour_model.py
@@ -1,6 +1,8 @@
 import numpy as np
+import scipy
 from skimage import data
 from skimage.color import rgb2gray
+from skimage.draw import circle_perimeter
 from skimage.filters import gaussian
 from skimage.segmentation import active_contour
 from numpy.testing import assert_equal, assert_allclose, assert_raises
@@ -104,6 +106,25 @@ def test_bad_input():
                             bc='wrong')
     assert_raises(ValueError, active_contour, img, init,
                             max_iterations=-15)
+
+
+def test_callback():
+    iterations = []
+
+    def cb(snake, it, dist):
+        iterations.append(it)
+
+    img = np.zeros((100, 100))
+    rr, cc = circle_perimeter(35, 45, 25)
+    img[rr, cc] = 1
+    img = gaussian(img, 2)
+    s = np.linspace(0, 2*np.pi, 100)
+    init = 50*np.array([np.cos(s), np.sin(s)]).T+50
+    snake = active_contour(img, init, callback=cb)
+
+    assert_equal(iterations,
+                 [10, 21, 32, 43, 54, 65, 76, 87, 98, 109,
+                  120, 131, 142, 153, 164, 175, 186, 197])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Add an option for a callback function in active_contour.
The callback is called every (convergence_order + 1) iterations which in this case is every 11 iterations.

## Checklist

- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests


## References

implements enhancement #2092 
