### PR TITLE
added rect function to draw module

### DIFF
--- a/skimage/draw/__init__.py
+++ b/skimage/draw/__init__.py
@@ -1,7 +1,7 @@
 from .draw import (circle, ellipse, set_color, polygon_perimeter,
                    line, line_aa, polygon, ellipse_perimeter,
                    circle_perimeter, circle_perimeter_aa,
-                   bezier_curve)
+                   bezier_curve,rect)
 from .draw3d import ellipsoid, ellipsoid_stats
 from ._draw import _bezier_segment
 
@@ -17,4 +17,5 @@ __all__ = ['line',
            'circle',
            'circle_perimeter',
            'circle_perimeter_aa',
-           'set_color']
+           'set_color',
+           'rect']

--- a/skimage/draw/__init__.py
+++ b/skimage/draw/__init__.py
@@ -1,7 +1,7 @@
 from .draw import (circle, ellipse, set_color, polygon_perimeter,
                    line, line_aa, polygon, ellipse_perimeter,
                    circle_perimeter, circle_perimeter_aa,
-                   bezier_curve,rect)
+                   bezier_curve,rectangle)
 from .draw3d import ellipsoid, ellipsoid_stats
 from ._draw import _bezier_segment
 
@@ -18,4 +18,4 @@ __all__ = ['line',
            'circle_perimeter',
            'circle_perimeter_aa',
            'set_color',
-           'rect']
+           'rectangle']

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -705,7 +705,7 @@ def rectangle(start, end=None, extent=None, shape=None):
         Origin point of the rectangle, ([plane], row, column[, ...])
     end : tuple
         End point of the rectangle ([num_planes], num_rows, num_cols[, ...]).
-        Either end or extent must be specified."
+        Either end or extent must be specified.
     extent : tuple
         The extent (size) of the drawn rectangle.
         ([num_planes], num_rows, num_cols[, ...])

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -712,11 +712,8 @@ def rectangle(origin, extent, shape=None):
 
     Returns
     -------
-    coords : (M, N)
-        ndarray of int with thePixel coordinates of the nd rectangle.
-        May be used to directly index into an array,
-        e.g. for a 2d rectangle
-        ``img[rr, cc] = 1``.
+    coords : array of int, shape (Ndim, Npoints)
+        The coordinates of all pixels in the nD rectangle.
 
     Examples
     --------
@@ -736,14 +733,14 @@ def rectangle(origin, extent, shape=None):
 
     """
     if len(origin) != len(extent):
-        raise ValueError("origin and extent must have the same"
+        raise ValueError("origin and extent must have the same "
                          "number of dimensions")
     if shape is not None:
         if len(shape) == len(extent):
             extent = tuple(np.minimum(np.array(origin) + np.array(extent),
                            np.array(shape)))
         else:
-            raise ValueError("shape and extent must have the same"
+            raise ValueError("shape and extent must have the same "
                              "number of dimensions")
     coords = np.meshgrid(*[np.arange(o, ex) for o, ex in zip(origin, extent)])
     return coords

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -695,19 +695,21 @@ def bezier_curve(r0, c0, r1, c1, r2, c2, weight, shape=None):
     return _bezier_curve(r0, c0, r1, c1, r2, c2, weight, shape)
 
 
-def rectangle(start, end = None, extent = None, shape=None):
+def rectangle(start, end=None, extent=None, shape=None):
     """Generate coordinates of pixels within an nd-rectangle. Either
     end or extent are required but not both: (extent is None) ^ (end is None)
 
     Parameters
     ----------
     start : tuple
-        origin point of the rectangle, ([plane], row, column[, ...])
+        Origin point of the rectangle, ([plane], row, column[, ...])
     end : tuple
-        end point of the rectangle ([num_planes], num_rows, num_cols[, ...]).
+        End point of the rectangle ([num_planes], num_rows, num_cols[, ...]).
+        Either end or extent must be specified."
     extent : tuple
-        extent vector ([num_planes], num_rows, num_cols[, ...]) of the
-        rectangle. Will be added to start to find the end point.
+        The extent (size) of the drawn rectangle.
+        ([num_planes], num_rows, num_cols[, ...])
+        Either end or extent must be specified.
     shape : tuple, optional
         Image shape which is used to determine the maximum bounds of the output
         pixel coordinates. This is useful for rectangles that exceed the image
