### PR TITLE
benchmark: add some warping benchmarks to create a baseline

### DIFF
--- a/benchmarks/transform_warp.py
+++ b/benchmarks/transform_warp.py
@@ -1,0 +1,34 @@
+import numpy as np
+from skimage.transform import SimilarityTransform, warp
+from skimage.util.dtype import convert
+
+
+class WarpSuite:
+    params = ([np.uint8, np.uint16, np.float32, np.float64],
+              [128, 1024, 4096],
+              [0, 1, 3]
+              )
+    param_names = ['dtype_in', 'N', 'order']
+
+    def setup(self, dtype_in, N, order):
+        self.image = convert(np.random.random((N, N)), dtype=dtype_in)
+        self.tform = SimilarityTransform(scale=1, rotation=np.pi / 10,
+                                         translation=(0, 4))
+        self.order = order
+
+    def time_same_type(self):
+        """Test the case where the users wants to preserve their same low
+        precision data type."""
+        result = warp(self.image, self.tform, order=self.order,
+                      preserve_range=True)  # , dtype=self.image.dtype)
+
+        # With PR #3253, this line will be unecessary, and we can pass
+        # the parameter dtype_out above to specify casting back to the
+        # same time
+        result = result.astype(self.image.dtype)
+
+    def time_to_float64(self):
+        """Test the case where want to upvert to float64 for continued
+        transformations."""
+        result = warp(self.image, self.tform, order=self.order,
+                      preserve_range=True)  # , dtype=np.float64)

--- a/benchmarks/transform_warp.py
+++ b/benchmarks/transform_warp.py
@@ -1,6 +1,7 @@
 import numpy as np
 from skimage.transform import SimilarityTransform, warp
 from skimage.util.dtype import convert
+import warnings
 
 
 class WarpSuite:
@@ -11,12 +12,14 @@ class WarpSuite:
     param_names = ['dtype_in', 'N', 'order']
 
     def setup(self, dtype_in, N, order):
-        self.image = convert(np.random.random((N, N)), dtype=dtype_in)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "Possible precision loss")
+            self.image = convert(np.random.random((N, N)), dtype=dtype_in)
         self.tform = SimilarityTransform(scale=1, rotation=np.pi / 10,
                                          translation=(0, 4))
         self.order = order
 
-    def time_same_type(self):
+    def time_same_type(self, dtype_in, N, order):
         """Test the case where the users wants to preserve their same low
         precision data type."""
         result = warp(self.image, self.tform, order=self.order,
@@ -25,9 +28,9 @@ class WarpSuite:
         # With PR #3253, this line will be unecessary, and we can pass
         # the parameter dtype_out above to specify casting back to the
         # same time
-        result = result.astype(self.image.dtype)
+        result = result.astype(dtype_in)
 
-    def time_to_float64(self):
+    def time_to_float64(self, dtype_in, N, order):
         """Test the case where want to upvert to float64 for continued
         transformations."""
         result = warp(self.image, self.tform, order=self.order,


### PR DESCRIPTION
PR #3253 is about speeding up computation when you want to.

I figured I would add some benchmarks to create a baseline.

It considers 2 cases:
1. The case where want to go to "float64"
2. The case where we don't care and just want the warped result as the final image.

I really wish I could test this on my own machine but I tried to install asv:

```
pip install git+https://github.com/airspeed-velocity/asv.git@v0.2.2rc1#egg=asv
```
and
```
pip install git+https://github.com/airspeed-velocity/asv.git#egg=asv
```
but all failed with

```python
Traceback (most recent call last):
               File "/home/mark/miniconda3/envs/sk/lib/python3.6/site-packages/asv/benchmark.py", line 795, in <module>
                 commands[mode](args)
               File "/home/mark/miniconda3/envs/sk/lib/python3.6/site-packages/asv/benchmark.py", line 740, in main_discover
                 list_benchmarks(benchmark_dir, fp)
               File "/home/mark/miniconda3/envs/sk/lib/python3.6/site-packages/asv/benchmark.py", line 725, in list_benchmarks
                 for benchmark in disc_benchmarks(root):
               File "/home/mark/miniconda3/envs/sk/lib/python3.6/site-packages/asv/benchmark.py", line 710, in disc_benchmarks
                 for module in disc_files(root, os.path.basename(root) + '.'):
               File "/home/mark/miniconda3/envs/sk/lib/python3.6/site-packages/asv/benchmark.py", line 699, in disc_files
                 module = import_module(package + filename)
               File "/home/mark/git/scikit-image/.asv/env/eef864a9fed06fd59ca8023f9f5b02ad/lib/python3.6/importlib/__init__.py", line 126, in import_module
                 return _bootstrap._gcd_import(name[level:], package, level)
               File "<frozen importlib._bootstrap>", line 994, in _gcd_import
               File "<frozen importlib._bootstrap>", line 971, in _find_and_load
               File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
               File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
               File "<frozen importlib._bootstrap_external>", line 678, in exec_module
               File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
               File "/home/mark/git/scikit-image/benchmarks/transform_warp.py", line 2, in <module>
                 from skimage.transform import SimilarityTransform, warp

```

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
