### PR TITLE
Backport Cython 0.23.4 fix. PR  #3171

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -147,7 +147,7 @@ Build Requirements
 
 * `Python >= 2.7 <http://python.org>`__
 * `Numpy >= 1.11 <http://numpy.scipy.org/>`__
-* `Cython >= 0.23 <http://www.cython.org/>`__
+* `Cython >= 0.23.4 <http://www.cython.org/>`__
 * `Six >=1.7.3 <https://pypi.python.org/pypi/six>`__
 * `SciPy >=0.17.0 <http://scipy.org>`__
 * `numpydoc >=0.6 <https://github.com/numpy/numpydoc>`__

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,2 +1,2 @@
-Cython>=0.23
+Cython>=0.23.4
 wheel

--- a/skimage/_build.py
+++ b/skimage/_build.py
@@ -3,7 +3,7 @@ import os
 import hashlib
 from distutils.version import LooseVersion
 
-CYTHON_VERSION = '0.23'
+CYTHON_VERSION = '0.23.4'
 
 # WindowsError is not defined on unix systems
 try:


### PR DESCRIPTION
Backport Cython 0.23.4 fix. PR  #3171
## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
