### PR TITLE
Watershed segmentation: make usable for large arrays

### DIFF
--- a/skimage/morphology/_watershed.pyx
+++ b/skimage/morphology/_watershed.pyx
@@ -17,6 +17,7 @@ cimport cython
 
 
 ctypedef cnp.int32_t DTYPE_INT32_t
+ctypedef cnp.int64_t DTYPE_INT64_t
 ctypedef cnp.int8_t DTYPE_BOOL_t
 
 
@@ -28,8 +29,8 @@ include "heap_watershed.pxi"
 @cython.cdivision(True)
 @cython.overflowcheck(False)
 @cython.unraisable_tracebacks(False)
-cdef inline double _euclid_dist(cnp.int32_t pt0, cnp.int32_t pt1,
-                                cnp.int32_t[::1] strides):
+cdef inline double _euclid_dist(cnp.int64_t pt0, cnp.int64_t pt1,
+                                cnp.int64_t[::1] strides):
     """Return the Euclidean distance between raveled points pt0 and pt1."""
     cdef double result = 0
     cdef double curr = 0
@@ -46,7 +47,7 @@ cdef inline double _euclid_dist(cnp.int32_t pt0, cnp.int32_t pt1,
 @cython.cdivision(True)
 @cython.unraisable_tracebacks(False)
 cdef inline DTYPE_BOOL_t _diff_neighbors(DTYPE_INT32_t[::1] output,
-                                         DTYPE_INT32_t[::1] structure,
+                                         DTYPE_INT64_t[::1] structure,
                                          DTYPE_BOOL_t[::1] mask,
                                          Py_ssize_t index):
     """
@@ -78,10 +79,10 @@ cdef inline DTYPE_BOOL_t _diff_neighbors(DTYPE_INT32_t[::1] output,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def watershed_raveled(cnp.float64_t[::1] image,
-                      DTYPE_INT32_t[::1] marker_locations,
-                      DTYPE_INT32_t[::1] structure,
+                      DTYPE_INT64_t[::1] marker_locations,
+                      DTYPE_INT64_t[::1] structure,
                       DTYPE_BOOL_t[::1] mask,
-                      cnp.int32_t[::1] strides,
+                      cnp.int64_t[::1] strides,
                       cnp.double_t compactness,
                       DTYPE_INT32_t[::1] output,
                       DTYPE_BOOL_t wsl):

--- a/skimage/morphology/watershed.py
+++ b/skimage/morphology/watershed.py
@@ -130,7 +130,7 @@ def _compute_neighbors(image, structure, offset):
     locations = np.transpose(np.nonzero(structure))
     sqdistances = np.sum((locations - offset)**2, axis=1)
     neighborhood = (np.ravel_multi_index(locations.T, image.shape) -
-                    np.ravel_multi_index(offset, image.shape)).astype(np.int32)
+                    np.ravel_multi_index(offset, image.shape))
     sorted_neighborhood = neighborhood[np.argsort(sqdistances)]
     return sorted_neighborhood
 
@@ -254,8 +254,8 @@ def watershed(image, markers, connectivity=1, offset=None, mask=None,
     output = np.pad(markers, pad_width, mode='constant')
 
     flat_neighborhood = _compute_neighbors(image, connectivity, offset)
-    marker_locations = np.flatnonzero(output).astype(np.int32)
-    image_strides = np.array(image.strides, dtype=np.int32) // image.itemsize
+    marker_locations = np.flatnonzero(output)
+    image_strides = np.array(image.strides) // image.itemsize
 
     _watershed.watershed_raveled(image.ravel(),
                                  marker_locations, flat_neighborhood,

--- a/skimage/morphology/watershed.py
+++ b/skimage/morphology/watershed.py
@@ -102,17 +102,21 @@ def _validate_connectivity(image_dim, connectivity, offset):
     """
     if connectivity is None:
         connectivity = 1
+
     if np.isscalar(connectivity):
         c_connectivity = ndi.generate_binary_structure(image_dim, connectivity)
     else:
         c_connectivity = np.array(connectivity, bool)
         if c_connectivity.ndim != image_dim:
             raise ValueError("Connectivity dimension must be same as image")
+
     if offset is None:
         if any([x % 2 == 0 for x in c_connectivity.shape]):
             raise ValueError("Connectivity array must have an unambiguous "
                              "center")
+
         offset = np.array(c_connectivity.shape) // 2
+
     return c_connectivity, offset
 
 


### PR DESCRIPTION
The numbering of indexes is now 64-bit, to allow usage on arrays with more than 2<sup>31</sup>-1 elements. With volumes as large as (for example) 2048<sup>3</sup>, which is not an extraordinary size for 3D volumes anymore, 32-bit index numbering can not be used.

Additionally, some related quantities are kept 64-bit (and not converted to 32-bit, as before) to avoid redundant operations. These quantities are not parts of large arrays, so there is no noticeable effect on memory usage.

Also, some trivial refactoring is made: empty lines are inserted for readability and PEP8 compliance.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
