### PR TITLE
DOC: use Gaussian noise in non-local means example

### DIFF
--- a/doc/examples/filters/plot_nonlocal_means.py
+++ b/doc/examples/filters/plot_nonlocal_means.py
@@ -21,10 +21,11 @@ from skimage.restoration import denoise_nl_means
 astro = img_as_float(data.astronaut())
 astro = astro[30:180, 150:300]
 
-noisy = astro + 0.3 * np.random.random(astro.shape)
+sigma = 0.1
+noisy = astro + sigma * np.random.standard_normal(astro.shape)
 noisy = np.clip(noisy, 0, 1)
 
-denoise = denoise_nl_means(noisy, 7, 9, 0.08, multichannel=True)
+denoise = denoise_nl_means(noisy, 7, 9, 0.8*sigma, multichannel=True)
 
 fig, ax = plt.subplots(ncols=2, figsize=(8, 4), sharex=True, sharey=True,
                        subplot_kw={'adjustable': 'box-forced'})


### PR DESCRIPTION


## Description
When looking at the non-local means example, I noticed that it is adding noise that is distributed uniformly in [0, 1.] .  This results in the "noisy" image being brighter than the original.  I think it was probably intended to use Gaussian noise instead.  This PR makes the following two modifications:

1.) use normally distributed noise
2.) adjust the `h` parmeter as needed to give a reasonable denoising result with the new noise settings

Here is the result I get prior to this PR:
![result_master0](https://user-images.githubusercontent.com/6528957/32802194-504da09e-c94d-11e7-9b2a-0037ffc7dc00.png)

and here is after:
![result_master](https://user-images.githubusercontent.com/6528957/32802206-55810826-c94d-11e7-81c4-f763453293ae.png)



Also, there is a relatively simple modification to the weight calculation in non-local means that can further improve the denoising performance.  I hope to make a separate PR for that soon.  

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
