### PR TITLE
Corrected kwarg key spelling.

### DIFF
--- a/doc/examples/features_detection/plot_hog.py
+++ b/doc/examples/features_detection/plot_hog.py
@@ -88,7 +88,7 @@ from skimage import data, color, exposure
 image = color.rgb2gray(data.astronaut())
 
 fd, hog_image = hog(image, orientations=8, pixels_per_cell=(16, 16),
-                    cells_per_block=(1, 1), visualize=True)
+                    cells_per_block=(1, 1), visualise=True)
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4), sharex=True, sharey=True)
 


### PR DESCRIPTION
## Description
Fixed typo in hog feature example. Previously the example used the "visualize=True" flag whereas the correct flag uses the EN-UK spelling "visualise=True". This means the example now runs.


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
