### PR TITLE
Add benchmark suite for hough_line()

### DIFF
--- a/benchmarks/benchmark_transform.py
+++ b/benchmarks/benchmark_transform.py
@@ -1,0 +1,19 @@
+# See "Writing benchmarks" in the asv docs for more information.
+# http://asv.readthedocs.io/en/latest/writing_benchmarks.html
+import numpy as np
+from scipy import ndimage as ndi
+from skimage import transform
+
+
+class TransformSuite:
+    """Benchmark for transform routines in scikit-image."""
+    def setup(self):
+        self.image = np.zeros((2000, 2000))
+        idx = np.arange(500, 1500)
+        self.image[idx[::-1], idx] = 255
+        self.image[idx, idx] = 255
+
+    def time_hough_line(self):
+        # Running it 10 times to achieve significant performance time.
+        for i in range(10):
+            result1, result2, result3 = transform.hough_line(self.image)

--- a/benchmarks/benchmark_transform.py
+++ b/benchmarks/benchmark_transform.py
@@ -14,6 +14,4 @@ class TransformSuite:
         self.image[idx, idx] = 255
 
     def time_hough_line(self):
-        # Running it 10 times to achieve significant performance time.
-        for i in range(10):
-            result1, result2, result3 = transform.hough_line(self.image)
+        result1, result2, result3 = transform.hough_line(self.image)


### PR DESCRIPTION
## Description
I have added the benchmark suite for transform.hough_line() function. Running time is **500ms**.


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
