### PR TITLE
Build tools: Add an OSX build with optional dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,10 @@ matrix:
     - os: osx
       osx_image: xcode9
       language: objective-c
+      env: TRAVIS_PYTHON_VERSION=3.6 OPTIONAL_DEPS=1
+    - os: osx
+      osx_image: xcode9
+      language: objective-c
       env: TRAVIS_PYTHON_VERSION=3.7
 
 before_install:

--- a/tools/travis/osx_install.sh
+++ b/tools/travis/osx_install.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -ex
+
 brew update
 brew install ccache
 brew tap caskroom/cask
@@ -12,3 +14,13 @@ sudo tlmgr install ucs dvipng anyfontsize
 git clone https://github.com/matthew-brett/multibuild ~/multibuild
 source ~/multibuild/osx_utils.sh
 get_macpython_environment $TRAVIS_PYTHON_VERSION ~/venv
+
+# libpng 1.6.32 has a bug in reading PNG
+# that seems to be the default library that is installed
+# https://github.com/ImageMagick/ImageMagick/issues/747#issuecomment-328521685
+# It seems libpng causes gdal and postgis to get updated.
+# These cause conflicts in the update process and don't seem necessary
+brew uninstall postgis gdal
+brew upgrade libpng
+
+set +ex

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -21,28 +21,17 @@ section_end "Flake8.test"
 section "Tests.examples"
 # Run example applications
 echo Build or run examples
+pip install --retries 3 -q -r ./requirements/docs.txt
+echo 'backend : Template' > $MPL_DIR/matplotlibrc
 if [[ "${BUILD_DOCS}" == "1" ]]; then
-  # requirements/docs.txt fails on Travis OSX
-  pip install --retries 3 -q -r ./requirements/docs.txt
   export SPHINXCACHE=${HOME}/.cache/sphinx; make html
 elif [[ "${TEST_EXAMPLES}" != "0" ]]; then
-  # OSX Can't install sphinx-gallery.
-  # I think all it needs is scikit-learn from that requirements doc
-  # to run the tests. See Issue #3084
-  if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-    pip install --retries 3 -q scikit-learn
-  else
-    pip install --retries 3 -q -r ./requirements/docs.txt
-  fi
-  cp $MPL_DIR/matplotlibrc $MPL_DIR/matplotlibrc_backup
-  echo 'backend : Template' > $MPL_DIR/matplotlibrc
   for f in doc/examples/*/*.py; do
     python "${f}"
     if [ $? -ne 0 ]; then
       exit 1
     fi
   done
-  mv $MPL_DIR/matplotlibrc_backup $MPL_DIR/matplotlibrc
 fi
 section_end "Tests.examples"
 


### PR DESCRIPTION
Note that this might fail.

The fix is likely this:
https://github.com/scikit-image/scikit-image/pull/3231/files#diff-354f30a63fb0907d4ad57269548329e3R78

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
