### PR TITLE
MNT: Release the GIL in numerous cython functions

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -262,3 +262,7 @@
 
 - Laurent P. René de Cotret
   Implementation of masked image translation registration
+
+- Mark Harfouche
+  Enabled GIL free operation of many algorithms implemented in Cython.
+  Maintenance of the build and test infrastructure.

--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -67,6 +67,9 @@ def _line(Py_ssize_t r0, Py_ssize_t c0, Py_ssize_t r1, Py_ssize_t c1):
     cdef Py_ssize_t dc = abs(c1 - c0)
     cdef Py_ssize_t sr, sc, d, i
 
+    cdef Py_ssize_t[::1] rr = np.zeros(max(dc, dr) + 1, dtype=np.intp)
+    cdef Py_ssize_t[::1] cc = np.zeros(max(dc, dr) + 1, dtype=np.intp)
+
     with nogil:
         if (c1 - c) > 0:
             sc = 1
@@ -83,10 +86,6 @@ def _line(Py_ssize_t r0, Py_ssize_t c0, Py_ssize_t r1, Py_ssize_t c1):
             sc, sr = sr, sc
         d = (2 * dr) - dc
 
-    cdef Py_ssize_t[::1] rr = np.zeros(int(dc) + 1, dtype=np.intp)
-    cdef Py_ssize_t[::1] cc = np.zeros(int(dc) + 1, dtype=np.intp)
-
-    with nogil:
         for i in range(dc):
             if steep:
                 rr[i] = c

--- a/skimage/measure/_ccomp.pyx
+++ b/skimage/measure/_ccomp.pyx
@@ -10,12 +10,12 @@ cimport numpy as cnp
 
 
 DTYPE = np.intp
-BG_NODE_NULL = -999
+cdef DTYPE_t BG_NODE_NULL = -999
 
 cdef struct s_shpinfo
 
 ctypedef s_shpinfo shape_info
-ctypedef long (* fun_ravel)(long, long, long, shape_info *)
+ctypedef long (* fun_ravel)(long, long, long, shape_info *) nogil
 
 
 # For having stuff concerning background in one place
@@ -162,19 +162,19 @@ cdef void get_shape_info(inarr_shape, shape_info *res) except *:
 
 
 cdef inline void join_trees_wrapper(DTYPE_t *data_p, DTYPE_t *forest_p,
-                                    DTYPE_t rindex, DTYPE_t idxdiff):
+                                    DTYPE_t rindex, DTYPE_t idxdiff) nogil:
     if data_p[rindex] == data_p[rindex + idxdiff]:
         join_trees(forest_p, rindex, rindex + idxdiff)
 
 
-cdef long ravel_index1D(long x, long y, long z, shape_info *shapeinfo):
+cdef long ravel_index1D(long x, long y, long z, shape_info *shapeinfo) nogil:
     """
     Ravel index of a 1D array - trivial. y and z are ignored.
     """
     return x
 
 
-cdef long ravel_index2D(long x, long y, long z, shape_info *shapeinfo):
+cdef long ravel_index2D(long x, long y, long z, shape_info *shapeinfo) nogil:
     """
     Ravel index of a 2D array. z is ignored
     """
@@ -182,7 +182,7 @@ cdef long ravel_index2D(long x, long y, long z, shape_info *shapeinfo):
     return ret
 
 
-cdef long ravel_index3D(long x, long y, long z, shape_info *shapeinfo):
+cdef long ravel_index3D(long x, long y, long z, shape_info *shapeinfo) nogil:
     """
     Ravel index of a 3D array
     """
@@ -387,14 +387,15 @@ def label_cython(input_, neighbors=None, background=None, return_num=False,
             "Connectivity below 1 or above %d is illegal."
             % ndim)
 
-    scanBG(data_p, forest_p, &shapeinfo, &bg)
-    # the data are treated as degenerated 3D arrays if needed
-    # without any performance sacrifice
-    scan3D(data_p, forest_p, &shapeinfo, &bg, connectivity)
-
+    cdef DTYPE_t conn = connectivity
     # Label output
     cdef DTYPE_t ctr
-    ctr = resolve_labels(data_p, forest_p, &shapeinfo, &bg)
+    with nogil:
+        scanBG(data_p, forest_p, &shapeinfo, &bg)
+        # the data are treated as degenerated 3D arrays if needed
+        # without any performance sacrifice
+        scan3D(data_p, forest_p, &shapeinfo, &bg, conn)
+        ctr = resolve_labels(data_p, forest_p, &shapeinfo, &bg)
 
     # Work around a bug in ndimage's type checking on 32-bit platforms
     if data.dtype == np.int32:
@@ -410,7 +411,7 @@ def label_cython(input_, neighbors=None, background=None, return_num=False,
 
 
 cdef DTYPE_t resolve_labels(DTYPE_t *data_p, DTYPE_t *forest_p,
-                            shape_info *shapeinfo, bginfo *bg):
+                            shape_info *shapeinfo, bginfo *bg) nogil:
     """
     We iterate through the provisional labels and assign final labels based on
     our knowledge of prov. labels relationship.
@@ -441,7 +442,7 @@ cdef DTYPE_t resolve_labels(DTYPE_t *data_p, DTYPE_t *forest_p,
 
 
 cdef void scanBG(DTYPE_t *data_p, DTYPE_t *forest_p, shape_info *shapeinfo,
-                 bginfo *bg):
+                 bginfo *bg) nogil:
     """
     Settle all background pixels now and don't bother with them later.
     Since this only requires one linar sweep through the array, it is fast
@@ -485,7 +486,7 @@ cdef void scanBG(DTYPE_t *data_p, DTYPE_t *forest_p, shape_info *shapeinfo,
 
 
 cdef void scan1D(DTYPE_t *data_p, DTYPE_t *forest_p, shape_info *shapeinfo,
-                 bginfo *bg, DTYPE_t connectivity, DTYPE_t y, DTYPE_t z):
+                 bginfo *bg, DTYPE_t connectivity, DTYPE_t y, DTYPE_t z) nogil:
     """
     Perform forward scan on a 1D object, usually the first row of an image
     """
@@ -505,7 +506,7 @@ cdef void scan1D(DTYPE_t *data_p, DTYPE_t *forest_p, shape_info *shapeinfo,
 
 
 cdef void scan2D(DTYPE_t *data_p, DTYPE_t *forest_p, shape_info *shapeinfo,
-                 bginfo *bg, DTYPE_t connectivity, DTYPE_t z):
+                 bginfo *bg, DTYPE_t connectivity, DTYPE_t z) nogil:
     """
     Perform forward scan on a 2D array.
     """
