### PR TITLE
Improvement: rank_filters: Change how the bitdepth and max_bin are computed to ensure exact warnings.

### DIFF
--- a/skimage/filters/rank/_percentile.py
+++ b/skimage/filters/rank/_percentile.py
@@ -38,11 +38,11 @@ def _apply(func, image, selem, out, mask, shift_x, shift_y, p0, p1,
            out_dtype=None):
 
     assert_nD(image, 2)
-    image, selem, out, mask, max_bin = _handle_input(image, selem, out, mask,
-                                                     out_dtype)
+    image, selem, out, mask, n_bins = _handle_input(image, selem, out, mask,
+                                                    out_dtype)
 
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
-         out=out, max_bin=max_bin, p0=p0, p1=p1)
+         out=out, n_bins=n_bins, p0=p0, p1=p1)
 
     return out.reshape(out.shape[:2])
 

--- a/skimage/filters/rank/bilateral.py
+++ b/skimage/filters/rank/bilateral.py
@@ -37,11 +37,11 @@ def _apply(func, image, selem, out, mask, shift_x, shift_y, s0, s1,
            out_dtype=None):
 
     assert_nD(image, 2)
-    image, selem, out, mask, max_bin = _handle_input(image, selem, out, mask,
-                                                     out_dtype)
+    image, selem, out, mask, n_bins = _handle_input(image, selem, out, mask,
+                                                    out_dtype)
 
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
-         out=out, max_bin=max_bin, s0=s0, s1=s1)
+         out=out, n_bins=n_bins, s0=s0, s1=s1)
 
     return out.reshape(out.shape[:2])
 

