### PR TITLE
Line 91: Typo "Visualize" to "Visualise"

### DIFF
--- a/doc/examples/features_detection/plot_hog.py
+++ b/doc/examples/features_detection/plot_hog.py
@@ -88,7 +88,7 @@ from skimage import data, color, exposure
 image = color.rgb2gray(data.astronaut())
 
 fd, hog_image = hog(image, orientations=8, pixels_per_cell=(16, 16),
-                    cells_per_block=(1, 1), visualize=True)
+                    cells_per_block=(1, 1), visualise=True)
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4), sharex=True, sharey=True)
 


### PR DESCRIPTION
## Description
Line 91: Typo "Visualize" to "Visualise" to make code work

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
