### PR TITLE
Recover from exceptions in filters.try_all_threshold()

### DIFF
--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 from scipy import ndimage as ndi
 
@@ -15,6 +16,7 @@ from skimage.filters.thresholding import (threshold_local,
                                           threshold_mean,
                                           threshold_triangle,
                                           threshold_minimum,
+                                          try_all_threshold,
                                           _mean_std)
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_almost_equal
@@ -27,6 +29,16 @@ class TestSimpleImage():
                                [1, 2, 5, 4, 1],
                                [2, 4, 5, 2, 1],
                                [4, 5, 1, 0, 0]], dtype=int)
+
+    def test_minimum(self):
+        with pytest.raises(RuntimeError):
+            threshold_minimum(self.image)
+
+    def test_try_all_threshold(self):
+        fig, ax = try_all_threshold(self.image)
+        all_texts = [axis.texts for axis in ax if axis.texts != []]
+        text_content = [text.get_text() for x in all_texts for text in x]
+        assert 'RuntimeError' in text_content
 
     def test_otsu(self):
         assert threshold_otsu(self.image) == 2

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -59,8 +59,11 @@ def _try_all(image, methods=None, figsize=None, num_cols=2, verbose=True):
 
     i = 1
     for name, func in methods.items():
-        ax[i].imshow(func(image), cmap=plt.cm.gray)
         ax[i].set_title(name)
+        try:
+            ax[i].imshow(func(image), cmap=plt.cm.gray)
+        except Exception as e:
+            ax[i].text(0.5, 0.5, "%s" % type(e).__name__, ha="center", va="center", transform=ax[i].transAxes)
         i += 1
         if verbose:
             print(func.__orifunc__)

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -63,7 +63,8 @@ def _try_all(image, methods=None, figsize=None, num_cols=2, verbose=True):
         try:
             ax[i].imshow(func(image), cmap=plt.cm.gray)
         except Exception as e:
-            ax[i].text(0.5, 0.5, "%s" % type(e).__name__, ha="center", va="center", transform=ax[i].transAxes)
+            ax[i].text(0.5, 0.5, "%s" % type(e).__name__,
+                       ha="center", va="center", transform=ax[i].transAxes)
         i += 1
         if verbose:
             print(func.__orifunc__)


### PR DESCRIPTION
## Description
Currently if filters.try_all_threshold() encounters an exception in one of the threshold methods it fails to complete. I suggest instead the output should note which kind of exception was encountered and continue. 
Here's an example to illustrate:
```
%matplotlib inline
import numpy as np
from skimage.filters import try_all_threshold

simple_image = np.array([[0, 0, 1, 3, 5],
                         [0, 1, 4, 3, 4],
                         [1, 2, 5, 4, 1],
                         [2, 4, 5, 2, 1],
                         [4, 5, 1, 0, 0]], dtype=int)
flat_image = np.ones(simple_image.shape).astype(np.uint8)

try_all_threshold(simple_image)
try_all_threshold(flat_image)
```

### Proposed behaviour:
Output of `try_all_threshold(simple_image)`:
![proposed_tryallthreshold_flatimage](https://user-images.githubusercontent.com/30920819/40893054-833bf044-67e2-11e8-9ff6-13913cd5ea66.png)
Output_of `try_all_threshold(flat_image)`:
![proposed_tryallthreshold_simpleimage](https://user-images.githubusercontent.com/30920819/40893055-83656460-67e2-11e8-82b4-a1e7cdf4aa5e.png)

### Current behaviour:
Output of `try_all_threshold(simple_image)`:
![current_tryallthreshold_flatimage](https://user-images.githubusercontent.com/30920819/40893052-82e58ede-67e2-11e8-8a53-3876e21eba70.png)
Output_of `try_all_threshold(flat_image)`:
![current_tryallthreshold_simpleimage](https://user-images.githubusercontent.com/30920819/40893053-8310ff92-67e2-11e8-842a-514bfbf8a46a.png)

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## For reviewers

(Don't remove the checklist below.)

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
