### PR TITLE
WIP: Remove the wheelhouse in favour of pypi

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,15 +37,16 @@ install:
   - "curl https://raw.githubusercontent.com/chemeris/msinttypes/master/stdint.h -o skimage/external/tifffile/stdint.h"
 
   # Install the build and runtime dependencies of the project.
-  # The --pre flag is necessary to grab a SciPy wheel, which is in
-  # pre-release at the time of writing (03-10-2017)
-  - pip install --retries 3 --pre -r requirements.txt
   - pip install --retries 3 -r requirements/build.txt
+  # scipy, from default is required to build until #3158 is fixed.
+  - pip install --retries 3 -r requirements/default.txt
   - python setup.py bdist_wheel bdist_wininst
   - ps: "ls dist"
 
   # Install the generated wheel package to test it
-  - "pip install --pre --no-index --find-links dist/ scikit-image"
+  - "pip install --no-index --find-links dist/ scikit-image"
+  # Install the test dependencies
+  - pip install --retries 3 -r requirements/test.txt
 
 # Not a .NET project, we build scikit-image in the install step instead
 build: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,8 @@ before_install:
     - tools/check_sdist.py
 
 install:
-    - python setup.py develop
+    # build and install runtime dependencies
+    - python -m pip install .
     # Matplotlib settings - do not show figures during doc examples
     - |
       if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
@@ -82,13 +83,14 @@ install:
     # Install most of the optional packages
     - |
       if [[ "${OPTIONAL_DEPS}" == "1" ]]; then
-        pip install --retries 3 -q -r ./requirements/optional.txt $WHEELHOUSE
+        pip install --retries 3 -q -r ./requirements/optional.txt
       fi
     - |
       if [[ "${WITH_PYAMG}" == "1" ]]; then
         pip install --retries 3 -q pyamg
       fi
     - tools/travis/install_qt.sh
+    - pip install --retries 3 -q -r ./requirements/test.txt
 
 script: tools/travis/script.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,31 @@ install:
       if [[ "${WITH_PYAMG}" == "1" ]]; then
         pip install --retries 3 -q pyamg
       fi
-    - tools/travis/install_qt.sh
+    - |
+      if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+        echo "backend : Template" > $MPL_DIR/matplotlibrc
+      fi
+      # Now configure Matplotlib to use Qt5
+    - |
+      if [[ "${QT}" = "PyQt5" ]]; then
+          echo got here
+          pip install --retries 3 -q $PIP_FLAGS pyqt5
+          MPL_QT_API=PyQt5
+          export QT_API=pyqt5
+      elif [[ "${QT}" == "PySide2" ]]; then
+          pip install--retries 3 -q $PIP_FLAGS pyside2
+          MPL_QT_API=PySide2
+          export QT_API=pyside2
+      else
+          echo 'backend: Template' > $MPL_DIR/matplotlibrc
+      fi
+    - |
+      if [[ "${QT}" == "PyQt5" || "${QT}" == "PySide2" ]]; then
+          # Is this correct for PySide2?
+          echo got there
+          echo 'backend: Qt5Agg' > $MPL_DIR/matplotlibrc
+          echo 'backend.qt5 : '$MPL_QT_API >> $MPL_DIR/matplotlibrc
+      fi
     - pip install --retries 3 -q -r ./requirements/test.txt
 
 script: tools/travis/script.sh

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,3 +1,4 @@
 Cython>=0.23.4
 wheel
 numpy>=1.11
+numpydoc>=0.6

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -2,3 +2,4 @@ Cython>=0.23.4
 wheel
 numpy>=1.11
 numpydoc>=0.6
+requirements-parser

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,5 +1,4 @@
 Cython>=0.23.4
 wheel
 numpy>=1.11
-numpydoc>=0.6
 requirements-parser

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,5 @@
+flake8
 pytest
 pytest-cov
+codecov
 requirements-parser

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,4 +2,3 @@ flake8
 pytest
 pytest-cov
 codecov
-requirements-parser

