### PR TITLE
Update instructions et al for releases after 0.14.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,6 @@ coverage:
 	$(PYTESTS) skimage --cov=skimage
 
 html:
-	pip install -q sphinx pytest-runner sphinx-gallery
+	pip install -q -r requirements/docs.txt
+	rm -rf doc/build
 	export SPHINXOPTS=-W; make -C doc html

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ clean:
 	find . -name "*.so" -o -name "*.pyc" -o -name "*.md5" -o -name "*.pyd" | xargs rm -f
 	find . -name "*.pyx" -exec ./tools/rm_pyx_c_file.sh {} \;
 
+cleandoc:
+	rm -rf doc/build
+
 test:
 	$(PYTESTS) skimage --doctest-modules
 
@@ -20,5 +23,4 @@ coverage:
 
 html:
 	pip install -q -r requirements/docs.txt
-	rm -rf doc/build
 	export SPHINXOPTS=-W; make -C doc html

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -79,8 +79,16 @@ make a PR to update these notes after you are done with the release. ;-)
   - Update its ``.appveyor.yml`` file so that ``BUILD_COMMIT`` also points to
     this release tag.
   - Commit and push.
-  - Wait until the corresponding wheels appear at
-    http://wheels.scikit-image.org (about 15 minutes).
+  - Monitor the builds at
+    https://ci.appveyor.com/project/scikit-image/scikit-image-wheels and
+    https://travis-ci.org/scikit-image/scikit-image-wheels/branches
+  - When all is green, spot-check a couple of builds to make sure that the
+    wheels have correctly uploaded. You should see a message like:
+    ``python -m wheelhouse_uploader upload --local-folder``, with output:
+    ``Wheelhouse successfully published at:
+    http://[crazyrandomstring].rackcdn.com``
+  - Open that URL and check for the wheels as
+    ``scikit_image-<versiontag>-<platforminfo>.whl``
 
 - Update the docs:
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -80,6 +80,8 @@ the corresponding release branch.
 - Build the package wheels (pre-compiled binaries) for various platforms:
 
   - Clone https://github.com/scikit-image/scikit-image-wheels.
+  - (If making a patch release, switch to the appropriate v<major>.<minor>.x
+    branch.)
   - Update its ``.travis.yml`` file so that ``BUILD_COMMIT`` points to this
     release tag (e.g. ``v0.14.0``).
   - Update its ``.appveyor.yml`` file so that ``BUILD_COMMIT`` also points to

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -53,9 +53,9 @@ make a PR to update these notes after you are done with the release. ;-)
 - Update the docs:
 
   - Edit ``doc/source/_static/docversions.js`` and commit
-  - Build a clean version of the docs.  Run ``python setup.py install`` in the
-    root dir, then ``rm -rf build; make html`` in the ``doc`` dir.
-  - Build using ``make gh-pages``.
+  - Build a clean version of the docs. In the root directory, run
+    ``python setup.py install``, then ``make html``.
+  - In the ``doc/`` directory, build using ``make gh-pages``.
   - Update the symlink to ``stable``.
   - Push upstream: ``git push origin gh-pages`` in ``doc/gh-pages``.
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -50,15 +50,6 @@ make a PR to update these notes after you are done with the release. ;-)
 - Back on the release branch, update the version number to stable in
   ``skimage/__init__.py``, commit, and push.
 
-- Update the docs:
-
-  - Edit ``doc/source/_static/docversions.js`` and commit
-  - Build a clean version of the docs. In the root directory, run
-    ``python setup.py install``, then ``make html``.
-  - In the ``doc/`` directory, build using ``make gh-pages``.
-  - Update the symlink to ``stable``.
-  - Push upstream: ``git push origin gh-pages`` in ``doc/gh-pages``.
-
 - Add the version number as a tag in git::
 
    git tag -s -m <github_release_message> [-u <key-id>] v<major>.<minor>.0
@@ -88,6 +79,15 @@ make a PR to update these notes after you are done with the release. ;-)
   - Commit and push.
   - Wait until the corresponding wheels appear at
     http://wheels.scikit-image.org (about 15 minutes).
