### PR TITLE
Proposed changes to `skimage.transform._geometry`

### DIFF
--- a/doc/examples/transform/plot_piecewise_affine.py
+++ b/doc/examples/transform/plot_piecewise_affine.py
@@ -37,6 +37,6 @@ out = warp(image, tform, output_shape=(out_rows, out_cols))
 
 fig, ax = plt.subplots()
 ax.imshow(out)
-ax.plot(tform.inverse(src)[:, 0], tform.inverse(src)[:, 1], '.b')
+ax.plot(tform.inverse_map(src)[:, 0], tform.inverse_map(src)[:, 1], '.b')
 ax.axis((0, out_cols, out_rows, 0))
 plt.show()

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -740,7 +740,8 @@ class AffineTransform(ProjectiveTransform):
     Parameters
     ----------
     matrix : (3, 3) array, optional
-        Homogeneous transformation matrix.
+        Homogeneous transformation matrix. If matrix is specified, other
+        parameters are ignored.
     scale : (sx, sy) as array, list or tuple, optional
         Scale factors.
     rotation : float, optional
@@ -759,28 +760,13 @@ class AffineTransform(ProjectiveTransform):
 
     _coeffs = range(6)
 
-    def __init__(self, matrix=None, scale=None, rotation=None, shear=None,
-                 translation=None):
-        params = any(param is not None
-                     for param in (scale, rotation, shear, translation))
-
-        if params and matrix is not None:
-            raise ValueError("You cannot specify the transformation matrix and"
-                             " the implicit parameters at the same time.")
-        elif matrix is not None:
+    def __init__(self, matrix=None, *, scale=(1, 1), rotation=0, shear=0,
+                 translation=(0, 0)):
+        if matrix is not None:
             if matrix.shape != (3, 3):
                 raise ValueError("Invalid shape of transformation matrix.")
             self.params = matrix
-        elif params:
-            if scale is None:
-                scale = (1, 1)
-            if rotation is None:
-                rotation = 0
-            if shear is None:
-                shear = 0
-            if translation is None:
-                translation = (0, 0)
-
+        else:
             sx, sy = scale
             self.params = np.array([
                 [sx * math.cos(rotation), -sy * math.sin(rotation + shear), 0],
@@ -788,9 +774,6 @@ class AffineTransform(ProjectiveTransform):
                 [                      0,                                0, 1]
             ])
             self.params[0:2, 2] = translation
-        else:
-            # default to an identity transform
-            self.params = np.eye(3)
 
     @property
     def scale(self):
@@ -970,7 +953,8 @@ class EuclideanTransform(ProjectiveTransform):
     Parameters
     ----------
     matrix : (3, 3) array, optional
-        Homogeneous transformation matrix.
+        Homogeneous transformation matrix. If matrix is specified, other
+        parameters are ignored.
     rotation : float, optional
         Rotation angle in counter-clockwise direction as radians.
     translation : (tx, ty) as array, list or tuple, optional
@@ -983,18 +967,12 @@ class EuclideanTransform(ProjectiveTransform):
 
     """
 
-    def __init__(self, matrix=None, rotation=None, translation=None):
-        params = any(param is not None
-                     for param in (rotation, translation))
-
-        if params and matrix is not None:
-            raise ValueError("You cannot specify the transformation matrix and"
-                             " the implicit parameters at the same time.")
-        elif matrix is not None:
+    def __init__(self, matrix=None, *, rotation=0, translation=(0, 0)):
+        if matrix is not None:
             if matrix.shape != (3, 3):
                 raise ValueError("Invalid shape of transformation matrix.")
             self.params = matrix
-        elif params:
+        else:
             if rotation is None:
                 rotation = 0
             if translation is None:
@@ -1006,9 +984,6 @@ class EuclideanTransform(ProjectiveTransform):
                 [                 0,                    0, 1]
             ])
             self.params[0:2, 2] = translation
-        else:
-            # default to an identity transform
-            self.params = np.eye(3)
 
     def estimate(self, src, dst):
         """Estimate the transformation from a set of corresponding points.
@@ -1069,7 +1044,8 @@ class SimilarityTransform(EuclideanTransform):
     Parameters
     ----------
     matrix : (3, 3) array, optional
-        Homogeneous transformation matrix.
+        Homogeneous transformation matrix. If matrix is specified, other
+        parameters are ignored.
     scale : float, optional
         Scale factor.
     rotation : float, optional
