### PR TITLE
Add initial airspeed velocity (asv) framework

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,8 @@
 - [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
 - [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
 - [ ] Gallery example in `./doc/examples` (new features only)
+- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
+  existing benchmark
 - [ ] Unit tests
 
 [For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -52,6 +52,7 @@
     // followed by the pip installed packages).
     //
     "matrix": {
+         "cython": ["0.27", "0.28"],
          "numpy": ["1.13", "1.14"],
          "scipy": ["1.0", "1.1"],
          "matplotlib": ["2.2"]

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,140 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "scikit-image",
+
+    // The project's homepage
+    "project_url": "http://scikit-image.org/",
+
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": ".",
+
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "default" (for mercurial).
+    "branches": ["master"], // for git
+
+    // The DVCS being used.  If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    "dvcs": "git",
+
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv" or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "conda",
+
+    // timeout in seconds for installing any dependencies in environment
+    // defaults to 10 min
+    "install_timeout": 1200,
+
+    // the base URL to show a commit for the project.
+    "show_commit_url": "http://github.com/scikit-image/scikit-image/commit/",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    "pythons": ["3.6"],
+
+    // The matrix of dependencies to test.  Each key is the name of a
+    // package (in PyPI) and the values are version numbers.  An empty
+    // list or empty string indicates to just test against the default
+    // (latest) version. null indicates that the package is to not be
+    // installed. If the package to be tested is only available from
+    // PyPi, and the 'environment_type' is conda, then you can preface
+    // the package name by 'pip+', and the package will be installed via
+    // pip (with all the conda available packages installed first,
+    // followed by the pip installed packages).
+    //
+    "matrix": {
+         "numpy": ["1.13", "1.14"],
+         "scipy": ["1.0", "1.1"],
+         "matplotlib": ["2.2"]
+    },
+
+    // Combinations of libraries/python versions can be excluded/included
+    // from the set to test. Each entry is a dictionary containing additional
+    // key-value pairs to include/exclude.
+    //
+    // An exclude entry excludes entries where all values match. The
+    // values are regexps that should match the whole string.
+    //
+    // An include entry adds an environment. Only the packages listed
+    // are installed. The 'python' key is required. The exclude rules
+    // do not apply to includes.
+    //
+    // In addition to package names, the following keys are available:
+    //
+    // - python
+    //     Python version, as in the *pythons* variable above.
+    // - environment_type
+    //     Environment type, as above.
+    // - sys_platform
+    //     Platform, as in sys.platform. Possible values for the common
+    //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
+    //
+    // "exclude": [
+    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
+    //     {"environment_type": "conda", "six": null}, // don't run without six on conda
+    // ],
+    //
+    // "include": [
+    //     // additional env for python2.7
+    //     {"python": "2.7", "numpy": "1.8"},
+    //     // additional env if run on windows+conda
+    //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "libpython": ""},
+    // ],
+
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    // "benchmark_dir": "benchmarks",
+
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    "env_dir": ".asv/env",
+
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    "results_dir": ".asv/results",
+
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    "html_dir": ".asv/html",
+
+    // The number of characters to retain in the commit hashes.
+    // "hash_length": 8,
+
+    // `asv` will cache wheels of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // number of builds to keep, per environment.
+    // "wheel_cache_size": 0
+
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions.  The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    //
+    // "regressions_first_commits": {
+    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
+    //    "another_benchmark": null,   // Skip regression detection altogether
+    // }
+
+    // The thresholds for relative change in results, after which `asv
+    // publish` starts reporting regressions. Dictionary of the same
+    // form as in ``regressions_first_commits``, with values
+    // indicating the thresholds.  If multiple entries match, the
+    // maximum is taken. If no entry matches, the default is 5%.
+    //
+    // "regressions_thresholds": {
+    //    "some_benchmark": 0.01,     // Threshold of 1%
+    //    "another_benchmark": 0.5,   // Threshold of 50%
+    // }
+}

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,0 +1,17 @@
+# See "Writing benchmarks" in the asv docs for more information.
+from skimage import segmentation
+
+
+class SegmentationSuite:
+    """Benchmark for segmentation routines in scikit-image."""
+    def setup(self):
+        self.image = np.random.random((400, 400, 100))
+        self.image[:200, :200, :] += 1
+        self.image[300:, 300:, :] += 0.5
+
+    def time_slic_basic(self):
+        result = segmentation.slic(self.image, enforce_connectivity=False)
+
+    def mem_slic_basic(self):
+        result = segmentation.slic(self.image, enforce_connectivity=False)
+

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -1,4 +1,5 @@
 # See "Writing benchmarks" in the asv docs for more information.
+import numpy as np
 from skimage import segmentation
 
 

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -24,6 +24,10 @@ Improvements
 
 - ``skivi`` is now using ``qtpy`` for Qt4/Qt5/PySide/PySide2 compatibility (a
   new optional dependency).
+- Performance is now monitored by
+  `Airspeed Velocity <https://asv.readthedocs.io/en/stable/>`_. Benchmark
+  results will appear at https://pandas.pydata.org/speed/
+
 
 API Changes
 -----------

--- a/tools/check_sdist.py
+++ b/tools/check_sdist.py
@@ -19,11 +19,11 @@ data = ['./' + l.split(' ->')[0] for l in data]
 
 ignore_exts = ['.pyc', '.so', '.o', '#', '~', '.gitignore']
 ignore_dirs = ['./dist', './tools', './doc', './viewer_examples',
-               './downloads', './scikit_image.egg-info', 'benchmarks']
+               './downloads', './scikit_image.egg-info', './benchmarks']
 ignore_files = ['./TODO.md', './README.md', './MANIFEST',
                 './.gitignore', './.travis.yml', './.gitmodules',
                 './.mailmap', './.coveragerc', './.appveyor.yml',
-                './.pep8speaks.yml', 'asv.conf.json',
+                './.pep8speaks.yml', './asv.conf.json',
                 './skimage/filters/rank/README.rst']
 
 

--- a/tools/check_sdist.py
+++ b/tools/check_sdist.py
@@ -19,11 +19,11 @@ data = ['./' + l.split(' ->')[0] for l in data]
 
 ignore_exts = ['.pyc', '.so', '.o', '#', '~', '.gitignore']
 ignore_dirs = ['./dist', './tools', './doc', './viewer_examples',
-               './downloads', './scikit_image.egg-info']
+               './downloads', './scikit_image.egg-info', 'benchmarks']
 ignore_files = ['./TODO.md', './README.md', './MANIFEST',
                 './.gitignore', './.travis.yml', './.gitmodules',
                 './.mailmap', './.coveragerc', './.appveyor.yml',
-                './.pep8speaks.yml',
+                './.pep8speaks.yml', 'asv.conf.json',
                 './skimage/filters/rank/README.rst']
 
 

--- a/tools/check_sdist.py
+++ b/tools/check_sdist.py
@@ -17,7 +17,7 @@ data = [l for l in data if l.startswith('hard linking')]
 data = [l.replace('hard linking ', '') for l in data]
 data = ['./' + l.split(' ->')[0] for l in data]
 
-ignore_exts = ['.pyc', '.so', '.o', '#', '~', '.gitignore']
+ignore_exts = ['.pyc', '.so', '.o', '#', '~', '.gitignore', '.o.d']
 ignore_dirs = ['./dist', './tools', './doc', './viewer_examples',
                './downloads', './scikit_image.egg-info', './benchmarks']
 ignore_files = ['./TODO.md', './README.md', './MANIFEST',


### PR DESCRIPTION
## Description
In order to prevent performance regressions, we should set up asv to benchmark our slowest functions. This branch exists to work on that goal.

Closes #1061

## For reviewers

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
