### PR TITLE
Do not import submodules while building

### DIFF
--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -112,10 +112,10 @@ else:
         del geometry
     except ImportError as e:
         _raise_build_error(e)
+
+    # All skimage root imports go here
     from .util.dtype import *
     from .data import data_dir
-
-
-from .util.lookfor import lookfor
+    from .util.lookfor import lookfor
 
 del warnings, functools, imp, sys


### PR DESCRIPTION
This should fix our wheel builder, which is currently erroring during build because skimage tries to access scipy, which isn't a build dependency.