### PR TITLE
Add nD support to image moments computation

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -42,6 +42,6 @@ Version 0.16
 * Remove deprecated argument ``visualise`` from function skimage.feature.hog
 * Remove deprecated module ``skimage.novice``
 * In ``skimage.measure._regionprops``, remove all references to 
-  ``coordinates=`` and ``_xycoordinates``.
+  ``coordinates=``, ``_xycoordinates``, and ``_use_xy_warning``.
 * In ``skimage.measure.moments_central``, remove ``cc`` and ``**kwargs``
   arguments.

--- a/TODO.txt
+++ b/TODO.txt
@@ -41,3 +41,7 @@ Version 0.16
   ``skimage.transform.tests.test_warps.py``.
 * Remove deprecated argument ``visualise`` from function skimage.feature.hog
 * Remove deprecated module ``skimage.novice``
+* In ``skimage.measure._regionprops``, remove all references to 
+  ``coordinates=`` and ``_xycoordinates``.
+* In ``skimage.measure.moments_central``, remove ``cc`` and ``**kwargs``
+  arguments.

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -50,7 +50,10 @@ Deprecations
   using them now with ``regionprops(..., coordinates='rc')``. You can silence
   warning messages, and retain the old behavior, with
   ``regionprops(..., coordinates='xy')``. However, that option will go away
