### PR TITLE
Add Gaussian filter-based antialiasing to resize

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -24,6 +24,8 @@ Version 0.15
 * In ``skimage.transform.rescale``, set default value of ``mode`` to
   ``'reflect'``.
 * Remove deprecated ``skimage.util.montage2d`` and corresponding tests.
+* In ``skimage.transform.resize`` change default argument from
+  ``anti_aliasing=None`` to ``anti_aliasing=True``.
 
 Version 0.16
 ------------

--- a/doc/examples/transform/plot_rescale.py
+++ b/doc/examples/transform/plot_rescale.py
@@ -10,30 +10,27 @@ along each axis.
 `Resize` serves the same purpose, but allows to specify an output image shape
 instead of a scaling factor.
 
-`Downscale` operation serves the purpose of downsampling an n-dimensional image
-by Gaussian smoothing and by calculating local mean on the elements of each
-block of the size factors given as a parameter to the function.
+`Downscale` serves the purpose of downsampling an n-dimensional image by
+calculating local mean on the elements of each block of the size factors given
+as a parameter to the function.
 
-Note that when downsampling an image, `resize` and `rescale` might produce
-aliasing effects since they are not appropriately resampling the input image.
-Please, refer to the `downsize`, `downscale`, and `downscale_local_mean`
-functions in this case.
+Note that when downsampling an image, `resize` and `rescale` should perform
+Gaussian smoothing to avoid aliasing artifacts.
 
 """
 
 import matplotlib.pyplot as plt
 
 from skimage import data
-from skimage.transform import rescale, resize, downscale, downscale_local_mean
+from skimage.transform import rescale, resize, downscale_local_mean
 
 image = data.camera()
 
 image_rescaled = rescale(image, 0.5)
 image_resized = resize(image, (400, 400), mode='reflect')
-image_downscaled = downscale(image, 2)
-image_downscaled_local_mean = downscale_local_mean(image, (2, 2))
+image_downscaled = downscale_local_mean(image, (2, 2))
 
-fig, axes = plt.subplots(nrows=3, ncols=2, sharex=True, sharey=True)
+fig, axes = plt.subplots(nrows=2, ncols=2, sharex=True, sharey=True)
 
 ax = axes.ravel()
 
@@ -47,10 +44,7 @@ ax[2].imshow(image_resized, cmap='gray')
 ax[2].set_title("Resized image")
 
 ax[3].imshow(image_downscaled, cmap='gray')
-ax[3].set_title("Downscaled image using Gaussian smoothing")
-
-ax[4].imshow(image_downscaled_local_mean, cmap='gray')
-ax[4].set_title("Downscaled image using local averaging")
+ax[3].set_title("Downscaled image")
 
 ax[0].set_xlim(0, 512)
 ax[0].set_ylim(512, 0)

--- a/doc/examples/transform/plot_rescale.py
+++ b/doc/examples/transform/plot_rescale.py
@@ -3,31 +3,37 @@
 Rescale, resize, and downscale
 ==============================
 
-`Rescale` operation resizes an image by a given scaling factor.
-The scaling factor can either be a single floating point value,
-or multiple values - one along each axis.
+`Rescale` operation resizes an image by a given scaling factor. The scaling
+factor can either be a single floating point value, or multiple values - one
+along each axis.
 
-`Resize` serves the same purpose, but allows to specify an output
-image shape instead of a scaling factor.
+`Resize` serves the same purpose, but allows to specify an output image shape
+instead of a scaling factor.
 
-`Downscale` operation serves the purpose of downsampling an
-n-dimensional image by calculating local mean on the elements of
-each block of the size factors given as a parameter to the function.
+`Downscale` operation serves the purpose of downsampling an n-dimensional image
+by Gaussian smoothing and by calculating local mean on the elements of each
+block of the size factors given as a parameter to the function.
+
+Note that when downsampling an image, `resize` and `rescale` might produce
+aliasing effects since they are not appropriately resampling the input image.
+Please, refer to the `downsize`, `downscale`, and `downscale_local_mean`
+functions in this case.
+
 """
 
 import matplotlib.pyplot as plt
 
 from skimage import data
-from skimage.transform import rescale, resize, downscale_local_mean
+from skimage.transform import rescale, resize, downscale, downscale_local_mean
 
 image = data.camera()
 
 image_rescaled = rescale(image, 0.5)
 image_resized = resize(image, (400, 400), mode='reflect')
-image_downscaled = downscale_local_mean(image, (2, 3))
+image_downscaled = downscale(image, 2)
+image_downscaled_local_mean = downscale_local_mean(image, (2, 2))
 
-fig, axes = plt.subplots(nrows=2, ncols=2,
-                         sharex=True, sharey=True)
+fig, axes = plt.subplots(nrows=3, ncols=2, sharex=True, sharey=True)
 
 ax = axes.ravel()
 
@@ -41,7 +47,10 @@ ax[2].imshow(image_resized, cmap='gray')
 ax[2].set_title("Resized image")
 
 ax[3].imshow(image_downscaled, cmap='gray')
-ax[3].set_title("Image downscaled using local averaging")
+ax[3].set_title("Downscaled image using Gaussian smoothing")
+
+ax[4].imshow(image_downscaled_local_mean, cmap='gray')
+ax[4].set_title("Downscaled image using local averaging")
 
 ax[0].set_xlim(0, 512)
 ax[0].set_ylim(512, 0)

--- a/doc/examples/transform/plot_rescale.py
+++ b/doc/examples/transform/plot_rescale.py
@@ -10,27 +10,29 @@ along each axis.
 `Resize` serves the same purpose, but allows to specify an output image shape
 instead of a scaling factor.
 
-`Downscale` serves the purpose of downsampling an n-dimensional image by
-calculating local mean on the elements of each block of the size factors given
-as a parameter to the function.
+Note that when down-sampling an image, `resize` and `rescale` should perform
+Gaussian smoothing to avoid aliasing artifacts. See the `anti_aliasing` and
+`anti_aliasing_sigma` arguments to these functions.
 
