### PR TITLE
MNT: don't use filter_warnings in test suite.

### DIFF
--- a/skimage/restoration/tests/test_unwrap.py
+++ b/skimage/restoration/tests/test_unwrap.py
@@ -14,8 +14,8 @@ from skimage._shared._warnings import expected_warnings
 def assert_phase_almost_equal(a, b, *args, **kwargs):
     """An assert_almost_equal insensitive to phase shifts of n*2*pi."""
     shift = 2 * np.pi * np.round((b.mean() - a.mean()) / (2 * np.pi))
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    with expected_warnings([r'invalid value encountered|\A\Z',
+                            r'divide by zero encountered|\A\Z']):
         print('assert_phase_allclose, abs', np.max(np.abs(a - (b - shift))))
         print('assert_phase_allclose, rel',
               np.max(np.abs((a - (b - shift)) / a)))
@@ -24,8 +24,8 @@ def assert_phase_almost_equal(a, b, *args, **kwargs):
         assert_array_equal(a.mask, b.mask)
         au = np.asarray(a)
         bu = np.asarray(b)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
+        with expected_warnings([r'invalid value encountered|\A\Z',
+                                r'divide by zero encountered|\A\Z']):
             print('assert_phase_allclose, no mask, abs',
                   np.max(np.abs(au - (bu - shift))))
             print('assert_phase_allclose, no mask, rel',
@@ -88,9 +88,8 @@ def check_wrap_around(ndim, axis):
     index_first = tuple([0] * ndim)
     index_last = tuple([-1 if n == axis else 0 for n in range(ndim)])
     # unwrap the image without wrap around
-    with warnings.catch_warnings():
-        # We do not want warnings about length 1 dimensions
-        warnings.simplefilter("ignore")
+    # We do not want warnings about length 1 dimensions
+    with expected_warnings([r'Image has a length 1 dimension|\A\Z']):
         image_unwrap_no_wrap_around = unwrap_phase(image_wrapped, seed=0)
     print('endpoints without wrap_around:',
           image_unwrap_no_wrap_around[index_first],
@@ -100,9 +99,8 @@ def check_wrap_around(ndim, axis):
                 image_unwrap_no_wrap_around[index_last]) > np.pi)
     # unwrap the image with wrap around
     wrap_around = [n == axis for n in range(ndim)]
-    with warnings.catch_warnings():
-        # We do not want warnings about length 1 dimensions
-        warnings.simplefilter("ignore")
+    # We do not want warnings about length 1 dimensions
+    with expected_warnings([r'Image has a length 1 dimension.|\A\Z']):
         image_unwrap_wrap_around = unwrap_phase(image_wrapped, wrap_around,
                                                 seed=0)
     print('endpoints with wrap_around:',

--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -132,9 +132,9 @@ def test_clobber():
         for func_output_type in img_funcs:
             img = np.random.rand(5, 5)
 
-            with warnings.catch_warnings():
-                # UserWarning for possible precision loss, expected
-                warnings.simplefilter('ignore', UserWarning)
+            # UserWarning for possible precision loss, expected
+            with expected_warnings([r'Possible precision loss|\A\Z',
+                                    r'Possible sign loss|\A\Z']):
                 img_in = func_input_type(img)
                 img_in_before = img_in.copy()
                 img_out = func_output_type(img_in)


### PR DESCRIPTION
Follows the tips from the the script @stefanv linked to in this post
https://github.com/scikit-image/scikit-image/pull/3438#issuecomment-426446319

## For reviewers
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
