### PR TITLE
Minor updates to grammar in numpy images page

### DIFF
--- a/doc/source/user_guide/numpy_images.rst
+++ b/doc/source/user_guide/numpy_images.rst
@@ -54,7 +54,7 @@ whole sets of pixels using the different indexing capabilities of NumPy.
 
 Slicing::
 
-    >>> # Set to "black" (0) the first ten lines
+    >>> # Set the first ten lines to "black" (0)
     >>> camera[:10] = 0
 
 Masking (indexing with masks of booleans)::
@@ -72,7 +72,7 @@ Fancy indexing (indexing with sets of indices)::
 Masks are very useful when you need to select a set of pixels on which
 to perform the manipulations. The mask can be any boolean array
 of the same shape as the image (or a shape broadcastable to the image shape).
-This can be used to define a region of interest, for example, a disk-shaped::
+This can be used to define a region of interest, for example, a disk::
 
     >>> nrows, ncols = camera.shape
     >>> row, col = np.ogrid[:nrows, :ncols]
@@ -96,7 +96,7 @@ Boolean operations from NumPy can be used to define even more complex masks::
 Color images
 ------------
 
-All of the above is true for color images too: a color image is a
+All of the above remains true for color images. A color image is a
 NumPy array with an additional trailing dimension for the channels::
 
     >>> cat = data.chelsea()
@@ -143,7 +143,7 @@ also see ``rr`` and ``cc`` refer to lists of row and column
 coordinates. We distinguish this convention from ``(x, y)``, which commonly
 denote standard Cartesian coordinates, where ``x`` is the horizontal coordinate,
 ``y`` - the vertical one, and the origin is at the bottom left
-(Matplotlib, for example, uses this convention).
+(Matplotlib axes, for example, use this convention).
 
 In the case of multichannel images, the last dimension is used for color channels
 and is denoted by ``channel`` or ``ch``.
@@ -196,7 +196,7 @@ Notes on the order of array dimensions
 --------------------------------------
 
 Although the labeling of the axes might seem arbitrary, it can have a
-significant effect on the speed of operations. This is because the modern
+significant effect on the speed of operations. This is because modern
 processors never retrieve just one item from memory, but rather a whole
 chunk of adjacent items (an operation called prefetching). Therefore,
 processing of elements that are next to each other in memory is faster

--- a/doc/source/user_guide/numpy_images.rst
+++ b/doc/source/user_guide/numpy_images.rst
@@ -240,7 +240,7 @@ above, the ``*=`` numpy operator iterates over all remaining dimensions.
 A note on time
 --------------
 
-Although scikit-image does not currently (0.11) provide functions to
+Although scikit-image does not currently (0.14) provide functions to
 work specifically with time-varying 3D data, our compatibility with
 numpy arrays allows us to work quite naturally with a 5D array of the
 shape (t, pln, row, col, ch):

--- a/doc/source/user_guide/numpy_images.rst
+++ b/doc/source/user_guide/numpy_images.rst
@@ -4,21 +4,21 @@ A crash course on NumPy for images
 
 Images in ``scikit-image`` are represented by NumPy ndarrays. Hence, many 
 common operations can be achieved using standard NumPy methods for 
-manipulating arrays:
+manipulating arrays::
 
     >>> from skimage import data
     >>> camera = data.camera()
     >>> type(camera)
     <type 'numpy.ndarray'>
 
-Retrieving the geometry of the image and the number of pixels:
+Retrieving the geometry of the image and the number of pixels::
 
     >>> camera.shape
     (512, 512)
     >>> camera.size
     262144
 
-Retrieving statistical information about image intensity values:
+Retrieving statistical information about image intensity values::
 
     >>> camera.min(), camera.max()
     (0, 255)
@@ -34,12 +34,12 @@ NumPy indexing
 --------------
 
 NumPy indexing can be used both for looking at the pixel values and to
-modify them:
+modify them::
 
-    >>> # Get the value of the pixel in the (10th row, 20th column)
+    >>> # Get the value of the pixel at the 10th row and 20th column
     >>> camera[10, 20]
     153
