### PR TITLE
Remove matplotlib as a core dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       env: OPTIONAL_DEPS=1 WITH_PYSIDE=1 BUILD_DOCS=1 INSTALL_FROM_SDIST=1
     - os: linux
       python: 3.5
-      env: QT=PyQt5 MINIMUM_REQUIREMENTS=1
+      env: MINIMUM_REQUIREMENTS=1
     - os: linux
       python: 3.5
       env: QT=PyQt5 OPTIONAL_DEPS=1 MINIMUM_REQUIREMENTS=1
@@ -53,7 +53,7 @@ matrix:
       env: QT=PyQt5 OPTIONAL_DEPS=1 BUILD_DOCS=1 DEPLOY_DOCS=1
     - os: linux
       python: 3.6
-      env: QT=PyQt5 WITH_PYAMG=1
+      env: QT=PyQt5
     - os: linux
       python: 3.7
       dist: xenial # Required for Python 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,17 +110,18 @@ install:
       fi
     # Install testing requirements
     - pip install --retries 3 $PIP_FLAGS -r requirements/test.txt
-    # Matplotlib settings - do not show figures during doc examples
-    - export MPL_DIR=`python -c 'import matplotlib; print(matplotlib.get_configdir())'`
-    - mkdir -p ${MPL_DIR}
-    - touch ${MPL_DIR}/matplotlibrc
     # Install most of the optional packages
+    # Matplotlib settings - do not show figures during doc examples
+    # Qt is only needed if MPL is installed
     - |
       if [[ "${OPTIONAL_DEPS}" == "1" ]]; then
         pip install --retries 3 -r ./requirements/optional.txt $WHEELHOUSE
         pip install --retries 3 -r ./requirements/extras.txt $WHEELHOUSE
+        export MPL_DIR=`python -c 'import matplotlib; print(matplotlib.get_configdir())'`
+        mkdir -p ${MPL_DIR}
+        touch ${MPL_DIR}/matplotlibrc
+        tools/travis/install_qt.sh
       fi
-    - tools/travis/install_qt.sh
 
 script: tools/travis/script.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,9 @@ matrix:
       python: 3.6
       env: QT=PyQt5 OPTIONAL_DEPS=1 BUILD_DOCS=1 DEPLOY_DOCS=1
     - os: linux
+      python: 3.6
+      env: QT=PyQt5 WITH_PYAMG=1
+    - os: linux
       python: 3.7
       dist: xenial # Required for Python 3.7
       sudo: true   # travis-ci/travis-ci#9069

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,5 @@
 numpy>=1.11
 scipy>=0.17.0
-matplotlib>=2.0.0,!=3.0.0
 networkx>=2.0
 pillow>=4.3.0
 imageio>=2.0.1

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,6 +6,7 @@ sphinx-gallery
 sphinx-copybutton
 pytest-runner
 scikit-learn
+matplotlib>=2.0.0,!=3.0.0
 dask[array]>=0.9.0
 # cloudpickle is necessary to provide the 'processes' scheduler for dask
 cloudpickle>=0.2.1

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -3,6 +3,7 @@ astropy>=1.2.0
 tifffile
 qtpy
 pyamg
+matplotlib>=2.0.0,!=3.0.0
 dask[array]>=0.9.0
 # cloudpickle is necessary to provide the 'processes' scheduler for dask
 cloudpickle>=0.2.1

--- a/skimage/_shared/_geometry.py
+++ b/skimage/_shared/_geometry.py
@@ -9,32 +9,40 @@ def polygon_clip(rp, cp, r0, c0, r1, c1):
     Parameters
     ----------
     rp, cp : (N,) ndarray of double
-        Row and column coordinates of the polygon.
+        Row and column coordinates of the polygon. If the first and last
+        coordinate are not the same, the polygon will be closed automatically.
     (r0, c0), (r1, c1) : double
         Top-left and bottom-right coordinates of the bounding box.
 
     Returns
     -------
     r_clipped, c_clipped : (M,) ndarray of double
-        Coordinates of clipped polygon.
+        Coordinates of clipped polygon. The returned polygon will be close,
+        i.e. the first coordinate will be the same as the last coordinate.
 
     Notes
     -----
-    This makes use of Sutherland-Hodgman clipping as implemented in
-    AGG 2.4 and exposed in Matplotlib.
+    This makes use of the Sutherland-Hodgman algorithm for clipping [1]_.
 
