### PR TITLE
Fix Qt viewer painttool indexing

### DIFF
--- a/skimage/viewer/canvastools/painttool.py
+++ b/skimage/viewer/canvastools/painttool.py
@@ -220,7 +220,7 @@ class CenteredWindow(object):
         xmax = min(w, col + r + 1)
         ymin = max(0, row - r)
         ymax = min(h, row + r + 1)
-        return [slice(ymin, ymax), slice(xmin, xmax)]
+        return (slice(ymin, ymax), slice(xmin, xmax))
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/skimage/viewer/canvastools/painttool.py
+++ b/skimage/viewer/canvastools/painttool.py
@@ -206,7 +206,16 @@ class CenteredWindow(object):
 
     def at(self, row, col):
         h, w = self.array_shape
-        r = self.radius
+        r = round(self.radius)
+        # Note: the int() cast is necessary because row and col are np.float64,
+        # which does not get cast by round(), unlike a normal Python float:
+        # >>> round(4.5)
+        # 4
+        # >>> round(np.float64(4.5))
+        # 4.0
+        # >>> int(round(np.float64(4.5)))
+        # 4
+        row, col = int(round(row)), int(round(col))
         xmin = max(0, col - r)
         xmax = min(w, col + r + 1)
         ymin = max(0, row - r)

--- a/viewer_examples/plugins/watershed_demo.py
+++ b/viewer_examples/plugins/watershed_demo.py
@@ -28,7 +28,7 @@ class WatershedPlugin(LabelPainter):
 
     def _show_watershed(self):
         viewer = self.image_viewer
-        edge_image = filter.sobel(viewer.image)
+        edge_image = filters.sobel(viewer.image)
         labels = morphology.watershed(edge_image, self.paint_tool.overlay)
         viewer.ax.imshow(labels, cmap=plt.cm.jet, alpha=0.5)
         viewer.redraw()


### PR DESCRIPTION
## Description
Fixes #3209.

## For reviewers

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
