### PR TITLE
Speedup rgb2gray using matrix multiply

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -801,12 +801,8 @@ def rgb2gray(rgb):
         return np.ascontiguousarray(rgb)
 
     rgb = _prepare_colorarray(rgb[..., :3])
-
-    gray = 0.2125 * rgb[..., 0]
-    gray[:] += 0.7154 * rgb[..., 1]
-    gray[:] += 0.0721 * rgb[..., 2]
-
-    return gray
+    coeffs = np.array([0.2125, 0.7154, 0.0721], dtype=rgb.dtype)
+    return rgb @ coeffs
 
 
 rgb2grey = rgb2gray


### PR DESCRIPTION
1000 x 1000 x 3 array:
Original: 15ms
As proposed: 8-9ms

Run cell by cell
```python
import numpy as np

a = np.random.rand(1000, 1000, 3)

# %%
%%timeit

def rgb2gray(rgb):
    coeffs = np.array([0.2125, 0.7154, 0.0721], dtype=rgb.dtype)
    return rgb @ coeffs

d = rgb2gray(a)

# %%
%%timeit
def rgb2gray(rgb):
    gray = 0.2125 * rgb[..., 0]
    gray += 0.7154 * rgb[..., 1]
    gray += 0.0721 * rgb[..., 2]
    return gray

d = rgb2gray(a)
```

## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
