### PR TITLE
FIX: add estimate_sigma to __all__ in restoration module

### DIFF
--- a/skimage/restoration/__init__.py
+++ b/skimage/restoration/__init__.py
@@ -20,4 +20,5 @@ __all__ = ['wiener',
            'denoise_bilateral',
            'denoise_wavelet',
            'denoise_nl_means',
+           'estimate_sigma',
            'inpaint_biharmonic']


### PR DESCRIPTION
## Description
add `estimate_sigma` to `__all__` in  `skimage/restoration/__init__.py`

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