-    >>> # Set to black the pixel in the (3rd row, 10th column)
+    >>> # Set to black the pixel at the 3rd row and 10th column
     >>> camera[3, 10] = 0
 
 Be careful! In NumPy indexing, the first dimension (``camera.shape[0]``)
@@ -52,18 +52,18 @@ more details.
 Beyond individual pixels, it is possible to access/modify values of
 whole sets of pixels using the different indexing capabilities of NumPy.
 
-Slicing:
+Slicing::
 
     >>> # Set to "black" (0) the first ten lines
     >>> camera[:10] = 0
 
-Masking (indexing with masks of booleans):
+Masking (indexing with masks of booleans)::
 
     >>> mask = camera < 87
     >>> # Set to "white" (255) the pixels where mask is True
     >>> camera[mask] = 255
 
-Fancy indexing (indexing with sets of indices):
+Fancy indexing (indexing with sets of indices)::
 
     >>> inds_r = np.arange(len(camera))
     >>> inds_c = 4 * inds_r % len(camera)
@@ -72,7 +72,7 @@ Fancy indexing (indexing with sets of indices):
 Masks are very useful when you need to select a set of pixels on which
 to perform the manipulations. The mask can be any boolean array
 of the same shape as the image (or a shape broadcastable to the image shape).
-This can be used to define a region of interest, for example, a disk-shaped:
+This can be used to define a region of interest, for example, a disk-shaped::
 
     >>> nrows, ncols = camera.shape
     >>> row, col = np.ogrid[:nrows, :ncols]
@@ -85,7 +85,7 @@ This can be used to define a region of interest, for example, a disk-shaped:
     :width: 45%
     :target: ../auto_examples/numpy_operations/plot_camera_numpy.html
 
-Boolean operations from NumPy can be used to define even more complex masks:
+Boolean operations from NumPy can be used to define even more complex masks::
 
     >>> lower_half = row > cnt_row
     >>> lower_half_disk = np.logical_and(lower_half, outer_disk_mask)
@@ -97,7 +97,7 @@ Color images
 ------------
 
 All of the above is true for color images too: a color image is a
-NumPy array with an additional trailing dimension for the channels:
+NumPy array with an additional trailing dimension for the channels::
 
     >>> cat = data.chelsea()
     >>> type(cat)
@@ -106,8 +106,7 @@ NumPy array with an additional trailing dimension for the channels:
     (300, 451, 3)
 
 This shows that ``cat`` is a 300-by-451 pixel image with three channels
-(in this case, red, green, and blue). As before, we can get and set
-the pixel values:
+(red, green, and blue). As before, we can get and set the pixel values::
 
     >>> cat[10, 20]
     array([151, 129, 115], dtype=uint8)
@@ -117,7 +116,7 @@ the pixel values:
     >>> cat[50, 61] = [0, 255, 0]  # [red, green, blue]
 
 We can also use 2D boolean masks for 2D multichannel images, as we did with
-the grayscale image above:
+the grayscale image above::
 
 .. plot::
 
@@ -140,7 +139,7 @@ coordinate conventions must match. Two-dimensional (2D) grayscale images
 (such as `camera` above) are indexed by rows and columns (abbreviated to
 either ``(row, col)`` or ``(r, c)``), with the lowest element ``(0, 0)``
 at the top-left corner. In various parts of the library, you will
-also see ``rr`` and ``cc`` referring to lists of row and column
+also see ``rr`` and ``cc`` refer to lists of row and column
 coordinates. We distinguish this convention from ``(x, y)``, which commonly
 denote standard Cartesian coordinates, where ``x`` is the horizontal coordinate,
 ``y`` - the vertical one, and the origin is at the bottom left
@@ -167,7 +166,7 @@ These conventions are summarized below:
   =========================   ========================================
 
 
-Many functions in ``scikit-image`` can operate on 3D images directly:
+Many functions in ``scikit-image`` can operate on 3D images directly::
 
     >>> im3d = np.random.rand(100, 1000, 1000)
     >>> from skimage import morphology
@@ -177,15 +176,14 @@ Many functions in ``scikit-image`` can operate on 3D images directly:
 
 In many cases, however, the third spatial dimension has lower resolution
 than the other two. Some ``scikit-image`` functions provide a ``spacing``
