### PR TITLE
Fix link to Windows binaries in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - **Debian/Ubuntu:** ``sudo apt-get install python-skimage``
 - **OSX:** ``pip install scikit-image``
 - **Anaconda:** ``conda install scikit-image``
-- **Windows:** Download [Windows binaries](http://www.lfd.uci.edu/~gohlke/pythonlibs/#scikits.image)
+- **Windows:** Download [Windows binaries](http://www.lfd.uci.edu/~gohlke/pythonlibs/#scikit-image)
 
 Also see [installing ``scikit-image``](INSTALL.rst).
 


### PR DESCRIPTION
The link to the Windows binaries in the README specifies the wrong header. This PR fixes that by changing it from `#scikits.image` to `#scikit-image`.

`Old`: https://www.lfd.uci.edu/~gohlke/pythonlibs/#scikits.image
`New`: https://www.lfd.uci.edu/~gohlke/pythonlibs/#scikit-image