### PR TITLE
DOC: Restore custom sphinx-gallery CSS style settings

### DIFF
--- a/doc/source/themes/scikit-image/static/css/custom.css
+++ b/doc/source/themes/scikit-image/static/css/custom.css
@@ -262,3 +262,39 @@ td.field-body blockquote {
 td.field-body p {
     margin-bottom: 0.3em;
 }
+
+/*
+Overrride some default settings in sphinx-gallery's gallery.css.
+
+The !important property is necessary to ensure these settings take precedence
+over the ones bundled with sphinx-gallery.
+*/
+.sphx-glr-thumbcontainer {
+  border: solid #d6d6d6 1px !important;
+}
+
+div.sphx-glr-download {
+  width: auto !important;
+}
+
+div.sphx-glr-footer {
+    text-align: left  !important;
+}
+
+div.sphx-glr-download a {
+  background-color: #d9edf7 !important;
+  border: 1px solid #bce8f1 !important;
+  background-image: none !important;
+}
+
+div.sphx-glr-download code {
+  color: #3a87ad !important;
+}
+
+div.sphx-glr-download a:hover {
+  background-color: #d9edf7 !important;
+}
+
+p.sphx-glr-signature a.reference.external {
+  display: none !important;
+}


### PR DESCRIPTION

## Description

This restores stylistic changes to the sphinx gallery (primarily related to the appearance of the download buttons) that were inadvertently removed in #2666.  Rather than going back to a local copy of `sphinx-gallery`, the `custom.css` file is used to override settings specific to `sphinx-gallery`.

See also discussion in #2666

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
