### PR TITLE
Remove unused lib in skimage/__init__.py

### DIFF
--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -68,9 +68,6 @@ dtype_limits
 
 """
 
-import imp
-import functools
-import warnings
 import sys
 
 
@@ -106,6 +103,7 @@ def _raise_build_error(e):
 It seems that scikit-image has not been built correctly.
 %s""" % (e, msg))
 
+
 try:
     # This variable is injected in the __builtins__ by the build
     # process. It used to enable importing subpackages of skimage when
@@ -137,4 +135,4 @@ else:
     from .data import data_dir
     from .util.lookfor import lookfor
 
-del warnings, functools, imp, sys
+del sys


### PR DESCRIPTION
## Description

I discovered a warning related to the deprecation of imp since python 3.4
See here
https://docs.python.org/3/library/imp.html

Actually, the module is unused, so it's removed now.


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
