### PR TITLE
Make `imshow_collection` to plot images on a grid of convenient aspect ratio

### DIFF
--- a/skimage/io/_plugins/matplotlib_plugin.py
+++ b/skimage/io/_plugins/matplotlib_plugin.py
@@ -51,7 +51,7 @@ def _get_image_properties(image):
     out_of_range_float = (np.issubdtype(image.dtype, np.float) and
                           (immin < lo or immax > hi))
     low_data_range = (immin != immax and
-                         is_low_contrast(image))
+                      is_low_contrast(image))
     unsupported_dtype = image.dtype not in dtypes._supported_types
 
     return ImageProperties(signed, out_of_range_float,
@@ -169,10 +169,33 @@ def imshow_collection(ic, *args, **kwargs):
     """Display all images in the collection.
 
     """
-    fig, axes = plt.subplots(1, len(ic))
+    N = len(ic)
+    print N
+    k = (N * 12)**(0.5)
+    r1 = int(k/4)
+    r2 = r1 + 1
+    if N % r1 == 0:
+        c1 = N/r1
+    else:
+        c1 = N/r1 + 1
+    if N % r2 == 0:
+        c2 = N/r2
+    else:
+        c2 = N/r2 + 1
+
+    if float(r1)/c1 - 0.75 > float(r2)/c2 - 0.75:
+        nrows = r2
+        ncols = c2
+    else:
+        nrows = r1
+        ncols = c1
+    fig = plt.figure()
+
     for n, image in enumerate(ic):
-        kwargs['ax'] = axes[n]
+        ax = plt.subplot(nrows, ncols, n+1)
+        kwargs['ax'] = ax
         imshow(image, *args, **kwargs)
+    return fig
 
 
 imread = plt.imread

--- a/skimage/io/_plugins/matplotlib_plugin.py
+++ b/skimage/io/_plugins/matplotlib_plugin.py
@@ -170,7 +170,10 @@ def imshow(image, ax=None, show_cbar=None, **kwargs):
 
 def imshow_collection(ic, *args, **kwargs):
     """Display all images in the collection.
-
+    Returns
+    -------
+    fig : `matplotlib.figure.Figure`
+        The `Figure` object returned by `plt.subplots`.
     """
     # N : total images.
     # Aim : 4 nrows = 3 ncols
@@ -189,11 +192,11 @@ def imshow_collection(ic, *args, **kwargs):
         nrows, ncols = r1, c1
     else:
         nrows, ncols = r2, c2
-    fig = plt.figure()
+    fig, axes = plt.subplots(nrows, ncols)
+    ax = axes.ravel()
     for n, image in enumerate(ic):
-        ax = plt.subplot(nrows, ncols, n+1)
-        kwargs['ax'] = ax
-        imshow(image, *args, **kwargs)
+        ax[n].imshow(image, *args, **kwargs)
+    kwargs['ax'] = axes
     return fig
 
 

--- a/skimage/io/_plugins/matplotlib_plugin.py
+++ b/skimage/io/_plugins/matplotlib_plugin.py
@@ -8,7 +8,7 @@ from ...exposure import is_low_contrast
 from ...util.colormap import viridis
 from ..._shared.utils import warn
 from math import floor
-
+from math import ceil
 
 _default_colormap = 'gray'
 _nonstandard_colormap = viridis
@@ -183,8 +183,8 @@ def imshow_collection(ic, *args, **kwargs):
     k = (N * 12)**(0.5)
     r1 = floor(k/4)
     r2 = r1 + 1
-    c1 = N // r1 if N % r1 == 0 else N // r1 + 1
-    c2 = N // r2 if N % r2 == 0 else N // r2 + 1
+    c1 = ceil(N/r1)
+    c2 = ceil(N/r2)
     if abs(r1/c1 - 0.75) < abs(r2/c2 - 0.75):
         nrows, ncols = r1, c1
     else:

--- a/skimage/io/_plugins/matplotlib_plugin.py
+++ b/skimage/io/_plugins/matplotlib_plugin.py
@@ -1,3 +1,4 @@
+from __future__ import division
 from collections import namedtuple
 import numpy as np
 import matplotlib.pyplot as plt
@@ -6,6 +7,8 @@ from ...util import dtype as dtypes
 from ...exposure import is_low_contrast
 from ...util.colormap import viridis
 from ..._shared.utils import warn
+from math import floor
+
 
 _default_colormap = 'gray'
 _nonstandard_colormap = viridis
@@ -169,28 +172,24 @@ def imshow_collection(ic, *args, **kwargs):
     """Display all images in the collection.
 
     """
+    # N : total images.
+    # Aim : 4 nrows = 3 ncols
+    # 4r = 3c = k
+    # rc = N, => k = (12 N)^(0.5)
+    # r = floor(k/4) or floor(k/4) + 1
+    # c = N/r or N/r + 1
+    # Choose the pair which is closer to 3:4 = 0.75
     N = len(ic)
-    print N
     k = (N * 12)**(0.5)
-    r1 = int(k/4)
+    r1 = floor(k/4)
     r2 = r1 + 1
-    if N % r1 == 0:
-        c1 = N/r1
+    c1 = N // r1 if N % r1 == 0 else N // r1 + 1
+    c2 = N // r2 if N % r2 == 0 else N // r2 + 1
+    if abs(r1/c1 - 0.75) < abs(r2/c2 - 0.75):
+        nrows, ncols = r1, c1
     else:
-        c1 = N/r1 + 1
-    if N % r2 == 0:
-        c2 = N/r2
-    else:
-        c2 = N/r2 + 1
-
-    if float(r1)/c1 - 0.75 > float(r2)/c2 - 0.75:
-        nrows = r2
-        ncols = c2
-    else:
-        nrows = r1
-        ncols = c1
+        nrows, ncols = r2, c2
     fig = plt.figure()
-
     for n, image in enumerate(ic):
         ax = plt.subplot(nrows, ncols, n+1)
         kwargs['ax'] = ax


### PR DESCRIPTION
## Description
`skimage.io.imshow_collection` plots all the images in a single row. This PR fixes this by considering nrows:ncols as 3:4. More details in #2678. Also I have returned plt.figure() which can be later used if required, and I would want to know if there is any possible problem. 
Work left : create argument for batch_size.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

## References
Closes issue #2678 
## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
