### PR TITLE
MAINT: remove pyside restriction since we don't support Python 3.4 anymore

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,4 +1,3 @@
-PySide; python_version <= '3.4'
 imread
 SimpleITK; python_version < '3.7'
 astropy


### PR DESCRIPTION
Very short one.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
