### PR TITLE
Make simple watershed fast again

### DIFF
--- a/skimage/morphology/_watershed.pyx
+++ b/skimage/morphology/_watershed.pyx
@@ -121,35 +121,36 @@ def watershed_raveled(cnp.float64_t[::1] image,
 
         for i in range(nneighbors):
             # get the flattened address of the neighbor
-            index = structure[i] + elem.index
+            neighbor_index = structure[i] + elem.index
 
-            if not mask[index]:
+            if not mask[neighbor_index]:
                 # neighbor is not in mask
                 continue
 
-            if wsl and output[index] == wsl_label:
+            if wsl and output[neighbor_index] == wsl_label:
                 continue
 
-            if output[index]:
+            if output[neighbor_index]:
                 # neighbor has a label (but not wsl_label):
                 # the neighbor is not added to the queue.
                 if wsl:
                     # if the label of the neighbor is different
                     # from the label of the pixel taken from the queue,
                     # the latter takes the WSL label.
-                    if output[index] != output[elem.index]:
+                    if output[neighbor_index] != output[elem.index]:
                         output[elem.index] = wsl_label
                 continue
 
             age += 1
-            new_elem.value = image[index]
+            new_elem.value = image[neighbor_index]
             if compact:
                 new_elem.value += (compactness *
-                                   _euclid_dist(index, elem.source, strides))
+                                   _euclid_dist(neighbor_index, elem.source,
+                                                strides))
             else:
-                output[index] = output[elem.index]
+                output[neighbor_index] = output[elem.index]
             new_elem.age = age
-            new_elem.index = index
+            new_elem.index = neighbor_index
             new_elem.source = elem.source
 
             heappush(hp, &new_elem)

--- a/skimage/morphology/_watershed.pyx
+++ b/skimage/morphology/_watershed.pyx
@@ -113,7 +113,7 @@ def watershed_raveled(cnp.float64_t[::1] image,
             # wsl labels are not propagated.
             continue
 
-        if compact:
+        if compact or wsl:
             if output[elem.index] and elem.index != elem.source:
                 # non-marker, already visited from another neighbor
                 continue
@@ -147,7 +147,7 @@ def watershed_raveled(cnp.float64_t[::1] image,
                 new_elem.value += (compactness *
                                    _euclid_dist(neighbor_index, elem.source,
                                                 strides))
-            else:
+            elif not wsl:
                 output[neighbor_index] = output[elem.index]
             new_elem.age = age
             new_elem.index = neighbor_index

--- a/skimage/morphology/_watershed.pyx
+++ b/skimage/morphology/_watershed.pyx
@@ -144,6 +144,8 @@ def watershed_raveled(cnp.float64_t[::1] image,
             if compactness > 0:
                 new_elem.value += (compactness *
                                    _euclid_dist(index, elem.source, strides))
+            else:
+                output[index] = output[elem.index]
             new_elem.age = age
             new_elem.index = index
             new_elem.source = elem.source

--- a/skimage/morphology/_watershed.pyx
+++ b/skimage/morphology/_watershed.pyx
@@ -49,6 +49,11 @@ cdef inline DTYPE_BOOL_t _diff_neighbors(DTYPE_INT32_t[::1] output,
                                          DTYPE_INT32_t[::1] structure,
                                          DTYPE_BOOL_t[::1] mask,
                                          Py_ssize_t index):
+    """
+    Return ``True`` and set ``mask[index]`` to ``False`` if the neighbors of
+    ``index`` (as given by the offsets in ``structure``) have more than one
+    distinct nonzero label.
+    """
     cdef:
         Py_ssize_t i, neighbor_index
         DTYPE_INT32_t neighbor_label0, neighbor_label1

--- a/skimage/morphology/watershed.py
+++ b/skimage/morphology/watershed.py
@@ -261,8 +261,4 @@ def watershed(image, markers, connectivity=1, offset=None, mask=None,
 
     output = crop(output, pad_width, copy=True)
 
-    if watershed_line:
-        min_val = output.min()
-        output[output == min_val] = 0
-
     return output


### PR DESCRIPTION
## Description
Fixes #2636.

I also changed the implementation of watershed lines to use the mask instead of a dummy value. This is simpler and nicer to read imho.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
