### PR TITLE
Handle intersphinx and mpl deprecation warnings in docs

### DIFF
--- a/doc/examples/features_detection/plot_local_binary_pattern.py
+++ b/doc/examples/features_detection/plot_local_binary_pattern.py
@@ -107,7 +107,7 @@ lbp = local_binary_pattern(image, n_points, radius, METHOD)
 
 def hist(ax, lbp):
     n_bins = int(lbp.max() + 1)
-    return ax.hist(lbp.ravel(), normed=True, bins=n_bins, range=(0, n_bins),
+    return ax.hist(lbp.ravel(), density=True, bins=n_bins, range=(0, n_bins),
                    facecolor='0.5')
 
 
@@ -166,9 +166,9 @@ def match(refs, img):
     best_name = None
     lbp = local_binary_pattern(img, n_points, radius, METHOD)
     n_bins = int(lbp.max() + 1)
-    hist, _ = np.histogram(lbp, normed=True, bins=n_bins, range=(0, n_bins))
+    hist, _ = np.histogram(lbp, density=True, bins=n_bins, range=(0, n_bins))
     for name, ref in refs.items():
-        ref_hist, _ = np.histogram(ref, normed=True, bins=n_bins,
+        ref_hist, _ = np.histogram(ref, density=True, bins=n_bins,
                                    range=(0, n_bins))
         score = kullback_leibler_divergence(hist, ref_hist)
         if score < best_score:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -317,16 +317,16 @@ plot2rst_rcparams = {'image.cmap' : 'gray',
 # intersphinx
 # -----------------------------------------------------------------------------
 _python_version_str = '{0.major}.{0.minor}'.format(sys.version_info)
-_python_doc_base = 'http://docs.python.org/' + _python_version_str
+_python_doc_base = 'https://docs.python.org/' + _python_version_str
 intersphinx_mapping = {
     'python': (_python_doc_base, None),
-    'numpy': ('http://docs.scipy.org/doc/numpy',
+    'numpy': ('https://docs.scipy.org/doc/numpy',
               (None, './_intersphinx/numpy-objects.inv')),
-    'scipy': ('http://docs.scipy.org/doc/scipy/reference',
+    'scipy': ('https://docs.scipy.org/doc/scipy/reference',
               (None, './_intersphinx/scipy-objects.inv')),
-    'sklearn': ('http://scikit-learn.org/stable',
+    'sklearn': ('https://scikit-learn.org/stable',
                 (None, './_intersphinx/sklearn-objects.inv')),
-    'matplotlib': ('http://matplotlib.org/',
+    'matplotlib': ('https://matplotlib.org/',
                    (None, 'http://matplotlib.org/objects.inv'))
 }
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -324,7 +324,7 @@ intersphinx_mapping = {
               (None, './_intersphinx/numpy-objects.inv')),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference',
               (None, './_intersphinx/scipy-objects.inv')),
-    'sklearn': ('https://scikit-learn.org/stable',
+    'sklearn': ('http://scikit-learn.org/stable',
                 (None, './_intersphinx/sklearn-objects.inv')),
     'matplotlib': ('https://matplotlib.org/',
                    (None, 'http://matplotlib.org/objects.inv'))


### PR DESCRIPTION
## Description
Handle several new deprecation warnings in the doc building process:
```
loading intersphinx inventory from http://docs.python.org/3.6/objects.inv...
intersphinx inventory has moved: http://docs.python.org/3.6/objects.inv -> https://docs.python.org/3.6/objects.inv
loading intersphinx inventory from http://docs.scipy.org/doc/numpy/objects.inv...
intersphinx inventory has moved: http://docs.scipy.org/doc/numpy/objects.inv -> https://docs.scipy.org/doc/numpy/objects.inv
loading intersphinx inventory from http://docs.scipy.org/doc/scipy/reference/objects.inv...
intersphinx inventory has moved: http://docs.scipy.org/doc/scipy/reference/objects.inv -> https://docs.scipy.org/doc/scipy/reference/objects.inv
loading intersphinx inventory from http://scikit-learn.org/stable/objects.inv...
loading intersphinx inventory from http://matplotlib.org/objects.inv...
intersphinx inventory has moved: http://matplotlib.org/objects.inv -> https://matplotlib.org/objects.inv
...
/home/egor/Workspace/_contrib/py3/lib/python3.6/site-packages/matplotlib/axes/_axes.py:6462: UserWarning: The 'normed' kwarg is deprecated, and has been replaced by the 'density' kwarg.                                                                     
  warnings.warn("The 'normed' kwarg is deprecated, and has been "
/home/egor/Workspace/_contrib/scikit-image/doc/examples/features_detection/plot_local_binary_pattern.py:169: VisibleDeprecationWarning: Passing `normed=True` on non-uniform bins has always been broken, and computes neither the probability density function nor the probability mass function. The result is only correct if the bins are uniform, when density=True will produce the same result anyway. The argument will be removed in a future version of numpy.
  hist, _ = np.histogram(lbp, normed=True, bins=n_bins, range=(0, n_bins))
/home/egor/Workspace/_contrib/scikit-image/doc/examples/features_detection/plot_local_binary_pattern.py:172: VisibleDeprecationWarning: Passing `normed=True` on non-uniform bins has always been broken, and computes neither the probability density function nor the probability mass function. The result is only correct if the bins are uniform, when density=True will produce the same result anyway. The argument will be removed in a future version of numpy.
  range=(0, n_bins))
```

Squash-merge, please.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
