### PR TITLE
`draw.random_shapes` API improvements

### DIFF
--- a/doc/examples/edges/plot_random_shapes.py
+++ b/doc/examples/edges/plot_random_shapes.py
@@ -29,13 +29,17 @@ ax[0].set_title('Grayscale shape')
 
 # The generated images can be much more complex. For example, let's try many
 # shapes of any color. If we want the colors to be particularly light, we can
-# set the min_pixel_intensity to a high value from the range [0,255].
-image1, _ = random_shapes((128, 128), max_shapes=10, min_pixel_intensity=100)
+# set the `intensity_range` to an upper subrange of (0,255).
+image1, _ = random_shapes((128, 128), max_shapes=10,
+                          intensity_range=((100, 255),))
 
 # Moar :)
-image2, _ = random_shapes((128, 128), max_shapes=10, min_pixel_intensity=200)
-image3, _ = random_shapes((128, 128), max_shapes=10, min_pixel_intensity=50)
-image4, _ = random_shapes((128, 128), max_shapes=10, min_pixel_intensity=0)
+image2, _ = random_shapes((128, 128), max_shapes=10,
+                          intensity_range=((200, 255),))
+image3, _ = random_shapes((128, 128), max_shapes=10,
+                          intensity_range=((50, 255),))
+image4, _ = random_shapes((128, 128), max_shapes=10,
+                          intensity_range=((0, 255),))
 
 for i, image in enumerate([image1, image2, image3, image4], 1):
     ax[i].imshow(image)

--- a/doc/examples/edges/plot_random_shapes.py
+++ b/doc/examples/edges/plot_random_shapes.py
@@ -13,7 +13,7 @@ from skimage.draw import random_shapes
 # Let's start simple and generate a 128x128 image
 # with a single grayscale rectangle.
 result = random_shapes((128, 128), max_shapes=1, shape='rectangle',
-                       num_channels=1)
+                       multichannel=False)
 
 # We get back a tuple consisting of (1) the image with the generated shapes
 # and (2) a list of label tuples with the kind of shape (e.g. circle,
@@ -24,7 +24,7 @@ print('Image shape: {}\nLabels: {}'.format(image.shape, labels))
 # We can visualize the images.
 fig, axes = plt.subplots(nrows=2, ncols=3)
 ax = axes.ravel()
-ax[0].imshow(image.squeeze(), cmap='gray')
+ax[0].imshow(image, cmap='gray')
 ax[0].set_title('Grayscale shape')
 
 # The generated images can be much more complex. For example, let's try many

--- a/doc/examples/edges/plot_random_shapes.py
+++ b/doc/examples/edges/plot_random_shapes.py
@@ -41,8 +41,8 @@ for i, image in enumerate([image1, image2, image3, image4], 1):
     ax[i].imshow(image)
     ax[i].set_title('Colored shapes, #{}'.format(i-1))
 
-# These shapes are well suited to test segmentation algorithms. Often, we want
-# shapes to overlap to test the algorithm. This is also possible:
+# These shapes are well suited to test segmentation algorithms. Often, we
+# want shapes to overlap to test the algorithm. This is also possible:
 image, _ = random_shapes((128, 128), min_shapes=5, max_shapes=10,
                          min_size=20, allow_overlap=True)
 ax[5].imshow(image)

--- a/doc/examples/edges/plot_random_shapes.py
+++ b/doc/examples/edges/plot_random_shapes.py
@@ -12,18 +12,20 @@ from skimage.draw import random_shapes
 
 # Let's start simple and generate a 128x128 image
 # with a single grayscale rectangle.
-result = random_shapes((128, 128), max_shapes=1, shape='rectangle', gray=True)
+result = random_shapes((128, 128), max_shapes=1, shape='rectangle',
+                       num_channels=1)
 
 # We get back a tuple consisting of (1) the image with the generated shapes