-Note that when downsampling an image, `resize` and `rescale` should perform
-Gaussian smoothing to avoid aliasing artifacts.
+`Downscale` serves the purpose of down-sampling an n-dimensional image by
+integer factors using the local mean on the elements of each block of the size
+factors given as a parameter to the function.
 
 """
 
 import matplotlib.pyplot as plt
 
-from skimage import data
+from skimage import data, color
 from skimage.transform import rescale, resize, downscale_local_mean
 
-image = data.camera()
+image = color.rgb2gray(data.astronaut())
 
-image_rescaled = rescale(image, 0.5)
-image_resized = resize(image, (400, 400), mode='reflect')
-image_downscaled = downscale_local_mean(image, (2, 2))
+image_rescaled = rescale(image, 1.0 / 4.0, anti_aliasing=False)
+image_resized = resize(image, (image.shape[0] / 4, image.shape[1] / 4),
+                       anti_aliasing=True)
+image_downscaled = downscale_local_mean(image, (4, 3))
 
-fig, axes = plt.subplots(nrows=2, ncols=2, sharex=True, sharey=True)
+fig, axes = plt.subplots(nrows=2, ncols=2)
 
 ax = axes.ravel()
 
@@ -38,13 +40,13 @@ ax[0].imshow(image, cmap='gray')
 ax[0].set_title("Original image")
 
 ax[1].imshow(image_rescaled, cmap='gray')
-ax[1].set_title("Rescaled image")
+ax[1].set_title("Rescaled image (aliasing)")
 
 ax[2].imshow(image_resized, cmap='gray')
-ax[2].set_title("Resized image")
+ax[2].set_title("Resized image (no aliasing)")
 
 ax[3].imshow(image_downscaled, cmap='gray')
-ax[3].set_title("Downscaled image")
+ax[3].set_title("Downscaled image (no aliasing)")
 
 ax[0].set_xlim(0, 512)
 ax[0].set_ylim(512, 0)

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -23,11 +23,15 @@ New Features
 Improvements
 ------------
 - VisuShrink method for wavelet denoising (#2470)
+- ``skimage.transform.resize`` and ``skimage.transform.rescale`` have a new
+  ``anti_aliasing`` option to avoid aliasing artifacts when down-sampling
+  images (#2802)
 
 
 API Changes
 -----------
-- ``skimage.util.montage.montage2d`` is now available as ``skimage.util.montage2d``.
+- ``skimage.util.montage.montage2d`` is now available as
+  ``skimage.util.montage2d``.
 
 
 Deprecations
@@ -35,6 +39,9 @@ Deprecations
 - ``skimage.util.montage2d`` is deprecated and will be removed in 0.15.
   Use ``skimage.util.montage`` instead.
 - ``skimage.novice`` is deprecated and will be removed in 0.16.
+- ``skimage.transform.resize`` and ``skimage.transform.rescale`` have a new
+  ``anti_aliasing`` option that avoids aliasing artifacts when down-sampling
+  images. This option will be enabled by default in 0.15.
 
 
 Contributors to this release

--- a/skimage/transform/__init__.py
+++ b/skimage/transform/__init__.py
@@ -11,8 +11,8 @@ from ._geometric import (estimate_transform,
                          ProjectiveTransform, FundamentalMatrixTransform,
                          EssentialMatrixTransform, PolynomialTransform,
                          PiecewiseAffineTransform)
-from ._warps import (swirl, resize, rotate, rescale, downscale_local_mean,
-                     warp, warp_coords)
+from ._warps import (swirl, resize, rotate, rescale, downsize, downscale,
+                     downscale_local_mean, warp, warp_coords)
 from .pyramids import (pyramid_reduce, pyramid_expand,
                        pyramid_gaussian, pyramid_laplacian)
 from .seam_carving import seam_carve
@@ -48,6 +48,8 @@ __all__ = ['hough_circle',
            'resize',
            'rotate',
            'rescale',
+           'downsize',
+           'downscale'
            'downscale_local_mean',
            'pyramid_reduce',
            'pyramid_expand',

--- a/skimage/transform/__init__.py
+++ b/skimage/transform/__init__.py
@@ -11,7 +11,7 @@ from ._geometric import (estimate_transform,
                          ProjectiveTransform, FundamentalMatrixTransform,
                          EssentialMatrixTransform, PolynomialTransform,
                          PiecewiseAffineTransform)
-from ._warps import (swirl, resize, rotate, rescale, downsize, downscale,
+from ._warps import (swirl, resize, rotate, rescale,
                      downscale_local_mean, warp, warp_coords)
 from .pyramids import (pyramid_reduce, pyramid_expand,
                        pyramid_gaussian, pyramid_laplacian)
@@ -48,8 +48,6 @@ __all__ = ['hough_circle',
            'resize',
            'rotate',
            'rescale',
-           'downsize',
-           'downscale'
            'downscale_local_mean',
            'pyramid_reduce',
            'pyramid_expand',

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -74,11 +74,11 @@ def resize(image, output_shape, order=1, mode=None, cval=0, clip=True,
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
-    anti_aliasing : bool
+    anti_aliasing : bool, optional
         Whether to apply a Gaussian filter to smooth the image prior to
         down-scaling. It is crucial to filter when down-sampling the image to
         avoid aliasing artifacts.
-    anti_aliasing_sigma : {float, tuple of floats}
+    anti_aliasing_sigma : {float, tuple of floats}, optional
         Standard deviation for Gaussian filtering to avoid aliasing artifacts.
         By default, this value is chosen as (1 - s) / 2 where s is the
         down-scaling factor.
@@ -192,7 +192,7 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
             anti_aliasing=None, anti_aliasing_sigma=None):
     """Scale image by a certain factor.
 
-    Performs interpolation to up-size or down-size images. Note that anti-
+    Performs interpolation to up-scale or down-scale images. Note that anti-
     aliasing should be enabled when down-sizing images to avoid aliasing
     artifacts. For down-sampling N-dimensional images with an integer factor
     also see `skimage.transform.downscale_local_mean`.
