### PR TITLE
Type dependent inversion

### DIFF
--- a/skimage/util/_invert.py
+++ b/skimage/util/_invert.py
@@ -5,37 +5,59 @@ from .dtype import dtype_limits
 def invert(image, signed_float=False):
     """Invert an image.
 
-    Image inversion. If the image is of type unsignedinteger, the image
-    is subtracted from the maximum value allowed by the dtype maximum.
-    If the image is of type signedinteger, the image is subtracted from -1.
-    If the image is of float type and signed_float is true, the result is
-    -image. If the image is of float type and signed_float is false (default)
-    the result is 1.0 - image.
+    Invert the intensity range of the input image, so that the maximum value is
+    now the minimum for the input dtype, and vice-versa. This operation is
+    slightly different depending on the input dtype:
+
+    - unsigned integers: subtract the image from the dtype maximum
+    - signed integers: subtract the image from -1 (see Notes)
+    - floats: subtract the image from 1 (if signed_float is False, so we
+      assume the image is unsigned), or from 0 (if signed_float is True).
+
+    See the examples for clarification.
 
     Parameters
     ----------
     image : ndarray
-        The input image.
-    signed_float : bool
+        Input image.
+    signed_float : bool, optional
         If True and the image is of type float, the range is assumed to
         be [-1, 1]. If False and the image is of type float, the range is
-        assumed to be [0, 1]. Default value is False (i.e. the assumed range is
-        [0, 1].
+        assumed to be [0, 1].
 
     Returns
     -------
-    invert : ndarray
+    inverted : ndarray
         Inverted image.
+
+    Notes
+    -----
+    Ideally, for signed integers we would simply multiply by -1. However,
+    signed integer ranges are asymmetric. For example, for np.int8, the range
+    of possible values is [-128, 127], so that -128 * -1 equals -128! By
+    subtracting from -1, we correctly map the maximum dtype value to the
+    minimum.
 
     Examples
     --------
-    >>> img = np.array([[100, 0, 200],
-    ...                 [0,  50, 0],
-    ...                 [30,  0, 255]], np.uint8)
+    >>> img = np.array([[100,  0, 200],
+    ...                 [  0, 50,   0],
+    ...                 [ 30,  0, 255]], np.uint8)
     >>> invert(img)
     array([[155, 255,  55],
            [255, 205, 255],
            [225, 255,   0]], dtype=uint8)
+    >>> img2 = np.array([[ -2, 0, -128],
+    ...                  [127, 0,    5]], np.int8)
+    >>> invert(img2)
+    array([[   1,   -1,  127],
+           [-128,   -1,   -6]], dtype=int8)
+    >>> img3 = np.array([[ 0., 1., 0.5, 0.75]])
+    >>> invert(img3)
+    array([[ 1.  ,  0.  ,  0.5 ,  0.25]])
+    >>> img4 = np.array([[ 0., 1., -1., -0.25]])
+    >>> invert(img4, signed_float=True)
+    array([[-0.  , -1.  ,  1.  ,  0.25]])
     """
     if image.dtype == 'bool':
         return(~image)

--- a/skimage/util/_invert.py
+++ b/skimage/util/_invert.py
@@ -60,13 +60,15 @@ def invert(image, signed_float=False):
     array([[-0.  , -1.  ,  1.  ,  0.25]])
     """
     if image.dtype == 'bool':
-        return(~image)
+        inverted = ~image
     elif np.issubdtype(image.dtype, np.unsignedinteger):
-        return(dtype_limits(image, clip_negative=False)[1] - image)
+        max_val = dtype_limits(image, clip_negative=False)[1]
+        inverted = max_val - image
     elif np.issubdtype(image.dtype, np.signedinteger):
-        return(-1 - image)
-    else:
+        inverted = -1 - image
+    else:  # float dtype
         if signed_float:
-            return(-image)
+            inverted = -image
         else:
-            return(1 - image)
+            inverted = 1 - image
+    return inverted

--- a/skimage/util/_invert.py
+++ b/skimage/util/_invert.py
@@ -5,8 +5,8 @@ from .dtype import dtype_limits
 def invert(image, signed_float=False):
     """Invert an image.
 
-    Invert the intensity range of the input image, so that the maximum value is
-    now the minimum for the input dtype, and vice-versa. This operation is
+    Invert the intensity range of the input image, so that the dtype maximum
+    is now the dtype minimum, and vice-versa. This operation is
     slightly different depending on the input dtype:
 
     - unsigned integers: subtract the image from the dtype maximum
@@ -34,7 +34,7 @@ def invert(image, signed_float=False):
     -----
     Ideally, for signed integers we would simply multiply by -1. However,
     signed integer ranges are asymmetric. For example, for np.int8, the range
-    of possible values is [-128, 127], so that -128 * -1 equals -128! By
+    of possible values is [-128, 127], so that -128 * -1 equals 128! By
     subtracting from -1, we correctly map the maximum dtype value to the
     minimum.
 

--- a/skimage/util/_invert.py
+++ b/skimage/util/_invert.py
@@ -2,15 +2,25 @@ import numpy as np
 from .dtype import dtype_limits
 
 