-  in 0.16 and result in an error.
+  in 0.16 and result in an error. This change has a number of consequences.
+  Specifically, the "orientation" region property will measure the
+  anticlockwise angle from a *vertical* line, i.e. from the vector (1, 0) in
+  row-column coordinates.
 
 
 Contributors to this release

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -19,6 +19,9 @@ New Features
 - lookfor function (#2713)
 - montage function (#2626)
 - 2D and 3D segmentation with morphological snakes (#2791)
+- nD support for image moments (#2603)
+- inertia tensor and its eigenvalues can now be computed outside of
+  regionprops (#2603)
 
 
 Improvements
@@ -43,6 +46,11 @@ Deprecations
 - ``skimage.transform.resize`` and ``skimage.transform.rescale`` have a new
   ``anti_aliasing`` option that avoids aliasing artifacts when down-sampling
   images. This option will be enabled by default in 0.15.
+- ``regionprops`` will use row-column coordinates in 0.16. You can start
+  using them now with ``regionprops(..., coordinates='rc')``. You can silence
+  warning messages, and retain the old behavior, with
+  ``regionprops(..., coordinates='xy')``. However, that option will go away
+  in 0.16 and result in an error.
 
 
 Contributors to this release

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -21,7 +21,7 @@ New Features
 - 2D and 3D segmentation with morphological snakes (#2791)
 - nD support for image moments (#2603)
 - inertia tensor and its eigenvalues can now be computed outside of
-  regionprops (#2603)
+  regionprops; available in ``skimage.measure.inertia_tensor`` (#2603)
 
 
 Improvements

--- a/skimage/draw/tests/test_draw.py
+++ b/skimage/draw/tests/test_draw.py
@@ -550,7 +550,8 @@ def test_ellipse_rotated():
         rr, cc = ellipse(500, 600, 200, 400, rotation=angle)
         img[rr, cc] = 1
         # estimate orientation of ellipse
-        angle_estim = np.round(regionprops(img)[0].orientation, 3) % (np.pi / 2)
+        angle_estim_raw = regionprops(img, coordinates='xy')[0].orientation
+        angle_estim = np.round(angle_estim_raw, 3) % (np.pi / 2)
         assert_almost_equal(angle_estim, angle % (np.pi / 2), 2)
 
 

--- a/skimage/measure/__init__.py
+++ b/skimage/measure/__init__.py
@@ -8,7 +8,8 @@ from .simple_metrics import compare_mse, compare_nrmse, compare_psnr
 from ._structural_similarity import compare_ssim
 from ._polygon import approximate_polygon, subdivide_polygon
 from .pnpoly import points_in_poly, grid_points_in_poly
-from ._moments import moments, moments_central, moments_normalized, moments_hu
+from ._moments import (moments, moments_central, moments_normalized, centroid,
+                       moments_hu, inertia_tensor, inertia_tensor_eigvals)
 from .profile import profile_line
 from .fit import LineModelND, CircleModel, EllipseModel, ransac
 from .block import block_reduce

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -248,6 +248,7 @@ def inertia_tensor(image, mu=None):
         The input image.
     mu : array, optional
         The pre-computed central moments of ``image``.
+
     Returns
     -------
     T : array, shape ``(image.ndim, image.ndim)``

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from __future__ import division
 import numpy as np
 from . import _moments_cy
 import itertools

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -180,7 +180,7 @@ def moments_normalized(mu, order=3):
     nu = np.zeros_like(mu)
     mu0 = mu.ravel()[0]
     for powers in itertools.product(range(order + 1), repeat=mu.ndim):
-        if sum(powers) < mu.ndim:
+        if sum(powers) < 2:
             nu[powers] = np.nan
         else:
             nu[powers] = mu[powers] / (mu0 ** (sum(powers) / nu.ndim + 1))
@@ -200,7 +200,7 @@ def moments_hu(nu):
 
     Returns
     -------
-    nu : (7, 1) array
+    nu : (7,) array
         Hu's set of image moments.
 
     References

--- a/skimage/measure/_moments_cy.pyx
+++ b/skimage/measure/_moments_cy.pyx
@@ -1,45 +1,7 @@
 #cython: cdivision=True
-#cython: boundscheck=False
 #cython: nonecheck=False
 #cython: wraparound=False
 import numpy as np
-import cython
-
-
-ctypedef fused image_t:
-    cython.uchar[:, :]
-    cython.double[:, :]
-
-
-cpdef moments_central(image_t image, double cr, double cc, Py_ssize_t order):
-    cdef Py_ssize_t p, q, r, c
-    cdef double[:, ::1] mu = np.zeros((order + 1, order + 1), dtype=np.double)
-    cdef double val, dr, dc, dcp, drq
-    for r in range(image.shape[0]):
-        dr = r - cr
-        for c in range(image.shape[1]):
-            dc = c - cc
-            val = image[r, c]
-            dcp = 1
-            for p in range(order + 1):
-                drq = 1
-                for q in range(order + 1):
-                    mu[p, q] += val * drq * dcp
-                    drq *= dr
-                dcp *= dc
-    return np.asarray(mu)
-
-
-def moments_normalized(double[:, :] mu, Py_ssize_t order=3):
-    cdef Py_ssize_t p, q
-    cdef double[:, ::1] nu = np.zeros((order + 1, order + 1), dtype=np.double)
-    for p in range(order + 1):
-        for q in range(order + 1):
-            if p + q >= 2:
-                nu[p, q] = mu[p, q] / mu[0, 0] ** (<double>(p + q) / 2 + 1)
-            else:
-                nu[p, q] = np.nan
-    return np.asarray(nu)
 
 
 def moments_hu(double[:, :] nu):

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -203,25 +203,12 @@ class _RegionProperties(object):
     @_cached
     def inertia_tensor(self):
         mu = self.moments_central
-        mu0 = mu[(0,) * self._ndim]
-        result = np.zeros((self._ndim, self._ndim))
-
-        corners2 = tuple(2 * np.eye(self._ndim, dtype=int))
-        d = np.diag(result)
-        d.flags.writeable = True
-        d[:] = mu[corners2] / mu0
-
-        for dims in itertools.combinations(range(self._ndim), 2):
-            mu_index = np.zeros(self._ndim, dtype=int)
-            mu_index[list(dims)] = 1
-            result[dims] = -mu[tuple(mu_index)] / mu0
-            result.T[dims] = -mu[tuple(mu_index)] / mu0
-        return result
+        return _moments.inertia_tensor(self.image, mu)
 
     @_cached
     def inertia_tensor_eigvals(self):
-        eigvals = np.linalg.eigvalsh(self.inertia_tensor)
-        return sorted(eigvals, reverse=True)
+        return _moments.inertia_tensor_eigvals(self.image,
+                                               T=self.inertia_tensor)
 
     @_cached
     def intensity_image(self):

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -127,6 +127,9 @@ class _RegionProperties(object):
         elif coordinates is None:
             self._warned = False
             self._transpose_moments = True
+        else:
+            raise ValueError('Incorrect value for regionprops coordinates: %s.'
+                             ' Possible values are: "rc", "xy", or None')
 
     @_cached
     def area(self):

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from __future__ import division
 from math import sqrt, atan2, pi as PI
+import itertools
 import numpy as np
 from scipy import ndimage as ndi
 
@@ -156,10 +157,9 @@ class _RegionProperties(object):
         elif self._ndim == 3:
             return (6 * self.area / PI) ** (1. / 3)
 
-    @only2d
     def euler_number(self):
         euler_array = self.filled_image != self.image
-        _, num = label(euler_array, neighbors=8, return_num=True,
+        _, num = label(euler_array, connectivity=self._ndim, return_num=True,
                        background=0)
         return -num + 1
 
@@ -171,7 +171,7 @@ class _RegionProperties(object):
 
     @_cached
     def filled_image(self):
-        structure = STREL_8 if self._ndim == 2 else STREL_26_3D
+        structure = np.ones((3,) * self._ndim)
         return ndi.binary_fill_holes(self.image, structure)
 
     @_cached

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -255,14 +255,13 @@ class _RegionProperties(object):
     @only2d
     def orientation(self):
         a, b, b, c = self.inertia_tensor.flat
-        b = -b
         if a - c == 0:
-            if b > 0:
+            if b < 0:
                 return -PI / 4.
             else:
                 return PI / 4.
         else:
-            return - 0.5 * atan2(2 * b, (a - c))
+            return -0.5 * atan2(-2 * b, (a - c))
 
     @only2d
     def perimeter(self):
@@ -270,7 +269,7 @@ class _RegionProperties(object):
 
     @only2d
     def solidity(self):
-        return self.moments[0, 0] / np.sum(self.convex_image)
+        return self.area / self.convex_area
 
     @only2d
     def weighted_centroid(self):

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -2,6 +2,7 @@
 from __future__ import division
 from math import sqrt, atan2, pi as PI
 import itertools
+from warnings import warn
 import numpy as np
 from scipy import ndimage as ndi
 
@@ -119,13 +120,13 @@ class _RegionProperties(object):
         # Many properties used xy coordinates, instead of rc. This attribute
         # helps with the deprecation process and should be removed in 0.16.
         if label_image.ndim > 2 or coordinates == 'rc':
-            self._warned = True
+            self._use_xy_warning = False
             self._transpose_moments = False
         elif coordinates == 'xy':
-            self._warned = True  # no need to warn if 'xy' given explicitly
+            self._use_xy_warning = False  # don't warn if 'xy' given explicitly
             self._transpose_moments = True
         elif coordinates is None:
-            self._warned = False
+            self._use_xy_warning = True
             self._transpose_moments = True
         else:
             raise ValueError('Incorrect value for regionprops coordinates: %s.'
@@ -246,10 +247,8 @@ class _RegionProperties(object):
     @_cached
     def moments(self):
         M = _moments.moments(self.image.astype(np.uint8), 3)
-        if not self._warned:
-            from warnings import warn
+        if self._use_xy_warning:
             warn(XY_TO_RC_DEPRECATION_MESSAGE)
-            self.warned = True
         if self._transpose_moments:
             M = M.T
         return M
@@ -258,10 +257,8 @@ class _RegionProperties(object):
     def moments_central(self):
         mu = _moments.moments_central(self.image.astype(np.uint8),
                                       self.local_centroid, order=3)
-        if not self._warned:
-            from warnings import warn
+        if self._use_xy_warning:
             warn(XY_TO_RC_DEPRECATION_MESSAGE)
-            self.warned = True
         if self._transpose_moments:
             mu = mu.T
         return mu

--- a/skimage/measure/tests/test_moments.py
+++ b/skimage/measure/tests/test_moments.py
@@ -2,6 +2,8 @@ from numpy.testing import assert_equal, assert_almost_equal
 import pytest
 import numpy as np
 
+from skimage._shared._warnings import expected_warnings
+from skimage import draw
 from skimage.measure import (moments, moments_central, moments_normalized,
                              moments_hu)
 
@@ -14,8 +16,8 @@ def test_moments():
     image[15, 14] = 0.5
     m = moments(image)
     assert_equal(m[0, 0], 3)
-    assert_almost_equal(m[0, 1] / m[0, 0], 14.5)
     assert_almost_equal(m[1, 0] / m[0, 0], 14.5)
+    assert_almost_equal(m[0, 1] / m[0, 0], 14.5)
 
 
 def test_moments_central():
@@ -24,7 +26,7 @@ def test_moments_central():
     image[15, 15] = 1
     image[14, 15] = 0.5
     image[15, 14] = 0.5
-    mu = moments_central(image, 14.5, 14.5)
+    mu = moments_central(image, (14.5, 14.5))
 
     # shift image by dx=2, dy=2
     image2 = np.zeros((20, 20), dtype=np.double)
@@ -32,47 +34,64 @@ def test_moments_central():
     image2[17, 17] = 1
     image2[16, 17] = 0.5
     image2[17, 16] = 0.5
-    mu2 = moments_central(image2, 14.5 + 2, 14.5 + 2)
+    mu2 = moments_central(image2, (14.5 + 2, 14.5 + 2))
     # central moments must be translation invariant
     assert_equal(mu, mu2)
+
+
+def test_moments_central_deprecated():
+    image = np.zeros((20, 20), dtype=np.double)
+    image[5:-5, 5:-5] = np.random.random((10, 10))
+    center = moments(image, 1)[[1, 0], [0, 1]]
+    cr, cc = center
+    with expected_warnings(['deprecated 2D-only']):
+        mu0 = moments_central(image, cr, cc)
+        mu1 = moments_central(image, cr=cr, cc=cc)
+    mu_ref = moments_central(image, center)
+    assert_almost_equal(mu0.T, mu_ref)
+    assert_almost_equal(mu1.T, mu_ref)
 
 
 def test_moments_normalized():
     image = np.zeros((20, 20), dtype=np.double)
     image[13:17, 13:17] = 1
-    mu = moments_central(image, 14.5, 14.5)
+    mu = moments_central(image, (14.5, 14.5))
     nu = moments_normalized(mu)
     # shift image by dx=-3, dy=-3 and scale by 0.5
     image2 = np.zeros((20, 20), dtype=np.double)
     image2[11:13, 11:13] = 1
-    mu2 = moments_central(image2, 11.5, 11.5)
+    mu2 = moments_central(image2, (11.5, 11.5))
     nu2 = moments_normalized(mu2)
     # central moments must be translation and scale invariant
     assert_almost_equal(nu, nu2, decimal=1)
 
 
+def test_moments_normalized_3d():
+    image = draw.ellipsoid(1, 1, 10)
+    mu = moments_central(image)
+    nu = moments_normalized(mu)
+    assert nu[0, 0, 2] > nu[0, 2, 0]
+    assert_almost_equal(nu[0, 2, 0], nu[2, 0, 0])
+
+
 def test_moments_normalized_invalid():
-    with pytest.raises(TypeError):
-        moments_normalized(np.zeros((3, 3, 3)))
-    with pytest.raises(TypeError):
-        moments_normalized(np.zeros((3,)))
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         moments_normalized(np.zeros((3, 3)), 3)
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         moments_normalized(np.zeros((3, 3)), 4)
 
 
 def test_moments_hu():
     image = np.zeros((20, 20), dtype=np.double)
     image[13:15, 13:17] = 1
-    mu = moments_central(image, 13.5, 14.5)
+    mu = moments_central(image, (13.5, 14.5))
     nu = moments_normalized(mu)
     hu = moments_hu(nu)
     # shift image by dx=2, dy=3, scale by 0.5 and rotate by 90deg
     image2 = np.zeros((20, 20), dtype=np.double)
     image2[11, 11:13] = 1
     image2 = image2.T
-    mu2 = moments_central(image2, 11.5, 11)
+    mu2 = moments_central(image2, (11.5, 11))
     nu2 = moments_normalized(mu2)
     hu2 = moments_hu(nu2)
     # central moments must be translation and scale invariant

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -473,6 +473,11 @@ def test_docstrings_and_props():
     assert len(ds.split('\n')) > 3
 
 
+def test_incorrect_coordinate_convention():
+    with pytest.raises(ValueError):
+        region = regionprops_default(SAMPLE, coordinates='xyz')[0]
+
+
 if __name__ == "__main__":
     from numpy.testing import run_module_suite
     run_module_suite()

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -3,9 +3,14 @@ from numpy.testing import assert_array_equal, assert_almost_equal, \
 import pytest
 import numpy as np
 import math
+import functools
 
-from skimage.measure._regionprops import (regionprops, PROPS, perimeter,
-                                          _parse_docs)
+
+from skimage.measure._regionprops import (regionprops as regionprops_default,
+                                          PROPS, perimeter, _parse_docs)
+
+
+regionprops = functools.partial(regionprops_default, coordinates='rc')
 
 
 SAMPLE = np.array(

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -87,14 +87,14 @@ def test_bbox_area():
 def test_moments_central():
     mu = regionprops(SAMPLE)[0].moments_central
     # determined with OpenCV
-    assert_almost_equal(mu[0,2], 436.00000000000045)
+    assert_almost_equal(mu[2, 0], 436.00000000000045)
     # different from OpenCV results, bug in OpenCV
-    assert_almost_equal(mu[0,3], -737.333333333333)
-    assert_almost_equal(mu[1,1], -87.33333333333303)
-    assert_almost_equal(mu[1,2], -127.5555555555593)
-    assert_almost_equal(mu[2,0], 1259.7777777777774)
-    assert_almost_equal(mu[2,1], 2000.296296296291)
-    assert_almost_equal(mu[3,0], -760.0246913580195)
+    assert_almost_equal(mu[3, 0], -737.333333333333)
+    assert_almost_equal(mu[1, 1], -87.33333333333303)
+    assert_almost_equal(mu[2, 1], -127.5555555555593)
+    assert_almost_equal(mu[0, 2], 1259.7777777777774)
+    assert_almost_equal(mu[1, 2], 2000.296296296291)
+    assert_almost_equal(mu[0, 3], -760.0246913580195)
 
 
 def test_centroid():
@@ -186,7 +186,7 @@ def test_moments_hu():
          1.23151193e-03,
          1.38882330e-06,
         -2.72586158e-05,
-         6.48350653e-06
+        -6.48350653e-06
     ])
     # bug in OpenCV caused in Central Moments calculation?
     assert_array_almost_equal(hu, ref)
@@ -256,7 +256,7 @@ def test_minor_axis_length():
 
 
 def test_moments():
-    m = regionprops(SAMPLE)[0].moments
+    m = regionprops(SAMPLE)[0].moments.T  # test was written with x/y coords
     # determined with OpenCV
     assert_almost_equal(m[0,0], 72.0)
     assert_almost_equal(m[0,1], 408.0)
@@ -271,7 +271,8 @@ def test_moments():
 
 
 def test_moments_normalized():
-    nu = regionprops(SAMPLE)[0].moments_normalized
+    nu = regionprops(SAMPLE)[0].moments_normalized.T  # test was written with
+                                                      #  x/y coords
     # determined with OpenCV
     assert_almost_equal(nu[0,2], 0.08410493827160502)
     assert_almost_equal(nu[1,1], -0.016846707818929982)
@@ -282,11 +283,11 @@ def test_moments_normalized():
 
 
 def test_orientation():
-    orientation = regionprops(SAMPLE)[0].orientation
+    orientation = regionprops(SAMPLE.T)[0].orientation
     # determined with MATLAB
     assert_almost_equal(orientation, 0.10446844651921)
     # test correct quadrant determination
-    orientation2 = regionprops(SAMPLE.T)[0].orientation
+    orientation2 = regionprops(SAMPLE)[0].orientation
     assert_almost_equal(orientation2, math.pi / 2 - orientation)
     # test diagonal regions
     diag = np.eye(10, dtype=int)
@@ -316,7 +317,7 @@ def test_solidity():
 
 def test_weighted_moments_central():
     wmu = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE
-                      )[0].weighted_moments_central
+                      )[0].weighted_moments_central.T  # test used x/y coords
     ref = np.array(
         [[  7.4000000000e+01, -2.1316282073e-13,  4.7837837838e+02,
             -7.5943608473e+02],
@@ -347,14 +348,14 @@ def test_weighted_moments_hu():
         1.2565683360e-03,
         8.3014209421e-07,
         -3.5073773473e-05,
-        6.7936409056e-06
+        -6.7936409056e-06
     ])
     assert_array_almost_equal(whu, ref)
 
 
 def test_weighted_moments():
     wm = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE
-                     )[0].weighted_moments
+                     )[0].weighted_moments.T  # test used x/y coords
     ref = np.array(
         [[  7.4000000000e+01, 4.1000000000e+02, 2.7500000000e+03,
             1.9778000000e+04],
@@ -370,7 +371,7 @@ def test_weighted_moments():
 
 def test_weighted_moments_normalized():
     wnu = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE
-                      )[0].weighted_moments_normalized
+                      )[0].weighted_moments_normalized.T  # test used x/y coord
     ref = np.array(
         [[       np.nan,        np.nan,  0.0873590903, -0.0161217406],
          [       np.nan, -0.0160405109, -0.0031421072, -0.0031376984],

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -7,10 +7,7 @@ from ..util import unique_rows
 
 __all__ = ['convex_hull_image', 'convex_hull_object']
 
-try:
-    from scipy.spatial import Delaunay
-except ImportError:
-    Delaunay = None
+from scipy.spatial import Delaunay
 
 
 def convex_hull_image(image):
@@ -36,10 +33,6 @@ def convex_hull_image(image):
     """
     if image.ndim > 2:
         raise ValueError("Input must be a 2D image")
-
-    if Delaunay is None:
-        raise ImportError("Could not import scipy.spatial.Delaunay, "
-                          "only available in scipy >= 0.9.")
 
     # Here we do an optimisation by choosing only pixels that are
     # the starting or ending pixel of a row or column.  This vastly


### PR DESCRIPTION
## Description
Image moments can now be computed for images of any dimension. Many thanks to @jaimefrio for his optimization help on the mailing list for these functions. Reference: https://mail.python.org/pipermail/scikit-image/2017-April/005169.html