### PR TITLE
Remove cython md5 hashing since it breaks the build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ before_install:
         virtualenv -p python ~/venv;
         source ~/venv/bin/activate;
       fi
-    - ccache -s
+    - ccache --zero-stats
     - export PATH=/usr/lib/ccache:${PATH}
     - source tools/travis/before_install.sh
     - which python; python --version
@@ -86,6 +86,7 @@ before_install:
 
 install:
     - python setup.py develop
+    - ccache --show-stats
     # Install testing requirements
     - pip install --retries 3 -q $PIP_FLAGS -r requirements/test.txt
     # Matplotlib settings - do not show figures during doc examples

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,7 @@ include requirements/README.md
 include Makefile
 include pyproject.toml
 include skimage/scripts/skivi
-recursive-include skimage *.pyx *.pxd *.pxi *.py *.c *.h *.ini *.md5 *.npy *.txt *.in *.cpp *.md
+recursive-include skimage *.pyx *.pxd *.pxi *.py *.c *.h *.ini *.npy *.txt *.in *.cpp *.md
 recursive-include skimage/data *
 
 include doc/Makefile

--- a/skimage/_build.py
+++ b/skimage/_build.py
@@ -1,6 +1,5 @@
 import sys
 import os
-import hashlib
 from distutils.version import LooseVersion
 
 CYTHON_VERSION = '0.23.4'
@@ -46,46 +45,11 @@ def cython(pyx_files, working_path=''):
     else:
         for pyxfile in [os.path.join(working_path, f) for f in pyx_files]:
 
-            # if the .pyx file stayed the same, we don't need to recompile
-            if not _changed(pyxfile):
-                continue
-
             if pyxfile.endswith('.pyx.in'):
                 process_tempita_pyx(pyxfile)
                 pyxfile = pyxfile.replace('.pyx.in', '.pyx')
 
             cythonize(pyxfile)
-
-
-def _md5sum(f):
-    m = hashlib.new('md5')
-    while True:
-        # Hash one 8096 byte block at a time
-        d = f.read(8096)
-        if not d:
-            break
-        m.update(d)
-    return m.hexdigest()
-
-
-def _changed(filename):
-    """Compare the hash of a Cython file to the cached hash value on disk.
-
-    """
-    filename_cache = filename + '.md5'
-
-    try:
-        md5_cached = open(filename_cache, 'rb').read()
-    except IOError:
-        md5_cached = '0'
-
-    with open(filename, 'rb') as f:
-        md5_new = _md5sum(f)
-
-        with open(filename_cache, 'wb') as cf:
-            cf.write(md5_new.encode('utf-8'))
-
-    return md5_cached != md5_new.encode('utf-8')
 
 
 def process_tempita_pyx(fromfile):

--- a/skimage/_build.py
+++ b/skimage/_build.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from distutils.version import LooseVersion
+from multiprocessing import cpu_count
 
 CYTHON_VERSION = '0.23.4'
 
@@ -43,13 +44,15 @@ def cython(pyx_files, working_path=''):
         print("Cython >= %s not found; falling back to pre-built %s" \
               % (CYTHON_VERSION, " ".join(c_files)))
     else:
-        for pyxfile in [os.path.join(working_path, f) for f in pyx_files]:
-
+        pyx_files = [os.path.join(working_path, f) for f in pyx_files]
+        for i, pyxfile in enumerate(pyx_files):
             if pyxfile.endswith('.pyx.in'):
                 process_tempita_pyx(pyxfile)
-                pyxfile = pyxfile.replace('.pyx.in', '.pyx')
+                pyx_files[i] = pyxfile.replace('.pyx.in', '.pyx')
 
-            cythonize(pyxfile)
+        # Cython doesn't automatically choose a number of threads > 1
+        # https://github.com/cython/cython/blob/a0bbb940c847dfe92cac446c8784c34c28c92836/Cython/Build/Dependencies.py#L923-L925
+        cythonize(pyx_files, nthreads=cpu_count())
 
 
 def process_tempita_pyx(fromfile):

--- a/skimage/_shared/setup.py
+++ b/skimage/_shared/setup.py
@@ -13,9 +13,9 @@ def configuration(parent_package='', top_path=None):
     config = Configuration('_shared', parent_package, top_path)
     config.add_data_dir('tests')
 
