### PR TITLE
MNT: Early stop rank kernel noise filter as intended

### DIFF
--- a/skimage/filters/rank/generic_cy.pyx
+++ b/skimage/filters/rank/generic_cy.pyx
@@ -335,6 +335,7 @@ cdef inline void _kernel_noise_filter(dtype_t_out* out, Py_ssize_t odepth,
     # early stop if at least one pixel of the neighborhood has the same g
     if histo[g] > 0:
         out[0] = <dtype_t_out>0
+        return
 
     for i in range(g, -1, -1):
         if histo[i]:


### PR DESCRIPTION
This is in my series of rank filter fixes.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
