### PR TITLE
do not assume 3 channels during non-local means denoising

### DIFF
--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -65,10 +65,10 @@ cdef inline double patch_distance_2d(IMGDTYPE [:, :] p1,
     return distance
 
 
-cdef inline double patch_distance_2drgb(IMGDTYPE [:, :, :] p1,
-                                        IMGDTYPE [:, :, :] p2,
-                                        IMGDTYPE [:, ::] w, int s, double var,
-                                        int n_ch):
+cdef inline double patch_distance_2dmultichannel(IMGDTYPE [:, :, :] p1,
+                                                 IMGDTYPE [:, :, :] p2,
+                                                 IMGDTYPE [:, ::] w,
+                                                 int s, double var, int n_ch):
     """
     Compute a Gaussian distance between two image patches.
 
@@ -247,7 +247,7 @@ def _nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1,
                                         col_start_j:col_end_j, 0],
                                  w, s, var)
                     else:
-                        weight = patch_distance_2drgb(
+                        weight = patch_distance_2dmultichannel(
                                  padded[row_start:row_end,
                                         col_start:col_end, :],
                                  padded[row_start_i:row_end_i,

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -68,7 +68,8 @@ cdef inline double patch_distance_2d(IMGDTYPE [:, :] p1,
 cdef inline double patch_distance_2dmultichannel(IMGDTYPE [:, :, :] p1,
                                                  IMGDTYPE [:, :, :] p2,
                                                  IMGDTYPE [:, ::] w,
-                                                 int s, double var, int n_ch):
+                                                 int s, double var,
+                                                 int n_channels):
     """
     Compute a Gaussian distance between two image patches.
 
@@ -84,6 +85,8 @@ cdef inline double patch_distance_2dmultichannel(IMGDTYPE [:, :, :] p1,
         Linear size of the patches.
     var : double
         Expected noise variance.
+    n_channels : int
+        The number of channels.
 
     Returns
     -------
@@ -104,7 +107,7 @@ cdef inline double patch_distance_2dmultichannel(IMGDTYPE [:, :, :] p1,
         if distance > DISTANCE_CUTOFF:
             return 0.
         for j in range(s):
-            for channel in range(n_ch):
+            for channel in range(n_channels):
                 tmp_diff = p1[i, j, channel] - p2[i, j, channel]
                 distance += w[i, j] * (tmp_diff * tmp_diff - 2 * var)
     distance = max(distance, 0)
@@ -191,13 +194,13 @@ def _nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1,
     """
     if s % 2 == 0:
         s += 1  # odd value for symmetric patch
-    cdef int n_row, n_col, n_ch
-    n_row, n_col, n_ch = image.shape
+    cdef int n_row, n_col, n_channels
+    n_row, n_col, n_channels = image.shape
     cdef int offset = s / 2
     cdef int row, col, i, j, channel
     cdef int row_start, row_end, col_start, col_end
     cdef int row_start_i, row_end_i, col_start_j, col_end_j
-    cdef IMGDTYPE [::1] new_values = np.zeros(n_ch).astype(np.float64)
+    cdef IMGDTYPE [::1] new_values = np.zeros(n_channels).astype(np.float64)
     cdef IMGDTYPE [:, :, ::1] padded = np.ascontiguousarray(np.pad(image,
                        ((offset, offset), (offset, offset), (0, 0)),
                         mode='reflect').astype(np.float64))
@@ -210,7 +213,7 @@ def _nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1,
                              -(xg_row ** 2 + xg_col ** 2) / (2 * A ** 2)).
                              astype(np.float64))
     cdef double distance
-    w = 1. / (n_ch * np.sum(w) * h ** 2) * w
+    w = 1. / (n_channels * np.sum(w) * h ** 2) * w
 
     # Coordinates of central pixel
     # Iterate over rows, taking padding into account
@@ -220,7 +223,7 @@ def _nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1,
         # Iterate over columns, taking padding into account
         for col in range(offset, n_col + offset):
             # Initialize per-channel bins
-            for channel in range(n_ch):
+            for channel in range(n_channels):
                 new_values[channel] = 0
             # Reset weights for each local region
             weight_sum = 0
@@ -239,7 +242,7 @@ def _nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1,
                     col_start_j = col_start + j
                     col_end_j = col_end + j
                     # Shortcut for grayscale, else assume RGB
-                    if n_ch == 1:
+                    if n_channels == 1:
                         weight = patch_distance_2d(
                                  padded[row_start:row_end,
                                         col_start:col_end, 0],
@@ -252,18 +255,18 @@ def _nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1,
                                         col_start:col_end, :],
                                  padded[row_start_i:row_end_i,
                                         col_start_j:col_end_j, :],
-                                        w, s, var, n_ch)
+                                        w, s, var, n_channels)
 
                     # Collect results in weight sum
                     weight_sum += weight
                     # Apply to each channel multiplicatively
-                    for channel in range(n_ch):
+                    for channel in range(n_channels):
                         new_values[channel] += weight * padded[row + i,
                                                                col + j,
                                                                channel]
 
             # Normalize the result
-            for channel in range(n_ch):
+            for channel in range(n_channels):
                 result[row, col, channel] = new_values[channel] / weight_sum
 
     # Return cropped result, undoing padding
@@ -430,7 +433,7 @@ cdef inline double _integral_to_distance_3d(IMGDTYPE [:, :, ::] integral,
 
 cdef inline _integral_image_2d(IMGDTYPE [:, :, ::] padded,
                                IMGDTYPE [:, ::] integral, int t_row,
-                               int t_col, int n_row, int n_col, int n_ch,
+                               int t_col, int n_row, int n_col, int n_channels,
                                double var):
     """
     Computes the integral of the squared difference between an image ``padded``
@@ -438,7 +441,7 @@ cdef inline _integral_image_2d(IMGDTYPE [:, :, ::] padded,
 
     Parameters
     ----------
-    padded : ndarray of shape (n_row, n_col, n_ch)
+    padded : ndarray of shape (n_row, n_col, n_channels)
         Image of interest.
     integral : ndarray
         Output of the function. The array is filled with integral values.
@@ -449,7 +452,7 @@ cdef inline _integral_image_2d(IMGDTYPE [:, :, ::] padded,
         Shift along the column axis.
     n_row : int
     n_col : int
-    n_ch : int
+    n_channels : int
     var : double
         Expected noise variance.  If non-zero, this is used to reduce the
         apparent patch distances by the expected distance due to the noise.
@@ -461,20 +464,20 @@ cdef inline _integral_image_2d(IMGDTYPE [:, :, ::] padded,
     ``transform.integral_image``, but this helper function saves memory
     by avoiding copies of ``padded``.
     """
-    cdef int row, col
+    cdef int row, col, channel
     cdef double distance
     for row in range(max(1, -t_row), min(n_row, n_row - t_row)):
         for col in range(max(1, -t_col), min(n_col, n_col - t_col)):
-            if n_ch == 1:
+            if n_channels == 1:
                 distance = (padded[row, col, 0] -
                             padded[row + t_row, col + t_col, 0])**2
                 distance -= 2 * var
             else:
                 distance = 0
-                for ch in range(n_ch):
-                    distance += (padded[row, col, ch] -
-                                 padded[row + t_row, col + t_col, ch])**2
-                distance -= 2 * n_ch * var
+                for channel in range(n_channels):
+                    distance += (padded[row, col, channel] -
+                                 padded[row + t_row, col + t_col, channel])**2
+                distance -= 2 * n_channels * var
             integral[row, col] = distance + \
                                  integral[row - 1, col] + \
                                  integral[row, col - 1] - \
@@ -583,13 +586,13 @@ def _fast_nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1,
     cdef IMGDTYPE [:, :, ::1] result = np.zeros_like(padded)
     cdef IMGDTYPE [:, ::1] weights = np.zeros_like(padded[..., 0], order='C')
     cdef IMGDTYPE [:, ::1] integral = np.zeros_like(padded[..., 0], order='C')
-    cdef int n_row, n_col, n_ch, t_row, t_col, row, col
+    cdef int n_row, n_col, t_row, t_col, row, col, n_channels, channel
     cdef double weight, distance
     cdef double alpha
     cdef double h2 = h ** 2.
     cdef double s2 = s ** 2.
-    n_row, n_col, n_ch = image.shape
-    cdef double h2s2 = n_ch * h2 * s2
+    n_row, n_col, n_channels = image.shape
+    cdef double h2s2 = n_channels * h2 * s2
     n_row += 2 * pad_size
     n_col += 2 * pad_size
 
@@ -609,7 +612,7 @@ def _fast_nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1,
             # padded and the same image shifted by (t_row, t_col)
             integral = np.zeros_like(padded[..., 0], order='C')
             _integral_image_2d(padded, integral, t_row, t_col,
-                               n_row, n_col, n_ch, var)
+                               n_row, n_col, n_channels, var)
 
             # Inner loops on pixel coordinates
             # Iterate over rows, taking offset and shift into account
@@ -629,16 +632,16 @@ def _fast_nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1,
                     weights[row, col] += weight
                     weights[row + t_row, col + t_col] += weight
                     # Iterate over channels
-                    for ch in range(n_ch):
-                        result[row, col, ch] += weight * \
-                                    padded[row + t_row, col + t_col, ch]
-                        result[row + t_row, col + t_col, ch] += \
-                                        weight * padded[row, col, ch]
+                    for channel in range(n_channels):
+                        result[row, col, channel] += weight * \
+                                    padded[row + t_row, col + t_col, channel]
+                        result[row + t_row, col + t_col, channel] += \
+                                        weight * padded[row, col, channel]
 
     # Normalize pixel values using sum of weights of contributing patches
     for row in range(offset, n_row - offset):
         for col in range(offset, n_col - offset):
-            for channel in range(n_ch):
+            for channel in range(n_channels):
                 # No risk of division by zero, since the contribution
                 # of a null shift is strictly positive
                 result[row, col, channel] /= weights[row, col]

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -362,7 +362,7 @@ def _nl_means_denoising_3d(image, int s=7, int d=13, double h=0.1,
                                     padded[pln_start_i:pln_end_i,
                                            row_start_j:row_end_j,
                                            col_start_k:col_end_k],
-                                    w, s, var*var)
+                                    w, s, var)
                             # Collect results in weight sum
                             weight_sum += weight
                             new_value += weight * padded[pln + i,

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -256,17 +256,16 @@ def test_denoise_nl_means_2d_multichannel():
     imgn = np.clip(imgn, 0, 1)
     for fast_mode in [True, False]:
         for s in [sigma, 0]:
-            for n_chan in [2, 3, 6]:
-                psnr_noisy = compare_psnr(img[..., :n_chan],
-                                          imgn[..., :n_chan])
-                denoised = restoration.denoise_nl_means(imgn[..., :n_chan],
+            for n_channels in [2, 3, 6]:
+                psnr_noisy = compare_psnr(img[..., :n_channels],
+                                          imgn[..., :n_channels])
+                denoised = restoration.denoise_nl_means(imgn[..., :n_channels],
                                                         3, 5, h=0.75 * sigma,
                                                         fast_mode=fast_mode,
                                                         multichannel=True,
                                                         sigma=s)
-                psnr_denoised = compare_psnr(denoised[..., :n_chan],
-                                             img[..., :n_chan])
-                print(psnr_noisy, psnr_denoised)
+                psnr_denoised = compare_psnr(denoised[..., :n_channels],
+                                             img[..., :n_channels])
                 # make sure noise is reduced
                 assert_(psnr_denoised > psnr_noisy)
 

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -245,24 +245,30 @@ def test_denoise_nl_means_2d():
         assert_(img.std() > denoised.std())
 
 
-def test_denoise_nl_means_2drgb():
-    # reduce image size because nl means is very slow
+def test_denoise_nl_means_2d_multichannel():
+    # reduce image size because nl means is slow
     img = np.copy(astro[:50, :50])
+    img = np.concatenate((img, )*2, )  # 6 channels
+
     # add some random noise
-    sigma = 0.5
-    img += sigma * img.std() * np.random.random(img.shape)
-    img = np.clip(img, 0, 1)
-    for s in [sigma, 0]:
-        denoised = restoration.denoise_nl_means(img, 7, 9, 0.3,
-                                                fast_mode=True,
-                                                multichannel=True, sigma=s)
-        # make sure noise is reduced
-        assert_(img.std() > denoised.std())
-        denoised = restoration.denoise_nl_means(img, 7, 9, 0.3,
-                                                fast_mode=False,
-                                                multichannel=True, sigma=s)
-        # make sure noise is reduced
-        assert_(img.std() > denoised.std())
+    sigma = 0.1
+    imgn = img + sigma * np.random.standard_normal(img.shape)
+    imgn = np.clip(imgn, 0, 1)
+    for fast_mode in [True, False]:
+        for s in [sigma, 0]:
+            for n_chan in [2, 3, 6]:
+                psnr_noisy = compare_psnr(img[..., :n_chan],
+                                          imgn[..., :n_chan])
+                denoised = restoration.denoise_nl_means(imgn[..., :n_chan],
+                                                        3, 5, h=0.75*sigma,
+                                                        fast_mode=fast_mode,
+                                                        multichannel=True,
+                                                        sigma=s)
+                psnr_denoised = compare_psnr(denoised[..., :n_chan],
+                                             img[..., :n_chan])
+                print(psnr_noisy, psnr_denoised)
+                # make sure noise is reduced
+                assert_(psnr_denoised > psnr_noisy)
 
 
 def test_denoise_nl_means_3d():

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -248,7 +248,7 @@ def test_denoise_nl_means_2d():
 def test_denoise_nl_means_2d_multichannel():
     # reduce image size because nl means is slow
     img = np.copy(astro[:50, :50])
-    img = np.concatenate((img, )*2, )  # 6 channels
+    img = np.concatenate((img, ) * 2, )  # 6 channels
 
     # add some random noise
     sigma = 0.1
@@ -260,7 +260,7 @@ def test_denoise_nl_means_2d_multichannel():
                 psnr_noisy = compare_psnr(img[..., :n_chan],
                                           imgn[..., :n_chan])
                 denoised = restoration.denoise_nl_means(imgn[..., :n_chan],
-                                                        3, 5, h=0.75*sigma,
+                                                        3, 5, h=0.75 * sigma,
                                                         fast_mode=fast_mode,
                                                         multichannel=True,
                                                         sigma=s)
@@ -278,12 +278,12 @@ def test_denoise_nl_means_3d():
     imgn = img + sigma * np.random.randn(*img.shape)
     psnr_noisy = compare_psnr(img, imgn)
     for s in [sigma, 0]:
-        denoised = restoration.denoise_nl_means(imgn, 3, 4, h=0.75*sigma,
+        denoised = restoration.denoise_nl_means(imgn, 3, 4, h=0.75 * sigma,
                                                 fast_mode=True,
                                                 multichannel=False, sigma=s)
         # make sure noise is reduced
         assert_(compare_psnr(img, denoised) > psnr_noisy)
-        denoised = restoration.denoise_nl_means(imgn, 3, 4, h=0.75*sigma,
+        denoised = restoration.denoise_nl_means(imgn, 3, 4, h=0.75 * sigma,
                                                 fast_mode=False,
                                                 multichannel=False, sigma=s)
         # make sure noise is reduced


### PR DESCRIPTION
 See #2913 for a more detailed description of the issue.

## Description
After this PR, non-local means will consider all channels when computing patch weights (rather than always assuming 3 channels).


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests

## References
closes #2913

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
