### PR TITLE
Allow tifffile.py to handle I/O.

### DIFF
--- a/skimage/io/_plugins/tifffile_plugin.py
+++ b/skimage/io/_plugins/tifffile_plugin.py
@@ -26,6 +26,5 @@ def imread(fname, dtype=None, **kwargs):
     """
     if 'img_num' in kwargs:
         kwargs['key'] = kwargs.pop('img_num')
-    with open(fname, 'rb') as f:
-        tif = TiffFile(f)
+    with TiffFile(fname) as tif:
         return tif.asarray(**kwargs)

--- a/skimage/io/tests/test_tifffile.py
+++ b/skimage/io/tests/test_tifffile.py
@@ -38,6 +38,14 @@ def test_imread_multipage_rgb_tif():
     assert img.shape == (2, 10, 10, 3), img.shape
 
 
+def test_imread_handle():
+    expected = np.load(os.path.join(data_dir, 'chessboard_GRAY_U8.npy'))
+    with open(os.path.join(data_dir, 'chessboard_GRAY_U16.tif'), 'rb') as fh:
+        img = imread(fh)
+    assert img.dtype == np.uint16
+    assert_array_almost_equal(img, expected)
+
+
 class TestSave:
     def roundtrip(self, dtype, x):
         f = NamedTemporaryFile(suffix='.tif')


### PR DESCRIPTION
## Description
tifffile.py handles the same sets of input variants that the imread contract expects (file handle, file path).  The current implementation breaks when a file handle is passed to tifffile_plugin.


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
