### PR TITLE
Allow different rescale factors in multichannel warp

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -264,9 +264,9 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
     """
     multichannel = _multichannel_default(multichannel, image.ndim)
     scale = np.atleast_1d(scale)
-    if len(scale) > 1 and (len(scale) != image.ndim or
+    if len(scale) > 1 and ((not multichannel and len(scale) != image.ndim) or
                            (multichannel and len(scale) != image.ndim - 1)):
-        raise ValueError("must supply a single scale or one value per axis")
+        raise ValueError("Supply a single scale or one value per spatial axis")
     orig_shape = np.asarray(image.shape)
     output_shape = np.round(scale * orig_shape)
     if multichannel:  # don't scale channel dimension

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -267,7 +267,8 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
     if len(scale) > 1:
         if ((not multichannel and len(scale) != image.ndim) or
                 (multichannel and len(scale) != image.ndim - 1)):
-            raise ValueError("Supply a single scale or one value per spatial axis")
+            raise ValueError("Supply a single scale, or one value per spatial "
+                             "axis")
         if multichannel:
             scale = np.concatenate((scale, [1]))
     orig_shape = np.asarray(image.shape)

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -264,9 +264,12 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
     """
     multichannel = _multichannel_default(multichannel, image.ndim)
     scale = np.atleast_1d(scale)
-    if len(scale) > 1 and ((not multichannel and len(scale) != image.ndim) or
-                           (multichannel and len(scale) != image.ndim - 1)):
-        raise ValueError("Supply a single scale or one value per spatial axis")
+    if len(scale) > 1:
+        if ((not multichannel and len(scale) != image.ndim) or
+                (multichannel and len(scale) != image.ndim - 1)):
+            raise ValueError("Supply a single scale or one value per spatial axis")
+        if multichannel:
+            scale = np.concatenate((scale, [1]))
     orig_shape = np.asarray(image.shape)
     output_shape = np.round(scale * orig_shape)
     if multichannel:  # don't scale channel dimension

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -214,6 +214,13 @@ def test_rescale_multichannel():
     assert_equal(scaled.shape, (16, 16, 16, 6))
 
 
+def test_rescale_multichannel_multiscale():
+    x = np.zeros((5, 5, 3), dtype=np.double)
+    scaled = rescale(x, (2, 1), order=0, multichannel=True,
+                     anti_aliasing=False)
+    assert_equal(scaled.shape, (10, 5, 3))
+
+
 def test_rescale_multichannel_defaults():
     # ensure multichannel=None matches the previous default behaviour
 


### PR DESCRIPTION
Fixes #2939.

Also adds test to prevent regression.

Thanks to @magee256 for reporting.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] ~~Gallery example in `./doc/examples` (new features only)~~
- [x] Unit tests

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
