### PR TITLE
New function: skimage.filters.try_all_threshold_dict (counterpart to try_all_threshold)

### DIFF
--- a/doc/examples/segmentation/plot_thresholding.py
+++ b/doc/examples/segmentation/plot_thresholding.py
@@ -70,3 +70,16 @@ img = data.page()
 # If it is not specified, only global algorithms are called.
 fig, ax = try_all_threshold(img, figsize=(10, 8), verbose=False)
 plt.show()
+
+######################################################################
+# The corresponding function `try_all_threshold_dict` returns the values
+# of these different threshold methods as an ordered dictionary.
+#
+
+from skimage import data
+from skimage.filters import try_all_threshold_dict
+
+img = data.page()
+threshold_results = try_all_threshold_dict(img)
+for method, result in threshold_results.items():
+    print("{} threshold: {}".format(method, result))

--- a/doc/examples/segmentation/plot_thresholding.py
+++ b/doc/examples/segmentation/plot_thresholding.py
@@ -66,8 +66,6 @@ from skimage.filters import try_all_threshold
 
 img = data.page()
 
-# Here, we specify a radius for local thresholding algorithms.
-# If it is not specified, only global algorithms are called.
 fig, ax = try_all_threshold(img, figsize=(10, 8), verbose=False)
 plt.show()
 

--- a/doc/examples/segmentation/plot_thresholding.py
+++ b/doc/examples/segmentation/plot_thresholding.py
@@ -62,6 +62,7 @@ plt.show()
 # mechanisms.
 #
 
+from skimage import data
 from skimage.filters import try_all_threshold
 
 img = data.page()

--- a/doc/examples/xx_applications/plot_thresholding.py
+++ b/doc/examples/xx_applications/plot_thresholding.py
@@ -39,6 +39,19 @@ fig, ax = try_all_threshold(img, figsize=(10, 8), verbose=False)
 plt.show()
 
 ######################################################################
+# The corresponding function `try_all_threshold_dict` returns the values
+# of these different threshold methods as an ordered dictionary.
+#
+
+from skimage import data
+from skimage.filters import try_all_threshold_dict
+
+img = data.page()
+threshold_results = try_all_threshold_dict(img)
+for method, result in threshold_results.items():
+    print("{} threshold: {}".format(method, result))
+
+######################################################################
 # How to apply a threshold?
 # =========================
 #

--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -1,3 +1,7 @@
+Version 0.15
+------------
+- ``skimage.filters.try_all_threshold_dict`` has been added, and complements the existing function ``sckimage.filters.try_all_threshold``.
+
 Version 0.14
 ------------
 - ``skimage.filters.gaussian_filter`` has been removed. Use

--- a/skimage/filters/__init__.py
+++ b/skimage/filters/__init__.py
@@ -12,7 +12,8 @@ from .thresholding import (threshold_local, threshold_otsu, threshold_yen,
                            threshold_isodata, threshold_li, threshold_minimum,
                            threshold_mean, threshold_triangle,
                            threshold_niblack, threshold_sauvola,
-                           try_all_threshold, apply_hysteresis_threshold)
+                           try_all_threshold, try_all_threshold_dict,
+                           apply_hysteresis_threshold)
 from . import rank
 from .rank import median
 from ._unsharp_mask import unsharp_mask