--- a/skimage/filters/rank/bilateral_cy.pyx
+++ b/skimage/filters/rank/bilateral_cy.pyx
@@ -12,7 +12,7 @@ from .core_cy cimport dtype_t, dtype_t_out, _core
 cdef inline void _kernel_mean(dtype_t_out* out, Py_ssize_t odepth,
                               Py_ssize_t* histo,
                               double pop, dtype_t g,
-                              Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                              Py_ssize_t n_bins, Py_ssize_t mid_bin,
                               double p0, double p1,
                               Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -21,7 +21,7 @@ cdef inline void _kernel_mean(dtype_t_out* out, Py_ssize_t odepth,
     cdef Py_ssize_t mean = 0
 
     if pop:
-        for i in range(max_bin):
+        for i in range(n_bins):
             if (g > (i - s0)) and (g < (i + s1)):
                 bilat_pop += histo[i]
                 mean += histo[i] * i
@@ -36,7 +36,7 @@ cdef inline void _kernel_mean(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_pop(dtype_t_out* out, Py_ssize_t odepth,
                              Py_ssize_t* histo,
                              double pop, dtype_t g,
-                             Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                             Py_ssize_t n_bins, Py_ssize_t mid_bin,
                              double p0, double p1,
                              Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -44,7 +44,7 @@ cdef inline void _kernel_pop(dtype_t_out* out, Py_ssize_t odepth,
     cdef Py_ssize_t bilat_pop = 0
 
     if pop:
-        for i in range(max_bin):
+        for i in range(n_bins):
             if (g > (i - s0)) and (g < (i + s1)):
                 bilat_pop += histo[i]
         out[0] = <dtype_t_out>bilat_pop
@@ -55,7 +55,7 @@ cdef inline void _kernel_pop(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_sum(dtype_t_out* out, Py_ssize_t odepth,
                              Py_ssize_t* histo,
                              double pop, dtype_t g,
-                             Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                             Py_ssize_t n_bins, Py_ssize_t mid_bin,
                              double p0, double p1,
                              Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -64,7 +64,7 @@ cdef inline void _kernel_sum(dtype_t_out* out, Py_ssize_t odepth,
     cdef Py_ssize_t sum = 0
 
     if pop:
-        for i in range(max_bin):
+        for i in range(n_bins):
             if (g > (i - s0)) and (g < (i + s1)):
                 bilat_pop += histo[i]
                 sum += histo[i] * i
@@ -81,10 +81,10 @@ def _mean(dtype_t[:, ::1] image,
           char[:, ::1] mask,
           dtype_t_out[:, :, ::1] out,
           signed char shift_x, signed char shift_y, Py_ssize_t s0, Py_ssize_t s1,
-          Py_ssize_t max_bin):
+          Py_ssize_t n_bins):
 
     _core(_kernel_mean[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, s0, s1, max_bin)
+          shift_x, shift_y, 0, 0, s0, s1, n_bins)
 
 
 def _pop(dtype_t[:, ::1] image,
@@ -92,10 +92,10 @@ def _pop(dtype_t[:, ::1] image,
          char[:, ::1] mask,
          dtype_t_out[:, :, ::1] out,
          signed char shift_x, signed char shift_y, Py_ssize_t s0, Py_ssize_t s1,
-         Py_ssize_t max_bin):
+         Py_ssize_t n_bins):
 
     _core(_kernel_pop[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, s0, s1, max_bin)
+          shift_x, shift_y, 0, 0, s0, s1, n_bins)
 
 
 def _sum(dtype_t[:, ::1] image,
@@ -103,7 +103,7 @@ def _sum(dtype_t[:, ::1] image,
          char[:, ::1] mask,
          dtype_t_out[:, :, ::1] out,
          signed char shift_x, signed char shift_y, Py_ssize_t s0, Py_ssize_t s1,
-         Py_ssize_t max_bin):
+         Py_ssize_t n_bins):
 
     _core(_kernel_sum[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, s0, s1, max_bin)
+          shift_x, shift_y, 0, 0, s0, s1, n_bins)

--- a/skimage/filters/rank/core_cy.pxd
+++ b/skimage/filters/rank/core_cy.pxd
@@ -25,4 +25,4 @@ cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t*, double,
                 signed char shift_x, signed char shift_y,
                 double p0, double p1,
                 Py_ssize_t s0, Py_ssize_t s1,
-                Py_ssize_t max_bin) except *
+                Py_ssize_t n_bins) except *

--- a/skimage/filters/rank/core_cy.pyx
+++ b/skimage/filters/rank/core_cy.pyx
@@ -52,7 +52,7 @@ cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t*, double,
                 signed char shift_x, signed char shift_y,
                 double p0, double p1,
                 Py_ssize_t s0, Py_ssize_t s1,
-                Py_ssize_t max_bin) except *:
+                Py_ssize_t n_bins) except *:
     """Compute histogram for each pixel neighborhood, apply kernel function and
     use kernel function return value for output image.
     """
@@ -73,7 +73,7 @@ cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t*, double,
     assert centre_c < scols
 
 
-    cdef Py_ssize_t mid_bin = max_bin / 2
+    cdef Py_ssize_t mid_bin = n_bins / 2
 
     # define pointers to the data
     cdef char* mask_data = &mask[0, 0]
@@ -85,8 +85,8 @@ cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t*, double,
     cdef double pop = 0
 
     # the current local histogram distribution
-    cdef Py_ssize_t* histo = <Py_ssize_t*>malloc(max_bin * sizeof(Py_ssize_t))
-    for i in range(max_bin):
+    cdef Py_ssize_t* histo = <Py_ssize_t*>malloc(n_bins * sizeof(Py_ssize_t))
+    for i in range(n_bins):
         histo[i] = 0
 
     # these lists contain the relative pixel row and column for each of the 4
@@ -152,7 +152,7 @@ cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t*, double,
 
         r = 0
         c = 0
-        kernel(&out[r, c, 0], odepth, histo, pop, image[r, c], max_bin, mid_bin,
+        kernel(&out[r, c, 0], odepth, histo, pop, image[r, c], n_bins, mid_bin,
                p0, p1, s0, s1)
 
         # main loop
@@ -173,7 +173,7 @@ cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t*, double,
                     if is_in_mask(rows, cols, rr, cc, mask_data):
                         histogram_decrement(histo, &pop, image[rr, cc])
 
-                kernel(&out[r, c, 0], odepth, histo, pop, image[r, c], max_bin,
+                kernel(&out[r, c, 0], odepth, histo, pop, image[r, c], n_bins,
                        mid_bin, p0, p1, s0, s1)
 
             r += 1  # pass to the next row
@@ -193,7 +193,7 @@ cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t*, double,
                 if is_in_mask(rows, cols, rr, cc, mask_data):
                     histogram_decrement(histo, &pop, image[rr, cc])
 
-            kernel(&out[r, c, 0], odepth, histo, pop, image[r, c], max_bin,
+            kernel(&out[r, c, 0], odepth, histo, pop, image[r, c], n_bins,
                    mid_bin, p0, p1, s0, s1)
 
             # ---> east to west
@@ -210,7 +210,7 @@ cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t*, double,
                     if is_in_mask(rows, cols, rr, cc, mask_data):
                         histogram_decrement(histo, &pop, image[rr, cc])
 
-                kernel(&out[r, c, 0], odepth, histo, pop, image[r, c], max_bin,
+                kernel(&out[r, c, 0], odepth, histo, pop, image[r, c], n_bins,
                        mid_bin, p0, p1, s0, s1)
 
             r += 1  # pass to the next row
@@ -231,7 +231,7 @@ cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t*, double,
                     histogram_decrement(histo, &pop, image[rr, cc])
 
             kernel(&out[r, c, 0], odepth, histo, pop, image[r, c],
-                   max_bin, mid_bin, p0, p1, s0, s1)
+                   n_bins, mid_bin, p0, p1, s0, s1)
 
         # release memory allocated by malloc
         free(se_e_r)

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -92,28 +92,28 @@ def _handle_input(image, selem, out, mask, out_dtype=None, pixel_size=1):
     is_8bit = image.dtype in (np.uint8, np.int8)
 
     if is_8bit:
-        max_bin = 256
+        n_bins = 256
     else:
         # Convert to a Python int to avoid the potential overflow when we add
         # 1 to the maximum of the image.
-        max_bin = int(max(3, image.max())) + 1
+        n_bins = int(max(3, image.max())) + 1
 
-    if max_bin > 2**10:
+    if n_bins > 2**10:
         warn("Bad rank filter performance is expected due to a "
              "large number of bins ({}), equivalent to an approximate "
-             "bitdepth of {:.1f}.".format(max_bin, np.log2(max_bin)))
+             "bitdepth of {:.1f}.".format(n_bins, np.log2(n_bins)))
 
-    return image, selem, out, mask, max_bin
+    return image, selem, out, mask, n_bins
 
 
 def _apply_scalar_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
                             out_dtype=None):
 
-    image, selem, out, mask, max_bin = _handle_input(image, selem, out, mask,
-                                                     out_dtype)
+    image, selem, out, mask, n_bins = _handle_input(image, selem, out, mask,
+                                                    out_dtype)
 
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
-         out=out, max_bin=max_bin)
+         out=out, n_bins=n_bins)
 
     return out.reshape(out.shape[:2])
 
@@ -121,12 +121,12 @@ def _apply_scalar_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
 def _apply_vector_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
                             out_dtype=None, pixel_size=1):
 
-    image, selem, out, mask, max_bin = _handle_input(image, selem, out, mask,
-                                                     out_dtype,
-                                                     pixel_size=pixel_size)
+    image, selem, out, mask, n_bins = _handle_input(image, selem, out, mask,
+                                                    out_dtype,
+                                                    pixel_size=pixel_size)
 
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
-         out=out, max_bin=max_bin)
+         out=out, n_bins=n_bins)
 
     return out
 

