### PR TITLE
Switch to basis numpy int dtypes in dtype_range

### DIFF
--- a/skimage/measure/_structural_similarity.py
+++ b/skimage/measure/_structural_similarity.py
@@ -5,8 +5,7 @@ from scipy.ndimage import uniform_filter, gaussian_filter
 
 from ..util.dtype import dtype_range
 from ..util.arraycrop import crop
-from .._shared.utils import deprecated
-from .._shared.utils import skimage_deprecation, warn
+
 
 __all__ = ['compare_ssim']
 

--- a/skimage/util/_invert.py
+++ b/skimage/util/_invert.py
@@ -63,12 +63,12 @@ def invert(image, signed_float=False):
         inverted = ~image
     elif np.issubdtype(image.dtype, np.unsignedinteger):
         max_val = dtype_limits(image, clip_negative=False)[1]
-        inverted = max_val - image
+        inverted = np.subtract(max_val, image, dtype=image.dtype)
     elif np.issubdtype(image.dtype, np.signedinteger):
-        inverted = -1 - image
+        inverted = np.subtract(-1, image, dtype=image.dtype)
     else:  # float dtype
         if signed_float:
             inverted = -image
         else:
-            inverted = 1 - image
+            inverted = np.subtract(1, image, dtype=image.dtype)
     return inverted

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -14,7 +14,8 @@ __all__ = ['img_as_float32', 'img_as_float64', 'img_as_float',
 # we use the basis dtypes here. For more information, see:
 # - https://github.com/scikit-image/scikit-image/issues/3043
 # For convenience, for these dtypes we indicate also the possible bit depths
-# (some of them are platform specific).
+# (some of them are platform specific). For the details, see:
+# http://www.unix.org/whitepapers/64bit.html
 _integer_types = (np.byte, np.ubyte,          # 8 bits
                   np.short, np.ushort,        # 16 bits
                   np.intc, np.uintc,          # 16 or 32 or 64 bits

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -2,28 +2,29 @@ from __future__ import division
 import numpy as np
 from warnings import warn
 
+
 __all__ = ['img_as_float32', 'img_as_float64', 'img_as_float',
            'img_as_int', 'img_as_uint', 'img_as_ubyte',
            'img_as_bool', 'dtype_limits']
 
+# For integers Numpy uses `_integer_types` basis internally, and builds a leaky
+# `np.XintYY` abstraction on top of it. This leads to situations when, for
+# example, there are two np.Xint64 dtypes with the same attributes but
+# different object references. In order to avoid any potential issues,
+# we use the basis dtypes here. For more information, see:
+# - https://github.com/scikit-image/scikit-image/issues/3043
+_integer_types = (np.byte, np.short, np.intc, np.int_, np.longlong,
+                  np.ubyte, np.ushort, np.uintc, np.uint, np.ulonglong)
+_integer_ranges = {t: (np.iinfo(t).min, np.iinfo(t).max)
+                   for t in _integer_types}
 dtype_range = {np.bool_: (False, True),
                np.bool8: (False, True),
-               np.uint8: (0, 255),
-               np.uint16: (0, 65535),
-               np.uint32: (0, 2**32 - 1),
-               np.uint64: (0, 2**64 - 1),
-               np.int8: (-128, 127),
-               np.int16: (-32768, 32767),
-               np.int32: (-2**31, 2**31 - 1),
-               np.int64: (-2**63, 2**63 - 1),
                np.float16: (-1, 1),
                np.float32: (-1, 1),
-               np.float64: (-1, 1)}
+               np.float64: (-1, 1),
+               **_integer_ranges}
 
-_supported_types = (np.bool_, np.bool8,
-                    np.uint8, np.uint16, np.uint32, np.uint64,
-                    np.int8, np.int16, np.int32, np.int64,
-                    np.float16, np.float32, np.float64)
+_supported_types = list(dtype_range.keys())
 
 
 def dtype_limits(image, clip_negative=None):

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -13,8 +13,13 @@ __all__ = ['img_as_float32', 'img_as_float64', 'img_as_float',
 # different object references. In order to avoid any potential issues,
 # we use the basis dtypes here. For more information, see:
 # - https://github.com/scikit-image/scikit-image/issues/3043
-_integer_types = (np.byte, np.short, np.intc, np.int_, np.longlong,
-                  np.ubyte, np.ushort, np.uintc, np.uint, np.ulonglong)
+# For convenience, for these dtypes we indicate also the possible bit depths
+# (some of them are platform specific).
+_integer_types = (np.byte, np.ubyte,          # 8 bits
+                  np.short, np.ushort,        # 16 bits
+                  np.intc, np.uintc,          # 16 or 32 or 64 bits
+                  np.int_, np.uint,           # 32 or 64 bits
+                  np.longlong, np.ulonglong)  # 64 bits
 _integer_ranges = {t: (np.iinfo(t).min, np.iinfo(t).max)
                    for t in _integer_types}
 dtype_range = {np.bool_: (False, True),

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -21,8 +21,8 @@ dtype_range = {np.bool_: (False, True),
                np.bool8: (False, True),
                np.float16: (-1, 1),
                np.float32: (-1, 1),
-               np.float64: (-1, 1),
-               **_integer_ranges}
+               np.float64: (-1, 1)}
+dtype_range.update(_integer_ranges)
 
 _supported_types = list(dtype_range.keys())
 

--- a/skimage/util/tests/test_invert.py
+++ b/skimage/util/tests/test_invert.py
@@ -1,5 +1,6 @@
 import numpy as np
 from skimage import dtype_limits
+from skimage.util.dtype import dtype_range
 from skimage.util import invert
 
 from skimage._shared.testing import assert_array_equal
@@ -67,3 +68,10 @@ def test_invert_float64_unsigned():
     expected[1, :] = upper_dtype_limit
     result = invert(image)
     assert_array_equal(expected, result)
+
+
+def test_invert_roundtrip():
+    for t, limits in dtype_range.items():
+        image = np.array(limits, dtype=t)
+        expected = invert(invert(image))
+        assert_array_equal(image, expected)


### PR DESCRIPTION
## Description

```
In [1]: import numpy as np
   ...: 
   ...: _integer_types = (np.byte, np.short, np.intc, np.int_, np.longlong,
   ...:                   np.ubyte, np.ushort, np.uintc, np.uint, np.ulonglong)
   ...: _integer_ranges = {t: (np.iinfo(t).min, np.iinfo(t).max)
   ...:                    for t in _integer_types}
   ...: dtype_range = {np.bool_: (False, True),
   ...:                np.bool8: (False, True),
   ...:                np.float16: (-1, 1),
   ...:                np.float32: (-1, 1),
   ...:                np.float64: (-1, 1)}
   ...: dtype_range.update(_integer_ranges)
   ...:                

In [2]: dtype_range[np.uint64]
Out[2]: (0, 18446744073709551615)

In [3]: dtype_range[np.int8]
Out[3]: (-128, 127)

In [4]: list(dtype_range.keys())
Out[4]: 
[numpy.bool_,
 numpy.float16,
 numpy.float32,
 numpy.float64,
 numpy.int8,
 numpy.int16,
 numpy.int32,
 numpy.int64,
 numpy.int64,
 numpy.uint8,
 numpy.uint16,
 numpy.uint32,
 numpy.uint64,
 numpy.uint64]
```

## References
Closes https://github.com/scikit-image/scikit-image/issues/3043.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
