### PR TITLE
Preserving the fill_value of a masked array

### DIFF
--- a/skimage/restoration/tests/test_unwrap.py
+++ b/skimage/restoration/tests/test_unwrap.py
@@ -22,6 +22,7 @@ def assert_phase_almost_equal(a, b, *args, **kwargs):
     if np.ma.isMaskedArray(a):
         assert_(np.ma.isMaskedArray(b))
         assert_array_equal(a.mask, b.mask)
+        assert_(a.fill_value == b.fill_value)
         au = np.asarray(a)
         bu = np.asarray(b)
         with warnings.catch_warnings():
@@ -37,8 +38,8 @@ def check_unwrap(image, mask=None):
     image_wrapped = np.angle(np.exp(1j * image))
     if mask is not None:
         print('Testing a masked image')
-        image = np.ma.array(image, mask=mask)
-        image_wrapped = np.ma.array(image_wrapped, mask=mask)
+        image = np.ma.array(image, mask=mask, fill_value=0.5)
+        image_wrapped = np.ma.array(image_wrapped, mask=mask, fill_value=0.5)
     image_unwrapped = unwrap_phase(image_wrapped, seed=0)
     assert_phase_almost_equal(image_unwrapped, image)
 

--- a/skimage/restoration/unwrap.py
+++ b/skimage/restoration/unwrap.py
@@ -107,6 +107,7 @@ def unwrap_phase(image, wrap_around=False, seed=None):
                   wrap_around, seed)
 
     if np.ma.isMaskedArray(image):
-        return np.ma.array(image_unwrapped, mask=mask)
+        return np.ma.array(image_unwrapped, mask=mask,
+                           fill_value=image.fill_value)
     else:
         return image_unwrapped


### PR DESCRIPTION
In the function unwrap_phase the fill_value of a masked numpy array is
currently not preserved. This functionality is added with corresponding
test case.

## Description
[Tell us about your new feature, improvement, or fix! If relevant, please supplement the PR with images.]


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
