### PR TITLE
Ensure stdev is always nonnegative in _mean_std

### DIFF
--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -421,3 +421,13 @@ def test_mean_std_3d():
     expected_s = ndi.generic_filter(image, np.std, size=window_size,
                                     mode='mirror')
     np.testing.assert_allclose(s, expected_s)
+
+
+def test_niblack_sauvola_pathological_image():
+    # For certain values, floating point error can cause
+    # E(X^2) - (E(X))^2 to be negative, and taking the square root of this
+    # resulted in NaNs. Here we check that these are safely caught.
+    # see https://github.com/scikit-image/scikit-image/issues/3007
+    value = 0.03082192 + 2.19178082e-09
+    src_img = np.full((4, 4), value).astype(np.float64)
+    assert not np.any(np.isnan(threshold_niblack(src_img)))

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -772,6 +772,8 @@ def _mean_std(image, w):
     m = crop(sum_full, (left_pad, right_pad)) / (w ** image.ndim)
     sum_sq_full = ndi.correlate(integral_sq, kern, mode='constant')
     g2 = crop(sum_sq_full, (left_pad, right_pad)) / (w ** image.ndim)
+    # Note: we use np.clip because g2 is not guaranteed to be greater than
+    # m*m when floating point error is considered
     s = np.sqrt(np.clip(g2 - m * m, 0, None))
     return m, s
 

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -772,7 +772,7 @@ def _mean_std(image, w):
     m = crop(sum_full, (left_pad, right_pad)) / (w ** image.ndim)
     sum_sq_full = ndi.correlate(integral_sq, kern, mode='constant')
     g2 = crop(sum_sq_full, (left_pad, right_pad)) / (w ** image.ndim)
-    s = np.sqrt(g2 - m * m)
+    s = np.sqrt(np.clip(g2 - m * m, 0, None))
     return m, s
 
 


### PR DESCRIPTION
For some values, floating point error can cause VarX = E(X^2) - (EX)^2
to be negative, resulting in NaNs when taking StdX = sqrt(VarX). Here
we ensure that VarX is nonnegative before taking the square root.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests


## References
Closes issue #3007 

## For reviewers

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
