### PR TITLE
Travis cleanup pip commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,8 @@ before_install:
 
 install:
     - python setup.py develop
+    # Install testing requirements
+    - pip install --retries 3 -q $PIP_FLAGS -r requirements/test.txt
     # Matplotlib settings - do not show figures during doc examples
     - |
       if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,3 +1,4 @@
 Cython>=0.23.4
 wheel
 numpy>=1.11
+requirements-parser

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,4 @@
 sphinx>=1.3
-numpydoc
+numpydoc>=0.6
 sphinx-gallery
 scikit-learn

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,2 +1,4 @@
 pytest
 pytest-cov
+flake8
+codecov

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,2 @@
 pytest
 pytest-cov
-requirements-parser

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ev
+set -ex
 
 export PIP_DEFAULT_TIMEOUT=60
 

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -51,7 +51,6 @@ retry () {
 
 # add build dependencies
 echo "cython>=0.23.4" >> requirements/default.txt
-echo "numpydoc>=0.6" >> requirements/default.txt
 
 if [[ $MINIMUM_REQUIREMENTS == 1 ]]; then
     for filename in requirements/*.txt; do

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -62,7 +62,7 @@ fi
 python -m pip install --upgrade pip
 pip install --retries 3 -q wheel flake8 codecov pytest pytest-cov
 # install numpy from PyPI instead of our wheelhouse
-pip install --retries 3 -q wheel numpy
+pip install --retries 3 -q wheel $(grep numpy requirements/build.txt)
 
 # install wheels
 for requirement in $WHEELBINARIES; do

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -59,7 +59,6 @@ if [[ $MINIMUM_REQUIREMENTS == 1 ]]; then
 fi
 
 python -m pip install --upgrade pip
-pip install --retries 3 -q wheel flake8 codecov pytest pytest-cov
 # install numpy from PyPI instead of our wheelhouse
 pip install --retries 3 -q wheel $(grep numpy requirements/build.txt)
 

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -54,7 +54,9 @@ echo "cython>=0.23.4" >> requirements/default.txt
 echo "numpydoc>=0.6" >> requirements/default.txt
 
 if [[ $MINIMUM_REQUIREMENTS == 1 ]]; then
-    sed -i 's/>=/==/g' requirements/default.txt
+    for filename in requirements/*.txt; do
+        sed -i 's/>=/==/g' $filename
+    done
 fi
 
 python -m pip install --upgrade pip


### PR DESCRIPTION
## Description
Travis build scripts had a few pip commands that were sprinkled inside the `before_install.sh`.
This caused version numbers to have to be updated in yet an other location. 
This removes these random occurrences. 

In doing so:
1. Versions will respect those in the requirements folder.
2. the --pre build now pulls in the numpy pre release (which as of time of writing, fails tests)
3. Minimum version requirements can also be set for testing and building tools

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
