### PR TITLE
appveyor: don't upload any artifacts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,9 +65,9 @@ test_script:
   # Run unit tests with pytest
   - pytest -v --pyargs skimage
 
-artifacts:
-  # Archive the generated wheel package in the ci.appveyor.com build report.
-  - path: dist\*
+#artifacts:
+#  # Archive the generated wheel package in the ci.appveyor.com build report.
+#  - path: dist\*
 
 #on_success:
 #  - TODO: upload the content of dist/*.whl to a public wheelhouse


### PR DESCRIPTION
Issue #3307

I don't really think these wheels are even used as this repo https://github.com/scikit-image/scikit-image-wheels just rebuilds them from scratch.

Should be backported.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