-# and (2) a list of label tuples with the kind of shape (e.g. circle, rectangle)
-# and ((r0, r1), (c0, c1)) coordinates.
+# and (2) a list of label tuples with the kind of shape (e.g. circle,
+# rectangle) and ((r0, r1), (c0, c1)) coordinates.
 image, labels = result
-print(image.shape, labels)
+print('Image shape: {}\nLabels: {}'.format(image.shape, labels))
 
 # We can visualize the images.
-fig, axis = plt.subplots()
-axis.imshow(image.squeeze(), cmap='gray')
-axis.set_axis_off()
+fig, axes = plt.subplots(nrows=2, ncols=3)
+ax = axes.ravel()
+ax[0].imshow(image.squeeze(), cmap='gray')
+ax[0].set_title('Grayscale shape')
 
 # The generated images can be much more complex. For example, let's try many
 # shapes of any color. If we want the colors to be particularly light, we can
@@ -35,18 +37,19 @@ image2, _ = random_shapes((128, 128), max_shapes=10, min_pixel_intensity=200)
 image3, _ = random_shapes((128, 128), max_shapes=10, min_pixel_intensity=50)
 image4, _ = random_shapes((128, 128), max_shapes=10, min_pixel_intensity=0)
 
-fig, axes = plt.subplots(2, 2, figsize=(10, 10))
-for ax, image in zip(axes.ravel(), [image1, image2, image3, image4]):
-    ax.imshow(image)
-    ax.set_axis_off()
+for i, image in enumerate([image1, image2, image3, image4], 1):
+    ax[i].imshow(image)
+    ax[i].set_title('Colored shapes, #{}'.format(i-1))
 
 # These shapes are well suited to test segmentation algorithms. Often, we want
 # shapes to overlap to test the algorithm. This is also possible:
