### PR TITLE
Add detail to ProjectiveTransform repr and str

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -719,6 +719,36 @@ class ProjectiveTransform(GeometricTransform):
             raise TypeError("Cannot combine transformations of differing "
                             "types.")
 
+    def __nice__(self):
+        """ common 'paramstr' used by __str__ and __repr__ """
+        # paramstr = str(self.params.tolist())  # original proposal
+        npstring = np.array2string(self.params, separator=', ')
+        # add a newline and indentation after the first square braket to ensure
+        # the columns of the params matrix are aligned in the repr
+        lines = npstring[1:].split('\n ')
+        indented_lines = ['    ' + p for p in lines]
+        paramstr = 'matrix=[\n' + '\n'.join(indented_lines)
+        print(paramstr)
+        return paramstr
+
+    def __repr__(self):
+        """ Add standard repr formatting around a nice string """
+        paramstr = self.__nice__()
+        classname = self.__class__.__name__
+        classstr = classname
+        # modname = self.__class__.__module__  # uncomment for more verbosity
+        # classstr = modname + '.' + classname
+        return '<{}({}) at {}>'.format(classstr, paramstr, hex(id(self)))
+
+    def __str__(self):
+        """ Add standard str formatting around a nice string """
+        paramstr = self.__nice__()
+        classname = self.__class__.__name__
+        classstr = classname
+        # modname = self.__class__.__module__  # uncomment for more verbosity
+        # classstr = modname + '.' + classname
+        return '<{}({})>'.format(classstr, paramstr)
+
 
 class AffineTransform(ProjectiveTransform):
     """2D affine transformation.

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -721,7 +721,6 @@ class ProjectiveTransform(GeometricTransform):
 
     def __nice__(self):
         """ common 'paramstr' used by __str__ and __repr__ """
-        # paramstr = str(self.params.tolist())  # original proposal
         npstring = np.array2string(self.params, separator=', ')
         # add a newline and indentation after the first square braket to ensure
         # the columns of the params matrix are aligned in the repr
@@ -735,8 +734,6 @@ class ProjectiveTransform(GeometricTransform):
         paramstr = self.__nice__()
         classname = self.__class__.__name__
         classstr = classname
-        # modname = self.__class__.__module__  # uncomment for more verbosity
-        # classstr = modname + '.' + classname
         return '<{}({}) at {}>'.format(classstr, paramstr, hex(id(self)))
 
     def __str__(self):
@@ -744,8 +741,6 @@ class ProjectiveTransform(GeometricTransform):
         paramstr = self.__nice__()
         classname = self.__class__.__name__
         classstr = classname
-        # modname = self.__class__.__module__  # uncomment for more verbosity
-        # classstr = modname + '.' + classname
         return '<{}({})>'.format(classstr, paramstr)
 
 

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -728,7 +728,6 @@ class ProjectiveTransform(GeometricTransform):
         lines = npstring[1:].split('\n ')
         indented_lines = ['    ' + p for p in lines]
         paramstr = 'matrix=[\n' + '\n'.join(indented_lines)
-        print(paramstr)
         return paramstr
 
     def __repr__(self):

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -483,16 +483,25 @@ def test_projective_repr():
             [0., 1., 0.],
             [0., 0., 1.]]) at
         ''').strip()) + ' 0x[a-f0-9]+' + re.escape('>')
+    # Hack the escaped regex to allow whitespace before each number for
+    # compatibility with different numpy versions.
+    want = want.replace('0\\.', ' *0\\.')
+    want = want.replace('1\\.', ' *1\\.')
     assert re.match(want, repr(tform))
 
 
 def test_projective_str():
     tform = ProjectiveTransform()
-    want = textwrap.dedent(
+    want = re.escape(textwrap.dedent(
         '''
         <ProjectiveTransform(matrix=[
             [1., 0., 0.],
             [0., 1., 0.],
             [0., 0., 1.]])>
-        ''').strip()
-    assert str(tform) == want
+        ''').strip())
+    # Hack the escaped regex to allow whitespace before each number for
+    # compatibility with different numpy versions.
+    want = want.replace('0\\.', ' *0\\.')
+    want = want.replace('1\\.', ' *1\\.')
+    print(want)
+    assert re.match(want, str(tform))

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -1,4 +1,5 @@
 import numpy as np
+import re
 from skimage.transform._geometric import GeometricTransform
 from skimage.transform import (estimate_transform, matrix_transform,
                                EuclideanTransform, SimilarityTransform,

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -9,6 +9,7 @@ from skimage.transform import (estimate_transform, matrix_transform,
 
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_almost_equal
+import textwrap
 
 
 SRC = np.array([
@@ -471,3 +472,27 @@ def test_degenerate():
         # Prior to gh-3926, under the above circumstances,
         # a transform could be returned with nan values.
         assert(not tform.estimate(src, dst) or np.isfinite(tform.params).all())
+
+
+def test_projective_repr():
+    tform = ProjectiveTransform()
+    want = re.escape(textwrap.dedent(
+        '''
+        <ProjectiveTransform(matrix=[
+            [1., 0., 0.],
+            [0., 1., 0.],
+            [0., 0., 1.]]) at
+        ''').strip()) + ' 0x[a-f0-9]+' + re.escape('>')
+    assert re.match(want, repr(tform))
+
+
+def test_projective_str():
+    tform = ProjectiveTransform()
+    want = textwrap.dedent(
+        '''
+        <ProjectiveTransform(matrix=[
+            [1., 0., 0.],
+            [0., 1., 0.],
+            [0., 0., 1.]])>
+        ''').strip()
+    assert str(tform) == want


### PR DESCRIPTION
## Description
This is a very simple improvement. I've simply added information on the matrix parameters to ProjectiveTransform. My motivation to make this change is that I had a list of AffineTransforms and I wanted to visually see the difference between them. Sure you can just get the params attribute with a list comprehension, but I thought it might be nicer if the repr and str functions were a bit more detailed.

Before when you had a projective transform (or a list of them) and go the repr you would see: 

```
<skimage.transform._geometric.ProjectiveTransform at 0x7fc6d65e4cf8>
```

and now with this change you will see something like:

```
<skimage.transform._geometric.ProjectiveTransform([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]) at 0x7fc6d65e4cf8>'
```

Analogous to the defaults in object, the str method is the same except it doesn't have the hex-id of the object.

## Implementation Choices

To start, I made the simplest possible change I could by just adding the parameter info. I cast `self.params` to a list to ensure that messy newlines wouldn't enter the repr. 

If I was to implement this in one of my own libraries I would probably make the following changes: 

* Remove the modname before the classname repr so the above would reduce the repr to simply 

```
<ProjectiveTransform([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]) at 0x7fc6d65e4cf8>
```

* Use `''.join([p.strip() for p in repr(self.params).split('\n')])` instead of `str(self.params.tolist())`, which makes the parameter repr a bit more concise when that matrix parameters have lots of decimals. This would change the above to 

```
<ProjectiveTransform(array([[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]])) at 0x7fc6d65e4cf8>
```


To be conservative I started with the simplest method, but I can modify the PR to include any of the above modifications as well. 

(Actually if I was really doing this in one of my libraries, I would inherit from [`ubelt.NiceRepr`](https://github.com/Erotemic/ubelt/blob/master/ubelt/util_mixins.py) and define the `__nice__` method to return `''.join([p.strip() for p in repr(self.params).split('\n')])`.)

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [X] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [X] Unit tests

I feel the other things in the checklist are NA to this change

- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
