### PR TITLE
Add hysteresis thresholding function

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,5 +23,5 @@
 - [ ] Check that the PR title is short, concise, and will make sense 1 year
   later.
 - [ ] Check that new functions are imported in corresponding `__init__.py`.
-- [ ] Check that new features are mentioned in `doc/release/release_dev.rst`.
-- [ ] Check that API changes are mentioned in `doc/release/release_dev.rst`.
+- [ ] Check that new features, API changes, and deprecations are mentioned in
+      `doc/release/release_dev.rst`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,10 @@
 
 ## For reviewers
 
+(Don't remove the checklist below.)
+
 - [ ] Check that the PR title is short, concise, and will make sense 1 year
   later.
+- [ ] Check that new functions are imported in corresponding `__init__.py`.
 - [ ] Check that new features are mentioned in `doc/release/release_dev.rst`.
+- [ ] Check that API changes are mentioned in `doc/release/release_dev.rst`.

--- a/doc/examples/filters/plot_hysteresis.py
+++ b/doc/examples/filters/plot_hysteresis.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 =======================
 Hysteresis thresholding

--- a/doc/examples/filters/plot_hysteresis.py
+++ b/doc/examples/filters/plot_hysteresis.py
@@ -1,0 +1,50 @@
+"""
+=======================
+Hysteresis thresholding
+=======================
+
+*Hysteresis* is the lagging of an effect — a kind of inertia. In the
+context of thresholding, it means that areas above some *low* threshold
+are considered to be above the threshold *if* they are also connected
+to areas above a higher, more stringent, threshold. They can thus be
+seen as continuations of these high-confidence areas.
+
+Below, we compare normal thresholding to hysteresis thresholding.
+Notice how hysteresis allows one to ignore "noise" outside of the coin
+edges.
+"""
+
+import matplotlib.pyplot as plt
+from skimage import data, filters
+
+fig, ax = plt.subplots(nrows=2, ncols=2,
+                       subplot_kw={'adjustable': 'box-forced'})
+
+image = data.coins()
+edges = filters.sobel(image)
+
+low = 0.05
+high = 0.35
+
+lowt = (edges > low).astype(int)
+hight = (edges > high).astype(int)
+hyst = filters.apply_hysteresis_threshold(edges, low, high)
+
+ax[0, 0].imshow(image, cmap='gray')
+ax[0, 0].set_title('Original image')
+
+ax[0, 1].imshow(edges, cmap='magma')
+ax[0, 1].set_title('Sobel edges')
+
+ax[1, 0].imshow(lowt, cmap='magma')
+ax[1, 0].set_title('Low threshold')
+
+ax[1, 1].imshow(hight + hyst, cmap='magma')
+ax[1, 1].set_title('Hysteresis threshold')
+
+for a in ax.ravel():
+    a.axis('off')
+
+plt.tight_layout()
+
+plt.show()

--- a/doc/examples/filters/plot_hysteresis.py
+++ b/doc/examples/filters/plot_hysteresis.py
@@ -24,7 +24,7 @@ fig, ax = plt.subplots(nrows=2, ncols=2,
 image = data.coins()
 edges = filters.sobel(image)
 
-low = 0.05
+low = 0.1
 high = 0.35
 
 lowt = (edges > low).astype(int)

--- a/doc/examples/filters/plot_hysteresis.py
+++ b/doc/examples/filters/plot_hysteresis.py
@@ -4,7 +4,7 @@
 Hysteresis thresholding
 =======================
 
-*Hysteresis* is the lagging of an effect — a kind of inertia. In the
+*Hysteresis* is the lagging of an effect---a kind of inertia. In the
 context of thresholding, it means that areas above some *low* threshold
 are considered to be above the threshold *if* they are also connected
 to areas above a higher, more stringent, threshold. They can thus be

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -15,6 +15,7 @@ http://scikit-image.org
 New Features
 ------------
 - manual segmentation with matplotlib (#2584)
+- hysteresis thresholding in filters (#2665)
 
 
 

--- a/skimage/filters/__init__.py
+++ b/skimage/filters/__init__.py
@@ -13,7 +13,7 @@ from .thresholding import (threshold_local,
                            threshold_isodata, threshold_li, threshold_minimum,
                            threshold_mean, threshold_triangle,
                            threshold_niblack, threshold_sauvola,
-                           try_all_threshold)
+                           try_all_threshold, apply_hysteresis_threshold)
 from . import rank
 from .rank import median
 
@@ -51,4 +51,5 @@ __all__ = ['inverse',
            'threshold_niblack',
            'threshold_sauvola',
            'threshold_triangle',
+           'apply_hysteresis_threshold'
            'rank']

--- a/skimage/filters/__init__.py
+++ b/skimage/filters/__init__.py
@@ -51,5 +51,5 @@ __all__ = ['inverse',
            'threshold_niblack',
            'threshold_sauvola',
            'threshold_triangle',
-           'apply_hysteresis_threshold'
+           'apply_hysteresis_threshold',
            'rank']

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -918,6 +918,5 @@ def apply_hysteresis_threshold(image, low, high):
     # Check which connected components contain pixels from mask_high
     sums = ndi.sum(mask_high, labels_low, np.arange(num_labels + 1))
     connected_to_high = sums > 0
-    connected_to_high[0] = False
     thresholded = connected_to_high[labels_low]
     return thresholded

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -893,12 +893,12 @@ def apply_hysteresis_threshold(image, low, high):
 
     Parameters
     ----------
-    image : array
-        The input image.
+    image : array, shape (M,[ N, ..., P])
+        Grayscale input image.
     low : float
-        The low threshold.
+        Lower threshold.
     high : float
-        The high threshold.
+        Higher threshold.
 
     Returns
     -------
@@ -911,6 +911,13 @@ def apply_hysteresis_threshold(image, low, high):
     >>> image = np.array([1, 2, 3, 2, 1, 2, 1, 3, 2])
     >>> apply_hysteresis_threshold(image, 1.5, 2.5).astype(int)
     array([0, 1, 1, 1, 0, 0, 0, 1, 1])
+
+    References
+    ----------
+    .. [1] J. Canny. A computational approach to edge detection.
+           IEEE Transactions on Pattern Analysis and Machine Intelligence.
+           1986; vol. 8, pp.679-698.
+           DOI: 10.1109/TPAMI.1986.4767851
     """
     mask_low = image > low
     mask_high = image > high

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -21,7 +21,8 @@ __all__ = ['try_all_threshold',
            'threshold_mean',
            'threshold_niblack',
            'threshold_sauvola',
-           'threshold_triangle']
+           'threshold_triangle',
+           'apply_hysteresis_threshold']
 
 
 def _try_all(image, methods=None, figsize=None, num_cols=2, verbose=True):


### PR DESCRIPTION
## Description
The new function keeps a pixel if it is above the high threshold OR if it is above the low threshold *and* connected to a high-threshold region.

This is based on @emmanuelle's code in [this (excellent) post](http://emmanuelle.github.io/a-tutorial-on-segmentation.html). There's other nuggets ripe for pilfering in there (e.g. building a consensus segmentation from many randomly-seeded random walkers), but this was definitely a low-hanging fruit that should be considered for fast-track inclusion!

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

## For reviewers

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new features are mentioned in `doc/release/release_dev.rst`.
