### PR TITLE
[WIP] Optional multichannel histograms 

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -19,7 +19,7 @@ DTYPE_RANGE.update({'uint10': (0, 2 ** 10 - 1),
                     'float': dtype_range[np.float64]})
 
 
-def histogram(image, nbins=256):
+def histogram(image, nbins=256, multichannel=True):
     """Return histogram of image.
 
     Unlike `numpy.histogram`, this function returns the centers of bins and

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -64,6 +64,12 @@ def histogram(image, nbins=256):
              "computed on the flattened image. You can instead "
              "apply this function to each color channel.")
 
+    hist, bin_edges = _histogram(image, nbins)
+    return hist, bin_edges
+
+
+def _histogram(image, nbins):
+
     # For integer types, histogramming with bincount is more efficient.
     if np.issubdtype(image.dtype, np.integer):
         offset = 0

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -26,9 +26,11 @@ def histogram(image, nbins=256, multichannel=True):
     does not rebin integer arrays. For integer arrays, each integer value has
     its own bin, which improves speed and intensity-resolution.
 
-    The histogram is computed on the flattened image: for color images, the
-    function should be used separately on each channel to obtain a histogram
-    for each color channel.
+    If multichannel is not set, the histogram is computed on the flattened
+    image. For color or multichannel images, the function should either be
+    the function should be either be used separately on each
+    channel to obtain a histogram for each color channel with separate binning,
+    or by setting multichannel=True to use a common binning for all channels.
 
     Parameters
     ----------

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -19,7 +19,7 @@ DTYPE_RANGE.update({'uint10': (0, 2 ** 10 - 1),
                     'float': dtype_range[np.float64]})
 
 
-def histogram(image, nbins=256, multichannel=True):
+def histogram(image, nbins=256, multichannel=False):
     """Return histogram of image.
 
     Unlike `numpy.histogram`, this function returns the centers of bins and

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -70,7 +70,15 @@ def histogram(image, nbins=256, multichannel=True):
              "apply this function to each color channel, or set "
              "multichannel=True")
 
-    hist, bin_edges = _histogram(image, nbins)
+    if multichannel:
+        channels = sh[-1]
+        hist = np.empty(channels, nbins)
+        for chan in range(channels):
+            hist[chan, :], bin_centers[chan, :] = _histogram(image, nbins)
+
+    else:
+        hist, bin_edges = _histogram(image, nbins)
+
     return hist, bin_edges
 
 

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -72,14 +72,15 @@ def histogram(image, nbins=256, multichannel=False):
 
     if multichannel:
         channels = sh[-1]
-        hist = np.empty(channels, nbins)
+        hist = np.empty((channels, nbins))
+        bin_centers = np.empty((channels, nbins))
         for chan in range(channels):
             hist[chan, :], bin_centers[chan, :] = _histogram(image, nbins)
 
     else:
-        hist, bin_edges = _histogram(image, nbins)
+        hist, bin_centers = _histogram(image, nbins)
 
-    return hist, bin_edges
+    return hist, bin_centers
 
 
 def _histogram(image, nbins):

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -37,6 +37,9 @@ def histogram(image, nbins=256, multichannel=True):
     nbins : int
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
+    multichannel : bool, optional
+        If True, calculates the histogram for all the channels using the same
+        binning.
 
     Returns
     -------

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -62,10 +62,11 @@ def histogram(image, nbins=256, multichannel=True):
     (array([107432, 154712]), array([ 0.25,  0.75]))
     """
     sh = image.shape
-    if len(sh) == 3 and sh[-1] < 4:
+    if len(sh) == 3 and sh[-1] < 4 and not multichannel:
         warn("This might be a color image. The histogram will be "
              "computed on the flattened image. You can instead "
-             "apply this function to each color channel.")
+             "apply this function to each color channel, or set "
+             "multichannel=True")
 
     hist, bin_edges = _histogram(image, nbins)
     return hist, bin_edges

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -33,18 +33,20 @@ def test_all_negative_image():
     assert frequencies[-1] == 1
     assert_array_equal(frequencies[1:-1], 0)
 
+
 # Test multichannel histograms
 # ============================
 
 def test_multichannel_hist_common_bins_uint8():
     """Check that all channels use the same binning."""
-    im = np.array([[0],[127]], dtype=np.int8)
+    im = np.array([[0], [127]], dtype=np.int8)
     frequencies, bin_centers = exposure.histogram(im, multichannel=True)
     assert_array_equal(bin_centers, np.arange(0, 128))
-    assert frequencies[0,  0] == 1
+    assert frequencies[0, 0] == 1
     assert frequencies[0, -1] == 0
-    assert frequencies[1,  0] == 0
+    assert frequencies[1, 0] == 0
     assert frequencies[1, -1] == 1
+
 
 # Test histogram equalization
 # ===========================

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -33,6 +33,18 @@ def test_all_negative_image():
     assert frequencies[-1] == 1
     assert_array_equal(frequencies[1:-1], 0)
 
+# Test multichannel histograms
+# ============================
+
+def test_multichannel_hist_common_bins_uint8():
+    """Check that all channels use the same binning."""
+    im = np.array([[0],[127]], dtype=np.int8)
+    frequencies, bin_centers = exposure.histogram(im, multichannel=True)
+    assert_array_equal(bin_centers, np.arange(0, 128))
+    assert frequencies[0,  0] == 1
+    assert frequencies[0, -1] == 0
+    assert frequencies[1,  0] == 0
+    assert frequencies[1, -1] == 1
 
 # Test histogram equalization
 # ===========================


### PR DESCRIPTION
## Description
Doing multichannel histograms by applying histogram separately for each channel is fine if you only care about the separate histograms, but comparing and visualizing histograms requires in general for them to be calculated using the same binning for each channel. Generating single-binning multichannel histograms is easiest to implement in histogram by adding a multichannel parameter which does exactly this. This would default to False (or None) which would replicate current behaviour, and when True would return a 2d array of histograms (one per channel).

## Checklist
Calculation of histograms for all the channels using
- [x] same number of bins
- [ ] the same bins (needs a way to specify either bins or range + nbins)

API changes
- [x] A new option to handle multichannel histogram generation in histogram

Documentation
- [ ] Example of multichannel=True usage in docstring
- [ ] Example in Gallery

## References
- Since single-channel images and multichannel images use the same single-channel histogram calculation, #2786 makes code branching cleaner to implement (and this PR builds on top of it).
- Implementing the common binning may requires either separate range parameter (discussed at #2479) or an explicit way to pass the bins.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
