### PR TITLE
Fixed typo in hog() method keyword argument visualise

### DIFF
--- a/doc/examples/features_detection/plot_hog.py
+++ b/doc/examples/features_detection/plot_hog.py
@@ -88,7 +88,7 @@ from skimage import data, color, exposure
 image = color.rgb2gray(data.astronaut())
 
 fd, hog_image = hog(image, orientations=8, pixels_per_cell=(16, 16),
-                    cells_per_block=(1, 1), visualize=True)
+                    cells_per_block=(1, 1), visualise=True)
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4), sharex=True, sharey=True)
 


### PR DESCRIPTION
## Description
Fixed typo in `plot_hog.py` example. In the example, the call to `hog()` method uses `visualize` keyword argument which raises a type error (see issue #2812). The correct keyword argument is changed to `visualise` as per the [method documentation](http://scikit-image.org/docs/stable/api/skimage.feature.html#skimage.feature.hog).

Note to reviewers; this is my first contribution to the project. Please indicate if I also need to update the .ipynb file for the example.

Thank you!

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

Checklist items not verified and assumed to be OK (simple typo correction).

## References
Closing issue #2812.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
