### PR TITLE
fixed spelling typo in NL means code

### DIFF
--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -21,7 +21,7 @@ cdef inline float patch_distance_2d(IMGDTYPE [:, :] p1,
     p2 : 2-D array_like
         Second patch.
     w : 2-D array_like
-        Array of weigths for the different pixels of the patches.
+        Array of weights for the different pixels of the patches.
     s : int
         Linear size of the patches.
 


### PR DESCRIPTION
Tiny PR fixing a typo in the distance function used in NL means.

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
