### PR TITLE
FIX numpydoc error in skimage/io

### DIFF
--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -36,17 +36,15 @@ def imread(fname, as_grey=False, plugin=None, flatten=None,
     flatten : bool
         Backward compatible keyword, superseded by `as_grey`.
 
+    plugin_args : keywords
+        Passed to the given plugin.
+
     Returns
     -------
     img_array : ndarray
         The different color bands/channels are stored in the
         third dimension, such that a grey-image is MxN, an
         RGB-image MxNx3 and an RGBA-image MxNx4.
-
-    Other parameters
-    ----------------
-    plugin_args : keywords
-        Passed to the given plugin.
 
     """
     # Backward compatibility


### PR DESCRIPTION
Fixes #2721 

The documentation should now build again.