### PR TITLE
Add multichannel support to `feature.hog`

### DIFF
--- a/doc/examples/features_detection/plot_hog.py
+++ b/doc/examples/features_detection/plot_hog.py
@@ -82,13 +82,13 @@ References
 import matplotlib.pyplot as plt
 
 from skimage.feature import hog
-from skimage import data, color, exposure
+from skimage import data, exposure
 
 
-image = color.rgb2gray(data.astronaut())
+image = data.astronaut()
 
-fd, hog_image = hog(image, orientations=8, pixels_per_cell=(32, 32),
-                    cells_per_block=(1, 1), visualize=True)
+fd, hog_image = hog(image, orientations=8, pixels_per_cell=(16, 16),
+                    cells_per_block=(1, 1), visualize=True, multichannel=True)
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4), sharex=True, sharey=True)
 
@@ -98,7 +98,7 @@ ax1.set_title('Input image')
 ax1.set_adjustable('box-forced')
 
 # Rescale histogram for better display
-hog_image_rescaled = exposure.rescale_intensity(hog_image, in_range=(0, 0.02))
+hog_image_rescaled = exposure.rescale_intensity(hog_image, in_range=(0, 10))
 
 ax2.axis('off')
 ax2.imshow(hog_image_rescaled, cmap=plt.cm.gray)

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -32,6 +32,7 @@ Improvements
 - ``skimage.transform.resize`` and ``skimage.transform.rescale`` have a new
   ``anti_aliasing`` option to avoid aliasing artifacts when down-sampling
   images (#2802)
+- Support for multichannel images for ``skimage.feature.hog`` (#2870)
 
 
 API Changes

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -186,8 +186,8 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
         image = image.astype('float')
 
     if multichannel:
-        g_col_by_ch = np.empty_like(image, dtype=np.double)
         g_row_by_ch = np.empty_like(image, dtype=np.double)
+        g_col_by_ch = np.empty_like(image, dtype=np.double)
         g_magn = np.empty_like(image, dtype=np.double)
 
         for idx_ch in range(image.shape[2]):
@@ -253,9 +253,9 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
         dr_arr = radius * np.sin(orientation_bin_midpoints)
         dc_arr = radius * np.cos(orientation_bin_midpoints)
         hog_image = np.zeros((s_row, s_col), dtype=float)
-        for c in range(n_cells_col):
-            for r in range(n_cells_row):
-                for o, dc, dr in zip(orientations_arr, dc_arr, dr_arr):
+        for r in range(n_cells_row):
+            for c in range(n_cells_col):
+                for o, dr, dc in zip(orientations_arr, dr_arr, dc_arr):
                     centre = tuple([r * c_row + c_row // 2,
                                     c * c_col + c_col // 2])
                     rr, cc = draw.line(int(centre[0] - dc),
@@ -279,13 +279,13 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
     Gradient (HOG) descriptors.
     """
 
-    n_blocks_col = (n_cells_col - b_col) + 1
     n_blocks_row = (n_cells_row - b_row) + 1
+    n_blocks_col = (n_cells_col - b_col) + 1
     normalized_blocks = np.zeros((n_blocks_row, n_blocks_col,
                                   b_row, b_col, orientations))
 
-    for c in range(n_blocks_col):
-        for r in range(n_blocks_row):
+    for r in range(n_blocks_row):
+        for c in range(n_blocks_col):
             block = orientation_histogram[r:r + b_row, c:c + b_col, :]
             normalized_blocks[r, c, :] = \
                 _hog_normalize_block(block, method=block_norm)
@@ -297,10 +297,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
     """
 
     if feature_vector:
-        print(normalized_blocks.shape)
         normalized_blocks = normalized_blocks.ravel()
-        print(normalized_blocks.shape)
-    print(hog_image.shape)
 
     if visualize:
         return normalized_blocks, hog_image

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -185,9 +185,9 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
         image = image.astype('float')
 
     if multichannel:
-        gx_by_ch = np.empty_like(image)
-        gy_by_ch = np.empty_like(image)
-        g_magn = np.empty_like(image)
+        gx_by_ch = np.empty_like(image, dtype=np.double)
+        gy_by_ch = np.empty_like(image, dtype=np.double)
+        g_magn = np.empty_like(image, dtype=np.double)
 
         for idx_ch in range(image.shape[2]):
             gx_by_ch[:, :, idx_ch], gy_by_ch[:, :, idx_ch] = \

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -203,7 +203,8 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
         idcs_max = g_magn.argmax(axis=2)
         rr, cc = np.meshgrid(np.arange(image.shape[0]),
                              np.arange(image.shape[1]),
-                             indexing='ij')
+                             indexing='ij',
+                             sparse=True)
         g_row = g_row_by_ch[rr, cc, idcs_max]
         g_col = g_col_by_ch[rr, cc, idcs_max]
     else:

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -182,23 +182,20 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
         image = image.astype('float')
 
     if len(image.shape) == 3:
-        channel_gradients = []
-        gradient = np.zeros(image.shape)
+        #If image is a color image
+        x_gradient = np.zeros(image.shape)
+        y_gradient = np.zeros(image.shape)
+        gradient_magnitude = np.zeros(image.shape)
 
         for dimension in range(image.shape[2]):
-            gx, gy = compute_image_gradients(image[:, :, dimension])
-            gradient[:, :, dimension] = np.hypot(gx, gy)
-            channel_gradients.append((gx, gy))
+            x_gradient[:, :, dimension], y_gradient[:, :, dimension] = compute_image_gradients(image[:, :, dimension])
+            gradient_magnitude[:, :, dimension] = np.hypot(x_gradient[:, :, dimension], y_gradient[:, :, dimension])
 
-        gx = np.empty(image.shape[0:2], dtype=np.double)
-        gy = np.empty(image.shape[0:2], dtype=np.double)
+        max_index_array = gradient_magnitude.argmax(axis=2)
+        rr, cc = np.meshgrid(np.arange(image.shape[0]), np.arange(image.shape[1]))
 
-        max_index_array = gradient.argmax(axis = 2)
-
-        for row_index, row in enumerate(max_index_array):
-            for col_index, value in enumerate(row):
-                gx[row_index][col_index] = channel_gradients[value][0][row_index][col_index]
-                gy[row_index][col_index] = channel_gradients[value][1][row_index][col_index]
+        gx = x_gradient[rr, cc, max_index_array]
+        gy = y_gradient[rr, cc, max_index_array]
     else:
         gx, gy = compute_image_gradients(image)
 

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -47,7 +47,7 @@ def _hog_channel_gradient(channel):
 
 def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
         block_norm=None, visualize=False, visualise=None, transform_sqrt=False,
-        feature_vector=True, multichannel=False):
+        feature_vector=True, multichannel=None):
     """Extract Histogram of Oriented Gradients (HOG) for a given image.
 
     Compute a Histogram of Oriented Gradients (HOG) by
@@ -150,6 +150,9 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
              skimage_deprecation)
 
     image = np.atleast_2d(image)
+
+    if multichannel is None:
+        multichannel = (image.ndim == 3)
 
     ndim_spatial = image.ndim - 1 if multichannel else image.ndim
     if ndim_spatial != 2:

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -222,8 +222,8 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
     """
 
     s_row, s_col = image.shape[:2]
-    c_col, c_row = pixels_per_cell
-    b_col, b_row = cells_per_block
+    c_row, c_col = pixels_per_cell
+    b_row, b_col = cells_per_block
 
     n_cells_row = int(s_row // c_row)  # number of cells along row-axis
     n_cells_col = int(s_col // c_col)  # number of cells along col-axis

--- a/skimage/feature/_hoghistogram.pyx
+++ b/skimage/feature/_hoghistogram.pyx
@@ -111,7 +111,7 @@ def hog_histograms(double[:, ::1] gradient_columns,
                                              gradient_rows)
     cdef double[:, ::1] orientation = \
         np.rad2deg(np.arctan2(gradient_rows, gradient_columns)) % 180
-    cdef int i, c, y, o, r_i, c_i, cc, cr, c_0, r_0, \
+    cdef int i, c, r, o, r_i, c_i, cc, cr, c_0, r_0, \
         range_rows_start, range_rows_stop, \
         range_columns_start, range_columns_stop
     cdef float orientation_start, orientation_end, \
@@ -134,11 +134,11 @@ def hog_histograms(double[:, ::1] gradient_columns,
             orientation_start = number_of_orientations_per_180 * (i + 1)
             orientation_end = number_of_orientations_per_180 * i
             c = c_0
-            y = r_0
+            r = r_0
             r_i = 0
             c_i = 0
 
-            while y < cc:
+            while r < cc:
                 c_i = 0
                 c = c_0
 
@@ -146,7 +146,7 @@ def hog_histograms(double[:, ::1] gradient_columns,
                     orientation_histogram[r_i, c_i, i] = \
                         cell_hog(magnitude, orientation,
                                  orientation_start, orientation_end,
-                                 cell_columns, cell_rows, c, y,
+                                 cell_columns, cell_rows, c, r,
                                  size_columns, size_rows,
                                  range_rows_start, range_rows_stop,
                                  range_columns_start, range_columns_stop)
@@ -154,4 +154,4 @@ def hog_histograms(double[:, ::1] gradient_columns,
                     c += cell_columns
 
                 r_i += 1
-                y += cell_rows
+                r += cell_rows

--- a/skimage/feature/_hoghistogram.pyx
+++ b/skimage/feature/_hoghistogram.pyx
@@ -111,14 +111,14 @@ def hog_histograms(double[:, ::1] gradient_columns,
                                              gradient_rows)
     cdef double[:, ::1] orientation = \
         np.rad2deg(np.arctan2(gradient_rows, gradient_columns)) % 180
-    cdef int i, x, y, o, yi, xi, cc, cr, x0, y0, \
+    cdef int i, c, y, o, r_i, c_i, cc, cr, c_0, r_0, \
         range_rows_start, range_rows_stop, \
         range_columns_start, range_columns_stop
     cdef float orientation_start, orientation_end, \
         number_of_orientations_per_180
 
-    y0 = cell_rows / 2
-    x0 = cell_columns / 2
+    r_0 = cell_rows / 2
+    c_0 = cell_columns / 2
     cc = cell_rows * number_of_cells_rows
     cr = cell_columns * number_of_cells_columns
     range_rows_stop = cell_rows / 2
@@ -133,25 +133,25 @@ def hog_histograms(double[:, ::1] gradient_columns,
             # isolate orientations in this range
             orientation_start = number_of_orientations_per_180 * (i + 1)
             orientation_end = number_of_orientations_per_180 * i
-            x = x0
-            y = y0
-            yi = 0
-            xi = 0
+            c = c_0
+            y = r_0
+            r_i = 0
+            c_i = 0
 
             while y < cc:
-                xi = 0
-                x = x0
+                c_i = 0
+                c = c_0
 
-                while x < cr:
-                    orientation_histogram[yi, xi, i] = \
+                while c < cr:
+                    orientation_histogram[r_i, c_i, i] = \
                         cell_hog(magnitude, orientation,
                                  orientation_start, orientation_end,
-                                 cell_columns, cell_rows, x, y,
+                                 cell_columns, cell_rows, c, y,
                                  size_columns, size_rows,
                                  range_rows_start, range_rows_stop,
                                  range_columns_start, range_columns_stop)
-                    xi += 1
-                    x += cell_columns
+                    c_i += 1
+                    c += cell_columns
 
-                yi += 1
+                r_i += 1
                 y += cell_rows

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -50,12 +50,6 @@ def test_hog_image_size_cell_size_mismatch():
     assert len(fd) == 9 * (150 // 8) * (200 // 8)
 
 
-def test_hog_color_image_unsupported_error():
-    image = np.zeros((20, 20, 3))
-    with testing.raises(ValueError):
-        feature.hog(image)
-
-
 def test_hog_basic_orientations_and_data_types():
     # scenario:
     #  1) create image (with float values) where upper half is filled by

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -228,3 +228,24 @@ def test_hog_block_normalization_incorrect_error():
     img = np.eye(4)
     with testing.raises(ValueError):
         feature.hog(img, block_norm='Linf')
+
+
+@testing.parametrize("shape,multichannel", [
+    ((3, 3, 3), False),
+    ((3, 3), True),
+    ((3, 3, 3, 3), True),
+])
+def test_hog_incorrect_dimensions(shape, multichannel):
+    img = np.zeros(shape)
+    with testing.raises(ValueError):
+        feature.hog(img, multichannel=multichannel)
+
+
+def test_hog_output_equivariance_multichannel():
+    img = data.astronaut()
+    img[:, :, (1, 2)] = 0
+    hog_ref = feature.hog(img, multichannel=True)
+
+    for n in (1, 2):
+        hog_fact = feature.hog(np.roll(img, n, axis=2), multichannel=True)
+        assert_almost_equal(hog_ref, hog_fact)


### PR DESCRIPTION
## Description
This PR implements the support for multichannel images for HOG descriptor.
Gallery example has been modified to use an RGB image.

Before:
![figure_1](https://user-images.githubusercontent.com/1315589/32403912-6253062a-c156-11e7-8b28-068c82de91c4.png)

With this PR:
![figure_2](https://user-images.githubusercontent.com/1315589/32403914-658b298a-c156-11e7-971b-fa07a6d256cd.png)

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]

## References
Closes https://github.com/scikit-image/scikit-image/issues/1879.
Based on https://github.com/scikit-image/scikit-image/pull/1963.

## For reviewers

(Don't remove the checklist below.)

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.