### PR TITLE
Linking preserve_range parameter calls to docs

### DIFF
--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -230,7 +230,7 @@ def convert_to_float(image, preserve_range):
         Input image.
     preserve_range : bool
         Determines if the range of the image should be kept or transformed
-        using img_as_float. See URL for more
+        using img_as_float. Also see
         http://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Returns

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -230,7 +230,8 @@ def convert_to_float(image, preserve_range):
         Input image.
     preserve_range : bool
         Determines if the range of the image should be kept or transformed
-        using img_as_float.
+        using img_as_float. See URL for more
+        http://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Returns
     -------
@@ -242,4 +243,3 @@ def convert_to_float(image, preserve_range):
     else:
         image = img_as_float(image)
     return image
-

--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -15,10 +15,9 @@ def _convert_input(image, preserve_range):
     Parameters
     ----------
     preserve_range : bool, optional
-    Whether to keep the original range of values. Otherwise, the input
-    image is converted according to the conventions of `img_as_float`.
-    See URL for more
-    http://scikit-image.org/docs/dev/user_guide/data_types.html
+        Whether to keep the original range of values. Otherwise, the input
+        image is converted according to the conventions of `img_as_float`.
+        Also see http://scikit-image.org/docs/dev/user_guide/data_types.html
     """
     if preserve_range:
         image = image.astype(np.double)
@@ -59,7 +58,7 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
-        See more URL for more
+        Also see
         http://scikit-image.org/docs/dev/user_guide/data_types.html
     truncate : float, optional
         Truncate the filter at this many standard deviations.

--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -11,6 +11,15 @@ __all__ = ['gaussian']
 
 
 def _convert_input(image, preserve_range):
+    """
+    Parameters
+    ----------
+    preserve_range : bool, optional
+    Whether to keep the original range of values. Otherwise, the input
+    image is converted according to the conventions of `img_as_float`.
+    See URL for more
+    http://scikit-image.org/docs/dev/user_guide/data_types.html
+    """
     if preserve_range:
         image = image.astype(np.double)
     else:
@@ -50,6 +59,8 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
+        See more URL for more
+        http://scikit-image.org/docs/dev/user_guide/data_types.html
     truncate : float, optional
         Truncate the filter at this many standard deviations.
 

--- a/skimage/filters/_unsharp_mask.py
+++ b/skimage/filters/_unsharp_mask.py
@@ -44,6 +44,7 @@ def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
     preserve_range: bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
+        Also see http://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Returns
     -------

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -74,6 +74,8 @@ def resize(image, output_shape, order=1, mode=None, cval=0, clip=True,
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
+        See URL for more
+        http://scikit-image.org/docs/dev/user_guide/data_types.html
     anti_aliasing : bool, optional
         Whether to apply a Gaussian filter to smooth the image prior to
         down-scaling. It is crucial to filter when down-sampling the image to
@@ -229,6 +231,8 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
+        See URL for more
+        http://scikit-image.org/docs/dev/user_guide/data_types.html
     multichannel : bool, optional
         Whether the last axis of the image is to be interpreted as multiple
         channels or another spatial dimension. By default, is set to True for
@@ -323,6 +327,8 @@ def rotate(image, angle, resize=False, center=None, order=1, mode='constant',
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
+        See URL for more
+        http://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Notes
     -----
@@ -491,6 +497,8 @@ def swirl(image, center=None, strength=1, radius=100, rotation=0,
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
+        See URL for more
+        http://scikit-image.org/docs/dev/user_guide/data_types.html
 
     """
     if mode is None:
@@ -725,6 +733,8 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=1,
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
+        See URL for more
+        http://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Returns
     -------

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -74,8 +74,7 @@ def resize(image, output_shape, order=1, mode=None, cval=0, clip=True,
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
-        See URL for more
-        http://scikit-image.org/docs/dev/user_guide/data_types.html
+        Also see http://scikit-image.org/docs/dev/user_guide/data_types.html
     anti_aliasing : bool, optional
         Whether to apply a Gaussian filter to smooth the image prior to
         down-scaling. It is crucial to filter when down-sampling the image to
@@ -231,7 +230,7 @@ def rescale(image, scale, order=1, mode=None, cval=0, clip=True,
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
-        See URL for more
+        Also see
         http://scikit-image.org/docs/dev/user_guide/data_types.html
     multichannel : bool, optional
         Whether the last axis of the image is to be interpreted as multiple
@@ -327,7 +326,7 @@ def rotate(image, angle, resize=False, center=None, order=1, mode='constant',
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
-        See URL for more
+        Also see
         http://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Notes
@@ -497,7 +496,7 @@ def swirl(image, center=None, strength=1, radius=100, rotation=0,
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
-        See URL for more
+        Also see
         http://scikit-image.org/docs/dev/user_guide/data_types.html
 
     """
@@ -733,7 +732,7 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=1,
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
-        See URL for more
+        Also see
         http://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Returns


### PR DESCRIPTION
If committed, this will add links to http://scikit-image.org/docs/dev/user_guide/data_types.html wherever preserve_range is used.

