### PR TITLE
Switched from np.power to np.cbrt

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1131,7 +1131,7 @@ def xyz2luv(xyz, illuminant="D65", observer="2"):
     xyz_ref_white = np.array(get_xyz_coords(illuminant, observer))
     L = y / xyz_ref_white[1]
     mask = L > 0.008856
-    L[mask] = 116. * np.power(L[mask], 1. / 3.) - 16.
+    L[mask] = 116. * np.cbrt(L[mask]) - 16.
     L[~mask] = 903.3 * L[~mask]
 
     u0 = 4 * xyz_ref_white[0] / ([1, 15, 3] @ xyz_ref_white)

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -922,7 +922,7 @@ def xyz2lab(xyz, illuminant="D65", observer="2"):
 
     # Nonlinear distortion and linear transformation
     mask = arr > 0.008856
-    arr[mask] = np.power(arr[mask], 1. / 3.)
+    arr[mask] = np.cbrt(arr[mask])
     arr[~mask] = 7.787 * arr[~mask] + 16. / 116.
 
     x, y, z = arr[..., 0], arr[..., 1], arr[..., 2]


### PR DESCRIPTION
## Description
This doubles the speed of `xyz2lab`, and by extension, `rgb2lab` also which addresses at least in part #1133. 

### Note
`cbrt` does require `numpy` v1.10.0 (released on 6 Oct 2015)... but the current skimage requirement is v1.11.0 anyway. 

## References
#1133 

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
