### PR TITLE
Backport: Travis should fail on failed tests

### DIFF
--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Fail on non-zero exit and print commands
+set -ex
 export PY=${TRAVIS_PYTHON_VERSION}
 
 section "Tests.flake8"


### PR DESCRIPTION
A few apologies @jni, a previous omnibus PR removed an important line from `tools/travis/script.sh` 
https://github.com/scikit-image/scikit-image/commit/10b05435c9b99b267262d977d1b18b38abdadaf5#diff-5abd172b82bc646ebb9b7b6dae6a67d7L2

```
set -ex
```

would cause fail on non-zero exit.

This caused the documentation to silently fail when @stefanv [modernized](https://github.com/scikit-image/scikit-image/commit/b980eba2dcda9225ea1ca9bd3bbc4ad581443683#diff-26dee18463b5da190f343abcc74cf708L41) it but removed the links to anaconda, enthought, python xy, and winpython

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
