### PR TITLE
delay importing pyplot in manual segmentation

### DIFF
--- a/skimage/future/manual_segmentation.py
+++ b/skimage/future/manual_segmentation.py
@@ -1,7 +1,5 @@
 from functools import reduce
 import numpy as np
-import matplotlib
-import matplotlib.pyplot as plt
 from matplotlib.patches import Polygon
 from matplotlib.collections import PatchCollection
 from ..draw import polygon
@@ -21,6 +19,8 @@ def _mask_from_vertices(vertices, shape, label):
 
 
 def _draw_polygon(ax, vertices, alpha=0.4):
+    import matplotlib.pyplot as plt
+
     polygon = Polygon(vertices, closed=True)
     p = PatchCollection([polygon], match_original=True, alpha=alpha)
     polygon_object = ax.add_collection(p)
@@ -63,6 +63,8 @@ def manual_polygon_segmentation(image, alpha=0.4, return_all=False):
     >>> io.imshow(mask)  # doctest: +SKIP
     >>> io.show()  # doctest: +SKIP
     """
+    import matplotlib.pyplot as plt
+
     list_of_vertex_lists = []
     polygons_drawn = []
 
@@ -173,6 +175,8 @@ def manual_lasso_segmentation(image, alpha=0.4, return_all=False):
     >>> io.imshow(mask)  # doctest: +SKIP
     >>> io.show()  # doctest: +SKIP
     """
+    import matplotlib.pyplot as plt
+
     list_of_vertex_lists = []
     polygons_drawn = []
 


### PR DESCRIPTION
We've run into trouble with this before because pyplot used to set the backend.

This was found when developing: https://github.com/scikit-image/scikit-image/pull/3129

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
