### PR TITLE
Remove alpha channel when saving to jpg format

### DIFF
--- a/skimage/novice/_novice.py
+++ b/skimage/novice/_novice.py
@@ -326,8 +326,8 @@ class Picture(object):
         path : str
             Path (with file extension) where the picture is saved.
         """
-        if (self.array.ndim >= 3 and self.array.shape[-1] >= 4 and
-                os.path.splitext(path)[-1] in ['.jpg', '.jpeg']):
+        if (self.array.ndim == 3 and self.array.shape[-1] == 4 and
+                os.path.splitext(path)[-1].lower() in ['.jpg', '.jpeg']):
             self.array = self.array[..., :-1]
         io.imsave(path, self.array)
         self._modified = False

--- a/skimage/novice/_novice.py
+++ b/skimage/novice/_novice.py
@@ -326,8 +326,8 @@ class Picture(object):
         path : str
             Path (with file extension) where the picture is saved.
         """
-        if (self.array.ndim >= 3 and self.array.shape[-1] >= 4
-                and os.path.splitext(path)[-1] in ['.jpg', '.jpeg']):
+        if (self.array.ndim >= 3 and self.array.shape[-1] >= 4 and
+                os.path.splitext(path)[-1] in ['.jpg', '.jpeg']):
             self.array = self.array[..., :-1]
         io.imsave(path, self.array)
         self._modified = False

--- a/skimage/novice/_novice.py
+++ b/skimage/novice/_novice.py
@@ -326,6 +326,9 @@ class Picture(object):
         path : str
             Path (with file extension) where the picture is saved.
         """
+        if (self.array.ndim >= 3 and self.array.shape[-1] >= 4
+                and os.path.splitext(path)[-1] in ['.jpg', '.jpeg']):
+            self.array = self.array[..., :-1]
         io.imsave(path, self.array)
         self._modified = False
         self._path = os.path.abspath(path)

--- a/skimage/novice/tests/test_novice.py
+++ b/skimage/novice/tests/test_novice.py
@@ -168,6 +168,16 @@ def test_update_on_save():
         os.unlink(filename)
 
 
+def test_save_with_alpha_channel():
+    # create an image with an alpha channel
+    pic = novice.Picture(array=np.zeros((3, 3, 4)))
+
+    fd, filename = tempfile.mkstemp(suffix=".jpg")
+    os.close(fd)
+    pic.save(filename)
+    os.unlink(filename)
+
+
 def test_indexing():
     array = 128 * np.ones((10, 10, 3), dtype=np.uint8)
     pic = novice.Picture(array=array)


### PR DESCRIPTION
This pull request corrects a bug that is currently making travis fail. It happens when one tries to save to jpg format an image with an alpha channel. A quick workaround is to remove the alpha channel.



## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
