### PR TITLE
BUGFIX: handle correctly the maximum number of lines in hough transform

### DIFF
--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -529,7 +529,7 @@ def _probabilistic_hough_line(cnp.ndarray img, Py_ssize_t threshold,
                 lines[nlines, 1, 0] = line_end[2]
                 lines[nlines, 1, 1] = line_end[3]
                 nlines += 1
-                if nlines > lines_max:
+                if nlines >= lines_max:
                     break
 
     PyMem_Free(line_end)


### PR DESCRIPTION
…the bug outlined by issue #3507

## Description
In line 532, of the file '_hough_transform.pyx', I changed the line from

532 if nlines > lines_max:

to 

532 if nlines >= lines_max:

this should solve issue #3507

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