-keyword argument to help handling this situation:
+keyword argument to help handle this kind of data::
 
     >>> from skimage import segmentation
     >>> slics = segmentation.slic(im3d, spacing=[5, 1, 1], multichannel=False)
 
-Other functions may be lacking support for any non-2D images, and have to be used
-for processing of such data in plane-wise manner. When planes are stacked
+Other times, the processing must be done plane-wise. When planes are stacked
 along the leading dimension (in agreement with our convention), the following
-syntax can be used:
+syntax can be used::
 
     >>> from skimage import filters
     >>> edges = np.empty_like(im3d)
@@ -197,13 +195,13 @@ syntax can be used:
 Notes on the order of array dimensions
 --------------------------------------
 
-Although the labeling of the axes might seems arbitrary, it can have a
-significant effect on the speed of operations. To put it simply, this
-is related to the fact that the modern processors never retrieve just
-one item from memory, but rather a whole chunk of adjacent items
-(an operation called prefetching). Therefore, processing of elements
-that are next to each other in memory is faster than processing them
-when they are scattered, even if the number of operations is the same:
+Although the labeling of the axes might seem arbitrary, it can have a
+significant effect on the speed of operations. This is because the modern
+processors never retrieve just one item from memory, but rather a whole
+chunk of adjacent items (an operation called prefetching). Therefore,
+processing of elements that are next to each other in memory is faster
+than processing them when they are scattered, even if the number of operations
+is the same::
 
     >>> def in_order_multiply(arr, scalar):
     ...     for plane in list(range(arr.shape[0])):
@@ -230,20 +228,20 @@ when they are scattered, even if the number of operations is the same:
 
 When the last/rightmost dimension becomes even larger the speedup is
 even more dramatic. It is worth thinking about *data locality* when
-you are developing algorithms. In particular, you should know that
-``scikit-image`` uses C-contiguous arrays unless otherwise specified.
+developing algorithms. In particular, ``scikit-image`` uses C-contiguous
+arrays by default.
 When using nested loops, the last/rightmost dimension of the array
 should be in the innermost loop of the computation. In the example
 above, the ``*=`` numpy operator iterates over all remaining dimensions.
 
 
-A note on time dimension
-------------------------
+A note on the time dimension
+----------------------------
 
 Although ``scikit-image`` does not currently provide functions to
 work specifically with time-varying 3D data, its compatibility with
 NumPy arrays allows us to work quite naturally with a 5D array of the
-shape (t, pln, row, col, ch):
+shape (t, pln, row, col, ch)::
 
     >>> for timepoint in image5d:  # doctest: +SKIP
     ...     # Each timepoint is a 3D multichannel image

--- a/doc/source/user_guide/numpy_images.rst
+++ b/doc/source/user_guide/numpy_images.rst
@@ -2,8 +2,9 @@
 A crash course on NumPy for images
 ==================================
 
-Images manipulated by ``scikit-image`` are simply NumPy arrays. Hence, a
-large fraction of operations on images will just consist of using NumPy::
+Images in ``scikit-image`` are represented by NumPy ndarrays. Hence, many 
+common operations can be achieved using normal NumPy methods for 
+manipulating arrays.::
 
     >>> from skimage import data
     >>> camera = data.camera()
@@ -201,7 +202,7 @@ Notes on array order
 Although the labeling of the axes seems arbitrary, it can have a
 significant effect on the speed of operations. This is because modern
 processors never retrieve just one item from memory, but rather a
-whole chunk of adjacent items (called prefetching).
+whole chunk of adjacent items (an operation called prefetching).
 Therefore, processing elements that are
 next to each other in memory is faster than processing them
 in a different order, even if the number of operations is the same:
@@ -240,7 +241,7 @@ above, the ``*=`` numpy operator iterates over all remaining dimensions.
 A note on time
 --------------
 
-Although scikit-image does not currently (0.14) provide functions to
+Although scikit-image does not currently provide functions to
 work specifically with time-varying 3D data, our compatibility with
 numpy arrays allows us to work quite naturally with a 5D array of the
 shape (t, pln, row, col, ch):

--- a/doc/source/user_guide/numpy_images.rst
+++ b/doc/source/user_guide/numpy_images.rst
@@ -3,22 +3,22 @@ A crash course on NumPy for images
 ==================================
 
 Images in ``scikit-image`` are represented by NumPy ndarrays. Hence, many 
