### PR TITLE
Handle dask deprecation in cycle_spin

### DIFF
--- a/skimage/restoration/_cycle_spin.py
+++ b/skimage/restoration/_cycle_spin.py
@@ -155,5 +155,6 @@ def cycle_spin(x, func, max_shifts, shift_steps=1, num_workers=None,
         # multithreaded via dask
         futures = [dask.delayed(_run_one_shift)(s) for s in all_shifts]
         mean = sum(futures) / len(futures)
-        mean = mean.compute(get=dask.threaded.get, num_workers=num_workers)
+        mean = mean.compute(scheduler='processes',
+                            num_workers=num_workers)
     return mean

--- a/skimage/restoration/_cycle_spin.py
+++ b/skimage/restoration/_cycle_spin.py
@@ -1,4 +1,3 @@
-
 from itertools import product
 
 import numpy as np
@@ -155,6 +154,5 @@ def cycle_spin(x, func, max_shifts, shift_steps=1, num_workers=None,
         # multithreaded via dask
         futures = [dask.delayed(_run_one_shift)(s) for s in all_shifts]
         mean = sum(futures) / len(futures)
-        mean = mean.compute(scheduler='processes',
-                            num_workers=num_workers)
+        mean = mean.compute(num_workers=num_workers)
     return mean


### PR DESCRIPTION
## Description
```
========================================================== warnings summary ===========================================================
tests/test_denoise.py::test_cycle_spinning_multichannel
  /venv/lib/python3.5/site-packages/dask/base.py:833: UserWarning: The get= keyword has been deprecated. Please use the scheduler= keyword instead with the name of the desired scheduler like 'threads' or 'processes'
    warnings.warn("The get= keyword has been deprecated. "
```
See http://dask.pydata.org/en/latest/scheduling.html#local-threads and http://dask.pydata.org/en/latest/scheduling.html#local-processes .

## For reviewers

(Don't remove the checklist below.)

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [x] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
