### PR TITLE
TST: don't use the pytest.fixtures decorator anymore in class fixtures 

### DIFF
--- a/skimage/filters/tests/test_lpi_filter.py
+++ b/skimage/filters/tests/test_lpi_filter.py
@@ -23,7 +23,6 @@ class TestLPIFilter2D(unittest.TestCase):
     def filt_func(self, r, c):
         return np.exp(-np.hypot(r, c) / 1)
 
-    @testing.fixture(autouse=True)
     def setUp(self):
         self.f = LPIFilter2D(self.filt_func)
 

--- a/skimage/io/tests/test_collection.py
+++ b/skimage/io/tests/test_collection.py
@@ -32,7 +32,6 @@ class TestImageCollection(TestCase):
     pattern_matched = [os.path.join(data_dir, pic)
                        for pic in ['camera.png', 'moon.png']]
 
-    @testing.fixture(autouse=True)
     def setUp(self):
         reset_plugins()
         # Generic image collection with images of different shapes.

--- a/skimage/io/tests/test_multi_image.py
+++ b/skimage/io/tests/test_multi_image.py
@@ -10,7 +10,6 @@ from skimage._shared.testing import assert_equal, assert_allclose, TestCase
 
 
 class TestMultiImage(TestCase):
-    @testing.fixture(autouse=True)
     def setUp(self):
         # This multipage TIF file was created with imagemagick:
         # convert im1.tif im2.tif -adjoin multipage.tif

--- a/skimage/morphology/tests/test_grey.py
+++ b/skimage/morphology/tests/test_grey.py
@@ -50,7 +50,6 @@ class TestMorphology(TestCase):
 
 
 class TestEccentricStructuringElements(TestCase):
-    @testing.fixture(autouse=True)
     def setUp(self):
         self.black_pixel = 255 * np.ones((4, 4), dtype=np.uint8)
         self.black_pixel[1, 1] = 0


### PR DESCRIPTION
as explained by a pytest warning

> RemovedInPytest4Warning: Fixture "setUp" called directly. Fixtures are not meant to be called directly, are created automatically when test functions request them as parameters. See https://docs.pytest.org/en/latest/fixture.html for more information.

If you can make sense of why this works, you are a hero. I can't, but it works.

## For reviewers

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
