### PR TITLE
Change default args from list to tuple in `feature.draw_multiblock_lbp`

### DIFF
--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -369,8 +369,8 @@ def multiblock_lbp(int_image, r, c, width, height):
 
 def draw_multiblock_lbp(image, r, c, width, height,
                         lbp_code=0,
-                        color_greater_block=[1, 1, 1],
-                        color_less_block=[0, 0.69, 0.96],
+                        color_greater_block=(1, 1, 1),
+                        color_less_block=(0, 0.69, 0.96),
                         alpha=0.5
                         ):
     """Multi-block local binary pattern visualization.
@@ -396,15 +396,15 @@ def draw_multiblock_lbp(image, r, c, width, height,
     lbp_code : int
         The descriptor of feature to visualize. If not provided, the
         descriptor with 0 value will be used.
-    color_greater_block : list of 3 floats
+    color_greater_block : tuple of 3 floats
         Floats specifying the color for the block that has greater
         intensity value. They should be in the range [0, 1].
         Corresponding values define (R, G, B) values. Default value
-        is white [1, 1, 1].
-    color_greater_block : list of 3 floats
+        is white (1, 1, 1).
+    color_greater_block : tuple of 3 floats
         Floats specifying the color for the block that has greater intensity
         value. They should be in the range [0, 1]. Corresponding values define
-        (R, G, B) values. Default value is cyan [0, 0.69, 0.96].
+        (R, G, B) values. Default value is cyan (0, 0.69, 0.96).
     alpha : float
         Value in the range [0, 1] that specifies opacity of visualization.
         1 - fully transparent, 0 - opaque.


### PR DESCRIPTION
## Description
Changed the type of the default arguments <color_greater_block> and <color_less_block> of the function `draw_multiblock_lbp`.
The type was changed from a mutable list to an immutable tuple as requested by issue #2850 

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [X ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [X ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests


## References
It closes issue #2850

## For reviewers
(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
