### PR TITLE
[MRG] DOC fix documentation build

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -50,10 +50,7 @@ sphinx_gallery_conf = {
     'gallery_dirs'  : 'auto_examples',
     'backreferences_dir': 'api',
     'reference_url'     : {
-            'skimage': None,
-            'matplotlib': 'http://matplotlib.org',
-            'numpy': 'http://docs.scipy.org/doc/numpy-1.6.0',
-            'scipy': 'http://docs.scipy.org/doc/scipy-0.11.0/reference',}
+            'skimage': None,}
     }
 
 # Determine if the matplotlib has a recent enough version of the
@@ -388,5 +385,3 @@ def linkcode_resolve(domain, info):
     else:
         return ("http://github.com/scikit-image/scikit-image/blob/"
                 "v%s/skimage/%s%s" % (skimage.__version__, fn, linespec))
-
-


### PR DESCRIPTION
There is no need for giving the `reference_url` for the sphinx-gallery since intersphinx is used.
It should solve the travis failure when building the doc.