@@ -234,11 +234,11 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
         channels or another spatial dimension. By default, is set to True for
         3D (2D+color) inputs, and False for others. Starting in release 0.16,
         this will always default to False.
-    anti_aliasing : bool
+    anti_aliasing : bool, optional
         Whether to apply a Gaussian filter to smooth the image prior to
         down-scaling. It is crucial to filter when down-sampling the image to
         avoid aliasing artifacts.
-    anti_aliasing_sigma : {float, tuple of floats}
+    anti_aliasing_sigma : {float, tuple of floats}, optional
         Standard deviation for Gaussian filtering to avoid aliasing artifacts.
         By default, this value is chosen as (1 - s) / 2 where s is the
         down-scaling factor.

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -23,7 +23,7 @@ def _multichannel_default(multichannel, ndim):
     else:
         warn('The default multichannel argument (None) is deprecated.  Please '
              'specify either True or False explicitly.  multichannel will '
-             'default to False starting with release 0.16. ')
+             'default to False starting with release 0.16.')
         # utility for maintaining previous color image default behavior
         if ndim == 3:
             return True

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -76,7 +76,8 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
         sigma = 2 * downscale / 6.0
 
     smoothed = _smooth(image, sigma, mode, cval, multichannel)
-    out = resize(smoothed, out_shape, order=order, mode=mode, cval=cval)
+    out = resize(smoothed, out_shape, order=order, mode=mode, cval=cval,
+                 anti_aliasing=False)
 
     return out
 
@@ -134,7 +135,7 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
         sigma = 2 * upscale / 6.0
 
     resized = resize(image, out_shape, order=order,
-                     mode=mode, cval=cval)
+                     mode=mode, cval=cval, anti_aliasing=False)
     out = _smooth(resized, sigma, mode, cval, multichannel)
 
     return out
@@ -302,8 +303,8 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
         if multichannel:
             out_shape = out_shape[:-1]
 
-        resized_image = resize(smoothed_image, out_shape,
-                               order=order, mode=mode, cval=cval)
+        resized_image = resize(smoothed_image, out_shape, order=order,
+                               mode=mode, cval=cval, anti_aliasing=False)
         smoothed_image = _smooth(resized_image, sigma, mode, cval,
                                  multichannel)
         current_shape = np.asarray(resized_image.shape)

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -15,16 +15,14 @@ image_gray = image[..., 0]
 
 def test_pyramid_reduce_rgb():
     rows, cols, dim = image.shape
-    with expected_warnings(['The default multichannel',
-                            "Anti-aliasing will be enabled by default"]):
+    with expected_warnings(['The default multichannel']):
         out = pyramids.pyramid_reduce(image, downscale=2)
     assert_array_equal(out.shape, (rows / 2, cols / 2, dim))
 
 
 def test_pyramid_reduce_gray():
     rows, cols = image_gray.shape
-    with expected_warnings(['The default multichannel',
-                            "Anti-aliasing will be enabled by default"]):
+    with expected_warnings(['The default multichannel']):
         out = pyramids.pyramid_reduce(image_gray, downscale=2)
     assert_array_equal(out.shape, (rows / 2, cols / 2))
 
@@ -32,25 +30,22 @@ def test_pyramid_reduce_gray():
 def test_pyramid_reduce_nd():
     for ndim in [1, 2, 3, 4]:
         img = np.random.randn(*((8, ) * ndim))
-        with expected_warnings(["Anti-aliasing will be enabled by default"]):
-            out = pyramids.pyramid_reduce(img, downscale=2,
-                                          multichannel=False)
+        out = pyramids.pyramid_reduce(img, downscale=2,
+                                      multichannel=False)
         expected_shape = np.asarray(img.shape) / 2
         assert_array_equal(out.shape, expected_shape)
 
 
 def test_pyramid_expand_rgb():
     rows, cols, dim = image.shape
-    with expected_warnings(['The default multichannel',
-                            "Anti-aliasing will be enabled by default"]):
+    with expected_warnings(['The default multichannel']):
         out = pyramids.pyramid_expand(image, upscale=2)
     assert_array_equal(out.shape, (rows * 2, cols * 2, dim))
 
 
 def test_pyramid_expand_gray():
     rows, cols = image_gray.shape
-    with expected_warnings(['The default multichannel',
-                            "Anti-aliasing will be enabled by default"]):
+    with expected_warnings(['The default multichannel']):
         out = pyramids.pyramid_expand(image_gray, upscale=2)
     assert_array_equal(out.shape, (rows * 2, cols * 2))
 
@@ -58,17 +53,15 @@ def test_pyramid_expand_gray():
 def test_pyramid_expand_nd():
     for ndim in [1, 2, 3, 4]:
         img = np.random.randn(*((4, ) * ndim))
-        with expected_warnings(["Anti-aliasing will be enabled by default"]):
-            out = pyramids.pyramid_expand(img, upscale=2,
-                                          multichannel=False)
+        out = pyramids.pyramid_expand(img, upscale=2,
+                                      multichannel=False)
         expected_shape = np.asarray(img.shape) * 2
         assert_array_equal(out.shape, expected_shape)
 
 
 def test_build_gaussian_pyramid_rgb():
     rows, cols, dim = image.shape
-    with expected_warnings(['The default multichannel',
-                            "Anti-aliasing will be enabled by default"]):
+    with expected_warnings(['The default multichannel']):
         pyramid = pyramids.pyramid_gaussian(image, downscale=2)
         for layer, out in enumerate(pyramid):
             layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
@@ -77,8 +70,7 @@ def test_build_gaussian_pyramid_rgb():
 
 def test_build_gaussian_pyramid_gray():
     rows, cols = image_gray.shape
-    with expected_warnings(['The default multichannel',
-                            "Anti-aliasing will be enabled by default"]):
+    with expected_warnings(['The default multichannel']):
         pyramid = pyramids.pyramid_gaussian(image_gray, downscale=2)
         for layer, out in enumerate(pyramid):
             layer_shape = (rows / 2 ** layer, cols / 2 ** layer)
