### PR TITLE
assert_all_close doesn't exist, make it `assert_array_equal`

### DIFF
--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -99,7 +99,7 @@ def test_float_out_of_range():
 
 def test_float_float_all_ranges():
     arr_in = np.array([[-10., 10., 1e20]], dtype=np.float32)
-    np.testing.assert_all_close(img_as_float(arr_in), arr_in)
+    np.testing.assert_array_equal(img_as_float(arr_in), arr_in)
 
 
 def test_copy():


### PR DESCRIPTION
assert_allclose exists, but I think in this case we should make a 
stronger assertion

@jni

Re: PR https://github.com/scikit-image/scikit-image/pull/3052

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
