### PR TITLE
Allow @hmaarrfk to mention MeeseeksDev to backport.

### DIFF
--- a/.meeseeksdev.yml
+++ b/.meeseeksdev.yml
@@ -1,0 +1,12 @@
+users:
+  hmaarrfk:
+    can:
+      - backport
+      - tag
+    config:
+      tag:
+        any: False
+        only:
+           - 'backport: 0.14.x'
+
+

--- a/tools/check_sdist.py
+++ b/tools/check_sdist.py
@@ -24,7 +24,7 @@ ignore_files = ['./TODO.md', './README.md', './MANIFEST',
                 './.gitignore', './.travis.yml', './.gitmodules',
                 './.mailmap', './.coveragerc', './.appveyor.yml',
                 './.pep8speaks.yml', './asv.conf.json',
-                './skimage/filters/rank/README.rst']
+                './skimage/filters/rank/README.rst', './.meeseeksdev.yml']
 
 # These docstring artifacts are hard to avoid without adding noise to the
 # docstrings. They typically show up if you run the whole test suite in the


### PR DESCRIPTION
And to tag issues with the 'backport: 0.14.x' label.

Thanks @Carreau!