### PR TITLE
During color conversion, maintain float precision

### DIFF
--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -1,6 +1,6 @@
 import numpy as np
 import itertools
-from skimage import (img_as_int, img_as_float,
+from skimage import (img_as_int, img_as_float64, img_as_float,
                      img_as_uint, img_as_ubyte)
 from skimage.util.dtype import convert
 
@@ -17,7 +17,7 @@ dtype_range = {np.uint8: (0, 255),
                np.float64: (-1.0, 1.0)}
 
 
-img_funcs = (img_as_int, img_as_float, img_as_uint, img_as_ubyte)
+img_funcs = (img_as_int, img_as_float64, img_as_uint, img_as_ubyte)
 dtypes_for_img_funcs = (np.int16, np.float64, np.uint16, np.ubyte)
 img_funcs_and_types = zip(img_funcs, dtypes_for_img_funcs)
 


### PR DESCRIPTION
## Description
Color conversion currently imposes 64 bit types. I don't think this should be the case. Many images are taken with 8bit sensors and as such 32 bit floating point types are probably adequate.

I would rather actually fix this in img_as_float itself. See the PR #3062. 


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
