### PR TITLE
Add benchmark suite for weiner and inverse functions

### DIFF
--- a/benchmarks/benchmark_filters.py
+++ b/benchmarks/benchmark_filters.py
@@ -22,3 +22,6 @@ class FiltersSuite:
 
     def time_inverse(self):
         result = filters.inverse(self.image, predefined_filter=self.f)
+
+    def time_wiener(self):
+        result = filters.wiener(self.image, predefined_filter=self.f)

--- a/benchmarks/benchmark_filters.py
+++ b/benchmarks/benchmark_filters.py
@@ -6,12 +6,19 @@ from skimage import filters
 
 class FiltersSuite:
     """Benchmark for filter routines in scikit-image."""
+    def _filt_func(self, r, c):
+        return np.exp(-np.hypot(r, c) / 1)
+
     def setup(self):
-        self.image = np.random.random((4000, 4000))
-        self.image[:2000, :2000] += 1
-        self.image[3000:, 3000] += 0.5
+        self.image = np.random.random((600, 600))
+        self.image[:250, :250] += 1
+        self.image[375:, 375] += 0.5
+        self.f = filters.LPIFilter2D(self._filt_func)
 
     def time_sobel(self):
-        result = filters.sobel(self.image)
+        # Running it 10 times to achieve significant performance time
+        for i in range(10):
+            result = filters.sobel(self.image)
 
-
+    def time_inverse(self):
+        result = filters.inverse(self.image, predefined_filter=self.f)


### PR DESCRIPTION
## Description
The running time for both the functions is approximately 1.5s.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
