### PR TITLE
noise-robust patch distance estimation for non-local means

### DIFF
--- a/doc/examples/filters/plot_nonlocal_means.py
+++ b/doc/examples/filters/plot_nonlocal_means.py
@@ -54,19 +54,19 @@ patch_kw = dict(patch_size=5,      # 5x5 patches
                 multichannel=True)
 
 # slow algorithm
-denoise = denoise_nl_means(noisy, h=1.15*sigma_est, fast_mode=False,
+denoise = denoise_nl_means(noisy, h=1.15 * sigma_est, fast_mode=False,
                            **patch_kw)
 
 # slow algorithm, sigma provided
-denoise2 = denoise_nl_means(noisy, h=0.8*sigma_est, sigma=sigma_est,
+denoise2 = denoise_nl_means(noisy, h=0.8 * sigma_est, sigma=sigma_est,
                             fast_mode=False, **patch_kw)
 
 # fast algorithm
-denoise_fast = denoise_nl_means(noisy, h=0.8*sigma_est, fast_mode=True,
+denoise_fast = denoise_nl_means(noisy, h=0.8 * sigma_est, fast_mode=True,
                                 **patch_kw)
 
 # fast algorithm, sigma provided
-denoise2_fast = denoise_nl_means(noisy, h=0.6*sigma_est, sigma=sigma_est,
+denoise2_fast = denoise_nl_means(noisy, h=0.6 * sigma_est, sigma=sigma_est,
                                  fast_mode=True, **patch_kw)
 
 fig, ax = plt.subplots(nrows=2, ncols=3, figsize=(8, 6),

--- a/doc/examples/filters/plot_nonlocal_means.py
+++ b/doc/examples/filters/plot_nonlocal_means.py
@@ -22,6 +22,9 @@ distances.  This can lead to a modest improvement in image quality.
 
 The `estimate_sigma` function can provide a good starting point for setting
 the `h` (and optionally, `sigma`) parameters for the non-local means algorithm.
+`h` is a constant that controls the decay in patch weights as a function of the
+distance between patches.  Larger `h` allows more smoothing between disimilar
+patches.
 
 In this demo, `h`, was hand-tuned to give the approximate best-case performance
 of each variant.

--- a/doc/examples/filters/plot_nonlocal_means.py
+++ b/doc/examples/filters/plot_nonlocal_means.py
@@ -96,10 +96,10 @@ fig.tight_layout()
 
 # print PSNR metric for each case
 psnr_noisy = compare_psnr(astro, noisy)
-psnr = compare_psnr(astro, denoise.astype(astro.dtype))
-psnr2 = compare_psnr(astro, denoise2.astype(astro.dtype))
-psnr_fast = compare_psnr(astro, denoise_fast.astype(astro.dtype))
-psnr2_fast = compare_psnr(astro, denoise2_fast.astype(astro.dtype))
+psnr = compare_psnr(astro, denoise)
+psnr2 = compare_psnr(astro, denoise2)
+psnr_fast = compare_psnr(astro, denoise_fast)
+psnr2_fast = compare_psnr(astro, denoise2_fast)
 
 print("PSNR (noisy) = {:0.2f}".format(psnr_noisy))
 print("PSNR (slow) = {:0.2f}".format(psnr))

--- a/doc/examples/filters/plot_nonlocal_means.py
+++ b/doc/examples/filters/plot_nonlocal_means.py
@@ -10,32 +10,98 @@ other pixels are compared to the patch centered on the pixel of interest, and
 the average is performed only for pixels that have patches close to the current
 patch. As a result, this algorithm can restore well textures, that would be
 blurred by other denoising algoritm.
+
+When the `fast_mode` argument is `False`, a spatial Gaussian weighting is
+applied to the patches when computing patch distances.  When `fast_mode` is
+`True` a faster algorithm employing uniform spatial weighting on the patches
+is applied.
+
+For either of these cases, if the noise standard deviation, `sigma`, is
+provided, the expected noise variance is subtracted out when computing patch
+distances.  This can lead to a modest improvement in image quality.
+
+The `estimate_sigma` function can provide a good starting point for setting
+the `h` (and optionally, `sigma`) parameters for the non-local means algorithm.
+
+In this demo, `h`, was hand-tuned to give the approximate best-case performance
+of each variant.
+
 """
 import numpy as np
 import matplotlib.pyplot as plt
 
 from skimage import data, img_as_float
-from skimage.restoration import denoise_nl_means
+from skimage.restoration import denoise_nl_means, estimate_sigma
+from skimage.measure import compare_psnr
 
 
 astro = img_as_float(data.astronaut())
 astro = astro[30:180, 150:300]
 
-noisy = astro + 0.3 * np.random.random(astro.shape)
+sigma = 0.08
+noisy = astro + sigma * np.random.standard_normal(astro.shape)
 noisy = np.clip(noisy, 0, 1)
 
-denoise = denoise_nl_means(noisy, 7, 9, 0.08, multichannel=True)
+# estimate the noise standard deviation from the noisy image
+sigma_est = np.mean(estimate_sigma(noisy, multichannel=True))
+print("estimated noise standard deviation = {}".format(sigma_est))
 
-fig, ax = plt.subplots(ncols=2, figsize=(8, 4), sharex=True, sharey=True,
+patch_kw = dict(patch_size=5,      # 5x5 patches
+                patch_distance=6,  # 13x13 search area
+                multichannel=True)
+
+# slow algorithm
+denoise = denoise_nl_means(noisy, h=1.15*sigma_est, fast_mode=False,
+                           **patch_kw)
+
+# slow algorithm, sigma provided
+denoise2 = denoise_nl_means(noisy, h=0.8*sigma_est, sigma=sigma_est,
+                            fast_mode=False, **patch_kw)
+
+# fast algorithm
+denoise_fast = denoise_nl_means(noisy, h=0.8*sigma_est, fast_mode=True,
+                                **patch_kw)
+
+# fast algorithm, sigma provided
+denoise2_fast = denoise_nl_means(noisy, h=0.6*sigma_est, sigma=sigma_est,
+                                 fast_mode=True, **patch_kw)
+
+fig, ax = plt.subplots(nrows=2, ncols=3, figsize=(8, 6),
+                       sharex=True, sharey=True,
                        subplot_kw={'adjustable': 'box-forced'})
 
-ax[0].imshow(noisy)
-ax[0].axis('off')
-ax[0].set_title('noisy')
-ax[1].imshow(denoise)
-ax[1].axis('off')
-ax[1].set_title('non-local means')
+ax[0, 0].imshow(noisy)
+ax[0, 0].axis('off')
+ax[0, 0].set_title('noisy')
+ax[0, 1].imshow(denoise)
+ax[0, 1].axis('off')
+ax[0, 1].set_title('non-local means\n(slow)')
+ax[0, 2].imshow(denoise2)
+ax[0, 2].axis('off')
+ax[0, 2].set_title('non-local means\n(slow, using $\sigma_{est}$)')
+ax[1, 0].imshow(astro)
+ax[1, 0].axis('off')
+ax[1, 0].set_title('original\n(noise free)')
+ax[1, 1].imshow(denoise_fast)
+ax[1, 1].axis('off')
+ax[1, 1].set_title('non-local means\n(fast)')
+ax[1, 2].imshow(denoise2_fast)
+ax[1, 2].axis('off')
+ax[1, 2].set_title('non-local means\n(fast, using $\sigma_{est}$)')
 
 fig.tight_layout()
+
+# print PSNR metric for each case
+psnr_noisy = compare_psnr(astro, noisy)
+psnr = compare_psnr(astro, denoise.astype(astro.dtype))
+psnr2 = compare_psnr(astro, denoise2.astype(astro.dtype))
+psnr_fast = compare_psnr(astro, denoise_fast.astype(astro.dtype))
+psnr2_fast = compare_psnr(astro, denoise2_fast.astype(astro.dtype))
+
+print("PSNR (noisy) = {:0.2f}".format(psnr_noisy))
+print("PSNR (slow) = {:0.2f}".format(psnr))
+print("PSNR (slow, using sigma) = {:0.2f}".format(psnr2))
+print("PSNR (fast) = {:0.2f}".format(psnr_fast))
+print("PSNR (fast, using sigma) = {:0.2f}".format(psnr2_fast))
 
 plt.show()

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -33,6 +33,9 @@ Improvements
   ``anti_aliasing`` option to avoid aliasing artifacts when down-sampling
   images (#2802)
 - Support for multichannel images for ``skimage.feature.hog`` (#2870)
+- Non-local means denoising (``denoise_nl_means``) has a new optional
+  parameter, `sigma`, that can be used to specify the noise standard deviation.
+  This enables noise-robust patch distance estimation. (#2890)
 
 
 API Changes

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -1,3 +1,5 @@
+#cython: initializedcheck=False, wraparound=False, boundscheck=False, cdivision=True
+
 import numpy as np
 cimport numpy as np
 cimport cython
@@ -9,10 +11,10 @@ cdef double DISTANCE_CUTOFF = 5.0
 cdef extern from "fast_exp.h":
     inline double fast_exp(double y) nogil
 
-@cython.boundscheck(False)
+
 cdef inline double patch_distance_2d(IMGDTYPE [:, :] p1,
-                                    IMGDTYPE [:, :] p2,
-                                    IMGDTYPE [:, ::] w, int s, double var):
+                                     IMGDTYPE [:, :] p2,
+                                     IMGDTYPE [:, ::] w, int s, double var):
     """
     Compute a Gaussian distance between two image patches.
 
@@ -60,10 +62,9 @@ cdef inline double patch_distance_2d(IMGDTYPE [:, :] p1,
     return distance
 
 
-@cython.boundscheck(False)
 cdef inline double patch_distance_2drgb(IMGDTYPE [:, :, :] p1,
-                                       IMGDTYPE [:, :, :] p2,
-                                       IMGDTYPE [:, ::] w, int s, double var):
+                                        IMGDTYPE [:, :, :] p2,
+                                        IMGDTYPE [:, ::] w, int s, double var):
     """
     Compute a Gaussian distance between two image patches.
 
@@ -109,10 +110,9 @@ cdef inline double patch_distance_2drgb(IMGDTYPE [:, :, :] p1,
     return distance
 
 
-@cython.boundscheck(False)
 cdef inline double patch_distance_3d(IMGDTYPE [:, :, :] p1,
-                                    IMGDTYPE [:, :, :] p2,
-                                    IMGDTYPE [:, :, ::] w, int s, double var):
+                                     IMGDTYPE [:, :, :] p2,
+                                     IMGDTYPE [:, :, ::] w, int s, double var):
     """
     Compute a Gaussian distance between two image patches.
 
@@ -156,8 +156,6 @@ cdef inline double patch_distance_3d(IMGDTYPE [:, :, :] p1,
     return distance
 
 
-@cython.cdivision(True)
-@cython.boundscheck(False)
 def _nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1,
                            double var=0.):
     """
@@ -263,8 +261,6 @@ def _nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1,
     return result[offset:-offset, offset:-offset]
 
 
-@cython.cdivision(True)
-@cython.boundscheck(False)
 def _nl_means_denoising_3d(image, int s=7, int d=13, double h=0.1,
                            double var=0.0):
     """
@@ -369,10 +365,8 @@ def _nl_means_denoising_3d(image, int s=7, int d=13, double h=0.1,
 #-------------- Accelerated algorithm of Froment 2015 ------------------
 
 
-@cython.cdivision(True)
-@cython.boundscheck(False)
-cdef inline double _integral_to_distance_2d(IMGDTYPE [:, ::] integral,
-                        int row, int col, int offset, double h2s2):
+cdef inline double _integral_to_distance_2d(
+        IMGDTYPE [:, ::] integral, int row, int col, int offset, double h2s2):
     """
     References
     ----------
@@ -394,12 +388,12 @@ cdef inline double _integral_to_distance_2d(IMGDTYPE [:, ::] integral,
     distance = max(distance, 0.0) / h2s2
     return distance
 
-
+# @cython.wraparound(False)
 @cython.cdivision(True)
 @cython.boundscheck(False)
-cdef inline double _integral_to_distance_3d(IMGDTYPE [:, :, ::] integral,
-                    int pln, int row, int col, int offset,
-                    double s_cube_h_square):
+cdef inline double _integral_to_distance_3d(
+        IMGDTYPE [:, :, ::] integral, int pln, int row, int col, int offset,
+        double s_cube_h_square):
     """
     References
     ----------
@@ -426,8 +420,6 @@ cdef inline double _integral_to_distance_3d(IMGDTYPE [:, :, ::] integral,
     return distance
 
 
-@cython.cdivision(True)
-@cython.boundscheck(False)
 cdef inline _integral_image_2d(IMGDTYPE [:, :, ::] padded,
                                IMGDTYPE [:, ::] integral, int t_row,
                                int t_col, int n_row, int n_col, int n_ch,
@@ -482,8 +474,7 @@ cdef inline _integral_image_2d(IMGDTYPE [:, :, ::] padded,
                                  integral[row, col - 1] - \
                                  integral[row - 1, col - 1]
 
-@cython.cdivision(True)
-@cython.boundscheck(False)
+
 cdef inline _integral_image_3d(IMGDTYPE [:, :, ::] padded,
                                IMGDTYPE [:, :, ::] integral, int t_pln,
                                int t_row, int t_col, int n_pln, int n_row,
@@ -538,8 +529,6 @@ cdef inline _integral_image_3d(IMGDTYPE [:, :, ::] padded,
                      integral[pln - 1, row, col - 1])
 
 
-@cython.cdivision(True)
-@cython.boundscheck(False)
 def _fast_nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1,
                                 double var=0.):
     """
@@ -652,8 +641,6 @@ def _fast_nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1,
     return result[pad_size:-pad_size, pad_size:-pad_size]
 
 
-@cython.cdivision(True)
-@cython.boundscheck(False)
 def _fast_nl_means_denoising_3d(image, int s=5, int d=7, double h=0.1,
                                 double var=0.):
     """

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -1,4 +1,7 @@
-#cython: initializedcheck=False, wraparound=False, boundscheck=False, cdivision=True
+#cython: initializedcheck=False
+#cython: wraparound=False
+#cython: boundscheck=False
+#cython: cdivision=True
 
 import numpy as np
 cimport numpy as np
@@ -365,8 +368,8 @@ def _nl_means_denoising_3d(image, int s=7, int d=13, double h=0.1,
 #-------------- Accelerated algorithm of Froment 2015 ------------------
 
 
-cdef inline double _integral_to_distance_2d(
-        IMGDTYPE [:, ::] integral, int row, int col, int offset, double h2s2):
+cdef inline double _integral_to_distance_2d(IMGDTYPE [:, ::] integral, int row,
+                                            int col, int offset, double h2s2):
     """
     References
     ----------
@@ -388,12 +391,11 @@ cdef inline double _integral_to_distance_2d(
     distance = max(distance, 0.0) / h2s2
     return distance
 
-# @cython.wraparound(False)
-@cython.cdivision(True)
-@cython.boundscheck(False)
-cdef inline double _integral_to_distance_3d(
-        IMGDTYPE [:, :, ::] integral, int pln, int row, int col, int offset,
-        double s_cube_h_square):
+
+cdef inline double _integral_to_distance_3d(IMGDTYPE [:, :, ::] integral,
+                                            int pln, int row, int col,
+                                            int offset,
+                                            double s_cube_h_square):
     """
     References
     ----------

--- a/skimage/restoration/non_local_means.py
+++ b/skimage/restoration/non_local_means.py
@@ -8,7 +8,7 @@ from ._nl_means_denoising import (
 
 
 def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
-                     multichannel=None, fast_mode=True):
+                     multichannel=None, fast_mode=True, sigma=0.):
     """
     Perform non-local means denoising on 2-D or 3-D grayscale images, and
     2-D RGB images.
@@ -114,17 +114,16 @@ def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
     if image.ndim != 3:
         raise NotImplementedError("Non-local means denoising is only \
         implemented for 2D grayscale and RGB images or 3-D grayscale images.")
+    nlm_kwargs = dict(s=patch_size, d=patch_distance, h=h, var=sigma*sigma)
     if multichannel:  # 2-D images
         if fast_mode:
-            return np.squeeze(np.array(_fast_nl_means_denoising_2d(image,
-                                       patch_size, patch_distance, h)))
+            return np.squeeze(
+                np.array(_fast_nl_means_denoising_2d(image, **nlm_kwargs)))
         else:
-            return np.squeeze(np.array(_nl_means_denoising_2d(image,
-                                       patch_size, patch_distance, h)))
+            return np.squeeze(
+                np.array(_nl_means_denoising_2d(image, **nlm_kwargs)))
     else:  # 3-D grayscale
         if fast_mode:
-            return np.array(_fast_nl_means_denoising_3d(image, s=patch_size,
-                                                        d=patch_distance, h=h))
+            return np.array(_fast_nl_means_denoising_3d(image, **nlm_kwargs))
         else:
-            return np.array(_nl_means_denoising_3d(image, patch_size,
-                            patch_distance, h))
+            return np.array(_nl_means_denoising_3d(image, **nlm_kwargs))

--- a/skimage/restoration/non_local_means.py
+++ b/skimage/restoration/non_local_means.py
@@ -138,7 +138,7 @@ def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
     if image.ndim != 3:
         raise NotImplementedError("Non-local means denoising is only \
         implemented for 2D grayscale and RGB images or 3-D grayscale images.")
-    nlm_kwargs = dict(s=patch_size, d=patch_distance, h=h, var=sigma*sigma)
+    nlm_kwargs = dict(s=patch_size, d=patch_distance, h=h, var=sigma * sigma)
     if multichannel:  # 2-D images
         if fast_mode:
             return np.squeeze(

--- a/skimage/restoration/non_local_means.py
+++ b/skimage/restoration/non_local_means.py
@@ -118,12 +118,12 @@ def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
     if multichannel:  # 2-D images
         if fast_mode:
             return np.squeeze(
-                np.array(_fast_nl_means_denoising_2d(image, **nlm_kwargs)))
+                np.asarray(_fast_nl_means_denoising_2d(image, **nlm_kwargs)))
         else:
             return np.squeeze(
-                np.array(_nl_means_denoising_2d(image, **nlm_kwargs)))
+                np.asarray(_nl_means_denoising_2d(image, **nlm_kwargs)))
     else:  # 3-D grayscale
         if fast_mode:
-            return np.array(_fast_nl_means_denoising_3d(image, **nlm_kwargs))
+            return np.asarray(_fast_nl_means_denoising_3d(image, **nlm_kwargs))
         else:
-            return np.array(_nl_means_denoising_3d(image, **nlm_kwargs))
+            return np.asarray(_nl_means_denoising_3d(image, **nlm_kwargs))

--- a/skimage/restoration/non_local_means.py
+++ b/skimage/restoration/non_local_means.py
@@ -35,6 +35,10 @@ def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
         If True (default value), a fast version of the non-local means
         algorithm is used. If False, the original version of non-local means is
         used. See the Notes section for more details about the algorithms.
+    sigma : float, optional
+        The standard deviation of the (Gaussian) noise.  If provided, a more
+        robust computation of patch weights is computed that takes the expected
+        noise variance into account (see Notes below).
 
     Returns
     -------
@@ -84,18 +88,38 @@ def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
     The image is padded using the `reflect` mode of `skimage.util.pad`
     before denoising.
 
+    If the noise standard deviation, `sigma`, is provided a more robust
+    computation of patch weights is used.  Subtracting the known noise variance
+    from the computed patch distances improves the estimates of patch
+    similarity, giving a moderate improvement to denoising performance [4]_.
+    It was also mentioned as an option for the fast variant of the algorithm in
+    [3]_.
+
+    When `sigma` is provided, a smaller `h` should typically be used to
+    avoid oversmoothing.  The optimal value for `h` depends on the image
+    content and noise level, but a reasonable starting point is
+    ``h = 0.8 * sigma`` when `fast_mode` is `True`, or ``h = 0.6 * sigma`` when
+    `fast_mode` is `False`.
+
     References
     ----------
-    .. [1] Buades, A., Coll, B., & Morel, J. M. (2005, June). A non-local
-           algorithm for image denoising. In CVPR 2005, Vol. 2, pp. 60-65, IEEE.
+    .. [1] A. Buades, B. Coll, & J-M. Morel. A non-local algorithm for image
+           denoising. In CVPR 2005, Vol. 2, pp. 60-65, IEEE.
+           DOI: 10.1109/CVPR.2005.38
 
     .. [2] J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
            nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
            International Symposium on Biomedical Imaging: From Nano to Macro,
            2008, pp. 1331-1334.
+           DOI: 10.1109/ISBI.2008.4541250
 
     .. [3] Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
-           Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.
+           Denoising. Image Processing On Line, 2014, vol. 4, pp. 300-326.
+           DOI: 10.5201/ipol.2014.120
+
+    .. [4] A. Buades, B. Coll, & J-M. Morel. Non-Local Means Denoising.
+           Image Processing On Line, 2011, vol. 1, pp. 208-212.
+           DOI: 10.5201/ipol.2011.bcm_nlm
 
     Examples
     --------

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -232,7 +232,7 @@ def test_denoise_nl_means_2d():
     img = np.zeros((40, 40))
     img[10:-10, 10:-10] = 1.
     sigma = 0.3
-    img += sigma*np.random.randn(*img.shape)
+    img += sigma * np.random.randn(*img.shape)
     for s in [sigma, 0]:
         denoised = restoration.denoise_nl_means(img, 7, 5, 0.2, fast_mode=True,
                                                 multichannel=True, sigma=s)
@@ -269,7 +269,7 @@ def test_denoise_nl_means_3d():
     img = np.zeros((20, 20, 10))
     img[5:-5, 5:-5, 3:-3] = 1.
     sigma = 0.3
-    img += sigma*np.random.randn(*img.shape)
+    img += sigma * np.random.randn(*img.shape)
     for s in [sigma, 0]:
         denoised = restoration.denoise_nl_means(img, 5, 4, 0.2, fast_mode=True,
                                                 multichannel=False, sigma=s)

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -231,45 +231,55 @@ def test_denoise_bilateral_nan():
 def test_denoise_nl_means_2d():
     img = np.zeros((40, 40))
     img[10:-10, 10:-10] = 1.
-    img += 0.3*np.random.randn(*img.shape)
-    denoised = restoration.denoise_nl_means(img, 7, 5, 0.2, fast_mode=True,
-                                            multichannel=True)
-    # make sure noise is reduced
-    assert_(img.std() > denoised.std())
-    denoised = restoration.denoise_nl_means(img, 7, 5, 0.2, fast_mode=False,
-                                            multichannel=True)
-    # make sure noise is reduced
-    assert_(img.std() > denoised.std())
+    sigma = 0.3
+    img += sigma*np.random.randn(*img.shape)
+    for s in [sigma, 0]:
+        denoised = restoration.denoise_nl_means(img, 7, 5, 0.2, fast_mode=True,
+                                                multichannel=True, sigma=s)
+        # make sure noise is reduced
+        assert_(img.std() > denoised.std())
+        denoised = restoration.denoise_nl_means(img, 7, 5, 0.2,
+                                                fast_mode=False,
+                                                multichannel=True, sigma=s)
+        # make sure noise is reduced
+        assert_(img.std() > denoised.std())
 
 
 def test_denoise_nl_means_2drgb():
     # reduce image size because nl means is very slow
     img = np.copy(astro[:50, :50])
     # add some random noise
-    img += 0.5 * img.std() * np.random.random(img.shape)
+    sigma = 0.5
+    img += sigma * img.std() * np.random.random(img.shape)
     img = np.clip(img, 0, 1)
-    denoised = restoration.denoise_nl_means(img, 7, 9, 0.3, fast_mode=True,
-                                            multichannel=True)
-    # make sure noise is reduced
-    assert_(img.std() > denoised.std())
-    denoised = restoration.denoise_nl_means(img, 7, 9, 0.3, fast_mode=False,
-                                            multichannel=True)
-    # make sure noise is reduced
-    assert_(img.std() > denoised.std())
+    for s in [sigma, 0]:
+        denoised = restoration.denoise_nl_means(img, 7, 9, 0.3,
+                                                fast_mode=True,
+                                                multichannel=True, sigma=s)
+        # make sure noise is reduced
+        assert_(img.std() > denoised.std())
+        denoised = restoration.denoise_nl_means(img, 7, 9, 0.3,
+                                                fast_mode=False,
+                                                multichannel=True, sigma=s)
+        # make sure noise is reduced
+        assert_(img.std() > denoised.std())
 
 
 def test_denoise_nl_means_3d():
     img = np.zeros((20, 20, 10))
     img[5:-5, 5:-5, 3:-3] = 1.
-    img += 0.3*np.random.randn(*img.shape)
-    denoised = restoration.denoise_nl_means(img, 5, 4, 0.2, fast_mode=True,
-                                            multichannel=False)
-    # make sure noise is reduced
-    assert_(img.std() > denoised.std())
-    denoised = restoration.denoise_nl_means(img, 5, 4, 0.2, fast_mode=False,
-                                            multichannel=False)
-    # make sure noise is reduced
-    assert_(img.std() > denoised.std())
+    sigma = 0.3
+    img += sigma*np.random.randn(*img.shape)
+    for s in [sigma, 0]:
+        denoised = restoration.denoise_nl_means(img, 5, 4, 0.2, fast_mode=True,
+                                                multichannel=False, sigma=s)
+        # make sure noise is reduced
+        assert_(img.std() > denoised.std())
+        denoised = restoration.denoise_nl_means(img, 5, 4, 0.2,
+                                                fast_mode=False,
+                                                multichannel=False, sigma=s)
+        # make sure noise is reduced
+        assert_(img.std() > denoised.std())
 
 
 def test_denoise_nl_means_multichannel():


### PR DESCRIPTION
## Description

This PR adds an additional optional parameter, `sigma`, to non-local means denoising.  This can be used to provide an estimate of the noise variance for use in a more robust determination of patch weights (i.e. the expected noise variance will be subtracted out of the estimates of patch distances).  This is the form discussed in section 2 of the paper given under References below (it was not proposed in the original non-local means paper).

The default of `sigma=0` matches the previously existing behavior.  The non-local means demo has been updated to show the relative PSNR achieved by both the fast and slow variants of non-local means when used with and without `sigma`.  The optimal choice of `h` is a bit different in each case and was hand-tuned in the demo to provide a best case for each variant tested.

Here is the output of the modified demo:

![non_local_comparison](https://user-images.githubusercontent.com/6528957/33142825-bdebf608-cf85-11e7-910c-8e091393a8db.png)

The quantitative PSNR numbers for each denoising case are:
PSNR (fast) = 28.38
PSNR (fast, using sigma) = 29.26
PSNR (slow) = 29.34
PSNR (slow, using sigma) = 29.68

So, providing `sigma` improves the PSNR of the denoised image, particularly for the fast variant of the algorithm.

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests


## References

A. Buades, B. Coll, & J-M. Morel. Non-Local Means Denoising.
Image Processing On Line, 2011, vol. 1, pp. 208-212.
DOI: 10.5201/ipol.2011.bcm_nlm

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
