### PR TITLE
Bug fix in projective tranformation composition with inverse transformation

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -706,7 +706,7 @@ class ProjectiveTransform(GeometricTransform):
         elif (hasattr(other, '__name__')
                 and other.__name__ == 'inverse'
                 and hasattr(get_bound_method_class(other), '_inv_matrix')):
-            return ProjectiveTransform(self._inv_matrix.dot(self.params))
+            return ProjectiveTransform(other.__self__._inv_matrix.dot(self.params))
         else:
             raise TypeError("Cannot combine transformations of differing "
                             "types.")

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -358,6 +358,12 @@ def test_union():
     tform = AffineTransform(scale=(0.1, 0.1), rotation=0.3)
     assert_almost_equal((tform + tform.inverse).params, np.eye(3))
 
+    tform1 = SimilarityTransform(scale=0.1, rotation=0.3)
+    tform2 = SimilarityTransform(scale=0.1, rotation=0.9)
+    tform3 = SimilarityTransform(scale=0.1 * 1/0.1, rotation=0.3 - 0.9)
+    tform = tform1 + tform2.inverse
+    assert_almost_equal(tform.params, tform3.params)
+
 
 def test_union_differing_types():
     tform1 = SimilarityTransform()


### PR DESCRIPTION
## Description
When composing a projective transform with the inverse of another, like `t1 + t2.inverse`, the result was always the identity because it internally composed `self` with `self.inverse`.
The tests did not find this issue because the only test on this was like `t1 + t1.inverse`.
I have also expanded the test to cover this case.


## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] ~Gallery example in `./doc/examples` (new features only)~
- [x] Unit tests

## For reviewers
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
