### PR TITLE
Fix skimage.measure.regionprops 1x1 image bug 

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -546,8 +546,6 @@ def regionprops(label_image, intensity_image=None, cache=True,
 
     """
 
-    label_image = np.squeeze(label_image)
-
     if label_image.ndim not in (2, 3):
         raise TypeError('Only 2-D and 3-D images supported.')
 

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -365,6 +365,13 @@ def regionprops(label_image, intensity_image=None, cache=True,
     ----------
     label_image : (N, M) ndarray
         Labeled input image. Labels with value 0 are ignored.
+
+        .. versionchanged:: 0.14.1
+            Previously, ``label_image`` was processed by ``numpy.squeeze`` and
+            so any number of singleton dimensions was allowed. This resulted in
+            inconsistent handling of images with singleton dimensions. To
+            recover the old behaviour, use
+            ``regionprops(np.squeeze(label_image), ...)``.
     intensity_image : (N, M) ndarray, optional
         Intensity (i.e., input) image with same size as labeled image.
         Default is None.

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -63,7 +63,6 @@ def test_dtype():
 def test_ndim():
     regionprops(np.zeros((10, 10), dtype=np.int))
     regionprops(np.zeros((10, 10, 1), dtype=np.int))
-    regionprops(np.zeros((10, 10, 1, 1), dtype=np.int))
     regionprops(np.zeros((10, 10, 10), dtype=np.int))
     with testing.raises(TypeError):
         regionprops(np.zeros((10, 10, 10, 2), dtype=np.int))

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -64,6 +64,8 @@ def test_ndim():
     regionprops(np.zeros((10, 10), dtype=np.int))
     regionprops(np.zeros((10, 10, 1), dtype=np.int))
     regionprops(np.zeros((10, 10, 10), dtype=np.int))
+    regionprops(np.zeros((1, 1), dtype=np.int))
+    regionprops(np.zeros((1, 1, 1), dtype=np.int))
     with testing.raises(TypeError):
         regionprops(np.zeros((10, 10, 10, 2), dtype=np.int))
 


### PR DESCRIPTION
## Description
Fix #3278 by removing `np.squeeze`. Also I removed one test which incompatible with fix (i have no idea how to fix bug and keep this test, it's just ambiguous situation) and added two tests with 1x1/1x1x1 inputs.
## References
#3278 

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