@@ -86,21 +78,19 @@ def test_build_gaussian_pyramid_gray():
 
 
 def test_build_gaussian_pyramid_nd():
-    with expected_warnings(["Anti-aliasing will be enabled by default"]):
-        for ndim in [1, 2, 3, 4]:
-            img = np.random.randn(*((8, ) * ndim))
-            original_shape = np.asarray(img.shape)
-            pyramid = pyramids.pyramid_gaussian(img, downscale=2,
-                                                multichannel=False)
-            for layer, out in enumerate(pyramid):
-                layer_shape = original_shape / 2 ** layer
-                assert_array_equal(out.shape, layer_shape)
+    for ndim in [1, 2, 3, 4]:
+        img = np.random.randn(*((8, ) * ndim))
+        original_shape = np.asarray(img.shape)
+        pyramid = pyramids.pyramid_gaussian(img, downscale=2,
+                                            multichannel=False)
+        for layer, out in enumerate(pyramid):
+            layer_shape = original_shape / 2 ** layer
+            assert_array_equal(out.shape, layer_shape)
 
 
 def test_build_laplacian_pyramid_rgb():
     rows, cols, dim = image.shape
-    with expected_warnings(['The default multichannel',
-                            "Anti-aliasing will be enabled by default"]):
+    with expected_warnings(['The default multichannel']):
         pyramid = pyramids.pyramid_laplacian(image, downscale=2)
         for layer, out in enumerate(pyramid):
             layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
@@ -108,35 +98,33 @@ def test_build_laplacian_pyramid_rgb():
 
 
 def test_build_laplacian_pyramid_nd():
-    with expected_warnings(["Anti-aliasing will be enabled by default"]):
-        for ndim in [1, 2, 3, 4]:
-            img = np.random.randn(*(16, )*ndim)
-            original_shape = np.asarray(img.shape)
-            pyramid = pyramids.pyramid_laplacian(img, downscale=2,
-                                                 multichannel=False)
-            for layer, out in enumerate(pyramid):
-                print(out.shape)
-                layer_shape = original_shape / 2 ** layer
-                assert_array_equal(out.shape, layer_shape)
+    for ndim in [1, 2, 3, 4]:
+        img = np.random.randn(*(16, )*ndim)
+        original_shape = np.asarray(img.shape)
+        pyramid = pyramids.pyramid_laplacian(img, downscale=2,
+                                             multichannel=False)
+        for layer, out in enumerate(pyramid):
+            print(out.shape)
+            layer_shape = original_shape / 2 ** layer
+            assert_array_equal(out.shape, layer_shape)
 
 
 def test_laplacian_pyramid_max_layers():
-    with expected_warnings(["Anti-aliasing will be enabled by default"]):
-        for downscale in [2, 3, 5, 7]:
-            img = np.random.randn(32, 8)
-            pyramid = pyramids.pyramid_laplacian(img, downscale=downscale,
-                                                 multichannel=False)
-            max_layer = int(np.ceil(math.log(np.max(img.shape), downscale)))
-            for layer, out in enumerate(pyramid):
-                if layer < max_layer:
-                    # should not reach all axes as size 1 prior to final level
-                    assert_(np.max(out.shape) > 1)
+    for downscale in [2, 3, 5, 7]:
+        img = np.random.randn(32, 8)
+        pyramid = pyramids.pyramid_laplacian(img, downscale=downscale,
+                                             multichannel=False)
+        max_layer = int(np.ceil(math.log(np.max(img.shape), downscale)))
+        for layer, out in enumerate(pyramid):
+            if layer < max_layer:
+                # should not reach all axes as size 1 prior to final level
+                assert_(np.max(out.shape) > 1)
 
-            # total number of images is max_layer + 1
-            assert_equal(max_layer, layer)
+        # total number of images is max_layer + 1
+        assert_equal(max_layer, layer)
 
-            # final layer should be size 1 on all axes
-            assert_array_equal((out.shape), (1, 1))
+        # final layer should be size 1 on all axes
+        assert_array_equal((out.shape), (1, 1))
 
 
 def test_check_factor():

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -15,14 +15,16 @@ image_gray = image[..., 0]
 
 def test_pyramid_reduce_rgb():
     rows, cols, dim = image.shape
-    with expected_warnings(['The default multichannel']):
+    with expected_warnings(['The default multichannel',
+                            "Anti-aliasing will be enabled by default"]):
         out = pyramids.pyramid_reduce(image, downscale=2)
     assert_array_equal(out.shape, (rows / 2, cols / 2, dim))
 
 
 def test_pyramid_reduce_gray():
     rows, cols = image_gray.shape
-    with expected_warnings(['The default multichannel']):
+    with expected_warnings(['The default multichannel',
+                            "Anti-aliasing will be enabled by default"]):
         out = pyramids.pyramid_reduce(image_gray, downscale=2)
     assert_array_equal(out.shape, (rows / 2, cols / 2))
 
@@ -30,22 +32,25 @@ def test_pyramid_reduce_gray():
 def test_pyramid_reduce_nd():
     for ndim in [1, 2, 3, 4]:
         img = np.random.randn(*((8, ) * ndim))
-        out = pyramids.pyramid_reduce(img, downscale=2,
-                                      multichannel=False)
+        with expected_warnings(["Anti-aliasing will be enabled by default"]):
+            out = pyramids.pyramid_reduce(img, downscale=2,
+                                          multichannel=False)
         expected_shape = np.asarray(img.shape) / 2
         assert_array_equal(out.shape, expected_shape)
 
 
 def test_pyramid_expand_rgb():
     rows, cols, dim = image.shape
-    with expected_warnings(['The default multichannel']):
+    with expected_warnings(['The default multichannel',
+                            "Anti-aliasing will be enabled by default"]):
         out = pyramids.pyramid_expand(image, upscale=2)
     assert_array_equal(out.shape, (rows * 2, cols * 2, dim))
 
 
 def test_pyramid_expand_gray():
     rows, cols = image_gray.shape
