### PR TITLE
TST: numpy empty arrays are not inherently Falsy

### DIFF
--- a/skimage/feature/tests/test_peak.py
+++ b/skimage/feature/tests/test_peak.py
@@ -13,7 +13,7 @@ class TestPeakLocalMax():
         trivial = np.zeros((25, 25))
         peak_indices = peak.peak_local_max(trivial, min_distance=1, indices=True)
         assert type(peak_indices) is np.ndarray
-        assert not peak_indices     # inherent boolean-ness of empty list
+        assert peak_indices.size == 0
         peaks = peak.peak_local_max(trivial, min_distance=1, indices=False)
         assert (peaks.astype(np.bool) == trivial).all()
 


### PR DESCRIPTION
As explained by a warning

## For reviewers
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
