### PR TITLE
Incompatible modes with anti-aliasing in skimage.transform.resize

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -129,8 +129,24 @@ def resize(image, output_shape, order=1, mode='reflect', cval=0, clip=True,
                 warn("Anti-aliasing standard deviation greater than zero but "
                      "not down-sampling along all axes")
 
+        # Translate modes used by np.pad to those used by ndi.gaussian_filter
+        if mode == "constant":
+            gf_mode = "constant"
+        elif mode == "edge":
+            gf_mode = "nearest"
+        elif mode == "symmetric":
+            gf_mode = "reflect"
+        elif mode == "reflect":
+            gf_mode = "mirror"
+        elif mode == "wrap":
+            gf_mode = "wrap"
+        else:
+            raise ValueError("Unknown mode, or cannot translate mode. The "
+                             "mode should be one of 'constant', 'edge', "
+                             "'symmetric', 'reflect', or 'wrap'.")
+
         image = ndi.gaussian_filter(image, anti_aliasing_sigma,
-                                    cval=cval, mode=mode)
+                                    cval=cval, mode=gf_mode)
 
     # 2-dimensional interpolation
     if len(output_shape) == 2 or (len(output_shape) == 3 and

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -130,23 +130,23 @@ def resize(image, output_shape, order=1, mode='reflect', cval=0, clip=True,
                      "not down-sampling along all axes")
 
         # Translate modes used by np.pad to those used by ndi.gaussian_filter
-        if mode == "constant":
-            gf_mode = "constant"
-        elif mode == "edge":
-            gf_mode = "nearest"
-        elif mode == "symmetric":
-            gf_mode = "reflect"
-        elif mode == "reflect":
-            gf_mode = "mirror"
-        elif mode == "wrap":
-            gf_mode = "wrap"
-        else:
+        np_pad_to_ndimage = {
+            'constant': 'constant',
+            'edge': 'nearest',
+            'symmetric': 'reflect',
+            'reflect': 'mirror',
+            'wrap': 'wrap'
+        }
+        try:
+            ndi_mode = np_pad_to_ndimage[mode]
+        except KeyError:
             raise ValueError("Unknown mode, or cannot translate mode. The "
                              "mode should be one of 'constant', 'edge', "
-                             "'symmetric', 'reflect', or 'wrap'.")
+                             "'symmetric', 'reflect', or 'wrap'. See the "
+                             "documentation of numpy.pad for more info.")
 
         image = ndi.gaussian_filter(image, anti_aliasing_sigma,
-                                    cval=cval, mode=gf_mode)
+                                    cval=cval, mode=ndi_mode)
 
     # 2-dimensional interpolation
     if len(output_shape) == 2 or (len(output_shape) == 3 and

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -436,6 +436,23 @@ def test_downscale_anti_aliasing():
     assert_equal(scaled[3:, :].sum(), 0)
     assert_equal(scaled[:, 3:].sum(), 0)
 
+    sigma = 0.12499999  # The filter will be three pixels wide
+    out_size = (5, 5)
+    resize(x, out_size, order=1, mode='constant',
+           anti_aliasing=True, anti_aliasing_sigma=sigma)
+    resize(x, out_size, order=1, mode='edge',
+           anti_aliasing=True, anti_aliasing_sigma=sigma)
+    resize(x, out_size, order=1, mode='symmetric',
+           anti_aliasing=True, anti_aliasing_sigma=sigma)
+    resize(x, out_size, order=1, mode='reflect',
+           anti_aliasing=True, anti_aliasing_sigma=sigma)
+    resize(x, out_size, order=1, mode='wrap',
+           anti_aliasing=True, anti_aliasing_sigma=sigma)
+
+    with testing.raises(ValueError):  # Unknown mode, or cannot translate mode
+        resize(x, out_size, order=1, mode='non-existent',
+               anti_aliasing=True, anti_aliasing_sigma=sigma)
+
 
 def test_downscale_local_mean():
     image1 = np.arange(4 * 6).reshape(4, 6)

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -402,6 +402,23 @@ def test_downsize_anti_aliasing():
     assert_equal(scaled[3:, :].sum(), 0)
     assert_equal(scaled[:, 3:].sum(), 0)
 
+    sigma = 0.125
+    out_size = (5, 5)
+    resize(x, out_size, order=1, mode='constant',
+           anti_aliasing=True, anti_aliasing_sigma=sigma)
+    resize(x, out_size, order=1, mode='edge',
+           anti_aliasing=True, anti_aliasing_sigma=sigma)
+    resize(x, out_size, order=1, mode='symmetric',
+           anti_aliasing=True, anti_aliasing_sigma=sigma)
+    resize(x, out_size, order=1, mode='reflect',
+           anti_aliasing=True, anti_aliasing_sigma=sigma)
+    resize(x, out_size, order=1, mode='wrap',
+           anti_aliasing=True, anti_aliasing_sigma=sigma)
+
+    with testing.raises(ValueError):  # Unknown mode, or cannot translate mode
+        resize(x, out_size, order=1, mode='non-existent',
+               anti_aliasing=True, anti_aliasing_sigma=sigma)
+
 
 def test_downsize_anti_aliasing_invalid_stddev():
     x = np.zeros((10, 10), dtype=np.double)
@@ -435,23 +452,6 @@ def test_downscale_anti_aliasing():
     assert np.all(scaled[:3, :3] > 0)
     assert_equal(scaled[3:, :].sum(), 0)
     assert_equal(scaled[:, 3:].sum(), 0)
-
-    sigma = 0.12499999  # The filter will be three pixels wide
-    out_size = (5, 5)
-    resize(x, out_size, order=1, mode='constant',
-           anti_aliasing=True, anti_aliasing_sigma=sigma)
-    resize(x, out_size, order=1, mode='edge',
-           anti_aliasing=True, anti_aliasing_sigma=sigma)
-    resize(x, out_size, order=1, mode='symmetric',
-           anti_aliasing=True, anti_aliasing_sigma=sigma)
-    resize(x, out_size, order=1, mode='reflect',
-           anti_aliasing=True, anti_aliasing_sigma=sigma)
-    resize(x, out_size, order=1, mode='wrap',
-           anti_aliasing=True, anti_aliasing_sigma=sigma)
-
-    with testing.raises(ValueError):  # Unknown mode, or cannot translate mode
-        resize(x, out_size, order=1, mode='non-existent',
-               anti_aliasing=True, anti_aliasing_sigma=sigma)
 
 
 def test_downscale_local_mean():


### PR DESCRIPTION


## Description
A bug in skimage.transform.resize prevented the use of anti_aliasing with some modes. This was because of a mismatch between the names for the modes in np.pad and ndi.gaussian_filter.

I've just added a few if-statements that translates from the np.pad format to the ndi.gaussian_filter format.

I've also added an addition to the unit test (to test_downscale_anti_aliasing) that checks that the updated code does not crash, and that it crashed when a mode that's not supported is provided.


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
Closes issue #3299.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
