### PR TITLE
Fix data type error with marching_cubes_lewiner(allow_degenerate=False)

### DIFF
--- a/skimage/measure/_marching_cubes_lewiner.py
+++ b/skimage/measure/_marching_cubes_lewiner.py
@@ -172,7 +172,7 @@ def marching_cubes_lewiner(volume, level=None, spacing=(1., 1., 1.),
         return vertices, faces, normals, values
     else:
         fun = _marching_cubes_lewiner_cy.remove_degenerate_faces
-        return fun(vertices.astype(np.float), faces, normals, values)
+        return fun(vertices.astype(np.float32), faces, normals, values)
 
 
 def _to_array(args):

--- a/skimage/measure/_marching_cubes_lewiner.py
+++ b/skimage/measure/_marching_cubes_lewiner.py
@@ -172,7 +172,7 @@ def marching_cubes_lewiner(volume, level=None, spacing=(1., 1., 1.),
         return vertices, faces, normals, values
     else:
         fun = _marching_cubes_lewiner_cy.remove_degenerate_faces
-        return fun(vertices, faces, normals, values)
+        return fun(vertices.astype(np.float32), faces, normals, values)
 
 
 def _to_array(args):

--- a/skimage/measure/_marching_cubes_lewiner.py
+++ b/skimage/measure/_marching_cubes_lewiner.py
@@ -172,7 +172,7 @@ def marching_cubes_lewiner(volume, level=None, spacing=(1., 1., 1.),
         return vertices, faces, normals, values
     else:
         fun = _marching_cubes_lewiner_cy.remove_degenerate_faces
-        return fun(vertices.astype(np.float32), faces, normals, values)
+        return fun(vertices.astype(np.float), faces, normals, values)
 
 
 def _to_array(args):

--- a/skimage/measure/tests/test_marching_cubes.py
+++ b/skimage/measure/tests/test_marching_cubes.py
@@ -42,6 +42,9 @@ def test_marching_cubes_anisotropic():
     # Test within 1.5% tolerance for anisotropic. Will always underestimate.
     assert surf > surf_calc and surf_calc > surf * 0.985
 
+    # Test spacing together with allow_degenerate=False
+    marching_cubes_lewiner(ellipsoid_anisotropic, 0, spacing=spacing,allow_degenerate=False)
+
 
 def test_invalid_input():
     # Classic

--- a/skimage/measure/tests/test_marching_cubes.py
+++ b/skimage/measure/tests/test_marching_cubes.py
@@ -44,7 +44,7 @@ def test_marching_cubes_anisotropic():
 
     # Test spacing together with allow_degenerate=False
     marching_cubes_lewiner(ellipsoid_anisotropic, 0, spacing=spacing,
-        allow_degenerate=False)
+                           allow_degenerate=False)
 
 
 def test_invalid_input():

--- a/skimage/measure/tests/test_marching_cubes.py
+++ b/skimage/measure/tests/test_marching_cubes.py
@@ -43,7 +43,8 @@ def test_marching_cubes_anisotropic():
     assert surf > surf_calc and surf_calc > surf * 0.985
 
     # Test spacing together with allow_degenerate=False
-    marching_cubes_lewiner(ellipsoid_anisotropic, 0, spacing=spacing,allow_degenerate=False)
+    marching_cubes_lewiner(ellipsoid_anisotropic, 0, spacing=spacing,
+        allow_degenerate=False)
 
 
 def test_invalid_input():


### PR DESCRIPTION
## Description
A bug fix for an error I encountered when using `skimage.measure.marching_cubes_lewiner()`
with the option `allow_degenerate=False`. The underlying C function expects a float array
for the vertices, and will give an error if supplied a double array.

## Checklist

- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

## References
closes #2693

## For reviewers

(Don't remove the checklist below.)

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.