### PR TITLE
Support contours in future.manual_segmentation

### DIFF
--- a/skimage/future/manual_segmentation.py
+++ b/skimage/future/manual_segmentation.py
@@ -52,10 +52,9 @@ def manual_polygon_segmentation(image, alpha=0.4, return_all=False):
     labels : array of int, shape ([Q, ]M, N)
         The segmented regions. If mode is `'separate'`, the leading dimension
         of the array corresponds to the number of regions that the user drew.
-    contours : array of float, shape ([Q, ]O)
-        The contours of the segmented regions. If mode is `'separate'`, the
-        leading dimension of the array corresponds to the number of regions
-        that the user drew.
+    contours : array of float, shape (Q, 2)
+        The contours of the segmented regions. The leading dimension of the
+        array corresponds to the number of regions that the user drew.
 
     Notes
     -----
@@ -173,10 +172,9 @@ def manual_lasso_segmentation(image, alpha=0.4, return_all=False):
     labels : array of int, shape ([Q, ]M, N)
         The segmented regions. If mode is `'separate'`, the leading dimension
         of the array corresponds to the number of regions that the user drew.
-    contours : array of float, shape ([Q, ]O)
-        The contours of the segmented regions. If mode is `'separate'`, the
-        leading dimension of the array corresponds to the number of regions
-        that the user drew.
+    contours : array of float, shape (Q, 2)
+        The contours of the segmented regions. The leading dimension of the
+        array corresponds to the number of regions that the user drew.
 
     Notes
     -----

--- a/skimage/future/manual_segmentation.py
+++ b/skimage/future/manual_segmentation.py
@@ -32,7 +32,8 @@ def _draw_polygon(ax, vertices, alpha=0.4):
 
 @require("matplotlib", ">=3.3")
 def manual_polygon_segmentation(image, alpha=0.4, return_all=False):
-    """Return a label image and list of contours based on polygon selections made with the mouse.
+    """Return a label image and list of contours based on polygon selections
+    made with the mouse.
 
     Parameters
     ----------
@@ -65,7 +66,8 @@ def manual_polygon_segmentation(image, alpha=0.4, return_all=False):
     --------
     >>> from skimage import data, future, io
     >>> camera = data.camera()
-    >>> mask, contours = future.manual_polygon_segmentation(camera)   doctest: +SKIP
+    >>> mask, contours = \
+            future.manual_polygon_segmentation(camera)   doctest: +SKIP
     >>> io.imshow(mask)   doctest: +SKIP
     >>> io.show()   doctest: +SKIP
     """
@@ -147,12 +149,18 @@ def manual_polygon_segmentation(image, alpha=0.4, return_all=False):
     if return_all:
         return np.stack(labels), list_of_vertex_lists
     else:
-        return reduce(np.maximum, labels, np.broadcast_to(0, image.shape[:2])), list_of_vertex_lists
+        return reduce(
+            np.maximum,
+            labels,
+            np.broadcast_to(0, image.shape[:2])
+        ),
+        list_of_vertex_lists
 
 
 @require("matplotlib", ">=3.3")
 def manual_lasso_segmentation(image, alpha=0.4, return_all=False):
-    """Return a label image  and list of contours based on freeform selections made with the mouse.
+    """Return a label image  and list of contours based on freeform selections
+    made with the mouse.
 
     Parameters
     ----------
@@ -184,7 +192,8 @@ def manual_lasso_segmentation(image, alpha=0.4, return_all=False):
     --------
     >>> from skimage import data, future, io
     >>> camera = data.camera()
-    >>> mask, contours = future.manual_lasso_segmentation(camera)   doctest: +SKIP
+    >>> mask, contours = \
+            future.manual_lasso_segmentation(camera)   doctest: +SKIP
     >>> io.imshow(mask)   doctest: +SKIP
     >>> io.show()   doctest: +SKIP
     """
@@ -234,4 +243,9 @@ def manual_lasso_segmentation(image, alpha=0.4, return_all=False):
     if return_all:
         return np.stack(labels), list_of_vertex_lists
     else:
-        return reduce(np.maximum, labels, np.broadcast_to(0, image.shape[:2])), list_of_vertex_lists
+        return reduce(
+            np.maximum,
+            labels,
+            np.broadcast_to(0, image.shape[:2])
+        ),
+        list_of_vertex_lists

--- a/skimage/future/manual_segmentation.py
+++ b/skimage/future/manual_segmentation.py
@@ -32,7 +32,7 @@ def _draw_polygon(ax, vertices, alpha=0.4):
 
 @require("matplotlib", ">=3.3")
 def manual_polygon_segmentation(image, alpha=0.4, return_all=False):
-    """Return a label image based on polygon selections made with the mouse.
+    """Return a label image and list of contours based on polygon selections made with the mouse.
 
     Parameters
     ----------
