### PR TITLE
Fix `centroid` and add test coverage.

### DIFF
--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -235,7 +235,9 @@ def centroid(image):
         The centroid of the (nonzero) pixels in ``image``.
     """
     M = moments_central(image, center=(0,) * image.ndim, order=1)
-    center = M[tuple(np.eye(image.ndim, dtype=int))]
+    center = (M[tuple(np.eye(image.ndim, dtype=int))]  # array of weighted sums
+                                                       # for each axis
+              / M[(0,) * image.ndim])  # weighted sum of all points
     return center
 
 

--- a/skimage/measure/tests/test_moments.py
+++ b/skimage/measure/tests/test_moments.py
@@ -1,7 +1,7 @@
 import numpy as np
 from skimage import draw
 from skimage.measure import (moments, moments_central, moments_normalized,
-                             moments_hu)
+                             moments_hu, centroid)
 
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_almost_equal
@@ -27,6 +27,10 @@ def test_moments_central():
     image[14, 15] = 0.5
     image[15, 14] = 0.5
     mu = moments_central(image, (14.5, 14.5))
+
+    # check for proper centroid computation
+    mu_calc_centroid = moments_central(image)
+    assert_equal(mu, mu_calc_centroid)
 
     # shift image by dx=2, dy=2
     image2 = np.zeros((20, 20), dtype=np.double)

--- a/skimage/measure/tests/test_moments.py
+++ b/skimage/measure/tests/test_moments.py
@@ -1,10 +1,12 @@
+from __future__ import division
 import numpy as np
 from skimage import draw
 from skimage.measure import (moments, moments_central, moments_normalized,
                              moments_hu, centroid)
 
 from skimage._shared import testing
-from skimage._shared.testing import assert_equal, assert_almost_equal
+from skimage._shared.testing import (assert_equal, assert_almost_equal,
+                                     assert_allclose)
 from skimage._shared._warnings import expected_warnings
 
 
@@ -104,9 +106,7 @@ def test_moments_hu():
 
 def test_centroid():
     image = np.zeros((20, 20), dtype=np.double)
-    image[14, 14] = 1
-    image[15, 15] = 1
-    image[14, 15] = 0.5
-    image[15, 14] = 0.5
+    image[14, 14:16] = 1
+    image[15, 14:16] = 1/3
     image_centroid = centroid(image)
-    assert_equal(image_centroid, (14.5, 14.5))
+    assert_allclose(image_centroid, (14.25, 14.5))

--- a/skimage/measure/tests/test_moments.py
+++ b/skimage/measure/tests/test_moments.py
@@ -100,3 +100,13 @@ def test_moments_hu():
     hu2 = moments_hu(nu2)
     # central moments must be translation and scale invariant
     assert_almost_equal(hu, hu2, decimal=1)
+
+
+def test_centroid():
+    image = np.zeros((20, 20), dtype=np.double)
+    image[14, 14] = 1
+    image[15, 15] = 1
+    image[14, 15] = 0.5
+    image[15, 14] = 0.5
+    image_centroid = centroid(image)
+    assert_equal(image_centroid, (14.5, 14.5))


### PR DESCRIPTION
## Description
Fixes the computation of centroid in `centroid` by dividing the sum of each axes' weighted points by the "area" (sum of all weighted points).


## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] Unit tests


## References
Closes #2868.

## For reviewers

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
