### PR TITLE
 DOC: Fix LaTeX build via `make latexpdf` 

### DIFF
--- a/doc/release/release_0.14.rst
+++ b/doc/release/release_0.14.rst
@@ -165,7 +165,7 @@ Contributors to this release
 - Alex Rothberg
 - Arka Sadhu
 - Max Schambach
-- Johannes Schönberger
+- Johannes Schönberger
 - Sourav Singh
 - Kesavan Subburam
 - Matt Swain

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -234,7 +234,7 @@ latex_font_size = '10pt'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('contents', 'scikit-image.tex', u'The scikit-image Documentation',
+  ('index', 'scikit-image.tex', u'The scikit-image Documentation',
    u'scikit-image development team', 'manual'),
 ]
 


### PR DESCRIPTION
## Description

a) `startdocname` (first element of 5-tuple) in latex_documents configuration was renamed from 'contents' to 'index' some time ago. Now this change is reflected in LaTex configuration too.
b) Surname 'Schönberger' was writter as letter 'O' followed by Combining Diaeresis U+308 which gave latexmk hard times parsing it. Using Latin Small Letter O with Diaeresis U+00F6 is fine though.

## References

Related: Offline documentation request #458. Not sure if #closes ?

## For reviewers

(Don't remove the checklist below.)

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
