### PR TITLE
Ellipsis fitting: Check the condition number before computiing eigen vectors

### DIFF
--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -434,6 +434,12 @@ class EllipseModel(BaseModel):
         except np.linalg.LinAlgError:  # LinAlgError: Singular matrix
             return False
 
+        # While S3 might be well conditioned enough to take an inverse
+        # M might not be well conditioned.
+        # Wikipedia says you loose log2(cond(M)) digits of precision
+        if math.log2(np.linalg.cond(M)) > 12:
+            return False
+
         # M*|a b c >=l|a b c >. Find eigenvalues and eigenvectors
         # from this equation [eqn. 28]
         eig_vals, eig_vecs = np.linalg.eig(M)

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -225,11 +225,20 @@ def test_ellipse_model_estimate_from_data():
                'details: '
                'https://github.com/scikit-image/scikit-image/issues/3091 '
                'https://github.com/scikit-image/scikit-image/issues/2670'))
-def test_ellipse_model_estimate_failers():
+@testing.parametrize('epsilon', 10.**np.arange(-4, -20, -1))
+def test_ellipse_model_estimate_failers(epsilon):
+    # This test is known to return true on 32 bit machines with epsilon = 0
+    # Setting the value of espilon to a small number causes it return true
+    # on 64 machiens too.
+    # Unfortunately, it seems to depend on the version of python that is used
+    # Therefore, test for many cases for different values of epsilon.
+
     # estimate parameters of real data
     model = EllipseModel()
     assert not model.estimate(np.ones((5, 2)))
-    assert not model.estimate(np.array([[50, 80], [51, 81], [52, 80]]))
+    assert not model.estimate(np.array([[50, 80],
+                                        [51, 81],
+                                        [52, 80 + epsilon]]))
 
 
 def test_ellipse_model_residuals():


### PR DESCRIPTION
Under certain conditions, the result of a matrix we have to invert becomes ill conditioneed. The 32 bit solver and 64 bit solver converge on different answers.
We first check if that matrix is ill conditioned before we move forward with the computation.

See #3091

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