@@ -726,7 +728,7 @@ def rectangle(start, end = None, extent = None, shape=None):
     >>> img = np.zeros((5, 5), dtype=np.uint8)
     >>> start = (1, 1)
     >>> extent = (3, 3)
-    >>> rr, cc = rectangle(start, extent = extent, shape = img.shape)
+    >>> rr, cc = rectangle(start, extent=extent, shape=img.shape)
     >>> img[rr, cc] = 1
     >>> img
     array([[0, 0, 0, 0, 0],
@@ -739,7 +741,7 @@ def rectangle(start, end = None, extent = None, shape=None):
     >>> img = np.zeros((5, 5), dtype=np.uint8)
     >>> start = (0, 1)
     >>> end = (3, 3)
-    >>> rr, cc = rectangle(start, end = end, shape = img.shape)
+    >>> rr, cc = rectangle(start, end=end, shape=img.shape)
     >>> img[rr, cc] = 1
     >>> img
     array([[0, 1, 1, 1, 0],

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -696,7 +696,7 @@ def bezier_curve(r0, c0, r1, c1, r2, c2, weight, shape=None):
 
 
 def rectangle(start, end=None, extent=None, shape=None):
-    """Generate coordinates of pixels within a nd-rectangle.
+    """Generate coordinates of pixels within a rectangle.
 
     Parameters
     ----------
@@ -719,6 +719,11 @@ def rectangle(start, end=None, extent=None, shape=None):
     -------
     coords : array of int, shape (Ndim, Npoints)
         The coordinates of all pixels in the rectangle.
+
+    Notes
+    -----
+    The function will also work for N-dimensions, by passing 'start' and
+    'end' or 'extent' as tuples of lenght N.
 
     Examples
     --------

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -696,29 +696,28 @@ def bezier_curve(r0, c0, r1, c1, r2, c2, weight, shape=None):
 
 
 def rectangle(start, end=None, extent=None, shape=None):
-    """Generate coordinates of pixels within an nd-rectangle. Either
-    end or extent are required.
+    """Generate coordinates of pixels within an nd-rectangle.
 
     Parameters
     ----------
     start : tuple
-        Origin point of the rectangle, ([plane], row, column[, ...])
+        Origin point of the rectangle, ('[plane]', 'row', 'column''[, ...]')
     end : tuple
-        End point of the rectangle ([num_planes], num_rows, num_cols[, ...]).
-        Either end or extent must be specified.
+        End point of the rectangle ('[plane]', 'row', 'column''[, ...]').
+        Either 'end' or 'extent' must be specified.
     extent : tuple
         The extent (size) of the drawn rectangle.
-        ([num_planes], num_rows, num_cols[, ...])
-        Either end or extent must be specified.
+        (['num_planes'], 'num_rows', 'num_cols''[, ...]')
+        Either 'end' or 'extent' must be specified.
     shape : tuple, optional
         Image shape which is used to determine the maximum bounds of the output
         pixel coordinates. This is useful for rectangles that exceed the image
-        size. If None, the bounds are determined from the bounds of
+        size. If 'None', the bounds are determined from the bounds of
         the rectangle.
 
     Returns
     -------
-    coords : array of int, shape (Ndim, Npoints)
+    coords : array of int, shape ('Ndim', 'Npoints')
         The coordinates of all pixels in the nD rectangle.
 
     Examples

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -701,19 +701,18 @@ def rectangle(start, end=None, extent=None, shape=None):
     Parameters
     ----------
     start : tuple
-        Origin point of the rectangle, ('[plane]', 'row', 'column')
+        Origin point of the rectangle, e.g., ``([plane,] row, column)``.
     end : tuple
-        End point of the rectangle ('[plane]', 'row', 'column').
-        Either 'end' or 'extent' must be specified.
+        End point of the rectangle ``([plane,] row, column)``.
+        Either `end` or `extent` must be specified.
     extent : tuple
-        The extent (size) of the drawn rectangle.
-        (['num_planes'], 'num_rows', 'num_cols')
-        Either 'end' or 'extent' must be specified.
+        The extent (size) of the drawn rectangle.  E.g.,
+        ``([num_planes,] num_rows, num_cols)``.
+        Either `end` or `extent` must be specified.
     shape : tuple, optional
-        Image shape which is used to determine the maximum bounds of the output
-        pixel coordinates. This is useful for rectangles that exceed the image
-        size. If 'None', the bounds are determined from the bounds of
-        the rectangle.
+        Image shape used to determine the maximum bounds of the output
+        coordinates. This is useful for clipping rectangles that exceed
+        the image size. By default, no clipping is done.
 
     Returns
     -------
@@ -722,8 +721,8 @@ def rectangle(start, end=None, extent=None, shape=None):
 
     Notes
     -----
-    The function will also work for N-dimensions, by passing 'start' and
-    'end' or 'extent' as tuples of lenght N.
+    This function can be applied to N-dimensional images, by passing `start` and
+    `end` or `extent` as tuples of length N.
 
     Examples
     --------
@@ -758,7 +757,7 @@ def rectangle(start, end=None, extent=None, shape=None):
     if extent is not None:
         end = np.array(start) + np.array(extent)
     elif end is None:
-        raise ValueError("Either an 'end' or 'extent' must be given")
+        raise ValueError("Either `end` or `extent` must be given")
     tl = np.minimum(start, end)
     br = np.maximum(start, end)
     if extent is None:

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -717,7 +717,7 @@ def rectangle(start, end=None, extent=None, shape=None):
 
     Returns
     -------
-    coords : array of int, shape ('Ndim', 'Npoints')
+    coords : array of int, shape (Ndim, Npoints)
         The coordinates of all pixels in the nD rectangle.
 
     Examples

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -709,7 +709,7 @@ def rectangle(start, end = None, extent = None, shape=None):
         extent vector ([num_planes], num_rows, num_cols[, ...]) of the
         rectangle. Will be added to start to find the end point.
     shape : tuple, optional
-        Image shape which is used to determine the maximum extent of output
+        Image shape which is used to determine the maximum bounds of the output
         pixel coordinates. This is useful for rectangles that exceed the image
         size. If None, the bounds are determined from the bounds of
         the rectangle.

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -701,9 +701,9 @@ def rectangle(origin, extent, shape=None):
     Parameters
     ----------
     origin : tuple
-        origin of the rectangle, (page,row,column,channel)
+        origin of the rectangle, ([plane], row, column[, ...])
     extent : tuple
-        extent (num_pages,num_rows,num_cols,num_chanels..) of the rectangle.
+        extent ([num_planes], num_rows, num_cols[, ...]) of the rectangle.
     shape : tuple, optional
         Image shape which is used to determine the maximum extent of output
         pixel coordinates. This is useful for rectangles that exceed the image
@@ -712,8 +712,8 @@ def rectangle(origin, extent, shape=None):
 
     Returns
     -------
-    coords : (M, n) ndarray of int with the
-        Pixel coordinates of the nd rectangle.
+    coords : (M, N)
+        ndarray of int with thePixel coordinates of the nd rectangle.
         May be used to directly index into an array,
         e.g. for a 2d rectangle
         ``img[rr, cc] = 1``.
@@ -735,15 +735,15 @@ def rectangle(origin, extent, shape=None):
            [0, 0, 0, 0, 0]], dtype=uint8)
 
     """
-    if not(len(origin) == len(extent)):
-        raise ValueError("origin and extent must have the same\
-                          number of dimensions")
-    if not(shape is None):
+    if len(origin) != len(extent):
+        raise ValueError("origin and extent must have the same"
+                         "number of dimensions")
+    if shape is not None:
         if len(shape) == len(extent):
             extent = tuple(np.minimum(np.array(origin) + np.array(extent),
                            np.array(shape)))
         else:
-            raise ValueError("shape and extent must have the same\
-                              number of dimensions")
+            raise ValueError("shape and extent must have the same"
+                             "number of dimensions")
     coords = np.meshgrid(*[np.arange(o, ex) for o, ex in zip(origin, extent)])
     return coords

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -706,7 +706,7 @@ def rect(origin, extent, shape=None):
         Image shape which is used to determine the maximum extent of output
         pixel coordinates. This is useful for rectangles that exceed the image
         size. If None, the bounds are determined from the bounds of
-        the rectangle so.
+        the rectangle .
 
     Returns
     -------
@@ -741,6 +741,6 @@ def rect(origin, extent, shape=None):
                            np.array(shape)))
         else:
             raise ValueError("shape and extent must have the same\
-                              number of dimension")
+                              number of dimensions")
     coords = np.meshgrid(*[np.arange(o, ex) for o, ex in zip(origin, extent)])
     return coords

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -696,7 +696,7 @@ def bezier_curve(r0, c0, r1, c1, r2, c2, weight, shape=None):
 
 
 def rectangle(start, end=None, extent=None, shape=None):
-    """Generate coordinates of pixels within a rectangle or rectangular volume.
+    """Generate coordinates of pixels within a nd-rectangle.
 
     Parameters
     ----------
@@ -750,8 +750,6 @@ def rectangle(start, end=None, extent=None, shape=None):
            [0, 0, 0, 0, 0]], dtype=uint8)
 
     """
-    if len(start) not in [2, 3]:
-        raise ValueError("len(start) must be 2 or 3")
     if extent is not None:
         end = np.array(start) + np.array(extent)
     elif end is None:

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -696,18 +696,18 @@ def bezier_curve(r0, c0, r1, c1, r2, c2, weight, shape=None):
 
 
 def rectangle(start, end=None, extent=None, shape=None):
-    """Generate coordinates of pixels within an nd-rectangle.
+    """Generate coordinates of pixels within a rectangle or rectangular volume.
 
     Parameters
     ----------
     start : tuple
-        Origin point of the rectangle, ('[plane]', 'row', 'column''[, ...]')
+        Origin point of the rectangle, ('[plane]', 'row', 'column')
     end : tuple
-        End point of the rectangle ('[plane]', 'row', 'column''[, ...]').
+        End point of the rectangle ('[plane]', 'row', 'column').
         Either 'end' or 'extent' must be specified.
     extent : tuple
         The extent (size) of the drawn rectangle.
-        (['num_planes'], 'num_rows', 'num_cols''[, ...]')
+        (['num_planes'], 'num_rows', 'num_cols')
         Either 'end' or 'extent' must be specified.
     shape : tuple, optional
         Image shape which is used to determine the maximum bounds of the output
@@ -718,7 +718,7 @@ def rectangle(start, end=None, extent=None, shape=None):
     Returns
     -------
     coords : array of int, shape (Ndim, Npoints)
-        The coordinates of all pixels in the nD rectangle.
+        The coordinates of all pixels in the rectangle.
 
     Examples
     --------
@@ -750,10 +750,12 @@ def rectangle(start, end=None, extent=None, shape=None):
            [0, 0, 0, 0, 0]], dtype=uint8)
 
     """
+    if len(start) not in [2, 3]:
+        raise ValueError("len(start) must be 2 or 3")
     if extent is not None:
         end = np.array(start) + np.array(extent)
     elif end is None:
-        raise ValueError("Either an end or extent must be given")
+        raise ValueError("Either an 'end' or 'extent' must be given")
     tl = np.minimum(start, end)
     br = np.maximum(start, end)
     if extent is None:

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -695,18 +695,20 @@ def bezier_curve(r0, c0, r1, c1, r2, c2, weight, shape=None):
     return _bezier_curve(r0, c0, r1, c1, r2, c2, weight, shape)
 
 
-def rect(origin, extent, shape=None):
-    """Generate coordinates of pixels within a nd-rectangle.
+def rectangle(origin, extent, shape=None):
+    """Generate coordinates of pixels within an nd-rectangle.
 
     Parameters
     ----------
-    origin, extent : tuple
-        origin and extent (width,length,ect..) of the rectangle.
+    origin : tuple
+        origin of the rectangle, (page,row,column,channel)
+    extent : tuple
+        extent (num_pages,num_rows,num_cols,num_chanels..) of the rectangle.
     shape : tuple, optional
         Image shape which is used to determine the maximum extent of output
         pixel coordinates. This is useful for rectangles that exceed the image
         size. If None, the bounds are determined from the bounds of
-        the rectangle .
+        the rectangle.
 
     Returns
     -------
@@ -719,11 +721,12 @@ def rect(origin, extent, shape=None):
     Examples
     --------
     >>> import numpy as np
-    >>> img = np.zeros((5, 5),dtype=np.uint8)
-    >>> origin = (1,1)
-    >>> extent = (2,2)
-    >>> rr,cc = rect(origin,extent,img.shape)
-    >>> img[rr,cc] = 1
+    >>> from skimage.draw import rectangle
+    >>> img = np.zeros((5, 5), dtype=np.uint8)
+    >>> origin = (1, 1)
+    >>> extent = (2, 2)
+    >>> rr, cc = rectangle(origin, extent, img.shape)
+    >>> img[rr, cc] = 1
     >>> img
     array([[0, 0, 0, 0, 0],
            [0, 1, 1, 0, 0],

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -697,7 +697,7 @@ def bezier_curve(r0, c0, r1, c1, r2, c2, weight, shape=None):
 
 def rectangle(start, end=None, extent=None, shape=None):
     """Generate coordinates of pixels within an nd-rectangle. Either
