### PR TITLE
Fix missing `wavelet_levels` in `denoise_wavelet` when `convert2ycbcr`

### DIFF
--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -569,7 +569,8 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
                 channel = out[..., i] - min
                 channel /= max - min
                 out[..., i] = denoise_wavelet(channel, sigma=sigma[i],
-                                              wavelet=wavelet, mode=mode)
+                                              wavelet=wavelet, mode=mode,
+                                              wavelet_levels=wavelet_levels)
 
                 out[..., i] = out[..., i] * (max - min)
                 out[..., i] += min
@@ -577,14 +578,13 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
         else:
             out = np.empty_like(image)
             for c in range(image.shape[-1]):
-                out[..., c] = _wavelet_threshold(image[..., c], wavelet=wavelet,
-                                                 mode=mode, sigma=sigma[c],
+                out[..., c] = _wavelet_threshold(image[..., c], sigma=sigma[c],
+                                                 wavelet=wavelet, mode=mode,
                                                  wavelet_levels=wavelet_levels)
 
     else:
-        out = _wavelet_threshold(image, wavelet=wavelet, mode=mode,
-                                 sigma=sigma,
-                                 wavelet_levels=wavelet_levels)
+        out = _wavelet_threshold(image, sigma=sigma, wavelet=wavelet,
+                                 mode=mode, wavelet_levels=wavelet_levels)
 
     clip_range = (-1, 1) if image.min() < 0 else (0, 1)
     return np.clip(out, *clip_range)

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -22,9 +22,9 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
     distance between two pixels and a certain standard deviation
     (`sigma_spatial`).
 
-    Radiometric similarity is measured by the Gaussian function of the Euclidean
-    distance between two color values and a certain standard deviation
-    (`sigma_color`).
+    Radiometric similarity is measured by the Gaussian function of the
+    Euclidean distance between two color values and a certain standard
+    deviation (`sigma_color`).
 
     Parameters
     ----------

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -223,7 +223,7 @@ def test_denoise_bilateral_multidimensional():
 
 
 def test_denoise_bilateral_nan():
-    img = np.NaN + np.empty((50, 50))
+    img = np.full((50, 50), np.NaN)
     out = restoration.denoise_bilateral(img, multichannel=False)
     assert_equal(img, out)
 

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -157,7 +157,7 @@ def test_denoise_tv_bregman_3d():
 
 
 def test_denoise_bilateral_2d():
-    img = checkerboard_gray.copy()[:50,:50]
+    img = checkerboard_gray.copy()[:50, :50]
     # add some random noise
     img += 0.5 * img.std() * np.random.rand(*img.shape)
     img = np.clip(img, 0, 1)
@@ -201,8 +201,7 @@ def test_denoise_bilateral_color():
 def test_denoise_bilateral_3d_grayscale():
     img = np.ones((50, 50, 3))
     with pytest.raises(ValueError):
-        restoration.denoise_bilateral(img,
-                  multichannel=False)
+        restoration.denoise_bilateral(img, multichannel=False)
 
 
 def test_denoise_bilateral_3d_multichannel():

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -345,25 +345,38 @@ def test_wavelet_denoising():
     astro_gray_odd = astro_gray[:, :-1]
     astro_odd = astro[:, :-1]
 
-    for img, multichannel in [(astro_gray, False), (astro_gray_odd, False),
-                              (astro_odd, True)]:
+    for img, multichannel, convert2ycbcr in [(astro_gray, False, False),
+                                             (astro_gray_odd, False, False),
+                                             (astro_odd, True, False),
+                                             (astro_odd, True, True)]:
         sigma = 0.1
         noisy = img + sigma * rstate.randn(*(img.shape))
         noisy = np.clip(noisy, 0, 1)
 
         # Verify that SNR is improved when true sigma is used
         denoised = restoration.denoise_wavelet(noisy, sigma=sigma,
-                                               multichannel=multichannel)
+                                               multichannel=multichannel,
+                                               convert2ycbcr=convert2ycbcr)
         psnr_noisy = compare_psnr(img, noisy)
         psnr_denoised = compare_psnr(img, denoised)
         assert_(psnr_denoised > psnr_noisy)
 
         # Verify that SNR is improved with internally estimated sigma
         denoised = restoration.denoise_wavelet(noisy,
-                                               multichannel=multichannel)
+                                               multichannel=multichannel,
+                                               convert2ycbcr=convert2ycbcr)
         psnr_noisy = compare_psnr(img, noisy)
         psnr_denoised = compare_psnr(img, denoised)
         assert_(psnr_denoised > psnr_noisy)
+
+        # SNR is improved less with 1 wavelet level than with the default.
+        denoised_1 = restoration.denoise_wavelet(noisy,
+                                                 multichannel=multichannel,
+                                                 wavelet_levels=1,
+                                                 convert2ycbcr=convert2ycbcr)
+        psnr_denoised_1 = compare_psnr(img, denoised_1)
+        assert_(psnr_denoised > psnr_denoised_1)
+        assert_(psnr_denoised_1 > psnr_noisy)
 
         # Test changing noise_std (higher threshold, so less energy in signal)
         res1 = restoration.denoise_wavelet(noisy, sigma=2*sigma,
@@ -490,6 +503,7 @@ def test_estimate_sigma_color():
 
     # default multichannel=False should raise a warning about last axis size
     assert_warns(UserWarning, restoration.estimate_sigma, img)
+
 
 def test_wavelet_denoising_args():
     """


### PR DESCRIPTION
## Description
This PR fixes a bug in `denoise_wavelet` where the parameter `wavelet_level` was ignored if `convert2ycbcr == True`.

New tests cases were added to verify worse performance with 1 level of decomposition as opposed to the default (multilevel with number of levels determined based on image size).
