### PR TITLE
Rename 'mnxc' (masked normalize cross-correlation) to something more descriptive

### DIFF
--- a/skimage/feature/masked_register_translation.py
+++ b/skimage/feature/masked_register_translation.py
@@ -81,8 +81,9 @@ def masked_register_translation(
     # cross-correlation
     size_mismatch = np.array(target_image.shape) - np.array(src_image.shape)
 
-    xcorr = cross_correlate_masked(target_image, src_image, target_mask, src_mask,
-                 axes=(0, 1), mode='full', overlap_ratio=overlap_ratio)
+    xcorr = cross_correlate_masked(target_image, src_image, 
+                 target_mask, src_mask, axes=(0, 1), mode='full', 
+                 overlap_ratio=overlap_ratio)
 
     # Generalize to the average of multiple equal maxima
     maxima = np.transpose(np.nonzero(xcorr == xcorr.max()))
@@ -91,7 +92,8 @@ def masked_register_translation(
     return -shifts + (size_mismatch / 2)
 
 
-def cross_correlate_masked(arr1, arr2, m1, m2, mode='full', axes=(-2, -1), overlap_ratio=3 / 10):
+def cross_correlate_masked(arr1, arr2, m1, m2, mode='full', axes=(-2, -1), 
+                           overlap_ratio=3 / 10):
     """
     Masked normalized cross-correlation between arrays.
 

--- a/skimage/feature/masked_register_translation.py
+++ b/skimage/feature/masked_register_translation.py
@@ -1,5 +1,5 @@
 """
-Implementation of the masked normalized cross-correlation (MNXC)
+Implementation of the masked normalized cross-correlation.
 
 Based on the following publication:
 D. Padfield. Masked object registration in the Fourier domain.
@@ -81,7 +81,7 @@ def masked_register_translation(
     # cross-correlation
     size_mismatch = np.array(target_image.shape) - np.array(src_image.shape)
 
-    xcorr = mnxc(target_image, src_image, target_mask, src_mask,
+    xcorr = cross_correlate_masked(target_image, src_image, target_mask, src_mask,
                  axes=(0, 1), mode='full', overlap_ratio=overlap_ratio)
 
     # Generalize to the average of multiple equal maxima
@@ -91,9 +91,9 @@ def masked_register_translation(
     return -shifts + (size_mismatch / 2)
 
 
-def mnxc(arr1, arr2, m1, m2, mode='full', axes=(-2, -1), overlap_ratio=3 / 10):
+def cross_correlate_masked(arr1, arr2, m1, m2, mode='full', axes=(-2, -1), overlap_ratio=3 / 10):
     """
-    Masked normalized cross-correlation (MNXC) between arrays.
+    Masked normalized cross-correlation between arrays.
 
     Parameters
     ----------

--- a/skimage/feature/tests/test_masked_register_translation.py
+++ b/skimage/feature/tests/test_masked_register_translation.py
@@ -89,10 +89,12 @@ def test_cross_correlate_masked_output_shape():
     m1 = np.ones_like(arr1)
     m2 = np.ones_like(arr2)
 
-    full_xcorr = cross_correlate_masked(arr1, arr2, m1, m2, axes=(0, 1, 2), mode='full')
+    full_xcorr = cross_correlate_masked(
+        arr1, arr2, m1, m2, axes=(0, 1, 2), mode='full')
     assert_equal(full_xcorr.shape, expected_full_shape)
 
-    same_xcorr = cross_correlate_masked(arr1, arr2, m1, m2, axes=(0, 1, 2), mode='same')
+    same_xcorr = cross_correlate_masked(
+        arr1, arr2, m1, m2, axes=(0, 1, 2), mode='same')
     assert_equal(same_xcorr.shape, expected_same_shape)
 
 
@@ -175,12 +177,14 @@ def test_cross_correlate_masked_over_axes():
     with_loop = np.empty_like(arr1, dtype=np.complex)
     for index in range(arr1.shape[-1]):
         with_loop[:, :, index] = cross_correlate_masked(arr1[:, :, index],
-                                      arr2[:, :, index],
-                                      m1[:, :, index],
-                                      m2[:, :, index],
-                                      axes=(0, 1), mode='same')
+                                                        arr2[:, :, index],
+                                                        m1[:, :, index],
+                                                        m2[:, :, index],
+                                                        axes=(0, 1), 
+                                                        mode='same')
 
-    over_axes = cross_correlate_masked(arr1, arr2, m1, m2, axes=(0, 1), mode='same')
+    over_axes = cross_correlate_masked(
+        arr1, arr2, m1, m2, axes=(0, 1), mode='same')
 
     testing.assert_array_almost_equal(with_loop, over_axes)
 


### PR DESCRIPTION

The function `mnxc` (Masked normalized cross-correlation) has an undescriptive name. See discussion in #3334 .

For now, the suggestion is 'cross_correlate_masked'.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests


## References
Based on feedback from @stefanv in #3334 ; at the time, the pull request had already been merged.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
