### PR TITLE
Avoid Sphinx 1.7.8

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,6 @@
-sphinx>=1.3
+# Sphinx 1.7.8 has a bug when building on cached envs
+# https://github.com/sphinx-doc/sphinx/issues/5361
+sphinx>=1.3,!=1.7.8
 numpydoc>=0.6
 sphinx-gallery
 scikit-learn


### PR DESCRIPTION
It appears to have issues with environment caches from older versions:
https://github.com/sphinx-doc/sphinx/issues/5361

This caused failures in #3370.

# For reviewers

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
