### PR TITLE
Deprecate `visualise` in favor of `visualize` in `skimage.feature.hog`

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -37,3 +37,4 @@ Version 0.16
 * Remove checks for the ``multichannel`` deprecation warnings in several tests
   in ``skimage.transform.tests.test_pyramids.py`` and
   ``skimage.transform.tests.test_warps.py``.
+* Remove deprecated argument ``visualise`` from function skimage.feature.hog

--- a/doc/examples/features_detection/plot_hog.py
+++ b/doc/examples/features_detection/plot_hog.py
@@ -88,7 +88,7 @@ from skimage import data, color, exposure
 image = color.rgb2gray(data.astronaut())
 
 fd, hog_image = hog(image, orientations=8, pixels_per_cell=(16, 16),
-                    cells_per_block=(1, 1), visualise=True)
+                    cells_per_block=(1, 1), visualize=True)
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4), sharex=True, sharey=True)
 

--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -23,6 +23,7 @@ Version 0.14
   favor of ``skimage.restoration.denoise_nl_means``.
 - ``skimage.measure.LineModel`` has been removed in favor of
   ``skimage.measure.LineModelND``.
+- In ``skimage.feature.hog`` visualise has been changed to visualize.
 
 Version 0.13
 ------------

--- a/doc/source/user_guide/tutorial_parallelization.rst
+++ b/doc/source/user_guide/tutorial_parallelization.rst
@@ -20,7 +20,7 @@ loops. Here is an example of such repetitive tasks:
         image = denoise_tv_chambolle(image[0][0], weight=0.1, multichannel=True)
         fd, hog_image = hog(color.rgb2gray(image), orientations=8,
                             pixels_per_cell=(16, 16), cells_per_block=(1, 1),
-                            visualise=True)
+                            visualize=True)
         return hog_image
 
 

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -23,7 +23,7 @@ def _hog_normalize_block(block, method, eps=1e-5):
 
 
 def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
-        block_norm='L1', visualise=False, transform_sqrt=False,
+        block_norm='L1', visualize=False, visualise=None, transform_sqrt=False,
         feature_vector=True):
     """Extract Histogram of Oriented Gradients (HOG) for a given image.
 
@@ -60,7 +60,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
            renormalization using L2-norm.
            For details, see [3]_, [4]_.
 
-    visualise : bool, optional
+    visualize : bool, optional
         Also return an image of the HOG.
     transform_sqrt : bool, optional
         Apply power law compression to normalize the image before
@@ -74,7 +74,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
     -------
     newarr : ndarray
         HOG for the image as a 1D (flattened) array.
-    hog_image : ndarray (if visualise=True)
+    hog_image : ndarray (if visualize=True)
         A visualisation of the HOG image.
 
     References
@@ -181,7 +181,11 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
     # now compute the histogram for each cell
     hog_image = None
 
-    if visualise:
+    if visualise is not None:
+        visualize = visualise
+        warn('Argument `visualise` is deprecated and will '
+             'be changed to `visualize` in v0.16', skimage_deprecation)
+    if visualize:
         from .. import draw
 
         radius = min(cx, cy) // 2 - 1
@@ -234,7 +238,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
     if feature_vector:
         normalized_blocks = normalized_blocks.ravel()
 
-    if visualise:
+    if visualize:
         return normalized_blocks, hog_image
     else:
         return normalized_blocks

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -27,7 +27,7 @@ def test_hog_output_correctness_l1_norm():
     output = feature.hog(img, orientations=9, pixels_per_cell=(8, 8),
                          cells_per_block=(3, 3), block_norm='L1',
                          feature_vector=True, transform_sqrt=False,
-                         visualise=False)
+                         visualize=False)
     assert_almost_equal(output, correct_output)
 
 
@@ -39,7 +39,7 @@ def test_hog_output_correctness_l2hys_norm():
     output = feature.hog(img, orientations=9, pixels_per_cell=(8, 8),
                          cells_per_block=(3, 3), block_norm='L2-Hys',
                          feature_vector=True, transform_sqrt=False,
-                         visualise=False)
+                         visualize=False)
     assert_almost_equal(output, correct_output)
 
 
@@ -82,16 +82,16 @@ def test_hog_basic_orientations_and_data_types():
 
         (hog_float, hog_img_float) = feature.hog(
             image_float, orientations=4, pixels_per_cell=(8, 8),
-            cells_per_block=(1, 1), visualise=True, transform_sqrt=False)
+            cells_per_block=(1, 1), visualize=True, transform_sqrt=False)
         (hog_uint8, hog_img_uint8) = feature.hog(
             image_uint8, orientations=4, pixels_per_cell=(8, 8),
-            cells_per_block=(1, 1), visualise=True, transform_sqrt=False)
+            cells_per_block=(1, 1), visualize=True, transform_sqrt=False)
         (hog_float_norm, hog_img_float_norm) = feature.hog(
             image_float, orientations=4, pixels_per_cell=(8, 8),
-            cells_per_block=(1, 1), visualise=True, transform_sqrt=True)
+            cells_per_block=(1, 1), visualize=True, transform_sqrt=True)
         (hog_uint8_norm, hog_img_uint8_norm) = feature.hog(
             image_uint8, orientations=4, pixels_per_cell=(8, 8),
-            cells_per_block=(1, 1), visualise=True, transform_sqrt=True)
+            cells_per_block=(1, 1), visualize=True, transform_sqrt=True)
 
         # set to True to enable manual debugging with graphical output,
         # must be False for automatic testing
@@ -169,7 +169,7 @@ def test_hog_orientations_circle():
     for orientations in range(2, 15):
         (hog, hog_img) = feature.hog(image, orientations=orientations,
                                      pixels_per_cell=(8, 8),
-                                     cells_per_block=(1, 1), visualise=True,
+                                     cells_per_block=(1, 1), visualize=True,
                                      transform_sqrt=False)
 
         # set to True to enable manual debugging with graphical output,


### PR DESCRIPTION
## Description
Fixing issue #2644: replace visualise by visualize in hog() to respect our recommendations


## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [na] Gallery example in `./doc/examples` (new features only)
- [na?] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
closes #2644

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