-    with expected_warnings(['The default multichannel']):
+    with expected_warnings(['The default multichannel',
+                            "Anti-aliasing will be enabled by default"]):
         out = pyramids.pyramid_expand(image_gray, upscale=2)
     assert_array_equal(out.shape, (rows * 2, cols * 2))
 
@@ -53,15 +58,17 @@ def test_pyramid_expand_gray():
 def test_pyramid_expand_nd():
     for ndim in [1, 2, 3, 4]:
         img = np.random.randn(*((4, ) * ndim))
-        out = pyramids.pyramid_expand(img, upscale=2,
-                                      multichannel=False)
+        with expected_warnings(["Anti-aliasing will be enabled by default"]):
+            out = pyramids.pyramid_expand(img, upscale=2,
+                                          multichannel=False)
         expected_shape = np.asarray(img.shape) * 2
         assert_array_equal(out.shape, expected_shape)
 
 
 def test_build_gaussian_pyramid_rgb():
     rows, cols, dim = image.shape
-    with expected_warnings(['The default multichannel']):
+    with expected_warnings(['The default multichannel',
+                            "Anti-aliasing will be enabled by default"]):
         pyramid = pyramids.pyramid_gaussian(image, downscale=2)
         for layer, out in enumerate(pyramid):
             layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
@@ -70,7 +77,8 @@ def test_build_gaussian_pyramid_rgb():
 
 def test_build_gaussian_pyramid_gray():
     rows, cols = image_gray.shape
-    with expected_warnings(['The default multichannel']):
+    with expected_warnings(['The default multichannel',
+                            "Anti-aliasing will be enabled by default"]):
         pyramid = pyramids.pyramid_gaussian(image_gray, downscale=2)
         for layer, out in enumerate(pyramid):
             layer_shape = (rows / 2 ** layer, cols / 2 ** layer)
@@ -78,19 +86,21 @@ def test_build_gaussian_pyramid_gray():
 
 
 def test_build_gaussian_pyramid_nd():
-    for ndim in [1, 2, 3, 4]:
-        img = np.random.randn(*((8, ) * ndim))
-        original_shape = np.asarray(img.shape)
-        pyramid = pyramids.pyramid_gaussian(img, downscale=2,
-                                            multichannel=False)
-        for layer, out in enumerate(pyramid):
-            layer_shape = original_shape / 2 ** layer
-            assert_array_equal(out.shape, layer_shape)
+    with expected_warnings(["Anti-aliasing will be enabled by default"]):
+        for ndim in [1, 2, 3, 4]:
+            img = np.random.randn(*((8, ) * ndim))
+            original_shape = np.asarray(img.shape)
+            pyramid = pyramids.pyramid_gaussian(img, downscale=2,
+                                                multichannel=False)
+            for layer, out in enumerate(pyramid):
+                layer_shape = original_shape / 2 ** layer
+                assert_array_equal(out.shape, layer_shape)
 
 
 def test_build_laplacian_pyramid_rgb():
     rows, cols, dim = image.shape
-    with expected_warnings(['The default multichannel']):
+    with expected_warnings(['The default multichannel',
+                            "Anti-aliasing will be enabled by default"]):
         pyramid = pyramids.pyramid_laplacian(image, downscale=2)
         for layer, out in enumerate(pyramid):
             layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
@@ -98,33 +108,35 @@ def test_build_laplacian_pyramid_rgb():
 
 
 def test_build_laplacian_pyramid_nd():
-    for ndim in [1, 2, 3, 4]:
-        img = np.random.randn(*(16, )*ndim)
-        original_shape = np.asarray(img.shape)
-        pyramid = pyramids.pyramid_laplacian(img, downscale=2,
-                                             multichannel=False)
-        for layer, out in enumerate(pyramid):
-            print(out.shape)
-            layer_shape = original_shape / 2 ** layer
-            assert_array_equal(out.shape, layer_shape)
+    with expected_warnings(["Anti-aliasing will be enabled by default"]):
+        for ndim in [1, 2, 3, 4]:
+            img = np.random.randn(*(16, )*ndim)
+            original_shape = np.asarray(img.shape)
+            pyramid = pyramids.pyramid_laplacian(img, downscale=2,
+                                                 multichannel=False)
+            for layer, out in enumerate(pyramid):
+                print(out.shape)
+                layer_shape = original_shape / 2 ** layer
+                assert_array_equal(out.shape, layer_shape)
 
 
 def test_laplacian_pyramid_max_layers():
-    for downscale in [2, 3, 5, 7]:
-        img = np.random.randn(32, 8)
-        pyramid = pyramids.pyramid_laplacian(img, downscale=downscale,
-                                             multichannel=False)
-        max_layer = int(np.ceil(math.log(np.max(img.shape), downscale)))
-        for layer, out in enumerate(pyramid):
-            if layer < max_layer:
-                # should not reach all axes as size 1 prior to final level
-                assert_(np.max(out.shape) > 1)
+    with expected_warnings(["Anti-aliasing will be enabled by default"]):
+        for downscale in [2, 3, 5, 7]:
+            img = np.random.randn(32, 8)
+            pyramid = pyramids.pyramid_laplacian(img, downscale=downscale,
+                                                 multichannel=False)
+            max_layer = int(np.ceil(math.log(np.max(img.shape), downscale)))
+            for layer, out in enumerate(pyramid):
+                if layer < max_layer:
+                    # should not reach all axes as size 1 prior to final level
+                    assert_(np.max(out.shape) > 1)
 
-        # total number of images is max_layer + 1
-        assert_equal(max_layer, layer)
+            # total number of images is max_layer + 1
+            assert_equal(max_layer, layer)
 
