### PR TITLE
Optimize _probabilistic_hough_line function

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ install:
         throw "There are newer queued builds for this pull request, failing early." }
 
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - "python -m pip install -U pip"
+  - "python -m pip install --retries 3 -U pip"
 
   # Check that we have the expected version and architecture for Python
   - "python --version"
@@ -40,8 +40,8 @@ install:
   # Install the build and runtime dependencies of the project.
   # The --pre flag is necessary to grab a SciPy wheel, which is in
   # pre-release at the time of writing (03-10-2017)
-  - pip install --pre -r requirements.txt
-  - pip install -r requirements/build.txt
+  - pip install --retries 3 --pre -r requirements.txt
+  - pip install --retries 3 -r requirements/build.txt
   - python setup.py bdist_wheel bdist_wininst
   - ps: "ls dist"
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,13 @@ __pycache__
 *.pyd
 *.bak
 *.c
+skimage/feature/_haar.cpp
 *.new
 *.md5
 *.old
+.pytest_cache
+temp.tif
+.ropeproject
 doc/source/api
 doc/build
 source/api

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
     - texlive-latex-extra
     - dvipng
     - python-qt4
+
 env:
   global:
     - GH_REF: github.com/scikit-image/docs.git
@@ -36,25 +37,30 @@ notifications:
 
 matrix:
   include:
+    # 2.7 build (until 0.14 is release)
     - os: linux
       python: 2.7
-      env: PIP_FLAGS="--pre"
+      env: WITH_PYAMG=1 QT=PyQt4
     - os: linux
       python: 2.7
-      env: WITH_PYAMG=1 MINIMUM_REQUIREMENTS=1 WITH_QT=1
+      env: WITH_PYAMG=1 QT=PyQt4 PIP_FLAGS="--pre"
+    - os: linux
+      python: 2.7
+      env: MINIMUM_REQUIREMENTS=1
     - os: linux
       python: 3.4
-      env: OPTIONAL_DEPS=1 WITH_PYSIDE=1 BUILD_DOCS=1 DEPLOY_DOCS=1
     - os: linux
       python: 3.5
-    - os: linux
-      python: 3.5
-      env: PIP_FLAGS="--pre"
     - os: linux
       python: 3.6
+      env: QT=PyQt5 WITH_PYAMG=1 OPTIONAL_DEPS=1 BUILD_DOCS=1 DEPLOY_DOCS=1
+    - os: linux
+      python: 3.6
+      env: QT=PyQt5 WITH_PYAMG=1 OPTIONAL_DEPS=1 PIP_FLAGS="--pre"
     - os: osx
       osx_image: xcode9
       language: objective-c
+      # OS X has a hard time installing the docs dependencies
       env: TRAVIS_PYTHON_VERSION=3.5
 
 before_install:
@@ -72,12 +78,31 @@ before_install:
     - tools/check_sdist.py
 
 install:
-    - section build
     - python setup.py develop
-    - section_end build
+    # Matplotlib settings - do not show figures during doc examples
+    - |
+      if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+        export MPL_DIR=${HOME}/.matplotlib
+      else
+        export MPL_DIR=${HOME}/.config/matplotlib
+      fi
+    - mkdir -p ${MPL_DIR}
+    - touch ${MPL_DIR}/matplotlibrc
+    # Install most of the optional packages
+    - |
+      if [[ "${OPTIONAL_DEPS}" == "1" ]]; then
+        pip install --retries 3 -q -r ./requirements/optional.txt $WHEELHOUSE
+      fi
+    - |
+      if [[ "${WITH_PYAMG}" == "1" ]]; then
+        pip install --retries 3 -q pyamg
+      fi
+    - source tools/travis/install_qt.sh
 
 script: tools/travis/script.sh
 
 after_success:
     - codecov
+    # Prepare.release
+    - doc/release/contribs.py HEAD~10
     - bash tools/travis/deploy_docs.sh

--- a/TODO.txt
+++ b/TODO.txt
@@ -39,6 +39,8 @@ Version 0.16
 * Remove checks for the ``multichannel`` deprecation warnings in several tests
   in ``skimage.transform.tests.test_pyramids.py`` and
   ``skimage.transform.tests.test_warps.py``.
+* Remove `flatten` for `imread` in ``skimage.io._io.py``.
+* Remove `as_grey` for `load` in ``skimage.data.__init__.py``.
 * Remove deprecated argument ``visualise`` from function skimage.feature.hog
 * Remove deprecated module ``skimage.novice``
 * In ``skimage.measure._regionprops``, remove all references to

--- a/TODO.txt
+++ b/TODO.txt
@@ -26,6 +26,8 @@ Version 0.15
 * Remove deprecated ``skimage.util.montage2d`` and corresponding tests.
 * In ``skimage.transform.resize`` change default argument from
   ``anti_aliasing=None`` to ``anti_aliasing=True``.
+* In ``skimage/restoration/tests/test_denoise.py``, there is an optional
+  warning that needs to be made mandatory when we move on from python 2.7
 
 Version 0.16
 ------------

--- a/doc/examples/edges/plot_random_shapes.py
+++ b/doc/examples/edges/plot_random_shapes.py
@@ -12,41 +12,48 @@ from skimage.draw import random_shapes
 
 # Let's start simple and generate a 128x128 image
 # with a single grayscale rectangle.
-result = random_shapes((128, 128), max_shapes=1, shape='rectangle', gray=True)
+result = random_shapes((128, 128), max_shapes=1, shape='rectangle',
+                       multichannel=False)
 
 # We get back a tuple consisting of (1) the image with the generated shapes
-# and (2) a list of label tuples with the kind of shape (e.g. circle, rectangle)
-# and ((r0, r1), (c0, c1)) coordinates.
+# and (2) a list of label tuples with the kind of shape (e.g. circle,
+# rectangle) and ((r0, r1), (c0, c1)) coordinates.
 image, labels = result
-print(image.shape, labels)
+print('Image shape: {}\nLabels: {}'.format(image.shape, labels))
 
 # We can visualize the images.
-fig, axis = plt.subplots()
-axis.imshow(image.squeeze(), cmap='gray')
-axis.set_axis_off()
+fig, axes = plt.subplots(nrows=2, ncols=3)
+ax = axes.ravel()
+ax[0].imshow(image, cmap='gray')
+ax[0].set_title('Grayscale shape')
 
 # The generated images can be much more complex. For example, let's try many
 # shapes of any color. If we want the colors to be particularly light, we can
-# set the min_pixel_intensity to a high value from the range [0,255].
-image1, _ = random_shapes((128, 128), max_shapes=10, min_pixel_intensity=100)
+# set the `intensity_range` to an upper subrange of (0,255).
+image1, _ = random_shapes((128, 128), max_shapes=10,
+                          intensity_range=((100, 255),))
 
 # Moar :)
-image2, _ = random_shapes((128, 128), max_shapes=10, min_pixel_intensity=200)
-image3, _ = random_shapes((128, 128), max_shapes=10, min_pixel_intensity=50)
-image4, _ = random_shapes((128, 128), max_shapes=10, min_pixel_intensity=0)
+image2, _ = random_shapes((128, 128), max_shapes=10,
+                          intensity_range=((200, 255),))
+image3, _ = random_shapes((128, 128), max_shapes=10,
+                          intensity_range=((50, 255),))
+image4, _ = random_shapes((128, 128), max_shapes=10,
+                          intensity_range=((0, 255),))
 
-fig, axes = plt.subplots(2, 2, figsize=(10, 10))
-for ax, image in zip(axes.ravel(), [image1, image2, image3, image4]):
-    ax.imshow(image)
-    ax.set_axis_off()
+for i, image in enumerate([image1, image2, image3, image4], 1):
+    ax[i].imshow(image)
+    ax[i].set_title('Colored shapes, #{}'.format(i-1))
 
-# These shapes are well suited to test segmentation algorithms. Often, we want
-# shapes to overlap to test the algorithm. This is also possible:
-image, _ = random_shapes(
-    (128, 128), min_shapes=5, max_shapes=10, min_size=20, allow_overlap=True
-)
-fig, axis = plt.subplots()
-axis.imshow(image)
-axis.set_axis_off()
+# These shapes are well suited to test segmentation algorithms. Often, we
+# want shapes to overlap to test the algorithm. This is also possible:
+image, _ = random_shapes((128, 128), min_shapes=5, max_shapes=10,
+                         min_size=20, allow_overlap=True)
+ax[5].imshow(image)
+ax[5].set_title('Overlapping shapes')
+
+for a in ax:
+    a.set_xticklabels([])
+    a.set_yticklabels([])
 
 plt.show()

--- a/doc/examples/filters/plot_frangi.py
+++ b/doc/examples/filters/plot_frangi.py
@@ -29,3 +29,4 @@ for a in ax:
     a.axis('off')
 
 plt.tight_layout()
+plt.show()

--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -67,7 +67,7 @@ from skimage.io import imread
 from skimage import data_dir
 from skimage.transform import radon, rescale
 
-image = imread(data_dir + "/phantom.png", as_grey=True)
+image = imread(data_dir + "/phantom.png", as_gray=True)
 image = rescale(image, scale=0.4, mode='reflect', multichannel=False)
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4.5))

--- a/doc/examples/xx_applications/plot_coins_segmentation.py
+++ b/doc/examples/xx_applications/plot_coins_segmentation.py
@@ -151,3 +151,5 @@ for a in axes:
     a.axis('off')
 
 plt.tight_layout()
+
+plt.show()

--- a/doc/examples/xx_applications/plot_geometric.py
+++ b/doc/examples/xx_applications/plot_geometric.py
@@ -113,3 +113,5 @@ for a in ax:
     a.axis('off')
 
 plt.tight_layout()
+
+plt.show()

--- a/doc/examples/xx_applications/plot_haar_extraction_selection_classification.py
+++ b/doc/examples/xx_applications/plot_haar_extraction_selection_classification.py
@@ -1,0 +1,176 @@
+"""
+======================================================
+Face classification using Haar-like feature descriptor
+======================================================
+
+Haar-like feature descriptors were successfully used to implement the first
+real-time face detector [1]_. Inspired by this application, we propose an
+example illustrating the extraction, selection, and classification of Haar-like
+features to detect faces vs. non-faces.
+
+Notes
+-----
+
+This example relies on scikit-learn to select and classify features.
+
+References
+----------
+
+.. [1] Viola, Paul, and Michael J. Jones. "Robust real-time face
+       detection." International journal of computer vision 57.2
+       (2004): 137-154.
+       http://www.merl.com/publications/docs/TR2004-043.pdf
+       DOI: 10.1109/CVPR.2001.990517
+
+"""
+from __future__ import division, print_function
+from time import time
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from dask import delayed, threaded, multiprocessing
+
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import roc_auc_score
+
+from skimage.data import lfw_subset
+from skimage.transform import integral_image
+from skimage.feature import haar_like_feature
+from skimage.feature import haar_like_feature_coord
+from skimage.feature import draw_haar_like_feature
+
+###############################################################################
+# The usual feature extraction scheme
+###############################################################################
+# The procedure to extract the Haar-like feature for an image is quite easy: a
+# region of interest (ROI) is defined for which all possible feature will be
+# extracted. The integral image of this ROI will be computed and all possible
+# features will be computed.
+
+
+@delayed
+def extract_feature_image(img, feature_type, feature_coord=None):
+    """Extract the haar feature for the current image"""
+    ii = integral_image(img)
+    return haar_like_feature(ii, 0, 0, ii.shape[0], ii.shape[1],
+                             feature_type=feature_type,
+                             feature_coord=feature_coord)
+
+
+###############################################################################
+# We will use a subset of the CBCL which is composed of 100 face images and 100
+# non-face images. Each image has been resized to a ROI of 19 by 19 pixels. We
+# will keep 75 images from each group to train a classifier and check which
+# extracted features are the most salient, and use the remaining 25 from each
+# class to check the performance of the classifier.
+
+images = lfw_subset()
+# For speed, only extract the two first types of features
+feature_types = ['type-2-x', 'type-2-y']
+
+# Build a computation graph using dask. This allows using multiple CPUs for
+# the computation step
+X = delayed(extract_feature_image(img, feature_types)
+            for img in images)
+# Compute the result using the "multiprocessing" dask backend
+t_start = time()
+X = np.array(X.compute(get=multiprocessing.get))
+time_full_feature_comp = time() - t_start
+y = np.array([1] * 100 + [0] * 100)
+X_train, X_test, y_train, y_test = train_test_split(X, y, train_size=150,
+                                                    random_state=0,
+                                                    stratify=y)
+
+# Extract all possible features to be able to select the most salient.
+feature_coord, feature_type = \
+        haar_like_feature_coord(width=images.shape[2], height=images.shape[1],
+                                feature_type=feature_types)
+
+###############################################################################
+# A random forest classifier can be trained in order to select the most salient
+# features, specifically for face classification. The idea is to check which
+# features are the most often used by the ensemble of trees. By using only
+# the most salient features in subsequent steps, we can dramatically speed up
+# computation, while retaining accuracy.
+
+# Train a random forest classifier and check performance
+clf = RandomForestClassifier(n_estimators=1000, max_depth=None,
+                             max_features=100, n_jobs=-1, random_state=0)
+t_start = time()
+clf.fit(X_train, y_train)
+time_full_train = time() - t_start
+auc_full_features = roc_auc_score(y_test, clf.predict_proba(X_test)[:, 1])
+
+# Sort features in order of importance, plot six most significant
+idx_sorted = np.argsort(clf.feature_importances_)[::-1]
+
+fig, axes = plt.subplots(3, 2)
+for idx, ax in enumerate(axes.ravel()):
+    image = images[0]
+    image = draw_haar_like_feature(image, 0, 0,
+                                   images.shape[2],
+                                   images.shape[1],
+                                   [feature_coord[idx_sorted[idx]]])
+    ax.imshow(image)
+    ax.set_xticks([])
+    ax.set_yticks([])
+
+fig.suptitle('The most important features')
+
+###############################################################################
+# We can select the most important features by checking the cumulative sum of
+# the feature importance index; below, we keep features representing 70% of the
+# cumulative value which represent only 3% of the total number of features.
+
+cdf_feature_importances = np.cumsum(clf.feature_importances_[idx_sorted])
+cdf_feature_importances /= np.max(cdf_feature_importances)
+sig_feature_count = np.count_nonzero(cdf_feature_importances < 0.7)
+sig_feature_percent = round(sig_feature_count /
+                            len(cdf_feature_importances) * 100, 1)
+print(('{} features, or {}%, account for 70% of branch points in the random '
+       'forest.').format(sig_feature_count, sig_feature_percent))
+
+# Select the most informative features
+selected_feature_coord = feature_coord[idx_sorted[:sig_feature_count]]
+selected_feature_type = feature_type[idx_sorted[:sig_feature_count]]
+# Note: we could select those features from the
+# original matrix X but we would like to emphasize the usage of `feature_coord`
+# and `feature_type` to recompute a subset of desired features.
+
+# Delay the computation and build the graph using dask
+X = delayed(extract_feature_image(img, selected_feature_type,
+                                  selected_feature_coord)
+            for img in images)
+# Compute the result using the *threaded* backend:
+# When computing all features, the Python GIL is acquired to process each ROI,
+# and this is where most of the time is spent, so multiprocessing is faster.
+# For this small subset, most of the time is spent on the feature computation
+# rather than the ROI scanning, and using threaded is *much* faster, because
+# we avoid the overhead of launching a new process.
+t_start = time()
+X = np.array(X.compute(get=threaded.get))
+time_subs_feature_comp = time() - t_start
+y = np.array([1] * 100 + [0] * 100)
+X_train, X_test, y_train, y_test = train_test_split(X, y, train_size=150,
+                                                    random_state=0,
+                                                    stratify=y)
+
+###############################################################################
+# Once the features are extracted, we can train and test the a new classifier.
+
+t_start = time()
+clf.fit(X_train, y_train)
+time_subs_train = time() - t_start
+
+auc_subs_features = roc_auc_score(y_test, clf.predict_proba(X_test)[:, 1])
+
+summary = (('Computing the full feature set took {:.3f}s, plus {:.3f}s '
+            'training, for an AUC of {:.2f}. Computing the restricted feature '
+            'set took {:.3f}s, plus {:.3f}s training, for an AUC of {:.2f}.')
+           .format(time_full_feature_comp, time_full_train, auc_full_features,
+                   time_subs_feature_comp, time_subs_train, auc_subs_features))
+
+print(summary)
+plt.show()

