### PR TITLE
Remove restriction on simpleitk for python 3.7

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -45,9 +45,6 @@ Other
   for sparse matricies (``np.matrix``) used by scipy.sparse in
   ``test_random_walker.py``. Note that there is also a chance ``scipy.sparse``
   moves away from using ``np.matrix`` in a future version too.
-* Monitor SimpleITK Pypi releases to find when a 3.7 release comes out.
-  Remove version restriction in requirements file when appropriate.
-  `https://github.com/SimpleITK/SimpleITK/issues/551`
 * When minimum supported version of ``scipy`` reaches 0.18, use 
   ``scipy.fftpack.next_fast_len`` directly in 
   ``skimage.feature.masked_register_translation``.

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,5 +1,5 @@
 imread
-SimpleITK; python_version < '3.7'
+SimpleITK
 astropy
 tifffile
 qtpy


### PR DESCRIPTION
https://github.com/SimpleITK/SimpleITK/issues/551

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
