### PR TITLE
Replace scipy.sparse.*.todense() with toarray()

### DIFF
--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -509,7 +509,7 @@ def _solve_bf(lap_sparse, B, return_full_prob=False):
     """
     lap_sparse = lap_sparse.tocsc()
     solver = sparse.linalg.factorized(lap_sparse.astype(np.double))
-    X = np.array([solver(np.array((-B[i]).todense()).ravel())
+    X = np.array([solver(np.array((-B[i]).toarray()).ravel())
                   for i in range(len(B))])
     if not return_full_prob:
         X = np.argmax(X, axis=0)
@@ -525,7 +525,7 @@ def _solve_cg(lap_sparse, B, tol, return_full_prob=False):
     lap_sparse = lap_sparse.tocsc()
     X = []
     for i in range(len(B)):
-        x0 = cg(lap_sparse, -B[i].todense(), tol=tol)[0]
+        x0 = cg(lap_sparse, -B[i].toarray(), tol=tol)[0]
         X.append(x0)
     if not return_full_prob:
         X = np.array(X)
@@ -544,7 +544,7 @@ def _solve_cg_mg(lap_sparse, B, tol, return_full_prob=False):
     ml = ruge_stuben_solver(lap_sparse)
     M = ml.aspreconditioner(cycle='V')
     for i in range(len(B)):
-        x0 = cg(lap_sparse, -B[i].todense(), tol=tol, M=M, maxiter=30)[0]
+        x0 = cg(lap_sparse, -B[i].toarray(), tol=tol, M=M, maxiter=30)[0]
         X.append(x0)
     if not return_full_prob:
         X = np.array(X)


### PR DESCRIPTION
NumPy 1.15 started warning about not using `np.matrix`, which breaks our
CI, because `todense()` returns a `np.matrix` rather than a `np.array`.
Replacing this with `toarray()` removes the warning and has no effect on
the expressions where it is being replaced.

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests

## References
For an example of the errors, see [this build](https://travis-ci.org/scikit-image/scikit-image/jobs/407599944)

## For reviewers
(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
