### PR TITLE
Update Li thresholding (Backport of #3402)

### DIFF
--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -15,7 +15,9 @@ from skimage.filters.thresholding import (threshold_local,
                                           threshold_mean,
                                           threshold_triangle,
                                           threshold_minimum,
-                                          _mean_std)
+                                          try_all_threshold,
+                                          _mean_std,
+                                          _cross_entropy)
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_almost_equal
 
@@ -40,19 +42,18 @@ class TestSimpleImage():
         assert 2 <= threshold_otsu(image) < 3
 
     def test_li(self):
-        assert int(threshold_li(self.image)) == 2
+        assert 2 < threshold_li(self.image) < 3
 
     def test_li_negative_int(self):
         image = self.image - 2
-        assert int(threshold_li(image)) == 0
+        assert 0 < threshold_li(image) < 1
 
     def test_li_float_image(self):
-        image = np.float64(self.image)
-        assert 2 <= threshold_li(image) < 3
+        image = self.image.astype(float)
+        assert 2 < threshold_li(image) < 3
 
     def test_li_constant_image(self):
-        with testing.raises(ValueError):
-            threshold_li(np.ones((10, 10)))
+        assert threshold_li(np.ones((10, 10))) == 1.
 
     def test_yen(self):
         assert threshold_yen(self.image) == 2
@@ -231,23 +232,60 @@ def test_otsu_one_color_image():
 
 
 def test_li_camera_image():
-    camera = skimage.img_as_ubyte(data.camera())
-    assert 63 < threshold_li(camera) < 65
+    image = skimage.img_as_ubyte(data.camera())
+    threshold = threshold_li(image)
+    ce_actual = _cross_entropy(image, threshold)
+    assert 62 < threshold_li(image) < 63
+    assert ce_actual < _cross_entropy(image, threshold + 1)
+    assert ce_actual < _cross_entropy(image, threshold - 1)
 
 
 def test_li_coins_image():
-    coins = skimage.img_as_ubyte(data.coins())
-    assert 95 < threshold_li(coins) < 97
+    image = skimage.img_as_ubyte(data.coins())
+    threshold = threshold_li(image)
+    ce_actual = _cross_entropy(image, threshold)
+    assert 94 < threshold_li(image) < 95
+    assert ce_actual < _cross_entropy(image, threshold + 1)
+    # in the case of the coins image, the minimum cross-entropy is achieved one
+    # threshold below that found by the iterative method. Not sure why that is
+    # but `threshold_li` does find the stationary point of the function (ie the
+    # tolerance can be reduced arbitrarily but the exact same threshold is
+    # found), so my guess some kind of histogram binning effect.
+    assert ce_actual < _cross_entropy(image, threshold - 2)
 
 
 def test_li_coins_image_as_float():
     coins = skimage.img_as_float(data.coins())
-    assert 0.37 < threshold_li(coins) < 0.38
+    assert 94/255 < threshold_li(coins) < 95/255
 
 
 def test_li_astro_image():
-    img = skimage.img_as_ubyte(data.astronaut())
-    assert 66 < threshold_li(img) < 68
+    image = skimage.img_as_ubyte(data.astronaut())
+    threshold = threshold_li(image)
+    ce_actual = _cross_entropy(image, threshold)
+    assert 64 < threshold < 65
+    assert ce_actual < _cross_entropy(image, threshold + 1)
+    assert ce_actual < _cross_entropy(image, threshold - 1)
+
+
+def test_li_nan_image():
+    image = np.full((5, 5), np.nan)
+    assert np.isnan(threshold_li(image))
+
+
+def test_li_inf_image():
+    image = np.array([np.inf, np.nan])
+    assert threshold_li(image) == np.inf
+
+
+def test_li_inf_minus_inf():
+    image = np.array([np.inf, -np.inf])
+    assert threshold_li(image) == 0
+
+
+def test_li_constant_image_with_nan():
+    image = np.array([8, 8, 8, 8, np.nan])
+    assert threshold_li(image) == 8
 
 
 def test_yen_camera_image():

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import numpy as np
 from scipy import ndimage as ndi
 

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -466,13 +466,73 @@ def threshold_isodata(image, nbins=256, return_all=False):
         return thresholds[0]
 
 
-def threshold_li(image):
-    """Return threshold value based on adaptation of Li's Minimum Cross Entropy method.
+# Computing a histogram using np.histogram on a uint8 image with bins=256
+# doesn't work and results in aliasing problems. We use a fully specified set
+# of bins to ensure that each uint8 value false into its own bin.
+_DEFAULT_ENTROPY_BINS = tuple(np.arange(-0.5, 255.51, 1))
+
+
+def _cross_entropy(image, threshold, bins=_DEFAULT_ENTROPY_BINS):
+    """Compute cross-entropy between distributions above and below a threshold.
 
     Parameters
     ----------
