### PR TITLE
Remove pytest yield

### DIFF
--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -93,24 +93,26 @@ def check_cdf_slope(cdf):
 # ====================
 
 
-def test_intensity_range_uint8():
+@pytest.mark.parametrize("test_input,expected", [
+    ('image', [0, 1]),
+    ('dtype', [0, 255]),
+    ((10, 20), [10, 20])
+])
+def test_intensity_range_uint8(test_input, expected):
     image = np.array([0, 1], dtype=np.uint8)
-    input_and_expected = [('image', [0, 1]),
-                          ('dtype', [0, 255]),
-                          ((10, 20), [10, 20])]
-    for range_values, expected_values in input_and_expected:
-        out = intensity_range(image, range_values=range_values)
-        yield assert_array_equal, out, expected_values
+    out = intensity_range(image, range_values=test_input)
+    assert_array_equal(out, expected)
 
 
-def test_intensity_range_float():
+@pytest.mark.parametrize("test_input,expected", [
+    ('image', [0.1, 0.2]),
+    ('dtype', [-1, 1]),
+    ((0.3, 0.4), [0.3, 0.4])
+])
+def test_intensity_range_float(test_input, expected):
     image = np.array([0.1, 0.2], dtype=np.float64)
-    input_and_expected = [('image', [0.1, 0.2]),
-                          ('dtype', [-1, 1]),
-                          ((0.3, 0.4), [0.3, 0.4])]
-    for range_values, expected_values in input_and_expected:
-        out = intensity_range(image, range_values=range_values)
-        yield assert_array_equal, out, expected_values
+    out = intensity_range(image, range_values=test_input)
+    assert_array_equal(out, expected)
 
 
 def test_intensity_range_clipped_float():

--- a/skimage/external/test_tifffile.py
+++ b/skimage/external/test_tifffile.py
@@ -1,5 +1,6 @@
 import os
 import numpy as np
+import itertools
 
 try:
     import skimage as si
@@ -67,17 +68,19 @@ class TestSave:
         y = imread(b)
         assert_array_equal(x, y)
 
-    def test_imsave_roundtrip(self):
-        for shape in [(10, 10), (10, 10, 3), (10, 10, 4)]:
-            for dtype in (np.uint8, np.uint16, np.float32, np.int16,
-                          np.float64):
-                x = np.random.rand(*shape)
+    shapes = ((10, 10), (10, 10, 3), (10, 10, 4))
+    dtypes = (np.uint8, np.uint16, np.float32, np.int16, np.float64)
 
-                if not np.issubdtype(dtype, float):
-                    x = (x * np.iinfo(dtype).max).astype(dtype)
-                else:
-                    x = x.astype(dtype)
-                yield self.roundtrip, dtype, x
+    @pytest.mark.parametrize("shape, dtype",
+                             itertools.product(shapes, dtypes))
+    def test_imsave_roundtrip(self, shape, dtype):
+        x = np.random.rand(*shape)
+
+        if not np.issubdtype(dtype, float):
+            x = (x * np.iinfo(dtype).max).astype(dtype)
+        else:
+            x = x.astype(dtype)
+        self.roundtrip(dtype, x)
 
 
 if __name__ == "__main__":

--- a/skimage/feature/tests/test_template.py
+++ b/skimage/feature/tests/test_template.py
@@ -33,7 +33,7 @@ def test_template():
     positions = positions[np.argsort(positions[:, 0])]
 
     for xy_target, xy in zip(target_positions, positions):
-        yield assert_almost_equal, xy, xy_target
+        assert_almost_equal(xy, xy_target)
 
 
 def test_normalization():

--- a/skimage/filters/tests/test_edges.py
+++ b/skimage/filters/tests/test_edges.py
@@ -382,6 +382,7 @@ def test_horizontal_mask_line(grad_func):
     result = grad_func(vgrad, mask)
     assert_close(result, expected)
 
+
 @pytest.mark.parametrize("grad_func", (
     filters.prewitt_v, filters.sobel_v, filters.scharr_v
 ))

--- a/skimage/filters/tests/test_edges.py
+++ b/skimage/filters/tests/test_edges.py
@@ -1,6 +1,7 @@
 import numpy as np
 from numpy.testing import (assert_array_almost_equal as assert_close,
                            assert_, assert_allclose)
