### PR TITLE
Use correct NumPy version comparison in pytest configuration

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,8 @@
 # TODO: remove this workaround once minimal required numpy is set to 1.14.0
 import numpy as np
 
-if np.version.full_version >= '1.14.0':
+numpy_version = [int(i) for i in np.version.full_version.split('.')[:2]]
+if numpy_version >= [1, 14]:
     np.set_printoptions(legacy='1.13')
 
 # List of files that pytest should ignore

--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,10 @@
 # Use legacy numpy printing. This fix is made to keep doctests functional.
 # For more info, see https://github.com/scikit-image/scikit-image/pull/2935 .
 # TODO: remove this workaround once minimal required numpy is set to 1.14.0
+from distutils.version import LooseVersion as Version
 import numpy as np
 
-numpy_version = [int(i) for i in np.version.full_version.split('.')[:2]]
-if numpy_version >= [1, 14]:
+if Version(np.__version__) >= Version('1.14'):
     np.set_printoptions(legacy='1.13')
 
 # List of files that pytest should ignore


### PR DESCRIPTION
## Description
Implements the fix proposed by @Borda in this review - https://github.com/scikit-image/scikit-image/pull/2935#discussion_r171282185 . I've decided to use `[:2]` to properly handle also the release candidate versions.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
https://github.com/scikit-image/scikit-image/pull/2935#discussion_r171282185

## For reviewers

(Don't remove the checklist below.)

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
