### PR TITLE
MAINT Use np.full instead of cst*np.ones

### DIFF
--- a/doc/examples/filters/plot_entropy.py
+++ b/doc/examples/filters/plot_entropy.py
@@ -30,7 +30,7 @@ from skimage.morphology import disk
 
 # First example: object detection.
 
-noise_mask = 28 * np.ones((128, 128), dtype=np.uint8)
+noise_mask = np.full((128, 128), 28, dtype=np.uint8)
 noise_mask[32:-32, 32:-32] = 30
 
 noise = (noise_mask * np.random.random(noise_mask.shape) - 0.5 *

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -157,5 +157,5 @@ def test_avg():
 
 def test_negative_intensity():
     labels = np.arange(100).reshape(10, 10)
-    image = -1 * np.ones((10, 10))
+    image = np.full((10, 10), -1)
     assert_warns(UserWarning, label2rgb, labels, image)

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -157,5 +157,5 @@ def test_avg():
 
 def test_negative_intensity():
     labels = np.arange(100).reshape(10, 10)
-    image = np.full((10, 10), -1)
+    image = np.full((10, 10), -1, dtype='float64')
     assert_warns(UserWarning, label2rgb, labels, image)

--- a/skimage/draw/_random_shapes.py
+++ b/skimage/draw/_random_shapes.py
@@ -315,7 +315,7 @@ def random_shapes(image_shape,
     random = np.random.RandomState(random_seed)
     user_shape = shape
     image_shape = (image_shape[0], image_shape[1], num_channels)
-    image = np.ones(image_shape, dtype=np.uint8) * 255
+    image = np.full(image_shape, 255, dtype=np.uint8)
     filled = np.zeros(image_shape, dtype=bool)
     labels = []
 

--- a/skimage/feature/orb.py
+++ b/skimage/feature/orb.py
@@ -187,7 +187,7 @@ class ORB(FeatureDetector, DescriptorExtractor):
             keypoints_list.append(keypoints * self.downscale ** octave)
             orientations_list.append(orientations)
             scales_list.append(np.full(
-                keypoints.shape[0], self.downscale ** octave, dtype=np.intp))
+                keypoints.shape[0], self.downscale ** octave, dtype='float64'))
             responses_list.append(responses)
 
         keypoints = np.vstack(keypoints_list)

--- a/skimage/feature/orb.py
+++ b/skimage/feature/orb.py
@@ -186,8 +186,8 @@ class ORB(FeatureDetector, DescriptorExtractor):
 
             keypoints_list.append(keypoints * self.downscale ** octave)
             orientations_list.append(orientations)
-            scales_list.append(self.downscale ** octave
-                               * np.ones(keypoints.shape[0], dtype=np.intp))
+            scales_list.append(np.full(
+                keypoints.shape[0], self.downscale ** octave, dtype=np.intp))
             responses_list.append(responses)
 
         keypoints = np.vstack(keypoints_list)

--- a/skimage/feature/tests/test_peak.py
+++ b/skimage/feature/tests/test_peak.py
@@ -48,7 +48,7 @@ class TestPeakLocalMax():
         assert_array_almost_equal(peaks, [(3, 3)])
 
     def test_constant_image(self):
-        image = 128 * np.ones((20, 20), dtype=np.uint8)
+        image = np.full((20, 20), 128, dtype=np.uint8)
         peaks = peak.peak_local_max(image, min_distance=1)
         assert len(peaks) == 0
 

--- a/skimage/feature/tests/test_template.py
+++ b/skimage/feature/tests/test_template.py
@@ -10,7 +10,7 @@ from skimage._shared import testing
 def test_template():
     size = 100
     # Float prefactors ensure that image range is between 0 and 1
-    image = 0.5 * np.ones((400, 400))
+    image = np.full((400, 400), 0.5)
     target = 0.1 * (np.tri(size) + np.tri(size)[::-1])
     target_positions = [(50, 50), (200, 200)]
     for x, y in target_positions:
@@ -47,7 +47,7 @@ def test_normalization():
     N = 20
     ipos, jpos = (2, 3)
     ineg, jneg = (12, 11)
-    image = 0.5 * np.ones((N, N))
+    image = np.full((N, N), 0.5)
     image[ipos:ipos + n, jpos:jpos + n] = 1
     image[ineg:ineg + n, jneg:jneg + n] = 0
 

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -183,7 +183,7 @@ class TestRank():
         mask = np.ones((100, 100), dtype=np.uint8)
 
         for i in range(5):
