### PR TITLE
For sparse CG solver, provide atol=0 keyword for SciPy >= 1.1

### DIFF
--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -13,7 +13,6 @@ from scipy import sparse, ndimage as ndi
 
 from .._shared.utils import warn
 
-
 # executive summary for next code block: try to import umfpack from
 # scipy, but make sure not to raise a fuss if it fails since it's only
 # needed to speed up a few cases.
@@ -39,9 +38,17 @@ try:
     amg_loaded = True
 except ImportError:
     amg_loaded = False
-from scipy.sparse.linalg import cg
+
 from ..util import img_as_float
 from ..filters import rank_order
+
+from scipy.sparse.linalg import cg
+import scipy
+from distutils.version import LooseVersion as Version
+import functools
+
+if Version(scipy.__version__) >= Version('1.1'):
+    cg = functools.partial(cg, atol=0)
 
 #-----------Laplacian--------------------
 


### PR DESCRIPTION
## Description
This is cherry-picked from #3020 and fixes some of our current Travis problems. @scikit-image/core please review and merge urgently!

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] ~~[Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)~~
- [ ] ~~Gallery example in `./doc/examples` (new features only)~~
- [ ] ~~Unit tests~~

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