-def invert(image):
+def invert(image, signed_float=False):
     """Invert an image.
 
-    Substract the image to the maximum value allowed by the dtype maximum.
+    Image inversion. If the image is of type unsignedinteger, the image
+    is subtracted from the maximum value allowed by the dtype maximum.
+    If the image is of type signedinteger, the image is subtracted from -1.
+    If the image is of float type and signed_float is true, the result is
+    -image. If the image is of float type and signed_float is false (default)
+    the result is 1.0 - image.
 
     Parameters
     ----------
     image : ndarray
         The input image.
+    signed_float : bool
+        If True and the image is of type float, the range is assumed to
+        be [-1, 1]. If False and the image is of type float, the range is
+        assumed to be [0, 1]. Default value is False (i.e. the assumed range is
+        [0, 1].
 
     Returns
     -------
@@ -28,6 +38,13 @@ def invert(image):
            [225, 255,   0]], dtype=uint8)
     """
     if image.dtype == 'bool':
-        return ~image
+        return(~image)
+    elif np.issubdtype(image.dtype, np.unsignedinteger):
+        return(dtype_limits(image, clip_negative=False)[1] - image)
+    elif np.issubdtype(image.dtype, np.signedinteger):
+        return(-1 - image)
     else:
-        return dtype_limits(image, clip_negative=False)[1] - image
+        if signed_float:
+            return(-image)
+        else:
+            return(1 - image)

--- a/skimage/util/tests/test_invert.py
+++ b/skimage/util/tests/test_invert.py
@@ -30,10 +30,13 @@ def test_invert_uint8():
 def test_invert_int8():
     dtype = 'int8'
     image = np.zeros((3, 3), dtype=dtype)
-    upper_dtype_limit = dtype_limits(image, clip_negative=False)[1]
-    image[1, :] = upper_dtype_limit
-    expected = np.zeros((3, 3), dtype=dtype) + upper_dtype_limit
-    expected[1, :] = 0
+    lower_dtype_limit, upper_dtype_limit = \
+        dtype_limits(image, clip_negative=False)
+    image[1, :] = lower_dtype_limit
+    image[2, :] = upper_dtype_limit
+    expected = np.zeros((3, 3), dtype=dtype)
+    expected[2, :] = lower_dtype_limit
+    expected[1, :] = upper_dtype_limit
     result = invert(image)
     assert_array_equal(expected, result)
 
@@ -41,9 +44,25 @@ def test_invert_int8():
 def test_invert_float64():
     dtype = 'float64'
     image = np.zeros((3, 3), dtype=dtype)
-    upper_dtype_limit = dtype_limits(image, clip_negative=False)[1]
-    image[1, :] = upper_dtype_limit
-    expected = np.zeros((3, 3), dtype=dtype) + upper_dtype_limit
-    expected[1, :] = 0
+    lower_dtype_limit, upper_dtype_limit = \
+        dtype_limits(image, clip_negative=False)
+    image[1, :] = lower_dtype_limit
+    image[2, :] = upper_dtype_limit
+    expected = np.zeros((3, 3), dtype=dtype)
+    expected[2, :] = lower_dtype_limit
+    expected[1, :] = upper_dtype_limit
+    result = invert(image)
+    assert_array_equal(expected, result)
+
+
+def test_invert_float64_b():
+    dtype = 'float64'
+    image = np.zeros((3, 3), dtype=dtype)
+    lower_dtype_limit, upper_dtype_limit = \
+        dtype_limits(image, clip_negative=True)
+    image[2, :] = upper_dtype_limit
+    expected = np.zeros((3, 3), dtype=dtype)
+    expected[0, :] = upper_dtype_limit
+    expected[1, :] = upper_dtype_limit
     result = invert(image)
     assert_array_equal(expected, result)

--- a/skimage/util/tests/test_invert.py
+++ b/skimage/util/tests/test_invert.py
@@ -41,7 +41,7 @@ def test_invert_int8():
     assert_array_equal(expected, result)
 
 
-def test_invert_float64():
+def test_invert_float64_signed():
     dtype = 'float64'
     image = np.zeros((3, 3), dtype=dtype)
     lower_dtype_limit, upper_dtype_limit = \
@@ -55,7 +55,7 @@ def test_invert_float64():
     assert_array_equal(expected, result)
 
 
-def test_invert_float64_b():
+def test_invert_float64_unsigned():
     dtype = 'float64'
     image = np.zeros((3, 3), dtype=dtype)
     lower_dtype_limit, upper_dtype_limit = \


### PR DESCRIPTION
## Description
Depending on the image type we would expect the behaviour of inversion to be quite different. This was discussed in issue #3028. Concretely:
- for unsigned integer: `img_inv = dtype_limits(image, clip_negative=False)[1] - image`
- for signed integer types: `img_inv = -1-image`
- for float: `img_inv = -image` if the allowed range is `[-1,1]` and `img_inv = 1-image` if the allowed range is `[0,1]`
As something like the "allowed range" does not exist in scikit-image, the user should decide for the float type, how the behaviour of the function should be.


## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
This concerns issue #3028. 

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.