### PR TITLE
Bugfix LineModelND.residuals does not use the optional parameter `params`

### DIFF
--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -123,7 +123,7 @@ class LineModelND(BaseModel):
         if len(params) != 2:
             raise ValueError('Parameters are defined by 2 sets.')
 
-        origin, direction = self.params
+        origin, direction = params
         res = (data - origin) - \
               np.dot(data - origin, direction)[..., np.newaxis] * direction
         return _norm_along_axis(res, axis=1)

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -94,6 +94,10 @@ def test_line_model_nd_residuals():
     assert_equal(abs(model.residuals(np.array([[0, 0, 0]]))), 0)
     assert_equal(abs(model.residuals(np.array([[0, 0, 1]]))), 0)
     assert_equal(abs(model.residuals(np.array([[10, 0, 0]]))), 10)
+    # test params argument in model.rediduals
+    data = np.array([[10, 0, 0]])
+    params = (np.array([0, 0, 0]), np.array([2, 0, 0]))
+    assert_equal(abs(model.residuals(data, params=params)), 30)
 
 
 def test_line_modelND_under_determined():


### PR DESCRIPTION

## Description
Bugfix. Formerly, the argument `params` in `LineModelND.rediduals(self, data, params=None) ` was always overwritten by self.params. Now, assignment of `origin, direction` was changed from `self.params` to `params`. Formerly, `params` argument would have been ignored no matter if it was `None` or not. Now, if `params` is `None` it is set to `self.params` as defined in line 120 and 121 of fit.py. Otherwise, if params is not None, the `params` argument will be used to set origin, direction.


## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.