### PR TITLE
Add license file to the wheel (binary) distribution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_file = LICENSE.txt


### PR DESCRIPTION
Apparently this is the only way to ensure that the [LICENSE.txt](https://github.com/scikit-image/scikit-image/blob/master/LICENSE.txt) file gets included in the wheel distribution.

>  2. Redistributions in binary form must reproduce the above copyright
>    notice, this list of conditions and the following disclaimer in
>    the documentation and/or other materials provided with the
>    distribution.

## References
  * [pypa setup.cfg](https://github.com/pypa/sampleproject/blob/master/setup.cfg)
  * [pypa documentation](https://github.com/pypa/python-packaging-user-guide/blob/master/source/guides/distributing-packages-using-setuptools.rst#setup-cfg)



## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
