### PR TITLE
Add Mock RNG for Testing

### DIFF
--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -31,6 +31,30 @@ raises = pytest.raises
 fixture = pytest.fixture
 
 
+class MockRNG:
+    """A mock (controlled) random number generator.
+
+    Parameters
+    ----------
+    name : String
+        The name of the function that will output the mock values.
+    mock_values : list
+        The mock values to return in order. Will loop if the end is reached.
+    """
+    def __init__(self, name, mock_values):
+        self.values = mock_values
+        self.index = 0
+
+        def nxt():
+            """Returns the next value requested"""
+            val = self.values[self.index]
+            self.index += 1
+            self.index %= len(self.values)
+            return val
+
+        setattr(self, name, nxt)
+
+
 def assert_less(a, b, msg=None):
     message = "%r is not lower than %r" % (a, b)
     if msg is not None:

--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -45,7 +45,7 @@ class MockRNG:
         self.values = mock_values
         self.index = 0
 
-        def nxt():
+        def nxt(*args, **kwargs):
             """Returns the next value requested"""
             val = self.values[self.index]
             self.index += 1

--- a/skimage/_shared/tests/test_testing.py
+++ b/skimage/_shared/tests/test_testing.py
@@ -112,6 +112,15 @@ def test_mock_rng():
     # loops
     assert_equal(rng.randint(), 42)
 
+    # test that it can take in dummy args
+    assert_equal(rng.randint(3, 12, 15), 3)
+
+    # test that it can take in dummy kwargs
+    assert_equal(rng.randint(foo="bar"), 5)
+
+    # test that it can take in both
+    assert_equal(rng.randint(42, foo="bar"), 42)
+
 
 if __name__ == '__main__':
     np.testing.run_module_suite()

--- a/skimage/_shared/tests/test_testing.py
+++ b/skimage/_shared/tests/test_testing.py
@@ -3,7 +3,8 @@
 
 import numpy as np
 from numpy.testing import assert_equal
-from skimage._shared.testing import doctest_skip_parser, test_parallel
+from skimage._shared.testing import (doctest_skip_parser, test_parallel,
+                                     MockRNG)
 from skimage._shared import testing
 
 
@@ -95,6 +96,21 @@ def test_test_parallel():
         state.append(None)
     change_state3()
     assert len(state) == 6
+
+
+def test_mock_rng():
+    rng = MockRNG('randint', [42, 3, 5])
+
+    # successfully named attr
+    assert_equal(hasattr(rng, 'randint'), True)
+
+    # gives mock values in order
+    assert_equal(rng.randint(), 42)
+    assert_equal(rng.randint(), 3)
+    assert_equal(rng.randint(), 5)
+
+    # loops
+    assert_equal(rng.randint(), 42)
 
 
 if __name__ == '__main__':

--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -1,4 +1,4 @@
-from skimage._shared.utils import (copy_func, assert_nD)
+from skimage._shared.utils import (copy_func, assert_nD, assert_attrs)
 import numpy.testing as npt
 import numpy as np
 from skimage._shared import testing
@@ -9,6 +9,21 @@ def test_assert_nD():
     x = z[10:30, 30:10]
     with testing.raises(ValueError):
         assert_nD(x, 2)
+
+
+def test_hasattrs():
+    foo = lambda: 0
+    foo.bar = 42
+    foo.baz = 'hello world'
+    assert_attrs(foo, ['bar', 'baz'])
+
+    detects_no_attr = False
+    try:
+        assert_attrs(foo, ['boo'])
+    except AttributeError:
+        detects_no_attr = True
+
+    assert detects_no_attr
 
 
 def test_copyfunc():

--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -11,7 +11,7 @@ def test_assert_nD():
         assert_nD(x, 2)
 
 
-def test_hasattrs():
+def test_assert_attrs():
     foo = lambda: 0
     foo.bar = 42
     foo.baz = 'hello world'

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -221,6 +221,33 @@ def check_random_state(seed):
                      ' instance' % seed)
 
 
+def assert_attrs(obj, attrs):
+    """Asserts that an object has all the attributes specified.
+
+    Parameters
+    ----------
+    obj : object
+        The object to check.
+    attrs : List of String
+        The names of the attributes it must have.
+
+    Raises
+    ------
+    AttributeError
+        If `obj` does not contain one or more `attrs`.
+    """
+    f = np.vectorize(lambda name: not hasattr(obj, name))
+    no_attrs = f(attrs)
+    if no_attrs.any():
+        obj_name = obj.__name__
+        no_attrs = np.asarray(attrs)[no_attrs]
+        message = obj_name + " has no attribute(s): "
+        for attr in no_attrs:
+            message += attr + ", "
+        message = message[:-2]
+        raise AttributeError(message)
+
+
 def convert_to_float(image, preserve_range):
     """Convert input image to double image with the appropriate range.
 
@@ -242,4 +269,3 @@ def convert_to_float(image, preserve_range):
     else:
         image = img_as_float(image)
     return image
-


### PR DESCRIPTION
## Description
Adds a mock RNG class for better control over testing functions with random properties.

Ideally, all random functions would be reworked to take in a random number generator that must have a function that returns a value of the specified data type.

Example:
```python
def foo(random):
    """Does something.

    Parameters
    ----------
    random : object with function `rand` which returns an int
        Random number generator.

    Returns
    -------
    bar : int
        Your result.
    """
    assert_attrs(random, ['rand'])
    return random.rand()
```
Then it would behave as follows:
```python
>>> random = MockRNG('rand', [42, 24, 5])
>>> foo(random)
42
>>> foo(random)
24
>>> foo(random)
5
>>> foo(random)
42
```


## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
https://github.com/scikit-image/scikit-image/pull/2877#issuecomment-345417868
#2773 

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
