### PR TITLE
Round instead of ceil output shape when rotating image

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -371,7 +371,7 @@ def rotate(image, angle, resize=False, center=None, order=1, mode='constant',
         maxr = corners[:, 1].max()
         out_rows = maxr - minr + 1
         out_cols = maxc - minc + 1
-        output_shape = np.ceil((out_rows, out_cols))
+        output_shape = np.round((out_rows, out_cols))
 
         # fit output image in new shape
         translation = (minc, minr)

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -371,7 +371,7 @@ def rotate(image, angle, resize=False, center=None, order=1, mode='constant',
         maxr = corners[:, 1].max()
         out_rows = maxr - minr + 1
         out_cols = maxc - minc + 1
-        output_shape = np.round((out_rows, out_cols))
+        output_shape = np.around((out_rows, out_cols))
 
         # fit output image in new shape
         translation = (minc, minr)

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -160,6 +160,11 @@ def test_rotate_resize_center():
     assert_equal(x45, ref_x45)
 
 
+def test_rotate_resize_90():
+    x90 = rotate(np.zeros((470, 230), dtype=np.double), 90, resize=True)
+    assert x90.shape == (230, 470)
+
+
 def test_rescale():
     # same scale factor
     x = np.zeros((5, 5), dtype=np.double)


### PR DESCRIPTION
Addresses issue https://github.com/scikit-image/scikit-image/issues/3071

Previously, we ensured that the output contained every subpixel information
from the input when rotating by ceiling the shape. This lead to inconsistent
output when rotating by multiples of 90 degrees. For example:

    >>> transform.rotate(np.zeros((470, 230)), angle=90, resize=True).shape
    (231, 470)

The new behavior correctly produces an output shape of (230, 470).