### PR TITLE
MNT: Update maplotlib minimum dependencies to 2.1.1

### DIFF
--- a/doc/examples/color_exposure/plot_adapt_argb.py
+++ b/doc/examples/color_exposure/plot_adapt_argb.py
@@ -1,0 +1,2 @@
+from skimage import data
+image = data.astronaut()

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,6 @@
 numpy>=1.11
 scipy>=0.17.0
-matplotlib>=2.0.0
+matplotlib>=2.1.1
 networkx>=2.0
 pillow>=4.3.0
 imageio>=2.0.1

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,6 @@
 numpy>=1.11
 scipy>=0.17.0
-matplotlib>=2.1.1
+matplotlib>=2.1.0
 networkx>=2.0
 pillow>=4.3.0
 imageio>=2.0.1

--- a/tools/travis/install_qt.sh
+++ b/tools/travis/install_qt.sh
@@ -6,7 +6,11 @@ if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
 fi
 # Now configure Matplotlib to use Qt5
 if [[ "${QT}" == "PyQt5" ]]; then
-    pip install --retries 3 -q $PIP_FLAGS pyqt5
+    if [[ $MINIMUM_REQUIREMENTS == 1 ]]; then
+        pip install --retries 3 -q $PIP_FLAGS "pyqt5<5.11"
+    else
+        pip install --retries 3 -q $PIP_FLAGS pyqt5
+    fi
     MPL_QT_API=PyQt5
     export QT_API=pyqt5
 elif [[ "${QT}" == "PySide2" ]]; then

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -55,6 +55,7 @@ elif [[ "${TEST_EXAMPLES}" != "0" ]]; then
   cp $MPL_DIR/matplotlibrc $MPL_DIR/matplotlibrc_backup
   echo 'backend : Template' > $MPL_DIR/matplotlibrc
   for f in doc/examples/*/*.py; do
+    echo Testing example ${f}
     python "${f}"
     if [ $? -ne 0 ]; then
       exit 1


### PR DESCRIPTION
#3300 was merged too rappidly Matplotlib min version has to be increased.

Supersedes #3400 

My new theory is that the old version of Pillow probably conflicts with the newer version of MPL.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