--- a/doc/examples/xx_applications/plot_morphology.py
+++ b/doc/examples/xx_applications/plot_morphology.py
@@ -240,3 +240,5 @@ plot_comparison(horse_mask, hull2, 'convex hull')
 # /ImageProcessing-html/topic4.htm>`_
 #
 # 3. http://en.wikipedia.org/wiki/Mathematical_morphology
+
+plt.show()

--- a/doc/examples/xx_applications/plot_morphology.py
+++ b/doc/examples/xx_applications/plot_morphology.py
@@ -22,7 +22,7 @@ In this document we outline the following basic morphological operations:
 
 
 To get started, let's load an image using ``io.imread``. Note that morphology
-functions only work on gray-scale or binary images, so we set ``as_grey=True``.
+functions only work on gray-scale or binary images, so we set ``as_gray=True``.
 """
 
 import os
@@ -32,7 +32,7 @@ from skimage.util import img_as_ubyte
 from skimage import io
 
 orig_phantom = img_as_ubyte(io.imread(os.path.join(data_dir, "phantom.png"),
-                                      as_grey=True))
+                                      as_gray=True))
 fig, ax = plt.subplots()
 ax.imshow(orig_phantom, cmap=plt.cm.gray)
 
@@ -191,7 +191,7 @@ plot_comparison(phantom, b_tophat, 'black tophat')
 #*single-pixel wide skeleton*. It is important to note that this is
 #performed on binary images only.
 
-horse = io.imread(os.path.join(data_dir, "horse.png"), as_grey=True)
+horse = io.imread(os.path.join(data_dir, "horse.png"), as_gray=True)
 
 sk = skeletonize(horse == 0)
 plot_comparison(horse, sk, 'skeletonize')

--- a/doc/examples/xx_applications/plot_rank_filters.py
+++ b/doc/examples/xx_applications/plot_rank_filters.py
@@ -677,3 +677,5 @@ ax.set_ylabel('Time (ms)')
 ax.set_xlabel('Image size')
 
 plt.tight_layout()
+
+plt.show()

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -24,6 +24,7 @@ New Features
   regionprops; available in ``skimage.measure.inertia_tensor`` (#2603)
 - cycle-spinning function for approximating shift-invariance by averaging
   results from a series of spatial shifts (#2647)
+- data generation with random_shapes function (#2773)
 - Haar-like feature (#2848)
 - subset of LFW database (#2905)
 - Image moments from coordinate input (#2859)

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -6,3 +6,4 @@ six>=1.10.0
 pillow>=2.1.0
 PyWavelets>=0.4.0
 dask[array]>=0.9.0
+cloudpickle>=0.2.1

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,9 +1,9 @@
 numpy>=1.11
 scipy>=0.17.0
-matplotlib>=1.3.1
+matplotlib>=2.0.0
 networkx>=1.8
 six>=1.10.0
-pillow>=2.1.0
+pillow>=4.3.0
 PyWavelets>=0.4.0
 dask[array]>=0.9.0
 cloudpickle>=0.2.1

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,3 +1,4 @@
 sphinx>=1.3
 numpydoc
 sphinx-gallery
+scikit-learn

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -94,15 +94,16 @@ def guess_spatial_dimensions(image):
 def convert_colorspace(arr, fromspace, tospace):
     """Convert an image array to a new color space.
 
+    Valid color spaces are:
+        'RGB', 'HSV', 'RGB CIE', 'XYZ', 'YUV', 'YIQ', 'YPbPr', 'YCbCr', 'YDbDr'
+
     Parameters
     ----------
     arr : array_like
         The image to convert.
-    fromspace : {'RGB', 'HSV', 'RGB CIE', 'XYZ', 'YUV',
-                 'YIQ', 'YPbPr', 'YCbCr', 'YDbDr'}
+    fromspace : valid color space
         The color space to convert from. Can be specified in lower case.
-    tospace : {'RGB', 'HSV', 'RGB CIE', 'XYZ', 'YUV',
-               'YIQ', 'YPbPr', 'YCbCr', 'YDbDr'}
+    tospace : valid color space
         The color space to convert to. Can be specified in lower case.
 
     Returns
@@ -121,6 +122,7 @@ def convert_colorspace(arr, fromspace, tospace):
     >>> from skimage import data
     >>> img = data.astronaut()
     >>> img_hsv = convert_colorspace(img, 'RGB', 'HSV')
+
     """
     fromdict = {'rgb': lambda im: im, 'hsv': hsv2rgb, 'rgb cie': rgbcie2rgb,
                 'xyz': xyz2rgb, 'yuv': yuv2rgb, 'yiq': yiq2rgb,

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -14,12 +14,13 @@ import numpy as _np
 
 from .. import data_dir
 from ..io import imread, use_plugin
-from .._shared._warnings import expected_warnings
-from ._binary_blobs import binary_blobs
+from .._shared._warnings import expected_warnings, warn
 from .. import img_as_bool
+from ._binary_blobs import binary_blobs
 
 __all__ = ['load',
            'astronaut',
+           'binary_blobs',
            'camera',
            'checkerboard',
            'chelsea',
@@ -38,23 +39,32 @@ __all__ = ['load',
            'stereo_motorcycle']
 
 
-def load(f, as_grey=False):
+def load(f, as_gray=False, as_grey=None):
     """Load an image file located in the data directory.
 
     Parameters
     ----------
     f : string
         File name.
-    as_grey : bool, optional
-        Convert to greyscale.
+    as_gray : bool, optional
+        Convert to grayscale.
+    as_grey : bool or None, optional
+        Deprecated keyword argument. Use `as_gray` instead.
+        If None, `as_gray` is used.
+        Convert to grayscale.
 
     Returns
     -------
     img : ndarray
         Image loaded from ``skimage.data_dir``.
     """
+    if as_grey is not None:
+        as_gray = as_grey
+        warn('`as_grey` has been deprecated in favor of `as_gray`'
+             ' and will be removed in v0.16.')
+
     use_plugin('pil')
-    return imread(_os.path.join(data_dir, f), as_grey=as_grey)
+    return imread(_os.path.join(data_dir, f), as_gray=as_gray)
 
 
 def camera():
@@ -205,7 +215,7 @@ def horse():
         Horse image.
     """
     with expected_warnings(['Possible precision loss', 'Possible sign loss']):
-        return img_as_bool(load("horse.png", as_grey=True))
+        return img_as_bool(load("horse.png", as_gray=True))
 
 
 def clock():
@@ -332,15 +342,15 @@ def rocket():
 def stereo_motorcycle():
     """Rectified stereo image pair with ground-truth disparities.
 
-    The two images are rectified such that every pixel in the left image has its
-    corresponding pixel on the same scanline in the right image. That means that
-    both images are warped such that they have the same orientation but a
+    The two images are rectified such that every pixel in the left image has
+    its corresponding pixel on the same scanline in the right image. That means
+    that both images are warped such that they have the same orientation but a
     horizontal spatial offset (baseline). The ground-truth pixel offset in
     column direction is specified by the included disparity map.
 
-    The two images are part of the Middlebury 2014 stereo benchmark. The dataset
-    was created by Nera Nesic, Porter Westling, Xi Wang, York Kitajima, Greg
-    Krathwohl, and Daniel Scharstein at Middlebury College. A detailed
+    The two images are part of the Middlebury 2014 stereo benchmark. The
+    dataset was created by Nera Nesic, Porter Westling, Xi Wang, York Kitajima,
+    Greg Krathwohl, and Daniel Scharstein at Middlebury College. A detailed
     description of the acquisition process can be found in [1]_.
 
     The images included here are down-sampled versions of the default exposure
@@ -370,14 +380,15 @@ def stereo_motorcycle():
 
     Notes
     -----
-    The original resolution images, images with different exposure and lighting,
-    and ground-truth depth maps can be found at the Middlebury website [2]_.
+    The original resolution images, images with different exposure and
+    lighting, and ground-truth depth maps can be found at the Middlebury
+    website [2]_.
 
     References
     ----------
-    .. [1] D. Scharstein, H. Hirschmueller, Y. Kitajima, G. Krathwohl, N. Nesic,
-           X. Wang, and P. Westling. High-resolution stereo datasets with
-           subpixel-accurate ground truth. In German Conference on Pattern
+    .. [1] D. Scharstein, H. Hirschmueller, Y. Kitajima, G. Krathwohl, N.
+           Nesic, X. Wang, and P. Westling. High-resolution stereo datasets
+           with subpixel-accurate ground truth. In German Conference on Pattern
            Recognition (GCPR 2014), Muenster, Germany, September 2014.
     .. [2] http://vision.middlebury.edu/stereo/data/scenes2014/
 

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -139,7 +139,7 @@ def coins():
     -----
     This image was downloaded from the
     `Brooklyn Museum Collection
-    <http://www.brooklynmuseum.org/opencollection/archives/image/33814>`__.
+    <https://www.brooklynmuseum.org/opencollection/archives/image/51611>`__.
 
     No known copyright restrictions.
 

--- a/skimage/draw/tests/test_random_shapes.py
+++ b/skimage/draw/tests/test_random_shapes.py
@@ -3,7 +3,7 @@ import numpy as np
 from skimage.draw import random_shapes
 
 from skimage._shared import testing
-from skimage._shared._warnings import expected_warnings
+from skimage._shared.testing import expected_warnings
 
 
 def test_generates_color_images_with_correct_shape():

--- a/skimage/draw/tests/test_random_shapes.py
+++ b/skimage/draw/tests/test_random_shapes.py
@@ -3,6 +3,7 @@ import numpy as np
 from skimage.draw import random_shapes
 
 from skimage._shared import testing
+from skimage._shared._warnings import expected_warnings
 
 
 def test_generates_color_images_with_correct_shape():
@@ -12,8 +13,8 @@ def test_generates_color_images_with_correct_shape():
 
 def test_generates_gray_images_with_correct_shape():
     image, _ = random_shapes(
-        (4567, 123), min_shapes=3, max_shapes=20, gray=True)
-    assert image.shape == (4567, 123, 1)
+        (4567, 123), min_shapes=3, max_shapes=20, multichannel=False)
+    assert image.shape == (4567, 123)
 
 
 def test_generates_correct_bounding_boxes_for_rectangles():
@@ -21,7 +22,6 @@ def test_generates_correct_bounding_boxes_for_rectangles():
         (128, 128),
         max_shapes=1,
         shape='rectangle',
-        min_pixel_intensity=1,
         random_seed=42)
     assert len(labels) == 1
     label, bbox = labels[0]
@@ -30,7 +30,7 @@ def test_generates_correct_bounding_boxes_for_rectangles():
     crop = image[bbox[0][0]:bbox[0][1], bbox[1][0]:bbox[1][1]]
 
     # The crop is filled.
-    assert (crop >= 1).all() and (crop <= 255).all()
+    assert (crop >= 0).all() and (crop < 255).all()
 
     # The crop is complete.
     image[bbox[0][0]:bbox[0][1], bbox[1][0]:bbox[1][1]] = 255
@@ -42,7 +42,6 @@ def test_generates_correct_bounding_boxes_for_triangles():
         (128, 128),
         max_shapes=1,
         shape='triangle',
-        min_pixel_intensity=1,
         random_seed=42)
     assert len(labels) == 1
     label, bbox = labels[0]
@@ -51,7 +50,7 @@ def test_generates_correct_bounding_boxes_for_triangles():
     crop = image[bbox[0][0]:bbox[0][1], bbox[1][0]:bbox[1][1]]
 
     # The crop is filled.
-    assert (crop >= 1).any() and (crop <= 255).any()
+    assert (crop >= 0).any() and (crop < 255).any()
 
     # The crop is complete.
     image[bbox[0][0]:bbox[0][1], bbox[1][0]:bbox[1][1]] = 255
@@ -65,7 +64,6 @@ def test_generates_correct_bounding_boxes_for_circles():
         min_size=20,
         max_size=20,
         shape='circle',
-        min_pixel_intensity=1,
         random_seed=42)
     assert len(labels) == 1
     label, bbox = labels[0]
@@ -74,7 +72,7 @@ def test_generates_correct_bounding_boxes_for_circles():
     crop = image[bbox[0][0]:bbox[0][1], bbox[1][0]:bbox[1][1]]
 
     # The crop is filled.
-    assert (crop >= 1).any() and (crop <= 255).any()
+    assert (crop >= 0).any() and (crop < 255).any()
 
     # The crop is complete.
     image[bbox[0][0]:bbox[0][1], bbox[1][0]:bbox[1][1]] = 255
@@ -99,28 +97,30 @@ def test_can_generate_one_by_one_rectangle():
         max_shapes=1,
         min_size=1,
         max_size=1,
-        shape='rectangle',
-        min_pixel_intensity=1)
+        shape='rectangle')
     assert len(labels) == 1
     _, bbox = labels[0]
     crop = image[bbox[0][0]:bbox[0][1], bbox[1][0]:bbox[1][1]]
 
     # rgb
     assert (np.shape(crop) == (1, 1, 3) and np.any(crop >= 1)
-            and np.any(crop <= 255))
+            and np.any(crop < 255))
 
 
-def test_throws_when_min_pixel_intensity_out_of_range():
+def test_throws_when_intensity_range_out_of_range():
     with testing.raises(ValueError):
-        random_shapes((1000, 1234), max_shapes=1, min_pixel_intensity=256)
+        random_shapes((1000, 1234), max_shapes=1, multichannel=False,
+                      intensity_range=(0, 256))
     with testing.raises(ValueError):
-        random_shapes((2, 2), max_shapes=1, min_pixel_intensity=-1)
+        random_shapes((2, 2), max_shapes=1,
+                      intensity_range=((-1, 255),))
 
 
 def test_returns_empty_labels_and_white_image_when_cannot_fit_shape():
     # The circle will never fit this.
-    image, labels = random_shapes(
-        (10000, 10000), max_shapes=1, min_size=10000, shape='circle')
+    with expected_warnings(['Could not fit']):
+        image, labels = random_shapes(
+            (10000, 10000), max_shapes=1, min_size=10000, shape='circle')
     assert len(labels) == 0
     assert (image == 255).all()
 
@@ -129,14 +129,15 @@ def test_random_shapes_is_reproducible_with_seed():
     random_seed = 42
     labels = []
     for _ in range(5):
-        _, l = random_shapes(
-            (128, 128), max_shapes=5, random_seed=random_seed)
-        labels.append(l)
+        _, label = random_shapes((128, 128), max_shapes=5,
+                                 random_seed=random_seed)
+        labels.append(label)
     assert all(other == labels[0] for other in labels[1:])
 
 
-def test_generates_white_image_when_min_pixel_intensity_255():
-    image, labels = random_shapes(
-        (128, 128), max_shapes=3, min_pixel_intensity=255, random_seed=42)
+def test_generates_white_image_when_intensity_range_255():
+    image, labels = random_shapes((128, 128), max_shapes=3,
+                                  intensity_range=((255, 255),),
+                                  random_seed=42)
     assert len(labels) > 0
     assert (image == 255).all()

--- a/skimage/feature/haar.py
+++ b/skimage/feature/haar.py
@@ -136,6 +136,17 @@ def haar_like_feature(int_image, r, c, width, height, feature_type=None,
         is `uint` or `int` and `float` when the data type of `int_image` is
         `float`.
 
+    Notes
+    -----
+    When extracting those features in parallel, be aware that the choice of the
+    backend (i.e. multiprocessing vs threading) will have an impact on the
+    performance. The rule of thumb is as follows: use multiprocessing when
+    extracting features for all possible ROI in an image; use threading when
+    extracting the feature at specific location for a limited number of ROIs.
+    Refer to the example
+    :ref:`sphx_glr_auto_examples_xx_applications_plot_haar_extraction_selection_classification.py`
+    for more insights.
+
     Examples
     --------
     >>> import numpy as np

--- a/skimage/feature/tests/test_censure.py
+++ b/skimage/feature/tests/test_censure.py
@@ -65,7 +65,11 @@ def test_keypoints_censure_moon_image_octagon():
     the expected values for Octagon filter."""
 
     detector = CENSURE(mode='octagon')