-    cython(['geometry.pyx'], working_path=base_path)
-    cython(['transform.pyx'], working_path=base_path)
-    cython(['interpolation.pyx'], working_path=base_path)
+    cython(['geometry.pyx',
+            'transform.pyx',
+            'interpolation.pyx'], working_path=base_path)
 
     config.add_extension('geometry', sources=['geometry.c'])
     config.add_extension('transform', sources=['transform.c'],

--- a/skimage/feature/setup.py
+++ b/skimage/feature/setup.py
@@ -12,15 +12,17 @@ def configuration(parent_package='', top_path=None):
     config = Configuration('feature', parent_package, top_path)
     config.add_data_dir('tests')
 
-    cython(['_cascade.pyx'], working_path=base_path)
-    cython(['corner_cy.pyx'], working_path=base_path)
-    cython(['censure_cy.pyx'], working_path=base_path)
-    cython(['orb_cy.pyx'], working_path=base_path)
-    cython(['brief_cy.pyx'], working_path=base_path)
-    cython(['_texture.pyx'], working_path=base_path)
-    cython(['_hessian_det_appx.pyx'], working_path=base_path)
-    cython(['_hoghistogram.pyx'], working_path=base_path)
-    cython(['_haar.pyx'], working_path=base_path)
+    cython(['corner_cy.pyx',
+            'censure_cy.pyx',
+            'orb_cy.pyx',
+            'brief_cy.pyx',
+            '_texture.pyx',
+            '_hessian_det_appx.pyx',
+            '_hoghistogram.pyx',
+            ], working_path=base_path)
+    # _haar uses c++, so it must be cythonized seperately
+    cython(['_cascade.pyx',
+            '_haar.pyx'], working_path=base_path)
 
     config.add_extension('_cascade', sources=['_cascade.cpp'],
                          include_dirs=[get_numpy_include_dirs()],

--- a/skimage/filters/setup.py
+++ b/skimage/filters/setup.py
@@ -13,11 +13,11 @@ def configuration(parent_package='', top_path=None):
     config.add_data_dir('tests')
     config.add_data_dir('rank/tests')
 
-    cython(['_ctmf.pyx'], working_path=base_path)
-    cython(['rank/core_cy.pyx'], working_path=base_path)
-    cython(['rank/generic_cy.pyx'], working_path=base_path)
-    cython(['rank/percentile_cy.pyx'], working_path=base_path)
-    cython(['rank/bilateral_cy.pyx'], working_path=base_path)
+    cython(['_ctmf.pyx',
+            'rank/core_cy.pyx',
+            'rank/generic_cy.pyx',
+            'rank/percentile_cy.pyx',
+            'rank/bilateral_cy.pyx'], working_path=base_path)
 
     config.add_extension('_ctmf', sources=['_ctmf.c'],
                          include_dirs=[get_numpy_include_dirs()])

--- a/skimage/graph/setup.py
+++ b/skimage/graph/setup.py
@@ -14,9 +14,9 @@ def configuration(parent_package='', top_path=None):
 
     # This function tries to create C files from the given .pyx files.  If
     # it fails, try to build with pre-generated .c files.
-    cython(['_spath.pyx'], working_path=base_path)
-    cython(['_mcp.pyx'], working_path=base_path)
-    cython(['heap.pyx'], working_path=base_path)
+    cython(['_spath.pyx',
+            '_mcp.pyx',
+            'heap.pyx'], working_path=base_path)
 
     config.add_extension('_spath', sources=['_spath.c'],
                          include_dirs=[get_numpy_include_dirs()])

--- a/skimage/measure/setup.py
+++ b/skimage/measure/setup.py
@@ -12,12 +12,12 @@ def configuration(parent_package='', top_path=None):
     config = Configuration('measure', parent_package, top_path)
     config.add_data_dir('tests')
 
-    cython(['_ccomp.pyx'], working_path=base_path)
-    cython(['_find_contours_cy.pyx'], working_path=base_path)
-    cython(['_moments_cy.pyx'], working_path=base_path)
-    cython(['_marching_cubes_classic_cy.pyx'], working_path=base_path)
-    cython(['_marching_cubes_lewiner_cy.pyx'], working_path=base_path)
-    cython(['_pnpoly.pyx'], working_path=base_path)
+    cython(['_ccomp.pyx',
+            '_find_contours_cy.pyx',
+            '_moments_cy.pyx',
+            '_marching_cubes_classic_cy.pyx',
+            '_marching_cubes_lewiner_cy.pyx',
+            '_pnpoly.pyx'], working_path=base_path)
 
     config.add_extension('_ccomp', sources=['_ccomp.c'],
                          include_dirs=[get_numpy_include_dirs()])

--- a/skimage/morphology/setup.py
+++ b/skimage/morphology/setup.py
@@ -12,12 +12,12 @@ def configuration(parent_package='', top_path=None):
     config = Configuration('morphology', parent_package, top_path)
     config.add_data_dir('tests')
 
-    cython(['_watershed.pyx'], working_path=base_path)
-    cython(['_skeletonize_cy.pyx'], working_path=base_path)
-    cython(['_convex_hull.pyx'], working_path=base_path)
-    cython(['_greyreconstruct.pyx'], working_path=base_path)
-    cython(['_skeletonize_3d_cy.pyx.in'], working_path=base_path)
-    cython(['_extrema_cy.pyx'], working_path=base_path)
+    cython(['_watershed.pyx',
+            '_skeletonize_cy.pyx',
+            '_convex_hull.pyx',
+            '_greyreconstruct.pyx',
+            '_skeletonize_3d_cy.pyx.in',
+            '_extrema_cy.pyx'], working_path=base_path)
 
     config.add_extension('_watershed', sources=['_watershed.c'],
                          include_dirs=[get_numpy_include_dirs()])

--- a/skimage/restoration/setup.py
+++ b/skimage/restoration/setup.py
@@ -13,11 +13,11 @@ def configuration(parent_package='', top_path=None):
     config = Configuration('restoration', parent_package, top_path)
     config.add_data_dir('tests')
 
-    cython(['_unwrap_1d.pyx'], working_path=base_path)
-    cython(['_unwrap_2d.pyx'], working_path=base_path)
-    cython(['_unwrap_3d.pyx'], working_path=base_path)
-    cython(['_denoise_cy.pyx'], working_path=base_path)
-    cython(['_nl_means_denoising.pyx'], working_path=base_path)
+    cython(['_unwrap_1d.pyx',
+            '_unwrap_2d.pyx',
+            '_unwrap_3d.pyx',
+            '_denoise_cy.pyx',
+            '_nl_means_denoising.pyx'], working_path=base_path)
 
     config.add_extension('_unwrap_1d', sources=['_unwrap_1d.c'],
                          include_dirs=[get_numpy_include_dirs()])

--- a/skimage/segmentation/setup.py
+++ b/skimage/segmentation/setup.py
@@ -11,13 +11,13 @@ def configuration(parent_package='', top_path=None):
 
     config = Configuration('segmentation', parent_package, top_path)
 
-    cython(['_felzenszwalb_cy.pyx'], working_path=base_path)
+    cython(['_felzenszwalb_cy.pyx',
+            '_quickshift_cy.pyx',
+            '_slic.pyx'], working_path=base_path)
     config.add_extension('_felzenszwalb_cy', sources=['_felzenszwalb_cy.c'],
                          include_dirs=[get_numpy_include_dirs()])
-    cython(['_quickshift_cy.pyx'], working_path=base_path)
     config.add_extension('_quickshift_cy', sources=['_quickshift_cy.c'],
                          include_dirs=[get_numpy_include_dirs()])
-    cython(['_slic.pyx'], working_path=base_path)
     config.add_extension('_slic', sources=['_slic.c'],
                          include_dirs=[get_numpy_include_dirs()])
 

--- a/skimage/transform/setup.py
+++ b/skimage/transform/setup.py
@@ -13,10 +13,10 @@ def configuration(parent_package='', top_path=None):
     config = Configuration('transform', parent_package, top_path)
     config.add_data_dir('tests')
 
-    cython(['_hough_transform.pyx'], working_path=base_path)
-    cython(['_warps_cy.pyx'], working_path=base_path)
-    cython(['_radon_transform.pyx'], working_path=base_path)
-    cython(['_seam_carving.pyx'], working_path=base_path)
+    cython(['_hough_transform.pyx',
+            '_warps_cy.pyx',
+            '_radon_transform.pyx',
+            '_seam_carving.pyx'], working_path=base_path)
 
     config.add_extension('_hough_transform', sources=['_hough_transform.c'],
                          include_dirs=[get_numpy_include_dirs()])


### PR DESCRIPTION
In developing  #3253, I had to keep issuing commands:

```
rm */*/*.md5 */*/*.c 
git checkout -- skimage/restoration/unwrap_2d_ljmu.c skimage/restoration/unwrap_3d_ljmu.c
```
this is because the hashing doesn't consider `pxd` files.
This leads to the cython compiler doing really weird things and crashing.

Finally, cython will check itself if the files have changed, so this isn't necessary.

As a bonus, if you clump together c and c++ files seperately, cython will cythonize them in parallel using our infrastructure. This speeds things up greatly on multicore machines.

~~You have to hard code the number of threads to use, or maybe somebody knows the `nproc` command in python, but 8 is a safe number for now :/~~  Thanks @emmanuelle 

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
