### PR TITLE
Allow passing callable for high and low threshold of Canny

### DIFF
--- a/doc/examples/edges/plot_canny.py
+++ b/doc/examples/edges/plot_canny.py
@@ -20,7 +20,7 @@ import matplotlib.pyplot as plt
 from scipy import ndimage as ndi
 
 from skimage import feature
-from skimage.filters import threshold_li, threshold_otsu
+from skimage.filters import threshold_otsu
 
 
 # Generate noisy image of a square
@@ -74,7 +74,7 @@ axes[0][3].set_title('Canny filter, $\sigma=3$\nusing quantiles')
 
 axes[0][4].imshow(edges1_4,  cmap=plt.cm.gray)
 axes[0][4].axis('off')
-axes[0][4].set_title('Canny filter, $\sigma=3$\nLi thresholding')
+axes[0][4].set_title('Canny filter, $\sigma=3$\nOtsu threshold (callable)')
 
 axes[1][0].imshow(im2, cmap=plt.cm.gray)
 axes[1][0].axis('off')
@@ -94,7 +94,7 @@ axes[1][3].set_title('Canny filter, $\sigma=3$\nquantiles')
 
 axes[1][4].imshow(edges2_4,  cmap=plt.cm.gray)
 axes[1][4].axis('off')
-axes[1][4].set_title('Canny filter, $\sigma=3$\nLi thresholding')
+axes[1][4].set_title('Canny filter, $\sigma=3$\nOtsu threshold (callable)')
 
 fig.tight_layout()
 

--- a/doc/examples/edges/plot_canny.py
+++ b/doc/examples/edges/plot_canny.py
@@ -20,6 +20,7 @@ import matplotlib.pyplot as plt
 from scipy import ndimage as ndi
 
 from skimage import feature
+from skimage.filters import threshold_li, threshold_otsu
 
 
 # Generate noisy image of a square
@@ -30,25 +31,70 @@ im = ndi.rotate(im, 15, mode='constant')
 im = ndi.gaussian_filter(im, 4)
 im += 0.2 * np.random.random(im.shape)
 
+# Generate lower SNR noisy image of a square
+im2 = np.zeros((128, 128))
+im2[32:-32, 32:-32] = 1
+
+im2 = ndi.rotate(im2, 15, mode='constant')
+im2 = ndi.gaussian_filter(im2, 4)
+im2 += 0.4 * np.random.randn(*(im2.shape))
+
 # Compute the Canny filter for two values of sigma
-edges1 = feature.canny(im)
-edges2 = feature.canny(im, sigma=3)
+edges1_1 = feature.canny(im)
+edges1_2 = feature.canny(im, sigma=3)
+edges1_3 = feature.canny(im, use_quantiles=True, sigma=3)
+edges1_4 = feature.canny(im, sigma=3, high_threshold=threshold_otsu,
+                         low_threshold=threshold_otsu)
+
+edges2_1 = feature.canny(im2)
+edges2_2 = feature.canny(im2, sigma=3)
+edges2_3 = feature.canny(im2, sigma=3, use_quantiles=True)
+edges2_4 = feature.canny(im2, sigma=3, low_threshold=threshold_otsu,
+                         high_threshold=threshold_otsu)
 
 # display results
