### PR TITLE
MAINT: Reverted the changes in #3300 that broke the MINIMIUM_REQUIREMENTS tests

### DIFF
--- a/doc/examples/features_detection/plot_local_binary_pattern.py
+++ b/doc/examples/features_detection/plot_local_binary_pattern.py
@@ -107,7 +107,7 @@ lbp = local_binary_pattern(image, n_points, radius, METHOD)
 
 def hist(ax, lbp):
     n_bins = int(lbp.max() + 1)
-    return ax.hist(lbp.ravel(), density=True, bins=n_bins, range=(0, n_bins),
+    return ax.hist(lbp.ravel(), normed=True, bins=n_bins, range=(0, n_bins),
                    facecolor='0.5')
 
 
@@ -166,9 +166,9 @@ def match(refs, img):
     best_name = None
     lbp = local_binary_pattern(img, n_points, radius, METHOD)
     n_bins = int(lbp.max() + 1)
-    hist, _ = np.histogram(lbp, density=True, bins=n_bins, range=(0, n_bins))
+    hist, _ = np.histogram(lbp, normed=True, bins=n_bins, range=(0, n_bins))
     for name, ref in refs.items():
-        ref_hist, _ = np.histogram(ref, density=True, bins=n_bins,
+        ref_hist, _ = np.histogram(ref, normed=True, bins=n_bins,
                                    range=(0, n_bins))
         score = kullback_leibler_divergence(hist, ref_hist)
         if score < best_score:


### PR DESCRIPTION
## Description
Bumping the minimum requirements seems to require more thought and care than just changing the Matplotlib version as shown by two attempts:

  * https://github.com/scikit-image/scikit-image/pull/3400
  * https://github.com/scikit-image/scikit-image/pull/3426

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Unit tests

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