+import pytest
 
 from skimage import filters
 from skimage.filters.edges import _mask_filter_result
@@ -363,7 +364,10 @@ def test_laplace_mask():
     assert (np.all(result == 0))
 
 
-def test_horizontal_mask_line():
+@pytest.mark.parametrize("grad_func", (
+    filters.prewitt_h, filters.sobel_h, filters.scharr_h
+))
+def test_horizontal_mask_line(grad_func):
     """Horizontal edge filters mask pixels surrounding input mask."""
     vgrad, _ = np.mgrid[:1:11j, :1:11j]  # vertical gradient with spacing 0.1
     vgrad[5, :] = 1                      # bad horizontal line
@@ -375,11 +379,13 @@ def test_horizontal_mask_line():
     expected[1:-1, 1:-1] = 0.2           # constant gradient for most of image,
     expected[4:7, 1:-1] = 0              # but line and neighbors masked
 
-    for grad_func in (filters.prewitt_h, filters.sobel_h, filters.scharr_h):
-        result = grad_func(vgrad, mask)
-        yield assert_close, result, expected
+    result = grad_func(vgrad, mask)
+    assert_close(result, expected)
 
-def test_vertical_mask_line():
+@pytest.mark.parametrize("grad_func", (
+    filters.prewitt_v, filters.sobel_v, filters.scharr_v
+))
+def test_vertical_mask_line(grad_func):
     """Vertical edge filters mask pixels surrounding input mask."""
     _, hgrad = np.mgrid[:1:11j, :1:11j]  # horizontal gradient with spacing 0.1
     hgrad[:, 5] = 1                      # bad vertical line
@@ -391,9 +397,8 @@ def test_vertical_mask_line():
     expected[1:-1, 1:-1] = 0.2           # constant gradient for most of image,
     expected[1:-1, 4:7] = 0              # but line and neighbors masked
 
-    for grad_func in (filters.prewitt_v, filters.sobel_v, filters.scharr_v):
-        result = grad_func(hgrad, mask)
-        yield assert_close, result, expected
+    result = grad_func(hgrad, mask)
+    assert_close(result, expected)
 
 
 def test_range():

--- a/skimage/graph/tests/test_mcp.py
+++ b/skimage/graph/tests/test_mcp.py
@@ -6,6 +6,8 @@ from numpy.testing import (assert_array_equal,
 import skimage.graph.mcp as mcp
 from skimage._shared._warnings import expected_warnings
 
+import pytest
+
 np.random.seed(0)
 a = np.ones((8, 8), dtype=np.float32)
 a[1:-1, 1] = 0
@@ -135,9 +137,9 @@ def test_offsets():
                         [10,  0,  1,  2,  3,  4,  5,  6]])
 
 
-def test_crashing():
-    for shape in [(100, 100), (5, 8, 13, 17)] * 5:
-        yield _test_random, shape
+@pytest.mark.parametrize("shape", [(100, 100), (5, 8, 13, 17)] * 5)
+def test_crashing(shape):
+    _test_random(shape)
 
 
 def _test_random(shape):

--- a/skimage/io/tests/test_tifffile.py
+++ b/skimage/io/tests/test_tifffile.py
@@ -2,9 +2,11 @@ import os
 from ... import data_dir
 from .. import imread, imsave, use_plugin, reset_plugins
 import numpy as np
+import itertools
 
 from numpy.testing import (
     assert_array_equal, assert_array_almost_equal, run_module_suite)
+import pytest
 
 from tempfile import NamedTemporaryFile
 
@@ -46,17 +48,19 @@ class TestSave:
         y = imread(fname)
         assert_array_equal(x, y)
 
-    def test_imsave_roundtrip(self):
-        for shape in [(10, 10), (10, 10, 3), (10, 10, 4)]:
-            for dtype in (np.uint8, np.uint16, np.float32, np.int16,
-                          np.float64):
-                x = np.random.rand(*shape)
+    shapes = ((10, 10), (10, 10, 3), (10, 10, 4))
+    dtypes = (np.uint8, np.uint16, np.float32, np.int16, np.float64)
 
