### PR TITLE
Generalised existing CLAHE implementation to support n dimensions

### DIFF
--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -161,7 +161,7 @@ def _clahe(image, kernel_size, clip_limit, nbins=128):
     starts = [0] * image.ndim
     prev_inds = [0] * image.ndim
 
-    for inds in np.ndindex(*[ns[dim]+1 for dim in range(image.ndim)]):
+    for inds in np.ndindex(*[ns[dim] + 1 for dim in range(image.ndim)]):
 
         for dim in range(image.ndim):
             if inds[dim] != prev_inds[dim]:
@@ -170,7 +170,7 @@ def _clahe(image, kernel_size, clip_limit, nbins=128):
         for dim in range(image.ndim):
             if dim < image.ndim - 1:
                 if inds[dim] != prev_inds[dim]:
-                    starts[dim+1] = 0
+                    starts[dim + 1] = 0
 
         prev_inds = inds[:]
 
@@ -190,7 +190,7 @@ def _clahe(image, kernel_size, clip_limit, nbins=128):
                 uppers[dim] = inds[dim]
 
         maps = []
-        for edge in np.ndindex(*([2]*image.ndim)):
+        for edge in np.ndindex(*([2] * image.ndim)):
             maps.append(map_array[tuple([[lowers, uppers][edge[dim]][dim]
                                          for dim in range(image.ndim)])])
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -262,13 +262,12 @@ def test_adapthist_grayscale_Nd():
     np.random.seed(0)
     img2d = np.random.random((25, 25))
     img3d = np.array([img2d] * 25)
-    with expected_warnings(['precision loss']):
-        adapted2d = exposure.equalize_adapthist(img2d,
-                                                kernel_size=5,
-                                                clip_limit=0.01)
-        adapted3d = exposure.equalize_adapthist(img3d,
-                                                kernel_size=5,
-                                                clip_limit=0.01)
+    adapted2d = exposure.equalize_adapthist(img2d,
+                                            kernel_size=5,
+                                            clip_limit=0.01)
+    adapted3d = exposure.equalize_adapthist(img3d,
+                                            kernel_size=5,
+                                            clip_limit=0.01)
 
     # check that dimensions of input and output match
     assert img2d.shape == adapted2d.shape

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -252,6 +252,33 @@ def test_adapthist_alpha():
     assert_almost_equal(norm_brightness_err(full_scale, adapted), 0.0248, 3)
 
 
+def test_adapthist_grayscale_Nd():
+    """
+    Test for n-dimensional consistency with float images
+    Note: Currently if img.ndim == 3, img.shape[2] > 4 must hold for the image
+    not to be interpreted as a color image by @adapt_rgb
+    """
+    # construct a 2d image and a stack of it
+    np.random.seed(0)
+    img2d = np.random.random((25, 25))
+    img3d = np.array([img2d] * 25)
+    with expected_warnings(['precision loss']):
+        adapted2d = exposure.equalize_adapthist(img2d,
+                                                kernel_size=5,
+                                                clip_limit=0.01)
+        adapted3d = exposure.equalize_adapthist(img3d,
+                                                kernel_size=5,
+                                                clip_limit=0.01)
+
+    # check that dimensions of input and output match
+    assert img2d.shape == adapted2d.shape
+    assert img3d.shape == adapted3d.shape
+
+    # check that the result from the stack of 2d images is similar
+    # to the underlying 2d image
+    assert np.mean(np.abs(adapted2d - adapted3d[12])) < 0.06
+
+
 def peak_snr(img1, img2):
     """Peak signal to noise ratio of two images
 


### PR DESCRIPTION
## Description
CLAHE (https://en.wikipedia.org/wiki/Adaptive_histogram_equalization) is well defined for n dimensions and I extended the existing implementation in a straight forward manner.

  - only change in main function equalize_adapthist: handling of default argument
  - changed: _clahe and interpolate naturally extended to nd
  - unchanged: functions clip_histogram and map_histogram

First (and only) tests I performed:
- using the new equalize_adapthist on a 2d np.uint16 image yields the same result as the old equalize_adapthist
- new equalize_adapthist yields sensible results in 3d


## Checklist
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests

## References
- the unwanted artefact reported in #2219 is still present (EDIT: fixes #2219)

## For reviewers
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
