### PR TITLE
MNT: handle a deprecation warning for np.linspace and floats for the num parameter

### DIFF
--- a/skimage/measure/profile.py
+++ b/skimage/measure/profile.py
@@ -100,7 +100,7 @@ def _line_profile_coordinates(src, dst, linewidth=1):
     d_row, d_col = dst - src
     theta = np.arctan2(d_row, d_col)
 
-    length = np.ceil(np.hypot(d_row, d_col) + 1)
+    length = int(np.ceil(np.hypot(d_row, d_col) + 1))
     # we add one above because we include the last point in the profile
     # (in contrast to standard numpy indexing)
     line_col = np.linspace(src_col, dst_col, length)


### PR DESCRIPTION
The num parameter in np.linspace can't be a float. As explained by a warning.

## For reviewers
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