-                if not np.issubdtype(dtype, float):
-                    x = (x * np.iinfo(dtype).max).astype(dtype)
-                else:
-                    x = x.astype(dtype)
-                yield self.roundtrip, dtype, x
+    @pytest.mark.parametrize("shape, dtype",
+                             itertools.product(shapes, dtypes))
+    def test_imsave_roundtrip(self, shape, dtype):
+        x = np.random.rand(*shape)
+
+        if not np.issubdtype(dtype, float):
+            x = (x * np.iinfo(dtype).max).astype(dtype)
+        else:
+            x = x.astype(dtype)
+        self.roundtrip(dtype, x)
 
 
 if __name__ == "__main__":

--- a/skimage/morphology/tests/test_binary.py
+++ b/skimage/morphology/tests/test_binary.py
@@ -66,6 +66,7 @@ def test_out_argument():
         testing.assert_(np.any(out != out_saved))
         testing.assert_array_equal(out, func(img, strel))
 
+
 binary_functions = [binary.binary_erosion, binary.binary_dilation,
                     binary.binary_opening, binary.binary_closing]
 
@@ -101,6 +102,7 @@ def test_3d_fallback_default_selem():
     image_expected = np.zeros((7, 7, 7), dtype=bool)
     image_expected[2:5, 2:5, 2:5] = ndi.generate_binary_structure(3, 1)
     testing.assert_array_equal(opened, image_expected)
+
 
 binary_3d_fallback_functions = [binary.binary_opening, binary.binary_closing]
 

--- a/skimage/morphology/tests/test_grey.py
+++ b/skimage/morphology/tests/test_grey.py
@@ -102,10 +102,13 @@ class TestEccentricStructuringElements(unittest.TestCase):
             assert np.all(tophat == 0)
 
 
-def test_default_selem():
-    functions = [grey.erosion, grey.dilation,
-                 grey.opening, grey.closing,
-                 grey.white_tophat, grey.black_tophat]
+grey_functions = [grey.erosion, grey.dilation,
+                  grey.opening, grey.closing,
+                  grey.white_tophat, grey.black_tophat]
+
+
+@pytest.mark.parametrize("function", grey_functions)
+def test_default_selem(function):
     strel = selem.diamond(radius=1)
     image = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -120,10 +123,9 @@ def test_default_selem():
                       [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
                       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], np.uint8)
-    for function in functions:
-        im_expected = function(image, strel)
-        im_test = function(image)
-        yield testing.assert_array_equal, im_expected, im_test
+    im_expected = function(image, strel)
+    im_test = function(image)
+    testing.assert_array_equal(im_expected, im_test)
 
 
 def test_3d_fallback_default_selem():
@@ -139,16 +141,19 @@ def test_3d_fallback_default_selem():
     testing.assert_array_equal(opened, image_expected)
 
 
-def test_3d_fallback_cube_selem():
+grey_3d_fallback_functions = [grey.closing, grey.opening]
+
+
+@pytest.mark.parametrize("function", grey_3d_fallback_functions)
+def test_3d_fallback_cube_selem(function):
     # 3x3x3 cube inside a 7x7x7 image:
     image = np.zeros((7, 7, 7), np.bool)
     image[2:-2, 2:-2, 2:-2] = 1
 
     cube = np.ones((3, 3, 3), dtype=np.uint8)
 
-    for function in [grey.closing, grey.opening]:
-        new_image = function(image, cube)
-        yield testing.assert_array_equal, new_image, image
+    new_image = function(image, cube)
+    testing.assert_array_equal(new_image, image)
 
 
 def test_3d_fallback_white_tophat():

--- a/skimage/morphology/tests/test_skeletonize_3d.py
+++ b/skimage/morphology/tests/test_skeletonize_3d.py
@@ -79,19 +79,20 @@ def test_dtype_conv():
         res = skeletonize_3d(img)
 
     assert_equal(res.dtype, np.uint8)
-    assert_equal(img, orig)  # operation does not clobber the original 
+    assert_equal(img, orig)  # operation does not clobber the original
     assert_equal(res.max(),
                  img_as_ubyte(img).max())    # the intensity range is preserved
 
 
