### PR TITLE
fix link to equalist_hist blog reference

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -155,7 +155,7 @@ def equalize_hist(image, nbins=256, mask=None):
 
     References
     ----------
-    .. [1] http://www.janeriksolem.net/2009/06/histogram-equalization-with-python-and.html
+    .. [1] http://www.janeriksolem.net/histogram-equalization-with-python-and.html
     .. [2] http://en.wikipedia.org/wiki/Histogram_equalization
 
     """


### PR DESCRIPTION
## Description
The reference to the `exposure.equalize_hist` function had a broken link- the author change the format of his links at some point, but the post still exists.

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests

## References


## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