-            image = np.ones((100, 100), dtype=np.uint16) * 255 * 2 ** i
+            image = np.full((100, 100), 255 * 2 ** i, dtype=np.uint16)
             if i > 3:
                 expected = ["Bitdepth of"]
             else:
@@ -244,7 +244,7 @@ class TestRank():
     def test_pass_on_bitdepth(self):
         # should pass because data bitdepth is not too high for the function
 
-        image = np.ones((100, 100), dtype=np.uint16) * 2 ** 11
+        image = np.full((100, 100), 2 ** 11, dtype=np.uint16)
         elem = np.ones((3, 3), dtype=np.uint8)
         out = np.empty_like(image)
         mask = np.ones(image.shape, dtype=np.uint8)

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -435,7 +435,7 @@ def test_mean_std_2d():
     image = np.random.rand(256, 256)
     window_size = 11
     m, s = _mean_std(image, w=window_size)
-    mean_kernel = np.ones((window_size,) * 2) / window_size**2
+    mean_kernel = np.full((window_size,) * 2,  1 / window_size**2)
     expected_m = ndi.convolve(image, mean_kernel, mode='mirror')
     np.testing.assert_allclose(m, expected_m)
     expected_s = ndi.generic_filter(image, np.std, size=window_size,
@@ -446,7 +446,7 @@ def test_mean_std_2d():
 def test_mean_std_3d():
     image = np.random.rand(40, 40, 40)
     window_size = 5
-    mean_kernel = np.ones((window_size,) * 3) / window_size**3
+    mean_kernel = np.full((window_size,) * 3, 1 / window_size**3)
     m, s = _mean_std(image, w=window_size)
     expected_m = ndi.convolve(image, mean_kernel, mode='mirror')
     np.testing.assert_allclose(m, expected_m)

--- a/skimage/graph/spath.py
+++ b/skimage/graph/spath.py
@@ -57,7 +57,8 @@ def shortest_path(arr, reach=1, axis=-1, output_indexlist=False):
                               np.zeros(non_axis_shape), axis=0)
     starts = np.reshape(start_indices, (arr.ndim, non_axis_size), order='F').T
     end_indices = np.insert(non_axis_indices, axis,
-                            np.full(non_axis_shape, -1), axis=0)
+                            np.full(non_axis_shape, -1,
+                                    dtype=non_axis_indices.dtype), axis=0)
     ends = np.reshape(end_indices, (arr.ndim, non_axis_size), order='F').T
 
     # Find the minimum-cost path to one of the end-points

--- a/skimage/graph/spath.py
+++ b/skimage/graph/spath.py
@@ -56,8 +56,8 @@ def shortest_path(arr, reach=1, axis=-1, output_indexlist=False):
     start_indices = np.insert(non_axis_indices, axis,
                               np.zeros(non_axis_shape), axis=0)
     starts = np.reshape(start_indices, (arr.ndim, non_axis_size), order='F').T
-    end_indices = np.insert(non_axis_indices, axis, -np.ones(non_axis_shape),
-                            axis=0)
+    end_indices = np.insert(non_axis_indices, axis,
+                            np.full(non_axis_shape, -1), axis=0)
     ends = np.reshape(end_indices, (arr.ndim, non_axis_size), order='F').T
 
     # Find the minimum-cost path to one of the end-points

--- a/skimage/io/tests/test_colormixer.py
+++ b/skimage/io/tests/test_colormixer.py
@@ -7,7 +7,7 @@ from skimage._shared.testing import (assert_array_equal, assert_almost_equal,
 
 class ColorMixerTest(object):
     def setup(self):
-        self.state = np.ones((18, 33, 3), dtype=np.uint8) * 200
+        self.state = np.full((18, 33, 3), 200, dtype=np.uint8)
         self.img = np.zeros_like(self.state)
 
     def test_basic(self):
@@ -18,7 +18,7 @@ class ColorMixerTest(object):
     def test_clip(self):
         self.op(self.img, self.state, 0, self.positive_clip)
         assert_array_equal(self.img[..., 0],
-                           np.ones_like(self.img[..., 0]) * 255)
+                           np.full_like(self.img[..., 0], 255))
 
     def test_negative(self):
         self.op(self.img, self.state, 0, self.negative)

--- a/skimage/morphology/greyreconstruct.py
+++ b/skimage/morphology/greyreconstruct.py
@@ -157,7 +157,7 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
     else:
         raise ValueError("Reconstruction method can be one of 'erosion' "
                          "or 'dilation'. Got '%s'." % method)
-    images = np.ones(dims) * pad_value
+    images = np.full(dims, pad_value)
     images[(0, *inside_slices)] = seed
     images[(1, *inside_slices)] = mask
 
