### PR TITLE
Deprecate the novice module (#2742)

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -38,3 +38,4 @@ Version 0.16
   in ``skimage.transform.tests.test_pyramids.py`` and
   ``skimage.transform.tests.test_warps.py``.
 * Remove deprecated argument ``visualise`` from function skimage.feature.hog
+* Remove deprecated module ``skimage.novice``

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -34,6 +34,7 @@ Deprecations
 ------------
 - ``skimage.util.montage2d`` is deprecated and will be removed in 0.15.
   Use ``skimage.util.montage`` instead.
+- ``skimage.novice`` is deprecated and will be removed in 0.16.
 
 
 Contributors to this release

--- a/skimage/novice/__init__.py
+++ b/skimage/novice/__init__.py
@@ -96,7 +96,11 @@ An image can also be restored to its original state after modification:
 >>> picture.compare()  # doctest: +SKIP
 
 """
+import warnings
 from ._novice import Picture, open, colors, color_dict
 
+
+warnings.warn("This module was deprecated in version 0.14. "
+              "It will be removed in 0.16.")
 
 __all__ = ['Picture', 'open', 'colors', 'color_dict']


### PR DESCRIPTION
## Description
This marks the `novice` module as deprecated as required for #2742.

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

## References
Closes #2742.

## For reviewers

(Don't remove the checklist below.)

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
