### PR TITLE
Do not merge! Travis: explicitely run optional tests and QT test for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,16 +38,16 @@ matrix:
   include:
     - os: linux
       python: 3.5
-      env: OPTIONAL_DEPS=1 WITH_PYSIDE=1 BUILD_DOCS=1
+      env: BUILD_DOCS=1
     - os: linux
       python: 3.5
       env: QT=PyQt5 WITH_PYAMG=1 MINIMUM_REQUIREMENTS=1
     - os: linux
       python: 3.6
-      env: QT=PyQt5 WITH_PYAMG=1 OPTIONAL_DEPS=1 BUILD_DOCS=1 DEPLOY_DOCS=1
+      env: QT=PyQt5 WITH_PYAMG=1 BUILD_DOCS=1 DEPLOY_DOCS=1
     - os: linux
       python: 3.6
-      env: QT=PyQt5 WITH_PYAMG=1 OPTIONAL_DEPS=1 PIP_FLAGS="--pre"
+      env: QT=PyQt5 WITH_PYAMG=1 PIP_FLAGS="--pre"
     - os: osx
       osx_image: xcode9
       language: objective-c
@@ -88,18 +88,10 @@ install:
       else
         export MPL_DIR=${HOME}/.config/matplotlib
       fi
-    - mkdir -p ${MPL_DIR}
-    - touch ${MPL_DIR}/matplotlibrc
-    # Install most of the optional packages
-    - |
-      if [[ "${OPTIONAL_DEPS}" == "1" ]]; then
-        pip install --retries 3 -q -r ./requirements/optional.txt $WHEELHOUSE
-      fi
     - |
       if [[ "${WITH_PYAMG}" == "1" ]]; then
         pip install --retries 3 -q pyamg
       fi
-    - tools/travis/install_qt.sh
 
 script: tools/travis/script.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,13 @@ matrix:
       env: BUILD_DOCS=1
     - os: linux
       python: 3.5
-      env: QT=PyQt5 MINIMUM_REQUIREMENTS=1
+      env: MINIMUM_REQUIREMENTS=1
     - os: linux
       python: 3.6
-      env: QT=PyQt5 BUILD_DOCS=1 DEPLOY_DOCS=1
+      env: BUILD_DOCS=1 DEPLOY_DOCS=1
     - os: linux
       python: 3.6
-      env: QT=PyQt5 PIP_FLAGS="--pre"
+      env: PIP_FLAGS="--pre"
     - os: osx
       osx_image: xcode9
       language: objective-c
@@ -79,13 +79,6 @@ install:
     - python setup.py develop
     # Install testing requirements
     - pip install --retries 3 -q $PIP_FLAGS -r requirements/test.txt
-    # Matplotlib settings - do not show figures during doc examples
-    - |
-      if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-        export MPL_DIR=${HOME}/.matplotlib
-      else
-        export MPL_DIR=${HOME}/.config/matplotlib
-      fi
 
 script: tools/travis/script.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,11 @@ matrix:
       language: objective-c
       # OS X has a hard time installing the docs dependencies
       env: TRAVIS_PYTHON_VERSION=3.5
+    - os: osx
+      osx_image: xcode9
+      language: objective-c
+      # OS X has a hard time installing the docs dependencies
+      env: TRAVIS_PYTHON_VERSION=3.6
 
 before_install:
     # libpng 1.6.32 has a bug in reading PNG

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,12 +51,10 @@ matrix:
     - os: osx
       osx_image: xcode9
       language: objective-c
-      # OS X has a hard time installing the docs dependencies
       env: TRAVIS_PYTHON_VERSION=3.5
     - os: osx
       osx_image: xcode9
       language: objective-c
-      # OS X has a hard time installing the docs dependencies
       env: TRAVIS_PYTHON_VERSION=3.6
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,12 @@ matrix:
       env: TRAVIS_PYTHON_VERSION=3.5
 
 before_install:
+    # libpng 1.6.32 has a bug in reading PNG
+    # that seems to be the default library that is installed
+    # https://github.com/ImageMagick/ImageMagick/issues/747#issuecomment-328521685
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         source tools/travis/osx_install.sh;
+        brew upgrade libpng;
       else
         virtualenv -p python ~/venv;
         source ~/venv/bin/activate;

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ matrix:
   include:
     - os: linux
       python: 3.5
-      env: BUILD_DOCS=1
     - os: linux
       python: 3.5
       env: MINIMUM_REQUIREMENTS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,19 +34,33 @@ notifications:
     on_failure: always  # options: [always|never|change] default: always
     on_start: false     # default: false
 
