### PR TITLE
Matplotlib 2.2.3 +  PyQt5.11

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -37,9 +37,6 @@ Other
   once minimal required ``numpy`` is set to >= 1.14.0.
 * Remove deprecated ``Hxx, Hxy, Hyy`` API of ``hessian_matrix_eigvals`` in
   ``skimage.feature.corner``.
-* Monitor when ``matplotlib`` releases a version greater than 2.2.2 and test
-  to see if it becomes compatible with PyQt5.11. If it is compatible,
-  remove the version limiting logic in ``tools/travis/install_qt.sh``.
 * Remove the conditional warning logic when ``numpy`` is set to >= 1.15.0
   for ``scipy`` and ``pywl`` (``pywavelet``) in ``test_lpi_filter.py`` and
   ``test_denoise.py`` regarding multidimensional indexing.

--- a/tools/travis/install_qt.sh
+++ b/tools/travis/install_qt.sh
@@ -6,10 +6,7 @@ if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
 fi
 # Now configure Matplotlib to use Qt5
 if [[ "${QT}" == "PyQt5" ]]; then
-    # Matplotlib 2.2.2 doesn't support pyqt5 5.11 until this commit
-    # https://github.com/matplotlib/matplotlib/commit/260e6d611afae9adaac528c28a4879097c357b74#diff-025508b6963efcfa97ba27389f2d2b86
-    # becomes released
-    pip install --retries 3 -q $PIP_FLAGS 'pyqt5<5.11'
+    pip install --retries 3 -q $PIP_FLAGS pyqt5
     MPL_QT_API=PyQt5
     export QT_API=pyqt5
 elif [[ "${QT}" == "PySide2" ]]; then


### PR DESCRIPTION
They work together now

https://mail.python.org/pipermail/matplotlib-users/2018-August/001479.html
## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
