### PR TITLE
Decrease the verbosity of the testing

### DIFF
--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -27,8 +27,9 @@ fi
 export WHEELHOUSE
 
 export DISPLAY=:99.0
-export PYTHONWARNINGS="d,all:::skimage"
-export TEST_ARGS="-v --doctest-modules"
+# This causes way too many internal warnings within python.
+# export PYTHONWARNINGS="d,all:::skimage"
+export TEST_ARGS="--doctest-modules"
 WHEELBINARIES="matplotlib scipy pillow cython"
 
 retry () {

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -ev
 
 export PIP_DEFAULT_TIMEOUT=60
 

--- a/tools/travis/install_qt.sh
+++ b/tools/travis/install_qt.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -ev
 
 if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
     echo "backend : Template" > $MPL_DIR/matplotlibrc
@@ -21,5 +21,3 @@ if [[ "${QT}" == "PyQt5" || "${QT}" == "PySide2" ]]; then
     echo 'backend: Qt5Agg' > $MPL_DIR/matplotlibrc
     echo 'backend.qt5 : '$MPL_QT_API >> $MPL_DIR/matplotlibrc
 fi
-
-set -ex

--- a/tools/travis/install_qt.sh
+++ b/tools/travis/install_qt.sh
@@ -21,3 +21,5 @@ if [[ "${QT}" == "PyQt5" || "${QT}" == "PySide2" ]]; then
     echo 'backend: Qt5Agg' > $MPL_DIR/matplotlibrc
     echo 'backend.qt5 : '$MPL_QT_API >> $MPL_DIR/matplotlibrc
 fi
+
+set +ev

--- a/tools/travis/notes.txt
+++ b/tools/travis/notes.txt
@@ -9,9 +9,13 @@
 
    ```
      #!/usr/bin/env bash
-     set -ex
+     set -ev
    ```
 
+- The `-e` flag ensures that the script exits on non-zero exit from a command.
+- The `-v` flag will print out the command as it is read.
+- The `-x` flag will print out the expanded parsed command, as well as the PS4.
+  which can be quite verbose. Use this when debugging.
 - Use the `retry` bash function from `before_install.sh` before a command to
   have it try 3 times before failing.
 - Use `pip install --retries N` for retrying package downloads.

--- a/tools/travis/notes.txt
+++ b/tools/travis/notes.txt
@@ -5,11 +5,17 @@
 - Use bash scripts for `before_install` and `script` or any part that
   has conditional statements
    - Make sure they are "executable" (chmod +x)
-   - Use the following header:
+   - Use the following header to enable some local flags:
 
-   ```
+   ```bash
      #!/usr/bin/env bash
      set -ev
+   ```
+
+   - Use the following footer to turn off the flags after the script:
+
+   ```
+     set +ev
    ```
 
 - The `-e` flag ensures that the script exits on non-zero exit from a command.

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -63,3 +63,5 @@ elif [[ "${TEST_EXAMPLES}" != "0" ]]; then
   mv $MPL_DIR/matplotlibrc_backup $MPL_DIR/matplotlibrc
 fi
 section_end "Tests.examples"
+
+set +ev

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Fail on non-zero exit and echo the commands
-set -ex
+set -ev
 export PY=${TRAVIS_PYTHON_VERSION}
 
 # Matplotlib settings - do not show figures during doc examples


### PR DESCRIPTION
Give travis a break!

The python warnings were just too much. Python needs to fix their internal libs ;).
The verbose testing was nice, but one `parametrize` caused then number of tests to nearly double (which is good!) but made it too hard for travis to handle.

## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
