### PR TITLE
Add RGB to grayscale example to gallery

### DIFF
--- a/doc/examples/color_exposure/plot_local_equalize.py
+++ b/doc/examples/color_exposure/plot_local_equalize.py
@@ -3,7 +3,7 @@
 Local Histogram Equalization
 ============================
 
-This examples enhances an image with low contrast, using a method called *local
+This example enhances an image with low contrast, using a method called *local
 histogram equalization*, which spreads out the most frequent intensity values
 in an image.
 

--- a/doc/examples/color_exposure/plot_rgb_to_gray.py
+++ b/doc/examples/color_exposure/plot_rgb_to_gray.py
@@ -3,16 +3,16 @@
 RGB to grayscale
 ================
 
-This example converts an image with RGB channels into an image with a single 
-grayscale channel. 
+This example converts an image with RGB channels into an image with a single
+grayscale channel.
 
-The value of each grayscale pixel is calculated as the weighted sum of the 
+The value of each grayscale pixel is calculated as the weighted sum of the
 corresponding red, green and blue pixels as::
 
         Y = 0.2125 R + 0.7154 G + 0.0721 B
 
-These weights are used by CRT phosphors as they better represent human 
-perception of red, green and blue than equal weights. [1]_ 
+These weights are used by CRT phosphors as they better represent human
+perception of red, green and blue than equal weights. [1]_
 
 References
 ----------

--- a/doc/examples/color_exposure/plot_rgb_to_gray.py
+++ b/doc/examples/color_exposure/plot_rgb_to_gray.py
@@ -1,0 +1,40 @@
+"""
+================
+RGB to grayscale
+================
+
+This example converts an image with RGB channels into an image with a single 
+grayscale channel. 
+
+The value of each grayscale pixel is calculated as the weighted sum of the 
+corresponding red, green and blue pixels as::
+
+        Y = 0.2125 R + 0.7154 G + 0.0721 B
+
+These weights are used by CRT phosphors as they better represent human 
+perception of red, green and blue than equal weights. [1]_ 
+
+References
+----------
+.. [1] http://www.poynton.com/PDFs/ColorFAQ.pdf
+
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+
+from skimage import data
+from skimage.color import rgb2gray
+
+original = data.astronaut()
+grayscale = rgb2gray(original)
+
+fig, axes = plt.subplots(1, 2, figsize=(8, 4))
+ax = axes.ravel()
+
+ax[0].imshow(original)
+ax[0].set_title("Original")
+ax[1].imshow(grayscale, cmap=plt.cm.gray)
+ax[1].set_title("Grayscale")
+
+fig.tight_layout()
+plt.show()


### PR DESCRIPTION
## Description
Added RGB to grayscale example to gallery. Also fixed a small typo in `plot_local_equalize.py`.

## References
Related to #1231

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