@@ -40,6 +41,7 @@ __all__ = ['inverse',
            'gabor_kernel',
            'gabor',
            'try_all_threshold',
+           'try_all_threshold_dict',
            'frangi',
            'hessian',
            'threshold_otsu',

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -43,7 +43,7 @@ class TestSimpleImage():
 
     def test_try_all_threshold_dict_exception(self):
         result = try_all_threshold_dict(self.image)
-        assert result['Minimum'] == None
+        assert result['Minimum'] is None
 
     def test_otsu(self):
         assert threshold_otsu(self.image) == 2

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 from scipy import ndimage as ndi
+from collections import OrderedDict
 
 import skimage
 from skimage import data
@@ -16,6 +17,7 @@ from skimage.filters.thresholding import (threshold_local,
                                           threshold_triangle,
                                           threshold_minimum,
                                           try_all_threshold,
+                                          try_all_threshold_dict,
                                           _mean_std)
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_almost_equal
@@ -38,6 +40,10 @@ class TestSimpleImage():
         all_texts = [axis.texts for axis in ax if axis.texts != []]
         text_content = [text.get_text() for x in all_texts for text in x]
         assert 'RuntimeError' in text_content
+
+    def test_try_all_threshold_dict_exception(self):
+        result = try_all_threshold_dict(self.image)
+        assert result['Minimum'] == None
 
     def test_otsu(self):
         assert threshold_otsu(self.image) == 2
@@ -176,6 +182,32 @@ class TestSimpleImage():
         thres = threshold_sauvola(self.image, window_size=3, k=0.2, r=128)
         out = self.image > thres
         assert_equal(ref, out)
+
+
+def test_try_all_threshold_dict_camera_image():
+    camera = skimage.data.camera()
+    expected_result = OrderedDict([('Isodata', 87),
+                                   ('Li', 64.5089042757881),
+                                   ('Mean', 118.31400299072266),
+                                   ('Minimum', 76),
+                                   ('Otsu', 87),
+                                   ('Triangle', 22),
+                                   ('Yen', 198)])
+    result = try_all_threshold_dict(camera)
+    assert result == expected_result
+
+
+def test_try_all_threshold_dict_coins_image():
+    coins = skimage.data.coins()
+    expected_result = OrderedDict([('Isodata', 107),
+                                   ('Li', 96.54139265230047),
+                                   ('Mean', 96.85551602035204),
+                                   ('Minimum', 143),
+                                   ('Otsu', 107),
+                                   ('Triangle', 80),
+                                   ('Yen', 110)])
+    result = try_all_threshold_dict(coins)
+    assert result == expected_result
 
 
 def test_otsu_camera_image():

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -10,6 +10,7 @@ from ..util import crop, dtype_limits
 
 
 __all__ = ['try_all_threshold',
+           'try_all_threshold_dict',
            'threshold_otsu',
            'threshold_yen',
            'threshold_isodata',
@@ -132,6 +133,59 @@ def try_all_threshold(image, figsize=(8, 5), verbose=True):
 
     return _try_all(image, figsize=figsize,
                     methods=methods, verbose=verbose)
+
+
+def try_all_threshold_dict(image):
+    """Returns a dictionary comparing the output of different threshold methods.
+
+    Parameters
+    ----------
+    image : (N, M) ndarray
+        Input image.
+
+    Returns
+    -------
+    threshold_results : dict
+        Dictionary of threshold results in format: {'threshold_method': result}
+        If an exception is encountered in a thresholding method, None is given
+        for that method.
+
+    Notes
+    -----
+    The following algorithms are used:
+
+    * isodata
+    * li
+    * mean
+    * minimum
+    * otsu
+    * triangle
+    * yen
+
+    Examples
+    --------
+    >>> from skimage.data import text
+    >>> dict = try_all_threshold_dict(text())
+    """
+    # Global algorithms.
+    methods = OrderedDict({'Isodata': threshold_isodata,
+                           'Li': threshold_li,
+                           'Mean': threshold_mean,
+                           'Minimum': threshold_minimum,
+                           'Otsu': threshold_otsu,
+                           'Triangle': threshold_triangle,
+                           'Yen': threshold_yen})
+
+    threshold_results = OrderedDict({})
+    for name, func in methods.items():
+        try:
+            threshold_value = func(image)
+        except Exception:
+            threshold_results[name] = None
+        else:
+            threshold_results[name] = threshold_value
+
+    return threshold_results
 
 
 def threshold_local(image, block_size, method='gaussian', offset=0,


### PR DESCRIPTION
## Description
A new function `skimage.filters.try_all_threshold_dict` is implemented. 

An ordered dictionary is returned from `skimage.filters.try_all_threshold_dict` (keys = threshold method names, values = numeric value or None), whereas its counterpart `skimage.filters.try_all_threshold` returns a matplotlib visualisation.

```
>>> from skimage import data
>>> from skimage.filters import try_all_threshold_dict
>>> img = data.page()
>>> threshold_results = try_all_threshold_dict(img)
>>> for method, result in threshold_results.items():
...    print("{} threshold: {}".format(method, result))

Isodata threshold: 157
Li threshold: 148.1795556988551
Mean threshold: 171.54482984293193
Minimum threshold: 191
Otsu threshold: 157
Triangle threshold: 206
Yen threshold: 121
```

This is implemented as a separate function to `skimage.filters.try_all_threshold` for the reasons @jni outlines [here](https://github.com/scikit-image/scikit-image/pull/3149#issuecomment-395619331):
> As we are aiming to remove our matplotlib dependency in the medium term, probably the right approach is to have separate functions for visualising, rather than a keyword argument. This will make it easier to contain all mpl functionality in a single sub-package.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
First suggested by @stefanv in [2178](https://github.com/scikit-image/scikit-image/issues/2178#issuecomment-280072278), and requested by @emmanuelle in [3149](https://github.com/scikit-image/scikit-image/pull/3149#issuecomment-395195413).

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
