### PR TITLE
Handle deprecation of numpy `_validate_lengths`

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -45,6 +45,8 @@ Other
   for sparse matricies (``np.matrix``) used by scipy.sparse in
   ``test_random_walker.py``. Note that there is also a chance ``scipy.sparse``
   moves away from using ``np.matrix`` in a future version too.
+* Remove the conditional import and function call when ``numpy`` is set
+  to > 1.15.x in ``skimage/util/arraycrop.py``.
 * When minimum supported version of ``scipy`` reaches 0.18, use 
   ``scipy.fftpack.next_fast_len`` directly in 
   ``skimage.feature.masked_register_translation``.

--- a/skimage/util/arraycrop.py
+++ b/skimage/util/arraycrop.py
@@ -4,138 +4,17 @@ n-dimensional array.
 """
 
 import numpy as np
-from numpy.lib.arraypad import _validate_lengths
 
+# After numpy 1.15, a new backward compatible function have been implemented.
+# See https://github.com/numpy/numpy/pull/11966
+from distutils.version import LooseVersion as Version
+old_numpy = Version(np.__version__) < Version('1.16')
+if old_numpy:
+    from numpy.lib.arraypad import _validate_lengths
+else:
+    from numpy.lib.arraypad import _as_pairs
 
 __all__ = ['crop']
-
-
-# The below functions are retained in comments in case the NumPy architecture
-# changes and we need copies of these helper functions for `crop`.
-# These are identical to functions in numpy.lib.arraypad.py as of NumPy v1.11
-
-# def _normalize_shape(ndarray, shape, cast_to_int=True):
-#     """
-#     Private function which does some checks and normalizes the possibly
-#     much simpler representations of 'pad_width', 'stat_length',
-#     'constant_values', 'end_values'.
-#
-#     Parameters
-#     ----------
-#     narray : ndarray
-#         Input ndarray
-#     shape : {sequence, array_like, float, int}, optional
-#         The width of padding (pad_width), the number of elements on the
-#         edge of the narray used for statistics (stat_length), the constant
-#         value(s) to use when filling padded regions (constant_values), or the
-#         endpoint target(s) for linear ramps (end_values).
-#         ((before_1, after_1), ... (before_N, after_N)) unique number of
-#         elements for each axis where `N` is rank of `narray`.
-#         ((before, after),) yields same before and after constants for each
-#         axis.
-#         (constant,) or val is a shortcut for before = after = constant for
-#         all axes.
-#     cast_to_int : bool, optional
-#         Controls if values in ``shape`` will be rounded and cast to int
-#         before being returned.
-#
-#     Returns
-#     -------
-#     normalized_shape : tuple of tuples
-#         val                               => ((val, val), (val, val), ...)
-#         [[val1, val2], [val3, val4], ...] => ((val1, val2), (val3, val4), ...)
-#         ((val1, val2), (val3, val4), ...) => no change
-#         [[val1, val2], ]                  => ((val1, val2), (val1, val2), ...)
-#         ((val1, val2), )                  => ((val1, val2), (val1, val2), ...)
-#         [[val ,     ], ]                  => ((val, val), (val, val), ...)
-#         ((val ,     ), )                  => ((val, val), (val, val), ...)
-#
-#     """
-#     ndims = ndarray.ndim
-#
-#     # Shortcut shape=None
-#     if shape is None:
-#         return ((None, None), ) * ndims
-#
-#     # Convert any input `info` to a NumPy array
-#     arr = np.asarray(shape)
-#
-#     # Switch based on what input looks like
-#     if arr.ndim <= 1:
-#         if arr.shape == () or arr.shape == (1,):
-#             # Single scalar input
-#             #   Create new array of ones, multiply by the scalar
-#             arr = np.ones((ndims, 2), dtype=ndarray.dtype) * arr
-#         elif arr.shape == (2,):
-#             # Apply padding (before, after) each axis
-#             #   Create new axis 0, repeat along it for every axis
-#             arr = arr[np.newaxis, :].repeat(ndims, axis=0)
-#         else:
-#             fmt = "Unable to create correctly shaped tuple from %s"
-#             raise ValueError(fmt % (shape,))
-#
-#     elif arr.ndim == 2:
-#         if arr.shape[1] == 1 and arr.shape[0] == ndims:
-#             # Padded before and after by the same amount
-#             arr = arr.repeat(2, axis=1)
-#         elif arr.shape[0] == ndims:
-#             # Input correctly formatted, pass it on as `arr`
-#             arr = shape
-#         else:
-#             fmt = "Unable to create correctly shaped tuple from %s"
-#             raise ValueError(fmt % (shape,))
-#
-#     else:
-#         fmt = "Unable to create correctly shaped tuple from %s"
-#         raise ValueError(fmt % (shape,))
-#
-#     # Cast if necessary
-#     if cast_to_int is True:
-#         arr = np.round(arr).astype(int)
-#
-#     # Convert list of lists to tuple of tuples
-#     return tuple(tuple(axis) for axis in arr.tolist())
-
-
-# def _validate_lengths(narray, number_elements):
-#     """
-#     Private function which does some checks and reformats pad_width and
-#     stat_length using _normalize_shape.
-#
-#     Parameters
-#     ----------
-#     narray : ndarray
-#         Input ndarray
-#     number_elements : {sequence, int}, optional
-#         The width of padding (pad_width) or the number of elements on the edge
-#         of the narray used for statistics (stat_length).
-#         ((before_1, after_1), ... (before_N, after_N)) unique number of
-#         elements for each axis.
-#         ((before, after),) yields same before and after constants for each
-#         axis.
-#         (constant,) or int is a shortcut for before = after = constant for all
-#         axes.
-#
-#     Returns
-#     -------
-#     _validate_lengths : tuple of tuples
-#         int                               => ((int, int), (int, int), ...)
-#         [[int1, int2], [int3, int4], ...] => ((int1, int2), (int3, int4), ...)
-#         ((int1, int2), (int3, int4), ...) => no change
-#         [[int1, int2], ]                  => ((int1, int2), (int1, int2), ...)
-#         ((int1, int2), )                  => ((int1, int2), (int1, int2), ...)
-#         [[int ,     ], ]                  => ((int, int), (int, int), ...)
-#         ((int ,     ), )                  => ((int, int), (int, int), ...)
-#
-#     """
-#     normshp = _normalize_shape(narray, number_elements)
-#     for i in normshp:
-#         chk = [1 if x is None else x for x in i]
-#         chk = [1 if x >= 0 else -1 for x in chk]
-#         if (chk[0] < 0) or (chk[1] < 0):
-#             fmt = "%s cannot contain negative values."
-#             raise ValueError(fmt % (number_elements,))
-#     return normshp
 
 
 def crop(ar, crop_width, copy=False, order='K'):
@@ -168,7 +47,10 @@ def crop(ar, crop_width, copy=False, order='K'):
         view of the input array.
     """
     ar = np.array(ar, copy=False)
-    crops = _validate_lengths(ar, crop_width)
+    if old_numpy:
+        crops = _validate_lengths(ar, crop_width)
+    else:
+        crops = _as_pairs(crop_width, ar.ndim, as_index=True)
     slices = tuple(slice(a, ar.shape[i] - b)
                    for i, (a, b) in enumerate(crops))
     if copy:


### PR DESCRIPTION
## Description

Fixes #3551 

I had to make a choice here. I preferred to keep using numpy. I removed the commented code (IMHO, not such a good practice to do that, we can browse numpy's history at any time)

A TODO task is added to remove the conditional function call.

This PR needs to be backported.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
