### PR TITLE
Add support for 1D arrays for grey erosion

### DIFF
--- a/skimage/morphology/grey.py
+++ b/skimage/morphology/grey.py
@@ -29,8 +29,8 @@ def _shift_selem(selem, shift_x, shift_y):
     out : 2D array, shape (M + int(shift_x), N + int(shift_y))
         The shifted structuring element.
     """
-    if selem.ndim > 2:
-        # do nothing for 3D or higher structuring elements
+    if selem.ndim != 2:
+        # do nothing for 1D or 3D or higher structuring elements
         return selem
     m, n = selem.shape
     if m % 2 == 0:

--- a/skimage/morphology/tests/test_grey.py
+++ b/skimage/morphology/tests/test_grey.py
@@ -266,5 +266,12 @@ def test_discontiguous_out_array():
     testing.assert_array_equal(out_array_big, expected_erosion)
 
 
+def test_1d_erosion():
+    image = np.array([1, 2, 3, 2, 1])
+    expected = np.array([0, 1, 2, 1, 0])
+    eroded = grey.erosion(image)
+    testing.assert_array_equal(eroded, expected)
+
+
 if __name__ == '__main__':
     testing.run_module_suite()

--- a/skimage/morphology/tests/test_grey.py
+++ b/skimage/morphology/tests/test_grey.py
@@ -268,7 +268,7 @@ def test_discontiguous_out_array():
 
 def test_1d_erosion():
     image = np.array([1, 2, 3, 2, 1])
-    expected = np.array([0, 1, 2, 1, 0])
+    expected = np.array([1, 1, 2, 1, 1])
     eroded = grey.erosion(image)
     testing.assert_array_equal(eroded, expected)
 


### PR DESCRIPTION
## Description
Modifies an overly stringent dimensionality check to allow support for 1D arrays in morphological operations.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
Closes issue #2687 

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
