### PR TITLE
add missing cdef in _integral_image_3d (non-local means)

### DIFF
--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -514,6 +514,7 @@ cdef inline _integral_image_3d(IMGDTYPE [:, :, ::] padded,
     by avoiding copies of ``padded``.
     """
     cdef int pln, row, col
+    cdef double distance
     for pln in range(max(1, -t_pln), min(n_pln, n_pln - t_pln)):
         for row in range(max(1, -t_row), min(n_row, n_row - t_row)):
             for col in range(max(1, -t_col), min(n_col, n_col - t_col)):


### PR DESCRIPTION
## Description
Adding this missing Cython cdef to the fast_mode=True mode in 3D non-local means gave me an 8-fold speedup on an example that i tried (for shape 64x64x64, patch_size=3, patch_distance=3).  

and trivial to review as well!

cc:   @blochl 

p.s. I encountered this when looking into potentially adding `nogil` to the non-local means Cython functions so that they can be accelerated with multi-threading (e.g. via block-wise processing with dask). 

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
