### PR TITLE
Add rgba2rgb to API docs

### DIFF
--- a/skimage/color/__init__.py
+++ b/skimage/color/__init__.py
@@ -69,6 +69,7 @@ from .delta_e import (deltaE_cie76,
 
 __all__ = ['convert_colorspace',
            'guess_spatial_dimensions',
+           'rgba2rgb',
            'rgb2hsv',
            'hsv2rgb',
            'rgb2xyz',


### PR DESCRIPTION
I saw `rgba2rgb` referenced from here:
http://scikit-image.org/docs/dev/user_guide/transforming_image_data.html#conversion-from-rgba-to-rgb-removing-alpha-channel-through-alpha-blending

But it doesn't show up in the API docs:
* http://scikit-image.org/docs/dev/api/skimage.color.html
* http://scikit-image.org/docs/dev/search.html?q=rgba2rgb&check_keywords=yes&area=default#

This is an attempt to add it.

Is this the correct way to do it?
(I didn't try the docs build locally and check.)