@@ -1084,26 +1060,13 @@ class SimilarityTransform(EuclideanTransform):
 
     """
 
-    def __init__(self, matrix=None, scale=None, rotation=None,
-                 translation=None):
-        params = any(param is not None
-                     for param in (scale, rotation, translation))
-
-        if params and matrix is not None:
-            raise ValueError("You cannot specify the transformation matrix and"
-                             " the implicit parameters at the same time.")
-        elif matrix is not None:
+    def __init__(self, matrix=None, *, scale=1, rotation=0,
+                 translation=(0, 0)):
+        if matrix is not None:
             if matrix.shape != (3, 3):
                 raise ValueError("Invalid shape of transformation matrix.")
             self.params = matrix
-        elif params:
-            if scale is None:
-                scale = 1
-            if rotation is None:
-                rotation = 0
-            if translation is None:
-                translation = (0, 0)
-
+        else:
             self.params = np.array([
                 [math.cos(rotation), - math.sin(rotation), 0],
                 [math.sin(rotation),   math.cos(rotation), 0],
@@ -1111,9 +1074,7 @@ class SimilarityTransform(EuclideanTransform):
             ])
             self.params[0:2, 0:2] *= scale
             self.params[0:2, 2] = translation
-        else:
-            # default to an identity transform
-            self.params = np.eye(3)
+            
 
     def estimate(self, src, dst):
         """Estimate the transformation from a set of corresponding points.

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -680,7 +680,8 @@ class ProjectiveTransform(GeometricTransform):
                 tform = self.__class__
             else:
                 tform = ProjectiveTransform
-            return tform(matrix=self.params @ other.params)
+            # 2.7 compatibility
+            return tform(matrix=self.params.dot(other.params))
         else:
             raise TypeError("Cannot combine transformations of differing "
                             "types.")
@@ -741,7 +742,7 @@ class AffineTransform(ProjectiveTransform):
 
     _coeffs = range(6)
 
