### PR TITLE
skivi: Use qtpy to handle different Qt versions

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -22,7 +22,7 @@ New Features
 Improvements
 ------------
 
-
+- qtpy (MIT) now an optional dependency for skivi to run properly.
 
 API Changes
 -----------

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -4,3 +4,4 @@ SimpleITK
 astropy
 tifffile
 imageio
+qtpy

--- a/skimage/io/_plugins/q_color_mixer.py
+++ b/skimage/io/_plugins/q_color_mixer.py
@@ -1,6 +1,8 @@
 # the module for the qt color_mixer plugin
-from PyQt4 import QtGui, QtCore
-from PyQt4.QtGui import (QWidget, QStackedWidget, QSlider, QGridLayout, QLabel)
+from qtpy import QtCore
+from qtpy.QtWidgets import (QWidget, QStackedWidget, QSlider, QGridLayout,
+                            QLabel, QFrame, QComboBox, QRadioButton,
+                            QPushButton)
 
 from .util import ColorMixer
 
@@ -66,7 +68,7 @@ class IntelligentSlider(QWidget):
         return self.slider.value() * self.a + self.b
 
 
-class MixerPanel(QtGui.QFrame):
+class MixerPanel(QFrame):
     '''A color mixer to hook up to an image.
     You pass the image you the panel to operate on
     and it operates on that image in place. You also
@@ -74,8 +76,8 @@ class MixerPanel(QtGui.QFrame):
     This callback is called every time the mixer modifies
     your image.'''
     def __init__(self, img):
-        QtGui.QFrame.__init__(self)
-        #self.setFrameStyle(QtGui.QFrame.Box|QtGui.QFrame.Sunken)
+        QFrame.__init__(self)
+        #self.setFrameStyle(QFrame.Box|QFrame.Sunken)
 
         self.img = img
         self.mixer = ColorMixer(self.img)
@@ -89,7 +91,7 @@ class MixerPanel(QtGui.QFrame):
                                   'Brightness/Contrast',
                                   'Gamma',
                                   'Gamma (Sigmoidal)']
-        self.combo_box = QtGui.QComboBox()
+        self.combo_box = QComboBox()
         for entry in self.combo_box_entries:
             self.combo_box.addItem(entry)
         self.combo_box.currentIndexChanged.connect(self.combo_box_changed)
@@ -99,8 +101,8 @@ class MixerPanel(QtGui.QFrame):
         #---------------------------------------------------------------
 
         # radio buttons
-        self.rgb_add = QtGui.QRadioButton('Additive')
-        self.rgb_mul = QtGui.QRadioButton('Multiplicative')
+        self.rgb_add = QRadioButton('Additive')
+        self.rgb_mul = QRadioButton('Multiplicative')
         self.rgb_mul.toggled.connect(self.rgb_radio_changed)
         self.rgb_add.toggled.connect(self.rgb_radio_changed)
 
@@ -124,8 +126,8 @@ class MixerPanel(QtGui.QFrame):
         # HSV sliders
         #---------------------------------------------------------------
         # radio buttons
-        self.hsv_add = QtGui.QRadioButton('Additive')
-        self.hsv_mul = QtGui.QRadioButton('Multiplicative')
+        self.hsv_add = QRadioButton('Additive')
+        self.hsv_mul = QRadioButton('Multiplicative')
         self.hsv_mul.toggled.connect(self.hsv_radio_changed)
         self.hsv_mul.toggled.connect(self.hsv_radio_changed)
 
@@ -156,7 +158,7 @@ class MixerPanel(QtGui.QFrame):
 
         # layout
         self.bright_widget = QWidget()
-        self.bright_widget.layout = QtGui.QGridLayout(self.bright_widget)
+        self.bright_widget.layout = QGridLayout(self.bright_widget)
         self.bright_widget.layout.addWidget(self.cont, 0, 0)
         self.bright_widget.layout.addWidget(self.bright, 0, 1)
 
@@ -168,7 +170,7 @@ class MixerPanel(QtGui.QFrame):
 
         # layout
         self.gamma_widget = QWidget()
