### PR TITLE
Ensure warning to provide bool array is warranted

### DIFF
--- a/skimage/morphology/misc.py
+++ b/skimage/morphology/misc.py
@@ -123,7 +123,7 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
                          "relabeling the input with `scipy.ndimage.label` or "
                          "`skimage.morphology.label`.")
 
-    if len(component_sizes) == 2:
+    if len(component_sizes) == 2 and out.dtype != bool:
         warn("Only one label was provided to `remove_small_objects`. "
              "Did you mean to use a boolean array?")
 

--- a/skimage/morphology/tests/test_misc.py
+++ b/skimage/morphology/tests/test_misc.py
@@ -179,6 +179,7 @@ def test_label_warning_holes():
                                    dtype=np.int_)
     with expected_warnings(['use a boolean array?']):
         remove_small_holes(labeled_holes_image, area_threshold=3)
+    remove_small_holes(labeled_holes_image.astype(bool), area_threshold=3)
 
 
 def test_float_input_holes():


### PR DESCRIPTION
When providing a volume with only two labels, `morphology.remove_small_objects` warns that the user probably meant to provide a bool array. However, if the user provides a bool array that only has one connected components, the warning still pops up!

This commit ensures that the warning only pops up if the user did *not* provide a bool array.

Reported by @husby036 at:

https://github.com/scikit-image/scikit-image/commit/a2def31fca2dddce920c924fd57a211820e14b45#commitcomment-26398024

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
https://github.com/scikit-image/scikit-image/commit/a2def31fca2dddce920c924fd57a211820e14b45#commitcomment-26398024

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
