### PR TITLE
Sanitizing marching_cubes_lewiner spacing input argument

### DIFF
--- a/skimage/measure/_marching_cubes_lewiner.py
+++ b/skimage/measure/_marching_cubes_lewiner.py
@@ -134,7 +134,7 @@ def marching_cubes_lewiner(volume, level=None, spacing=(1., 1., 1.),
         if level < volume.min() or level > volume.max():
             raise ValueError("Surface level must be within volume data range.")
     # spacing
-    if isinstance(spacing, np.ndarray): # it should be a tuple
+    if isinstance(spacing, np.ndarray):  # it should be a tuple
         spacing = tuple(spacing)
     if len(spacing) != 3:
         raise ValueError("`spacing` must consist of three floats.")

--- a/skimage/measure/_marching_cubes_lewiner.py
+++ b/skimage/measure/_marching_cubes_lewiner.py
@@ -165,7 +165,7 @@ def marching_cubes_lewiner(volume, level=None, spacing=(1., 1., 1.),
     elif not gradient_direction == 'ascent':
         raise ValueError("Incorrect input %s in `gradient_direction`, see "
                          "docstring." % (gradient_direction))
-    if np.array_equal(spacing, (1, 1, 1)):
+    if not np.array_equal(spacing, (1, 1, 1)):
         vertices = vertices * np.r_[spacing]
 
     if allow_degenerate:

--- a/skimage/measure/_marching_cubes_lewiner.py
+++ b/skimage/measure/_marching_cubes_lewiner.py
@@ -134,8 +134,6 @@ def marching_cubes_lewiner(volume, level=None, spacing=(1., 1., 1.),
         if level < volume.min() or level > volume.max():
             raise ValueError("Surface level must be within volume data range.")
     # spacing
-    if isinstance(spacing, np.ndarray):  # it should be a tuple
-        spacing = tuple(spacing)
     if len(spacing) != 3:
         raise ValueError("`spacing` must consist of three floats.")
     # step_size
@@ -167,7 +165,7 @@ def marching_cubes_lewiner(volume, level=None, spacing=(1., 1., 1.),
     elif not gradient_direction == 'ascent':
         raise ValueError("Incorrect input %s in `gradient_direction`, see "
                          "docstring." % (gradient_direction))
-    if spacing != (1, 1, 1):
+    if np.array_equal(spacing, (1, 1, 1)):
         vertices = vertices * np.r_[spacing]
 
     if allow_degenerate:

--- a/skimage/measure/_marching_cubes_lewiner.py
+++ b/skimage/measure/_marching_cubes_lewiner.py
@@ -134,6 +134,8 @@ def marching_cubes_lewiner(volume, level=None, spacing=(1., 1., 1.),
         if level < volume.min() or level > volume.max():
             raise ValueError("Surface level must be within volume data range.")
     # spacing
+    if isinstance(spacing, np.ndarray): # it should be a tuple
+        spacing = tuple(spacing)
     if len(spacing) != 3:
         raise ValueError("`spacing` must consist of three floats.")
     # step_size

--- a/skimage/measure/tests/test_marching_cubes.py
+++ b/skimage/measure/tests/test_marching_cubes.py
@@ -24,7 +24,8 @@ def test_marching_cubes_isotropic():
 
 
 def test_marching_cubes_anisotropic():
-    spacing = (1., 10 / 6., 16 / 6.)
+    # test spacing as numpy array (and not just tuple)
+    spacing = np.array([1., 10 / 6., 16 / 6.])
     ellipsoid_anisotropic = ellipsoid(6, 10, 16, spacing=spacing,
                                       levelset=True)
     _, surf = ellipsoid_stats(6, 10, 16)


### PR DESCRIPTION
convert an np.array to a tuple

## Description
Fixing the problem if you feed a np.ndarray to the spacing argument of `skimage.measure.marching_cubes_lewiner` https://github.com/scikit-image/scikit-image/issues/3073

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests


## References
Fixes https://github.com/scikit-image/scikit-image/issues/3073

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
