### PR TITLE
Make `img_as_float` act as `ensure_img_is_float` of any precision

### DIFF
--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -370,7 +370,36 @@ def img_as_float64(image, force_copy=False):
     return convert(image, np.float64, force_copy)
 
 
-img_as_float = img_as_float64
+def img_as_float(image, force_copy=False, default_dtype=np.float64):
+    """Ensure that an image is of floating point type.
+
+    First checks if the image is a floating point (any precision). If not
+    it will convert it to the desired precision (by default, 64-bit).
+
+    Parameters
+    ----------
+    image : ndarray
+        Input image.
+    force_copy : bool, optional
+        Force a copy of the data, irrespective of its current dtype.
+    default_dtype: np.dtype
+        Desired for the image if it is not already a float.
+
+    Returns
+    -------
+    out : ndarray of desired precision
+        Output image.
+    """
+    if np.dtype(default_dtype).kind != 'f':
+        raise ValueError('Provided default_dtype should be a float.')
+
+    if image.dtype.kind == 'f':
+        if force_copy:
+            return image.copy()
+        else:
+            return image
+    else:
+        convert(image, dtype=default_dtype, force_copy=force_copy)
 
 
 def img_as_uint(image, force_copy=False):

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -399,7 +399,7 @@ def img_as_float(image, force_copy=False, default_dtype=np.float64):
         else:
             return image
     else:
-        convert(image, dtype=default_dtype, force_copy=force_copy)
+        return convert(image, dtype=default_dtype, force_copy=force_copy)
 
 
 def img_as_uint(image, force_copy=False):


### PR DESCRIPTION
## Description
Currently if you provide a `float32` image, it would get converted to `float64` by almost any function.
This is because `img_as_float` is an alias for `img_as_float64`.

I would like `img_as_float` to leave `float32` (or `float16`) to whatever precision they have.
It is only important if you are providing integer images (and in that case, you shouldn't be going from `uint8->float64`, that is a little excessive, but maybe not doing that is "premature optimization")

Image as float now takes an additional parameter that allows the user to specify the desired precision if the image is not already a floating point.

The function should probably be called `ensure_img_is_float`, but I figured many people were using this function as a "make my image float".

If this strategy is accepted, then PR #3060 is not necessary.
I would also have to add some tests.


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests
- [ ] If #3055  is accepted, then we also need to allow img_as_float to take the issue warning parameter.

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
xref: #1234, #1737
PR #3060 
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
