### PR TITLE
WIP: tidy up register_translation a tiny bit

### DIFF
--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -184,7 +184,7 @@ def register_translation(src_image, target_image, upsample_factor=1,
     # Locate maximum
     maxima = np.unravel_index(np.argmax(np.abs(cross_correlation)),
                               cross_correlation.shape)
-    midpoints = np.array([np.fix(axis_size / 2) for axis_size in shape])
+    midpoints = np.asarray(shape, dtype=np.floating) // 2
 
     shifts = np.array(maxima, dtype=np.float64)
     shifts[shifts > midpoints] -= np.array(shape)[shifts > midpoints]
@@ -196,7 +196,6 @@ def register_translation(src_image, target_image, upsample_factor=1,
     # If upsampling > 1, then refine estimate with matrix multiply DFT
     else:
         # Initial shift estimate in upsampled grid
-        shifts = np.round(shifts * upsample_factor) / upsample_factor
         upsampled_region_size = np.ceil(upsample_factor * 1.5)
         # Center of output array at dftshift + 1
         dftshift = np.fix(upsampled_region_size / 2.0)


### PR DESCRIPTION
I've been trying to accelerate register_translation for a personal project using `cupy`. Cupy complained a little bit about a few things that were being done.

These changes are mostly benign and make the code look good for sure and while addressing some of the issues I ran into.

There were a few other problems in certain spots, but those changes would actually make the code look worse.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
