### PR TITLE
Improve hysteresis docstring

### DIFF
--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -874,8 +874,8 @@ def threshold_sauvola(image, window_size=15, k=0.2, r=None):
     --------
     >>> from skimage import data
     >>> image = data.page()
-    >>> binary_sauvola = threshold_sauvola(image,
-    ...                                    window_size=15, k=0.2)
+    >>> t_sauvola = threshold_sauvola(image, window_size=15, k=0.2)
+    >>> binary_image = image > t_sauvola
     """
     if r is None:
         imin, imax = dtype_limits(image, clip_negative=False)

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -895,9 +895,9 @@ def apply_hysteresis_threshold(image, low, high):
     ----------
     image : array, shape (M,[ N, ..., P])
         Grayscale input image.
-    low : float
+    low : float, or array of same shape as `image`
         Lower threshold.
-    high : float
+    high : float, or array of same shape as `image`
         Higher threshold.
 
     Returns
@@ -919,6 +919,7 @@ def apply_hysteresis_threshold(image, low, high):
            1986; vol. 8, pp.679-698.
            DOI: 10.1109/TPAMI.1986.4767851
     """
+    low = np.clip(low, a_min=None, a_max=high)  # ensure low always below high
     mask_low = image > low
     mask_high = image > high
     # Connected components of mask_low


### PR DESCRIPTION
## Description
As suggested in #2665, this adds explicit support for hysteresis thresholding using threshold arrays. (Rather than simply floats.)

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] ~~~Gallery example in `./doc/examples` (new features only)~~~
- [ ] Unit tests

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