-image, _ = random_shapes(
-    (128, 128), min_shapes=5, max_shapes=10, min_size=20, allow_overlap=True
-)
-fig, axis = plt.subplots()
-axis.imshow(image)
-axis.set_axis_off()
+image, _ = random_shapes((128, 128), min_shapes=5, max_shapes=10,
+                         min_size=20, allow_overlap=True)
+ax[5].imshow(image)
+ax[5].set_title('Overlapping shapes')
+
+for a in ax:
+    a.set_xticklabels([])
+    a.set_yticklabels([])
 
 plt.show()

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -24,6 +24,7 @@ New Features
   regionprops; available in ``skimage.measure.inertia_tensor`` (#2603)
 - cycle-spinning function for approximating shift-invariance by averaging
   results from a series of spatial shifts (#2647)
+- data generation with random_shapes function (#2773)
 - Haar-like feature (#2848)
 - subset of LFW database (#2905)
 

--- a/skimage/draw/_random_shapes.py
+++ b/skimage/draw/_random_shapes.py
@@ -249,7 +249,7 @@ def random_shapes(image_shape,
         The name of the shape to generate or `None` to pick random ones.
     intensity_range : {tuple of tuples of ints, tuple of ints}, optional
         The range of values to sample pixel values from. For grayscale images
-        the format is (min_, max_). For multichannel - ((min_, max_),) if the
+        the format is (min, max). For multichannel - ((min, max),) if the
         ranges are equal across the channels, and ((min_0, max_0), ... (min_N, max_N))
         if they differ. Maximum range is (0, 255). If None, set to (1, 255) for
         each channel reserving 0-intensity color for background.
@@ -294,7 +294,7 @@ def random_shapes(image_shape,
     if intensity_range is None:
         intensity_range = (1, 255) if num_channels == 1 else ((1, 255), )
     else:
-        tmp = (intensity_range, ) if num_channels != 1 else intensity_range
+        tmp = (intensity_range, ) if num_channels == 1 else intensity_range
         for intensity_pair in tmp:
             for intensity in intensity_pair:
                 if not (0 <= intensity <= 255):

--- a/skimage/draw/_random_shapes.py
+++ b/skimage/draw/_random_shapes.py
@@ -204,7 +204,7 @@ def _generate_random_color(num_channels, intensity_range, random):
     else:
         if len(intensity_range) == 1:
             intensity_range = intensity_range * num_channels
-        return [random.randint(*r) for r in intensity_range]
+        return [random.randint(r[0], r[1]+1) for r in intensity_range]
 
 
 def random_shapes(image_shape,

--- a/skimage/draw/_random_shapes.py
+++ b/skimage/draw/_random_shapes.py
@@ -171,13 +171,13 @@ SHAPE_GENERATORS = dict(
 SHAPE_CHOICES = list(SHAPE_GENERATORS.values())
 
 
-def _generate_random_color(gray, min_pixel_intensity, random):
+def _generate_random_color(num_channels, min_pixel_intensity, random):
     """Generates a random color array.
 
     Parameters
     ----------
-    gray : bool
-        If `True`, the color will be a scalar, else a 3-element array.
+    num_channels : int
+        Number of elements representing color.
     min_pixel_intensity : [0-255] int
         The lower bound for the pixel values.
     random : np.random.RandomState
@@ -191,16 +191,17 @@ def _generate_random_color(gray, min_pixel_intensity, random):
     Returns
     -------
     color : scalar or array
-        If gray is True, a single random scalar in the range of
-        [min_pixel_intensity, 255], else an array of three elements, each in
-        the range of [min_pixel_intensity, 255].
+        If `num_channels` is 1, a single random scalar in the range of
+        [min_pixel_intensity, 255], else an array of `num_channels` elements,
+        each in the range of [min_pixel_intensity, 255].
 
     """
     if not (0 <= min_pixel_intensity <= 255):
         raise ValueError('Minimum intensity must be in interval [0, 255]')
-    if gray:
+    if num_channels == 1:
         return random.randint(min_pixel_intensity, 256)
-    return random.randint(min_pixel_intensity, 256, size=3)
+    else:
+        return random.randint(min_pixel_intensity, 256, size=num_channels)
 
 
 def random_shapes(image_shape,
@@ -208,7 +209,7 @@ def random_shapes(image_shape,
                   min_shapes=1,
                   min_size=2,
                   max_size=None,
-                  gray=False,
+                  num_channels=3,
                   shape=None,
                   min_pixel_intensity=0,
                   allow_overlap=False,
@@ -238,9 +239,9 @@ def random_shapes(image_shape,
         The minimum dimension of each shape to fit into the image.
     max_size : int, optional
         The maximum dimension of each shape to fit into the image.
-    gray : bool, optional
-        If `True`, generate monochrome images, else color images with multiple
-        channels.
+    num_channels : int, optional
+        Number of channels in the generated image. If 1, generate monochrome
+        images, else color images with multiple channels.
     shape : {rectangle, circle, triangle, None} str, optional
         The name of the shape to generate or `None` to pick random ones.
     min_pixel_intensity : [0-255] int, optional
@@ -258,9 +259,9 @@ def random_shapes(image_shape,
     image : uint8 array
         An image with the fitted shapes.
     labels : list
-        A list of labels, one per shape in the image. Each label is a (category,
-        ((r0, r1), (c0, c1))) tuple specifying the category and bounding box
-        coordinates of the shape.
+        A list of labels, one per shape in the image. Each label is a
+        (category, ((r0, r1), (c0, c1))) tuple specifying the category and
+        bounding box coordinates of the shape.
 
     Examples
     --------
@@ -285,12 +286,12 @@ def random_shapes(image_shape,
 
     random = np.random.RandomState(random_seed)
     user_shape = shape
-    image_shape = (image_shape[0], image_shape[1], 1 if gray else 3)
+    image_shape = (image_shape[0], image_shape[1], num_channels)
     image = np.ones(image_shape, dtype=np.uint8) * 255
     filled = np.zeros(image_shape, dtype=bool)
     labels = []
     for _ in range(random.randint(min_shapes, max_shapes + 1)):
-        color = _generate_random_color(gray, min_pixel_intensity, random)
+        color = _generate_random_color(num_channels, min_pixel_intensity, random)
         if user_shape is None:
             shape_generator = random.choice(SHAPE_CHOICES)
         else:

--- a/skimage/draw/_random_shapes.py
+++ b/skimage/draw/_random_shapes.py
@@ -254,12 +254,13 @@ def random_shapes(image_shape,
         ``multichannel`` is set to False.
     shape : {rectangle, circle, triangle, None} str, optional
         The name of the shape to generate or `None` to pick random ones.
-    intensity_range : {tuple of tuples of ints, tuple of ints}, optional
+    intensity_range : {tuple of tuples of uint8, tuple of uint8}, optional
         The range of values to sample pixel values from. For grayscale images
         the format is (min, max). For multichannel - ((min, max),) if the
         ranges are equal across the channels, and ((min_0, max_0), ... (min_N, max_N))
-        if they differ. Maximum range is (0, 255). If None, set to (1, 255) for
-        each channel reserving 0-intensity color for background.
+        if they differ. As the function supports generation of uint8 arrays only,
+        the maximum range is (0, 255). If None, set to (0, 254) for each
+        channel reserving color of intensity = 255 for background.
     allow_overlap : bool, optional
         If `True`, allow shapes to overlap.
     num_trials : int, optional
@@ -302,7 +303,7 @@ def random_shapes(image_shape,
         num_channels = 1
 
     if intensity_range is None:
-        intensity_range = (1, 255) if num_channels == 1 else ((1, 255), )
+        intensity_range = (0, 254) if num_channels == 1 else ((0, 254), )
     else:
         tmp = (intensity_range, ) if num_channels == 1 else intensity_range
         for intensity_pair in tmp:

--- a/skimage/draw/_random_shapes.py
+++ b/skimage/draw/_random_shapes.py
@@ -172,7 +172,7 @@ SHAPE_CHOICES = list(SHAPE_GENERATORS.values())
 
 
 def _generate_random_colors(num_colors, num_channels, intensity_range, random):
-    """Generates an array of random colors.
+    """Generate an array of random colors.
 
     Parameters
     ----------
@@ -298,7 +298,7 @@ def random_shapes(image_shape,
         raise ValueError('Minimum dimension must be less than ncols and nrows')
     max_size = max_size or max(image_shape[0], image_shape[1])
 
-    if multichannel is False:
+    if not multichannel:
         num_channels = 1
 
     if intensity_range is None:
@@ -348,6 +348,6 @@ def random_shapes(image_shape,
             warn('Could not fit any shapes to image, '
                  'consider reducing the minimum dimension')
 
-    if multichannel is False:
+    if not multichannel:
         image = np.squeeze(image, axis=2)
     return image, labels

--- a/skimage/draw/tests/test_random_shapes.py
+++ b/skimage/draw/tests/test_random_shapes.py
@@ -21,7 +21,6 @@ def test_generates_correct_bounding_boxes_for_rectangles():
         (128, 128),
         max_shapes=1,
         shape='rectangle',
-        min_pixel_intensity=1,
         random_seed=42)
     assert len(labels) == 1
     label, bbox = labels[0]
@@ -42,7 +41,6 @@ def test_generates_correct_bounding_boxes_for_triangles():
         (128, 128),
         max_shapes=1,
         shape='triangle',
-        min_pixel_intensity=1,
         random_seed=42)
     assert len(labels) == 1
     label, bbox = labels[0]
@@ -65,7 +63,6 @@ def test_generates_correct_bounding_boxes_for_circles():
         min_size=20,
         max_size=20,
         shape='circle',
-        min_pixel_intensity=1,
         random_seed=42)
     assert len(labels) == 1
     label, bbox = labels[0]
@@ -99,8 +96,7 @@ def test_can_generate_one_by_one_rectangle():
         max_shapes=1,
         min_size=1,
         max_size=1,
-        shape='rectangle',
-        min_pixel_intensity=1)
+        shape='rectangle')
     assert len(labels) == 1
     _, bbox = labels[0]
     crop = image[bbox[0][0]:bbox[0][1], bbox[1][0]:bbox[1][1]]
@@ -110,11 +106,13 @@ def test_can_generate_one_by_one_rectangle():
             and np.any(crop <= 255))
 
 
-def test_throws_when_min_pixel_intensity_out_of_range():
+def test_throws_when_intensity_range_out_of_range():
     with testing.raises(ValueError):
-        random_shapes((1000, 1234), max_shapes=1, min_pixel_intensity=256)
+        random_shapes((1000, 1234), max_shapes=1, num_channels=1,
+                      intensity_range=(0, 256))
     with testing.raises(ValueError):
-        random_shapes((2, 2), max_shapes=1, min_pixel_intensity=-1)
+        random_shapes((2, 2), max_shapes=1,
+                      intensity_range=((-1, 255),))
 
 
 def test_returns_empty_labels_and_white_image_when_cannot_fit_shape():
@@ -129,14 +127,15 @@ def test_random_shapes_is_reproducible_with_seed():
     random_seed = 42
     labels = []
     for _ in range(5):
-        _, l = random_shapes(
-            (128, 128), max_shapes=5, random_seed=random_seed)
+        _, l = random_shapes((128, 128), max_shapes=5,
+                             random_seed=random_seed)
         labels.append(l)
     assert all(other == labels[0] for other in labels[1:])
 
 
-def test_generates_white_image_when_min_pixel_intensity_255():
-    image, labels = random_shapes(
-        (128, 128), max_shapes=3, min_pixel_intensity=255, random_seed=42)
+def test_generates_white_image_when_intensity_range_255():
+    image, labels = random_shapes((128, 128), max_shapes=3,
+                                  intensity_range=((255, 255),),
+                                  random_seed=42)
     assert len(labels) > 0
     assert (image == 255).all()

--- a/skimage/draw/tests/test_random_shapes.py
+++ b/skimage/draw/tests/test_random_shapes.py
@@ -3,6 +3,7 @@ import numpy as np
 from skimage.draw import random_shapes
 
 from skimage._shared import testing
+from skimage._shared._warnings import expected_warnings
 
 
 def test_generates_color_images_with_correct_shape():
@@ -12,8 +13,8 @@ def test_generates_color_images_with_correct_shape():
 
 def test_generates_gray_images_with_correct_shape():
     image, _ = random_shapes(
-        (4567, 123), min_shapes=3, max_shapes=20, num_channels=1)
-    assert image.shape == (4567, 123, 1)
+        (4567, 123), min_shapes=3, max_shapes=20, multichannel=False)
+    assert image.shape == (4567, 123)
 
 
 def test_generates_correct_bounding_boxes_for_rectangles():
@@ -108,7 +109,7 @@ def test_can_generate_one_by_one_rectangle():
 
 def test_throws_when_intensity_range_out_of_range():
     with testing.raises(ValueError):
-        random_shapes((1000, 1234), max_shapes=1, num_channels=1,
+        random_shapes((1000, 1234), max_shapes=1, multichannel=False,
                       intensity_range=(0, 256))
     with testing.raises(ValueError):
         random_shapes((2, 2), max_shapes=1,
@@ -117,8 +118,9 @@ def test_throws_when_intensity_range_out_of_range():
 
 def test_returns_empty_labels_and_white_image_when_cannot_fit_shape():
     # The circle will never fit this.
-    image, labels = random_shapes(
-        (10000, 10000), max_shapes=1, min_size=10000, shape='circle')
+    with expected_warnings(['Could not fit']):
+        image, labels = random_shapes(
+            (10000, 10000), max_shapes=1, min_size=10000, shape='circle')
     assert len(labels) == 0
     assert (image == 255).all()
 
@@ -127,9 +129,9 @@ def test_random_shapes_is_reproducible_with_seed():
     random_seed = 42
     labels = []
     for _ in range(5):
-        _, l = random_shapes((128, 128), max_shapes=5,
-                             random_seed=random_seed)
-        labels.append(l)
+        _, label = random_shapes((128, 128), max_shapes=5,
+                                 random_seed=random_seed)
+        labels.append(label)
     assert all(other == labels[0] for other in labels[1:])
 
 

--- a/skimage/draw/tests/test_random_shapes.py
+++ b/skimage/draw/tests/test_random_shapes.py
@@ -30,7 +30,7 @@ def test_generates_correct_bounding_boxes_for_rectangles():
     crop = image[bbox[0][0]:bbox[0][1], bbox[1][0]:bbox[1][1]]
 
     # The crop is filled.
-    assert (crop >= 1).all() and (crop <= 255).all()
+    assert (crop >= 0).all() and (crop < 255).all()
 
     # The crop is complete.
     image[bbox[0][0]:bbox[0][1], bbox[1][0]:bbox[1][1]] = 255
@@ -50,7 +50,7 @@ def test_generates_correct_bounding_boxes_for_triangles():
     crop = image[bbox[0][0]:bbox[0][1], bbox[1][0]:bbox[1][1]]
 
     # The crop is filled.
-    assert (crop >= 1).any() and (crop <= 255).any()
+    assert (crop >= 0).any() and (crop < 255).any()
 
     # The crop is complete.
     image[bbox[0][0]:bbox[0][1], bbox[1][0]:bbox[1][1]] = 255
@@ -72,7 +72,7 @@ def test_generates_correct_bounding_boxes_for_circles():
     crop = image[bbox[0][0]:bbox[0][1], bbox[1][0]:bbox[1][1]]
 
     # The crop is filled.
-    assert (crop >= 1).any() and (crop <= 255).any()
+    assert (crop >= 0).any() and (crop < 255).any()
 
     # The crop is complete.
     image[bbox[0][0]:bbox[0][1], bbox[1][0]:bbox[1][1]] = 255
@@ -104,7 +104,7 @@ def test_can_generate_one_by_one_rectangle():
 
     # rgb
     assert (np.shape(crop) == (1, 1, 3) and np.any(crop >= 1)
-            and np.any(crop <= 255))
+            and np.any(crop < 255))
 
 
 def test_throws_when_intensity_range_out_of_range():

--- a/skimage/draw/tests/test_random_shapes.py
+++ b/skimage/draw/tests/test_random_shapes.py
@@ -12,7 +12,7 @@ def test_generates_color_images_with_correct_shape():
 
 def test_generates_gray_images_with_correct_shape():
     image, _ = random_shapes(
-        (4567, 123), min_shapes=3, max_shapes=20, gray=True)
+        (4567, 123), min_shapes=3, max_shapes=20, num_channels=1)
     assert image.shape == (4567, 123, 1)
 
 


### PR DESCRIPTION
## Description
This PR implements modifications proposed in #2884 :
- [x] Switched from parameter `gray` to `num_channels` to allow generating images with arbitrary number of channels;
- [x] Switched from parameter `min_pixel_intensity` to `intensity_range` to enable specification of the intensity range upper bound and source color subspace;
- [x] Updated gallery example to make different images more distinguishable (see http://scikit-image.org/docs/dev/auto_examples/edges/plot_random_shapes.html) by adding the axes and reorganizing the layout;
- [x] Made gallery example output more informative;
- [x] Added a mention of https://github.com/scikit-image/scikit-image/pull/2773 to `doc/release/release_dev.rst` .

## References
Closes https://github.com/scikit-image/scikit-image/issues/2884.

## For reviewers

(Don't remove the checklist below.)

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
