### PR TITLE
Add tests covering erroneous input to morphology.watershed

### DIFF
--- a/skimage/morphology/tests/test_watershed.py
+++ b/skimage/morphology/tests/test_watershed.py
@@ -483,7 +483,7 @@ def test_numeric_seed_watershed():
     np.testing.assert_equal(compact, expected)
 
 
-def test_water(arr1, arr2):
+def test_incorrect_markers_shape():
     with pytest.raises(ValueError):
         image = np.ones((5, 6))
         markers = np.ones((5, 7))

--- a/skimage/morphology/tests/test_watershed.py
+++ b/skimage/morphology/tests/test_watershed.py
@@ -44,7 +44,7 @@ Original author: Lee Kamentsky
 
 import math
 import unittest
-
+import pytest
 import numpy as np
 from scipy import ndimage as ndi
 
@@ -482,6 +482,12 @@ def test_numeric_seed_watershed():
                          [1, 1, 1, 1, 2, 2]], dtype=np.int32)
     np.testing.assert_equal(compact, expected)
 
+
+def test_water(arr1, arr2):
+    with pytest.raises(ValueError):
+        image = np.ones((5,6))
+        markers = np.ones((5,7))
+        output = watershed(image, markers)
 
 if __name__ == "__main__":
     np.testing.run_module_suite()

--- a/skimage/morphology/tests/test_watershed.py
+++ b/skimage/morphology/tests/test_watershed.py
@@ -485,8 +485,8 @@ def test_numeric_seed_watershed():
 
 def test_water(arr1, arr2):
     with pytest.raises(ValueError):
-        image = np.ones((5,6))
-        markers = np.ones((5,7))
+        image = np.ones((5, 6))
+        markers = np.ones((5, 7))
         output = watershed(image, markers)
 
 if __name__ == "__main__":


### PR DESCRIPTION
I've included a basic test for the ValueErrors not covered in test_watershed.py. The test uses the new convention that uses pytest to test errors as opposed to the old convention of using numpy.testing.



## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new features are mentioned in `doc/release/release_dev.rst`.


Closes #2574