-        self.gamma_widget.layout = QtGui.QGridLayout(self.gamma_widget)
+        self.gamma_widget.layout = QGridLayout(self.gamma_widget)
         self.gamma_widget.layout.addWidget(self.gamma, 0, 0)
 
         #---------------------------------------------------------------
@@ -182,16 +184,16 @@ class MixerPanel(QtGui.QFrame):
 
         # layout
         self.sig_gamma_widget = QWidget()
-        self.sig_gamma_widget.layout = QtGui.QGridLayout(self.sig_gamma_widget)
+        self.sig_gamma_widget.layout = QGridLayout(self.sig_gamma_widget)
         self.sig_gamma_widget.layout.addWidget(self.a_gamma, 0, 0)
         self.sig_gamma_widget.layout.addWidget(self.b_gamma, 0, 1)
 
         #---------------------------------------------------------------
         # Buttons
         #---------------------------------------------------------------
-        self.commit_button = QtGui.QPushButton('Commit')
+        self.commit_button = QPushButton('Commit')
         self.commit_button.clicked.connect(self.commit_changes)
-        self.revert_button = QtGui.QPushButton('Revert')
+        self.revert_button = QPushButton('Revert')
         self.revert_button.clicked.connect(self.revert_changes)
 
         #---------------------------------------------------------------
@@ -204,7 +206,7 @@ class MixerPanel(QtGui.QFrame):
         self.sliders.addWidget(self.gamma_widget)
         self.sliders.addWidget(self.sig_gamma_widget)
 
-        self.layout = QtGui.QGridLayout(self)
+        self.layout = QGridLayout(self)
         self.layout.addWidget(self.combo_box, 0, 0)
         self.layout.addWidget(self.sliders, 1, 0)
         self.layout.addWidget(self.commit_button, 2, 0)

--- a/skimage/io/_plugins/q_histogram.py
+++ b/skimage/io/_plugins/q_histogram.py
@@ -1,6 +1,7 @@
 import numpy as np
 
-from PyQt4.QtGui import QWidget, QPainter, QGridLayout, QColor, QFrame
+from qtpy.QtGui import QPainter, QColor
+from qtpy.QtWidgets import QWidget, QGridLayout, QFrame
 
 from .util import histograms
 
@@ -122,7 +123,7 @@ class QuadHistogram(QFrame):
 
         self.setFrameStyle(QFrame.StyledPanel | QFrame.Sunken)
         self.layout = QGridLayout(self)
-        self.layout.setMargin(0)
+        self.layout.setContentsMargins(0, 0, 0, 0)
 
         order_map = {'R': self.r_hist, 'G': self.g_hist, 'B': self.b_hist,
                      'V': self.v_hist}

--- a/skimage/io/_plugins/qt_plugin.py
+++ b/skimage/io/_plugins/qt_plugin.py
@@ -2,30 +2,14 @@ import numpy as np
 from .util import prepare_for_display, window_manager
 from ..._shared.utils import warn
 
+from qtpy.QtWidgets import (QApplication, QLabel, QMainWindow, QWidget,
+                            QGridLayout)
+from qtpy.QtGui import QImage, QPixmap
+from qtpy import QtCore
 
 # We try to aquire the gui lock first or else the gui import might
 # trample another GUI's PyOS_InputHook.
 window_manager.acquire('qt')
-
-try:
-    from PyQt4.QtGui import (QApplication, QImage,
-                             QLabel, QMainWindow, QPixmap, QWidget)
-    from PyQt4 import QtCore, QtGui
-    import sip
-
-except ImportError:
-    window_manager._release('qt')
-
-    raise ImportError("""\
-    PyQt4 libraries not installed. Please refer to
-
-    http://www.riverbankcomputing.co.uk/software/pyqt/intro
-
-    for more information.  PyQt4 is GPL licensed.  For an
-    LGPL equivalent, see
-
-    http://www.pyside.org
-    """)
 
 app = None
 
@@ -65,7 +49,7 @@ class ImageWindow(QMainWindow):
         self.setWindowTitle('skimage')
         self.mgr = mgr
         self.main_widget = QWidget()
