### PR TITLE
Fix default value of `methods` in `_try_all` to avoid exception

### DIFF
--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -47,6 +47,9 @@ def _try_all(image, methods=None, figsize=None, num_cols=2, verbose=True):
     """
     from matplotlib import pyplot as plt
 
+    # Handle default value
+    methods = methods or {}
+
     num_rows = math.ceil((len(methods) + 1.) / num_cols)
     num_rows = int(num_rows)  # Python 2.7 support
     fig, ax = plt.subplots(num_rows, num_cols, figsize=figsize,


### PR DESCRIPTION
## Description

I discovered a trivial bug if method is used with the default value. len(None) will throw a TypeError. The bug was introduced by myself. However, it's not critical. The function is private.

