### PR TITLE
Allow mixed dtypes in compare_ssim, compare_psnr, etc.

### DIFF
--- a/skimage/measure/_structural_similarity.py
+++ b/skimage/measure/_structural_similarity.py
@@ -81,9 +81,6 @@ def compare_ssim(X, Y, win_size=None, gradient=False,
        DOI:10.1007/s10043-009-0119-z
 
     """
-    if not X.dtype == Y.dtype:
-        raise ValueError('Input images must have the same dtype.')
-
     if not X.shape == Y.shape:
         raise ValueError('Input images must have the same dimensions.')
 

--- a/skimage/measure/_structural_similarity.py
+++ b/skimage/measure/_structural_similarity.py
@@ -5,7 +5,7 @@ from scipy.ndimage import uniform_filter, gaussian_filter
 
 from ..util.dtype import dtype_range
 from ..util.arraycrop import crop
-
+from .._shared.utils import warn
 
 __all__ = ['compare_ssim']
 
@@ -145,6 +145,9 @@ def compare_ssim(X, Y, win_size=None, gradient=False,
         raise ValueError('Window size must be odd.')
 
     if data_range is None:
+        if X.dtype != Y.dtype:
+            warn("Inputs have mismatched dtype.  Setting data_range based on "
+                 "X.dtype.")
         dmin, dmax = dtype_range[X.dtype.type]
         data_range = dmax - dmin
 

--- a/skimage/measure/simple_metrics.py
+++ b/skimage/measure/simple_metrics.py
@@ -129,6 +129,9 @@ def compare_psnr(im_true, im_test, data_range=None, dynamic_range=None):
         data_range = dynamic_range
 
     if data_range is None:
+        if im_true.dtype != im_test.dtype:
+            warn("Inputs have mismatched dtype.  Setting data_range based on "
+                 "im_true.")
         dmin, dmax = dtype_range[im_true.dtype.type]
         true_min, true_max = np.min(im_true), np.max(im_true)
         if true_max > dmax or true_min < dmin:

--- a/skimage/measure/simple_metrics.py
+++ b/skimage/measure/simple_metrics.py
@@ -12,8 +12,6 @@ __all__ = ['compare_mse',
 
 def _assert_compatible(im1, im2):
     """Raise an error if the shape and dtype do not match."""
-    if not im1.dtype == im2.dtype:
-        raise ValueError('Input images must have the same dtype.')
     if not im1.shape == im2.shape:
         raise ValueError('Input images must have the same dimensions.')
     return
@@ -22,10 +20,8 @@ def _assert_compatible(im1, im2):
 def _as_floats(im1, im2):
     """Promote im1, im2 to nearest appropriate floating point precision."""
     float_type = np.result_type(im1.dtype, im2.dtype, np.float32)
-    if im1.dtype != float_type:
-        im1 = im1.astype(float_type)
-    if im2.dtype != float_type:
-        im2 = im2.astype(float_type)
+    im1 = np.asarray(im1, dtype=float_type)
+    im2 = np.asarray(im2, dtype=float_type)
     return im1, im2
 
 

--- a/skimage/measure/tests/test_simple_metrics.py
+++ b/skimage/measure/tests/test_simple_metrics.py
@@ -25,16 +25,18 @@ def test_PSNR_vs_IPOL():
 
 def test_PSNR_float():
     p_uint8 = compare_psnr(cam, cam_noisy)
-    p_float64 = compare_psnr(cam/255., cam_noisy/255., data_range=1)
+    p_float64 = compare_psnr(cam / 255., cam_noisy / 255.,
+                             data_range=1)
     assert_almost_equal(p_uint8, p_float64, decimal=5)
 
     # mixed precision inputs
-    p_mixed = compare_psnr(cam/255., np.float32(cam_noisy/255.), data_range=1)
+    p_mixed = compare_psnr(cam / 255., np.float32(cam_noisy / 255.),
+                           data_range=1)
     assert_almost_equal(p_mixed, p_float64, decimal=5)
 
     # mismatched dtype results in a warning if data_range is unspecified
     with expected_warnings(['Inputs have mismatched dtype']):
-        p_mixed = compare_psnr(cam/255., np.float32(cam_noisy/255.))
+        p_mixed = compare_psnr(cam / 255., np.float32(cam_noisy / 255.))
     assert_almost_equal(p_mixed, p_float64, decimal=5)
 
 
@@ -64,7 +66,7 @@ def test_NRMSE():
 
     # mixed precision inputs are allowed
     assert_almost_equal(compare_nrmse(y, np.float32(x), 'min-max'),
-                        1/(y.max()-y.min()))
+                        1 / (y.max() - y.min()))
 
 
 def test_NRMSE_no_int_overflow():

--- a/skimage/measure/tests/test_simple_metrics.py
+++ b/skimage/measure/tests/test_simple_metrics.py
@@ -28,6 +28,10 @@ def test_PSNR_float():
     p_float64 = compare_psnr(cam/255., cam_noisy/255., data_range=1)
     assert_almost_equal(p_uint8, p_float64, decimal=5)
 
+    # mixed precision inputs
+    p_mixed = compare_psnr(cam/255., np.float32(cam_noisy/255.), data_range=1)
+    assert_almost_equal(p_mixed, p_float64, decimal=5)
+
 
 def test_PSNR_dynamic_range_and_data_range():
     # Tests deprecation of "dynamic_range" in favor of "data_range"
@@ -41,8 +45,7 @@ def test_PSNR_dynamic_range_and_data_range():
 
 
 def test_PSNR_errors():
-    with testing.raises(ValueError):
-        compare_psnr(cam, cam.astype(np.float32))
+    # shape mismatch
     with testing.raises(ValueError):
         compare_psnr(cam, cam[:-1, :])
 
@@ -53,6 +56,10 @@ def test_NRMSE():
     assert_equal(compare_nrmse(y, x, 'mean'), 1/np.mean(y))
     assert_equal(compare_nrmse(y, x, 'Euclidean'), 1/np.sqrt(3))
     assert_equal(compare_nrmse(y, x, 'min-max'), 1/(y.max()-y.min()))
+
+    # mixed precision inputs are allowed
+    assert_almost_equal(compare_nrmse(y, np.float32(x), 'min-max'),
+                        1/(y.max()-y.min()))
 
 
 def test_NRMSE_no_int_overflow():
@@ -66,8 +73,7 @@ def test_NRMSE_no_int_overflow():
 
 def test_NRMSE_errors():
     x = np.ones(4)
-    with testing.raises(ValueError):
-        compare_nrmse(x.astype(np.uint8), x.astype(np.float32))
+    # shape mismatch
     with testing.raises(ValueError):
         compare_nrmse(x[:-1], x)
     # invalid normalization name

--- a/skimage/measure/tests/test_simple_metrics.py
+++ b/skimage/measure/tests/test_simple_metrics.py
@@ -32,6 +32,11 @@ def test_PSNR_float():
     p_mixed = compare_psnr(cam/255., np.float32(cam_noisy/255.), data_range=1)
     assert_almost_equal(p_mixed, p_float64, decimal=5)
 
+    # mismatched dtype results in a warning if data_range is unspecified
+    with expected_warnings(['Inputs have mismatched dtype']):
+        p_mixed = compare_psnr(cam/255., np.float32(cam_noisy/255.))
+    assert_almost_equal(p_mixed, p_float64, decimal=5)
+
 
 def test_PSNR_dynamic_range_and_data_range():
     # Tests deprecation of "dynamic_range" in favor of "data_range"

--- a/skimage/measure/tests/test_structural_similarity.py
+++ b/skimage/measure/tests/test_structural_similarity.py
@@ -192,23 +192,21 @@ def test_mssim_vs_legacy():
     assert_almost_equal(mssim, mssim_skimage_0pt11)
 
 
+def test_mssim_mixed_dtype():
+    mssim = ssim(cam, cam_noisy)
+    mssim_mixed = ssim(cam, cam_noisy.astype(np.float32))
+    assert_almost_equal(mssim, mssim_mixed)
+
+
 def test_invalid_input():
-    X = np.zeros((3, 3), dtype=np.double)
-    Y = np.zeros((3, 3), dtype=np.int)
+    # size mismatch
+    X = np.zeros((9, 9), dtype=np.double)
+    Y = np.zeros((8, 8), dtype=np.double)
     with testing.raises(ValueError):
         ssim(X, Y)
-
-    Y = np.zeros((4, 4), dtype=np.double)
+    # win_size exceeds image extent
     with testing.raises(ValueError):
-        ssim(X, Y)
-
-    with testing.raises(ValueError):
-        ssim(X, X, win_size=8)
-
-    # do not allow both image content weighting and gradient calculation
-    with testing.raises(ValueError):
-        ssim(X, X, image_content_weighting=True,
-             gradient=True)
+        ssim(X, X, win_size=X.shape[0]+1)
     # some kwarg inputs must be non-negative
     with testing.raises(ValueError):
         ssim(X, X, K1=-0.1)

--- a/skimage/measure/tests/test_structural_similarity.py
+++ b/skimage/measure/tests/test_structural_similarity.py
@@ -212,7 +212,7 @@ def test_invalid_input():
         ssim(X, Y)
     # win_size exceeds image extent
     with testing.raises(ValueError):
-        ssim(X, X, win_size=X.shape[0]+1)
+        ssim(X, X, win_size=X.shape[0] + 1)
     # some kwarg inputs must be non-negative
     with testing.raises(ValueError):
         ssim(X, X, K1=-0.1)

--- a/skimage/measure/tests/test_structural_similarity.py
+++ b/skimage/measure/tests/test_structural_similarity.py
@@ -5,6 +5,7 @@ from skimage import data, data_dir
 from skimage.measure import compare_ssim as ssim
 
 from skimage._shared import testing
+from skimage._shared._warnings import expected_warnings
 from skimage._shared.testing import (assert_equal, assert_almost_equal,
                                      assert_array_almost_equal)
 
@@ -194,7 +195,12 @@ def test_mssim_vs_legacy():
 
 def test_mssim_mixed_dtype():
     mssim = ssim(cam, cam_noisy)
-    mssim_mixed = ssim(cam, cam_noisy.astype(np.float32))
+    with expected_warnings(['Inputs have mismatched dtype']):
+        mssim_mixed = ssim(cam, cam_noisy.astype(np.float32))
+    assert_almost_equal(mssim, mssim_mixed)
+
+    # no warning when user supplies data_range
+    mssim_mixed = ssim(cam, cam_noisy.astype(np.float32), data_range=255)
     assert_almost_equal(mssim, mssim_mixed)
 
 


### PR DESCRIPTION
## Description

This PR removes checks that were requiring matching dtype for the inputs to `compare_nrmse`, `compare_mse`, `compare_psnr` and `compare_ssim`.  All of these already were converting the inputs to floating point type prior to computing the measure, so this will not change the computed metrics.

When `data_range` is not specified, both `compare_psnr` and `compare_ssim` determine an appropriate range based on the input data dtype.  I think this may have been the original rationale for forcing both inputs to have the same dtype.  I have added a warning when the input dtype is mismatched in these two functions only in the case that `data_range` is not provided.

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests


## References
closes #2892

## For reviewers
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
