### PR TITLE
Also document submodules, and ignore private modules `_*`

### DIFF
--- a/doc/tools/apigen.py
+++ b/doc/tools/apigen.py
@@ -21,7 +21,7 @@ is an MIT-licensed project.
 import os
 import re
 
-from types import BuiltinFunctionType, FunctionType
+from types import BuiltinFunctionType, FunctionType, ModuleType
 
 # suppress print statements (warnings for empty files)
 DEBUG = True
@@ -199,12 +199,15 @@ class ApiDocWriter(object):
             A list of (public) function names in the module.
         classes : list of str
             A list of (public) class names in the module.
+        submodules : list of str
+            A list of (public) submodule names in the module.
         """
         mod = __import__(uri, fromlist=[uri.split('.')[-1]])
         # find all public objects in the module.
         obj_strs = [obj for obj in dir(mod) if not obj.startswith('_')]
         functions = []
         classes = []
+        submodules = []
         for obj_str in obj_strs:
             # find the actual object from its string representation
             if obj_str not in mod.__dict__:
@@ -214,6 +217,8 @@ class ApiDocWriter(object):
             # figure out if obj is a function or class
             if isinstance(obj, (FunctionType, BuiltinFunctionType)):
                 functions.append(obj_str)
+            elif isinstance(obj, ModuleType):
+                submodules.append(obj_str)
             else:
                 try:
                     issubclass(obj, object)
@@ -221,7 +226,7 @@ class ApiDocWriter(object):
                 except TypeError:
                     # not a function or class
                     pass
-        return functions, classes
+        return functions, classes, submodules
 
     def _parse_lines(self, linesource):
         ''' Parse lines of text for functions and classes '''
@@ -258,9 +263,9 @@ class ApiDocWriter(object):
             Contents of API doc
         '''
         # get the names of all classes and functions
-        functions, classes = self._parse_module_with_import(uri)
-        if not len(functions) and not len(classes) and DEBUG:
-            print('WARNING: Empty -', uri)  # dbg
+        functions, classes, submodules = self._parse_module_with_import(uri)
+        if not (len(functions) or len(classes) or len(submodules)) and DEBUG:
+            print('WARNING: Empty -', uri)
             return ''
 
         # Make a shorter version of the uri that omits the package name for
@@ -285,6 +290,9 @@ class ApiDocWriter(object):
         ad += '\n'
         for c in classes:
             ad += '   ' + uri + '.' + c + '\n'
+        ad += '\n'
+        for m in submodules:
+            ad += '    ' + uri + '.' + m + '\n'
         ad += '\n'
 
         for f in functions:
@@ -389,7 +397,9 @@ class ApiDocWriter(object):
     def write_modules_api(self, modules, outdir):
         # write the list
         written_modules = []
-        for m in modules:
+        public_modules = [m for m in modules
+                          if not m.split('.')[-1].startswith('_')]
+        for m in public_modules:
             api_str = self.generate_api_doc(m)
             if not api_str:
                 continue
@@ -423,7 +433,7 @@ class ApiDocWriter(object):
             os.mkdir(outdir)
         # compose list of modules
         modules = self.discover_modules()
-        self.write_modules_api(modules,outdir)
+        self.write_modules_api(modules, outdir)
 
     def write_index(self, outdir, froot='gen', relative_to=None):
         """Make a reST API index file from written files

--- a/doc/tools/apigen.py
+++ b/doc/tools/apigen.py
@@ -204,7 +204,8 @@ class ApiDocWriter(object):
         """
         mod = __import__(uri, fromlist=[uri.split('.')[-1]])
         # find all public objects in the module.
-        obj_strs = [obj for obj in dir(mod) if not obj.startswith('_')]
+        obj_strs = getattr(mod, '__all__',
+                           [obj for obj in dir(mod) if not obj.startswith('_')])
         functions = []
         classes = []
         submodules = []
@@ -217,7 +218,7 @@ class ApiDocWriter(object):
             # figure out if obj is a function or class
             if isinstance(obj, (FunctionType, BuiltinFunctionType)):
                 functions.append(obj_str)
-            elif isinstance(obj, ModuleType):
+            elif isinstance(obj, ModuleType) and 'skimage' in mod.__name__:
                 submodules.append(obj_str)
             else:
                 try:

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -10,7 +10,7 @@ For more images, see
 
 import os as _os
 
-import numpy as np
+import numpy as _np
 
 from .. import data_dir
 from ..io import imread, use_plugin
@@ -383,4 +383,4 @@ def stereo_motorcycle():
     """
     return (load("motorcycle_left.png"),
             load("motorcycle_right.png"),
-            np.load(_os.path.join(data_dir, "motorcycle_disp.npz"))["arr_0"])
+            _np.load(_os.path.join(data_dir, "motorcycle_disp.npz"))["arr_0"])

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -641,7 +641,7 @@ def enhance_contrast(image, selem, out=None, mask=None, shift_x=False,
         structuring element).
 
     Returns
-        Output image.
+    -------
     out : 2-D array (same dtype as input image)
         The result of the local enhance_contrast.
 


### PR DESCRIPTION
This allows `skimage.future` to be included in the API guide.