### PR TITLE
Add travis-ci badge to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/scikit-image/scikit-image?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![codecov.io](https://codecov.io/github/scikit-image/scikit-image/coverage.svg?branch=master)](https://codecov.io/github/scikit-image/scikit-image?branch=master)
+[![travis-ci](https://travis-ci.org/scikit-image/scikit-image.svg?branch=master)](https://travis-ci.org/scikit-image/scikit-image)
 
 - **Website (including documentation):** [http://scikit-image.org/](http://scikit-image.org)
 - **Mailing list:** [https://mail.python.org/mailman/listinfo/scikit-image](https://mail.python.org/mailman/listinfo/scikit-image)


### PR DESCRIPTION
## Description
Minor update to README.md to add a badge to the current master build on travis-ci.  
This also provides a convenient link to the travis project page so new users know it's active.

It would also be great to get a badge to the appveyor build but it appears you need to be an admin of the appveyor project to get the url of the badge. https://github.com/scikit-image/scikit-image/issues/2514#issuecomment-340942721

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