-        # final layer should be size 1 on all axes
-        assert_array_equal((out.shape), (1, 1))
+            # final layer should be size 1 on all axes
+            assert_array_equal((out.shape), (1, 1))
 
 
 def test_check_factor():

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -9,8 +9,6 @@ from skimage.transform import (warp, warp_coords, rotate, resize, rescale,
                                AffineTransform,
                                ProjectiveTransform,
                                SimilarityTransform,
-                               downsize,
-                               downscale,
                                downscale_local_mean)
 from skimage import transform as tf, data, img_as_float
 from skimage.color import rgb2gray
@@ -96,11 +94,11 @@ def test_warp_clip():
     x[2, 2] = 1
 
     with expected_warnings(['The default mode', 'The default multichannel']):
-        outx = rescale(x, 3, order=3, clip=False)
+        outx = rescale(x, 3, order=3, clip=False, anti_aliasing=False)
     assert outx.min() < 0
 
     with expected_warnings(['The default mode', 'The default multichannel']):
-        outx = rescale(x, 3, order=3, clip=True)
+        outx = rescale(x, 3, order=3, clip=True, anti_aliasing=False)
     assert_almost_equal(outx.min(), 0)
     assert_almost_equal(outx.max(), 1)
 
@@ -167,7 +165,7 @@ def test_rescale():
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
     with expected_warnings(['The default mode', 'The default multichannel']):
-        scaled = rescale(x, 2, order=0)
+        scaled = rescale(x, 2, order=0, anti_aliasing=False)
     ref = np.zeros((10, 10))
     ref[2:4, 2:4] = 1
     assert_almost_equal(scaled, ref)
@@ -176,7 +174,7 @@ def test_rescale():
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
     with expected_warnings(['The default mode', 'The default multichannel']):
-        scaled = rescale(x, (2, 1), order=0)
+        scaled = rescale(x, (2, 1), order=0, anti_aliasing=False)
     ref = np.zeros((10, 5))
     ref[2:4, 1] = 1
     assert_almost_equal(scaled, ref)
@@ -185,26 +183,26 @@ def test_rescale():
 def test_rescale_multichannel():
     # 1D + channels
     x = np.zeros((8, 3), dtype=np.double)
-    scaled = rescale(x, 2, order=0, multichannel=True)
+    scaled = rescale(x, 2, order=0, multichannel=True, anti_aliasing=False)
     assert_equal(scaled.shape, (16, 3))
     # 2D
-    scaled = rescale(x, 2, order=0, multichannel=False)
+    scaled = rescale(x, 2, order=0, multichannel=False, anti_aliasing=False)
     assert_equal(scaled.shape, (16, 6))
 
     # 2D + channels
     x = np.zeros((8, 8, 3), dtype=np.double)
-    scaled = rescale(x, 2, order=0, multichannel=True)
+    scaled = rescale(x, 2, order=0, multichannel=True, anti_aliasing=False)
     assert_equal(scaled.shape, (16, 16, 3))
     # 3D
-    scaled = rescale(x, 2, order=0, multichannel=False)
+    scaled = rescale(x, 2, order=0, multichannel=False, anti_aliasing=False)
     assert_equal(scaled.shape, (16, 16, 6))
 
     # 3D + channels
     x = np.zeros((8, 8, 8, 3), dtype=np.double)
-    scaled = rescale(x, 2, order=0, multichannel=True)
+    scaled = rescale(x, 2, order=0, multichannel=True, anti_aliasing=False)
     assert_equal(scaled.shape, (16, 16, 16, 3))
     # 4D
-    scaled = rescale(x, 2, order=0, multichannel=False)
+    scaled = rescale(x, 2, order=0, multichannel=False, anti_aliasing=False)
     assert_equal(scaled.shape, (16, 16, 16, 6))
 
 
@@ -214,13 +212,13 @@ def test_rescale_multichannel_defaults():
     # 2D: multichannel should default to False
     x = np.zeros((8, 3), dtype=np.double)
     with expected_warnings(['The default mode', 'The default multichannel']):
-        scaled = rescale(x, 2, order=0)
+        scaled = rescale(x, 2, order=0, anti_aliasing=False)
     assert_equal(scaled.shape, (16, 6))
 
     # 3D: multichannel should default to True
     x = np.zeros((8, 8, 3), dtype=np.double)
     with expected_warnings(['The default mode', 'The default multichannel']):
-        scaled = rescale(x, 2, order=0,)
+        scaled = rescale(x, 2, order=0, anti_aliasing=False)
     assert_equal(scaled.shape, (16, 16, 3))
 
 
@@ -228,7 +226,7 @@ def test_resize2d():
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
     with expected_warnings(['The default mode']):
-        resized = resize(x, (10, 10), order=0)
+        resized = resize(x, (10, 10), order=0, anti_aliasing=False)
     ref = np.zeros((10, 10))
     ref[2:4, 2:4] = 1
     assert_almost_equal(resized, ref)
@@ -239,15 +237,15 @@ def test_resize3d_keep():
     x = np.zeros((5, 5, 3), dtype=np.double)
     x[1, 1, :] = 1
     with expected_warnings(['The default mode']):
-        resized = resize(x, (10, 10), order=0)
+        resized = resize(x, (10, 10), order=0, anti_aliasing=False)
         with pytest.raises(ValueError):
             # output_shape too short
-            resize(x, (10, ), order=0)
+            resize(x, (10, ), order=0, anti_aliasing=False)
     ref = np.zeros((10, 10, 3))
     ref[2:4, 2:4, :] = 1
     assert_almost_equal(resized, ref)
     with expected_warnings(['The default mode']):
-        resized = resize(x, (10, 10, 3), order=0)
+        resized = resize(x, (10, 10, 3), order=0, anti_aliasing=False)
     assert_almost_equal(resized, ref)
 
 
@@ -256,7 +254,7 @@ def test_resize3d_resize():
     x = np.zeros((5, 5, 3), dtype=np.double)
     x[1, 1, :] = 1
     with expected_warnings(['The default mode']):
-        resized = resize(x, (10, 10, 1), order=0)
+        resized = resize(x, (10, 10, 1), order=0, anti_aliasing=False)
     ref = np.zeros((10, 10, 1))
     ref[2:4, 2:4] = 1
     assert_almost_equal(resized, ref)
