### PR TITLE
BUG: make plot_matches compatible with Matplotlib 2.0.1

### DIFF
--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -114,7 +114,7 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
         idx2 = matches[i, 1]
 
         if matches_color is None:
-            color = np.random.rand(3, 1)
+            color = np.random.rand(3)
         else:
             color = matches_color
 


### PR DESCRIPTION
## Description
Using a 2D array for the `color` argument to `plot` as done in `plot_matches` seems unnecessary and causes a crash with Matplotlib 2.0.1.  This was causing problems on Travis now that it is using 2.0.1 (see #2649).

I verified locally that the example now runs on both Matplotlib 2.0.1 and 1.5.3

closes #2649