### PR TITLE
Better document remove_small_objects behaviour: int vs bool

### DIFF
--- a/skimage/morphology/misc.py
+++ b/skimage/morphology/misc.py
@@ -46,22 +46,21 @@ def _check_dtype_supported(ar):
 
 def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
     """Remove objects smaller than the specified size.
-    If ar is bool, labels connected components and removes objects smaller than
-    min_size. If ar is int, assumes objects have already been labelled. This
-    means that int arrays with only one value above 0 are treated differently
-    than boolean arrays, and all non-zero pixels are considered a single object
-    even if they are not touching.
-
+    Expects ar to be an array with labelled objects, and removes objects
+    smaller than min_size. If ar is bool, the image is first labelled.
+    This leads to potentially different behavior for bool and 0-and-1
+    arrays.
+    
     Parameters
     ----------
     ar : ndarray (arbitrary shape, int or bool type)
         The array containing the objects of interest. If the array type is
-        int, it is assumed that it contains already-labeled objects.
-        The ints must be non-negative.
+        int, the ints must be non-negative.
     min_size : int, optional (default: 64)
         The smallest allowable object size.
     connectivity : int, {1, 2, ..., ar.ndim}, optional (default: 1)
-        The connectivity defining the neighborhood of a pixel.
+        The connectivity defining the neighborhood of a pixel. Used during
+        labelling if ar is bool.
     in_place : bool, optional (default: False)
         If `True`, remove the objects in the input array itself.
         Otherwise, make a copy.

--- a/skimage/morphology/misc.py
+++ b/skimage/morphology/misc.py
@@ -45,20 +45,25 @@ def _check_dtype_supported(ar):
                         "Got %s." % ar.dtype)
 
 def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
-    """Remove connected components smaller than the specified size.
-
+    """Remove objects smaller than the specified size.
+    If ar is bool, labels connected components and removes objects smaller than
+    min_size. If ar is int, assumes objects have already been labelled. This
+    means that int arrays with only one value above 0 are treated differently
+    than boolean arrays, and all non-zero pixels are considered a single object,
+    even if they are not touching.
+    
     Parameters
     ----------
     ar : ndarray (arbitrary shape, int or bool type)
-        The array containing the connected components of interest. If the array
-        type is int, it is assumed that it contains already-labeled objects.
+        The array containing the objects of interest. If the array type is
+        int, it is assumed that it contains already-labeled objects.
         The ints must be non-negative.
     min_size : int, optional (default: 64)
-        The smallest allowable connected component size.
+        The smallest allowable object size.
     connectivity : int, {1, 2, ..., ar.ndim}, optional (default: 1)
         The connectivity defining the neighborhood of a pixel.
     in_place : bool, optional (default: False)
-        If `True`, remove the connected components in the input array itself.
+        If `True`, remove the objects in the input array itself.
         Otherwise, make a copy.
 
     Raises
@@ -92,6 +97,13 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
     >>> d = morphology.remove_small_objects(a, 6, in_place=True)
     >>> d is a
     True
+    >>> e = morphology.remove_small_objects(a.astype(int), 6)
+    /usr/local/lib/python3.5/dist-packages/skimage/morphology/misc.py:122: UserWarning: Only one label was provided to `remove_small_objects`. Did you mean to use a boolean array?
+  warn("Only one label was provided to `remove_small_objects`. "
+    >>> e
+    array([[0, 0, 0, 1, 0],
+           [1, 1, 1, 0, 0],
+           [1, 1, 1, 0, 1]])
     """
     # Raising type error if not int or bool
     _check_dtype_supported(ar)

--- a/skimage/morphology/misc.py
+++ b/skimage/morphology/misc.py
@@ -46,8 +46,9 @@ def _check_dtype_supported(ar):
 
 def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
     """Remove objects smaller than the specified size.
-    Expects ar to be an array with labelled objects, and removes objects
-    smaller than min_size. If ar is bool, the image is first labelled.
+
+    Expects ar to be an array with labeled objects, and removes objects
+    smaller than min_size. If `ar` is bool, the image is first labeled.
     This leads to potentially different behavior for bool and 0-and-1
     arrays.
 
@@ -60,9 +61,9 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
         The smallest allowable object size.
     connectivity : int, {1, 2, ..., ar.ndim}, optional (default: 1)
         The connectivity defining the neighborhood of a pixel. Used during
-        labelling if ar is bool.
+        labelling if `ar` is bool.
     in_place : bool, optional (default: False)
-        If `True`, remove the objects in the input array itself.
+        If ``True``, remove the objects in the input array itself.
         Otherwise, make a copy.
 
     Raises
@@ -96,15 +97,6 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
     >>> d = morphology.remove_small_objects(a, 6, in_place=True)
     >>> d is a
     True
-    >>> e = morphology.remove_small_objects(a.astype(int), 6)
-    /usr/local/lib/python3.5/dist-packages/skimage/morphology/misc.py:135:
-    UserWarning: Only one label was provided to `remove_small_objects`.
-    Did you mean to use a boolean array?
-  warn("Only one label was provided to `remove_small_objects`. "
-    >>> e
-    array([[0, 0, 0, 1, 0],
-           [1, 1, 1, 0, 0],
-           [1, 1, 1, 0, 1]])
     """
     # Raising type error if not int or bool
     _check_dtype_supported(ar)

--- a/skimage/morphology/misc.py
+++ b/skimage/morphology/misc.py
@@ -50,7 +50,7 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
     smaller than min_size. If ar is bool, the image is first labelled.
     This leads to potentially different behavior for bool and 0-and-1
     arrays.
-    
+
     Parameters
     ----------
     ar : ndarray (arbitrary shape, int or bool type)

--- a/skimage/morphology/misc.py
+++ b/skimage/morphology/misc.py
@@ -97,7 +97,7 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
     >>> d is a
     True
     >>> e = morphology.remove_small_objects(a.astype(int), 6)
-    /usr/local/lib/python3.5/dist-packages/skimage/morphology/misc.py:122:
+    /usr/local/lib/python3.5/dist-packages/skimage/morphology/misc.py:135:
     UserWarning: Only one label was provided to `remove_small_objects`.
     Did you mean to use a boolean array?
   warn("Only one label was provided to `remove_small_objects`. "

--- a/skimage/morphology/misc.py
+++ b/skimage/morphology/misc.py
@@ -49,9 +49,9 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
     If ar is bool, labels connected components and removes objects smaller than
     min_size. If ar is int, assumes objects have already been labelled. This
     means that int arrays with only one value above 0 are treated differently
-    than boolean arrays, and all non-zero pixels are considered a single object,
+    than boolean arrays, and all non-zero pixels are considered a single object
     even if they are not touching.
-    
+
     Parameters
     ----------
     ar : ndarray (arbitrary shape, int or bool type)
@@ -98,7 +98,9 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
     >>> d is a
     True
     >>> e = morphology.remove_small_objects(a.astype(int), 6)
-    /usr/local/lib/python3.5/dist-packages/skimage/morphology/misc.py:122: UserWarning: Only one label was provided to `remove_small_objects`. Did you mean to use a boolean array?
+    /usr/local/lib/python3.5/dist-packages/skimage/morphology/misc.py:122:
+    UserWarning: Only one label was provided to `remove_small_objects`.
+    Did you mean to use a boolean array?
   warn("Only one label was provided to `remove_small_objects`. "
     >>> e
     array([[0, 0, 0, 1, 0],


### PR DESCRIPTION
Fixing documentation according to https://github.com/scikit-image/scikit-image/issues/2825

Also added an example showing the different in behaviour together with the warning that I get.


## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
