### PR TITLE
Implementation and test fix for shannon_entropy calculation.

### DIFF
--- a/skimage/measure/entropy.py
+++ b/skimage/measure/entropy.py
@@ -33,7 +33,7 @@ def shannon_entropy(image, base=2):
     --------
     >>> from skimage import data
     >>> shannon_entropy(data.camera())
-    4.8852702980667759
+    7.0479552324230861
     """
 
     _, counts = unique(image, return_counts=True)

--- a/skimage/measure/entropy.py
+++ b/skimage/measure/entropy.py
@@ -1,3 +1,4 @@
+from numpy import unique
 from scipy.stats import entropy as scipy_entropy
 
 
@@ -5,7 +6,7 @@ def shannon_entropy(image, base=2):
     """Calculate the Shannon entropy of an image.
 
     The Shannon entropy is defined as S = -sum(pk * log(pk)),
-    where pk are the number of pixels of value k.
+    where pk are frequency/probability of pixels of value k.
 
     Parameters
     ----------
@@ -32,6 +33,8 @@ def shannon_entropy(image, base=2):
     --------
     >>> from skimage import data
     >>> shannon_entropy(data.camera())
-    17.732031303342747
+    4.8852702980667759
     """
-    return scipy_entropy(image.ravel(), base=base)
+
+    _, counts = unique(image, return_counts=True)
+    return scipy_entropy(counts, base=base)

--- a/skimage/measure/tests/test_entropy.py
+++ b/skimage/measure/tests/test_entropy.py
@@ -9,10 +9,11 @@ def test_shannon_ones():
     res = shannon_entropy(img, base=np.e)
     assert_almost_equal(res, 0.0)
 
+
 def test_shannon_all_unique():
     img = np.arange(64)
     res = shannon_entropy(img, base=2)
-    assert_almost_equal(res, np.log(64)/np.log(2))
+    assert_almost_equal(res, np.log(64) / np.log(2))
 
 if __name__ == "__main__":
     from numpy.testing import run_module_suite

--- a/skimage/measure/tests/test_entropy.py
+++ b/skimage/measure/tests/test_entropy.py
@@ -7,8 +7,12 @@ from skimage.measure import shannon_entropy
 def test_shannon_ones():
     img = np.ones((10, 10))
     res = shannon_entropy(img, base=np.e)
-    assert_almost_equal(res, np.log(10*10))
+    assert_almost_equal(res, 0.0)
 
+def test_shannon_all_unique():
+    img = np.arange(64)
+    res = shannon_entropy(img, base=2)
+    assert_almost_equal(res, np.log(64)/np.log(2))
 
 if __name__ == "__main__":
     from numpy.testing import run_module_suite


### PR DESCRIPTION
Somewhere Shannon entropy became misunderstood.
First of all, the definition uses probabilities not counts in the equation, 
so the documentation of the function is wrong.
This is easily fixable using numpy.unique which can count the unique elements.

Obviously, the test case and the docstring test are wrong. 
To highlight this: the data.camera() is an uint8 image, which has maximum 8 bits  entropy, not 17 like in the example. 
Uniform image by definition must have 0 entropy, and 2^N different symbols with uniform equal probabilities should have N bit of entropy.

Anyway, I think the pull request handles these issues.
Please, review it.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
