### PR TITLE
Add W503 to pep8speaks ignore.

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -5,6 +5,7 @@ pycodestyle:
   ignore:  # Errors and warnings to ignore
     - W391 # blank line at the end of file
     - E203 # whitespace before ,;:
+    - W503 # newline before binary operator
 
 no_blank_comment: True  # If True, no comment is made when the bot does not find any pep8 errors
 


### PR DESCRIPTION
Ignore PEP8 warning W503: "newline before binary operator."

This is due to a conflict with the [PEP8 style guide write-up](https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator).

The following will no longer prompt a complaint from the @pep8speaks bot:
```python
foo += (42
        * "bar")
```