### PR TITLE
Fix segmentation fault/memory corruption on py2.7

### DIFF
--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -174,7 +174,7 @@ def slic(image, n_segments=100, compactness=10., max_iter=10, sigma=0,
     labels = _slic_cython(image, segments, step, max_iter, spacing, slic_zero)
 
     if enforce_connectivity:
-        segment_size = depth * height * width / n_segments
+        segment_size = depth * height * width / float(n_segments)
         min_size = int(min_size_factor * segment_size)
         max_size = int(max_size_factor * segment_size)
         labels = _enforce_label_connectivity_cython(labels,


### PR DESCRIPTION
Fixes the following segmentation fault when testing scikit-image-0.13.1.win-amd64-py2.7. The issue is that integer division may result in `segment_size` being 0.

```
Windows exception: access violation

Current thread 0x0000168c (most recent call first):
  File "X:\Python27-x64\lib\site-packages\skimage\segmentation\slic_superpixels.py", line 183 in slic
  File "X:\Python27-x64\lib\site-packages\skimage\segmentation\tests\test_slic.py", line 208 in test_more_segments_than_pixels
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 197 in runTest
  File "X:\Python27-x64\lib\unittest\case.py", line 329 in run
  File "X:\Python27-x64\lib\unittest\case.py", line 393 in __call__
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 151 in runTest
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 133 in run
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 45 in __call__
  File "X:\Python27-x64\lib\site-packages\nose\suite.py", line 224 in run
  File "X:\Python27-x64\lib\site-packages\nose\suite.py", line 177 in __call__
  File "X:\Python27-x64\lib\site-packages\nose\suite.py", line 224 in run
  File "X:\Python27-x64\lib\site-packages\nose\suite.py", line 177 in __call__
  File "X:\Python27-x64\lib\site-packages\nose\suite.py", line 224 in run
  File "X:\Python27-x64\lib\site-packages\nose\suite.py", line 177 in __call__
  File "X:\Python27-x64\lib\site-packages\nose\suite.py", line 224 in run
  File "X:\Python27-x64\lib\site-packages\nose\suite.py", line 177 in __call__
  File "X:\Python27-x64\lib\site-packages\nose\suite.py", line 224 in run
  File "X:\Python27-x64\lib\site-packages\nose\suite.py", line 177 in __call__
  File "X:\Python27-x64\lib\site-packages\nose\core.py", line 62 in run
  File "X:\Python27-x64\lib\site-packages\nose\core.py", line 207 in runTests
  File "X:\Python27-x64\lib\unittest\main.py", line 95 in __init__
  File "X:\Python27-x64\lib\site-packages\nose\core.py", line 121 in __init__
  File "X:\Python27-x64\lib\site-packages\nose\core.py", line 301 in run
  File "X:\Python27-x64\lib\site-packages\skimage\__init__.py", line 95 in _test
```

Code that crashes:
```
              /* "skimage/segmentation/_slic.pyx":256
 *                     coord_list[bfs_visited, 0] = z
 *                     coord_list[bfs_visited, 1] = y
 *                     coord_list[bfs_visited, 2] = x             # <<<<<<<<<<<<<<
 * 
 *                     #perform a breadth first search to find
```
Call stack:
```
>	_slic.pyd!__pyx_pf_7skimage_12segmentation_5_slic_2_enforce_label_connectivity_cython(_object * __pyx_self=0x0000000000000000, __Pyx_memviewslice __pyx_v_segments={...}, __int64 __pyx_v_n_segments=500, __int64 __pyx_v_min_size=0, __int64 __pyx_v_max_size=0)  Line 4743 + 0x2c bytes	C
 	_slic.pyd!__pyx_pw_7skimage_12segmentation_5_slic_3_enforce_label_connectivity_cython(_object * __pyx_self=0x0000000000000000, _object * __pyx_args=0x000000009620d818, _object * __pyx_kwds=0x0000000000000000)  Line 4224 + 0x43 bytes	C
 	python27.dll!PyCFunction_Call(_object * func=0x0000000000000004, _object * arg=0x0000000007881f60, _object * kw=0x0000000050a24f48)  Line 85 + 0x8 bytes	C
 	python27.dll!call_function(_object * * * pp_stack=0x000000001355cfdf, int oparg=0)  Line 4357 + 0xaf bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x000000008129cd28, int throwflag=1352837888)  Line 2998	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x0000000050175f30, _object * globals=0x0000000000000001, _object * locals=0x0000000050a2ab00, _object * * args=0x0000000000000000, int argcount=1, _object * * kws=0x000000008389ef38, int kwcount=5, _object * * defs=0x0000000050a2ab00, int defcount=11, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!fast_function(_object * func=0x0000000000000001, _object * * * pp_stack=0x000000000000000b, int n=1352864040, int na=1919887379, int nk=5)  Line 4456	C
 	python27.dll!call_function(_object * * * pp_stack=0x000000005b265129, int oparg=0)  Line 4377 + 0x16 bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x000000008389ed98, int throwflag=126378056)  Line 2998	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x000000007adb4eb0, _object * globals=0x000000007e1313a8, _object * locals=0x0000000000000000, _object * * args=0x0000000058256e08, int argcount=0, _object * * kws=0x0000000000000000, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!function_call(_object * func=0x0000000000000000, _object * arg=0x0000000007886048, _object * kw=0x0000000000000000)  Line 528 + 0x37 bytes	C
 	python27.dll!PyObject_Call(_object * func=0x000000007adb7cf8, _object * arg=0x0000000000000000, _object * kw=0x0000000007886048)  Line 2548	C
 	python27.dll!ext_do_call(_object * func=0x000000007adb7cf8, _object * * * pp_stack=0x0000000000000001, int flags=140, int na=0, int nk=0)  Line 4671 + 0xe bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x000000007e1303a8, int throwflag=1)  Line 3036	C
 	python27.dll!fast_function(_object * func=0x0000000000000001, _object * * * pp_stack=0x0000000000000001, int n=636408328, int na=1920199338, int nk=0)  Line 4443	C
 	python27.dll!call_function(_object * * * pp_stack=0x00000000137cade3, int oparg=0)  Line 4377 + 0x16 bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x000000005de00de8, int throwflag=0)  Line 2998	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x0000000013775e30, _object * globals=0x0000000000000002, _object * locals=0x0000000000000000, _object * * args=0x0000000007881f60, int argcount=2, _object * * kws=0x0000000007886060, int kwcount=0, _object * * defs=0x0000000013792808, int defcount=1, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!function_call(_object * func=0x0000000000000000, _object * arg=0x0000000090cabfc8, _object * kw=0x000000009af37d08)  Line 528 + 0x37 bytes	C
 	python27.dll!PyObject_Call(_object * func=0x0000000013797908, _object * arg=0x000000009af37d08, _object * kw=0x00000000970e00b8)  Line 2548	C
 	python27.dll!ext_do_call(_object * func=0x0000000013797908, _object * * * pp_stack=0x0000000000000003, int flags=2061135768, int na=1, int nk=0)  Line 4671 + 0xe bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x000000007e12e3d8, int throwflag=0)  Line 3036	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x0000000013775f30, _object * globals=0x0000000000000001, _object * locals=0x0000000000000000, _object * * args=0x0000000090cabe88, int argcount=2, _object * * kws=0x0000000000000000, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!function_call(_object * func=0x00000000137979e8, _object * arg=0x0000000090cabe88, _object * kw=0x0000000000000000)  Line 528 + 0x37 bytes	C
 	python27.dll!PyObject_Call(_object * func=0x000000007ada6f98, _object * arg=0x000000007291dc58, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!instancemethod_call(_object * func=0x0000447a84c7a91e, _object * arg=0x0000000072754d2d, _object * kw=0x000000007e12e3b8)  Line 2603	C
 	python27.dll!PyObject_Call(_object * func=0x00000000137979e8, _object * arg=0x000000009206c320, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!slot_tp_call(_object * self=0x0000000000000000, _object * args=0x0000000000000001, _object * kwds=0x000000009206c320)  Line 5602	C
 	python27.dll!PyObject_Call(_object * func=0x0000000000000000, _object * arg=0x0000000000000000, _object * kw=0x0000000000000001)  Line 2548	C
 	python27.dll!do_call(_object * func=0x0000000000000001, _object * * * pp_stack=0x0000000000000001, int na=2061135768, int nk=14593208)  Line 4574 + 0xe bytes	C
 	python27.dll!call_function(_object * * * pp_stack=0x00000000201c256c, int oparg=0)  Line 4379 + 0x11 bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x000000007e12e210, int throwflag=2)  Line 2998	C
 	python27.dll!fast_function(_object * func=0x0000000000000002, _object * * * pp_stack=0x0000000000000002, int n=636407992, int na=1920199338, int nk=0)  Line 4443	C
 	python27.dll!call_function(_object * * * pp_stack=0x00000000201ced9d, int oparg=0)  Line 4377 + 0x16 bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x000000007c860980, int throwflag=0)  Line 2998	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x00000000201d5a30, _object * globals=0x0000000000000002, _object * locals=0x0000000000000000, _object * * args=0x0000000025d1ed00, int argcount=2, _object * * kws=0x0000000007886060, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!function_call(_object * func=0x0000000000000000, _object * arg=0x0000000090cabbc8, _object * kw=0x000000009af377b8)  Line 528 + 0x37 bytes	C
 	python27.dll!PyObject_Call(_object * func=0x0000000025eed048, _object * arg=0x000000009af377b8, _object * kw=0x000000008a858c18)  Line 2548	C
 	python27.dll!ext_do_call(_object * func=0x0000000025eed048, _object * * * pp_stack=0x0000000000000003, int flags=-1760689936, int na=1, int nk=0)  Line 4671 + 0xe bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x000000007e12e048, int throwflag=0)  Line 3036	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x000000001f68f8b0, _object * globals=0x0000000000000001, _object * locals=0x0000000000000000, _object * * args=0x0000000007881f60, int argcount=2, _object * * kws=0x0000000000000000, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!function_call(_object * func=0x0000000025c63c18, _object * arg=0x0000000090cabb48, _object * kw=0x0000000000000000)  Line 528 + 0x37 bytes	C
 	python27.dll!PyObject_Call(_object * func=0x00000000970e00f0, _object * arg=0x0000000090cabb48, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!instancemethod_call(_object * func=0x0000000072928d28, _object * arg=0x0000000092089fb0, _object * kw=0x0000000092089fc0)  Line 2603	C
 	python27.dll!PyObject_Call(_object * func=0x0000000025c63c18, _object * arg=0x000000008a858a90, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!slot_tp_call(_object * self=0x0000000000000000, _object * args=0x0000000000000001, _object * kwds=0x000000008a858a90)  Line 5602	C
 	python27.dll!PyObject_Call(_object * func=0x0000000000000000, _object * arg=0x000000001fcdecf8, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!do_call(_object * func=0x0000000000000001, _object * * * pp_stack=0x0000000000000001, int na=-1760689936, int nk=14595976)  Line 4574 + 0xe bytes	C
 	python27.dll!call_function(_object * * * pp_stack=0x000000001f45852a, int oparg=0)  Line 4379 + 0x11 bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x0000000092089e10, int throwflag=0)  Line 2998	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x000000001fcfe930, _object * globals=0x0000000000000002, _object * locals=0x0000000000000000, _object * * args=0x0000000025d1ed00, int argcount=2, _object * * kws=0x0000000007886060, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!function_call(_object * func=0x0000000000000000, _object * arg=0x0000000090cabac8, _object * kw=0x0000000093b34378)  Line 528 + 0x37 bytes	C
 	python27.dll!PyObject_Call(_object * func=0x0000000025b519e8, _object * arg=0x0000000093b34378, _object * kw=0x000000007bfed780)  Line 2548	C
 	python27.dll!ext_do_call(_object * func=0x0000000025b519e8, _object * * * pp_stack=0x0000000000000003, int flags=2061230208, int na=1, int nk=0)  Line 4671 + 0xe bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x000000008a82f048, int throwflag=0)  Line 3036	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x000000001fcfe730, _object * globals=0x0000000000000001, _object * locals=0x0000000000000000, _object * * args=0x0000000007881f60, int argcount=2, _object * * kws=0x0000000000000000, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!function_call(_object * func=0x0000000025b51898, _object * arg=0x0000000090cabb08, _object * kw=0x0000000000000000)  Line 528 + 0x37 bytes	C
 	python27.dll!PyObject_Call(_object * func=0x000000007adbe080, _object * arg=0x0000000090cabb08, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!instancemethod_call(_object * func=0x0000000000000000, _object * arg=0x0000000000000000, _object * kw=0x00000000920895e8)  Line 2603	C
 	python27.dll!PyObject_Call(_object * func=0x0000000025b51898, _object * arg=0x000000007bfed6d8, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!slot_tp_call(_object * self=0x0000000000000000, _object * args=0x0000000000000001, _object * kwds=0x000000007bfed6d8)  Line 5602	C
 	python27.dll!PyObject_Call(_object * func=0x0000000000000000, _object * arg=0x000000001fcdecf8, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!do_call(_object * func=0x0000000000000001, _object * * * pp_stack=0x0000000000000001, int na=2061230208, int nk=14598264)  Line 4574 + 0xe bytes	C
 	python27.dll!call_function(_object * * * pp_stack=0x000000001f45852a, int oparg=0)  Line 4379 + 0x11 bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x0000000092089438, int throwflag=0)  Line 2998	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x000000001fcfe930, _object * globals=0x0000000000000002, _object * locals=0x0000000000000000, _object * * args=0x000000007279eeab, int argcount=2, _object * * kws=0x0000000007886060, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!function_call(_object * func=0x0000000000000000, _object * arg=0x0000000093b3c308, _object * kw=0x000000009af2fe18)  Line 528 + 0x37 bytes	C
 	python27.dll!PyObject_Call(_object * func=0x0000000025b519e8, _object * arg=0x000000009af2fe18, _object * kw=0x000000007bfed6a0)  Line 2548	C
 	python27.dll!ext_do_call(_object * func=0x0000000025b519e8, _object * * * pp_stack=0x0000000000000003, int flags=2061059016, int na=1, int nk=0)  Line 4671 + 0xe bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x0000000091f5fe10, int throwflag=0)  Line 3036	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x000000001fcfe730, _object * globals=0x0000000000000001, _object * locals=0x0000000000000000, _object * * args=0x0000000007881f60, int argcount=2, _object * * kws=0x0000000000000000, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!function_call(_object * func=0x0000000025b51898, _object * arg=0x0000000093b3c1c8, _object * kw=0x0000000000000000)  Line 528 + 0x37 bytes	C
 	python27.dll!PyObject_Call(_object * func=0x000000007ad943c8, _object * arg=0x0000000093b3c1c8, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!instancemethod_call(_object * func=0x0000000000000000, _object * arg=0x0000000000000000, _object * kw=0x0000000092089bd0)  Line 2603	C
 	python27.dll!PyObject_Call(_object * func=0x0000000025b51898, _object * arg=0x000000007bfc8588, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!slot_tp_call(_object * self=0x0000000000000000, _object * args=0x0000000000000001, _object * kwds=0x000000007bfc8588)  Line 5602	C
 	python27.dll!PyObject_Call(_object * func=0x0000000000000000, _object * arg=0x000000001fcdecf8, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!do_call(_object * func=0x0000000000000001, _object * * * pp_stack=0x0000000000000001, int na=2061059016, int nk=14600552)  Line 4574 + 0xe bytes	C
 	python27.dll!call_function(_object * * * pp_stack=0x000000001f45852a, int oparg=0)  Line 4379 + 0x11 bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x0000000092089a20, int throwflag=0)  Line 2998	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x000000001fcfe930, _object * globals=0x0000000000000002, _object * locals=0x0000000000000000, _object * * args=0x000000007279eeab, int argcount=2, _object * * kws=0x0000000007886060, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!function_call(_object * func=0x0000000000000000, _object * arg=0x0000000093b3c2c8, _object * kw=0x00000000970aa048)  Line 528 + 0x37 bytes	C
 	python27.dll!PyObject_Call(_object * func=0x0000000025b519e8, _object * arg=0x00000000970aa048, _object * kw=0x000000007bfed438)  Line 2548	C
 	python27.dll!ext_do_call(_object * func=0x0000000025b519e8, _object * * * pp_stack=0x0000000000000003, int flags=2061164616, int na=1, int nk=0)  Line 4671 + 0xe bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x000000009af0fcc0, int throwflag=0)  Line 3036	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x000000001fcfe730, _object * globals=0x0000000000000001, _object * locals=0x0000000000000000, _object * * args=0x0000000072965d10, int argcount=2, _object * * kws=0x0000000000000000, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!function_call(_object * func=0x0000000025b51898, _object * arg=0x0000000093b3c3c8, _object * kw=0x0000000000000000)  Line 528 + 0x37 bytes	C
 	python27.dll!PyObject_Call(_object * func=0x000000007adae048, _object * arg=0x0000000093b3c3c8, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!instancemethod_call(_object * func=0x0000000000000000, _object * arg=0x0000000000000000, _object * kw=0x000000007e12c3f0)  Line 2603	C
 	python27.dll!PyObject_Call(_object * func=0x0000000025b51898, _object * arg=0x000000007bfed470, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!slot_tp_call(_object * self=0x0000000000000000, _object * args=0x0000000000000001, _object * kwds=0x000000007bfed470)  Line 5602	C
 	python27.dll!PyObject_Call(_object * func=0x0000000000000000, _object * arg=0x000000001fcdecf8, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!do_call(_object * func=0x0000000000000001, _object * * * pp_stack=0x0000000000000001, int na=2061164616, int nk=14602840)  Line 4574 + 0xe bytes	C
 	python27.dll!call_function(_object * * * pp_stack=0x000000001f45852a, int oparg=0)  Line 4379 + 0x11 bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x000000007e12c240, int throwflag=0)  Line 2998	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x000000001fcfe930, _object * globals=0x0000000000000002, _object * locals=0x0000000000000000, _object * * args=0x000000007279eeab, int argcount=2, _object * * kws=0x0000000007886060, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!function_call(_object * func=0x0000000000000000, _object * arg=0x000000007bfdefc8, _object * kw=0x000000007e12bbf8)  Line 528 + 0x37 bytes	C
 	python27.dll!PyObject_Call(_object * func=0x0000000025b519e8, _object * arg=0x000000007e12bbf8, _object * kw=0x000000007bfdd978)  Line 2548	C
 	python27.dll!ext_do_call(_object * func=0x0000000025b519e8, _object * * * pp_stack=0x0000000000000003, int flags=915010112, int na=1, int nk=0)  Line 4671 + 0xe bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x000000007bb68930, int throwflag=0)  Line 3036	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x000000001fcfe730, _object * globals=0x0000000000000001, _object * locals=0x0000000000000000, _object * * args=0x0000000007881f60, int argcount=2, _object * * kws=0x0000000000000000, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!function_call(_object * func=0x0000000025b51898, _object * arg=0x000000007bfcc808, _object * kw=0x0000000000000000)  Line 528 + 0x37 bytes	C
 	python27.dll!PyObject_Call(_object * func=0x000000003689f240, _object * arg=0x000000007bfcc808, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!instancemethod_call(_object * func=0x0000000000000000, _object * arg=0x0000000000000000, _object * kw=0x000000005b824fc0)  Line 2603	C
 	python27.dll!PyObject_Call(_object * func=0x0000000025b51898, _object * arg=0x000000007bfbdeb8, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!slot_tp_call(_object * self=0x0000000000000000, _object * args=0x0000000000000001, _object * kwds=0x000000007bfbdeb8)  Line 5602	C
 	python27.dll!PyObject_Call(_object * func=0x0000000000000000, _object * arg=0x000000001fcdecf8, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!do_call(_object * func=0x0000000000000001, _object * * * pp_stack=0x0000000000000001, int na=915010112, int nk=14605128)  Line 4574 + 0xe bytes	C
 	python27.dll!call_function(_object * * * pp_stack=0x000000001f45852a, int oparg=0)  Line 4379 + 0x11 bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x000000005b824e10, int throwflag=0)  Line 2998	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x000000001fcfe930, _object * globals=0x0000000000000002, _object * locals=0x0000000000000000, _object * * args=0x0000000000000002, int argcount=2, _object * * kws=0x0000000007886060, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!function_call(_object * func=0x0000000000000000, _object * arg=0x000000007bfdef88, _object * kw=0x000000007e12b7b8)  Line 528 + 0x37 bytes	C
 	python27.dll!PyObject_Call(_object * func=0x0000000025b519e8, _object * arg=0x000000007e12b7b8, _object * kw=0x000000007bb75a90)  Line 2548	C
 	python27.dll!ext_do_call(_object * func=0x0000000025b519e8, _object * * * pp_stack=0x0000000000000003, int flags=915009664, int na=1, int nk=0)  Line 4671 + 0xe bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x000000007bb685a0, int throwflag=0)  Line 3036	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x000000001fcfe730, _object * globals=0x0000000000000001, _object * locals=0x0000000000000000, _object * * args=0x00000000368933c8, int argcount=2, _object * * kws=0x0000000000000000, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!function_call(_object * func=0x0000000025b51898, _object * arg=0x00000000368933c8, _object * kw=0x0000000000000000)  Line 528 + 0x37 bytes	C
 	python27.dll!PyObject_Call(_object * func=0x000000003689f080, _object * arg=0x000000007291dc58, _object * kw=0x0000000007886210)  Line 2548	C
 	python27.dll!instancemethod_call(_object * func=0x000000000a979b20, _object * arg=0x00000000548adf88, _object * kw=0x00000000548adf98)  Line 2603	C
 	python27.dll!PyObject_Call(_object * func=0x0000000025b51898, _object * arg=0x000000007b4d77f0, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!slot_tp_call(_object * self=0x0000000000000000, _object * args=0x0000000000000001, _object * kwds=0x000000007b4d77f0)  Line 5602	C
 	python27.dll!PyObject_Call(_object * func=0x0000000000000000, _object * arg=0x0000000000000000, _object * kw=0x000000000b223688)  Line 2548	C
 	python27.dll!do_call(_object * func=0x0000000000000001, _object * * * pp_stack=0x0000000000000001, int na=915009664, int nk=14607416)  Line 4574 + 0xe bytes	C
 	python27.dll!call_function(_object * * * pp_stack=0x000000001ebee796, int oparg=0)  Line 4379 + 0x11 bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x00000000548addd8, int throwflag=2)  Line 2998	C
 	python27.dll!fast_function(_object * func=0x0000000000000002, _object * * * pp_stack=0x0000000000000002, int n=633516888, int na=1920199254, int nk=0)  Line 4443	C
 	python27.dll!call_function(_object * * * pp_stack=0x000000001e8ac566, int oparg=0)  Line 4377 + 0x16 bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x00000000132c9dd8, int throwflag=1)  Line 2998	C
 	python27.dll!fast_function(_object * func=0x0000000000000001, _object * * * pp_stack=0x0000000000000001, int n=633517560, int na=1920199338, int nk=0)  Line 4443	C
 	python27.dll!call_function(_object * * * pp_stack=0x00000000130bd6b4, int oparg=0)  Line 4377 + 0x16 bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x00000000093fddf8, int throwflag=326776672)  Line 2998	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x00000000137a30b0, _object * globals=0x0000000000000001, _object * locals=0x0000000000000006, _object * * args=0x0000000025ef04a8, int argcount=1, _object * * kws=0x000000002025eba0, int kwcount=6, _object * * defs=0x00000000137a3760, int defcount=10, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!function_call(_object * func=0x0000000013c5f358, _object * arg=0x000000000853d710, _object * kw=0x00000000259eae18)  Line 528 + 0x37 bytes	C
 	python27.dll!PyObject_Call(_object * func=0x00000000201bbfb0, _object * arg=0x000000000853d710, _object * kw=0x0000000013d07c68)  Line 2548	C
 	python27.dll!instancemethod_call(_object * func=0x0000000000000000, _object * arg=0x00000000130d9870, _object * kw=0x0000000000000002)  Line 2603	C
 	python27.dll!PyObject_Call(_object * func=0x00000000202e0750, _object * arg=0x00000000259eae18, _object * kw=0x0000000000000000)  Line 2548	C
 	python27.dll!ext_do_call(_object * func=0x00000000202e0750, _object * * * pp_stack=0x0000000000000002, int flags=0, int na=1, int nk=5)  Line 4671 + 0xe bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x0000000009165da8, int throwflag=538772504)  Line 3036	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x000000001f20e130, _object * globals=0x0000000000000002, _object * locals=0x0000000000000002, _object * * args=0x00120000727a1551, int argcount=2, _object * * kws=0x00000000085514c0, int kwcount=2, _object * * defs=0x00000000201d0418, int defcount=11, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!function_call(_object * func=0x0000000025c2b3c8, _object * arg=0x000000000a2fbc48, _object * kw=0x00000000259dbd08)  Line 528 + 0x37 bytes	C
 	python27.dll!PyObject_Call(_object * func=0x0000000025ef04a8, _object * arg=0x0000000000001000, _object * kw=0x00000000093c3fe0)  Line 2548	C
 	python27.dll!instancemethod_call(_object * func=0x0000000000000000, _object * arg=0x0000000000000020, _object * kw=0x0000000000000003)  Line 2603	C
 	python27.dll!PyObject_Call(_object * func=0x0000000025ef04a8, _object * arg=0x000000000853d748, _object * kw=0x00000000259dbd08)  Line 2548	C
 	python27.dll!slot_tp_init(_object * self=0x0000000025ef04a8, _object * args=0x000000000853d748, _object * kwds=0x00000000259dbd08)  Line 5861	C
 	python27.dll!type_call(_typeobject * type=0x00000000259dbd08, _object * args=0x00000000259dbd08, _object * kwds=0x000000000853d4a8)  Line 765 + 0x22 bytes	C
 	python27.dll!PyObject_Call(_object * func=0x000000000a77bc68, _object * arg=0x00000000259dbd08, _object * kw=0x000000000853d4a8)  Line 2548	C
 	python27.dll!ext_do_call(_object * func=0x000000000a77bc68, _object * * * pp_stack=0x0000000000000003, int flags=142, int na=0, int nk=0)  Line 4671 + 0xe bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x000000001f1e4ac8, int throwflag=1)  Line 3036	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x000000001f2135b0, _object * globals=0x0000000000000000, _object * locals=0x0000000000000000, _object * * args=0x000000007291dc58, int argcount=1, _object * * kws=0x00000000162cbfc0, int kwcount=1, _object * * defs=0x0000000000000000, int defcount=0, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!fast_function(_object * func=0x0000000000000001, _object * * * pp_stack=0x0000000000000003, int n=633516552, int na=1920199254, int nk=1)  Line 4456	C
 	python27.dll!call_function(_object * * * pp_stack=0x0000000007ca2757, int oparg=0)  Line 4377 + 0x16 bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x00000000162cbe08, int throwflag=170911392)  Line 2998	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x0000000007c97130, _object * globals=0x0000000000000000, _object * locals=0x000000000a2fe6a0, _object * * args=0x00000000078cbd00, int argcount=0, _object * * kws=0x00000000078acbb8, int kwcount=0, _object * * defs=0x000000000a2fe6a0, int defcount=2, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!fast_function(_object * func=0x0000000000000000, _object * * * pp_stack=0x0000000000000000, int n=170868520, int na=1920199254, int nk=0)  Line 4456	C
 	python27.dll!call_function(_object * * * pp_stack=0x0000000008531b7b, int oparg=0)  Line 4377 + 0x16 bytes	C
 	python27.dll!PyEval_EvalFrameEx(_frame * f=0x00000000078aca38, int throwflag=130589288)  Line 2998	C
 	python27.dll!PyEval_EvalCodeEx(PyCodeObject * co=0x00000000078ade30, _object * globals=0x0000000007c8a268, _object * locals=0x00000000078ade30, _object * * args=0x0000000007c8a268, int argcount=0, _object * * kws=0x0000000000000000, int kwcount=0, _object * * defs=0x0000000000000000, int defcount=0, _object * closure=0x0000000000000000)  Line 3589 + 0xf bytes	C
 	python27.dll!run_mod(_mod * mod=0x0000000007c8a268, const char * filename=0x0000000000000000, _object * globals=0x0000000000000000, _object * locals=0x00000000727bb0ff, PyCompilerFlags * flags=0x0000000000defb78, _arena * arena=0x000000000a645fe0)  Line 1377	C
 	python27.dll!PyRun_StringFlags(const char * str=0x000000000787bfb0, int start=130587744, _object * globals=0x000000000787bfb0, _object * locals=0x0000000000defb78, PyCompilerFlags * flags=0x0000000000defb78)  Line 1339 + 0x1f bytes	C
 	python27.dll!PyRun_SimpleStringFlags(const char * command=0x0000000000000001, PyCompilerFlags * flags=0x0000000007879f70)  Line 974 + 0x18 bytes	C
 	python27.dll!Py_Main(int argc=0, char * * argv=0x000000ee00000000)  Line 589 + 0x10 bytes	C
 	python.exe!__tmainCRTStartup()  Line 586 + 0x19 bytes	C
 	kernel32.dll!00007ffbeb6c2774() 	
 	[Frames below may be incorrect and/or missing, no symbols loaded for kernel32.dll]	
 	ntdll.dll!00007ffbedb10d51() 	
```

Locals:
```
+		_save	0x0000000007881f60 {next=0x0000000000000000 interp=0x000000000787dfb0 frame=0x000000008129cd28 ...}	_ts *
+		__pyx_self	0x0000000000000000 {ob_refcnt=??? ob_type=??? }	_object *
		__pyx_v_min_size	0	__int64
+		__pyx_r	0x0000000000000000 {ob_refcnt=??? ob_type=??? }	_object *
		__pyx_v_n_segments	500	__int64
-		__pyx_v_segments	{memview=0x0000000000de9980 data=0x00000000000001f4 <Bad Ptr> shape=0x0000000000de9768 ...}	__Pyx_memviewslice
+		memview	0x0000000000de9980 {ob_refcnt=2080055016 ob_type=0x0000000044f9e2e0 __pyx_vtab=0x0000000000000001 ...}	__pyx_memoryview_obj *
+		data	0x00000000000001f4 <Bad Ptr>	char *
+		shape	0x0000000000de9768	__int64 [8]
+		strides	0x0000000000de97a8	__int64 [8]
+		suboffsets	0x0000000000de97e8	__int64 [8]
		__pyx_v_label	0	__int64
		__pyx_t_10	0	__int64
		__pyx_t_18	0	int
		__pyx_t_22	0	__int64
		__pyx_t_64	140720001662847	__int64
		__pyx_t_67	16781314	__int64
		__pyx_t_75	32	__int64
		__pyx_v_width	21	__int64
+		__pyx_v_coord_list	{memview=0x0000000092eabc78 data=0x000000003774fff0 "" shape=0x0000000000de8bd0 ...}	__Pyx_memviewslice
+		__pyx_t_4	0x0000000000000000 {ob_refcnt=??? ob_type=??? }	_object *
		__pyx_t_11	20	__int64
		__pyx_t_19	0	__int64
		__pyx_t_52	16781314	__int64
		__pyx_v_z	0	__int64
		__pyx_v_x	0	__int64
		__pyx_t_15	0	__int64
		__pyx_t_26	0	__int64
		__pyx_t_32	1407648792	__int64
		__pyx_t_47	140720001302187	__int64
		__pyx_t_56	1407613287	__int64
		__pyx_t_60	1920303588	__int64
		__pyx_t_69	1407552339	__int64
+		__pyx_v_ddx	{memview=0x000000007bfb1ad8 data=0x000000001ecaafd0 "" shape=0x0000000000de8a90 ...}	__Pyx_memviewslice
		__pyx_v_max_size	0	__int64
+		__pyx_t_1	0x0000000000000000 {ob_refcnt=??? ob_type=??? }	_object *
		__pyx_t_30	2	__int64
		__pyx_t_46	140720000949786	__int64
		__pyx_t_61	0	__int64
		__pyx_t_72	140720001881626	__int64
		__pyx_v_current_new_label	0	__int64
+		__pyx_t_5	{memview=0x0000000000000000 data=0x0000000000000000 <Bad Ptr> shape=0x0000000000de8980 ...}	__Pyx_memviewslice
		__pyx_t_13	21	__int64
		__pyx_t_35	0	__int64
		__pyx_t_37	14584224	__int64
		__pyx_t_38	256	__int64
		__pyx_t_44	0	__int64
+		__pyx_v_ddy	{memview=0x0000000092eabee8 data=0x000000005bfedfd0 "" shape=0x0000000000de8880 ...}	__Pyx_memviewslice
		__pyx_t_33	420	__int64
+		__pyx_v_ddz	{memview=0x0000000092eab5f8 data=0x0000000053b8bfd0 "" shape=0x0000000000de87a0 ...}	__Pyx_memviewslice
		__pyx_t_31	0	int
		__pyx_t_41	0	__int64
		__pyx_t_51	0	__int64
		__pyx_t_62	0	__int64
		__pyx_t_65	0	__int64
		__pyx_v_height	20	__int64
		__pyx_v_bfs_visited	0	__int64
		__pyx_v_adjacent	0	__int64
		__pyx_t_34	0	__int64
		__pyx_t_54	420	__int64
		__pyx_t_74	0	__int64
+		__pyx_t_2	0x0000000000000000 {ob_refcnt=??? ob_type=??? }	_object *
+		__pyx_t_8	{memview=0x0000000000000000 data=0x0000000000000000 <Bad Ptr> shape=0x0000000000de8670 ...}	__Pyx_memviewslice
		__pyx_t_17	0	__int64
		__pyx_t_21	0	__int64
		__pyx_t_23	0	__int64
		__pyx_t_39	319686496	__int64
		__pyx_t_40	1574965192	__int64
		__pyx_t_68	14590920	__int64
		__pyx_t_71	631134136	__int64
		__pyx_t_73	326938083	__int64
		__pyx_t_16	0	__int64
		__pyx_t_27	0	__int64
		__pyx_t_29	0	__int64
		__pyx_t_48	2115175336	__int64
		__pyx_t_49	126361440	__int64
		__pyx_t_50	1	__int64
+		__pyx_v_connected_segments	{memview=0x0000000092eabba8 data=0x000000007bebe2e0 "" shape=0x0000000000de8530 ...}	__Pyx_memviewslice
		__pyx_v_current_segment_size	1	__int64
		__pyx_t_25	0	__int64
		__pyx_t_9	1	__int64
		__pyx_t_12	0	__int64
		__pyx_t_58	14584560	__int64
		__pyx_t_66	1921861684	__int64
		__pyx_v_zz	14590656	__int64
		__pyx_t_14	0	__int64
		__pyx_t_24	0	__int64
		__pyx_t_28	1	__int64
		__pyx_t_36	1919156224	__int64
		__pyx_t_45	1922572288	__int64
		__pyx_t_53	14590272	__int64
		__pyx_v_xx	14590272	__int64
		__pyx_t_20	0	__int64
		__pyx_t_55	158913789957	__int64
		__pyx_t_57	1920593795	__int64
		__pyx_t_59	158913789955	__int64
		__pyx_t_63	4294967296	__int64
		__pyx_t_70	412316860417	__int64
		__pyx_v_yy	0	__int64
		__pyx_v_y	0	__int64
		__pyx_v_i	14614528	__int64
+		__pyx_t_3	0x0000000000000000 {ob_refcnt=??? ob_type=??? }	_object *
		__pyx_t_42	2818048	int
		__pyx_v_depth	1	__int64
+		__pyx_t_6	0x0000000000000000 {ob_refcnt=??? ob_type=??? }	_object *
+		__pyx_t_7	{memview=0x0000000000000000 data=0x0000000000000000 <Bad Ptr> shape=0x0000000000de8380 ...}	__Pyx_memviewslice
		__pyx_t_43	25	__int64
		__pyx_t_76	1407756800	__int64
```