### PR TITLE
cython: check for presence of cpp files during install from sdist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
   include:
     - os: linux
       python: 3.5
-      env: OPTIONAL_DEPS=1 WITH_PYSIDE=1 BUILD_DOCS=1
+      env: OPTIONAL_DEPS=1 WITH_PYSIDE=1 BUILD_DOCS=1 INSTALL_FROM_SDIST=1
     - os: linux
       python: 3.5
       env: QT=PyQt5 MINIMUM_REQUIREMENTS=1
@@ -87,8 +87,14 @@ before_install:
     - tools/check_sdist.py $SDIST_NAME
 
 install:
-    - python setup.py develop
     - ccache --show-stats
+    # Test installing without cython using the sdist
+    - if [[ "$INSTALL_FROM_SDIST" == "1" ]]; then
+        pip uninstall cython -y ;
+        pip install dist/scikit-image-*.tar.gz ;
+      else
+        python setup.py develop ;
+      fi
     # Install testing requirements
     - pip install --retries 3 -q $PIP_FLAGS -r requirements/test.txt
     # Matplotlib settings - do not show figures during doc examples

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,10 +90,10 @@ install:
     - ccache --show-stats
     # Test installing without cython using the sdist
     - if [[ "$INSTALL_FROM_SDIST" == "1" ]]; then
-        pip uninstall cython -y ;
-        pip install dist/scikit-image-*.tar.gz ;
+        pip uninstall cython -y;
+        pip install dist/scikit-image-*.tar.gz;
       else
-        python setup.py develop ;
+        pip install --no-build-isolation .;
       fi
     # Install testing requirements
     - pip install --retries 3 -q $PIP_FLAGS -r requirements/test.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ before_install:
 install:
     - ccache --show-stats
     # Test installing without cython using the sdist
-    - if [[ "$INSTALL_FROM_SDIST" == "1" ]]; then
+    - if [[ $INSTALL_FROM_SDIST ]]; then
         pip uninstall cython -y;
         pip install dist/scikit-image-*.tar.gz;
       else

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,10 @@ before_install:
 install:
     - ccache --show-stats
     # Test installing without cython using the sdist
+    # --no-build-isolation ensures even in the presense of a pyproject.toml
+    # pip will not create a virtual environment, just for building the package
+    # This is problematic because the version of numpy of that virtual environment
+    # may be higher than the version we want to test with.
     - if [[ $INSTALL_FROM_SDIST ]]; then
         pip uninstall cython -y;
         pip install dist/scikit-image-*.tar.gz;

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include setup*.py
-include conftest.py
 include MANIFEST.in
 include *.txt
 include *.rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy", "cython"]
+requires = ["setuptools", "wheel", "numpy"]

--- a/skimage/_build.py
+++ b/skimage/_build.py
@@ -13,6 +13,19 @@ except NameError:
         pass
 
 
