### PR TITLE
generalize dimensionality of rescale

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -152,7 +152,7 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
         Input image.
     scale : {float, tuple of floats}
         Scale factors. Separate scale factors can be defined as
-        `(row_scale, col_scale)`.
+        `(axis_0_scale, axis_1_scale, ..., axis_n_scale)`.
 
     Returns
     -------
@@ -192,16 +192,17 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
     """
 
     try:
-        row_scale, col_scale = scale
+        iter(scale)
     except TypeError:
-        row_scale = col_scale = scale
+        scale = [scale] * image.ndim
 
-    orig_rows, orig_cols = image.shape[0], image.shape[1]
-    rows = np.round(row_scale * orig_rows)
-    cols = np.round(col_scale * orig_cols)
-    output_shape = (rows, cols)
+    orig_dims = image.shape
+    new_dims = []
+    for (orig_dim, dim_scale) in zip(orig_dims, scale):
+        new_dim = np.round(dim_scale * orig_dim)
+        new_dims.append(new_dim)
 
-    return resize(image, output_shape, order=order, mode=mode, cval=cval,
+    return resize(image, new_dims, order=order, mode=mode, cval=cval,
                   clip=clip, preserve_range=preserve_range)
 
 

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -177,6 +177,15 @@ def test_rescale():
     ref[2:4, 1] = 1
     assert_almost_equal(scaled, ref)
 
+    # >2 scale factors
+    x = np.zeros((5, 5, 4), dtype=np.double)
+    x[1, 1, 1] = 1
+    with expected_warnings(['The default mode']):
+        scaled = rescale(x, (2, 1, 3), order=0)
+    ref = np.zeros((10, 5, 12))
+    ref[2:4, 1, 3:6] = 1
+    assert_almost_equal(scaled, ref)
+
 
 def test_resize2d():
     x = np.zeros((5, 5), dtype=np.double)


### PR DESCRIPTION
## Description
Handle n-dimensional arrays in transform.rescale
Previously it only handled 1- and 2-dimensional arrays

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [n/a] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

## References

implements enhancement #2568