--- a/skimage/filters/rank/generic_cy.pyx
+++ b/skimage/filters/rank/generic_cy.pyx
@@ -8,29 +8,29 @@ from libc.math cimport log, exp
 
 from .core_cy cimport dtype_t, dtype_t_out, _core
 
-from ..._shared.interpolation cimport round 
+from ..._shared.interpolation cimport round
 
 cdef inline void _kernel_autolevel(dtype_t_out* out, Py_ssize_t odepth,
                                    Py_ssize_t* histo,
                                    double pop, dtype_t g,
-                                   Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                                   Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                    double p0, double p1,
                                    Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i, imin, imax, delta
 
     if pop:
-        for i in range(max_bin - 1, -1, -1):
+        for i in range(n_bins - 1, -1, -1):
             if histo[i]:
                 imax = i
                 break
-        for i in range(max_bin):
+        for i in range(n_bins):
             if histo[i]:
                 imin = i
                 break
         delta = imax - imin
         if delta > 0:
-            out[0] = <dtype_t_out>((max_bin - 1) * (g - imin) / delta)
+            out[0] = <dtype_t_out>((n_bins - 1) * (g - imin) / delta)
         else:
             out[0] = <dtype_t_out>0
     else:
@@ -40,14 +40,14 @@ cdef inline void _kernel_autolevel(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_bottomhat(dtype_t_out* out, Py_ssize_t odepth,
                                    Py_ssize_t* histo,
                                    double pop, dtype_t g,
-                                   Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                                   Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                    double p0, double p1,
                                    Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i
 
     if pop:
-        for i in range(max_bin):
+        for i in range(n_bins):
             if histo[i]:
                 break
         out[0] = <dtype_t_out>(g - i)
@@ -58,7 +58,7 @@ cdef inline void _kernel_bottomhat(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_equalize(dtype_t_out* out, Py_ssize_t odepth,
                                   Py_ssize_t* histo,
                                   double pop, dtype_t g,
-                                  Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                                  Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                   double p0, double p1,
                                   Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -66,11 +66,11 @@ cdef inline void _kernel_equalize(dtype_t_out* out, Py_ssize_t odepth,
     cdef Py_ssize_t sum = 0
 
     if pop:
-        for i in range(max_bin):
+        for i in range(n_bins):
             sum += histo[i]
             if i >= g:
                 break
-        out[0] = <dtype_t_out>(((max_bin - 1) * sum) / pop)
+        out[0] = <dtype_t_out>(((n_bins - 1) * sum) / pop)
     else:
         out[0] = <dtype_t_out>0
 
@@ -78,18 +78,18 @@ cdef inline void _kernel_equalize(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_gradient(dtype_t_out* out, Py_ssize_t odepth,
                                   Py_ssize_t* histo,
                                   double pop, dtype_t g,
-                                  Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                                  Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                   double p0, double p1,
                                   Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i, imin, imax
 
     if pop:
-        for i in range(max_bin - 1, -1, -1):
+        for i in range(n_bins - 1, -1, -1):
             if histo[i]:
                 imax = i
                 break
-        for i in range(max_bin):
+        for i in range(n_bins):
             if histo[i]:
                 imin = i
                 break
@@ -101,14 +101,14 @@ cdef inline void _kernel_gradient(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_maximum(dtype_t_out* out, Py_ssize_t odepth,
                                  Py_ssize_t* histo,
                                  double pop, dtype_t g,
-                                 Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                                 Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                  double p0, double p1,
                                  Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i
 
     if pop:
-        for i in range(max_bin - 1, -1, -1):
+        for i in range(n_bins - 1, -1, -1):
             if histo[i]:
                 out[0] = <dtype_t_out>i
                 return
@@ -119,7 +119,7 @@ cdef inline void _kernel_maximum(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_mean(dtype_t_out* out, Py_ssize_t odepth,
                               Py_ssize_t* histo,
                               double pop, dtype_t g,
-                              Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                              Py_ssize_t n_bins, Py_ssize_t mid_bin,
                               double p0, double p1,
                               Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -127,7 +127,7 @@ cdef inline void _kernel_mean(dtype_t_out* out, Py_ssize_t odepth,
     cdef Py_ssize_t mean = 0
 
     if pop:
-        for i in range(max_bin):
+        for i in range(n_bins):
             mean += histo[i] * i
         out[0] = <dtype_t_out>(mean / pop)
     else:
@@ -137,7 +137,7 @@ cdef inline void _kernel_mean(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_geometric_mean(dtype_t_out* out, Py_ssize_t odepth,
                                         Py_ssize_t* histo,
                                         double pop, dtype_t g,
-                                        Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                                        Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                         double p0, double p1,
                                         Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -145,7 +145,7 @@ cdef inline void _kernel_geometric_mean(dtype_t_out* out, Py_ssize_t odepth,
     cdef double mean = 0.
 
     if pop:
-        for i in range(max_bin):
+        for i in range(n_bins):
             if histo[i]:
                 mean += (histo[i] * log(i+1))
         out[0] = <dtype_t_out>round(exp(mean / pop)-1)
@@ -156,7 +156,7 @@ cdef inline void _kernel_geometric_mean(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_subtract_mean(dtype_t_out* out, Py_ssize_t odepth,
                                        Py_ssize_t* histo,
                                        double pop, dtype_t g,
-                                       Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                                       Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                        double p0, double p1,
                                        Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -164,7 +164,7 @@ cdef inline void _kernel_subtract_mean(dtype_t_out* out, Py_ssize_t odepth,
     cdef Py_ssize_t mean = 0
 
     if pop:
-        for i in range(max_bin):
+        for i in range(n_bins):
             mean += histo[i] * i
         out[0] = <dtype_t_out>((g - mean / pop) / 2. + 127)
     else:
@@ -174,7 +174,7 @@ cdef inline void _kernel_subtract_mean(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_median(dtype_t_out* out, Py_ssize_t odepth,
                                 Py_ssize_t* histo,
                                 double pop, dtype_t g,
-                                Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                                Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                 double p0, double p1,
                                 Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -182,7 +182,7 @@ cdef inline void _kernel_median(dtype_t_out* out, Py_ssize_t odepth,
     cdef double sum = pop / 2.0
 
     if pop:
-        for i in range(max_bin):
+        for i in range(n_bins):
             if histo[i]:
                 sum -= histo[i]
                 if sum < 0:
@@ -195,14 +195,14 @@ cdef inline void _kernel_median(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_minimum(dtype_t_out* out, Py_ssize_t odepth,
                                  Py_ssize_t* histo,
                                  double pop, dtype_t g,
-                                 Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                                 Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                  double p0, double p1,
                                  Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i
 
     if pop:
-        for i in range(max_bin):
+        for i in range(n_bins):
             if histo[i]:
                 out[0] = <dtype_t_out>i
                 return
@@ -213,14 +213,14 @@ cdef inline void _kernel_minimum(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_modal(dtype_t_out* out, Py_ssize_t odepth,
                                Py_ssize_t* histo,
                                double pop, dtype_t g,
-                               Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                               Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                double p0, double p1,
                                Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t hmax = 0, imax = 0
 
     if pop:
-        for i in range(max_bin):
+        for i in range(n_bins):
             if histo[i] > hmax:
                 hmax = histo[i]
                 imax = i
@@ -234,7 +234,7 @@ cdef inline void _kernel_enhance_contrast(dtype_t_out* out,
                                           Py_ssize_t* histo,
                                           double pop,
                                           dtype_t g,
-                                          Py_ssize_t max_bin,
+                                          Py_ssize_t n_bins,
                                           Py_ssize_t mid_bin, double p0,
                                           double p1, Py_ssize_t s0,
                                           Py_ssize_t s1) nogil:
@@ -242,11 +242,11 @@ cdef inline void _kernel_enhance_contrast(dtype_t_out* out,
     cdef Py_ssize_t i, imin, imax
 
     if pop:
-        for i in range(max_bin - 1, -1, -1):
+        for i in range(n_bins - 1, -1, -1):
             if histo[i]:
                 imax = i
                 break
-        for i in range(max_bin):
+        for i in range(n_bins):
             if histo[i]:
                 imin = i
                 break
@@ -261,7 +261,7 @@ cdef inline void _kernel_enhance_contrast(dtype_t_out* out,
 cdef inline void _kernel_pop(dtype_t_out* out, Py_ssize_t odepth,
                              Py_ssize_t* histo,
                              double pop, dtype_t g,
-                             Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                             Py_ssize_t n_bins, Py_ssize_t mid_bin,
                              double p0, double p1,
                              Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -271,7 +271,7 @@ cdef inline void _kernel_pop(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_sum(dtype_t_out* out, Py_ssize_t odepth,
                              Py_ssize_t* histo,
                              double pop, dtype_t g,
-                             Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                             Py_ssize_t n_bins, Py_ssize_t mid_bin,
                              double p0, double p1,
                              Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -279,7 +279,7 @@ cdef inline void _kernel_sum(dtype_t_out* out, Py_ssize_t odepth,
     cdef Py_ssize_t sum = 0
 
     if pop:
-        for i in range(max_bin):
+        for i in range(n_bins):
             sum += histo[i] * i
         out[0] = <dtype_t_out>sum
     else:
@@ -289,7 +289,7 @@ cdef inline void _kernel_sum(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_threshold(dtype_t_out* out, Py_ssize_t odepth,
                                    Py_ssize_t* histo,
                                    double pop, dtype_t g,
-                                   Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                                   Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                    double p0, double p1,
                                    Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -297,7 +297,7 @@ cdef inline void _kernel_threshold(dtype_t_out* out, Py_ssize_t odepth,
     cdef Py_ssize_t mean = 0
 
     if pop:
-        for i in range(max_bin):
+        for i in range(n_bins):
             mean += histo[i] * i
         out[0] = <dtype_t_out>(g > (mean / pop))
     else:
@@ -307,14 +307,14 @@ cdef inline void _kernel_threshold(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_tophat(dtype_t_out* out, Py_ssize_t odepth,
                                 Py_ssize_t* histo,
                                 double pop, dtype_t g,
-                                Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                                Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                 double p0, double p1,
                                 Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i
 
     if pop:
-        for i in range(max_bin - 1, -1, -1):
+        for i in range(n_bins - 1, -1, -1):
             if histo[i]:
                 break
         out[0] = <dtype_t_out>(i - g)
@@ -325,7 +325,7 @@ cdef inline void _kernel_tophat(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_noise_filter(dtype_t_out* out, Py_ssize_t odepth,
                                       Py_ssize_t* histo,
                                       double pop, dtype_t g,
-                                      Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                                      Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                       double p0, double p1,
                                       Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -340,7 +340,7 @@ cdef inline void _kernel_noise_filter(dtype_t_out* out, Py_ssize_t odepth,
         if histo[i]:
             break
     min_i = g - i
-    for i in range(g, max_bin):
+    for i in range(g, n_bins):
         if histo[i]:
             break
     if i - g < min_i:
@@ -352,7 +352,7 @@ cdef inline void _kernel_noise_filter(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_entropy(dtype_t_out* out, Py_ssize_t odepth,
                                  Py_ssize_t* histo,
                                  double pop, dtype_t g,
-                                 Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                                 Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                  double p0, double p1,
                                  Py_ssize_t s0, Py_ssize_t s1) nogil:
     cdef Py_ssize_t i
@@ -360,7 +360,7 @@ cdef inline void _kernel_entropy(dtype_t_out* out, Py_ssize_t odepth,
 
     if pop:
         e = 0.
-        for i in range(max_bin):
+        for i in range(n_bins):
             p = histo[i] / pop
             if p > 0:
                 e -= p * log(p) / 0.6931471805599453
@@ -372,7 +372,7 @@ cdef inline void _kernel_entropy(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_otsu(dtype_t_out* out, Py_ssize_t odepth,
                               Py_ssize_t* histo,
                               double pop, dtype_t g,
-                              Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                              Py_ssize_t n_bins, Py_ssize_t mid_bin,
                               double p0, double p1,
                               Py_ssize_t s0, Py_ssize_t s1) nogil:
     cdef Py_ssize_t i
@@ -382,7 +382,7 @@ cdef inline void _kernel_otsu(dtype_t_out* out, Py_ssize_t odepth,
 
     # compute local mean
     if pop:
-        for i in range(max_bin):
+        for i in range(n_bins):
             mu += histo[i] * i
         mu = mu / pop
     else:
@@ -394,7 +394,7 @@ cdef inline void _kernel_otsu(dtype_t_out* out, Py_ssize_t odepth,
     mu1 = 0.
     max_sigma_b = 0.
 
-    for i in range(1, max_bin):
+    for i in range(1, n_bins):
         P = histo[i] / pop
         new_q1 = q1 + P
         if new_q1 > 0:
@@ -413,7 +413,7 @@ cdef inline void _kernel_otsu(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_win_hist(dtype_t_out* out, Py_ssize_t odepth,
                                   Py_ssize_t* histo,
                                   double pop, dtype_t g,
-                                  Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                                  Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                   double p0, double p1,
                                   Py_ssize_t s0, Py_ssize_t s1) nogil:
     cdef Py_ssize_t i
@@ -432,197 +432,197 @@ def _autolevel(dtype_t[:, ::1] image,
                char[:, ::1] selem,
                char[:, ::1] mask,
                dtype_t_out[:, :, ::1] out,
-               signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+               signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_autolevel[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _bottomhat(dtype_t[:, ::1] image,
                char[:, ::1] selem,
                char[:, ::1] mask,
                dtype_t_out[:, :, ::1] out,
-               signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+               signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_bottomhat[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _equalize(dtype_t[:, ::1] image,
               char[:, ::1] selem,
               char[:, ::1] mask,
               dtype_t_out[:, :, ::1] out,
-              signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+              signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_equalize[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _gradient(dtype_t[:, ::1] image,
               char[:, ::1] selem,
               char[:, ::1] mask,
               dtype_t_out[:, :, ::1] out,
-              signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+              signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_gradient[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _maximum(dtype_t[:, ::1] image,
              char[:, ::1] selem,
              char[:, ::1] mask,
              dtype_t_out[:, :, ::1] out,
-             signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+             signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_maximum[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _mean(dtype_t[:, ::1] image,
           char[:, ::1] selem,
           char[:, ::1] mask,
           dtype_t_out[:, :, ::1] out,
-          signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+          signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_mean[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _geometric_mean(dtype_t[:, ::1] image,
                     char[:, ::1] selem,
                     char[:, ::1] mask,
                     dtype_t_out[:, :, ::1] out,
-                    signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+                    signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_geometric_mean[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _subtract_mean(dtype_t[:, ::1] image,
                    char[:, ::1] selem,
                    char[:, ::1] mask,
                    dtype_t_out[:, :, ::1] out,
-                   signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+                   signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_subtract_mean[dtype_t_out, dtype_t], image, selem, mask,
-          out, shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          out, shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _median(dtype_t[:, ::1] image,
             char[:, ::1] selem,
             char[:, ::1] mask,
             dtype_t_out[:, :, ::1] out,
-            signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+            signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_median[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _minimum(dtype_t[:, ::1] image,
              char[:, ::1] selem,
              char[:, ::1] mask,
              dtype_t_out[:, :, ::1] out,
-             signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+             signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_minimum[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _enhance_contrast(dtype_t[:, ::1] image,
                       char[:, ::1] selem,
                       char[:, ::1] mask,
                       dtype_t_out[:, :, ::1] out,
-                      signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+                      signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_enhance_contrast[dtype_t_out, dtype_t], image, selem, mask,
-          out, shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          out, shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _modal(dtype_t[:, ::1] image,
            char[:, ::1] selem,
            char[:, ::1] mask,
            dtype_t_out[:, :, ::1] out,
-           signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+           signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_modal[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _pop(dtype_t[:, ::1] image,
          char[:, ::1] selem,
          char[:, ::1] mask,
          dtype_t_out[:, :, ::1] out,
-         signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+         signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_pop[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _sum(dtype_t[:, ::1] image,
          char[:, ::1] selem,
          char[:, ::1] mask,
          dtype_t_out[:, :, ::1] out,
-         signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+         signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_sum[dtype_t_out, dtype_t], image, selem, mask,
-          out, shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          out, shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _threshold(dtype_t[:, ::1] image,
                char[:, ::1] selem,
                char[:, ::1] mask,
                dtype_t_out[:, :, ::1] out,
-               signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+               signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_threshold[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _tophat(dtype_t[:, ::1] image,
             char[:, ::1] selem,
             char[:, ::1] mask,
             dtype_t_out[:, :, ::1] out,
-            signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+            signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_tophat[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _noise_filter(dtype_t[:, ::1] image,
                   char[:, ::1] selem,
                   char[:, ::1] mask,
                   dtype_t_out[:, :, ::1] out,
-                  signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+                  signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_noise_filter[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _entropy(dtype_t[:, ::1] image,
              char[:, ::1] selem,
              char[:, ::1] mask,
              dtype_t_out[:, :, ::1] out,
-             signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+             signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_entropy[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _otsu(dtype_t[:, ::1] image,
           char[:, ::1] selem,
           char[:, ::1] mask,
           dtype_t_out[:, :, ::1] out,
-          signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+          signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_otsu[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          shift_x, shift_y, 0, 0, 0, 0, n_bins)
 
 
 def _windowed_hist(dtype_t[:, ::1] image,
                    char[:, ::1] selem,
                    char[:, ::1] mask,
                    dtype_t_out[:, :, ::1] out,
-                   signed char shift_x, signed char shift_y, Py_ssize_t max_bin):
+                   signed char shift_x, signed char shift_y, Py_ssize_t n_bins):
 
     _core(_kernel_win_hist[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, 0, 0, 0, 0, max_bin)
+          shift_x, shift_y, 0, 0, 0, 0, n_bins)

--- a/skimage/filters/rank/percentile_cy.pyx
+++ b/skimage/filters/rank/percentile_cy.pyx
@@ -10,7 +10,7 @@ from .core_cy cimport dtype_t, dtype_t_out, _core, _min, _max
 cdef inline void _kernel_autolevel(dtype_t_out* out, Py_ssize_t odepth,
                                    Py_ssize_t* histo,
                                    double pop, dtype_t g,
-                                   Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                                   Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                    double p0, double p1,
                                    Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -19,13 +19,13 @@ cdef inline void _kernel_autolevel(dtype_t_out* out, Py_ssize_t odepth,
     if pop:
         sum = 0
         p1 = 1.0 - p1
-        for i in range(max_bin):
+        for i in range(n_bins):
             sum += histo[i]
             if sum > p0 * pop:
                 imin = i
                 break
         sum = 0
-        for i in range(max_bin - 1, -1, -1):
+        for i in range(n_bins - 1, -1, -1):
             sum += histo[i]
             if sum > p1 * pop:
                 imax = i
@@ -33,7 +33,7 @@ cdef inline void _kernel_autolevel(dtype_t_out* out, Py_ssize_t odepth,
 
         delta = imax - imin
         if delta > 0:
-            out[0] = <dtype_t_out>((max_bin - 1) * (_min(_max(imin, g), imax)
+            out[0] = <dtype_t_out>((n_bins - 1) * (_min(_max(imin, g), imax)
                                            - imin) / delta)
         else:
             out[0] = <dtype_t_out>(imax - imin)
@@ -44,7 +44,7 @@ cdef inline void _kernel_autolevel(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_gradient(dtype_t_out* out, Py_ssize_t odepth,
                                   Py_ssize_t* histo,
                                   double pop, dtype_t g,
-                                  Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                                  Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                   double p0, double p1,
                                   Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -53,13 +53,13 @@ cdef inline void _kernel_gradient(dtype_t_out* out, Py_ssize_t odepth,
     if pop:
         sum = 0
         p1 = 1.0 - p1
-        for i in range(max_bin):
+        for i in range(n_bins):
             sum += histo[i]
             if sum >= p0 * pop:
                 imin = i
                 break
         sum = 0
-        for i in range(max_bin - 1, -1, -1):
+        for i in range(n_bins - 1, -1, -1):
             sum += histo[i]
             if sum >= p1 * pop:
                 imax = i
@@ -73,7 +73,7 @@ cdef inline void _kernel_gradient(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_mean(dtype_t_out* out, Py_ssize_t odepth,
                               Py_ssize_t* histo,
                               double pop, dtype_t g,
-                              Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                              Py_ssize_t n_bins, Py_ssize_t mid_bin,
                               double p0, double p1,
                               Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -83,7 +83,7 @@ cdef inline void _kernel_mean(dtype_t_out* out, Py_ssize_t odepth,
         sum = 0
         mean = 0
         n = 0
-        for i in range(max_bin):
+        for i in range(n_bins):
             sum += histo[i]
             if (sum >= p0 * pop) and (sum <= p1 * pop):
                 n += histo[i]
@@ -99,7 +99,7 @@ cdef inline void _kernel_mean(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_sum(dtype_t_out* out, Py_ssize_t odepth,
                              Py_ssize_t* histo,
                              double pop, dtype_t g,
-                             Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                             Py_ssize_t n_bins, Py_ssize_t mid_bin,
                              double p0, double p1,
                              Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -109,7 +109,7 @@ cdef inline void _kernel_sum(dtype_t_out* out, Py_ssize_t odepth,
         sum = 0
         sum_g = 0
         n = 0
-        for i in range(max_bin):
+        for i in range(n_bins):
             sum += histo[i]
             if (sum >= p0 * pop) and (sum <= p1 * pop):
                 n += histo[i]
@@ -125,7 +125,7 @@ cdef inline void _kernel_sum(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_subtract_mean(dtype_t_out* out, Py_ssize_t odepth,
                                        Py_ssize_t* histo,
                                        double pop, dtype_t g,
-                                       Py_ssize_t max_bin,
+                                       Py_ssize_t n_bins,
                                        Py_ssize_t mid_bin, double p0,
                                        double p1, Py_ssize_t s0,
                                        Py_ssize_t s1) nogil:
@@ -136,7 +136,7 @@ cdef inline void _kernel_subtract_mean(dtype_t_out* out, Py_ssize_t odepth,
         sum = 0
         mean = 0
         n = 0
-        for i in range(max_bin):
+        for i in range(n_bins):
             sum += histo[i]
             if (sum >= p0 * pop) and (sum <= p1 * pop):
                 n += histo[i]
@@ -153,7 +153,7 @@ cdef inline void _kernel_enhance_contrast(dtype_t_out* out,
                                           Py_ssize_t odepth,
                                           Py_ssize_t* histo, double pop,
                                           dtype_t g,
-                                          Py_ssize_t max_bin,
+                                          Py_ssize_t n_bins,
                                           Py_ssize_t mid_bin, double p0,
                                           double p1, Py_ssize_t s0,
                                           Py_ssize_t s1) nogil:
@@ -163,13 +163,13 @@ cdef inline void _kernel_enhance_contrast(dtype_t_out* out,
     if pop:
         sum = 0
         p1 = 1.0 - p1
-        for i in range(max_bin):
+        for i in range(n_bins):
             sum += histo[i]
             if sum > p0 * pop:
                 imin = i
                 break
         sum = 0
-        for i in range(max_bin - 1, -1, -1):
+        for i in range(n_bins - 1, -1, -1):
             sum += histo[i]
             if sum > p1 * pop:
                 imax = i
@@ -189,7 +189,7 @@ cdef inline void _kernel_enhance_contrast(dtype_t_out* out,
 cdef inline void _kernel_percentile(dtype_t_out* out, Py_ssize_t odepth,
                                     Py_ssize_t* histo,
                                     double pop, dtype_t g,
-                                    Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                                    Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                     double p0, double p1,
                                     Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -198,11 +198,11 @@ cdef inline void _kernel_percentile(dtype_t_out* out, Py_ssize_t odepth,
 
     if pop:
         if p0 == 1:  # make sure p0 = 1 returns the maximum filter
-            for i in range(max_bin - 1, -1, -1):
+            for i in range(n_bins - 1, -1, -1):
                 if histo[i]:
                     break
         else:
-            for i in range(max_bin):
+            for i in range(n_bins):
                 sum += histo[i]
                 if sum > p0 * pop:
                     break
@@ -214,7 +214,7 @@ cdef inline void _kernel_percentile(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_pop(dtype_t_out* out, Py_ssize_t odepth,
                              Py_ssize_t* histo,
                              double pop, dtype_t g,
-                             Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                             Py_ssize_t n_bins, Py_ssize_t mid_bin,
                              double p0, double p1,
                              Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -223,7 +223,7 @@ cdef inline void _kernel_pop(dtype_t_out* out, Py_ssize_t odepth,
     if pop:
         sum = 0
         n = 0
-        for i in range(max_bin):
+        for i in range(n_bins):
             sum += histo[i]
             if (sum >= p0 * pop) and (sum <= p1 * pop):
                 n += histo[i]
@@ -235,7 +235,7 @@ cdef inline void _kernel_pop(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_threshold(dtype_t_out* out, Py_ssize_t odepth,
                                    Py_ssize_t* histo,
                                    double pop, dtype_t g,
-                                   Py_ssize_t max_bin, Py_ssize_t mid_bin,
+                                   Py_ssize_t n_bins, Py_ssize_t mid_bin,
                                    double p0, double p1,
                                    Py_ssize_t s0, Py_ssize_t s1) nogil:
 
@@ -243,12 +243,12 @@ cdef inline void _kernel_threshold(dtype_t_out* out, Py_ssize_t odepth,
     cdef Py_ssize_t sum = 0
 
     if pop:
-        for i in range(max_bin):
+        for i in range(n_bins):
             sum += histo[i]
             if sum >= p0 * pop:
                 break
 
-        out[0] = <dtype_t_out>((max_bin - 1) * (g >= i))
+        out[0] = <dtype_t_out>((n_bins - 1) * (g >= i))
     else:
         out[0] = <dtype_t_out>0
 
@@ -258,10 +258,10 @@ def _autolevel(dtype_t[:, ::1] image,
                char[:, ::1] mask,
                dtype_t_out[:, :, ::1] out,
                signed char shift_x, signed char shift_y, double p0, double p1,
-               Py_ssize_t max_bin):
+               Py_ssize_t n_bins):
 
     _core(_kernel_autolevel[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, p0, p1, 0, 0, max_bin)
+          shift_x, shift_y, p0, p1, 0, 0, n_bins)
 
 
 def _gradient(dtype_t[:, ::1] image,
@@ -269,10 +269,10 @@ def _gradient(dtype_t[:, ::1] image,
               char[:, ::1] mask,
               dtype_t_out[:, :, ::1] out,
               signed char shift_x, signed char shift_y, double p0, double p1,
-              Py_ssize_t max_bin):
+              Py_ssize_t n_bins):
 
     _core(_kernel_gradient[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, p0, p1, 0, 0, max_bin)
+          shift_x, shift_y, p0, p1, 0, 0, n_bins)
 
 
 def _mean(dtype_t[:, ::1] image,
@@ -280,10 +280,10 @@ def _mean(dtype_t[:, ::1] image,
           char[:, ::1] mask,
           dtype_t_out[:, :, ::1] out,
           signed char shift_x, signed char shift_y, double p0, double p1,
-          Py_ssize_t max_bin):
+          Py_ssize_t n_bins):
 
     _core(_kernel_mean[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, p0, p1, 0, 0, max_bin)
+          shift_x, shift_y, p0, p1, 0, 0, n_bins)
 
 
 def _sum(dtype_t[:, ::1] image,
@@ -291,10 +291,10 @@ def _sum(dtype_t[:, ::1] image,
          char[:, ::1] mask,
          dtype_t_out[:, :, ::1] out,
          signed char shift_x, signed char shift_y, double p0, double p1,
-         Py_ssize_t max_bin):
+         Py_ssize_t n_bins):
 
     _core(_kernel_sum[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, p0, p1, 0, 0, max_bin)
+          shift_x, shift_y, p0, p1, 0, 0, n_bins)
 
 
 def _subtract_mean(dtype_t[:, ::1] image,
@@ -302,10 +302,10 @@ def _subtract_mean(dtype_t[:, ::1] image,
                    char[:, ::1] mask,
                    dtype_t_out[:, :, ::1] out,
                    signed char shift_x, signed char shift_y, double p0, double p1,
-                   Py_ssize_t max_bin):
+                   Py_ssize_t n_bins):
 
     _core(_kernel_subtract_mean[dtype_t_out, dtype_t], image, selem, mask,
-          out, shift_x, shift_y, p0, p1, 0, 0, max_bin)
+          out, shift_x, shift_y, p0, p1, 0, 0, n_bins)
 
 
 def _enhance_contrast(dtype_t[:, ::1] image,
@@ -313,10 +313,10 @@ def _enhance_contrast(dtype_t[:, ::1] image,
                       char[:, ::1] mask,
                       dtype_t_out[:, :, ::1] out,
                       signed char shift_x, signed char shift_y, double p0, double p1,
-                      Py_ssize_t max_bin):
+                      Py_ssize_t n_bins):
 
     _core(_kernel_enhance_contrast[dtype_t_out, dtype_t], image, selem, mask,
-          out, shift_x, shift_y, p0, p1, 0, 0, max_bin)
+          out, shift_x, shift_y, p0, p1, 0, 0, n_bins)
 
 
 def _percentile(dtype_t[:, ::1] image,
@@ -324,10 +324,10 @@ def _percentile(dtype_t[:, ::1] image,
                 char[:, ::1] mask,
                 dtype_t_out[:, :, ::1] out,
                 signed char shift_x, signed char shift_y, double p0, double p1,
-                Py_ssize_t max_bin):
+                Py_ssize_t n_bins):
 
     _core(_kernel_percentile[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, p0, 1, 0, 0, max_bin)
+          shift_x, shift_y, p0, 1, 0, 0, n_bins)
 
 
 def _pop(dtype_t[:, ::1] image,
@@ -335,10 +335,10 @@ def _pop(dtype_t[:, ::1] image,
          char[:, ::1] mask,
          dtype_t_out[:, :, ::1] out,
          signed char shift_x, signed char shift_y, double p0, double p1,
-         Py_ssize_t max_bin):
+         Py_ssize_t n_bins):
 
     _core(_kernel_pop[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, p0, p1, 0, 0, max_bin)
+          shift_x, shift_y, p0, p1, 0, 0, n_bins)
 
 
 def _threshold(dtype_t[:, ::1] image,
@@ -346,7 +346,7 @@ def _threshold(dtype_t[:, ::1] image,
                char[:, ::1] mask,
                dtype_t_out[:, :, ::1] out,
                signed char shift_x, signed char shift_y, double p0, double p1,
-               Py_ssize_t max_bin):
+               Py_ssize_t n_bins):
 
     _core(_kernel_threshold[dtype_t_out, dtype_t], image, selem, mask, out,
-          shift_x, shift_y, p0, 1, 0, 0, max_bin)
+          shift_x, shift_y, p0, 1, 0, 0, n_bins)

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -9,7 +9,7 @@ from skimage import data, util, morphology
 from skimage.morphology import grey, disk
 from skimage.filters import rank
 from skimage._shared._warnings import expected_warnings
-from skimage._shared.testing import test_parallel, xfail, arch32
+from skimage._shared.testing import test_parallel, xfail, arch32, parametrize
 
 
 class TestRank():


### PR DESCRIPTION
Rank was giving a non-sensical warning due to floating point rounding errors.

See for example the test

https://github.com/scikit-image/scikit-image/blob/6f45aaa0d58e442667ae3b4cecc70f26903daff7/skimage/filters/rank/tests/test_rank.py#L529-L534

I renamed max_bin to n_bin because max_bin was only the maximum value of a bin in 1 line. In Cython, `+=1` was applied to make it the `number of bins`, but it carried its name. It was really confusing reading `range(max_bin)` and having to think: 

* Well range is not inclusive
* but max_bin is actually the number of bins
* So there isn't an off by 1 error.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