+    References
+    ----------
+    .. [1]  Wikipedia. Sutherland–Hodgman algorithm
+            https://en.wikipedia.org/wiki/Sutherland%E2%80%93Hodgman_algorithm
     """
-    from matplotlib import path, transforms
 
-    poly = path.Path(np.vstack((rp, cp)).T, closed=True)
-    clip_rect = transforms.Bbox([[r0, c0], [r1, c1]])
-    poly_clipped = poly.clip_to_bbox(clip_rect).to_polygons()[0]
-
-    # This should be fixed in matplotlib >1.5
-    if np.all(poly_clipped[-1] == poly_clipped[-2]):
-        poly_clipped = poly_clipped[:-1]
-
-    return poly_clipped[:, 0], poly_clipped[:, 1]
+    rbox, cbox = _bbox(r0, c0, r1, c1)
+    r_clipped, c_clipped = _clip_sutherland_hodgman(rp, cp, rbox, cbox)
+    # make sure we return a closed polygon
+    # as we did when when
+    # matplotlib's functions were called.
+    if not (r_clipped[0] == r_clipped[-1] and c_clipped[0] == c_clipped[-1]):
+        # cast to list
+        r_clipped = list(r_clipped)
+        c_clipped = list(c_clipped)
+        # Append the first element to close the polygon
+        r_clipped.append(r_clipped[0])
+        c_clipped.append(c_clipped[0])
+    return np.asarray(r_clipped), np.asarray(c_clipped)
 
 
 def polygon_area(pr, pc):
@@ -53,3 +61,81 @@ def polygon_area(pr, pc):
     pr = np.asarray(pr)
     pc = np.asarray(pc)
     return 0.5 * np.abs(np.sum((pc[:-1] * pr[1:]) - (pc[1:] * pr[:-1])))
+
+
+def _clip_sutherland_hodgman(rp, cp, rclip, cclip):
+    """Clip an arbitrary polygon by an other convex polygon.
+
+    Implements the Sutherland-Hodgman algorithm to clip one polygon by
+    an other convex polygon [1]_.
+
+    Parameters
+    ----------
+    rp, cp : (N,) ndarray of double
+        Row and column coordinates of the polygon. Open polygons are OK.
+    rclip, cclip : (N,) ndarray of double
+        Row and column coordinates of the clipping polygon. This polygon should
+        be closed. The polygon is also assumed to be in the clock-wise
+        direction.
+
+    Returns
+    -------
+    r_clipped, c_clipped : (M,) ndarray of double
+        Coordinates of clipped polygon. This polygon may potentially be open.
+
+    References
+    ----------
+    .. [1]  Wikipedia. Sutherland–Hodgman algorithm
+            https://en.wikipedia.org/wiki/Sutherland%E2%80%93Hodgman_algorithm
+    """
+
+    def intersect(start, end, normal, point):
+        # equation 1
+        # n_y y + n_x x - n @ p = 0
+
+        # equation 2
+        # dr * y + dc * x - [dr dc] @ s = 0
+        dr = end[0] - start[0]
+        dc = end[1] - start[1]
+        normal_2 = np.asarray([dc, -dr])
+
+        # We now have a system of equations
+        # [[normal],     [[y],  =   [[n @ p],
+        #  [normal_2]]    [x]]       [n2 @ s]]
+        # That we should solve
+        A = np.stack([normal, normal_2], axis=0)
+        b = np.asarray([normal @ point, normal_2 @ s])
+        return np.linalg.solve(A, b)
+
+    # each edge is defined by a normal, and a single point on the edge
+    dr = rclip[1:] - rclip[:-1]
+    dc = cclip[1:] - cclip[:-1]
+    clip_normals = np.stack([dc, -dr], axis=1)
+    clip_points = np.stack([rclip[:-1], cclip[:-1]], axis=1)
+
+    out_coords = list(zip(rp, cp))
+    # start and end points of the edge
+    for normal, point in zip(clip_normals, clip_points):
+        coords = out_coords
+        out_coords = []
+        s = coords[-1]
+        # This test is true for a convex, clockwise polygon
+        start_in = normal @ s - normal @ point >= 0
+        for e in coords:
+            end_in = normal @ e - normal @ point >= 0
+            if end_in:
+                if not start_in:
+                    out_coords.append(intersect(s, e, normal, point))
+                out_coords.append(e)
+            elif start_in:
+                out_coords.append(intersect(s, e, normal, point))
+            s = e
+            start_in = end_in
+
+    return zip(*out_coords)
+
+
+def _bbox(r0, c0, r1, c1):
+    r = np.asarray([r0, r0, r1, r1, r0])
+    c = np.asarray([c0, c1, c1, c0, c0])
+    return r, c

--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -31,6 +31,7 @@ xfail = pytest.mark.xfail
 parametrize = pytest.mark.parametrize
 raises = pytest.raises
 fixture = pytest.fixture
+importorskip = pytest.importorskip
 
 # true if python is running in 32bit mode
 # Calculate the size of a void * pointer in bits

--- a/skimage/_shared/tests/test_geometry.py
+++ b/skimage/_shared/tests/test_geometry.py
@@ -1,4 +1,6 @@
 from skimage._shared._geometry import polygon_clip, polygon_area
+from skimage._shared.version_requirements import is_installed
+from skimage._shared import testing
 
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal

--- a/skimage/draw/tests/test_draw.py
+++ b/skimage/draw/tests/test_draw.py
@@ -11,6 +11,9 @@ from skimage.draw import (set_color, line, line_aa, polygon, polygon_perimeter,
                           rectangle_perimeter)
 from skimage.measure import regionprops
 
+from skimage._shared.version_requirements import is_installed
+from skimage._shared import testing
+
 
 def test_set_color():
     img = np.zeros((10, 10))

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -20,6 +20,7 @@ from skimage.filters.thresholding import (threshold_local,
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_almost_equal
 from skimage._shared.testing import assert_array_equal
+from skimage._shared.version_requirements import is_installed
 
 
 class TestSimpleImage():
@@ -34,6 +35,8 @@ class TestSimpleImage():
         with pytest.raises(RuntimeError):
             threshold_minimum(self.image)
 
+    @testing.skipif(not is_installed('matplotlib'),
+                    reason='try_all returns a matplotlib figure.')
     def test_try_all_threshold(self):
         fig, ax = try_all_threshold(self.image)
         all_texts = [axis.texts for axis in ax if axis.texts != []]

--- a/skimage/future/manual_segmentation.py
+++ b/skimage/future/manual_segmentation.py
@@ -20,6 +20,8 @@ def _draw_polygon(ax, vertices, alpha=0.4):
     from matplotlib.patches import Polygon
     from matplotlib.collections import PatchCollection
     import matplotlib.pyplot as plt
+    from matplotlib.patches import Polygon
+    from matplotlib.collections import PatchCollection
 
     polygon = Polygon(vertices, closed=True)
     p = PatchCollection([polygon], match_original=True, alpha=alpha)

--- a/skimage/io/tests/test_mpl_imshow.py
+++ b/skimage/io/tests/test_mpl_imshow.py
@@ -2,6 +2,9 @@
 import numpy as np
 from skimage import io
 from skimage._shared._warnings import expected_warnings
+from skimage._shared.testing import importorskip
+matplotlib = importorskip('matplotlib')
+
 import matplotlib.pyplot as plt
 
 

--- a/skimage/viewer/__init__.py
+++ b/skimage/viewer/__init__.py
@@ -1,6 +1,13 @@
 from .._shared.utils import warn
-from .viewers import ImageViewer, CollectionViewer
-from .qt import has_qt
+from .._shared.version_requirements import is_installed
 
+from .qt import has_qt
 if not has_qt:
     warn('Viewer requires Qt')
+
+if is_installed('matplotlib'):
+    from .viewers import ImageViewer, CollectionViewer
+    __all__ = ['ImageViewer', 'CollectionViewer']
+else:
+    __all__ = []
+    warn('Viewer requires matplotlib.')

--- a/skimage/viewer/tests/test_plugins.py
+++ b/skimage/viewer/tests/test_plugins.py
@@ -3,17 +3,20 @@ import skimage
 import skimage.data as data
 from skimage.filters.rank import median
 from skimage.morphology import disk
+
+from skimage._shared.testing import (assert_equal, assert_allclose,
+                                     assert_almost_equal)
+from skimage._shared._warnings import expected_warnings
+
+from skimage._shared import testing
+matplotlib = testing.importorskip('matplotlib')
+
 from skimage.viewer import ImageViewer, has_qt
 from skimage.viewer.plugins.base import Plugin
 from skimage.viewer.widgets import Slider
 from skimage.viewer.plugins import (
     LineProfile, Measure, CannyPlugin, LabelPainter, Crop, ColorHistogram,
     PlotPlugin)
-
-from skimage._shared import testing
-from skimage._shared.testing import (assert_equal, assert_allclose,
-                                     assert_almost_equal)
-from skimage._shared._warnings import expected_warnings
 
 
 def setup_line_profile(image, limits='image'):

--- a/skimage/viewer/tests/test_tools.py
+++ b/skimage/viewer/tests/test_tools.py
@@ -2,13 +2,16 @@ from collections import namedtuple
 
 import numpy as np
 from skimage import data
+from skimage._shared import testing
+from skimage._shared.testing import assert_equal, parametrize
+
+matplotlib = testing.importorskip("matplotlib")
+
 from skimage.viewer import ImageViewer, has_qt
 from skimage.viewer.canvastools import (
     LineTool, ThickLineTool, RectangleTool, PaintTool)
 from skimage.viewer.canvastools.base import CanvasToolBase
 
-from skimage._shared import testing
-from skimage._shared.testing import assert_equal, parametrize
 
 try:
     from matplotlib.testing.decorators import cleanup

--- a/skimage/viewer/tests/test_utils.py
+++ b/skimage/viewer/tests/test_utils.py
@@ -1,3 +1,6 @@
+from skimage._shared import testing
+matplotlib = testing.importorskip('matplotlib')
+
 from skimage.viewer import utils
 from skimage.viewer.utils import dialogs
 from skimage.viewer.qt import QtCore, QtWidgets, has_qt

--- a/skimage/viewer/tests/test_viewer.py
+++ b/skimage/viewer/tests/test_viewer.py
@@ -3,6 +3,10 @@ from skimage.transform import pyramid_gaussian
 from skimage.filters import sobel
 
 from skimage.viewer.qt import QtGui, QtCore, has_qt
+
+from skimage._shared.testing import importorskip
+matplotlib = importorskip('matplotlib')
+
 from skimage.viewer import ImageViewer, CollectionViewer
 from skimage.viewer.plugins import OverlayPlugin
 

--- a/skimage/viewer/tests/test_widgets.py
+++ b/skimage/viewer/tests/test_widgets.py
@@ -1,16 +1,17 @@
 import os
 
 from skimage import data, img_as_float, io, img_as_uint
+from skimage._shared._warnings import expected_warnings
+from skimage._shared import testing
+from skimage._shared.testing import assert_almost_equal, assert_equal
+
+matplotlib = testing.importorskip("matplotlib")
 
 from skimage.viewer import ImageViewer
 from skimage.viewer.qt import QtWidgets, QtCore, has_qt
 from skimage.viewer.widgets import (
     Slider, OKCancelButtons, SaveButtons, ComboBox, CheckBox, Text)
 from skimage.viewer.plugins.base import Plugin
-
-from skimage._shared._warnings import expected_warnings
-from skimage._shared import testing
-from skimage._shared.testing import assert_almost_equal, assert_equal
 
 
 def get_image_viewer():

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -37,8 +37,12 @@ export WHEELHOUSE
 
 # This causes way too many internal warnings within python.
 # export PYTHONWARNINGS="d,all:::skimage"
-
-export TEST_ARGS="--doctest-modules --cov=skimage"
+if [[ "$OPTIONAL_DEPS" == "1" ]]; then
+  # We must run doctests with the optional deps since
+  # it seems to crawl through the code base. if it cannot find
+  # matplotlib, it causes an error when it gathers the tests
+  export TEST_ARGS="--doctest-modules --cov=skimage"
+fi
 
 retry () {
     # https://gist.github.com/fungusakafungus/1026804
@@ -67,7 +71,7 @@ python -m pip install --upgrade pip
 pip install --retries 3 -q wheel
 
 # install specific wheels from wheelhouse
-for requirement in matplotlib scipy pillow; do
+for requirement in scipy pillow; do
     WHEELS="$WHEELS $(grep $requirement requirements/default.txt)"
 done
 # cython is not in the default.txt requirements

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -3,10 +3,7 @@
 set -ev
 export PY=${TRAVIS_PYTHON_VERSION}
 
-mkdir -p $MPL_DIR
-touch $MPL_DIR/matplotlibrc
-
-if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+if [[ $TRAVIS_OS_NAME == "osx" && "${OPTIONAL_DEPS}" == "1" ]]; then
     echo 'backend : Template' > $MPL_DIR/matplotlibrc
 fi
 
@@ -32,6 +29,9 @@ echo Build or run examples
 pip install --retries 3 -q -r ./requirements/docs.txt
 pip list
 tools/build_versions.py
+# MPL_DIR is not a default requirement, therefore we need to ensure
+# MPL_DIR is defined here
+MPL_DIR=`python -c 'import matplotlib; print(matplotlib.get_configdir())'`
 echo 'backend : Template' > $MPL_DIR/matplotlibrc
 if [[ "${BUILD_DOCS}" == "1" ]]; then
   export SPHINXCACHE=${HOME}/.cache/sphinx; make html


### PR DESCRIPTION
Issue #2710

Move matplotlib to optional dependency.
Skip tests that can't run without matplotlib

Few questions:
  - `geometry.polygon_clip` requires `matplotlib path, transforms`. :
         - Look into updating the [celiagg](https://github.com/celiagg/celiagg) conda recipe so it isn't pinned to numpy 1.12. Ultimately, we decided against this since it seemed like we were just removing matplotliib and replacing it with a different dependency.
              - See this PR https://github.com/conda-forge/celiagg-feedstock/pull/4 on celiagg's feedstock
         - A python implemented of the required algorithm was written to replace the matplotlib exposed algorithm.


Note: This was rebased onto: https://github.com/scikit-image/scikit-image/pull/3432
## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
