### PR TITLE
Mark tests known to fail on 32bit architectures with xfail

### DIFF
--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -34,7 +34,7 @@ fixture = pytest.fixture
 
 # true if python is running in 32bit mode
 # Calculate the size of a void * pointer in bits
-# https://docs.python.org/2/library/struct.html
+# https://docs.python.org/3/library/struct.html
 arch32 = struct.calcsize("P") * 8 == 32
 
 

--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -33,6 +33,8 @@ raises = pytest.raises
 fixture = pytest.fixture
 
 # true if python is running in 32bit mode
+# Calculate the size of a void * pointer in bits
+# https://docs.python.org/2/library/struct.html
 arch32 = struct.calcsize("P") * 8 == 32
 
 

--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -4,6 +4,7 @@ Testing utilities.
 
 import os
 import re
+import struct
 import threading
 import functools
 from tempfile import NamedTemporaryFile
@@ -26,9 +27,13 @@ import pytest
 SKIP_RE = re.compile("(\s*>>>.*?)(\s*)#\s*skip\s+if\s+(.*)$")
 
 skipif = pytest.mark.skipif
+xfail = pytest.mark.xfail
 parametrize = pytest.mark.parametrize
 raises = pytest.raises
 fixture = pytest.fixture
+
+# true if python is running in 32bit mode
+arch32 = struct.calcsize("P") * 8 == 32
 
 
 def assert_less(a, b, msg=None):

--- a/skimage/feature/tests/test_orb.py
+++ b/skimage/feature/tests/test_orb.py
@@ -69,7 +69,8 @@ def test_keypoints_orb_less_than_desired_no_of_keypoints():
     assert_almost_equal(exp_cols, detector_extractor.keypoints[:, 1])
 
 
-@xfail(condition=arch32)
+@xfail(condition=arch32,
+       reason='https://github.com/scikit-image/scikit-image/issues/3091')
 def test_descriptor_orb():
     detector_extractor = ORB(fast_n=12, fast_threshold=0.20)
 

--- a/skimage/feature/tests/test_orb.py
+++ b/skimage/feature/tests/test_orb.py
@@ -70,7 +70,8 @@ def test_keypoints_orb_less_than_desired_no_of_keypoints():
 
 
 @xfail(condition=arch32,
-       reason=('Known test failure on 32-bit platforms. See links for details:'
+       reason=('Known test failure on 32-bit platforms. See links for '
+               'details: '
                'https://github.com/scikit-image/scikit-image/issues/3091 '
                'https://github.com/scikit-image/scikit-image/issues/2529'))
 def test_descriptor_orb():

--- a/skimage/feature/tests/test_orb.py
+++ b/skimage/feature/tests/test_orb.py
@@ -3,7 +3,7 @@ from skimage._shared.testing import assert_equal, assert_almost_equal
 from skimage.feature import ORB
 from skimage._shared import testing
 from skimage import data
-from skimage._shared.testing import test_parallel
+from skimage._shared.testing import test_parallel, xfail, arch32
 
 
 img = data.coins()
@@ -69,6 +69,7 @@ def test_keypoints_orb_less_than_desired_no_of_keypoints():
     assert_almost_equal(exp_cols, detector_extractor.keypoints[:, 1])
 
 
+@xfail(condition=arch32)
 def test_descriptor_orb():
     detector_extractor = ORB(fast_n=12, fast_threshold=0.20)
 

--- a/skimage/feature/tests/test_orb.py
+++ b/skimage/feature/tests/test_orb.py
@@ -70,7 +70,9 @@ def test_keypoints_orb_less_than_desired_no_of_keypoints():
 
 
 @xfail(condition=arch32,
-       reason='https://github.com/scikit-image/scikit-image/issues/3091')
+       reason=('Known test failure on 32-bit platforms. See links for details:'
+               'https://github.com/scikit-image/scikit-image/issues/3091 '
+               'https://github.com/scikit-image/scikit-image/issues/2529'))
 def test_descriptor_orb():
     detector_extractor = ORB(fast_n=12, fast_threshold=0.20)
 

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -22,7 +22,10 @@ class TestRank():
         np.random.seed(0)
 
     @xfail(condition=arch32,
-           reason='https://github.com/scikit-image/scikit-image/issues/3091')
+           reason=('Known test failure on 32-bit platforms. See links for '
+                   'details: '
+                   'https://github.com/scikit-image/scikit-image/issues/3091 '
+                   'https://github.com/scikit-image/scikit-image/issues/2528'))
     def test_all(self):
         @test_parallel()
         def check_all():

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -9,7 +9,7 @@ from skimage import data, util, morphology
 from skimage.morphology import grey, disk
 from skimage.filters import rank
 from skimage._shared._warnings import expected_warnings
