### PR TITLE
Speedup image dtype conversion by switching to `asarray`

### DIFF
--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -279,7 +279,7 @@ def convert(image, dtype, force_copy=False, uniform=False):
             image *= 2.0
             image += 1.0
             image /= imax_in - imin_in
-        return image.astype(dtype_out)
+        return np.asarray(image, dtype_out)
 
     # unsigned int -> signed/unsigned int
     if kind_in == 'u':


### PR DESCRIPTION
## Description
In the # signed/unsigned int -> float portion of the convert function in utils.dtype.convert I changed the last line from return image.astype(dtype_out) to return image because the call to astype seems to be redundant with a previous call to astype. All the tests that passed in the master branch still passed with this change (the main master branch fails 7 tests to begin with, which as far as I can tell are unrelated to this function).

For a 720x1920 px image this saves about 40% processing time in the function call, for smaller images (300x400) it has little effect.

Note that in other sections (e.g. # float -> any) a similar seemingly redundant astype call is actually necessary to pass the tests.

This PR addresses the closed issue #2711

Using suggestion from @grlee77 to change astype call to np.asarray.

There are other locations this could be done as well, but I don't think the calls are redundant in those cases based on my experimentation.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [na] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [na] Gallery example in `./doc/examples` (new features only)
- [na] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
