### PR TITLE
Refractor python version checking.

### DIFF
--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -87,27 +87,6 @@ Newer versions of these tools avoid installing packages incompatible
 with your version of Python.
 """)
 
-if sys.version_info < (3, 5):
-    raise ImportError("""
-
-You are running scikit-image on an unsupported version of Python.
-Likely Python 2.
-
-Unfortunately, scikit-image 0.15 and above no longer work on this
-version of Python.  You therefore have two options: either upgrade to
-Python 3.5, or install an older version of scikit-image. For Python 2.7, use
-
- $ pip install 'scikit-image<0.15'
-
-Please also consider updating `pip` and `setuptools`:
-
- $ pip install pip setuptools --upgrade
-
-Newer versions of these tools avoid installing packages incompatible
-with your version of Python.
-""")
-
-
 # Logic for checking for improper install and importing while in the source
 # tree when package has not been installed inplace.
 # Code adapted from scikit-learn's __check_build module.

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -87,14 +87,15 @@ Newer versions of these tools avoid installing packages incompatible
 with your version of Python.
 """)
 
-if sys.version_info < (3,):
+if sys.version_info < (3, 5):
     raise ImportError("""
 
-You are running scikit-image on Python 2.
+You are running scikit-image on an unsupported version of Python.
+Likely Python 2.
 
 Unfortunately, scikit-image 0.15 and above no longer work on this
 version of Python.  You therefore have two options: either upgrade to
-Python 3, or install an older version of scikit-image using
+Python 3.5, or install an older version of scikit-image. For Python 2.7, use
 
  $ pip install 'scikit-image<0.15'
 

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -67,8 +67,8 @@ data_dir = osp.join(pkg_dir, 'data')
 
 __version__ = '0.15dev'
 
-from ._shared.version_requirements import check_python_version
-check_python_version((3, 5))
+from ._shared.version_requirements import ensure_python_version
+ensure_python_version((3, 5))
 
 # Logic for checking for improper install and importing while in the source
 # tree when package has not been installed inplace.

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -75,7 +75,7 @@ Likely Python 2.
 
 Unfortunately, scikit-image 0.15 and above no longer work on this
 version of Python.  You therefore have two options: either upgrade to
-Python 3.5, or install an older version of scikit-image using
+Python 3.5, or install an older version of scikit-image. For Python 2.7, use
 
  $ pip install 'scikit-image<0.15'
 

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -67,27 +67,8 @@ data_dir = osp.join(pkg_dir, 'data')
 
 __version__ = '0.15dev'
 
-
-if sys.version_info < (3, 5):
-    raise ImportError("""
-
-You are running scikit-image on an unsupported version of Python.
-Likely Python 2.
-
-Unfortunately, scikit-image 0.15 and above no longer work on this
-version of Python.  You therefore have two options: either upgrade to
-Python 3.5, or install an older version of scikit-image. For Python 2.7, use
-
- $ pip install 'scikit-image<0.15'
-
-Please also consider updating `pip` and `setuptools`:
-
- $ pip install pip setuptools --upgrade
-
-Newer versions of these tools avoid installing packages incompatible
-with your version of Python.
-""")
-
+from ._shared.version_requirements import check_python_version
+check_python_version((3, 5))
 
 # Logic for checking for improper install and importing while in the source
 # tree when package has not been installed inplace.

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -67,6 +67,25 @@ data_dir = osp.join(pkg_dir, 'data')
 
 __version__ = '0.15dev'
 
+if sys.version_info < (3, 5):
+    raise ImportError("""
+
+You are running scikit-image on an unsupported version of Python.
+Likely Python 2.
+
+Unfortunately, scikit-image 0.15 and above no longer work on this
+version of Python.  You therefore have two options: either upgrade to
+Python 3.5, or install an older version of scikit-image using
+
+ $ pip install 'scikit-image<0.15'
+
+Please also consider updating `pip` and `setuptools`:
+
+ $ pip install pip setuptools --upgrade
+
+Newer versions of these tools avoid installing packages incompatible
+with your version of Python.
+""")
 
 if sys.version_info < (3,):
     raise ImportError("""

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -67,6 +67,7 @@ data_dir = osp.join(pkg_dir, 'data')
 
 __version__ = '0.15dev'
 
+
 if sys.version_info < (3, 5):
     raise ImportError("""
 
@@ -86,6 +87,7 @@ Please also consider updating `pip` and `setuptools`:
 Newer versions of these tools avoid installing packages incompatible
 with your version of Python.
 """)
+
 
 # Logic for checking for improper install and importing while in the source
 # tree when package has not been installed inplace.

--- a/skimage/_shared/version_requirements.py
+++ b/skimage/_shared/version_requirements.py
@@ -1,4 +1,5 @@
 from distutils.version import LooseVersion
+from platform import python_version
 import functools
 import re
 import sys
@@ -13,9 +14,11 @@ def check_python_version(min_version):
 You are running scikit-image on an unsupported version of Python.
 Likely Python 2.
 
-Unfortunately, scikit-image 0.15 and above no longer work on this
-version of Python.  You therefore have two options: either upgrade to
-Python %s, or install an older version of scikit-image. For Python 2.7, use
+Unfortunately, scikit-image 0.15 and above no longer work with your installed
+version of Python (%s).  You therefore have two options: either upgrade to
+Python %s, or install an older version of scikit-image.
+
+For Python 2.7 or Python 3.4, use
 
  $ pip install 'scikit-image<0.15'
 
@@ -25,7 +28,7 @@ Please also consider updating `pip` and `setuptools`:
 
 Newer versions of these tools avoid installing packages incompatible
 with your version of Python.
-""" % '.'.join([str(v) for v in min_version]))
+""" % (python_version(), '.'.join([str(v) for v in min_version])))
 
 
 def _check_version(actver, version, cmp_op):

