### PR TITLE
Lazy apply_parallel

### DIFF
--- a/skimage/util/apply_parallel.py
+++ b/skimage/util/apply_parallel.py
@@ -51,7 +51,7 @@ def _get_chunks(shape, ncpu):
 
 
 def apply_parallel(function, array, chunks=None, depth=0, mode=None,
-                 extra_arguments=(), extra_keywords={}):
+                   extra_arguments=(), extra_keywords={}):
     """Map a function in parallel across an array.
 
     Split an array into possibly overlapping chunks of a given depth and

--- a/skimage/util/apply_parallel.py
+++ b/skimage/util/apply_parallel.py
@@ -51,7 +51,7 @@ def _get_chunks(shape, ncpu):
 
 
 def apply_parallel(function, array, chunks=None, depth=0, mode=None,
-                   extra_arguments=(), extra_keywords={}):
+                   extra_arguments=(), extra_keywords={}, compute=True):
     """Map a function in parallel across an array.
 
     Split an array into possibly overlapping chunks of a given depth and
@@ -112,4 +112,9 @@ def apply_parallel(function, array, chunks=None, depth=0, mode=None,
         return function(arr, *extra_arguments, **extra_keywords)
 
     darr = da.from_array(array, chunks=chunks)
-    return darr.map_overlap(wrapped_func, depth, boundary=mode).compute()
+
+    res = darr.map_overlap(wrapped_func, depth, boundary=mode)
+    if compute:
+        res = dres.compute()
+
+    return res

--- a/skimage/util/apply_parallel.py
+++ b/skimage/util/apply_parallel.py
@@ -122,6 +122,6 @@ def apply_parallel(function, array, chunks=None, depth=0, mode=None,
 
     res = darr.map_overlap(wrapped_func, depth, boundary=mode)
     if compute:
-        res = dres.compute()
+        res = res.compute()
 
     return res

--- a/skimage/util/apply_parallel.py
+++ b/skimage/util/apply_parallel.py
@@ -69,7 +69,7 @@ def apply_parallel(function, array, chunks=None, depth=0, mode=None,
     ----------
     function : function
         Function to be mapped which takes an array as an argument.
-    array : numpy array
+    array : numpy array or dask array
         Array which the function will be applied to.
     chunks : int, tuple, or tuple of tuples, optional
         A single integer is interpreted as the length of one side of a square
@@ -91,13 +91,23 @@ def apply_parallel(function, array, chunks=None, depth=0, mode=None,
         Dictionary of keyword arguments to be passed to the function.
     compute : bool, optional
         Whether to compute right away (default) or
-        skip computing and return a Dask Array.
+        skip computing and return a dask Array.
+
+    Returns
+    -------
+    out : ndarray or dask Array
+        Returns the result of the applying the operation.
+        Type is dependent on the ``compute`` argument.
 
     Notes
     -----
     Numpy edge modes 'symmetric', 'wrap', and 'edge' are converted to the
-    equivalent `dask` boundary modes 'reflect', 'periodic' and 'nearest',
+    equivalent ``dask`` boundary modes 'reflect', 'periodic' and 'nearest',
     respectively.
+    Setting ``compute=False`` can be useful for chaining later operations.
+    For example region selection to preview a result or storing large data
+    to disk instead of loading in memory.
+
     """
     if not dask_available:
         raise RuntimeError("Could not import 'dask'.  Please install "

--- a/skimage/util/apply_parallel.py
+++ b/skimage/util/apply_parallel.py
@@ -50,6 +50,13 @@ def _get_chunks(shape, ncpu):
     return tuple(chunks)
 
 
+def _ensure_dask_array(array, chunks=None):
+    if isinstance(array, da.Array):
+        return array
+
+    return da.from_array(array, chunks=chunks)
+
+
 def apply_parallel(function, array, chunks=None, depth=0, mode=None,
                    extra_arguments=(), extra_keywords={}, *, compute=True):
     """Map a function in parallel across an array.
@@ -93,18 +100,13 @@ def apply_parallel(function, array, chunks=None, depth=0, mode=None,
         raise RuntimeError("Could not import 'dask'.  Please install "
                            "using 'pip install dask'")
 
-    if not isinstance(array, da.Array):
-        if chunks is None:
-            shape = array.shape
-            try:
-                ncpu = cpu_count()
-            except NotImplementedError:
-                ncpu = 4
-            chunks = _get_chunks(shape, ncpu)
-
-        darr = da.from_array(array, chunks=chunks)
-    else:
-        darr = array
+    if chunks is None:
+        shape = array.shape
+        try:
+            ncpu = cpu_count()
+        except NotImplementedError:
+            ncpu = 4
+        chunks = _get_chunks(shape, ncpu)
 
     if mode == 'wrap':
         mode = 'periodic'
@@ -115,6 +117,8 @@ def apply_parallel(function, array, chunks=None, depth=0, mode=None,
 
     def wrapped_func(arr):
         return function(arr, *extra_arguments, **extra_keywords)
+
+    darr = _ensure_dask_array(array, chunks=chunks)
 
     res = darr.map_overlap(wrapped_func, depth, boundary=mode)
     if compute:

--- a/skimage/util/apply_parallel.py
+++ b/skimage/util/apply_parallel.py
@@ -51,7 +51,7 @@ def _get_chunks(shape, ncpu):
 
 
 def apply_parallel(function, array, chunks=None, depth=0, mode=None,
-                   extra_arguments=(), extra_keywords={}, compute=True):
+                   extra_arguments=(), extra_keywords={}, *, compute=True):
     """Map a function in parallel across an array.
 
     Split an array into possibly overlapping chunks of a given depth and

--- a/skimage/util/apply_parallel.py
+++ b/skimage/util/apply_parallel.py
@@ -89,6 +89,9 @@ def apply_parallel(function, array, chunks=None, depth=0, mode=None,
         Tuple of arguments to be passed to the function.
     extra_keywords : dictionary, optional
         Dictionary of keyword arguments to be passed to the function.
+    compute : bool, optional
+        Whether to compute right away (default) or
+        skip computing and return a Dask Array.
 
     Notes
     -----

--- a/skimage/util/tests/test_apply_parallel.py
+++ b/skimage/util/tests/test_apply_parallel.py
@@ -43,7 +43,7 @@ def test_apply_parallel_lazy():
                              extra_keywords={'mode': 'reflect'},
                              compute=False)
 
-    assert isinstance(result, da.Array)
+    assert isinstance(result1, da.Array)
 
     assert_array_almost_equal(result1.compute(), expected1)
 

--- a/skimage/util/tests/test_apply_parallel.py
+++ b/skimage/util/tests/test_apply_parallel.py
@@ -35,6 +35,7 @@ def test_apply_parallel_lazy():
 
     # data
     a = np.arange(144).reshape(12, 12).astype(float)
+    d = da.from_array(a, chunks=(6, 6))
 
     # apply the filter
     expected1 = threshold_local(a, 3)
@@ -43,9 +44,19 @@ def test_apply_parallel_lazy():
                              extra_keywords={'mode': 'reflect'},
                              compute=False)
 
+    # apply the filter on a Dask Array
+    result2 = apply_parallel(threshold_local, d, depth=5,
+                             extra_arguments=(3,),
+                             extra_keywords={'mode': 'reflect'},
+                             compute=False)
+
     assert isinstance(result1, da.Array)
 
     assert_array_almost_equal(result1.compute(), expected1)
+
+    assert isinstance(result2, da.Array)
+
+    assert_array_almost_equal(result2.compute(), expected1)
 
 
 @testing.skipif(not dask_available, reason="dask not installed")

--- a/skimage/util/tests/test_apply_parallel.py
+++ b/skimage/util/tests/test_apply_parallel.py
@@ -30,6 +30,25 @@ def test_apply_parallel():
 
 
 @testing.skipif(not dask_available, reason="dask not installed")
+def test_apply_parallel_lazy():
+    import dask.array as da
+
+    # data
+    a = np.arange(144).reshape(12, 12).astype(float)
+
+    # apply the filter
+    expected1 = threshold_local(a, 3)
+    result1 = apply_parallel(threshold_local, a, chunks=(6, 6), depth=5,
+                             extra_arguments=(3,),
+                             extra_keywords={'mode': 'reflect'},
+                             compute=False)
+
+    assert isinstance(result, da.Array)
+
+    assert_array_almost_equal(result1.compute(), expected1)
+
+
+@testing.skipif(not dask_available, reason="dask not installed")
 def test_no_chunks():
     a = np.ones(1 * 4 * 8 * 9).reshape(1, 4, 8, 9)
 


### PR DESCRIPTION
## Description
[Tell us about your new feature, improvement, or fix! If relevant, please supplement the PR with images.]

Provides the option to disable computing in `apply_parallel` returning a Dask Array in this case. Default behavior is backwards compatibility with `apply_parallel`.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
