### PR TITLE
Build tools: Dedicate a --pre build in appveyor and ensure other builds don't download --pre

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,15 +39,16 @@ install:
   - "curl https://raw.githubusercontent.com/chemeris/msinttypes/master/stdint.h -o skimage/external/tifffile/stdint.h"
 
   # Install the build and runtime dependencies of the project.
-  # The --pre flag is necessary to grab a SciPy wheel, which is in
-  # pre-release at the time of writing (03-10-2017)
-  - pip install --retries 3 --pre -r requirements.txt
   - pip install --retries 3 -r requirements/build.txt
+  # scipy, from default is required to build until #3158 is fixed.
+  - pip install --retries 3 -r requirements/default.txt
   - python setup.py bdist_wheel bdist_wininst
   - ps: "ls dist"
 
   # Install the generated wheel package to test it
-  - "pip install --pre --no-index --find-links dist/ scikit-image"
+  - "pip install --no-index --find-links dist/ scikit-image"
+  # Install the test dependencies
+  - pip install --retries 3 -r requirements/test.txt
 
 # Not a .NET project, we build scikit-image in the install step instead
 build: false

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,6 +8,8 @@ environment:
     - PYTHON: C:\Python36-x64
     - PYTHON: C:\Python37
     - PYTHON: C:\Python37-x64
+    - PYTHON: C:\Python37-x64
+      PIP_FLAGS: --pre
 
 matrix:
   fast_finish: true
@@ -39,16 +41,15 @@ install:
   - "curl https://raw.githubusercontent.com/chemeris/msinttypes/master/stdint.h -o skimage/external/tifffile/stdint.h"
 
   # Install the build and runtime dependencies of the project.
-  - pip install --retries 3 -r requirements/build.txt
-  # scipy, from default is required to build until #3158 is fixed.
-  - pip install --retries 3 -r requirements/default.txt
+  - pip install %PIP_FLAGS% --retries 3 -r requirements/default.txt
+  - pip install %PIP_FLAGS% --retries 3 -r requirements/build.txt
   - python setup.py bdist_wheel bdist_wininst
   - ps: "ls dist"
 
-  # Install the generated wheel package to test it
-  - "pip install --no-index --find-links dist/ scikit-image"
+  # Install the generated wheel package to test it.
+  - pip install %PIP_FLAGS% --no-index --find-links dist/ scikit-image
   # Install the test dependencies
-  - pip install --retries 3 -r requirements/test.txt
+  - pip install %PIP_FLAGS% --retries 3 -r requirements/test.txt
 
 # Not a .NET project, we build scikit-image in the install step instead
 build: false


### PR DESCRIPTION
Pre was only needed in 2017 before wheels became widely available.

pre was failing on appveyor.
now it is fixed because it doen't install everything in requirements from prereleases..... (and likely does what we want it to do)

@jni

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