+def _compiled_filename(f):
+    """Check for the presence of a .pyx[.in] file as a .c or .cpp."""
+    basename = f.replace('.in', '').replace('.pyx', '')
+    for ext in ('.c', '.cpp'):
+        filename = basename + ext
+        if os.path.exists(filename):
+            return filename
+    else:
+        raise RuntimeError('Cython >= %s is required to build '
+                           'scikit-image from git checkout' %
+                           CYTHON_VERSION)
+
+
 def cython(pyx_files, working_path=''):
     """Use Cython to convert the given files to C.
 
@@ -34,15 +47,12 @@ def cython(pyx_files, working_path=''):
         from Cython.Build import cythonize
     except ImportError:
         # If cython is not found, the build will make use of
-        # the distributed .c files if present
-        c_files = [f.replace('.pyx.in', '.c').replace('.pyx', '.c') for f in pyx_files]
-        for cfile in [os.path.join(working_path, f) for f in c_files]:
-            if not os.path.isfile(cfile):
-                raise RuntimeError('Cython >= %s is required to build scikit-image from git checkout' \
-                                   % CYTHON_VERSION)
+        # the distributed .c or .cpp files if present
+        c_files_used = [_compiled_filename(os.path.join(working_path, f))
+                        for f in pyx_files]
 
         print("Cython >= %s not found; falling back to pre-built %s" \
-              % (CYTHON_VERSION, " ".join(c_files)))
+              % (CYTHON_VERSION, " ".join(c_files_used)))
     else:
         pyx_files = [os.path.join(working_path, f) for f in pyx_files]
         for i, pyxfile in enumerate(pyx_files):

--- a/skimage/conftest.py
+++ b/skimage/conftest.py
@@ -8,15 +8,11 @@ if Version(np.__version__) >= Version('1.14'):
     np.set_printoptions(legacy='1.13')
 
 # List of files that pytest should ignore
-collect_ignore = ["setup.py",
-                  "skimage/io/_plugins",
-                  "doc/",
-                  "tools/",
-                  "viewer_examples"]
+collect_ignore = ["io/_plugins",]
 try:
     import visvis
 except ImportError:
-    collect_ignore.append("skimage/measure/mc_meta/visual_test.py")
+    collect_ignore.append("measure/mc_meta/visual_test.py")
 
 # importing skimage.novice issues some warnings. Without these lines,
 # pytest issues numerous warnings when crawling the package.

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -29,8 +29,19 @@ export WHEELHOUSE
 export DISPLAY=:99.0
 # This causes way too many internal warnings within python.
 # export PYTHONWARNINGS="d,all:::skimage"
-# codecov will combine different paths
-export TEST_ARGS="--doctest-modules --cov=skimage"
+
+# Doctest's don't run well on other's systems because of the
+# need for conftest.py
+# Maybe it is time to bring back the test function
+# https://github.com/scikit-image/scikit-image/pull/3164
+# Though, the configuration of conftest would have to be added to it
+if [[ "$INSTALL_FROM_SDIST" != "1" ]]; then
+  # codecov will combine different paths
+  export TEST_ARGS="--doctest-modules --cov=skimage"
+fi
+if [[ "$OPTIONAL_DEPS" == "1" ]]; then
+  export TEST_ARGS="${TEST_ARGS} --cov=skimage"
+fi
 
 retry () {
     # https://gist.github.com/fungusakafungus/1026804

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -30,18 +30,7 @@ export DISPLAY=:99.0
 # This causes way too many internal warnings within python.
 # export PYTHONWARNINGS="d,all:::skimage"
 
-# Doctest's don't run well on other's systems because of the
-# need for conftest.py
-# Maybe it is time to bring back the test function
-# https://github.com/scikit-image/scikit-image/pull/3164
-# Though, the configuration of conftest would have to be added to it
-if [[ "$INSTALL_FROM_SDIST" != "1" ]]; then
-  # codecov will combine different paths
-  export TEST_ARGS="--doctest-modules --cov=skimage"
-fi
-if [[ "$OPTIONAL_DEPS" == "1" ]]; then
-  export TEST_ARGS="${TEST_ARGS} --cov=skimage"
-fi
+export TEST_ARGS="--doctest-modules --cov=skimage"
 
 retry () {
     # https://gist.github.com/fungusakafungus/1026804

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -16,7 +16,13 @@ tools/build_versions.py
 section_end "List.installed.dependencies"
 
 section "Test"
-pytest $TEST_ARGS skimage
+if [[ "$INSTALL_FROM_SDIST" == "1" ]]; then
+    pushd ..
+    pytest $TEST_ARGS --pyargs skimage
+    popd
+else
+    pytest $TEST_ARGS skimage
+fi
 section_end "Test"
 
 section "Flake8.test"

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -16,11 +16,10 @@ tools/build_versions.py
 section_end "List.installed.dependencies"
 
 section "Test"
+# When installing from sdist
 # We can't run it in the git directory since there is a folder called `skimage`
-# in there. pytest will crawl that instead of the module.
-pushd ..
-pytest $TEST_ARGS --pyargs skimage
-popd
+# in there. pytest will crawl that instead of the module we installed and want to test
+(cd .. && pytest $TEST_ARGS --pyargs skimage)
 section_end "Test"
 
 section "Flake8.test"

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -16,13 +16,11 @@ tools/build_versions.py
 section_end "List.installed.dependencies"
 
 section "Test"
-if [[ "$INSTALL_FROM_SDIST" == "1" ]]; then
-    pushd ..
-    pytest $TEST_ARGS --pyargs skimage
-    popd
-else
-    pytest $TEST_ARGS skimage
-fi
+# We can't run it in the git directory since there is a folder called `skimage`
+# in there. pytest will crawl that instead of the module.
+pushd ..
+pytest $TEST_ARGS --pyargs skimage
+popd
 section_end "Test"
 
 section "Flake8.test"


### PR DESCRIPTION
Only used if cython isn't present. Allows for the installation from sdist without 
cython.

This was brought up on the mailing list. The issue is that `_harr.pyx` compiles to `_harr.cpp` and previous to this PR, the logic only checked for `_harr.c`. This also checks for `.cpp` for all the `pyx` files provided.

This allows us to remove `cython` from `pyproject.toml`

~~This PR should be backported too.~~


## References
https://mail.python.org/pipermail/scikit-image/2018-July/005597.html

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
