### PR TITLE
Fix VisibleDeprecationWarning from np.histogram, normed=True

### DIFF
--- a/doc/examples/features_detection/plot_local_binary_pattern.py
+++ b/doc/examples/features_detection/plot_local_binary_pattern.py
@@ -166,9 +166,9 @@ def match(refs, img):
     best_name = None
     lbp = local_binary_pattern(img, n_points, radius, METHOD)
     n_bins = int(lbp.max() + 1)
-    hist, _ = np.histogram(lbp, normed=True, bins=n_bins, range=(0, n_bins))
+    hist, _ = np.histogram(lbp, density=True, bins=n_bins, range=(0, n_bins))
     for name, ref in refs.items():
-        ref_hist, _ = np.histogram(ref, normed=True, bins=n_bins,
+        ref_hist, _ = np.histogram(ref, density=True, bins=n_bins,
                                    range=(0, n_bins))
         score = kullback_leibler_divergence(hist, ref_hist)
         if score < best_score:


### PR DESCRIPTION
## Description

In our builds:

```
/home/travis/build/scikit-image/scikit-image/doc/examples/features_detection/plot_local_binary_pattern.py:169: VisibleDeprecationWarning: Passing `normed=True` on non-uniform bins has always been broken, and computes neither the probability density function nor the probability mass function. The result is only correct if the bins are uniform, when density=True will produce the same result anyway. The argument will be removed in a future version of numpy.
  hist, _ = np.histogram(lbp, normed=True, bins=n_bins, range=(0, n_bins))
/home/travis/build/scikit-image/scikit-image/doc/examples/features_detection/plot_local_binary_pattern.py:172: VisibleDeprecationWarning: Passing `normed=True` on non-uniform bins has always been broken, and computes neither the probability density function nor the probability mass function. The result is only correct if the bins are uniform, when density=True will produce the same result anyway. The argument will be removed in a future version of numpy.

```


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