@@ -556,7 +557,7 @@ cdef void scan2D(DTYPE_t *data_p, DTYPE_t *forest_p, shape_info *shapeinfo,
 
 
 cdef void scan3D(DTYPE_t *data_p, DTYPE_t *forest_p, shape_info *shapeinfo,
-                 bginfo *bg, DTYPE_t connectivity):
+                 bginfo *bg, DTYPE_t connectivity) nogil:
     """
     Perform forward scan on a 3D array.
 

--- a/skimage/measure/_pnpoly.pyx
+++ b/skimage/measure/_pnpoly.pyx
@@ -47,9 +47,10 @@ def _grid_points_in_poly(shape, verts):
     cdef cnp.ndarray[dtype=cnp.uint8_t, ndim=2, mode="c"] out = \
          np.zeros((M, N), dtype=np.uint8)
 
-    for m in range(M):
-        for n in range(N):
-            out[m, n] = point_in_polygon(V, &vx[0], &vy[0], m, n)
+    with nogil:
+        for m in range(M):
+            for n in range(N):
+                out[m, n] = point_in_polygon(V, &vx[0], &vy[0], m, n)
 
     return out.view(bool)
 
@@ -94,4 +95,3 @@ def _points_in_poly(points, verts):
                       <unsigned char*>out.data)
 
     return out.astype(bool)
-

--- a/skimage/morphology/_convex_hull.pyx
+++ b/skimage/morphology/_convex_hull.pyx
@@ -38,35 +38,36 @@ def possible_hull(cnp.uint8_t[:, ::1] img):
     cdef Py_ssize_t rows_2_cols = 2 * rows + cols
     cdef Py_ssize_t rows_cols_r, rows_c
 
-    for r in range(rows):
+    with nogil:
+        for r in range(rows):
 
-        rows_cols_r = rows_cols + r
+            rows_cols_r = rows_cols + r
 
-        for c in range(cols):
+            for c in range(cols):
 
-            if img[r, c] != 0:
+                if img[r, c] != 0:
 
-                rows_c = rows + c
-                rows_2_cols_c = rows_2_cols + c
+                    rows_c = rows + c
+                    rows_2_cols_c = rows_2_cols + c
 
-                # Left check
-                if nonzero[r, 1] == -1:
-                    nonzero[r, 0] = r
-                    nonzero[r, 1] = c
+                    # Left check
+                    if nonzero[r, 1] == -1:
+                        nonzero[r, 0] = r
+                        nonzero[r, 1] = c
 
-                # Right check
-                elif nonzero[rows_cols_r, 1] < c:
-                    nonzero[rows_cols_r, 0] = r
-                    nonzero[rows_cols_r, 1] = c
+                    # Right check
+                    elif nonzero[rows_cols_r, 1] < c:
+                        nonzero[rows_cols_r, 0] = r
+                        nonzero[rows_cols_r, 1] = c
 
-                # Top check
-                if nonzero[rows_c, 1] == -1:
-                    nonzero[rows_c, 0] = r
-                    nonzero[rows_c, 1] = c
-
-                # Bottom check
-                elif nonzero[rows_2_cols_c, 0] < r:
-                    nonzero[rows_2_cols_c, 0] = r
-                    nonzero[rows_2_cols_c, 1] = c
+                    # Top check
+                    if nonzero[rows_c, 1] == -1:
+                        nonzero[rows_c, 0] = r
+                        nonzero[rows_c, 1] = c
+  
+                    # Bottom check
+                    elif nonzero[rows_2_cols_c, 0] < r:
+                        nonzero[rows_2_cols_c, 0] = r
+                        nonzero[rows_2_cols_c, 1] = c
 
     return coords[coords[:, 0] != -1]

--- a/skimage/morphology/_greyreconstruct.pyx
+++ b/skimage/morphology/_greyreconstruct.pyx
@@ -56,39 +56,39 @@ def reconstruction_loop(cnp.ndarray[dtype=cnp.uint32_t, ndim=1,
     cdef cnp.int32_t *next = <cnp.int32_t *>(anext.data)
     cdef cnp.int32_t *strides = <cnp.int32_t *>(astrides.data)
 
-    while current_idx != -1:
-        if current_idx < image_stride:
-            current_rank = ranks[current_idx]
-            if current_rank == 0:
-                break
-            for i in range(nstrides):
-                neighbor_idx = current_idx + strides[i]
-                neighbor_rank = ranks[neighbor_idx]
-                # Only propagate neighbors ranked below the current rank
-                if neighbor_rank < current_rank:
-                    mask_rank = ranks[neighbor_idx + image_stride]
-                    # Only propagate neighbors ranked below the mask rank
-                    if neighbor_rank < mask_rank:
-                        # Raise the neighbor to the mask rank if
-                        # the mask ranked below the current rank
-                        if mask_rank < current_rank:
-                            current_link = neighbor_idx + image_stride
-                            ranks[neighbor_idx] = mask_rank
-                        else:
-                            current_link = current_idx
-                            ranks[neighbor_idx] = current_rank
-                        # unlink the neighbor
-                        nprev = prev[neighbor_idx]
-                        nnext = next[neighbor_idx]
-                        next[nprev] = nnext
-                        if nnext != -1:
-                            prev[nnext] = nprev
-                        # link to the neighbor after the current link
-                        nnext = next[current_link]
-                        next[neighbor_idx] = nnext
-                        prev[neighbor_idx] = current_link
-                        if nnext >= 0:
-                            prev[nnext] = neighbor_idx
-                            next[current_link] = neighbor_idx
-        current_idx = next[current_idx]
-
+    with nogil:
+        while current_idx != -1:
+            if current_idx < image_stride:
+                current_rank = ranks[current_idx]
+                if current_rank == 0:
+                    break
+                for i in range(nstrides):
+                    neighbor_idx = current_idx + strides[i]
+                    neighbor_rank = ranks[neighbor_idx]
+                    # Only propagate neighbors ranked below the current rank
+                    if neighbor_rank < current_rank:
+                        mask_rank = ranks[neighbor_idx + image_stride]
+                        # Only propagate neighbors ranked below the mask rank
+                        if neighbor_rank < mask_rank:
+                            # Raise the neighbor to the mask rank if
+                            # the mask ranked below the current rank
+                            if mask_rank < current_rank:
+                                current_link = neighbor_idx + image_stride
+                                ranks[neighbor_idx] = mask_rank
+                            else:
+                                current_link = current_idx
+                                ranks[neighbor_idx] = current_rank
+                            # unlink the neighbor
+                            nprev = prev[neighbor_idx]
+                            nnext = next[neighbor_idx]
+                            next[nprev] = nnext
+                            if nnext != -1:
+                                prev[nnext] = nprev
+                            # link to the neighbor after the current link
+                            nnext = next[current_link]
+                            next[neighbor_idx] = nnext
+                            prev[neighbor_idx] = current_link
+                            if nnext >= 0:
+                                prev[nnext] = neighbor_idx
+                                next[current_link] = neighbor_idx
+            current_idx = next[current_idx]

--- a/skimage/morphology/_skeletonize_cy.pyx
+++ b/skimage/morphology/_skeletonize_cy.pyx
@@ -65,7 +65,7 @@ def _fast_skeletonize(image):
     _cleaned_skeleton = _skeleton.copy()
 
     # cdef'd numpy-arrays for fast, typed access
-    cdef cnp.ndarray[cnp.uint8_t, ndim=2] skeleton, cleaned_skeleton
+    cdef cnp.uint8_t [:, ::1] skeleton, cleaned_skeleton
 
     skeleton = _skeleton
     cleaned_skeleton = _cleaned_skeleton
@@ -74,39 +74,42 @@ def _fast_skeletonize(image):
 
     # the algorithm reiterates the thinning till
     # no further thinning occurred (variable pixel_removed set)
+    with nogil:
+        while pixel_removed:
+            pixel_removed = False
 
-    while pixel_removed:
-        pixel_removed = False
+            # there are two phases, in the first phase, pixels labeled (see below)
+            # 1 and 3 are removed, in the second 2 and 3
 
-        # there are two phases, in the first phase, pixels labeled (see below)
-        # 1 and 3 are removed, in the second 2 and 3
+            # nogil can't iterate through `(True, False)` because it is a Python
+            # tuple. Use the fact that 0 is Falsy, and 1 is truthy in C
+            # for the iteration instead.
+            # for first_pass in (True, False):
+            for first_pass in range(1, -1, -1):
+                for row in range(1, nrows-1):
+                    for col in range(1, ncols-1):
+                        # all set pixels ...
+                        if skeleton[row, col]:
+                            # are correlated with a kernel (coefficients spread around here ...)
+                            # to apply a unique number to every possible neighborhood ...
 
-        for first_pass in (True, False):
-            for row in range(1, nrows-1):
-                for col in range(1, ncols-1):
-                    # all set pixels ...
-                    if skeleton[row, col]:
-                        # are correlated with a kernel (coefficients spread around here ...)
-                        # to apply a unique number to every possible neighborhood ...
+                            # which is used with the lut to find the "connectivity type"
 
-                        # which is used with the lut to find the "connectivity type"
+                            neighbors = lut[  1*skeleton[row - 1, col - 1] +   2*skeleton[row - 1, col] +\
+                                              4*skeleton[row - 1, col + 1] +   8*skeleton[row, col + 1] +\
+                                             16*skeleton[row + 1, col + 1] +  32*skeleton[row + 1, col] +\
+                                             64*skeleton[row + 1, col - 1] + 128*skeleton[row, col - 1]]
 
-                        neighbors = lut[  1*skeleton[row - 1, col - 1] +   2*skeleton[row - 1, col] +\
-                                          4*skeleton[row - 1, col + 1] +   8*skeleton[row, col + 1] +\
-                                         16*skeleton[row + 1, col + 1] +  32*skeleton[row + 1, col] +\
-                                         64*skeleton[row + 1, col - 1] + 128*skeleton[row, col - 1]]
+                            # if the condition is met, the pixel is removed (unset)
+                            if ((neighbors == 1 and first_pass) or
+                                    (neighbors == 2 and not first_pass) or
+                                    (neighbors == 3)):
+                                cleaned_skeleton[row, col] = 0
+                                pixel_removed = True
 
-                        # if the condition is met, the pixel is removed (unset)
-                        if ((neighbors == 1 and first_pass) or
-                                (neighbors == 2 and not first_pass) or
-                                (neighbors == 3)):
-                            cleaned_skeleton[row, col] = 0
-                            pixel_removed = True
-
-            # once a step has been processed, the original skeleton
-            # is overwritten with the cleaned version
-            _skeleton = _cleaned_skeleton.copy()
-            skeleton = _skeleton
+                # once a step has been processed, the original skeleton
+                # is overwritten with the cleaned version
+                skeleton[:, :] = cleaned_skeleton[:, :]
 
     return _skeleton[1:nrows-1, 1:ncols-1].astype(np.bool)
 
@@ -167,32 +170,33 @@ def _skeletonize_loop(cnp.uint8_t[:, ::1] result,
         Py_ssize_t rows = result.shape[0]
         Py_ssize_t cols = result.shape[1]
 
-    for index in range(order.shape[0]):
-        accumulator = 16
-        order_index = order[index]
-        ii = i[order_index]
-        jj = j[order_index]
-        # Compute the configuration around the pixel
-        if ii > 0:
-            if jj > 0 and result[ii - 1, jj - 1]:
-                accumulator += 1
-            if result[ii - 1, jj]:
-                accumulator += 2
-            if jj < cols - 1 and result[ii - 1, jj + 1]:
-                    accumulator += 4
-            if jj > 0 and result[ii, jj - 1]:
-                accumulator += 8
-            if jj < cols - 1 and result[ii, jj + 1]:
-                accumulator += 32
-            if ii < rows - 1:
-                if jj > 0 and result[ii + 1, jj - 1]:
-                    accumulator += 64
-                if result[ii + 1, jj]:
-                    accumulator += 128
-                if jj < cols - 1 and result[ii + 1, jj + 1]:
-                    accumulator += 256
-            # Assign the value of table corresponding to the configuration
-            result[ii, jj] = table[accumulator]
+    with nogil:
+        for index in range(order.shape[0]):
+            accumulator = 16
+            order_index = order[index]
+            ii = i[order_index]
+            jj = j[order_index]
+            # Compute the configuration around the pixel
+            if ii > 0:
+                if jj > 0 and result[ii - 1, jj - 1]:
+                    accumulator += 1
+                if result[ii - 1, jj]:
+                    accumulator += 2
+                if jj < cols - 1 and result[ii - 1, jj + 1]:
+                        accumulator += 4
+                if jj > 0 and result[ii, jj - 1]:
+                    accumulator += 8
+                if jj < cols - 1 and result[ii, jj + 1]:
+                    accumulator += 32
+                if ii < rows - 1:
+                    if jj > 0 and result[ii + 1, jj - 1]:
+                        accumulator += 64
+                    if result[ii + 1, jj]:
+                        accumulator += 128
+                    if jj < cols - 1 and result[ii + 1, jj + 1]:
+                        accumulator += 256
+                # Assign the value of table corresponding to the configuration
+                result[ii, jj] = table[accumulator]
 
 
 
@@ -235,79 +239,79 @@ def _table_lookup_index(cnp.uint8_t[:, ::1] image):
     i_stride  = image.strides[0]
     assert i_shape >= 3 and j_shape >= 3, \
         "Please use the slow method for arrays < 3x3"
+    with nogil:
+        for i in range(1, i_shape-1):
+            offset = i_stride* i + 1
+            for j in range(1, j_shape - 1):
+                if p_image[offset]:
+                    p_indexer[offset + i_stride + 1] += 1
+                    p_indexer[offset + i_stride] += 2
+                    p_indexer[offset + i_stride - 1] += 4
+                    p_indexer[offset + 1] += 8
+                    p_indexer[offset] += 16
+                    p_indexer[offset - 1] += 32
+                    p_indexer[offset - i_stride + 1] += 64
+                    p_indexer[offset - i_stride] += 128
+                    p_indexer[offset - i_stride - 1] += 256
+                offset += 1
+        #
+        # Do the corner cases (literally)
+        #
+        if image[0, 0]:
+            indexer[0, 0] += 16
+            indexer[0, 1] += 8
+            indexer[1, 0] += 2
+            indexer[1, 1] += 1
 
-    for i in range(1, i_shape-1):
-        offset = i_stride* i + 1
+        if image[0, j_shape - 1]:
+            indexer[0, j_shape - 2] += 32
+            indexer[0, j_shape - 1] += 16
+            indexer[1, j_shape - 2] += 4
+            indexer[1, j_shape - 1] += 2
+
+        if image[i_shape - 1, 0]:
+            indexer[i_shape - 2, 0] += 128
+            indexer[i_shape - 2, 1] += 64
+            indexer[i_shape - 1, 0] += 16
+            indexer[i_shape - 1, 1] += 8
+
+        if image[i_shape - 1, j_shape - 1]:
+            indexer[i_shape - 2, j_shape - 2] += 256
+            indexer[i_shape - 2, j_shape - 1] += 128
+            indexer[i_shape - 1, j_shape - 2] += 32
+            indexer[i_shape - 1, j_shape - 1] += 16
+        #
+        # Do the edges
+        #
         for j in range(1, j_shape - 1):
-            if p_image[offset]:
-                p_indexer[offset + i_stride + 1] += 1
-                p_indexer[offset + i_stride] += 2
-                p_indexer[offset + i_stride - 1] += 4
-                p_indexer[offset + 1] += 8
-                p_indexer[offset] += 16
-                p_indexer[offset - 1] += 32
-                p_indexer[offset - i_stride + 1] += 64
-                p_indexer[offset - i_stride] += 128
-                p_indexer[offset - i_stride - 1] += 256
-            offset += 1
-    #
-    # Do the corner cases (literally)
-    #
-    if image[0, 0]:
-        indexer[0, 0] += 16
-        indexer[0, 1] += 8
-        indexer[1, 0] += 2
-        indexer[1, 1] += 1
+            if image[0, j]:
+                indexer[0, j - 1] += 32
+                indexer[0, j] += 16
+                indexer[0, j + 1] += 8
+                indexer[1, j - 1] += 4
+                indexer[1, j] += 2
+                indexer[1, j + 1] += 1
+            if image[i_shape - 1, j]:
+                indexer[i_shape - 2, j - 1] += 256
+                indexer[i_shape - 2, j] += 128
+                indexer[i_shape - 2, j + 1] += 64
+                indexer[i_shape - 1, j - 1] += 32
+                indexer[i_shape - 1, j] += 16
+                indexer[i_shape - 1, j + 1] += 8
 
-    if image[0, j_shape - 1]:
-        indexer[0, j_shape - 2] += 32
-        indexer[0, j_shape - 1] += 16
-        indexer[1, j_shape - 2] += 4
-        indexer[1, j_shape - 1] += 2
-
-    if image[i_shape - 1, 0]:
-        indexer[i_shape - 2, 0] += 128
-        indexer[i_shape - 2, 1] += 64
-        indexer[i_shape - 1, 0] += 16
-        indexer[i_shape - 1, 1] += 8
-
-    if image[i_shape - 1, j_shape - 1]:
-        indexer[i_shape - 2, j_shape - 2] += 256
-        indexer[i_shape - 2, j_shape - 1] += 128
-        indexer[i_shape - 1, j_shape - 2] += 32
-        indexer[i_shape - 1, j_shape - 1] += 16
-    #
-    # Do the edges
-    #
-    for j in range(1, j_shape - 1):
-        if image[0, j]:
-            indexer[0, j - 1] += 32
-            indexer[0, j] += 16
-            indexer[0, j + 1] += 8
-            indexer[1, j - 1] += 4
-            indexer[1, j] += 2
-            indexer[1, j + 1] += 1
-        if image[i_shape - 1, j]:
-            indexer[i_shape - 2, j - 1] += 256
-            indexer[i_shape - 2, j] += 128
-            indexer[i_shape - 2, j + 1] += 64
-            indexer[i_shape - 1, j - 1] += 32
-            indexer[i_shape - 1, j] += 16
-            indexer[i_shape - 1, j + 1] += 8
-
-    for i in range(1, i_shape - 1):
-        if image[i, 0]:
-            indexer[i - 1, 0] += 128
-            indexer[i, 0] += 16
-            indexer[i + 1, 0] += 2
-            indexer[i - 1, 1] += 64
-            indexer[i, 1] += 8
-            indexer[i + 1, 1] += 1
-        if image[i, j_shape - 1]:
-            indexer[i - 1, j_shape - 2] += 256
-            indexer[i, j_shape - 2] += 32
-            indexer[i + 1, j_shape - 2] += 4
-            indexer[i - 1, j_shape - 1] += 128
-            indexer[i, j_shape - 1] += 16
-            indexer[i + 1, j_shape - 1] += 2
+        for i in range(1, i_shape - 1):
+            if image[i, 0]:
+                indexer[i - 1, 0] += 128
+                indexer[i, 0] += 16
+                indexer[i + 1, 0] += 2
+                indexer[i - 1, 1] += 64
+                indexer[i, 1] += 8
+                indexer[i + 1, 1] += 1
+            if image[i, j_shape - 1]:
+                indexer[i - 1, j_shape - 2] += 256
+                indexer[i, j_shape - 2] += 32
+                indexer[i + 1, j_shape - 2] += 4
+                indexer[i - 1, j_shape - 1] += 128
+                indexer[i, j_shape - 1] += 16
+                indexer[i + 1, j_shape - 1] += 2
     return np.asarray(indexer)

--- a/skimage/morphology/_skeletonize_cy.pyx
+++ b/skimage/morphology/_skeletonize_cy.pyx
@@ -85,7 +85,8 @@ def _fast_skeletonize(image):
             # tuple. Use the fact that 0 is Falsy, and 1 is truthy in C
             # for the iteration instead.
             # for first_pass in (True, False):
-            for first_pass in range(1, -1, -1):
+            for pass_num in range(2):
+                first_pass = (pass_num == 0)
                 for row in range(1, nrows-1):
                     for col in range(1, ncols-1):
                         # all set pixels ...

--- a/skimage/morphology/heap_general.pxi
+++ b/skimage/morphology/heap_general.pxi
@@ -19,7 +19,7 @@ cdef struct Heap:
     Heapitem *data
     Heapitem **ptrs
 
-cdef inline Heap *heap_from_numpy2():
+cdef inline Heap *heap_from_numpy2() nogil:
     cdef Py_ssize_t k
     cdef Heap *heap
     heap = <Heap *> malloc(sizeof (Heap))
@@ -31,12 +31,12 @@ cdef inline Heap *heap_from_numpy2():
         heap.ptrs[k] = heap.data + k
     return heap
 
-cdef inline void heap_done(Heap *heap):
+cdef inline void heap_done(Heap *heap) nogil:
    free(heap.data)
    free(heap.ptrs)
    free(heap)
 
-cdef inline void swap(Py_ssize_t a, Py_ssize_t b, Heap *h):
+cdef inline void swap(Py_ssize_t a, Py_ssize_t b, Heap *h) nogil:
     h.ptrs[a], h.ptrs[b] = h.ptrs[b], h.ptrs[a]
 
 
@@ -47,7 +47,7 @@ cdef inline void swap(Py_ssize_t a, Py_ssize_t b, Heap *h):
 #
 # Note: heap ordering is the same as python heapq, i.e., smallest first.
 ######################################################
-cdef inline void heappop(Heap *heap, Heapitem *dest):
+cdef inline void heappop(Heap *heap, Heapitem *dest) nogil:
 
     cdef Py_ssize_t i, smallest, l, r # heap indices
 
@@ -100,7 +100,7 @@ cdef inline void heappop(Heap *heap, Heapitem *dest):
 #
 # Note: heap ordering is the same as python heapq, i.e., smallest first.
 ##################################################
-cdef inline void heappush(Heap *heap, Heapitem *new_elem):
+cdef inline void heappush(Heap *heap, Heapitem *new_elem) nogil:
 
     cdef Py_ssize_t child = heap.items
     cdef Py_ssize_t parent

--- a/skimage/morphology/heap_watershed.pxi
+++ b/skimage/morphology/heap_watershed.pxi
@@ -19,7 +19,7 @@ cdef struct Heapitem:
     Py_ssize_t source
 
 
-cdef inline int smaller(Heapitem *a, Heapitem *b):
+cdef inline int smaller(Heapitem *a, Heapitem *b) nogil:
     if a.value != b.value:
         return a.value < b.value
     return a.age < b.age

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -17,7 +17,7 @@ cdef extern from "fast_exp.h":
 
 cdef inline double patch_distance_2d(IMGDTYPE [:, :] p1,
                                      IMGDTYPE [:, :] p2,
-                                     IMGDTYPE [:, ::] w, int s, double var):
+                                     IMGDTYPE [:, ::] w, int s, double var) nogil:
     """
     Compute a Gaussian distance between two image patches.
 
