### PR TITLE
Add copybutton

### DIFF
--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -333,10 +333,6 @@ the documentation.
     pip install sphinx_gallery
     pip install sphinx-copybutton
 
-`copybutton file <https://github.com/choldgraf/sphinx-copybutton/blob/master/sphinx_copybutton/_static/copybutton.css>`__ is modified to generate the online documentation by
-adding ``background: transparent no-repeat none; border: none;`` and
-adjusting ``margin: 0.5px; height: 1.6em; padding: 0 2px 0px;`` at ``a.copybtn``.
-
 **LaTeX Ubuntu:**
 
 .. code:: sh

--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -330,6 +330,12 @@ the documentation.
 .. code:: sh
 
     pip install sphinx
+    pip install sphinx_gallery
+    pip install sphinx-copybutton
+
+`copybutton file <https://github.com/choldgraf/sphinx-copybutton/blob/master/sphinx_copybutton/_static/copybutton.css>`__ is modified to generate the online documentation by
+adding ``background: transparent no-repeat none; border: none;`` and
+adjusting ``margin: 0.5px; height: 1.6em; padding: 0 2px 0px;`` at ``a.copybtn``.
 
 **LaTeX Ubuntu:**
 

--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -317,7 +317,19 @@ Building docs
 -------------
 
 To build docs, run ``make`` from the ``doc`` directory. ``make help`` lists
-all targets.
+all targets. For example, to build the HTML documentation, you can run:
+
+.. code:: sh
+
+    make SPHINXOPTS= html
+
+Then, all the HTML files will be generated in ``scikit-image/doc/build/html/``.
+To rebuild a full clean documentation, run:
+
+.. code:: sh
+
+    make clean
+    make SPHINXOPTS= html
 
 Requirements
 ~~~~~~~~~~~~
@@ -327,11 +339,12 @@ the documentation.
 
 **Sphinx:**
 
+Sphinx and other python packages needed to build the documentation
+can be installed using ``scikit-image/requirements/docs.txt`` file.
+
 .. code:: sh
 
-    pip install sphinx
-    pip install sphinx_gallery
-    pip install sphinx-copybutton
+    pip install -r requirements/docs.txt
 
 **LaTeX Ubuntu:**
 

--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -340,7 +340,7 @@ the documentation.
 **Sphinx:**
 
 Sphinx and other python packages needed to build the documentation
-can be installed using ``scikit-image/requirements/docs.txt`` file.
+can be installed using: ``scikit-image/requirements/docs.txt`` file.
 
 .. code:: sh
 

--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -321,7 +321,7 @@ all targets. For example, to build the HTML documentation, you can run:
 
 .. code:: sh
 
-    make SPHINXOPTS= html
+    make html
 
 Then, all the HTML files will be generated in ``scikit-image/doc/build/html/``.
 To rebuild a full clean documentation, run:
@@ -329,7 +329,7 @@ To rebuild a full clean documentation, run:
 .. code:: sh
 
     make clean
-    make SPHINXOPTS= html
+    make html
 
 Requirements
 ~~~~~~~~~~~~

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,7 +27,8 @@ sys.path.append(os.path.join(curpath, '..', 'ext'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc',
+extensions = ['sphinx_copybutton',
+              'sphinx.ext.autodoc',
               'sphinx.ext.mathjax',
               'numpydoc',
               'doi_role',

--- a/doc/source/themes/scikit-image/static/css/custom.css
+++ b/doc/source/themes/scikit-image/static/css/custom.css
@@ -298,3 +298,15 @@ div.sphx-glr-download a:hover {
 p.sphx-glr-signature a.reference.external {
   display: none !important;
 }
+
+a.copybtn {
+    background: transparent no-repeat none;
+    border:none;
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin: 0.5px !important;
+    width: 1em;
+    height: 1.6em !important;
+    padding: 0 2px 0px !important;
+  }

--- a/doc/source/themes/scikit-image/static/css/custom.css
+++ b/doc/source/themes/scikit-image/static/css/custom.css
@@ -301,7 +301,7 @@ p.sphx-glr-signature a.reference.external {
 
 a.copybtn {
     background: transparent no-repeat none;
-    border:none;
+    border: none;
     position: absolute;
     top: 0;
     right: 0;
@@ -309,4 +309,15 @@ a.copybtn {
     width: 1em;
     height: 1.6em !important;
     padding: 0 2px 0px !important;
+    text-shadow: none;
   }
+
+
+  .o-tooltip--left:after {
+    opacity: 0;
+    font-family: monospace !important;
+    font-weight: bold;
+    font-size: 13px !important;
+    background: #3F556B !important;
+    z-index: 100 !important;
+}

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -3,5 +3,6 @@
 sphinx>=1.3,!=1.7.8
 numpydoc>=0.6
 sphinx-gallery
+sphinx-copybutton
 pytest-runner
 scikit-learn


### PR DESCRIPTION
Close ##3482. 
Add sphinx-copybutton so that the code block generated by sphinx can be copied by a single click. 
More details about sphinix-copybutton can be found [here](https://github.com/choldgraf/sphinx-copybutton).
 Here is how it looks with the click button at the upper right corner.

![](https://farm5.staticflickr.com/4837/30744153557_5c30b176a5_b.jpg) 