### PR TITLE
WIP: Turn off relabelling in label2rgb

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -46,6 +46,7 @@ Version 0.16
 * In ``skimage.measure.moments_central``, remove ``cc`` and ``**kwargs``
   arguments.
 * In ``skimage.morphology.remove_small_holes``, remove ``min_size`` argument.
+* Change default values in ``skimage.color.label2rgb``.
 
 Other
 -----

--- a/skimage/_shared/_default_value.py
+++ b/skimage/_shared/_default_value.py
@@ -1,0 +1,14 @@
+class DefaultValue(object):
+    """Class to provide a dummy default value other than None.
+
+    This is useful for cases where it makes sense to pass 'None' as an
+    actual value.
+    """
+    def __repr__(self):
+        return 'None'
+
+    def __str__(self):
+        return 'None'
+
+
+DEFAULT = DefaultValue()

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -122,9 +122,10 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
 
     Parameters
     ----------
-    label : array, shape (M, N)
-        Integer array of labels with the same shape as `image`.
-    image : array, shape (M, N, 3), optional
+    label : array, shape (M, N,[[ P,] ...])
+        Integer array of labels with the same shape as `image` (not including
+        channels).
+    image : array, shape (M, N,[[[ P,] ...,] 3]), optional
         Image used as underlay for labels. If the input is an RGB image, it's
         converted to grayscale before coloring.
     colors : list, optional
@@ -142,7 +143,7 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
 
     Returns
     -------
-    result : array of float, shape (M, N, 3)
+    result : array of float, shape (M, N,[[ P,] ...,] 3)
         The result of blending a cycling colormap (`colors`) for each distinct
         value in `label` with the image, at a certain alpha value.
     """
@@ -155,7 +156,7 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
         # Opacity doesn't make sense if no image exists.
         alpha = 1
     else:
-        if not image.shape[:2] == label.shape:
+        if not image.shape[:label.ndim] == label.shape:
             raise ValueError("`image` and `label` must be the same shape")
 
         if image.min() < 0:

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -159,9 +159,6 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
         if not image.shape[:label.ndim] == label.shape:
             raise ValueError("`image` and `label` must be the same shape")
 
-        if image.min() < 0:
-            warn("Negative intensities in `image` are not supported")
-
         image = img_as_float(rgb2gray(image))
         image = gray2rgb(image) * image_alpha + (1 - image_alpha)
 

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -165,8 +165,11 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
                    'examples/xx_applications/plot_coins_segmentation.html')
             raise ValueError(msg)
 
-        image = img_as_float(rgb2gray(image))
-        image = gray2rgb(image) * image_alpha + (1 - image_alpha)
+        # convert image to an gray-only RGB image to enable blending with
+        # label colors. Note that rgb2gray is a no-op if the original image
+        # is grayscale already.
+        image = (image_alpha * gray2rgb(rgb2gray(image))
+                 + (1 - image_alpha))
 
     # Ensure that all labels are non-negative so we can index into
     # `label_to_color` correctly.

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -3,6 +3,7 @@ import itertools
 import numpy as np
 
 from .._shared.utils import warn
+from .._shared._default_value import DEFAULT
 from ..util import img_as_float
 from . import rgb_colors
 from .colorconv import rgb2gray, gray2rgb
@@ -75,7 +76,8 @@ def _match_label_with_color(label, colors, bg_label, bg_color):
 
 
 def label2rgb(label, image=None, colors=None, alpha=0.3,
-              bg_label=-1, bg_color=(0, 0, 0), image_alpha=1, kind='overlay'):
+              background=DEFAULT, background_color=None, image_alpha=1,
+              kind='overlay', bg_label=DEFAULT, bg_color=DEFAULT):
     """Return an RGB image where color-coded labels are painted over the image.
 
     Parameters
