### PR TITLE
MAINT: Blacklist specific Cython versions

### DIFF
--- a/requirements/README.md
+++ b/requirements/README.md
@@ -30,5 +30,5 @@ $ pip install -U -r requirements/test.txt
 
 ## Blacklist justification
 
-  * cython 0.28.2 was empircally found to fail tests.
-  * cython 0.29.0 eroneously sets the the `__path__` to `none`. See https://github.com/cython/cython/issues/2662
+  * cython 0.28.2 was empircally found to fail tests when other patch releases of `0.28` didn't
+  * cython 0.29.0 eroneously sets the the `__path__` to `None`. See https://github.com/cython/cython/issues/2662

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -27,3 +27,8 @@ $ pip install -U -r requirements/default.txt
 $ pip install -U -r requirements/default.txt
 $ pip install -U -r requirements/test.txt
 ```
+
+## Blacklist justification
+
+  * cython 0.28.2 was empircally found to fail tests.
+  * cython 0.29.0 eroneously sets the the `__path__` to `none`. See https://github.com/cython/cython/issues/2662

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -30,5 +30,5 @@ $ pip install -U -r requirements/test.txt
 
 ## Blacklist justification
 
-  * cython 0.28.2 was empircally found to fail tests when other patch releases of `0.28` didn't
-  * cython 0.29.0 eroneously sets the the `__path__` to `None`. See https://github.com/cython/cython/issues/2662
+* Cython 0.28.2 was empircally found to fail tests while other patch-releases 0.28.x do not
+* Cython 0.29.0 erroneously sets the `__path__` to `None`. See https://github.com/cython/cython/issues/2662

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,4 +1,4 @@
-Cython>=0.23.4,<0.28.2
+Cython>=0.23.4,!=0.28.2,!=0.29.0
 wheel
 numpy>=1.11
 requirements-parser


### PR DESCRIPTION
I think #3477 was prematurely merged.

This fix is much less restrictive as it is likely that Cython will get fixed in the next minor release.

Also see discussion in #3475

## For reviewers
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
