### PR TITLE
BUILD: Add pyproject.toml to ensure cython is present

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include *.rst
 recursive-include requirements *.txt
 include requirements/README.md
 include Makefile
+include pyproject.toml
 include skimage/scripts/skivi
 recursive-include skimage *.pyx *.pxd *.pxi *.py *.c *.h *.ini *.md5 *.npy *.txt *.in *.cpp *.md
 recursive-include skimage/data *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "cython"]
+requires = ["setuptools", "wheel", "numpy", "cython"]


### PR DESCRIPTION
PEP 517, implemented by pip 10 and newer, will ensure that cython is
present for the build by specifying the build dependencies in
pyproject.toml.

## Description
[Tell us about your new feature, improvement, or fix! If relevant, please supplement the PR with images.]

This intends to address an issue reported on the mailing; the build will fail if Cython is not pre-installed.


## References

https://www.python.org/dev/peps/pep-0517/

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