@@ -69,7 +69,7 @@ cdef inline double patch_distance_2dmultichannel(IMGDTYPE [:, :, :] p1,
                                                  IMGDTYPE [:, :, :] p2,
                                                  IMGDTYPE [:, ::] w,
                                                  int s, double var,
-                                                 int n_channels):
+                                                 int n_channels) nogil:
     """
     Compute a Gaussian distance between two image patches.
 
@@ -117,7 +117,7 @@ cdef inline double patch_distance_2dmultichannel(IMGDTYPE [:, :, :] p1,
 
 cdef inline double patch_distance_3d(IMGDTYPE [:, :, :] p1,
                                      IMGDTYPE [:, :, :] p2,
-                                     IMGDTYPE [:, :, ::] w, int s, double var):
+                                     IMGDTYPE [:, :, ::] w, int s, double var) nogil:
     """
     Compute a Gaussian distance between two image patches.
 
@@ -217,57 +217,58 @@ def _nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1,
 
     # Coordinates of central pixel
     # Iterate over rows, taking padding into account
-    for row in range(offset, n_row + offset):
-        row_start = row - offset
-        row_end = row + offset + 1
-        # Iterate over columns, taking padding into account
-        for col in range(offset, n_col + offset):
-            # Initialize per-channel bins
-            for channel in range(n_channels):
-                new_values[channel] = 0
-            # Reset weights for each local region
-            weight_sum = 0
-            col_start = col - offset
-            col_end = col + offset + 1
+    with nogil:
+        for row in range(offset, n_row + offset):
+            row_start = row - offset
+            row_end = row + offset + 1
+            # Iterate over columns, taking padding into account
+            for col in range(offset, n_col + offset):
+                # Initialize per-channel bins
+                for channel in range(n_channels):
+                    new_values[channel] = 0
+                # Reset weights for each local region
+                weight_sum = 0
+                col_start = col - offset
+                col_end = col + offset + 1
 