@@ -179,8 +179,8 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
         index_sorted = index_sorted[::-1]
 
     # Make a linked list of pixels sorted by value. -1 is the list terminator.
-    prev = -np.ones(len(images), np.int32)
-    next = -np.ones(len(images), np.int32)
+    prev = np.full(len(images), -1, np.int32)
+    next = np.full(len(images), -1, np.int32)
     prev[index_sorted[1:]] = index_sorted[:-1]
     next[index_sorted[:-1]] = index_sorted[1:]
 

--- a/skimage/morphology/greyreconstruct.py
+++ b/skimage/morphology/greyreconstruct.py
@@ -157,7 +157,7 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
     else:
         raise ValueError("Reconstruction method can be one of 'erosion' "
                          "or 'dilation'. Got '%s'." % method)
-    images = np.full(dims, pad_value)
+    images = np.full(dims, pad_value, dtype='float64')
     images[(0, *inside_slices)] = seed
     images[(1, *inside_slices)] = mask
 

--- a/skimage/novice/tests/test_novice.py
+++ b/skimage/novice/tests/test_novice.py
@@ -183,7 +183,7 @@ def test_save_with_alpha_channel():
 
 
 def test_indexing():
-    array = 128 * np.ones((10, 10, 3), dtype=np.uint8)
+    array = np.full((10, 10, 3), 128, dtype=np.uint8)
     pic = novice.Picture(array=array)
 
     pic[0:5, 0:5] = (0, 0, 0)

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -378,7 +378,7 @@ def richardson_lucy(image, psf, iterations=50, clip=True):
 
     image = image.astype(np.float)
     psf = psf.astype(np.float)
-    im_deconv = 0.5 * np.ones(image.shape)
+    im_deconv = np.full(image.shape, 0.5)
     psf_mirror = psf[::-1, ::-1]
 
     for _ in range(iterations):

--- a/skimage/segmentation/_slic.pyx
+++ b/skimage/segmentation/_slic.pyx
@@ -226,7 +226,7 @@ def _enforce_label_connectivity_cython(Py_ssize_t[:, :, ::1] segments,
 
     # new object with connected segments initialized to -1
     cdef Py_ssize_t[:, :, ::1] connected_segments \
-        = -1 * np.ones_like(segments, dtype=np.intp)
+        = np.full_like(segments, -1, dtype=np.intp)
 
     cdef Py_ssize_t current_new_label = 0
     cdef Py_ssize_t label = 0

--- a/skimage/segmentation/tests/test_chan_vese.py
+++ b/skimage/segmentation/tests/test_chan_vese.py
@@ -14,7 +14,7 @@ def test_chan_vese_flat_level_set():
     # infinite time, the segmentation will still converge.
     img = np.zeros((10, 10))
     img[3:6, 3:6] = np.ones((3, 3))
-    ls = np.ones((10, 10)) * 1000
+    ls = np.full((10, 10), 1000)
     result = chan_vese(img, mu=0.0, tol=1e-3, init_level_set=ls)
     assert_array_equal(result.astype(np.float), np.ones((10, 10)))
     result = chan_vese(img, mu=0.0, tol=1e-3, init_level_set=-ls)

--- a/skimage/util/_regular_grid.py
+++ b/skimage/util/_regular_grid.py
@@ -65,7 +65,7 @@ def regular_grid(ar_shape, n_points):
     space_size = float(np.prod(ar_shape))
     if space_size <= n_points:
         return (slice(None), ) * ndim
-    stepsizes = (space_size / n_points) ** (1.0 / ndim) * np.ones(ndim)
+    stepsizes = np.full(ndim, (space_size / n_points) ** (1.0 / ndim))
     if (sorted_dims < stepsizes).any():
         for dim in range(ndim):
             stepsizes[dim] = sorted_dims[dim]

--- a/skimage/util/_regular_grid.py
+++ b/skimage/util/_regular_grid.py
@@ -65,7 +65,8 @@ def regular_grid(ar_shape, n_points):
     space_size = float(np.prod(ar_shape))
     if space_size <= n_points:
         return (slice(None), ) * ndim
-    stepsizes = np.full(ndim, (space_size / n_points) ** (1.0 / ndim))
+    stepsizes = np.full(ndim, (space_size / n_points) ** (1.0 / ndim),
+                        dtype='float64')
     if (sorted_dims < stepsizes).any():
         for dim in range(ndim):
             stepsizes[dim] = sorted_dims[dim]


### PR DESCRIPTION
This replaces `cst*np.ones` by `np.full` in a few places which avoids a memory copy and should be ~2x faster.