### PR TITLE
Speed up inner loop of GLCM

### DIFF
--- a/benchmarks/benchmark_feature.py
+++ b/benchmarks/benchmark_feature.py
@@ -2,7 +2,7 @@
 # http://asv.readthedocs.io/en/latest/writing_benchmarks.html
 import numpy as np
 from scipy import ndimage as ndi
-from skimage import feature
+from skimage import feature, util
 
 
 class FeatureSuite:
@@ -15,5 +15,11 @@ class FeatureSuite:
         self.image = ndi.gaussian_filter(self.image, 4)
         self.image += 0.2 * np.random.random(self.image.shape)
 
+        self.image_ubyte = util.img_as_ubyte(np.clip(self.image, 0, 1))
+
     def time_canny(self):
         result = feature.canny(self.image)
+
+    def time_glcm(self):
+        pi = np.pi
+        result = feature.greycomatrix(self.image_ubyte, [1, 2], [0, pi/4, pi/2, 3*pi/4])

--- a/benchmarks/benchmark_feature.py
+++ b/benchmarks/benchmark_feature.py
@@ -22,4 +22,5 @@ class FeatureSuite:
 
     def time_glcm(self):
         pi = np.pi
-        result = feature.greycomatrix(self.image_ubyte, [1, 2], [0, pi/4, pi/2, 3*pi/4])
+        result = feature.greycomatrix(self.image_ubyte, distances=[1, 2],
+                                      angles=[0, pi/4, pi/2, 3*pi/4])

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,6 @@
-pytest
+# pytest 3.7.3 is broken on macOS, see:
+# https://github.com/pytest-dev/pytest/issues/3888
+pytest!=3.7.3
 pytest-cov
 flake8
 codecov

--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -48,7 +48,8 @@ def _glcm_loop(any_int[:, ::1] image, double[:] distances,
     """
 
     cdef:
-        Py_ssize_t a_idx, d_idx, r, c, rows, cols, row, col
+        Py_ssize_t a_idx, d_idx, r, c, rows, cols, row, col, start_row,\
+                   end_row, start_col, end_col, offset_row, offset_col
         any_int i, j
         cnp.float64_t angle, distance
 
@@ -60,22 +61,21 @@ def _glcm_loop(any_int[:, ::1] image, double[:] distances,
             angle = angles[a_idx]
             for d_idx in range(distances.shape[0]):
                 distance = distances[d_idx]
-                for r in range(rows):
-                    for c in range(cols):
+                offset_row = <int>round(sin(angle) * distance)
+                offset_col = <int>round(cos(angle) * distance)
+                start_row = max(0, -offset_row)
+                end_row = min(rows, rows - offset_row)
+                start_col = max(0, -offset_col)
+                end_col = min(cols, cols - offset_col)
+                for r in range(start_row, end_row):
+                    for c in range(start_col, end_col):
                         i = image[r, c]
-
                         # compute the location of the offset pixel
-                        row = r + <int>round(sin(angle) * distance)
-                        col = c + <int>round(cos(angle) * distance)
-
-                        # make sure the offset is within bounds
-                        if row >= 0 and row < rows and \
-                           col >= 0 and col < cols:
-                            j = image[row, col]
-
-                            if i >= 0 and i < levels and \
-                               j >= 0 and j < levels:
-                                out[i, j, d_idx, a_idx] += 1
+                        row = r + offset_row
+                        col = c + offset_col
+                        j = image[row, col]
+                        if 0 <= i < levels and 0 <= j < levels:
+                            out[i, j, d_idx, a_idx] += 1
 
 
 cdef inline int _bit_rotate_right(int value, int length) nogil:


### PR DESCRIPTION
## Description
As suggested by @abTest-123 in #3377, pulling some computations and comparisons outside of the inner loop of the gray level co-occurrence matrix results in a significant speedup. In my machine, the included benchmark runs in 9.6ms with the new code, vs 14.7ms on master!


## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] ~~[Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)~~
- [x] ~~Gallery example in `./doc/examples` (new features only)~~
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] ~~Unit tests~~

## References
Closes #3377 

## For reviewers

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
