### PR TITLE
TST: filter away novice deprecation warnings during testing

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -25,6 +25,7 @@ Version 0.16
 * Remove deprecated argument ``visualise`` from function skimage.feature.hog
 * Remove deprecated module ``skimage.novice``
   * Remove the ``save-demo.jpg`` line from ``.gitignore``
+  * Remove the warning filter from ``conftest.py``
 * In ``skimage.measure._regionprops``, remove all references to
   ``coordinates=``, ``_xycoordinates``, and ``_use_xy_warning``.
 * In ``skimage.measure.moments_central``, remove ``cc`` and ``**kwargs``

--- a/conftest.py
+++ b/conftest.py
@@ -17,3 +17,9 @@ try:
     import visvis
 except ImportError:
     collect_ignore.append("skimage/measure/mc_meta/visual_test.py")
+
+# importing skimage.novice issues some warnings. Without these lines,
+# pytest issues numerous warnings when crawling the package.
+import warnings
+
+warnings.filterwarnings('ignore', message='The `skimage.novice` module')


### PR DESCRIPTION
## For reviewers
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
