### PR TITLE
Cython warnings

### DIFF
--- a/skimage/morphology/_watershed.pyx
+++ b/skimage/morphology/_watershed.pyx
@@ -125,6 +125,7 @@ def watershed_raveled(cnp.float64_t[::1] image,
     cdef Py_ssize_t i = 0
     cdef Py_ssize_t age = 1
     cdef Py_ssize_t index = 0
+    cdef Py_ssize_t neighbor_index = 0
     cdef DTYPE_BOOL_t compact = (compactness > 0)
 
     cdef Heap *hp = <Heap *> heap_from_numpy2()

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -12,7 +12,7 @@ ctypedef np.float64_t IMGDTYPE
 cdef double DISTANCE_CUTOFF = 5.0
 
 cdef extern from "fast_exp.h":
-    inline double fast_exp(double y) nogil
+    double fast_exp(double y) nogil
 
 
 cdef inline double patch_distance_2d(IMGDTYPE [:, :] p1,


### PR DESCRIPTION
Addressed Cython warnings emitted during cythonization step of scikit-image build process:

```
[1/1] Cythonizing ./work/scikit-image/skimage/restoration/_nl_means_denoising.pyx
warning: skimage/restoration/_nl_means_denoising.pyx:15:26: Declarations should not be declared inline.

[1/1] Cythonizing ./work/scikit-image/skimage/morphology/_watershed.pyx
warning: skimage/morphology/_watershed.pyx:166:24: Index should be typed for more efficient access
```

I am using Cython 0.27.3.