### PR TITLE
WIP: Deal with long running command on travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all clean test
 PYTHON=python
-PYTESTS=py.test
+PYTESTS=pytest
 
 all:
 	$(PYTHON) setup.py build_ext --inplace

--- a/skimage/future/graph/graph_cut.py
+++ b/skimage/future/graph/graph_cut.py
@@ -111,7 +111,7 @@ def cut_normalized(labels, rag, thresh=0.001, num_cuts=10, in_place=True,
     >>> from skimage import data, segmentation
     >>> from skimage.future import graph
     >>> img = data.astronaut()
-    >>> labels = segmentation.slic(img, compactness=30, n_segments=400)
+    >>> labels = segmentation.slic(img)
     >>> rag = graph.rag_mean_color(img, labels, mode='similarity')
     >>> new_labels = graph.cut_normalized(labels, rag)
 

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -18,7 +18,7 @@ if [[ $TRAVIS_OS_NAME == "osx" ]]; then
 fi
 
 section "Test.with.min.requirements"
-py.test $TEST_ARGS skimage
+pytest $TEST_ARGS skimage
 section_end "Test.with.min.requirements"
 
 section "Build.docs"
@@ -115,7 +115,7 @@ section "Test.with.optional.dependencies"
 if [[ $OPTIONAL_DEPS == 1 ]]; then
     TEST_ARGS="$TEST_ARGS --cov=skimage"
 fi
-py.test $TEST_ARGS
+pytest $TEST_ARGS
 
 section_end "Test.with.optional.dependencies"
 


### PR DESCRIPTION
## Description

Changes
```
    >>> labels = segmentation.slic(img, compactness=30, n_segments=400)
```
to
```
    >>> labels = segmentation.slic(img)
```
in ``skimage/future/graph/graph_cut.py``.  On my laptop, when I run
```
PYTHONPATH=. pytest --doctest-modules  skimage/future/graph/graph_cut.py
```
this changes the run time from about 13s to 4s.  (How 13s translates to over 10m on Travis, I do not know.)

To see if this reduces the frequency of travis timeout failures, perhaps someone with permission can periodically restart travis on this PR (at least 2 more times) and check.

(I also changed the  deprecated ``py.test`` to  ``pytest``, but that shouldn't change anything.)

Before merging this, we should create an issue so that we return to this later.  However, if this helps prevent timeouts (at least until we figure out why travis keeps timing out on this doctest), I recommend we merge it.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
