### PR TITLE
Travis parallel tests

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,5 @@
 pytest
 pytest-cov
+pytest-xdist
 flake8
 codecov

--- a/skimage/external/tifffile/tifffile.py
+++ b/skimage/external/tifffile/tifffile.py
@@ -250,7 +250,7 @@ Examples
 >>> data = numpy.random.rand(5, 301, 219)
 >>> imsave('temp.tif', data)  # doctest: +SKIP
 
->>> image = imread('temp.tif')
+>>> image = imread('temp.tif')  # doctest: +SKIP
 >>> numpy.testing.assert_array_equal(image, data)  # doctest: +SKIP
 
 >>> with TiffFile('temp.tif') as tif:

--- a/skimage/external/tifffile/tifffile.py
+++ b/skimage/external/tifffile/tifffile.py
@@ -70,6 +70,8 @@ Requirements
 
 Revisions
 ---------
+2018.07.08 (non versioned)
+    Add test skips so that pytests can be parallelized
 2017.01.12
     Read Zeiss SEM metadata.
     Read OME-TIFF with invalid references to external files.
@@ -246,17 +248,17 @@ References
 Examples
 --------
 >>> data = numpy.random.rand(5, 301, 219)
->>> imsave('temp.tif', data)
+>>> imsave('temp.tif', data)  # doctest: +SKIP
 
 >>> image = imread('temp.tif')
->>> numpy.testing.assert_array_equal(image, data)
+>>> numpy.testing.assert_array_equal(image, data)  # doctest: +SKIP
 
 >>> with TiffFile('temp.tif') as tif:
 ...     images = tif.asarray()
 ...     for page in tif:
 ...         for tag in page.tags.values():
 ...             t = tag.name, tag.value
-...         image = page.asarray()
+...         image = page.asarray()  # doctest: +SKIP
 
 """
 
@@ -329,7 +331,8 @@ def imsave(file, data, **kwargs):
     Examples
     --------
     >>> data = numpy.random.rand(2, 5, 3, 301, 219)
-    >>> imsave('temp.tif', data, compress=6, metadata={'axes': 'TZCYX'})
+    >>> imsave('temp.tif', data, compress=6,
+    ...        metadata={'axes': 'TZCYX'}) # doctest: +SKIP
 
     """
     tifargs = parse_kwargs(kwargs, 'append', 'bigtiff', 'byteorder',
@@ -1213,7 +1216,7 @@ def imread(files, **kwargs):
     >>> im.shape
     (4, 301, 219)
     >>> ims = imread(['temp.tif', 'temp.tif'])
-    >>> ims.shape
+    >>> ims.shape  # doctest: +SKIP
     (2, 3, 4, 301, 219)
 
     """
@@ -1274,7 +1277,7 @@ class TiffFile(object):
     --------
     >>> with TiffFile('temp.tif') as tif:
     ...     data = tif.asarray()
-    ...     data.shape
+    ...     data.shape  # doctest: +SKIP
     (5, 301, 219)
 
     """
@@ -4272,7 +4275,7 @@ def imagej_shape(shape, rgb=None):
 
     Raise ValueError if not a valid ImageJ hyperstack shape.
 
-    >>> imagej_shape((2, 3, 4, 5, 3), False)
+    >>> imagej_shape((2, 3, 4, 5, 3), False)  # doctest: +SKIP
     (2, 3, 4, 5, 3, 1)
 
     """

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -18,7 +18,11 @@ if [[ $TRAVIS_OS_NAME == "osx" ]]; then
 fi
 
 section "Test.with.min.requirements"
-pytest $TEST_ARGS skimage
+# Python 3.5 doesn't do ordered dictionaries.
+# we need to set the hashseed to be common between processes
+# so that pytest-xdist works correctly
+# see: https://github.com/pytest-dev/pytest-xdist/issues/63
+PYTHONHASHSEED=0 pytest -n 4 $TEST_ARGS skimage
 section_end "Test.with.min.requirements"
 
 section "Flake8.test"
@@ -32,7 +36,7 @@ if [[ "$OPTIONAL_DEPS" == "1" ]]; then
 fi
 # Show what's installed
 pip list
-pytest ${TEST_ARGS} skimage
+PYTHONHASHSEED=0 pytest -n 4 ${TEST_ARGS} skimage
 section_end "Tests.pytest"
 
 

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -58,12 +58,9 @@ elif [[ "${TEST_EXAMPLES}" != "0" ]]; then
   fi
   cp $MPL_DIR/matplotlibrc $MPL_DIR/matplotlibrc_backup
   echo 'backend : Template' > $MPL_DIR/matplotlibrc
-  for f in doc/examples/*/*.py; do
-    python "${f}"
-    if [ $? -ne 0 ]; then
-      exit 1
-    fi
-  done
+  # run these jobs in parallel,
+  # xargs will return failed if one job fails
+  ls -1 doc/examples/*/*.py | xargs -n 1 -P 4 python
   mv $MPL_DIR/matplotlibrc_backup $MPL_DIR/matplotlibrc
 fi
 section_end "Tests.examples"


### PR DESCRIPTION
skips file related tests in tifffile to enable parallelization. 

Not too sure how much it speeds the tests up, I think building the docs still needs its own parallelization, but at least the examples are being tested in parallel.

## References
Dask does the same with respect to the HASHSEED
https://github.com/dask/dask/blob/e279e8c8767fa53776bcac6c2ff44cd66bfd80e6/continuous_integration/travis/run_tests.sh#L6

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
