### PR TITLE
[WIP] Add 3D support to sobel

### DIFF
--- a/skimage/filters/__init__.py
+++ b/skimage/filters/__init__.py
@@ -1,6 +1,6 @@
 from .lpi_filter import inverse, wiener, LPIFilter2D
 from ._gaussian import gaussian
-from .edges import (sobel, sobel_h, sobel_v,
+from .edges import (sobel, sobel_h, sobel_v, sobel_axis,
                     scharr, scharr_h, scharr_v,
                     prewitt, prewitt_h, prewitt_v,
                     roberts, roberts_pos_diag, roberts_neg_diag,
@@ -25,6 +25,7 @@ __all__ = ['inverse',
            'sobel',
            'sobel_h',
            'sobel_v',
+           'sobel_axis',
            'scharr',
            'scharr_h',
            'scharr_v',

--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -169,6 +169,53 @@ def sobel_v(image, mask=None):
     result = convolve(image, VSOBEL_WEIGHTS)
     return _mask_filter_result(result, mask)
 
+def get_sobel_weights(ndim):
+    """Produce Sobel kernel for axis 0.
+
+    Parameters
+    ----------
+    ndim : number of dimensions
+
+    Returns
+    -------
+    output : max(ndim,1)-dimensional array containing Sobel kernel in
+        direction of axis 0.
+
+    Notes
+    -----
+    If ndim < 0, then ndim is assumed to be 1.
+    To change the axis, use transpose(0, axis).
+    """
+    ret = np.array([1, 0, -1])
+    h = np.array([1, 2, 1])
+    for i in range(ndim - 1):
+        ret = np.multiply.outer(ret, h)
+    factor = ret.sum(1).max() #  Find maximum factor for normalization
+    return ret / factor
+
+def sobel_axis(image, axis, mask=None):
+    """Find the axis edges of an image using the Sobel transform.
+
+    Parameters
+    ----------
+    image : 2-D or 3-D array
+        Image to process.
+    mask : 2-D or 3-D array, optional
+        An optional mask to limit the application to a certain area.
+        Must match the dimensions of image.
+        Note that pixels surrounding masked regions are also masked to
+        prevent masked regions from affecting the result.
+
+    Returns
+    -------
+    output : array
+        The Sobel edge map. Matches the dimensions of image.
+    """
+    image = img_as_float(image)
+    weights = get_sobel_weights(image.ndim).swapaxes(0, axis)
+    result = convolve(image, weights)
+    return _mask_filter_result(result, mask)
+
 
 def scharr(image, mask=None):
     """Find the edge magnitude using the Scharr transform.

--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -169,6 +169,7 @@ def sobel_v(image, mask=None):
     result = convolve(image, VSOBEL_WEIGHTS)
     return _mask_filter_result(result, mask)
 
+
 def get_sobel_weights(ndim):
     """Produce Sobel kernel for axis 0.
 
@@ -190,8 +191,9 @@ def get_sobel_weights(ndim):
     h = np.array([1, 2, 1])
     for i in range(ndim - 1):
         ret = np.multiply.outer(ret, h)
-    factor = ret.sum(1).max() #  Find maximum factor for normalization
+    factor = ret.sum(1).max()  # Find maximum factor for normalization
     return ret / factor
+
 
 def sobel_axis(image, axis, mask=None):
     """Find the axis edges of an image using the Sobel transform.

--- a/skimage/filters/tests/test_edges.py
+++ b/skimage/filters/tests/test_edges.py
@@ -132,6 +132,7 @@ def test_sobel_v_horizontal():
     result = filters.sobel_v(image)
     assert_allclose(result, 0)
 
+
 def test_sobel_axis_1_line():
     """Sobel over axis 1 on an edge along ax 0 should be a line along
     axis 0."""
@@ -142,6 +143,7 @@ def test_sobel_axis_1_line():
     j[np.abs(i) == 5] = 10000
     assert (np.all(result[j == 0] == 1))
     assert (np.all(result[np.abs(j) > 1] == 0))
+
 
 def test_sobel_axis_2_line():
     """Sobel over axis 2 on an edge orthogonal to ax 2 should be a plane
@@ -159,6 +161,7 @@ def test_sobel_axis_2_line():
     assert (np.all(result[grid == 0] >= 1))
     # and most likely < 5000
     assert (np.all(result[np.abs(grid) > 5000] == 0))
+
 
 def test_sobel_axis_3_zero():
     """Sobel over axis 3 on an edge orthogonal to ax 2 should be zero."""

--- a/skimage/filters/tests/test_edges.py
+++ b/skimage/filters/tests/test_edges.py
@@ -132,6 +132,42 @@ def test_sobel_v_horizontal():
     result = filters.sobel_v(image)
     assert_allclose(result, 0)
 
+def test_sobel_axis_1_line():
+    """Sobel over axis 1 on an edge along ax 0 should be a line along
+    axis 0."""
+    i, j = np.mgrid[-5:6, -5:6]
+    image = (j >= 0).astype(float)
+    result = filters.sobel_axis(image, 1)
+    # Fudge the eroded points
+    j[np.abs(i) == 5] = 10000
+    assert (np.all(result[j == 0] == 1))
+    assert (np.all(result[np.abs(j) > 1] == 0))
+
+def test_sobel_axis_2_line():
+    """Sobel over axis 2 on an edge orthogonal to ax 2 should be a plane
+    orthogonal to axis 2.
+    """
+    grids = np.mgrid[-5:6, -5:6, -5:6]
+    grid = grids[2]
+    image = (grid >= 0).astype(float)
+    result = filters.sobel_axis(image, 2)
+    # Acknowledge that outer edges are not supposed to be detected
+    for fudge_grid in grids:
+        if grid is not fudge_grid:
+            grid[np.abs(fudge_grid) == 5] = 10000
+    # N-dimensional value of detected pixels will be >=1 (but not always ==1)
+    assert (np.all(result[grid == 0] >= 1))
+    # and most likely < 5000
+    assert (np.all(result[np.abs(grid) > 5000] == 0))
+
+def test_sobel_axis_3_zero():
+    """Sobel over axis 3 on an edge orthogonal to ax 2 should be zero."""
+    grids = np.mgrid[-5:6, -5:6, -5:6, -5:6]
+    grid = grids[2]
+    image = (grid >= 0).astype(float)
+    result = filters.sobel_axis(image, 3)
+    assert_allclose(result, 0)
+
 
 def test_scharr_zeros():
     """Scharr on an array of all zeros."""


### PR DESCRIPTION
Added generalized version of Sobel edge detection in a particular direction. Accepts N-dimensional images, using h=[1, 2, 1] and h'=[1, 0, -1]. Only tested for 3D images. however.

## Description

This change provides a way to implement a full Sobel operator, as noted in https://github.com/scikit-image/scikit-image/issues/2247

The sobel implementation is directional, and provides a function generating kernels. The values of sobel function can be *greater than 1*, despite normalizing the matrix. Dimensions above 3 were not checked, since I don't know what to expect and how to write tests.

Adding a full Sobel shouldn't be difficult, e.g. by analogy to 2-dim Sobel:

```
        res = numpy.empty_like(image)
        for axis in range(image.ndim):
            res += sobel(image, axis, mask) ** 2
        res /= np.sqrt(2)
```

I did not implement that, since I don't know whether sqrt(2) is a suitable factor for higher dimensions.

## Checklist

- [ ] Full sobel
- [ ] Unit tests for fimensions above 3

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
