### PR TITLE
Allow convex_hull_image on empty images

### DIFF
--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -49,10 +49,10 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10):
     """
     ndim = image.ndim
     if not np.max(image):
-        # if there are no non-zero points print a warning and return an empty image
-        warn("Input image is entirely zero and does not have a valid convex hull"
+        # if image is empty print a warning and return an empty image
+        warn("Input image is entirely zero, no valid convex hull"
              "Returning empty image", UserWarning)
-        return np.zeros(image.shape, dtype = bool)
+        return np.zeros(image.shape, dtype=bool)
     # In 2D, we do an optimisation by choosing only pixels that are
     # the starting or ending pixel of a row or column.  This vastly
     # limits the number of coordinates to examine for the virtual hull.

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -6,6 +6,7 @@ from ..measure.pnpoly import grid_points_in_poly
 from ._convex_hull import possible_hull
 from ..measure._label import label
 from ..util import unique_rows
+from .._shared.utils import warn
 
 __all__ = ['convex_hull_image', 'convex_hull_object']
 
@@ -47,7 +48,11 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10):
 
     """
     ndim = image.ndim
-
+    if not np.max(image):
+        # if there are no non-zero points print a warning and return an empty image
+        warn("Input image is entirely zero and does not have a valid convex hull"
+             "Returning empty image", UserWarning)
+        return np.zeros(image.shape, dtype = bool)
     # In 2D, we do an optimisation by choosing only pixels that are
     # the starting or ending pixel of a row or column.  This vastly
     # limits the number of coordinates to examine for the virtual hull.

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -49,10 +49,9 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10):
     """
     ndim = image.ndim
     if not np.max(image):
-        # if image is empty print a warning and return an empty image
-        warn("Input image is entirely zero, no valid convex hull"
+        warn("Input image is entirely zero, no valid convex hull. "
              "Returning empty image", UserWarning)
-        return np.zeros(image.shape, dtype=bool)
+        return np.zeros(image.shape, dtype=np.bool_)
     # In 2D, we do an optimisation by choosing only pixels that are
     # the starting or ending pixel of a row or column.  This vastly
     # limits the number of coordinates to examine for the virtual hull.

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -48,7 +48,7 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10):
 
     """
     ndim = image.ndim
-    if not np.max(image):
+    if np.max(image)<1:
         warn("Input image is entirely zero, no valid convex hull. "
              "Returning empty image", UserWarning)
         return np.zeros(image.shape, dtype=np.bool_)

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -48,7 +48,7 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10):
 
     """
     ndim = image.ndim
-    if np.max(image)<1:
+    if np.count_nonzero(image) == 0:
         warn("Input image is entirely zero, no valid convex hull. "
              "Returning empty image", UserWarning)
         return np.zeros(image.shape, dtype=np.bool_)

--- a/skimage/morphology/tests/test_convex_hull.py
+++ b/skimage/morphology/tests/test_convex_hull.py
@@ -7,23 +7,9 @@ from skimage._shared.testing import assert_array_equal
 
 
 def test_basic():
-    image = np.array(
-        [[0, 0, 0, 0, 0, 0, 0, 0, 0],
-         [0, 0, 0, 0, 1, 0, 0, 0, 0],
-         [0, 0, 0, 1, 0, 1, 0, 0, 0],
-         [0, 0, 1, 0, 0, 0, 1, 0, 0],
-         [0, 1, 0, 0, 0, 0, 0, 1, 0],
-         [0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=bool)
-
-    expected = np.array(
-        [[0, 0, 0, 0, 0, 0, 0, 0, 0],
-         [0, 0, 0, 0, 1, 0, 0, 0, 0],
-         [0, 0, 0, 1, 1, 1, 0, 0, 0],
-         [0, 0, 1, 1, 1, 1, 1, 0, 0],
-         [0, 1, 1, 1, 1, 1, 1, 1, 0],
-         [0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=bool)
-
-    assert_array_equal(convex_hull_image(image), expected)
+    image = np.zeros((6, 6), dtype=bool)
+    
+    assert_array_equal(convex_hull_image(image), image)
 
 
 def test_empty_image():

--- a/skimage/morphology/tests/test_convex_hull.py
+++ b/skimage/morphology/tests/test_convex_hull.py
@@ -26,6 +26,26 @@ def test_basic():
     assert_array_equal(convex_hull_image(image), expected)
 
 
+def test_empty_image():
+    image = np.array(
+        [[0, 0, 0, 0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=bool)
+
+    expected = np.array(
+        [[0, 0, 0, 0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=bool)
+
+    assert_array_equal(convex_hull_image(image), expected)
+
+
 def test_qhull_offset_example():
     nonzeros = (([1367, 1368, 1368, 1368, 1369, 1369, 1369, 1369, 1369, 1370,
                   1370, 1370, 1370, 1370, 1370, 1370, 1371, 1371, 1371, 1371,

--- a/skimage/morphology/tests/test_convex_hull.py
+++ b/skimage/morphology/tests/test_convex_hull.py
@@ -7,29 +7,29 @@ from skimage._shared.testing import assert_array_equal
 
 
 def test_basic():
-    image = np.zeros((6, 6), dtype=bool)
-    
-    assert_array_equal(convex_hull_image(image), image)
-
-
-def test_empty_image():
     image = np.array(
         [[0, 0, 0, 0, 0, 0, 0, 0, 0],
-         [0, 0, 0, 0, 0, 0, 0, 0, 0],
-         [0, 0, 0, 0, 0, 0, 0, 0, 0],
-         [0, 0, 0, 0, 0, 0, 0, 0, 0],
-         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 1, 0, 0, 0, 0],
+         [0, 0, 0, 1, 0, 1, 0, 0, 0],
+         [0, 0, 1, 0, 0, 0, 1, 0, 0],
+         [0, 1, 0, 0, 0, 0, 0, 1, 0],
          [0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=bool)
 
     expected = np.array(
         [[0, 0, 0, 0, 0, 0, 0, 0, 0],
-         [0, 0, 0, 0, 0, 0, 0, 0, 0],
-         [0, 0, 0, 0, 0, 0, 0, 0, 0],
-         [0, 0, 0, 0, 0, 0, 0, 0, 0],
-         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 1, 0, 0, 0, 0],
+         [0, 0, 0, 1, 1, 1, 0, 0, 0],
+         [0, 0, 1, 1, 1, 1, 1, 0, 0],
+         [0, 1, 1, 1, 1, 1, 1, 1, 0],
          [0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=bool)
 
     assert_array_equal(convex_hull_image(image), expected)
+
+
+def test_empty_image():
+    image = np.zeros((6, 6), dtype=bool)
+    
+    assert_array_equal(convex_hull_image(image), image)
 
 
 def test_qhull_offset_example():


### PR DESCRIPTION
## Description
changing convex_hull_image behavior to show a warning and return an empty image if given an empty image

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests



## References
Closes issue: https://github.com/scikit-image/scikit-image/issues/3075

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