+
+- Update the docs:
+
+  - Edit ``doc/source/_static/docversions.js`` and commit
+  - Build a clean version of the docs. In the root directory, run
+    ``python setup.py install``, then ``make html``.
+  - In the ``doc/`` directory, build using ``make gh-pages``.
+  - Update the symlink to ``stable``.
+  - Push upstream: ``git push origin gh-pages`` in ``doc/gh-pages``.
 
 - Upload the wheels to PyPI:
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -105,6 +105,8 @@ make a PR to update these notes after you are done with the release. ;-)
     ``pip install twine``.
   - Download ``wheel-uploader`` [1]_ and place it on your PATH.
   - Run ``tools/upload_wheels.sh``.
+  - If everything worked, delete the wheels from your local directory with
+    ``rm -rf *.whl``
 
 .. [1] https://github.com/MacPython/terryfy/blob/master/wheel-uploader
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -136,6 +136,11 @@ make a PR to update these notes after you are done with the release. ;-)
 - Update the version and the release date on Wikipedia
   https://en.wikipedia.org/wiki/Scikit-image
 
+- Make a PR to scikit-image with any updates you might have to these notes
+
+- If making a patch release (v<major>.<minor>.<patch>), forward-port the
+  release notes to the master branch and make a PR.
+
 Conda-forge
 -----------
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -144,6 +144,14 @@ make a PR to update these notes after you are done with the release. ;-)
 Conda-forge
 -----------
 
+**Note**: conda-forge now has an automated bot who makes the below PR for you.
+Now all you have to do is to look at pull requests at
+https://github.com/conda-forge/scikit-image-feedstock/pulls
+and check for a new one for this version. Wait for all the continuous
+integration checks to go green, then merge.
+
+The manual instructions remain below in case the bot fails for some reason.
+
 A scikit-image build recipe resides at
 https://github.com/conda-forge/scikit-image-feedstock. You should update it to
 point to the most recent release. You can do this by following these steps:
@@ -166,8 +174,13 @@ point to the most recent release. You can do this by following these steps:
   - Update any requirements in the appropriate sections (build or run).
     Note: don't remove ``numpy x.x``. This tells conda-smithy, conda-forge's
     build system, that the library must be linked against NumPy at build time.
+  - Commit these changes.
+  - Update the infrastructure around the recipe with ``conda-smithy``:
+    * Install conda-smithy either with conda or pip
+    * Run ``conda-smithy rerender`` in the root of the repository, and commit
+      the changes.
 
-- Commit the changes, push to your fork, and submit a pull request to the
+- Push to your fork, and submit a pull request to the
   upstream repo.
 
 Debian

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -5,6 +5,12 @@ While following this guide, note down all the times that you need to consult a
 previous release manager, or that you find an instruction unclear. You will
 make a PR to update these notes after you are done with the release. ;-)
 
+Some of the instructions don't apply to patch releases. As a reminder, we use a
+variant of "semantic versioning", where version numbers are classified as
+v<major>.<minor>.<patch>. If you are making a patch release, skip the first
+three steps. Instead, make a PR to update ``release_<major>.<minor>.txt`` on
+the corresponding release branch.
+
 - Check ``TODO.txt`` for any outstanding tasks.
 
 - Branch v<major>.<minor>.x from master. This is the "release branch", where

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -100,7 +100,7 @@ the corresponding release branch.
 
   - Edit ``doc/source/_static/docversions.js`` and commit
   - Build a clean version of the docs. In the root directory, run
-    ``python setup.py install``, then ``make html``.
+    ``python setup.py install``, then ``make cleandoc; make html``.
   - In the ``doc/`` directory, build using ``make gh-pages``.
   - Update the symlink to ``stable``.
   - Push upstream: ``git push origin gh-pages`` in ``doc/gh-pages``.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -76,6 +76,8 @@ make a PR to update these notes after you are done with the release. ;-)
   - Clone https://github.com/scikit-image/scikit-image-wheels.
   - Update its ``.travis.yml`` file so that ``BUILD_COMMIT`` points to this
     release tag (e.g. ``v0.14.0``).
+  - Update its ``.appveyor.yml`` file so that ``BUILD_COMMIT`` also points to
+    this release tag.
   - Commit and push.
   - Wait until the corresponding wheels appear at
     http://wheels.scikit-image.org (about 15 minutes).