-    def __init__(self, matrix=None, *, scale=(1, 1), rotation=0, shear=0,
+    def __init__(self, matrix=None, scale=(1, 1), rotation=0, shear=0,
                  translation=(0, 0)):
         if matrix is not None:
             if matrix.shape != (3, 3):
@@ -952,7 +953,7 @@ class EuclideanTransform(ProjectiveTransform):
 
     """
 
-    def __init__(self, matrix=None, *, rotation=0, translation=(0, 0)):
+    def __init__(self, matrix=None, rotation=0, translation=(0, 0)):
         if matrix is not None:
             if matrix.shape != (3, 3):
                 raise ValueError("Invalid shape of transformation matrix.")
@@ -1045,7 +1046,7 @@ class SimilarityTransform(EuclideanTransform):
 
     """
 
-    def __init__(self, matrix=None, *, scale=1, rotation=0,
+    def __init__(self, matrix=None, scale=1, rotation=0,
                  translation=(0, 0)):
         if matrix is not None:
             if matrix.shape != (3, 3):

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -170,9 +170,6 @@ class GeometricTransform(object):
     @property
     def inverse(self):
         """Return the inverse transformation."""
-        # ASK: Can you make a property a class method too?
-        # I don't thinkl that solves out problem though, we would still
-        # have to use some kind of instrospection no?
         return self.__class__(matrix=self.inverse_params)
 
     def residuals(self, src, dst):
@@ -877,7 +874,11 @@ class PiecewiseAffineTransform(GeometricTransform):
 
     @property
     def inverse(self):
-        raise NotImplementedError()
+        raise NotImplementedError(
+            "Inverse transforms for ``PiecewiseAffineTransform`` has not "
+            "been implemented yet. If you need to apply the inverse map, "
+            "consider calling the function ``inverse_map`` instead."
+        )
 
     def inverse_map(self, coords):
         """Apply inverse transformation.

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -353,7 +353,7 @@ def rotate(image, angle, resize=False, center=None, order=1, mode='constant',
     tform1 = SimilarityTransform(translation=center)
     tform2 = SimilarityTransform(rotation=np.deg2rad(angle))
     tform3 = SimilarityTransform(translation=-center)
-    tform = tform3 + tform2 + tform1
+    tform = tform1 @ tform2 @ tform3
 
     output_shape = None
     if resize:
@@ -376,7 +376,7 @@ def rotate(image, angle, resize=False, center=None, order=1, mode='constant',
         # fit output image in new shape
         translation = (minc, minr)
         tform4 = SimilarityTransform(translation=translation)
-        tform = tform4 + tform
+        tform = tform @ tform4
 
     # Make sure the transform is exactly affine, to ensure fast warping.
     tform.params[2] = (0, 0, 1)

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -364,7 +364,7 @@ def rotate(image, angle, resize=False, center=None, order=1, mode='constant',
             [cols - 1, rows - 1],
             [cols - 1, 0]
         ])
-        corners = tform.inverse(corners)
+        corners = tform.inverse_map(corners)
         minc = corners[:, 0].min()
         minr = corners[:, 1].min()
         maxc = corners[:, 0].max()
@@ -536,7 +536,7 @@ def warp_coords(coord_map, shape, dtype=np.float64):
 
     Parameters
     ----------
-    coord_map : callable like GeometricTransform.inverse
+    coord_map : callable like GeometricTransform.inverse_map
         Return input coordinates for given output coordinates.
         Coordinates are in the shape (P, 2), where P is the number
         of coordinates and each element is a ``(row, col)`` pair.
@@ -769,7 +769,7 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=1,
 
     You can also use the inverse of a geometric transformation (fast):
 
-    >>> warped = warp(image, tform.inverse)
+    >>> warped = warp(image, tform.inverse_map)
 
     For N-D images you can pass a coordinate array, that specifies the
     coordinates in the input image for every element in the output image. E.g.
@@ -830,7 +830,7 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=1,
             matrix = inverse_map.params
 
         elif (hasattr(inverse_map, '__name__') and
-              inverse_map.__name__ == 'inverse' and
+              inverse_map.__name__ == 'inverse_map' and
               get_bound_method_class(inverse_map) in HOMOGRAPHY_TRANSFORMS):
             # inverse_map is the inverse of a homography
             matrix = np.linalg.inv(inverse_map.__self__.params)

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -353,7 +353,9 @@ def rotate(image, angle, resize=False, center=None, order=1, mode='constant',
     tform1 = SimilarityTransform(translation=center)
     tform2 = SimilarityTransform(rotation=np.deg2rad(angle))
     tform3 = SimilarityTransform(translation=-center)
-    tform = tform1 @ tform2 @ tform3
+    # 2.7
+    tform = tform1.__matmul__(tform2).__matmul__(tform3)
+    # tform = tform1 @ tform2 @ tform3
 
     output_shape = None
     if resize:
@@ -376,7 +378,8 @@ def rotate(image, angle, resize=False, center=None, order=1, mode='constant',
         # fit output image in new shape
         translation = (minc, minr)
         tform4 = SimilarityTransform(translation=translation)
-        tform = tform @ tform4
+        # tform = tform @ tform4
+        tform = tform.__matmul__(tform4)
 
     # Make sure the transform is exactly affine, to ensure fast warping.
     tform.params[2] = (0, 0, 1)

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -364,7 +364,7 @@ def rotate(image, angle, resize=False, center=None, order=1, mode='constant',
             [cols - 1, rows - 1],
             [cols - 1, 0]
         ])
-        corners = tform.inverse_map(corners)
+        corners = tform.inverse(corners)
         minc = corners[:, 0].min()
         minr = corners[:, 1].min()
         maxc = corners[:, 0].max()
@@ -536,7 +536,7 @@ def warp_coords(coord_map, shape, dtype=np.float64):
 
     Parameters
     ----------
-    coord_map : callable like GeometricTransform.inverse_map
+    coord_map : callable like GeometricTransform.inverse
         Return input coordinates for given output coordinates.
         Coordinates are in the shape (P, 2), where P is the number
         of coordinates and each element is a ``(row, col)`` pair.
@@ -769,7 +769,7 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=1,
 
     You can also use the inverse of a geometric transformation (fast):
 
-    >>> warped = warp(image, tform.inverse_map)
+    >>> warped = warp(image, tform.inverse)
 
     For N-D images you can pass a coordinate array, that specifies the
     coordinates in the input image for every element in the output image. E.g.
@@ -832,6 +832,7 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=1,
         elif (hasattr(inverse_map, '__name__') and
               inverse_map.__name__ == 'inverse_map' and
               get_bound_method_class(inverse_map) in HOMOGRAPHY_TRANSFORMS):
+            # TODO: do we still need this introspection hack?
             # inverse_map is the inverse of a homography
             matrix = np.linalg.inv(inverse_map.__self__.params)
 

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -8,6 +8,7 @@ from skimage.transform import (estimate_transform, matrix_transform,
 
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_almost_equal
+from skimage._shared._warnings import expected_warnings
 
 
 SRC = np.array([
@@ -345,23 +346,49 @@ def test_union():
     tform1 = SimilarityTransform(scale=0.1, rotation=0.3)
     tform2 = SimilarityTransform(scale=0.1, rotation=0.9)
     tform3 = SimilarityTransform(scale=0.1 ** 2, rotation=0.3 + 0.9)
-    tform = tform1 + tform2
+
+    with expected_warnings(['deprecated']):
+        tform = tform1 + tform2
     assert_almost_equal(tform.params, tform3.params)
+    assert tform.__class__ == SimilarityTransform
+
+    # Multiply version swaps the order of operands to match linear algebra
+    tform = tform2 @ tform1
+    assert_almost_equal(tform.params, tform3.params)
+    assert tform.__class__ == SimilarityTransform
+
 
     tform1 = AffineTransform(scale=(0.1, 0.1), rotation=0.3)
     tform2 = SimilarityTransform(scale=0.1, rotation=0.9)
     tform3 = SimilarityTransform(scale=0.1 ** 2, rotation=0.3 + 0.9)
-    tform = tform1 + tform2
+    with expected_warnings(['deprecated']):
+        tform = tform1 + tform2
+    assert_almost_equal(tform.params, tform3.params)
+    assert tform.__class__ == ProjectiveTransform
+
+    tform = tform2 @ tform1
     assert_almost_equal(tform.params, tform3.params)
     assert tform.__class__ == ProjectiveTransform
 
     tform = AffineTransform(scale=(0.1, 0.1), rotation=0.3)
-    assert_almost_equal((tform + tform.inverse).params, np.eye(3))
+    with expected_warnings(['deprecated']):
+        assert_almost_equal((tform + tform.inverse).params, np.eye(3))
+    assert_almost_equal((tform @ tform.inverse).params, np.eye(3))
+    assert_almost_equal((tform.inverse @ tform).params, np.eye(3))
 
     tform1 = SimilarityTransform(scale=0.1, rotation=0.3)
     tform2 = SimilarityTransform(scale=0.1, rotation=0.9)
     tform3 = SimilarityTransform(scale=0.1 * 1/0.1, rotation=0.3 - 0.9)
-    tform = tform1 + tform2.inverse
+    with expected_warnings(['deprecated']):
+        tform = tform1 + tform2.inverse
+    assert_almost_equal(tform.params, tform3.params)
+    tform = tform2.inverse @ tform1
+    assert_almost_equal(tform.params, tform3.params)
+
+    tform1 = SimilarityTransform(scale=0.1, rotation=0.3)
+    tform2 = SimilarityTransform(translation=(10, 20))
+    tform3 = SimilarityTransform(scale=0.1, rotation=0.3, translation=(10, 20))
+    tform = tform2 @ tform1
     assert_almost_equal(tform.params, tform3.params)
 
 
@@ -369,7 +396,11 @@ def test_union_differing_types():
     tform1 = SimilarityTransform()
     tform2 = PolynomialTransform()
     with testing.raises(TypeError):
-        tform1.__add__(tform2)
+        with expected_warnings(['deprecated']):
+            tform1.__add__(tform2)
+
+    with testing.raises(TypeError):
+            tform1 @ tform2
 
 
 def test_geometric_tform():
@@ -379,7 +410,10 @@ def test_geometric_tform():
     with testing.raises(NotImplementedError):
         tform.inverse
     with testing.raises(NotImplementedError):
-        tform.__add__(0)
+        with expected_warnings(['deprecated']):
+            tform.__add__(0)
+    with testing.raises(NotImplementedError):
+        tform.__matmul__(0)
 
 
 def test_invalid_input():

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -54,7 +54,7 @@ def test_euclidean_estimation():
 
     # over-determined
     tform2 = estimate_transform('euclidean', SRC, DST)
-    assert_almost_equal(tform2.inverse_map(tform2(SRC)), SRC)
+    assert_almost_equal(tform2.inverse(tform2(SRC)), SRC)
     assert_almost_equal(tform2.params[0, 0], tform2.params[1, 1])
     assert_almost_equal(tform2.params[0, 1], - tform2.params[1, 0])
 
@@ -101,7 +101,7 @@ def test_similarity_estimation():
 
     # over-determined
     tform2 = estimate_transform('similarity', SRC, DST)
-    assert_almost_equal(tform2.inverse_map(tform2(SRC)), SRC)
+    assert_almost_equal(tform2.inverse(tform2(SRC)), SRC)
     assert_almost_equal(tform2.params[0, 0], tform2.params[1, 1])
     assert_almost_equal(tform2.params[0, 1], - tform2.params[1, 0])
 
@@ -156,7 +156,7 @@ def test_affine_estimation():
 
     # over-determined
     tform2 = estimate_transform('affine', SRC, DST)
-    assert_almost_equal(tform2.inverse_map(tform2(SRC)), SRC)
+    assert_almost_equal(tform2.inverse(tform2(SRC)), SRC)
 
     # via estimate method
     tform3 = AffineTransform()
@@ -231,13 +231,13 @@ def test_fundamental_matrix_forward():
     assert_almost_equal(tform(src), [[0, -1, 0], [0, -1, 1], [0, -1, 1]])
 
 
-def test_fundamental_matrix_inverse_map():
+def test_fundamental_matrix_inverse():
     essential_matrix_tform = EssentialMatrixTransform(
         rotation=np.eye(3), translation=np.array([1, 0, 0]))
     tform = FundamentalMatrixTransform()
     tform.params = essential_matrix_tform.params
     src = np.array([[0, 0], [0, 1], [1, 1]])
-    assert_almost_equal(tform.inverse_map(src),
+    assert_almost_equal(tform.inverse(src),
                         [[0, 1, 0], [0, 1, -1], [0, 1, -1]])
 
 
@@ -274,11 +274,11 @@ def test_essential_matrix_forward():
     assert_almost_equal(tform(src), [[0, -1, 0], [0, -1, 1], [0, -1, 1]])
 
 
-def test_essential_matrix_inverse_map():
+def test_essential_matrix_inverse():
     tform = EssentialMatrixTransform(rotation=np.eye(3),
                                      translation=np.array([1, 0, 0]))
     src = np.array([[0, 0], [0, 1], [1, 1]])
-    assert_almost_equal(tform.inverse_map(src),
+    assert_almost_equal(tform.inverse(src),
                         [[0, 1, 0], [0, 1, -1], [0, 1, -1]])
 
 
@@ -297,7 +297,7 @@ def test_projective_estimation():
 
     # over-determined
     tform2 = estimate_transform('projective', SRC, DST)
-    assert_almost_equal(tform2.inverse_map(tform2(SRC)), SRC)
+    assert_almost_equal(tform2.inverse(tform2(SRC)), SRC)
 
     # via estimate method
     tform3 = ProjectiveTransform()
@@ -336,9 +336,9 @@ def test_polynomial_default_order():
     assert_almost_equal(tform2.params, tform.params)
 
 
-def test_polynomial_inverse_map():
+def test_polynomial_inverse():
     with testing.raises(Exception):
-        PolynomialTransform().inverse_map(0)
+        PolynomialTransform().inverse(0)
 
 
 def test_union():
@@ -356,14 +356,12 @@ def test_union():
     assert tform.__class__ == ProjectiveTransform
 
     tform = AffineTransform(scale=(0.1, 0.1), rotation=0.3)
-    # TODO: Change me, this should be inverse and not inverse_map
-    assert_almost_equal((tform + tform.inverse_map).params, np.eye(3))
+    assert_almost_equal((tform + tform.inverse).params, np.eye(3))
 
     tform1 = SimilarityTransform(scale=0.1, rotation=0.3)
     tform2 = SimilarityTransform(scale=0.1, rotation=0.9)
     tform3 = SimilarityTransform(scale=0.1 * 1/0.1, rotation=0.3 - 0.9)
-    # TODO: Change me, this should be inverse and not inverse_map
-    tform = tform1 + tform2.inverse_map
+    tform = tform1 + tform2.inverse
     assert_almost_equal(tform.params, tform3.params)
 
 
@@ -379,7 +377,7 @@ def test_geometric_tform():
     with testing.raises(NotImplementedError):
         tform(0)
     with testing.raises(NotImplementedError):
-        tform.inverse_map(0)
+        tform.inverse
     with testing.raises(NotImplementedError):
         tform.__add__(0)
 

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -54,7 +54,7 @@ def test_euclidean_estimation():
 
     # over-determined
     tform2 = estimate_transform('euclidean', SRC, DST)
-    assert_almost_equal(tform2.inverse(tform2(SRC)), SRC)
+    assert_almost_equal(tform2.inverse_map(tform2(SRC)), SRC)
     assert_almost_equal(tform2.params[0, 0], tform2.params[1, 1])
     assert_almost_equal(tform2.params[0, 1], - tform2.params[1, 0])
 
@@ -101,7 +101,7 @@ def test_similarity_estimation():
 
     # over-determined
     tform2 = estimate_transform('similarity', SRC, DST)
-    assert_almost_equal(tform2.inverse(tform2(SRC)), SRC)
+    assert_almost_equal(tform2.inverse_map(tform2(SRC)), SRC)
     assert_almost_equal(tform2.params[0, 0], tform2.params[1, 1])
     assert_almost_equal(tform2.params[0, 1], - tform2.params[1, 0])
 
@@ -156,7 +156,7 @@ def test_affine_estimation():
 
     # over-determined
     tform2 = estimate_transform('affine', SRC, DST)
-    assert_almost_equal(tform2.inverse(tform2(SRC)), SRC)
+    assert_almost_equal(tform2.inverse_map(tform2(SRC)), SRC)
 
     # via estimate method
     tform3 = AffineTransform()
@@ -190,7 +190,7 @@ def test_piecewise_affine():
     tform.estimate(SRC, DST)
     # make sure each single affine transform is exactly estimated
     assert_almost_equal(tform(SRC), DST)
-    assert_almost_equal(tform.inverse(DST), SRC)
+    assert_almost_equal(tform.inverse_map(DST), SRC)
 
 
 def test_fundamental_matrix_estimation():
@@ -231,13 +231,13 @@ def test_fundamental_matrix_forward():
     assert_almost_equal(tform(src), [[0, -1, 0], [0, -1, 1], [0, -1, 1]])
 
 
-def test_fundamental_matrix_inverse():
+def test_fundamental_matrix_inverse_map():
     essential_matrix_tform = EssentialMatrixTransform(
         rotation=np.eye(3), translation=np.array([1, 0, 0]))
     tform = FundamentalMatrixTransform()
     tform.params = essential_matrix_tform.params
     src = np.array([[0, 0], [0, 1], [1, 1]])
-    assert_almost_equal(tform.inverse(src),
+    assert_almost_equal(tform.inverse_map(src),
                         [[0, 1, 0], [0, 1, -1], [0, 1, -1]])
 
 
@@ -274,11 +274,11 @@ def test_essential_matrix_forward():
     assert_almost_equal(tform(src), [[0, -1, 0], [0, -1, 1], [0, -1, 1]])
 
 
-def test_essential_matrix_inverse():
+def test_essential_matrix_inverse_map():
     tform = EssentialMatrixTransform(rotation=np.eye(3),
                                      translation=np.array([1, 0, 0]))
     src = np.array([[0, 0], [0, 1], [1, 1]])
-    assert_almost_equal(tform.inverse(src),
+    assert_almost_equal(tform.inverse_map(src),
                         [[0, 1, 0], [0, 1, -1], [0, 1, -1]])
 
 
@@ -297,7 +297,7 @@ def test_projective_estimation():
 
     # over-determined
     tform2 = estimate_transform('projective', SRC, DST)
-    assert_almost_equal(tform2.inverse(tform2(SRC)), SRC)
+    assert_almost_equal(tform2.inverse_map(tform2(SRC)), SRC)
 
     # via estimate method
     tform3 = ProjectiveTransform()
@@ -336,9 +336,9 @@ def test_polynomial_default_order():
     assert_almost_equal(tform2.params, tform.params)
 
 
-def test_polynomial_inverse():
+def test_polynomial_inverse_map():
     with testing.raises(Exception):
-        PolynomialTransform().inverse(0)
+        PolynomialTransform().inverse_map(0)
 
 
 def test_union():
@@ -356,12 +356,14 @@ def test_union():
     assert tform.__class__ == ProjectiveTransform
 
     tform = AffineTransform(scale=(0.1, 0.1), rotation=0.3)
-    assert_almost_equal((tform + tform.inverse).params, np.eye(3))
+    # TODO: Change me, this should be inverse and not inverse_map
+    assert_almost_equal((tform + tform.inverse_map).params, np.eye(3))
 
     tform1 = SimilarityTransform(scale=0.1, rotation=0.3)
     tform2 = SimilarityTransform(scale=0.1, rotation=0.9)
     tform3 = SimilarityTransform(scale=0.1 * 1/0.1, rotation=0.3 - 0.9)
-    tform = tform1 + tform2.inverse
+    # TODO: Change me, this should be inverse and not inverse_map
+    tform = tform1 + tform2.inverse_map
     assert_almost_equal(tform.params, tform3.params)
 
 
@@ -377,7 +379,7 @@ def test_geometric_tform():
     with testing.raises(NotImplementedError):
         tform(0)
     with testing.raises(NotImplementedError):
-        tform.inverse(0)
+        tform.inverse_map(0)
     with testing.raises(NotImplementedError):
         tform.__add__(0)
 

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -353,7 +353,8 @@ def test_union():
     assert tform.__class__ == SimilarityTransform
 
     # Multiply version swaps the order of operands to match linear algebra
-    tform = tform2 @ tform1
+    # tform = tform2 @ tform1
+    tform = tform2.__matmul__(tform1)
     assert_almost_equal(tform.params, tform3.params)
     assert tform.__class__ == SimilarityTransform
 
@@ -366,15 +367,18 @@ def test_union():
     assert_almost_equal(tform.params, tform3.params)
     assert tform.__class__ == ProjectiveTransform
 
-    tform = tform2 @ tform1
+    # tform = tform2 @ tform1
+    tform = tform2.__matmul__(tform1)
     assert_almost_equal(tform.params, tform3.params)
     assert tform.__class__ == ProjectiveTransform
 
     tform = AffineTransform(scale=(0.1, 0.1), rotation=0.3)
     with expected_warnings(['deprecated']):
         assert_almost_equal((tform + tform.inverse).params, np.eye(3))
-    assert_almost_equal((tform @ tform.inverse).params, np.eye(3))
-    assert_almost_equal((tform.inverse @ tform).params, np.eye(3))
+    # assert_almost_equal((tform @ tform.inverse).params, np.eye(3))
+    # assert_almost_equal((tform.inverse @ tform).params, np.eye(3))
+    assert_almost_equal((tform.__matmul__(tform.inverse)).params, np.eye(3))
+    assert_almost_equal((tform.inverse.__matmul__(tform)).params, np.eye(3))
 
     tform1 = SimilarityTransform(scale=0.1, rotation=0.3)
     tform2 = SimilarityTransform(scale=0.1, rotation=0.9)
@@ -382,13 +386,15 @@ def test_union():
     with expected_warnings(['deprecated']):
         tform = tform1 + tform2.inverse
     assert_almost_equal(tform.params, tform3.params)
-    tform = tform2.inverse @ tform1
+    # tform = tform2.inverse @ tform1
+    tform = tform2.inverse.__matmul__(tform1)
     assert_almost_equal(tform.params, tform3.params)
 
     tform1 = SimilarityTransform(scale=0.1, rotation=0.3)
     tform2 = SimilarityTransform(translation=(10, 20))
     tform3 = SimilarityTransform(scale=0.1, rotation=0.3, translation=(10, 20))
-    tform = tform2 @ tform1
+    # tform = tform2 @ tform1
+    tform = tform2.__matmul__(tform1)
     assert_almost_equal(tform.params, tform3.params)
 
 
@@ -400,7 +406,8 @@ def test_union_differing_types():
             tform1.__add__(tform2)
 
     with testing.raises(TypeError):
-            tform1 @ tform2
+            # tform1 @ tform2
+            tform1.__matmul__(tform2)
 
 
 def test_geometric_tform():

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -37,7 +37,7 @@ def test_warp_tform():
     x90 = warp(x, tform, order=1)
     assert_almost_equal(x90, np.rot90(x))
 
-    x90 = warp(x, tform.inverse_map, order=1)
+    x90 = warp(x, tform.inverse, order=1)
     assert_almost_equal(x90, np.rot90(x))
 
 
@@ -112,7 +112,7 @@ def test_homography():
                   [0,               0,             1]])
 
     x90 = warp(x,
-               inverse_map=ProjectiveTransform(M).inverse_map,
+               inverse_map=ProjectiveTransform(M).inverse,
                order=1)
     assert_almost_equal(x90, np.rot90(x))
 
@@ -461,7 +461,7 @@ def test_inverse():
     tform = SimilarityTransform(scale=0.5, rotation=0.1)
     inverse_tform = SimilarityTransform(matrix=np.linalg.inv(tform.params))
     image = np.arange(10 * 10).reshape(10, 10).astype(np.double)
-    assert_equal(warp(image, inverse_tform), warp(image, tform.inverse_map))
+    assert_equal(warp(image, inverse_tform), warp(image, tform.inverse))
 
 
 def test_slow_warp_nonint_oshape():

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -37,7 +37,7 @@ def test_warp_tform():
     x90 = warp(x, tform, order=1)
     assert_almost_equal(x90, np.rot90(x))
 
-    x90 = warp(x, tform.inverse, order=1)
+    x90 = warp(x, tform.inverse_map, order=1)
     assert_almost_equal(x90, np.rot90(x))
 
 
@@ -112,7 +112,7 @@ def test_homography():
                   [0,               0,             1]])
 
     x90 = warp(x,
-               inverse_map=ProjectiveTransform(M).inverse,
+               inverse_map=ProjectiveTransform(M).inverse_map,
                order=1)
     assert_almost_equal(x90, np.rot90(x))
 
@@ -461,7 +461,7 @@ def test_inverse():
     tform = SimilarityTransform(scale=0.5, rotation=0.1)
     inverse_tform = SimilarityTransform(matrix=np.linalg.inv(tform.params))
     image = np.arange(10 * 10).reshape(10, 10).astype(np.double)
-    assert_equal(warp(image, inverse_tform), warp(image, tform.inverse))
+    assert_equal(warp(image, inverse_tform), warp(image, tform.inverse_map))
 
 
 def test_slow_warp_nonint_oshape():


### PR DESCRIPTION
# Proposed changes to `skimage.transform._geometry`

I would like to propose a few small breaking changes to the transform API.
Theses proposals turned into an implementation during a long flight.

1. I would like to make `inverse` a property that returns an instance of the same class (if possible).
2. I would like to deprecate the `__add__` API in favour of the `__matmul__` api. I guess we could use `dot` for 2.7, but I find `dot` confusing because there are so many `dot` products out there.
3. Further, I would like to reverse the order of the operands in `__matmul__` compared to the current implementation to match the linear algebraic language.

Since this requires the `@` operator which is python 3 only, I think this should just wait until python 2.7 support is dropped.

## 1. Changes to the behaviour of `inverse`
Currently, calling `.inverse` doesn't actually return a transform. It returns a function that maps the outputs to the inputs. This is fine, but I think it leads to a little bit of confusion. A lot of the notation in the `transform` API uses matrix multiplication language. You would think that things like the identity would be well defined:

For example, if the matrix $A$ is the mathematical representation of the `SimilarityTransform` we are working with, we would expect the following two statements to hold for the identity

In math
$$
I = A^{-1}A
I = A A^{-1}
$$
And in python, you would wish that
```python
I = A.inverse @ A
I = A @ A.inverse
```
Currently, only one of them actually works (due to some hacky code IMO see below)

```python
    def __add__(self, other):
        [...]
        elif (hasattr(other, '__name__')
               and other.__name__ == 'inverse'
               and hasattr(get_bound_method_class(other), '_inv_matrix')):
           return ProjectiveTransform(other.__self__._inv_matrix.dot(self.params))
        [...]
```

~~I understand that this would require a small change to the way `warp` works too.~~ I implemented the necessary changes. There might be a few more lines to delete in `warp` that I marked with a TODO

I suggest:

  1. For `GeometricTransforms` `inverse` returns the mathematical inverse of the original `GeometricTransform`
  2. ~~The old function can be retained as `inverse_map` matching the naming convention established in the `warp` function.~~ This isn't necessary since you can simply call `t.inverse(coords)` just like you used to since the `GeometricTransforms` are callable themselves.

## 2. Deprecating `__add__` in favour of `__matmult__`
The language used to describe most of these transformations seems to be that of linear algebra. My limited knowledge of linearly algebra states that addition is commutative. That said, in this case, addition is **not** commutative.

In scikit-image, if `B` and `A` are `SimilarityTransform`, `B + A` and `A + B` lead to different results which is not what linear algebra tells us.

Using `__matmul__` makes it much cleaner that the `combination` of the transforms is not commutative since it is known that matrix multiply is not commutative.

I suggest
a. We cause the `__add__` function to raise a Warning (if people want to shoot themselves in the foot, that is their choice for at least for for the first version this is accepted in).
b. We implement the `__matmut__` function as described below.

## 3. Reverse the order of the operands in `__matmult__` compared to `__add__`

Current, if `A` and `B` are `SimilarityTransform`, then
```python
C = A + B
# or as 2 suggest
C = A @ B
```
leads to the mathematical operation

$$
x_prime = Cx = BAx
$$
and not
$$
x_prime = Cx = ABx = A(B(x))
$$

I don't think this it makes sense to swap the order of the matricies. Therefore, I suggest that the python operation, matches the linear algebraic one too.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
