### PR TITLE
DOC: Development installation instructions for Ubuntu are missing tkinter

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -90,7 +90,7 @@ Install all the required dependencies::
 
 Install suitable compilers::
 
-  sudo apt-get install build-essential cython
+  sudo apt-get install build-essential cython3
 
 Complete the general development installation instructions above.
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -86,7 +86,7 @@ b. Debian and Ubuntu
 ````````````````````
 Install all the required dependencies::
 
-  sudo apt-get install python-matplotlib python-numpy python-pil python-scipy
+  sudo apt-get install python-matplotlib python-numpy python-pil python-scipy python3-tk
 
 Install suitable compilers::
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -86,7 +86,7 @@ b. Debian and Ubuntu
 ````````````````````
 Install all the required dependencies::
 
-  sudo apt-get install python-matplotlib python-numpy python-pil python-scipy python3-tk
+  sudo apt-get install python3-matplotlib python3-numpy python3-pil python3-scipy python3-tk
 
 Install suitable compilers::
 


### PR DESCRIPTION
## Description
OS-specific installation instruction for Ubuntu is missing tkinter module.
Although according to the docs tkinter is part of the standard library it does not seem to be always shipped with the core python installation. Missing tkinter module is causing that unit tests are failing.

## References
Closes #3519

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