@@ -267,7 +265,7 @@ def test_resize3d_2din_3dout():
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
     with expected_warnings(['The default mode']):
-        resized = resize(x, (10, 10, 1), order=0)
+        resized = resize(x, (10, 10, 1), order=0, anti_aliasing=False)
     ref = np.zeros((10, 10, 1))
     ref[2:4, 2:4] = 1
     assert_almost_equal(resized, ref)
@@ -278,7 +276,7 @@ def test_resize2d_4d():
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
     out_shape = (10, 10, 1, 1)
-    resized = resize(x, out_shape, order=0)
+    resized = resize(x, out_shape, order=0, anti_aliasing=False)
     ref = np.zeros(out_shape)
     ref[2:4, 2:4, ...] = 1
     assert_almost_equal(resized, ref)
@@ -289,7 +287,8 @@ def test_resize_nd():
         shape = 2 + np.arange(dim) * 2
         x = np.ones(shape)
         out_shape = np.asarray(shape) * 1.5
-        resized = resize(x, out_shape, order=0, mode='reflect')
+        resized = resize(x, out_shape, order=0, mode='reflect',
+                         anti_aliasing=False)
         expected_shape = 1.5 * shape
         assert_equal(resized.shape, expected_shape)
         assert np.all(resized == 1)
@@ -300,7 +299,8 @@ def test_resize3d_bilinear():
     x = np.zeros((5, 5, 2), dtype=np.double)
     x[1, 1, 0] = 0
     x[1, 1, 1] = 1
-    resized = resize(x, (10, 10, 1), order=1, mode='constant')
+    resized = resize(x, (10, 10, 1), order=1, mode='constant',
+                     anti_aliasing=False)
     ref = np.zeros((10, 10, 1))
     ref[1:5, 1:5, :] = 0.03125
     ref[1:5, 2:4, :] = 0.09375
@@ -361,23 +361,52 @@ def test_warp_coords_example():
 def test_downsize():
     x = np.zeros((10, 10), dtype=np.double)
     x[2:4, 2:4] = 1
-    scaled = downsize(x, (5, 5), order=0)
+    scaled = resize(x, (5, 5), order=0, anti_aliasing=False)
     assert_equal(scaled.shape, (5, 5))
-    assert_equal(scaled[:3, :3].sum(), 1)
-    assert_equal(scaled[3:, :].sum(), 0)
-    assert_equal(scaled[:, 3:].sum(), 0)
-    assert_raises(ValueError, downsize, x, (11, 11))
+    assert_equal(scaled[1, 1], 1)
+    assert_equal(scaled[2:, :].sum(), 0)
+    assert_equal(scaled[:, 2:].sum(), 0)
 
 
-def test_downsize():
+def test_downsize_anti_aliasing():
     x = np.zeros((10, 10), dtype=np.double)
     x[2:4, 2:4] = 1
-    scaled = downscale(x, 2, order=0)
+    scaled = resize(x, (5, 5), order=0, anti_aliasing=True)
     assert_equal(scaled.shape, (5, 5))
     assert_equal(scaled[:3, :3].sum(), 1)
     assert_equal(scaled[3:, :].sum(), 0)
     assert_equal(scaled[:, 3:].sum(), 0)
-    assert_raises(ValueError, downscale, x, (0.5, 0.5))
+
+
+def test_downsize_anti_aliasing_invalid_stddev():
+    x = np.zeros((10, 10), dtype=np.double)
+    assert_raises(ValueError, resize, x, (5, 5), order=0, anti_aliasing=True,
+                  anti_aliasing_stddev=-1)
+    with expected_warnings(["Anti-aliasing standard deviation greater"]):
+        resize(x, (5, 15), order=0, anti_aliasing=True,
+               anti_aliasing_stddev=(1, 1), mode="reflect")
+        resize(x, (5, 15), order=0, anti_aliasing=True,
+               anti_aliasing_stddev=(0, 1), mode="reflect")
+
+
+def test_downscale():
+    x = np.zeros((10, 10), dtype=np.double)
+    x[2:4, 2:4] = 1
+    scaled = rescale(x, 0.5, order=0, anti_aliasing=False)
+    assert_equal(scaled.shape, (5, 5))
+    assert_equal(scaled[1, 1], 1)
+    assert_equal(scaled[2:, :].sum(), 0)
+    assert_equal(scaled[:, 2:].sum(), 0)
+
+
+def test_downscale_anti_aliasing():
+    x = np.zeros((10, 10), dtype=np.double)
+    x[2:4, 2:4] = 1
+    scaled = rescale(x, 0.5, order=0, anti_aliasing=True)
+    assert_equal(scaled.shape, (5, 5))
+    assert_equal(scaled[:3, :3].sum(), 1)
+    assert_equal(scaled[3:, :].sum(), 0)
+    assert_equal(scaled[:, 3:].sum(), 0)
 
 
 def test_downscale_local_mean():
@@ -421,17 +450,20 @@ def test_keep_range():
     image = np.linspace(0, 2, 25).reshape(5, 5)
 
     with expected_warnings(['The default mode', 'The default multichannel']):
-        out = rescale(image, 2, preserve_range=False, clip=True, order=0)
+        out = rescale(image, 2, preserve_range=False, clip=True, order=0,
+                      anti_aliasing=False)
     assert out.min() == 0
     assert out.max() == 2
 
     with expected_warnings(['The default mode', 'The default multichannel']):
-        out = rescale(image, 2, preserve_range=True, clip=True, order=0)
+        out = rescale(image, 2, preserve_range=True, clip=True, order=0,
+                      anti_aliasing=False)
     assert out.min() == 0
     assert out.max() == 2
 
     with expected_warnings(['The default mode', 'The default multichannel']):
         out = rescale(image.astype(np.uint8), 2, preserve_range=False,
+                      anti_aliasing=False,
                       clip=True, order=0)
     assert out.min() == 0
     assert out.max() == 2 / 255.0

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -180,6 +180,14 @@ def test_rescale():
     assert_almost_equal(scaled, ref)
 
 
