### PR TITLE
Various updates to the ASV benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ doc/release/_release_notes_for_docs.txt
 doc/gh-pages
 wheels
 skimage/morphology/_skeletonize_3d_cy.pyx
+.asv

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -11,8 +11,7 @@ class SegmentationSuite:
         self.image[300:, 300:, :] += 0.5
 
     def time_slic_basic(self):
-        result = segmentation.slic(self.image, enforce_connectivity=False)
+        segmentation.slic(self.image, enforce_connectivity=False)
 
     def mem_slic_basic(self):
-        result = segmentation.slic(self.image, enforce_connectivity=False)
-
+        return segmentation.slic(self.image, enforce_connectivity=False)


### PR DESCRIPTION
## Description

A few fixups for the ASV benchmarks:

1. ASV expects a `__init__.py` in the benchmarks dir
2. For `mem_` tests, the object has to be returned
3. Added the generated `.asv` directory to the `.gitignore` 

## Checklist

- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`