### PR TITLE
remove unused parameter 'n_segments' in `_enforce_label_connectivity_cython()`

### DIFF
--- a/skimage/segmentation/_slic.pyx
+++ b/skimage/segmentation/_slic.pyx
@@ -190,7 +190,6 @@ def _slic_cython(double[:, :, :, ::1] image_zyx,
 
 
 def _enforce_label_connectivity_cython(Py_ssize_t[:, :, ::1] segments,
-                                       Py_ssize_t n_segments,
                                        Py_ssize_t min_size,
                                        Py_ssize_t max_size):
     """ Helper function to remove small disconnected regions from the labels
@@ -199,8 +198,6 @@ def _enforce_label_connectivity_cython(Py_ssize_t[:, :, ::1] segments,
     ----------
     segments : 3D array of int, shape (Z, Y, X)
         The label field/superpixels found by SLIC.
-    n_segments: int
-        Number of specified segments
     min_size: int
         Minimum size of the segment
     max_size: int

--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -179,7 +179,6 @@ def slic(image, n_segments=100, compactness=10., max_iter=10, sigma=0,
         min_size = int(min_size_factor * segment_size)
         max_size = int(max_size_factor * segment_size)
         labels = _enforce_label_connectivity_cython(labels,
-                                                    n_segments,
                                                     min_size,
                                                     max_size)
 


### PR DESCRIPTION
## Description

The `n_segments` in the` _enforce_label_connectivity_cython() `method currently in 'segmentation._slic.pyx' are legacy parameters not used in the function. I want to remove it to clarify the semantics of the function and increase the readability of the code.

- I remove the second parameter `n_segments` from the` _enforce_label_connectivity_cython()`method in` segmentation._slic.pyx '.

- In `segmentation.slic_superpixels.py`
 I remove the second variable `n_segments` which is injected into` _enforce_label_connectivity_cython()`.

- I check `segmentation.tests.test_slic.py`, and confirmed that there is no test for ` _enforce_label_connectivity_cython()` alone.

- I remove the description of `n_segments` in docstring of` segmentation._slic.pyx`.

## Checklist
- [O] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [O] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [-] Gallery example in `./doc/examples` (new features only)
- [-] Unit tests

## References

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
