### PR TITLE
Remove deprecated `dynamic_range` in `measure.compare_psnr`

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -35,9 +35,11 @@ Improvements
 
 API Changes
 -----------
+
+- Parameter ``dynamic_range`` in ``skimage.measure.compare_psnr`` has been
+  removed. Use parameter ``data_range`` instead.
 - imageio is now the preferred plugin for reading and writing images.
 - imageio is now a dependency of scikit-image.
-
 - ``rectangular_grid`` now returns a tuple instead of a list for compatiblity
   with numpy 1.15
 - ``colorconv.separate_stains`` and ``colorconv.combine_stains`` now uses

--- a/skimage/measure/simple_metrics.py
+++ b/skimage/measure/simple_metrics.py
@@ -96,7 +96,7 @@ def compare_nrmse(im_true, im_test, norm_type='Euclidean'):
     return np.sqrt(compare_mse(im_true, im_test)) / denom
 
 
-def compare_psnr(im_true, im_test, data_range=None, dynamic_range=None):
+def compare_psnr(im_true, im_test, data_range=None):
     """ Compute the peak signal to noise ratio (PSNR) for an image.
 
     Parameters
@@ -121,11 +121,6 @@ def compare_psnr(im_true, im_test, data_range=None, dynamic_range=None):
 
     """
     _assert_compatible(im_true, im_test)
-    if dynamic_range is not None:
-        warn('`dynamic_range` has been deprecated in favor of '
-             '`data_range`. The `dynamic_range` keyword argument '
-             'will be removed in v0.14', skimage_deprecation)
-        data_range = dynamic_range
 
     if data_range is None:
         if im_true.dtype != im_test.dtype:

--- a/skimage/measure/tests/test_simple_metrics.py
+++ b/skimage/measure/tests/test_simple_metrics.py
@@ -40,17 +40,6 @@ def test_PSNR_float():
     assert_almost_equal(p_mixed, p_float64, decimal=5)
 
 
-def test_PSNR_dynamic_range_and_data_range():
-    # Tests deprecation of "dynamic_range" in favor of "data_range"
-    out1 = compare_psnr(cam/255., cam_noisy/255., data_range=1)
-    with expected_warnings([
-            '`dynamic_range` has been deprecated in favor of '
-            '`data_range`. The `dynamic_range` keyword argument '
-            'will be removed in v0.14']):
-        out2 = compare_psnr(cam/255., cam_noisy/255., dynamic_range=1)
-    assert_equal(out1, out2)
-
-
 def test_PSNR_errors():
     # shape mismatch
     with testing.raises(ValueError):


### PR DESCRIPTION
## For reviewers

(Don't remove the checklist below.)

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [x] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
