### PR TITLE
Respect input array type in apply_parallel by default

### DIFF
--- a/skimage/util/apply_parallel.py
+++ b/skimage/util/apply_parallel.py
@@ -58,7 +58,7 @@ def _ensure_dask_array(array, chunks=None):
 
 
 def apply_parallel(function, array, chunks=None, depth=0, mode=None,
-                   extra_arguments=(), extra_keywords={}, *, compute=True):
+                   extra_arguments=(), extra_keywords={}, *, compute=None):
     """Map a function in parallel across an array.
 
     Split an array into possibly overlapping chunks of a given depth and
@@ -90,8 +90,10 @@ def apply_parallel(function, array, chunks=None, depth=0, mode=None,
     extra_keywords : dictionary, optional
         Dictionary of keyword arguments to be passed to the function.
     compute : bool, optional
-        Whether to compute right away (default) or
-        skip computing and return a dask Array.
+        If ``True``, compute eagerly returning a NumPy Array.
+        If ``False``, compute lazily returning a Dask Array.
+        If ``None`` (default), compute based on array type provided
+        (eagerly for NumPy Arrays and lazily for Dask Arrays).
 
     Returns
     -------
@@ -112,6 +114,9 @@ def apply_parallel(function, array, chunks=None, depth=0, mode=None,
     if not dask_available:
         raise RuntimeError("Could not import 'dask'.  Please install "
                            "using 'pip install dask'")
+
+    if compute is None:
+        compute = not isinstance(array, da.Array)
 
     if chunks is None:
         shape = array.shape

--- a/skimage/util/tests/test_apply_parallel.py
+++ b/skimage/util/tests/test_apply_parallel.py
@@ -9,6 +9,8 @@ from skimage.util.apply_parallel import apply_parallel, dask_available
 
 @testing.skipif(not dask_available, reason="dask not installed")
 def test_apply_parallel():
+    import dask.array as da
+
     # data
     a = np.arange(144).reshape(12, 12).astype(float)
 
@@ -27,6 +29,14 @@ def test_apply_parallel():
     result2 = apply_parallel(wrapped_gauss, a, chunks=(6, 6), depth=5)
 
     assert_array_almost_equal(result2, expected2)
+
+    expected3 = gaussian(a, 1, mode='reflect')
+    result3 = apply_parallel(
+        wrapped_gauss, da.from_array(a, chunks=(6, 6)), depth=5, compute=True
+    )
+
+    assert isinstance(result3, np.ndarray)
+    assert_array_almost_equal(result3, expected3)
 
 
 @testing.skipif(not dask_available, reason="dask not installed")
@@ -47,8 +57,7 @@ def test_apply_parallel_lazy():
     # apply the filter on a Dask Array
     result2 = apply_parallel(threshold_local, d, depth=5,
                              extra_arguments=(3,),
-                             extra_keywords={'mode': 'reflect'},
-                             compute=False)
+                             extra_keywords={'mode': 'reflect'})
 
     assert isinstance(result1, da.Array)
 


### PR DESCRIPTION
## Description

Sets `compute=None` by default and fixes this value to `True` or `False` based on the array type (if the user leaves `compute` unspecified) based on [this discussion]( https://github.com/scikit-image/scikit-image/pull/3121#pullrequestreview-132169980 ).

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References

Follow-up for lazy `apply_parallel` added in PR ( https://github.com/scikit-image/scikit-image/pull/3121 ).

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
