### PR TITLE
Fix background indexing in _label2rgb_avg

### DIFF
--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -219,7 +219,8 @@ def _label2rgb_avg(label_field, image, bg_label=0, bg_color=(0, 0, 0)):
     bg = (labels == bg_label)
     if bg.any():
         labels = labels[labels != bg_label]
-        out[bg] = bg_color
+        mask = (label_field == bg_label).nonzero()
+        out[mask] = bg_color
     for label in labels:
         mask = (label_field == label).nonzero()
         color = image[mask].mean(axis=0)

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -159,38 +159,3 @@ def test_negative_intensity():
     labels = np.arange(100).reshape(10, 10)
     image = -1 * np.ones((10, 10))
     assert_warns(UserWarning, label2rgb, labels, image)
-
-
-def test_bg_color_with_avg():
-    # label image
-    label_field = np.array([[0, 0, 0, 1],
-                            [0, 1, 1, 1],
-                            [1, 1, 1, 1]], dtype=np.uint8)
-
-    # color image
-    r = np.array([[1., 1., 0., 0.],
-                  [0., 0., 1., 1.],
-                  [0., 0., 0., 0.]])
-    g = np.array([[0., 0., 0., 1.],
-                  [1., 1., 1., 0.],
-                  [0., 0., 0., 0.]])
-    b = np.array([[0., 0., 0., 1.],
-                  [0., 1., 1., 1.],
-                  [0., 0., 1., 1.]])
-    image = np.dstack((r, g, b))
-
-    # reference label-colored image
-    rout = np.array([[1.0, 1.0, 1.0, 0.5],
-                     [1.0, 0.5, 0.5, 0.5],
-                     [0.0, 0.0, 0.0, 0.0]])
-    gout = np.array([[1.00, 1.00, 1.00, 0.75],
-                     [1.00, 0.75, 0.75, 0.75],
-                     [0.00, 0.00, 0.00, 0.00]])
-    bout = np.array([[1.0, 1.0, 1.0, 1.0],
-                     [1.0, 1.0, 1.0, 1.0],
-                     [0.5, 0.5, 0.5, 0.5]])
-    expected_out = np.dstack((rout, gout, bout))
-
-    # test standard averaging with bg color
-    out = label2rgb(label_field, image, bg_label=0, bg_color=1.0, kind="avg")
-    assert_array_almost_equal(out, expected_out)

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -113,7 +113,7 @@ def test_avg():
     # label image
     label_field = np.array([[1, 1, 1, 2],
                             [1, 2, 2, 2],
-                            [3, 3, 3, 3]], dtype=np.uint8)
+                            [3, 3, 4, 4]], dtype=np.uint8)
 
     # color image
     r = np.array([[1., 1., 0., 0.],
@@ -136,7 +136,7 @@ def test_avg():
                      [0.  , 0.  , 0.  , 0.  ]])
     bout = np.array([[0. , 0. , 0. , 1. ],
                      [0. , 1. , 1. , 1. ],
-                     [0.5, 0.5, 0.5, 0.5]])
+                     [0.0, 0.0, 1.0, 1.0]])
     expected_out = np.dstack((rout, gout, bout))
 
     # test standard averaging
@@ -159,3 +159,38 @@ def test_negative_intensity():
     labels = np.arange(100).reshape(10, 10)
     image = -1 * np.ones((10, 10))
     assert_warns(UserWarning, label2rgb, labels, image)
+
+
+def test_bg_color_with_avg():
+    # label image
+    label_field = np.array([[0, 0, 0, 1],
+                            [0, 1, 1, 1],
+                            [1, 1, 1, 1]], dtype=np.uint8)
+
+    # color image
+    r = np.array([[1., 1., 0., 0.],
+                  [0., 0., 1., 1.],
+                  [0., 0., 0., 0.]])
+    g = np.array([[0., 0., 0., 1.],
+                  [1., 1., 1., 0.],
+                  [0., 0., 0., 0.]])
+    b = np.array([[0., 0., 0., 1.],
+                  [0., 1., 1., 1.],
+                  [0., 0., 1., 1.]])
+    image = np.dstack((r, g, b))
+
+    # reference label-colored image
+    rout = np.array([[1.0, 1.0, 1.0, 0.5],
+                     [1.0, 0.5, 0.5, 0.5],
+                     [0.0, 0.0, 0.0, 0.0]])
+    gout = np.array([[1.00, 1.00, 1.00, 0.75],
+                     [1.00, 0.75, 0.75, 0.75],
+                     [0.00, 0.00, 0.00, 0.00]])
+    bout = np.array([[1.0, 1.0, 1.0, 1.0],
+                     [1.0, 1.0, 1.0, 1.0],
+                     [0.5, 0.5, 0.5, 0.5]])
+    expected_out = np.dstack((rout, gout, bout))
+
+    # test standard averaging with bg color
+    out = label2rgb(label_field, image, bg_label=0, bg_color=1.0, kind="avg")
+    assert_array_almost_equal(out, expected_out)


### PR DESCRIPTION
Line ``out[bg] = bg_color`` raised an index error since bg is an array of 2 elements and out an array the size of the image.

Fixes #3279

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
