### PR TITLE
Move skimage._build.py to tools/skimage_build_helpers.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ recursive-include requirements *.txt
 include requirements/README.md
 include Makefile
 include skimage/scripts/skivi
+include tools/skimage_build_helpers.py
 recursive-include skimage *.pyx *.pxd *.pxi *.py *.c *.h *.ini *.md5 *.npy *.txt *.in *.cpp *.md
 recursive-include skimage/data *
 

--- a/setup.py
+++ b/setup.py
@@ -39,16 +39,6 @@ For Python 2.7, please install the 0.14.x Long Term Support using:
     sys.stderr.write(error + "\n")
     sys.exit(1)
 
-import builtins
-
-# This is a bit (!) hackish: we are setting a global variable so that the main
-# skimage __init__ can detect if it is being loaded by the setup routine, to
-# avoid attempting to load components that aren't built yet:
-# the numpy distutils extensions that are used by scikit-image to recursively
-# build the compiled extensions in sub-packages is based on the Python import
-# machinery.
-builtins.__SKIMAGE_SETUP__ = True
-
 
 with open('skimage/__init__.py') as fid:
     for line in fid:

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -56,12 +56,6 @@ img_as_ubyte
 
 """
 
-import imp
-import functools
-import warnings
-import sys
-
-
 __version__ = '0.15.dev0'
 
 from ._shared.version_requirements import ensure_python_version
@@ -80,8 +74,10 @@ Your install of scikit-image appears to be broken.
 Try re-installing the package following the instructions at:
 http://scikit-image.org/docs/stable/install.html """
 
-
-def _raise_build_error(e):
+try:
+    from ._shared import geometry
+    del geometry
+except ImportError as e:
     # Raise a comprehensible error
     local_dir = osp.split(__file__)[0]
     msg = _STANDARD_MSG
