### PR TITLE
fix gaussian filtering for arbitrary spatial dims

### DIFF
--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -110,7 +110,11 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
 
     """
 
-    spatial_dims = guess_spatial_dimensions(image)
+    spatial_dims = None
+    try:
+        guess_spatial_dimensions(image)
+    except ValueError:
+        pass
     if spatial_dims is None and multichannel is None:
         msg = ("Images with dimensions (M, N, 3) are interpreted as 2D+RGB "
                "by default. Use `multichannel=False` to interpret as "


### PR DESCRIPTION
## Description

gaussian filtering should work when spatial dims cannot be guessed (rather than throwing a self-contradictory error, e.g.: `skimage/filters/_gaussian.py:103:Expected 2D, 3D, or 4D array, got 4D`)

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] ~~[Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)~~
- [x] ~~Gallery example in `./doc/examples` (new features only)~~
- [ ] Unit tests

## For reviewers

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
