### PR TITLE
updated second link, first link still has paywall

### DIFF
--- a/skimage/feature/censure.py
+++ b/skimage/feature/censure.py
@@ -153,7 +153,7 @@ class CENSURE(FeatureDetector):
     .. [2] Adam Schmidt, Marek Kraft, Michal Fularz and Zuzanna Domagala
            "Comparative Assessment of Point Feature Detectors and
            Descriptors in the Context of Robot Navigation"
-           http://www.jamris.org/01_2013/saveas.php?QUEST=JAMRIS_No01_2013_P_11-20.pdf
+           http://yadda.icm.edu.pl/yadda/element/bwmeta1.element.baztech-268aaf28-0faf-4872-a4df-7e2e61cb364c/c/Schmidt_comparative.pdf
 
     Examples
     --------

--- a/skimage/feature/censure.py
+++ b/skimage/feature/censure.py
@@ -148,12 +148,14 @@ class CENSURE(FeatureDetector):
     .. [1] Motilal Agrawal, Kurt Konolige and Morten Rufus Blas
            "CENSURE: Center Surround Extremas for Realtime Feature
            Detection and Matching",
-           http://link.springer.com/content/pdf/10.1007%2F978-3-540-88693-8_8.pdf
+           https://link.springer.com/chapter/10.1007/978-3-540-88693-8_8
+           DOI:10.1007/978-3-540-88693-8_8
 
     .. [2] Adam Schmidt, Marek Kraft, Michal Fularz and Zuzanna Domagala
            "Comparative Assessment of Point Feature Detectors and
            Descriptors in the Context of Robot Navigation"
            http://yadda.icm.edu.pl/yadda/element/bwmeta1.element.baztech-268aaf28-0faf-4872-a4df-7e2e61cb364c/c/Schmidt_comparative.pdf
+           DOI:10.1.1.465.1117
 
     Examples
     --------


### PR DESCRIPTION
## Description
Addressed second part of issue 2767 (feature/censure.py references), found link for second reference. Could not find a link for the first reference without a paywall.  

## References
Closes #2767.

## For reviewers
(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