-def test_input():
+@pytest.mark.parametrize("img", [
+    np.ones((8, 8), dtype=float), np.ones((4, 8, 8), dtype=float),
+    np.ones((8, 8), dtype=np.uint8), np.ones((4, 8, 8), dtype=np.uint8),
+    np.ones((8, 8), dtype=bool), np.ones((4, 8, 8), dtype=bool)
+])
+def test_input(img):
     # check that the input is not clobbered
     # for 2D and 3D images of varying dtypes
-    imgs = [np.ones((8, 8), dtype=float), np.ones((4, 8, 8), dtype=float),
-            np.ones((8, 8), dtype=np.uint8), np.ones((4, 8, 8), dtype=np.uint8),
-            np.ones((8, 8), dtype=bool), np.ones((4, 8, 8), dtype=bool)]
-    for img in imgs:
-        yield check_input, img
+    check_input(img)
 
 
 def check_input(img):

--- a/skimage/restoration/tests/test_unwrap.py
+++ b/skimage/restoration/tests/test_unwrap.py
@@ -109,10 +109,12 @@ def check_wrap_around(ndim, axis):
                         image_unwrap_wrap_around[index_last])
 
 
-def test_wrap_around():
-    for ndim in (2, 3):
-        for axis in range(ndim):
-            yield check_wrap_around, ndim, axis
+dim_axis = [(ndim, axis) for ndim in (2, 3) for axis in range(ndim)]
+
+
+@pytest.mark.parametrize("ndim, axis", dim_axis)
+def test_wrap_around(ndim, axis):
+    check_wrap_around(ndim, axis)
 
 
 def test_mask():

--- a/skimage/restoration/tests/test_unwrap.py
+++ b/skimage/restoration/tests/test_unwrap.py
@@ -54,21 +54,25 @@ def test_unwrap_1d():
         unwrap_phase(image, True, seed=0)
 
 
-def test_unwrap_2d():
+@pytest.mark.parametrize("check_with_mask", (False, True))
+def test_unwrap_2d(check_with_mask):
+    mask = None
     x, y = np.ogrid[:8, :16]
     image = 2 * np.pi * (x * 0.2 + y * 0.1)
-    check_unwrap(image)
-    mask = np.zeros(image.shape, dtype=np.bool)
-    mask[4:6, 4:8] = True
+    if check_with_mask:
+        mask = np.zeros(image.shape, dtype=np.bool)
+        mask[4:6, 4:8] = True
     check_unwrap(image, mask)
 
 
-def test_unwrap_3d():
+@pytest.mark.parametrize("check_with_mask", (False, True))
+def test_unwrap_3d(check_with_mask):
+    mask = None
     x, y, z = np.ogrid[:8, :12, :16]
     image = 2 * np.pi * (x * 0.2 + y * 0.1 + z * 0.05)
-    check_unwrap(image)
-    mask = np.zeros(image.shape, dtype=np.bool)
-    mask[4:6, 4:6, 1:3] = True
+    if check_with_mask:
+        mask = np.zeros(image.shape, dtype=np.bool)
+        mask[4:6, 4:6, 1:3] = True
     check_unwrap(image, mask)
 
 

--- a/skimage/restoration/tests/test_unwrap.py
+++ b/skimage/restoration/tests/test_unwrap.py
@@ -57,19 +57,19 @@ def test_unwrap_1d():
 def test_unwrap_2d():
     x, y = np.ogrid[:8, :16]
     image = 2 * np.pi * (x * 0.2 + y * 0.1)
-    yield check_unwrap, image
+    check_unwrap(image)
     mask = np.zeros(image.shape, dtype=np.bool)
     mask[4:6, 4:8] = True
-    yield check_unwrap, image, mask
+    check_unwrap(image, mask)
 
 
 def test_unwrap_3d():
     x, y, z = np.ogrid[:8, :12, :16]
     image = 2 * np.pi * (x * 0.2 + y * 0.1 + z * 0.05)
-    yield check_unwrap, image
+    check_unwrap(image)
     mask = np.zeros(image.shape, dtype=np.bool)
     mask[4:6, 4:6, 1:3] = True
-    yield check_unwrap, image, mask
+    check_unwrap(image, mask)
 
 
 def check_wrap_around(ndim, axis):

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -61,8 +61,9 @@ shapes_for_test_radon_center = [(16, 16), (17, 17)]
 circles_for_test_radon_center = [False, True]
 
 
