### PR TITLE
Allow float->float conversion of any range

### DIFF
--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -240,14 +240,14 @@ def convert(image, dtype, force_copy=False, uniform=False):
 
     # float -> any
     if kind_in == 'f':
-        if np.min(image) < -1.0 or np.max(image) > 1.0:
-            raise ValueError("Images of type float must be between -1 and 1.")
         if kind_out == 'f':
             # float -> float
             if itemsize_in > itemsize_out:
                 prec_loss()
             return image.astype(dtype_out)
 
+        if np.min(image) < -1.0 or np.max(image) > 1.0:
+            raise ValueError("Images of type float must be between -1 and 1.")
         # floating point -> integer
         prec_loss()
         # use float type that can represent output integer type

--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -94,6 +94,11 @@ def test_float_out_of_range():
         img_as_int(too_low)
 
 
+def test_float_float_all_ranges():
+    arr_in = np.array([[-10., 10., 1e20]], dtype=np.float32)
+    np.testing.assert_all_close(img_as_float(arr_in), arr_in)
+
+
 def test_copy():
     x = np.array([1], dtype=np.float64)
     y = img_as_float(x)


### PR DESCRIPTION
Fixes #3051.

When converting from float, we were checking for valid input ranges
*before* checking whether the target format was also float, in which
case the range doesn't matter. This PR corrects this so that float-only
conversions, which don't entail any rescaling, don't check for input
range.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

# For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
