### PR TITLE
Update docs: specify conda-forge channel for scikit-image conda install

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -27,7 +27,7 @@ On all other systems, install it via shell/command prompt::
 
 If you are running Anaconda or miniconda, use::
 
-  conda install scikit-image
+  conda install -c conda-install scikit-image
 
 2. Development Installation:
 ----------------------------

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -27,7 +27,7 @@ On all other systems, install it via shell/command prompt::
 
 If you are running Anaconda or miniconda, use::
 
-  conda install -c conda-install scikit-image
+  conda install -c conda-forge scikit-image
 
 2. Development Installation:
 ----------------------------

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 - **Debian/Ubuntu:** ``sudo apt-get install python-skimage``
 - **OSX:** ``pip install scikit-image``
-- **Anaconda:** ``conda install scikit-image``
+- **Anaconda:** ``conda install -c conda-forge scikit-image``
 - **Windows:** Download [Windows binaries](http://www.lfd.uci.edu/~gohlke/pythonlibs/#scikit-image)
 
 Also see [installing ``scikit-image``](INSTALL.rst).


### PR DESCRIPTION
## Description
[Tell us about your new feature, improvement, or fix! If relevant, please supplement the PR with images.]
I've updated the conda install instructions at http://scikit-image.org/, so probably need to do the same thing here for consistency.
 
Right now `conda install scikit-image` gives you v0.13.1 from the default channel, rather than the latest stable release v0.14.0 from conda-forge.  

To avoid this problem, I've updated to specify the conda-forge channel:
`conda install -c conda-forge scikit-image` 

## References
See also: https://github.com/scikit-image/scikit-image-web/issues/48

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