-@pytest.mark.parametrize("shape", shapes_for_test_radon_center)
-@pytest.mark.parametrize("circle", circles_for_test_radon_center)
+@pytest.mark.parametrize("shape, circle",
+                         itertools.product(shapes_for_test_radon_center,
+                                           circles_for_test_radon_center))
 def test_radon_center(shape, circle):
     check_radon_center(shape, circle)
 
@@ -118,9 +119,10 @@ thetas_for_test_iradon_center = [0, 90]
 circles_for_test_iradon_center = [False, True]
 
 
-@pytest.mark.parametrize("size", sizes_for_test_iradon_center)
-@pytest.mark.parametrize("theta", thetas_for_test_iradon_center)
-@pytest.mark.parametrize("circle", circles_for_test_radon_center)
+@pytest.mark.parametrize("size, theta, circle",
+                         itertools.product(sizes_for_test_iradon_center,
+                                           thetas_for_test_iradon_center,
+                                           circles_for_test_radon_center))
 def test_iradon_center(size, theta, circle):
     check_iradon_center(size, theta, circle)
 
@@ -290,10 +292,7 @@ def check_sinogram_circle_to_square(size):
             argmax_shape(sinogram_circle_to_square))
 
 
-sizes_for_test_sinogram_circle_to_square = (50, 51)
-
-
-@pytest.mark.parametrize("size", sizes_for_test_sinogram_circle_to_square)
+@pytest.mark.parametrize("size", (50, 51))
 def test_sinogram_circle_to_square(size):
     check_sinogram_circle_to_square(size)
 
@@ -337,9 +336,10 @@ output_sizes = (None,
                 97)
 
 
-@pytest.mark.parametrize("shape", shapes_radon_iradon_circle)
-@pytest.mark.parametrize("interpolation", interpolations)
-@pytest.mark.parametrize("output_size", output_sizes)
+@pytest.mark.parametrize("shape, interpolation, output_size",
+                         itertools.product(shapes_radon_iradon_circle,
+                                           interpolations,
+                                           output_sizes))
 def test_radon_iradon_circle(shape, interpolation, output_size):
     check_radon_iradon_circle(interpolation, shape, output_size)
 

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -325,14 +325,12 @@ def check_radon_iradon_circle(interpolation, shape, output_size):
     np.allclose(reconstruction_rectangle, reconstruction_circle)
 
 
-# this might be overkill:
-# in order to allow tests of multiple shapes, the shape is packed in a tuple
-# and using chain to get min or max of all shapes
+# if adding more shapes to test data, you might want to look at commit d0f2bac3f
 shapes_radon_iradon_circle = ((61, 79), )
 interpolations = ('nearest', 'linear')
 output_sizes = (None,
-                min(itertools.chain.from_iterable(shapes_radon_iradon_circle)),
-                max(itertools.chain.from_iterable(shapes_radon_iradon_circle)),
+                min(shapes_radon_iradon_circle[0]),
+                max(shapes_radon_iradon_circle[0]),
                 97)
 
 

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -57,14 +57,22 @@ def check_radon_center(shape, circle):
     assert np.std(sinogram_max) < 1e-6
 
 
-def test_radon_center():
-    shapes = [(16, 16), (17, 17)]
-    circles = [False, True]
-    for shape, circle in itertools.product(shapes, circles):
-        yield check_radon_center, shape, circle
-    rectangular_shapes = [(32, 16), (33, 17)]
-    for shape in rectangular_shapes:
-        yield check_radon_center, shape, False
+shapes_for_test_radon_center = [(16, 16), (17, 17)]
+circles_for_test_radon_center = [False, True]
+
+
+@pytest.mark.parametrize("shape", shapes_for_test_radon_center)
+@pytest.mark.parametrize("circle", circles_for_test_radon_center)
+def test_radon_center(shape, circle):
+    check_radon_center(shape, circle)
+
+
+rectangular_shapes = [(32, 16), (33, 17)]
+
+
+@pytest.mark.parametrize("shape", rectangular_shapes)
+def test_radon_center_rectangular(shape):
+    check_radon_center(shape, False)
 
 
 def check_iradon_center(size, theta, circle):
