### PR TITLE
Defer skimage.io import of matplotlib.pyplot until needed

### DIFF
--- a/skimage/io/_plugins/matplotlib_plugin.py
+++ b/skimage/io/_plugins/matplotlib_plugin.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 import numpy as np
-import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
+import matplotlib.image
 from ...util import dtype as dtypes
 from ...exposure import is_low_contrast
 from ...util.colormap import viridis
@@ -146,6 +146,7 @@ def imshow(image, ax=None, show_cbar=None, **kwargs):
     ax_im : `matplotlib.pyplot.AxesImage`
         The `AxesImage` object returned by `plt.imshow`.
     """
+    import matplotlib.pyplot as plt
     if kwargs.get('cmap', None) == 'viridis':
         kwargs['cmap'] = viridis
     lo, hi, cmap = _get_display_range(image)
@@ -174,6 +175,8 @@ def imshow_collection(ic, *args, **kwargs):
     fig : `matplotlib.figure.Figure`
         The `Figure` object returned by `plt.subplots`.
     """
+    import matplotlib.pyplot as plt
+
     if len(ic) < 1:
         raise ValueError('Number of images to plot must be greater than 0')
 
@@ -199,9 +202,9 @@ def imshow_collection(ic, *args, **kwargs):
     return fig
 
 
-imread = plt.imread
-show = plt.show
+imread = matplotlib.image.imread
 
 
 def _app_show():
+    from matplotlib.pyplot import show
     show()


### PR DESCRIPTION
I'm getting this warning:
```
$ python -c 'import skimage.io; import matplotlib; matplotlib.use("agg")'
-c:1: UserWarning: 
This call to matplotlib.use() has no effect because the backend has already
been chosen; matplotlib.use() must be called *before* pylab, matplotlib.pyplot,
or matplotlib.backends is imported for the first time.

The backend was *originally* set to 'MacOSX' by the following code:
  File "<string>", line 1, in <module>
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/skimage/io/__init__.py", line 15, in <module>
    reset_plugins()
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/skimage/io/manage_plugins.py", line 95, in reset_plugins
    _load_preferred_plugins()
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/skimage/io/manage_plugins.py", line 75, in _load_preferred_plugins
    _set_plugin(p_type, preferred_plugins['all'])
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/skimage/io/manage_plugins.py", line 87, in _set_plugin
    use_plugin(plugin, kind=plugin_type)
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/skimage/io/manage_plugins.py", line 258, in use_plugin
    _load(name)
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/skimage/io/manage_plugins.py", line 302, in _load
    fromlist=[modname])
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/skimage/io/_plugins/matplotlib_plugin.py", line 4, in <module>
    import matplotlib.pyplot as plt
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/matplotlib/pyplot.py", line 71, in <module>
    from matplotlib.backends import pylab_setup
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/matplotlib/backends/__init__.py", line 16, in <module>
    line for line in traceback.format_stack()
```

Should `import skimage.io` trigger `import matplotlib.pyplot`?
I think that import shouldn't be necessary to do I/O, and it would be better to avoid it, no?

This is with Python 3.6,  scikit-image v0.14.0, matplotlib 2.2.2 and conda on Mac.