### PR TITLE
Bugfix: erroneous use of cython wrap around

### DIFF
--- a/skimage/restoration/_denoise_cy.pyx
+++ b/skimage/restoration/_denoise_cy.pyx
@@ -193,13 +193,15 @@ def _denoise_tv_bregman(image, double weight, int max_iter, double eps,
         double rmse = DBL_MAX
         double norm = (weight + 4 * lam)
 
-    u[1:-1, 1:-1] = image
+    height, width = image.shape[:2]
+    u_height, u_width = u.shape[:2]
+    u[1:u_height-1, 1:u_width-1] = image
 
     # reflect image
-    u[0, 1:-1] = image[1, :]
-    u[1:-1, 0] = image[:, 1]
-    u[-1, 1:-1] = image[-2, :]
-    u[1:-1, -1] = image[:, -2]
+    u[0, 1:u_width-1] = image[1, :]
+    u[1:u_height-1, 0] = image[:, 1]
+    u[u_height-1, 1:u_width-1] = image[height-2, :]
+    u[1:u_height-1, u_width-1] = image[:, width-2]
 
     while i < max_iter and rmse > eps:
 
@@ -276,4 +278,4 @@ def _denoise_tv_bregman(image, double weight, int max_iter, double eps,
         rmse = sqrt(rmse / total)
         i += 1
 
-    return np.squeeze(np.asarray(u[1:-1, 1:-1]))
+    return np.squeeze(np.asarray(u[1:u_height-1, 1:u_width-1]))


### PR DESCRIPTION
I don't understand why this wasn't throwing errors.

There may only be a few places where this is needed. depending on the conclusion from this clarification request: https://github.com/cython/cython/issues/2667

@jni @AetherUnbound

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Unit tests??? Man this memory stuff is really hard to test. Not like I can create explicit failers easily

## For reviewers
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
