### PR TITLE
Add seed parameter to probabilistic_hough_line

### DIFF
--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -314,7 +314,7 @@ def _hough_line(cnp.ndarray img,
 def _probabilistic_hough_line(cnp.ndarray img, int threshold,
                               int line_length, int line_gap,
                               cnp.ndarray[ndim=1, dtype=cnp.double_t] theta,
-                              bint use_seed, unsigned int seed):
+                              seed=None):
     """Return lines from a progressive probabilistic line Hough transform.
 
     Parameters
@@ -331,9 +331,7 @@ def _probabilistic_hough_line(cnp.ndarray img, int threshold,
         Increase the parameter to merge broken lines more aggresively.
     theta : 1D ndarray, dtype=double
         Angles at which to compute the transform, in radians.
-    use_seed : bool
-        Whether to use the seed value.
-    seed : int
+    seed : int, optional
         Seed to initialize the random number generator.
 
     Returns
@@ -383,7 +381,7 @@ def _probabilistic_hough_line(cnp.ndarray img, int threshold,
     # mask all non-zero indexes
     mask[y_idxs, x_idxs] = 1
 
-    random_state = np.random.RandomState(seed if use_seed else None)
+    random_state = np.random.RandomState(seed)
 
     while 1:
 

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -8,7 +8,6 @@ cimport numpy as cnp
 cimport cython
 
 from libc.math cimport abs, fabs, sqrt, ceil, atan2, M_PI
-from libc.stdlib cimport rand, srand
 
 from ..draw import circle_perimeter
 

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -8,7 +8,7 @@ cimport numpy as cnp
 cimport cython
 
 from libc.math cimport abs, fabs, sqrt, ceil, atan2, M_PI
-from libc.stdlib cimport rand
+from libc.stdlib cimport rand, srand
 
 from ..draw import circle_perimeter
 
@@ -314,7 +314,8 @@ def _hough_line(cnp.ndarray img,
 
 def _probabilistic_hough_line(cnp.ndarray img, int threshold,
                               int line_length, int line_gap,
-                              cnp.ndarray[ndim=1, dtype=cnp.double_t] theta):
+                              cnp.ndarray[ndim=1, dtype=cnp.double_t] theta,
+                              seed=None):
     """Return lines from a progressive probabilistic line Hough transform.
 
     Parameters
