### PR TITLE
FIX: making the plot_marching_cubes example visible.

### DIFF
--- a/doc/examples/edges/plot_marching_cubes.py
+++ b/doc/examples/edges/plot_marching_cubes.py
@@ -54,10 +54,5 @@ ax.set_xlim(0, 24)  # a = 6 (times two for 2nd ellipsoid)
 ax.set_ylim(0, 20)  # b = 10
 ax.set_zlim(0, 32)  # c = 16
 
-# This block of loop is for a temporary fix of an issue caused by matplotlib
-# Reference: https://github.com/matplotlib/matplotlib/issues/12239
-for spine in ax.spines.values():
-    spine.set_visible(False)
-
 plt.tight_layout()
 plt.show()

--- a/doc/examples/edges/plot_marching_cubes.py
+++ b/doc/examples/edges/plot_marching_cubes.py
@@ -56,7 +56,6 @@ ax.set_zlim(0, 32)  # c = 16
 
 # This block of loop is for a temporary fix of an issue caused by matplotlib
 # Reference: https://github.com/matplotlib/matplotlib/issues/12239
-
 for spine in ax.spines.values():
     spine.set_visible(False)
 

--- a/doc/examples/edges/plot_marching_cubes.py
+++ b/doc/examples/edges/plot_marching_cubes.py
@@ -54,5 +54,11 @@ ax.set_xlim(0, 24)  # a = 6 (times two for 2nd ellipsoid)
 ax.set_ylim(0, 20)  # b = 10
 ax.set_zlim(0, 32)  # c = 16
 
+# This block of loop is for a temporary fix of an issue caused by matplotlib
+# Reference: https://github.com/matplotlib/matplotlib/issues/12239
+
+for spine in ax.spines.values():
+    spine.set_visible(False)
+
 plt.tight_layout()
 plt.show()

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,6 @@
 numpy>=1.11
 scipy>=0.17.0
-matplotlib>=2.0.0
+matplotlib>=2.0.0,!=3.0.0
 networkx>=2.0
 pillow>=4.3.0
 imageio>=2.0.1


### PR DESCRIPTION
## Description
Fix on #3466, where there is no graph picture for the marching cubes in the doc: http://scikit-image.org/docs/dev/auto_examples/edges/plot_marching_cubes.html#sphx-glr-auto-examples-edges-plot-marching-cubes-py. 

It seems like it's an issue from the matplotlib as seen here: https://github.com/matplotlib/matplotlib/issues/12239 

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

## References
it closes issue #3466

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
