### PR TITLE
Remove deprecated `skimage.measure.correct_mesh_orientation`

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -39,6 +39,9 @@ API Changes
   ``skimage.io.imread``. Use ``as_gray`` instead.
 - Parameter ``min_size`` has been removed from
   ``skimage.morphology.remove_small_holes``. Use ``area_threshold`` instead.
+- Deprecated ``correct_mesh_orientation`` in ``skimage.measure`` has been
+  removed.
+
 
 Bugfixes
 --------

--- a/skimage/measure/__init__.py
+++ b/skimage/measure/__init__.py
@@ -1,8 +1,7 @@
 from ._find_contours import find_contours
 from ._marching_cubes_lewiner import marching_cubes_lewiner
 from ._marching_cubes_classic import (marching_cubes_classic,
-                                      mesh_surface_area,
-                                      correct_mesh_orientation)
+                                      mesh_surface_area)
 from ._regionprops import regionprops, perimeter
 from .simple_metrics import compare_mse, compare_nrmse, compare_psnr
 from ._structural_similarity import compare_ssim
@@ -37,7 +36,6 @@ __all__ = ['find_contours',
            'marching_cubes_lewiner',
            'marching_cubes_classic',
            'mesh_surface_area',
-           'correct_mesh_orientation',
            'profile_line',
            'label',
            'points_in_poly',

--- a/skimage/measure/_marching_cubes_classic.py
+++ b/skimage/measure/_marching_cubes_classic.py
@@ -166,7 +166,6 @@ def mesh_surface_area(verts, faces):
     --------
     skimage.measure.marching_cubes
     skimage.measure.marching_cubes_classic
-    skimage.measure.correct_mesh_orientation
 
     """
     # Fancy indexing to define two vector arrays from triangle vertices
@@ -177,79 +176,6 @@ def mesh_surface_area(verts, faces):
 
     # Area of triangle in 3D = 1/2 * Euclidean norm of cross product
     return ((np.cross(a, b) ** 2).sum(axis=1) ** 0.5).sum() / 2.
-
-
-def correct_mesh_orientation(volume, verts, faces, spacing=(1., 1., 1.),
-                             gradient_direction='descent'):
-    """
-    Correct orientations of mesh faces.
-
-    Parameters
-    ----------
-    volume : (M, N, P) array of doubles
-        Input data volume to find isosurfaces. Will be cast to `np.float64`.
-    verts : (V, 3) array of floats
-        Array containing (x, y, z) coordinates for V unique mesh vertices.
-    faces : (F, 3) array of ints
-        List of length-3 lists of integers, referencing vertex coordinates as
-        provided in `verts`.
-    spacing : length-3 tuple of floats
-        Voxel spacing in spatial dimensions corresponding to numpy array
-        indexing dimensions (M, N, P) as in `volume`.
-    gradient_direction : string
-        Controls if the mesh was generated from an isosurface with gradient
-        descent toward objects of interest (the default), or the opposite.
-        The two options are:
-        * descent : Object was greater than exterior
-        * ascent : Exterior was greater than object
-
-    Returns
-    -------
-    faces_corrected (F, 3) array of ints
-        Corrected list of faces referencing vertex coordinates in `verts`.
-
-    Notes
-    -----
-    Certain applications and mesh processing algorithms require all faces
-    to be oriented in a consistent way. Generally, this means a normal vector
-    points "out" of the meshed shapes. This algorithm corrects the output from
-    `skimage.measure.marching_cubes_classic` by flipping the orientation of
-    mis-oriented faces.
-
-    Because marching cubes could be used to find isosurfaces either on
-    gradient descent (where the desired object has greater values than the
-    exterior) or ascent (where the desired object has lower values than the
-    exterior), the ``gradient_direction`` kwarg allows the user to inform this
-    algorithm which is correct. If the resulting mesh appears to be oriented
-    completely incorrectly, try changing this option.
-
-    The arguments expected by this function are the exact outputs from
-    `skimage.measure.marching_cubes_classic`. Only `faces` is corrected and
-    returned, as the vertices do not change; only the order in which they are
-    referenced.
-
-    This algorithm assumes ``faces`` provided are all triangles.
-
-    See Also
-    --------
-    skimage.measure.marching_cubes_classic
-    skimage.measure.mesh_surface_area
-
-    """
-    warn(DeprecationWarning("`correct_mesh_orientation` is deprecated for "
-                            "removal as `marching_cubes_classic` now "
-                            "guarantees correct mesh orientation."))
-
-    verts = verts.copy()
-    verts[:, 0] /= spacing[0]
-    verts[:, 1] /= spacing[1]
-    verts[:, 2] /= spacing[2]
-
-    # Fancy indexing to define two vector arrays from triangle vertices
-    actual_verts = verts[faces]
-
-    return _correct_mesh_orientation(volume, actual_verts, faces, spacing,
-                                     gradient_direction)
 
 
 def _correct_mesh_orientation(volume, actual_verts, faces,

--- a/skimage/measure/tests/test_marching_cubes.py
+++ b/skimage/measure/tests/test_marching_cubes.py
@@ -1,7 +1,7 @@
 import numpy as np
 from skimage.draw import ellipsoid, ellipsoid_stats
 from skimage.measure import (marching_cubes_classic, marching_cubes_lewiner,
-                             mesh_surface_area, correct_mesh_orientation)
+                             mesh_surface_area)
 from skimage._shared import testing
 from skimage._shared.testing import assert_array_equal
 from skimage._shared._warnings import expected_warnings
@@ -71,44 +71,6 @@ def test_invalid_input():
                                spacing=(1, 2))
     with testing.raises(ValueError):
         marching_cubes_lewiner(np.zeros((20, 20)), 0)
-
-
-def test_correct_mesh_orientation():
-    sphere_small = ellipsoid(1, 1, 1, levelset=True)
-
-    # Mesh with incorrectly oriented faces which was previously returned from
-    # `marching_cubes`, before it guaranteed correct mesh orientation
-    verts = np.array([[1., 2., 2.],
-                      [2., 2., 1.],
-                      [2., 1., 2.],
-                      [2., 2., 3.],
-                      [2., 3., 2.],
-                      [3., 2., 2.]])
-
-    faces = np.array([[0, 1, 2],
-                      [2, 0, 3],
-                      [1, 0, 4],
-                      [4, 0, 3],
-                      [1, 2, 5],
-                      [2, 3, 5],
-                      [1, 4, 5],
-                      [5, 4, 3]])
-
-    # Correct mesh orientation - descent
-    with expected_warnings(['`correct_mesh_orientation` is deprecated']):
-        corrected_faces1 = correct_mesh_orientation(
-            sphere_small, verts, faces, gradient_direction='descent')
-        corrected_faces2 = correct_mesh_orientation(
-            sphere_small, verts, faces, gradient_direction='ascent')
-
-    # Ensure ascent is opposite of descent for all faces
-    assert_array_equal(corrected_faces1, corrected_faces2[:, ::-1])
-
-    # Ensure correct faces have been reversed: 1, 4, and 5
-    idx = [1, 4, 5]
-    expected = faces.copy()
-    expected[idx] = expected[idx, ::-1]
-    assert_array_equal(expected, corrected_faces1)
 
 
 def test_both_algs_same_result_ellipse():


### PR DESCRIPTION
## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
