### PR TITLE
Build tools: Fix PyQt installed in minimum requirements build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ before_install:
     - export PATH=/usr/lib/ccache:${PATH}
     - source tools/travis/before_install.sh
     - which python; python --version
+    - pip list
     - tools/build_versions.py
     - tools/check_sdist.py
 

--- a/tools/travis/install_qt.sh
+++ b/tools/travis/install_qt.sh
@@ -6,7 +6,14 @@ if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
 fi
 # Now configure Matplotlib to use Qt5
 if [[ "${QT}" == "PyQt5" ]]; then
-    pip install --retries 3 -q $PIP_FLAGS pyqt5
+    if [[ $MINIMUM_REQUIREMENTS == "1" ]]; then
+        # PyQt 5.11 changed how they ship SIP
+        # Which conflicts with how matplotlib detects the
+        # presence of PyQt before MPL 2.2.3
+        pip install --retries 3 -q $PIP_FLAGS "pyqt5<5.11"
+    else
+        pip install --retries 3 -q $PIP_FLAGS pyqt5
+    fi
     MPL_QT_API=PyQt5
     export QT_API=pyqt5
 elif [[ "${QT}" == "PySide2" ]]; then

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -10,6 +10,11 @@ if [[ $TRAVIS_OS_NAME == "osx" ]]; then
     echo 'backend : Template' > $MPL_DIR/matplotlibrc
 fi
 
+section "list.installed.dependencies"
+pip list
+tools/build_versions.py
+section_end "list.installed.dependencies"
+
 section "Test"
 pytest $TEST_ARGS skimage
 section_end "Test"
@@ -22,6 +27,8 @@ section "Tests.examples"
 # Run example applications
 echo Build or run examples
 pip install --retries 3 -q -r ./requirements/docs.txt
+pip list
+tools/build_versions.py
 echo 'backend : Template' > $MPL_DIR/matplotlibrc
 if [[ "${BUILD_DOCS}" == "1" ]]; then
   export SPHINXCACHE=${HOME}/.cache/sphinx; make html

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -10,10 +10,10 @@ if [[ $TRAVIS_OS_NAME == "osx" ]]; then
     echo 'backend : Template' > $MPL_DIR/matplotlibrc
 fi
 
-section "list.installed.dependencies"
+section "List.installed.dependencies"
 pip list
 tools/build_versions.py
-section_end "list.installed.dependencies"
+section_end "List.installed.dependencies"
 
 section "Test"
 pytest $TEST_ARGS skimage


### PR DESCRIPTION
Somewhere along the last few maintenance PRs the MINIMUM_REQUIREMENTS broke.

See this build that failed 
https://travis-ci.org/scikit-image/scikit-image/jobs/435259570

Hopefully the build process will be a little more normalized after this. `MINIMUM_REQUIREMENTS` is just really fragile....

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
