### PR TITLE
Nl means fixes for large datasets

### DIFF
--- a/skimage/_shared/fast_exp.h
+++ b/skimage/_shared/fast_exp.h
@@ -1,0 +1,40 @@
+/* A fast approximation of the exponential function.
+ * Reference [1]: https://schraudolph.org/pubs/Schraudolph99.pdf
+ * Reference [2]: http://dx.doi.org/10.1162/089976600300015033
+ * Additional improvements by Leonid Bloch. */
+
+/* use just EXP_A = 1512775 for integer version, to avoid FP calculations */
+#define EXP_A (1512775.3951951856938)  /* 2^20*ln2 */
+/* For min. RMS error */
+#define EXP_BC 1072632447              /* 1023*2^20 - 60801 */
+/* For min. max. relative error */
+/* #define EXP_BC 1072647449 */        /* 1023*2^20 - 45799 */
+/* For min. mean relative error */
+/* #define EXP_BC 1072625005 */        /* 1023*2^20 - 68243 */
+
+__inline double fast_exp (double y)
+{
+    union
+    {
+        double d;
+        struct { int i, j; } n;
+        char t[8];
+    } _eco;
+
+    _eco.n.i = 1;
+
+    switch(_eco.t[0]) {
+        case 1:
+            /* Little endian */
+            _eco.n.j = (int)(EXP_A*(y)) + EXP_BC;
+            _eco.n.i = 0;
+            break;
+        case 0:
+            /* Big endian */
+            _eco.n.i = (int)(EXP_A*(y)) + EXP_BC;
+            _eco.n.j = 0;
+            break;
+    }
+
+    return _eco.d;
+}

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -493,7 +493,6 @@ cdef inline _integral_image_3d(IMGDTYPE [:, :, ::] padded,
     by avoiding copies of ``padded``.
     """
     cdef int pln, row, col
-    cdef float distance
     for pln in range(max(1, -t_pln), min(n_pln, n_pln - t_pln)):
         for row in range(max(1, -t_row), min(n_row, n_row - t_row)):
             for col in range(max(1, -t_col), min(n_col, n_col - t_col)):

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -5,7 +5,7 @@ from libc.math cimport exp
 
 ctypedef np.float32_t IMGDTYPE
 
-cdef float DISTANCE_CUTOFF = 5.
+cdef double DISTANCE_CUTOFF = 5.0
 
 @cython.boundscheck(False)
 cdef inline float patch_distance_2d(IMGDTYPE [:, :] p1,
@@ -696,7 +696,8 @@ def _fast_nl_means_denoising_3d(image, int s=5, int d=7, float h=0.1):
                 if t_col == 0 and (t_pln is not 0 or t_row is not 0):
                     alpha = 0.5
                 else:
-                    alpha = 1.
+                    alpha = 1.0
+
                 # Compute integral image of the squared difference between
                 # padded and the same image shifted by (t_pln, t_row, t_col)
                 integral = np.zeros_like(padded)

--- a/skimage/restoration/setup.py
+++ b/skimage/restoration/setup.py
@@ -31,7 +31,8 @@ def configuration(parent_package='', top_path=None):
         include_dirs=[get_numpy_include_dirs(), '../_shared'])
     config.add_extension('_nl_means_denoising',
                          sources=['_nl_means_denoising.c'],
-                         include_dirs=[get_numpy_include_dirs()])
+                         include_dirs=[get_numpy_include_dirs(),
+                                       '../_shared'])
 
     return config
 


### PR DESCRIPTION
During a work on a large (600x1000x1000) dataset, I have noticed two problems with NL Means implementation in scikit-image:

1) At large xyz values (bottom right part of the volume, if viewed from above) a lot of noise was introduced. Not only that the data was not denoised there, it was corrupted and unusable.
2) It is extremely slow.

I address both of these problems in this series of patches. Firstly, now the data in NL Means is treated as double (float64) instead of float (float32). This solves the noise introduction issue completely. Secondly, a very substantial fraction of the computation time is being spent on calculating exponents (for determining the weight). An extremely precise result is not needed here, so a good and fast approximation would suffice. I have used the very fast and compact approximation described by Nic Schraudolph[1], to achieve a speedup of more than twice, after verifying that the deviation of this approximation from the math library exp function is not more than 3%.

## References
[1] https://schraudolph.org/pubs/Schraudolph99.pdf

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
