### PR TITLE
TST: make test_wavelet_denoising_levels compatible with PyWavelets 1.0

### DIFF
--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -473,13 +473,22 @@ def test_wavelet_denoising_levels():
     # multi-level case should outperform single level case
     assert_(psnr_denoised > psnr_denoised_1 > psnr_noisy)
 
-    # invalid number of wavelet levels results in a ValueError
+    # invalid number of wavelet levels results in a ValueError or UserWarning
     max_level = pywt.dwt_max_level(np.min(img.shape),
                                    pywt.Wavelet(wavelet).dec_len)
-    with testing.raises(ValueError):
-        with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
+    if Version(pywt.__version__) < '1.0.0':
+        # exceeding max_level raises a ValueError in PyWavelets 0.4-0.5.2
+        with testing.raises(ValueError):
+            with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
+                restoration.denoise_wavelet(
+                    noisy, wavelet=wavelet, wavelet_levels=max_level + 1)
+    else:
+        # exceeding max_level raises a UserWarning in PyWavelets >= 1.0.0
+        with expected_warnings([
+                'all coefficients will experience boundary effects']):
             restoration.denoise_wavelet(
                 noisy, wavelet=wavelet, wavelet_levels=max_level + 1)
+
     with testing.raises(ValueError):
         with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
             restoration.denoise_wavelet(


### PR DESCRIPTION
## Description
In PyWavelets 0.5.x, exceeding the number of transform levels recommended by `dwt_max_level` resulted in a ValueError. In PyWavelets 1.0, this was changed instead to a `UserWarning` (see PyWavelets/pywt#403).  

This PR updates a test case for `denoise_wavelet` to take this into account

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
thanks to @jni for noticing this here:
https://github.com/scikit-image/scikit-image/pull/3401#issuecomment-420954976


## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
