### PR TITLE
fix bug in horizontal seam_carve and seam_carve test. issue :#2545

### DIFF
--- a/skimage/transform/seam_carving.py
+++ b/skimage/transform/seam_carving.py
@@ -55,12 +55,13 @@ def seam_carve(image, energy_map, mode, num, border=1, force_copy=True):
         image = image[..., np.newaxis]
 
     if mode == 'horizontal':
-        image = np.transpose(image, (1, 0, 2))
+        image = np.swapaxes(image, 0, 1)
+        energy_map = np.swapaxes(energy_map, 0, 1)
 
     image = np.ascontiguousarray(image)
     out = _seam_carve_v(image, energy_map, num, border)
 
     if mode == 'horizontal':
-        out = np.transpose(out, (1, 0, 2))
+        out = np.swapaxes(out, 0, 1)
 
     return np.squeeze(out)

--- a/skimage/transform/tests/test_seam_carving.py
+++ b/skimage/transform/tests/test_seam_carving.py
@@ -7,17 +7,25 @@ def test_seam_carving():
     img = np.array([[0, 0, 1, 0, 0],
                     [0, 0, 1, 0, 0],
                     [0, 0, 1, 0, 0],
-                    [0, 1, 0, 0, 0],
-                    [1, 0, 0, 0, 0]], dtype=np.float)
+                    [0, 1, 0, 0, 1],
+                    [1, 0, 0, 1, 0]], dtype=np.float)
+
+    expected = np.array([[0, 0, 0, 0],
+                        [0, 0, 0, 0],
+                        [0, 0, 0, 0],
+                        [0, 0, 0, 1],
+                        [0, 0, 1, 0]], dtype=np.float)
+
     energy = 1 - img
 
     out = transform.seam_carve(img, energy, 'vertical', 1, border=0)
-    testing.assert_allclose(out, 0)
+    testing.assert_equal(out, expected)
 
     img = img.T
     energy = energy.T
+
     out = transform.seam_carve(img, energy, 'horizontal', 1, border=0)
-    testing.assert_allclose(out, 0)
+    testing.assert_equal(out, expected.T)
 
 
 if __name__ == '__main__':

--- a/skimage/transform/tests/test_seam_carving.py
+++ b/skimage/transform/tests/test_seam_carving.py
@@ -15,6 +15,7 @@ def test_seam_carving():
     testing.assert_allclose(out, 0)
 
     img = img.T
+    energy = energy.T
     out = transform.seam_carve(img, energy, 'horizontal', 1, border=0)
     testing.assert_allclose(out, 0)
 


### PR DESCRIPTION
## Description

#### The problem:

Re: issue #2545 :  when calling `seam_carve` with `mode="horizontal"`,  `energy_map` was not transposed with the image, so it was not working properly. Additionally the `energy_map` arg passed to  to `seam_carve` in tests was  not transposed when being called with `mode="horizontal"` so the image and the energy map were mismatched.  

#### What I've done: 

- Added line to flip the `energy_map` when `seam_carve` is called in `horizontal` mode.  before passing it to `_seam_carve_v`. 
    **Note**: I've used `np.swapaxes` throughout the function in place of `np.transpose(img, (1, 0, 2))` as i feel it's maybe a little cleaner but if reviewers prefer I can revert.

- Transposed the `energy` var in  `test_seam_carving` before passing it to `seam_carve` (so that it has the same orientation as the test image). Tests now pass.


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)  - I think so ... I have linted,  but please let me know if there are any style issues.
- [n/a] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)  - PR does not modify existing docstrings.
- [n/a] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests - corrections to existing test

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
Closes #2545.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
