### PR TITLE
Fix link order in example

### DIFF
--- a/doc/examples/features_detection/plot_gabors_from_astronaut.py
+++ b/doc/examples/features_detection/plot_gabors_from_astronaut.py
@@ -28,13 +28,13 @@ is not rocket science.
 .. [1] http://en.wikipedia.org/wiki/Gabor_filter
 .. [2] http://en.wikipedia.org/wiki/Simple_cell
 .. [3] http://en.wikipedia.org/wiki/Receptive_field
-.. [4] http://en.wikipedia.org/wiki/K-means_clustering
-.. [5] http://en.wikipedia.org/wiki/Lateral_geniculate_nucleus
-.. [6] D. H. Hubel and T. N., Wiesel Receptive Fields of Single Neurones
+.. [4] D. H. Hubel and T. N., Wiesel Receptive Fields of Single Neurones
        in the Cat's Striate Cortex, J. Physiol. pp. 574-591 (148) 1959
-.. [7] D. H. Hubel and T. N., Wiesel Receptive Fields, Binocular
+.. [5] D. H. Hubel and T. N., Wiesel Receptive Fields, Binocular
        Interaction, and Functional Architecture in the Cat's Visual Cortex,
        J. Physiol. 160 pp.  106-154 1962
+.. [6] http://en.wikipedia.org/wiki/K-means_clustering
+.. [7] http://en.wikipedia.org/wiki/Lateral_geniculate_nucleus
 """
 import numpy as np
 from scipy.cluster.vq import kmeans2


### PR DESCRIPTION
## Description
Fix link order in documentation.


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