-from skimage._shared.testing import test_parallel, xfail arch32
+from skimage._shared.testing import test_parallel, xfail, arch32
 
 
 class TestRank():
@@ -21,7 +21,8 @@ class TestRank():
         # Set again the seed for the other tests.
         np.random.seed(0)
 
-    @xfail(condition=arch32)
+    @xfail(condition=arch32,
+           reason='https://github.com/scikit-image/scikit-image/issues/3091')
     def test_all(self):
         @test_parallel()
         def check_all():

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -9,7 +9,7 @@ from skimage import data, util, morphology
 from skimage.morphology import grey, disk
 from skimage.filters import rank
 from skimage._shared._warnings import expected_warnings
-from skimage._shared.testing import test_parallel
+from skimage._shared.testing import test_parallel, xfail arch32
 
 
 class TestRank():
@@ -21,6 +21,7 @@ class TestRank():
         # Set again the seed for the other tests.
         np.random.seed(0)
 
+    @xfail(condition=arch32)
     def test_all(self):
         @test_parallel()
         def check_all():

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -5,7 +5,7 @@ from skimage.measure.fit import _dynamic_max_trials
 
 from skimage._shared import testing
 from skimage._shared.testing import (assert_equal, assert_almost_equal,
-                                     assert_array_less)
+                                     assert_array_less, xfail, arch32)
 
 
 def test_line_model_invalid_input():
@@ -220,6 +220,8 @@ def test_ellipse_model_estimate_from_data():
     assert_array_less(np.abs(model.params[:4]), np.array([2e3] * 4))
 
 
+@xfail(condition=arch32,
+       reason='https://github.com/scikit-image/scikit-image/issues/3091')
 def test_ellipse_model_estimate_failers():
     # estimate parameters of real data
     model = EllipseModel()

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -221,7 +221,10 @@ def test_ellipse_model_estimate_from_data():
 
 
 @xfail(condition=arch32,
-       reason='https://github.com/scikit-image/scikit-image/issues/3091')
+       reason=('Known test failure on 32-bit platforms. See links for '
+               'details: '
+               'https://github.com/scikit-image/scikit-image/issues/3091 '
+               'https://github.com/scikit-image/scikit-image/issues/2670'))
 def test_ellipse_model_estimate_failers():
     # estimate parameters of real data
     model = EllipseModel()

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -257,7 +257,10 @@ def test_spacing_0():
 
 
 @xfail(condition=arch32,
-       reason='https://github.com/scikit-image/scikit-image/issues/3092')
+       reason=('Known test failure on 32-bit platforms. See links for '
+               'details: '
+               'https://github.com/scikit-image/scikit-image/issues/3091 '
+               'https://github.com/scikit-image/scikit-image/issues/3092'))
 def test_spacing_1():
     n = 30
     lx, ly, lz = n, n, n

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -3,6 +3,7 @@ from skimage.segmentation import random_walker
 from skimage.transform import resize
 from skimage._shared._warnings import expected_warnings
 from skimage._shared import testing
+from skimage._shared.testing import xfail, arch32
 import scipy
 import numpy as np
 from distutils.version import LooseVersion as Version
@@ -255,6 +256,7 @@ def test_spacing_0():
     assert (labels_aniso[13:17, 13:17, 7:9] == 2).all()
 
 
+@xfail(condition=arch32)
 def test_spacing_1():
     n = 30
     lx, ly, lz = n, n, n

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -256,7 +256,8 @@ def test_spacing_0():
     assert (labels_aniso[13:17, 13:17, 7:9] == 2).all()
 
 
-@xfail(condition=arch32)
+@xfail(condition=arch32,
+       reason='https://github.com/scikit-image/scikit-image/issues/3092')
 def test_spacing_1():
     n = 30
     lx, ly, lz = n, n, n


### PR DESCRIPTION
@jni please test on wheel builder.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
