### PR TITLE
Remove warning when data type is bool

### DIFF
--- a/skimage/morphology/misc.py
+++ b/skimage/morphology/misc.py
@@ -118,7 +118,7 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
                          "relabeling the input with `scipy.ndimage.label` or "
                          "`skimage.morphology.label`.")
 
-    if len(component_sizes) == 2:
+    if len(component_sizes) == 2 and ar.dtype != bool:
         warn("Only one label was provided to `remove_small_objects`. "
              "Did you mean to use a boolean array?")
 


### PR DESCRIPTION
## Description
Small fix - `remove_small_objects ` was giving unwanted warn when the array type is already bool.
## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
