### PR TITLE
DOC: Document that now PYTHONOPTMIZE build is blocked by SciPy

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -48,8 +48,7 @@ Other
 * Monitor SimpleITK Pypi releases to find when a 3.7 release comes out.
   Remove version restriction in requirements file when appropriate.
   `https://github.com/SimpleITK/SimpleITK/issues/551`
-* Monitor scipy for a new release that passes PYTHONOPTIMIZE builds
-  `https://github.com/scipy/scipy/pull/9373` This was identified as an issue
-  in SciPy 1.1.0
-    * When SciPy becomes compatible with PYTHONOPTIMIZE, add an environment
-      ``PYTHONOPTIMIZE=2`` to one of the builds.
+* Monitor SciPy for a new release that passes PYTHONOPTIMIZE builds
+  `https://github.com/scipy/scipy/pull/9373`. This was identified as an issue
+  in SciPy 1.1.0. When SciPy becomes compatible with PYTHONOPTIMIZE, add an
+  environment variable ``PYTHONOPTIMIZE=2`` to one of the builds.

--- a/TODO.txt
+++ b/TODO.txt
@@ -48,4 +48,8 @@ Other
 * Monitor SimpleITK Pypi releases to find when a 3.7 release comes out.
   Remove version restriction in requirements file when appropriate.
   `https://github.com/SimpleITK/SimpleITK/issues/551`
-* Monitor next Pillow release to have a build with PYTHONOPTIMIZE=2 (See #3398).
+* Monitor scipy for a new release that passes PYTHONOPTIMIZE builds
+  `https://github.com/scipy/scipy/pull/9373` This was identified as an issue
+  in SciPy 1.1.0
+    * When SciPy becomes compatible with PYTHONOPTIMIZE, add an environment
+      ``PYTHONOPTIMIZE=2`` to one of the builds.


### PR DESCRIPTION
This reverts commit b2e33fba5d8739af14a5ba10900b00d1466f4d19.

XREF #3398

@gst worked really hard. then I suggested he wait on a change, and the next day Pillow came out with a release. Truely sorry about that.

## For reviewers

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
