### PR TITLE
MNT; handle deprecation warnings in tifffile

### DIFF
--- a/skimage/external/tifffile/tifffile.py
+++ b/skimage/external/tifffile/tifffile.py
@@ -72,6 +72,10 @@ Revisions
 ---------
 2018.10.08
     No longer use numpy.fromstring just use numpy.frombuffer.
+    Note that this has been fixed upstream in 2018.02.18.
+    Unfortunately, upstream code claims to depend on Numpy 1.14.
+    To not bump the minimum version requirements of scikit-image,
+    this targetted fix was added to the vendored version.
 2017.01.12
     Read Zeiss SEM metadata.
     Read OME-TIFF with invalid references to external files.


### PR DESCRIPTION
Apparently numpy.fromtstring shouldn't be used on bytes.

This came to me in the form of a warning from numpy.

## For reviewers
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