-common operations can be achieved using normal NumPy methods for 
-manipulating arrays.::
+common operations can be achieved using standard NumPy methods for 
+manipulating arrays:
 
     >>> from skimage import data
     >>> camera = data.camera()
     >>> type(camera)
     <type 'numpy.ndarray'>
 
-Retrieving the geometry of the image and the number of pixels: ::
+Retrieving the geometry of the image and the number of pixels:
 
     >>> camera.shape
     (512, 512)
     >>> camera.size
     262144
 
-Retrieving statistical information about gray values: ::
+Retrieving statistical information about image intensity values:
 
     >>> camera.min(), camera.max()
     (0, 255)
@@ -27,22 +27,22 @@ Retrieving statistical information about gray values: ::
 
 NumPy arrays representing images can be of different integer or float
 numerical types. See :ref:`data_types` for more information about these
-types and how scikit-image treats them.
+types and how ``scikit-image`` treats them.
 
 
 NumPy indexing
 --------------
 
-NumPy indexing can be used both for looking at pixel values and to
-modify pixel values: ::
+NumPy indexing can be used both for looking at the pixel values and to
+modify them:
 
-    >>> # Get the value of the pixel on the 10th row and 20th column
+    >>> # Get the value of the pixel in the (10th row, 20th column)
     >>> camera[10, 20]
     153
-    >>> # Set to black the pixel on the 3rd row and 10th column
+    >>> # Set to black the pixel in the (3rd row, 10th column)
     >>> camera[3, 10] = 0
 
-Be careful: in NumPy indexing, the first dimension (``camera.shape[0]``)
+Be careful! In NumPy indexing, the first dimension (``camera.shape[0]``)
 corresponds to rows, while the second (``camera.shape[1]``) corresponds
 to columns, with the origin (``camera[0, 0]``) at the top-left corner.
 This matches matrix/linear algebra notation, but is in contrast to
@@ -50,31 +50,29 @@ Cartesian (x, y) coordinates. See `Coordinate conventions`_ below for
 more details.
 
 Beyond individual pixels, it is possible to access/modify values of
-whole sets of pixels using the different indexing possibilities of
-NumPy.
+whole sets of pixels using the different indexing capabilities of NumPy.
 
-Slicing::
+Slicing:
 
-    >>> # Set to black the ten first lines
+    >>> # Set to "black" (0) the first ten lines
     >>> camera[:10] = 0
 
-Masking (indexing with masks of booleans)::
+Masking (indexing with masks of booleans):
 
     >>> mask = camera < 87
-    >>> # Set to "white" (255) pixels where mask is True
+    >>> # Set to "white" (255) the pixels where mask is True
     >>> camera[mask] = 255
 
-Fancy indexing (indexing with sets of indices) ::
+Fancy indexing (indexing with sets of indices):
 
     >>> inds_r = np.arange(len(camera))
     >>> inds_c = 4 * inds_r % len(camera)
     >>> camera[inds_r, inds_c] = 0
 
-Using masks is very useful to select a set of pixels on
-which to perform further manipulations. The mask can be any boolean array
+Masks are very useful when you need to select a set of pixels on which
+to perform the manipulations. The mask can be any boolean array
 of the same shape as the image (or a shape broadcastable to the image shape).
-This can be useful to define a region of interest, such as a
-disk: ::
+This can be used to define a region of interest, for example, a disk-shaped:
 
     >>> nrows, ncols = camera.shape
     >>> row, col = np.ogrid[:nrows, :ncols]
@@ -87,7 +85,7 @@ disk: ::
     :width: 45%
     :target: ../auto_examples/numpy_operations/plot_camera_numpy.html
 
-Boolean arithmetic can be used to define more complex masks: ::
+Boolean operations from NumPy can be used to define even more complex masks:
 
     >>> lower_half = row > cnt_row
     >>> lower_half_disk = np.logical_and(lower_half, outer_disk_mask)
@@ -98,8 +96,8 @@ Boolean arithmetic can be used to define more complex masks: ::
 Color images
 ------------
 
