### PR TITLE
 Backport PR #3162 and #3161 on branch v0.14.x

### DIFF
--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -177,18 +177,6 @@ else:
                              dtype_limits)
 
 
-def lookfor(what):
-    """Do a keyword search on scikit-image docstrings.
-
-    Parameters
-    ----------
-    what : str
-        Words to look for.
-
-    """
-    import numpy as np
-    import sys
-    return np.lookfor(what, sys.modules[__name__])
-
+from .util import lookfor
 
 del warnings, functools, osp, imp, sys

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -177,6 +177,6 @@ else:
                              dtype_limits)
 
 
-from .util import lookfor
+from .util.lookfor import lookfor
 
 del warnings, functools, osp, imp, sys

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -173,7 +173,6 @@ else:
                              img_as_bool,
                              dtype_limits)
 
-
     from .util.lookfor import lookfor
     from .data import data_dir
 

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -68,16 +68,13 @@ dtype_limits
 
 """
 
-import os.path as osp
 import imp
 import functools
 import warnings
 import sys
 
-pkg_dir = osp.abspath(osp.dirname(__file__))
-data_dir = osp.join(pkg_dir, 'data')
-
 __version__ = '0.14.0'
+
 
 try:
     imp.find_module('pytest')
@@ -177,6 +174,8 @@ else:
                              dtype_limits)
 
 
-from .util.lookfor import lookfor
+    from .util.lookfor import lookfor
+    from .data import data_dir
 
-del warnings, functools, osp, imp, sys
+
+del warnings, functools, imp, sys

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -12,13 +12,16 @@ import os as _os
 
 import numpy as _np
 
-from .. import data_dir
 from ..io import imread, use_plugin
 from .._shared._warnings import expected_warnings, warn
-from .. import img_as_bool
+from ..util.dtype import img_as_bool
 from ._binary_blobs import binary_blobs
 
-__all__ = ['load',
+import os.path as osp
+data_dir = osp.abspath(osp.dirname(__file__))
+
+__all__ = ['data_dir',
+           'load',
            'astronaut',
            'binary_blobs',
            'camera',

--- a/skimage/util/lookfor.py
+++ b/skimage/util/lookfor.py
@@ -1,0 +1,14 @@
+import numpy as np
+import sys
+
+
+def lookfor(what):
+    """Do a keyword search on scikit-image docstrings.
+
+    Parameters
+    ----------
+    what : str
+        Words to look for.
+
+    """
+    return np.lookfor(what, sys.modules[__name__.split('.')[0]])

--- a/skimage/util/lookfor.py
+++ b/skimage/util/lookfor.py
@@ -10,5 +10,15 @@ def lookfor(what):
     what : str
         Words to look for.
 
+    Examples
+    --------
+    >>> import skimage
+    >>> skimage.lookfor('regular_grid')
+    Search results for 'regular_grid'
+    ---------------------------------
+    skimage.lookfor
+        Do a keyword search on scikit-image docstrings.
+    skimage.util.regular_grid
+        Find `n_points` regularly spaced along `ar_shape`.
     """
     return np.lookfor(what, sys.modules[__name__.split('.')[0]])


### PR DESCRIPTION
PR #3161
PR #3162

Supersedes https://github.com/scikit-image/scikit-image/pull/3371 

@soupault 

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
