### PR TITLE
Update compare_nrmse docstring

### DIFF
--- a/skimage/measure/simple_metrics.py
+++ b/skimage/measure/simple_metrics.py
@@ -64,20 +64,17 @@ def compare_nrmse(im_true, im_test, norm_type='Euclidean'):
         literature [1]_.  The methods available here are as follows:
 
         - 'Euclidean' : normalize by the averaged Euclidean norm of
-                        ``im_true``, i.e.
+          ``im_true``::
 
-                            NRMSE = RMSE * sqrt(N) / || ``im_true`` ||,
+              NRMSE = RMSE * sqrt(N) / || im_true ||
 
-                        where || . || denotes the Frobenius norm and
-                        N = ``np.size(im_true)`` the size of the input image.
-                        This result is equivalent to:
+          where || . || denotes the Frobenius norm and ``N = im_true.size``.
+          This result is equivalent to::
 
-                            NRMSE = || ``im_true`` - ``im_test`` || /
-                            || ``im_true`` ||
+              NRMSE = || im_true - im_test || / || im_true ||.
 
         - 'min-max'   : normalize by the intensity range of ``im_true``.
-
-        - 'mean'      : normalize by the mean of ``im_true``.
+        - 'mean'      : normalize by the mean of ``im_true``
 
     Returns
     -------

--- a/skimage/measure/simple_metrics.py
+++ b/skimage/measure/simple_metrics.py
@@ -63,8 +63,20 @@ def compare_nrmse(im_true, im_test, norm_type='Euclidean'):
         NRMSE.  There is no standard method of normalization across the
         literature [1]_.  The methods available here are as follows:
 
-        - 'Euclidean' : normalize by the Euclidean norm of ``im_true``.
+        - 'Euclidean' : normalize by the averaged Euclidean norm of
+                        ``im_true``, i.e.
+
+                            NRMSE = RMSE * sqrt(N) / || ``im_true`` ||,
+
+                        where || . || denotes the Frobenius norm and
+                        N = ``np.size(im_true)`` the size of the input image.
+                        This result is equivalent to:
+
+                            NRMSE = || ``im_true`` - ``im_test`` || /
+                            || ``im_true`` ||
+
         - 'min-max'   : normalize by the intensity range of ``im_true``.
+
         - 'mean'      : normalize by the mean of ``im_true``.
 
     Returns


### PR DESCRIPTION
## Description
Include a more detailed documentation of the normalization by Euclidean norm in the ``compare_nrmse `` function of the ``measure`` module, in particular regarding the additional normalization by the size of the input image.


## Checklist

- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests


## References
Closes Issue #2842 .


## For reviewers

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
