### PR TITLE
Remove scipy version check in `active_contour`

### DIFF
--- a/doc/examples/edges/plot_active_contours.py
+++ b/doc/examples/edges/plot_active_contours.py
@@ -31,15 +31,6 @@ from skimage import data
 from skimage.filters import gaussian
 from skimage.segmentation import active_contour
 
-# Test scipy version, since active contour is only possible
-# with recent scipy version
-import scipy
-split_version = scipy.__version__.split('.')
-if not(split_version[-1].isdigit()): # Remove dev string if present
-        split_version.pop()
-scipy_version = list(map(int, split_version))
-new_scipy = scipy_version[0] > 0 or \
-            (scipy_version[0] == 0 and scipy_version[1] >= 14)
 
 img = data.astronaut()
 img = rgb2gray(img)
@@ -49,23 +40,15 @@ x = 220 + 100*np.cos(s)
 y = 100 + 100*np.sin(s)
 init = np.array([x, y]).T
 
-if not new_scipy:
-    print('You are using an old version of scipy. '
-          'Active contours is implemented for scipy versions '
-          '0.14.0 and above.')
+snake = active_contour(gaussian(img, 3),
+                       init, alpha=0.015, beta=10, gamma=0.001)
 
-if new_scipy:
-    snake = active_contour(gaussian(img, 3),
-                           init, alpha=0.015, beta=10, gamma=0.001)
-
-    fig = plt.figure(figsize=(7, 7))
-    ax = fig.add_subplot(111)
-    plt.gray()
-    ax.imshow(img)
-    ax.plot(init[:, 0], init[:, 1], '--r', lw=3)
-    ax.plot(snake[:, 0], snake[:, 1], '-b', lw=3)
-    ax.set_xticks([]), ax.set_yticks([])
-    ax.axis([0, img.shape[1], img.shape[0], 0])
+fig, ax = plt.subplots(figsize=(7, 7))
+ax.imshow(img, cmap=plt.cm.gray)
+ax.plot(init[:, 0], init[:, 1], '--r', lw=3)
+ax.plot(snake[:, 0], snake[:, 1], '-b', lw=3)
+ax.set_xticks([]), ax.set_yticks([])
+ax.axis([0, img.shape[1], img.shape[0], 0])
 
 ######################################################################
 # Here we initialize a straight line between two points, `(5, 136)` and
@@ -79,17 +62,14 @@ x = np.linspace(5, 424, 100)
 y = np.linspace(136, 50, 100)
 init = np.array([x, y]).T
 
-if new_scipy:
-    snake = active_contour(gaussian(img, 1), init, bc='fixed',
-                           alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1)
+snake = active_contour(gaussian(img, 1), init, bc='fixed',
+                       alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1)
 
-    fig = plt.figure(figsize=(9, 5))
-    ax = fig.add_subplot(111)
-    plt.gray()
-    ax.imshow(img)
-    ax.plot(init[:, 0], init[:, 1], '--r', lw=3)
-    ax.plot(snake[:, 0], snake[:, 1], '-b', lw=3)
-    ax.set_xticks([]), ax.set_yticks([])
-    ax.axis([0, img.shape[1], img.shape[0], 0])
+fig, ax = plt.subplots(figsize=(9, 5))
+ax.imshow(img, cmap=plt.cm.gray)
+ax.plot(init[:, 0], init[:, 1], '--r', lw=3)
+ax.plot(snake[:, 0], snake[:, 1], '-b', lw=3)
+ax.set_xticks([]), ax.set_yticks([])
+ax.axis([0, img.shape[1], img.shape[0], 0])
 
 plt.show()

--- a/skimage/segmentation/tests/test_active_contour_model.py
+++ b/skimage/segmentation/tests/test_active_contour_model.py
@@ -3,13 +3,11 @@ from skimage import data
 from skimage.color import rgb2gray
 from skimage.filters import gaussian
 from skimage.segmentation import active_contour
-from skimage.segmentation.active_contour_model import new_scipy
 
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_allclose
 
 
-@testing.skipif(not new_scipy, reason="scipy < 0.14")
 def test_periodic_reference():
     img = data.astronaut()
     img = rgb2gray(img)
@@ -25,7 +23,6 @@ def test_periodic_reference():
     assert_equal(np.array(snake[:10, 1], dtype=np.int32), refy)
 
 
-@testing.skipif(not new_scipy, reason="scipy < 0.14")
 def test_fixed_reference():
     img = data.text()
     x = np.linspace(5, 424, 100)
@@ -39,7 +36,6 @@ def test_fixed_reference():
     assert_equal(np.array(snake[:10, 1], dtype=np.int32), refy)
 
 
-@testing.skipif(not new_scipy, reason="scipy < 0.14")
 def test_free_reference():
     img = data.text()
     x = np.linspace(5, 424, 100)
@@ -53,7 +49,6 @@ def test_free_reference():
     assert_equal(np.array(snake[:10, 1], dtype=np.int32), refy)
 
 
-@testing.skipif(not new_scipy, reason="scipy < 0.14")
 def test_RGB():
     img = gaussian(data.text(), 1)
     imgR = np.zeros((img.shape[0], img.shape[1], 3))
@@ -81,7 +76,6 @@ def test_RGB():
     assert_equal(np.array(snake[:10, 1], dtype=np.int32), refy)
 
 
-@testing.skipif(not new_scipy, reason="scipy < 0.14")
 def test_end_points():
     img = data.astronaut()
     img = rgb2gray(img)
@@ -103,7 +97,6 @@ def test_end_points():
     assert_allclose(snake[0, :], [x[0], y[0]], atol=1e-5)
 
 
-@testing.skipif(not new_scipy, reason="scipy < 0.14")
 def test_bad_input():
     img = np.zeros((10, 10))
     x = np.linspace(5, 424, 100)


### PR DESCRIPTION
## Description
Since recently we started to require scipy>=0.17 (https://github.com/scikit-image/scikit-image/blob/master/requirements/default.txt#L2).

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]

## For reviewers

(Don't remove the checklist below.)

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
