### PR TITLE
Regression fix: Travis should fail if tests fail

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -16,8 +16,10 @@ environment.
 -------------------------
 
 ``scikit-image`` comes pre-installed with several Python distributions,
-including Anaconda_, `Enthought Canopy`_, `Python(x,y)`_ and
-`WinPython`_.
+including `Anaconda <https://www.anaconda.com/download/>`_,
+`Enthought Canopy <https://www.enthought.com/product/canopy/>`_,
+`Python(x,y) <https://python-xy.github.io/>`_ and
+`WinPython <https://winpython.github.io/>`_.
 
 On all other systems, install it via shell/command prompt::
 

--- a/skimage/filters/_unsharp_mask.py
+++ b/skimage/filters/_unsharp_mask.py
@@ -93,9 +93,9 @@ def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
     >>> array[2,2] = 127
     >>> np.around(unsharp_mask(array, radius=0.5, amount=2),2)
     array([[ 0.79,  0.79,  0.79,  0.79,  0.79],
-           [ 0.79,  0.79,  0.79,  0.79,  0.79],
-           [ 0.79,  0.79,  1.  ,  0.79,  0.79],
-           [ 0.79,  0.79,  0.79,  0.79,  0.79],
+           [ 0.79,  0.78,  0.75,  0.78,  0.79],
+           [ 0.79,  0.75,  1.  ,  0.75,  0.79],
+           [ 0.79,  0.78,  0.75,  0.78,  0.79],
            [ 0.79,  0.79,  0.79,  0.79,  0.79]])
 
     >>> np.around(unsharp_mask(array, radius=0.5, amount=2, preserve_range=True), 2)

--- a/skimage/filters/_unsharp_mask.py
+++ b/skimage/filters/_unsharp_mask.py
@@ -68,7 +68,7 @@ def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
     color bleeding may occur. More visually pleasing result can be
     achieved by processing only the brightness/lightness/intensity
     channel in a suitable color space such as HSV, HSL, YUV, or YCbCr.
- 
+
     Unsharp masking is described in most introductory digital image
     processing books. This implementation is based on [1]_.
 
@@ -84,9 +84,9 @@ def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
            [100, 100, 100, 100, 100]], dtype=uint8)
     >>> np.around(unsharp_mask(array, radius=0.5, amount=2),2)
     array([[ 0.39,  0.39,  0.39,  0.39,  0.39],
-           [ 0.39,  0.39,  0.39,  0.39,  0.39],
-           [ 0.39,  0.39,  0.47,  0.39,  0.39],
-           [ 0.39,  0.39,  0.39,  0.39,  0.39],
+           [ 0.39,  0.39,  0.38,  0.39,  0.39],
+           [ 0.39,  0.38,  0.53,  0.38,  0.39],
+           [ 0.39,  0.39,  0.38,  0.39,  0.39],
            [ 0.39,  0.39,  0.39,  0.39,  0.39]])
 
     >>> array = np.ones(shape=(5,5), dtype=np.int8)*100

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -72,7 +72,8 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
     >>> astro = astro[220:300, 220:320]
     >>> noisy = astro + 0.6 * astro.std() * np.random.random(astro.shape)
     >>> noisy = np.clip(noisy, 0, 1)
-    >>> denoised = denoise_bilateral(noisy, sigma_color=0.05, sigma_spatial=15)
+    >>> denoised = denoise_bilateral(noisy, sigma_color=0.05, sigma_spatial=15,
+    ...                              multichannel=True)
     """
     if multichannel:
         if image.ndim != 3:

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -224,8 +224,10 @@ def test_denoise_bilateral_multidimensional():
 
 def test_denoise_bilateral_nan():
     img = np.full((50, 50), np.NaN)
-    out = assert_warns(RuntimeWarning, restoration.denoise_bilateral,
-                       img, multichannel=False)
+    # This is in fact an optional warning for our test suite.
+    # Python 3.5 will not trigger a warning.
+    with expected_warnings(['invalid|\A\Z']):
+        out = restoration.denoise_bilateral(img, multichannel=False)
     assert_equal(img, out)
 
 

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Fail on non-zero exit and echo the commands
+set -ex
 export PY=${TRAVIS_PYTHON_VERSION}
 
 # Matplotlib settings - do not show figures during doc examples


### PR DESCRIPTION
This is the PR to merge this PR #3169 into master.

A few apologies @jni, a previous omnibus PR removed an important line from `tools/travis/script.sh` 
https://github.com/scikit-image/scikit-image/commit/10b05435c9b99b267262d977d1b18b38abdadaf5#diff-5abd172b82bc646ebb9b7b6dae6a67d7L2

```
set -ex
```

would cause fail on non-zero exit.

This caused the documentation to silently fail when @stefanv [modernized](https://github.com/scikit-image/scikit-image/commit/b980eba2dcda9225ea1ca9bd3bbc4ad581443683#diff-26dee18463b5da190f343abcc74cf708L41) it but removed the links to anaconda, enthought, python xy, and winpython

filter._unsharp mask is also given troubles. I can't pinpoint the source the bug just yet.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
