### PR TITLE
Guide the user of denoise_wavelet to choose an orthogonal wavelet.

### DIFF
--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -428,6 +428,10 @@ def _wavelet_threshold(image, wavelet, method=None, threshold=None,
 
     """
     wavelet = pywt.Wavelet(wavelet)
+    if not wavelet.orthogonal:
+        warn(("Wavelet thresholding was designed for use with orthogonal "
+              "wavelets. For nonorthogonal wavelets such as {}, results are "
+              "likely to be suboptimal.").format(wavelet.name))
 
     # original_extent is used to workaround PyWavelets issue #80
     # odd-sized input results in an image with 1 extra sample after waverecn
@@ -545,15 +549,25 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
     When YCbCr conversion is done, every color channel is scaled between 0
     and 1, and `sigma` values are applied to these scaled color channels.
 
-    Many wavelet coefficient thresholding approaches have been proposed.  By
+    Many wavelet coefficient thresholding approaches have been proposed. By
     default, ``denoise_wavelet`` applies BayesShrink, which is an adaptive
     thresholding method that computes separate thresholds for each wavelet
     sub-band as described in [1]_.
 
     If ``method == "VisuShrink"``, a single "universal threshold" is applied to
-    all wavelet detail coefficients as described in [2]_.  This threshold
+    all wavelet detail coefficients as described in [2]_. This threshold
     is designed to remove all Gaussian noise at a given ``sigma`` with high
     probability, but tends to produce images that appear overly smooth.
+
+    Although any of the wavelets from ``PyWavelets`` can be selected, the
+    thresholding methods assume an orthogonal wavelet transform and may not
+    choose the threshold appropriately for biorthogonal wavelets. Orthogonal
+    wavelets are desirable because white noise in the input remains white noise
+    in the subbands. Biorthogonal wavelets lead to colored noise in the
+    subbands. Additionally, the orthogonal wavelets in PyWavelets are
+    orthonormal so that noise variance in the subbands remains identical to the
+    noise variance of the input. Example orthogonal wavelets are the Daubechies
+    (e.g. 'db2') or symmlet (e.g. 'sym2') families.
 
     References
     ----------

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -532,6 +532,13 @@ def test_wavelet_denoising_args():
                                             multichannel=multichannel)
 
 
+def test_denoise_wavelet_biorthogonal():
+    """Biorthogonal wavelets should raise a warning during thresholding."""
+    img = astro_gray
+    assert_warns(UserWarning, restoration.denoise_wavelet, img,
+                 wavelet='bior2.2', multichannel=False)
+
+
 def test_cycle_spinning_multichannel():
     sigma = 0.1
     rstate = np.random.RandomState(1234)


### PR DESCRIPTION
## Description

This PR adds a warning during wavelet thresholding if the selected wavelet is not orthogonal.  Biorthogonal wavelets violate the assumptions of the thresholding methods and are likely to yield substantially poorer performance.  A corresponding note was added to the `denoise_wavelet` docstring.

Specifically orthogonal wavelets ensure that:
   1.) The variance in the wavelet subbands is equal to the variance of the data being transformed.
   2.) Noise remains white within wavelet subbands.
Neither of these is true for biorthogonal wavelets.

**edit** I have corrected statement 2 above. I had misstated it previously. To visualize if I take the DWT of Gaussian random noise and then take the FFT of a subband it will still have a flat frequency response (white noise):

```python
import numpy as np
import pywt
x = np.random.randn(100000)
a_ortho, d_ortho = pywt.dwt(x, 'db2', mode='periodization')
a_bior, d_bior = pywt.dwt(x, 'bior2.2', mode='periodization')

fig, axes = plt.subplots(1, 3)
axes[0].plot(np.abs(np.fft.fft(x, norm='ortho')))
axes[0].set_ylim([0, 3.2])
axes[0].set_ylabel('|FFT(x)|')
axes[0].set_title('FFT of Gaussian noise')
axes[1].plot(np.abs(np.fft.fft(d_ortho, norm='ortho')))
axes[1].set_ylim([0, 3.2])
axes[1].set_ylabel('|FFT(d)|')
axes[1].set_title('FFT of detail coeffs\n(orthogonal DWT)')
axes[2].plot(np.abs(np.fft.fft(d_bior, norm='ortho')))
axes[2].set_ylim([1, 3.2])
axes[2].set_title('FFT of non-orthogonal detail coeffs\n(biorthogonal DWT)')
axes[2].set_ylabel('|FFT(d)|')
```
![noise](https://user-images.githubusercontent.com/6528957/43219079-52da896a-9014-11e8-9555-e4e45d3f46ef.png)


## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)~
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests

## References

details on denoising with non-orthogonal wavelets are covered in the following publication.
http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.56.8832

I did not think it was worth the effort to implement this in scikit-image as the existing methods work well as long as the wavelet is orthogonal.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