+
+# DEFAULT VALUES:
+# RUN_EXAMPLES != 0  (runs all the files in the examples)
+# BUILD_DOCS != 1  (runs make html in docs)
+# RUN_TESTS != 0  (runs pytest [twice] and flake8)
+# MINIMUM_REQUIREMENTS != 1  (pins the requirements.txt files)
 matrix:
   include:
     - os: linux
       python: 3.5
+      env: RUN_EXAMPLES=0
     - os: linux
       python: 3.5
-      env: MINIMUM_REQUIREMENTS=1
+      env: MINIMUM_REQUIREMENTS=1 RUN_EXAMPLES=0
     - os: linux
       python: 3.6
-      env: BUILD_DOCS=1 DEPLOY_DOCS=1
+      env: RUN_EXAMPLES=0
+    # Linux seems to finish in 40 minutes (max is 45)
+    # Therefore run the long examples in a seperate build
+    - os: linux
+      python: 3.5
+      env: RUN_TESTS=0 RUN_EXAMPLES=1
     - os: linux
       python: 3.6
-      env: PIP_FLAGS="--pre"
+      env: RUN_TESTS=0 BUILD_DOCS=1 DEPLOY_DOCS=1
+    # OSX seems to finish in under 30 minutes, therefore we can
+    # run the tests and examples in the build
     - os: osx
       osx_image: xcode9
       language: objective-c
@@ -55,6 +69,10 @@ matrix:
       osx_image: xcode9
       language: objective-c
       env: TRAVIS_PYTHON_VERSION=3.6
+    # Includea  --pre build to catch errors
+    - os: linux
+      python: 3.6
+      env: PIP_FLAGS="--pre" RUN_EXAMPLES=0
 
 before_install:
     # libpng 1.6.32 has a bug in reading PNG

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,13 @@ matrix:
       env: BUILD_DOCS=1
     - os: linux
       python: 3.5
-      env: QT=PyQt5 WITH_PYAMG=1 MINIMUM_REQUIREMENTS=1
+      env: QT=PyQt5 MINIMUM_REQUIREMENTS=1
     - os: linux
       python: 3.6
-      env: QT=PyQt5 WITH_PYAMG=1 BUILD_DOCS=1 DEPLOY_DOCS=1
+      env: QT=PyQt5 BUILD_DOCS=1 DEPLOY_DOCS=1
     - os: linux
       python: 3.6
-      env: QT=PyQt5 WITH_PYAMG=1 PIP_FLAGS="--pre"
+      env: QT=PyQt5 PIP_FLAGS="--pre"
     - os: osx
       osx_image: xcode9
       language: objective-c
@@ -87,10 +87,6 @@ install:
         export MPL_DIR=${HOME}/.matplotlib
       else
         export MPL_DIR=${HOME}/.config/matplotlib
-      fi
-    - |
-      if [[ "${WITH_PYAMG}" == "1" ]]; then
-        pip install --retries 3 -q pyamg
       fi
 
 script: tools/travis/script.sh

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,6 +1,6 @@
-PySide; python_version <= '3.4'
 imread
 SimpleITK
 astropy
 tifffile
 qtpy
+pyamg

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -29,7 +29,6 @@ export WHEELHOUSE
 export DISPLAY=:99.0
 # This causes way too many internal warnings within python.
 # export PYTHONWARNINGS="d,all:::skimage"