-            # Iterate over local 2d patch for each pixel
-            # First rows
-            for i in range(max(-d, offset - row),
-                           min(d + 1, n_row + offset - row)):
-                row_start_i = row_start + i
-                row_end_i = row_end + i
-                # Local patch columns
-                for j in range(max(-d, offset - col),
-                               min(d + 1, n_col + offset - col)):
-                    col_start_j = col_start + j
-                    col_end_j = col_end + j
-                    # Shortcut for grayscale, else assume RGB
-                    if n_channels == 1:
-                        weight = patch_distance_2d(
-                                 padded[row_start:row_end,
-                                        col_start:col_end, 0],
-                                 padded[row_start_i:row_end_i,
-                                        col_start_j:col_end_j, 0],
-                                 w, s, var)
-                    else:
-                        weight = patch_distance_2dmultichannel(
-                                 padded[row_start:row_end,
-                                        col_start:col_end, :],
-                                 padded[row_start_i:row_end_i,
-                                        col_start_j:col_end_j, :],
-                                        w, s, var, n_channels)
+                # Iterate over local 2d patch for each pixel
+                # First rows
+                for i in range(max(-d, offset - row),
+                               min(d + 1, n_row + offset - row)):
+                    row_start_i = row_start + i
+                    row_end_i = row_end + i
+                    # Local patch columns
+                    for j in range(max(-d, offset - col),
+                                   min(d + 1, n_col + offset - col)):
+                        col_start_j = col_start + j
+                        col_end_j = col_end + j
+                        # Shortcut for grayscale, else assume RGB
+                        if n_channels == 1:
+                            weight = patch_distance_2d(
+                                     padded[row_start:row_end,
+                                            col_start:col_end, 0],
+                                     padded[row_start_i:row_end_i,
+                                            col_start_j:col_end_j, 0],
+                                     w, s, var)
+                        else:
+                            weight = patch_distance_2dmultichannel(
+                                     padded[row_start:row_end,
+                                            col_start:col_end, :],
+                                     padded[row_start_i:row_end_i,
+                                            col_start_j:col_end_j, :],
+                                            w, s, var, n_channels)
 
