### PR TITLE
Normalized the package number to PEP440

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -42,7 +42,10 @@ make a PR to update these notes after you are done with the release. ;-)
   - Once the consensus is found, ask the project maintainers to merge the PR.
 
 - In the master branch, update the version number in ``skimage/__init__.py``
-  to the next ``-dev`` version, commit, and push.
+  to the next ``.dev0`` version, commit, and push. This should follow PEP440
+  meaning that the appropriate version number would look something like
+  ``0.20.dev0`` with the period beteween ``20`` and ``dev`` and a trailing
+  ``0`` immediately after ``dev``. 
 
 - Back on the release branch, update the version number to stable in
   ``skimage/__init__.py``, commit, and push.

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -65,7 +65,7 @@ import sys
 pkg_dir = osp.abspath(osp.dirname(__file__))
 data_dir = osp.join(pkg_dir, 'data')
 
-__version__ = '0.15dev'
+__version__ = '0.15.dev0'
 
 
 if sys.version_info < (3,):


### PR DESCRIPTION
Now set to `0.15.dev0` instead of `0.15dev` since you used to keep
getting the warning:

```
[...]/site-packages/setuptools/dist.py:398: UserWarning: Normalizing
'0.15dev' to '0.15.dev0'
```

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