-    end or extent are required but not both: (extent is None) ^ (end is None)
+    end or extent are required.
 
     Parameters
     ----------
@@ -751,21 +751,17 @@ def rectangle(start, end=None, extent=None, shape=None):
            [0, 0, 0, 0, 0]], dtype=uint8)
 
     """
-    if end is None:
-        if extent is None:
-            raise ValueError("either an end or extent must be given")
-        else:
-            end = np.array(start) + np.array(extent)
-    else:
-        if extent is not None:
-            raise ValueError("only end or extent can be given not both")
-    bl = np.minimum(np.array(start), np.array(end))
-    tr = np.maximum(np.array(start), np.array(end))
-    if shape is not None:
-        tr = np.minimum(np.array(shape), np.array(tr))
-        bl = np.maximum(np.zeros_like(shape), np.array(bl))
+    if extent is not None:
+        end = np.array(start) + np.array(extent)
+    elif end is None:
+        raise ValueError("Either an end or extent must be given")
+    tl = np.minimum(start, end)
+    br = np.maximum(start, end)
     if extent is None:
-        tr += 1
-    coords = np.meshgrid(*[np.arange(o, ex) for o, ex in zip(tuple(bl),
-                                                             tuple(tr))])
+        br += 1
+    if shape is not None:
+        br = np.minimum(shape, br)
+        tl = np.maximum(np.zeros_like(shape), tl)
+    coords = np.meshgrid(*[np.arange(st, en) for st, en in zip(tuple(tl),
+                                                               tuple(br))])
     return coords

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -694,27 +694,28 @@ def bezier_curve(r0, c0, r1, c1, r2, c2, weight, shape=None):
     """
     return _bezier_curve(r0, c0, r1, c1, r2, c2, weight, shape)
 