@@ -331,6 +332,8 @@ def _probabilistic_hough_line(cnp.ndarray img, int threshold,
         Increase the parameter to merge broken lines more aggresively.
     theta : 1D ndarray, dtype=double
         Angles at which to compute the transform, in radians.
+    seed : int, optional
+        Seed to initialize the random number generator.
 
     Returns
     -------
@@ -378,6 +381,9 @@ def _probabilistic_hough_line(cnp.ndarray img, int threshold,
     cdef list points = list(zip(x_idxs, y_idxs))
     # mask all non-zero indexes
     mask[y_idxs, x_idxs] = 1
+
+    if seed is not None:
+        srand(seed)
 
     while 1:
 

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -315,7 +315,7 @@ def _hough_line(cnp.ndarray img,
 def _probabilistic_hough_line(cnp.ndarray img, int threshold,
                               int line_length, int line_gap,
                               cnp.ndarray[ndim=1, dtype=cnp.double_t] theta,
-                              seed=None):
+                              bint use_seed, unsigned int seed):
     """Return lines from a progressive probabilistic line Hough transform.
 
     Parameters
@@ -332,7 +332,9 @@ def _probabilistic_hough_line(cnp.ndarray img, int threshold,
         Increase the parameter to merge broken lines more aggresively.
     theta : 1D ndarray, dtype=double
         Angles at which to compute the transform, in radians.
-    seed : int, optional
+    use_seed : bool
+        Whether to use the seed value.
+    seed : int
         Seed to initialize the random number generator.
 
     Returns
@@ -382,8 +384,7 @@ def _probabilistic_hough_line(cnp.ndarray img, int threshold,
     # mask all non-zero indexes
     mask[y_idxs, x_idxs] = 1
 
-    if seed is not None:
-        srand(seed)
+    random_state = np.random.RandomState(seed if use_seed else None)
 
     while 1:
 
@@ -393,7 +394,7 @@ def _probabilistic_hough_line(cnp.ndarray img, int threshold,
             break
 
         # select random non-zero point
-        index = rand() % count
+        index = random_state.randint(0, count)
         x = points[index][0]
         y = points[index][1]
         del points[index]

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -222,7 +222,7 @@ def hough_line(image, theta=None):
 
 
 def probabilistic_hough_line(image, threshold=10, line_length=50, line_gap=10,
-                             theta=None):
+                             theta=None, seed=None):
     """Return lines from a progressive probabilistic line Hough transform.
 
     Parameters
@@ -240,6 +240,8 @@ def probabilistic_hough_line(image, threshold=10, line_length=50, line_gap=10,
     theta : 1D ndarray, dtype=double, optional
         Angles at which to compute the transform, in radians.
         If None, use a range from -pi/2 to pi/2.
+    seed : int, optional
+        Seed to initialize the random number generator.
 
     Returns
     -------
@@ -261,7 +263,7 @@ def probabilistic_hough_line(image, threshold=10, line_length=50, line_gap=10,
         theta = np.pi / 2 - np.arange(180) / 180.0 * np.pi
 
     return _prob_hough_line(image, threshold=threshold, line_length=line_length,
-                            line_gap=line_gap, theta=theta)
+                            line_gap=line_gap, theta=theta, seed=seed)
 
 
 def hough_circle_peaks(hspaces, radii, min_xdistance=1, min_ydistance=1,

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -262,8 +262,12 @@ def probabilistic_hough_line(image, threshold=10, line_length=50, line_gap=10,
     if theta is None:
         theta = np.pi / 2 - np.arange(180) / 180.0 * np.pi
 
+    use_seed = seed is not None
+    seed = 0 if seed is None else seed
+
     return _prob_hough_line(image, threshold=threshold, line_length=line_length,
-                            line_gap=line_gap, theta=theta, seed=seed)
+                            line_gap=line_gap, theta=theta, use_seed=use_seed,
+                            seed=seed)
 
 
 def hough_circle_peaks(hspaces, radii, min_xdistance=1, min_ydistance=1,

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -266,8 +266,7 @@ def probabilistic_hough_line(image, threshold=10, line_length=50, line_gap=10,
     seed = 0 if seed is None else seed
 
     return _prob_hough_line(image, threshold=threshold, line_length=line_length,
-                            line_gap=line_gap, theta=theta, use_seed=use_seed,
-                            seed=seed)
+                            line_gap=line_gap, theta=theta, seed=seed)
 
 
 def hough_circle_peaks(hspaces, radii, min_xdistance=1, min_ydistance=1,

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -262,9 +262,6 @@ def probabilistic_hough_line(image, threshold=10, line_length=50, line_gap=10,
     if theta is None:
         theta = np.pi / 2 - np.arange(180) / 180.0 * np.pi
 
-    use_seed = seed is not None
-    seed = 0 if seed is None else seed
-
     return _prob_hough_line(image, threshold=threshold, line_length=line_length,
                             line_gap=line_gap, theta=theta, seed=seed)
 

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -79,7 +79,7 @@ def test_probabilistic_hough_seed():
     lines = transform.probabilistic_hough_line(image, threshold=50,
                                                line_length=50, line_gap=1,
                                                seed=1234)
-    assert len(lines) == 59
+    assert len(lines) == 64
 
 
 def test_probabilistic_hough_bad_input():

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -1,6 +1,8 @@
 import numpy as np
 
 from skimage import transform
+from skimage import data
+from skimage.feature import canny
 from skimage.draw import line, circle_perimeter, ellipse_perimeter
 
 from skimage._shared import testing
@@ -61,12 +63,22 @@ def test_probabilistic_hough():
         line = list(line)
         line.sort(key=lambda x: x[0])
         sorted_lines.append(line)
-
     assert([(25, 75), (74, 26)] in sorted_lines)
     assert([(25, 25), (74, 74)] in sorted_lines)
 
     # Execute with default theta
     transform.probabilistic_hough_line(img, line_length=10, line_gap=3)
+
+
+def test_probabilistic_hough_seed():
+    # Load image that is likely to give a randomly varying number of lines
+    image = data.checkerboard()
+
+    # Use constant seed to ensure a deterministic output
+    lines = transform.probabilistic_hough_line(image, threshold=50,
+                                               line_length=50, line_gap=1,
+                                               seed=1234)
+    assert len(lines) == 59
 
 
 def test_probabilistic_hough_bad_input():

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -63,6 +63,7 @@ def test_probabilistic_hough():
         line = list(line)
         line.sort(key=lambda x: x[0])
         sorted_lines.append(line)
+
     assert([(25, 75), (74, 26)] in sorted_lines)
     assert([(25, 25), (74, 74)] in sorted_lines)
 


### PR DESCRIPTION
## Description
Rebased #2736, and changed the behaviour to set no seed when seed=None.


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] ~~Gallery example in `./doc/examples` (new features only)~~
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
Fixes #2734 
Replaces #2736 

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
