### PR TITLE
Corrected docstring formatting so that code block is displayed as code

### DIFF
--- a/skimage/measure/profile.py
+++ b/skimage/measure/profile.py
@@ -51,6 +51,7 @@ def profile_line(image, src, dst, linewidth=1,
     The destination point is included in the profile, in contrast to
     standard numpy indexing.
     For example:
+
     >>> profile_line(img, (1, 0), (1, 6))  # The final point is out of bounds
     array([ 1.,  1.,  1.,  2.,  2.,  2.,  0.])
     >>> profile_line(img, (1, 0), (1, 5))  # This accesses the full first row


### PR DESCRIPTION
Very minor change :-). I built the doc to verify it does what it should. See http://scikit-image.org/docs/stable/api/skimage.measure.html#profile-line to see the problematic formatting