### PR TITLE
Get rid of the requirements-parser dependency

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,4 +1,3 @@
 Cython>=0.23.4,!=0.28.2,!=0.29.0
 wheel
 numpy>=1.11
-requirements-parser

--- a/tools/build_versions.py
+++ b/tools/build_versions.py
@@ -12,11 +12,22 @@ def main():
         print(requirement_file.name)
         with open(str(requirement_file), 'r') as f:
             for req in f:
+                # Remove trailing and leading whitespace.
                 req = req.strip()
-                if req[0] == '#':
+
+                if not req:
+                    # skip empty or white space only lines
                     continue
+                elif req.startswith('#'):
+                    continue
+
+                # Get the name of the package
                 req = re.split('<|>|=|!|;', req)[0]
                 try:
+                    # use pkg_resources to reliably get the version at install time
+                    # by package name. pkg_resources needs the name of the package
+                    # from pip, and not "import". 
+                    # e.g. req is 'scikit-learn', not 'sklearn'
                     version = pkg_resources.get_distribution(req).version
                     print(req.rjust(20), version)
                 except pkg_resources.DistributionNotFound:

--- a/tools/build_versions.py
+++ b/tools/build_versions.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 from pathlib import Path
-import requirements
 import pkg_resources
+import re
 
 
 def main():
@@ -10,13 +10,17 @@ def main():
 
     for requirement_file in requirements_dir.glob('*.txt'):
         print(requirement_file.name)
-        with open(str(requirement_file), 'r') as fd:
-            for req in requirements.parse(fd):
+        with open(str(requirement_file), 'r') as f:
+            for req in f:
+                req = req.strip()
+                if req[0] == '#':
+                    continue
+                req = re.split('<|>|=|!|;', req)[0]
                 try:
-                    version = pkg_resources.get_distribution(req.name).version
-                    print(req.name.rjust(20), version)
+                    version = pkg_resources.get_distribution(req).version
+                    print(req.rjust(20), version)
                 except pkg_resources.DistributionNotFound:
-                    print(req.name.rjust(20), 'is not installed')
+                    print(req.rjust(20), 'is not installed')
 
 
 if __name__ == '__main__':

--- a/tools/build_versions.py
+++ b/tools/build_versions.py
@@ -24,9 +24,9 @@ def main():
                 # Get the name of the package
                 req = re.split('<|>|=|!|;', req)[0]
                 try:
-                    # use pkg_resources to reliably get the version at install time
-                    # by package name. pkg_resources needs the name of the package
-                    # from pip, and not "import". 
+                    # use pkg_resources to reliably get the version at install
+                    # time by package name. pkg_resources needs the name of the
+                    # package from pip, and not "import".
                     # e.g. req is 'scikit-learn', not 'sklearn'
                     version = pkg_resources.get_distribution(req).version
                     print(req.rjust(20), version)


### PR DESCRIPTION
I got rid of it in my own projects because when debugging, you things to be able to run on any python install.

Even that lightweight dependency is too much.

```
docs.txt
              sphinx is not installed
            numpydoc is not installed
      sphinx-gallery is not installed
       pytest-runner is not installed
        scikit-learn is not installed
default.txt
               numpy 1.15.3
               scipy 1.1.0
          matplotlib 3.0.1
            networkx 2.2
              pillow 5.3.0
             imageio 2.3.0
          PyWavelets 1.0.1
         dask[array] 0.20.0
         cloudpickle 0.6.1
build.txt
              Cython 0.29
               wheel 0.32.2
               numpy 1.15.3
test.txt
              pytest 3.9.3
          pytest-cov is not installed
              flake8 is not installed
             codecov is not installed
optional.txt
              imread is not installed
           SimpleITK is not installed
             astropy is not installed
            tifffile is not installed
                qtpy is not installed
               pyamg is not installed

```

Output is unchanged
## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