-                    # Collect results in weight sum
-                    weight_sum += weight
-                    # Apply to each channel multiplicatively
-                    for channel in range(n_channels):
-                        new_values[channel] += weight * padded[row + i,
-                                                               col + j,
-                                                               channel]
+                        # Collect results in weight sum
+                        weight_sum += weight
+                        # Apply to each channel multiplicatively
+                        for channel in range(n_channels):
+                            new_values[channel] += weight * padded[row + i,
+                                                                   col + j,
+                                                                   channel]
 
-            # Normalize the result
-            for channel in range(n_channels):
-                result[row, col, channel] = new_values[channel] / weight_sum
+                # Normalize the result
+                for channel in range(n_channels):
+                    result[row, col, channel] = new_values[channel] / weight_sum
 
     # Return cropped result, undoing padding
     return result[offset:-offset, offset:-offset]
@@ -326,51 +327,52 @@ def _nl_means_denoising_3d(image, int s=7, int d=13, double h=0.1,
 
     # Coordinates of central pixel
     # Iterate over planes, taking padding into account
-    for pln in range(offset, n_pln + offset):
-        pln_start = pln - offset
-        pln_end = pln + offset + 1
-        # Iterate over rows, taking padding into account
-        for row in range(offset, n_row + offset):
-            row_start = row - offset
-            row_end = row + offset + 1
-            # Iterate over columns, taking padding into account
-            for col in range(offset, n_col + offset):
-                col_start = col - offset
-                col_end = col + offset + 1
-                new_value = 0
-                weight_sum = 0
+    with nogil:
+        for pln in range(offset, n_pln + offset):
+            pln_start = pln - offset
+            pln_end = pln + offset + 1
+            # Iterate over rows, taking padding into account
+            for row in range(offset, n_row + offset):
+                row_start = row - offset
+                row_end = row + offset + 1
+                # Iterate over columns, taking padding into account
+                for col in range(offset, n_col + offset):
+                    col_start = col - offset
+                    col_end = col + offset + 1
+                    new_value = 0
+                    weight_sum = 0
 
-                # Iterate over local 3d patch for each pixel
-                # First planes
-                for i in range(max(-d, offset - pln),
-                               min(d + 1, n_pln + offset - pln)):
-                    pln_start_i = pln_start + i
-                    pln_end_i = pln_end + i
-                    # Rows
-                    for j in range(max(-d, offset - row),
-                                   min(d + 1, n_row + offset - row)):
-                        row_start_j = row_start + j
-                        row_end_j = row_end + j
-                        # Columns
-                        for k in range(max(-d, offset - col),
-                                       min(d + 1, n_col + offset - col)):
-                            col_start_k = col_start + k
-                            col_end_k = col_end + k
-                            weight = patch_distance_3d(
-                                    padded[pln_start:pln_end,
-                                           row_start:row_end,
-                                           col_start:col_end],
-                                    padded[pln_start_i:pln_end_i,
-                                           row_start_j:row_end_j,
-                                           col_start_k:col_end_k],
-                                    w, s, var)
-                            # Collect results in weight sum
-                            weight_sum += weight
-                            new_value += weight * padded[pln + i,
-                                                         row + j, col + k]
+                    # Iterate over local 3d patch for each pixel
+                    # First planes
+                    for i in range(max(-d, offset - pln),
+                                   min(d + 1, n_pln + offset - pln)):
+                        pln_start_i = pln_start + i
+                        pln_end_i = pln_end + i
+                        # Rows
+                        for j in range(max(-d, offset - row),
+                                       min(d + 1, n_row + offset - row)):
+                            row_start_j = row_start + j
+                            row_end_j = row_end + j
+                            # Columns
+                            for k in range(max(-d, offset - col),
+                                           min(d + 1, n_col + offset - col)):
+                                col_start_k = col_start + k
+                                col_end_k = col_end + k
+                                weight = patch_distance_3d(
+                                        padded[pln_start:pln_end,
+                                               row_start:row_end,
+                                               col_start:col_end],
+                                        padded[pln_start_i:pln_end_i,
+                                               row_start_j:row_end_j,
+                                               col_start_k:col_end_k],
+                                        w, s, var)
+                                # Collect results in weight sum
+                                weight_sum += weight
+                                new_value += weight * padded[pln + i,
+                                                             row + j, col + k]
 
-                # Normalize the result
-                result[pln, row, col] = new_value / weight_sum
+                    # Normalize the result
+                    result[pln, row, col] = new_value / weight_sum
 
     # Return cropped result, undoing padding
     return result[offset:-offset, offset:-offset, offset:-offset]
@@ -379,7 +381,7 @@ def _nl_means_denoising_3d(image, int s=7, int d=13, double h=0.1,
 
 
 cdef inline double _integral_to_distance_2d(IMGDTYPE [:, ::] integral, int row,
-                                            int col, int offset, double h2s2):
+                                            int col, int offset, double h2s2) nogil:
     """
     References
     ----------
@@ -405,7 +407,7 @@ cdef inline double _integral_to_distance_2d(IMGDTYPE [:, ::] integral, int row,
 cdef inline double _integral_to_distance_3d(IMGDTYPE [:, :, ::] integral,
                                             int pln, int row, int col,
                                             int offset,
-                                            double s_cube_h_square):
+                                            double s_cube_h_square) nogil:
     """
     References
     ----------
@@ -432,10 +434,10 @@ cdef inline double _integral_to_distance_3d(IMGDTYPE [:, :, ::] integral,
     return distance
 
 
-cdef inline _integral_image_2d(IMGDTYPE [:, :, ::] padded,
-                               IMGDTYPE [:, ::] integral, int t_row,
-                               int t_col, int n_row, int n_col, int n_channels,
-                               double var):
+cdef inline void _integral_image_2d(IMGDTYPE [:, :, ::] padded,
+                                    IMGDTYPE [:, ::] integral, int t_row,
+                                    int t_col, int n_row, int n_col,
+                                    int n_channels, double var) nogil:
     """
     Computes the integral of the squared difference between an image ``padded``
     and the same image shifted by ``(t_row, t_col)``.
@@ -487,11 +489,10 @@ cdef inline _integral_image_2d(IMGDTYPE [:, :, ::] padded,
                                  integral[row - 1, col - 1]
 
 
-cdef inline _integral_image_3d(IMGDTYPE [:, :, ::] padded,
-                               IMGDTYPE [:, :, ::] integral, int t_pln,
-                               int t_row, int t_col, int n_pln, int n_row,
-                               int n_col,
-                               double var):
+cdef inline void _integral_image_3d(IMGDTYPE [:, :, ::] padded,
+                                    IMGDTYPE [:, :, ::] integral, int t_pln,
+                                    int t_row, int t_col, int n_pln, int n_row,
+                                    int n_col, double var) nogil:
     """
     Computes the integral of the squared difference between an image ``padded``
     and the same image shifted by ``(t_pln, t_row, t_col)``.
@@ -591,7 +592,7 @@ def _fast_nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1,
                           mode='reflect').astype(np.float64))
     cdef IMGDTYPE [:, :, ::1] result = np.zeros_like(padded)
     cdef IMGDTYPE [:, ::1] weights = np.zeros_like(padded[..., 0], order='C')
