### PR TITLE
Correct rotate method's center parameter doc

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -293,7 +293,9 @@ def rotate(image, angle, resize=False, center=None, order=1, mode='constant',
         False.
     center : iterable of length 2
         The rotation center. If ``center=None``, the image is rotated around
-        its center, i.e. ``center=(rows / 2 - 0.5, cols / 2 - 0.5)``.
+        its center, i.e. ``center=(cols / 2 - 0.5, rows / 2 - 0.5)``.  Please
+        note that this parameter is (cols, rows), contrary to normal skimage
+        ordering.
 
     Returns
     -------


### PR DESCRIPTION
The existing doc for the center parameter of the rotate method implies the parameter should look like (rows, cols) but in fact it operates in (cols, rows) ordering.  This commit corrects the documentation to clarify the unusual usage of (cols, rows) ordering.


## References
This fix is in reference to issue  2671.  https://github.com/scikit-image/scikit-image/issues/2671

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
