### PR TITLE
MNT: Convert links using http to https

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@
   existing benchmark
 - [ ] Unit tests
 
-[For detailed information on these and other aspects see [scikit-image contribution guidelines](http://scikit-image.org/docs/dev/contribute.html)]
+[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]
 
 
 ## References

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 # vim ft=yaml
 
 # After changing this file, check it on:
-#   http://yaml-online-parser.appspot.com/
+#   https://yaml-online-parser.appspot.com/
 
 # See tools/travis/notes.txt for some guidelines
 
 language: python
 sudo: false
 cache:
-  # See http://docs.travis-ci.com/user/caching/#pip-cache
+  # See https://docs.travis-ci.com/user/caching/#pip-cache
   directories:
     - $HOME/.cache/pip
     - $HOME/.cache/sphinx

--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -26,7 +26,7 @@ Here's the long and short of it:
 1. If you are a first-time contributor:
 
    * Go to `https://github.com/scikit-image/scikit-image
-     <http://github.com/scikit-image/scikit-image>`_ and click the
+     <https://github.com/scikit-image/scikit-image>`_ and click the
      "fork" button to create your own copy of the project.
 
    * Clone the project to your local computer::

--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -98,7 +98,7 @@ For a more detailed discussion, read these :doc:`detailed documents
      and commit. As soon as those changes are pushed up (to the same branch as
      before) the pull request will update automatically.
 
-   * `Travis-CI <http://travis-ci.org/>`__, a continuous integration service,
+   * `Travis-CI <https://travis-ci.org/>`__, a continuous integration service,
      is triggered after each Pull Request update to build the code, run unit
      tests, measure code coverage and check coding style (PEP8) of your
      branch. The Travis tests must pass before your PR can be merged. If
@@ -188,7 +188,7 @@ Stylistic Guidelines
 --------------------
 
 * Set up your editor to remove trailing whitespace.  Follow `PEP08
-  <http://www.python.org/dev/peps/pep-0008/>`__.  Check code with pyflakes / flake8.
+  <https://www.python.org/dev/peps/pep-0008/>`__.  Check code with pyflakes / flake8.
 
 * Use numpy data types instead of strings (``np.uint8`` instead of
   ``"uint8"``).
@@ -296,7 +296,7 @@ Travis-CI checks all unittests in the project to prevent breakage.
 Before sending a pull request, you may want to check that Travis-CI
 successfully passes all tests. To do so,
 
-* Go to `Travis-CI <http://travis-ci.org/>`__ and follow the Sign In link at
+* Go to `Travis-CI <https://travis-ci.org/>`__ and follow the Sign In link at
   the top
 
 * Go to your `profile page <https://travis-ci.org/profile>`__ and switch on
@@ -378,7 +378,7 @@ scikit-image/tools/deploy-docs.sh
 -  The decrypted GH\_TOKEN env var will be available for travis scripts
 
 https://help.github.com/articles/creating-an-access-token-for-command-line-use/
-http://docs.travis-ci.com/user/encryption-keys/
+https://docs.travis-ci.com/user/encryption-keys/
 
 Deprecation cycle
 -----------------

--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -273,7 +273,7 @@ Tests for a module should ideally cover all code in that module,
 i.e., statement coverage should be at 100%.
 
 To measure the test coverage, install
-`pytest-cov <http://pytest-cov.readthedocs.io/en/latest/>`__
+`pytest-cov <https://pytest-cov.readthedocs.io/en/latest/>`__
 (using ``easy_install pytest-cov``) and then run::
 
   $ make coverage
@@ -303,14 +303,14 @@ successfully passes all tests. To do so,
   your scikit-image fork
 
 It corresponds to steps one and two in
-`Travis-CI documentation <http://about.travis-ci.org/docs/user/getting-started/>`__
+`Travis-CI documentation <https://about.travis-ci.org/docs/user/getting-started/>`__
 (Step three is already done in scikit-image).
 
 Thus, as soon as you push your code to your fork, it will trigger Travis-CI,
 and you will receive an email notification when the process is done.
 
 Every time Travis is triggered, it also calls on `Codecov
-<http://codecov.io>`_ to inspect the current test overage.
+<https://codecov.io>`_ to inspect the current test overage.
 
 
 Building docs
@@ -339,9 +339,9 @@ the documentation.
 
 **LaTeX Mac:**
 
-Install the full `MacTex <http://www.tug.org/mactex/>`__ installation or
+Install the full `MacTex <https://www.tug.org/mactex/>`__ installation or
 install the smaller
-`BasicTex <http://www.tug.org/mactex/morepackages.html>`__ and add *ucs*
+`BasicTex <https://www.tug.org/mactex/morepackages.html>`__ and add *ucs*
 and *dvipng* packages:
 
 .. code:: sh

--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -80,7 +80,7 @@ Here's the long and short of it:
 
 For a more detailed discussion, read these :doc:`detailed documents
 <gitwash/index>` on how to use Git with ``scikit-image``
-(`<http://scikit-image.org/docs/dev/gitwash/index.html>`_).
+(`<https://scikit-image.org/docs/dev/gitwash/index.html>`_).
 
 4. Review process:
 
@@ -167,7 +167,7 @@ Once you've fixed all merge conflicts, do::
 .. note::
 
    Advanced Git users are encouraged to `rebase instead of merge
-   <http://scikit-image.org/docs/dev/gitwash/development_workflow.html#rebasing-on-trunk>`__,
+   <https://scikit-image.org/docs/dev/gitwash/development_workflow.html#rebasing-on-trunk>`__,
    but we squash and merge most PRs either way.
 
 Guidelines

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -79,7 +79,7 @@ our `setup of AppVeyor`_ (a continuous integration service).
 .. _setup of AppVeyor: https://github.com/scikit-image/scikit-image/blob/master/.appveyor.yml
 .. _here: https://wiki.python.org/moin/WindowsCompilers#Microsoft_Visual_C.2B-.2B-_14.0_standalone:_Visual_C.2B-.2B-_Build_Tools_2015_.28x86.2C_x64.2C_ARM.29
 .. _venv: https://docs.python.org/3/library/venv.html
-.. _virtual environments: http://docs.python-guide.org/en/latest/dev/virtualenvs/
+.. _virtual environments: https://docs.python-guide.org/en/latest/dev/virtualenvs/
 .. _MinGW compilers: http://www.mingw.org/wiki/howto_install_the_mingw_gcc_compiler_suite
 
 b. Debian and Ubuntu

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/scikit-image/scikit-image?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![codecov.io](https://codecov.io/github/scikit-image/scikit-image/coverage.svg?branch=master)](https://codecov.io/github/scikit-image/scikit-image?branch=master)
 
-- **Website (including documentation):** [http://scikit-image.org/](http://scikit-image.org)
+- **Website (including documentation):** [https://scikit-image.org/](https://scikit-image.org)
 - **Mailing list:** [https://mail.python.org/mailman/listinfo/scikit-image](https://mail.python.org/mailman/listinfo/scikit-image)
 - **Source:** [https://github.com/scikit-image/scikit-image](https://github.com/scikit-image/scikit-image)
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -128,10 +128,10 @@ Conda-forge
 -----------
 
 A scikit-image build recipe resides at
-http://github.com/conda-forge/scikit-image-feedstock. You should update it to
+https://github.com/conda-forge/scikit-image-feedstock. You should update it to
 point to the most recent release. You can do this by following these steps:
 
-- Fork the repository at http://github.com/conda-forge/scikit-image-feedstock,
+- Fork the repository at https://github.com/conda-forge/scikit-image-feedstock,
   and clone it to your machine.
 - Sprout a new branch, e.g. ``v<major>.<minor>``.
 - Find out the SHA256 hash of the source distribution. You can find this at

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -7,7 +7,7 @@
     "project": "scikit-image",
 
     // The project's homepage
-    "project_url": "http://scikit-image.org/",
+    "project_url": "https://scikit-image.org/",
 
     // The URL or local path of the source code repository for the
     // project being benchmarked

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -35,7 +35,7 @@
     "install_timeout": 1200,
 
     // the base URL to show a commit for the project.
-    "show_commit_url": "http://github.com/scikit-image/scikit-image/commit/",
+    "show_commit_url": "https://github.com/scikit-image/scikit-image/commit/",
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.

--- a/benchmarks/benchmark_exposure.py
+++ b/benchmarks/benchmark_exposure.py
@@ -1,5 +1,5 @@
 # See "Writing benchmarks" in the asv docs for more information.
-# http://asv.readthedocs.io/en/latest/writing_benchmarks.html
+# https://asv.readthedocs.io/en/latest/writing_benchmarks.html
 import numpy as np
 
 from skimage import data, img_as_float

--- a/benchmarks/benchmark_feature.py
+++ b/benchmarks/benchmark_feature.py
@@ -1,5 +1,5 @@
 # See "Writing benchmarks" in the asv docs for more information.
-# http://asv.readthedocs.io/en/latest/writing_benchmarks.html
+# https://asv.readthedocs.io/en/latest/writing_benchmarks.html
 import numpy as np
 from scipy import ndimage as ndi
 from skimage import feature, util

--- a/benchmarks/benchmark_filters.py
+++ b/benchmarks/benchmark_filters.py
@@ -1,5 +1,5 @@
 # See "Writing benchmarks" in the asv docs for more information.
-# http://asv.readthedocs.io/en/latest/writing_benchmarks.html
+# https://asv.readthedocs.io/en/latest/writing_benchmarks.html
 import numpy as np
 from skimage import filters
 

--- a/benchmarks/benchmark_morphology.py
+++ b/benchmarks/benchmark_morphology.py
@@ -29,7 +29,7 @@ class Watershed(object):
 
         References
         ----------
-        .. [1]: http://asv.readthedocs.io/en/stable/writing_benchmarks.html#peak-memory
+        .. [1]: https://asv.readthedocs.io/en/stable/writing_benchmarks.html#peak-memory
         """
         pass
 

--- a/benchmarks/benchmark_segmentation.py
+++ b/benchmarks/benchmark_segmentation.py
@@ -26,7 +26,7 @@ class SegmentationSuite:
 
         References
         ----------
-        .. [1]: http://asv.readthedocs.io/en/stable/writing_benchmarks.html#peak-memory
+        .. [1]: https://asv.readthedocs.io/en/stable/writing_benchmarks.html#peak-memory
         """
         pass
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -129,7 +129,7 @@ gh-pages:
 
 gitwash:
 	$(PYTHON) tools/gitwash/gitwash_dumper.py source scikit-image \
-	--project-url=http://scikit-image.org \
+	--project-url=https://scikit-image.org \
 	--project-ml-url=https://mail.python.org/mailman/listinfo/scikit-image \
 	--repo-name=scikit-image \
 	--github-user=scikit-image \

--- a/doc/examples/color_exposure/plot_equalize.py
+++ b/doc/examples/color_exposure/plot_equalize.py
@@ -13,7 +13,7 @@ it sometimes yields unnatural looking images.  An alternative method is
 *contrast stretching*, where the image is rescaled to include all intensities
 that fall within the 2nd and 98th percentiles [2]_.
 
-.. [1] http://en.wikipedia.org/wiki/Histogram_equalization
+.. [1] https://en.wikipedia.org/wiki/Histogram_equalization
 .. [2] http://homepages.inf.ed.ac.uk/rbf/HIPR2/stretch.htm
 
 """

--- a/doc/examples/color_exposure/plot_local_equalize.py
+++ b/doc/examples/color_exposure/plot_local_equalize.py
@@ -15,8 +15,8 @@ graylevel variations.
 
 References
 ----------
-.. [1] http://en.wikipedia.org/wiki/Histogram_equalization
-.. [2] http://en.wikipedia.org/wiki/Adaptive_histogram_equalization
+.. [1] https://en.wikipedia.org/wiki/Histogram_equalization
+.. [2] https://en.wikipedia.org/wiki/Adaptive_histogram_equalization
 
 """
 import numpy as np

--- a/doc/examples/color_exposure/plot_tinting_grayscale_images.py
+++ b/doc/examples/color_exposure/plot_tinting_grayscale_images.py
@@ -46,7 +46,7 @@ ax2.imshow(yellow_multiplier * image)
 # to 1, so that hue, saturation, and value all share the same scale.
 #
 # .. _color spaces:
-#     http://en.wikipedia.org/wiki/List_of_color_spaces_and_their_uses
+#     https://en.wikipedia.org/wiki/List_of_color_spaces_and_their_uses
 #
 # Below, we plot a linear gradient in the hue, with the saturation and value
 # turned all the way up:
@@ -68,7 +68,7 @@ ax.set_axis_off()
 # reflects the fact that the hues wrap around like the color wheel (see HSV_
 # for more info).
 #
-# .. _HSV: http://en.wikipedia.org/wiki/HSL_and_HSV
+# .. _HSV: https://en.wikipedia.org/wiki/HSL_and_HSV
 #
 # Now, let's create a little utility function to take an RGB image and:
 #

--- a/doc/examples/edges/plot_circular_elliptical_hough_transform.py
+++ b/doc/examples/edges/plot_circular_elliptical_hough_transform.py
@@ -4,7 +4,7 @@ Circular and Elliptical Hough Transforms
 ========================================
 
 The Hough transform in its simplest form is a `method to detect
-straight lines <http://en.wikipedia.org/wiki/Hough_transform>`__
+straight lines <https://en.wikipedia.org/wiki/Hough_transform>`__
 but it can also be used to detect circles or ellipses.
 The algorithm assumes that the edge is detected and it is robust against
 noise or missing points.

--- a/doc/examples/edges/plot_line_hough_transform.py
+++ b/doc/examples/edges/plot_line_hough_transform.py
@@ -7,7 +7,7 @@ The Hough transform in its simplest form is a method to detect straight lines
 [1]_.
 
 In the following example, we construct an image with a line intersection. We
-then use the `Hough transform  <http://en.wikipedia.org/wiki/Hough_transform>`__.
+then use the `Hough transform  <https://en.wikipedia.org/wiki/Hough_transform>`__.
 to explore a parameter space for straight lines that may run through the image.
 
 Algorithm overview

--- a/doc/examples/features_detection/plot_corner.py
+++ b/doc/examples/features_detection/plot_corner.py
@@ -6,8 +6,8 @@ Corner detection
 Detect corner points using the Harris corner detector and determine the
 subpixel position of corners ([1]_, [2]_).
 
-.. [1] http://en.wikipedia.org/wiki/Corner_detection
-.. [2] http://en.wikipedia.org/wiki/Interest_point_detection
+.. [1] https://en.wikipedia.org/wiki/Corner_detection
+.. [2] https://en.wikipedia.org/wiki/Interest_point_detection
 
 """
 from matplotlib import pyplot as plt

--- a/doc/examples/features_detection/plot_gabors_from_astronaut.py
+++ b/doc/examples/features_detection/plot_gabors_from_astronaut.py
@@ -25,16 +25,16 @@ approximation.
 Enjoy ;-) And keep in mind that getting Gabors on natural image patches
 is not rocket science.
 
-.. [1] http://en.wikipedia.org/wiki/Gabor_filter
-.. [2] http://en.wikipedia.org/wiki/Simple_cell
-.. [3] http://en.wikipedia.org/wiki/Receptive_field
+.. [1] https://en.wikipedia.org/wiki/Gabor_filter
+.. [2] https://en.wikipedia.org/wiki/Simple_cell
+.. [3] https://en.wikipedia.org/wiki/Receptive_field
 .. [4] D. H. Hubel and T. N., Wiesel Receptive Fields of Single Neurones
        in the Cat's Striate Cortex, J. Physiol. pp. 574-591 (148) 1959
 .. [5] D. H. Hubel and T. N., Wiesel Receptive Fields, Binocular
        Interaction, and Functional Architecture in the Cat's Visual Cortex,
        J. Physiol. 160 pp.  106-154 1962
-.. [6] http://en.wikipedia.org/wiki/K-means_clustering
-.. [7] http://en.wikipedia.org/wiki/Lateral_geniculate_nucleus
+.. [6] https://en.wikipedia.org/wiki/K-means_clustering
+.. [7] https://en.wikipedia.org/wiki/Lateral_geniculate_nucleus
 """
 import numpy as np
 from scipy.cluster.vq import kmeans2

--- a/doc/examples/features_detection/plot_hog.py
+++ b/doc/examples/features_detection/plot_hog.py
@@ -7,7 +7,7 @@ The Histogram of Oriented Gradient (HOG) feature descriptor is popular
 for object detection [1]_.
 
 In the following example, we compute the `HOG descriptor
-<http://en.wikipedia.org/wiki/Histogram_of_oriented_gradients>`__
+<https://en.wikipedia.org/wiki/Histogram_of_oriented_gradients>`__
 and display a visualisation.
 
 Algorithm overview

--- a/doc/examples/filters/plot_deconvolution.py
+++ b/doc/examples/filters/plot_deconvolution.py
@@ -14,7 +14,7 @@ iterations, which needs to be hand-tuned.
        Method of Image Restoration",
        J. Opt. Soc. Am. A 27, 1593-1607 (1972), :DOI:`10.1364/JOSA.62.000055`
 
-.. [2] http://en.wikipedia.org/wiki/Richardson%E2%80%93Lucy_deconvolution
+.. [2] https://en.wikipedia.org/wiki/Richardson%E2%80%93Lucy_deconvolution
 """
 import numpy as np
 import matplotlib.pyplot as plt

--- a/doc/examples/segmentation/plot_marked_watershed.py
+++ b/doc/examples/segmentation/plot_marked_watershed.py
@@ -14,7 +14,7 @@ found.
 
 See Wikipedia_ for more details on the algorithm.
 
-.. _Wikipedia: http://en.wikipedia.org/wiki/Watershed_(image_processing)
+.. _Wikipedia: https://en.wikipedia.org/wiki/Watershed_(image_processing)
 
 """
 

--- a/doc/examples/segmentation/plot_segmentations.py
+++ b/doc/examples/segmentation/plot_segmentations.py
@@ -75,7 +75,7 @@ As with SLIC, there is an additional *compactness* argument that makes it
 harder for markers to flood faraway pixels. This makes the watershed regions
 more regularly shaped. [5]_
 
-.. [4] http://en.wikipedia.org/wiki/Watershed_%28image_processing%29
+.. [4] https://en.wikipedia.org/wiki/Watershed_%28image_processing%29
 
 .. [5] Peer Neubert & Peter Protzel (2014). Compact Watershed and
        Preemptive SLIC: On Improving Trade-offs of Superpixel Segmentation

--- a/doc/examples/segmentation/plot_thresholding.py
+++ b/doc/examples/segmentation/plot_thresholding.py
@@ -20,7 +20,7 @@ Thresholding is used to create a binary image from a grayscale image [1]_.
 # which are separated by the threshold. Equivalently, this threshold minimizes
 # the intra-class variance.
 #
-# .. [2] http://en.wikipedia.org/wiki/Otsu's_method
+# .. [2] https://en.wikipedia.org/wiki/Otsu's_method
 #
 
 import matplotlib.pyplot as plt

--- a/doc/examples/segmentation/plot_watershed.py
+++ b/doc/examples/segmentation/plot_watershed.py
@@ -21,7 +21,7 @@ line.
 
 See Wikipedia_ for more details on the algorithm.
 
-.. _Wikipedia: http://en.wikipedia.org/wiki/Watershed_(image_processing)
+.. _Wikipedia: https://en.wikipedia.org/wiki/Watershed_(image_processing)
 
 """
 import numpy as np

--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -35,7 +35,7 @@ For further information on tomographic reconstruction, see
        IEEE Press 1988. http://www.slaney.org/pct/pct-toc.html
 
 .. [2] Wikipedia, Radon transform,
-       http://en.wikipedia.org/wiki/Radon_transform#Relationship_with_the_Fourier_transform
+       https://en.wikipedia.org/wiki/Radon_transform#Relationship_with_the_Fourier_transform
 
 .. [3] S Kaczmarz, "Angenaeherte Aufloesung von Systemen linearer
        Gleichungen", Bulletin International de l'Academie Polonaise

--- a/doc/examples/xx_applications/plot_face_detection.py
+++ b/doc/examples/xx_applications/plot_face_detection.py
@@ -59,7 +59,7 @@ leaves the clusters that have a same or bigger number of detections in them.
 You should also take into account that false detections are inevitable and if
 you want to have a really precise detector, you will have to train it yourself
 using `OpenCV train cascade utility
-<http://docs.opencv.org/doc/user_guide/ug_traincascade.html>`_.
+<https://docs.opencv.org/doc/user_guide/ug_traincascade.html>`_.
 """
 
 from skimage import data

--- a/doc/examples/xx_applications/plot_morphology.py
+++ b/doc/examples/xx_applications/plot_morphology.py
@@ -239,6 +239,6 @@ plot_comparison(horse_mask, hull2, 'convex hull')
 # Processing <http://www.cs.auckland.ac.nz/courses/compsci773s1c/lectures
 # /ImageProcessing-html/topic4.htm>`_
 #
-# 3. http://en.wikipedia.org/wiki/Mathematical_morphology
+# 3. https://en.wikipedia.org/wiki/Mathematical_morphology
 
 plt.show()

--- a/doc/examples/xx_applications/plot_rank_filters.py
+++ b/doc/examples/xx_applications/plot_rank_filters.py
@@ -172,8 +172,8 @@ plt.tight_layout()
 # function for each pixel neighborhood. The local version [3]_ of the
 # histogram equalization emphasizes every local gray-level variations.
 #
-# .. [2] http://en.wikipedia.org/wiki/Histogram_equalization
-# .. [3] http://en.wikipedia.org/wiki/Adaptive_histogram_equalization
+# .. [2] https://en.wikipedia.org/wiki/Histogram_equalization
+# .. [3] https://en.wikipedia.org/wiki/Adaptive_histogram_equalization
 
 from skimage import exposure
 from skimage.filters import rank
@@ -361,7 +361,7 @@ plt.tight_layout()
 #     Otsu thresholding can be found in :
 #     :py:func:`skimage.filters.threshold_otsu`.
 #
-# .. [4] http://en.wikipedia.org/wiki/Otsu's_method
+# .. [4] https://en.wikipedia.org/wiki/Otsu's_method
 
 from skimage.filters.rank import otsu
 from skimage.filters import threshold_otsu

--- a/doc/examples/xx_applications/plot_thresholding.py
+++ b/doc/examples/xx_applications/plot_thresholding.py
@@ -108,7 +108,7 @@ plt.show()
 # which are separated by the threshold. Equivalently, this threshold minimizes
 # the intra-class variance.
 #
-# .. [2] http://en.wikipedia.org/wiki/Otsu's_method
+# .. [2] https://en.wikipedia.org/wiki/Otsu's_method
 #
 
 from skimage.filters import threshold_otsu

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -9,7 +9,7 @@ analysis, filtering, morphology, feature detection, and more.
 
 For more information, examples, and documentation, please visit our website:
 
-http://scikit-image.org
+https://scikit-image.org
 
 
 

--- a/doc/release/release_template.rst
+++ b/doc/release/release_template.rst
@@ -9,7 +9,7 @@ analysis, filtering, morphology, feature detection, and more.
 
 For more information, examples, and documentation, please visit our website:
 
-http://scikit-image.org
+https://scikit-image.org
 
 
 New Features

--- a/doc/source/_static/docversions.js
+++ b/doc/source/_static/docversions.js
@@ -12,7 +12,7 @@ function insert_version_links() {
         document.write(open_list);
         document.write('<a href="URL">skimage VERSION</a> </li>\n'
                         .replace('VERSION', versions[i])
-                        .replace('URL', 'http://scikit-image.org/docs/' + versions[i]));
+                        .replace('URL', 'https://scikit-image.org/docs/' + versions[i]));
     }
 }
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -381,8 +381,8 @@ def linkcode_resolve(domain, info):
     fn = relpath(fn, start=dirname(skimage.__file__))
 
     if 'dev' in skimage.__version__:
-        return ("http://github.com/scikit-image/scikit-image/blob/"
+        return ("https://github.com/scikit-image/scikit-image/blob/"
                 "master/skimage/%s%s" % (fn, linespec))
     else:
-        return ("http://github.com/scikit-image/scikit-image/blob/"
+        return ("https://github.com/scikit-image/scikit-image/blob/"
                 "v%s/skimage/%s%s" % (skimage.__version__, fn, linespec))

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -328,7 +328,7 @@ intersphinx_mapping = {
     'sklearn': ('http://scikit-learn.org/stable',
                 (None, './_intersphinx/sklearn-objects.inv')),
     'matplotlib': ('https://matplotlib.org/',
-                   (None, 'http://matplotlib.org/objects.inv'))
+                   (None, 'https://matplotlib.org/objects.inv'))
 }
 
 # ----------------------------------------------------------------------------

--- a/doc/source/gitwash/development_workflow.rst
+++ b/doc/source/gitwash/development_workflow.rst
@@ -150,7 +150,7 @@ Ask for your changes to be reviewed or merged
 When you are ready to ask for someone to review your code and consider a merge:
 
 #. Go to the URL of your forked repo, say
-   ``http://github.com/your-user-name/scikit-image``.
+   ``https://github.com/your-user-name/scikit-image``.
 #. Use the 'Switch Branches' dropdown menu near the top left of the page to
    select the branch with your changes:
 
@@ -183,7 +183,7 @@ Delete a branch on github
    git push origin :my-unwanted-branch
 
 (Note the colon ``:`` before ``test-branch``.  See also:
-http://github.com/guides/remove-a-remote-branch
+https://github.com/guides/remove-a-remote-branch
 
 Several people sharing a single repository
 ------------------------------------------
@@ -195,7 +195,7 @@ share it via github.
 First fork scikit-image into your account, as from :ref:`forking`.
 
 Then, go to your forked repository github page, say
-``http://github.com/your-user-name/scikit-image``
+``https://github.com/your-user-name/scikit-image``
 
 Click on the 'Admin' button, and add anyone else to the repo as a
 collaborator:

--- a/doc/source/gitwash/forking_hell.rst
+++ b/doc/source/gitwash/forking_hell.rst
@@ -5,7 +5,7 @@ Making your own copy (fork) of scikit-image
 ======================================================
 
 You need to do this only once.  The instructions here are very similar
-to the instructions at http://help.github.com/forking/ |emdash| please see
+to the instructions at https://help.github.com/forking/ |emdash| please see
 that page for more detail.  We're repeating some of it here just to give the
 specifics for the `scikit-image`_ project, and to suggest some default names.
 

--- a/doc/source/gitwash/git_install.rst
+++ b/doc/source/gitwash/git_install.rst
@@ -21,6 +21,7 @@ See the git page for the most recent information.
 
 Have a look at the github install help pages available from `github help`_
 
-There are good instructions here: http://book.git-scm.com/2_installing_git.html
+There are good instructions here:
+https://book.git-scm.com/book/en/v2/Getting-Started-Installing-Git
 
 .. include:: links.inc

--- a/doc/source/gitwash/git_links.inc
+++ b/doc/source/gitwash/git_links.inc
@@ -10,16 +10,16 @@
 
 .. git stuff
 .. _git: http://git-scm.com/
-.. _github: http://github.com
+.. _github: https://github.com
 .. _github help: http://help.github.com
 .. _msysgit: https://git-for-windows.github.io/
 .. _git-osx-installer: http://code.google.com/p/git-osx-installer/downloads/list
 .. _subversion: http://subversion.tigris.org/
-.. _git cheat sheet: http://github.com/guides/git-cheat-sheet
+.. _git cheat sheet: https://github.com/guides/git-cheat-sheet
 .. _pro git book: http://progit.org/
 .. _git svn crash course: http://git-scm.com/course/svn.html
 .. _learn.github: http://learn.github.com/
-.. _network graph visualizer: http://github.com/blog/39-say-hello-to-the-network-graph-visualizer
+.. _network graph visualizer: https://github.com/blog/39-say-hello-to-the-network-graph-visualizer
 .. _git user manual: http://schacon.github.com/git/user-manual.html
 .. _git tutorial: http://schacon.github.com/git/gittutorial.html
 .. _git community book: http://book.git-scm.com/

--- a/doc/source/gitwash/git_links.inc
+++ b/doc/source/gitwash/git_links.inc
@@ -54,7 +54,7 @@
 .. _ipython git workflow: http://mail.scipy.org/pipermail/ipython-dev/2010-October/006746.html
 
 .. other stuff
-.. _python: http://www.python.org
+.. _python: https://www.python.org
 
 .. |emdash| unicode:: U+02014
 

--- a/doc/source/gitwash/git_links.inc
+++ b/doc/source/gitwash/git_links.inc
@@ -9,48 +9,48 @@
    nipy, NIPY, Nipy, etc...
 
 .. git stuff
-.. _git: http://git-scm.com/
+.. _git: https://git-scm.com/
 .. _github: https://github.com
-.. _github help: http://help.github.com
+.. _github help: https://help.github.com
 .. _msysgit: https://git-for-windows.github.io/
-.. _git-osx-installer: http://code.google.com/p/git-osx-installer/downloads/list
+.. _git-osx-installer: https://code.google.com/p/git-osx-installer/downloads/list
 .. _subversion: http://subversion.tigris.org/
 .. _git cheat sheet: https://github.com/guides/git-cheat-sheet
-.. _pro git book: http://progit.org/
-.. _git svn crash course: http://git-scm.com/course/svn.html
-.. _learn.github: http://learn.github.com/
+.. _pro git book: https://git-scm.com/book/en/v2
+.. _git svn crash course: https://git-scm.com/course/svn.html
+.. _learn.github: https://learn.github.com/
 .. _network graph visualizer: https://github.com/blog/39-say-hello-to-the-network-graph-visualizer
-.. _git user manual: http://schacon.github.com/git/user-manual.html
-.. _git tutorial: http://schacon.github.com/git/gittutorial.html
-.. _git community book: http://book.git-scm.com/
+.. _git user manual: https://schacon.github.com/git/user-manual.html
+.. _git tutorial: https://schacon.github.com/git/gittutorial.html
+.. _git community book: https://book.git-scm.com/
 .. _git ready: http://www.gitready.com/
 .. _git casts: http://www.gitcasts.com/
 .. _Fernando's git page: http://www.fperez.org/py4science/git.html
 .. _git magic: http://www-cs-students.stanford.edu/~blynn/gitmagic/index.html
-.. _git concepts: http://www.eecs.harvard.edu/~cduan/technical/git/
-.. _git clone: http://schacon.github.com/git/git-clone.html
-.. _git checkout: http://schacon.github.com/git/git-checkout.html
-.. _git commit: http://schacon.github.com/git/git-commit.html
-.. _git push: http://schacon.github.com/git/git-push.html
-.. _git pull: http://schacon.github.com/git/git-pull.html
-.. _git add: http://schacon.github.com/git/git-add.html
-.. _git status: http://schacon.github.com/git/git-status.html
-.. _git diff: http://schacon.github.com/git/git-diff.html
-.. _git log: http://schacon.github.com/git/git-log.html
-.. _git branch: http://schacon.github.com/git/git-branch.html
-.. _git remote: http://schacon.github.com/git/git-remote.html
-.. _git rebase: http://schacon.github.com/git/git-rebase.html
-.. _git config: http://schacon.github.com/git/git-config.html
+.. _git concepts: https://www.eecs.harvard.edu/~cduan/technical/git/
+.. _git clone: https://schacon.github.com/git/git-clone.html
+.. _git checkout: https://schacon.github.com/git/git-checkout.html
+.. _git commit: https://schacon.github.com/git/git-commit.html
+.. _git push: https://schacon.github.com/git/git-push.html
+.. _git pull: https://schacon.github.com/git/git-pull.html
+.. _git add: https://schacon.github.com/git/git-add.html
+.. _git status: https://schacon.github.com/git/git-status.html
+.. _git diff: https://schacon.github.com/git/git-diff.html
+.. _git log: https://schacon.github.com/git/git-log.html
+.. _git branch: https://schacon.github.com/git/git-branch.html
+.. _git remote: https://schacon.github.com/git/git-remote.html
+.. _git rebase: https://schacon.github.com/git/git-rebase.html
+.. _git config: https://schacon.github.com/git/git-config.html
 .. _why the -a flag?: http://www.gitready.com/beginner/2009/01/18/the-staging-area.html
 .. _git staging area: http://www.gitready.com/beginner/2009/01/18/the-staging-area.html
-.. _tangled working copy problem: http://tomayko.com/writings/the-thing-about-git 
+.. _tangled working copy problem: http://tomayko.com/writings/the-thing-about-git
 .. _git management: http://kerneltrap.org/Linux/Git_Management
-.. _linux git workflow: http://www.mail-archive.com/dri-devel@lists.sourceforge.net/msg39091.html
+.. _linux git workflow: https://www.mail-archive.com/dri-devel@lists.sourceforge.net/msg39091.html
 .. _git parable: http://tom.preston-werner.com/2009/05/19/the-git-parable.html
 .. _git foundation: http://matthew-brett.github.com/pydagogue/foundation.html
 .. _deleting master on github: http://matthew-brett.github.com/pydagogue/gh_delete_master.html
 .. _rebase without tears: http://matthew-brett.github.com/pydagogue/rebase_without_tears.html
-.. _resolving a merge: http://schacon.github.com/git/user-manual.html#resolving-a-merge
+.. _resolving a merge: https://schacon.github.com/git/user-manual.html#resolving-a-merge
 .. _ipython git workflow: http://mail.scipy.org/pipermail/ipython-dev/2010-October/006746.html
 
 .. other stuff

--- a/doc/source/gitwash/known_projects.inc
+++ b/doc/source/gitwash/known_projects.inc
@@ -2,40 +2,40 @@
 
 .. PROJECTNAME placeholders
 .. _PROJECTNAME: http://neuroimaging.scipy.org
-.. _`PROJECTNAME github`: http://github.com/nipy
+.. _`PROJECTNAME github`: https://github.com/nipy
 .. _`PROJECTNAME mailing list`: http://projects.scipy.org/mailman/listinfo/nipy-devel
 
 .. numpy
 .. _numpy: http://numpy.org
-.. _`numpy github`: http://github.com/numpy/numpy
+.. _`numpy github`: https://github.com/numpy/numpy
 .. _`numpy mailing list`: http://mail.scipy.org/mailman/listinfo/numpy-discussion
 
 .. scipy
 .. _scipy: http://www.scipy.org
-.. _`scipy github`: http://github.com/scipy/scipy
+.. _`scipy github`: https://github.com/scipy/scipy
 .. _`scipy mailing list`: http://mail.scipy.org/mailman/listinfo/scipy-dev
 
 .. nipy
 .. _nipy: http://nipy.org/nipy
-.. _`nipy github`: http://github.com/nipy/nipy
+.. _`nipy github`: https://github.com/nipy/nipy
 .. _`nipy mailing list`: http://mail.scipy.org/mailman/listinfo/nipy-devel
 
 .. ipython
 .. _ipython: http://ipython.scipy.org
-.. _`ipython github`: http://github.com/ipython/ipython
+.. _`ipython github`: https://github.com/ipython/ipython
 .. _`ipython mailing list`: http://mail.scipy.org/mailman/listinfo/IPython-dev
 
 .. dipy
 .. _dipy: http://nipy.org/dipy
-.. _`dipy github`: http://github.com/Garyfallidis/dipy
+.. _`dipy github`: https://github.com/Garyfallidis/dipy
 .. _`dipy mailing list`: http://mail.scipy.org/mailman/listinfo/nipy-devel
 
 .. nibabel
 .. _nibabel: http://nipy.org/nibabel
-.. _`nibabel github`: http://github.com/nipy/nibabel
+.. _`nibabel github`: https://github.com/nipy/nibabel
 .. _`nibabel mailing list`: http://mail.scipy.org/mailman/listinfo/nipy-devel
 
 .. marsbar
 .. _marsbar: http://marsbar.sourceforge.net
-.. _`marsbar github`: http://github.com/matthew-brett/marsbar
+.. _`marsbar github`: https://github.com/matthew-brett/marsbar
 .. _`MarsBaR mailing list`: https://lists.sourceforge.net/lists/listinfo/marsbar-users

--- a/doc/source/gitwash/this_project.inc
+++ b/doc/source/gitwash/this_project.inc
@@ -1,5 +1,5 @@
 .. scikit-image
-.. _`scikit-image`: http://scikit-image.org
+.. _`scikit-image`: https://scikit-image.org
 .. _`scikit-image github`: http://github.com/scikit-image/scikit-image
 
 .. _`scikit-image mailing list`: https://mail.python.org/mailman/listinfo/scikit-image

--- a/doc/source/gitwash/this_project.inc
+++ b/doc/source/gitwash/this_project.inc
@@ -1,5 +1,5 @@
 .. scikit-image
 .. _`scikit-image`: https://scikit-image.org
-.. _`scikit-image github`: http://github.com/scikit-image/scikit-image
+.. _`scikit-image github`: https://github.com/scikit-image/scikit-image
 
 .. _`scikit-image mailing list`: https://mail.python.org/mailman/listinfo/scikit-image

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -16,7 +16,7 @@ https://scikit-image.org
 
 Source, bugs and patches
 ------------------------
-http://github.com/scikit-image/scikit-image
+https://github.com/scikit-image/scikit-image
 
 Mailing List
 ------------

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -1,7 +1,7 @@
 Image Processing SciKit
 =======================
 
-The `scikit-image <http://scikit-image.org>`__ SciKit (toolkit for
+The `scikit-image <https://scikit-image.org>`__ SciKit (toolkit for
 `SciPy <http://www.scipy.org>`__) extends ``scipy.ndimage`` to provide
 a versatile set of image processing routines.  It is written in the
 `Python <http://www.python.org>`_ language.
@@ -12,7 +12,7 @@ mailing list (address provided below).
 
 Homepage
 --------
-http://scikit-image.org
+https://scikit-image.org
 
 Source, bugs and patches
 ------------------------

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -4,7 +4,7 @@ Image Processing SciKit
 The `scikit-image <https://scikit-image.org>`__ SciKit (toolkit for
 `SciPy <http://www.scipy.org>`__) extends ``scipy.ndimage`` to provide
 a versatile set of image processing routines.  It is written in the
-`Python <http://www.python.org>`_ language.
+`Python <https://www.python.org>`_ language.
 
 This `SciKit <http://scikits.appspot.com>`_ is developed by the SciPy
 community.  All contributions are most welcome!  Please join us on the

--- a/doc/source/random_gallery.py
+++ b/doc/source/random_gallery.py
@@ -32,8 +32,8 @@ gallery_div = '''\
 examples = glob.glob(os.path.join(example_dir, '**/plot_*.py'), recursive=True)
 
 images, links = [], []
-image_url = 'http://scikit-image.org/docs/dev/_images/'
-link_url = 'http://scikit-image.org/docs/dev/auto_examples/'
+image_url = 'https://scikit-image.org/docs/dev/_images/'
+link_url = 'https://scikit-image.org/docs/dev/auto_examples/'
 
 for example_path in examples:
     example_path = os.path.relpath(example_path, example_dir)

--- a/doc/source/themes/scikit-image/layout.html
+++ b/doc/source/themes/scikit-image/layout.html
@@ -79,7 +79,7 @@
     {%- block extrahead %}{% endblock %}
 </head>
 <body class="container">
-    <a href="http://scikit-image.org" class="logo"><img src="{{ pathto('_static/', 1) }}img/logo.png" alt=""></a>
+    <a href="https://scikit-image.org" class="logo"><img src="{{ pathto('_static/', 1) }}img/logo.png" alt=""></a>
     <div class="clearfix"></div>
     <div class="navbar">
         <div class="navbar-inner">

--- a/doc/source/user_guide/data_types.rst
+++ b/doc/source/user_guide/data_types.rst
@@ -241,6 +241,6 @@ just the positive range of a signed dtype.
 References
 ==========
 
-.. _numpy: http://docs.scipy.org/doc/numpy/user/
-.. [1] http://docs.scipy.org/doc/numpy/user/basics.types.html
+.. _numpy: https://docs.scipy.org/doc/numpy/user/
+.. [1] https://docs.scipy.org/doc/numpy/user/basics.types.html
 .. _OpenCV: http://opencv.org/

--- a/doc/source/user_guide/getting_started.rst
+++ b/doc/source/user_guide/getting_started.rst
@@ -12,7 +12,7 @@ Most functions of ``skimage`` are found within submodules: ::
     >>> camera = data.camera()
 
 A list of submodules and functions is found on the `API reference
-<http://scikit-image.org/docs/stable/api/api.html>`_ webpage.
+<https://scikit-image.org/docs/stable/api/api.html>`_ webpage.
 
 Within scikit-image, images are represented as NumPy arrays, for
 example 2-D arrays for grayscale 2-D images ::

--- a/doc/source/user_guide/transforming_image_data.rst
+++ b/doc/source/user_guide/transforming_image_data.rst
@@ -14,14 +14,14 @@ Conversion between color models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Color images can be represented using different `color spaces
-<http://en.wikipedia.org/wiki/Color_space>`_. One of the most common
+<https://en.wikipedia.org/wiki/Color_space>`_. One of the most common
 color spaces is the `RGB space
-<http://en.wikipedia.org/wiki/RGB_color_model>`_, where an image has red,
+<https://en.wikipedia.org/wiki/RGB_color_model>`_, where an image has red,
 green and blue channels. However, other color models are widely used,
 such as the `HSV color model
-<http://en.wikipedia.org/wiki/HSL_and_HSV>`_, where hue, saturation and
+<https://en.wikipedia.org/wiki/HSL_and_HSV>`_, where hue, saturation and
 value are independent channels, or the `CMYK model
-<http://en.wikipedia.org/wiki/CMYK_color_model>`_ used for printing.
+<https://en.wikipedia.org/wiki/CMYK_color_model>`_ used for printing.
 
 :mod:`skimage.color` provides utility functions to convert images
 to and from different color spaces. Integer-type arrays can be
@@ -67,7 +67,7 @@ Converting an RGB image to a grayscale image is realized with
 :func:`rgb2gray` uses a non-uniform weighting of color channels, because of the
 different sensitivity of the human eye to different colors. Therefore,
 such a weighting ensures `luminance preservation
-<http://en.wikipedia.org/wiki/Grayscale#Converting_color_to_grayscale>`_
+<https://en.wikipedia.org/wiki/Grayscale#Converting_color_to_grayscale>`_
 from RGB to grayscale::
 
     >>> red_pixel = np.array([[[255, 0, 0]]], dtype=np.uint8)
@@ -133,7 +133,7 @@ A first class of methods compute a nonlinear function of the intensity,
 that is independent of the pixel values of a specific image. Such methods
 are often used for correcting a known non-linearity of sensors, or
 receptors such as the human eye. A well-known example is `Gamma
-correction <http://en.wikipedia.org/wiki/Gamma_correction>`_, implemented
+correction <https://en.wikipedia.org/wiki/Gamma_correction>`_, implemented
 in :func:`adjust_gamma`.
 
 Other methods re-distribute pixel values according to the *histogram* of

--- a/doc/source/user_guide/tutorial_segmentation.rst
+++ b/doc/source/user_guide/tutorial_segmentation.rst
@@ -38,7 +38,7 @@ Edge-based segmentation
 
 Let us first try to detect edges that enclose the coins. For edge
 detection, we use the `Canny detector 
-<http://en.wikipedia.org/wiki/Canny_edge_detector>`_ of ``skimage.feature.canny``
+<https://en.wikipedia.org/wiki/Canny_edge_detector>`_ of ``skimage.feature.canny``
 
 ::
 
@@ -108,7 +108,7 @@ histogram of grey values:
    
 We will use these markers in a watershed segmentation. The name watershed
 comes from an analogy with hydrology. The `watershed transform
-<http://en.wikipedia.org/wiki/Watershed_%28image_processing%29>`_ floods
+<https://en.wikipedia.org/wiki/Watershed_%28image_processing%29>`_ floods
 an image of elevation starting from markers, in order to determine the catchment
 basins of these markers. Watershed lines separate these catchment basins,
 and correspond to the desired segmentation.

--- a/doc/source/user_guide/video.rst
+++ b/doc/source/user_guide/video.rst
@@ -126,6 +126,6 @@ OpenCV
 ^^^^^^
 
 Finally, another solution is the `VideoReader
-<http://docs.opencv.org/modules/highgui/doc/reading_and_writing_images_and_video.html#videocapture-open>`__
+<https://docs.opencv.org/modules/highgui/doc/reading_and_writing_images_and_video.html#videocapture-open>`__
 class in OpenCV, which has bindings to FFmpeg. If you need OpenCV for other reasons,
 then this may be the best approach.

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ MAINTAINER = 'Stefan van der Walt'
 MAINTAINER_EMAIL = 'stefan@sun.ac.za'
 URL = 'https://scikit-image.org'
 LICENSE = 'Modified BSD'
-DOWNLOAD_URL = 'http://github.com/scikit-image/scikit-image'
+DOWNLOAD_URL = 'https://github.com/scikit-image/scikit-image'
 
 import os
 import sys

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ Image processing algorithms for SciPy, including IO, morphology, filtering,
 warping, color manipulation, object detection, etc.
 
 Please refer to the online documentation at
-http://scikit-image.org/
+https://scikit-image.org/
 """
 
 DISTNAME = 'scikit-image'
@@ -14,7 +14,7 @@ DESCRIPTION = 'Image processing routines for SciPy'
 LONG_DESCRIPTION = descr
 MAINTAINER = 'Stefan van der Walt'
 MAINTAINER_EMAIL = 'stefan@sun.ac.za'
-URL = 'http://scikit-image.org'
+URL = 'https://scikit-image.org'
 LICENSE = 'Modified BSD'
 DOWNLOAD_URL = 'http://github.com/scikit-image/scikit-image'
 
@@ -172,7 +172,7 @@ if __name__ == "__main__":
                   'Install numpy with pip:\n' +
                   'pip install numpy\n'
                   'Or use your operating system package manager. For more\n' +
-                  'details, see http://scikit-image.org/docs/stable/install.html')
+                  'details, see https://scikit-image.org/docs/stable/install.html')
             sys.exit(1)
 
     setup(

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -87,7 +87,7 @@ directory and you need to try from another location."""
 _STANDARD_MSG = """
 Your install of scikit-image appears to be broken.
 Try re-installing the package following the instructions at:
-http://scikit-image.org/docs/stable/install.html """
+https://scikit-image.org/docs/stable/install.html """
 
 
 def _raise_build_error(e):

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -228,7 +228,7 @@ def convert_to_float(image, preserve_range):
     preserve_range : bool
         Determines if the range of the image should be kept or transformed
         using img_as_float. Also see
-        http://scikit-image.org/docs/dev/user_guide/data_types.html
+        https://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Returns
     -------

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -45,8 +45,8 @@ References
 ----------
 .. [1] Official specification of sRGB, IEC 61966-2-1:1999.
 .. [2] http://www.poynton.com/ColorFAQ.html
-.. [3] http://en.wikipedia.org/wiki/HSL_and_HSV
-.. [4] http://en.wikipedia.org/wiki/CIE_1931_color_space
+.. [3] https://en.wikipedia.org/wiki/HSL_and_HSV
+.. [4] https://en.wikipedia.org/wiki/CIE_1931_color_space
 """
 
 
@@ -243,7 +243,7 @@ def rgb2hsv(rgb):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/HSL_and_HSV
+    .. [1] https://en.wikipedia.org/wiki/HSL_and_HSV
 
     Examples
     --------
@@ -318,7 +318,7 @@ def hsv2rgb(hsv):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/HSL_and_HSV
+    .. [1] https://en.wikipedia.org/wiki/HSL_and_HSV
 
     Examples
     --------
@@ -364,7 +364,7 @@ xyz_from_rgb = np.array([[0.412453, 0.357580, 0.180423],
 
 rgb_from_xyz = linalg.inv(xyz_from_rgb)
 
-# From http://en.wikipedia.org/wiki/CIE_1931_color_space
+# From https://en.wikipedia.org/wiki/CIE_1931_color_space
 # Note: Travis's code did not have the divide by 0.17697
 xyz_from_rgbcie = np.array([[0.49, 0.31, 0.20],
                             [0.17697, 0.81240, 0.01063],
@@ -437,7 +437,7 @@ lab_ref_white = np.array([0.95047, 1., 1.08883])
 #
 #     References
 #    ----------
-#    .. [1] http://en.wikipedia.org/wiki/Standard_illuminant
+#    .. [1] https://en.wikipedia.org/wiki/Standard_illuminant
 
 illuminants = \
     {"A": {'2': (1.098466069456375, 1, 0.3558228003436005),
@@ -478,7 +478,7 @@ def get_xyz_coords(illuminant, observer):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Standard_illuminant
+    .. [1] https://en.wikipedia.org/wiki/Standard_illuminant
 
     """
     illuminant = illuminant.upper()
@@ -621,7 +621,7 @@ def xyz2rgb(xyz):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/CIE_1931_color_space
+    .. [1] https://en.wikipedia.org/wiki/CIE_1931_color_space
 
     Examples
     --------
@@ -669,7 +669,7 @@ def rgb2xyz(rgb):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/CIE_1931_color_space
+    .. [1] https://en.wikipedia.org/wiki/CIE_1931_color_space
 
     Examples
     --------
@@ -706,7 +706,7 @@ def rgb2rgbcie(rgb):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/CIE_1931_color_space
+    .. [1] https://en.wikipedia.org/wiki/CIE_1931_color_space
 
     Examples
     --------
@@ -738,7 +738,7 @@ def rgbcie2rgb(rgbcie):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/CIE_1931_color_space
+    .. [1] https://en.wikipedia.org/wiki/CIE_1931_color_space
 
     Examples
     --------
@@ -904,7 +904,7 @@ def xyz2lab(xyz, illuminant="D65", observer="2"):
     References
     ----------
     .. [1] http://www.easyrgb.com/index.php?X=MATH&H=07#text7
-    .. [2] http://en.wikipedia.org/wiki/Lab_color_space
+    .. [2] https://en.wikipedia.org/wiki/Lab_color_space
 
     Examples
     --------
@@ -973,7 +973,7 @@ def lab2xyz(lab, illuminant="D65", observer="2"):
     References
     ----------
     .. [1] http://www.easyrgb.com/index.php?X=MATH&H=07#text7
-    .. [2] http://en.wikipedia.org/wiki/Lab_color_space
+    .. [2] https://en.wikipedia.org/wiki/Lab_color_space
 
     """
 
@@ -1111,7 +1111,7 @@ def xyz2luv(xyz, illuminant="D65", observer="2"):
     References
     ----------
     .. [1] http://www.easyrgb.com/index.php?X=MATH&H=16#text16
-    .. [2] http://en.wikipedia.org/wiki/CIELUV
+    .. [2] https://en.wikipedia.org/wiki/CIELUV
 
     Examples
     --------
@@ -1187,7 +1187,7 @@ def luv2xyz(luv, illuminant="D65", observer="2"):
     References
     ----------
     .. [1] http://www.easyrgb.com/index.php?X=MATH&H=16#text16
-    .. [2] http://en.wikipedia.org/wiki/CIELUV
+    .. [2] https://en.wikipedia.org/wiki/CIELUV
 
     """
 
@@ -1249,7 +1249,7 @@ def rgb2luv(rgb):
     ----------
     .. [1] http://www.easyrgb.com/index.php?X=MATH&H=16#text16
     .. [2] http://www.easyrgb.com/index.php?X=MATH&H=02#text2
-    .. [3] http://en.wikipedia.org/wiki/CIELUV
+    .. [3] https://en.wikipedia.org/wiki/CIELUV
 
     """
     return xyz2luv(rgb2xyz(rgb))

--- a/skimage/color/delta_e.py
+++ b/skimage/color/delta_e.py
@@ -14,7 +14,7 @@ The delta-E notation comes from the German word for "Sensation" (Empfindung).
 
 Reference
 ---------
-http://en.wikipedia.org/wiki/Color_difference
+https://en.wikipedia.org/wiki/Color_difference
 
 """
 
@@ -40,7 +40,7 @@ def deltaE_cie76(lab1, lab2):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Color_difference
+    .. [1] https://en.wikipedia.org/wiki/Color_difference
     .. [2] A. R. Robertson, "The CIE 1976 color-difference formulae,"
            Color Res. Appl. 2, 7-11 (1977).
     """
@@ -99,7 +99,7 @@ def deltaE_ciede94(lab1, lab2, kH=1, kC=1, kL=1, k1=0.045, k2=0.015):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Color_difference
+    .. [1] https://en.wikipedia.org/wiki/Color_difference
     .. [2] http://www.brucelindbloom.com/index.html?Eqn_DeltaE_CIE94.html
     """
     L1, C1 = np.rollaxis(lab2lch(lab1), -1)[:2]
@@ -151,7 +151,7 @@ def deltaE_ciede2000(lab1, lab2, kL=1, kC=1, kH=1):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Color_difference
+    .. [1] https://en.wikipedia.org/wiki/Color_difference
     .. [2] http://www.ece.rochester.edu/~gsharma/ciede2000/ciede2000noteCRNA.pdf
            :DOI:`10.1364/AO.33.008069`
     .. [3] M. Melgosa, J. Quesada, and E. Hita, "Uniformity of some recent
@@ -277,7 +277,7 @@ def deltaE_cmc(lab1, lab2, kL=1, kC=1):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Color_difference
+    .. [1] https://en.wikipedia.org/wiki/Color_difference
     .. [2] http://www.brucelindbloom.com/index.html?Eqn_DeltaE_CIE94.html
     .. [3] F. J. J. Clarke, R. McDonald, and B. Rigg, "Modification to the
            JPC79 colour-difference formula," J. Soc. Dyers Colour. 100, 128-132

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -111,7 +111,7 @@ def text():
     Notes
     -----
     This image was downloaded from Wikipedia
-    <http://en.wikipedia.org/wiki/File:Corner.png>`__.
+    <https://en.wikipedia.org/wiki/File:Corner.png>`__.
 
     No known copyright restrictions, released into the public domain.
 

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -482,7 +482,7 @@ def is_low_contrast(image, fraction_threshold=0.05, lower_percentile=1,
 
     References
     ----------
-    .. [1] http://scikit-image.org/docs/dev/user_guide/data_types.html
+    .. [1] https://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Examples
     --------

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -112,7 +112,7 @@ def cumulative_distribution(image, nbins=256):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Cumulative_distribution_function
+    .. [1] https://en.wikipedia.org/wiki/Cumulative_distribution_function
 
     Examples
     --------
@@ -156,7 +156,7 @@ def equalize_hist(image, nbins=256, mask=None):
     References
     ----------
     .. [1] http://www.janeriksolem.net/histogram-equalization-with-python-and.html
-    .. [2] http://en.wikipedia.org/wiki/Histogram_equalization
+    .. [2] https://en.wikipedia.org/wiki/Histogram_equalization
 
     """
     if mask is not None:
@@ -340,7 +340,7 @@ def adjust_gamma(image, gamma=1, gain=1):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Gamma_correction
+    .. [1] https://en.wikipedia.org/wiki/Gamma_correction
 
     Examples
     --------

--- a/skimage/external/tifffile/tifffile.py
+++ b/skimage/external/tifffile/tifffile.py
@@ -62,7 +62,7 @@ For command line usage run `python tifffile.py --help`
 
 Requirements
 ------------
-* `CPython 2.7 or 3.5 <http://www.python.org>`_ (64-bit recommended)
+* `CPython 2.7 or 3.5 <https://www.python.org>`_ (64-bit recommended)
 * `Numpy 1.11 <http://www.numpy.org>`_
 * `Matplotlib 1.5 <http://www.matplotlib.org>`_ (optional for plotting)
 * `Tifffile.c 2017.01.10 <http://www.lfd.uci.edu/~gohlke/>`_

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -109,7 +109,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Histogram_of_oriented_gradients
+    .. [1] https://en.wikipedia.org/wiki/Histogram_of_oriented_gradients
 
     .. [2] Dalal, N and Triggs, B, Histograms of Oriented Gradients for
            Human Detection, IEEE Computer Society Conference on Computer

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -12,7 +12,7 @@ from .._shared.utils import assert_nD
 
 # This basic blob detection algorithm is based on:
 # http://www.cs.utah.edu/~jfishbau/advimproc/project1/ (04.04.2013)
-# Theory behind: http://en.wikipedia.org/wiki/Blob_detection (04.04.2013)
+# Theory behind: https://en.wikipedia.org/wiki/Blob_detection (04.04.2013)
 
 
 def _compute_disk_overlap(d, r1, r2):
@@ -206,7 +206,7 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Blob_detection#The_difference_of_Gaussians_approach
+    .. [1] https://en.wikipedia.org/wiki/Blob_detection#The_difference_of_Gaussians_approach
 
     Examples
     --------
@@ -320,7 +320,7 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Blob_detection#The_Laplacian_of_Gaussian
+    .. [1] https://en.wikipedia.org/wiki/Blob_detection#The_Laplacian_of_Gaussian
 
     Examples
     --------
@@ -423,7 +423,7 @@ def blob_doh(image, min_sigma=1, max_sigma=30, num_sigma=10, threshold=0.01,
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Blob_detection#The_determinant_of_the_Hessian
+    .. [1] https://en.wikipedia.org/wiki/Blob_detection#The_determinant_of_the_Hessian
 
     .. [2] Herbert Bay, Andreas Ess, Tinne Tuytelaars, Luc Van Gool,
            "SURF: Speeded Up Robust Features"

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -504,7 +504,7 @@ def corner_harris(image, method='k', k=0.05, eps=1e-6, sigma=1):
     References
     ----------
     .. [1] http://kiwi.cs.dal.ca/~dparks/CornerDetection/harris.htm
-    .. [2] http://en.wikipedia.org/wiki/Corner_detection
+    .. [2] https://en.wikipedia.org/wiki/Corner_detection
 
     Examples
     --------
@@ -574,7 +574,7 @@ def corner_shi_tomasi(image, sigma=1):
     References
     ----------
     .. [1] http://kiwi.cs.dal.ca/~dparks/CornerDetection/harris.htm
-    .. [2] http://en.wikipedia.org/wiki/Corner_detection
+    .. [2] https://en.wikipedia.org/wiki/Corner_detection
 
     Examples
     --------
@@ -640,7 +640,7 @@ def corner_foerstner(image, sigma=1):
     References
     ----------
     .. [1] http://www.ipb.uni-bonn.de/uploads/tx_ikgpublication/foerstner87.fast.pdf
-    .. [2] http://en.wikipedia.org/wiki/Corner_detection
+    .. [2] https://en.wikipedia.org/wiki/Corner_detection
 
     Examples
     --------
@@ -781,7 +781,7 @@ def corner_subpix(image, corners, window_size=11, alpha=0.99):
     ----------
     .. [1] http://www.ipb.uni-bonn.de/uploads/tx_ikgpublication/\
            foerstner87.fast.pdf
-    .. [2] http://en.wikipedia.org/wiki/Corner_detection
+    .. [2] https://en.wikipedia.org/wiki/Corner_detection
 
     Examples
     --------
@@ -1001,7 +1001,7 @@ def corner_moravec(image, window_size=1):
     References
     ----------
     .. [1] http://kiwi.cs.dal.ca/~dparks/CornerDetection/moravec.htm
-    .. [2] http://en.wikipedia.org/wiki/Corner_detection
+    .. [2] https://en.wikipedia.org/wiki/Corner_detection
 
     Examples
     --------

--- a/skimage/feature/corner_cy.pyx
+++ b/skimage/feature/corner_cy.pyx
@@ -34,7 +34,7 @@ def _corner_moravec(image, Py_ssize_t window_size=1):
     References
     ----------
     .. [1] http://kiwi.cs.dal.ca/~dparks/CornerDetection/moravec.htm
-    .. [2] http://en.wikipedia.org/wiki/Corner_detection
+    .. [2] https://en.wikipedia.org/wiki/Corner_detection
 
     Examples
     --------

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -63,7 +63,7 @@ def greycomatrix(image, distances, angles, levels=None, symmetric=False,
            http://www.fp.ucalgary.ca/mhallbey/tutorial.htm
     .. [2] Pattern Recognition Engineering, Morton Nadler & Eric P.
            Smith
-    .. [3] Wikipedia, http://en.wikipedia.org/wiki/Co-occurrence_matrix
+    .. [3] Wikipedia, https://en.wikipedia.org/wiki/Co-occurrence_matrix
 
 
     Examples

--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -110,7 +110,7 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
     else:
         mesg = ("plot_matches accepts either 'horizontal' or 'vertical' for "
                 "alignment, but '{}' was given. See "
-                "http://scikit-image.org/docs/dev/api/skimage.feature.html#skimage.feature.plot_matches "  # noqa
+                "https://scikit-image.org/docs/dev/api/skimage.feature.html#skimage.feature.plot_matches "  # noqa
                 "for details.").format(alignment)
         raise ValueError(mesg)
 

--- a/skimage/filters/_gabor.py
+++ b/skimage/filters/_gabor.py
@@ -51,7 +51,7 @@ def gabor_kernel(frequency, theta=0, bandwidth=1, sigma_x=None, sigma_y=None,
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Gabor_filter
+    .. [1] https://en.wikipedia.org/wiki/Gabor_filter
     .. [2] http://mplab.ucsd.edu/tutorials/gabor.pdf
 
     Examples
@@ -143,7 +143,7 @@ def gabor(image, frequency, theta=0, bandwidth=1, sigma_x=None,
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Gabor_filter
+    .. [1] https://en.wikipedia.org/wiki/Gabor_filter
     .. [2] http://mplab.ucsd.edu/tutorials/gabor.pdf
 
     Examples

--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -17,7 +17,7 @@ def _convert_input(image, preserve_range):
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
-        Also see http://scikit-image.org/docs/dev/user_guide/data_types.html
+        Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
     """
     if preserve_range:
         image = image.astype(np.double)
@@ -59,7 +59,7 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
         Also see
-        http://scikit-image.org/docs/dev/user_guide/data_types.html
+        https://scikit-image.org/docs/dev/user_guide/data_types.html
     truncate : float, optional
         Truncate the filter at this many standard deviations.
 

--- a/skimage/filters/_unsharp_mask.py
+++ b/skimage/filters/_unsharp_mask.py
@@ -44,7 +44,7 @@ def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
     preserve_range: bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
-        Also see http://scikit-image.org/docs/dev/user_guide/data_types.html
+        Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Returns
     -------

--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -203,7 +203,7 @@ def scharr(image, mask=None):
     .. [1] D. Kroon, 2009, Short Paper University Twente, Numerical
            Optimization of Kernel Based Image Derivatives.
 
-    .. [2] http://en.wikipedia.org/wiki/Sobel_operator#Alternative_operators
+    .. [2] https://en.wikipedia.org/wiki/Sobel_operator#Alternative_operators
 
     Examples
     --------

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -934,7 +934,7 @@ def entropy(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Entropy_(information_theory)
+    .. [1] https://en.wikipedia.org/wiki/Entropy_(information_theory)
 
     Examples
     --------
@@ -978,7 +978,7 @@ def otsu(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Otsu's_method
+    .. [1] https://en.wikipedia.org/wiki/Otsu's_method
 
     Examples
     --------

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -252,7 +252,7 @@ def threshold_otsu(image, nbins=256):
 
     References
     ----------
-    .. [1] Wikipedia, http://en.wikipedia.org/wiki/Otsu's_Method
+    .. [1] Wikipedia, https://en.wikipedia.org/wiki/Otsu's_Method
 
     Examples
     --------

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -184,7 +184,7 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
 
     References
     ----------
-    .. [1] http://docs.opencv.org/modules/imgproc/doc/miscellaneous_transformations.html?highlight=threshold#adaptivethreshold
+    .. [1] https://docs.opencv.org/modules/imgproc/doc/miscellaneous_transformations.html?highlight=threshold#adaptivethreshold
 
     Examples
     --------

--- a/skimage/io/_plugins/_colormixer.pyx
+++ b/skimage/io/_plugins/_colormixer.pyx
@@ -359,7 +359,7 @@ def py_hsv_2_rgb(H, S, V):
         Each from 0 - 255
 
     conversion convention from here:
-    http://en.wikipedia.org/wiki/HSL_and_HSV
+    https://en.wikipedia.org/wiki/HSL_and_HSV
 
     '''
     cdef float HSV[3]
@@ -398,7 +398,7 @@ def py_rgb_2_hsv(R, G, B):
         Ranges (0...360), (0...1), (0...1)
 
     conversion convention from here:
-    http://en.wikipedia.org/wiki/HSL_and_HSV
+    https://en.wikipedia.org/wiki/HSL_and_HSV
 
     '''
     cdef float HSV[3]

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -178,7 +178,7 @@ def moments(image, order=3):
     .. [3] T. H. Reiss. Recognizing Planar Objects Using Invariant Image
            Features, from Lecture notes in computer science, p. 676. Springer,
            Berlin, 1993.
-    .. [4] http://en.wikipedia.org/wiki/Image_moment
+    .. [4] https://en.wikipedia.org/wiki/Image_moment
 
     Examples
     --------
@@ -233,7 +233,7 @@ def moments_central(image, center=None, cc=None, order=3, **kwargs):
     .. [3] T. H. Reiss. Recognizing Planar Objects Using Invariant Image
            Features, from Lecture notes in computer science, p. 676. Springer,
            Berlin, 1993.
-    .. [4] http://en.wikipedia.org/wiki/Image_moment
+    .. [4] https://en.wikipedia.org/wiki/Image_moment
 
     Examples
     --------
@@ -299,7 +299,7 @@ def moments_normalized(mu, order=3):
     .. [3] T. H. Reiss. Recognizing Planar Objects Using Invariant Image
            Features, from Lecture notes in computer science, p. 676. Springer,
            Berlin, 1993.
-    .. [4] http://en.wikipedia.org/wiki/Image_moment
+    .. [4] https://en.wikipedia.org/wiki/Image_moment
 
     Examples
     --------
@@ -355,7 +355,7 @@ def moments_hu(nu):
     .. [4] T. H. Reiss. Recognizing Planar Objects Using Invariant Image
            Features, from Lecture notes in computer science, p. 676. Springer,
            Berlin, 1993.
-    .. [5] http://en.wikipedia.org/wiki/Image_moment
+    .. [5] https://en.wikipedia.org/wiki/Image_moment
 
 
     """

--- a/skimage/measure/_polygon.py
+++ b/skimage/measure/_polygon.py
@@ -26,7 +26,7 @@ def approximate_polygon(coords, tolerance):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Ramer-Douglas-Peucker_algorithm
+    .. [1] https://en.wikipedia.org/wiki/Ramer-Douglas-Peucker_algorithm
     """
     if tolerance <= 0:
         return coords

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -17,7 +17,7 @@ XY_TO_RC_DEPRECATION_MESSAGE = (
     'regionprops and image moments (including moments, normalized moments, '
     'central moments, and inertia tensor) of 2D images will change from xy '
     'coordinates to rc coordinates in version 0.16.\nSee '
-    'http://scikit-image.org/docs/0.14.x/release_notes_and_installation.html#deprecations '
+    'https://scikit-image.org/docs/0.14.x/release_notes_and_installation.html#deprecations '
     'for details on how to avoid this message.'
 )
 STREL_4 = np.array([[0, 1, 0],

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -539,7 +539,7 @@ def regionprops(label_image, intensity_image=None, cache=True,
     .. [3] T. H. Reiss. Recognizing Planar Objects Using Invariant Image
            Features, from Lecture notes in computer science, p. 676. Springer,
            Berlin, 1993.
-    .. [4] http://en.wikipedia.org/wiki/Image_moment
+    .. [4] https://en.wikipedia.org/wiki/Image_moment
 
     Examples
     --------

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -708,7 +708,7 @@ def ransac(data, model_class, min_samples, residual_threshold,
 
     References
     ----------
-    .. [1] "RANSAC", Wikipedia, http://en.wikipedia.org/wiki/RANSAC
+    .. [1] "RANSAC", Wikipedia, https://en.wikipedia.org/wiki/RANSAC
 
     Examples
     --------

--- a/skimage/measure/tests/test_simple_metrics.py
+++ b/skimage/measure/tests/test_simple_metrics.py
@@ -17,7 +17,7 @@ cam_noisy = cam_noisy.astype(cam.dtype)
 
 def test_PSNR_vs_IPOL():
     # Tests vs. imdiff result from the following IPOL article and code:
-    # http://www.ipol.im/pub/art/2011/g_lmii/
+    # https://www.ipol.im/pub/art/2011/g_lmii/
     p_IPOL = 22.4497
     p = compare_psnr(cam, cam_noisy)
     assert_almost_equal(p, p_IPOL, decimal=4)

--- a/skimage/measure/tests/test_structural_similarity.py
+++ b/skimage/measure/tests/test_structural_similarity.py
@@ -156,7 +156,7 @@ def test_ssim_multichannel_chelsea():
 
 def test_gaussian_mssim_vs_IPOL():
     # Tests vs. imdiff result from the following IPOL article and code:
-    # http://www.ipol.im/pub/art/2011/g_lmii/
+    # https://www.ipol.im/pub/art/2011/g_lmii/
     mssim_IPOL = 0.327309966087341
     mssim = ssim(cam, cam_noisy, gaussian_weights=True,
                  use_sample_covariance=False)

--- a/skimage/morphology/_skeletonize_3d_cy.pyx.in
+++ b/skimage/morphology/_skeletonize_3d_cy.pyx.in
@@ -1,17 +1,17 @@
 """
 This is an implementation of the 2D/3D thinning algorithm
-of [Lee94]_ of binary images, based on [IAC15]_. 
+of [Lee94]_ of binary images, based on [IAC15]_.
 
 The original Java code [IAC15]_ carries the following message:
 
  * This work is an implementation by Ignacio Arganda-Carreras of the
- * 3D thinning algorithm from Lee et al. "Building skeleton models via 3-D 
- * medial surface/axis thinning algorithms. Computer Vision, Graphics, and 
+ * 3D thinning algorithm from Lee et al. "Building skeleton models via 3-D
+ * medial surface/axis thinning algorithms. Computer Vision, Graphics, and
  * Image Processing, 56(6):462-478, 1994." Based on the ITK version from
  * Hanno Homann <a href="http://hdl.handle.net/1926/1292"> http://hdl.handle.net/1926/1292</a>
  * <p>
  *  More information at Skeletonize3D homepage:
- *  http://fiji.sc/Skeletonize3D
+ *  https://imagej.net/Skeletonize3D
  *
  * @version 1.0 11/13/2015 (unique BSD licensed version for scikit-image)
  * @author Ignacio Arganda-Carreras (iargandacarreras at gmail.com)
@@ -23,7 +23,7 @@ References
        Computer Vision, Graphics, and Image Processing, 56(6):462-478, 1994.
 
 .. [IAC15] Ignacio Arganda-Carreras, 2015. Skeletonize3D plugin for ImageJ(C).
-           http://fiji.sc/Skeletonize3D
+           https://imagej.net/Skeletonize3D
 
 """
 
@@ -133,7 +133,7 @@ cdef list find_simple_point_candidates(pixel_type[:, :, ::1] img,
         int[::1] Euler_LUT = LUT
 
     # loop through the image
-    # NB: each loop is from 1 to size-1: img is padded from all sides 
+    # NB: each loop is from 1 to size-1: img is padded from all sides
     for p in range(1, img.shape[0] - 1):
         for r in range(1, img.shape[1] - 1):
             for c in range(1, img.shape[2] - 1):
@@ -154,7 +154,7 @@ cdef list find_simple_point_candidates(pixel_type[:, :, ::1] img,
 
                 get_neighborhood(img, p, r, c, neighborhood)
 
-                # check if (p, r, c) can be deleted: 
+                # check if (p, r, c) can be deleted:
                 # * it must not be an endpoint;
                 # * it must be Euler invariant (condition 1 in [Lee94]_); and
                 # * it must be simple (i.e., its deletion does not change
@@ -178,7 +178,7 @@ cdef void get_neighborhood(pixel_type[:, :, ::1] img,
                            pixel_type neighborhood[]):
     """Get the neighborhood of a pixel.
 
-    Assume zero boundary conditions. 
+    Assume zero boundary conditions.
     Image is already padded, so no out-of-bounds checking.
 
     For the numbering of points see Fig. 1a. of [Lee94]_, where the numbers
@@ -402,7 +402,7 @@ cdef void octree_labeling(int octant, int label, pixel_type cube[]):
     ----------
     octant : int
         octant index
-    label : int 
+    label : int
         the current label of the center point
     cube : uint8 C array, shape(26,)
         local neighborhood of the point

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -44,7 +44,7 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10):
 
     References
     ----------
-    .. [1] http://blogs.mathworks.com/steve/2011/10/04/binary-image-convex-hull-algorithm-notes/
+    .. [1] https://blogs.mathworks.com/steve/2011/10/04/binary-image-convex-hull-algorithm-notes/
 
     """
     ndim = image.ndim

--- a/skimage/morphology/watershed.py
+++ b/skimage/morphology/watershed.py
@@ -220,7 +220,7 @@ def watershed(image, markers, connectivity=1, offset=None, mask=None,
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Watershed_%28image_processing%29
+    .. [1] https://en.wikipedia.org/wiki/Watershed_%28image_processing%29
 
     .. [2] http://cmm.ensmp.fr/~beucher/wtshed.html
 

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -147,7 +147,7 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Total_variation_denoising
+    .. [1] https://en.wikipedia.org/wiki/Total_variation_denoising
     .. [2] Tom Goldstein and Stanley Osher, "The Split Bregman Method For L1
            Regularized Problems",
            ftp://ftp.math.ucla.edu/pub/camreport/cam08-29.pdf
@@ -278,7 +278,7 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, n_iter_max=200,
     Make sure to set the multichannel parameter appropriately for color images.
 
     The principle of total variation denoising is explained in
-    http://en.wikipedia.org/wiki/Total_variation_denoising
+    https://en.wikipedia.org/wiki/Total_variation_denoising
 
     The principle of total variation denoising is to minimize the
     total variation of the image, which can be roughly described as

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -62,7 +62,7 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
 
     References
     ----------
-    .. [1] http://users.soe.ucsc.edu/~manduchi/Papers/ICCV98.pdf
+    .. [1] https://users.soe.ucsc.edu/~manduchi/Papers/ICCV98.pdf
 
     Examples
     --------
@@ -153,8 +153,8 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True):
            ftp://ftp.math.ucla.edu/pub/camreport/cam08-29.pdf
     .. [3] Pascal Getreuer, "Rudin–Osher–Fatemi Total Variation Denoising
            using Split Bregman" in Image Processing On Line on 2012–05–19,
-           http://www.ipol.im/pub/art/2012/g-tvd/article_lr.pdf
-    .. [4] http://www.math.ucsb.edu/~cgarcia/UGProjects/BregmanAlgorithms_JacquelineBush.pdf
+           https://www.ipol.im/pub/art/2012/g-tvd/article_lr.pdf
+    .. [4] https://web.math.ucsb.edu/~cgarcia/UGProjects/BregmanAlgorithms_JacquelineBush.pdf
 
     """
     return _denoise_tv_bregman(image, weight, max_iter, eps, isotropic)

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -104,7 +104,7 @@ def wiener(image, psf, balance, reg=None, is_real=True, clip=True):
            spread function parameters for Wiener-Hunt deconvolution",
            J. Opt. Soc. Am. A 27, 1593-1607 (2010)
 
-           http://www.opticsinfobase.org/josaa/abstract.cfm?URI=josaa-27-7-1593
+           https://www.osapublishing.org/josaa/abstract.cfm?URI=josaa-27-7-1593
 
            http://research.orieux.fr/files/papers/OGR-JOSA10.pdf
 
@@ -226,7 +226,7 @@ def unsupervised_wiener(image, psf, reg=None, user_params=None, is_real=True,
            spread function parameters for Wiener-Hunt deconvolution",
            J. Opt. Soc. Am. A 27, 1593-1607 (2010)
 
-           http://www.opticsinfobase.org/josaa/abstract.cfm?URI=josaa-27-7-1593
+           https://www.osapublishing.org/josaa/abstract.cfm?URI=josaa-27-7-1593
 
            http://research.orieux.fr/files/papers/OGR-JOSA10.pdf
     """

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -359,7 +359,7 @@ def richardson_lucy(image, psf, iterations=50, clip=True):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Richardson%E2%80%93Lucy_deconvolution
+    .. [1] https://en.wikipedia.org/wiki/Richardson%E2%80%93Lucy_deconvolution
     """
     # compute the times for direct convolution and the fft method. The fft is of
     # complexity O(N log(N)) for each dimension and the direct method does

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -18,7 +18,7 @@ from .._shared.utils import warn
 # needed to speed up a few cases.
 # See discussions at:
 # https://groups.google.com/d/msg/scikit-image/FrM5IGP6wh4/1hp-FtVZmfcJ
-# http://stackoverflow.com/questions/13977970/ignore-exceptions-printed-to-stderr-in-del/13977992?noredirect=1#comment28386412_13977992
+# https://stackoverflow.com/questions/13977970/ignore-exceptions-printed-to-stderr-in-del/13977992?noredirect=1#comment28386412_13977992
 try:
     from scipy.sparse.linalg.dsolve import umfpack
     old_del = umfpack.UmfpackContext.__del__

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -254,7 +254,7 @@ def random_walker(data, labels, beta=130, mode='bf', tol=1.e-3, copy=True,
         - 'cg_mg' (conjugate gradient with multigrid preconditioner): a
           preconditioner is computed using a multigrid solver, then the
           solution is computed with the Conjugate Gradient method.  This mode
-          requires that the pyamg module (http://pyamg.org/) is
+          requires that the pyamg module (http://pyamg.github.io/) is
           installed. For images of size > 512x512, this is the recommended
           (fastest) mode.
 
@@ -470,7 +470,7 @@ def random_walker(data, labels, beta=130, mode='bf', tol=1.e-3, copy=True,
                       return_full_prob=return_full_prob)
     if mode == 'cg_mg':
         if not amg_loaded:
-            warn("""pyamg (http://pyamg.org/)) is needed to use
+            warn("""pyamg (http://pyamg.github.io/)) is needed to use
                 this mode, but is not installed. The 'cg' mode will be used
                 instead.""")
             X = _solve_cg(lap_sparse, B, tol=tol,

--- a/skimage/transform/_seam_carving.pyx
+++ b/skimage/transform/_seam_carving.pyx
@@ -166,7 +166,7 @@ def _seam_carve_v(img, energy_map, iters, border):
     ----------
     .. [1] Shai Avidan and Ariel Shamir
            "Seam Carving for Content-Aware Image Resizing"
-           http://www.cs.jhu.edu/~misha/ReadingSeminar/Papers/Avidan07.pdf
+           https://www.cs.jhu.edu/~misha/ReadingSeminar/Papers/Avidan07.pdf
     """
     # This reference has been kept to be used for the `np.argsort` call
     last_row_obj = np.zeros(img.shape[1], dtype=np.float)

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -72,7 +72,7 @@ def resize(image, output_shape, order=1, mode='reflect', cval=0, clip=True,
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
-        Also see http://scikit-image.org/docs/dev/user_guide/data_types.html
+        Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
     anti_aliasing : bool, optional
         Whether to apply a Gaussian filter to smooth the image prior to
         down-scaling. It is crucial to filter when down-sampling the image to
@@ -223,7 +223,7 @@ def rescale(image, scale, order=1, mode='reflect', cval=0, clip=True,
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
         Also see
-        http://scikit-image.org/docs/dev/user_guide/data_types.html
+        https://scikit-image.org/docs/dev/user_guide/data_types.html
     multichannel : bool, optional
         Whether the last axis of the image is to be interpreted as multiple
         channels or another spatial dimension. By default, is set to True for
@@ -321,7 +321,7 @@ def rotate(image, angle, resize=False, center=None, order=1, mode='constant',
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
         Also see
-        http://scikit-image.org/docs/dev/user_guide/data_types.html
+        https://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Notes
     -----
@@ -494,7 +494,7 @@ def swirl(image, center=None, strength=1, radius=100, rotation=0,
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
         Also see
-        http://scikit-image.org/docs/dev/user_guide/data_types.html
+        https://scikit-image.org/docs/dev/user_guide/data_types.html
 
     """
     if center is None:
@@ -725,7 +725,7 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=1,
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
         Also see
-        http://scikit-image.org/docs/dev/user_guide/data_types.html
+        https://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Returns
     -------

--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -44,7 +44,7 @@ def radon(image, theta=None, circle=True):
     Notes
     -----
     Based on code of Justin K. Romberg
-    (http://www.clear.rice.edu/elec431/projects96/DSP/bpanalysis.html)
+    (https://www.clear.rice.edu/elec431/projects96/DSP/bpanalysis.html)
 
     """
     if image.ndim != 2:

--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -385,7 +385,7 @@ def iradon_sart(radon_image, theta=None, image=None, projection_shifts=None,
            reconstruction based on the golden section." Nuclear Science
            Symposium Conference Record, 2004 IEEE. Vol. 6. IEEE, 2004.
     .. [5] Kaczmarz' method, Wikipedia,
-           http://en.wikipedia.org/wiki/Kaczmarz_method
+           https://en.wikipedia.org/wiki/Kaczmarz_method
     """
     if radon_image.ndim != 2:
         raise ValueError('radon_image must be two dimensional')

--- a/skimage/transform/seam_carving.py
+++ b/skimage/transform/seam_carving.py
@@ -44,7 +44,7 @@ def seam_carve(image, energy_map, mode, num, border=1, force_copy=True):
     ----------
     .. [1] Shai Avidan and Ariel Shamir
            "Seam Carving for Content-Aware Image Resizing"
-           http://www.cs.jhu.edu/~misha/ReadingSeminar/Papers/Avidan07.pdf
+           https://www.cs.jhu.edu/~misha/ReadingSeminar/Papers/Avidan07.pdf
     """
 
     utils.assert_nD(image, (2, 3))

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -86,7 +86,7 @@ def convert(image, dtype, force_copy=False, uniform=False):
     References
     ----------
     .. [1] DirectX data conversion rules.
-           http://msdn.microsoft.com/en-us/library/windows/desktop/dd607323%28v=vs.85%29.aspx
+           https://msdn.microsoft.com/en-us/library/windows/desktop/dd607323%28v=vs.85%29.aspx
     .. [2] Data Conversions. In "OpenGL ES 2.0 Specification v2.0.25",
            pp 7-8. Khronos Group, 2010.
     .. [3] Proper treatment of pixels as integers. A.W. Paeth.

--- a/skimage/util/shape.py
+++ b/skimage/util/shape.py
@@ -146,7 +146,7 @@ def view_as_windows(arr_in, window_shape, step=1):
 
     References
     ----------
-    .. [1] http://en.wikipedia.org/wiki/Hyperrectangle
+    .. [1] https://en.wikipedia.org/wiki/Hyperrectangle
 
     Examples
     --------

--- a/tools/travis/deploy_docs.sh
+++ b/tools/travis/deploy_docs.sh
@@ -3,7 +3,7 @@ if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_BRANCH == "master" &&
       $BUILD_DOCS == 1 && $DEPLOY_DOCS == 1 ]]
 then
     # See https://help.github.com/articles/creating-an-access-token-for-command-line-use/ for how to generate a token
-    # See http://docs.travis-ci.com/user/encryption-keys/ for how to generate 
+    # See https://docs.travis-ci.com/user/encryption-keys/ for how to generate 
     # a secure variable on Travis
     echo "-- pushing docs --"
 

--- a/tools/travis/notes.txt
+++ b/tools/travis/notes.txt
@@ -1,5 +1,5 @@
-- Use http://yaml-online-parser.appspot.com/ to make sure the yaml file is valid.
-  http://lint.travis-ci.org/ is recommended elsewhere but does not give helpful
+- Use https://yaml-online-parser.appspot.com/ to make sure the yaml file is valid.
+  https://lint.travis-ci.org/ is recommended elsewhere but does not give helpful
   error reports.
 - Make sure all of your "-" lines start on the same column
 - Use bash scripts for `before_install` and `script` or any part that


### PR DESCRIPTION
Harden some known links with https

I had a check a few of the ones in later commits.

I got bored so there are still ~50 links with http that could be converted to https today.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
