### PR TITLE
MNT: Set the stack level of `_warnings.warn` to the correct location

### DIFF
--- a/skimage/_shared/_warnings.py
+++ b/skimage/_shared/_warnings.py
@@ -3,17 +3,13 @@ import sys
 import warnings
 import inspect
 import re
+import functools
 
 __all__ = ['all_warnings', 'expected_warnings', 'warn']
 
-
-def warn(message, category=None, stacklevel=2):
-    """A version of `warnings.warn` with a default stacklevel of 2.
-    """
-    if category is not None:
-        warnings.warn(message, category=category, stacklevel=stacklevel)
-    else:
-        warnings.warn(message, stacklevel=stacklevel)
+# Setting the stacklevel to 2 will point to the user's code in most cases
+# rather than to the line where the warning was generated.
+warn = functools.partial(warnings.warn, stacklevel=2)
 
 
 @contextmanager

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -5,7 +5,6 @@ import numpy as np
 import types
 import numbers
 
-from ..util import img_as_float
 from ._warnings import all_warnings, warn
 
 __all__ = ['deprecated', 'get_bound_method_class', 'all_warnings',
@@ -216,27 +215,3 @@ def check_random_state(seed):
         return seed
     raise ValueError('%r cannot be used to seed a numpy.random.RandomState'
                      ' instance' % seed)
-
-
-def convert_to_float(image, preserve_range):
-    """Convert input image to double image with the appropriate range.
-
-    Parameters
-    ----------
-    image : ndarray
-        Input image.
-    preserve_range : bool
-        Determines if the range of the image should be kept or transformed
-        using img_as_float. Also see
-        https://scikit-image.org/docs/dev/user_guide/data_types.html
-
-    Returns
-    -------
-    image : ndarray
-        Transformed version of the input.
-    """
-    if preserve_range:
-        image = image.astype(np.double)
-    else:
-        image = img_as_float(image)
-    return image

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -50,7 +50,7 @@ References
 """
 
 
-from warnings import warn
+from .._shared.utils import warn
 import numpy as np
 from scipy import linalg
 from ..util import dtype, dtype_limits

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -12,7 +12,7 @@ from ._hessian_det_appx import _hessian_matrix_det
 from ..transform import integral_image
 from .._shared.utils import safe_as_int
 from .corner_cy import _corner_moravec, _corner_orientations
-from warnings import warn
+from .._shared.utils import warn
 
 
 def _compute_derivatives(image, mode='constant', cval=0):

--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -4,7 +4,7 @@ http://www.mathworks.com/matlabcentral/fileexchange/18401-efficient-subpixel-ima
 """
 
 import numpy as np
-import warnings
+from .._shared.utils import warn
 
 def _upsampled_dft(data, upsampled_region_size,
                    upsample_factor=1, axis_offsets=None):
@@ -97,8 +97,8 @@ def _upsampled_dft(data, upsampled_region_size,
             return np.einsum('ijk, li, mj, nk -> lmn', data, *dim_kernels,
                          optimize=True)
         except TypeError:
-            warnings.warn("Subpixel registration of 3D images will be very slow"
-                          " if your numpy version is earlier than 1.12")
+            warn("Subpixel registration of 3D images will be very slow "
+                 "if your numpy version is earlier than 1.12")
             return np.einsum('ijk, li, mj, nk -> lmn', data, *dim_kernels)
 
     else:

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -3,7 +3,6 @@ Methods to characterize image textures.
 """
 
 import numpy as np
-import warnings
 from .._shared.utils import assert_nD
 from ..util import img_as_float
 from ..color import gray2rgb

--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -3,8 +3,9 @@ import numpy as np
 from scipy import ndimage as ndi
 
 from ..util import img_as_float
+from ..util.dtype import convert_to_float
 from ..color import guess_spatial_dimensions
-from .._shared.utils import warn, convert_to_float
+from .._shared.utils import warn
 
 
 __all__ = ['gaussian']

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -2,7 +2,7 @@ import numpy as np
 from .._shared.utils import assert_nD
 from . import _moments_cy
 import itertools
-from warnings import warn
+from .._shared.utils import warn
 
 
 def moments_coords(coords, order=3):

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -1,11 +1,10 @@
 from math import sqrt, atan2, pi as PI
-import itertools
-from warnings import warn
 import numpy as np
 from scipy import ndimage as ndi
 
 from ._label import label
 from . import _moments
+from .._shared.utils import warn
 
 
 from functools import wraps

--- a/skimage/morphology/tests/test_skeletonize_3d.py
+++ b/skimage/morphology/tests/test_skeletonize_3d.py
@@ -1,6 +1,5 @@
 
 import os
-import warnings
 
 import numpy as np
 import scipy.ndimage as ndi

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -6,8 +6,8 @@ from ._geometric import (SimilarityTransform, AffineTransform,
 from ._warps_cy import _warp_fast
 from ..measure import block_reduce
 
-from .._shared.utils import (get_bound_method_class, safe_as_int, warn,
-                             convert_to_float)
+from .._shared.utils import (get_bound_method_class, safe_as_int, warn)
+from ..util.dtype import convert_to_float
 
 HOMOGRAPHY_TRANSFORMS = (
     SimilarityTransform,

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -22,7 +22,7 @@ def _multichannel_default(multichannel, ndim):
     else:
         warn('The default multichannel argument (None) is deprecated.  Please '
              'specify either True or False explicitly.  multichannel will '
-             'default to False starting with release 0.16.')
+             'default to False starting with release 0.16.', stacklevel=3)
         # utility for maintaining previous color image default behavior
         if ndim == 3:
             return True

--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -3,7 +3,7 @@ from scipy.fftpack import fft, ifft, fftfreq
 from scipy.interpolate import interp1d
 from ._warps_cy import _warp_fast
 from ._radon_transform import sart_projection_update
-from warnings import warn
+from .._shared.utils import warn
 
 
 __all__ = ['radon', 'order_angles_golden_ratio', 'iradon', 'iradon_sart']

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -509,3 +509,27 @@ def img_as_bool(image, force_copy=False):
 
     """
     return convert(image, np.bool_, force_copy)
+
+
+def convert_to_float(image, preserve_range):
+    """Convert input image to double image with the appropriate range.
+
+    Parameters
+    ----------
+    image : ndarray
+        Input image.
+    preserve_range : bool
+        Determines if the range of the image should be kept or transformed
+        using img_as_float. Also see
+        https://scikit-image.org/docs/dev/user_guide/data_types.html
+
+    Returns
+    -------
+    image : ndarray
+        Transformed version of the input.
+    """
+    if preserve_range:
+        image = image.astype(np.double)
+    else:
+        image = img_as_float(image)
+    return image

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -1,5 +1,5 @@
 import numpy as np
-from warnings import warn
+from .._shared.utils import warn
 
 
 __all__ = ['img_as_float32', 'img_as_float64', 'img_as_float',
@@ -132,7 +132,7 @@ def convert(image, dtype, force_copy=False, uniform=False):
 
     def prec_loss():
         warn("Possible precision loss when converting from {} to {}"
-             .format(dtypeobj_in, dtypeobj_out))
+             .format(dtypeobj_in, dtypeobj_out), stacklevel=3)
 
     def _dtype_itemsize(itemsize, *dtypes):
         # Return first of `dtypes` with itemsize greater than `itemsize`
@@ -181,7 +181,8 @@ def convert(image, dtype, force_copy=False, uniform=False):
                 dtype = "uint{}".format(mnew)
             n = int(np.ceil(n / 2) * 2)
             warn("Downcasting {} to {} without scaling because max "
-                 "value {} fits in {}".format(a.dtype, dtype, a.max(), dtype))
+                 "value {} fits in {}".format(a.dtype, dtype, a.max(), dtype),
+                 stacklevel=3)
             return a.astype(_dtype_bits(kind, m))
         elif n == m:
             return a.copy() if copy else a

--- a/skimage/util/shape.py
+++ b/skimage/util/shape.py
@@ -1,7 +1,7 @@
 import numbers
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
-from warnings import warn
+from .._shared.utils import warn
 
 __all__ = ['view_as_blocks', 'view_as_windows']
 

--- a/skimage/viewer/plugins/base.py
+++ b/skimage/viewer/plugins/base.py
@@ -1,7 +1,7 @@
 """
 Base class for Plugins that interact with ImageViewer.
 """
-from warnings import warn
+from ..._shared.utils import warn
 
 import numpy as np
 from ..qt import QtWidgets, QtCore, Signal

--- a/skimage/viewer/plugins/overlayplugin.py
+++ b/skimage/viewer/plugins/overlayplugin.py
@@ -1,4 +1,4 @@
-from warnings import warn
+from ..._shared.utils import warn
 
 from ...util.dtype import dtype_range
 from .base import Plugin
@@ -116,4 +116,3 @@ class OverlayPlugin(Plugin):
         data : None
         """
         return (self.overlay, None)
-


### PR DESCRIPTION
Currently the user experience of warnings is a little all over the place. The warnings are pointing to internal scikit-image functions, see Issue #3436 for example.

I think an attempt to alleviate this was by writing a custom warn function, but it seems that writing it as a function introduced an other `stacklevel` which was not taken into account in the default parameter choice.

I don't think we should be making our own function for warnings since many contributors might be used to the standard warnings function, and understand what the `stacklevel` parameter means there.

This fixes this by using `functools.partial` to avoid the creation of a new stack level. I also modified the stack level in an internal function to 3 to increase the chances of it pointing to the user's code.

I kinda went through searching for `import warnings` and `from warnings` and modified the code as needed.

I had some code that would actually test that the warning was provided at the correct location, but I'm not sure how to adapt it for scikit-image's usecase. Depending on the amount of automagic we do, it might still be wrong. For example `img_as_[u]int` might be called in a `rank` algorithm at which case the correct warning level would be at least 1 above the standard one.

https://github.com/hmaarrfk/wabisabi/blob/master/wabisabi/tests/test_default_parameter_change.py#L67

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
  existing benchmark
- [ ] Unit tests

## For reviewers
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