-All of the above is true of color images too: a color image is a
-NumPy array, with an additional trailing dimension for the channels:
+All of the above is true for color images too: a color image is a
+NumPy array with an additional trailing dimension for the channels:
 
     >>> cat = data.chelsea()
     >>> type(cat)
@@ -107,18 +105,18 @@ NumPy array, with an additional trailing dimension for the channels:
     >>> cat.shape
     (300, 451, 3)
 
-This shows that ``cat`` is a 300-by-451 pixel image with three
-channels (red, green, and blue).
-As before, we can get and set pixel values:
+This shows that ``cat`` is a 300-by-451 pixel image with three channels
+(in this case, red, green, and blue). As before, we can get and set
+the pixel values:
 
     >>> cat[10, 20]
     array([151, 129, 115], dtype=uint8)
-    >>> # set the pixel at row 50, column 60 to black
+    >>> # Set the pixel at (50th row, 60th column) to "black"
     >>> cat[50, 60] = 0
-    >>> # set the pixel at row 50, column 61 to green
-    >>> cat[50, 61] = [0, 255, 0] # [red, green, blue]
+    >>> # set the pixel at (50th row, 61st column) to "green"
+    >>> cat[50, 61] = [0, 255, 0]  # [red, green, blue]
 
-We can also use 2D boolean masks for a 2D color image, as we did with
+We can also use 2D boolean masks for 2D multichannel images, as we did with
 the grayscale image above:
 
 .. plot::
@@ -137,22 +135,22 @@ the grayscale image above:
 Coordinate conventions
 ----------------------
 
-Because we represent images with numpy arrays, our coordinates must
-match accordingly. Two-dimensional (2D) grayscale images (such as
-`camera` above) are indexed by row and columns (abbreviated to either
-``(row, col)`` or ``(r, c)``), with the lowest element ``(0, 0)`` at
-the top-left corner. In various parts of the library, you will
-also see ``rr`` and ``cc`` refer to lists of row and column
-coordinates. We distinguish this from ``(x, y)``, which commonly denote
-standard Cartesian coordinates, where ``x`` is the horizontal coordinate,
-``y`` the vertical, and the origin is at the bottom left.
-(Matplotlib, for example, uses this convention.)
+Because ``scikit-image`` represents images using NumPy arrays, the
+coordinate conventions must match. Two-dimensional (2D) grayscale images
+(such as `camera` above) are indexed by rows and columns (abbreviated to
+either ``(row, col)`` or ``(r, c)``), with the lowest element ``(0, 0)``
+at the top-left corner. In various parts of the library, you will
+also see ``rr`` and ``cc`` referring to lists of row and column
+coordinates. We distinguish this convention from ``(x, y)``, which commonly
+denote standard Cartesian coordinates, where ``x`` is the horizontal coordinate,
+``y`` - the vertical one, and the origin is at the bottom left
+(Matplotlib, for example, uses this convention).
 
-In the case of color (or multichannel) images, the last dimension
-contains the color information and is denoted ``channel`` or ``ch``.
+In the case of multichannel images, the last dimension is used for color channels
+and is denoted by ``channel`` or ``ch``.
 
-Finally, for 3D images, such as videos, magnetic resonance imaging
-(MRI) scans, or confocal microscopy, we refer to the leading dimension
+Finally, for volumetric (3D) images, such as videos, magnetic resonance imaging
+(MRI) scans, confocal microscopy, etc. we refer to the leading dimension
 as ``plane``, abbreviated as ``pln`` or ``p``.
 
 These conventions are summarized below:
@@ -160,7 +158,7 @@ These conventions are summarized below:
 .. table:: Dimension name and order conventions in scikit-image
 
   =========================   ========================================
-  Image type                  coordinates
+  Image type                  Coordinates
   =========================   ========================================
   2D grayscale                (row, col)
   2D multichannel (eg. RGB)   (row, col, ch)
@@ -169,7 +167,7 @@ These conventions are summarized below:
   =========================   ========================================
 
 
-Many functions in scikit-image operate on 3D images directly:
+Many functions in ``scikit-image`` can operate on 3D images directly:
 
     >>> im3d = np.random.rand(100, 1000, 1000)
     >>> from skimage import morphology
