### PR TITLE
[WIP] Refactor histogram to separate logic for multi- and single-channel images

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -64,6 +64,12 @@ def histogram(image, nbins=256):
              "computed on the flattened image. You can instead "
              "apply this function to each color channel.")
 
+    hist, bin_edges = _histogram(image, nbins)
+    return hist, bin_edges
+
+
+def _histogram(image, nbins):
+
     # For integer types, histogramming with bincount is more efficient.
     if np.issubdtype(image.dtype, np.integer):
         offset = 0


### PR DESCRIPTION
## Description
In preparation for future histogram options for multichannel images, this PR separates the single-channel histogram calculation to an internal function, with any channel-number dependent branching (currently only the warning) in the exposed function.

## Checklist
- [x] No new functionality
- [ ] Rebase on #2479

## References
- The changes in #2479 probably need to be taken into account
- This enables cleaner branching for implementing #2788

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
