### PR TITLE
pin sphinx to <1.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,5 @@ coverage:
 	$(PYTESTS) skimage --cov=skimage
 
 html:
-	pip install -q sphinx
+	pip install -q 'sphinx<1.6'
 	export SPHINXOPTS=-W; make -C doc html

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ environment:
 install:
   - ECHO "Filesystem root:"
   - ps: "ls \"C:/\""
-    
+
   # Install Python and all the required packages.
   - "powershell ./tools/appveyor/install.ps1"
 
@@ -59,7 +59,7 @@ build: false
 
 test_script:
   # Build the docs
-  - pip install sphinx
+  - pip install "sphinx<1.6"
   - SET PYTHON=%PYTHON%\\python.exe && cd doc && make html
 
   # Change to a non-source folder to make sure we run the tests on the


### PR DESCRIPTION
## Description
temporarily require sphinx <1.6 on the CI services (see #2661)