@@ -177,35 +175,35 @@ Many functions in scikit-image operate on 3D images directly:
     >>> seeds = ndi.label(im3d < 0.1)[0]
     >>> ws = morphology.watershed(im3d, seeds)
 
-In many cases,
-the third imaging dimension has lower resolution than the other two.
-Some scikit-image functions provide a ``spacing`` keyword argument
-to process these images:
+In many cases, however, the third spatial dimension has lower resolution
+than the other two. Some ``scikit-image`` functions provide a ``spacing``
+keyword argument to help handling this situation:
 
     >>> from skimage import segmentation
     >>> slics = segmentation.slic(im3d, spacing=[5, 1, 1], multichannel=False)
 
-
-Other times, processing must be done plane-wise. When planes are the
-leading dimension, we can use the following syntax:
+Other functions may be lacking support for any non-2D images, and have to be used
+for processing of such data in plane-wise manner. When planes are stacked
+along the leading dimension (in agreement with our convention), the following
+syntax can be used:
 
     >>> from skimage import filters
-    >>> edges = np.zeros_like(im3d)
+    >>> edges = np.empty_like(im3d)
     >>> for pln, image in enumerate(im3d):
-    ...     # iterate over the leading dimension (planes)
+    ...     # Iterate over the leading dimension 
     ...     edges[pln] = filters.sobel(image)
 
 
-Notes on array order
---------------------
+Notes on the order of array dimensions
+--------------------------------------
 
-Although the labeling of the axes seems arbitrary, it can have a
-significant effect on the speed of operations. This is because modern
-processors never retrieve just one item from memory, but rather a
-whole chunk of adjacent items (an operation called prefetching).
-Therefore, processing elements that are
-next to each other in memory is faster than processing them
-in a different order, even if the number of operations is the same:
+Although the labeling of the axes might seems arbitrary, it can have a
+significant effect on the speed of operations. To put it simply, this
+is related to the fact that the modern processors never retrieve just
+one item from memory, but rather a whole chunk of adjacent items
+(an operation called prefetching). Therefore, processing of elements
+that are next to each other in memory is faster than processing them
+when they are scattered, even if the number of operations is the same:
 
     >>> def in_order_multiply(arr, scalar):
     ...     for plane in list(range(arr.shape[0])):
@@ -220,7 +218,7 @@ in a different order, even if the number of operations is the same:
     >>> t0 = time.time(); x = in_order_multiply(im3d, 5); t1 = time.time()
     >>> print("%.2f seconds" % (t1 - t0))  # doctest: +SKIP
     0.14 seconds
-    >>> im3d_t = np.transpose(im3d).copy() # place "planes" dimension at end
+    >>> im3d_t = np.transpose(im3d).copy()  # place "planes" dimension at end
     >>> im3d_t.shape
     (1024, 1024, 100)
     >>> s0 = time.time(); x = out_of_order_multiply(im3d, 5); s1 = time.time()
@@ -230,26 +228,26 @@ in a different order, even if the number of operations is the same:
     Speedup: 8.6x
 
 
-When the last/rightmost dimension becomes even larger, the
-speedup is even more dramatic. It is worth thinking about
-*data locality* when writing algorithms. In particular, know that
-scikit-image uses C-contiguous arrays unless otherwise specified.
+When the last/rightmost dimension becomes even larger the speedup is
+even more dramatic. It is worth thinking about *data locality* when
+you are developing algorithms. In particular, you should know that
+``scikit-image`` uses C-contiguous arrays unless otherwise specified.
 When using nested loops, the last/rightmost dimension of the array
 should be in the innermost loop of the computation. In the example
 above, the ``*=`` numpy operator iterates over all remaining dimensions.
 
-A note on time
---------------
 
-Although scikit-image does not currently provide functions to
-work specifically with time-varying 3D data, our compatibility with
-numpy arrays allows us to work quite naturally with a 5D array of the
+A note on time dimension
+------------------------
+
+Although ``scikit-image`` does not currently provide functions to
+work specifically with time-varying 3D data, its compatibility with
+NumPy arrays allows us to work quite naturally with a 5D array of the
 shape (t, pln, row, col, ch):
 
     >>> for timepoint in image5d:  # doctest: +SKIP
