### PR TITLE
Add handling for uniform arrays when finding local extrema.

### DIFF
--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -212,6 +212,10 @@ def _find_min_diff(image):
     Find the minimal difference of grey levels inside the image.
     """
     img_vec = np.unique(image.flatten())
+
+    if img_vec.shape == (1,):
+        return 0
+
     min_diff = np.min(img_vec[1:] - img_vec[:-1])
     return min_diff
 
@@ -278,6 +282,8 @@ def local_maxima(image, selem=None):
     if np.issubdtype(image.dtype, 'half'):
         # find the minimal grey level difference
         h = _find_min_diff(image)
+        if h == 0:
+            return np.zeros(image.shape, np.uint8)
     else:
         h = 1
     local_max = h_maxima(image, h, selem=selem)
@@ -346,6 +352,8 @@ def local_minima(image, selem=None):
     if np.issubdtype(image.dtype, 'half'):
         # find the minimal grey level difference
         h = _find_min_diff(image)
+        if h == 0:
+            return np.zeros(image.shape, np.uint8)
     else:
         h = 1
     local_min = h_minima(image, h, selem=selem)

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -213,7 +213,7 @@ def _find_min_diff(image):
     """
     img_vec = np.unique(image.flatten())
 
-    if img_vec.shape == (1,):
+    if img_vec.size == 1:
         return 0
 
     min_diff = np.min(img_vec[1:] - img_vec[:-1])
@@ -279,12 +279,11 @@ def local_maxima(image, selem=None):
 
     The resulting image will contain all 6 local maxima.
     """
-    if np.issubdtype(image.dtype, 'half'):
-        # find the minimal grey level difference
-        h = _find_min_diff(image)
-        if h == 0:
-            return np.zeros(image.shape, np.uint8)
-    else:
+    # find the minimal grey level difference
+    h = _find_min_diff(image)
+    if h == 0:
+        return np.zeros(image.shape, np.uint8)
+    if not(np.issubdtype(image.dtype, 'half')):
         h = 1
     local_max = h_maxima(image, h, selem=selem)
     return local_max
@@ -349,12 +348,11 @@ def local_minima(image, selem=None):
 
     The resulting image will contain all 6 local minima.
     """
-    if np.issubdtype(image.dtype, 'half'):
-        # find the minimal grey level difference
-        h = _find_min_diff(image)
-        if h == 0:
-            return np.zeros(image.shape, np.uint8)
-    else:
+    # find the minimal grey level difference
+    h = _find_min_diff(image)
+    if h == 0:
+        return np.zeros(image.shape, np.uint8)
+    if not(np.issubdtype(image.dtype, 'half')):
         h = 1
     local_min = h_minima(image, h, selem=selem)
     return local_min

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -283,7 +283,7 @@ def local_maxima(image, selem=None):
     h = _find_min_diff(image)
     if h == 0:
         return np.zeros(image.shape, np.uint8)
-    if not(np.issubdtype(image.dtype, 'half')):
+    if not np.issubdtype(image.dtype, 'half'):
         h = 1
     local_max = h_maxima(image, h, selem=selem)
     return local_max
@@ -352,7 +352,7 @@ def local_minima(image, selem=None):
     h = _find_min_diff(image)
     if h == 0:
         return np.zeros(image.shape, np.uint8)
-    if not(np.issubdtype(image.dtype, 'half')):
+    if not np.issubdtype(image.dtype, 'half'):
         h = 1
     local_min = h_minima(image, h, selem=selem)
     return local_min

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -192,6 +192,42 @@ class TestExtrema(unittest.TestCase):
             assert error < eps
             assert out.dtype == expected_result.dtype
 
+    def test_local_extrema_uniform(self):
+        "local extrema tests for uniform arrays with various data types"
+
+        data = np.array([[42, 42, 42, 42, 42, 42],
+                         [42, 42, 42, 42, 42, 42],
+                         [42, 42, 42, 42, 42, 42],
+                         [42, 42, 42, 42, 42, 42],
+                         [42, 42, 42, 42, 42, 42],
+                         [42, 42, 42, 42, 42, 42],
+                         [42, 42, 42, 42, 42, 42]],
+                        dtype=np.uint8)
+
+        expected_result = np.array([[0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0],
+                                    [0, 0, 0, 0, 0, 0]],
+                                   dtype=np.uint8)
+
+        for dtype in [np.uint8, np.uint64, np.int8, np.int64]:
+            data = data.astype(dtype)
+
+            # test for local maxima
+            out = extrema.local_maxima(data)
+            error = diff(expected_result, out)
+            assert error < eps
+            assert out.dtype == expected_result.dtype
+
+            # test for local minima
+            out = extrema.local_minima(data)
+            error = diff(expected_result, out)
+            assert error < eps
+            assert out.dtype == expected_result.dtype
+
     def test_extrema_float(self):
         "specific tests for float type"
         data = np.array([[0.10, 0.11, 0.13, 0.14, 0.14, 0.15, 0.14,

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -195,9 +195,9 @@ class TestExtrema(unittest.TestCase):
     def test_local_extrema_uniform(self):
         "local extrema tests for uniform arrays with various data types"
 
-        data = np.array((7,6), 42, dtype=np.uint8)
+        data = np.array((7, 6), 42, dtype=np.uint8)
 
-        expected_result = np.zeros((7,6), dtype=np.uint8)
+        expected_result = np.zeros((7, 6), dtype=np.uint8)
 
         for dtype in [np.uint8, np.uint64, np.int8, np.int64]:
             data = data.astype(dtype)

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -195,23 +195,9 @@ class TestExtrema(unittest.TestCase):
     def test_local_extrema_uniform(self):
         "local extrema tests for uniform arrays with various data types"
 
-        data = np.array([[42, 42, 42, 42, 42, 42],
-                         [42, 42, 42, 42, 42, 42],
-                         [42, 42, 42, 42, 42, 42],
-                         [42, 42, 42, 42, 42, 42],
-                         [42, 42, 42, 42, 42, 42],
-                         [42, 42, 42, 42, 42, 42],
-                         [42, 42, 42, 42, 42, 42]],
-                        dtype=np.uint8)
+        data = np.array((7,6), 42, dtype=np.uint8)
 
-        expected_result = np.array([[0, 0, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0, 0]],
-                                   dtype=np.uint8)
+        expected_result = np.zeros((7,6), dtype=np.uint8)
 
         for dtype in [np.uint8, np.uint64, np.int8, np.int64]:
             data = data.astype(dtype)


### PR DESCRIPTION
## Description
Passing in a uniform array to either `local_maxima` or `local_minima` of the 'morphology' module would result in an error. This pull request fixes the issues by returning a numpy array of zeros in the shape of the passed in image to represent that there are no local extrema.

## References
Closes issue #2691.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