-fig, (ax1, ax2, ax3) = plt.subplots(nrows=1, ncols=3, figsize=(8, 3),
+fig, axes = plt.subplots(nrows=2, ncols=5, figsize=(12, 6),
                                     sharex=True, sharey=True)
 
-ax1.imshow(im, cmap=plt.cm.gray)
-ax1.axis('off')
-ax1.set_title('noisy image', fontsize=20)
+axes[0][0].imshow(im, cmap=plt.cm.gray)
+axes[0][0].axis('off')
+axes[0][0].set_title('Low noise image')
 
-ax2.imshow(edges1, cmap=plt.cm.gray)
-ax2.axis('off')
-ax2.set_title('Canny filter, $\sigma=1$', fontsize=20)
+axes[0][1].imshow(edges1_1, cmap=plt.cm.gray)
+axes[0][1].axis('off')
+axes[0][1].set_title('Canny filter, $\sigma=1$')
 
-ax3.imshow(edges2, cmap=plt.cm.gray)
-ax3.axis('off')
-ax3.set_title('Canny filter, $\sigma=3$', fontsize=20)
+axes[0][2].imshow(edges1_2, cmap=plt.cm.gray)
+axes[0][2].axis('off')
+axes[0][2].set_title('Canny filter, $\sigma=3$')
+
+axes[0][3].imshow(edges1_3, cmap=plt.cm.gray)
+axes[0][3].axis('off')
+axes[0][3].set_title('Canny filter, $\sigma=3$\nusing quantiles')
+
+axes[0][4].imshow(edges1_4,  cmap=plt.cm.gray)
+axes[0][4].axis('off')
+axes[0][4].set_title('Canny filter, $\sigma=3$\nLi thresholding')
+
+axes[1][0].imshow(im2, cmap=plt.cm.gray)
+axes[1][0].axis('off')
+axes[1][0].set_title('High noise image')
+
+axes[1][1].imshow(edges2_1, cmap=plt.cm.gray)
+axes[1][1].axis('off')
+axes[1][1].set_title('Canny filter, $\sigma=1$\ndefault threshold')
+
+axes[1][2].imshow(edges2_2, cmap=plt.cm.gray)
+axes[1][2].axis('off')
+axes[1][2].set_title('Canny filter, $\sigma=3$\ndefault threshold')
+
+axes[1][3].imshow(edges2_3, cmap=plt.cm.gray)
+axes[1][3].axis('off')
+axes[1][3].set_title('Canny filter, $\sigma=3$\nquantiles')
+
+axes[1][4].imshow(edges2_4,  cmap=plt.cm.gray)
+axes[1][4].axis('off')
+axes[1][4].set_title('Canny filter, $\sigma=3$\nLi thresholding')
 
 fig.tight_layout()
 

--- a/doc/examples/edges/plot_canny.py
+++ b/doc/examples/edges/plot_canny.py
@@ -56,45 +56,38 @@ edges2_4 = feature.canny(im2, sigma=3, low_threshold=threshold_otsu,
 fig, axes = plt.subplots(nrows=2, ncols=5, figsize=(12, 6),
                                     sharex=True, sharey=True)
 
-axes[0][0].imshow(im, cmap=plt.cm.gray)
-axes[0][0].axis('off')
-axes[0][0].set_title('Low noise image')
+axes[0, 0].imshow(im, cmap=plt.cm.gray)
+axes[0, 0].set_title('Low noise image')
 
-axes[0][1].imshow(edges1_1, cmap=plt.cm.gray)
-axes[0][1].axis('off')
-axes[0][1].set_title('Canny filter, $\sigma=1$')
+axes[0, 1].imshow(edges1_1, cmap=plt.cm.gray)
+axes[0, 1].set_title('Canny filter, $\sigma=1$')
 
-axes[0][2].imshow(edges1_2, cmap=plt.cm.gray)
-axes[0][2].axis('off')
-axes[0][2].set_title('Canny filter, $\sigma=3$')
+axes[0, 2].imshow(edges1_2, cmap=plt.cm.gray)
+axes[0, 2].set_title('Canny filter, $\sigma=3$')
 
-axes[0][3].imshow(edges1_3, cmap=plt.cm.gray)
-axes[0][3].axis('off')
-axes[0][3].set_title('Canny filter, $\sigma=3$\nusing quantiles')
+axes[0, 3].imshow(edges1_3, cmap=plt.cm.gray)
+axes[0, 3].set_title('Canny filter, $\sigma=3$\nusing quantiles')
 
-axes[0][4].imshow(edges1_4,  cmap=plt.cm.gray)
-axes[0][4].axis('off')
-axes[0][4].set_title('Canny filter, $\sigma=3$\nOtsu threshold (callable)')
+axes[0, 4].imshow(edges1_4,  cmap=plt.cm.gray)
+axes[0, 4].set_title('Canny filter, $\sigma=3$\nOtsu threshold (callable)')
 
-axes[1][0].imshow(im2, cmap=plt.cm.gray)
-axes[1][0].axis('off')
-axes[1][0].set_title('High noise image')
+axes[1, 0].imshow(im2, cmap=plt.cm.gray)
+axes[1, 0].set_title('High noise image')
 
-axes[1][1].imshow(edges2_1, cmap=plt.cm.gray)
-axes[1][1].axis('off')
-axes[1][1].set_title('Canny filter, $\sigma=1$\ndefault threshold')
+axes[1, 1].imshow(edges2_1, cmap=plt.cm.gray)
+axes[1, 1].set_title('Canny filter, $\sigma=1$\ndefault threshold')
 
-axes[1][2].imshow(edges2_2, cmap=plt.cm.gray)
-axes[1][2].axis('off')
-axes[1][2].set_title('Canny filter, $\sigma=3$\ndefault threshold')
+axes[1, 2].imshow(edges2_2, cmap=plt.cm.gray)
+axes[1, 2].set_title('Canny filter, $\sigma=3$\ndefault threshold')
 
-axes[1][3].imshow(edges2_3, cmap=plt.cm.gray)
-axes[1][3].axis('off')
-axes[1][3].set_title('Canny filter, $\sigma=3$\nquantiles')
+axes[1, 3].imshow(edges2_3, cmap=plt.cm.gray)
+axes[1, 3].set_title('Canny filter, $\sigma=3$\nquantiles')
 
-axes[1][4].imshow(edges2_4,  cmap=plt.cm.gray)
-axes[1][4].axis('off')
-axes[1][4].set_title('Canny filter, $\sigma=3$\nOtsu threshold (callable)')
+axes[1, 4].imshow(edges2_4,  cmap=plt.cm.gray)
+axes[1, 4].set_title('Canny filter, $\sigma=3$\nOtsu threshold (callable)')
+
+for ax in axes.ravel():
+    ax.axis('off')
 
 fig.tight_layout()
 

--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -60,11 +60,15 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None, mask=None,
         Greyscale input image to detect edges on; can be of any dtype.
     sigma : float
         Standard deviation of the Gaussian filter.
-    low_threshold : float
+    low_threshold : float or callable
         Lower bound for hysteresis thresholding (linking edges).
+        If callable is given, it is applied to the gradient image
+        to generate the low_threshold.
         If None, low_threshold is set to 10% of dtype's max.
-    high_threshold : float
+    high_threshold : float or callable
         Upper bound for hysteresis thresholding (linking edges).
+        If callable is given, it is applied to the gradient image
+        to generate the high_threshold.
         If None, high_threshold is set to 20% of dtype's max.
     mask : array, dtype=bool, optional
         Mask to limit the application of Canny to a certain area.
@@ -265,6 +269,16 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None, mask=None,
 
         high_threshold = np.percentile(magnitude, 100.0 * high_threshold)
         low_threshold = np.percentile(magnitude, 100.0 * low_threshold)
+    else:
+        #
+        # Else if high_threshold and/or low_threshold are callables
+        # call them to determine the threshold value / image
+        #
+        if callable(high_threshold):
+            high_threshold = high_threshold(magnitude)
+        if callable(low_threshold):
+            low_threshold = low_threshold(magnitude)
+
 
     #
     #---- Create two masks at the two thresholds.

--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -16,6 +16,8 @@ import numpy as np
 import scipy.ndimage as ndi
 from scipy.ndimage import (gaussian_filter,
                            generate_binary_structure, binary_erosion, label)
+import numbers
+import traceback
 from .. import dtype_limits
 from .._shared.utils import assert_nD
 
@@ -275,11 +277,27 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None, mask=None,
         # Else if high_threshold and/or low_threshold are callables
         # apply them to determine the threshold value / image
         if callable(high_threshold):
-            high_threshold = high_threshold(magnitude)
+            try:
+                high_threshold = high_threshold(magnitude)
+            except:
+                traceback.print_exc()
+                raise ValueError("Callable `high_threshold` raised above exception.\nIt must take one input (image array) and return a scalar value or image array of the same shape as input image")
+
+            if not( isinstance(high_threshold, numbers.Number) or (
+                    isinstance(high_threshold, np.ndarray) and
+                    (high_threshold.shape == magnitude.shape))):
+                raise ValueError("Callable `high_threshold` must take one input (image array) and return a scalar value or image array of the same shape as input image")
         if callable(low_threshold):
             mask_threshold = magnitude < high_threshold
-            low_threshold = low_threshold(magnitude[mask_threshold])
-
+            try:
+                low_threshold = low_threshold(magnitude[mask_threshold])
+            except:
+                traceback.print_exc()
+                raise ValueError("Callable `low_threshold` raised above exception.\nIt must take one input (image array) and return a scalar value or image array of the same shape as input image")
+            if not( isinstance(low_threshold, numbers.Number) or (
+                    isinstance(low_threshold, np.ndarray) and
+                    (low_threshold.shape == magnitude.shape))):
+                raise ValueError("Callable `low_threshold` must take one input (image array) and return a scalar value or image array of the same shape as input image")
 
     #
     #---- Create two masks at the two thresholds.

--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -62,13 +62,15 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None, mask=None,
         Standard deviation of the Gaussian filter.
     low_threshold : float or callable
         Lower bound for hysteresis thresholding (linking edges).
-        If callable is given, it is applied to the gradient image
-        to generate the low_threshold.
+        If callable is given, it should take one input, `image`,
+        the gradient magnitude image, and return a float or an
+        array of the same shape as `image`.
         If None, low_threshold is set to 10% of dtype's max.
     high_threshold : float or callable
         Upper bound for hysteresis thresholding (linking edges).
-        If callable is given, it is applied to the gradient image
-        to generate the high_threshold.
+        If callable is given, it should take one input, `image`,
+        the gradient magnitude image, and return a float or an
+        array of the same shape as `image`.
         If None, high_threshold is set to 20% of dtype's max.
     mask : array, dtype=bool, optional
         Mask to limit the application of Canny to a certain area.
@@ -270,10 +272,8 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None, mask=None,
         high_threshold = np.percentile(magnitude, 100.0 * high_threshold)
         low_threshold = np.percentile(magnitude, 100.0 * low_threshold)
     else:
-        #
         # Else if high_threshold and/or low_threshold are callables
-        # call them to determine the threshold value / image
-        #
+        # apply them to determine the threshold value / image
         if callable(high_threshold):
             high_threshold = high_threshold(magnitude)
         if callable(low_threshold):

--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -277,7 +277,8 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None, mask=None,
         if callable(high_threshold):
             high_threshold = high_threshold(magnitude)
         if callable(low_threshold):
-            low_threshold = low_threshold(magnitude)
+            mask_threshold = magnitude < high_threshold
+            low_threshold = low_threshold(magnitude[mask_threshold])
 
 
     #

--- a/skimage/feature/tests/test_canny.py
+++ b/skimage/feature/tests/test_canny.py
@@ -104,3 +104,38 @@ class TestCanny(unittest.TestCase):
 
         self.assertRaises(ValueError, F.canny, image, use_quantiles=True,
                           low_threshold=0.5, high_threshold=-100)
+
+    def test_use_callables(self):
+        image = img_as_float(data.camera()[::50, ::50])
+
+        # Correct output produced manually with quantiles
+        # of 0.8 and 0.6 for high and low respectively
+        correct_output = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0],
+           [0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0],
+           [0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0],
+           [0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0],
+           [0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0],
+           [0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0],
+           [0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
+           [0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=bool)
+
+        # Test using percentile callables so we can check using the same
+        # data as was used in the quantiles test
+        result = F.canny(image, low_threshold=lambda im : np.percentile(im, 60),
+                         high_threshold=lambda im : np.percentile(im, 80))
+
+        assert_equal(result, correct_output)
+
+    def test_invalid_use_callables(self):
+        image = img_as_float(data.camera()[::50, ::50])
+
+        self.assertRaises(TypeError, F.canny, image,
+                          low_threshold=lambda x: True,
+                          high_threshold=lambda : True)
+
+        self.assertRaises(TypeError, F.canny, image,
+                          low_threshold=lambda : True,
+                          high_threshold=lambda x : True)


### PR DESCRIPTION
## Description
Adds option of passing callables for `high_threshold` and `low_threshold`, which 
take the magnitude image as inputs. This allows more general threshold strategies. 

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

## References

Closes #3054, a feature request to add this option.

## For reviewers

(Don't remove the checklist below.)

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