-        self.layout = QtGui.QGridLayout(self.main_widget)
+        self.layout = QGridLayout(self.main_widget)
         self.setCentralWidget(self.main_widget)
 
         self.label = ImageLabel(self, arr)
@@ -80,7 +64,7 @@ class ImageWindow(QMainWindow):
         self.mgr.remove_window(self)
 
 
-def imread_qt(filename):
+def imread(filename):
     """
     Read an image using QT's QImage.load
     """
@@ -114,14 +98,6 @@ def imread_qt(filename):
     elif bytes_per_pixel == 4:
         img[:, :, 0:3] = img[:, :, 2::-1]
     return img
-
-if sip.SIP_VERSION >= 0x040c00:
-    # sip.voidptr only acquired a buffer view in 4.12.0, so our imread
-    # doesn't work with earlier versions
-    imread = imread_qt
-else:
-    warn(RuntimeWarning("sip version too old. QT imread disabled"))
-
 
 def imshow(arr, fancy=False):
     global app

--- a/skimage/io/_plugins/skivi.py
+++ b/skimage/io/_plugins/skivi.py
@@ -15,8 +15,9 @@ Use skimage.io.imshow(img, fancy=True)'''
 
 from textwrap import dedent
 
-from PyQt4 import QtCore, QtGui
-from PyQt4.QtGui import QMainWindow, QImage, QPixmap, QLabel, QWidget, QFrame
+from qtpy import QtCore, QtWidgets
+from qtpy.QtWidgets import QMainWindow, QLabel, QWidget, QFrame, QGridLayout
+from qtpy.QtGui import QImage, QPixmap
 
 from .q_color_mixer import MixerPanel
 from .q_histogram import QuadHistogram
@@ -65,7 +66,7 @@ class ImageLabel(QLabel):
 class RGBHSVDisplay(QFrame):
     def __init__(self):
         QFrame.__init__(self)
-        self.setFrameStyle(QtGui.QFrame.Box | QtGui.QFrame.Sunken)
+        self.setFrameStyle(QFrame.Box | QFrame.Sunken)
 
         self.posx_label = QLabel('X-pos:')
         self.posx_value = QLabel()
@@ -84,7 +85,7 @@ class RGBHSVDisplay(QFrame):
         self.v_label = QLabel('V:')
         self.v_value = QLabel()
 
-        self.layout = QtGui.QGridLayout(self)
+        self.layout = QGridLayout(self)
         self.layout.addWidget(self.posx_label, 0, 0)
         self.layout.addWidget(self.posx_value, 0, 1)
         self.layout.addWidget(self.posy_label, 1, 0)
@@ -122,17 +123,16 @@ class SkiviImageWindow(QMainWindow):
 
         self.mgr = mgr
         self.main_widget = QWidget()
-        self.layout = QtGui.QGridLayout(self.main_widget)
+        self.layout = QGridLayout(self.main_widget)
         self.setCentralWidget(self.main_widget)
 
         self.label = ImageLabel(self, arr)
         self.label_container = QFrame()
-        self.label_container.setFrameShape(
-            QtGui.QFrame.StyledPanel | QtGui.QFrame.Sunken)
+        self.label_container.setFrameShape(QFrame.StyledPanel | QFrame.Sunken)
         self.label_container.setLineWidth(1)
 
-        self.label_container.layout = QtGui.QGridLayout(self.label_container)
-        self.label_container.layout.setMargin(0)
+        self.label_container.layout = QGridLayout(self.label_container)
+        self.label_container.layout.setContentsMargins(0, 0, 0, 0)
         self.label_container.layout.addWidget(self.label, 0, 0)
         self.layout.addWidget(self.label_container, 0, 0)
 
@@ -157,9 +157,9 @@ class SkiviImageWindow(QMainWindow):
         self.layout.setColumnStretch(0, 1)
         self.layout.setRowStretch(0, 1)
 
-        self.save_file = QtGui.QPushButton('Save to File')
+        self.save_file = QtWidgets.QPushButton('Save to File')
         self.save_file.clicked.connect(self.save_to_file)
-        self.save_stack = QtGui.QPushButton('Save to Stack')
+        self.save_stack = QtWidgets.QPushButton('Save to Stack')
         self.save_stack.clicked.connect(self.save_to_stack)
         self.save_file.show()
         self.save_stack.show()
@@ -217,18 +217,18 @@ class SkiviImageWindow(QMainWindow):
             Use io.pop() to retrieve the most recently
             pushed image.''')
         msglabel = QLabel(msg)