--- a/doc/release/release_0.14.rst
+++ b/doc/release/release_0.14.rst
@@ -1,3 +1,114 @@
+Announcement: scikit-image 0.14.1
+=================================
+
+We're happy to announce the release of scikit-image v0.14.1!
+
+scikit-image is an image processing toolbox for SciPy that includes algorithms
+for segmentation, geometric transformations, color space manipulation,
+analysis, filtering, morphology, feature detection, and more.
+
+This is our first release under our Long Term Support for 0.14 policy. As a
+reminder, 0.14 is the last release to support Python 2.7, but it will be
+updated with bug fixes and popular features until January 1st, 2020.
+
+This release contains the following changes from 0.14.0:
+
+
+Bug fixes
+---------
+- ``skimage.color.adapt_rgb`` was applying input functions to the wrong axis
+  (#3097)
+- ``CollectionViewer`` now indexes correctly (it had been broken by an update
+  to NumPy indexing) (#3288)
+- Handle deprecated indexing-by-list and NumPy ``matrix`` from NumPy 1.15
+  (#3238, #3242, #3292)
+- Fix incorrect inertia tensor calculation (#3303) (Special thanks to JP Cornil
+  for reporting this bug and for their patient help with this fix)
+- Fix missing comma in ``__all__`` listing of ``moments_coord_central``, so it
+  and ``moments_normalized`` can now be correctly imported from the ``measure``
+  namespace (#3374)
+- Fix background color in ``label2rgb(..., kind='avg')`` (#3280)
+
+Enhancements
+------------
+- "Reflect" mode in transforms now works fine when an image dimension has size
+  1 (#3179)
+- ``img_as_float`` now allows single-precision (32-bit) float arrays to pass
+  through unmodified, rather than being up-converted to 64-bit (#3110, #3052,
+  #3391)
+- Speed up rgb2gray computation (#3187)
+- The scikit-image viewer now works with different PyQt versions (#3157)
+- The ``cycle_spin`` function for enhanced denoising works single-threaded
+  when dask is not installed now (#3218)
+- scikit-image's ``io`` module will no longer inadvertently set the matplotlib
+  backend when imported (#3243)
+- Fix deprecated ``get`` keyword from dask in favor of ``scheduler`` (#3366)
+- Add missing ``cval`` parameter to threshold_local (#3382)
+
+
+API changes
+-----------
+- Remove deprecated ``dynamic_range`` in ``measure.compare_psnr`` (#3314)
+
+Documentation
+-------------
+- Improve the documentation on data locality (#3127)
+- Improve the documentation on dealing with video (#3176)
+- Update broken link for Canny filter documentation (#3276)
+- Fix incorrect documentation for the ``center`` parameter of
+  ``skimage.transform.rotate`` (#3341)
+- Fix incorrect formatting of docstring in ``measure.profile_line`` (#3236)
+
+Build process / development
+---------------------------
+- Ensure Cython is 0.23.4 or newer (#3171)
+- Suppress warnings during testing (#3143)
+- Fix skimage.test (#3152)
+- Don't upload artifacts to AppVeyor (there is no way to delete them) (#3315)
+- Remove ``import *`` from the scikit-image package root (#3265)
+- Allow named non-core contributors to issue MeeseeksDev commands (#3358)
+- Add testing in Python 3.7 (#3359)
+- Add license file to the binary distribution (#3322)
+- ``lookfor`` is no longer defined in ``__init__.py`` but rather imported to it
+  (#3162)
+- Add ``pyproject.toml`` to ensure Cython is present before building (#3295)
+
+Credits
+-------
+Made with commits from (alphabetical by last name):
+
+- Christoph Deil
+- François Boulogne
+- Genevieve Buckley
+- Sean Budd
+- Matthias Bussonnier
+- Sarkis Dallakian
+- François-Michel De Rainville
+- Emmanuelle Gouillart
+- Yaroslav Halchenko
+- Mark Harfouche
+- Jonathan Helmus
+- Matt McCormick
+- Juan Nunez-Iglesias
+- Egor Panfilov
+- Jesse Pangburn
+- Johannes Schönberger
+- Stefan van der Walt
+
+Reviewed by (alphabetical by last name):
+
+- François Boulogne
+- Emmanuelle Gouillart
+- Mark Harfouche
+- Juan Nunez-Iglesias
+- Egor Panfilov
+- Stéfan van der Walt
+- Josh Warner
+
+And with the special support of [MeeseeksDev](https://github.com/MeeseeksBox),
+created by Matthias Bussonnier
+
+
 Announcement: scikit-image 0.14.0
 =================================
 

--- a/doc/release/release_0.14.rst
+++ b/doc/release/release_0.14.rst
@@ -94,6 +94,7 @@ Made with commits from (alphabetical by last name):
 - Yaroslav Halchenko
 - Mark Harfouche
 - Jonathan Helmus
+- @Legodev
 - Matt McCormick
 - Juan Nunez-Iglesias
 - Egor Panfilov

--- a/doc/release/release_0.14.rst
+++ b/doc/release/release_0.14.rst
@@ -83,12 +83,12 @@ Credits
 -------
 Made with commits from (alphabetical by last name):
 
-- Christoph Deil
 - François Boulogne
 - Genevieve Buckley
 - Sean Budd
 - Matthias Bussonnier
 - Sarkis Dallakian
+- Christoph Deil
 - François-Michel De Rainville
 - Emmanuelle Gouillart
 - Yaroslav Halchenko

--- a/doc/release/release_0.14.rst
+++ b/doc/release/release_0.14.rst
@@ -32,7 +32,7 @@ Bug fixes
 Enhancements
 ------------
 - "Reflect" mode in transforms now works fine when an image dimension has size
-  1 (#3179)
+  1 (#3174)
 - ``img_as_float`` now allows single-precision (32-bit) float arrays to pass
   through unmodified, rather than being up-converted to 64-bit (#3110, #3052,
   #3391)
@@ -43,12 +43,12 @@ Enhancements
 - scikit-image's ``io`` module will no longer inadvertently set the matplotlib
   backend when imported (#3243)
 - Fix deprecated ``get`` keyword from dask in favor of ``scheduler`` (#3366)
-- Add missing ``cval`` parameter to threshold_local (#3382)
+- Add missing ``cval`` parameter to threshold_local (#3370)
 
 
 API changes
 -----------
-- Remove deprecated ``dynamic_range`` in ``measure.compare_psnr`` (#3314)
+- Remove deprecated ``dynamic_range`` in ``measure.compare_psnr`` (#3313)
 
 Documentation
 -------------
@@ -66,12 +66,18 @@ Build process / development
 - Fix skimage.test (#3152)
 - Don't upload artifacts to AppVeyor (there is no way to delete them) (#3315)
 - Remove ``import *`` from the scikit-image package root (#3265)
-- Allow named non-core contributors to issue MeeseeksDev commands (#3358)
+- Allow named non-core contributors to issue MeeseeksDev commands (#3357,
+  #3358)
 - Add testing in Python 3.7 (#3359)
 - Add license file to the binary distribution (#3322)
 - ``lookfor`` is no longer defined in ``__init__.py`` but rather imported to it
   (#3162)
 - Add ``pyproject.toml`` to ensure Cython is present before building (#3295)
+- Add explicit Python version Trove classifiers for PyPI (#3417)
+- Ignore known test failures in 32-bit releases, allowing 32-bit wheel builds
+  (#3434)
+- Ignore failure to raise floating point warnings on certain ARM platforms
+  (#3337)
 
 Credits
 -------

--- a/doc/release/release_0.14.rst
+++ b/doc/release/release_0.14.rst
@@ -78,6 +78,7 @@ Build process / development
   (#3434)
 - Ignore failure to raise floating point warnings on certain ARM platforms
   (#3337)
+- Fix tests to be compatible with PyWavelets 1.0 (#3406)
 
 Credits
 -------
@@ -94,6 +95,7 @@ Made with commits from (alphabetical by last name):
 - Yaroslav Halchenko
 - Mark Harfouche
 - Jonathan Helmus
+- Gregory Lee
 - @Legodev
 - Matt McCormick
 - Juan Nunez-Iglesias

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -3,4 +3,5 @@
 sphinx>=1.3,!=1.7.8
 numpydoc>=0.6
 sphinx-gallery
+pytest-runner
 scikit-learn

--- a/tools/upload_wheels.sh
+++ b/tools/upload_wheels.sh
@@ -16,3 +16,4 @@ fi
 echo "Trying download / upload of version ${SK_VERSION:1}"
 wheel-uploader -v scikit_image "${SK_VERSION:1}"
 wheel-uploader -v scikit_image -t manylinux1 "${SK_VERSION:1}"
+wheel-uploader -v scikit_image -t win "${SK_VERSION:1}"


### PR DESCRIPTION
After working on 0.14.1 I've made a few more changes to the release instructions. I've also forward-ported the 0.14.1 release notes to master, and updated a bit of the tooling.