### PR TITLE
Update default parameter values in the docstring of `skimage.restoration.unsupervised_wiener`

### DIFF
--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -186,12 +186,12 @@ def unsupervised_wiener(image, psf, reg=None, user_params=None, is_real=True,
        samples, see Notes section). 1e-4 by default.
     burnin : int
        The number of sample to ignore to start computation of the
-       mean. 100 by default.
+       mean. 15 by default.
     min_iter : int
        The minimum number of iterations. 30 by default.
     max_iter : int
        The maximum number of iterations if ``threshold`` is not
-       satisfied. 150 by default.
+       satisfied. 200 by default.
     callback : callable (None by default)
        A user provided callable to which is passed, if the function
        exists, the current image sample for whatever purpose. The user


### PR DESCRIPTION
In `skimage.restoration.unsupervised_wiener`, `burnin` and `max_iter` documented default values (100 and 150 resp.) were not matching actual code default values (15 and 200).

## Description
Update the documentation to match actual (code) default values.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
