### PR TITLE
Replace pow function calls in Cython modules to fix performance issues on Windows

### DIFF
--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -385,7 +385,7 @@ def _circle_perimeter_aa(Py_ssize_t r_o, Py_ssize_t c_o,
 
     while r > c + 1:
         c += 1
-        dceil = sqrt(radius**2 - c**2)
+        dceil = sqrt(radius * radius - c * c)
         dceil = ceil(dceil) - dceil
         if dceil < dceil_prev:
             r -= 1
@@ -447,8 +447,8 @@ def _ellipse_perimeter(Py_ssize_t r_o, Py_ssize_t c_o, Py_ssize_t r_radius,
     cdef list cc = list()
 
     # Compute useful values
-    cdef  Py_ssize_t rd = r_radius**2
-    cdef  Py_ssize_t cd = c_radius**2
+    cdef  Py_ssize_t rd = r_radius * r_radius
+    cdef  Py_ssize_t cd = c_radius * c_radius
 
     cdef Py_ssize_t r, c, e2, err
 

--- a/skimage/feature/_haar.pyx
+++ b/skimage/feature/_haar.pyx
@@ -25,7 +25,7 @@ cdef vector[vector[Rectangle]] _haar_like_feature_coord(
     """Private function to compute the coordinates of all Haar-like features.
     """
     cdef:
-        Py_ssize_t max_feature = height ** 2 * width ** 2
+        Py_ssize_t max_feature = height * height * width * width
         vector[vector[Rectangle]] rect_feat
         Rectangle single_rect
         Py_ssize_t n_rectangle

--- a/skimage/feature/corner_cy.pyx
+++ b/skimage/feature/corner_cy.pyx
@@ -65,8 +65,8 @@ def _corner_moravec(image, Py_ssize_t window_size=1):
     cdef double[:, ::1] cimage = np.ascontiguousarray(img_as_float(image))
     cdef double[:, ::1] out = np.zeros(image.shape, dtype=np.double)
 
-    cdef double msum, min_msum
-    cdef Py_ssize_t r, c, br, bc, mr, mc, a, b, t
+    cdef double msum, min_msum, t
+    cdef Py_ssize_t r, c, br, bc, mr, mc, a, b
 
     with nogil:
         for r in range(2 * window_size, rows - 2 * window_size):

--- a/skimage/feature/corner_cy.pyx
+++ b/skimage/feature/corner_cy.pyx
@@ -66,7 +66,7 @@ def _corner_moravec(image, Py_ssize_t window_size=1):
     cdef double[:, ::1] out = np.zeros(image.shape, dtype=np.double)
 
     cdef double msum, min_msum
-    cdef Py_ssize_t r, c, br, bc, mr, mc, a, b
+    cdef Py_ssize_t r, c, br, bc, mr, mc, a, b, t
 
     with nogil:
         for r in range(2 * window_size, rows - 2 * window_size):
@@ -78,8 +78,8 @@ def _corner_moravec(image, Py_ssize_t window_size=1):
                             msum = 0
                             for mr in range(- window_size, window_size + 1):
                                 for mc in range(- window_size, window_size + 1):
-                                    msum += (cimage[r + mr, c + mc]
-                                             - cimage[br + mr, bc + mc]) ** 2
+                                    t = cimage[r + mr, c + mc] - cimage[br + mr, bc + mc]
+                                    msum += t * t
                             min_msum = min(msum, min_msum)
 
                 out[r, c] = min_msum

--- a/skimage/filters/rank/generic_cy.pyx
+++ b/skimage/filters/rank/generic_cy.pyx
@@ -377,7 +377,7 @@ cdef inline void _kernel_otsu(dtype_t_out* out, Py_ssize_t odepth,
                               Py_ssize_t s0, Py_ssize_t s1) nogil:
     cdef Py_ssize_t i
     cdef Py_ssize_t max_i
-    cdef double P, mu1, mu2, q1, new_q1, sigma_b, max_sigma_b
+    cdef double P, mu1, mu2, q1, new_q1, sigma_b, max_sigma_b, t
     cdef double mu = 0.
 
     # compute local mean
@@ -400,7 +400,8 @@ cdef inline void _kernel_otsu(dtype_t_out* out, Py_ssize_t odepth,
         if new_q1 > 0:
             mu1 = (q1 * mu1 + i * P) / new_q1
             mu2 = (mu - new_q1 * mu1) / (1. - new_q1)
-            sigma_b = new_q1 * (1. - new_q1) * (mu1 - mu2) ** 2
+            t = mu1 - mu2
+            sigma_b = new_q1 * (1. - new_q1) * (t * t)
             if sigma_b > max_sigma_b:
                 max_sigma_b = sigma_b
                 max_i = i

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -210,10 +210,10 @@ def _nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1,
     cdef double weight_sum, weight
     xg_row, xg_col = np.mgrid[-offset:offset + 1, -offset:offset + 1]
     cdef IMGDTYPE [:, ::1] w = np.ascontiguousarray(np.exp(
-                             -(xg_row ** 2 + xg_col ** 2) / (2 * A ** 2)).
+                             -(xg_row * xg_row + xg_col * xg_col) / (2 * A * A)).
                              astype(np.float64))
     cdef double distance
-    w = 1. / (n_channels * np.sum(w) * h ** 2) * w
+    w = 1. / (n_channels * np.sum(w) * h * h) * w
 
     # Coordinates of central pixel
     # Iterate over rows, taking padding into account
@@ -314,14 +314,15 @@ def _nl_means_denoising_3d(image, int s=7, int d=13, double h=0.1,
                                       -offset: offset + 1,
                                       -offset: offset + 1]
     cdef IMGDTYPE [:, :, ::1] w = np.ascontiguousarray(np.exp(
-                            -(xg_pln ** 2 + xg_row ** 2 + xg_col ** 2) /
-                             (2 * A ** 2)).astype(np.float64))
+                            -(xg_pln * xg_pln + xg_row * xg_row +
+                              xg_col * xg_col) /
+                             (2 * A * A)).astype(np.float64))
     cdef double distance
     cdef int pln, row, col, i, j, k
     cdef int pln_start, pln_end, row_start, row_end, col_start, col_end
     cdef int pln_start_i, pln_end_i, row_start_j, row_end_j, \
              col_start_k, col_end_k
-    w = 1. / (np.sum(w) * h ** 2) * w
+    w = 1. / (np.sum(w) * h * h) * w
 
     # Coordinates of central pixel
     # Iterate over planes, taking padding into account
@@ -465,19 +466,21 @@ cdef inline _integral_image_2d(IMGDTYPE [:, :, ::] padded,
     by avoiding copies of ``padded``.
     """
     cdef int row, col, channel
-    cdef double distance
+    cdef double distance, t
+    var *= 2.0
+
     for row in range(max(1, -t_row), min(n_row, n_row - t_row)):
         for col in range(max(1, -t_col), min(n_col, n_col - t_col)):
             if n_channels == 1:
-                distance = (padded[row, col, 0] -
-                            padded[row + t_row, col + t_col, 0])**2
-                distance -= 2 * var
+                t = padded[row, col, 0] - padded[row + t_row, col + t_col, 0]
+                distance = t * t - var
             else:
                 distance = 0
                 for channel in range(n_channels):
-                    distance += (padded[row, col, channel] -
-                                 padded[row + t_row, col + t_col, channel])**2
-                distance -= 2 * n_channels * var
+                    t = (padded[row, col, channel] -
+                         padded[row + t_row, col + t_col, channel])
+                    distance += t * t
+                distance -= n_channels * var
             integral[row, col] = distance + \
                                  integral[row - 1, col] + \
                                  integral[row, col - 1] - \
@@ -522,14 +525,16 @@ cdef inline _integral_image_3d(IMGDTYPE [:, :, ::] padded,
     """
     cdef int pln, row, col
     cdef double distance
+    var *= 2.0
     for pln in range(max(1, -t_pln), min(n_pln, n_pln - t_pln)):
         for row in range(max(1, -t_row), min(n_row, n_row - t_row)):
             for col in range(max(1, -t_col), min(n_col, n_col - t_col)):
                 distance = (padded[pln, row, col] -
-                            padded[pln + t_pln, row + t_row, col + t_col])**2
-                distance -= 2 * var
-                integral[pln, row, col] = \
-                    (distance +
+                            padded[pln + t_pln, row + t_row, col + t_col])
+                distance *= distance
+                distance -= var
+                integral[pln, row, col] = (
+                     distance +
                      integral[pln - 1, row, col] +
                      integral[pln, row - 1, col] +
                      integral[pln, row, col - 1] +
@@ -590,8 +595,8 @@ def _fast_nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1,
     cdef int n_row, n_col, t_row, t_col, row, col, n_channels, channel
     cdef double weight, distance
     cdef double alpha
-    cdef double h2 = h ** 2.
-    cdef double s2 = s ** 2.
+    cdef double h2 = h * h
+    cdef double s2 = s * s
     n_row, n_col, n_channels = image.shape
     cdef double h2s2 = n_channels * h2 * s2
     n_row += 2 * pad_size
@@ -704,8 +709,8 @@ def _fast_nl_means_denoising_3d(image, int s=5, int d=7, double h=0.1,
              col_dist_min, col_dist_max
     cdef double weight, distance
     cdef double alpha
-    cdef double h_square = h ** 2.0
-    cdef double s_cube = s ** 3.0
+    cdef double h_square = h * h
+    cdef double s_cube = s * s * s
     cdef double s_cube_h_square = h_square * s_cube
     n_pln, n_row, n_col = image.shape
     n_pln += 2 * pad_size

--- a/skimage/segmentation/_slic.pyx
+++ b/skimage/segmentation/_slic.pyx
@@ -87,7 +87,7 @@ def _slic_cython(double[:, :, :, ::1] image_zyx,
 
     cdef Py_ssize_t i, c, k, x, y, z, x_min, x_max, y_min, y_max, z_min, z_max
     cdef char change
-    cdef double dist_center, cx, cy, cz, dy, dz
+    cdef double dist_center, cx, cy, cz, dx, dy, dz, t
 
     cdef double sz, sy, sx
     sz = spacing[0]
@@ -100,7 +100,7 @@ def _slic_cython(double[:, :, :, ::1] image_zyx,
     cdef double dist_color
 
     # The reference implementation (Achanta et al.) calls this invxywt
-    cdef double spatial_weight = float(1) / (step ** 2)
+    cdef double spatial_weight = float(1) / (step * step)
 
     with nogil:
         for i in range(max_iter):
@@ -124,15 +124,19 @@ def _slic_cython(double[:, :, :, ::1] image_zyx,
                 x_max = <Py_ssize_t>min(cx + 2 * step_x + 1, width)
 
                 for z in range(z_min, z_max):
-                    dz = (sz * (cz - z)) ** 2
+                    dz = sz * (cz - z)
+                    dz *= dz
                     for y in range(y_min, y_max):
-                        dy = (sy * (cy - y)) ** 2
+                        dy = sy * (cy - y)
+                        dy *= dy
                         for x in range(x_min, x_max):
-                            dist_center = (dz + dy + (sx * (cx - x)) ** 2) * spatial_weight
+                            dx = sx * (cx - x)
+                            dx *= dx
+                            dist_center = (dz + dy + dx) * spatial_weight
                             dist_color = 0
                             for c in range(3, n_features):
-                                dist_color += (image_zyx[z, y, x, c - 3]
-                                                - segments[k, c]) ** 2
+                                t = image_zyx[z, y, x, c - 3] - segments[k, c]
+                                dist_color += t * t
                             if slic_zero:
                                 dist_center += dist_color / max_dist_color[k]
                             else:
@@ -178,8 +182,8 @@ def _slic_cython(double[:, :, :, ::1] image_zyx,
                             dist_color = 0
 
                             for c in range(3, n_features):
-                                dist_color += (image_zyx[z, y, x, c - 3] -
-                                               segments[k, c]) ** 2
+                                t = image_zyx[z, y, x, c - 3] - segments[k, c]
+                                dist_color += t * t
 
                             # The reference implementation seems to only change
                             # the color if it increases from previous iteration

--- a/skimage/transform/_radon_transform.pyx
+++ b/skimage/transform/_radon_transform.pyx
@@ -39,7 +39,7 @@ cpdef bilinear_ray_sum(cnp.double_t[:, :] image, cnp.double_t theta,
     cdef cnp.double_t t = ray_position - projection_center
     # s0 is the half-length of the ray's path in the reconstruction circle
     cdef cnp.double_t s0
-    s0 = sqrt(radius**2 - t**2) if radius**2 >= t**2 else 0.
+    s0 = sqrt(radius * radius - t * t) if radius*radius >= t*t else 0.
     cdef Py_ssize_t Ns = 2 * (<Py_ssize_t>ceil(2 * s0))  # number of steps
                                                          # along the ray
     cdef cnp.double_t ray_sum = 0.
@@ -71,19 +71,19 @@ cpdef bilinear_ray_sum(cnp.double_t[:, :] image, cnp.double_t theta,
                 if i > 0 and j > 0:
                     weight = (1. - di) * (1. - dj) * ds
                     ray_sum += weight * image[i, j]
-                    weight_norm += weight**2
+                    weight_norm += weight * weight
                 if i > 0 and j < image.shape[1] - 1:
                     weight = (1. - di) * dj * ds
                     ray_sum += weight * image[i, j+1]
-                    weight_norm += weight**2
+                    weight_norm += weight * weight
                 if i < image.shape[0] - 1 and j > 0:
                     weight = di * (1 - dj) * ds
                     ray_sum += weight * image[i+1, j]
-                    weight_norm += weight**2
+                    weight_norm += weight * weight
                 if i < image.shape[0] - 1 and j < image.shape[1] - 1:
                     weight = di * dj * ds
                     ray_sum += weight * image[i+1, j+1]
-                    weight_norm += weight**2
+                    weight_norm += weight * weight
 
     return ray_sum, weight_norm
 
@@ -126,7 +126,7 @@ cpdef bilinear_ray_update(cnp.double_t[:, :] image,
     cdef cnp.double_t t = ray_position - projection_center
     # s0 is the half-length of the ray's path in the reconstruction circle
     cdef cnp.double_t s0
-    s0 = sqrt(radius*radius - t*t) if radius**2 >= t**2 else 0.
+    s0 = sqrt(radius*radius - t*t) if radius*radius >= t*t else 0.
     cdef Py_ssize_t Ns = 2 * (<Py_ssize_t>ceil(2 * s0))
     # beta for equiripple Hamming window
     cdef cnp.double_t hamming_beta = 0.46164


### PR DESCRIPTION
## Description
Fixes/improves several performance issues on Windows by replacing `x**2`  function calls with `x*x` statements in Cython extension modules.

Tested on Windows 10, Python 3.6.5 64-bit, Cython 0.28.2, Visual Studio 14 Update 3.

FWIW, some Cython modules could be improved by releasing the GIL, not accessing Python objects in inner loops, and consistent use of `Py_ssize_t` for sizes and indices.

## References
Closes #3032. 
Partly fixes #2657
Supersedes #3032

## For reviewers

(Don't remove the checklist below.)

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
