### PR TITLE
bugfix: an index needs to be an integer not an float in CollectionViewer

### DIFF
--- a/skimage/viewer/viewers/core.py
+++ b/skimage/viewer/viewers/core.py
@@ -386,7 +386,7 @@ class CollectionViewer(ImageViewer):
             key = event.key()
             # Number keys (code: 0 = key 48, 9 = key 57) move to deciles
             if 48 <= key < 58:
-                index = 0.1 * int(key - 48) * self.num_images
+                index = int(0.1 * (key - 48) * self.num_images)
                 self.update_index('', index)
                 event.accept()
             else:


### PR DESCRIPTION
## Description
there is an misplaced type conversation within the index calculation in `core.py -> CollectionViewer` that needs to be applied to the whole calculation not just a part of it

## Checklist
none

## References
none

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
