### PR TITLE
speedup for inpaint

### DIFF
--- a/skimage/restoration/inpaint.py
+++ b/skimage/restoration/inpaint.py
@@ -37,12 +37,13 @@ def _inpaint_biharmonic_single_channel(mask, out, limits):
 
         # Iterate over masked point's neighborhood
         it_inner = np.nditer(neigh_coef, flags=['multi_index'])
-        for coef in it_inner:
+        coefs, multi_indices = [(coef, it_inner.multi_index) for coef in it_inner]
+        multi_indices = np.vstack(multi_indices)
+        tmp_pt_idxs = multi_indices + b_lo
+        tmp_pt_is = np.ravel_multi_index(tmp_pt_idxs.transpose(), mask.shape)
+        for coef, tmp_pt_idx, tmp_pt_i in zip(coefs, tmp_pt_idxs, tmp_pt_is):
             if coef == 0:
                 continue
-            tmp_pt_idx = np.add(b_lo, it_inner.multi_index)
-            tmp_pt_i = np.ravel_multi_index(tmp_pt_idx, mask.shape)
-
             if mask[tuple(tmp_pt_idx)]:
                 matrix_unknown[mask_pt_n, tmp_pt_i] = coef
             else:


### PR DESCRIPTION
## Description
This is a speedup for the inpaint method, specifically for the '_inpaint_biharmonic_single_channel' method, in the part where the masked points are being iterated over.

I've added a bit of speedup in 2 steps, each in a separate commit:
1. I've made a bit of speedup by vectorizing a few operations
2. I've added a speedup (perhaps a more significant one) by converting the iteration to a parallel manner.


## Checklist
I'm new to contributing to open source projects so before I start working on the checklist I would like to receive your thoughts about it :)

Btw, as i'm new to contributing i'd love to hear your advice on my attempt to contribute and i'd appreciate your help in completing this feature enhancement :)

## References
This is an enhancement regarding this issue #2008

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