-def rect(origin,extent,shape = None):
+
+def rect(origin, extent, shape=None):
     """Generate coordinates of pixels within a nd-rectangle.
 
     Parameters
     ----------
     origin, extent : tuple
-        origin and extent of the rectangle.
+        origin and extent (width,length,ect..) of the rectangle.
     shape : tuple, optional
         Image shape which is used to determine the maximum extent of output
         pixel coordinates. This is useful for rectangles that exceed the image
         size. If None, the bounds are determined from the bounds of
-        the rectangle (origin + extent).
+        the rectangle so.
 
     Returns
     -------
-    coords : sequence of ndarrays of int
+    coords : (M, n) ndarray of int with the
         Pixel coordinates of the nd rectangle.
-        May be used to directly index into an array, 
+        May be used to directly index into an array,
         e.g. for a 2d rectangle
         ``img[rr, cc] = 1``.
-        
+
     Examples
     --------
     >>> import numpy as np
@@ -729,15 +730,17 @@ def rect(origin,extent,shape = None):
            [0, 1, 1, 0, 0],
            [0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0]], dtype=uint8)
-       
+
     """
     if not(len(origin) == len(extent)):
-        raise ValueError("origin and extent must have the same number of dimensions")
-    if not(shape==None):
+        raise ValueError("origin and extent must have the same\
+                          number of dimensions")
+    if not(shape is None):
         if len(shape) == len(extent):
