### PR TITLE
Raise meaningful exception in warping when image is empty

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -794,6 +794,10 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=1,
     >>> warped = warp(cube, coords)
 
     """
+
+    if image.size == 0:
+        raise ValueError("Cannot warp empty image with dimensions", image.shape)
+
     image = convert_to_float(image, preserve_range)
 
     input_shape = np.array(image.shape)

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -491,3 +491,18 @@ def test_keep_range():
                   clip=True, order=0)
     assert out.min() == 0
     assert out.max() == 2 / 255.0
+
+
+def test_zero_image_size():
+    with testing.raises(ValueError):
+        warp(np.zeros(0),
+             SimilarityTransform())
+    with testing.raises(ValueError):
+        warp(np.zeros((0, 10)),
+             SimilarityTransform())
+    with testing.raises(ValueError):
+        warp(np.zeros((10, 0)),
+             SimilarityTransform())
+    with testing.raises(ValueError):
+        warp(np.zeros((10, 10, 0)),
+             SimilarityTransform())


### PR DESCRIPTION
Previously, we did not raise a descriptive error when the input image has a zero dimension.