### PR TITLE
Fix local min/maxima for flat images

### DIFF
--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -108,6 +108,7 @@ def h_maxima(image, h, selem=None):
 
     The resulting image will contain 4 local maxima.
     """
+
     if np.issubdtype(image.dtype, 'half'):
         resolution = 2 * np.finfo(image.dtype).resolution
         if h < resolution:
@@ -211,8 +212,10 @@ def _find_min_diff(image):
     """
     Find the minimal difference of grey levels inside the image.
     """
-    img_vec = np.unique(image.flatten())
-    min_diff = np.min(img_vec[1:] - img_vec[:-1])
+    img_vec  = np.unique(image.flatten())
+    min_diff = 0
+    if img_vec.size != 1:
+        min_diff = np.min(img_vec[1:] - img_vec[:-1])
     return min_diff
 
 
@@ -222,6 +225,9 @@ def local_maxima(image, selem=None):
     The local maxima are defined as connected sets of pixels with equal
     grey level strictly greater than the grey levels of all pixels in direct
     neighborhood of the set.
+
+    Flat images return `np.zeros_like(image)`, as there are no neighboring
+    pixels to be strictly greater than.
 
     For integer typed images, this corresponds to the h-maxima with h=1.
     For float typed images, h is determined as the smallest difference
@@ -280,7 +286,7 @@ def local_maxima(image, selem=None):
         h = _find_min_diff(image)
     else:
         h = 1
-    local_max = h_maxima(image, h, selem=selem)
+    local_max = h_maxima(image, h, selem=selem) if h != 0 else np.zeros_like(image)
     return local_max
 
 
@@ -290,6 +296,9 @@ def local_minima(image, selem=None):
     The local minima are defined as connected sets of pixels with equal
     grey level strictly smaller than the grey levels of all pixels in direct
     neighborhood of the set.
+
+    Flat images return `np.zeros_like(image)`, as there are no neighboring
+    pixels to be strictly smaller than.
 
     For integer typed images, this corresponds to the h-minima with h=1.
     For float typed images, h is determined as the smallest difference
@@ -348,5 +357,5 @@ def local_minima(image, selem=None):
         h = _find_min_diff(image)
     else:
         h = 1
-    local_min = h_minima(image, h, selem=selem)
+    local_min = h_minima(image, h, selem=selem) if h != 0 else np.zeros_like(image)
     return local_min

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -91,6 +91,33 @@ class TestExtrema(unittest.TestCase):
             assert error < eps
             assert out.dtype == expected_result.dtype
 
+
+    def test_without_local_maxima(self):
+        "local maxima test without variation"
+        flat = np.ones((5, 5))
+        out  = extrema.local_maxima(flat)
+        assert((out == np.zeros_like(flat)).all())
+
+    def test_without_local_minima(self):
+        "local maxima test without variation"
+        flat = np.ones((5, 5))
+        out  = extrema.local_minima(flat)
+        assert((out == np.zeros_like(flat)).all())
+
+    def test_min_diff(self):
+        "test minimum difference"
+        img = np.zeros((9, 9))
+        img[2:7, 2:7] = 4
+        img[4, 4] = 5
+        out = extrema._find_min_diff(img)
+        assert(out == 1.0)
+
+    def test_minless_diff(self):
+        "test minimum difference, when there is no difference"
+        img = np.zeros((9, 9))
+        out = extrema._find_min_diff(img)
+        assert(out == 0.0)
+
     def test_local_minima(self):
         "local minima for various data types"
 


### PR DESCRIPTION
## Description

Bug fix from `morphology.extreama` and corresponding tests. Now `local_minima`
and `local_maxima` return `np.zeros_like` for flat images.

## Checklist

- [ x ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ x ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ x ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
Issue #2691 

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