-    detector.detect(rescale(img, 0.25))     # quarter scale image for speed
+    # quarter scale image for speed
+    detector.detect(rescale(img, 0.25,
+                            multichannel=False,
+                            anti_aliasing=False,
+                            mode='constant'))
     expected_keypoints = np.array([[ 23,  27],
                                    [ 29,  89],
                                    [ 31,  87],
@@ -82,7 +86,11 @@ def test_keypoints_censure_moon_image_star():
     """Verify the actual Censure keypoints and their corresponding scale with
     the expected values for STAR filter."""
     detector = CENSURE(mode='star')
-    detector.detect(rescale(img, 0.25))     # quarter scale image for speed
+    # quarter scale image for speed
+    detector.detect(rescale(img, 0.25,
+                            multichannel=False,
+                            anti_aliasing=False,
+                            mode='constant'))
     expected_keypoints = np.array([[ 23,  27],
                                    [ 29,  89],
                                    [ 30,  86],

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -6,7 +6,7 @@ from skimage import img_as_float
 from skimage import draw
 from skimage.color import rgb2gray
 from skimage.morphology import octagon
-from skimage._shared.testing import test_parallel
+from skimage._shared.testing import test_parallel, expected_warnings
 from skimage._shared import testing
 import pytest
 
@@ -170,7 +170,8 @@ def test_hessian_matrix_det_3d(im3d):
 def test_shape_index():
     square = np.zeros((5, 5))
     square[2, 2] = 4
-    s = shape_index(square, sigma=0.1)
+    with expected_warnings(['divide by zero', 'invalid value']):
+        s = shape_index(square, sigma=0.1)
     assert_almost_equal(
         s, np.array([[ np.nan, np.nan,   -0.5, np.nan, np.nan],
                      [ np.nan,      0, np.nan,      0, np.nan],

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -8,13 +8,14 @@ from skimage import img_as_float
 from skimage import draw
 from skimage._shared.testing import assert_almost_equal
 from skimage._shared import testing
+from skimage._shared.testing import expected_warnings
 
 
 def test_hog_output_size():
     img = img_as_float(data.astronaut()[:256, :].mean(axis=2))
 
     fd = feature.hog(img, orientations=9, pixels_per_cell=(8, 8),
-                     cells_per_block=(1, 1))
+                     cells_per_block=(1, 1), block_norm='L1')
 
     assert len(fd) == 9 * (256 // 8) * (512 // 8)
 
@@ -46,7 +47,7 @@ def test_hog_output_correctness_l2hys_norm():
 def test_hog_image_size_cell_size_mismatch():
     image = data.camera()[:150, :200]
     fd = feature.hog(image, orientations=9, pixels_per_cell=(8, 8),
-                     cells_per_block=(1, 1))
+                     cells_per_block=(1, 1), block_norm='L1')
     assert len(fd) == 9 * (150 // 8) * (200 // 8)
 
 
@@ -76,16 +77,20 @@ def test_hog_basic_orientations_and_data_types():
 
         (hog_float, hog_img_float) = feature.hog(
             image_float, orientations=4, pixels_per_cell=(8, 8),
-            cells_per_block=(1, 1), visualize=True, transform_sqrt=False)
+            cells_per_block=(1, 1), visualize=True, transform_sqrt=False,
+            block_norm='L1')
         (hog_uint8, hog_img_uint8) = feature.hog(
             image_uint8, orientations=4, pixels_per_cell=(8, 8),
-            cells_per_block=(1, 1), visualize=True, transform_sqrt=False)
+            cells_per_block=(1, 1), visualize=True, transform_sqrt=False,
+            block_norm='L1')
         (hog_float_norm, hog_img_float_norm) = feature.hog(
             image_float, orientations=4, pixels_per_cell=(8, 8),
-            cells_per_block=(1, 1), visualize=True, transform_sqrt=True)
+            cells_per_block=(1, 1), visualize=True, transform_sqrt=True,
+            block_norm='L1')
         (hog_uint8_norm, hog_img_uint8_norm) = feature.hog(
             image_uint8, orientations=4, pixels_per_cell=(8, 8),
-            cells_per_block=(1, 1), visualize=True, transform_sqrt=True)
+            cells_per_block=(1, 1), visualize=True, transform_sqrt=True,
+            block_norm='L1')
 
         # set to True to enable manual debugging with graphical output,
         # must be False for automatic testing
@@ -164,7 +169,8 @@ def test_hog_orientations_circle():
         (hog, hog_img) = feature.hog(image, orientations=orientations,
                                      pixels_per_cell=(8, 8),
                                      cells_per_block=(1, 1), visualize=True,
-                                     transform_sqrt=False)
+                                     transform_sqrt=False,
+                                     block_norm='L1')
 
         # set to True to enable manual debugging with graphical output,
         # must be False for automatic testing
@@ -214,7 +220,8 @@ def test_hog_visualization_orientation():
         orientations=3,
         pixels_per_cell=(width, height),
         cells_per_block=(1, 1),
-        visualize=True
+        visualize=True,
+        block_norm='L1'
     )
 
     middle_index = height // 2
@@ -238,14 +245,15 @@ def test_hog_block_normalization_incorrect_error():
 def test_hog_incorrect_dimensions(shape, multichannel):
     img = np.zeros(shape)
     with testing.raises(ValueError):
-        feature.hog(img, multichannel=multichannel)
+        feature.hog(img, multichannel=multichannel, block_norm='L1')
 
 
 def test_hog_output_equivariance_multichannel():
     img = data.astronaut()
     img[:, :, (1, 2)] = 0
-    hog_ref = feature.hog(img, multichannel=True)
+    hog_ref = feature.hog(img, multichannel=True, block_norm='L1')
 
     for n in (1, 2):
-        hog_fact = feature.hog(np.roll(img, n, axis=2), multichannel=True)
+        hog_fact = feature.hog(np.roll(img, n, axis=2), multichannel=True,
+                               block_norm='L1')
         assert_almost_equal(hog_ref, hog_fact)

--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -12,7 +12,7 @@ __all__ = ['imread', 'imsave', 'imshow', 'show',
            'imread_collection', 'imshow_collection']
 
 
-def imread(fname, as_grey=False, plugin=None, flatten=None,
+def imread(fname, as_gray=False, plugin=None, flatten=None,
            **plugin_args):
     """Load an image from file.
 
@@ -20,10 +20,10 @@ def imread(fname, as_grey=False, plugin=None, flatten=None,
     ----------
     fname : string
         Image file name, e.g. ``test.jpg`` or URL.
-    as_grey : bool
-        If True, convert color images to grey-scale (64-bit floats).
-        Images that are already in grey-scale format are not converted.
-    plugin : str
+    as_gray : bool, optional
+        If True, convert color images to gray-scale (64-bit floats).
+        Images that are already in gray-scale format are not converted.
+    plugin : str, optional
         Name of plugin to use.  By default, the different plugins are
         tried (starting with the Python Imaging Library) until a suitable
         candidate is found.  If not given and fname is a tiff file, the
@@ -34,7 +34,7 @@ def imread(fname, as_grey=False, plugin=None, flatten=None,
     plugin_args : keywords
         Passed to the given plugin.
     flatten : bool
-        Backward compatible keyword, superseded by `as_grey`.
+        Backward compatible keyword, superseded by `as_gray`.
 
     Returns
     -------
@@ -44,9 +44,15 @@ def imread(fname, as_grey=False, plugin=None, flatten=None,
         RGB-image MxNx3 and an RGBA-image MxNx4.
 
     """
+    if 'as_grey' in plugin_args.keys():
+        as_gray = plugin_args.pop('as_grey', as_gray)
+        warn('`as_grey` has been deprecated in favor of `as_gray`')
+
     # Backward compatibility
     if flatten is not None:
-        as_grey = flatten
+        as_gray = flatten
+        warn('`flatten` has been deprecated in favor of `as_gray`'
+             ' and will be removed in v0.16.')
 
     if plugin is None and hasattr(fname, 'lower'):
         if fname.lower().endswith(('.tiff', '.tif')):
@@ -63,7 +69,7 @@ def imread(fname, as_grey=False, plugin=None, flatten=None,
             img = np.swapaxes(img, -1, -3)
             img = np.swapaxes(img, -2, -3)
 
-        if as_grey:
+        if as_gray:
             img = rgb2grey(img)
 
     return img

--- a/skimage/io/tests/test_pil.py
+++ b/skimage/io/tests/test_pil.py
@@ -45,18 +45,26 @@ def test_png_round_trip():
     fname = f.name
     f.close()
     I = np.eye(3)
-    imsave(fname, I)
+    with expected_warnings(['Possible precision loss']):
+        imsave(fname, I)
     Ip = img_as_float(imread(fname))
     os.remove(fname)
     assert np.sum(np.abs(Ip-I)) < 1e-3
 
 
+def test_img_as_gray_flatten():
+    img = imread(os.path.join(data_dir, 'color.png'), as_gray=True)
+    with expected_warnings(['deprecated']):
+        img_flat = imread(os.path.join(data_dir, 'color.png'), flatten=True)
+    assert_array_equal(img, img_flat)
+
+
 def test_imread_flatten():
     # a color image is flattened
-    img = imread(os.path.join(data_dir, 'color.png'), flatten=True)
+    img = imread(os.path.join(data_dir, 'color.png'), as_gray=True)
     assert img.ndim == 2
     assert img.dtype == np.float64
-    img = imread(os.path.join(data_dir, 'camera.png'), flatten=True)
+    img = imread(os.path.join(data_dir, 'camera.png'), as_gray=True)
     # check that flattening does not occur for an image that is grey already.
     assert np.sctype2char(img.dtype) in np.typecodes['AllInteger']
 
@@ -190,9 +198,11 @@ class TestSave:
 def test_imsave_incorrect_dimension():
     with temporary_file(suffix='.png') as fname:
         with testing.raises(ValueError):
-            imsave(fname, np.zeros((2, 3, 3, 1)))
+            with expected_warnings([fname + ' is a low contrast image']):
+                imsave(fname, np.zeros((2, 3, 3, 1)))
         with testing.raises(ValueError):
-            imsave(fname, np.zeros((2, 3, 2)))
+            with expected_warnings([fname + ' is a low contrast image']):
+                imsave(fname, np.zeros((2, 3, 2)))
 
 
 def test_imsave_filelike():
@@ -239,12 +249,15 @@ def test_imexport_imimport():
 
 
 def test_all_color():
-    color_check('pil')
-    color_check('pil', 'bmp')
+    with expected_warnings(['.* is a boolean image']):
+        color_check('pil')
+    with expected_warnings(['.* is a boolean image']):
+        color_check('pil', 'bmp')
 
 
 def test_all_mono():
-    mono_check('pil')
+    with expected_warnings(['.* is a boolean image']):
+        mono_check('pil')
 
 
 def test_multi_page_gif():

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -125,10 +125,13 @@ def find_contours(array, level,
 
 def _take_2(seq):
     iterator = iter(seq)
-    while(True):
-        n1 = next(iterator)
-        n2 = next(iterator)
-        yield (n1, n2)
+    while True:
+        try:
+            n1 = next(iterator)
+            n2 = next(iterator)
+            yield (n1, n2)
+        except StopIteration:
+            return
 
 
 def _assemble_contours(points_iterator):

--- a/skimage/measure/_marching_cubes_lewiner.py
+++ b/skimage/measure/_marching_cubes_lewiner.py
@@ -165,7 +165,7 @@ def marching_cubes_lewiner(volume, level=None, spacing=(1., 1., 1.),
     elif not gradient_direction == 'ascent':
         raise ValueError("Incorrect input %s in `gradient_direction`, see "
                          "docstring." % (gradient_direction))
-    if spacing != (1, 1, 1):
+    if not np.array_equal(spacing, (1, 1, 1)):
         vertices = vertices * np.r_[spacing]
 
     if allow_degenerate:

--- a/skimage/measure/_structural_similarity.py
+++ b/skimage/measure/_structural_similarity.py
@@ -5,8 +5,7 @@ from scipy.ndimage import uniform_filter, gaussian_filter
 
 from ..util.dtype import dtype_range
 from ..util.arraycrop import crop
-from .._shared.utils import deprecated
-from .._shared.utils import skimage_deprecation, warn
+
 
 __all__ = ['compare_ssim']
 

--- a/skimage/measure/_structural_similarity.py
+++ b/skimage/measure/_structural_similarity.py
@@ -5,7 +5,7 @@ from scipy.ndimage import uniform_filter, gaussian_filter
 
 from ..util.dtype import dtype_range
 from ..util.arraycrop import crop
-
+from .._shared.utils import warn
 
 __all__ = ['compare_ssim']
 
@@ -81,9 +81,6 @@ def compare_ssim(X, Y, win_size=None, gradient=False,
        DOI:10.1007/s10043-009-0119-z
 
     """
-    if not X.dtype == Y.dtype:
-        raise ValueError('Input images must have the same dtype.')
-
     if not X.shape == Y.shape:
         raise ValueError('Input images must have the same dimensions.')
 
@@ -148,6 +145,9 @@ def compare_ssim(X, Y, win_size=None, gradient=False,
         raise ValueError('Window size must be odd.')
 
     if data_range is None:
+        if X.dtype != Y.dtype:
+            warn("Inputs have mismatched dtype.  Setting data_range based on "
+                 "X.dtype.")
         dmin, dmax = dtype_range[X.dtype.type]
         data_range = dmax - dmin
 

--- a/skimage/measure/simple_metrics.py
+++ b/skimage/measure/simple_metrics.py
@@ -12,8 +12,6 @@ __all__ = ['compare_mse',
 
 def _assert_compatible(im1, im2):
     """Raise an error if the shape and dtype do not match."""
-    if not im1.dtype == im2.dtype:
-        raise ValueError('Input images must have the same dtype.')
     if not im1.shape == im2.shape:
         raise ValueError('Input images must have the same dimensions.')
     return
@@ -22,10 +20,8 @@ def _assert_compatible(im1, im2):
 def _as_floats(im1, im2):
     """Promote im1, im2 to nearest appropriate floating point precision."""
     float_type = np.result_type(im1.dtype, im2.dtype, np.float32)
-    if im1.dtype != float_type:
-        im1 = im1.astype(float_type)
-    if im2.dtype != float_type:
-        im2 = im2.astype(float_type)
+    im1 = np.asarray(im1, dtype=float_type)
+    im2 = np.asarray(im2, dtype=float_type)
     return im1, im2
 
 
@@ -133,6 +129,9 @@ def compare_psnr(im_true, im_test, data_range=None, dynamic_range=None):
         data_range = dynamic_range
 
     if data_range is None:
+        if im_true.dtype != im_test.dtype:
+            warn("Inputs have mismatched dtype.  Setting data_range based on "
+                 "im_true.")
         dmin, dmax = dtype_range[im_true.dtype.type]
         true_min, true_max = np.min(im_true), np.max(im_true)
         if true_max > dmax or true_min < dmin:

--- a/skimage/measure/tests/test_marching_cubes.py
+++ b/skimage/measure/tests/test_marching_cubes.py
@@ -24,7 +24,8 @@ def test_marching_cubes_isotropic():
 
 
 def test_marching_cubes_anisotropic():
-    spacing = (1., 10 / 6., 16 / 6.)
+    # test spacing as numpy array (and not just tuple)
+    spacing = np.array([1., 10 / 6., 16 / 6.])
     ellipsoid_anisotropic = ellipsoid(6, 10, 16, spacing=spacing,
                                       levelset=True)
     _, surf = ellipsoid_stats(6, 10, 16)

--- a/skimage/measure/tests/test_simple_metrics.py
+++ b/skimage/measure/tests/test_simple_metrics.py
@@ -25,8 +25,19 @@ def test_PSNR_vs_IPOL():
 
 def test_PSNR_float():
     p_uint8 = compare_psnr(cam, cam_noisy)
-    p_float64 = compare_psnr(cam/255., cam_noisy/255., data_range=1)
+    p_float64 = compare_psnr(cam / 255., cam_noisy / 255.,
+                             data_range=1)
     assert_almost_equal(p_uint8, p_float64, decimal=5)
+
+    # mixed precision inputs
+    p_mixed = compare_psnr(cam / 255., np.float32(cam_noisy / 255.),
+                           data_range=1)
+    assert_almost_equal(p_mixed, p_float64, decimal=5)
+
+    # mismatched dtype results in a warning if data_range is unspecified
+    with expected_warnings(['Inputs have mismatched dtype']):
+        p_mixed = compare_psnr(cam / 255., np.float32(cam_noisy / 255.))
+    assert_almost_equal(p_mixed, p_float64, decimal=5)
 
 
 def test_PSNR_dynamic_range_and_data_range():
@@ -41,8 +52,7 @@ def test_PSNR_dynamic_range_and_data_range():
 
 
 def test_PSNR_errors():
-    with testing.raises(ValueError):
-        compare_psnr(cam, cam.astype(np.float32))
+    # shape mismatch
     with testing.raises(ValueError):
         compare_psnr(cam, cam[:-1, :])
 
@@ -53,6 +63,10 @@ def test_NRMSE():
     assert_equal(compare_nrmse(y, x, 'mean'), 1/np.mean(y))
     assert_equal(compare_nrmse(y, x, 'Euclidean'), 1/np.sqrt(3))
     assert_equal(compare_nrmse(y, x, 'min-max'), 1/(y.max()-y.min()))
+
+    # mixed precision inputs are allowed
+    assert_almost_equal(compare_nrmse(y, np.float32(x), 'min-max'),
+                        1 / (y.max() - y.min()))
 
 
 def test_NRMSE_no_int_overflow():
@@ -66,8 +80,7 @@ def test_NRMSE_no_int_overflow():
 
 def test_NRMSE_errors():
     x = np.ones(4)
-    with testing.raises(ValueError):
-        compare_nrmse(x.astype(np.uint8), x.astype(np.float32))
+    # shape mismatch
     with testing.raises(ValueError):
         compare_nrmse(x[:-1], x)
     # invalid normalization name

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -6,6 +6,7 @@ from ..measure.pnpoly import grid_points_in_poly
 from ._convex_hull import possible_hull
 from ..measure._label import label
 from ..util import unique_rows
+from .._shared.utils import warn
 
 __all__ = ['convex_hull_image', 'convex_hull_object']
 
@@ -47,7 +48,10 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10):
 
     """
     ndim = image.ndim
-
+    if np.count_nonzero(image) == 0:
+        warn("Input image is entirely zero, no valid convex hull. "
+             "Returning empty image", UserWarning)
+        return np.zeros(image.shape, dtype=np.bool_)
     # In 2D, we do an optimisation by choosing only pixels that are
     # the starting or ending pixel of a row or column.  This vastly
     # limits the number of coordinates to examine for the virtual hull.

--- a/skimage/morphology/tests/test_convex_hull.py
+++ b/skimage/morphology/tests/test_convex_hull.py
@@ -3,7 +3,7 @@ from skimage.morphology import convex_hull_image, convex_hull_object
 from skimage.morphology._convex_hull import possible_hull
 
 from skimage._shared import testing
-from skimage._shared.testing import assert_array_equal
+from skimage._shared.testing import assert_array_equal, expected_warnings
 
 
 def test_basic():
@@ -28,8 +28,8 @@ def test_basic():
 
 def test_empty_image():
     image = np.zeros((6, 6), dtype=bool)
-    
-    assert_array_equal(convex_hull_image(image), image)
+    with expected_warnings(['entirely zero']):
+        assert_array_equal(convex_hull_image(image), image)
 
 
 def test_qhull_offset_example():

--- a/skimage/morphology/tests/test_convex_hull.py
+++ b/skimage/morphology/tests/test_convex_hull.py
@@ -26,6 +26,12 @@ def test_basic():
     assert_array_equal(convex_hull_image(image), expected)
 
 
+def test_empty_image():
+    image = np.zeros((6, 6), dtype=bool)
+    
+    assert_array_equal(convex_hull_image(image), image)
+
+
 def test_qhull_offset_example():
     nonzeros = (([1367, 1368, 1368, 1368, 1369, 1369, 1369, 1369, 1369, 1370,
                   1370, 1370, 1370, 1370, 1370, 1370, 1371, 1371, 1371, 1371,

--- a/skimage/morphology/tests/test_misc.py
+++ b/skimage/morphology/tests/test_misc.py
@@ -141,7 +141,8 @@ def test_labeled_image_holes():
                          [0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
                          [0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
                          [0, 0, 0, 0, 0, 0, 0, 1, 1, 1]], dtype=np.bool_)
-    observed = remove_small_holes(labeled_holes_image, area_threshold=3)
+    with expected_warnings(['returned as a boolean array']):
+        observed = remove_small_holes(labeled_holes_image, area_threshold=3)
     assert_array_equal(observed, expected)
 
 
@@ -163,7 +164,8 @@ def test_uint_image_holes():
                          [0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
                          [0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
                          [0, 0, 0, 0, 0, 0, 0, 1, 1, 1]], dtype=np.bool_)
-    observed = remove_small_holes(labeled_holes_image, area_threshold=3)
+    with expected_warnings(['returned as a boolean array']):
+        observed = remove_small_holes(labeled_holes_image, area_threshold=3)
     assert_array_equal(observed, expected)
 
 

--- a/skimage/morphology/tests/test_skeletonize.py
+++ b/skimage/morphology/tests/test_skeletonize.py
@@ -60,7 +60,7 @@ class TestSkeletonize():
         assert_array_equal(result, im)
 
     def test_skeletonize_output(self):
-        im = imread(os.path.join(data_dir, "bw_text.png"), as_grey=True)
+        im = imread(os.path.join(data_dir, "bw_text.png"), as_gray=True)
 
         # make black the foreground
         im = (im == 0)

--- a/skimage/morphology/tests/test_skeletonize_3d.py
+++ b/skimage/morphology/tests/test_skeletonize_3d.py
@@ -13,7 +13,7 @@ from skimage.morphology import skeletonize_3d
 
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_, parametrize
-
+from skimage._shared._warnings import expected_warnings
 
 # basic behavior tests (mostly copied over from 2D skeletonize)
 
@@ -71,24 +71,33 @@ def test_dtype_conv():
     img[img < 0.5] = 0
 
     orig = img.copy()
-
-    with warnings.catch_warnings():
-        # UserWarning for possible precision loss, expected
-        warnings.simplefilter('ignore', UserWarning)
+    with expected_warnings(['precision']):
         res = skeletonize_3d(img)
+    with expected_warnings(['precision']):
+        img_max = img_as_ubyte(img).max()
 
     assert_equal(res.dtype, np.uint8)
     assert_equal(img, orig)  # operation does not clobber the original
-    assert_equal(res.max(),
-                 img_as_ubyte(img).max())    # the intensity range is preserved
+    assert_equal(res.max(), img_max)    # the intensity range is preserved
 
 
 @parametrize("img", [
-    np.ones((8, 8), dtype=float), np.ones((4, 8, 8), dtype=float),
+    np.ones((8, 8), dtype=float), np.ones((4, 8, 8), dtype=float)
+])
+def test_input_with_warning(img):
+    # check that the input is not clobbered
+    # for 2D and 3D images of varying dtypes
+    # Skeletonize changes it to uint8. Therefore, for images of type float,
+    # we can expect a warning.
+    with expected_warnings(['precision']):
+        check_input(img)
+
+
+@parametrize("img", [
     np.ones((8, 8), dtype=np.uint8), np.ones((4, 8, 8), dtype=np.uint8),
     np.ones((8, 8), dtype=bool), np.ones((4, 8, 8), dtype=bool)
 ])
-def test_input(img):
+def test_input_without_warning(img):
     # check that the input is not clobbered
     # for 2D and 3D images of varying dtypes
     check_input(img)
@@ -96,10 +105,7 @@ def test_input(img):
 
 def check_input(img):
     orig = img.copy()
-    with warnings.catch_warnings():
-        # UserWarning for possible precision loss, expected
-        warnings.simplefilter('ignore', UserWarning)
-        skeletonize_3d(img)
+    skeletonize_3d(img)
     assert_equal(img, orig)
 
 
@@ -126,7 +132,8 @@ def test_skeletonize_num_neighbours():
     circle2 = (ic - 135)**2 + (ir - 150)**2 < 20**2
     image[circle1] = 1
     image[circle2] = 0
-    result = skeletonize_3d(image)
+    with expected_warnings(['precision']):
+        result = skeletonize_3d(image)
 
     # there should never be a 2x2 block of foreground pixels in a skeleton
     mask = np.array([[1,  1],

--- a/skimage/novice/_novice.py
+++ b/skimage/novice/_novice.py
@@ -371,7 +371,8 @@ class Picture(object):
             # skimage dimensions are flipped: y, x
             new_size = (int(value[1]), int(value[0]))
             new_array = resize(self.array, new_size, order=0,
-                               preserve_range=True)
+                               preserve_range=True, mode='constant',
+                               anti_aliasing=False)
             self.array = new_array.astype(np.uint8)
 
             self._array_modified()

--- a/skimage/novice/tests/test_novice.py
+++ b/skimage/novice/tests/test_novice.py
@@ -8,7 +8,8 @@ from skimage.novice._novice import (array_to_xy_origin, xy_to_array_origin,
 from skimage import data_dir
 
 from skimage._shared import testing
-from skimage._shared.testing import assert_equal, assert_allclose
+from skimage._shared.testing import (assert_equal, assert_allclose,
+                                     expected_warnings)
 from skimage._shared.utils import all_warnings
 
 
@@ -176,7 +177,8 @@ def test_save_with_alpha_channel():
 
     fd, filename = tempfile.mkstemp(suffix=".png")
     os.close(fd)
-    pic.save(filename)
+    with expected_warnings(['is a low contrast']):
+        pic.save(filename)
     os.unlink(filename)
 
 

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -8,7 +8,7 @@ import pywt
 from skimage._shared import testing
 from skimage._shared.testing import (assert_equal, assert_almost_equal,
                                      assert_warns, assert_)
-from skimage._shared._warnings import expected_warnings
+from skimage._shared._warnings import expected_warnings, warnings
 
 
 np.random.seed(1234)
@@ -223,8 +223,13 @@ def test_denoise_bilateral_multidimensional():
 
 
 def test_denoise_bilateral_nan():
+    import sys
     img = np.full((50, 50), np.NaN)
-    out = restoration.denoise_bilateral(img, multichannel=False)
+
+    # TODO: This warning is not optional in python3. This should be
+    # made a strict warning when we get to 0.15
+    with expected_warnings(['invalid|\A\Z']):
+        out = restoration.denoise_bilateral(img, multichannel=False)
     assert_equal(img, out)
 
 

--- a/skimage/restoration/tests/test_unwrap.py
+++ b/skimage/restoration/tests/test_unwrap.py
@@ -2,12 +2,13 @@ from __future__ import print_function, division
 
 import numpy as np
 from skimage.restoration import unwrap_phase
+import sys
 
 import warnings
 from skimage._shared import testing
 from skimage._shared.testing import (assert_array_almost_equal_nulp,
                                      assert_almost_equal, assert_array_equal,
-                                     assert_)
+                                     assert_, skipif)
 from skimage._shared._warnings import expected_warnings
 
 
@@ -116,6 +117,8 @@ def check_wrap_around(ndim, axis):
 dim_axis = [(ndim, axis) for ndim in (2, 3) for axis in range(ndim)]
 
 
+@skipif(sys.version_info[:2] == (3, 4),
+        reason="Doesn't work with python 3.4. See issue #3079")
 @testing.parametrize("ndim, axis", dim_axis)
 def test_wrap_around(ndim, axis):
     check_wrap_around(ndim, axis)

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -13,7 +13,6 @@ from scipy import sparse, ndimage as ndi
 
 from .._shared.utils import warn
 
-
 # executive summary for next code block: try to import umfpack from
 # scipy, but make sure not to raise a fuss if it fails since it's only
 # needed to speed up a few cases.
@@ -39,9 +38,17 @@ try:
     amg_loaded = True
 except ImportError:
     amg_loaded = False
-from scipy.sparse.linalg import cg
+
 from ..util import img_as_float
 from ..filters import rank_order
+
+from scipy.sparse.linalg import cg
+import scipy
+from distutils.version import LooseVersion as Version
+import functools
+
+if Version(scipy.__version__) >= Version('1.1'):
+    cg = functools.partial(cg, atol=0)
 
 #-----------Laplacian--------------------
 

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -4,6 +4,7 @@ from skimage.transform import resize
 from skimage._shared._warnings import expected_warnings
 from skimage._shared import testing
 
+
 # older versions of scipy raise a warning with new NumPy because they use
 # numpy.rank() instead of arr.ndim or numpy.linalg.matrix_rank.
 SCIPY_EXPECTED = 'numpy.linalg.matrix_rank|\A\Z'
@@ -214,7 +215,9 @@ def test_spacing_0():
     # Rescale `data` along Z axis
     data_aniso = np.zeros((n, n, n // 2))
     for i, yz in enumerate(data):
-        data_aniso[i, :, :] = resize(yz, (n, n // 2))
+        data_aniso[i, :, :] = resize(yz, (n, n // 2),
+                                     mode='constant',
+                                     anti_aliasing=False)
 
     # Generate new labels
     small_l = int(lx // 5)
@@ -227,7 +230,7 @@ def test_spacing_0():
     # Test with `spacing` kwarg
     with expected_warnings(['"cg" mode' + '|' + SCIPY_EXPECTED]):
         labels_aniso = random_walker(data_aniso, labels_aniso, mode='cg',
-                                 spacing=(1., 1., 0.5))
+                                     spacing=(1., 1., 0.5))
 
     assert (labels_aniso[13:17, 13:17, 7:9] == 2).all()
 
@@ -241,7 +244,9 @@ def test_spacing_1():
     # `resize` is not yet 3D capable, so this must be done by looping in 2D.
     data_aniso = np.zeros((n, n * 2, n))
     for i, yz in enumerate(data):
-        data_aniso[i, :, :] = resize(yz, (n * 2, n))
+        data_aniso[i, :, :] = resize(yz, (n * 2, n),
+                                     mode='constant',
+                                     anti_aliasing=False)
 
     # Generate new labels
     small_l = int(lx // 5)
@@ -262,7 +267,9 @@ def test_spacing_1():
     # `resize` is not yet 3D capable, so this must be done by looping in 2D.
     data_aniso = np.zeros((n, n * 2, n))
     for i in range(data.shape[1]):
-        data_aniso[i, :, :] = resize(data[:, 1, :], (n * 2, n))
+        data_aniso[i, :, :] = resize(data[:, 1, :], (n * 2, n),
+                                     mode='constant',
+                                     anti_aliasing=False)
 
     # Generate new labels
     small_l = int(lx // 5)
@@ -360,4 +367,3 @@ def test_isolated_seeds():
     res = random_walker(a, mask, return_full_prob=True)
     assert res[0, 1, 1] == 1
     assert res[1, 1, 1] == 0
-

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -7,6 +7,7 @@ import numpy as np
 cimport numpy as cnp
 cimport cython
 
+from cpython.mem cimport PyMem_Malloc, PyMem_Free
 from libc.stdlib cimport abs
 from libc.math cimport fabs, sqrt, ceil, atan2, M_PI
 
@@ -365,8 +366,11 @@ def _probabilistic_hough_line(cnp.ndarray img, Py_ssize_t threshold,
 
     # compute the bins and allocate the accumulator array
     cdef cnp.ndarray[ndim=2, dtype=cnp.uint8_t] mask = \
-         np.zeros((height, width), dtype=np.uint8)
-    cdef cnp.intp_t[:, ::1] line_end = np.zeros((2, 2), dtype=np.intp)
+        np.zeros((height, width), dtype=np.uint8)
+    cdef Py_ssize_t *line_end = \
+        <Py_ssize_t *>PyMem_Malloc(4 * sizeof(Py_ssize_t))
+    if not line_end:
+        raise MemoryError('could not allocate line_end')
     cdef Py_ssize_t max_distance, offset, num_indexes, index
     cdef double a, b
     cdef Py_ssize_t nidxs, i, j, k, x, y, px, py, accum_idx, max_theta
@@ -378,7 +382,6 @@ def _probabilistic_hough_line(cnp.ndarray img, Py_ssize_t threshold,
     cdef Py_ssize_t lines_max = 2 ** 15  # maximum line number cutoff
     cdef cnp.intp_t[:, :, ::1] lines = np.zeros((lines_max, 2, 2),
                                                 dtype=np.intp)
-
     max_distance = 2 * <Py_ssize_t>ceil((sqrt(img.shape[0] * img.shape[0] +
                                               img.shape[1] * img.shape[1])))
     cdef cnp.int64_t[:, ::1] accum = np.zeros((max_distance, theta.shape[0]),
@@ -400,7 +403,7 @@ def _probabilistic_hough_line(cnp.ndarray img, Py_ssize_t threshold,
     count = len(x_idxs)
     random_state = np.random.RandomState(seed)
     random_ = np.arange(count, dtype=np.intp)
-    np.random.shuffle(random_)
+    random_state.shuffle(random_)
     cdef cnp.intp_t[::1] random = random_
 
     with nogil:
@@ -478,8 +481,8 @@ def _probabilistic_hough_line(cnp.ndarray img, Py_ssize_t threshold,
                     # if non-zero point found, continue the line
                     if mask[y1, x1]:
                         gap = 0
-                        line_end[k, 1] = y1
-                        line_end[k, 0] = x1
+                        line_end[2*k] = x1
+                        line_end[2*k + 1] = y1
                     # if gap to this point was too large, end the line
                     elif gap > line_gap:
                         break
@@ -487,8 +490,8 @@ def _probabilistic_hough_line(cnp.ndarray img, Py_ssize_t threshold,
                     py += dy
 
             # confirm line length is sufficient
-            good_line = abs(line_end[1, 1] - line_end[0, 1]) >= line_length or \
-                        abs(line_end[1, 0] - line_end[0, 0]) >= line_length
+            good_line = (abs(line_end[3] - line_end[1]) >= line_length or
+                         abs(line_end[2] - line_end[0]) >= line_length)
 
             # pass 2: walk the line again and reset accumulator and mask
             for k in range(2):
@@ -509,25 +512,26 @@ def _probabilistic_hough_line(cnp.ndarray img, Py_ssize_t threshold,
                     # if non-zero point found, continue the line
                     if mask[y1, x1]:
                         if good_line:
-                            accum_idx = round((ctheta[j] * x1 + stheta[j] * y1)) \
-                                        + offset
+                            accum_idx = round(
+                                (ctheta[j] * x1 + stheta[j] * y1)) + offset
                             accum[accum_idx, max_theta] -= 1
                             mask[y1, x1] = 0
                     # exit when the point is the line end
-                    if x1 == line_end[k, 0] and y1 == line_end[k, 1]:
+                    if x1 == line_end[2*k] and y1 == line_end[2*k + 1]:
                         break
                     px += dx
                     py += dy
 
             # add line to the result
             if good_line:
-                lines[nlines, 0, 0] = line_end[0, 0]
-                lines[nlines, 0, 1] = line_end[0, 1]
-                lines[nlines, 1, 0] = line_end[1, 0]
-                lines[nlines, 1, 1] = line_end[1, 1]
+                lines[nlines, 0, 0] = line_end[0]
+                lines[nlines, 0, 1] = line_end[1]
+                lines[nlines, 1, 0] = line_end[2]
+                lines[nlines, 1, 1] = line_end[3]
                 nlines += 1
                 if nlines > lines_max:
                     break
 
+    PyMem_Free(line_end)
     return [((line[0, 0], line[0, 1]), (line[1, 0], line[1, 1]))
             for line in lines[:nlines]]

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -7,7 +7,8 @@ import numpy as np
 cimport numpy as cnp
 cimport cython
 
-from libc.math cimport abs, fabs, sqrt, ceil, atan2, M_PI
+from libc.stdlib cimport abs
+from libc.math cimport fabs, sqrt, ceil, atan2, M_PI
 
 from ..draw import circle_perimeter
 
@@ -97,8 +98,8 @@ def _hough_circle(cnp.ndarray img,
     return acc
 
 
-def _hough_ellipse(cnp.ndarray img, int threshold=4, double accuracy=1,
-                   int min_size=4, max_size=None):
+def _hough_ellipse(cnp.ndarray img, Py_ssize_t threshold=4, double accuracy=1,
+                   Py_ssize_t min_size=4, max_size=None):
     """Perform an elliptical Hough transform.
 
     Parameters
@@ -159,7 +160,7 @@ def _hough_ellipse(cnp.ndarray img, int threshold=4, double accuracy=1,
     cdef list results = list()
     cdef double bin_size = accuracy * accuracy
 
-    cdef int max_b_squared
+    cdef double max_b_squared
     if max_size is None:
         if img.shape[0] < img.shape[1]:
             max_b_squared = np.round(0.5 * img.shape[0])
@@ -318,14 +319,14 @@ def _hough_line(cnp.ndarray img,
             x = x_idxs[i]
             y = y_idxs[i]
             for j in range(nthetas):
-                accum_idx = <int>round((ctheta[j] * x + stheta[j] * y)) + offset
+                accum_idx = round((ctheta[j] * x + stheta[j] * y)) + offset
                 accum[accum_idx, j] += 1
 
     return accum, theta, bins
 
 
-def _probabilistic_hough_line(cnp.ndarray img, int threshold,
-                              int line_length, int line_gap,
+def _probabilistic_hough_line(cnp.ndarray img, Py_ssize_t threshold,
+                              Py_ssize_t line_length, Py_ssize_t line_gap,
                               cnp.ndarray[ndim=1, dtype=cnp.double_t] theta,
                               seed=None):
     """Return lines from a progressive probabilistic line Hough transform.
@@ -365,161 +366,168 @@ def _probabilistic_hough_line(cnp.ndarray img, int threshold,
     # compute the bins and allocate the accumulator array
     cdef cnp.ndarray[ndim=2, dtype=cnp.uint8_t] mask = \
          np.zeros((height, width), dtype=np.uint8)
-    cdef cnp.int32_t[:, ::1] line_end = np.zeros((2, 2), dtype=np.int32)
+    cdef cnp.intp_t[:, ::1] line_end = np.zeros((2, 2), dtype=np.intp)
     cdef Py_ssize_t max_distance, offset, num_indexes, index
     cdef double a, b
-    cdef Py_ssize_t nidxs, i, j, x, y, px, py, accum_idx
-    cdef int value, max_value, max_theta
+    cdef Py_ssize_t nidxs, i, j, k, x, y, px, py, accum_idx, max_theta
+    cdef Py_ssize_t xflag, x0, y0, dx0, dy0, dx, dy, gap, x1, y1, count
+    cdef cnp.int64_t value, max_value,
     cdef int shift = 16
-    # maximum line number cutoff
-    cdef Py_ssize_t lines_max = 2 ** 15
-    cdef Py_ssize_t xflag, x0, y0, dx0, dy0, dx, dy, gap, x1, y1, \
-                    good_line, count
-    cdef list lines = list()
+    cdef int good_line
+    cdef Py_ssize_t nlines = 0
+    cdef Py_ssize_t lines_max = 2 ** 15  # maximum line number cutoff
+    cdef cnp.intp_t[:, :, ::1] lines = np.zeros((lines_max, 2, 2),
+                                                dtype=np.intp)
 
-    max_distance = 2 * <int>ceil((sqrt(img.shape[0] * img.shape[0] +
-                                       img.shape[1] * img.shape[1])))
-    cdef cnp.int64_t[:, ::1] accum = \
-        np.zeros((max_distance, theta.shape[0]), dtype=np.int64)
+    max_distance = 2 * <Py_ssize_t>ceil((sqrt(img.shape[0] * img.shape[0] +
+                                              img.shape[1] * img.shape[1])))
+    cdef cnp.int64_t[:, ::1] accum = np.zeros((max_distance, theta.shape[0]),
+                                              dtype=np.int64)
     offset = max_distance / 2
-    nthetas = theta.shape[0]
+    cdef Py_ssize_t nthetas = theta.shape[0]
 
     # compute sine and cosine of angles
     cdef cnp.double_t[::1] ctheta = np.cos(theta)
     cdef cnp.double_t[::1] stheta = np.sin(theta)
 
     # find the nonzero indexes
+    cdef cnp.intp_t[:] y_idxs, x_idxs
     y_idxs, x_idxs = np.nonzero(img)
-    cdef list points = list(zip(x_idxs, y_idxs))
+
     # mask all non-zero indexes
     mask[y_idxs, x_idxs] = 1
 
+    count = len(x_idxs)
     random_state = np.random.RandomState(seed)
+    random_ = np.arange(count, dtype=np.intp)
+    np.random.shuffle(random_)
+    cdef cnp.intp_t[::1] random = random_
 
-    while 1:
+    with nogil:
+        while count > 0:
+            count -= 1
+            # select random non-zero point
+            index = random[count]
+            x = x_idxs[index]
+            y = y_idxs[index]
 
-        # quit if no remaining points
-        count = len(points)
-        if count == 0:
-            break
+            # if previously eliminated, skip
+            if not mask[y, x]:
+                continue
 
-        # select random non-zero point
-        index = random_state.randint(0, count)
-        x = points[index][0]
-        y = points[index][1]
-        del points[index]
+            value = 0
+            max_value = threshold - 1
+            max_theta = -1
 
-        # if previously eliminated, skip
-        if not mask[y, x]:
-            continue
+            # apply hough transform on point
+            for j in range(nthetas):
+                accum_idx = round((ctheta[j] * x + stheta[j] * y)) + offset
+                accum[accum_idx, j] += 1
+                value = accum[accum_idx, j]
+                if value > max_value:
+                    max_value = value
+                    max_theta = j
+            if max_value < threshold:
+                continue
 
-        value = 0
-        max_value = threshold - 1
-        max_theta = -1
-
-        # apply hough transform on point
-        for j in range(nthetas):
-            accum_idx = <int>round((ctheta[j] * x + stheta[j] * y)) + offset
-            accum[accum_idx, j] += 1
-            value = accum[accum_idx, j]
-            if value > max_value:
-                max_value = value
-                max_theta = j
-        if max_value < threshold:
-            continue
-
-        # from the random point walk in opposite directions and find line
-        # beginning and end
-        a = -stheta[max_theta]
-        b = ctheta[max_theta]
-        x0 = x
-        y0 = y
-        # calculate gradient of walks using fixed point math
-        xflag = fabs(a) > fabs(b)
-        if xflag:
-            if a > 0:
-                dx0 = 1
-            else:
-                dx0 = -1
-            dy0 = <int>round(b * (1 << shift) / fabs(a))
-            y0 = (y0 << shift) + (1 << (shift - 1))
-        else:
-            if b > 0:
-                dy0 = 1
-            else:
-                dy0 = -1
-            dx0 = <int>round(a * (1 << shift) / fabs(b))
-            x0 = (x0 << shift) + (1 << (shift - 1))
-
-        # pass 1: walk the line, merging lines less than specified gap length
-        for k in range(2):
-            gap = 0
-            px = x0
-            py = y0
-            dx = dx0
-            dy = dy0
-            if k > 0:
-                dx = -dx
-                dy = -dy
-            while 1:
-                if xflag:
-                    x1 = px
-                    y1 = py >> shift
+            # from the random point walk in opposite directions and find line
+            # beginning and end
+            a = -stheta[max_theta]
+            b = ctheta[max_theta]
+            x0 = x
+            y0 = y
+            # calculate gradient of walks using fixed point math
+            xflag = fabs(a) > fabs(b)
+            if xflag:
+                if a > 0:
+                    dx0 = 1
                 else:
-                    x1 = px >> shift
-                    y1 = py
-                # check when line exits image boundary
-                if x1 < 0 or x1 >= width or y1 < 0 or y1 >= height:
-                    break
-                gap += 1
-                # if non-zero point found, continue the line
-                if mask[y1, x1]:
-                    gap = 0
-                    line_end[k, 1] = y1
-                    line_end[k, 0] = x1
-                # if gap to this point was too large, end the line
-                elif gap > line_gap:
-                    break
-                px += dx
-                py += dy
-        # confirm line length is sufficient
-        good_line = abs(line_end[1, 1] - line_end[0, 1]) >= line_length or \
-                    abs(line_end[1, 0] - line_end[0, 0]) >= line_length
-
-        # pass 2: walk the line again and reset accumulator and mask
-        for k in range(2):
-            px = x0
-            py = y0
-            dx = dx0
-            dy = dy0
-            if k > 0:
-                dx = -dx
-                dy = -dy
-            while 1:
-                if xflag:
-                    x1 = px
-                    y1 = py >> shift
+                    dx0 = -1
+                dy0 = round(b * (1 << shift) / fabs(a))
+                y0 = (y0 << shift) + (1 << (shift - 1))
+            else:
+                if b > 0:
+                    dy0 = 1
                 else:
-                    x1 = px >> shift
-                    y1 = py
-                # if non-zero point found, continue the line
-                if mask[y1, x1]:
-                    if good_line:
-                        accum_idx = <int>round((ctheta[j] * x1 \
-                                                + stheta[j] * y1)) + offset
-                        accum[accum_idx, max_theta] -= 1
-                        mask[y1, x1] = 0
-                # exit when the point is the line end
-                if x1 == line_end[k, 0] and y1 == line_end[k, 1]:
+                    dy0 = -1
+                dx0 = round(a * (1 << shift) / fabs(b))
+                x0 = (x0 << shift) + (1 << (shift - 1))
+
+            # pass 1: walk the line, merging lines less than specified gap
+            # length
+            for k in range(2):
+                gap = 0
+                px = x0
+                py = y0
+                dx = dx0
+                dy = dy0
+                if k > 0:
+                    dx = -dx
+                    dy = -dy
+                while 1:
+                    if xflag:
+                        x1 = px
+                        y1 = py >> shift
+                    else:
+                        x1 = px >> shift
+                        y1 = py
+                    # check when line exits image boundary
+                    if x1 < 0 or x1 >= width or y1 < 0 or y1 >= height:
+                        break
+                    gap += 1
+                    # if non-zero point found, continue the line
+                    if mask[y1, x1]:
+                        gap = 0
+                        line_end[k, 1] = y1
+                        line_end[k, 0] = x1
+                    # if gap to this point was too large, end the line
+                    elif gap > line_gap:
+                        break
+                    px += dx
+                    py += dy
+
+            # confirm line length is sufficient
+            good_line = abs(line_end[1, 1] - line_end[0, 1]) >= line_length or \
+                        abs(line_end[1, 0] - line_end[0, 0]) >= line_length
+
+            # pass 2: walk the line again and reset accumulator and mask
+            for k in range(2):
+                px = x0
+                py = y0
+                dx = dx0
+                dy = dy0
+                if k > 0:
+                    dx = -dx
+                    dy = -dy
+                while 1:
+                    if xflag:
+                        x1 = px
+                        y1 = py >> shift
+                    else:
+                        x1 = px >> shift
+                        y1 = py
+                    # if non-zero point found, continue the line
+                    if mask[y1, x1]:
+                        if good_line:
+                            accum_idx = round((ctheta[j] * x1 + stheta[j] * y1)) \
+                                        + offset
+                            accum[accum_idx, max_theta] -= 1
+                            mask[y1, x1] = 0
+                    # exit when the point is the line end
+                    if x1 == line_end[k, 0] and y1 == line_end[k, 1]:
+                        break
+                    px += dx
+                    py += dy
+
+            # add line to the result
+            if good_line:
+                lines[nlines, 0, 0] = line_end[0, 0]
+                lines[nlines, 0, 1] = line_end[0, 1]
+                lines[nlines, 1, 0] = line_end[1, 0]
+                lines[nlines, 1, 1] = line_end[1, 1]
+                nlines += 1
+                if nlines > lines_max:
                     break
-                px += dx
-                py += dy
 
-        # add line to the result
-        if good_line:
-            lines.append(((line_end[0, 0], line_end[0, 1]),
-                          (line_end[1, 0], line_end[1, 1])))
-            if len(lines) > lines_max:
-                return lines
-
-    return lines
+    return [((line[0, 0], line[0, 1]), (line[1, 0], line[1, 1]))
+            for line in lines[:nlines]]

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -118,7 +118,7 @@ def _hough_ellipse(cnp.ndarray img, int threshold=4, double accuracy=1,
 
     Returns
     -------
-    result : ndarray with fields [(accumulator, y0, x0, a, b, orientation)]
+    result : ndarray with fields [(accumulator, yc, xc, a, b, orientation)]
           Where ``(yc, xc)`` is the center, ``(a, b)`` the major and minor
           axes, respectively. The `orientation` value follows
           `skimage.draw.ellipse_perimeter` convention.
@@ -146,7 +146,14 @@ def _hough_ellipse(cnp.ndarray img, int threshold=4, double accuracy=1,
     if img.ndim != 2:
             raise ValueError('The input image must be 2D.')
 
+    # The creation of the array `pixels` results in a rather nasty error
+    # when the image is empty.
+    # As discussed in GitHub #2820 and #2996, we opt to return an empty array.
+    if not np.any(img):
+        return np.zeros((0, 6))
+
     cdef Py_ssize_t[:, ::1] pixels = np.row_stack(np.nonzero(img))
+
     cdef Py_ssize_t num_pixels = pixels.shape[1]
     cdef list acc = list()
     cdef list results = list()

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -131,7 +131,7 @@ def hough_ellipse(image, threshold=4, accuracy=1, min_size=4, max_size=None):
 
     Returns
     -------
-    result : ndarray with fields [(accumulator, y0, x0, a, b, orientation)]
+    result : ndarray with fields [(accumulator, yc, xc, a, b, orientation)].
           Where ``(yc, xc)`` is the center, ``(a, b)`` the major and minor
           axes, respectively. The `orientation` value follows
           `skimage.draw.ellipse_perimeter` convention.

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -460,3 +460,7 @@ def test_hough_ellipse_non_zero_negangle4():
                                  orientation=best[5])
     assert_equal(rr, rr2)
     assert_equal(cc, cc2)
+
+
+def test_hough_ellipse_all_black_img():
+    assert(transform.hough_ellipse(np.zeros((100, 100))).shape == (0, 6))

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -79,7 +79,7 @@ def test_probabilistic_hough_seed():
     lines = transform.probabilistic_hough_line(image, threshold=50,
                                                line_length=50, line_gap=1,
                                                seed=1234)
-    assert len(lines) == 64
+    assert len(lines) == 60
 
 
 def test_probabilistic_hough_bad_input():

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -79,7 +79,7 @@ def test_probabilistic_hough_seed():
     lines = transform.probabilistic_hough_line(image, threshold=50,
                                                line_length=50, line_gap=1,
                                                seed=1234)
-    assert len(lines) == 60
+    assert len(lines) == 65
 
 
 def test_probabilistic_hough_bad_input():

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -14,7 +14,7 @@ from skimage._shared._warnings import expected_warnings
 
 
 PHANTOM = imread(os.path.join(data_dir, "phantom.png"),
-                 as_grey=True)[::2, ::2]
+                 as_gray=True)[::2, ::2]
 PHANTOM = rescale(PHANTOM, 0.5, order=1, multichannel=False)
 
 

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -15,7 +15,8 @@ from skimage._shared._warnings import expected_warnings
 
 PHANTOM = imread(os.path.join(data_dir, "phantom.png"),
                  as_gray=True)[::2, ::2]
-PHANTOM = rescale(PHANTOM, 0.5, order=1, multichannel=False)
+PHANTOM = rescale(PHANTOM, 0.5, order=1,
+                  mode='constant', anti_aliasing=False, multichannel=False)
 
 
 def _debug_plot(original, result, sinogram=None):
@@ -133,7 +134,7 @@ def check_radon_iradon(interpolation_type, filter_type):
     debug = False
     image = PHANTOM
     reconstructed = iradon(radon(image, circle=False), filter=filter_type,
-                           interpolation=interpolation_type)
+                           interpolation=interpolation_type, circle=False)
     delta = np.mean(np.abs(image - reconstructed))
     print('\n\tmean error:', delta)
     if debug:
@@ -360,7 +361,8 @@ def test_order_angles_golden_ratio():
 def test_iradon_sart():
     debug = False
 
-    image = rescale(PHANTOM, 0.8, mode='reflect')
+    image = rescale(PHANTOM, 0.8, mode='reflect',
+                    multichannel=False, anti_aliasing=False)
     theta_ordered = np.linspace(0., 180., image.shape[0], endpoint=False)
     theta_missing_wedge = np.linspace(0., 150., image.shape[0], endpoint=True)
     for theta, error_factor in ((theta_ordered, 1.),

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -93,12 +93,12 @@ def test_warp_clip():
     x = np.zeros((5, 5), dtype=np.double)
     x[2, 2] = 1
 
-    with expected_warnings(['The default mode', 'The default multichannel']):
-        outx = rescale(x, 3, order=3, clip=False, anti_aliasing=False)
+    outx = rescale(x, 3, order=3, clip=False,
+                   multichannel=False, anti_aliasing=False, mode='constant')
     assert outx.min() < 0
 
-    with expected_warnings(['The default mode', 'The default multichannel']):
-        outx = rescale(x, 3, order=3, clip=True, anti_aliasing=False)
+    outx = rescale(x, 3, order=3, clip=True,
+                   multichannel=False, anti_aliasing=False, mode='constant')
     assert_almost_equal(outx.min(), 0)
     assert_almost_equal(outx.max(), 1)
 
@@ -164,8 +164,8 @@ def test_rescale():
     # same scale factor
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
-    with expected_warnings(['The default mode', 'The default multichannel']):
-        scaled = rescale(x, 2, order=0, anti_aliasing=False)
+    scaled = rescale(x, 2, order=0,
+                     multichannel=False, anti_aliasing=False, mode='constant')
     ref = np.zeros((10, 10))
     ref[2:4, 2:4] = 1
     assert_almost_equal(scaled, ref)
@@ -173,8 +173,9 @@ def test_rescale():
     # different scale factors
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
-    with expected_warnings(['The default mode', 'The default multichannel']):
-        scaled = rescale(x, (2, 1), order=0, anti_aliasing=False)
+
+    scaled = rescale(x, (2, 1), order=0,
+                     multichannel=False, anti_aliasing=False, mode='constant')
     ref = np.zeros((10, 5))
     ref[2:4, 1] = 1
     assert_almost_equal(scaled, ref)
@@ -183,41 +184,49 @@ def test_rescale():
 def test_rescale_invalid_scale():
     x = np.zeros((10, 10, 3))
     with testing.raises(ValueError):
-        rescale(x, (2, 2), multichannel=False)
+        rescale(x, (2, 2),
+                multichannel=False, anti_aliasing=False, mode='constant')
     with testing.raises(ValueError):
-        rescale(x, (2, 2, 2), multichannel=True)
+        rescale(x, (2, 2, 2),
+                multichannel=True, anti_aliasing=False, mode='constant')
 
 
 def test_rescale_multichannel():
     # 1D + channels
     x = np.zeros((8, 3), dtype=np.double)
-    scaled = rescale(x, 2, order=0, multichannel=True, anti_aliasing=False)
+    scaled = rescale(x, 2, order=0, multichannel=True, anti_aliasing=False,
+                     mode='constant')
     assert_equal(scaled.shape, (16, 3))
     # 2D
-    scaled = rescale(x, 2, order=0, multichannel=False, anti_aliasing=False)
+    scaled = rescale(x, 2, order=0, multichannel=False, anti_aliasing=False,
+                     mode='constant')
     assert_equal(scaled.shape, (16, 6))
 
     # 2D + channels
     x = np.zeros((8, 8, 3), dtype=np.double)
-    scaled = rescale(x, 2, order=0, multichannel=True, anti_aliasing=False)
+    scaled = rescale(x, 2, order=0, multichannel=True, anti_aliasing=False,
+                     mode='constant')
     assert_equal(scaled.shape, (16, 16, 3))
     # 3D
-    scaled = rescale(x, 2, order=0, multichannel=False, anti_aliasing=False)
+    scaled = rescale(x, 2, order=0, multichannel=False, anti_aliasing=False,
+                     mode='constant')
     assert_equal(scaled.shape, (16, 16, 6))
 
     # 3D + channels
     x = np.zeros((8, 8, 8, 3), dtype=np.double)
-    scaled = rescale(x, 2, order=0, multichannel=True, anti_aliasing=False)
+    scaled = rescale(x, 2, order=0, multichannel=True, anti_aliasing=False,
+                     mode='constant')
     assert_equal(scaled.shape, (16, 16, 16, 3))
     # 4D
-    scaled = rescale(x, 2, order=0, multichannel=False, anti_aliasing=False)
+    scaled = rescale(x, 2, order=0, multichannel=False, anti_aliasing=False,
+                     mode='constant')
     assert_equal(scaled.shape, (16, 16, 16, 6))
 
 
 def test_rescale_multichannel_multiscale():
     x = np.zeros((5, 5, 3), dtype=np.double)
     scaled = rescale(x, (2, 1), order=0, multichannel=True,
-                     anti_aliasing=False)
+                     anti_aliasing=False, mode='constant')
     assert_equal(scaled.shape, (10, 5, 3))
 
 
@@ -226,22 +235,22 @@ def test_rescale_multichannel_defaults():
 
     # 2D: multichannel should default to False
     x = np.zeros((8, 3), dtype=np.double)
-    with expected_warnings(['The default mode', 'The default multichannel']):
-        scaled = rescale(x, 2, order=0, anti_aliasing=False)
+    with expected_warnings(['multichannel']):
+        scaled = rescale(x, 2, order=0, anti_aliasing=False, mode='constant')
     assert_equal(scaled.shape, (16, 6))
 
     # 3D: multichannel should default to True
     x = np.zeros((8, 8, 3), dtype=np.double)
-    with expected_warnings(['The default mode', 'The default multichannel']):
-        scaled = rescale(x, 2, order=0, anti_aliasing=False)
+    with expected_warnings(['multichannel']):
+        scaled = rescale(x, 2, order=0, anti_aliasing=False, mode='constant')
     assert_equal(scaled.shape, (16, 16, 3))
 
 
 def test_resize2d():
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
-    with expected_warnings(['The default mode']):
-        resized = resize(x, (10, 10), order=0, anti_aliasing=False)
+    resized = resize(x, (10, 10), order=0, anti_aliasing=False,
+                     mode='constant')
     ref = np.zeros((10, 10))
     ref[2:4, 2:4] = 1
     assert_almost_equal(resized, ref)
@@ -251,16 +260,16 @@ def test_resize3d_keep():
     # keep 3rd dimension
     x = np.zeros((5, 5, 3), dtype=np.double)
     x[1, 1, :] = 1
-    with expected_warnings(['The default mode']):
-        resized = resize(x, (10, 10), order=0, anti_aliasing=False)
-        with testing.raises(ValueError):
-            # output_shape too short
-            resize(x, (10, ), order=0, anti_aliasing=False)
+    resized = resize(x, (10, 10), order=0, anti_aliasing=False,
+                     mode='constant')
+    with testing.raises(ValueError):
+        # output_shape too short
+        resize(x, (10, ), order=0, anti_aliasing=False, mode='constant')
     ref = np.zeros((10, 10, 3))
     ref[2:4, 2:4, :] = 1
     assert_almost_equal(resized, ref)
-    with expected_warnings(['The default mode']):
-        resized = resize(x, (10, 10, 3), order=0, anti_aliasing=False)
+    resized = resize(x, (10, 10, 3), order=0, anti_aliasing=False,
+                     mode='constant')
     assert_almost_equal(resized, ref)
 
 
@@ -268,8 +277,8 @@ def test_resize3d_resize():
     # resize 3rd dimension
     x = np.zeros((5, 5, 3), dtype=np.double)
     x[1, 1, :] = 1
-    with expected_warnings(['The default mode']):
-        resized = resize(x, (10, 10, 1), order=0, anti_aliasing=False)
+    resized = resize(x, (10, 10, 1), order=0, anti_aliasing=False,
+                     mode='constant')
     ref = np.zeros((10, 10, 1))
     ref[2:4, 2:4] = 1
     assert_almost_equal(resized, ref)
@@ -279,8 +288,8 @@ def test_resize3d_2din_3dout():
     # 3D output with 2D input
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
-    with expected_warnings(['The default mode']):
-        resized = resize(x, (10, 10, 1), order=0, anti_aliasing=False)
+    resized = resize(x, (10, 10, 1), order=0, anti_aliasing=False,
+                     mode='constant')
     ref = np.zeros((10, 10, 1))
     ref[2:4, 2:4] = 1
     assert_almost_equal(resized, ref)
@@ -291,7 +300,8 @@ def test_resize2d_4d():
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
     out_shape = (10, 10, 1, 1)
-    resized = resize(x, out_shape, order=0, anti_aliasing=False)
+    resized = resize(x, out_shape, order=0, anti_aliasing=False,
+                     mode='constant')
     ref = np.zeros(out_shape)
     ref[2:4, 2:4, ...] = 1
     assert_almost_equal(resized, ref)
@@ -376,7 +386,7 @@ def test_warp_coords_example():
 def test_downsize():
     x = np.zeros((10, 10), dtype=np.double)
     x[2:4, 2:4] = 1
-    scaled = resize(x, (5, 5), order=0, anti_aliasing=False)
+    scaled = resize(x, (5, 5), order=0, anti_aliasing=False, mode='constant')
     assert_equal(scaled.shape, (5, 5))
     assert_equal(scaled[1, 1], 1)
     assert_equal(scaled[2:, :].sum(), 0)
@@ -386,7 +396,7 @@ def test_downsize():
 def test_downsize_anti_aliasing():
     x = np.zeros((10, 10), dtype=np.double)
     x[2, 2] = 1
-    scaled = resize(x, (5, 5), order=1, anti_aliasing=True)
+    scaled = resize(x, (5, 5), order=1, anti_aliasing=True, mode='constant')
     assert_equal(scaled.shape, (5, 5))
     assert np.all(scaled[:3, :3] > 0)
     assert_equal(scaled[3:, :].sum(), 0)
@@ -396,7 +406,8 @@ def test_downsize_anti_aliasing():
 def test_downsize_anti_aliasing_invalid_stddev():
     x = np.zeros((10, 10), dtype=np.double)
     with testing.raises(ValueError):
-        resize(x, (5, 5), order=0, anti_aliasing=True, anti_aliasing_sigma=-1)
+        resize(x, (5, 5), order=0, anti_aliasing=True, anti_aliasing_sigma=-1,
+               mode='constant')
     with expected_warnings(["Anti-aliasing standard deviation greater"]):
         resize(x, (5, 15), order=0, anti_aliasing=True,
                anti_aliasing_sigma=(1, 1), mode="reflect")
@@ -407,7 +418,8 @@ def test_downsize_anti_aliasing_invalid_stddev():
 def test_downscale():
     x = np.zeros((10, 10), dtype=np.double)
     x[2:4, 2:4] = 1
-    scaled = rescale(x, 0.5, order=0, anti_aliasing=False)
+    scaled = rescale(x, 0.5, order=0, anti_aliasing=False,
+                     multichannel=False, mode='constant')
     assert_equal(scaled.shape, (5, 5))
     assert_equal(scaled[1, 1], 1)
     assert_equal(scaled[2:, :].sum(), 0)
@@ -417,7 +429,8 @@ def test_downscale():
 def test_downscale_anti_aliasing():
     x = np.zeros((10, 10), dtype=np.double)
     x[2, 2] = 1
-    scaled = rescale(x, 0.5, order=1, anti_aliasing=True)
+    scaled = rescale(x, 0.5, order=1, anti_aliasing=True,
+                     multichannel=False, mode='constant')
     assert_equal(scaled.shape, (5, 5))
     assert np.all(scaled[:3, :3] > 0)
     assert_equal(scaled[3:, :].sum(), 0)
@@ -463,22 +476,18 @@ def test_slow_warp_nonint_oshape():
 
 def test_keep_range():
     image = np.linspace(0, 2, 25).reshape(5, 5)
-
-    with expected_warnings(['The default mode', 'The default multichannel']):
-        out = rescale(image, 2, preserve_range=False, clip=True, order=0,
-                      anti_aliasing=False)
+    out = rescale(image, 2, preserve_range=False, clip=True, order=0,
+                  mode='constant', multichannel='False', anti_aliasing=False)
     assert out.min() == 0
     assert out.max() == 2
 
-    with expected_warnings(['The default mode', 'The default multichannel']):
-        out = rescale(image, 2, preserve_range=True, clip=True, order=0,
-                      anti_aliasing=False)
+    out = rescale(image, 2, preserve_range=True, clip=True, order=0,
+                  mode='constant', multichannel='False', anti_aliasing=False)
     assert out.min() == 0
     assert out.max() == 2
 
-    with expected_warnings(['The default mode', 'The default multichannel']):
-        out = rescale(image.astype(np.uint8), 2, preserve_range=False,
-                      anti_aliasing=False,
-                      clip=True, order=0)
+    out = rescale(image.astype(np.uint8), 2, preserve_range=False,
+                  mode='constant', multichannel='False', anti_aliasing=False,
+                  clip=True, order=0)
     assert out.min() == 0
     assert out.max() == 2 / 255.0

--- a/skimage/util/_invert.py
+++ b/skimage/util/_invert.py
@@ -63,12 +63,12 @@ def invert(image, signed_float=False):
         inverted = ~image
     elif np.issubdtype(image.dtype, np.unsignedinteger):
         max_val = dtype_limits(image, clip_negative=False)[1]
-        inverted = max_val - image
+        inverted = np.subtract(max_val, image, dtype=image.dtype)
     elif np.issubdtype(image.dtype, np.signedinteger):
-        inverted = -1 - image
+        inverted = np.subtract(-1, image, dtype=image.dtype)
     else:  # float dtype
         if signed_float:
             inverted = -image
         else:
-            inverted = 1 - image
+            inverted = np.subtract(1, image, dtype=image.dtype)
     return inverted

--- a/skimage/util/tests/test_invert.py
+++ b/skimage/util/tests/test_invert.py
@@ -1,5 +1,6 @@
 import numpy as np
 from skimage import dtype_limits
+from skimage.util.dtype import dtype_range
 from skimage.util import invert
 
 from skimage._shared.testing import assert_array_equal
@@ -67,3 +68,10 @@ def test_invert_float64_unsigned():
     expected[1, :] = upper_dtype_limit
     result = invert(image)
     assert_array_equal(expected, result)
+
+
+def test_invert_roundtrip():
+    for t, limits in dtype_range.items():
+        image = np.array(limits, dtype=t)
+        expected = invert(invert(image))
+        assert_array_equal(image, expected)

--- a/skimage/util/tests/test_montage.py
+++ b/skimage/util/tests/test_montage.py
@@ -1,8 +1,15 @@
 from skimage._shared import testing
-from skimage._shared.testing import assert_equal, assert_array_equal
+from skimage._shared.testing import (assert_equal, assert_array_equal,
+                                     expected_warnings)
 
 import numpy as np
-from skimage.util import montage2d, montage
+from skimage.util import montage
+from skimage.util import montage2d as montage2d_deprecated
+
+
+def montage2d(*args, **kwargs):
+    with expected_warnings(['deprecated']):
+        return montage2d_deprecated(*args, **kwargs)
 
 
 def test_montage2d_simple():

--- a/skimage/viewer/tests/test_utils.py
+++ b/skimage/viewer/tests/test_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from skimage.viewer import utils
 from skimage.viewer.utils import dialogs
-from skimage.viewer.qt import QtCore, QtGui, has_qt
+from skimage.viewer.qt import QtCore, QtWidgets, has_qt
 from skimage._shared import testing
 
 
@@ -9,7 +9,7 @@ from skimage._shared import testing
 def test_event_loop():
     utils.init_qtapp()
     timer = QtCore.QTimer()
-    timer.singleShot(10, QtGui.QApplication.quit)
+    timer.singleShot(10, QtWidgets.QApplication.quit)
     utils.start_qtapp()
 
 
@@ -21,19 +21,21 @@ def test_format_filename():
     assert fname is None
 
 
+@testing.skipif(True, reason="Can't automatically close window. See #3081.")
 @testing.skipif(not has_qt, reason="Qt not installed")
 def test_open_file_dialog():
-    utils.init_qtapp()
+    QApp = utils.init_qtapp()
     timer = QtCore.QTimer()
-    timer.singleShot(100, lambda: QtGui.QApplication.quit())
+    timer.singleShot(100, lambda: QApp.quit())
     filename = dialogs.open_file_dialog()
     assert filename is None
 
 
+@testing.skipif(True, reason="Can't automatically close window. See #3081.")
 @testing.skipif(not has_qt, reason="Qt not installed")
 def test_save_file_dialog():
-    utils.init_qtapp()
+    QApp = utils.init_qtapp()
     timer = QtCore.QTimer()
-    timer.singleShot(100, lambda: QtGui.QApplication.quit())
+    timer.singleShot(100, lambda: QApp.quit())
     filename = dialogs.save_file_dialog()
     assert filename is None

--- a/skimage/viewer/tests/test_widgets.py
+++ b/skimage/viewer/tests/test_widgets.py
@@ -3,7 +3,7 @@ import os
 from skimage import data, img_as_float, io, img_as_uint
 
 from skimage.viewer import ImageViewer
-from skimage.viewer.qt import QtGui, QtCore, has_qt
+from skimage.viewer.qt import QtWidgets, QtCore, has_qt
 from skimage.viewer.widgets import (
     Slider, OKCancelButtons, SaveButtons, ComboBox, CheckBox, Text)
 from skimage.viewer.plugins.base import Plugin
@@ -88,6 +88,7 @@ def test_slider_float():
     assert_almost_equal(sld.val, 2.5, 2)
 
 
+@testing.skipif(True, reason="Can't automatically close window. See #3081.")
 @testing.skipif(not has_qt, reason="Qt not installed")
 def test_save_buttons():
     viewer = get_image_viewer()
@@ -99,7 +100,7 @@ def test_save_buttons():
     os.close(fid)
 
     timer = QtCore.QTimer()
-    timer.singleShot(100, QtGui.QApplication.quit)
+    timer.singleShot(100, QtWidgets.QApplication.quit)
 
     # exercise the button clicks
     sv.save_stack.click()
@@ -129,4 +130,3 @@ def test_ok_buttons():
 
     ok.update_original_image(),
     ok.close_plugin()
-

--- a/skimage/viewer/utils/dialogs.py
+++ b/skimage/viewer/utils/dialogs.py
@@ -1,6 +1,6 @@
 import os
 
-from ..qt import QtGui
+from ..qt import QtWidgets
 
 
 __all__ = ['open_file_dialog', 'save_file_dialog']
@@ -17,18 +17,18 @@ def _format_filename(filename):
 
 def open_file_dialog():
     """Return user-selected file path."""
-    filename = QtGui.QFileDialog.getOpenFileName()
+    filename = QtWidgets.QFileDialog.getOpenFileName()
     filename = _format_filename(filename)
     return filename
 
 
 def save_file_dialog(default_format='png'):
     """Return user-selected file path."""
-    filename = QtGui.QFileDialog.getSaveFileName()
+    filename = QtWidgets.QFileDialog.getSaveFileName()
     filename = _format_filename(filename)
     if filename is None:
         return None
-    #TODO: io plugins should assign default image formats
+    # TODO: io plugins should assign default image formats
     basename, ext = os.path.splitext(filename)
     if not ext:
         filename = '%s.%s' % (filename, default_format)

--- a/skimage/viewer/viewers/core.py
+++ b/skimage/viewer/viewers/core.py
@@ -6,7 +6,7 @@ import numpy as np
 from ... import io, img_as_float
 from ...util.dtype import dtype_range
 from ...exposure import rescale_intensity
-from ..qt import QtWidgets, Qt, Signal
+from ..qt import QtWidgets, QtGui, Qt, Signal
 from ..widgets import Slider
 from ..utils import (dialogs, init_qtapp, figimage, start_qtapp,
                      update_axes_image)
@@ -93,7 +93,7 @@ class ImageViewer(QtWidgets.QMainWindow):
         init_qtapp()
         super(ImageViewer, self).__init__()
 
-        #TODO: Add ImageViewer to skimage.io window manager
+        # TODO: Add ImageViewer to skimage.io window manager
 
         self.setAttribute(Qt.WA_DeleteOnClose)
         self.setWindowTitle("Image Viewer")
@@ -361,7 +361,7 @@ class CollectionViewer(ImageViewer):
         self.slider = Slider('frame', **slider_kws)
         self.layout.addWidget(self.slider)
 
-        #TODO: Adjust height to accomodate slider; the following doesn't work
+        # TODO: Adjust height to accomodate slider; the following doesn't work
         # s_size = self.slider.sizeHint()
         # cs_size = self.canvas.sizeHint()
         # self.resize(cs_size.width(), cs_size.height() + s_size.height())
@@ -382,7 +382,7 @@ class CollectionViewer(ImageViewer):
         self.update_image(self.image_collection[index])
 
     def keyPressEvent(self, event):
-        if type(event) == QtWidgets.QKeyEvent:
+        if type(event) == QtGui.QKeyEvent:
             key = event.key()
             # Number keys (code: 0 = key 48, 9 = key 57) move to deciles
             if 48 <= key < 58:

--- a/skimage/viewer/widgets/core.py
+++ b/skimage/viewer/widgets/core.py
@@ -5,7 +5,6 @@ from ..utils import RequiredAttr
 __all__ = ['BaseWidget', 'Slider', 'ComboBox', 'CheckBox', 'Text', 'Button']
 
 
-
 class BaseWidget(QtWidgets.QWidget):
 
     plugin = RequiredAttr("Widget is not attached to a Plugin.")
@@ -75,6 +74,7 @@ class Slider(BaseWidget):
     update_on : {'release' | 'move'}, optional
         Control when callback function is called: on slider move or release.
     """
+
     def __init__(self, name, low=0.0, high=1.0, value=None, value_type='float',
                  ptype='kwarg', callback=None, max_edit_width=60,
                  orientation='horizontal', update_on='release'):
@@ -84,7 +84,7 @@ class Slider(BaseWidget):
             value = (high - low) / 2.
 
         # Set widget orientation
-        #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         if orientation == 'vertical':
             self.slider = QtWidgets.QSlider(Qt.Vertical)
             alignment = QtCore.Qt.AlignHCenter
@@ -100,10 +100,10 @@ class Slider(BaseWidget):
         else:
             msg = "Unexpected value %s for 'orientation'"
             raise ValueError(msg % orientation)
-        #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
         # Set slider behavior for float and int values.
-        #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         if value_type == 'float':
             # divide slider into 1000 discrete values
             slider_max = 1000
@@ -116,7 +116,7 @@ class Slider(BaseWidget):
         else:
             msg = "Expected `value_type` to be 'float' or 'int'; received: %s"
             raise ValueError(msg % value_type)
-        #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
         self.value_type = value_type
         self._low = low
@@ -299,10 +299,11 @@ class Button(BaseWidget):
     callback : callable f()
         Function to call when button is clicked.
     """
+
     def __init__(self, name, callback):
         super(Button, self).__init__(self)
-        self._button = QtGui.QPushButton(name)
+        self._button = QtWidgets.QPushButton(name)
         self._button.clicked.connect(callback)
 
-        self.layout = QtGui.QHBoxLayout(self)
+        self.layout = QtWidgets.QHBoxLayout(self)
         self.layout.addWidget(self._button)

--- a/skimage/viewer/widgets/history.py
+++ b/skimage/viewer/widgets/history.py
@@ -1,6 +1,6 @@
 from textwrap import dedent
 
-from ..qt import QtGui, QtCore
+from ..qt import QtGui, QtCore, QtWidgets
 import numpy as np
 
 import skimage
@@ -18,20 +18,21 @@ class OKCancelButtons(BaseWidget):
     OK will replace the original image with the current (filtered) image.
     Cancel will just close the plugin.
     """
+
     def __init__(self, button_width=80):
         name = 'OK/Cancel'
         super(OKCancelButtons, self).__init__(name)
 
-        self.ok = QtGui.QPushButton('OK')
+        self.ok = QtWidgets.QPushButton('OK')
         self.ok.clicked.connect(self.update_original_image)
         self.ok.setMaximumWidth(button_width)
         self.ok.setFocusPolicy(QtCore.Qt.NoFocus)
-        self.cancel = QtGui.QPushButton('Cancel')
+        self.cancel = QtWidgets.QPushButton('Cancel')
         self.cancel.clicked.connect(self.close_plugin)
         self.cancel.setMaximumWidth(button_width)
         self.cancel.setFocusPolicy(QtCore.Qt.NoFocus)
 
-        self.layout = QtGui.QHBoxLayout(self)
+        self.layout = QtWidgets.QHBoxLayout(self)
         self.layout.addStretch()
         self.layout.addWidget(self.cancel)
         self.layout.addWidget(self.ok)
@@ -54,17 +55,17 @@ class SaveButtons(BaseWidget):
 
         self.default_format = default_format
 
-        self.name_label = QtGui.QLabel()
+        self.name_label = QtWidgets.QLabel()
         self.name_label.setText(name)
 
-        self.save_file = QtGui.QPushButton('File')
+        self.save_file = QtWidgets.QPushButton('File')
         self.save_file.clicked.connect(self.save_to_file)
         self.save_file.setFocusPolicy(QtCore.Qt.NoFocus)
-        self.save_stack = QtGui.QPushButton('Stack')
+        self.save_stack = QtWidgets.QPushButton('Stack')
         self.save_stack.clicked.connect(self.save_to_stack)
         self.save_stack.setFocusPolicy(QtCore.Qt.NoFocus)
 
-        self.layout = QtGui.QHBoxLayout(self)
+        self.layout = QtWidgets.QHBoxLayout(self)
         self.layout.addWidget(self.name_label)
         self.layout.addWidget(self.save_stack)
         self.layout.addWidget(self.save_file)
@@ -86,18 +87,18 @@ class SaveButtons(BaseWidget):
             return
         image = self.plugin.filtered_image
         if image.dtype == np.bool:
-            #TODO: This check/conversion should probably be in `imsave`.
+            # TODO: This check/conversion should probably be in `imsave`.
             image = img_as_ubyte(image)
         io.imsave(filename, image)
 
 
 def notify(msg):
-    msglabel = QtGui.QLabel(msg)
-    dialog = QtGui.QDialog()
-    ok = QtGui.QPushButton('OK', dialog)
+    msglabel = QtWidgets.QLabel(msg)
+    dialog = QtWidgets.QDialog()
+    ok = QtWidgets.QPushButton('OK', dialog)
     ok.clicked.connect(dialog.accept)
     ok.setDefault(True)
-    dialog.layout = QtGui.QGridLayout(dialog)
+    dialog.layout = QtWidgets.QGridLayout(dialog)
     dialog.layout.addWidget(msglabel, 0, 0, 1, 3)
     dialog.layout.addWidget(ok, 1, 1)
     dialog.exec_()

--- a/tools/travis/install_qt.sh
+++ b/tools/travis/install_qt.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -ex
+
+if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+    echo "backend : Template" > $MPL_DIR/matplotlibrc
+fi
+# Now configure Matplotlib to use Qt4
+if [[ "${QT}" == "PyQt4" ]]; then
+    # only do this for python 2.7
+    # http://stackoverflow.com/a/9716100
+    LIBS=( PyQt4 sip.so )
+
+    VAR=( $(which -a python$PY) )
+
+    GET_PYTHON_LIB_CMD="from distutils.sysconfig import get_python_lib; print (get_python_lib())"
+    LIB_VIRTUALENV_PATH=$(python -c "$GET_PYTHON_LIB_CMD")
+    LIB_SYSTEM_PATH=$(${VAR[-1]} -c "$GET_PYTHON_LIB_CMD")
+
+    for LIB in ${LIBS[@]}
+    do
+        ln -sf $LIB_SYSTEM_PATH/$LIB $LIB_VIRTUALENV_PATH/$LIB
+    done
+
+    MPL_QT_API=PyQt4
+    export QT_API=pyqt
+elif [[ "${QT}" == "PySide" ]]; then
+    python ~/venv/bin/pyside_postinstall.py -install
+    MPL_QT_API=PySide
+    export QT_API=pyside
+elif [[ "${QT}" == "PyQt5" ]]; then
+    pip install --retries 3 -q $PIP_FLAGS pyqt5
+    MPL_QT_API=PyQt5
+    export QT_API=pyqt5
+elif [[ "${QT}" == "PySide2" ]]; then
+    pip install--retries 3 -q $PIP_FLAGS pyside2
+    MPL_QT_API=PySide2
+    export QT_API=pyside2
+else
+    echo 'backend: Template' > $MPL_DIR/matplotlibrc
+fi
+if [[ "${QT}" == "PyQt4" || "${QT}" == "PySide" ]]; then
+    echo 'backend: Qt4Agg' > $MPL_DIR/matplotlibrc
+    echo 'backend.qt4 : '$MPL_QT_API >> $MPL_DIR/matplotlibrc
+elif [[ "${QT}" == "PyQt5" || "${QT}" == "PySide2" ]]; then
+    # Is this correct for PySide2?
+    echo 'backend: Qt5Agg' > $MPL_DIR/matplotlibrc
+    echo 'backend.qt5 : '$MPL_QT_API >> $MPL_DIR/matplotlibrc
+fi
+
+set -ex

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -1,123 +1,46 @@
 #!/usr/bin/env bash
-set -ex
+export PY=${TRAVIS_PYTHON_VERSION}
 
-PY=$TRAVIS_PYTHON_VERSION
-
-# Matplotlib settings - do not show figures during doc examples
-if [[ $MINIMUM_REQUIREMENTS == 1 || $TRAVIS_OS_NAME == "osx" ]]; then
-    MPL_DIR=$HOME/.matplotlib
-else
-    MPL_DIR=$HOME/.config/matplotlib
-fi
-
-mkdir -p $MPL_DIR
-touch $MPL_DIR/matplotlibrc
-
-if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-    echo 'backend : Template' > $MPL_DIR/matplotlibrc
-fi
-
-section "Test.with.min.requirements"
-pytest $TEST_ARGS skimage
-section_end "Test.with.min.requirements"
-
-section "Flake8.test"
+section "Tests.flake8"
 flake8 --exit-zero --exclude=test_*,six.py skimage doc/examples viewer_examples
-section_end "Flake8.test"
+section_end "Tests.flake8"
 
 
-section "Install.optional.dependencies"
-
-# Install most of the optional packages
-if [[ $OPTIONAL_DEPS == 1 ]]; then
-    pip install --retries 3 -q -r ./requirements/optional.txt $WHEELHOUSE
+section "Tests.pytest"
+# run tests. If running with optional dependencies, report coverage
+if [[ "$OPTIONAL_DEPS" == "1" ]]; then
+  export TEST_ARGS="${TEST_ARGS} --cov=skimage"
 fi
-
-# Install Qt and then update the Matplotlib settings
-if [[ $WITH_QT == 1 ]]; then
-    # http://stackoverflow.com/a/9716100
-    LIBS=( PyQt4 sip.so )
-
-    VAR=( $(which -a python$PY) )
-
-    GET_PYTHON_LIB_CMD="from distutils.sysconfig import get_python_lib; print (get_python_lib())"
-    LIB_VIRTUALENV_PATH=$(python -c "$GET_PYTHON_LIB_CMD")
-    LIB_SYSTEM_PATH=$(${VAR[-1]} -c "$GET_PYTHON_LIB_CMD")
-
-    for LIB in ${LIBS[@]}
-    do
-        ln -sf $LIB_SYSTEM_PATH/$LIB $LIB_VIRTUALENV_PATH/$LIB
-    done
-
-elif [ "$WITH_PYSIDE" == 1 ] && [ -e ~/venv/bin/pyside_postinstall.py ]; then
-    python ~/venv/bin/pyside_postinstall.py -install
-fi
-
-if [[ $WITH_PYAMG == 1 ]]; then
-    pip install --retries 3 -q pyamg
-fi
-
 # Show what's installed
 pip list
-
-section_end "Install.optional.dependencies"
-
-
-section "Build.docs.or.run.examples"
-
-pip install --retries 3 -q -r ./requirements/docs.txt
-
-if [[ $BUILD_DOCS == 1 ]]; then
-    export SPHINXCACHE=$HOME/.cache/sphinx; make html
-else
-    echo 'backend : Template' > $MPL_DIR/matplotlibrc
-
-    for f in doc/examples/*/*.py; do
-        python "$f"
-        if [ $? -ne 0 ]; then
-            exit 1
-        fi
-    done
-fi
-
-section_end "Build.docs.or.run.examples"
+pytest ${TEST_ARGS} skimage
+section_end "Tests.pytest"
 
 
-section "Run.doc.applications"
-
-for f in doc/examples/xx_applications/*.py; do
-    python "$f"
+section "Tests.examples"
+# Run example applications
+echo Build or run examples
+if [[ "${BUILD_DOCS}" == "1" ]]; then
+  # requirements/docs.txt fails on Travis OSX
+  pip install --retries 3 -q -r ./requirements/docs.txt
+  export SPHINXCACHE=${HOME}/.cache/sphinx; make html
+elif [[ "${TEST_EXAMPLES}" != "0" ]]; then
+  # OSX Can't install sphinx-gallery.
+  # I think all it needs is scikit-learn from that requirements doc
+  # to run the tests. See Issue #3084
+  if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+    pip install --retries 3 -q scikit-learn
+  else
+    pip install --retries 3 -q -r ./requirements/docs.txt
+  fi
+  cp $MPL_DIR/matplotlibrc $MPL_DIR/matplotlibrc_backup
+  echo 'backend : Template' > $MPL_DIR/matplotlibrc
+  for f in doc/examples/*/*.py; do
+    python "${f}"
     if [ $? -ne 0 ]; then
-        exit 1
+      exit 1
     fi
-done
-
-# Now configure Matplotlib to use Qt4
-if [[ $WITH_QT == 1 ]]; then
-    MPL_QT_API=PyQt4
-    export QT_API=pyqt
-elif [[ $WITH_PYSIDE == 1 ]]; then
-    MPL_QT_API=PySide
-    export QT_API=pyside
+  done
+  mv $MPL_DIR/matplotlibrc_backup $MPL_DIR/matplotlibrc
 fi
-if [[ $WITH_QT == 1 || $WITH_PYSIDE == 1 ]]; then
-    echo 'backend: Qt4Agg' > $MPL_DIR/matplotlibrc
-    echo 'backend.qt4 : '$MPL_QT_API >> $MPL_DIR/matplotlibrc
-fi
-
-section_end "Run.doc.applications"
-
-
-section "Test.with.optional.dependencies"
-
-# run tests again with optional dependencies to get more coverage
-if [[ $OPTIONAL_DEPS == 1 ]]; then
-    TEST_ARGS="$TEST_ARGS --cov=skimage"
-fi
-pytest $TEST_ARGS
-
-section_end "Test.with.optional.dependencies"
-
-section "Prepare.release"
-doc/release/contribs.py HEAD~10
-section_end "Prepare.release"
+section_end "Tests.examples"


### PR DESCRIPTION
## Description

Release the GIL.
Use `ssize_t` for sizes and indices.
Replace weird `point` list with numpy arrays.
Store lines in a pre-allocated numpy array.

Tested on win-amd64-py3.7 only.

This change is not backwards compatible if seed is specified because of the use of `random.shuffle` instead of `random_state.randint`. One test needed to be adjusted.

Why does the `_probabilistic_hough_line` function return a "list of tuples of tuples" instead of a 3D numpy array?

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
