### PR TITLE
Add helper functions img_as_float32 and img_as_float64

### DIFF
--- a/skimage/util/__init__.py
+++ b/skimage/util/__init__.py
@@ -1,4 +1,5 @@
-from .dtype import (img_as_float, img_as_int, img_as_uint, img_as_ubyte,
+from .dtype import (img_as_float32, img_as_float64, img_as_float,
+                    img_as_int, img_as_uint, img_as_ubyte,
                     img_as_bool, dtype_limits)
 from .shape import view_as_blocks, view_as_windows
 from .noise import random_noise
@@ -15,7 +16,9 @@ from numpy import pad as numpy_pad
 pad = copy_func(numpy_pad, name='pad')
 
 
-__all__ = ['img_as_float',
+__all__ = ['img_as_float32',
+           'img_as_float64',
+           'img_as_float',
            'img_as_int',
            'img_as_uint',
            'img_as_ubyte',

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -2,7 +2,8 @@ from __future__ import division
 import numpy as np
 from warnings import warn
 
-__all__ = ['img_as_float', 'img_as_int', 'img_as_uint', 'img_as_ubyte',
+__all__ = ['img_as_float32', 'img_as_float64', 'img_as_float',
+           'img_as_int', 'img_as_uint', 'img_as_ubyte',
            'img_as_bool', 'dtype_limits']
 
 dtype_range = {np.bool_: (False, True),
@@ -310,7 +311,33 @@ def convert(image, dtype, force_copy=False, uniform=False):
     return image.astype(dtype_out)
 
 
-def img_as_float(image, force_copy=False):
+def img_as_float32(image, force_copy=False):
+    """Convert an image to single-precision (32-bit) floating point format.
+
+    Parameters
+    ----------
+    image : ndarray
+        Input image.
+    force_copy : bool, optional
+        Force a copy of the data, irrespective of its current dtype.
+
+    Returns
+    -------
+    out : ndarray of float32
+        Output image.
+
+    Notes
+    -----
+    The range of a floating point image is [0.0, 1.0] or [-1.0, 1.0] when
+    converting from unsigned or signed datatypes, respectively.
+    If the input image has a float type, intensity values are not modified
+    and can be outside the ranges [0.0, 1.0] or [-1.0, 1.0].
+
+    """
+    return convert(image, np.float32, force_copy)
+
+
+def img_as_float64(image, force_copy=False):
     """Convert an image to double-precision (64-bit) floating point format.
 
     Parameters
@@ -334,6 +361,9 @@ def img_as_float(image, force_copy=False):
 
     """
     return convert(image, np.float64, force_copy)
+
+
+img_as_float = img_as_float64
 
 
 def img_as_uint(image, force_copy=False):


### PR DESCRIPTION
## Description
The `img_as_float` converts images to `float64` (double precision). However sometimes it can be helpful if we store images in `float32` (single precision) regarding memory consumption and bandwidth.
This PR adds two helper functions `img_as_float32` and `img_as_float64` to skimage.util.dtype, and change `img_as_float` to an alias to `img_as_float64`.

Changes:
- Add `img_as_float32`: Converts image to `float32`
- Add `img_as_float64`: Converts image to `float64`
- Change `img_as_float` to an alias to `img_as_float64`


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
