### PR TITLE
Fix bug in `color.convert_colorspace` for YCbCr, YPbPr

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -98,26 +98,21 @@ def convert_colorspace(arr, fromspace, tospace):
     ----------
     arr : array_like
         The image to convert.
-    fromspace : str
-        The color space to convert from. Valid color space strings are
-        ``['RGB', 'HSV', 'RGB CIE', 'XYZ', 'YUV', 'YIQ', 'YPbPr', 'YCbCr']``.
-        Value may also be specified as lower case.
-
-    tospace : str
-        The color space to convert to. Valid color space strings are
-        ``['RGB', 'HSV', 'RGB CIE', 'XYZ', 'YUV', 'YIQ', 'YPbPr', 'YCbCr']``.
-        Value may also be specified as lower case.
+    fromspace : {'RGB', 'HSV', 'RGB CIE', 'XYZ', 'YUV', 'YIQ', 'YPbPr', 'YCbCr'}
+        The color space to convert from. Can be specified in lower case.
+    tospace : {'RGB', 'HSV', 'RGB CIE', 'XYZ', 'YUV', 'YIQ', 'YPbPr', 'YCbCr'}
+        The color space to convert to. Can be specified in lower case.
 
     Returns
     -------
-    newarr : ndarray
+    out : ndarray
         The converted image.
 
     Notes
     -----
-    Conversion occurs through the "central" RGB color space, i.e. conversion
-    from XYZ to HSV is implemented as ``XYZ -> RGB -> HSV`` instead of
-    directly.
+    Conversion is performed through the "central" RGB color space,
+    i.e. conversion from XYZ to HSV is implemented as ``XYZ -> RGB -> HSV``
+    instead of directly.
 
     Examples
     --------
@@ -125,19 +120,21 @@ def convert_colorspace(arr, fromspace, tospace):
     >>> img = data.astronaut()
     >>> img_hsv = convert_colorspace(img, 'RGB', 'HSV')
     """
-    fromdict = {'RGB': lambda im: im, 'HSV': hsv2rgb, 'RGB CIE': rgbcie2rgb,
-                'XYZ': xyz2rgb, 'YUV': yuv2rgb, 'YIQ': yiq2rgb,
-                'YPbPr': ypbpr2rgb, 'YCbCr': ycbcr2rgb}
-    todict = {'RGB': lambda im: im, 'HSV': rgb2hsv, 'RGB CIE': rgb2rgbcie,
-              'XYZ': rgb2xyz, 'YUV': rgb2yuv, 'YIQ': rgb2yiq,
-              'YPbPr': rgb2ypbpr, 'YCbCr': rgb2ycbcr}
+    fromdict = {'rgb': lambda im: im, 'hsv': hsv2rgb, 'rgb cie': rgbcie2rgb,
+                'xyz': xyz2rgb, 'yuv': yuv2rgb, 'yiq': yiq2rgb,
+                'ypbpr': ypbpr2rgb, 'ycbcr': ycbcr2rgb}
+    todict = {'rgb': lambda im: im, 'hsv': rgb2hsv, 'rgb cie': rgb2rgbcie,
+              'xyz': rgb2xyz, 'yuv': rgb2yuv, 'yiq': rgb2yiq,
+              'ypbpr': rgb2ypbpr, 'ycbcr': rgb2ycbcr}
 
-    fromspace = fromspace.upper()
-    tospace = tospace.upper()
+    fromspace = fromspace.lower()
+    tospace = tospace.lower()
     if fromspace not in fromdict.keys():
-        raise ValueError('fromspace needs to be one of %s' % fromdict.keys())
+        msg = '`fromspace` has to be one of {}'.format(fromdict.keys())
+        raise ValueError(msg)
     if tospace not in todict.keys():
-        raise ValueError('tospace needs to be one of %s' % todict.keys())
+        msg = '`tospace` has to be one of {}'.format(todict.keys())
+        raise ValueError(msg)
 
     return todict[tospace](fromdict[fromspace](arr))
 

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -129,10 +129,10 @@ def convert_colorspace(arr, fromspace, tospace):
 
     fromspace = fromspace.lower()
     tospace = tospace.lower()
-    if fromspace not in fromdict.keys():
+    if fromspace not in fromdict:
         msg = '`fromspace` has to be one of {}'.format(fromdict.keys())
         raise ValueError(msg)
-    if tospace not in todict.keys():
+    if tospace not in todict:
         msg = '`tospace` has to be one of {}'.format(todict.keys())
         raise ValueError(msg)
 

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -40,8 +40,7 @@ from skimage.color import (rgb2hsv, hsv2rgb,
                            rgb2ypbpr, ypbpr2rgb,
                            rgb2ycbcr, ycbcr2rgb,
                            rgba2rgb,
-                           guess_spatial_dimensions
-                           )
+                           guess_spatial_dimensions)
 
 from skimage import data_dir
 from skimage._shared._warnings import expected_warnings
@@ -223,24 +222,26 @@ class TestColorconv(TestCase):
                             self.colbars_array)
 
     def test_convert_colorspace(self):
-        colspaces = ['HSV', 'RGB CIE', 'XYZ']
-        colfuncs_from = [hsv2rgb, rgbcie2rgb, xyz2rgb]
-        colfuncs_to = [rgb2hsv, rgb2rgbcie, rgb2xyz]
+        colspaces = ['HSV', 'RGB CIE', 'XYZ', 'YCbCr', 'YPbPr']
+        colfuncs_from = [hsv2rgb, rgbcie2rgb, xyz2rgb, ycbcr2rgb, ypbpr2rgb]
+        colfuncs_to = [rgb2hsv, rgb2rgbcie, rgb2xyz, rgb2ycbcr, rgb2ypbpr]
 
-        assert_almost_equal(convert_colorspace(self.colbars_array, 'RGB',
-                                               'RGB'), self.colbars_array)
+        assert_almost_equal(
+            convert_colorspace(self.colbars_array, 'RGB', 'RGB'),
+            self.colbars_array)
+
         for i, space in enumerate(colspaces):
             gt = colfuncs_from[i](self.colbars_array)
-            assert_almost_equal(convert_colorspace(self.colbars_array, space,
-                                                  'RGB'), gt)
+            assert_almost_equal(
+                convert_colorspace(self.colbars_array, space, 'RGB'), gt)
             gt = colfuncs_to[i](self.colbars_array)
-            assert_almost_equal(convert_colorspace(self.colbars_array, 'RGB',
-                                                   space), gt)
+            assert_almost_equal(
+                convert_colorspace(self.colbars_array, 'RGB', space), gt)
 
-        self.assertRaises(ValueError, convert_colorspace, self.colbars_array,
-                                                           'nokey', 'XYZ')
-        self.assertRaises(ValueError, convert_colorspace, self.colbars_array,
-                                                           'RGB', 'nokey')
+        self.assertRaises(ValueError, convert_colorspace,
+                          self.colbars_array, 'nokey', 'XYZ')
+        self.assertRaises(ValueError, convert_colorspace,
+                          self.colbars_array, 'RGB', 'nokey')
 
     def test_rgb2grey(self):
         x = np.array([1, 1, 1]).reshape((1, 1, 3)).astype(np.float)


### PR DESCRIPTION
## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
Closes https://github.com/scikit-image/scikit-image/issues/2679.

## For reviewers

(Don't remove the checklist below.)

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
