### PR TITLE
bump min matplotlib version to 2.1.0 to follow edits in #3300

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,6 @@
 numpy>=1.11
 scipy>=0.17.0
-matplotlib>=2.2.0
+matplotlib>=2.2.3
 networkx>=2.0
 pillow>=4.3.0
 imageio>=2.0.1

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,6 @@
 numpy>=1.11
 scipy>=0.17.0
-matplotlib>=2.0.0
+matplotlib>=2.2.0
 networkx>=2.0
 pillow>=4.3.0
 imageio>=2.0.1


### PR DESCRIPTION
## Description


I merged too rapidly #3300 Matplotlib min version has to be increased.