-        dialog = QtGui.QDialog()
-        ok = QtGui.QPushButton('OK', dialog)
+        dialog = QtWidgets.QDialog()
+        ok = QtWidgets.QPushButton('OK', dialog)
         ok.clicked.connect(dialog.accept)
         ok.setDefault(True)
-        dialog.layout = QtGui.QGridLayout(dialog)
+        dialog.layout = QGridLayout(dialog)
         dialog.layout.addWidget(msglabel, 0, 0, 1, 3)
         dialog.layout.addWidget(ok, 1, 1)
         dialog.exec_()
 
     def save_to_file(self):
         from ... import io
-        filename = str(QtGui.QFileDialog.getSaveFileName())
+        filename = str(QtWidgets.QFileDialog.getSaveFileName())
         if len(filename) == 0:
             return
         io.imsave(filename, self.arr)

--- a/skimage/io/_plugins/util.py
+++ b/skimage/io/_plugins/util.py
@@ -201,21 +201,21 @@ class ThreadDispatch(object):
             self.chunks.append((img, stateimg))
 
         elif self.cores >= 4:
-            self.chunks.append((img[:(height / 4), :, :],
-                                stateimg[:(height / 4), :, :]))
-            self.chunks.append((img[(height / 4):(height / 2), :, :],
-                                stateimg[(height / 4):(height / 2), :, :]))
-            self.chunks.append((img[(height / 2):(3 * height / 4), :, :],
-                                stateimg[(height / 2):(3 * height / 4), :, :]))
-            self.chunks.append((img[(3 * height / 4):, :, :],
-                                stateimg[(3 * height / 4):, :, :]))
+            self.chunks.append((img[:(height // 4), :, :],
+                                stateimg[:(height // 4), :, :]))
+            self.chunks.append((img[(height // 4):(height // 2), :, :],
+                                stateimg[(height // 4):(height // 2), :, :]))
+            self.chunks.append((img[(height // 2):(3 * height // 4), :, :],
+                                stateimg[(height // 2):(3 * height // 4), :, :]))
+            self.chunks.append((img[(3 * height // 4):, :, :],
+                                stateimg[(3 * height // 4):, :, :]))
 
         # if they dont have 1, or 4 or more, 2 is good.
         else:
-            self.chunks.append((img[:(height / 2), :, :],
-                                stateimg[:(height / 2), :, :]))
-            self.chunks.append((img[(height / 2):, :, :],
-                               stateimg[(height / 2):, :, :]))
+            self.chunks.append((img[:(height // 2), :, :],
+                                stateimg[:(height // 2), :, :]))
+            self.chunks.append((img[(height // 2):, :, :],
+                               stateimg[(height // 2):, :, :]))
 
         for i in range(len(self.chunks)):
             self.threads.append(ImgThread(func, self.chunks[i][0],


### PR DESCRIPTION
qtpy is MIT Licensed.

## Description
skivi was completely broken.

Now I only get the following warnings:
```
QWindowsWindow::setGeometry: Unable to set geometry 150x46+1600+800 on QWidgetWindow/'QPushButtonClassWindow'. Resulting geometry:  232x46+1600+800 (frame: 13, 58, 13, 13, custom margin: 0, 0, 0, 0, minimum size: 0x0, maximum size: 16777215x16777215).
QWindowsWindow::setGeometry: Unable to set geometry 150x46+1600+800 on QWidgetWindow/'QPushButtonClassWindow'. Resulting geometry:  232x46+1600+800 (frame: 13, 58, 13, 13, custom margin: 0, 0, 0, 0, minimum size: 0x0, maximum size: 16777215x16777215).
```
And I can change the colors (used `floordiv` instead of `truediv`). I haven't tried saving.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
