### PR TITLE
BENCH: Add benchmarks for morphology.watershed

### DIFF
--- a/benchmarks/benchmark_morphology.py
+++ b/benchmarks/benchmark_morphology.py
@@ -1,0 +1,38 @@
+"""Benchmarks for `skimage.morphology`."""
+
+
+import numpy as np
+from skimage import data, filters, morphology
+
+
+class Watershed(object):
+
+    param_names = ["seed_count", "connectivity", "compactness"]
+    params = [(5, 500), (1, 2), (0, 0.01)]
+
+    def setup(self, *args):
+        self.image = filters.sobel(data.coins())
+
+    def time_watershed(self, seed_count, connectivity, compactness):
+        morphology.watershed(self.image, seed_count, connectivity,
+                             compactness=compactness)
+
+    def peakmem_reference(self, *args):
+        """Provide reference for memory measurement with empty benchmark.
+
+        Peakmem benchmarks measure the maximum amount of RAM used by a
+        function. However, this maximum also includes the memory used
+        during the setup routine (as of asv 0.2.1; see [1]_).
+        Measuring an empty peakmem function might allow us to disambiguate
+        between the memory used by setup and the memory used by target (see
+        other ``peakmem_`` functions below).
+
+        References
+        ----------
+        .. [1]: http://asv.readthedocs.io/en/stable/writing_benchmarks.html#peak-memory
+        """
+        pass
+
+    def peakmem_watershed(self, seed_count, connectivity, compactness):
+        morphology.watershed(self.image, seed_count, connectivity,
+                             compactness=compactness)


### PR DESCRIPTION
## Description
A prerequisite to #3233 ensuring that performance regressions are noticed. 

Some notes for anyone wondering:
- `data.coins()` should provide a more realistic benchmark than a synthetic image.
- I'm trying to use as much of the input handling provided by `watershed` as possible, therefore the arguments `markers` and `connectivity` are only provided as integers and not prepared ahead of time.
- This benchmark is not comprehensive (only 2d, not all parameters are used) but should cover most use cases.

## For reviewers
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] <strike>Check that new functions are imported in corresponding `__init__.py`.</strike>
- [x] <strike>Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.</strike>
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`

cc @jni, @soupault 