@@ -105,12 +113,16 @@ def check_iradon_center(size, theta, circle):
     assert np.allclose(reconstruction, reconstruction_opposite)
 
 
-def test_iradon_center():
-    sizes = [16, 17]
-    thetas = [0, 90]
-    circles = [False, True]
-    for size, theta, circle in itertools.product(sizes, thetas, circles):
-        yield check_iradon_center, size, theta, circle
+sizes_for_test_iradon_center = [16, 17]
+thetas_for_test_iradon_center = [0, 90]
+circles_for_test_iradon_center = [False, True]
+
+
+@pytest.mark.parametrize("size", sizes_for_test_iradon_center)
+@pytest.mark.parametrize("theta", thetas_for_test_iradon_center)
+@pytest.mark.parametrize("circle", circles_for_test_radon_center)
+def test_iradon_center(size, theta, circle):
+    check_iradon_center(size, theta, circle)
 
 
 def check_radon_iradon(interpolation_type, filter_type):
@@ -132,14 +144,17 @@ def check_radon_iradon(interpolation_type, filter_type):
     assert delta < allowed_delta
 
 
-def test_radon_iradon():
-    filter_types = ["ramp", "shepp-logan", "cosine", "hamming", "hann"]
-    interpolation_types = ['linear', 'nearest']
-    for interpolation_type, filter_type in \
-            itertools.product(interpolation_types, filter_types):
-        yield check_radon_iradon, interpolation_type, filter_type
-    # cubic interpolation is slow; only run one test for it
-    yield check_radon_iradon, 'cubic', 'shepp-logan'
+filter_types = ["ramp", "shepp-logan", "cosine", "hamming", "hann"]
+interpolation_types = ['linear', 'nearest']
+radon_iradon_inputs = list(itertools.product(interpolation_types, filter_types))
+# cubic interpolation is slow; only run one test for it
+radon_iradon_inputs.append(('cubic', 'shepp-logan'))
+
+
+@pytest.mark.parametrize("interpolation_type, filter_type",
+                         radon_iradon_inputs)
+def test_radon_iradon(interpolation_type, filter_type):
+    check_radon_iradon(interpolation_type, filter_type)
 
 
 def test_iradon_angles():
@@ -185,14 +200,27 @@ def check_radon_iradon_minimal(shape, slices):
                 == np.unravel_index(np.argmax(image), image.shape))
 
 
-def test_radon_iradon_minimal():
-    shapes = [(3, 3), (4, 4), (5, 5)]
-    for shape in shapes:
+shapes = [(3, 3), (4, 4), (5, 5)]
+
+
+def generate_test_data_for_radon_iradon_minimal(shapes):
+    def shape2coordinates(shape):
         c0, c1 = shape[0] // 2, shape[1] // 2
         coordinates = itertools.product((c0 - 1, c0, c0 + 1),
                                         (c1 - 1, c1, c1 + 1))
-        for coordinate in coordinates:
-            yield check_radon_iradon_minimal, shape, coordinate
+        return coordinates
+
+    def shape2shapeandcoordinates(shape):
+        return itertools.product([shape], shape2coordinates(shape))
+
+    return itertools.chain.from_iterable([shape2shapeandcoordinates(shape)
+                                          for shape in shapes])
+
+
+@pytest.mark.parametrize("shape, coordinate",
+                         generate_test_data_for_radon_iradon_minimal(shapes))
+def test_radon_iradon_minimal(shape, coordinate):
+    check_radon_iradon_minimal(shape, coordinate)
 
 
 def test_reconstruct_with_wrong_angles():
@@ -261,9 +289,12 @@ def check_sinogram_circle_to_square(size):
             argmax_shape(sinogram_circle_to_square))
 
 
-def test_sinogram_circle_to_square():
-    for size in (50, 51):
-        yield check_sinogram_circle_to_square, size
+sizes_for_test_sinogram_circle_to_square = (50, 51)
+
+
+@pytest.mark.parametrize("size", sizes_for_test_sinogram_circle_to_square)
+def test_sinogram_circle_to_square(size):
+    check_sinogram_circle_to_square(size)
 
 
 def check_radon_iradon_circle(interpolation, shape, output_size):
