### PR TITLE
Remove skimage.test as it was never used.

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -47,6 +47,8 @@ API Changes
   and ``skimage.transform.rescale`` has been set to ``reflect``.
 - Default value of ``anti_aliasing`` parameter in ``skimage.transform.resize``
   and ``skimage.transform.rescale`` has been set to ``True``.
+- Removed the ``skimage.test`` function. This functionality can be achieved
+  by calling ``pytest`` directly.
 
 
 Bugfixes

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -88,49 +88,6 @@ with your version of Python.
 """)
 
 
-try:
-    imp.find_module('pytest')
-except ImportError:
-    def _test(doctest=False, verbose=False):
-        """This would run all unit tests, but pytest couldn't be
-        imported so the test suite can not run.
-        """
-        raise ImportError("Could not load pytest. Unit tests not available.")
-
-else:
-    def _test(doctest=False, verbose=False):
-        """Run all unit tests."""
-        import pytest
-        import warnings
-        args = ['--pyargs', 'skimage']
-        if verbose:
-            args.extend(['-v', '-s'])
-        if doctest:
-            args.extend(['--doctest-modules'])
-            # Make sure warnings do not break the doc tests
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                success = pytest.main(args)
-        else:
-            success = pytest.main(args)
-        # Return sys.exit code
-        if success:
-            return 0
-        else:
-            return 1
-
-
-# do not use `test` as function name as this leads to a recursion problem with
-# the nose test suite
-test = _test
-test_verbose = functools.partial(test, verbose=True)
-test_verbose.__doc__ = test.__doc__
-doctest = functools.partial(test, doctest=True)
-doctest.__doc__ = doctest.__doc__
-doctest_verbose = functools.partial(test, doctest=True, verbose=True)
-doctest_verbose.__doc__ = doctest.__doc__
-
-
 # Logic for checking for improper install and importing while in the source
 # tree when package has not been installed inplace.
 # Code adapted from scikit-learn's __check_build module.


### PR DESCRIPTION
Until  PR #3152 was merged, this function didn't actually work. Many of the build scripts just called `pytest` directly. The only one that I found that didn't call `pytest` directly was the`conda-forge` recipe,
which will be fixed when [thisPR](https://github.com/conda-forge/scikit-image-feedstock/pull/25)
is merged.


Previous comments from the omnibus PR #3147

@jni [mentionned](https://github.com/scikit-image/scikit-image/pull/3147#discussion_r193919183)
> I understand the sentiment, but I think we don't want to do this. The reason this exists is that we used to use nosetests and were bitten when it reached end-of-life. skimage.test allows us to keep the same testing syntax even if we decide to switch frameworks later on.

@jni [said](https://github.com/scikit-image/scikit-image/pull/3147#discussion_r193921324):
> also, "achieved". =P
> 
> I'm neither +1 or -1 on this btw. Running individual tests is more natural if we normalise with pytest. Just wanted to flag it since others (@soupault) have in the past preferred strongly hiding pytest (using skimage.testing.raises instead of pytest.raises, for example).

@hmaarrfk [replied]:
> @jni, I understand that the idea was to have the testing localized, but after having going through a few of the other build procedures, it seems that skimage.test was never used in the first in place.
>
> When I tried skimage.test myself a few months back, I thought I wasn't using the function correctly, but a recent PR showed me that it wasn't just me.
>
> I'm glad to go back to the old functionality, but I feel like the ship has sailed on that, even before my PR. I didn't have to change any of the other tests when I removed this function.



## Checklist
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Unit tests

## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
