### PR TITLE
codecov: ignore build scripts in coverage and don't comment on PRs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,5 +5,14 @@ ignore:
   - "setup.py"
   - "**/setup.py"
 
+coverage:
+  status:
+    project:
+      default:
+        # Drops on the order 0.01% are typical even when no change occurs
+        # Having this threshold set a little higher (0.1%) than that makes it 
+        # a little more tolerant to fluctuations
+        threshold: 0.1%
+
 # Disable PR comment
 comment: off

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,3 +5,5 @@ ignore:
   - "setup.py"
   - "**/setup.py"
 
+# Disable PR comment
+comment: off

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+ignore:
+  - "skimage/external/setup.py"
+  - "skimage/_build.py"
+  - "scripts/skivi.py"
+  - "setup.py"
+  - "**/setup.py"
+

--- a/tools/check_sdist.py
+++ b/tools/check_sdist.py
@@ -24,6 +24,7 @@ ignore_files = ['./TODO.md', './README.md', './MANIFEST',
                 './.gitignore', './.travis.yml', './.gitmodules',
                 './.mailmap', './.coveragerc', './.appveyor.yml',
                 './.pep8speaks.yml', './asv.conf.json',
+                './.codecov.yml',
                 './skimage/filters/rank/README.rst', './.meeseeksdev.yml']
 
 # These docstring artifacts are hard to avoid without adding noise to the

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -29,10 +29,8 @@ export WHEELHOUSE
 export DISPLAY=:99.0
 # This causes way too many internal warnings within python.
 # export PYTHONWARNINGS="d,all:::skimage"
-export TEST_ARGS="--doctest-modules"
-if [[ "$OPTIONAL_DEPS" == "1" ]]; then
-  export TEST_ARGS="${TEST_ARGS} --cov=skimage"
-fi
+# codecov will combine different paths
+export TEST_ARGS="--doctest-modules --cov=skimage"
 
 retry () {
     # https://gist.github.com/fungusakafungus/1026804


### PR DESCRIPTION
Ignore known build scripts from codecov. This also supresses codecov from commenting on the PR, but the check at the bottom should remain.

https://docs.codecov.io/docs/ignoring-paths

Curious to see how much we are actually testing the code.

## For reviewers
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