-    image : (N, M) ndarray
+    image : array
+        The input array of values.
+    threshold : float
+        The value dividing the foreground and background in ``image``.
+    bins : int or array of float, optional
+        The number of bins or the bin edges. (Any valid value to the ``bins``
+        argument of ``np.histogram`` will work here.) For an exact calculation,
+        each unique value should have its own bin. The default value for bins
+        ensures exact handling of uint8 images: ``bins=256`` results in
+        aliasing problems due to bin width not being equal to 1.
+
+    Returns
+    -------
+    nu : float
+        The cross-entropy target value as defined in [1]_.
+
+    Notes
+    -----
+    See Li and Lee, 1993 [1]_; this is the objective function `threshold_li`
+    minimizes. This function can be improved but this implementation most
+    closely matches equation 8 in [1]_ and equations 1-3 in [2]_.
+
+    References
+    ----------
+    .. [1] Li C.H. and Lee C.K. (1993) "Minimum Cross Entropy Thresholding"
+           Pattern Recognition, 26(4): 617-625
+           :DOI:`10.1016/0031-3203(93)90115-D`
+    .. [2] Li C.H. and Tam P.K.S. (1998) "An Iterative Algorithm for Minimum
+           Cross Entropy Thresholding" Pattern Recognition Letters, 18(8): 771-776
+           :DOI:`10.1016/S0167-8655(98)00057-9`
+    """
+    histogram, bin_edges = np.histogram(image, bins=bins, density=True)
+    bin_centers = np.convolve(bin_edges, [0.5, 0.5], mode='valid')
+    t = np.flatnonzero(bin_centers > threshold)[0]
+    m0a = np.sum(histogram[:t])  # 0th moment, background
+    m0b = np.sum(histogram[t:])
+    m1a = np.sum(histogram[:t] * bin_centers[:t])  # 1st moment, background
+    m1b = np.sum(histogram[t:] * bin_centers[t:])
+    mua = m1a / m0a  # mean value, background
+    mub = m1b / m0b
+    nu = -m1a * np.log(mua) - m1b * np.log(mub)
+    return nu
+
+
+def threshold_li(image):
+    """Compute threshold value by Li's iterative Minimum Cross Entropy method.
+
+    Parameters
+    ----------
+    image : ndarray
         Input image.
+
+    tolerance : float, optional
+        Finish the computation when the change in the threshold in an iteration
+        is less than this value. By default, this is half of the range of the
+        input image, divided by 256.
 
     Returns
     -------
@@ -501,44 +561,47 @@ def threshold_li(image):
     >>> thresh = threshold_li(image)
     >>> binary = image > thresh
     """
-    # Make sure image has more than one value
+    # Remove nan:
+    image = image[~np.isnan(image)]
+    if image.size == 0:
+        return np.nan
+
+    # Make sure image has more than one value; otherwise, return that value
+    # This works even for np.inf
     if np.all(image == image.flat[0]):
-        raise ValueError("threshold_li is expected to work with images "
-                         "having more than one value. The input image seems "
-                         "to have just one value {0}.".format(image.flat[0]))
+        return image.flat[0]
 
-    # Copy to ensure input image is not modified
-    image = image.copy()
-    # Requires positive image (because of log(mean))
-    immin = np.min(image)
-    image -= immin
-    imrange = np.max(image)
-    tolerance = 0.5 * imrange / 256
+    # At this point, the image only contains np.inf, -np.inf, or valid numbers
+    image = image[np.isfinite(image)]
+    # if there are no finite values in the image, return 0. This is because
+    # at this point we *know* that there are *both* inf and -inf values,
+    # because inf == inf evaluates to True. We might as well separate them.
+    if image.size == 0:
+        return 0.
 
-    # Calculate the mean gray-level
-    mean = np.mean(image)
+    # Li's algorithm requires positive image (because of log(mean))
+    image_min = np.min(image)
+    image -= image_min
+    image_range = np.max(image)
+    tolerance = 0.5 * image_range / 256
 
     # Initial estimate
-    new_thresh = mean
-    old_thresh = new_thresh + 2 * tolerance
+    t_curr = np.mean(image)
+    t_next = t_curr + 2 * tolerance
 
     # Stop the iterations when the difference between the
     # new and old threshold values is less than the tolerance
-    while abs(new_thresh - old_thresh) > tolerance:
-        old_thresh = new_thresh
-        threshold = old_thresh + tolerance   # range
-        # Calculate the means of background and object pixels
-        mean_back = image[image <= threshold].mean()
-        mean_obj = image[image > threshold].mean()
+    while abs(t_next - t_curr) > tolerance:
+        t_curr = t_next
+        foreground = (image > t_curr)
+        mean_fore = np.mean(image[foreground])
+        mean_back = np.mean(image[~foreground])
 
-        temp = (mean_back - mean_obj) / (np.log(mean_back) - np.log(mean_obj))
+        t_next = ((mean_back - mean_fore) /
+                  (np.log(mean_back) - np.log(mean_fore)))
 
-        if temp < 0:
-            new_thresh = temp - tolerance
-        else:
-            new_thresh = temp + tolerance
-
-    return threshold + immin
+    threshold = t_next + image_min
+    return threshold
 
 
 def threshold_minimum(image, nbins=256, max_iter=10000):


### PR DESCRIPTION
- images with np.nan and np.inf values are now processed correctly
- `temp` value becoming negative was impossible, and this line was not
  covered, so removed it
- code contained numerous fixes for integer offset errors. Since we
  deal with floating point, these are unnecessary. The code is now
  much simpler
- it is also more correct: the tolerance offset that was applied
  previously in fact was giving an incorrect threshold. I verify this
  with a new private function, _cross_entropy, which estimates the
  cross-entropy between foreground and background as defined in the
  original paper.

The only fly in this sweet ointment is that for *one* of our test
images, coins, the threshold found by the iterative method is one off
(or rather 0.32316 off, but this happens to fall on either side of an
integer) from the optimal threshold. I believe this is an unavoidable
side effect of images being discretized into integer bins.

Additional changes:
- Indicate optional arguments in docstrings
- Abstract away default bins to get immutable default arg
- Further explain rationale for default bins value in _cross_entropy
- Remove the "tolerance" keyword-only argument (this was never present
  in the 0.14 series)

## Description
[Tell us about your new feature, improvement, or fix! If relevant, please supplement the PR with images.]


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
