### PR TITLE
Corrected error with scales attribute in ORB.detect_and_extract

### DIFF
--- a/skimage/feature/orb.py
+++ b/skimage/feature/orb.py
@@ -312,11 +312,12 @@ class ORB(FeatureDetector, DescriptorExtractor):
             descriptors, mask = self._extract_octave(octave_image, keypoints,
                                                      orientations)
 
-            keypoints_list.append(keypoints[mask] * self.downscale ** octave)
+            scaled_keypoints = keypoints[mask] * self.downscale ** octave
+            keypoints_list.append(scaled_keypoints)
             responses_list.append(responses[mask])
             orientations_list.append(orientations[mask])
             scales_list.append(self.downscale ** octave *
-                               np.ones(keypoints.shape[0], dtype=np.intp))
+                               np.ones(scaled_keypoints.shape[0], dtype=np.intp))
             descriptors_list.append(descriptors)
 
         if len(scales_list) == 0:

--- a/skimage/feature/tests/test_orb.py
+++ b/skimage/feature/tests/test_orb.py
@@ -102,6 +102,10 @@ def test_descriptor_orb():
     detector_extractor.detect_and_extract(img)
     assert_equal(exp_descriptors,
                  detector_extractor.descriptors[100:120, 10:20])
+    assert detector_extractor.keypoints.shape[0] == detector_extractor.descriptors.shape[0]
+    assert detector_extractor.keypoints.shape[0] == detector_extractor.orientations.shape[0]
+    assert detector_extractor.keypoints.shape[0] == detector_extractor.responses.shape[0]
+    assert detector_extractor.keypoints.shape[0] == detector_extractor.scales.shape[0]
 
 
 def test_no_descriptors_extracted_orb():


### PR DESCRIPTION
Corrected error in the way scales were built in the ORB.detect_and_extract method

## Description

When using ORB.detect_and_extract there was an error in the way the scales attribute was built. It doesn't take into account the fact that other attributes are built using a mask and relies on the size of the size of an unmasked array instead of a masked one.
## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
