### PR TITLE
Force Appveyor to fail on failed tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,7 +64,7 @@ test_script:
   -  echo backend:Agg > matplotlibrc
 
   # Run unit tests with pytest
-  - "python -c \"import pytest; import skimage; pytest.main([skimage.pkg_dir])\""
+  - pytest -v --pyargs skimage
 
 artifacts:
   # Archive the generated wheel package in the ci.appveyor.com build report.

--- a/skimage/morphology/_watershed.pyx
+++ b/skimage/morphology/_watershed.pyx
@@ -17,7 +17,6 @@ cimport cython
 
 
 ctypedef cnp.int32_t DTYPE_INT32_t
-ctypedef cnp.int64_t DTYPE_INT64_t
 ctypedef cnp.int8_t DTYPE_BOOL_t
 
 
@@ -29,8 +28,8 @@ include "heap_watershed.pxi"
 @cython.cdivision(True)
 @cython.overflowcheck(False)
 @cython.unraisable_tracebacks(False)
-cdef inline double _euclid_dist(cnp.int64_t pt0, cnp.int64_t pt1,
-                                cnp.int64_t[::1] strides):
+cdef inline double _euclid_dist(Py_ssize_t pt0, Py_ssize_t pt1,
+                                cnp.intp_t[::1] strides):
     """Return the Euclidean distance between raveled points pt0 and pt1."""
     cdef double result = 0
     cdef double curr = 0
@@ -47,7 +46,7 @@ cdef inline double _euclid_dist(cnp.int64_t pt0, cnp.int64_t pt1,
 @cython.cdivision(True)
 @cython.unraisable_tracebacks(False)
 cdef inline DTYPE_BOOL_t _diff_neighbors(DTYPE_INT32_t[::1] output,
-                                         DTYPE_INT64_t[::1] structure,
+                                         cnp.intp_t[::1] structure,
                                          DTYPE_BOOL_t[::1] mask,
                                          Py_ssize_t index):
     """
@@ -79,10 +78,10 @@ cdef inline DTYPE_BOOL_t _diff_neighbors(DTYPE_INT32_t[::1] output,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def watershed_raveled(cnp.float64_t[::1] image,
-                      DTYPE_INT64_t[::1] marker_locations,
-                      DTYPE_INT64_t[::1] structure,
+                      cnp.intp_t[::1] marker_locations,
+                      cnp.intp_t[::1] structure,
                       DTYPE_BOOL_t[::1] mask,
-                      cnp.int64_t[::1] strides,
+                      cnp.intp_t[::1] strides,
                       cnp.double_t compactness,
                       DTYPE_INT32_t[::1] output,
                       DTYPE_BOOL_t wsl):


### PR DESCRIPTION
See discussion on #3091

I dont have appveyor setup. this is an easy way for it to get to run to test things.

Issues that remain 
- [x] Appveyor doesn't test `--doctest-modules`. #3094
- [x] 32 bit Appveyor (and Travis if somebody should set that up) doesn't pass certain tests: I suggest we skip them until their relevant [PR pass](https://github.com/scikit-image/scikit-image/issues/3089#issuecomment-391174973). #3089 

## Checklist
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
#3091

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
