### PR TITLE
Fix invert tests

### DIFF
--- a/skimage/util/tests/test_invert.py
+++ b/skimage/util/tests/test_invert.py
@@ -37,6 +37,7 @@ def test_invert_int8():
     expected = np.zeros((3, 3), dtype=dtype)
     expected[2, :] = lower_dtype_limit
     expected[1, :] = upper_dtype_limit
+    expected[0, :] = -1
     result = invert(image)
     assert_array_equal(expected, result)
 
@@ -51,7 +52,7 @@ def test_invert_float64_signed():
     expected = np.zeros((3, 3), dtype=dtype)
     expected[2, :] = lower_dtype_limit
     expected[1, :] = upper_dtype_limit
-    result = invert(image)
+    result = invert(image, signed_float=True)
     assert_array_equal(expected, result)
 
 


### PR DESCRIPTION
## Description
Fixes the following test failures:
```
______________________________ test_invert_int8 _______________________________

    def test_invert_int8():
        dtype = 'int8'
        image = np.zeros((3, 3), dtype=dtype)
        lower_dtype_limit, upper_dtype_limit = \
            dtype_limits(image, clip_negative=False)
        image[1, :] = lower_dtype_limit
        image[2, :] = upper_dtype_limit
        expected = np.zeros((3, 3), dtype=dtype)
        expected[2, :] = lower_dtype_limit
        expected[1, :] = upper_dtype_limit
        result = invert(image)
>       assert_array_equal(expected, result)
E       AssertionError:
E       Arrays are not equal
E
E       (mismatch 33.33333333333333%)
E        x: array([[   0,    0,    0],
E              [ 127,  127,  127],
E              [-128, -128, -128]], dtype=int8)
E        y: array([[  -1,   -1,   -1],
E              [ 127,  127,  127],
E              [-128, -128, -128]], dtype=int8)

X:\Python37\lib\site-packages\skimage\util\tests\test_invert.py:41: AssertionError
_________________________ test_invert_float64_signed __________________________

    def test_invert_float64_signed():
        dtype = 'float64'
        image = np.zeros((3, 3), dtype=dtype)
        lower_dtype_limit, upper_dtype_limit = \
            dtype_limits(image, clip_negative=False)
        image[1, :] = lower_dtype_limit
        image[2, :] = upper_dtype_limit
        expected = np.zeros((3, 3), dtype=dtype)
        expected[2, :] = lower_dtype_limit
        expected[1, :] = upper_dtype_limit
        result = invert(image)
>       assert_array_equal(expected, result)
E       AssertionError:
E       Arrays are not equal
E
E       (mismatch 100.0%)
E        x: array([[ 0.,  0.,  0.],
E              [ 1.,  1.,  1.],
E              [-1., -1., -1.]])
E        y: array([[1., 1., 1.],
E              [2., 2., 2.],
E              [0., 0., 0.]])
```
## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
