### PR TITLE
Fixed broken link on LBP documentation

### DIFF
--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -301,7 +301,7 @@ def local_binary_pattern(image, P, R, method='default'):
     .. [1] Multiresolution Gray-Scale and Rotation Invariant Texture
            Classification with Local Binary Patterns.
            Timo Ojala, Matti Pietikainen, Topi Maenpaa.
-           http://vision.stanford.edu/teaching/cs231b_spring1415/papers/lbp.pdf, 2002.
+           http://www.ee.oulu.fi/research/mvmp/mvg/files/pdf/pdf_94.pdf, 2002.
     .. [2] Face recognition with local binary patterns.
            Timo Ahonen, Abdenour Hadid, Matti Pietikainen,
            http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.214.6851,


### PR DESCRIPTION
## Description
The first reference in the local_binary_pattern() documentation has a broken link for the PDF document. I've updated the link pointing to the PDF version hosted on stanford.edu

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
N/A

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
