### PR TITLE
Add morphological snakes to release notes

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -18,7 +18,7 @@ New Features
 - hysteresis thresholding in filters (#2665)
 - lookfor function (#2713)
 - montage function (#2626)
-- nD segmentation with morphological snakes (#2791)
+- 2D and 3D segmentation with morphological snakes (#2791)
 
 
 Improvements

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -18,6 +18,7 @@ New Features
 - hysteresis thresholding in filters (#2665)
 - lookfor function (#2713)
 - montage function (#2626)
+- nD segmentation with morphological snakes (#2791)
 
 
 Improvements


### PR DESCRIPTION
In #2791, we forgot to add the new feature to the release notes. This PR rectifies that oversight.