@@ -90,18 +92,31 @@ def label2rgb(label, image=None, colors=None, alpha=0.3,
         then the colors are cycled.
     alpha : float [0, 1], optional
         Opacity of colorized labels. Ignored if image is `None`.
-    bg_label : int, optional
-        Label that's treated as the background.
-    bg_color : str or array, optional
-        Background color. Must be a name in `color_dict` or RGB float values
-        between [0, 1].
+    background : int, optional
+        Label to be treated as background. Currently defaults to -1, but
+        will default to 0 starting in version 0.16. Use None to indicate that
+        the image contains no background.
+    background_color : str, tuple, array, or None, optional
+        The color of the background. If None, background pixels will have
+        no overlay at all and will show the image directly.
     image_alpha : float [0, 1], optional
         Opacity of the image.
-    kind : string, one of {'overlay', 'avg'}
+    kind : string, one of {'overlay', 'avg', 'average'}
         The kind of color image desired. 'overlay' cycles over defined colors
-        and overlays the colored labels over the original image. 'avg' replaces
-        each labeled segment with its average color, for a stained-class or
-        pastel painting appearance.
+        and overlays the colored labels over the original image. 'avg' or
+        'average' replaces each labeled segment with its average color, for a
+        stained-glass or pastel painting appearance.
+
+    Other parameters
+    ----------------
+    bg_label : int, optional **DEPRECATED**
+        Label that's treated as the background. This parameter has been
+        deprecated in favor of 'background' and will be removed in version
+        0.16.
+    bg_color : str or array, optional **DEPRECATED**
+        Background color. Must be a name in `color_dict` or RGB float values
+        between [0, 1]. This parameter has been deprecated in favor of
+        'background_color' and will be removed in version 0.16.
 
     Returns
     -------
@@ -109,15 +124,41 @@ def label2rgb(label, image=None, colors=None, alpha=0.3,
         The result of blending a cycling colormap (`colors`) for each distinct
         value in `label` with the image, at a certain alpha value.
     """
+    if image is None and kind in ['avg' or 'average']:
+        mesg = ('"image" *must* be provided when average color mode is used '
+                'in label2rgb. See\n\n'
+                '* http://scikit-image.org/docs/dev/auto_examples/'
+                'segmentation/plot_boundary_merge.html\n\n'
+                'for example usage.')
+        raise ValueError(mesg)
+    if background is DEFAULT:
+        if bg_label is DEFAULT:
+            if np.any(labels == -1) or np.any(labels == 0):
+                mesg = ('Starting in version 0.16, label2rgb will consider '
+                        'label 0 to be background. Set background=None to '
+                        'suppress this message without defining a background, '
+                        'background=-1 to set -1 to be the background, or '
+                        'background=0 to suppress this message and use 0 '
+                        'as the background label.')
+                warn(mesg)
+                background = -1
+        else:
+            mesg = ('The parameter "bg_label" was renamed "background" in '
+                    'version 0.14 and will be removed in version 0.16.')
+            warn(mesg)
+            background = bg_label
+    if background is None:
+        background = int(np.max(labels)) + 1
     if kind == 'overlay':
-        return _label2rgb_overlay(label, image, colors, alpha, bg_label,
-                                  bg_color, image_alpha)
+        return _label2rgb_overlay(label, image, colors, alpha, background,
+                                  background_color, image_alpha)
     else:
-        return _label2rgb_avg(label, image, bg_label, bg_color)
+        return _label2rgb_avg(label, image, background, background_color)
 
 
 def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
-                       bg_label=-1, bg_color=None, image_alpha=1):
+                       background=None, background_color=None, image_alpha=1,
+                       bg_label=None, bg_color=None):
     """Return an RGB image where color-coded labels are painted over the image.
 
     Parameters
@@ -133,13 +174,24 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
         then the colors are cycled.
     alpha : float [0, 1], optional
         Opacity of colorized labels. Ignored if image is `None`.
-    bg_label : int, optional
-        Label that's treated as the background.
-    bg_color : str or array, optional
-        Background color. Must be a name in `color_dict` or RGB float values
-        between [0, 1].
+    background : int, optional
+        Label to be treated as background. Starting in version 0.16, this
+        default will change to 0.
+    background_color : str, tuple, array, or None, optional
+        The color of the background. If None, background pixels will have
+        no overlay at all and will show the image directly.
     image_alpha : float [0, 1], optional
         Opacity of the image.
+
+    Other parameters
+    ----------------
+    bg_label : int, optional **DEPRECATED**
+        Label that's treated as the background. This parameter has been
+        deprecated in favor of 'background'.
+    bg_color : str or array, optional **DEPRECATED**
+        Background color. Must be a name in `color_dict` or RGB float values
+        between [0, 1]. This parameter has been deprecated in favor of
+        'background_color'.
 
     Returns
     -------
@@ -153,7 +205,7 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
 
     if image is None:
         image = np.zeros(label.shape + (3,), dtype=np.float64)
-        # Opacity doesn't make sense if no image exists.
+        # Opacity doesn't make sense if no image is provided
         alpha = 1
     else:
         if not image.shape[:label.ndim] == label.shape:
@@ -175,10 +227,10 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
 
     # Ensure that all labels are non-negative so we can index into
     # `label_to_color` correctly.
-    offset = min(label.min(), bg_label)
+    offset = min(label.min(), background)
     if offset != 0:
         label = label - offset  # Make sure you don't modify the input array.
-        bg_label -= offset
+        background -= offset
 
     new_type = np.min_scalar_type(int(label.max()))
     if new_type == np.bool:
@@ -186,7 +238,7 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
     label = label.astype(new_type)
 
     mapped_labels_flat, color_cycle = _match_label_with_color(label, colors,
-                                                              bg_label, bg_color)
+                                                              background, background_color)
 
     if len(mapped_labels_flat) == 0:
         return image
@@ -200,14 +252,15 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
     result = label_to_color[mapped_labels] * alpha + image * (1 - alpha)
 
     # Remove background label if its color was not specified.
-    remove_background = 0 in mapped_labels_flat and bg_color is None
+    remove_background = 0 in mapped_labels_flat and background_color is None
     if remove_background:
-        result[label == bg_label] = image[label == bg_label]
+        result[label == background] = image[label == background]
 
     return result
 
 
-def _label2rgb_avg(label_field, image, bg_label=0, bg_color=(0, 0, 0)):
+def _label2rgb_avg(label_field, image, background=0,
+                   background_color=(0, 0, 0)):
     """Visualise each segment in `label_field` with its mean color in `image`.
 
     Parameters
@@ -216,9 +269,9 @@ def _label2rgb_avg(label_field, image, bg_label=0, bg_color=(0, 0, 0)):
         A segmentation of an image.
     image : array, shape ``label_field.shape + (3,)``
         A color image of the same spatial shape as `label_field`.
-    bg_label : int, optional
+    background : int, optional
         A value in `label_field` to be treated as background.
-    bg_color : 3-tuple of int, optional
+    background_color : 3-tuple of int, optional
         The color for the background label
 
     Returns
@@ -228,10 +281,10 @@ def _label2rgb_avg(label_field, image, bg_label=0, bg_color=(0, 0, 0)):
     """
     out = np.zeros_like(image)
     labels = np.unique(label_field)
-    bg = (labels == bg_label)
-    if bg.any():
-        labels = labels[labels != bg_label]
-        out[bg] = bg_color
+    is_background = (labels == background)
+    if is_background.any():
+        labels = labels[labels != background]
+        out[is_background] = background_color
     for label in labels:
         mask = (label_field == label).nonzero()
         color = image[mask].mean(axis=0)

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -157,12 +157,14 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
         alpha = 1
     else:
         if not image.shape[:label.ndim] == label.shape:
-            msg = ('The (non-color) shape of `image` and `label` passed to '
+            msg = ('The (non-color) shape of `image` and `label` passed to\n'
                    'skimage.color.label2rgb must exactly match. See the '
-                   'function documentation at http://scikit-image.org/docs/dev'
-                   '/api/skimage.color.html#skimage.color.label2rgb and '
-                   'example usage at http://scikit-image.org/docs/dev/auto_'
-                   'examples/xx_applications/plot_coins_segmentation.html')
+                   'function documentation at\n\n'
+                   '* http://scikit-image.org/docs/dev/api/'
+                   'skimage.color.html#skimage.color.label2rgb\n\n'
+                   'and example usage at\n\n'
+                   '* http://scikit-image.org/docs/dev/auto_examples/'
+                   'xx_applications/plot_coins_segmentation.html')
             raise ValueError(msg)
 
         # convert image to an gray-only RGB image to enable blending with

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -157,7 +157,13 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
         alpha = 1
     else:
         if not image.shape[:label.ndim] == label.shape:
-            raise ValueError("`image` and `label` must be the same shape")
+            msg = ('The (non-color) shape of `image` and `label` passed to '
+                   'skimage.color.label2rgb must exactly match. See the '
+                   'function documentation at http://scikit-image.org/docs/dev'
+                   '/api/skimage.color.html#skimage.color.label2rgb and '
+                   'example usage at http://scikit-image.org/docs/dev/auto_'
+                   'examples/xx_applications/plot_coins_segmentation.html')
+            raise ValueError(msg)
 
         image = img_as_float(rgb2gray(image))
         image = gray2rgb(image) * image_alpha + (1 - image_alpha)

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -153,9 +153,3 @@ def test_avg():
     # test default background color
     out_bg = label2rgb(label_field, image, bg_label=2, kind='avg')
     assert_array_equal(out_bg, expected_out_bg)
-
-
-def test_negative_intensity():
-    labels = np.arange(100).reshape(10, 10)
-    image = -1 * np.ones((10, 10))
-    assert_warns(UserWarning, label2rgb, labels, image)


### PR DESCRIPTION
## Description
I also updated parameter names and deprecated background=-1 as the default. I am currently stating that background=0 will be the default but I could also go for background=None.

This is the first PR with very verbose warning and error messages that we discussed in the mailing list. Comments very welcome.

Also included: a new utility DEFAULT value for use instead of None when deprecating. This makes it easy to distinguish between the use of the DEFAULT value because no value was passed, vs when the user explicitly passes None. I've kept it as simple as possible for now but this could be even more sophisticated, with a DEFAULT object actually holding a default value, rather than having to hardcode it somewhere inside the function. Comments also welcome here!

I still need to add tests for all the new code paths.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

## References
Closes issue #2674

## For reviewers

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
