### PR TITLE
Add benchmarks for morphology.local_maxima

### DIFF
--- a/benchmarks/benchmark_morphology.py
+++ b/benchmarks/benchmark_morphology.py
@@ -239,7 +239,7 @@ class LocalMaxima(object):
     def peakmem_reference(self, *args):
         """Provide reference for memory measurement with empty benchmark.
 
-        .. [1]: https://asv.readthedocs.io/en/stable/writing_benchmarks.html#peak-memory
+        .. [1] https://asv.readthedocs.io/en/stable/writing_benchmarks.html#peak-memory
         """
         pass
 

--- a/benchmarks/benchmark_morphology.py
+++ b/benchmarks/benchmark_morphology.py
@@ -220,3 +220,31 @@ class GrayReconstruction(object):
     def peakmem_reconstruction(self, shape, dtype):
         morphology.reconstruction(self.seed, self.mask)
 
+
+class LocalMaxima(object):
+
+    param_names = ["connectivity", "allow_borders"]
+    params = [(1, 2), (False, True)]
+
+    def setup(self, *args):
+        # Natural image with small extrema
+        self.image = data.moon()
+
+    def time_2d(self, connectivity, allow_borders):
+        morphology.local_maxima(
+            self.image, connectivity=connectivity,
+            allow_borders=allow_borders
+        )
+
+    def peakmem_reference(self, *args):
+        """Provide reference for memory measurement with empty benchmark.
+
+        .. [1]: https://asv.readthedocs.io/en/stable/writing_benchmarks.html#peak-memory
+        """
+        pass
+
+    def peakmem_2d(self,connectivity, allow_borders):
+        morphology.local_maxima(
+            self.image, connectivity=connectivity,
+            allow_borders=allow_borders
+        )


### PR DESCRIPTION
Basically two cases are benchmarked: A natural 2d image with many small extrema and a synthetic 3D "image" with few large extrema. The memory behavior of the latter is especially interesting because it requires the internal queue to grow quite a bit.

## Checklist
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] <strike>Check that new functions are imported in corresponding `__init__.py`.</strike>
- [x] <strike>Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.</strike>
- [X] <strike>Consider backporting the PR with `@meeseeksdev backport to v0.14.x`</strike>
