### PR TITLE
Add `alignment` parameter to `feature.plot_matches`

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -38,6 +38,7 @@ Improvements
 - Non-local means denoising (``denoise_nl_means``) has a new optional
   parameter, `sigma`, that can be used to specify the noise standard deviation.
   This enables noise-robust patch distance estimation. (#2890)
+- New ``alignment`` parameter in ``skimage.feature.plot_matches``. (#2955)
 
 
 API Changes

--- a/skimage/feature/tests/test_util.py
+++ b/skimage/feature/tests/test_util.py
@@ -4,7 +4,7 @@ try:
 except ImportError:
     plt = None
 
-#from skimage._shared.testing import assert_equal
+from skimage._shared.testing import assert_equal
 
 from skimage.feature.util import (FeatureDetector, DescriptorExtractor,
                                   _prepare_grayscale_input_2D,

--- a/skimage/feature/tests/test_util.py
+++ b/skimage/feature/tests/test_util.py
@@ -4,7 +4,7 @@ try:
 except ImportError:
     plt = None
 
-from skimage._shared.testing import assert_equal
+#from skimage._shared.testing import assert_equal
 
 from skimage.feature.util import (FeatureDetector, DescriptorExtractor,
                                   _prepare_grayscale_input_2D,
@@ -77,3 +77,5 @@ def test_plot_matches():
                      keypoints_color='r')
         plot_matches(ax, img1, img2, keypoints1, keypoints2, matches,
                      matches_color='r')
+        plot_matches(ax, img1, img2, keypoints1, keypoints2, matches,
+                     left_right=False)

--- a/skimage/feature/tests/test_util.py
+++ b/skimage/feature/tests/test_util.py
@@ -78,4 +78,4 @@ def test_plot_matches():
         plot_matches(ax, img1, img2, keypoints1, keypoints2, matches,
                      matches_color='r')
         plot_matches(ax, img1, img2, keypoints1, keypoints2, matches,
-                     left_right=False)
+                     alignment='vertical')

--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -41,7 +41,8 @@ class DescriptorExtractor(object):
 
 
 def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
-                 keypoints_color='k', matches_color=None, only_matches=False):
+                 keypoints_color='k', matches_color=None, only_matches=False,
+                 left_right=True):
     """Plot matched features.
 
     Parameters
@@ -67,6 +68,9 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
         color is chosen randomly.
     only_matches : bool, optional
         Whether to only plot matches and not plot the keypoint locations.
+    left_right : bool, optional
+        Whether to show images side by side (left and right) or one above
+        the other.
 
     """
 
@@ -96,18 +100,22 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
         new_image2[:image2.shape[0], :image2.shape[1]] = image2
         image2 = new_image2
 
-    image = np.concatenate([image1, image2], axis=1)
-
-    offset = image1.shape
+    offset = np.array(image1.shape)
+    if left_right is True:
+        image = np.concatenate([image1, image2], axis=1)
+        offset[0] = 0
+    else:
+        image = np.concatenate([image1, image2], axis=0)
+        offset[1] = 0
 
     if not only_matches:
         ax.scatter(keypoints1[:, 1], keypoints1[:, 0],
                    facecolors='none', edgecolors=keypoints_color)
-        ax.scatter(keypoints2[:, 1] + offset[1], keypoints2[:, 0],
+        ax.scatter(keypoints2[:, 1] + offset[1], keypoints2[:, 0] + offset[0],
                    facecolors='none', edgecolors=keypoints_color)
 
     ax.imshow(image, interpolation='nearest', cmap='gray')
-    ax.axis((0, 2 * offset[1], offset[0], 0))
+    ax.axis((0, image1.shape[1] + offset[1], image1.shape[0] + offset[0], 0))
 
     for i in range(matches.shape[0]):
         idx1 = matches[i, 0]
@@ -119,7 +127,7 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
             color = matches_color
 
         ax.plot((keypoints1[idx1, 1], keypoints2[idx2, 1] + offset[1]),
-                (keypoints1[idx1, 0], keypoints2[idx2, 0]),
+                (keypoints1[idx1, 0], keypoints2[idx2, 0] + offset[0]),
                 '-', color=color)
 
 

--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -42,7 +42,7 @@ class DescriptorExtractor(object):
 
 def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
                  keypoints_color='k', matches_color=None, only_matches=False,
-                 left_right=True):
+                 alignment='horizontal'):
     """Plot matched features.
 
     Parameters
@@ -68,9 +68,10 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
         color is chosen randomly.
     only_matches : bool, optional
         Whether to only plot matches and not plot the keypoint locations.
-    left_right : bool, optional
-        Whether to show images side by side (left and right) or one above
-        the other.
+    alignment : str, optional
+        Valid values are: 'horizontal' or 'vertical'
+        Whether to show images side by side, 'horizontal', or one above
+        the other, 'vertical'.
 
     """
 