-    cdef IMGDTYPE [:, ::1] integral = np.zeros_like(padded[..., 0], order='C')
+    cdef IMGDTYPE [:, ::1] integral = np.empty_like(padded[..., 0], order='C')
     cdef int n_row, n_col, t_row, t_col, row, col, n_channels, channel
     cdef double weight, distance
     cdef double alpha
@@ -602,55 +603,56 @@ def _fast_nl_means_denoising_2d(image, int s=7, int d=13, double h=0.1,
     n_row += 2 * pad_size
     n_col += 2 * pad_size
 
-    # Outer loops on patch shifts
-    # With t2 >= 0, reference patch is always on the left of test patch
-    # Iterate over shifts along the row axis
-    for t_row in range(-d, d + 1):
-        # Iterate over shifts along the column axis
-        for t_col in range(0, d + 1):
-            # alpha is to account for patches on the same column
-            # distance is computed twice in this case
-            if t_col == 0 and t_row is not 0:
-                alpha = 0.5
-            else:
-                alpha = 1.
-            # Compute integral image of the squared difference between
-            # padded and the same image shifted by (t_row, t_col)
-            integral = np.zeros_like(padded[..., 0], order='C')
-            _integral_image_2d(padded, integral, t_row, t_col,
-                               n_row, n_col, n_channels, var)
+    with nogil:
+        # Outer loops on patch shifts
+        # With t2 >= 0, reference patch is always on the left of test patch
+        # Iterate over shifts along the row axis
+        for t_row in range(-d, d + 1):
+            # Iterate over shifts along the column axis
+            for t_col in range(0, d + 1):
+                # alpha is to account for patches on the same column
+                # distance is computed twice in this case
+                if t_col == 0 and t_row is not 0:
+                    alpha = 0.5
+                else:
+                    alpha = 1.
+                # Compute integral image of the squared difference between
+                # padded and the same image shifted by (t_row, t_col)
+                integral[: ,:] = 0
+                _integral_image_2d(padded, integral, t_row, t_col,
+                                   n_row, n_col, n_channels, var)
 
-            # Inner loops on pixel coordinates
-            # Iterate over rows, taking offset and shift into account
-            for row in range(max(offset, offset - t_row),
-                             min(n_row - offset, n_row - offset - t_row)):
-                # Iterate over columns, taking offset and shift into account
-                for col in range(max(offset, offset - t_col),
-                                 min(n_col - offset, n_col - offset - t_col)):
-                    # Compute squared distance between shifted patches
-                    distance = _integral_to_distance_2d(integral, row, col,
-                                                     offset, h2s2)
-                    # exp of large negative numbers is close to zero
-                    if distance > DISTANCE_CUTOFF:
-                        continue
-                    weight = alpha * fast_exp(-distance)
-                    # Accumulate weights corresponding to different shifts
-                    weights[row, col] += weight
-                    weights[row + t_row, col + t_col] += weight
-                    # Iterate over channels
-                    for channel in range(n_channels):
-                        result[row, col, channel] += weight * \
-                                    padded[row + t_row, col + t_col, channel]
-                        result[row + t_row, col + t_col, channel] += \
-                                        weight * padded[row, col, channel]
+                # Inner loops on pixel coordinates
+                # Iterate over rows, taking offset and shift into account
+                for row in range(max(offset, offset - t_row),
+                                 min(n_row - offset, n_row - offset - t_row)):
+                    # Iterate over columns, taking offset and shift into account
+                    for col in range(max(offset, offset - t_col),
+                                     min(n_col - offset, n_col - offset - t_col)):
+                        # Compute squared distance between shifted patches
+                        distance = _integral_to_distance_2d(integral, row, col,
+                                                         offset, h2s2)
+                        # exp of large negative numbers is close to zero
+                        if distance > DISTANCE_CUTOFF:
+                            continue
+                        weight = alpha * fast_exp(-distance)
+                        # Accumulate weights corresponding to different shifts
+                        weights[row, col] += weight
+                        weights[row + t_row, col + t_col] += weight
+                        # Iterate over channels
+                        for channel in range(n_channels):
+                            result[row, col, channel] += weight * \
+                                        padded[row + t_row, col + t_col, channel]
+                            result[row + t_row, col + t_col, channel] += \
+                                            weight * padded[row, col, channel]
 
-    # Normalize pixel values using sum of weights of contributing patches
-    for row in range(offset, n_row - offset):
-        for col in range(offset, n_col - offset):
-            for channel in range(n_channels):
-                # No risk of division by zero, since the contribution
-                # of a null shift is strictly positive
-                result[row, col, channel] /= weights[row, col]
+        # Normalize pixel values using sum of weights of contributing patches
+        for row in range(offset, n_row - offset):
+            for col in range(offset, n_col - offset):
+                for channel in range(n_channels):
+                    # No risk of division by zero, since the contribution
+                    # of a null shift is strictly positive
+                    result[row, col, channel] /= weights[row, col]
 
     # Return cropped result, undoing padding
     return result[pad_size:-pad_size, pad_size:-pad_size]
@@ -702,7 +704,7 @@ def _fast_nl_means_denoising_3d(image, int s=5, int d=7, double h=0.1,
                                 pad_size, mode='reflect').astype(np.float64))
     cdef IMGDTYPE [:, :, ::1] result = np.zeros_like(padded)
     cdef IMGDTYPE [:, :, ::1] weights = np.zeros_like(padded)
