### PR TITLE
Install documentation dependencies on all builds

### DIFF
--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -21,13 +21,6 @@ section "Test.with.min.requirements"
 pytest $TEST_ARGS skimage
 section_end "Test.with.min.requirements"
 
-section "Build.docs"
-if [[ $BUILD_DOCS == 1 ]]; then
-    pip install --retries 3 -q -r ./requirements/docs.txt
-    export SPHINXCACHE=$HOME/.cache/sphinx; make html
-fi
-section_end "Build.docs"
-
 section "Flake8.test"
 flake8 --exit-zero --exclude=test_*,six.py skimage doc/examples viewer_examples
 section_end "Flake8.test"
@@ -70,18 +63,24 @@ pip list
 section_end "Install.optional.dependencies"
 
 
-section "Run.doc.examples"
-echo 'backend : Template' > $MPL_DIR/matplotlibrc
+section "Build.docs.or.run.examples"
 
+pip install --retries 3 -q -r ./requirements/docs.txt
 
-for f in doc/examples/*/*.py; do
-    python "$f"
-    if [ $? -ne 0 ]; then
-        exit 1
-    fi
-done
+if [[ $BUILD_DOCS == 1 ]]; then
+    export SPHINXCACHE=$HOME/.cache/sphinx; make html
+else
+    echo 'backend : Template' > $MPL_DIR/matplotlibrc
 
-section_end "Run.doc.examples"
+    for f in doc/examples/*/*.py; do
+        python "$f"
+        if [ $? -ne 0 ]; then
+            exit 1
+        fi
+    done
+fi
+
+section_end "Build.docs.or.run.examples"
 
 
 section "Run.doc.applications"


### PR DESCRIPTION
Builds either build the docs, or run the examples individually.  Either
way, we need to have the docs dependencies satisfied.

Closes #2899