### PR TITLE
DOC: Update docstring for is_low_constrast to match function signature

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -468,9 +468,9 @@ def is_low_contrast(image, fraction_threshold=0.05, lower_percentile=1,
         The low contrast fraction threshold. An image is considered low-
         contrast when its range of brightness spans less than this
         fraction of its data type's full range. [1]_
-    lower_bound : float, optional
+    lower_percentile : float, optional
         Disregard values below this percentile when computing image contrast.
-    upper_bound : float, optional
+    upper_percentile : float, optional
         Disregard values above this percentile when computing image contrast.
     method : str, optional
         The contrast determination method.  Right now the only available


### PR DESCRIPTION
## Description

The keywords in `exposure.is_low_constrast()` are `lower_percentile` and `upper_percentile`, but in the docstring they are listed as `lower_bound` and `upper_bound`.  This PR updates the docstring to match the function signature.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