--- a/skimage/_shared/version_requirements.py
+++ b/skimage/_shared/version_requirements.py
@@ -5,14 +5,13 @@ import re
 import sys
 
 
-def check_python_version(min_version):
+def ensure_python_version(min_version):
     if not isinstance(min_version, tuple):
         min_version = (min_version, )
     if sys.version_info < min_version:
         raise ImportError("""
 
 You are running scikit-image on an unsupported version of Python.
-Likely Python 2.
 
 Unfortunately, scikit-image 0.15 and above no longer work with your installed
 version of Python (%s).  You therefore have two options: either upgrade to

--- a/skimage/_shared/version_requirements.py
+++ b/skimage/_shared/version_requirements.py
@@ -4,6 +4,30 @@ import re
 import sys
 
 
+def check_python_version(min_version):
+    if not isinstance(min_version, tuple):
+        min_version = (min_version, )
+    if sys.version_info < min_version:
+        raise ImportError("""
+
+You are running scikit-image on an unsupported version of Python.
+Likely Python 2.
+
+Unfortunately, scikit-image 0.15 and above no longer work on this
+version of Python.  You therefore have two options: either upgrade to
+Python %s, or install an older version of scikit-image. For Python 2.7, use
+
+ $ pip install 'scikit-image<0.15'
+
+Please also consider updating `pip` and `setuptools`:
+
+ $ pip install pip setuptools --upgrade
+
+Newer versions of these tools avoid installing packages incompatible
+with your version of Python.
+""" % '.'.join([str(v) for v in min_version]))
+
+
 def _check_version(actver, version, cmp_op):
     """
     Check version string of an active module against a required version.


### PR DESCRIPTION
~~Developers will be knowledgeable enough to know that it isn't python2
compatible.~~

~~The wheels won't be available in pypi or conda for python 2~~

This removes a bunch of visual noise from the `__init__.py` file.

## Checklist
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
