### PR TITLE
WIP: do not merge, Feature expose precision loss logic

### DIFF
--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -127,8 +127,7 @@ def color_check(plugin, fmt='png'):
         r3 = roundtrip(img3, plugin, fmt)
     testing.assert_allclose(r3, img)
 
-    with expected_warnings(['precision loss']):
-        img4 = img_as_int(img)
+    img4 = img_as_int(img)
     if fmt.lower() in (('tif', 'tiff')):
         img4 -= 100
         with expected_warnings(['sign loss']):
@@ -167,8 +166,7 @@ def mono_check(plugin, fmt='png'):
     else:
         testing.assert_allclose(r3, img_as_uint(img))
 
-    with expected_warnings(['precision loss']):
-        img4 = img_as_int(img)
+    img4 = img_as_int(img)
     if fmt.lower() in (('tif', 'tiff')):
         img4 -= 100
         with expected_warnings(['sign loss|\A\Z']):

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -310,7 +310,7 @@ class TestRank():
         image = img_as_ubyte(data.camera())[::2, ::2]
         image[image > 127] = 0
         image_s = image.astype(np.int8)
-        with expected_warnings(['sign loss', 'precision loss']):
+        with expected_warnings(['sign loss']):
             image_u = img_as_ubyte(image_s)
             assert_equal(image_u, img_as_ubyte(image_s))
 
@@ -321,7 +321,7 @@ class TestRank():
         for method in methods:
             func = getattr(rank, method)
 
-            with expected_warnings(['sign loss', 'precision loss']):
+            with expected_warnings(['sign loss']):
                 out_u = func(image_u, disk(3))
                 out_s = func(image_s, disk(3))
             assert_equal(out_u, out_s)

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -48,12 +48,6 @@ def _check_precision_loss(dtypeobj_in, dtypeobj_out):
         dtype of the input image.
     dtypeobj_out: np.dtype
         dtype of the output image.
-    output_warning: bool, optional
-        Outputs a warning using `warn` if operation will incur loss of
-        precision.
-    int_same_size_ok: bool, optional
-        Should conversion between integers of the same same (and signedness)
-        be considered lossy.
 
     """
     def n_significant_bits(t):

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -60,7 +60,9 @@ def _check_precision_loss(dtypeobj_in, dtypeobj_out):
         dtypeobj = np.dtype(t)
         kind = dtypeobj.kind
         if kind == 'f':
-            return np.finfo(dtypeobj).nmant
+            # IEEE floating point point has an implied 1, increasing the number
+            # of significant bits given a mantisa of a certain size
+            return np.finfo(dtypeobj).nmant + 1
         elif kind == 'b':
             return 1
         elif kind == 'u':

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -87,7 +87,7 @@ def _check_precision_loss(dtypeobj_in, dtypeobj_out):
     return has_loss
 
 
-def dtype_limits(image, clip_negative=None):
+def dtype_limits(image, clip_negative=False):
     """Return intensity limits, i.e. (min, max) tuple, of the image's dtype.
 
     Parameters

--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -160,7 +160,7 @@ def test_float32_passthrough():
               (np.uint8, np.float32, False),
               (np.uint8, np.float64, False),
 
-              (np.int8, np.uint8, True),
+              (np.int8, np.uint8, False),
               (np.int8, np.int8, False),
               (np.int8, np.uint16, False),
               (np.int8, np.int16, False),
@@ -169,7 +169,7 @@ def test_float32_passthrough():
 
               (np.int16, np.uint8, True),
               (np.int16, np.int8, True),
-              (np.int16, np.uint16, True),
+              (np.int16, np.uint16, False),
               (np.int16, np.int16, False),
               (np.int16, np.float32, False),
               (np.int16, np.float64, False),
@@ -208,6 +208,12 @@ def test_float32_passthrough():
               (np.int16, np.bool, True),
               (np.float32, np.bool, True),
               (np.float64, np.bool, True),
+
+              # we don't support these types yet
+              (np.float32, np.int32, True),
+              (np.float16, np.int32, True),
+              (np.float16, np.int16, True),
+              (np.int16, np.float16, True),
               ])
 def test_check_precision_loss(dtype_in, dtype_out, expecting_loss):
     with expected_warnings(['precision loss|\A\Z']):


### PR DESCRIPTION
## Description
I'm working to convert images between raw with bayer pattern and rgb or grey scale. It would be good to have this logic exposed to avoid unnecessary image copies.

This logic will be reused there to catch most cases.

In writing the tests for this, I found Issue #3080. This PR fixes Issue #3080.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
