### PR TITLE
HOG returns incorrect features if pixels_per_cell is odd

### DIFF
--- a/skimage/feature/_hoghistogram.pyx
+++ b/skimage/feature/_hoghistogram.pyx
@@ -121,10 +121,10 @@ def hog_histograms(double[:, ::1] gradient_columns,
     c_0 = cell_columns / 2
     cc = cell_rows * number_of_cells_rows
     cr = cell_columns * number_of_cells_columns
-    range_rows_stop = cell_rows / 2
-    range_rows_start = -range_rows_stop
-    range_columns_stop = cell_columns / 2
-    range_columns_start = -range_columns_stop
+    range_rows_stop = (cell_rows+1) / 2
+    range_rows_start = -(cell_rows / 2)
+    range_columns_stop = (cell_columns + 1) / 2
+    range_columns_start = -(cell_columns / 2)
     number_of_orientations_per_180 = 180. / number_of_orientations
 
     with nogil:

--- a/skimage/feature/_hoghistogram.pyx
+++ b/skimage/feature/_hoghistogram.pyx
@@ -121,7 +121,7 @@ def hog_histograms(double[:, ::1] gradient_columns,
     c_0 = cell_columns / 2
     cc = cell_rows * number_of_cells_rows
     cr = cell_columns * number_of_cells_columns
-    range_rows_stop = (cell_rows+1) / 2
+    range_rows_stop = (cell_rows + 1) / 2
     range_rows_start = -(cell_rows / 2)
     range_columns_stop = (cell_columns + 1) / 2
     range_columns_start = -(cell_columns / 2)

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -63,7 +63,7 @@ def test_hog_odd_cell_size():
                          cells_per_block=(1, 1), block_norm='L1',
                          feature_vector=True, transform_sqrt=False,
                          visualize=False)
-    
+
     assert_almost_equal(output, correct_output)
 
 

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -56,13 +56,13 @@ def test_hog_odd_cell_size():
     img[2, 2] = 1
 
     correct_output = np.zeros((9, ))
-    correct_output[0] = 0.4999775
-    correct_output[4] = 0.4999775
+    correct_output[0] = 0.5
+    correct_output[4] = 0.5
 
     output = feature.hog(img, pixels_per_cell=(3, 3),
                          cells_per_block=(1, 1), block_norm='L1')
 
-    assert_almost_equal(output, correct_output)
+    assert_almost_equal(output, correct_output, decimal=1)
 
 
 def test_hog_basic_orientations_and_data_types():

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -59,10 +59,8 @@ def test_hog_odd_cell_size():
     correct_output[0] = 0.4999775
     correct_output[4] = 0.4999775
 
-    output = feature.hog(img, orientations=9, pixels_per_cell=(3, 3),
-                         cells_per_block=(1, 1), block_norm='L1',
-                         feature_vector=True, transform_sqrt=False,
-                         visualize=False)
+    output = feature.hog(img, pixels_per_cell=(3, 3),
+                         cells_per_block=(1, 1), block_norm='L1')
 
     assert_almost_equal(output, correct_output)
 

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -51,6 +51,22 @@ def test_hog_image_size_cell_size_mismatch():
     assert len(fd) == 9 * (150 // 8) * (200 // 8)
 
 
+def test_hog_odd_cell_size():
+    img = np.zeros((3, 3))
+    img[2, 2] = 1
+
+    correct_output = np.zeros((9, ))
+    correct_output[0] = 0.4999775
+    correct_output[4] = 0.4999775
+
+    output = feature.hog(img, orientations=9, pixels_per_cell=(3, 3),
+                         cells_per_block=(1, 1), block_norm='L1',
+                         feature_vector=True, transform_sqrt=False,
+                         visualize=False)
+    
+    assert_almost_equal(output, correct_output)
+
+
 def test_hog_basic_orientations_and_data_types():
     # scenario:
     #  1) create image (with float values) where upper half is filled by


### PR DESCRIPTION
## Description

`skimage.feature.hog` was ignoring last row/column of cell if `pixels_per_cell` is odd number.

Suppose `pixels_per_cell == (3, 3)`

In here `cell_rows == pixels_per_cell[0]`.
https://github.com/scikit-image/scikit-image/blob/9c4632f43eb6f6e85bf33f9adf8627d01b024496/skimage/feature/_hoghistogram.pyx#L120-L127

```
range_rows_stop = cell_rows / 2 = 1
range_rows_start = -range_rows_stop = -1
```

`cell_rows` is 3 but `[range_row_start, range_rows_stop)` contains only 2 integers, so last row will be ignored.
I fixed `range_rows_stop` (and `range_columns_stop`) calculation.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
