### PR TITLE
Fix ValueError: Buffer dtype mismatch, expected 'int64_t' but got 'int' on win_amd64

### DIFF
--- a/skimage/morphology/watershed.py
+++ b/skimage/morphology/watershed.py
@@ -255,7 +255,7 @@ def watershed(image, markers, connectivity=1, offset=None, mask=None,
 
     flat_neighborhood = _compute_neighbors(image, connectivity, offset)
     marker_locations = np.flatnonzero(output)
-    image_strides = np.array(image.strides) // image.itemsize
+    image_strides = np.array(image.strides, dtype=np.intp) // image.itemsize
 
     _watershed.watershed_raveled(image.ravel(),
                                  marker_locations, flat_neighborhood,


### PR DESCRIPTION
Fixes the following kind of TestWatershed failures on win-amd64:
```
py36 -c"import pytest; import skimage; pytest.main([skimage.pkg_dir])"
============================= test session starts =============================
platform win32 -- Python 3.6.5, pytest-3.5.1, py-1.5.3, pluggy-0.6.0
rootdir: X:\Python36\lib\site-packages\skimage, inifile:
plugins: pep8-1.0.6, faulthandler-1.5.0, cov-2.5.1, palladium-1.1.0.1, hypothesis-3.55.4, celery-4.1.0
collected 1591 items
X:\Python36\lib\site-packages\skimage\_shared\tests\test_geometry.py ... [  0%]
                                                                         [  0%]
X:\Python36\lib\site-packages\skimage\_shared\tests\test_interpolation.py . [  0%]
                                                                         [  0%]
X:\Python36\lib\site-packages\skimage\_shared\tests\test_safe_as_int.py . [  0%]
.                                                                        [  0%]
X:\Python36\lib\site-packages\skimage\_shared\tests\test_testing.py ...  [  0%]
X:\Python36\lib\site-packages\skimage\_shared\tests\test_utils.py ..     [  0%]
X:\Python36\lib\site-packages\skimage\_shared\tests\test_version_requirements.py . [  0%]
...                                                                      [  0%]
X:\Python36\lib\site-packages\skimage\color\tests\test_adapt_rgb.py .... [  1%]
..                                                                       [  1%]
X:\Python36\lib\site-packages\skimage\color\tests\test_colorconv.py .... [  1%]
..........................................                               [  4%]
X:\Python36\lib\site-packages\skimage\color\tests\test_colorlabel.py ... [  4%]
..........                                                               [  5%]
X:\Python36\lib\site-packages\skimage\color\tests\test_delta_e.py ...... [  5%]
..                                                                       [  5%]
X:\Python36\lib\site-packages\skimage\data\tests\test_data.py .......... [  6%]
.......                                                                  [  6%]
X:\Python36\lib\site-packages\skimage\draw\tests\test_draw.py .......... [  7%]
.................................                                        [  9%]
X:\Python36\lib\site-packages\skimage\draw\tests\test_draw3d.py ........ [  9%]
                                                                         [  9%]
X:\Python36\lib\site-packages\skimage\draw\tests\test_random_shapes.py . [  9%]
...........                                                              [ 10%]
X:\Python36\lib\site-packages\skimage\exposure\tests\test_exposure.py .. [ 10%]
....................................                                     [ 12%]
X:\Python36\lib\site-packages\skimage\external\test_tifffile.py ........ [ 13%]
..........                                                               [ 14%]
X:\Python36\lib\site-packages\skimage\feature\tests\test_blob.py .....   [ 14%]
X:\Python36\lib\site-packages\skimage\feature\tests\test_brief.py ...... [ 14%]
                                                                         [ 14%]
X:\Python36\lib\site-packages\skimage\feature\tests\test_canny.py ...... [ 15%]
..                                                                       [ 15%]
X:\Python36\lib\site-packages\skimage\feature\tests\test_censure.py .... [ 15%]
....                                                                     [ 15%]
X:\Python36\lib\site-packages\skimage\feature\tests\test_corner.py ..... [ 16%]
......................                                                   [ 17%]
X:\Python36\lib\site-packages\skimage\feature\tests\test_daisy.py ...... [ 17%]
.                                                                        [ 17%]
X:\Python36\lib\site-packages\skimage\feature\tests\test_haar.py ....... [ 18%]
................................................                         [ 21%]
X:\Python36\lib\site-packages\skimage\feature\tests\test_hog.py ........ [ 21%]
....                                                                     [ 22%]
X:\Python36\lib\site-packages\skimage\feature\tests\test_match.py ...... [ 22%]
                                                                         [ 22%]
X:\Python36\lib\site-packages\skimage\feature\tests\test_orb.py .....    [ 22%]
X:\Python36\lib\site-packages\skimage\feature\tests\test_peak.py ....... [ 23%]
........................                                                 [ 24%]
X:\Python36\lib\site-packages\skimage\feature\tests\test_register_translation.py . [ 24%]
........                                                                 [ 25%]
X:\Python36\lib\site-packages\skimage\feature\tests\test_template.py ... [ 25%]
.......                                                                  [ 25%]
X:\Python36\lib\site-packages\skimage\feature\tests\test_texture.py .... [ 26%]
......................                                                   [ 27%]
X:\Python36\lib\site-packages\skimage\feature\tests\test_util.py .....   [ 27%]
X:\Python36\lib\site-packages\skimage\filters\rank\tests\test_rank.py .. [ 28%]
.............................                                            [ 29%]
X:\Python36\lib\site-packages\skimage\filters\tests\test_edges.py ...... [ 30%]
..........................................                               [ 32%]
X:\Python36\lib\site-packages\skimage\filters\tests\test_frangi.py ....  [ 33%]
X:\Python36\lib\site-packages\skimage\filters\tests\test_gabor.py ...... [ 33%]
                                                                         [ 33%]
X:\Python36\lib\site-packages\skimage\filters\tests\test_gaussian.py ... [ 33%]
...                                                                      [ 33%]
X:\Python36\lib\site-packages\skimage\filters\tests\test_lpi_filter.py . [ 33%]
...                                                                      [ 34%]
X:\Python36\lib\site-packages\skimage\filters\tests\test_median.py .     [ 34%]
X:\Python36\lib\site-packages\skimage\filters\tests\test_thresholding.py . [ 34%]
....................................................                     [ 37%]
X:\Python36\lib\site-packages\skimage\future\graph\tests\test_rag.py ... [ 37%]
......                                                                   [ 38%]
X:\Python36\lib\site-packages\skimage\graph\tests\test_anisotropy.py .   [ 38%]
X:\Python36\lib\site-packages\skimage\graph\tests\test_connect.py .      [ 38%]
X:\Python36\lib\site-packages\skimage\graph\tests\test_flexible.py .     [ 38%]
X:\Python36\lib\site-packages\skimage\graph\tests\test_heap.py ..        [ 38%]
X:\Python36\lib\site-packages\skimage\graph\tests\test_mcp.py .......... [ 39%]
.....                                                                    [ 39%]
X:\Python36\lib\site-packages\skimage\graph\tests\test_spath.py ...      [ 39%]
X:\Python36\lib\site-packages\skimage\io\tests\test_collection.py ...... [ 39%]
....                                                                     [ 40%]
X:\Python36\lib\site-packages\skimage\io\tests\test_colormixer.py ...... [ 40%]
...............                                                          [ 41%]
X:\Python36\lib\site-packages\skimage\io\tests\test_fits.py .....        [ 41%]
X:\Python36\lib\site-packages\skimage\io\tests\test_histograms.py ..     [ 41%]
X:\Python36\lib\site-packages\skimage\io\tests\test_imageio.py ....      [ 42%]
X:\Python36\lib\site-packages\skimage\io\tests\test_imread.py .....      [ 42%]
X:\Python36\lib\site-packages\skimage\io\tests\test_io.py ...            [ 42%]
X:\Python36\lib\site-packages\skimage\io\tests\test_mpl_imshow.py ...... [ 43%]
.                                                                        [ 43%]
X:\Python36\lib\site-packages\skimage\io\tests\test_multi_image.py ..... [ 43%]
..                                                                       [ 43%]
X:\Python36\lib\site-packages\skimage\io\tests\test_pil.py ............. [ 44%]
..........                                                               [ 45%]
X:\Python36\lib\site-packages\skimage\io\tests\test_plugin.py ....       [ 45%]
X:\Python36\lib\site-packages\skimage\io\tests\test_plugin_util.py ..... [ 45%]
.....                                                                    [ 45%]
X:\Python36\lib\site-packages\skimage\io\tests\test_sift.py ..           [ 46%]
X:\Python36\lib\site-packages\skimage\io\tests\test_simpleitk.py .....   [ 46%]
X:\Python36\lib\site-packages\skimage\io\tests\test_tifffile.py ........ [ 46%]
..........                                                               [ 47%]
X:\Python36\lib\site-packages\skimage\measure\tests\test_block.py ...... [ 47%]
                                                                         [ 47%]
X:\Python36\lib\site-packages\skimage\measure\tests\test_entropy.py ..   [ 47%]
X:\Python36\lib\site-packages\skimage\measure\tests\test_find_contours.py . [ 48%]
...                                                                      [ 48%]
X:\Python36\lib\site-packages\skimage\measure\tests\test_fit.py ........ [ 48%]
...............                                                          [ 49%]
X:\Python36\lib\site-packages\skimage\measure\tests\test_marching_cubes.py . [ 49%]
.....                                                                    [ 50%]
X:\Python36\lib\site-packages\skimage\measure\tests\test_moments.py .... [ 50%]
......                                                                   [ 50%]
X:\Python36\lib\site-packages\skimage\measure\tests\test_pnpoly.py ....  [ 50%]
X:\Python36\lib\site-packages\skimage\measure\tests\test_polygon.py ..   [ 51%]
X:\Python36\lib\site-packages\skimage\measure\tests\test_profile.py .... [ 51%]
..........                                                               [ 51%]
X:\Python36\lib\site-packages\skimage\measure\tests\test_regionprops.py . [ 51%]
.............................................                            [ 54%]
X:\Python36\lib\site-packages\skimage\measure\tests\test_simple_metrics.py . [ 54%]
......                                                                   [ 55%]
X:\Python36\lib\site-packages\skimage\measure\tests\test_structural_similarity.py . [ 55%]
...........                                                              [ 56%]
X:\Python36\lib\site-packages\skimage\morphology\tests\test_binary.py .. [ 56%]
...............                                                          [ 57%]
X:\Python36\lib\site-packages\skimage\morphology\tests\test_ccomp.py ... [ 57%]
................                                                         [ 58%]
X:\Python36\lib\site-packages\skimage\morphology\tests\test_convex_hull.py . [ 58%]
.....                                                                    [ 58%]
X:\Python36\lib\site-packages\skimage\morphology\tests\test_extrema.py . [ 58%]
.......                                                                  [ 59%]
X:\Python36\lib\site-packages\skimage\morphology\tests\test_grey.py .... [ 59%]
......................                                                   [ 60%]
X:\Python36\lib\site-packages\skimage\morphology\tests\test_misc.py .... [ 61%]
...........                                                              [ 61%]
X:\Python36\lib\site-packages\skimage\morphology\tests\test_reconstruction.py . [ 61%]
.........                                                                [ 62%]
X:\Python36\lib\site-packages\skimage\morphology\tests\test_selem.py ... [ 62%]
.......                                                                  [ 62%]
X:\Python36\lib\site-packages\skimage\morphology\tests\test_skeletonize.py . [ 63%]
....................                                                     [ 64%]
X:\Python36\lib\site-packages\skimage\morphology\tests\test_skeletonize_3d.py . [ 64%]
...............                                                          [ 65%]
X:\Python36\lib\site-packages\skimage\morphology\tests\test_watershed.py . [ 65%]
..............                                                           [ 66%]
X:\Python36\lib\site-packages\skimage\novice\tests\test_novice.py ...... [ 66%]
.......................                                                  [ 68%]
X:\Python36\lib\site-packages\skimage\restoration\tests\test_denoise.py . [ 68%]
...................................                                      [ 70%]
X:\Python36\lib\site-packages\skimage\restoration\tests\test_inpaint.py . [ 70%]
..                                                                       [ 70%]
X:\Python36\lib\site-packages\skimage\restoration\tests\test_restoration.py . [ 70%]
...                                                                      [ 70%]
X:\Python36\lib\site-packages\skimage\restoration\tests\test_unwrap.py . [ 70%]
...............                                                          [ 71%]
X:\Python36\lib\site-packages\skimage\segmentation\tests\test_active_contour_model.py . [ 71%]
.....                                                                    [ 72%]
X:\Python36\lib\site-packages\skimage\segmentation\tests\test_boundaries.py . [ 72%]
....                                                                     [ 72%]
X:\Python36\lib\site-packages\skimage\segmentation\tests\test_chan_vese.py . [ 72%]
........                                                                 [ 73%]
X:\Python36\lib\site-packages\skimage\segmentation\tests\test_clear_border.py . [ 73%]
.....                                                                    [ 73%]
X:\Python36\lib\site-packages\skimage\segmentation\tests\test_felzenszwalb.py . [ 73%]
.....                                                                    [ 73%]
X:\Python36\lib\site-packages\skimage\segmentation\tests\test_join.py .. [ 73%]
...                                                                      [ 74%]
X:\Python36\lib\site-packages\skimage\segmentation\tests\test_morphsnakes.py . [ 74%]
......                                                                   [ 74%]
X:\Python36\lib\site-packages\skimage\segmentation\tests\test_quickshift.py . [ 74%]
..                                                                       [ 74%]
X:\Python36\lib\site-packages\skimage\segmentation\tests\test_random_walker.py . [ 74%]
FFF..FFFFFF....                                                          [ 75%]
X:\Python36\lib\site-packages\skimage\segmentation\tests\test_slic.py .. [ 75%]
..........                                                               [ 76%]
X:\Python36\lib\site-packages\skimage\transform\tests\test_finite_radon_transform.py . [ 76%]
                                                                         [ 76%]
X:\Python36\lib\site-packages\skimage\transform\tests\test_geometric.py . [ 76%]
............................                                             [ 78%]
X:\Python36\lib\site-packages\skimage\transform\tests\test_hough_transform.py . [ 78%]
.........................                                                [ 80%]
X:\Python36\lib\site-packages\skimage\transform\tests\test_integral.py . [ 80%]
...                                                                      [ 80%]
X:\Python36\lib\site-packages\skimage\transform\tests\test_pyramids.py . [ 80%]
............                                                             [ 81%]
X:\Python36\lib\site-packages\skimage\transform\tests\test_radon_transform.py . [ 81%]
...................................................................      [ 85%]
X:\Python36\lib\site-packages\skimage\transform\tests\test_seam_carving.py . [ 85%]
                                                                         [ 85%]
X:\Python36\lib\site-packages\skimage\transform\tests\test_warps.py .... [ 85%]
..................................                                       [ 87%]
X:\Python36\lib\site-packages\skimage\util\tests\test_apply_parallel.py . [ 87%]
...                                                                      [ 88%]
X:\Python36\lib\site-packages\skimage\util\tests\test_arraycrop.py ..... [ 88%]
                                                                         [ 88%]
X:\Python36\lib\site-packages\skimage\util\tests\test_arraypad.py ...... [ 88%]
........................................................                 [ 92%]
X:\Python36\lib\site-packages\skimage\util\tests\test_dtype.py ......... [ 92%]
.........................                                                [ 94%]
X:\Python36\lib\site-packages\skimage\util\tests\test_invert.py ....     [ 94%]
X:\Python36\lib\site-packages\skimage\util\tests\test_montage.py ....... [ 95%]
........                                                                 [ 95%]
X:\Python36\lib\site-packages\skimage\util\tests\test_random_noise.py .. [ 95%]
............                                                             [ 96%]
X:\Python36\lib\site-packages\skimage\util\tests\test_regular_grid.py .. [ 96%]
..                                                                       [ 96%]
X:\Python36\lib\site-packages\skimage\util\tests\test_shape.py ......... [ 97%]
.........                                                                [ 97%]
X:\Python36\lib\site-packages\skimage\util\tests\test_unique_rows.py ... [ 98%]
..                                                                       [ 98%]
X:\Python36\lib\site-packages\skimage\viewer\tests\test_plugins.py ..... [ 98%]
.....                                                                    [ 98%]
X:\Python36\lib\site-packages\skimage\viewer\tests\test_tools.py .....   [ 99%]
X:\Python36\lib\site-packages\skimage\viewer\tests\test_utils.py ....    [ 99%]
X:\Python36\lib\site-packages\skimage\viewer\tests\test_viewer.py ...    [ 99%]
X:\Python36\lib\site-packages\skimage\viewer\tests\test_widgets.py ..... [ 99%]
..                                                                       [100%]

================================== FAILURES ===================================

<snip>
_______________________ TestWatershed.test_watershed01 ________________________

self = <skimage.morphology.tests.test_watershed.TestWatershed testMethod=test_watershed01>

    def test_watershed01(self):
        "watershed 1"
        data = np.array([[0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0],
                            [0, 0, 0, 0, 0, 0, 0],
                               [0, 1, 1, 1, 1, 1, 0],
                               [0, 1, 0, 0, 0, 1, 0],
                               [0, 1, 0, 0, 0, 1, 0],
                               [0, 1, 0, 0, 0, 1, 0],
                               [0, 1, 1, 1, 1, 1, 0],
                               [0, 0, 0, 0, 0, 0, 0],
                               [0, 0, 0, 0, 0, 0, 0]], np.uint8)
        markers = np.array([[ -1, 0, 0, 0, 0, 0, 0],
                               [0, 0, 0, 0, 0, 0, 0],
                               [0, 0, 0, 0, 0, 0, 0],
                                  [  0, 0, 0, 0, 0, 0, 0],
                                  [  0, 0, 0, 0, 0, 0, 0],
                                  [  0, 0, 0, 1, 0, 0, 0],
                                  [  0, 0, 0, 0, 0, 0, 0],
                                  [  0, 0, 0, 0, 0, 0, 0],
                                  [  0, 0, 0, 0, 0, 0, 0],
                                  [  0, 0, 0, 0, 0, 0, 0]],
                                 np.int8)
>       out = watershed(data, markers, self.eight)

X:\Python36\lib\site-packages\skimage\morphology\tests\test_watershed.py:105:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
X:\Python36\lib\site-packages\skimage\morphology\watershed.py:264: in watershed
    watershed_line)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   ValueError: Buffer dtype mismatch, expected 'int64_t' but got 'int'

skimage\morphology\_watershed.pyx:85: ValueError

<snip>
======= 43 failed, 1447 passed, 7 skipped, 68 warnings in 62.78 seconds =======
```