-    cdef IMGDTYPE [:, :, ::1] integral = np.zeros_like(padded)
+    cdef IMGDTYPE [:, :, ::1] integral = np.empty_like(padded)
     cdef int n_pln, n_row, n_col, t_pln, t_row, t_col, \
              pln, row, col
     cdef int pln_dist_min, pln_dist_max, row_dist_min, row_dist_max, \
@@ -717,66 +719,67 @@ def _fast_nl_means_denoising_3d(image, int s=5, int d=7, double h=0.1,
     n_row += 2 * pad_size
     n_col += 2 * pad_size
 
-    # Outer loops on patch shifts
-    # With t2 >= 0, reference patch is always on the left of test patch
-    # Iterate over shifts along the plane axis
-    for t_pln in range(-d, d + 1):
-        pln_dist_min = max(offset, offset - t_pln)
-        pln_dist_max = min(n_pln - offset, n_pln - offset - t_pln)
-        # Iterate over shifts along the row axis
-        for t_row in range(-d, d + 1):
-            row_dist_min = max(offset, offset - t_row)
-            row_dist_max = min(n_row - offset, n_row - offset - t_row)
-            # Iterate over shifts along the column axis
-            for t_col in range(0, d + 1):
-                col_dist_min = max(offset, offset - t_col)
-                col_dist_max = min(n_col - offset, n_col - offset - t_col)
-                # alpha is to account for patches on the same column
-                # distance is computed twice in this case
-                if t_col == 0 and (t_pln is not 0 or t_row is not 0):
-                    alpha = 0.5
-                else:
-                    alpha = 1.0
+    with nogil:
+        # Outer loops on patch shifts
+        # With t2 >= 0, reference patch is always on the left of test patch
+        # Iterate over shifts along the plane axis
+        for t_pln in range(-d, d + 1):
+            pln_dist_min = max(offset, offset - t_pln)
+            pln_dist_max = min(n_pln - offset, n_pln - offset - t_pln)
+            # Iterate over shifts along the row axis
+            for t_row in range(-d, d + 1):
+                row_dist_min = max(offset, offset - t_row)
+                row_dist_max = min(n_row - offset, n_row - offset - t_row)
+                # Iterate over shifts along the column axis
+                for t_col in range(0, d + 1):
+                    col_dist_min = max(offset, offset - t_col)
+                    col_dist_max = min(n_col - offset, n_col - offset - t_col)
+                    # alpha is to account for patches on the same column
+                    # distance is computed twice in this case
+                    if t_col == 0 and (t_pln is not 0 or t_row is not 0):
+                        alpha = 0.5
+                    else:
+                        alpha = 1.0
 
-                # Compute integral image of the squared difference between
-                # padded and the same image shifted by (t_pln, t_row, t_col)
-                integral = np.zeros_like(padded)
-                _integral_image_3d(padded, integral, t_pln, t_row, t_col,
-                                   n_pln, n_row, n_col, var)
+                    # Compute integral image of the squared difference between
+                    # padded and the same image shifted by (t_pln, t_row, t_col)
+                    integral[:, :] = 0
+                    _integral_image_3d(padded, integral, t_pln, t_row, t_col,
+                                       n_pln, n_row, n_col, var)
 
-                # Inner loops on pixel coordinates
-                # Iterate over planes, taking offset and shift into account
-                for pln in range(pln_dist_min, pln_dist_max):
-                    # Iterate over rows, taking offset and shift into account
-                    for row in range(row_dist_min, row_dist_max):
-                        # Iterate over columns
-                        for col in range(col_dist_min, col_dist_max):
-                            # Compute squared distance between shifted patches
-                            distance = _integral_to_distance_3d(integral,
-                                        pln, row, col, offset, s_cube_h_square)
-                            # exp of large negative numbers is close to zero
-                            if distance > DISTANCE_CUTOFF:
-                                continue
+                    # Inner loops on pixel coordinates
+                    # Iterate over planes, taking offset and shift into account
+                    for pln in range(pln_dist_min, pln_dist_max):
+                        # Iterate over rows, taking offset and shift into account
+                        for row in range(row_dist_min, row_dist_max):
+                            # Iterate over columns
+                            for col in range(col_dist_min, col_dist_max):
+                                # Compute squared distance between shifted patches
+                                distance = _integral_to_distance_3d(integral,
+                                            pln, row, col, offset, s_cube_h_square)
+                                # exp of large negative numbers is close to zero
+                                if distance > DISTANCE_CUTOFF:
+                                    continue
 
-                            weight = alpha * fast_exp(-distance)
-                            # Accumulate weights for the different shifts
-                            weights[pln, row, col] += weight
-                            weights[pln + t_pln, row + t_row,
-                                                 col + t_col] += weight
-                            result[pln, row, col] += weight * \
-                                    padded[pln + t_pln, row + t_row,
-                                                        col + t_col]
-                            result[pln + t_pln, row + t_row,
-                                                col + t_col] += weight * \
-                                                  padded[pln, row, col]
+                                weight = alpha * fast_exp(-distance)
+                                # Accumulate weights for the different shifts
+                                weights[pln, row, col] += weight
+                                weights[pln + t_pln, row + t_row,
+                                                     col + t_col] += weight
+                                result[pln, row, col] += weight * \
+                                        padded[pln + t_pln, row + t_row,
+                                                            col + t_col]
+                                result[pln + t_pln, row + t_row,
+                                                    col + t_col] += weight * \
+                                                      padded[pln, row, col]
 
-    # Normalize pixel values using sum of weights of contributing patches
-    for pln in range(offset, n_pln - offset):
-        for row in range(offset, n_row - offset):
-            for col in range(offset, n_col - offset):
-                # No risk of division by zero, since the contribution
-                # of a null shift is strictly positive
-                result[pln, row, col] /= weights[pln, row, col]
+        # Normalize pixel values using sum of weights of contributing patches
+        for pln in range(offset, n_pln - offset):
+            for row in range(offset, n_row - offset):
+                for col in range(offset, n_col - offset):
+                    # No risk of division by zero, since the contribution
+                    # of a null shift is strictly positive
+                    result[pln, row, col] /= weights[pln, row, col]
 
     # Return cropped result, undoing padding
     return result[pad_size:-pad_size, pad_size:-pad_size, pad_size:-pad_size]

--- a/skimage/restoration/_unwrap_1d.pyx
+++ b/skimage/restoration/_unwrap_1d.pyx
@@ -12,11 +12,12 @@ def unwrap_1d(double[::1] image, double[::1] unwrapped_image):
         Py_ssize_t i
         double difference
         long periods = 0
-    unwrapped_image[0] = image[0]
-    for i in range(1, image.shape[0]):
-        difference = image[i] - image[i - 1]
-        if difference > M_PI:
-            periods -= 1
-        elif difference < -M_PI:
-            periods += 1
-        unwrapped_image[i] = image[i] + 2 * M_PI * periods
+    with nogil:
+        unwrapped_image[0] = image[0]
+        for i in range(1, image.shape[0]):
+            difference = image[i] - image[i - 1]
+            if difference > M_PI:
+                periods -= 1
+            elif difference < -M_PI:
+                periods += 1
+            unwrapped_image[i] = image[i] + 2 * M_PI * periods

--- a/skimage/restoration/_unwrap_2d.pyx
+++ b/skimage/restoration/_unwrap_2d.pyx
@@ -1,19 +1,35 @@
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: nonecheck=False
+# cython: wraparound=False
+
 cdef extern from *:
     void unwrap2D(double* wrapped_image,
                   double* unwrapped_image,
                   unsigned char* input_mask,
                   int image_width, int image_height,
                   int wrap_around_x, int wrap_around_y,
-                  char use_seed, unsigned int seed)
+                  char use_seed, unsigned int seed) nogil
 
 def unwrap_2d(double[:, ::1] image,
               unsigned char[:, ::1] mask,
               double[:, ::1] unwrapped_image,
               wrap_around,
               seed):
