### PR TITLE
Correct reference for the coins sample image

### DIFF
--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -139,7 +139,7 @@ def coins():
     -----
     This image was downloaded from the
     `Brooklyn Museum Collection
-    <http://www.brooklynmuseum.org/opencollection/archives/image/33814>`__.
+    <https://www.brooklynmuseum.org/opencollection/archives/image/51611>`__.
 
     No known copyright restrictions.
 


### PR DESCRIPTION
Updated the 'coins' reference URL to current https://www.brooklynmuseum.org/opencollection/archives/image/51611



## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