@@ -52,6 +52,10 @@ def manual_polygon_segmentation(image, alpha=0.4, return_all=False):
     labels : array of int, shape ([Q, ]M, N)
         The segmented regions. If mode is `'separate'`, the leading dimension
         of the array corresponds to the number of regions that the user drew.
+    contours : array of float, shape ([Q, ]O)
+        The contours of the segmented regions. If mode is `'separate'`, the
+        leading dimension of the array corresponds to the number of regions
+        that the user drew.
 
     Notes
     -----
@@ -62,9 +66,9 @@ def manual_polygon_segmentation(image, alpha=0.4, return_all=False):
     --------
     >>> from skimage import data, future, io
     >>> camera = data.camera()
-    >>> mask = future.manual_polygon_segmentation(camera)  # doctest: +SKIP
-    >>> io.imshow(mask)  # doctest: +SKIP
-    >>> io.show()  # doctest: +SKIP
+    >>> mask, contours = future.manual_polygon_segmentation(camera)   doctest: +SKIP
+    >>> io.imshow(mask)   doctest: +SKIP
+    >>> io.show()   doctest: +SKIP
     """
     import matplotlib
     import matplotlib.pyplot as plt
@@ -142,14 +146,14 @@ def manual_polygon_segmentation(image, alpha=0.4, return_all=False):
         for i, vertices in enumerate(list_of_vertex_lists, start=1)
     )
     if return_all:
-        return np.stack(labels)
+        return np.stack(labels), list_of_vertex_lists
     else:
-        return reduce(np.maximum, labels, np.broadcast_to(0, image.shape[:2]))
+        return reduce(np.maximum, labels, np.broadcast_to(0, image.shape[:2])), list_of_vertex_lists
 
 
 @require("matplotlib", ">=3.3")
 def manual_lasso_segmentation(image, alpha=0.4, return_all=False):
-    """Return a label image based on freeform selections made with the mouse.
+    """Return a label image  and list of contours based on freeform selections made with the mouse.
 
     Parameters
     ----------
@@ -169,6 +173,10 @@ def manual_lasso_segmentation(image, alpha=0.4, return_all=False):
     labels : array of int, shape ([Q, ]M, N)
         The segmented regions. If mode is `'separate'`, the leading dimension
         of the array corresponds to the number of regions that the user drew.
+    contours : array of float, shape ([Q, ]O)
+        The contours of the segmented regions. If mode is `'separate'`, the
+        leading dimension of the array corresponds to the number of regions
+        that the user drew.
 
     Notes
     -----
@@ -178,9 +186,9 @@ def manual_lasso_segmentation(image, alpha=0.4, return_all=False):
     --------
     >>> from skimage import data, future, io
     >>> camera = data.camera()
-    >>> mask = future.manual_lasso_segmentation(camera)  # doctest: +SKIP
-    >>> io.imshow(mask)  # doctest: +SKIP
-    >>> io.show()  # doctest: +SKIP
+    >>> mask, contours = future.manual_lasso_segmentation(camera)   doctest: +SKIP
+    >>> io.imshow(mask)   doctest: +SKIP
+    >>> io.show()   doctest: +SKIP
     """
     import matplotlib
     import matplotlib.pyplot as plt
@@ -226,6 +234,6 @@ def manual_lasso_segmentation(image, alpha=0.4, return_all=False):
         for i, vertices in enumerate(list_of_vertex_lists, start=1)
     )
     if return_all:
-        return np.stack(labels)
+        return np.stack(labels), list_of_vertex_lists
     else:
-        return reduce(np.maximum, labels, np.broadcast_to(0, image.shape[:2]))
+        return reduce(np.maximum, labels, np.broadcast_to(0, image.shape[:2])), list_of_vertex_lists


### PR DESCRIPTION
## Description
This PR updates the functions [`future.manual_segmentation.manual_polygon_segmentation`](http://scikit-image.org/docs/dev/api/skimage.future.html#manual-polygon-segmentation) and [`future.manual_segmentation.manual_lasso_segmentation`](http://scikit-image.org/docs/dev/api/skimage.future.html#manual-lasso-segmentation). The changes add a second return parameter that is the actual list of contour points. This is sometimes more useful to an end user than the mask only.

NB: This will break previous APIs that depended on these functions. Old code might have looked like this (from the docstrings);

```
camera = data.camera()
mask = manual_segmentation.manual_lasso_segmentation(camera)
io.imshow(mask)  
io.show()
```

Now, users will have to add a temporary variable to catch the contour, even if they are not interested in it; viz.

```
mask, _ = manual_segmentation.manual_lasso_segmentation(camera)
```

Docstrings are updated and the changes were fairly minimal - I haven't read all of PEP8, but I believe it should still be compatible (unless multiple return statements are a no-no).

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [X] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [X] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

##
Release notes message:
```
 ``future.manual_segmentation.manual_polygon_segmentation`` and
  ``future.manual_segmentation.manual_lasso_segmentation`` were updated to also
  return the contour points picked, not just a mask image.
```