### PR TITLE
Backport #3447: Fix morphology.local_maxima for input with any dimension < 3

### DIFF
--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -13,6 +13,8 @@ from __future__ import absolute_import
 
 import numpy as np
 
+from ..util import dtype_limits, invert, crop
+from .._shared.utils import warn
 from . import greyreconstruct
 from ..util import dtype_limits
 
@@ -279,14 +281,22 @@ def local_maxima(image, selem=None):
 
     The resulting image will contain all 6 local maxima.
     """
-    # find the minimal grey level difference
-    h = _find_min_diff(image)
-    if h == 0:
-        return np.zeros(image.shape, np.uint8)
-    if not np.issubdtype(image.dtype, np.floating):
-        h = 1
-    local_max = h_maxima(image, h, selem=selem)
-    return local_max
+    if selem is None:
+        if connectivity is None:
+            connectivity = ndim
+        selem = ndi.generate_binary_structure(ndim, connectivity)
+    else:
+        # Validate custom structured element
+        selem = np.asarray(selem, dtype=bool)
+        # Must specify neighbors for all dimensions
+        if selem.ndim != ndim:
+            raise ValueError(
+                "structuring element and image must have the same number of "
+                "dimensions"
+            )
+        # Must only specify direct neighbors
+        if any(s != 3 for s in selem.shape):
+            raise ValueError("dimension size in structuring element is not 3")
 
 
 def local_minima(image, selem=None):
@@ -305,27 +315,198 @@ def local_minima(image, selem=None):
     image : ndarray
         The input image for which the minima are to be calculated.
     selem : ndarray, optional
-        The neighborhood expressed as an n-D array of 1's and 0's.
-        Default is the ball of radius 1 according to the maximum norm
-        (i.e. a 3x3 square for 2D images, a 3x3x3 cube for 3D images, etc.)
+        A structuring element used to determine the neighborhood of each
+        evaluated pixel. It must contain only 1's and 0's, have the same number
+        of dimensions as `image`. If not given, all adjacent pixels are
+        considered as part of the neighborhood.
+    connectivity : int, optional
+        A number used to determine the neighborhood of each evaluated pixel.
+        Adjacent pixels whose squared distance from the center is larger or
+        equal to `connectivity` are considered neighbors. Ignored if
+        `selem` is not None.
+    indices : bool, optional
+        If True, the output will be a tuple of one-dimensional arrays
+        representing the indices of local maxima in each dimension. If False,
+        the output will be an array of 0's and 1's with the same shape as
+        `image`.
+    allow_borders : bool, optional
+        If true, plateaus that touch the image border are valid maxima.
 
     Returns
     -------
-    local_min : ndarray
-       All local minima of the image. The result image is a binary image,
-       where pixels belonging to local minima take value 1, the other pixels
-       take value 0.
+    maxima : ndarray or tuple[ndarray]
+        If `indices` is false, an array with the same shape as `image` is
+        returned with 1's indicating the position of local maxima
+        (0 otherwise). If `indices` is true, a tuple of one-dimensional arrays
+        containing the coordinates (indices) of all found maxima.
 
-    See also
+    Warns
+    -----
+    UserWarning
+        If `allow_borders` is false and any dimension of the given `image` is
+        shorter than 3 samples, maxima can't exist and a warning is shown.
+
+    See Also
     --------
-    skimage.morphology.extrema.h_minima
-    skimage.morphology.extrema.h_maxima
-    skimage.morphology.extrema.local_maxima
+    skimage.morphology.local_minima
+    skimage.morphology.h_maxima
+    skimage.morphology.h_minima
+
+    Notes
+    -----
+    This function operates on the following ideas:
+
+    1. Make a first pass over the image's last dimension and flag candidates
+       for local maxima by comparing pixels in only one direction.
+       If the pixels aren't connected in the last dimension all pixels are
+       flagged as candidates instead.
+
+    For each candidate:
+
+    2. Perform a flood-fill to find all connected pixels that have the same
+       gray value and are part of the plateau.
+    3. Consider the connected neighborhood of a plateau: if no bordering sample
+       has a higher gray level, mark the plateau as a definite local maximum.
 
     References
     ----------
     .. [1] Soille, P., "Morphological Image Analysis: Principles and
            Applications" (Chapter 6), 2nd edition (2003), ISBN 3540429883.
+
+    See also
+    --------
+    >>> from skimage.morphology import local_maxima
+    >>> image = np.zeros((4, 7), dtype=int)
+    >>> image[1:3, 1:3] = 1
+    >>> image[3, 0] = 1
+    >>> image[1:3, 4:6] = 2
+    >>> image[3, 6] = 3
+    >>> image
+    array([[0, 0, 0, 0, 0, 0, 0],
+           [0, 1, 1, 0, 2, 2, 0],
+           [0, 1, 1, 0, 2, 2, 0],
+           [1, 0, 0, 0, 0, 0, 3]])
+
+    Find local maxima by comparing to all neighboring pixels (maximal
+    connectivity):
+
+    >>> local_maxima(image)
+    array([[0, 0, 0, 0, 0, 0, 0],
+           [0, 1, 1, 0, 0, 0, 0],
+           [0, 1, 1, 0, 0, 0, 0],
+           [1, 0, 0, 0, 0, 0, 1]], dtype=uint8)
+    >>> local_maxima(image, indices=True)
+    (array([1, 1, 2, 2, 3, 3]), array([1, 2, 1, 2, 0, 6]))
+
+    Find local maxima without comparing to diagonal pixels (connectivity 1):
+
+    >>> local_maxima(image, connectivity=1)
+    array([[0, 0, 0, 0, 0, 0, 0],
+           [0, 1, 1, 0, 1, 1, 0],
+           [0, 1, 1, 0, 1, 1, 0],
+           [1, 0, 0, 0, 0, 0, 1]], dtype=uint8)
+
+    and exclude maxima that border the image edge:
+
+    >>> local_maxima(image, connectivity=1, allow_borders=False)
+    array([[0, 0, 0, 0, 0, 0, 0],
+           [0, 1, 1, 0, 1, 1, 0],
+           [0, 1, 1, 0, 1, 1, 0],
+           [0, 0, 0, 0, 0, 0, 0]], dtype=uint8)
+    """
+    image = np.asarray(image, order="C")
+    if image.size == 0:
+        # Return early for empty input
+        if indices:
+            # Make sure that output is a tuple of 1 empty array per dimension
+            return np.nonzero(image)
+        else:
+            return np.zeros(image.shape, dtype=np.uint8)
+
+    if allow_borders:
+        # Ensure that local maxima are always at least one smaller sample away
+        # from the image border
+        image = _fast_pad(image, image.min())
+
+    # Array of flags used to store the state of each pixel during evaluation.
+    # See _extrema_cy.pyx for their meaning
+    flags = np.zeros(image.shape, dtype=np.uint8)
+    _set_edge_values_inplace(flags, value=3)
+
+    if any(s < 3 for s in image.shape):
+        # Warn and skip if any dimension is smaller than 3
+        # -> no maxima can exist & structuring element can't be applied
+        warn(
+            "maxima can't exist for an image with any dimension smaller 3 "
+            "if borders aren't allowed",
+            stacklevel=3
+        )
+    else:
+        selem = _resolve_neighborhood(selem, connectivity, image.ndim)
+        neighbor_offsets = _offsets_to_raveled_neighbors(
+            image.shape, selem, center=((1,) * image.ndim)
+        )
+
+        try:
+            _local_maxima(image.ravel(), flags.ravel(), neighbor_offsets)
+        except TypeError:
+            if image.dtype == np.float16:
+                # Provide the user with clearer error message
+                raise TypeError("dtype of `image` is float16 which is not "
+                                "supported, try upcasting to float32")
+            else:
+                raise  # Otherwise raise original message
+
+    if allow_borders:
+        # Revert padding performed at the beginning of the function
+        flags = crop(flags, 1)
+    else:
+        # No padding was performed but set edge values back to 0
+        _set_edge_values_inplace(flags, value=0)
+
+    if indices:
+        return np.nonzero(flags)
+    else:
+        return flags
+
+
+def local_minima(image, selem=None, connectivity=None, indices=False,
+                 allow_borders=True):
+    """Find local minima of n-dimensional array.
+
+    The local minima are defined as connected sets of pixels with equal gray
+    level (plateaus) strictly smaller than the gray levels of all pixels in the
+    neighborhood.
+
+    References
+    ----------
+    image : ndarray
+        An n-dimensional array.
+    selem : ndarray, optional
+        A structuring element used to determine the neighborhood of each
+        evaluated pixel. It must contain only 1's and 0's, have the same number
+        of dimensions as `image`. If not given, all adjacent pixels are
+        considered as part of the neighborhood.
+    connectivity : int, optional
+        A number used to determine the neighborhood of each evaluated pixel.
+        Adjacent pixels whose squared distance from the center is larger or
+        equal to `connectivity` are considered neighbors. Ignored if
+        `selem` is not None.
+    indices : bool, optional
+        If True, the output will be a tuple of one-dimensional arrays
+        representing the indices of local minima in each dimension. If False,
+        the output will be an array of 0's and 1's with the same shape as
+        `image`.
+    allow_borders : bool, optional
+        If true, plateaus that touch the image border are valid minima.
+
+    Returns
+    -------
+    minima : ndarray or tuple[ndarray]
+        If `indices` is false, an array with the same shape as `image` is
+        returned with 1's indicating the position of local minima
+        (0 otherwise). If `indices` is true, a tuple of one-dimensional arrays
+        containing the coordinates (indices) of all found minima.
 
     Examples
     --------


### PR DESCRIPTION
* Fix local_maxima for input with dimensions < 3

local_maxima (and local_minima) failed with an ValueError for images
with at least 1 dimension with fewer than 3 elements. This was due to
the implementation which applies a structuring element with exactly 3
elements in each dimension to the image in question. This behavior was
only visible if `allow_borders` was false, otherwise the image was
padded internally.
This fix makes these functions work for the mentioned edge cases by
testing the image shape at the appropriate time.

* Fix output of local_maxima for empty arrays

The old output for empty arrays if `indices` was true didn't correspond
to the output for non-empty arrays and the description in the docstring.
This ensures that the output will always be a tuple of empty arrays.

If `indices` is false, the returned empty array now machtes the shape of
`image` as well.

* Show warning if no maxima are possible

which is the case for dimensions with fewer than 3 samples. Because
`local_minima` wraps `local_maxima` the warning can only set the correct
stacklevel for one of these functions. The latter was chosen because it
stands to reason that it is / will be used more frequently.

If may be possible to suppress and re-raise the warning with the context
manager from the warnings module but that would introduce non-thread-
safe code and introduce perhaps unnecessary complexity.

* Point user to allow_borders in warning message

## Description
[Tell us about your new feature, improvement, or fix! If relevant, please supplement the PR with images.]


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
