### PR TITLE
Demo: deprecators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ doc/build
 source/api
 build
 dist
-skimage/version.py
 *.swp
 .coverage
 doc/source/auto_examples/**/*

--- a/doc/tools/build_modref_templates.py
+++ b/doc/tools/build_modref_templates.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
 
     installed_version = V(module.__version__)
 
-    source_lines = open('../skimage/__init__.py').readlines()
+    source_lines = open('../skimage/version.py').readlines()
     version = 'vUndefined'
     for l in source_lines:
         if l.startswith('__version__'):

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -7,4 +7,4 @@ imageio>=2.0.1
 PyWavelets>=0.4.0
 dask[array]>=0.9.0
 cloudpickle>=0.2.1
-deprecation_factory>=0.2.3
+deprecation_factory>=0.2.4

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -7,4 +7,4 @@ imageio>=2.0.1
 PyWavelets>=0.4.0
 dask[array]>=0.9.0
 cloudpickle>=0.2.1
-deprecation-factory>=0.2.2
+deprecation_factory>=0.2.2

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -7,3 +7,4 @@ imageio>=2.0.1
 PyWavelets>=0.4.0
 dask[array]>=0.9.0
 cloudpickle>=0.2.1
+deprecation-factory>=0.2.2

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -7,4 +7,4 @@ imageio>=2.0.1
 PyWavelets>=0.4.0
 dask[array]>=0.9.0
 cloudpickle>=0.2.1
-deprecation_factory>=0.2.2
+deprecation_factory>=0.2.3

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ import builtins
 builtins.__SKIMAGE_SETUP__ = True
 
 
-with open('skimage/__init__.py') as fid:
+with open('skimage/version.py') as fid:
     for line in fid:
         if line.startswith('__version__'):
             VERSION = line.strip().split()[-1][1:-1]

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -74,7 +74,7 @@ import warnings
 import sys
 
 
-__version__ = '0.15.dev0'
+from .version import __version__
 
 from ._shared.version_requirements import ensure_python_version
 ensure_python_version((3, 5))

--- a/skimage/_shared/_deprecators.py
+++ b/skimage/_shared/_deprecators.py
@@ -1,0 +1,12 @@
+from functools import partial
+from ..version import __version__
+from deprecation_factory import kwonly_change
+from deprecation_factory import default_parameter_change
+
+kwonly_change = partial(kwonly_change,
+                        library_name='scikit-image',
+                        current_library_version=__version__)
+
+default_parameter_change = partial(default_parameter_change,
+                                   library_name='scikit-image',
+                                   current_library_version=__version__)

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -86,7 +86,7 @@ def pyramid_reduce(image, *, downscale=2, sigma=None, order=1,
 
 
 @kwonly_change('1.0')
-def pyramid_expand(image, upscale=2, sigma=None, order=1,
+def pyramid_expand(image, *, upscale=2, sigma=None, order=1,
                    mode='reflect', cval=0, multichannel=None):
     """Upsample and then smooth image.
 

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -24,7 +24,10 @@ def _check_factor(factor):
         raise ValueError('scale factor must be greater than 1')
 
 
-def pyramid_reduce(image, downscale=2, sigma=None, order=1,
+from .._shared._deprecators import kwonly_change
+
+@kwonly_change('1.0')
+def pyramid_reduce(image, *, downscale=2, sigma=None, order=1,
                    mode='reflect', cval=0, multichannel=None):
     """Smooth and then downsample image.
 
@@ -82,6 +85,7 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
     return out
 
 
+@kwonly_change('1.0')
 def pyramid_expand(image, upscale=2, sigma=None, order=1,
                    mode='reflect', cval=0, multichannel=None):
     """Upsample and then smooth image.
@@ -141,8 +145,12 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
     return out
 
 
-def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
-                     mode='reflect', cval=0, multichannel=None):
+@kwonly_change('1.0', previous_arg_order=['image', 'max_layer', 'downscale',
+                                          'sigma', 'order',
+                                          'mode', 'cval', 'multichannel'])
+def pyramid_gaussian(image, *, downscale=2, sigma=None, order=1,
+                     mode='reflect', cval=0, max_layer=-1,
+                     multichannel=None):
     """Yield images of the Gaussian pyramid formed by the input image.
 
     Recursively applies the `pyramid_reduce` function to the image, and yields

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -60,7 +60,8 @@ def test_pyramid_expand_nd():
 
 def test_build_gaussian_pyramid_rgb():
     rows, cols, dim = image.shape
-    with expected_warnings(['The default multichannel']):
+    with expected_warnings(['The default multichannel',
+                            'will become keyword-only argument']):
         pyramid = pyramids.pyramid_gaussian(image, downscale=2)
         for layer, out in enumerate(pyramid):
             layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
@@ -69,7 +70,8 @@ def test_build_gaussian_pyramid_rgb():
 
 def test_build_gaussian_pyramid_gray():
     rows, cols = image_gray.shape
-    with expected_warnings(['The default multichannel']):
+    with expected_warnings(['The default multichannel',
+                            'will become keyword-only argument']):
         pyramid = pyramids.pyramid_gaussian(image_gray, downscale=2)
         for layer, out in enumerate(pyramid):
             layer_shape = (rows / 2 ** layer, cols / 2 ** layer)

--- a/skimage/version.py
+++ b/skimage/version.py
@@ -1,0 +1,2 @@
+# Avoid circular imports
+__version__ = '0.15.dev0'


### PR DESCRIPTION
This is a small demo about how a decorator I wrote could be used to transition to keyword only arguments.

@jni 

If i can remember how to compile the docs, I'll try to show how they look in screenshots

But you can read more about the package here
https://deprecation-factory.readthedocs.io/en/latest/index.html
Some advantages of using this would be:

  * The library write the warning message in the docs.
  * The library warns your users telling them how to get rid of the warning too.
  * The library will point the user to their line of code, so that they can make the appropriate modifications.
  * It is even safe to leave the deprecators in place after the threshold version has been reached. The decorator will behave as a no-op and your library will use the updated version of your code. Deprecations should not have to be blockers for your development.


## References
https://github.com/scikit-image/scikit-image/issues/3045 (not exactly related to this particular demo, but the library can deprecate default values)

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