-            extent = tuple(np.minimum(np.array(origin) + np.array(extent),np.array(shape)))
+            extent = tuple(np.minimum(np.array(origin) + np.array(extent),
+                           np.array(shape)))
         else:
-            raise ValueError("shape and extent must have the same number of dimension")
-    coords = np.meshgrid(*[np.arange(o,ex) for o,ex in zip(origin,extent)])
+            raise ValueError("shape and extent must have the same\
+                              number of dimension")
+    coords = np.meshgrid(*[np.arange(o, ex) for o, ex in zip(origin, extent)])
     return coords
-    

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -693,3 +693,51 @@ def bezier_curve(r0, c0, r1, c1, r2, c2, weight, shape=None):
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=uint8)
     """
     return _bezier_curve(r0, c0, r1, c1, r2, c2, weight, shape)
+
+def rect(origin,extent,shape = None):
+    """Generate coordinates of pixels within a nd-rectangle.
+
+    Parameters
+    ----------
+    origin, extent : tuple
+        origin and extent of the rectangle.
+    shape : tuple, optional
+        Image shape which is used to determine the maximum extent of output
+        pixel coordinates. This is useful for rectangles that exceed the image
+        size. If None, the bounds are determined from the bounds of
+        the rectangle (origin + extent).
+
+    Returns
+    -------
+    coords : sequence of ndarrays of int
+        Pixel coordinates of the nd rectangle.
+        May be used to directly index into an array, 
+        e.g. for a 2d rectangle
+        ``img[rr, cc] = 1``.
+        
+    Examples
+    --------
+    >>> import numpy as np
+    >>> img = np.zeros((5, 5),dtype=np.uint8)
+    >>> origin = (1,1)
+    >>> extent = (2,2)
+    >>> rr,cc = rect(origin,extent,img.shape)
+    >>> img[rr,cc] = 1
+    >>> img
+    array([[0, 0, 0, 0, 0],
+           [0, 1, 1, 0, 0],
+           [0, 1, 1, 0, 0],
+           [0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0]], dtype=uint8)
+       
+    """
+    if not(len(origin) == len(extent)):
+        raise ValueError("origin and extent must have the same number of dimensions")
+    if not(shape==None):
+        if len(shape) == len(extent):
+            extent = tuple(np.minimum(np.array(origin) + np.array(extent),np.array(shape)))
+        else:
+            raise ValueError("shape and extent must have the same number of dimension")
+    coords = np.meshgrid(*[np.arange(o,ex) for o,ex in zip(origin,extent)])
+    return coords
+    

--- a/skimage/draw/tests/test_draw.py
+++ b/skimage/draw/tests/test_draw.py
@@ -863,18 +863,33 @@ def test_polygon_perimeter_outside_image():
     assert_equal(len(rr), 0)
     assert_equal(len(cc), 0)
 
-def test_rectangle():
+
+def test_rectangle_end():
+    expected = np.array([[0, 1, 1, 1, 0],
+                         [0, 1, 1, 1, 0],
+                         [0, 1, 1, 1, 0],
+                         [0, 1, 1, 1, 0],
+                         [0, 0, 0, 0, 0]], dtype=np.uint8)
+    img = np.zeros((5, 5), dtype=np.uint8)
+    start = (0, 1)
+    end = (3, 3)
+    rr, cc = rectangle(start, end=end, shape=img.shape)
+    img[rr, cc] = 1
+    assert_array_equal(img, expected)
+
+
+def test_rectangle_extent():
     expected = np.array([[0, 0, 0, 0, 0],
                          [0, 1, 1, 1, 0],
                          [0, 1, 1, 1, 0],
                          [0, 1, 1, 1, 0],
-                         [0, 0, 0, 0, 0]])
-    img = np.zeros((5, 5),dtype=np.uint8)
-    origin = (1,1)
-    extent = (3,3)
-    rr,cc = rectangle(origin,extent,img.shape)
-    img[rr,cc] = 1
-    assert_array_equal(img,expected)
+                         [0, 0, 0, 0, 0]], dtype=np.uint8)
+    img = np.zeros((5, 5), dtype=np.uint8)
+    start = (1, 1)
+    extent = (3, 3)
+    rr, cc = rectangle(start, extent= extent, shape=img.shape)
+    img[rr, cc] = 1
+    assert_array_equal(img, expected)
 
 if __name__ == "__main__":
     from numpy.testing import run_module_suite

--- a/skimage/draw/tests/test_draw.py
+++ b/skimage/draw/tests/test_draw.py
@@ -6,7 +6,8 @@ from skimage._shared.testing import test_parallel
 from skimage.draw import (set_color, line, line_aa, polygon, polygon_perimeter,
                           circle, circle_perimeter, circle_perimeter_aa,
                           ellipse, ellipse_perimeter,
-                          _bezier_segment, bezier_curve)
+                          _bezier_segment, bezier_curve,rect)
+
 from skimage.measure import regionprops
 
 
@@ -862,6 +863,18 @@ def test_polygon_perimeter_outside_image():
     assert_equal(len(rr), 0)
     assert_equal(len(cc), 0)
 
+def test_rect():
+    expected = np.array([[0, 0, 0, 0, 0],
+                         [0, 1, 1, 1, 0],
+                         [0, 1, 1, 1, 0],
+                         [0, 1, 1, 1, 0],
+                         [0, 0, 0, 0, 0]])
+    img = np.zeros((5, 5),dtype=np.uint8)
+    origin = (1,1)
+    extent = (3,3)
+    rr,cc = rect(origin,extent,img.shape)
+    img[rr,cc] = 1
+    assert_array_equal(img,expected)
 
 if __name__ == "__main__":
     from numpy.testing import run_module_suite

--- a/skimage/draw/tests/test_draw.py
+++ b/skimage/draw/tests/test_draw.py
@@ -6,7 +6,7 @@ from skimage._shared.testing import test_parallel
 from skimage.draw import (set_color, line, line_aa, polygon, polygon_perimeter,
                           circle, circle_perimeter, circle_perimeter_aa,
                           ellipse, ellipse_perimeter,
-                          _bezier_segment, bezier_curve,rect)
+                          _bezier_segment, bezier_curve,rectangle)
 
 from skimage.measure import regionprops
 
@@ -863,7 +863,7 @@ def test_polygon_perimeter_outside_image():
     assert_equal(len(rr), 0)
     assert_equal(len(cc), 0)
 
-def test_rect():
+def test_rectangle():
     expected = np.array([[0, 0, 0, 0, 0],
                          [0, 1, 1, 1, 0],
                          [0, 1, 1, 1, 0],
@@ -872,7 +872,7 @@ def test_rect():
     img = np.zeros((5, 5),dtype=np.uint8)
     origin = (1,1)
     extent = (3,3)
-    rr,cc = rect(origin,extent,img.shape)
+    rr,cc = rectangle(origin,extent,img.shape)
     img[rr,cc] = 1
     assert_array_equal(img,expected)
 

--- a/skimage/draw/tests/test_draw3d.py
+++ b/skimage/draw/tests/test_draw3d.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 import pytest
 
-from skimage.draw import ellipsoid, ellipsoid_stats, rect
+from skimage.draw import ellipsoid, ellipsoid_stats, rectangle
 
 
 def test_ellipsoid_sign_parameters1():
@@ -139,7 +139,7 @@ def test_rect_3d():
     img = np.zeros((4, 5, 5),dtype=np.uint8)
     origin = (0,0,2)
     extent = (5,2,3)
-    pp,rr,cc = rect(origin,extent,img.shape)
+    pp,rr,cc = rectangle(origin,extent,img.shape)
     img[pp,rr,cc] = 1
     assert_array_equal(img,expected)
 

--- a/skimage/draw/tests/test_draw3d.py
+++ b/skimage/draw/tests/test_draw3d.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 import pytest
 
-from skimage.draw import ellipsoid, ellipsoid_stats
+from skimage.draw import ellipsoid, ellipsoid_stats, rect
 
 
 def test_ellipsoid_sign_parameters1():
@@ -114,6 +114,34 @@ def test_ellipsoid_stats():
     vol, surf = ellipsoid_stats(17, 27, 169)
     assert_allclose(103428 * np.pi, vol, atol=1e-4)
     assert_allclose(37426.3, surf, atol=1e-1)
+
+def test_rect_3d():
+    expected = np.array([[[0, 0, 1, 1, 1],
+                          [0, 0, 1, 1, 1],
+                          [0, 0, 0, 0, 0],
+                          [0, 0, 0, 0, 0],
+                          [0, 0, 0, 0, 0]],
+                         [[0, 0, 1, 1, 1],
+                          [0, 0, 1, 1, 1],
+                          [0, 0, 0, 0, 0],
+                          [0, 0, 0, 0, 0],
+                          [0, 0, 0, 0, 0]],
+                         [[0, 0, 1, 1, 1],
+                          [0, 0, 1, 1, 1],
+                          [0, 0, 0, 0, 0],
+                          [0, 0, 0, 0, 0],
+                          [0, 0, 0, 0, 0]],
+                         [[0, 0, 1, 1, 1],
+                          [0, 0, 1, 1, 1],
+                          [0, 0, 0, 0, 0],
+                          [0, 0, 0, 0, 0],
+                          [0, 0, 0, 0, 0]]], dtype=np.uint8)
+    img = np.zeros((4, 5, 5),dtype=np.uint8)
+    origin = (0,0,2)
+    extent = (5,2,3)
+    pp,rr,cc = rect(origin,extent,img.shape)
+    img[pp,rr,cc] = 1
+    assert_array_equal(img,expected)
 
 
 if __name__ == "__main__":

--- a/skimage/draw/tests/test_draw3d.py
+++ b/skimage/draw/tests/test_draw3d.py
@@ -115,7 +115,8 @@ def test_ellipsoid_stats():
     assert_allclose(103428 * np.pi, vol, atol=1e-4)
     assert_allclose(37426.3, surf, atol=1e-1)
 
-def test_rect_3d():
+
+def test_rect_3d_extent():
     expected = np.array([[[0, 0, 1, 1, 1],
                           [0, 0, 1, 1, 1],
                           [0, 0, 0, 0, 0],
@@ -136,12 +137,41 @@ def test_rect_3d():
                           [0, 0, 0, 0, 0],
                           [0, 0, 0, 0, 0],
                           [0, 0, 0, 0, 0]]], dtype=np.uint8)
-    img = np.zeros((4, 5, 5),dtype=np.uint8)
-    origin = (0,0,2)
-    extent = (5,2,3)
-    pp,rr,cc = rectangle(origin,extent,img.shape)
-    img[pp,rr,cc] = 1
-    assert_array_equal(img,expected)
+    img = np.zeros((4, 5, 5), dtype=np.uint8)
+    start = (0, 0, 2)
+    extent = (5, 2, 3)
+    pp, rr, cc = rectangle(start, extent=extent, shape=img.shape)
+    img[pp, rr, cc] = 1
+    assert_array_equal(img, expected)
+
+
+def test_rect_3d_end():
+    expected = np.array([[[0, 0, 0, 0, 0],
+                          [0, 0, 0, 0, 0],
+                          [0, 0, 0, 0, 0],
+                          [0, 0, 0, 0, 0],
+                          [0, 0, 0, 0, 0]],
+                         [[0, 0, 1, 1, 0],
+                          [0, 0, 1, 1, 0],
+                          [0, 0, 1, 1, 0],
+                          [0, 0, 0, 0, 0],
+                          [0, 0, 0, 0, 0]],
+                         [[0, 0, 1, 1, 0],
+                          [0, 0, 1, 1, 0],
+                          [0, 0, 1, 1, 0],
+                          [0, 0, 0, 0, 0],
+                          [0, 0, 0, 0, 0]],
+                         [[0, 0, 1, 1, 0],
+                          [0, 0, 1, 1, 0],
+                          [0, 0, 1, 1, 0],
+                          [0, 0, 0, 0, 0],
+                          [0, 0, 0, 0, 0]]], dtype=np.uint8)
+    img = np.zeros((4, 5, 5), dtype=np.uint8)
+    start = (1, 0, 2)
+    end = (3, 2, 3)
+    pp, rr, cc = rectangle(start, end=end, shape=img.shape)
+    img[pp, rr, cc] = 1
+    assert_array_equal(img, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
implements a draw nd rectangle functions. Basically a wrapper for np.meshgrid but I tried to be consistent with the skimage API.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [X ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ X] Gallery example in `./doc/examples` (new features only)
- [ X] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]

## References
enhancement, it closes issue # 2688

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