@@ -93,28 +89,7 @@ def _raise_build_error(e):
 It seems that scikit-image has not been built correctly.
 %s""" % (e, msg))
 
-try:
-    # This variable is injected in the __builtins__ by the build
-    # process. It used to enable importing subpackages of skimage when
-    # the binaries are not built
-    __SKIMAGE_SETUP__
-except NameError:
-    __SKIMAGE_SETUP__ = False
-
-if __SKIMAGE_SETUP__:
-    sys.stderr.write('Partial import of skimage during the build process.\n')
-    # We are not importing the rest of the scikit during the build
-    # process, as it may not be compiled yet
-else:
-    try:
-        from ._shared import geometry
-        del geometry
-    except ImportError as e:
-        _raise_build_error(e)
-    from .util.dtype import *
-    from .data import data_dir
-
+from .util.dtype import *
+from .data import data_dir
 
 from .util.lookfor import lookfor
-
-del warnings, functools, imp, sys

--- a/skimage/_shared/setup.py
+++ b/skimage/_shared/setup.py
@@ -2,7 +2,7 @@
 
 import os
 
-from skimage._build import cython
+from tools.skimage_build_helpers import cython
 
 base_path = os.path.abspath(os.path.dirname(__file__))
 

--- a/skimage/draw/setup.py
+++ b/skimage/draw/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os
-from skimage._build import cython
+from tools.skimage_build_helpers import cython
 
 base_path = os.path.abspath(os.path.dirname(__file__))
 

--- a/skimage/feature/setup.py
+++ b/skimage/feature/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os
-from skimage._build import cython
+from tools.skimage_build_helpers import cython
 
 base_path = os.path.abspath(os.path.dirname(__file__))
 

--- a/skimage/filters/setup.py
+++ b/skimage/filters/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os
-from skimage._build import cython
+from tools.skimage_build_helpers import cython
 
 base_path = os.path.abspath(os.path.dirname(__file__))
 

--- a/skimage/future/graph/setup.py
+++ b/skimage/future/graph/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from skimage._build import cython
+from tools.skimage_build_helpers import cython
 import os.path
 
 base_path = os.path.abspath(os.path.dirname(__file__))

--- a/skimage/graph/setup.py
+++ b/skimage/graph/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from skimage._build import cython
+from tools.skimage_build_helpers import cython
 import os.path
 
 base_path = os.path.abspath(os.path.dirname(__file__))

--- a/skimage/io/setup.py
+++ b/skimage/io/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from skimage._build import cython
+from tools.skimage_build_helpers import cython
 
 import os.path
 

--- a/skimage/measure/setup.py
+++ b/skimage/measure/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from skimage._build import cython
+from tools.skimage_build_helpers import cython
 
 import os
 base_path = os.path.abspath(os.path.dirname(__file__))

--- a/skimage/morphology/setup.py
+++ b/skimage/morphology/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os
-from skimage._build import cython
+from tools.skimage_build_helpers import cython
 
 base_path = os.path.abspath(os.path.dirname(__file__))
 

--- a/skimage/restoration/setup.py
+++ b/skimage/restoration/setup.py
@@ -2,7 +2,7 @@
 
 import os
 
-from skimage._build import cython
+from tools.skimage_build_helpers import cython
 
 base_path = os.path.abspath(os.path.dirname(__file__))
 

--- a/skimage/segmentation/setup.py
+++ b/skimage/segmentation/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os
-from skimage._build import cython
+from tools.skimage_build_helpers import cython
 
 base_path = os.path.abspath(os.path.dirname(__file__))
 

--- a/skimage/transform/setup.py
+++ b/skimage/transform/setup.py
@@ -2,7 +2,7 @@
 
 import os
 
-from skimage._build import cython
+from tools.skimage_build_helpers import cython
 
 base_path = os.path.abspath(os.path.dirname(__file__))
 

--- a/tools/check_sdist.py
+++ b/tools/check_sdist.py
@@ -24,7 +24,13 @@ ignore_files = ['./TODO.md', './README.md', './MANIFEST',
                 './.gitignore', './.travis.yml', './.gitmodules',
                 './.mailmap', './.coveragerc', './.appveyor.yml',
                 './.pep8speaks.yml', './asv.conf.json',
-                './skimage/filters/rank/README.rst']
+                './skimage/filters/rank/README.rst',
+                './tools/check_sdist.py',
+                './tools/header.py',
+                './tools/mailmap.py',
+                './tools/rm_pyx_c_file.sh',
+                './tools/build_versions.py',
+                './tools/upload_wheels.sh']
 
 
 missing = []

--- a/tools/skimage_build_helpers.py
+++ b/tools/skimage_build_helpers.py
@@ -29,17 +29,23 @@ def cython(pyx_files, working_path=''):
     try:
         from Cython import __version__
         if LooseVersion(__version__) < CYTHON_VERSION:
-            raise RuntimeError('Cython >= %s needed to build scikit-image' % CYTHON_VERSION)
+            raise RuntimeError('Cython >= %s needed to build scikit-image' %
+                               CYTHON_VERSION)
 
         from Cython.Build import cythonize
     except ImportError:
         # If cython is not found, the build will make use of
         # the distributed .c files if present
-        c_files = [f.replace('.pyx.in', '.c').replace('.pyx', '.c') for f in pyx_files]
+        c_files = [f.replace('.pyx.in', '.c').replace('.pyx', '.c')
+                   for f in pyx_files]
         for cfile in [os.path.join(working_path, f) for f in c_files]:
-            if not os.path.isfile(cfile):
-                raise RuntimeError('Cython >= %s is required to build scikit-image from git checkout' \
-                                   % CYTHON_VERSION)
+            # check for both c and cpp files (at least _haar.cpp needs this)
+            if not (os.path.isfile(cfile) or os.path.isfile(cfile + 'pp')):
+                raise RuntimeError(
+                    ('Could not find file %s.\n'
+                     'Cython >= %s is required to build scikit-image'
+                     ' from git checkout.')
+                    % (cfile, CYTHON_VERSION))
 
         print("Cython >= %s not found; falling back to pre-built %s" \
               % (CYTHON_VERSION, " ".join(c_files)))
@@ -97,8 +103,8 @@ def process_tempita_pyx(fromfile):
     except ImportError:
         raise Exception('Building requires Tempita: '
                         'pip install --user Tempita')
-    template = tempita.Template.from_filename(fromfile,
-                                              encoding=sys.getdefaultencoding())
+    template = tempita.Template.from_filename(
+        fromfile, encoding=sys.getdefaultencoding())
     pyxcontent = template.substitute()
     if not fromfile.endswith('.pyx.in'):
         raise ValueError("Unexpected extension of %s." % fromfile)


### PR DESCRIPTION
This allows us to remove a lot of the convoluted logic in the `__init__.py`

in doing this, I also

### Fix the build process from `sdist` without `cython` 
Previously if you didn't have cython installed, the build process from the `sdist` would fail because it wouldn't look for the existance of `_haar.cpp` as it only checked for `_haar.c`.


### Todo
If #3221 is accepted before hand, there is a comment in the `before_install.sh` script that should be updated.
## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
