### PR TITLE
BUG: make resize with order=0 more robust to floating-point rounding

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -140,8 +140,8 @@ def resize(image, output_shape, order=1, mode=None, cval=0, clip=True,
                 # A negative shift is chosen to give a result equivalent to
                 # the result using the scipy.ndimage based n-dimensional case
                 # below.
-                dst_corners[:, 0] -= 100*np.finfo(np.float64).eps
-                dst_corners[:, 1] -= 100*np.finfo(np.float64).eps
+                dst_corners[:, 0] -= 1e-6
+                dst_corners[:, 1] -= 1e-6
 
             tform = AffineTransform()
             tform.estimate(src_corners, dst_corners)

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -132,6 +132,17 @@ def resize(image, output_shape, order=1, mode=None, cval=0, clip=True,
             dst_corners[:, 0] = dim_scales[1] * (src_corners[:, 0] + 0.5) - 0.5
             dst_corners[:, 1] = dim_scales[0] * (src_corners[:, 1] + 0.5) - 0.5
 
+            if order == 0:
+                # Small shift empirically observed to avoid results dependent
+                # on differences in floating point roundoff errors as observed
+                # for versions of numpy using different implementations of
+                # BLAS.  see a concrete example in gh-2629.
+                # A negative shift is chosen to give a result equivalent to
+                # the result using the scipy.ndimage based n-dimensional case
+                # below.
+                dst_corners[:, 0] -= 100*np.finfo(np.float64).eps
+                dst_corners[:, 1] -= 100*np.finfo(np.float64).eps
+
             tform = AffineTransform()
             tform.estimate(src_corners, dst_corners)
 

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -413,5 +413,29 @@ def test_keep_range():
     assert out.max() == 2 / 255.0
 
 
+def test_downscale_labels():
+    # specific test case from gh-2629
+    labels = np.zeros((20, 20), dtype=np.uint8)
+    labels[2:8, 2:8] = 1
+    labels[0:8, 12:18] = 2
+    labels[12:18, 0:8] = 3
+    labels[12:20, 12:20] = 4
+
+    downsized_2d = resize(labels,
+                          (10, 5),
+                          order=0,
+                          mode="edge",
+                          preserve_range=True)
+
+    downsized_3d = resize(labels[..., np.newaxis],
+                          (10, 5, 1),
+                          order=0,
+                          mode="edge",
+                          preserve_range=True)
+
+    # both 2D and nD code paths should give the same result
+    assert_almost_equal(downsized_2d, downsized_3d[..., 0])
+
+
 if __name__ == "__main__":
     run_module_suite()


### PR DESCRIPTION
## Description

As reported in gh-2629, which neighbor is judged to be nearest is currently dependent on
whether numpy was built with MKL or OpenBLAS.  By shifting coordinates by ~100 times machine
epsilon when order=0, this inconsistency can be avoided.  

The amount of shift was determined empirically as one which gives the same result across MKL and OpenBLAS numpy builds (as tested in parallel conda environments).

I'm not sure there is a good way to properly test this fix across BLAS builds, but I did add a test verifying that for the specific example of gh-2629, the transform gives the same result for both the 2D and n-dimensional code paths.