### PR TITLE
Added functions to convert between data types.

### DIFF
--- a/skimage/color/data_convert.py
+++ b/skimage/color/data_convert.py
@@ -47,7 +47,7 @@ def im2integer(image, dtype):
     else:
         raise TypeError("dtype must be a numpy integer type.")
 
-    if issubclass(image.dtype, np.floating):
+    if issubclass(image.dtype.type, np.floating):
         image_float = np.ldexp(image, bits)
         return image_float.astype(dtype)
     else:
@@ -61,7 +61,7 @@ def im2float(image, dtype):
 
     image_float = image.astype(dtype)
 
-    if issubclass(image.dtype, np.integer):
+    if issubclass(image.dtype.type, np.integer):
         max_val = np.iinfo(image.dtype.type).max
         image_float = image_float / max_val
 

--- a/skimage/color/data_convert.py
+++ b/skimage/color/data_convert.py
@@ -47,7 +47,7 @@ def im2integer(image, dtype):
     else:
         raise TypeError("dtype must be a numpy integer type.")
 
-    if issubclass(image.dtype.type, np.floating):
+    if issubclass(image.dtype, np.floating):
         image_float = np.ldexp(image, bits)
         return image_float.astype(dtype)
     else:
@@ -61,7 +61,7 @@ def im2float(image, dtype):
 
     image_float = image.astype(dtype)
 
-    if issubclass(image.dtype.type, np.integer):
+    if issubclass(image.dtype, np.integer):
         max_val = np.iinfo(image.dtype.type).max
         image_float = image_float / max_val
 

--- a/skimage/color/data_convert.py
+++ b/skimage/color/data_convert.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Functions for converting between data precision.
+
+Offloads most of the work to numpy.
+
+:author: Mark Harfouche
+
+:license: modified BSD
+"""
+
+import numpy as np
+
+
+def im2double(image):
+    """Convert image to double precision."""
+    return im2type(image, dtype=np.float64)
+
+
+def im2int16(image):
+    """Convert image to 16-bit signed integers."""
+    return im2type(image, dtype=np.int16)
+
+
+def im2single(image):
+    """Convert image to single precision (float32)."""
+    return im2type(image, dtype=np.float32)
+
+
+def im2uint16(image):
+    """Convert image to 16-bit unsigned integers."""
+    return im2type(image, np.uint16)
+
+
+def im2uint8(image):
+    """Convert image to 8-bit unsigned integers."""
+    return im2type(image, np.uint8)
+
+
+def im2integer(image, dtype):
+    """Covert an image to a generic integer type."""
+    if issubclass(dtype, np.signedinteger):
+        bits = np.iinfo(dtype).bits - 1
+    elif issubclass(dtype, np.unsignedinteger):
+        bits = np.iinfo(dtype).bits
+    else:
+        raise TypeError("dtype must be a numpy integer type.")
+
+    if issubclass(image.dtype.type, np.floating):
+        image_float = np.ldexp(image, bits)
+        return image_float.astype(dtype)
+    else:
+        return image.astype(dtype)
+
+
+def im2float(image, dtype):
+    """Convert image to a generic type of float."""
+    if not issubclass(dtype, np.floating):
+        raise TypeError("dtype must be a numpy float.")
+
+    image_float = image.astype(dtype)
+
+    if issubclass(image.dtype.type, np.integer):
+        max_val = np.iinfo(image.dtype.type).max
+        image_float = image_float / max_val
+
+    return image_float
+
+
+def im2type(image, dtype):
+    """Convert image to a generic numpy type."""
+    if issubclass(dtype, np.floating):
+        return im2float(image, dtype)
+    elif issubclass(dtype, np.integer):
+        return im2integer(image, dtype)
+    else:
+        raise TypeError("Unknown dtype. Must be subclass of "
+                        "np.floating or np.integer.")

--- a/skimage/color/data_convert.py
+++ b/skimage/color/data_convert.py
@@ -60,7 +60,6 @@ def im2integer(image, dtype):
         if issubclass(image.dtype.type, np.signedinteger):
             bits_input = bits_input - 1
 
-
         if bits_output < bits_input:
             return (image // (2 ** (bits_input - bits_output))).astype(dtype)
         elif bits_output > bits_input:

--- a/skimage/color/tests/test_data_convert.py
+++ b/skimage/color/tests/test_data_convert.py
@@ -21,10 +21,10 @@ def test_bogus_dtype():
     """
     image = np.ones((3, 3))
 
-    with testing.raises(ValueError):
+    with testing.raises(TypeError):
         im2integer(image, dtype=np.float)
 
-    with testing.raises(ValueError):
+    with testing.raises(TypeError):
         im2float(image, dtype=np.uint8)
 
 def test_im2type():

