### PR TITLE
Fix #3141: Add bins argument to hough_line()

### DIFF
--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -1,4 +1,5 @@
 import numpy as np
+import math
 from ._hough_transform import (_hough_circle,
                                _hough_ellipse,
                                _hough_line,
@@ -163,7 +164,7 @@ def hough_ellipse(image, threshold=4, accuracy=1, min_size=4, max_size=None):
                           min_size=min_size, max_size=max_size)
 
 
-def hough_line(image, theta=None):
+def hough_line(image, theta=None, bins=None):
     """Perform a straight line Hough transform.
 
     Parameters
@@ -173,6 +174,9 @@ def hough_line(image, theta=None):
     theta : 1D ndarray of double, optional
         Angles at which to compute the transform, in radians.
         Defaults to a vector of 180 angles evenly spaced from -pi/2 to pi/2.
+    bins : 1D ndarray of double, optional
+        Distances at which to compute the transform, in pixels.
+        Defaults to a variable sized vector proportional to the shape of the image
 
     Returns
     -------
@@ -218,7 +222,12 @@ def hough_line(image, theta=None):
         # These values are approximations of pi/2
         theta = np.linspace(-np.pi / 2, np.pi / 2, 180)
 
-    return _hough_line(image, theta=theta)
+    if bins is None:
+        max_distance = 2 * math.ceil(math.sqrt(image.shape[0] * image.shape[0] +
+                                     image.shape[1] * image.shape[1]))
+        bins = np.linspace(-max_distance / 2.0, max_distance / 2.0, max_distance)
+
+    return _hough_line(image, theta=theta, bins=bins)
 
 
 def probabilistic_hough_line(image, threshold=10, line_length=50, line_gap=10,


### PR DESCRIPTION
## Description
With the argument `bins`, the user can now specify distances at which he/she is interested in computing the transform.

Fixes #3141 

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