--- a/setup.py
+++ b/setup.py
@@ -88,14 +88,6 @@ if __name__ == "__main__":
     try:
         from numpy.distutils.core import setup
         extra = {'configuration': configuration}
-        # Do not try and upgrade larger dependencies
-        for lib in ['scipy', 'numpy', 'matplotlib', 'pillow']:
-            try:
-                __import__(lib)
-                INSTALL_REQUIRES = [i for i in INSTALL_REQUIRES
-                                    if lib not in i]
-            except ImportError:
-                pass
     except ImportError:
         if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or
                                    sys.argv[1] in ('--help-commands',

--- a/skimage/io/_plugins/gdal_plugin.py
+++ b/skimage/io/_plugins/gdal_plugin.py
@@ -1,11 +1,11 @@
-__all__ = ['imread']
-
 try:
     import osgeo.gdal as gdal
 except ImportError:
     raise ImportError("The GDAL Library could not be found. "
                       "Please refer to http://www.gdal.org/ "
                       "for further instructions.")
+
+__all__ = ['imread']
 
 
 def imread(fname, dtype=None):

--- a/skimage/io/_plugins/q_color_mixer.py
+++ b/skimage/io/_plugins/q_color_mixer.py
@@ -1,8 +1,20 @@
 # the module for the qt color_mixer plugin
-from qtpy import QtCore
-from qtpy.QtWidgets import (QWidget, QStackedWidget, QSlider, QGridLayout,
-                            QLabel, QFrame, QComboBox, QRadioButton,
-                            QPushButton)
+try:
+    from qtpy import QtCore
+    from qtpy.QtWidgets import (QWidget, QStackedWidget, QSlider, QGridLayout,
+                                QLabel, QFrame, QComboBox, QRadioButton,
+                                QPushButton)
+except ImportError:
+    raise ImportError("""\
+    This module requires some python bindings to Qt.
+
+    We recommend either PyQt5 (GPL licensed) or PySide2 (LGPL licensed).
+    More information can be found on their respective sites.
+
+    http://www.riverbankcomputing.co.uk/software/pyqt/intro
+
+    https://wiki.qt.io/Qt_for_Python
+    """)
 
 from .util import ColorMixer
 

--- a/skimage/io/_plugins/q_histogram.py
+++ b/skimage/io/_plugins/q_histogram.py
@@ -1,8 +1,18 @@
 import numpy as np
+try:
+    from qtpy.QtGui import QPainter, QColor
+    from qtpy.QtWidgets import QWidget, QGridLayout, QFrame
+except ImportError:
+    raise ImportError("""\
+    This module requires some python bindings to Qt.
 
-from qtpy.QtGui import QPainter, QColor
-from qtpy.QtWidgets import QWidget, QGridLayout, QFrame
+    We recommend either PyQt5 (GPL licensed) or PySide2 (LGPL licensed).
+    More information can be found on their respective sites.
 
+    http://www.riverbankcomputing.co.uk/software/pyqt/intro
+
+    https://wiki.qt.io/Qt_for_Python
+    """)
 from .util import histograms
 
 

--- a/skimage/io/_plugins/qt_plugin.py
+++ b/skimage/io/_plugins/qt_plugin.py
@@ -2,14 +2,28 @@ import numpy as np
 from .util import prepare_for_display, window_manager
 from ..._shared.utils import warn
 
-from qtpy.QtWidgets import (QApplication, QLabel, QMainWindow, QWidget,
-                            QGridLayout)
-from qtpy.QtGui import QImage, QPixmap
-from qtpy import QtCore
-
 # We try to aquire the gui lock first or else the gui import might
 # trample another GUI's PyOS_InputHook.
 window_manager.acquire('qt')
+
+try:
+    from qtpy.QtWidgets import (QApplication, QLabel, QMainWindow, QWidget,
+                                QGridLayout)
+    from qtpy.QtGui import QImage, QPixmap
+    from qtpy import QtCore
+except ImportError:
+    window_manager._release('qt')
+
+    raise ImportError("""\
+    This module requires some python bindings to Qt.
+
+    We recommend either PyQt5 (GPL licensed) or PySide2 (LGPL licensed).
+    More information can be found on their respective sites.
+
+    http://www.riverbankcomputing.co.uk/software/pyqt/intro
+
+    https://wiki.qt.io/Qt_for_Python
+    """)
 
 app = None
 

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -3,33 +3,10 @@ set -ev
 
 export PIP_DEFAULT_TIMEOUT=60
 
-# This URL is for any extra wheels that are not available on pypi.  As of 14
-# Jan 2017, the major packages such as numpy and matplotlib are up for all
-# platforms.  The URL points to a Rackspace CDN belonging to the scikit-learn
-# team.  Please contact Olivier Grisel or Matthew Brett if you need
-# permissions for this folder.
-EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
-WHEELHOUSE="--find-links=$EXTRA_WHEELS"
-
-if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
-    sh -e /etc/init.d/xvfb start
-    # This one is for wheels we can only build on the travis precise container.
-    # As of 14 Jan 2017, this is only pyside.  Also on Rackspace, see above.
-    # To build new wheels for this container, consider using:
-    # https://github.com/matthew-brett/travis-wheel-builder . The wheels from
-    # that building repo upload to the container "travis-wheels" available at
-    # https://8167b5c3a2af93a0a9fb-13c6eee0d707a05fa610c311eec04c66.ssl.cf2.rackcdn.com
-    # You then need to transfer them to the container pointed to by the URL
-    # below (called "precise-wheels" on the Rackspace interface).
-    PRECISE_WHEELS="https://7d8d0debcc2964ae0517-cec8b1780d3c0de237cc726d565607b4.ssl.cf2.rackcdn.com"
-    WHEELHOUSE="--find-links=$PRECISE_WHEELS $WHEELHOUSE"
-fi
-export WHEELHOUSE
-
 export DISPLAY=:99.0
 # This causes way too many internal warnings within python.
 # export PYTHONWARNINGS="d,all:::skimage"
-export TEST_ARGS="--doctest-modules"
+export TEST_ARGS="--doctest-modules --cov=skimage"
 WHEELBINARIES="matplotlib scipy pillow cython"
 
 retry () {
@@ -49,26 +26,14 @@ retry () {
     return 0
 }
 
-# add build dependencies
-echo "cython>=0.23.4" >> requirements/default.txt
-echo "numpydoc>=0.6" >> requirements/default.txt
-
 if [[ $MINIMUM_REQUIREMENTS == 1 ]]; then
-    sed -i 's/>=/==/g' requirements/default.txt
+    for filename in requirements/*.txt; do
+        sed -i 's/>=/==/g' $filename
+    done
 fi
 
 python -m pip install --upgrade pip
-pip install --retries 3 -q wheel flake8 codecov pytest pytest-cov
-# install numpy from PyPI instead of our wheelhouse
-pip install --retries 3 -q wheel numpy
-
-# install wheels
-for requirement in $WHEELBINARIES; do
-    WHEELS="$WHEELS $(grep $requirement requirements/default.txt)"
-done
-pip install --retries 3 -q $PIP_FLAGS $WHEELHOUSE $WHEELS
-
-pip install --retries 3 -q $PIP_FLAGS -r requirements.txt
+pip install --retries 3 -q $PIP_FLAGS -r requirements/build.txt
 
 # Show what's installed
 pip list

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -34,6 +34,11 @@ fi
 
 python -m pip install --upgrade pip
 pip install --retries 3 -q $PIP_FLAGS -r requirements/build.txt
+# The line below isn't necessary if #3158 is accepted.
+# That said, `pip install .` also install runtime requirements before
+# the build process starts. This line helps with the strange lazy loading
+# necessary to build the sdist packages.
+pip install --retries 3 -q $PIP_FLAGS -r requirements/default.txt
 
 # Show what's installed
 pip list

--- a/tools/travis/install_qt.sh
+++ b/tools/travis/install_qt.sh
@@ -5,7 +5,6 @@ if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
     echo "backend : Template" > $MPL_DIR/matplotlibrc
 fi
 
-echo ${QT}
 # Now configure Matplotlib to use Qt5
 if [[ "${QT}" = "PyQt5" ]]; then
     echo got here
@@ -21,7 +20,6 @@ else
 fi
 if [[ "${QT}" == "PyQt5" || "${QT}" == "PySide2" ]]; then
     # Is this correct for PySide2?
-    echo got there
     echo 'backend: Qt5Agg' > $MPL_DIR/matplotlibrc
     echo 'backend.qt5 : '$MPL_QT_API >> $MPL_DIR/matplotlibrc
 fi

--- a/tools/travis/install_qt.sh
+++ b/tools/travis/install_qt.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 set -ev
-
+section "install.qt"
 if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
     echo "backend : Template" > $MPL_DIR/matplotlibrc
 fi
+
+echo ${QT}
 # Now configure Matplotlib to use Qt5
-if [[ "${QT}" == "PyQt5" ]]; then
+if [[ "${QT}" = "PyQt5" ]]; then
+    echo got here
     pip install --retries 3 -q $PIP_FLAGS pyqt5
     MPL_QT_API=PyQt5
     export QT_API=pyqt5
@@ -18,8 +21,10 @@ else
 fi
 if [[ "${QT}" == "PyQt5" || "${QT}" == "PySide2" ]]; then
     # Is this correct for PySide2?
+    echo got there
     echo 'backend: Qt5Agg' > $MPL_DIR/matplotlibrc
     echo 'backend.qt5 : '$MPL_QT_API >> $MPL_DIR/matplotlibrc
 fi
+section_end "install.qt"
 
 set +ev

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -3,36 +3,15 @@
 set -ev
 export PY=${TRAVIS_PYTHON_VERSION}
 
-# Matplotlib settings - do not show figures during doc examples
-if [[ $MINIMUM_REQUIREMENTS == 1 || $TRAVIS_OS_NAME == "osx" ]]; then
-    MPL_DIR=$HOME/.matplotlib
-else
-    MPL_DIR=$HOME/.config/matplotlib
-fi
-
-mkdir -p $MPL_DIR
-touch $MPL_DIR/matplotlibrc
-
-if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-    echo 'backend : Template' > $MPL_DIR/matplotlibrc
-fi
-
-section "Test.with.min.requirements"
-pytest $TEST_ARGS skimage
-section_end "Test.with.min.requirements"
-
 section "Flake8.test"
 flake8 --exit-zero --exclude=test_* skimage doc/examples viewer_examples
 section_end "Flake8.test"
 
 section "Tests.pytest"
-# run tests. If running with optional dependencies, report coverage
-if [[ "$OPTIONAL_DEPS" == "1" ]]; then
-  export TEST_ARGS="${TEST_ARGS} --cov=skimage"
-fi
+
 # Show what's installed
 pip list
-pytest ${TEST_ARGS} skimage
+pytest ${TEST_ARGS} --pyargs skimage
 section_end "Tests.pytest"
 
 

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Fail on non-zero exit and echo the commands
-set -ev
+set -ex
 export PY=${TRAVIS_PYTHON_VERSION}
 
 section "Flake8.test"
@@ -11,7 +11,9 @@ section "Tests.pytest"
 
 # Show what's installed
 pip list
-pytest ${TEST_ARGS} --pyargs skimage
+pushd ..
+python -m pytest ${TEST_ARGS} --pyargs skimage
+popd
 section_end "Tests.pytest"
 
 


### PR DESCRIPTION
1. Remove stray pip commands in travis install that don't use a requirements file.
2. Pin all requirements files and not just default.txt
3. Remove the wheelhouse

Motivation to use the wheelhouse is that pypi is now quite good.,
We also had commands like 
```
pip install numpy
```
that didn't have pinning.
All of these changes fall into cleaning up the pip commands used during the build process.

### misc change
There was also the added addition of test duplication that was a cause of two large changes changes: a previous big fix to the build process #3072 and #3000 that removed python 2 compatibility

## References
Part of the larger effort to modernise the build process #3172

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
