### PR TITLE
Speedup 2D warping for affine transformations

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -164,8 +164,10 @@ def resize(image, output_shape, order=1, mode=None, cval=0, clip=True,
             tform = AffineTransform()
             tform.estimate(src_corners, dst_corners)
 
-        # Make sure the transform is exactly affine, to ensure fast warping.
+        # Make sure the transform is exactly metric, to ensure fast warping.
         tform.params[2] = (0, 0, 1)
+        tform.params[0, 1] = 0
+        tform.params[1, 0] = 0
 
         out = warp(image, tform, output_shape=output_shape, order=order,
                    mode=mode, cval=cval, clip=clip,

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -164,6 +164,9 @@ def resize(image, output_shape, order=1, mode=None, cval=0, clip=True,
             tform = AffineTransform()
             tform.estimate(src_corners, dst_corners)
 
+        # Make sure the transform is exactly affine, to ensure fast warping.
+        tform.params[2] = (0, 0, 1)
+
         out = warp(image, tform, output_shape=output_shape, order=order,
                    mode=mode, cval=cval, clip=clip,
                    preserve_range=preserve_range)
@@ -380,6 +383,9 @@ def rotate(image, angle, resize=False, center=None, order=1, mode='constant',
         translation = (minc, minr)
         tform4 = SimilarityTransform(translation=translation)
         tform = tform4 + tform
+
+    # Make sure the transform is exactly affine, to ensure fast warping.
+    tform.params[2] = (0, 0, 1)
 
     return warp(image, tform, output_shape=output_shape, order=order,
                 mode=mode, cval=cval, clip=clip, preserve_range=preserve_range)

--- a/skimage/transform/_warps_cy.pyx
+++ b/skimage/transform/_warps_cy.pyx
@@ -128,9 +128,7 @@ def _warp_fast(cnp.ndarray image, cnp.ndarray H, output_shape=None,
     cdef Py_ssize_t cols = img.shape[1]
 
     cdef void (*transform_func)(double, double, double*, double*, double*) nogil
-    if (abs(M[2, 0]) < 1e-10 and
-            abs(M[2, 1]) < 1e-10 and
-            abs(M[2, 2] - 1) < 1e-10):
+    if M[2, 0]) == 0 and M[2, 1] == 0 and M[2, 2] == 1:
         transform_func = _transform_affine
     else:
         transform_func = _transform_projective

--- a/skimage/transform/_warps_cy.pyx
+++ b/skimage/transform/_warps_cy.pyx
@@ -140,6 +140,8 @@ def _warp_fast(cnp.ndarray image, cnp.ndarray H, output_shape=None,
         interp_func = biquadratic_interpolation
     elif order == 3:
         interp_func = bicubic_interpolation
+    else:
+        raise ValueError("Unsupported interpolation order", order)
 
     with nogil:
         for tfr in range(out_r):

--- a/skimage/transform/_warps_cy.pyx
+++ b/skimage/transform/_warps_cy.pyx
@@ -24,9 +24,8 @@ cdef inline void _transform_affine(double x, double y, double* H,
         Output coordinate.
 
     """
-    cdef double xx, yy
-    xx = H[0] * x + H[1] * y + H[2]
-    yy = H[3] * x + H[4] * y + H[5]
+    x_[0] = H[0] * x + H[1] * y + H[2]
+    y_[0] = H[3] * x + H[4] * y + H[5]
 
 
 cdef inline void _transform_projective(double x, double y, double* H,
@@ -43,12 +42,10 @@ cdef inline void _transform_projective(double x, double y, double* H,
         Output coordinate.
 
     """
-    cdef double xx, yy, zz
-    xx = H[0] * x + H[1] * y + H[2]
-    yy = H[3] * x + H[4] * y + H[5]
-    zz = H[6] * x + H[7] * y + H[8]
-    x_[0] = xx / zz
-    y_[0] = yy / zz
+    cdef double z_
+    z_ = H[6] * x + H[7] * y + H[8]
+    x_[0] = (H[0] * x + H[1] * y + H[2]) / z_
+    y_[0] = (H[3] * x + H[4] * y + H[5]) / z_
 
 
 def _warp_fast(cnp.ndarray image, cnp.ndarray H, output_shape=None,

--- a/skimage/transform/_warps_cy.pyx
+++ b/skimage/transform/_warps_cy.pyx
@@ -128,7 +128,7 @@ def _warp_fast(cnp.ndarray image, cnp.ndarray H, output_shape=None,
     cdef Py_ssize_t cols = img.shape[1]
 
     cdef void (*transform_func)(double, double, double*, double*, double*) nogil
-    if M[2, 0]) == 0 and M[2, 1] == 0 and M[2, 2] == 1:
+    if M[2, 0] == 0 and M[2, 1] == 0 and M[2, 2] == 1:
         transform_func = _transform_affine
     else:
         transform_func = _transform_projective


### PR DESCRIPTION
## Description
Following up from https://twitter.com/jeremyphoward/status/931761385628778496, this should make non-projective transformations (any affine transformation) around 2x faster. In the end, we will not be able to reach the same speed as some of the highly optimized libraries, but this is a first step towards improving performance.