### PR TITLE
MAINT: PIL removed saving RGBA images as jpeg files

### DIFF
--- a/skimage/novice/tests/test_novice.py
+++ b/skimage/novice/tests/test_novice.py
@@ -158,14 +158,14 @@ def test_update_on_save():
     assert pic.modified
     assert pic.path is None
 
-    fd, filename = tempfile.mkstemp(suffix=".jpg")
+    fd, filename = tempfile.mkstemp(suffix=".png")
     os.close(fd)
     try:
         pic.save(filename)
 
         assert not pic.modified
         assert_equal(pic.path, os.path.abspath(filename))
-        assert_equal(pic.format, "jpeg")
+        assert_equal(pic.format, "png")
     finally:
         os.unlink(filename)
 
@@ -174,7 +174,7 @@ def test_save_with_alpha_channel():
     # create an image with an alpha channel
     pic = novice.Picture(array=np.zeros((3, 3, 4)))
 
-    fd, filename = tempfile.mkstemp(suffix=".jpg")
+    fd, filename = tempfile.mkstemp(suffix=".png")
     os.close(fd)
     pic.save(filename)
     os.unlink(filename)


### PR DESCRIPTION
Modifying test to save as PNG, since Picture stores RGB images as RGBA internally

## Description

`test_novice.py:test_update_on_save` is failing due to removal saving RGBA in PIL https://github.com/python-pillow/Pillow/issues/2609 

Modified test to save array as PNG file, rather than JPEG, as suggested in the referenced issue.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
