### PR TITLE
Repeat pixels in reflect mode when image has dimension 1

### DIFF
--- a/skimage/_shared/interpolation.pxd
+++ b/skimage/_shared/interpolation.pxd
@@ -330,8 +330,7 @@ cdef inline Py_ssize_t coord_map(Py_ssize_t dim, long coord, char mode) nogil:
         Whether to wrap, symmetric reflect, reflect or use the nearest
         coordinate if `coord` falls outside [0, dim).
     """
-    cdef Py_ssize_t cmax
-    cmax = dim - 1
+    cdef Py_ssize_t cmax = dim - 1
     if mode == 'S': # symmetric
         if coord < 0:
             coord = -coord - 1
@@ -351,7 +350,9 @@ cdef inline Py_ssize_t coord_map(Py_ssize_t dim, long coord, char mode) nogil:
         elif coord > cmax:
             return cmax
     elif mode == 'R': # reflect (mirror)
-        if coord < 0:
+        if dim == 1:
+            return 0
+        elif coord < 0:
             # How many times times does the coordinate wrap?
             if <Py_ssize_t>(-coord / cmax) % 2 != 0:
                 return cmax - <Py_ssize_t>(-coord % cmax)

--- a/skimage/_shared/tests/test_interpolation.py
+++ b/skimage/_shared/tests/test_interpolation.py
@@ -18,6 +18,10 @@ def test_coord_map():
     expected_reflect = [0, 1, 2, 3, 2, 1, 0, 1, 2, 3, 2, 1]
     assert_array_equal(reflect, expected_reflect)
 
+    reflect = [coord_map_py(1, n, 'R') for n in range(-6, 6)]
+    expected_reflect = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    assert_array_equal(reflect, expected_reflect)
+
     other = [coord_map_py(4, n, 'undefined') for n in range(-6, 6)]
     expected_other = list(range(-6, 6))
     assert_array_equal(other, expected_other)


### PR DESCRIPTION
This replicates the `np.pad` behavior and addresses issue https://github.com/scikit-image/scikit-image/issues/3001