### PR TITLE
Set minimum cython version to `0.23.4`

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -96,7 +96,7 @@ Build Requirements
 ------------------
 * `Python >= 3.5 <http://python.org>`__
 * `Numpy >= 1.11 <http://numpy.scipy.org/>`__
-* `Cython >= 0.23 <http://www.cython.org/>`__
+* `Cython >= 0.23.4 <http://www.cython.org/>`__
 
 Build Requirements (docs)
 -------------------------

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,2 +1,2 @@
-Cython>=0.23
+Cython>=0.23.4
 wheel

--- a/skimage/_build.py
+++ b/skimage/_build.py
@@ -3,7 +3,7 @@ import os
 import hashlib
 from distutils.version import LooseVersion
 
-CYTHON_VERSION = '0.23'
+CYTHON_VERSION = '0.23.4'
 
 # WindowsError is not defined on unix systems
 try:


### PR DESCRIPTION
According to `tools/travis/before_install.sh` we need Cython 0.23.4 and
not just 0.23

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
