### PR TITLE
 Fix morphology.local_maxima for input with any dimension < 3

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -69,6 +69,9 @@ API Changes
 Bugfixes
 --------
 
+- ``skimage.morphology.local_maxima`` and ``skimage.morphology.local_minima``
+  no longer raise an error if any dimension of the image is smaller 3 and
+  the keyword ``allow_borders`` was false.
 
 
 Deprecations

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -16,6 +16,7 @@ import numpy as np
 from scipy import ndimage as ndi
 
 from ..util import dtype_limits, invert, crop
+from .._shared.utils import warn
 from . import greyreconstruct
 from .watershed import _offsets_to_raveled_neighbors
 from ._extrema_cy import _local_maxima
@@ -368,6 +369,12 @@ def local_maxima(image, selem=None, connectivity=None, indices=False,
         (0 otherwise). If `indices` is true, a tuple of one-dimensional arrays
         containing the coordinates (indices) of all found maxima.
 
+    Warns
+    -----
+    UserWarning
+        If `allow_borders` is false and any dimension of the given `image` is
+        shorter than 3 samples, maxima can't exist and a warning is shown.
+
     See Also
     --------
     skimage.morphology.local_minima
@@ -451,9 +458,12 @@ def local_maxima(image, selem=None, connectivity=None, indices=False,
     _set_edge_values_inplace(flags, value=3)
 
     if any(s < 3 for s in image.shape):
-        # Skip if any dimension is smaller than 3
+        # Warn and skip if any dimension is smaller than 3
         # -> no maxima can exist & structuring element can't be applied
-        pass
+        warn(
+            "no maxima can exist for an image with any dimension smaller 3",
+            stacklevel=3
+        )
     else:
         selem = _resolve_neighborhood(selem, connectivity, image.ndim)
         neighbor_offsets = _offsets_to_raveled_neighbors(

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -461,7 +461,8 @@ def local_maxima(image, selem=None, connectivity=None, indices=False,
         # Warn and skip if any dimension is smaller than 3
         # -> no maxima can exist & structuring element can't be applied
         warn(
-            "no maxima can exist for an image with any dimension smaller 3",
+            "maxima can't exist for an image with any dimension smaller 3 "
+            "if borders aren't allowed",
             stacklevel=3
         )
     else:

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -434,7 +434,11 @@ def local_maxima(image, selem=None, connectivity=None, indices=False,
     image = np.asarray(image, order="C")
     if image.size == 0:
         # Return early for empty input
-        return np.array([], dtype=(np.intp if indices else np.uint8))
+        if indices:
+            # Make sure that output is a tuple of 1 empty array per dimension
+            return np.nonzero(image)
+        else:
+            return np.zeros(image.shape, dtype=np.uint8)
 
     if allow_borders:
         # Ensure that local maxima are always at least one smaller sample away

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -319,11 +319,13 @@ def _resolve_neighborhood(selem, connectivity, ndim):
         selem = np.asarray(selem, dtype=bool)
         # Must specify neighbors for all dimensions
         if selem.ndim != ndim:
-            raise ValueError("selem and image must have the same number of "
-                             "dimensions")
+            raise ValueError(
+                "structuring element and image must have the same number of "
+                "dimensions"
+            )
         # Must only specify direct neighbors
         if any(s != 3 for s in selem.shape):
-            raise ValueError("dimension size in selem is not 3")
+            raise ValueError("dimension size in structuring element is not 3")
 
     return selem
 
@@ -351,9 +353,10 @@ def local_maxima(image, selem=None, connectivity=None, indices=False,
         equal to `connectivity` are considered neighbors. Ignored if
         `selem` is not None.
     indices : bool, optional
-        If True, the output will be an array representing indices of local
-        maxima. If False, the output will be an array of 0's and 1's with the
-        same shape as `image`.
+        If True, the output will be a tuple of one-dimensional arrays
+        representing the indices of local maxima in each dimension. If False,
+        the output will be an array of 0's and 1's with the same shape as
+        `image`.
     allow_borders : bool, optional
         If true, plateaus that touch the image border are valid maxima.
 
@@ -438,24 +441,30 @@ def local_maxima(image, selem=None, connectivity=None, indices=False,
         # from the image border
         image = _fast_pad(image, image.min())
 
-    selem = _resolve_neighborhood(selem, connectivity, image.ndim)
-    neighbor_offsets = _offsets_to_raveled_neighbors(
-        image.shape, selem, center=((1,) * image.ndim))
-
     # Array of flags used to store the state of each pixel during evaluation.
     # See _extrema_cy.pyx for their meaning
     flags = np.zeros(image.shape, dtype=np.uint8)
     _set_edge_values_inplace(flags, value=3)
 
-    try:
-        _local_maxima(image.ravel(), flags.ravel(), neighbor_offsets)
-    except TypeError:
-        if image.dtype == np.float16:
-            # Provide the user with clearer error message
-            raise TypeError("dtype of `image` is float16 which is not "
-                            "supported, try upcasting to float32")
-        else:
-            raise
+    if any(s < 3 for s in image.shape):
+        # Skip if any dimension is smaller than 3
+        # -> no maxima can exist & structuring element can't be applied
+        pass
+    else:
+        selem = _resolve_neighborhood(selem, connectivity, image.ndim)
+        neighbor_offsets = _offsets_to_raveled_neighbors(
+            image.shape, selem, center=((1,) * image.ndim)
+        )
+
+        try:
+            _local_maxima(image.ravel(), flags.ravel(), neighbor_offsets)
+        except TypeError:
+            if image.dtype == np.float16:
+                # Provide the user with clearer error message
+                raise TypeError("dtype of `image` is float16 which is not "
+                                "supported, try upcasting to float32")
+            else:
+                raise  # Otherwise raise original message
 
     if allow_borders:
         # Revert padding performed at the beginning of the function
@@ -493,9 +502,10 @@ def local_minima(image, selem=None, connectivity=None, indices=False,
         equal to `connectivity` are considered neighbors. Ignored if
         `selem` is not None.
     indices : bool, optional
-        If True, the output will be an array representing indices of local
-        minima. If False, the output will be an array of 0's and 1's with the
-        same shape as `image`.
+        If True, the output will be a tuple of one-dimensional arrays
+        representing the indices of local minima in each dimension. If False,
+        the output will be an array of 0's and 1's with the same shape as
+        `image`.
     allow_borders : bool, optional
         If true, plateaus that touch the image border are valid minima.
 

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -2,7 +2,7 @@ import math
 import unittest
 
 import numpy as np
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_equal
 from pytest import raises, warns
 
 from skimage.morphology import extrema
@@ -235,7 +235,7 @@ class TestLocalMaxima(unittest.TestCase):
         """Test results with default configuration for all supported dtypes."""
         for dtype in self.supported_dtypes:
             result = extrema.local_maxima(self.image.astype(dtype))
-            assert_array_equal(result, self.expected_default)
+            assert_equal(result, self.expected_default)
 
     def test_dtypes_old(self):
         """
@@ -271,33 +271,33 @@ class TestLocalMaxima(unittest.TestCase):
         for dtype in self.supported_dtypes:
             image = data.astype(dtype)
             result = extrema.local_maxima(image)
-            assert_array_equal(result, expected)
+            assert_equal(result, expected)
 
     def test_connectivity(self):
         """Test results if selem is a scalar."""
         # Connectivity 1: generates cross shaped structuring element
         result_conn1 = extrema.local_maxima(self.image, connectivity=1)
-        assert_array_equal(result_conn1, self.expected_cross)
+        assert_equal(result_conn1, self.expected_cross)
 
         # Connectivity 2: generates square shaped structuring element
         result_conn2 = extrema.local_maxima(self.image, connectivity=2)
-        assert_array_equal(result_conn2, self.expected_default)
+        assert_equal(result_conn2, self.expected_default)
 
         # Connectivity 3: generates square shaped structuring element
         result_conn3 = extrema.local_maxima(self.image, connectivity=3)
-        assert_array_equal(result_conn3, self.expected_default)
+        assert_equal(result_conn3, self.expected_default)
 
     def test_selem(self):
         """Test results if selem is an array."""
         selem_cross = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]])
         result_selem_cross = extrema.local_maxima(
             self.image, selem=selem_cross)
-        assert_array_equal(result_selem_cross, self.expected_cross)
+        assert_equal(result_selem_cross, self.expected_cross)
 
         selem_square = np.ones((3, 3), dtype=np.uint8)
         result_selem_square = extrema.local_maxima(
             self.image, selem=selem_square)
-        assert_array_equal(result_selem_square, self.expected_default)
+        assert_equal(result_selem_square, self.expected_default)
 
         selem_x = np.array([[1, 0, 1], [0, 1, 0], [1, 0, 1]])
         expected_selem_x = np.array(
@@ -310,7 +310,7 @@ class TestLocalMaxima(unittest.TestCase):
             dtype=np.uint8
         )
         result_selem_x = extrema.local_maxima(self.image, selem=selem_x)
-        assert_array_equal(result_selem_x, expected_selem_x)
+        assert_equal(result_selem_x, expected_selem_x)
 
     def test_indices(self):
         """Test output if indices of peaks are desired."""
@@ -318,13 +318,13 @@ class TestLocalMaxima(unittest.TestCase):
         expected_conn1 = np.nonzero(self.expected_cross)
         result_conn1 = extrema.local_maxima(self.image, connectivity=1,
                                             indices=True)
-        assert_array_equal(result_conn1, expected_conn1)
+        assert_equal(result_conn1, expected_conn1)
 
         # Connectivity 2
         expected_conn2 = np.nonzero(self.expected_default)
         result_conn2 = extrema.local_maxima(self.image, connectivity=2,
                                             indices=True)
-        assert_array_equal(result_conn2, expected_conn2)
+        assert_equal(result_conn2, expected_conn2)
 
     def test_allow_borders(self):
         """Test maxima detection at the image border."""
@@ -332,7 +332,7 @@ class TestLocalMaxima(unittest.TestCase):
         # of interest
         result_with_boder = extrema.local_maxima(
             self.image, connectivity=1, allow_borders=True)
-        assert_array_equal(result_with_boder, self.expected_cross)
+        assert_equal(result_with_boder, self.expected_cross)
 
         expected_without_border = np.array(
             [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -345,7 +345,7 @@ class TestLocalMaxima(unittest.TestCase):
         )
         result_without_border = extrema.local_maxima(
             self.image, connectivity=1, allow_borders=False)
-        assert_array_equal(result_without_border, expected_without_border)
+        assert_equal(result_without_border, expected_without_border)
 
     def test_nd(self):
         """Test one- and three-dimensional case."""
@@ -354,7 +354,7 @@ class TestLocalMaxima(unittest.TestCase):
         expected_1d = np.array([1, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0],
                                dtype=np.uint8)
         result_1d = extrema.local_maxima(x_1d)
-        assert_array_equal(result_1d, expected_1d)
+        assert_equal(result_1d, expected_1d)
 
         # 3-dimensions (adapted from old unit test)
         x_3d = np.zeros((8, 8, 8), dtype=np.uint8)
@@ -379,7 +379,7 @@ class TestLocalMaxima(unittest.TestCase):
         x_3d[7, 7, 7] = 255
         expected_3d[7, 7, 7] = 1
         result_3d = extrema.local_maxima(x_3d)
-        assert_array_equal(result_3d, expected_3d)
+        assert_equal(result_3d, expected_3d)
 
     def test_constant(self):
         """Test behaviour for 'flat' images."""
@@ -389,10 +389,10 @@ class TestLocalMaxima(unittest.TestCase):
             const_image = const_image.astype(dtype)
             # test for local maxima
             result = extrema.local_maxima(const_image)
-            assert_array_equal(result, expected)
+            assert_equal(result, expected)
             # test for local minima
             result = extrema.local_minima(const_image)
-            assert_array_equal(result, expected)
+            assert_equal(result, expected)
 
     def test_extrema_float(self):
         """Specific tests for float type."""
@@ -427,11 +427,11 @@ class TestLocalMaxima(unittest.TestCase):
 
         # Test for local maxima with automatic step calculation
         out = extrema.local_maxima(image)
-        assert_array_equal(out, expected_result)
+        assert_equal(out, expected_result)
 
         # Test for local minima with automatic step calculation
         out = extrema.local_minima(inverted_image)
-        assert_array_equal(out, expected_result)
+        assert_equal(out, expected_result)
 
     def test_exceptions(self):
         """Test if input validation triggers correct exceptions."""
@@ -466,14 +466,14 @@ class TestLocalMaxima(unittest.TestCase):
             result = extrema.local_maxima(
                 np.array([0, 1]), allow_borders=False
             )
-        assert_array_equal(result, [0, 0])
+        assert_equal(result, [0, 0])
         assert result.dtype == np.uint8
 
         with warns(UserWarning, match=warning_msg):
             result = extrema.local_maxima(
                 np.array([[1, 2], [2, 2]]), allow_borders=False, indices=True
             )
-        assert_array_equal(result, np.zeros((2, 0), dtype=np.intp))
+        assert_equal(result, np.zeros((2, 0), dtype=np.intp))
         assert result[0].dtype == np.intp
         assert result[1].dtype == np.intp
 

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -2,7 +2,7 @@ import math
 import unittest
 
 import numpy as np
-from numpy.testing import assert_equal
+from numpy.testing import assert_array_equal
 from pytest import raises
 
 from skimage.morphology import extrema
@@ -224,7 +224,7 @@ class TestLocalMaxima(unittest.TestCase):
         """Test results with default configuration for all supported dtypes."""
         for dtype in self.supported_dtypes:
             result = extrema.local_maxima(self.image.astype(dtype))
-            assert_equal(result, self.expected_default)
+            assert_array_equal(result, self.expected_default)
 
     def test_dtypes_old(self):
         """
@@ -260,33 +260,33 @@ class TestLocalMaxima(unittest.TestCase):
         for dtype in self.supported_dtypes:
             image = data.astype(dtype)
             result = extrema.local_maxima(image)
-            assert_equal(result, expected)
+            assert_array_equal(result, expected)
 
     def test_connectivity(self):
         """Test results if selem is a scalar."""
         # Connectivity 1: generates cross shaped structuring element
         result_conn1 = extrema.local_maxima(self.image, connectivity=1)
-        assert_equal(result_conn1, self.expected_cross)
+        assert_array_equal(result_conn1, self.expected_cross)
 
         # Connectivity 2: generates square shaped structuring element
         result_conn2 = extrema.local_maxima(self.image, connectivity=2)
-        assert_equal(result_conn2, self.expected_default)
+        assert_array_equal(result_conn2, self.expected_default)
 
         # Connectivity 3: generates square shaped structuring element
         result_conn3 = extrema.local_maxima(self.image, connectivity=3)
-        assert_equal(result_conn3, self.expected_default)
+        assert_array_equal(result_conn3, self.expected_default)
 
     def test_selem(self):
         """Test results if selem is an array."""
         selem_cross = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]])
         result_selem_cross = extrema.local_maxima(
             self.image, selem=selem_cross)
-        assert_equal(result_selem_cross, self.expected_cross)
+        assert_array_equal(result_selem_cross, self.expected_cross)
 
         selem_square = np.ones((3, 3), dtype=np.uint8)
         result_selem_square = extrema.local_maxima(
             self.image, selem=selem_square)
-        assert_equal(result_selem_square, self.expected_default)
+        assert_array_equal(result_selem_square, self.expected_default)
 
         selem_x = np.array([[1, 0, 1], [0, 1, 0], [1, 0, 1]])
         expected_selem_x = np.array(
@@ -299,7 +299,7 @@ class TestLocalMaxima(unittest.TestCase):
             dtype=np.uint8
         )
         result_selem_x = extrema.local_maxima(self.image, selem=selem_x)
-        assert_equal(result_selem_x, expected_selem_x)
+        assert_array_equal(result_selem_x, expected_selem_x)
 
     def test_indices(self):
         """Test output if indices of peaks are desired."""
@@ -307,13 +307,13 @@ class TestLocalMaxima(unittest.TestCase):
         expected_conn1 = np.nonzero(self.expected_cross)
         result_conn1 = extrema.local_maxima(self.image, connectivity=1,
                                             indices=True)
-        assert_equal(result_conn1, expected_conn1)
+        assert_array_equal(result_conn1, expected_conn1)
 
         # Connectivity 2
         expected_conn2 = np.nonzero(self.expected_default)
         result_conn2 = extrema.local_maxima(self.image, connectivity=2,
                                             indices=True)
-        assert_equal(result_conn2, expected_conn2)
+        assert_array_equal(result_conn2, expected_conn2)
 
     def test_allow_borders(self):
         """Test maxima detection at the image border."""
@@ -321,7 +321,7 @@ class TestLocalMaxima(unittest.TestCase):
         # of interest
         result_with_boder = extrema.local_maxima(
             self.image, connectivity=1, allow_borders=True)
-        assert_equal(result_with_boder, self.expected_cross)
+        assert_array_equal(result_with_boder, self.expected_cross)
 
         expected_without_border = np.array(
             [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -334,7 +334,7 @@ class TestLocalMaxima(unittest.TestCase):
         )
         result_without_border = extrema.local_maxima(
             self.image, connectivity=1, allow_borders=False)
-        assert_equal(result_without_border, expected_without_border)
+        assert_array_equal(result_without_border, expected_without_border)
 
     def test_nd(self):
         """Test one- and three-dimensional case."""
@@ -343,7 +343,7 @@ class TestLocalMaxima(unittest.TestCase):
         expected_1d = np.array([1, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0],
                                dtype=np.uint8)
         result_1d = extrema.local_maxima(x_1d)
-        assert_equal(result_1d, expected_1d)
+        assert_array_equal(result_1d, expected_1d)
 
         # 3-dimensions (adapted from old unit test)
         x_3d = np.zeros((8, 8, 8), dtype=np.uint8)
@@ -368,7 +368,7 @@ class TestLocalMaxima(unittest.TestCase):
         x_3d[7, 7, 7] = 255
         expected_3d[7, 7, 7] = 1
         result_3d = extrema.local_maxima(x_3d)
-        assert_equal(result_3d, expected_3d)
+        assert_array_equal(result_3d, expected_3d)
 
     def test_constant(self):
         """Test behaviour for 'flat' images."""
@@ -378,10 +378,10 @@ class TestLocalMaxima(unittest.TestCase):
             const_image = const_image.astype(dtype)
             # test for local maxima
             result = extrema.local_maxima(const_image)
-            assert_equal(result, expected)
+            assert_array_equal(result, expected)
             # test for local minima
             result = extrema.local_minima(const_image)
-            assert_equal(result, expected)
+            assert_array_equal(result, expected)
 
     def test_extrema_float(self):
         """Specific tests for float type."""
@@ -416,11 +416,11 @@ class TestLocalMaxima(unittest.TestCase):
 
         # Test for local maxima with automatic step calculation
         out = extrema.local_maxima(image)
-        assert_equal(out, expected_result)
+        assert_array_equal(out, expected_result)
 
         # Test for local minima with automatic step calculation
         out = extrema.local_minima(inverted_image)
-        assert_equal(out, expected_result)
+        assert_array_equal(out, expected_result)
 
     def test_exceptions(self):
         """Test if input validation triggers correct exceptions."""
@@ -438,6 +438,28 @@ class TestLocalMaxima(unittest.TestCase):
 
         with raises(TypeError, match="float16 which is not supported"):
             extrema.local_maxima(np.empty(1, dtype=np.float16))
+
+    def test_small_array(self):
+        """Test output for arrays with dimension smaller 3.
+
+        If any dimension of an array is smaller than 3 and `allow_borders` is
+        false a structuring element, which has at least 3 elements in each
+        dimension, can't be applied. This is an implementation detail so
+        `local_maxima` should still return valid output (see gh-3261).
+
+        If `allow_borders` is true the array is padded internally and there is
+        no problem.
+        """
+        result = extrema.local_maxima(np.array([0, 1]), allow_borders=False)
+        assert_array_equal(result, [0, 0])
+        assert result.dtype == np.uint8
+
+        result = extrema.local_maxima(
+            np.array([[1, 2], [2, 2]]), allow_borders=False, indices=True
+        )
+        assert_array_equal(result, np.zeros((2, 0), dtype=np.intp))
+        assert result[0].dtype == np.intp
+        assert result[1].dtype == np.intp
 
 
 if __name__ == "__main__":

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -212,13 +212,24 @@ class TestLocalMaxima(unittest.TestCase):
 
     def test_empty(self):
         """Test result with empty image."""
-        result = extrema.local_maxima(np.array([]), indices=False)
+        result = extrema.local_maxima(np.array([[]]), indices=False)
         assert result.size == 0
         assert result.dtype == np.uint8
+        assert result.shape == (1, 0)
 
         result = extrema.local_maxima(np.array([]), indices=True)
-        assert result.size == 0
-        assert result.dtype == np.intp
+        assert isinstance(result, tuple)
+        assert len(result) == 1
+        assert result[0].size == 0
+        assert result[0].dtype == np.intp
+
+        result = extrema.local_maxima(np.array([[]]), indices=True)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        assert result[0].size == 0
+        assert result[0].dtype == np.intp
+        assert result[1].size == 0
+        assert result[1].dtype == np.intp
 
     def test_dtypes(self):
         """Test results with default configuration for all supported dtypes."""

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -461,18 +461,18 @@ class TestLocalMaxima(unittest.TestCase):
         If `allow_borders` is true the array is padded internally and there is
         no problem.
         """
-        warning_msg = "no maxima .* any dimension smaller 3"
+        warning_msg = "maxima can't exist .* any dimension smaller 3 .*"
+        x = np.array([0, 1])
+        extrema.local_maxima(x, allow_borders=True)  # no warning
         with warns(UserWarning, match=warning_msg):
-            result = extrema.local_maxima(
-                np.array([0, 1]), allow_borders=False
-            )
+            result = extrema.local_maxima(x, allow_borders=False)
         assert_equal(result, [0, 0])
         assert result.dtype == np.uint8
 
+        x = np.array([[1, 2], [2, 2]])
+        extrema.local_maxima(x, allow_borders=True, indices=True)  # no warning
         with warns(UserWarning, match=warning_msg):
-            result = extrema.local_maxima(
-                np.array([[1, 2], [2, 2]]), allow_borders=False, indices=True
-            )
+            result = extrema.local_maxima(x, allow_borders=False, indices=True)
         assert_equal(result, np.zeros((2, 0), dtype=np.intp))
         assert result[0].dtype == np.intp
         assert result[1].dtype == np.intp

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from pytest import raises
+from pytest import raises, warns
 
 from skimage.morphology import extrema
 
@@ -461,13 +461,18 @@ class TestLocalMaxima(unittest.TestCase):
         If `allow_borders` is true the array is padded internally and there is
         no problem.
         """
-        result = extrema.local_maxima(np.array([0, 1]), allow_borders=False)
+        warning_msg = "no maxima .* any dimension smaller 3"
+        with warns(UserWarning, match=warning_msg):
+            result = extrema.local_maxima(
+                np.array([0, 1]), allow_borders=False
+            )
         assert_array_equal(result, [0, 0])
         assert result.dtype == np.uint8
 
-        result = extrema.local_maxima(
-            np.array([[1, 2], [2, 2]]), allow_borders=False, indices=True
-        )
+        with warns(UserWarning, match=warning_msg):
+            result = extrema.local_maxima(
+                np.array([[1, 2], [2, 2]]), allow_borders=False, indices=True
+            )
         assert_array_equal(result, np.zeros((2, 0), dtype=np.intp))
         assert result[0].dtype == np.intp
         assert result[1].dtype == np.intp


### PR DESCRIPTION
## Description

- `local_maxima` (and `local_minima`) failed with a ValueError for images with at least 1 dimension with fewer than 3 elements. This was due to the implementation which applies a structuring element with exactly 3 elements in each dimension to the image in question. This behavior was only visible if `allow_borders` was false, otherwise the image was padded internally. 
This fix makes these functions work for the mentioned edge cases by testing the image shape at the appropriate time.
- The  output of `local_maxima([], indices=True)` didn't match the output for non-empty arrays and the description of the docstring. This is fixed as well.
- Replaced `assert_equal` with `assert_array_equal` which is more restrictive and (I think) more inline with what we actually want to test.

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] <strike>Gallery example in `./doc/examples` (new features only)</strike>
- [x] <strike>Benchmark in `./benchmarks`, if your changes aren't covered by an existing benchmark</strike>
- [x] Unit tests


## References
Closes #3261 

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] <strike>Check that new functions are imported in corresponding `__init__.py`.</strike>
- [x] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
