### PR TITLE
RANK: Optimize OTSU filter

### DIFF
--- a/benchmarks/benchmark_rank.py
+++ b/benchmarks/benchmark_rank.py
@@ -1,0 +1,18 @@
+import numpy as np
+from skimage import img_as_ubyte
+from skimage.filters import rank
+from skimage.filters.rank import __all__ as all_rank_filters
+from skimage.morphology import grey, disk
+
+
+class RankSuite(object):
+
+    param_names = ["filter", "shape"]
+    params = [sorted(all_rank_filters), [(32, 32), (256, 256)]]
+
+    def setup(self, filter, shape):
+        self.image = np.random.randint(0, 255, size=shape, dtype=np.uint8)
+        self.selem = disk(1)
+
+    def time_filter(self, filter, shape):
+        getattr(rank, filter)(self.image, self.selem)

--- a/skimage/filters/rank/generic_cy.pyx
+++ b/skimage/filters/rank/generic_cy.pyx
@@ -398,17 +398,21 @@ cdef inline void _kernel_otsu(dtype_t_out* out, Py_ssize_t odepth,
 
     for i in range(1, n_bins):
         P = histo[i]
+        if P == 0:
+            continue
+
         q1 = q1 + P
+
         if q1 == pop:
             break
-        if q1 > 0:
-            mu1 = mu1 + i * P
-            mu2 = mu - mu1
-            t = (pop - q1) * mu1 - mu2 * q1
-            sigma_b = (t * t) / (q1 * (pop - q1))
-            if sigma_b > max_sigma_b:
-                max_sigma_b = sigma_b
-                max_i = i
+
+        mu1 = mu1 + i * P
+        mu2 = mu - mu1
+        t = (pop - q1) * mu1 - mu2 * q1
+        sigma_b = (t * t) / (q1 * (pop - q1))
+        if sigma_b > max_sigma_b:
+            max_sigma_b = sigma_b
+            max_i = i
 
     out[0] = <dtype_t_out>max_i
 

--- a/skimage/filters/rank/generic_cy.pyx
+++ b/skimage/filters/rank/generic_cy.pyx
@@ -378,8 +378,8 @@ cdef inline void _kernel_otsu(dtype_t_out* out, Py_ssize_t odepth,
                               Py_ssize_t s0, Py_ssize_t s1) nogil:
     cdef Py_ssize_t i
     cdef Py_ssize_t max_i
-    cdef double P, mu1, mu2, q1, new_q1, sigma_b, max_sigma_b, t
-    cdef double mu = 0.
+    cdef Py_ssize_t P, q1, mu1, mu2, mu = 0
+    cdef double sigma_b, max_sigma_b, t
 
     # compute local mean
     if pop:
@@ -393,23 +393,22 @@ cdef inline void _kernel_otsu(dtype_t_out* out, Py_ssize_t odepth,
     # maximizing the between class variance
     max_i = 0
     q1 = histo[0]
-    mu1 = 0.
+    mu1 = 0
     max_sigma_b = 0.
 
     for i in range(1, n_bins):
         P = histo[i]
-        new_q1 = q1 + P
-        if new_q1 == pop:
+        q1 = q1 + P
+        if q1 == pop:
             break
-        if new_q1 > 0:
+        if q1 > 0:
             mu1 = mu1 + i * P
             mu2 = mu - mu1
-            t = (pop - new_q1) * mu1 - mu2 * new_q1
-            sigma_b = (t * t) / (new_q1 * (pop - new_q1))
+            t = (pop - q1) * mu1 - mu2 * q1
+            sigma_b = (t * t) / (q1 * (pop - q1))
             if sigma_b > max_sigma_b:
                 max_sigma_b = sigma_b
                 max_i = i
-            q1 = new_q1
 
     out[0] = <dtype_t_out>max_i
 

--- a/skimage/filters/rank/generic_cy.pyx
+++ b/skimage/filters/rank/generic_cy.pyx
@@ -385,24 +385,27 @@ cdef inline void _kernel_otsu(dtype_t_out* out, Py_ssize_t odepth,
     if pop:
         for i in range(n_bins):
             mu += histo[i] * i
-        mu = mu / pop
     else:
         out[0] = <dtype_t_out>0
+        return
+
 
     # maximizing the between class variance
     max_i = 0
-    q1 = histo[0] / pop
+    q1 = histo[0]
     mu1 = 0.
     max_sigma_b = 0.
 
     for i in range(1, n_bins):
-        P = histo[i] / pop
+        P = histo[i]
         new_q1 = q1 + P
+        if new_q1 == pop:
+            break
         if new_q1 > 0:
-            mu1 = (q1 * mu1 + i * P) / new_q1
-            mu2 = (mu - new_q1 * mu1) / (1. - new_q1)
-            t = mu1 - mu2
-            sigma_b = new_q1 * (1. - new_q1) * (t * t)
+            mu1 = mu1 + i * P
+            mu2 = mu - mu1
+            t = (pop - new_q1) * mu1 - mu2 * new_q1
+            sigma_b = (t * t) / (new_q1 * (pop - new_q1))
             if sigma_b > max_sigma_b:
                 max_sigma_b = sigma_b
                 max_i = i

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -19,16 +19,27 @@ def test_otsu_edge_case():
     # This is an edge case that causes OTSU to appear to misbehave
     # Pixel [1, 1] may take a value of of 41 or 81. Both should be considered
     # valid. The value will change depending on the particular implementation
-    # of OTSU. It also may depend on how the compiler chooses to optimize
-    # the order of the operations.
-    img = np.array([[  0,  41,   0],
-                    [ 30,  81, 106],
-                    [  0, 147,   0]], dtype=np.uint8)
+    # of OTSU.
+    # To better understand, see
+    # https://mybinder.org/v2/gist/hmaarrfk/4afae1cfded1d78e44c9e4f58285d552/master
+
     selem = np.array([[0, 1, 0],
                       [1, 1, 1],
                       [0, 1, 0]], dtype=np.uint8)
-    otsu = rank.otsu(img, selem)
-    assert otsu[1, 1] in [41, 81]
+
+    img = np.array([[  0,  41,   0],
+                    [ 30,  81, 106],
+                    [  0, 147,   0]], dtype=np.uint8)
+
+    result = rank.otsu(img, selem)
+    assert result[1, 1] in [41, 81]
+
+    img = np.array([[  0, 214,   0],
+                    [229, 104, 141],
+                    [  0, 172,   0]], dtype=np.uint8)
+    result = rank.otsu(img, selem)
+    assert result[1, 1] in [141, 172]
+
 
 
 class TestRank():
@@ -64,6 +75,10 @@ class TestRank():
                 # used.
                 assert result[3, 5] in [41, 81]
                 result[3, 5] = 81
+                # Pixel [19, 18] is also found to be problematic for the same
+                # reason.
+                assert result[19, 18] in [141, 172]
+                result[19, 18] = 172
                 assert_array_equal(expected, result)
             else:
                 assert_array_equal(expected, result)


### PR DESCRIPTION
I simplified the computation of OTSU by making most things multiplications. Gives a ~5x~ 4x speedup on random data.

<details> <summary> ASV is weird, I never know how to interpret the benchmarks</summary>

```
Optimizing OTSU:

Initial benchmark
otsu              2.57±0.09ms     145±2ms

No normalization 0be1e7718da91a85adc2e173dc4ecdff2f52f321
otsu              1.13±0.07ms     65.0±2ms

Even more simplification 31eeabd37aadab35fe70a624b29890485c1b0647
otsu              887±40μs    46.2±0.7ms

OTSU: skip unneded computations.
otsu              678±40μs     30.4±2ms


OTSU: keeping everything pop a double (two tries for the benchmark)
otsu               723±40μs     37.8±6ms
otsu              842±200μs    42.9±10ms

```
</details>

Redoing the benchmarks without touching my computer

```
[  0.00%] · For scikit-image commit c40b04b0 <optimize_otsu>:
                           otsu              514±0.6μs   25.2±0.02ms 
[ 20.00%] · For scikit-image commit 10c4c0ff <optimize_otsu~1>:
                           otsu               757±10μs    41.0±0.1ms 
[ 40.00%] · For scikit-image commit 89602d89 <optimize_otsu~2>:
                           otsu               934±5μs    52.4±0.07ms 
[ 60.00%] · For scikit-image commit cfa8855c <optimize_otsu~3>:
                           otsu              1.96±0.01ms    119±0.3ms  
[ 80.00%] · For scikit-image commit 5f03ec55 <optimize_otsu~4>:
                           otsu              1.95±0.01ms    119±0.2ms  
```


From what I remember, this needs https://github.com/scikit-image/scikit-image/pull/3506 for the tests to pass.

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
