### PR TITLE
build_versions.py is no longer hard coded.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ install:
       if [[ "${WITH_PYAMG}" == "1" ]]; then
         pip install --retries 3 -q pyamg
       fi
-    - source tools/travis/install_qt.sh
+    - tools/travis/install_qt.sh
 
 script: tools/travis/script.sh
 

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,2 +1,3 @@
 Cython>=0.23.4
 wheel
+numpy>=1.11

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-cov
+requirements-parser

--- a/tools/build_versions.py
+++ b/tools/build_versions.py
@@ -1,16 +1,23 @@
 #!/usr/bin/env python
 
-import numpy as np
-import scipy as sp
-import matplotlib as mpl
-from PIL import Image
-import Cython
-import networkx
+from pathlib import Path
+import requirements
+import pkg_resources
 
 
-for m in (np, sp, mpl, Image, networkx, Cython):
-    if m is Image:
-        version = m.VERSION
-    else:
-        version = m.__version__
-    print(m.__name__.rjust(10), ' ', version)
+def main():
+    requirements_dir = Path(__file__).parent / '..' / 'requirements'
+
+    for requirement_file in requirements_dir.glob('*.txt'):
+        print(requirement_file.name)
+        with open(str(requirement_file), 'r') as fd:
+            for req in requirements.parse(fd):
+                try:
+                    version = pkg_resources.get_distribution(req.name).version
+                    print(req.name.rjust(20), version)
+                except pkg_resources.DistributionNotFound:
+                    print(req.name.rjust(20), 'is not installed')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Added a test dependency on requirements-parser (BSD)

```bash
> python tools/build_versions.py 
docs.txt
              sphinx 1.7.5
            numpydoc 0.8.0
      sphinx-gallery is not installed
        scikit-learn is not installed
default.txt
               numpy 1.14.5
               scipy 1.1.0
          matplotlib 2.2.2
            networkx 2.1
              pillow 5.1.0
          PyWavelets 0.5.2
                dask 0.17.5
         cloudpickle 0.5.3
build.txt
              Cython 0.28.3
               wheel 0.31.0
               numpy 1.14.5
test.txt
              pytest 3.6.1
          pytest-cov is not installed
 requirements-parser 0.2.0
optional.txt
              PySide is not installed
              imread is not installed
           SimpleITK is not installed
             astropy is not installed
            tifffile is not installed
             imageio 2.3.0
                qtpy 1.4.2
```

## Checklist
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

## References
Improved version of #3181 taking into account @stefanv and @soupault comments.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