@@ -294,13 +325,22 @@ def check_radon_iradon_circle(interpolation, shape, output_size):
     np.allclose(reconstruction_rectangle, reconstruction_circle)
 
 
-def test_radon_iradon_circle():
-    shape = (61, 79)
-    interpolations = ('nearest', 'linear')
-    output_sizes = (None, min(shape), max(shape), 97)
-    for interpolation, output_size in itertools.product(interpolations,
-                                                        output_sizes):
-        yield check_radon_iradon_circle, interpolation, shape, output_size
+# this might be overkill:
+# in order to allow tests of multiple shapes, the shape is packed in a tuple
+# and using chain to get min or max of all shapes
+shapes_radon_iradon_circle = ((61, 79), )
+interpolations = ('nearest', 'linear')
+output_sizes = (None,
+                min(itertools.chain.from_iterable(shapes_radon_iradon_circle)),
+                max(itertools.chain.from_iterable(shapes_radon_iradon_circle)),
+                97)
+
+
+@pytest.mark.parametrize("shape", shapes_radon_iradon_circle)
+@pytest.mark.parametrize("interpolation", interpolations)
+@pytest.mark.parametrize("output_size", output_sizes)
+def test_radon_iradon_circle(shape, interpolation, output_size):
+    check_radon_iradon_circle(interpolation, shape, output_size)
 
 
 def test_order_angles_golden_ratio():

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -146,7 +146,8 @@ def check_radon_iradon(interpolation_type, filter_type):
 
 filter_types = ["ramp", "shepp-logan", "cosine", "hamming", "hann"]
 interpolation_types = ['linear', 'nearest']
-radon_iradon_inputs = list(itertools.product(interpolation_types, filter_types))
+radon_iradon_inputs = list(itertools.product(interpolation_types,
+                                             filter_types))
 # cubic interpolation is slow; only run one test for it
 radon_iradon_inputs.append(('cubic', 'shepp-logan'))
 

--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -15,62 +15,65 @@ dtype_range = {np.uint8: (0, 255),
                np.float64: (-1.0, 1.0)}
 
 
+img_funcs_and_types = {img_as_int: np.int16,
+                       img_as_float: np.float64,
+                       img_as_uint: np.uint16,
+                       img_as_ubyte: np.ubyte}
+
+
 def _verify_range(msg, x, vmin, vmax, dtype):
     assert_equal(x[0], vmin)
     assert_equal(x[-1], vmax)
     assert x.dtype == dtype
 
 
-def test_range():
-    for dtype in dtype_range:
-        imin, imax = dtype_range[dtype]
-        x = np.linspace(imin, imax, 10).astype(dtype)
+@pytest.mark.parametrize("dtype", dtype_range)
+@pytest.mark.parametrize("f", img_funcs_and_types)
+def test_range(dtype, f):
+    imin, imax = dtype_range[dtype]
+    x = np.linspace(imin, imax, 10).astype(dtype)
 
-        for (f, dt) in [(img_as_int, np.int16),
-                        (img_as_float, np.float64),
-                        (img_as_uint, np.uint16),
-                        (img_as_ubyte, np.ubyte)]:
+    dt = img_funcs_and_types[f]
 
-            with expected_warnings(['precision loss|sign loss|\A\Z']):
-                y = f(x)
+    with expected_warnings(['precision loss|sign loss|\A\Z']):
+        y = f(x)
 
-            omin, omax = dtype_range[dt]
+    omin, omax = dtype_range[dt]
 
-            if imin == 0 or omin == 0:
-                omin = 0
-                imin = 0
+    if imin == 0 or omin == 0:
+        omin = 0
+        imin = 0
 