+def test_rescale_invalid_scale():
+    x = np.zeros((10, 10, 3))
+    with pytest.raises(ValueError):
+        rescale(x, (2, 2), multichannel=False)
+    with pytest.raises(ValueError):
+        rescale(x, (2, 2, 2), multichannel=True)
+
+
 def test_rescale_multichannel():
     # 1D + channels
     x = np.zeros((8, 3), dtype=np.double)

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -381,12 +381,12 @@ def test_downsize_anti_aliasing():
 def test_downsize_anti_aliasing_invalid_stddev():
     x = np.zeros((10, 10), dtype=np.double)
     assert_raises(ValueError, resize, x, (5, 5), order=0, anti_aliasing=True,
-                  anti_aliasing_stddev=-1)
+                  anti_aliasing_sigma=-1)
     with expected_warnings(["Anti-aliasing standard deviation greater"]):
         resize(x, (5, 15), order=0, anti_aliasing=True,
-               anti_aliasing_stddev=(1, 1), mode="reflect")
+               anti_aliasing_sigma=(1, 1), mode="reflect")
         resize(x, (5, 15), order=0, anti_aliasing=True,
-               anti_aliasing_stddev=(0, 1), mode="reflect")
+               anti_aliasing_sigma=(0, 1), mode="reflect")
 
 
 def test_downscale():

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -370,10 +370,10 @@ def test_downsize():
 
 def test_downsize_anti_aliasing():
     x = np.zeros((10, 10), dtype=np.double)
-    x[2:4, 2:4] = 1
-    scaled = resize(x, (5, 5), order=0, anti_aliasing=True)
+    x[2, 2] = 1
+    scaled = resize(x, (5, 5), order=1, anti_aliasing=True)
     assert_equal(scaled.shape, (5, 5))
-    assert_equal(scaled[:3, :3].sum(), 1)
+    assert np.all(scaled[:3, :3] > 0)
     assert_equal(scaled[3:, :].sum(), 0)
     assert_equal(scaled[:, 3:].sum(), 0)
 
@@ -401,10 +401,10 @@ def test_downscale():
 
 def test_downscale_anti_aliasing():
     x = np.zeros((10, 10), dtype=np.double)
-    x[2:4, 2:4] = 1
-    scaled = rescale(x, 0.5, order=0, anti_aliasing=True)
+    x[2, 2] = 1
+    scaled = rescale(x, 0.5, order=1, anti_aliasing=True)
     assert_equal(scaled.shape, (5, 5))
-    assert_equal(scaled[:3, :3].sum(), 1)
+    assert np.all(scaled[:3, :3] > 0)
     assert_equal(scaled[3:, :].sum(), 0)
     assert_equal(scaled[:, 3:].sum(), 0)
 

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -1,5 +1,5 @@
 from numpy.testing import (assert_almost_equal, run_module_suite,
-                           assert_equal, assert_raises)
+                           assert_equal)
 import numpy as np
 import pytest
 from scipy.ndimage import map_coordinates
@@ -380,8 +380,8 @@ def test_downsize_anti_aliasing():
 
 def test_downsize_anti_aliasing_invalid_stddev():
     x = np.zeros((10, 10), dtype=np.double)
-    assert_raises(ValueError, resize, x, (5, 5), order=0, anti_aliasing=True,
-                  anti_aliasing_sigma=-1)
+    with pytest.raises(ValueError):
+        resize(x, (5, 5), order=0, anti_aliasing=True, anti_aliasing_sigma=-1)
     with expected_warnings(["Anti-aliasing standard deviation greater"]):
         resize(x, (5, 15), order=0, anti_aliasing=True,
                anti_aliasing_sigma=(1, 1), mode="reflect")

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -1,5 +1,5 @@
 from numpy.testing import (assert_almost_equal, run_module_suite,
-                           assert_equal)
+                           assert_equal, assert_raises)
 import numpy as np
 import pytest
 from scipy.ndimage import map_coordinates
@@ -9,6 +9,8 @@ from skimage.transform import (warp, warp_coords, rotate, resize, rescale,
                                AffineTransform,
                                ProjectiveTransform,
                                SimilarityTransform,
+                               downsize,
+                               downscale,
                                downscale_local_mean)
 from skimage import transform as tf, data, img_as_float
 from skimage.color import rgb2gray
@@ -354,6 +356,28 @@ def test_warp_coords_example():
     tform = SimilarityTransform(translation=(0, -10))
     coords = warp_coords(tform, (30, 30, 3))
     map_coordinates(image[:, :, 0], coords[:2])
+
+
+def test_downsize():
+    x = np.zeros((10, 10), dtype=np.double)
+    x[2:4, 2:4] = 1
+    scaled = downsize(x, (5, 5), order=0)
+    assert_equal(scaled.shape, (5, 5))
+    assert_equal(scaled[:3, :3].sum(), 1)
+    assert_equal(scaled[3:, :].sum(), 0)
+    assert_equal(scaled[:, 3:].sum(), 0)
+    assert_raises(ValueError, downsize, x, (11, 11))
+
+
+def test_downsize():
+    x = np.zeros((10, 10), dtype=np.double)
+    x[2:4, 2:4] = 1
+    scaled = downscale(x, 2, order=0)
+    assert_equal(scaled.shape, (5, 5))
+    assert_equal(scaled[:3, :3].sum(), 1)
+    assert_equal(scaled[3:, :].sum(), 0)
+    assert_equal(scaled[:, 3:].sum(), 0)
+    assert_raises(ValueError, downscale, x, (0.5, 0.5))
 
 
 def test_downscale_local_mean():


### PR DESCRIPTION
Previously, we only provided functions to resize/rescale images with
pure interpolation. This results in aliasing effects when reducing the
image size. The new functions properly account for this effect by
applying a Gaussian filter prior to interpolation.

## For reviewers

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
