### PR TITLE
Added small galleries in the API

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -30,7 +30,7 @@ sys.path.append(os.path.join(curpath, '..', 'ext'))
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.mathjax',
               'numpydoc',
-	      'sphinx.ext.autodoc',
+              'sphinx.ext.autodoc',
               'sphinx.ext.autosummary',
               'sphinx.ext.intersphinx',
               'sphinx.ext.linkcode',

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -30,6 +30,7 @@ sys.path.append(os.path.join(curpath, '..', 'ext'))
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.mathjax',
               'numpydoc',
+	      'sphinx.ext.autodoc',
               'sphinx.ext.autosummary',
               'sphinx.ext.intersphinx',
               'sphinx.ext.linkcode',

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -30,7 +30,6 @@ sys.path.append(os.path.join(curpath, '..', 'ext'))
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.mathjax',
               'numpydoc',
-              'sphinx.ext.autodoc',
               'sphinx.ext.autosummary',
               'sphinx.ext.intersphinx',
               'sphinx.ext.linkcode',

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -30,6 +30,7 @@ sys.path.append(os.path.join(curpath, '..', 'ext'))
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.mathjax',
               'numpydoc',
+	      'sphinx.ext.autodoc',
               'sphinx.ext.autosummary',
               'sphinx.ext.intersphinx',
               'sphinx.ext.linkcode',
@@ -43,7 +44,7 @@ autosummary_generate = True
 #------------------------------------------------------------------------
 
 sphinx_gallery_conf = {
-    'doc_module'        : 'skimage',
+    'doc_module'        : ('skimage',),
     # path to your examples scripts
     'examples_dirs' : '../examples',
     # path where to save gallery generated examples

--- a/doc/tools/apigen.py
+++ b/doc/tools/apigen.py
@@ -497,7 +497,8 @@ class ApiDocWriter(object):
         w(subtitle + "\n")
         w("-" * len(subtitle) + "\n\n")
 
-        w('.. toctree::\n\n')
+        w('.. toctree::\n')
+        w('   :maxdepth: 2\n\n')
         for f in self.written_modules:
             w('   %s\n' % os.path.join(relpath,f))
         idx.close()

--- a/doc/tools/apigen.py
+++ b/doc/tools/apigen.py
@@ -302,6 +302,7 @@ class ApiDocWriter(object):
             ad += f + '\n'
             ad += self.rst_section_levels[2] * len(f) + '\n'
             ad += '\n.. autofunction:: ' + full_f + '\n\n'
+            ad += '\n.. include:: ' + full_f + '.examples\n\n'
         for c in classes:
             ad += '\n:class:`' + c + '`\n' \
                   + self.rst_section_levels[2] * \


### PR DESCRIPTION
The possibility to have small galleries in the API with examples using each function is a nice feature of sphinx-gallery. (see http://sphinx-gallery.readthedocs.io/en/latest/advanced_configuration.html#adding-references-to-examples and http://sphinx-gallery.readthedocs.io/en/latest/advanced_configuration.html#auto-documenting-your-api-with-links-to-examples).

This PR enables this feature. By the way, the way we generate the API doc seems to be non-standard compared to what other packages do (numpy, scipy, ...). Maybe at some point we could consider using more standard tools and getting rid of our own ``apigen.py`` module.
