### PR TITLE
BF: perform computation serially (with a warning) if dask is not available

### DIFF
--- a/skimage/restoration/_cycle_spin.py
+++ b/skimage/restoration/_cycle_spin.py
@@ -3,7 +3,7 @@ from __future__ import division
 from itertools import product
 
 import numpy as np
-import dask
+import warnings
 
 
 def _generate_shifts(ndim, multichannel, max_shifts, shift_steps=1):
@@ -145,6 +145,16 @@ def cycle_spin(x, func, max_shifts, shift_steps=1, num_workers=None,
         tmp = func(xs, **func_kw)
         return _roll_axes(tmp, -np.asarray(shift))
 
+    if num_workers != 1:
+        try:
+            import dask
+        except ImportError:
+            import warnings
+            warnings.warn(
+                "dask is required for parallel computation, but it is "
+                "not available.  Computation will be performed serially."
+            )
+            num_workers = 1
     # compute a running average across the cycle shifts
     if num_workers == 1:
         # serial processing

--- a/skimage/restoration/_cycle_spin.py
+++ b/skimage/restoration/_cycle_spin.py
@@ -3,7 +3,6 @@ from __future__ import division
 from itertools import product
 
 import numpy as np
-import warnings
 
 
 def _generate_shifts(ndim, multichannel, max_shifts, shift_steps=1):


### PR DESCRIPTION
## Description
Initial reason for this change is absent package of dask in Debian for python2.  Although some tests are explicitly skipped if dask is not available, this functionality is used in other tests whenever num_workers is set to None or explicitly to 4.

In general imho it is preferable so some scripts which explicitly set num of workers would still work even without dask

This is an initial submission to seek feedback
## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
