### PR TITLE
Handle NumPy 1.14 API changes

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -46,3 +46,8 @@ Version 0.16
 * In ``skimage.measure.moments_central``, remove ``cc`` and ``**kwargs``
   arguments.
 * In ``skimage.morphology.remove_small_holes``, remove ``min_size`` argument.
+
+Other
+-----
+* Remove legacy pretty printing workaround for ``pytest`` in ``conftest.py``
+  once minimal required ``numpy`` is set to >= 1.14.0.

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,12 @@
-# List of files that pytest should ignore
+# Use legacy numpy printing. This fix is made to keep doctests functional.
+# For more info, see https://github.com/scikit-image/scikit-image/pull/2935 .
+# TODO: remove this workaround once minimal required numpy is set to 1.14.0
+import numpy as np
 
+if np.version.full_version >= '1.14.0':
+    np.set_printoptions(legacy='1.13')
+
+# List of files that pytest should ignore
 collect_ignore = ["setup.py",
                   "skimage/io/_plugins",
                   "doc/",

--- a/skimage/external/test_tifffile.py
+++ b/skimage/external/test_tifffile.py
@@ -73,7 +73,7 @@ class TestSave:
     def test_imsave_roundtrip(self, shape, dtype):
         x = np.random.rand(*shape)
 
-        if not np.issubdtype(dtype, float):
+        if not np.issubdtype(dtype, np.floating):
             x = (x * np.iinfo(dtype).max).astype(dtype)
         else:
             x = x.astype(dtype)

--- a/skimage/feature/match.py
+++ b/skimage/feature/match.py
@@ -54,7 +54,7 @@ def match_descriptors(descriptors1, descriptors2, metric=None, p=2,
         raise ValueError("Descriptor length must equal.")
 
     if metric is None:
-        if np.issubdtype(descriptors1.dtype, np.bool):
+        if np.issubdtype(descriptors1.dtype, np.bool_):
             metric = 'hamming'
         else:
             metric = 'euclidean'

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -106,7 +106,7 @@ def greycomatrix(image, distances, angles, levels=None, symmetric=False,
 
     image_max = image.max()
 
-    if np.issubdtype(image.dtype, np.float):
+    if np.issubdtype(image.dtype, np.floating):
         raise ValueError("Float images are not supported by greycomatrix. "
                          "Convert the image to an unsigned integer type.")
 

--- a/skimage/io/_plugins/matplotlib_plugin.py
+++ b/skimage/io/_plugins/matplotlib_plugin.py
@@ -51,7 +51,7 @@ def _get_image_properties(image):
         lo, hi = immin, immax
 
     signed = immin < 0
-    out_of_range_float = (np.issubdtype(image.dtype, np.float) and
+    out_of_range_float = (np.issubdtype(image.dtype, np.floating) and
                           (immin < lo or immax > hi))
     low_data_range = (immin != immax and
                       is_low_contrast(image))

--- a/skimage/io/tests/test_imageio.py
+++ b/skimage/io/tests/test_imageio.py
@@ -69,7 +69,7 @@ class TestSave(TestCase):
         for shape in [(10, 10), (10, 10, 3), (10, 10, 4)]:
             x = np.ones(shape, dtype=dtype) * np.random.rand(*shape)
 
-            if np.issubdtype(dtype, float):
+            if np.issubdtype(dtype, np.floating):
                 yield self.roundtrip, x, 255
             else:
                 x = (x * 255).astype(dtype)

--- a/skimage/io/tests/test_imread.py
+++ b/skimage/io/tests/test_imread.py
@@ -75,7 +75,7 @@ class TestSave(TestCase):
         for shape in [(10, 10), (10, 10, 3), (10, 10, 4)]:
             x = np.ones(shape, dtype=dtype) * np.random.rand(*shape)
 
-            if np.issubdtype(dtype, float):
+            if np.issubdtype(dtype, np.floating):
                 yield self.roundtrip, x, 255
             else:
                 x = (x * 255).astype(dtype)

--- a/skimage/io/tests/test_pil.py
+++ b/skimage/io/tests/test_pil.py
@@ -172,7 +172,7 @@ class TestSave:
             for dtype in (np.uint8, np.uint16, np.float32, np.float64):
                 x = np.ones(shape, dtype=dtype) * np.random.rand(*shape)
 
-                if np.issubdtype(dtype, float):
+                if np.issubdtype(dtype, np.floating):
                     yield (self.verify_roundtrip, dtype, x,
                            roundtrip_function(x), 255)
                 else:

--- a/skimage/io/tests/test_simpleitk.py
+++ b/skimage/io/tests/test_simpleitk.py
@@ -94,7 +94,7 @@ class TestSave(unittest.TestCase):
             for dtype in (np.uint8, np.uint16, np.float32, np.float64):
                 x = np.ones(shape, dtype=dtype) * np.random.rand(*shape)
 
-                if np.issubdtype(dtype, float):
+                if np.issubdtype(dtype, np.floating):
                     yield self.roundtrip, dtype, x
                 else:
                     x = (x * 255).astype(dtype)

--- a/skimage/io/tests/test_tifffile.py
+++ b/skimage/io/tests/test_tifffile.py
@@ -54,7 +54,7 @@ class TestSave:
     def test_imsave_roundtrip(self, shape, dtype):
         x = np.random.rand(*shape)
 
-        if not np.issubdtype(dtype, float):
+        if not np.issubdtype(dtype, np.floating):
             x = (x * np.iinfo(dtype).max).astype(dtype)
         else:
             x = x.astype(dtype)

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -108,7 +108,7 @@ def h_maxima(image, h, selem=None):
 
     The resulting image will contain 4 local maxima.
     """
-    if np.issubdtype(image.dtype, 'half'):
+    if np.issubdtype(image.dtype, np.half):
         resolution = 2 * np.finfo(image.dtype).resolution
         if h < resolution:
             h = resolution
@@ -189,7 +189,7 @@ def h_minima(image, h, selem=None):
 
     The resulting image will contain 4 local minima.
     """
-    if np.issubdtype(image.dtype, 'half'):
+    if np.issubdtype(image.dtype, np.half):
         resolution = 2 * np.finfo(image.dtype).resolution
         if h < resolution:
             h = resolution
@@ -283,7 +283,7 @@ def local_maxima(image, selem=None):
     h = _find_min_diff(image)
     if h == 0:
         return np.zeros(image.shape, np.uint8)
-    if not np.issubdtype(image.dtype, 'half'):
+    if not np.issubdtype(image.dtype, np.half):
         h = 1
     local_max = h_maxima(image, h, selem=selem)
     return local_max
@@ -352,7 +352,7 @@ def local_minima(image, selem=None):
     h = _find_min_diff(image)
     if h == 0:
         return np.zeros(image.shape, np.uint8)
-    if not np.issubdtype(image.dtype, 'half'):
+    if not np.issubdtype(image.dtype, np.half):
         h = 1
     local_min = h_minima(image, h, selem=selem)
     return local_min

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -108,7 +108,7 @@ def h_maxima(image, h, selem=None):
 
     The resulting image will contain 4 local maxima.
     """
-    if np.issubdtype(image.dtype, np.half):
+    if np.issubdtype(image.dtype, np.floating):
         resolution = 2 * np.finfo(image.dtype).resolution
         if h < resolution:
             h = resolution
@@ -189,7 +189,7 @@ def h_minima(image, h, selem=None):
 
     The resulting image will contain 4 local minima.
     """
-    if np.issubdtype(image.dtype, np.half):
+    if np.issubdtype(image.dtype, np.floating):
         resolution = 2 * np.finfo(image.dtype).resolution
         if h < resolution:
             h = resolution
@@ -283,7 +283,7 @@ def local_maxima(image, selem=None):
     h = _find_min_diff(image)
     if h == 0:
         return np.zeros(image.shape, np.uint8)
-    if not np.issubdtype(image.dtype, np.half):
+    if not np.issubdtype(image.dtype, np.floating):
         h = 1
     local_max = h_maxima(image, h, selem=selem)
     return local_max
@@ -352,7 +352,7 @@ def local_minima(image, selem=None):
     h = _find_min_diff(image)
     if h == 0:
         return np.zeros(image.shape, np.uint8)
-    if not np.issubdtype(image.dtype, np.half):
+    if not np.issubdtype(image.dtype, np.floating):
         h = 1
     local_min = h_minima(image, h, selem=selem)
     return local_min

--- a/skimage/morphology/grey.py
+++ b/skimage/morphology/grey.py
@@ -397,7 +397,10 @@ def white_tophat(image, selem=None, out=None):
     selem = np.array(selem)
     if out is image:
         opened = opening(image, selem)
-        out -= opened
+        if np.issubdtype(opened.dtype, np.bool_):
+            np.logical_xor(out, opened, out=out)
+        else:
+            out -= opened
         return out
     elif out is None:
         out = np.empty_like(image)
@@ -453,5 +456,8 @@ def black_tophat(image, selem=None, out=None):
     else:
         original = image
     out = closing(image, selem, out=out)
-    out -= original
+    if np.issubdtype(out.dtype, np.bool_):
+        np.logical_xor(out, original, out=out)
+    else:
+        out -= original
     return out

--- a/skimage/morphology/grey.py
+++ b/skimage/morphology/grey.py
@@ -404,7 +404,17 @@ def white_tophat(image, selem=None, out=None):
         return out
     elif out is None:
         out = np.empty_like(image)
-    out = ndi.white_tophat(image, footprint=selem, output=out)
+    # work-around for NumPy deprecation warning for arithmetic 
+    # operations on bool arrays
+    if isinstance(image, np.ndarray) and image.dtype == np.bool:
+        image_ = image.view(dtype=np.uint8)
+    else:
+        image_ = image
+    if isinstance(out, np.ndarray) and out.dtype == np.bool:
+        out_ = out.view(dtype=np.uint8)
+    else:
+        out_ = out
+    out_ = ndi.white_tophat(image_, footprint=selem, output=out_)
     return out
 
 

--- a/skimage/morphology/tests/test_grey.py
+++ b/skimage/morphology/tests/test_grey.py
@@ -167,7 +167,8 @@ def test_3d_fallback_white_tophat():
         new_image = grey.white_tophat(image)
     footprint = ndi.generate_binary_structure(3, 1)
     with expected_warnings(['operator.*deprecated|\A\Z']):
-        image_expected = ndi.white_tophat(image, footprint=footprint)
+        image_expected = ndi.white_tophat(
+            image.view(dtype=np.uint8), footprint=footprint)
     assert_array_equal(new_image, image_expected)
 
 
@@ -181,7 +182,8 @@ def test_3d_fallback_black_tophat():
         new_image = grey.black_tophat(image)
     footprint = ndi.generate_binary_structure(3, 1)
     with expected_warnings(['operator.*deprecated|\A\Z']):
-        image_expected = ndi.black_tophat(image, footprint=footprint)
+        image_expected = ndi.black_tophat(
+            image.view(dtype=np.uint8), footprint=footprint)
     assert_array_equal(new_image, image_expected)
 
 

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -115,7 +115,7 @@ def relabel_sequential(label_field, offset=1):
     array([5, 5, 6, 6, 7, 9, 8])
     """
     m = label_field.max()
-    if not np.issubdtype(label_field.dtype, np.int):
+    if not np.issubdtype(label_field.dtype, np.signedinteger):
         new_type = np.min_scalar_type(int(m))
         label_field = label_field.astype(new_type)
         m = m.astype(new_type)  # Ensures m is an integer

--- a/skimage/viewer/plugins/canny.py
+++ b/skimage/viewer/plugins/canny.py
@@ -17,7 +17,7 @@ class CannyPlugin(OverlayPlugin):
     def attach(self, image_viewer):
         image = image_viewer.image
         imin, imax = skimage.dtype_limits(image, clip_negative=False)
-        itype = 'float' if np.issubdtype(image.dtype, float) else 'int'
+        itype = 'float' if np.issubdtype(image.dtype, np.floating) else 'int'
         self.add_widget(Slider('sigma', 0, 5, update_on='release'))
         self.add_widget(Slider('low threshold', imin, imax, value_type=itype,
                         update_on='release'))


### PR DESCRIPTION

A number of test errors result when testing scikit-image with just released NumPy 1.14. The following change fixes the following errors:

```
'test_rag.test_rag_merge',
'test_rag.test_rag_hierarchical',
'test_rag.test_cut_normalized',
'test_rag.test_threshold_cut',
'skimage.io.tests.test_mpl_imshow.test_signed_image',
'skimage.io.tests.test_mpl_imshow.test_uint8',
'skimage.io.tests.test_mpl_imshow.test_uint16',
'skimage.io.tests.test_mpl_imshow.test_float',
'skimage.io.tests.test_mpl_imshow.test_nonstandard_type',
'skimage.io.tests.test_mpl_imshow.test_outside_standard_range',
'skimage.io.tests.test_mpl_imshow.test_low_data_range',
```

The fix is the same as [was applied](https://github.com/scikit-learn/scikit-learn/pull/9683/files#diff-904f5f849e36c648b8b05de140d7fad8R1089) to scikit-learn.

