### PR TITLE
Make `regionprops._slice` a user-facing property

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -58,6 +58,7 @@ PROPS = {
     'Perimeter': 'perimeter',
     # 'PixelIdxList',
     # 'PixelList',
+    'Slice': 'slice',
     'Solidity': 'solidity',
     # 'SubarrayIdx'
     'WeightedCentralMoments': 'weighted_moments_central',
@@ -110,6 +111,7 @@ class _RegionProperties(object):
         self.label = label
 
         self._slice = slice
+        self.slice = slice
         self._label_image = label_image
         self._intensity_image = intensity_image
 
@@ -143,8 +145,8 @@ class _RegionProperties(object):
         A tuple of the bounding box's start coordinates for each dimension,
         followed by the end coordinates for each dimension
         """
-        return tuple([self._slice[i].start for i in range(self._ndim)] +
-                     [self._slice[i].stop for i in range(self._ndim)])
+        return tuple([self.slice[i].start for i in range(self._ndim)] +
+                     [self.slice[i].stop for i in range(self._ndim)])
 
     def bbox_area(self):
         return self.image.size
@@ -163,7 +165,7 @@ class _RegionProperties(object):
 
     def coords(self):
         indices = np.nonzero(self.image)
-        return np.vstack([indices[i] + self._slice[i].start
+        return np.vstack([indices[i] + self.slice[i].start
                           for i in range(self._ndim)]).T
 
     @only2d
@@ -198,7 +200,7 @@ class _RegionProperties(object):
 
     @_cached
     def image(self):
-        return self._label_image[self._slice] == self.label
+        return self._label_image[self.slice] == self.label
 
     @_cached
     def inertia_tensor(self):
@@ -214,7 +216,7 @@ class _RegionProperties(object):
     def intensity_image(self):
         if self._intensity_image is None:
             raise AttributeError('No intensity image specified.')
-        return self._intensity_image[self._slice] * self.image
+        return self._intensity_image[self.slice] * self.image
 
     def _intensity_image_double(self):
         return self.intensity_image.astype(np.double)
@@ -291,7 +293,7 @@ class _RegionProperties(object):
     def weighted_centroid(self):
         ctr = self.weighted_local_centroid
         return tuple(idx + slc.start
-                     for idx, slc in zip(ctr, self._slice))
+                     for idx, slc in zip(ctr, self.slice))
 
     def weighted_local_centroid(self):
         M = self.weighted_moments
@@ -474,6 +476,8 @@ def regionprops(label_image, intensity_image=None, cache=True,
     **perimeter** : float
         Perimeter of object which approximates the contour as a line
         through the centers of border pixels using a 4-connectivity.
+    **slice** : tuple of slices
+        A slice to extract the object from the source image.
     **solidity** : float
         Ratio of pixels in the region to pixels of the convex hull image.
     **weighted_centroid** : array

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -36,7 +36,10 @@ INTENSITY_SAMPLE_3D = SAMPLE_3D.copy()
 def test_all_props():
     region = regionprops(SAMPLE, INTENSITY_SAMPLE)[0]
     for prop in PROPS:
-        assert_almost_equal(region[prop], getattr(region, PROPS[prop]))
+        try:
+            assert_almost_equal(region[prop], getattr(region, PROPS[prop]))
+        except TypeError:  # the `slice` property causes this
+            pass
 
 
 def test_all_props_3d():
@@ -44,7 +47,7 @@ def test_all_props_3d():
     for prop in PROPS:
         try:
             assert_almost_equal(region[prop], getattr(region, PROPS[prop]))
-        except NotImplementedError:
+        except (NotImplementedError, TypeError):
             pass
 
 
@@ -153,6 +156,14 @@ def test_coordinates():
     sample[coords[:, 0], coords[:, 1], coords[:, 2]] = 1
     prop_coords = regionprops(sample)[0].coords
     assert_array_equal(prop_coords, coords)
+
+
+def test_slice():
+    padded = np.pad(SAMPLE, ((2, 4), (5, 2)), mode='constant')
+    nrow, ncol = SAMPLE.shape
+    result = regionprops(padded)[0].slice
+    expected = (slice(2, 2+nrow), slice(5, 5+ncol))
+    assert_equal(result, expected)
 
 
 def test_eccentricity():


### PR DESCRIPTION
Currently, `_slice` is hidden from the user, even though it would be
a useful property in many instances (for example, extracting objects
from one channel based on the regionprops of another). In fact there
was a discussion about this when we were talking about the bounding box
property, but that went nowhere.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] <del>Gallery example in `./doc/examples` (new features only)</del>
- [x] Unit tests

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
