### PR TITLE
Fix deprecated keyword from dask

### DIFF
--- a/doc/examples/xx_applications/plot_haar_extraction_selection_classification.py
+++ b/doc/examples/xx_applications/plot_haar_extraction_selection_classification.py
@@ -29,7 +29,7 @@ from time import time
 import numpy as np
 import matplotlib.pyplot as plt
 
-from dask import delayed, threaded, multiprocessing
+from dask import delayed
 
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
@@ -74,9 +74,9 @@ feature_types = ['type-2-x', 'type-2-y']
 # the computation step
 X = delayed(extract_feature_image(img, feature_types)
             for img in images)
-# Compute the result using the "multiprocessing" dask backend
+# Compute the result using the "processes" dask backend
 t_start = time()
-X = np.array(X.compute(get=multiprocessing.get))
+X = np.array(X.compute(scheduler='processes'))
 time_full_feature_comp = time() - t_start
 y = np.array([1] * 100 + [0] * 100)
 X_train, X_test, y_train, y_test = train_test_split(X, y, train_size=150,
@@ -143,14 +143,14 @@ selected_feature_type = feature_type[idx_sorted[:sig_feature_count]]
 X = delayed(extract_feature_image(img, selected_feature_type,
                                   selected_feature_coord)
             for img in images)
-# Compute the result using the *threaded* backend:
+# Compute the result using the *threads* backend:
 # When computing all features, the Python GIL is acquired to process each ROI,
 # and this is where most of the time is spent, so multiprocessing is faster.
 # For this small subset, most of the time is spent on the feature computation
 # rather than the ROI scanning, and using threaded is *much* faster, because
 # we avoid the overhead of launching a new process.
 t_start = time()
-X = np.array(X.compute(get=threaded.get))
+X = np.array(X.compute(scheduler='threads'))
 time_subs_feature_comp = time() - t_start
 y = np.array([1] * 100 + [0] * 100)
 X_train, X_test, y_train, y_test = train_test_split(X, y, train_size=150,


### PR DESCRIPTION
## Description


This patch fixes in

doc/examples/xx_applications/plot_haar_extraction_selection_classification.py

```
/home/fr/.local/share/virtualenvs/sk/lib/python3.7/site-packages/dask/base.py:835:
UserWarning: The get= keyword has been deprecated. Please use the
scheduler= keyword instead with the name of the desired scheduler like
'threads' or 'processes'
  warnings.warn("The get= keyword has been deprecated. "

```


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]

 
## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
