### PR TITLE
OverflowError: Python int too large to convert to C long on win-amd64-py2.7

### DIFF
--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -250,7 +250,7 @@ def thin(image, max_iter=None):
            [0, 0, 0, 0, 0, 0, 0]], dtype=uint8)
     """
     # check parameters
-    max_iter = max_iter or sys.maxsize
+    max_iter = max_iter or 2**31-1
     # check that image is 2d
     assert_nD(image, 2)
 


### PR DESCRIPTION
Fixes two test errors for scikit-image-0.13.1.win-amd64-py2.7, where `xrange` is implemented using `C long` (32-bit). There's a related [CPython issue](https://bugs.python.org/issue26428), but it is "rejected".

```
======================================================================
ERROR: skimage.morphology.tests.test_skeletonize.TestThin.test_noiter
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27-x64\lib\site-packages\skimage\morphology\tests\test_skeletonize.py", line 144, in test_noiter
    result = thin(self.input_image).astype(np.uint8)
  File "X:\Python27-x64\lib\site-packages\skimage\morphology\_skeletonize.py", line 266, in thin
    for i in range(max_iter):
OverflowError: Python int too large to convert to C long

======================================================================
ERROR: skimage.morphology.tests.test_skeletonize.TestThin.test_zeros
----------------------------------------------------------------------
Traceback (most recent call last):
  File "X:\Python27-x64\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "X:\Python27-x64\lib\site-packages\skimage\morphology\tests\test_skeletonize.py", line 130, in test_zeros
    assert np.all(thin(np.zeros((10, 10))) == False)
  File "X:\Python27-x64\lib\site-packages\skimage\morphology\_skeletonize.py", line 266, in thin
    for i in range(max_iter):
OverflowError: Python int too large to convert to C long
```