### PR TITLE
Return empty list on flat images with hough_ellipse #2820

### DIFF
--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -118,11 +118,10 @@ def _hough_ellipse(cnp.ndarray img, int threshold=4, double accuracy=1,
 
     Returns
     -------
-    result : ndarray with fields [(accumulator, yc, xc, a, b, orientation)]
+    result : ndarray with fields [(accumulator, yc, xc, a, b, orientation)], or None
           Where ``(yc, xc)`` is the center, ``(a, b)`` the major and minor
           axes, respectively. The `orientation` value follows
           `skimage.draw.ellipse_perimeter` convention.
-          Returns None if no non-zero pixel in the image.
 
     Examples
     --------
@@ -147,6 +146,8 @@ def _hough_ellipse(cnp.ndarray img, int threshold=4, double accuracy=1,
     if img.ndim != 2:
             raise ValueError('The input image must be 2D.')
 
+    # The creation of the array `pixels` results in a rather nasty error when the image is empty.
+    # As discussed in GitHub #2820 and #2996, we opt instead to return None.
     if not np.any(img):
         return None
 

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -118,7 +118,8 @@ def _hough_ellipse(cnp.ndarray img, int threshold=4, double accuracy=1,
 
     Returns
     -------
-    result : ndarray with fields [(accumulator, yc, xc, a, b, orientation)], or None
+    result : ndarray with fields [(accumulator, yc, xc, a, b, orientation)],
+          or None
           Where ``(yc, xc)`` is the center, ``(a, b)`` the major and minor
           axes, respectively. The `orientation` value follows
           `skimage.draw.ellipse_perimeter` convention.
@@ -146,7 +147,8 @@ def _hough_ellipse(cnp.ndarray img, int threshold=4, double accuracy=1,
     if img.ndim != 2:
             raise ValueError('The input image must be 2D.')
 
-    # The creation of the array `pixels` results in a rather nasty error when the image is empty.
+    # The creation of the array `pixels` results in a rather nasty error
+    # when the image is empty.
     # As discussed in GitHub #2820 and #2996, we opt instead to return None.
     if not np.any(img):
         return None

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -118,10 +118,11 @@ def _hough_ellipse(cnp.ndarray img, int threshold=4, double accuracy=1,
 
     Returns
     -------
-    result : ndarray with fields [(accumulator, y0, x0, a, b, orientation)]
+    result : ndarray with fields [(accumulator, yc, xc, a, b, orientation)]
           Where ``(yc, xc)`` is the center, ``(a, b)`` the major and minor
           axes, respectively. The `orientation` value follows
           `skimage.draw.ellipse_perimeter` convention.
+          Returns None if no non-zero pixel in the image.
 
     Examples
     --------
@@ -146,11 +147,10 @@ def _hough_ellipse(cnp.ndarray img, int threshold=4, double accuracy=1,
     if img.ndim != 2:
             raise ValueError('The input image must be 2D.')
 
-    cdef cnp.ndarray[ndim=2, dtype=cnp.intp_t] noncontiguous_mem_pixels = np.row_stack(np.nonzero(img))
-    if noncontiguous_mem_pixels.shape[1] == 0:
+    if not np.any(img):
         return None
 
-    cdef Py_ssize_t[:, ::1] pixels = noncontiguous_mem_pixels
+    cdef Py_ssize_t[:, ::1] pixels = np.row_stack(np.nonzero(img))
 
     cdef Py_ssize_t num_pixels = pixels.shape[1]
     cdef list acc = list()

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -146,7 +146,12 @@ def _hough_ellipse(cnp.ndarray img, int threshold=4, double accuracy=1,
     if img.ndim != 2:
             raise ValueError('The input image must be 2D.')
 
-    cdef Py_ssize_t[:, ::1] pixels = np.row_stack(np.nonzero(img))
+    cdef cnp.ndarray[ndim=2, dtype=cnp.intp_t] noncontiguous_mem_pixels = np.row_stack(np.nonzero(img))
+    if noncontiguous_mem_pixels.shape[1] == 0:
+        return None
+
+    cdef Py_ssize_t[:, ::1] pixels = noncontiguous_mem_pixels
+
     cdef Py_ssize_t num_pixels = pixels.shape[1]
     cdef list acc = list()
     cdef list results = list()

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -149,9 +149,9 @@ def _hough_ellipse(cnp.ndarray img, int threshold=4, double accuracy=1,
 
     # The creation of the array `pixels` results in a rather nasty error
     # when the image is empty.
-    # As discussed in GitHub #2820 and #2996, we opt instead to return None.
+    # As discussed in GitHub #2820 and #2996, we opt to return an empty array.
     if not np.any(img):
-        return None
+        return np.zeros((0, 6))
 
     cdef Py_ssize_t[:, ::1] pixels = np.row_stack(np.nonzero(img))
 

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -118,8 +118,7 @@ def _hough_ellipse(cnp.ndarray img, int threshold=4, double accuracy=1,
 
     Returns
     -------
-    result : ndarray with fields [(accumulator, yc, xc, a, b, orientation)],
-          or None
+    result : ndarray with fields [(accumulator, yc, xc, a, b, orientation)]
           Where ``(yc, xc)`` is the center, ``(a, b)`` the major and minor
           axes, respectively. The `orientation` value follows
           `skimage.draw.ellipse_perimeter` convention.

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -131,7 +131,8 @@ def hough_ellipse(image, threshold=4, accuracy=1, min_size=4, max_size=None):
 
     Returns
     -------
-    result : ndarray with fields [(accumulator, yc, xc, a, b, orientation)], or None.
+    result : ndarray with fields [(accumulator, yc, xc, a, b, orientation)],
+          or None.
           Where ``(yc, xc)`` is the center, ``(a, b)`` the major and minor
           axes, respectively. The `orientation` value follows
           `skimage.draw.ellipse_perimeter` convention.

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -135,6 +135,7 @@ def hough_ellipse(image, threshold=4, accuracy=1, min_size=4, max_size=None):
           Where ``(yc, xc)`` is the center, ``(a, b)`` the major and minor
           axes, respectively. The `orientation` value follows
           `skimage.draw.ellipse_perimeter` convention.
+          Returns None if no non-zero pixel in the image.
 
     Examples
     --------

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -131,7 +131,7 @@ def hough_ellipse(image, threshold=4, accuracy=1, min_size=4, max_size=None):
 
     Returns
     -------
-    result : ndarray with fields [(accumulator, y0, x0, a, b, orientation)]
+    result : ndarray with fields [(accumulator, yc, xc, a, b, orientation)]
           Where ``(yc, xc)`` is the center, ``(a, b)`` the major and minor
           axes, respectively. The `orientation` value follows
           `skimage.draw.ellipse_perimeter` convention.

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -131,11 +131,10 @@ def hough_ellipse(image, threshold=4, accuracy=1, min_size=4, max_size=None):
 
     Returns
     -------
-    result : ndarray with fields [(accumulator, yc, xc, a, b, orientation)]
+    result : ndarray with fields [(accumulator, yc, xc, a, b, orientation)], or None.
           Where ``(yc, xc)`` is the center, ``(a, b)`` the major and minor
           axes, respectively. The `orientation` value follows
           `skimage.draw.ellipse_perimeter` convention.
-          Returns None if no non-zero pixel in the image.
 
     Examples
     --------

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -131,8 +131,7 @@ def hough_ellipse(image, threshold=4, accuracy=1, min_size=4, max_size=None):
 
     Returns
     -------
-    result : ndarray with fields [(accumulator, yc, xc, a, b, orientation)],
-          or None.
+    result : ndarray with fields [(accumulator, yc, xc, a, b, orientation)].
           Where ``(yc, xc)`` is the center, ``(a, b)`` the major and minor
           axes, respectively. The `orientation` value follows
           `skimage.draw.ellipse_perimeter` convention.

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -464,4 +464,3 @@ def test_hough_ellipse_non_zero_negangle4():
 
 def test_hough_ellipse_all_black_img():
     assert(transform.hough_ellipse(np.zeros((100, 100))) is None)
-    

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -460,3 +460,8 @@ def test_hough_ellipse_non_zero_negangle4():
                                  orientation=best[5])
     assert_equal(rr, rr2)
     assert_equal(cc, cc2)
+
+
+def test_hough_ellipse_all_black_img():
+    assert(transform.hough_ellipse(np.zeros((100, 100))) is None)
+    

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -463,4 +463,4 @@ def test_hough_ellipse_non_zero_negangle4():
 
 
 def test_hough_ellipse_all_black_img():
-    assert(transform.hough_ellipse(np.zeros((100, 100))) is None)
+    assert(transform.hough_ellipse(np.zeros((100, 100))).shape == (0, 6))


### PR DESCRIPTION
## Description
Previous behavior: Calling `hough_ellipse` on an array of zeros (all black image) caused a `ValueError`
Current behavior: Calling `hough_ellipse` on an array of zeros (all black image) returns an empty array.

Other change: Fixes a typo in the function's documentation.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x ] Gallery example in `./doc/examples` (new features only)
- [x ] Unit tests

I tested the modified function on numpy arrays of zeros as well as on images with artificially created ellipses.

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]

## References
If this is a bug-fix, it closes issue #2820 

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