@@ -101,12 +102,14 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
         image2 = new_image2
 
     offset = np.array(image1.shape)
-    if left_right is True:
+    if alignment == 'horizontal':
         image = np.concatenate([image1, image2], axis=1)
         offset[0] = 0
-    else:
+    elif alignment == 'vertical':
         image = np.concatenate([image1, image2], axis=0)
         offset[1] = 0
+    else:
+        raise ValueError('Incorrect value for alignment: %s' % alignment)
 
     if not only_matches:
         ax.scatter(keypoints1[:, 1], keypoints1[:, 0],

--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -68,10 +68,9 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
         color is chosen randomly.
     only_matches : bool, optional
         Whether to only plot matches and not plot the keypoint locations.
-    alignment : str, optional
-        Valid values are: 'horizontal' or 'vertical'
-        Whether to show images side by side, 'horizontal', or one above
-        the other, 'vertical'.
+    alignment : {'horizontal', 'vertical'}, optional
+        Whether to show images side by side, ``'horizontal'``, or one above
+        the other, ``'vertical'``.
 
     """
 
@@ -109,7 +108,11 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
         image = np.concatenate([image1, image2], axis=0)
         offset[1] = 0
     else:
-        raise ValueError('Incorrect value for alignment: %s' % alignment)
+        mesg = ("plot_matches accepts either 'horizontal' or 'vertical' for "
+                "alignment, but '{}' was given. See http://scikit-image.org/"
+                "docs/dev/api/skimage.feature.html#skimage.feature.plot_matches "
+                "for details.").format(alignment)
+        raise ValueError(mesg)
 
     if not only_matches:
         ax.scatter(keypoints1[:, 1], keypoints1[:, 0],

--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -109,9 +109,9 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
         offset[1] = 0
     else:
         mesg = ("plot_matches accepts either 'horizontal' or 'vertical' for "
-                "alignment, but '{}' was given. See"
-                "http://scikit-image.org/docs/dev/api/skimage.feature.html#skimage.feature.plot_matches"  # noqa
-                " for details.").format(alignment)
+                "alignment, but '{}' was given. See "
+                "http://scikit-image.org/docs/dev/api/skimage.feature.html#skimage.feature.plot_matches "  # noqa
+                "for details.").format(alignment)
         raise ValueError(mesg)
 
     if not only_matches:

--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -109,9 +109,9 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
         offset[1] = 0
     else:
         mesg = ("plot_matches accepts either 'horizontal' or 'vertical' for "
-                "alignment, but '{}' was given. See http://scikit-image.org/"
-                "docs/dev/api/skimage.feature.html#skimage.feature.plot_matches "
-                "for details.").format(alignment)
+                "alignment, but '{}' was given. See"
+                "http://scikit-image.org/docs/dev/api/skimage.feature.html#skimage.feature.plot_matches"  # noqa
+                " for details.").format(alignment)
         raise ValueError(mesg)
 
     if not only_matches:


### PR DESCRIPTION
This is actually PR #2949. Windows added a strange character to my branch so I couldn't check it out on linux. I had to create a new one...

## Description
Initially, you could only show features matched side by side:
![image](https://user-images.githubusercontent.com/90008/35404989-a6f29ef0-01b9-11e8-8070-1260c1751dff.png)

Now you can show features matched vertically too:
![image](https://user-images.githubusercontent.com/90008/35404978-98044254-01b9-11e8-838d-134ca5f3663c.png)


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [X] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [X] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [X] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