-    unwrap2D(&image[0, 0],
-             &unwrapped_image[0, 0],
-             &mask[0, 0],
-             image.shape[1], image.shape[0],
-             wrap_around[1], wrap_around[0],
-             seed is None, 0 if seed is None else seed)
+    cdef:
+        unsigned int cseed
+        char use_seed
+        int wrap_around_x
+        int wrap_around_y
+
+    # convert from python types to C types so we can release the GIL
+    use_seed = seed is None
+    cseed = 0 if seed is None else seed
+    wrap_around_y, wrap_around_x = wrap_around
+    with nogil:
+        unwrap2D(&image[0, 0],
+                 &unwrapped_image[0, 0],
+                 &mask[0, 0],
+                 image.shape[1], image.shape[0],
+                 wrap_around_x, wrap_around_y,
+                 use_seed, cseed)

--- a/skimage/restoration/_unwrap_3d.pyx
+++ b/skimage/restoration/_unwrap_3d.pyx
@@ -1,19 +1,37 @@
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: nonecheck=False
+# cython: wraparound=False
+
 cdef extern from *:
   void unwrap3D(double* wrapped_volume,
                 double* unwrapped_volume,
                 unsigned char* input_mask,
                 int image_width, int image_height, int volume_depth,
                 int wrap_around_x, int wrap_around_y, int wrap_around_z,
-                char use_seed, unsigned int seed)
+                char use_seed, unsigned int seed) nogil
 
 def unwrap_3d(double[:, :, ::1] image,
               unsigned char[:, :, ::1] mask,
               double[:, :, ::1] unwrapped_image,
               wrap_around,
               seed):
-    unwrap3D(&image[0, 0, 0],
-             &unwrapped_image[0, 0, 0],
-             &mask[0, 0, 0],
-             image.shape[2], image.shape[1], image.shape[0], #TODO: check!!!
-             wrap_around[2], wrap_around[1], wrap_around[0],
-             seed is None, 0 if seed is None else seed)
+    cdef:
+        unsigned int cseed
+        char use_seed
+        int wrap_around_x
+        int wrap_around_y
+        int wrap_around_z
+
+    # convert from python types to C types so we can release the GIL
+    use_seed = seed is None
+    cseed = 0 if seed is None else seed
+    wrap_around_z, wrap_around_y, wrap_around_x = wrap_around
+
+    with nogil:
+        unwrap3D(&image[0, 0, 0],
+                 &unwrapped_image[0, 0, 0],
+                 &mask[0, 0, 0],
+                 image.shape[2], image.shape[1], image.shape[0], #TODO: check!!!
+                 wrap_around_x, wrap_around_y, wrap_around_z,
+                 use_seed, cseed)


### PR DESCRIPTION
## Description
I thought this would be a rather fast fix, but it eventually ended up being pretty extensive.

Most fixes were super straight forward. I mostly typed `with nogil:` and press `Tab`.

Some smaller ones make sure that the GIL isn't release and reacquired.
```python
with nogil:
   pass  # Work 1
# do something with the gil
with nogil:
    pass  # Work 2
```
becomes 
```python
# do something with the gil
with nogil:
    pass  # Work 1
    pass  # Work 2
```

~~I tried to release the GIL during unwrapping, but it seems to introduce an error? Don't know why. so it was left out.~~

I didn't release the GIL in denoise since denoise is being worked on in other PRs.

Finally, a few algorithms are using python lists. This is a little annoying since we can't release the GIL. The best workaround for this seems to be using tge cpp stl library, but this seems like it would be more of a rewrite than a “small patch”

## For reviewers
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