--- a/skimage/color/tests/test_data_convert.py
+++ b/skimage/color/tests/test_data_convert.py
@@ -14,7 +14,7 @@ from skimage._shared.testing import (assert_array_almost_equal,
 
 
 def test_bogus_dtype():
-    """Ensures that image conversion will raise errors on bad dtypes.assert_array_almost_equal
+    """Ensures that image conversion will raise errors on bad types.
 
     im2integer should fail if passed a float
     im2float should fail if passed an int.
@@ -26,6 +26,7 @@ def test_bogus_dtype():
 
     with testing.raises(TypeError):
         im2float(image, dtype=np.uint8)
+
 
 def test_im2type():
     image = np.array([[1, 1, 1, 2],

--- a/skimage/color/tests/test_data_convert.py
+++ b/skimage/color/tests/test_data_convert.py
@@ -1,0 +1,62 @@
+"""Testing code for converting between different types of data.
+
+Mark Harfouche
+Feb 13, 2018
+"""
+
+import numpy as np
+
+from skimage.color.data_convert import *
+
+from skimage._shared import testing
+from skimage._shared.testing import (assert_array_almost_equal,
+                                     assert_array_equal, assert_warns)
+
+
+def test_bogus_dtype():
+    """Ensures that image conversion will raise errors on bad dtypes.assert_array_almost_equal
+
+    im2integer should fail if passed a float
+    im2float should fail if passed an int.
+    """
+    image = np.ones((3, 3))
+
+    with testing.raises(ValueError):
+        im2integer(image, dtype=np.float)
+
+    with testing.raises(ValueError):
+        im2float(image, dtype=np.uint8)
+
+def test_im2type():
+    image = np.array([[1, 1, 1, 2],
+                      [2, 2, 3, 3],
+                      [4, 4, 6, 6]], dtype=np.uint8)
+    image_max = 255
+
+    types = [np.float64, np.int16, np.float32,
+             np.uint16, np.uint8]
+
+    functions = [im2double, im2int16, im2single,
+                 im2uint16, im2uint8]
+
+    for input_type in types:
+        for output_type, func in zip(types, functions):
+            input_image = image.astype(input_type)
+
+            output_image_estimate = image.astype(output_type)
+            if issubclass(output_type, np.floating):
+                output_image_estimate = output_image_estimate / image_max
+
+            output_image = im2type(input_image, output_type)
+
+            if issubclass(output_type, np.floating):
+                assert_array_almost_equal(output_image, output_image_estimate)
+            else:
+                assert_array_equal(output_image, output_image_estimate)
+
+            output_image = func(input_image)
+
+            if issubclass(output_type, np.floating):
+                assert_array_almost_equal(output_image, output_image_estimate)
+            else:
+                assert_array_equal(output_image, output_image_estimate)

--- a/skimage/color/tests/test_data_convert.py
+++ b/skimage/color/tests/test_data_convert.py
@@ -27,6 +27,9 @@ def test_bogus_dtype():
     with testing.raises(TypeError):
         im2float(image, dtype=np.uint8)
 
+    with testing.raises(TypeError):
+        im2type(image, dtype=np.complex)
+
 
 def test_im2type():
     image = np.array([[1, 2, 3, 4],

--- a/skimage/color/tests/test_data_convert.py
+++ b/skimage/color/tests/test_data_convert.py
@@ -61,7 +61,6 @@ def test_im2type():
             else:
                 output_image_estimate = image.astype(output_type)
 
-
             output_image = im2type(input_image, output_type)
 
             float_decimals = 4

--- a/skimage/color/tests/test_data_convert.py
+++ b/skimage/color/tests/test_data_convert.py
@@ -69,11 +69,13 @@ def test_im2type():
                 float_decimals = 2
             if issubclass(output_type, np.floating):
                 assert_array_almost_equal(output_image, output_image_estimate,
-                                          decimal=float_decimals, err_msg=err_message)
-            elif issubclass(input_type, np.integer):
-                assert_array_almost_equal(output_image, output_image_estimate,
-                                          decimal=-np.abs(bits_input - bits_output),
+                                          decimal=float_decimals,
                                           err_msg=err_message)
+            elif issubclass(input_type, np.integer):
+                assert_array_almost_equal(
+                    output_image, output_image_estimate,
+                    decimal=-np.abs(bits_input - bits_output),
+                    err_msg=err_message)
             else:
                 assert_array_equal(output_image, output_image_estimate)
 
@@ -81,11 +83,12 @@ def test_im2type():
 
             if issubclass(output_type, np.floating):
                 assert_array_almost_equal(output_image, output_image_estimate,
-                                          decimal=float_decimals, err_msg=err_message)
-            elif issubclass(input_type, np.integer):
-                assert_array_almost_equal(output_image, output_image_estimate,
-                                          decimal=-np.abs(bits_input - bits_output),
+                                          decimal=float_decimals,
                                           err_msg=err_message)
+            elif issubclass(input_type, np.integer):
+                assert_array_almost_equal(
+                    output_image, output_image_estimate,
+                    decimal=-np.abs(bits_input - bits_output),
+                    err_msg=err_message)
             else:
                 assert_array_equal(output_image, output_image_estimate)
-


### PR DESCRIPTION
## Description
I'm trying to use skimage for my image analysis. Coming from Matlab, I found a few functions lacking.
I decided to take a hack at the easy ones listed on:
http://scikit-image.org/docs/0.11.x/coverage_table.html

It seems that coverage_table has been dropped in recent versions?


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