-export TEST_ARGS="--doctest-modules"
 
 retry () {
     # https://gist.github.com/fungusakafungus/1026804

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -49,8 +49,22 @@ retry () {
 
 if [[ $MINIMUM_REQUIREMENTS == 1 ]]; then
     for filename in requirements/*.txt; do
-        sed -i 's/>=/==/g' $filename
+        if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+            # sed command for OSX is different than unix
+            # https://stackoverflow.com/a/2420579/2321145
+            sed -i '' -e 's/>=/==/g' $filename
+        else
+            sed -i 's/>=/==/g' $filename
+        fi
     done
+fi
+
+
+# PYAMG is having trouble being installed on OSX
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    # sed command for OSX is different than unix
+    # https://stackoverflow.com/a/2420579/2321145
+    sed -i '' -e "/pyamg/d" ./requirements/optional.txt
 fi
 
 python -m pip install --upgrade pip

--- a/tools/travis/install_qt.sh
+++ b/tools/travis/install_qt.sh
@@ -1,28 +1,23 @@
 #!/usr/bin/env bash
-set -ev
+set -ex
 
-if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-    echo "backend : Template" > $MPL_DIR/matplotlibrc
-fi
 # Now configure Matplotlib to use Qt5
-if [[ "${QT}" == "PyQt5" ]]; then
+# Use Qt5 by default if no argument is passed.
+if [[ "${QT}" == "PySide2" ]]; then
+    pip install--retries 3 -q $PIP_FLAGS pyside2
+    MPL_QT_API=PySide2
+    export QT_API=pyside2
+else
     # Matplotlib 2.2.2 doesn't support pyqt5 5.11 until this commit
     # https://github.com/matplotlib/matplotlib/commit/260e6d611afae9adaac528c28a4879097c357b74#diff-025508b6963efcfa97ba27389f2d2b86
     # becomes released
     pip install --retries 3 -q $PIP_FLAGS 'pyqt5<5.11'
     MPL_QT_API=PyQt5
     export QT_API=pyqt5
-elif [[ "${QT}" == "PySide2" ]]; then
-    pip install--retries 3 -q $PIP_FLAGS pyside2
-    MPL_QT_API=PySide2
-    export QT_API=pyside2
-else
-    echo 'backend: Template' > $MPL_DIR/matplotlibrc
-fi
-if [[ "${QT}" == "PyQt5" || "${QT}" == "PySide2" ]]; then
-    # Is this correct for PySide2?
-    echo 'backend: Qt5Agg' > $MPL_DIR/matplotlibrc
-    echo 'backend.qt5 : '$MPL_QT_API >> $MPL_DIR/matplotlibrc
 fi
 
-set +ev
+# Is this correct for PySide2?
+echo 'backend: Qt5Agg' > $MPL_DIR/matplotlibrc
+echo 'backend.qt5 : '$MPL_QT_API >> $MPL_DIR/matplotlibrc
+
+set +ex

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -7,12 +7,9 @@ export PY=${TRAVIS_PYTHON_VERSION}
 export MPL_DIR=`python -c 'import matplotlib; print(matplotlib.get_configdir())'`
 
 mkdir -p $MPL_DIR
-touch $MPL_DIR/matplotlibrc
-
-# Matplotlib settings - do not show figures during doc examples
-if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-    echo 'backend : Template' > $MPL_DIR/matplotlibrc
-fi
+# by default, do not show figures
+# this may be overwritten by subsequent install script
+echo 'backend : Template' > $MPL_DIR/matplotlibrc
 
 section "Flake8.test"
 flake8 --exit-zero --exclude=test_* skimage doc/examples viewer_examples

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -17,24 +17,30 @@ if [[ $TRAVIS_OS_NAME == "osx" ]]; then
     echo 'backend : Template' > $MPL_DIR/matplotlibrc
 fi
 
-section "Test.with.min.requirements"
-pytest $TEST_ARGS skimage
-section_end "Test.with.min.requirements"
-
 section "Flake8.test"
 flake8 --exit-zero --exclude=test_* skimage doc/examples viewer_examples
 section_end "Flake8.test"
 
-section "Tests.pytest"
-# run tests. If running with optional dependencies, report coverage
-if [[ "$OPTIONAL_DEPS" == "1" ]]; then
-  export TEST_ARGS="${TEST_ARGS} --cov=skimage"
-fi
+section "Test.with.min.requirements"
+pytest skimage
+section_end "Test.with.min.requirements"
+
+# Install optional dependencies and pyqt
+section "Install.optional.dependencies"
+mkdir -p ${MPL_DIR}
+touch ${MPL_DIR}/matplotlibrc
+# matplotlib is one optional dependency that definitely needs to be installed
+# from the wheelhouse if we plan on testing linux 32 bit
+pip install --retries 3 -q -r ./requirements/optional.txt $WHEELHOUSE
+
+tools/travis/install_qt.sh
+section_end "Install.optional.dependencies"
+
+section "Test.with.optional.requirements"
 # Show what's installed
 pip list
-pytest ${TEST_ARGS} skimage
-section_end "Tests.pytest"
-
+pytest --doctest-modules --cov=skimage skimage
+section_end "Test.with.optional.requirements"
 
 section "Tests.examples"
 # Run example applications

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -39,19 +39,20 @@ section_end "Tests.pytest"
 section "Tests.examples"
 # Run example applications
 echo Build or run examples
-if [[ "${BUILD_DOCS}" == "1" ]]; then
-  # requirements/docs.txt fails on Travis OSX
+# OSX on Travis can't install sphinx-gallery.
+# I think all it needs is scikit-learn from that requirements doc
+# to run the tests. See Issue #3084
+if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+  pip install --retries 3 -q scikit-learn
+else
   pip install --retries 3 -q -r ./requirements/docs.txt
-  export SPHINXCACHE=${HOME}/.cache/sphinx; make html
-elif [[ "${TEST_EXAMPLES}" != "0" ]]; then
-  # OSX Can't install sphinx-gallery.
-  # I think all it needs is scikit-learn from that requirements doc
-  # to run the tests. See Issue #3084
-  if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-    pip install --retries 3 -q scikit-learn
-  else
-    pip install --retries 3 -q -r ./requirements/docs.txt
-  fi
+fi
+
+if [[ "${BUILD_DOCS}" == "1" ]]; then
+  export SPHINXCACHE=${HOME}/.cache/sphinx
+  make html
+else
+  # These test are run by sphinx automatically
   cp $MPL_DIR/matplotlibrc $MPL_DIR/matplotlibrc_backup
   echo 'backend : Template' > $MPL_DIR/matplotlibrc
   for f in doc/examples/*/*.py; do

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -3,16 +3,13 @@
 set -ev
 export PY=${TRAVIS_PYTHON_VERSION}
 
-# Matplotlib settings - do not show figures during doc examples
-if [[ $MINIMUM_REQUIREMENTS == 1 || $TRAVIS_OS_NAME == "osx" ]]; then
-    MPL_DIR=$HOME/.matplotlib
-else
-    MPL_DIR=$HOME/.config/matplotlib
-fi
+# Matplotlib directory location changes depending on OS and verison
+MPL_DIR=`python -c 'import matplotlib; print(matplotlib.get_configdir())'`
 
 mkdir -p $MPL_DIR
 touch $MPL_DIR/matplotlibrc
 
+# Matplotlib settings - do not show figures during doc examples
 if [[ $TRAVIS_OS_NAME == "osx" ]]; then
     echo 'backend : Template' > $MPL_DIR/matplotlibrc
 fi

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -22,6 +22,9 @@ flake8 --exit-zero --exclude=test_* skimage doc/examples viewer_examples
 section_end "Flake8.test"
 
 section "Test.with.min.requirements"
+# Show what's installed
+pip list
+tools/build_versions.py
 pytest skimage
 section_end "Test.with.min.requirements"
 
@@ -39,6 +42,7 @@ section_end "Install.optional.dependencies"
 section "Test.with.optional.requirements"
 # Show what's installed
 pip list
+tools/build_versions.py
 pytest --doctest-modules --cov=skimage skimage
 section_end "Test.with.optional.requirements"
 

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -56,9 +56,6 @@ elif [[ "${TEST_EXAMPLES}" != "0" ]]; then
   echo 'backend : Template' > $MPL_DIR/matplotlibrc
   for f in doc/examples/*/*.py; do
     python "${f}"
-    if [ $? -ne 0 ]; then
-      exit 1
-    fi
   done
   mv $MPL_DIR/matplotlibrc_backup $MPL_DIR/matplotlibrc
 fi

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -11,16 +11,18 @@ mkdir -p $MPL_DIR
 # this may be overwritten by subsequent install script
 echo 'backend : Template' > $MPL_DIR/matplotlibrc
 
-section "Flake8.test"
-flake8 --exit-zero --exclude=test_* skimage doc/examples viewer_examples
-section_end "Flake8.test"
+if [[ "${RUN_TESTS}" != "0" ]]; then
+  section "Flake8.test"
+  flake8 --exit-zero --exclude=test_* skimage doc/examples viewer_examples
+  section_end "Flake8.test"
 
-section "Test.with.min.requirements"
-# Show what's installed
-pip list
-tools/build_versions.py
-pytest skimage
-section_end "Test.with.min.requirements"
+  section "Test.with.min.requirements"
+  # Show what's installed
+  pip list
+  tools/build_versions.py
+  pytest skimage
+  section_end "Test.with.min.requirements"
+fi
 
 # Install optional dependencies and pyqt
 section "Install.optional.dependencies"
@@ -33,30 +35,36 @@ pip install --retries 3 -q -r ./requirements/optional.txt $WHEELHOUSE
 tools/travis/install_qt.sh
 section_end "Install.optional.dependencies"
 
-section "Test.with.optional.requirements"
-# Show what's installed
-pip list
-tools/build_versions.py
-pytest --doctest-modules --cov=skimage skimage
-section_end "Test.with.optional.requirements"
+if [[ "${RUN_TESTS}" != "0" ]]; then
+  section "Test.with.optional.requirements"
+  # Show what's installed
+  pip list
+  tools/build_versions.py
+  pytest --doctest-modules --cov=skimage skimage
+  section_end "Test.with.optional.requirements"
+fi
 
-section "Tests.examples"
 # Run example applications
 echo Build or run examples
-pip install --retries 3 -q -r ./requirements/docs.txt
-pip list
-tools/build_versions.py
-
 if [[ "${BUILD_DOCS}" == "1" ]]; then
+  section "build.docs"
+  pip install --retries 3 -q -r ./requirements/docs.txt
+  pip list
+  tools/build_versions.py
   export SPHINXCACHE=${HOME}/.cache/sphinx
   make html
-else
+  section_end "build.docs"
+elif [[ "${RUN_EXAMPLES}" != "0" ]]; then
+  section "Tests.examples"
+  pip install --retries 3 -q -r ./requirements/docs.txt
+  pip list
+  tools/build_versions.py
   # These test are run by sphinx automatically
   echo 'backend : Template' > $MPL_DIR/matplotlibrc
   for f in doc/examples/*/*.py; do
     python "${f}"
   done
+  section_end "Tests.examples"
 fi
-section_end "Tests.examples"
 
 set +ex

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -49,14 +49,9 @@ section_end "Test.with.optional.requirements"
 section "Tests.examples"
 # Run example applications
 echo Build or run examples
-# OSX on Travis can't install sphinx-gallery.
-# I think all it needs is scikit-learn from that requirements doc
-# to run the tests. See Issue #3084
-if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-  pip install --retries 3 -q scikit-learn
-else
-  pip install --retries 3 -q -r ./requirements/docs.txt
-fi
+pip install --retries 3 -q -r ./requirements/docs.txt
+pip list
+tools/build_versions.py
 
 if [[ "${BUILD_DOCS}" == "1" ]]; then
   export SPHINXCACHE=${HOME}/.cache/sphinx

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -4,7 +4,7 @@ set -ex
 export PY=${TRAVIS_PYTHON_VERSION}
 
 # Matplotlib directory location changes depending on OS and verison
-MPL_DIR=`python -c 'import matplotlib; print(matplotlib.get_configdir())'`
+export MPL_DIR=`python -c 'import matplotlib; print(matplotlib.get_configdir())'`
 
 mkdir -p $MPL_DIR
 touch $MPL_DIR/matplotlibrc
@@ -55,12 +55,10 @@ if [[ "${BUILD_DOCS}" == "1" ]]; then
   make html
 else
   # These test are run by sphinx automatically
-  cp $MPL_DIR/matplotlibrc $MPL_DIR/matplotlibrc_backup
   echo 'backend : Template' > $MPL_DIR/matplotlibrc
   for f in doc/examples/*/*.py; do
     python "${f}"
   done
-  mv $MPL_DIR/matplotlibrc_backup $MPL_DIR/matplotlibrc
 fi
 section_end "Tests.examples"
 

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Fail on non-zero exit and echo the commands
-set -ev
+set -ex
 export PY=${TRAVIS_PYTHON_VERSION}
 
 # Matplotlib directory location changes depending on OS and verison
@@ -64,4 +64,4 @@ else
 fi
 section_end "Tests.examples"
 
-set +ev
+set +ex


### PR DESCRIPTION
This is being abbandonned in favour of 4 or 5 smaller PRs

  * https://github.com/scikit-image/scikit-image/pull/3421
  * https://github.com/scikit-image/scikit-image/pull/3422
  * https://github.com/scikit-image/scikit-image/pull/3422
  * https://github.com/scikit-image/scikit-image/pull/3423
  * https://github.com/scikit-image/scikit-image/pull/3431

Sorry for so many commits refractoring the tests. I know these PRs are the hardest to review since there can be silent failures. A previous PR of mine likely caused benefit 4. not to appear sooner.

These became necessary when trying to pull out the matplotlib dependency PR #3129. That PR is almost ready too, but I had to include these 50 line changes which I figured were easier to review as a separate PR.

The tests were refractored to remove much of the logic in how they are run. 
I think this became easier to do when we stopped supporting python 2.7.
I find that too many if and else statements make things harder to read:

### Noticeable benefits
  1. Added a OSX Python 3.6 build (python 3.7 is out now ;) )
  2. OSX also installs and tests Qt
  3. PyAMG is an optional dependency: it isn't treated as a special case anymore
  4. OSX wasn't really testing with optional dependencies. This hid a bug in the version of libpng that was installed in travis. I explicitly upgrade libpng in OSX now

### Test and build steps:
1. Compile
2. Install
3. Setup matplotlib (will be moved below in PR #3129)
3. Test with minimal
4. Install additional dependencies and Qt
5. Test again and report coverage
6. Build docs (This didn't work if I tried to enable it in every branch, it complained that files already existed, maybe because of caching??)

Note, we probably should refractor appveyor to run the same steps.

# Xref
Fixes #3131
Fixes #3084 
## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
