### PR TITLE
numpy: Handle multidimentional indexing in 1.15

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -36,6 +36,8 @@ Improvements
 API Changes
 -----------
 
+- ``rectangular_grid`` now returns a tuple instead of a list for compatiblity
+  with numpy 1.15
 - ``colorconv.separate_stains`` and ``colorconv.combine_stains`` now uses
   base10 instead of the natural logarithm as discussed in issue #2995.
 - Default value of ``clip_negative`` parameter in ``skimage.util.dtype_limits``

--- a/skimage/data/_binary_blobs.py
+++ b/skimage/data/_binary_blobs.py
@@ -48,7 +48,7 @@ def binary_blobs(length=512, blob_size_fraction=0.1, n_dim=2,
     mask = np.zeros(shape)
     n_pts = max(int(1. / blob_size_fraction) ** n_dim, 1)
     points = (length * rs.rand(n_dim, n_pts)).astype(np.int)
-    mask[[indices for indices in points]] = 1
+    mask[tuple(indices for indices in points)] = 1
     mask = gaussian(mask, sigma=0.25 * length * blob_size_fraction)
     threshold = np.percentile(mask, 100 * (1 - volume_fraction))
     return np.logical_not(mask < threshold)

--- a/skimage/feature/template.py
+++ b/skimage/feature/template.py
@@ -176,4 +176,4 @@ def match_template(image, template, pad_input=False, mode='constant',
             d1 = d0 + image_shape[i] - template.shape[i] + 1
         slices.append(slice(d0, d1))
 
-    return response[slices]
+    return response[tuple(slices)]

--- a/skimage/filters/lpi_filter.py
+++ b/skimage/filters/lpi_filter.py
@@ -20,7 +20,7 @@ def _centre(x, oshape):
 
     """
     start = (np.array(x.shape) - np.array(oshape)) // 2 + 1
-    out = x[[slice(s, s + n) for s, n in zip(start, oshape)]]
+    out = x[tuple(slice(s, s + n) for s, n in zip(start, oshape))]
     return out
 
 
@@ -35,7 +35,7 @@ def _pad(data, shape):
 
     """
     out = np.zeros(shape)
-    out[[slice(0, n) for n in data.shape]] = data
+    out[tuple(slice(0, n) for n in data.shape)] = data
     return out
 
 

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -235,10 +235,10 @@ def _set_edge_values_inplace(image, value):
         sl = [slice(None)] * image.ndim
         # Set edge in front
         sl[axis] = 0
-        image[sl] = value
+        image[tuple(sl)] = value
         # Set edge to the end
         sl[axis] = -1
-        image[sl] = value
+        image[tuple(sl)] = value
 
 
 def _fast_pad(image, value):

--- a/skimage/morphology/greyreconstruct.py
+++ b/skimage/morphology/greyreconstruct.py
@@ -140,14 +140,14 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
             raise ValueError("Footprint dimensions must all be odd")
         offset = np.array([d // 2 for d in selem.shape])
     # Cross out the center of the selem
-    selem[[slice(d, d + 1) for d in offset]] = False
+    selem[tuple(slice(d, d + 1) for d in offset)] = False
 
     # Make padding for edges of reconstructed image so we can ignore boundaries
     padding = (np.array(selem.shape) / 2).astype(int)
     dims = np.zeros(seed.ndim + 1, dtype=int)
     dims[1:] = np.array(seed.shape) + 2 * padding
     dims[0] = 2
-    inside_slices = [slice(p, -p) for p in padding]
+    inside_slices = tuple(slice(p, -p) for p in padding)
     # Set padded region to minimum image intensity and mask along first axis so
     # we can interleave image and mask pixels when sorting.
     if method == 'dilation':
@@ -158,8 +158,8 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
         raise ValueError("Reconstruction method can be one of 'erosion' "
                          "or 'dilation'. Got '%s'." % method)
     images = np.ones(dims) * pad_value
-    images[[0] + inside_slices] = seed
-    images[[1] + inside_slices] = mask
+    images[(0, *inside_slices)] = seed
+    images[(1, *inside_slices)] = mask
 
     # Create a list of strides across the array to get the neighbors within
     # a flattened array

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -205,7 +205,7 @@ def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, n_iter_max=200):
                 slices_d[ax] = slice(1, None)
                 slices_p[ax+1] = slice(0, -1)
                 slices_p[0] = ax
-                d[slices_d] += p[slices_p]
+                d[tuple(slices_d)] += p[tuple(slices_p)]
                 slices_d[ax] = slice(None)
                 slices_p[ax+1] = slice(None)
             out = image + d
@@ -219,7 +219,7 @@ def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, n_iter_max=200):
         for ax in range(ndim):
             slices_g[ax+1] = slice(0, -1)
             slices_g[0] = ax
-            g[slices_g] = np.diff(out, axis=ax)
+            g[tuple(slices_g)] = np.diff(out, axis=ax)
             slices_g[ax+1] = slice(None)
 
         norm = np.sqrt((g ** 2).sum(axis=0))[np.newaxis, ...]
@@ -431,7 +431,7 @@ def _wavelet_threshold(image, wavelet, method=None, threshold=None,
 
     # original_extent is used to workaround PyWavelets issue #80
     # odd-sized input results in an image with 1 extra sample after waverecn
-    original_extent = [slice(s) for s in image.shape]
+    original_extent = tuple(slice(s) for s in image.shape)
 
     # Determine the number of wavelet decomposition levels
     if wavelet_levels is None:

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -408,7 +408,7 @@ def test_wavelet_denoising_nd():
                 img = 0.2*np.ones((128, )*ndim)
             else:
                 img = 0.2*np.ones((16, )*ndim)
-            img[[slice(5, 13), ] * ndim] = 0.8
+            img[(slice(5, 13), ) * ndim] = 0.8
 
             sigma = 0.1
             noisy = img + sigma * rstate.randn(*(img.shape))
@@ -433,7 +433,7 @@ def test_wavelet_denoising_levels():
     wavelet = 'db1'
     # Generate a very simple test image
     img = 0.2*np.ones((N, )*ndim)
-    img[[slice(5, 13), ] * ndim] = 0.8
+    img[(slice(5, 13), ) * ndim] = 0.8
 
     sigma = 0.1
     noisy = img + sigma * rstate.randn(*(img.shape))
@@ -481,7 +481,7 @@ def test_estimate_sigma_masked_image():
     rstate = np.random.RandomState(1234)
     # uniform image
     img = np.zeros((128, 128))
-    center_roi = [slice(32, 96), slice(32, 96)]
+    center_roi = (slice(32, 96), slice(32, 96))
     img[center_roi] = 0.8
     sigma = 0.1
 

--- a/skimage/restoration/uft.py
+++ b/skimage/restoration/uft.py
@@ -440,5 +440,5 @@ def laplacian(ndim, shape, is_real=True):
                               0.0,
                               -1.0]).reshape([-1 if i == dim else 1
                                               for i in range(ndim)])
-    impr[([slice(1, 2)] * ndim)] = 2.0 * ndim
+    impr[(slice(1, 2), ) * ndim] = 2.0 * ndim
     return ir2tf(impr, shape, is_real=is_real), impr

--- a/skimage/segmentation/_clear_border.py
+++ b/skimage/segmentation/_clear_border.py
@@ -55,9 +55,9 @@ def clear_border(labels, buffer_size=0, bgval=0, in_place=False):
     for d in range(image.ndim):
         slicedim = list(slices)
         slicedim[d] = slstart
-        borders[slicedim] = True
+        borders[tuple(slicedim)] = True
         slicedim[d] = slend
-        borders[slicedim] = True
+        borders[tuple(slicedim)] = True
 
     # Re-label, in case we are dealing with a binary image
     # and to get consistent labeling

--- a/skimage/segmentation/boundaries.py
+++ b/skimage/segmentation/boundaries.py
@@ -26,7 +26,7 @@ def _find_boundaries_subpixel(label_img):
 
     label_img_expanded = np.zeros([(2 * s - 1) for s in label_img.shape],
                                   label_img.dtype)
-    pixels = [slice(None, None, 2)] * ndim
+    pixels = (slice(None, None, 2), ) * ndim
     label_img_expanded[pixels] = label_img
 
     edges = np.ones(label_img_expanded.shape, dtype=bool)

--- a/skimage/util/_regular_grid.py
+++ b/skimage/util/_regular_grid.py
@@ -20,7 +20,7 @@ def regular_grid(ar_shape, n_points):
 
     Returns
     -------
-    slices : list of slice objects
+    slices : tuple of slice objects
         A slice along each dimension of `ar_shape`, such that the intersection
         of all the slices give the coordinates of regularly spaced points.
 
@@ -29,21 +29,21 @@ def regular_grid(ar_shape, n_points):
     >>> ar = np.zeros((20, 40))
     >>> g = regular_grid(ar.shape, 8)
     >>> g
-    [slice(5, None, 10), slice(5, None, 10)]
+    (slice(5, None, 10), slice(5, None, 10))
     >>> ar[g] = 1
     >>> ar.sum()
     8.0
     >>> ar = np.zeros((20, 40))
     >>> g = regular_grid(ar.shape, 32)
     >>> g
-    [slice(2, None, 5), slice(2, None, 5)]
+    (slice(2, None, 5), slice(2, None, 5))
     >>> ar[g] = 1
     >>> ar.sum()
     32.0
     >>> ar = np.zeros((3, 20, 40))
     >>> g = regular_grid(ar.shape, 8)
     >>> g
-    [slice(1, None, 3), slice(5, None, 10), slice(5, None, 10)]
+    (slice(1, None, 3), slice(5, None, 10), slice(5, None, 10))
     >>> ar[g] = 1
     >>> ar.sum()
     8.0
@@ -54,7 +54,7 @@ def regular_grid(ar_shape, n_points):
     sorted_dims = np.sort(ar_shape)
     space_size = float(np.prod(ar_shape))
     if space_size <= n_points:
-        return [slice(None)] * ndim
+        return (slice(None), ) * ndim
     stepsizes = (space_size / n_points) ** (1.0 / ndim) * np.ones(ndim)
     if (sorted_dims < stepsizes).any():
         for dim in range(ndim):
@@ -68,7 +68,7 @@ def regular_grid(ar_shape, n_points):
     stepsizes = np.round(stepsizes).astype(int)
     slices = [slice(start, None, step) for
               start, step in zip(starts, stepsizes)]
-    slices = [slices[i] for i in unsort_dim_idxs]
+    slices = tuple(slices[i] for i in unsort_dim_idxs)
     return slices
 
 

--- a/skimage/util/_regular_grid.py
+++ b/skimage/util/_regular_grid.py
@@ -24,6 +24,16 @@ def regular_grid(ar_shape, n_points):
         A slice along each dimension of `ar_shape`, such that the intersection
         of all the slices give the coordinates of regularly spaced points.
 
+        .. versionchanged:: 0.14.1
+            In scikit-image 0.14.1 and 0.15, the return type was changed from a
+            list to a tuple to ensure `compatibility with Numpy 1.15`_ and
+            higher. If your code requires the returned result to be a list, you
+            may convert the output of this function to a list with:
+
+            >>> result = list(regular_grid(ar_shape=(3, 20, 40), n_points=8))
+
+            .. _compatibility with NumPy 1.15: https://github.com/numpy/numpy/blob/master/doc/release/1.15.0-notes.rst#deprecations
+
     Examples
     --------
     >>> ar = np.zeros((20, 40))
@@ -47,18 +57,6 @@ def regular_grid(ar_shape, n_points):
     >>> ar[g] = 1
     >>> ar.sum()
     8.0
-
-    Note
-    ----
-    In scikit-image 0.15 the return type was changed from a list to a tuple to
-    ensure compatibility with Numpy 1.15:
-    https://github.com/numpy/numpy/blob/master/doc/release/1.15.0-notes.rst#deprecations
-
-    If your code requires the returned result to be a list, you may convert the
-    output of this function to a list with:
-
-    >>> result = list(regular_grid(ar_shape=(3, 20, 40), n_points=8))
-
     """
     ar_shape = np.asanyarray(ar_shape)
     ndim = len(ar_shape)

--- a/skimage/util/_regular_grid.py
+++ b/skimage/util/_regular_grid.py
@@ -47,6 +47,18 @@ def regular_grid(ar_shape, n_points):
     >>> ar[g] = 1
     >>> ar.sum()
     8.0
+
+    Note
+    ----
+    In scikit-image 0.15 the return type was changed from a list to a tuple to
+    ensure compatibility with Numpy 1.15:
+    https://github.com/numpy/numpy/blob/master/doc/release/1.15.0-notes.rst#deprecations
+
+    If your code requires the returned result to be a list, you may convert the
+    output of this function to a list with:
+
+    >>> result = list(regular_grid(ar_shape=(3, 20, 40), n_points=8))
+
     """
     ar_shape = np.asanyarray(ar_shape)
     ndim = len(ar_shape)

--- a/skimage/util/arraycrop.py
+++ b/skimage/util/arraycrop.py
@@ -169,7 +169,8 @@ def crop(ar, crop_width, copy=False, order='K'):
     """
     ar = np.array(ar, copy=False)
     crops = _validate_lengths(ar, crop_width)
-    slices = [slice(a, ar.shape[i] - b) for i, (a, b) in enumerate(crops)]
+    slices = tuple(slice(a, ar.shape[i] - b)
+                   for i, (a, b) in enumerate(crops))
     if copy:
         cropped = np.array(ar[slices], order=order, copy=True)
     else:

--- a/skimage/util/shape.py
+++ b/skimage/util/shape.py
@@ -248,7 +248,7 @@ def view_as_windows(arr_in, window_shape, step=1):
 
     arr_in = np.ascontiguousarray(arr_in)
 
-    slices = [slice(None, None, st) for st in step]
+    slices = tuple(slice(None, None, st) for st in step)
     window_strides = np.array(arr_in.strides)
 
     indexing_strides = arr_in[slices].strides


### PR DESCRIPTION
  * Handles all numpy deprecations.
  * ~~Goes in an catches the warnings from dependencies that don't follow numpy 1.15~~ PR #3242.
  * ~~Locks the expected warnings to a specific version.~~ #3242
  * ~~A few other small fixes where `expected_warnings` was passed as string as opposed to a list.~~ #3242
  * Issue #3235 is handled as a single commit so that it can be rebased if we don't like it.


Future me notes: use
```bash
git checkout master
git pull upstream master
git rebase -i master
```
to pull it out and edit it to whatever the final solution is chosen to be.


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