-            yield (_verify_range,
-                   "From %s to %s" % (np.dtype(dtype), np.dtype(dt)),
-                   y, omin, omax, np.dtype(dt))
+    _verify_range("From %s to %s" % (np.dtype(dtype), np.dtype(dt)),
+                  y, omin, omax, np.dtype(dt))
 
 
-def test_range_extra_dtypes():
+# Add non-standard data types that are allowed by the `convert` function.
+dtype_range_extra = dtype_range.copy()
+dtype_range_extra.update({np.int32: (-2147483648, 2147483647),
+                          np.uint32: (0, 4294967295)})
+
+dtype_pairs = [(np.uint8, np.uint32),
+               (np.int8, np.uint32),
+               (np.int8, np.int32),
+               (np.int32, np.int8),
+               (np.float64, np.float32),
+               (np.int32, np.float32)]
+
+
+@pytest.mark.parametrize("dtype_in, dt", dtype_pairs)
+def test_range_extra_dtypes(dtype_in, dt):
     """Test code paths that are not skipped by `test_range`"""
 
-    # Add non-standard data types that are allowed by the `convert` function.
-    dtype_range_extra = dtype_range.copy()
-    dtype_range_extra.update({np.int32: (-2147483648, 2147483647),
-                              np.uint32: (0, 4294967295)})
+    imin, imax = dtype_range_extra[dtype_in]
+    x = np.linspace(imin, imax, 10).astype(dtype_in)
 
-    dtype_pairs = [(np.uint8, np.uint32),
-                   (np.int8, np.uint32),
-                   (np.int8, np.int32),
-                   (np.int32, np.int8),
-                   (np.float64, np.float32),
-                   (np.int32, np.float32)]
+    with expected_warnings(['precision loss|sign loss|\A\Z']):
+        y = convert(x, dt)
 
-    for dtype_in, dt in dtype_pairs:
-        imin, imax = dtype_range_extra[dtype_in]
-        x = np.linspace(imin, imax, 10).astype(dtype_in)
-
-        with expected_warnings(['precision loss|sign loss|\A\Z']):
-            y = convert(x, dt)
-
-        omin, omax = dtype_range_extra[dt]
-        yield (_verify_range,
-               "From %s to %s" % (np.dtype(dtype_in), np.dtype(dt)),
-               y, omin, omax, np.dtype(dt))
+    omin, omax = dtype_range_extra[dt]
+    _verify_range("From %s to %s" % (np.dtype(dtype_in), np.dtype(dt)),
+                  y, omin, omax, np.dtype(dt))
 
 
 def test_downcast():
@@ -88,7 +91,7 @@ def test_float_out_of_range():
     too_low = np.array([-2], dtype=np.float32)
     with pytest.raises(ValueError):
         img_as_int(too_low)
-    
+
 
 def test_copy():
     x = np.array([1], dtype=np.float64)

--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -1,6 +1,7 @@
 import numpy as np
 from numpy.testing import assert_equal
 import pytest
+import itertools
 from skimage import img_as_int, img_as_float, \
                     img_as_uint, img_as_ubyte
 from skimage.util.dtype import convert
@@ -15,10 +16,9 @@ dtype_range = {np.uint8: (0, 255),
                np.float64: (-1.0, 1.0)}
 
 
-img_funcs_and_types = {img_as_int: np.int16,
-                       img_as_float: np.float64,
-                       img_as_uint: np.uint16,
-                       img_as_ubyte: np.ubyte}
+img_funcs = (img_as_int, img_as_float, img_as_uint, img_as_ubyte)
+dtypes_for_img_funcs = (np.int16, np.float64, np.uint16, np.ubyte)
+img_funcs_and_types = zip(img_funcs, dtypes_for_img_funcs)
 
 
 def _verify_range(msg, x, vmin, vmax, dtype):
@@ -27,13 +27,14 @@ def _verify_range(msg, x, vmin, vmax, dtype):
     assert x.dtype == dtype
 
 
-@pytest.mark.parametrize("dtype", dtype_range)
-@pytest.mark.parametrize("f", img_funcs_and_types)
-def test_range(dtype, f):
+@pytest.mark.parametrize("dtype, f_and_dt",
+                         itertools.product(dtype_range,
+                                           img_funcs_and_types))
+def test_range(dtype, f_and_dt):
     imin, imax = dtype_range[dtype]
     x = np.linspace(imin, imax, 10).astype(dtype)
 
-    dt = img_funcs_and_types[f]
+    f, dt = f_and_dt
 
     with expected_warnings(['precision loss|sign loss|\A\Z']):
         y = f(x)


### PR DESCRIPTION
## Description
handle issue: Pytest: yield tests are deprecated and must be removed. #2627


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
#2627 

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
