### PR TITLE
Build tools: Add a PySide2 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
   include:
     - os: linux
       python: 3.5
-      env: OPTIONAL_DEPS=1 WITH_PYSIDE=1 BUILD_DOCS=1
+      env: QT=PySide2 OPTIONAL_DEPS=1 BUILD_DOCS=1
     - os: linux
       python: 3.5
       env: QT=PyQt5 WITH_PYAMG=1 MINIMUM_REQUIREMENTS=1

--- a/tools/travis/install_qt.sh
+++ b/tools/travis/install_qt.sh
@@ -17,7 +17,7 @@ if [[ "${QT}" == "PyQt5" ]]; then
     MPL_QT_API=PyQt5
     export QT_API=pyqt5
 elif [[ "${QT}" == "PySide2" ]]; then
-    pip install--retries 3 -q $PIP_FLAGS pyside2
+    pip install --retries 3 -q $PIP_FLAGS pyside2
     MPL_QT_API=PySide2
     export QT_API=pyside2
 else


### PR DESCRIPTION
The previous PySide environment variable was defunct. We should either take it off or use the more current flags.

logic was added in previous maintenance PR to be compatible with PySide2 but PySide2 wasn't really availble on PyPi.

This is rebased onto: https://github.com/scikit-image/scikit-image/pull/3432

Confirmation that this was run with pyside2 https://travis-ci.org/scikit-image/scikit-image/jobs/435296973#L2568

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