-    ...     # each timepoint is a 3D multichannel image
+    ...     # Each timepoint is a 3D multichannel image
     ...     do_something_with(timepoint)
-
 
 We can then supplement the above table as follows:
 

--- a/doc/source/user_guide/numpy_images.rst
+++ b/doc/source/user_guide/numpy_images.rst
@@ -3,7 +3,7 @@ A crash course on NumPy for images
 ==================================
 
 Images manipulated by ``scikit-image`` are simply NumPy arrays. Hence, a
-large fraction of operations on images will just consist in using NumPy::
+large fraction of operations on images will just consist of using NumPy::
 
     >>> from skimage import data
     >>> camera = data.camera()
@@ -24,7 +24,7 @@ Retrieving statistical information about gray values: ::
     >>> camera.mean()
     118.31400299072266
 
-NumPy arrays representing images can be of different integer of float
+NumPy arrays representing images can be of different integer or float
 numerical types. See :ref:`data_types` for more information about these
 types and how scikit-image treats them.
 
@@ -32,7 +32,7 @@ types and how scikit-image treats them.
 NumPy indexing
 --------------
 
-NumPy indexing can be used both for looking at pixel values, and to
+NumPy indexing can be used both for looking at pixel values and to
 modify pixel values: ::
 
     >>> # Get the value of the pixel on the 10th row and 20th column
@@ -43,13 +43,13 @@ modify pixel values: ::
 
 Be careful: in NumPy indexing, the first dimension (``camera.shape[0]``)
 corresponds to rows, while the second (``camera.shape[1]``) corresponds
-to columns, with the origin (``camera[0, 0]``) on the top-left corner.
+to columns, with the origin (``camera[0, 0]``) at the top-left corner.
 This matches matrix/linear algebra notation, but is in contrast to
 Cartesian (x, y) coordinates. See `Coordinate conventions`_ below for
 more details.
 
-Beyond individual pixels, it is possible to access / modify values of
-whole sets of pixels, using the different indexing possibilities of
+Beyond individual pixels, it is possible to access/modify values of
+whole sets of pixels using the different indexing possibilities of
 NumPy.
 
 Slicing::
@@ -69,9 +69,9 @@ Fancy indexing (indexing with sets of indices) ::
     >>> inds_c = 4 * inds_r % len(camera)
     >>> camera[inds_r, inds_c] = 0
 
-Using masks, especially, is very useful to select a set of pixels on
+Using masks is very useful to select a set of pixels on
 which to perform further manipulations. The mask can be any boolean array
-of same shape as the image (or a shape broadcastable to the image shape).
+of the same shape as the image (or a shape broadcastable to the image shape).
 This can be useful to define a region of interest, such as a
 disk: ::
 
@@ -97,7 +97,7 @@ Boolean arithmetic can be used to define more complex masks: ::
 Color images
 ------------
 
-All of the above is true of color images, too: a color image is a
+All of the above is true of color images too: a color image is a
 NumPy array, with an additional trailing dimension for the channels:
 
     >>> cat = data.chelsea()
@@ -144,7 +144,7 @@ the top-left corner. In various parts of the library, you will
 also see ``rr`` and ``cc`` refer to lists of row and column
 coordinates. We distinguish this from ``(x, y)``, which commonly denote
 standard Cartesian coordinates, where ``x`` is the horizontal coordinate,
-``y`` the vertical, and the origin is on the bottom left.
+``y`` the vertical, and the origin is at the bottom left.
 (Matplotlib, for example, uses this convention.)
 
 In the case of color (or multichannel) images, the last dimension
@@ -199,9 +199,9 @@ Notes on array order
 --------------------
 
 Although the labeling of the axes seems arbitrary, it can have a
-significant effect on speed of operations. This is because modern
+significant effect on the speed of operations. This is because modern
 processors never retrieve just one item from memory, but rather a
-whole chunk of adjacent items. (This is called prefetching.)
+whole chunk of adjacent items (called prefetching).
 Therefore, processing elements that are
 next to each other in memory is faster than processing them
 in a different order, even if the number of operations is the same:


### PR DESCRIPTION
## Description
Correcting a few grammar issues in the user_guide/numpy_images page.
Hopefully the updates are small and non-contentious.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
