### PR TITLE
Remove precision and sign loss warnings from util.img_as_

### DIFF
--- a/doc/examples/applications/plot_rank_filters.py
+++ b/doc/examples/applications/plot_rank_filters.py
@@ -37,7 +37,7 @@ from ``skimage.data`` for all comparisons.
 import numpy as np
 import matplotlib.pyplot as plt
 
-from skimage import img_as_ubyte
+from skimage.util import img_as_ubyte
 from skimage import data
 from skimage.exposure import histogram
 

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -51,6 +51,7 @@ API Changes
   ``skimage.feature.corner.hessian_matrix_eigvals`` in favor of ``H_elems``.
 - Default value of ``order`` parameter has been set to ``rc`` in
   ``skimage.feature.hessian_matrix``.
+- ``skimage.util.img_as_*`` functions no longer raise precision and/or loss warnings.
 
 
 Bugfixes

--- a/doc/source/user_guide/data_types.rst
+++ b/doc/source/user_guide/data_types.rst
@@ -33,7 +33,7 @@ functions that convert dtypes and properly rescale image intensities (see
 `Input types`_). You should **never use** ``astype`` on an image, because it
 violates these assumptions about the dtype range::
 
-   >>> from skimage import img_as_float
+   >>> from skimage.util import img_as_float
    >>> image = np.arange(0, 50, 10, dtype=np.uint8)
    >>> print(image.astype(np.float)) # These float values are out of range.
    [  0.  10.  20.  30.  40.]
@@ -65,7 +65,7 @@ img_as_int     Convert to 16-bit int.
 These functions convert images to the desired dtype and *properly rescale their
 values*::
 
-   >>> from skimage import img_as_ubyte
+   >>> from skimage.util import img_as_ubyte
    >>> image = np.array([0, 0.5, 1], dtype=float)
    >>> img_as_ubyte(image)
    array([  0, 128, 255], dtype=uint8)
@@ -124,7 +124,7 @@ unnecessary data copies take place.
 A user that requires a specific type of output (e.g., for display purposes),
 may write::
 
-   >>> from skimage import img_as_uint
+   >>> from skimage.util import img_as_uint
    >>> out = img_as_uint(sobel(image))
    >>> plt.imshow(out)
 
@@ -160,7 +160,7 @@ If cv_image is an array of unsigned bytes, ``skimage`` will understand it by
 default. If you prefer working with floating point images, :func:`img_as_float`
 can be used to convert the image::
 
-    >>> from skimage import img_as_float
+    >>> from skimage.util import img_as_float
     >>> image = img_as_float(any_opencv_image)
 
 Using an image from ``skimage`` with OpenCV
@@ -168,7 +168,7 @@ Using an image from ``skimage`` with OpenCV
 
 The reverse can be achieved with :func:`img_as_ubyte`::
 
-    >>> from skimage import img_as_ubyte
+    >>> from skimage.util import img_as_ubyte
     >>> cv_image = img_as_ubyte(any_skimage_image)
 
 
@@ -181,7 +181,7 @@ a custom function that requires a particular dtype, you should call one of the
 dtype conversion functions (here, ``func1`` and ``func2`` are ``skimage``
 functions)::
 
-   >>> from skimage import img_as_float
+   >>> from skimage.util import img_as_float
    >>> image = img_as_float(func1(func2(image)))
    >>> processed_image = custom_func(image)
 

--- a/doc/source/user_guide/data_types.rst
+++ b/doc/source/user_guide/data_types.rst
@@ -70,22 +70,12 @@ values*::
    >>> img_as_ubyte(image)
    array([  0, 128, 255], dtype=uint8)
 
-These conversions can result in a loss of precision, since 8 bits cannot hold
-the same amount of information as 64 bits::
+Be careful! These conversions can result in a loss of precision, since 8 bits
+cannot hold the same amount of information as 64 bits::
 
    >>> image = np.array([0, 0.5, 0.503, 1], dtype=float)
    >>> image_as_ubyte(image)
    array([  0, 128, 128, 255], dtype=uint8)
-
-If desired, the user can be warned when such loss of information happens, by
-using a keyword argument::
-
-   >>> image_as_ubyte(image, warn_on_precision_loss=True)
-   UserWarning: Possible precision loss when converting from float64 to uint8
-   array([  0, 128, 128, 255], dtype=uint8)
-
-There is also a keyword argument to warn when it is possible to lose sign
-information, ``warn_on_sign_loss=True``.
 
 Additionally, some functions take a ``preserve_range`` argument where a range
 conversion is convenient but not necessary. For example, interpolation in

--- a/doc/source/user_guide/data_types.rst
+++ b/doc/source/user_guide/data_types.rst
@@ -63,24 +63,29 @@ img_as_int     Convert to 16-bit int.
 =============  =================================
 
 These functions convert images to the desired dtype and *properly rescale their
-values*. If conversion reduces the precision of the image, then a warning is
-issued::
+values*::
 
    >>> from skimage import img_as_ubyte
    >>> image = np.array([0, 0.5, 1], dtype=float)
    >>> img_as_ubyte(image)
-   WARNING:dtype_converter:Possible precision loss when converting from
-   float64 to uint8
    array([  0, 128, 255], dtype=uint8)
 
-Warnings can be locally ignored with a context manager::
+These conversions can result in a loss of precision, since 8 bits cannot hold
+the same amount of information as 64 bits::
 
-   >>> import warnings
-   >>> image = np.array([0, 0.5, 1], dtype=float)
-   >>> with warnings.catch_warnings():
-   ...     warnings.simplefilter("ignore")
-   ...     img_as_ubyte(image)
-   array([  0, 128, 255], dtype=uint8)
+   >>> image = np.array([0, 0.5, 0.503, 1], dtype=float)
+   >>> image_as_ubyte(image)
+   array([  0, 128, 128, 255], dtype=uint8)
+
+If desired, the user can be warned when such loss of information happens, by
+using a keyword argument::
+
+   >>> image_as_ubyte(image, warn_on_precision_loss=True)
+   UserWarning: Possible precision loss when converting from float64 to uint8
+   array([  0, 128, 128, 255], dtype=uint8)
+
+There is also a keyword argument to warn when it is possible to lose sign
+information, ``warn_on_sign_loss=True``.
 
 Additionally, some functions take a ``preserve_range`` argument where a range
 conversion is convenient but not necessary. For example, interpolation in

--- a/skimage/_shared/_warnings.py
+++ b/skimage/_shared/_warnings.py
@@ -85,8 +85,7 @@ def expected_warnings(matching):
     >>> from skimage import data
     >>> from skimage.util import img_as_ubyte, img_as_float
     >>> with expected_warnings(['precision loss']):
-    ...     d = img_as_ubyte(img_as_float(data.coins()),
-    ...                      warn_on_precision_loss=True)
+    ...     d = img_as_ubyte(img_as_float(data.coins()))
 
     Notes
     -----

--- a/skimage/_shared/_warnings.py
+++ b/skimage/_shared/_warnings.py
@@ -84,7 +84,8 @@ def expected_warnings(matching):
     --------
     >>> from skimage import data, img_as_ubyte, img_as_float
     >>> with expected_warnings(['precision loss']):
-    ...     d = img_as_ubyte(img_as_float(data.coins()))
+    ...     d = img_as_ubyte(img_as_float(data.coins()),
+    ...                      warn_on_precision_loss=True)
 
     Notes
     -----

--- a/skimage/_shared/_warnings.py
+++ b/skimage/_shared/_warnings.py
@@ -82,7 +82,8 @@ def expected_warnings(matching):
 
     Examples
     --------
-    >>> from skimage import data, img_as_ubyte, img_as_float
+    >>> from skimage import data
+    >>> from skimage.util import img_as_ubyte, img_as_float
     >>> with expected_warnings(['precision loss']):
     ...     d = img_as_ubyte(img_as_float(data.coins()),
     ...                      warn_on_precision_loss=True)

--- a/skimage/_shared/_warnings.py
+++ b/skimage/_shared/_warnings.py
@@ -82,10 +82,12 @@ def expected_warnings(matching):
 
     Examples
     --------
-    >>> from skimage import data
-    >>> from skimage.util import img_as_ubyte, img_as_float
-    >>> with expected_warnings(['precision loss']):
-    ...     d = img_as_ubyte(img_as_float(data.coins()))
+    >>> import numpy as np
+    >>> image = np.random.randint(0, 2**16, size=(100, 100), dtype=np.uint16)
+    >>> # rank filters are slow when bit-depth exceeds 10 bits
+    >>> from skimage import filters
+    >>> with expected_warnings(['Bad rank filter performance']):
+    ...     median_filtered = filters.rank.median(image)
 
     Notes
     -----

--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -20,7 +20,8 @@ from numpy.testing import (assert_array_equal, assert_array_almost_equal,
 from ._warnings import expected_warnings
 import warnings
 
-from .. import data, io, img_as_uint, img_as_float, img_as_int, img_as_ubyte
+from .. import data, io
+from ..util import img_as_uint, img_as_float, img_as_int, img_as_ubyte
 import pytest
 
 

--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -17,7 +17,6 @@ from numpy.testing import (assert_array_equal, assert_array_almost_equal,
                            assert_almost_equal, assert_, assert_warns,
                            assert_no_warnings)
 
-from ._warnings import expected_warnings
 import warnings
 
 from .. import data, io
@@ -131,25 +130,20 @@ def color_check(plugin, fmt='png'):
     testing.assert_allclose(img2.astype(np.uint8), r2)
 
     img3 = img_as_float(img)
-    with expected_warnings(['precision loss']):
-        r3 = roundtrip(img3, plugin, fmt)
+    r3 = roundtrip(img3, plugin, fmt)
     testing.assert_allclose(r3, img)
 
-    with expected_warnings(['precision loss']):
-        img4 = img_as_int(img)
+    img4 = img_as_int(img)
     if fmt.lower() in (('tif', 'tiff')):
         img4 -= 100
-        with expected_warnings(['sign loss']):
-            r4 = roundtrip(img4, plugin, fmt)
+        r4 = roundtrip(img4, plugin, fmt)
         testing.assert_allclose(r4, img4)
     else:
-        with expected_warnings(['sign loss|precision loss']):
-            r4 = roundtrip(img4, plugin, fmt)
-            testing.assert_allclose(r4, img_as_ubyte(img4))
+        r4 = roundtrip(img4, plugin, fmt)
+        testing.assert_allclose(r4, img_as_ubyte(img4))
 
     img5 = img_as_uint(img)
-    with expected_warnings(['precision loss']):
-        r5 = roundtrip(img5, plugin, fmt)
+    r5 = roundtrip(img5, plugin, fmt)
     testing.assert_allclose(r5, img)
 
 
@@ -168,24 +162,20 @@ def mono_check(plugin, fmt='png'):
     testing.assert_allclose(img2.astype(np.uint8), r2)
 
     img3 = img_as_float(img)
-    with expected_warnings([r'precision|\A\Z']):
-        r3 = roundtrip(img3, plugin, fmt)
+    r3 = roundtrip(img3, plugin, fmt)
     if r3.dtype.kind == 'f':
         testing.assert_allclose(img3, r3)
     else:
         testing.assert_allclose(r3, img_as_uint(img))
 
-    with expected_warnings(['precision loss']):
-        img4 = img_as_int(img)
+    img4 = img_as_int(img)
     if fmt.lower() in (('tif', 'tiff')):
         img4 -= 100
-        with expected_warnings([r'sign loss|\A\Z']):
-            r4 = roundtrip(img4, plugin, fmt)
+        r4 = roundtrip(img4, plugin, fmt)
         testing.assert_allclose(r4, img4)
     else:
-        with expected_warnings(['precision loss|sign loss']):
-            r4 = roundtrip(img4, plugin, fmt)
-            testing.assert_allclose(r4, img_as_uint(img4))
+        r4 = roundtrip(img4, plugin, fmt)
+        testing.assert_allclose(r4, img_as_uint(img4))
 
     img5 = img_as_uint(img)
     r5 = roundtrip(img5, plugin, fmt)

--- a/skimage/color/tests/test_adapt_rgb.py
+++ b/skimage/color/tests/test_adapt_rgb.py
@@ -5,7 +5,6 @@ import numpy as np
 from skimage import img_as_float, img_as_uint
 from skimage import color, data, filters
 from skimage.color.adapt_rgb import adapt_rgb, each_channel, hsv_value
-from skimage._shared._warnings import expected_warnings
 
 # Down-sample image for quicker testing.
 COLOR_IMAGE = data.astronaut()[::5, ::6]
@@ -45,8 +44,7 @@ def smooth_hsv(image, sigma):
 
 @adapt_rgb(hsv_value)
 def edges_hsv_uint(image):
-    with expected_warnings(['precision loss']):
-        return img_as_uint(filters.sobel(image))
+    return img_as_uint(filters.sobel(image))
 
 
 def test_gray_scale_image():

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -174,8 +174,7 @@ class TestColorconv(TestCase):
     # RGB<->HED roundtrip with ubyte image
     def test_hed_rgb_roundtrip(self):
         img_rgb = img_as_ubyte(self.img_rgb)
-        with expected_warnings(['precision loss']):
-            new = img_as_ubyte(hed2rgb(rgb2hed(img_rgb)))
+        new = img_as_ubyte(hed2rgb(rgb2hed(img_rgb)))
         assert_equal(new, img_rgb)
 
     # RGB<->HED roundtrip with float image
@@ -189,8 +188,7 @@ class TestColorconv(TestCase):
         img_rgb = self.img_rgb
         conv = combine_stains(separate_stains(img_rgb, hdx_from_rgb),
                               rgb_from_hdx)
-        with expected_warnings(['precision loss']):
-            assert_equal(img_as_ubyte(conv), img_rgb)
+        assert_equal(img_as_ubyte(conv), img_rgb)
 
     # RGB<->HDX roundtrip with float image
     def test_hdx_rgb_roundtrip_float(self):

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -15,7 +15,7 @@ from skimage._shared.testing import assert_equal, assert_almost_equal
 from skimage._shared.testing import assert_array_almost_equal
 from skimage._shared.testing import TestCase
 
-from skimage import img_as_float, img_as_ubyte
+from skimage.util import img_as_float, img_as_ubyte
 from skimage.io import imread
 from skimage.color import (rgb2hsv, hsv2rgb,
                            rgb2xyz, xyz2rgb,

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -236,8 +236,7 @@ def horse():
     horse : (328, 400) bool ndarray
         Horse image.
     """
-    with expected_warnings(['Possible precision loss', 'Possible sign loss']):
-        return img_as_bool(load("horse.png", as_gray=True))
+    return img_as_bool(load("horse.png", as_gray=True))
 
 
 def clock():

--- a/skimage/draw/tests/test_random_shapes.py
+++ b/skimage/draw/tests/test_random_shapes.py
@@ -3,7 +3,7 @@ import numpy as np
 from skimage.draw import random_shapes
 
 from skimage._shared import testing
-from skimage._shared.testing import expected_warnings
+from skimage._shared._warnings import expected_warnings
 
 
 def test_generates_color_images_with_correct_shape():

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -135,8 +135,7 @@ def test_equalize_uint8_approx():
 
 
 def test_equalize_ubyte():
-    with expected_warnings(['precision loss']):
-        img = util.img_as_ubyte(test_img)
+    img = util.img_as_ubyte(test_img)
     img_eq = exposure.equalize_hist(img)
 
     cdf, bin_edges = exposure.cumulative_distribution(img_eq)
@@ -277,7 +276,7 @@ def test_adapthist_grayscale():
     img = util.img_as_float(data.astronaut())
     img = rgb2gray(img)
     img = np.dstack((img, img, img))
-    with expected_warnings(['precision loss|non-contiguous input']):
+    with expected_warnings(['non-contiguous input']):
         adapted = exposure.equalize_adapthist(img, kernel_size=(57, 51),
                                               clip_limit=0.01, nbins=128)
     assert img.shape == adapted.shape
@@ -293,8 +292,7 @@ def test_adapthist_color():
         warnings.simplefilter('always')
         hist, bin_centers = exposure.histogram(img)
         assert len(w) > 0
-    with expected_warnings(['precision loss']):
-        adapted = exposure.equalize_adapthist(img, clip_limit=0.01)
+    adapted = exposure.equalize_adapthist(img, clip_limit=0.01)
 
     assert adapted.min() == 0
     assert adapted.max() == 1.0
@@ -311,8 +309,7 @@ def test_adapthist_alpha():
     img = util.img_as_float(data.astronaut())
     alpha = np.ones((img.shape[0], img.shape[1]), dtype=float)
     img = np.dstack((img, alpha))
-    with expected_warnings(['precision loss']):
-        adapted = exposure.equalize_adapthist(img)
+    adapted = exposure.equalize_adapthist(img)
     assert adapted.shape != img.shape
     img = img[:, :, :3]
     full_scale = exposure.rescale_intensity(img)

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -276,9 +276,8 @@ def test_adapthist_grayscale():
     img = util.img_as_float(data.astronaut())
     img = rgb2gray(img)
     img = np.dstack((img, img, img))
-    with expected_warnings(['non-contiguous input']):
-        adapted = exposure.equalize_adapthist(img, kernel_size=(57, 51),
-                                              clip_limit=0.01, nbins=128)
+    adapted = exposure.equalize_adapthist(img, kernel_size=(57, 51),
+                                          clip_limit=0.01, nbins=128)
     assert img.shape == adapted.shape
     assert_almost_equal(peak_snr(img, adapted), 102.078, 3)
     assert_almost_equal(norm_brightness_err(img, adapted), 0.0529, 3)

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -2,7 +2,7 @@ import warnings
 
 import numpy as np
 import pytest
-import skimage
+from skimage import util
 from skimage import data
 from skimage import exposure
 from skimage.exposure.exposure import intensity_range
@@ -123,7 +123,7 @@ np.random.seed(0)
 
 test_img_int = data.camera()
 # squeeze image intensities to lower image contrast
-test_img = skimage.img_as_float(test_img_int)
+test_img = util.img_as_float(test_img_int)
 test_img = exposure.rescale_intensity(test_img / 5. + 100)
 
 
@@ -136,7 +136,7 @@ def test_equalize_uint8_approx():
 
 def test_equalize_ubyte():
     with expected_warnings(['precision loss']):
-        img = skimage.img_as_ubyte(test_img)
+        img = util.img_as_ubyte(test_img)
     img_eq = exposure.equalize_hist(img)
 
     cdf, bin_edges = exposure.cumulative_distribution(img_eq)
@@ -144,7 +144,7 @@ def test_equalize_ubyte():
 
 
 def test_equalize_float():
-    img = skimage.img_as_float(test_img)
+    img = util.img_as_float(test_img)
     img_eq = exposure.equalize_hist(img)
 
     cdf, bin_edges = exposure.cumulative_distribution(img_eq)
@@ -152,7 +152,7 @@ def test_equalize_float():
 
 
 def test_equalize_masked():
-    img = skimage.img_as_float(test_img)
+    img = util.img_as_float(test_img)
     mask = np.zeros(test_img.shape)
     mask[50:150, 50:250] = 1
     img_mask_eq = exposure.equalize_hist(img, mask=mask)
@@ -274,7 +274,7 @@ def test_rescale_uint14_limits():
 def test_adapthist_grayscale():
     """Test a grayscale float image
     """
-    img = skimage.img_as_float(data.astronaut())
+    img = util.img_as_float(data.astronaut())
     img = rgb2gray(img)
     img = np.dstack((img, img, img))
     with expected_warnings(['precision loss|non-contiguous input']):
@@ -288,7 +288,7 @@ def test_adapthist_grayscale():
 def test_adapthist_color():
     """Test an RGB color uint16 image
     """
-    img = skimage.img_as_uint(data.astronaut())
+    img = util.img_as_uint(data.astronaut())
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         hist, bin_centers = exposure.histogram(img)
@@ -299,7 +299,7 @@ def test_adapthist_color():
     assert adapted.min() == 0
     assert adapted.max() == 1.0
     assert img.shape == adapted.shape
-    full_scale = skimage.exposure.rescale_intensity(img)
+    full_scale = exposure.rescale_intensity(img)
     assert_almost_equal(peak_snr(full_scale, adapted), 109.393, 1)
     assert_almost_equal(norm_brightness_err(full_scale, adapted), 0.02, 2)
     return data, adapted
@@ -308,14 +308,14 @@ def test_adapthist_color():
 def test_adapthist_alpha():
     """Test an RGBA color image
     """
-    img = skimage.img_as_float(data.astronaut())
+    img = util.img_as_float(data.astronaut())
     alpha = np.ones((img.shape[0], img.shape[1]), dtype=float)
     img = np.dstack((img, alpha))
     with expected_warnings(['precision loss']):
         adapted = exposure.equalize_adapthist(img)
     assert adapted.shape != img.shape
     img = img[:, :, :3]
-    full_scale = skimage.exposure.rescale_intensity(img)
+    full_scale = exposure.rescale_intensity(img)
     assert img.shape == adapted.shape
     assert_almost_equal(peak_snr(full_scale, adapted), 109.393, 2)
     assert_almost_equal(norm_brightness_err(full_scale, adapted), 0.0248, 3)
@@ -336,8 +336,8 @@ def peak_snr(img1, img2):
     """
     if img1.ndim == 3:
         img1, img2 = rgb2gray(img1.copy()), rgb2gray(img2.copy())
-    img1 = skimage.img_as_float(img1)
-    img2 = skimage.img_as_float(img2)
+    img1 = util.img_as_float(img1)
+    img2 = util.img_as_float(img2)
     mse = 1. / img1.size * np.square(img1 - img2).sum()
     _, max_ = dtype_range[img1.dtype.type]
     return 20 * np.log(max_ / mse)

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -6,7 +6,8 @@ from skimage import img_as_float
 from skimage import draw
 from skimage.color import rgb2gray
 from skimage.morphology import octagon
-from skimage._shared.testing import test_parallel, expected_warnings
+from skimage._shared.testing import test_parallel
+from skimage._shared._warnings import expected_warnings
 from skimage._shared import testing
 import pytest
 

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -67,6 +67,11 @@ def _handle_input(image, selem, out, mask, out_dtype=None, pixel_size=1):
 
     assert_nD(image, 2)
     if image.dtype not in (np.uint8, np.uint16):
+        message = ('Possible precision loss converting image of type {} to '
+                   'uint8 as required by rank filters. Convert manually using '
+                   'skimage.util.img_as_ubyte to silence this warning.'
+                   .format(image.dtype))
+        warn(message, stacklevel=2)
         image = img_as_ubyte(image)
 
     selem = np.ascontiguousarray(img_as_ubyte(selem > 0))
@@ -101,7 +106,8 @@ def _handle_input(image, selem, out, mask, out_dtype=None, pixel_size=1):
     if n_bins > 2**10:
         warn("Bad rank filter performance is expected due to a "
              "large number of bins ({}), equivalent to an approximate "
-             "bitdepth of {:.1f}.".format(n_bins, np.log2(n_bins)))
+             "bitdepth of {:.1f}.".format(n_bins, np.log2(n_bins)),
+             stacklevel=2)
 
     return image, selem, out, mask, n_bins
 

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -51,7 +51,7 @@ References
 import functools
 import numpy as np
 from scipy import ndimage as ndi
-from ... import img_as_ubyte
+from ...util import img_as_ubyte
 from ..._shared.utils import assert_nD, warn
 
 from . import generic_cy

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -5,7 +5,7 @@ from skimage._shared.testing import (assert_equal, assert_array_equal,
 from skimage._shared import testing
 
 import skimage
-from skimage import img_as_ubyte, img_as_float
+from skimage.util import img_as_ubyte, img_as_float
 from skimage import data, util, morphology
 from skimage.morphology import grey, disk
 from skimage.filters import rank

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -83,8 +83,7 @@ class TestRank():
             else:
                 assert_array_equal(expected, result)
 
-        with expected_warnings(['precision loss']):
-            check()
+        check()
 
 
     def test_random_sizes(self):
@@ -290,8 +289,7 @@ class TestRank():
         for method in methods:
             func = getattr(rank, method)
             out_u = func(image_uint, disk(3))
-            with expected_warnings(['precision loss']):
-                out_f = func(image_float, disk(3))
+            out_f = func(image_float, disk(3))
             assert_equal(out_u, out_f)
 
 
@@ -304,8 +302,11 @@ class TestRank():
         image[image > 127] = 0
         image_s = image.astype(np.int8)
         with expected_warnings(['sign loss', 'precision loss']):
-            image_u = img_as_ubyte(image_s)
-            assert_equal(image_u, img_as_ubyte(image_s))
+            image_u = img_as_ubyte(image_s, warn_on_precision_loss=True,
+                                   warn_on_sign_loss=True)
+            assert_equal(image_u, img_as_ubyte(image_s,
+                                               warn_on_precision_loss=True,
+                                               warn_on_sign_loss=True))
 
         methods = ['autolevel', 'bottomhat', 'equalize', 'gradient', 'maximum',
                    'mean', 'geometric_mean', 'subtract_mean', 'median', 'minimum',
@@ -313,10 +314,8 @@ class TestRank():
 
         for method in methods:
             func = getattr(rank, method)
-
-            with expected_warnings(['sign loss', 'precision loss']):
-                out_u = func(image_u, disk(3))
-                out_s = func(image_s, disk(3))
+            out_u = func(image_u, disk(3))
+            out_s = func(image_s, disk(3))
             assert_equal(out_u, out_s)
 
     @parametrize('method',

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -301,12 +301,8 @@ class TestRank():
         image = img_as_ubyte(data.camera())[::2, ::2]
         image[image > 127] = 0
         image_s = image.astype(np.int8)
-        with expected_warnings(['sign loss', 'precision loss']):
-            image_u = img_as_ubyte(image_s, warn_on_precision_loss=True,
-                                   warn_on_sign_loss=True)
-            assert_equal(image_u, img_as_ubyte(image_s,
-                                               warn_on_precision_loss=True,
-                                               warn_on_sign_loss=True))
+        image_u = img_as_ubyte(image_s)
+        assert_equal(image_u, img_as_ubyte(image_s))
 
         methods = ['autolevel', 'bottomhat', 'equalize', 'gradient', 'maximum',
                    'mean', 'geometric_mean', 'subtract_mean', 'median', 'minimum',

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -1,7 +1,8 @@
 import pytest
 import numpy as np
 from scipy import ndimage as ndi
-import skimage
+
+from skimage import util
 from skimage import data
 from skimage.draw import circle
 from skimage._shared._warnings import expected_warnings
@@ -215,22 +216,22 @@ class TestSimpleImage():
 
 
 def test_otsu_camera_image():
-    camera = skimage.img_as_ubyte(data.camera())
+    camera = util.img_as_ubyte(data.camera())
     assert 86 < threshold_otsu(camera) < 88
 
 
 def test_otsu_coins_image():
-    coins = skimage.img_as_ubyte(data.coins())
+    coins = util.img_as_ubyte(data.coins())
     assert 106 < threshold_otsu(coins) < 108
 
 
 def test_otsu_coins_image_as_float():
-    coins = skimage.img_as_float(data.coins())
+    coins = util.img_as_float(data.coins())
     assert 0.41 < threshold_otsu(coins) < 0.42
 
 
 def test_otsu_astro_image():
-    img = skimage.img_as_ubyte(data.astronaut())
+    img = util.img_as_ubyte(data.astronaut())
     with expected_warnings(['grayscale']):
         assert 109 < threshold_otsu(img) < 111
 
@@ -242,7 +243,7 @@ def test_otsu_one_color_image():
 
 
 def test_li_camera_image():
-    image = skimage.img_as_ubyte(data.camera())
+    image = util.img_as_ubyte(data.camera())
     threshold = threshold_li(image)
     ce_actual = _cross_entropy(image, threshold)
     assert 62 < threshold_li(image) < 63
@@ -251,7 +252,7 @@ def test_li_camera_image():
 
 
 def test_li_coins_image():
-    image = skimage.img_as_ubyte(data.coins())
+    image = util.img_as_ubyte(data.coins())
     threshold = threshold_li(image)
     ce_actual = _cross_entropy(image, threshold)
     assert 94 < threshold_li(image) < 95
@@ -265,12 +266,12 @@ def test_li_coins_image():
 
 
 def test_li_coins_image_as_float():
-    coins = skimage.img_as_float(data.coins())
+    coins = util.img_as_float(data.coins())
     assert 94/255 < threshold_li(coins) < 95/255
 
 
 def test_li_astro_image():
-    image = skimage.img_as_ubyte(data.astronaut())
+    image = util.img_as_ubyte(data.astronaut())
     threshold = threshold_li(image)
     ce_actual = _cross_entropy(image, threshold)
     assert 64 < threshold < 65
@@ -299,17 +300,17 @@ def test_li_constant_image_with_nan():
 
 
 def test_yen_camera_image():
-    camera = skimage.img_as_ubyte(data.camera())
+    camera = util.img_as_ubyte(data.camera())
     assert 197 < threshold_yen(camera) < 199
 
 
 def test_yen_coins_image():
-    coins = skimage.img_as_ubyte(data.coins())
+    coins = util.img_as_ubyte(data.coins())
     assert 109 < threshold_yen(coins) < 111
 
 
 def test_yen_coins_image_as_float():
-    coins = skimage.img_as_float(data.coins())
+    coins = util.img_as_float(data.coins())
     assert 0.43 < threshold_yen(coins) < 0.44
 
 
@@ -320,7 +321,7 @@ def test_local_even_block_size_error():
 
 
 def test_isodata_camera_image():
-    camera = skimage.img_as_ubyte(data.camera())
+    camera = util.img_as_ubyte(data.camera())
 
     threshold = threshold_isodata(camera)
     assert np.floor((camera[camera <= threshold].mean() +
@@ -331,7 +332,7 @@ def test_isodata_camera_image():
 
 
 def test_isodata_coins_image():
-    coins = skimage.img_as_ubyte(data.coins())
+    coins = util.img_as_ubyte(data.coins())
 
     threshold = threshold_isodata(coins)
     assert np.floor((coins[coins <= threshold].mean() +
@@ -342,7 +343,7 @@ def test_isodata_coins_image():
 
 
 def test_isodata_moon_image():
-    moon = skimage.img_as_ubyte(data.moon())
+    moon = util.img_as_ubyte(data.moon())
 
     threshold = threshold_isodata(moon)
     assert np.floor((moon[moon <= threshold].mean() +
@@ -357,7 +358,7 @@ def test_isodata_moon_image():
 
 
 def test_isodata_moon_image_negative_int():
-    moon = skimage.img_as_ubyte(data.moon()).astype(np.int32)
+    moon = util.img_as_ubyte(data.moon()).astype(np.int32)
     moon -= 100
 
     threshold = threshold_isodata(moon)
@@ -373,7 +374,7 @@ def test_isodata_moon_image_negative_int():
 
 
 def test_isodata_moon_image_negative_float():
-    moon = skimage.img_as_ubyte(data.moon()).astype(np.float64)
+    moon = util.img_as_ubyte(data.moon()).astype(np.float64)
     moon -= 100
 
     assert -14 < threshold_isodata(moon) < -13
@@ -385,12 +386,12 @@ def test_isodata_moon_image_negative_float():
 
 
 def test_threshold_minimum():
-    camera = skimage.img_as_ubyte(data.camera())
+    camera = util.img_as_ubyte(data.camera())
 
     threshold = threshold_minimum(camera)
     assert_equal(threshold, 76)
 
-    astronaut = skimage.img_as_ubyte(data.astronaut())
+    astronaut = util.img_as_ubyte(data.astronaut())
     threshold = threshold_minimum(astronaut)
     assert_equal(threshold, 114)
 

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -545,5 +545,5 @@ def test_multiotsu_output():
 def test_thresholds_dask_compatibility(thresholding, lower, upper):
     pytest.importorskip('dask', reason="dask python library is not installed")
     import dask.array as da
-    dask_camera = da.from_array(skimage.data.camera(), chunks=(256, 256))
+    dask_camera = da.from_array(data.camera(), chunks=(256, 256))
     assert lower < float(thresholding(dask_camera)) < upper

--- a/skimage/filters/tests/test_unsharp_mask.py
+++ b/skimage/filters/tests/test_unsharp_mask.py
@@ -1,7 +1,6 @@
 import numpy as np
 from skimage.filters import unsharp_mask
 from skimage._shared.testing import parametrize
-from skimage._shared._warnings import expected_warnings
 
 
 @parametrize("shape,multichannel",
@@ -25,8 +24,7 @@ def test_unsharp_masking_output_type_and_shape(
     array = ((array + offset) * 128).astype(dtype)
     if (preserve is False) and (dtype in [np.float32, np.float64]):
         array /= max(np.abs(array).max(), 1.0)
-    with expected_warnings([r'precision|\A\Z']):
-        output = unsharp_mask(array, radius, amount, multichannel, preserve)
+    output = unsharp_mask(array, radius, amount, multichannel, preserve)
     assert output.dtype in [np.float32, np.float64]
     assert output.shape == shape
 

--- a/skimage/io/tests/test_imageio.py
+++ b/skimage/io/tests/test_imageio.py
@@ -6,8 +6,8 @@ from skimage import data_dir
 from skimage.io import imread, imsave, use_plugin, reset_plugins
 
 from skimage._shared import testing
-from skimage._shared.testing import (assert_array_almost_equal, TestCase,
-                                     expected_warnings)
+from skimage._shared.testing import assert_array_almost_equal, TestCase
+from skimage._shared._warnings import expected_warnings
 
 
 def setup():

--- a/skimage/io/tests/test_pil.py
+++ b/skimage/io/tests/test_pil.py
@@ -51,12 +51,6 @@ def test_png_round_trip():
     assert np.sum(np.abs(Ip-I)) < 1e-3
 
 
-def test_imread_as_gray_flatten():
-    img = imread(os.path.join(data_dir, 'color.png'), as_gray=True)
-    img_flat = imread(os.path.join(data_dir, 'color.png'), flatten=True)
-    assert_array_equal(img, img_flat)
-
-
 def test_imread_as_gray():
     img = imread(os.path.join(data_dir, 'color.png'), as_gray=True)
     assert img.ndim == 2

--- a/skimage/io/tests/test_pil.py
+++ b/skimage/io/tests/test_pil.py
@@ -45,11 +45,16 @@ def test_png_round_trip():
     fname = f.name
     f.close()
     I = np.eye(3)
-    with expected_warnings(['Possible precision loss']):
-        imsave(fname, I)
+    imsave(fname, I)
     Ip = img_as_float(imread(fname))
     os.remove(fname)
     assert np.sum(np.abs(Ip-I)) < 1e-3
+
+
+def test_imread_as_gray_flatten():
+    img = imread(os.path.join(data_dir, 'color.png'), as_gray=True)
+    img_flat = imread(os.path.join(data_dir, 'color.png'), flatten=True)
+    assert_array_equal(img, img_flat)
 
 
 def test_imread_as_gray():
@@ -207,8 +212,7 @@ def test_imsave_filelike():
     s = BytesIO()
 
     # save to file-like object
-    with expected_warnings(['precision loss',
-                            'is a low contrast image']):
+    with expected_warnings(['is a low contrast image']):
         imsave(s, image)
 
     # read from file-like object
@@ -238,8 +242,7 @@ def test_imsave_boolean_input():
 def test_imexport_imimport():
     shape = (2, 2)
     image = np.zeros(shape)
-    with expected_warnings(['precision loss']):
-        pil_image = ndarray_to_pil(image)
+    pil_image = ndarray_to_pil(image)
     out = pil_to_ndarray(pil_image)
     assert_equal(out.shape, shape)
 

--- a/skimage/io/tests/test_plugin_util.py
+++ b/skimage/io/tests/test_plugin_util.py
@@ -11,39 +11,32 @@ np.random.seed(0)
 
 class TestPrepareForDisplay(TestCase):
     def test_basic(self):
-        with expected_warnings(['precision loss']):
-            prepare_for_display(np.random.rand(10, 10))
+        prepare_for_display(np.random.rand(10, 10))
 
     def test_dtype(self):
-        with expected_warnings(['precision loss']):
-            x = prepare_for_display(np.random.rand(10, 15))
+        x = prepare_for_display(np.random.rand(10, 15))
         assert x.dtype == np.dtype(np.uint8)
 
     def test_grey(self):
-        with expected_warnings(['precision loss']):
-            tmp = np.arange(12, dtype=float).reshape((4, 3)) / 11
-            x = prepare_for_display(tmp)
+        tmp = np.arange(12, dtype=float).reshape((4, 3)) / 11
+        x = prepare_for_display(tmp)
         assert_array_equal(x[..., 0], x[..., 2])
         assert x[0, 0, 0] == 0
         assert x[3, 2, 0] == 255
 
     def test_color(self):
-        with expected_warnings(['precision loss']):
-            prepare_for_display(np.random.rand(10, 10, 3))
+        prepare_for_display(np.random.rand(10, 10, 3))
 
     def test_alpha(self):
-        with expected_warnings(['precision loss']):
-            prepare_for_display(np.random.rand(10, 10, 4))
+        prepare_for_display(np.random.rand(10, 10, 4))
 
     def test_wrong_dimensionality(self):
         with testing.raises(ValueError):
-            with expected_warnings(['precision loss']):
-                prepare_for_display(np.random.rand(10, 10, 1, 1))
+            prepare_for_display(np.random.rand(10, 10, 1, 1))
 
     def test_wrong_depth(self):
         with testing.raises(ValueError):
-            with expected_warnings(['precision loss']):
-                prepare_for_display(np.random.rand(10, 10, 5))
+            prepare_for_display(np.random.rand(10, 10, 5))
 
 
 class TestWindowManager(TestCase):

--- a/skimage/morphology/tests/test_convex_hull.py
+++ b/skimage/morphology/tests/test_convex_hull.py
@@ -3,7 +3,8 @@ from skimage.morphology import convex_hull_image, convex_hull_object
 from skimage.morphology._convex_hull import possible_hull
 
 from skimage._shared import testing
-from skimage._shared.testing import assert_array_equal, expected_warnings
+from skimage._shared.testing import assert_array_equal
+from skimage._shared._warnings import expected_warnings
 
 
 def test_basic():

--- a/skimage/morphology/tests/test_grey.py
+++ b/skimage/morphology/tests/test_grey.py
@@ -3,8 +3,9 @@ import os
 import numpy as np
 from scipy import ndimage as ndi
 
+from skimage import data_dir
 from skimage import color, data, transform
-from skimage import img_as_uint, img_as_ubyte, data_dir
+from skimage.util import img_as_uint, img_as_ubyte
 from skimage.morphology import grey, selem
 from skimage._shared._warnings import expected_warnings
 from skimage._shared import testing

--- a/skimage/morphology/tests/test_grey.py
+++ b/skimage/morphology/tests/test_grey.py
@@ -30,7 +30,7 @@ class TestMorphology(TestCase):
                      selem.disk, selem.star)
 
         image = img_as_ubyte(transform.downscale_local_mean(
-                                    color.rgb2gray(data.coffee()), (20, 20)))
+            color.rgb2gray(data.coffee()), (20, 20)))
 
         output = {}
         for n in range(1, 4):
@@ -244,7 +244,7 @@ def test_float():
 
 def test_uint16():
     im16, eroded16, dilated16, opened16, closed16 = (
-            map(img_as_uint, [im, eroded, dilated, opened, closed]))
+        map(img_as_uint, [im, eroded, dilated, opened, closed]))
     np.testing.assert_allclose(grey.erosion(im16), eroded16)
     np.testing.assert_allclose(grey.dilation(im16), dilated16)
     np.testing.assert_allclose(grey.opening(im16), opened16)

--- a/skimage/morphology/tests/test_grey.py
+++ b/skimage/morphology/tests/test_grey.py
@@ -29,9 +29,8 @@ class TestMorphology(TestCase):
         selems_2D = (selem.square, selem.diamond,
                      selem.disk, selem.star)
 
-        with expected_warnings(['Possible precision loss']):
-            image = img_as_ubyte(transform.downscale_local_mean(
-                color.rgb2gray(data.coffee()), (20, 20)))
+        image = img_as_ubyte(transform.downscale_local_mean(
+                                    color.rgb2gray(data.coffee()), (20, 20)))
 
         output = {}
         for n in range(1, 4):
@@ -244,8 +243,7 @@ def test_float():
 
 
 def test_uint16():
-    with expected_warnings(['Possible precision loss']):
-        im16, eroded16, dilated16, opened16, closed16 = (
+    im16, eroded16, dilated16, opened16, closed16 = (
             map(img_as_uint, [im, eroded, dilated, opened, closed]))
     np.testing.assert_allclose(grey.erosion(im16), eroded16)
     np.testing.assert_allclose(grey.dilation(im16), dilated16)

--- a/skimage/morphology/tests/test_skeletonize_3d.py
+++ b/skimage/morphology/tests/test_skeletonize_3d.py
@@ -11,7 +11,6 @@ from skimage.morphology import skeletonize, skeletonize_3d
 
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_, parametrize
-from skimage._shared._warnings import expected_warnings
 
 # basic behavior tests (mostly copied over from 2D skeletonize)
 
@@ -76,10 +75,8 @@ def test_dtype_conv():
     img[img < 0.5] = 0
 
     orig = img.copy()
-    with expected_warnings(['precision']):
-        res = skeletonize(img, method='lee')
-    with expected_warnings(['precision']):
-        img_max = img_as_ubyte(img).max()
+    res = skeletonize(img, method='lee')
+    img_max = img_as_ubyte(img).max()
 
     assert_equal(res.dtype, np.uint8)
     assert_equal(img, orig)  # operation does not clobber the original
@@ -92,10 +89,7 @@ def test_dtype_conv():
 def test_input_with_warning(img):
     # check that the input is not clobbered
     # for 2D and 3D images of varying dtypes
-    # Skeletonize changes it to uint8. Therefore, for images of type float,
-    # we can expect a warning.
-    with expected_warnings(['precision']):
-        check_input(img)
+    check_input(img)
 
 
 @parametrize("img", [
@@ -137,8 +131,7 @@ def test_skeletonize_num_neighbours():
     circle2 = (ic - 135)**2 + (ir - 150)**2 < 20**2
     image[circle1] = 1
     image[circle2] = 0
-    with expected_warnings(['precision']):
-        result = skeletonize(image, method='lee')
+    result = skeletonize(image, method='lee')
 
     # there should never be a 2x2 block of foreground pixels in a skeleton
     mask = np.array([[1,  1],

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -337,8 +337,7 @@ def convert(image, dtype, force_copy=False, uniform=False, *,
     return image.astype(dtype_out)
 
 
-def img_as_float32(image, force_copy=False, *,
-                   warn_on_precision_loss=False, warn_on_sign_loss=False):
+def img_as_float32(image, force_copy=False):
     """Convert an image to single-precision (32-bit) floating point format.
 
     Parameters
@@ -347,18 +346,6 @@ def img_as_float32(image, force_copy=False, *,
         Input image.
     force_copy : bool, optional
         Force a copy of the data, irrespective of its current dtype.
-    warn_on_precision_loss : bool, optional
-        Issue a warning when converting to a format might incure a loss of
-        information.
-
-        .. versionadded:: 0.15
-            Previously, this warning would always be raised.
-    warn_on_sign_loss : bool, optional
-        Issue a warning when converting from a signed format to an unsigned
-        format.
-
-        .. versionadded:: 0.15
-            Previously, this warning would always be raised.
 
     Returns
     -------
@@ -373,13 +360,10 @@ def img_as_float32(image, force_copy=False, *,
     and can be outside the ranges [0.0, 1.0] or [-1.0, 1.0].
 
     """
-    return convert(image, np.float32, force_copy,
-                   warn_on_precision_loss=warn_on_precision_loss,
-                   warn_on_sign_loss=warn_on_sign_loss):
+    return convert(image, np.float32, force_copy)
 
 
-def img_as_float64(image, force_copy=False, *,
-                   warn_on_precision_loss=False, warn_on_sign_loss=False):
+def img_as_float64(image, force_copy=False):
     """Convert an image to double-precision (64-bit) floating point format.
 
     Parameters
@@ -388,18 +372,6 @@ def img_as_float64(image, force_copy=False, *,
         Input image.
     force_copy : bool, optional
         Force a copy of the data, irrespective of its current dtype.
-    warn_on_precision_loss : bool, optional
-        Issue a warning when converting to a format might incure a loss of
-        information.
-
-        .. versionadded:: 0.15
-            Previously, this warning would always be raised.
-    warn_on_sign_loss : bool, optional
-        Issue a warning when converting from a signed format to an unsigned
-        format.
-
-        .. versionadded:: 0.15
-            Previously, this warning would always be raised.
 
     Returns
     -------
@@ -415,12 +387,9 @@ def img_as_float64(image, force_copy=False, *,
 
     """
     return convert(image, np.float64, force_copy)
-                   warn_on_precision_loss=warn_on_precision_loss,
-                   warn_on_sign_loss=warn_on_sign_loss):
 
 
-def img_as_float(image, force_copy=False, *,
-                 warn_on_precision_loss=False, warn_on_sign_loss=False):
+def img_as_float(image, force_copy=False):
     """Convert an image to floating point format.
 
     This function is similar to `img_as_float64`, but will not convert
@@ -432,18 +401,6 @@ def img_as_float(image, force_copy=False, *,
         Input image.
     force_copy : bool, optional
         Force a copy of the data, irrespective of its current dtype.
-    warn_on_precision_loss : bool, optional
-        Issue a warning when converting to a format might incure a loss of
-        information.
-
-        .. versionadded:: 0.15
-            Previously, this warning would always be raised.
-    warn_on_sign_loss : bool, optional
-        Issue a warning when converting from a signed format to an unsigned
-        format.
-
-        .. versionadded:: 0.15
-            Previously, this warning would always be raised.
 
     Returns
     -------
@@ -458,13 +415,10 @@ def img_as_float(image, force_copy=False, *,
     and can be outside the ranges [0.0, 1.0] or [-1.0, 1.0].
 
     """
-    return convert(image, np.floating, force_copy,
-                   warn_on_precision_loss=warn_on_precision_loss,
-                   warn_on_sign_loss=warn_on_sign_loss)
+    return convert(image, np.floating, force_copy)
 
 
-def img_as_uint(image, force_copy=False, *,
-                warn_on_precision_loss=False, warn_on_sign_loss=False):
+def img_as_uint(image, force_copy=False):
     """Convert an image to 16-bit unsigned integer format.
 
     Parameters
@@ -473,18 +427,6 @@ def img_as_uint(image, force_copy=False, *,
         Input image.
     force_copy : bool, optional
         Force a copy of the data, irrespective of its current dtype.
-    warn_on_precision_loss : bool, optional
-        Issue a warning when converting to a format might incure a loss of
-        information.
-
-        .. versionadded:: 0.15
-            Previously, this warning would always be raised.
-    warn_on_sign_loss : bool, optional
-        Issue a warning when converting from a signed format to an unsigned
-        format.
-
-        .. versionadded:: 0.15
-            Previously, this warning would always be raised.
 
     Returns
     -------
@@ -497,13 +439,10 @@ def img_as_uint(image, force_copy=False, *,
     Positive values are scaled between 0 and 65535.
 
     """
-    return convert(image, np.uint16, force_copy,
-                   warn_on_precision_loss=warn_on_precision_loss,
-                   warn_on_sign_loss=warn_on_sign_loss)
+    return convert(image, np.uint16, force_copy)
 
 
-def img_as_int(image, force_copy=False, *,
-               warn_on_precision_loss=False, warn_on_sign_loss=False):
+def img_as_int(image, force_copy=False):
     """Convert an image to 16-bit signed integer format.
 
     Parameters
@@ -512,18 +451,6 @@ def img_as_int(image, force_copy=False, *,
         Input image.
     force_copy : bool, optional
         Force a copy of the data, irrespective of its current dtype.
-    warn_on_precision_loss : bool, optional
-        Issue a warning when converting to a format might incure a loss of
-        information.
-
-        .. versionadded:: 0.15
-            Previously, this warning would always be raised.
-    warn_on_sign_loss : bool, optional
-        Issue a warning when converting from a signed format to an unsigned
-        format.
-
-        .. versionadded:: 0.15
-            Previously, this warning would always be raised.
 
     Returns
     -------
@@ -537,13 +464,10 @@ def img_as_int(image, force_copy=False, *,
     the output image will still only have positive values.
 
     """
-    return convert(image, np.int16, force_copy,
-                   warn_on_precision_loss=warn_on_precision_loss,
-                   warn_on_sign_loss=warn_on_sign_loss)
+    return convert(image, np.int16, force_copy)
 
 
-def img_as_ubyte(image, force_copy=False, *,
-                 warn_on_precision_loss=False, warn_on_sign_loss=False):
+def img_as_ubyte(image, force_copy=False):
     """Convert an image to 8-bit unsigned integer format.
 
     Parameters
@@ -552,18 +476,6 @@ def img_as_ubyte(image, force_copy=False, *,
         Input image.
     force_copy : bool, optional
         Force a copy of the data, irrespective of its current dtype.
-    warn_on_precision_loss : bool, optional
-        Issue a warning when converting to a format might incure a loss of
-        information.
-
-        .. versionadded:: 0.15
-            Previously, this warning would always be raised.
-    warn_on_sign_loss : bool, optional
-        Issue a warning when converting from a signed format to an unsigned
-        format.
-
-        .. versionadded:: 0.15
-            Previously, this warning would always be raised.
 
     Returns
     -------
@@ -576,13 +488,10 @@ def img_as_ubyte(image, force_copy=False, *,
     Positive values are scaled between 0 and 255.
 
     """
-    return convert(image, np.uint8, force_copy,
-                   warn_on_precision_loss=warn_on_precision_loss,
-                   warn_on_sign_loss=warn_on_sign_loss)
+    return convert(image, np.uint8, force_copy)
 
 
-def img_as_bool(image, force_copy=False, *,
-                warn_on_precision_loss=False, warn_on_sign_loss=False):
+def img_as_bool(image, force_copy=False):
     """Convert an image to boolean format.
 
     Parameters
@@ -591,18 +500,6 @@ def img_as_bool(image, force_copy=False, *,
         Input image.
     force_copy : bool, optional
         Force a copy of the data, irrespective of its current dtype.
-    warn_on_precision_loss : bool, optional
-        Issue a warning when converting to a format might incure a loss of
-        information.
-
-        .. versionadded:: 0.15
-            Previously, this warning would always be raised.
-    warn_on_sign_loss : bool, optional
-        Issue a warning when converting from a signed format to an unsigned
-        format.
-
-        .. versionadded:: 0.15
-            Previously, this warning would always be raised.
 
     Returns
     -------
@@ -615,6 +512,4 @@ def img_as_bool(image, force_copy=False, *,
     half is False. All negative values (if present) are False.
 
     """
-    return convert(image, np.bool_, force_copy,
-                   warn_on_precision_loss=warn_on_precision_loss,
-                   warn_on_sign_loss=warn_on_sign_loss)
+    return convert(image, np.bool_, force_copy)

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -300,7 +300,8 @@ def convert(image, dtype, force_copy=False, uniform=False):
             # unsigned int -> unsigned int
             return _scale(image, 8 * itemsize_in, 8 * itemsize_out)
 
-        # signed int -> unsigned int
+    # signed int -> unsigned int
+    if kind_out == 'u':
         image = _scale(image, 8 * itemsize_in - 1, 8 * itemsize_out)
         result = np.empty(image.shape, dtype_out)
         np.maximum(image, 0, out=result, dtype=image.dtype, casting='unsafe')

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -352,7 +352,8 @@ def convert(image, dtype, force_copy=False, uniform=False, *,
     return image.astype(dtype_out)
 
 
-def img_as_float32(image, force_copy=False):
+def img_as_float32(image, force_copy=False, *,
+                   warn_on_precision_loss=False, warn_on_sign_loss=False):
     """Convert an image to single-precision (32-bit) floating point format.
 
     Parameters
@@ -361,6 +362,18 @@ def img_as_float32(image, force_copy=False):
         Input image.
     force_copy : bool, optional
         Force a copy of the data, irrespective of its current dtype.
+    warn_on_precision_loss : bool, optional
+        Issue a warning when converting to a format might incure a loss of
+        information.
+
+        .. versionadded:: 0.15
+            Previously, this warning would always be raised.
+    warn_on_sign_loss : bool, optional
+        Issue a warning when converting from a signed format to an unsigned
+        format.
+
+        .. versionadded:: 0.15
+            Previously, this warning would always be raised.
 
     Returns
     -------
@@ -375,10 +388,13 @@ def img_as_float32(image, force_copy=False):
     and can be outside the ranges [0.0, 1.0] or [-1.0, 1.0].
 
     """
-    return convert(image, np.float32, force_copy)
+    return convert(image, np.float32, force_copy,
+                   warn_on_precision_loss=warn_on_precision_loss,
+                   warn_on_sign_loss=warn_on_sign_loss):
 
 
-def img_as_float64(image, force_copy=False):
+def img_as_float64(image, force_copy=False, *,
+                   warn_on_precision_loss=False, warn_on_sign_loss=False):
     """Convert an image to double-precision (64-bit) floating point format.
 
     Parameters
@@ -387,6 +403,18 @@ def img_as_float64(image, force_copy=False):
         Input image.
     force_copy : bool, optional
         Force a copy of the data, irrespective of its current dtype.
+    warn_on_precision_loss : bool, optional
+        Issue a warning when converting to a format might incure a loss of
+        information.
+
+        .. versionadded:: 0.15
+            Previously, this warning would always be raised.
+    warn_on_sign_loss : bool, optional
+        Issue a warning when converting from a signed format to an unsigned
+        format.
+
+        .. versionadded:: 0.15
+            Previously, this warning would always be raised.
 
     Returns
     -------
@@ -402,9 +430,12 @@ def img_as_float64(image, force_copy=False):
 
     """
     return convert(image, np.float64, force_copy)
+                   warn_on_precision_loss=warn_on_precision_loss,
+                   warn_on_sign_loss=warn_on_sign_loss):
 
 
-def img_as_float(image, force_copy=False):
+def img_as_float(image, force_copy=False, *,
+                 warn_on_precision_loss=False, warn_on_sign_loss=False):
     """Convert an image to floating point format.
 
     This function is similar to `img_as_float64`, but will not convert
@@ -416,6 +447,18 @@ def img_as_float(image, force_copy=False):
         Input image.
     force_copy : bool, optional
         Force a copy of the data, irrespective of its current dtype.
+    warn_on_precision_loss : bool, optional
+        Issue a warning when converting to a format might incure a loss of
+        information.
+
+        .. versionadded:: 0.15
+            Previously, this warning would always be raised.
+    warn_on_sign_loss : bool, optional
+        Issue a warning when converting from a signed format to an unsigned
+        format.
+
+        .. versionadded:: 0.15
+            Previously, this warning would always be raised.
 
     Returns
     -------
@@ -430,10 +473,13 @@ def img_as_float(image, force_copy=False):
     and can be outside the ranges [0.0, 1.0] or [-1.0, 1.0].
 
     """
-    return convert(image, np.floating, force_copy)
+    return convert(image, np.floating, force_copy,
+                   warn_on_precision_loss=warn_on_precision_loss,
+                   warn_on_sign_loss=warn_on_sign_loss)
 
 
-def img_as_uint(image, force_copy=False):
+def img_as_uint(image, force_copy=False, *,
+                warn_on_precision_loss=False, warn_on_sign_loss=False):
     """Convert an image to 16-bit unsigned integer format.
 
     Parameters
@@ -442,6 +488,18 @@ def img_as_uint(image, force_copy=False):
         Input image.
     force_copy : bool, optional
         Force a copy of the data, irrespective of its current dtype.
+    warn_on_precision_loss : bool, optional
+        Issue a warning when converting to a format might incure a loss of
+        information.
+
+        .. versionadded:: 0.15
+            Previously, this warning would always be raised.
+    warn_on_sign_loss : bool, optional
+        Issue a warning when converting from a signed format to an unsigned
+        format.
+
+        .. versionadded:: 0.15
+            Previously, this warning would always be raised.
 
     Returns
     -------
@@ -454,10 +512,13 @@ def img_as_uint(image, force_copy=False):
     Positive values are scaled between 0 and 65535.
 
     """
-    return convert(image, np.uint16, force_copy)
+    return convert(image, np.uint16, force_copy,
+                   warn_on_precision_loss=warn_on_precision_loss,
+                   warn_on_sign_loss=warn_on_sign_loss)
 
 
-def img_as_int(image, force_copy=False):
+def img_as_int(image, force_copy=False, *,
+               warn_on_precision_loss=False, warn_on_sign_loss=False):
     """Convert an image to 16-bit signed integer format.
 
     Parameters
@@ -466,6 +527,18 @@ def img_as_int(image, force_copy=False):
         Input image.
     force_copy : bool, optional
         Force a copy of the data, irrespective of its current dtype.
+    warn_on_precision_loss : bool, optional
+        Issue a warning when converting to a format might incure a loss of
+        information.
+
+        .. versionadded:: 0.15
+            Previously, this warning would always be raised.
+    warn_on_sign_loss : bool, optional
+        Issue a warning when converting from a signed format to an unsigned
+        format.
+
+        .. versionadded:: 0.15
+            Previously, this warning would always be raised.
 
     Returns
     -------
@@ -479,10 +552,13 @@ def img_as_int(image, force_copy=False):
     the output image will still only have positive values.
 
     """
-    return convert(image, np.int16, force_copy)
+    return convert(image, np.int16, force_copy,
+                   warn_on_precision_loss=warn_on_precision_loss,
+                   warn_on_sign_loss=warn_on_sign_loss)
 
 
-def img_as_ubyte(image, force_copy=False):
+def img_as_ubyte(image, force_copy=False, *,
+                 warn_on_precision_loss=False, warn_on_sign_loss=False):
     """Convert an image to 8-bit unsigned integer format.
 
     Parameters
@@ -491,6 +567,18 @@ def img_as_ubyte(image, force_copy=False):
         Input image.
     force_copy : bool, optional
         Force a copy of the data, irrespective of its current dtype.
+    warn_on_precision_loss : bool, optional
+        Issue a warning when converting to a format might incure a loss of
+        information.
+
+        .. versionadded:: 0.15
+            Previously, this warning would always be raised.
+    warn_on_sign_loss : bool, optional
+        Issue a warning when converting from a signed format to an unsigned
+        format.
+
+        .. versionadded:: 0.15
+            Previously, this warning would always be raised.
 
     Returns
     -------
@@ -503,10 +591,13 @@ def img_as_ubyte(image, force_copy=False):
     Positive values are scaled between 0 and 255.
 
     """
-    return convert(image, np.uint8, force_copy)
+    return convert(image, np.uint8, force_copy,
+                   warn_on_precision_loss=warn_on_precision_loss,
+                   warn_on_sign_loss=warn_on_sign_loss)
 
 
-def img_as_bool(image, force_copy=False):
+def img_as_bool(image, force_copy=False, *,
+                warn_on_precision_loss=False, warn_on_sign_loss=False):
     """Convert an image to boolean format.
 
     Parameters
@@ -515,6 +606,18 @@ def img_as_bool(image, force_copy=False):
         Input image.
     force_copy : bool, optional
         Force a copy of the data, irrespective of its current dtype.
+    warn_on_precision_loss : bool, optional
+        Issue a warning when converting to a format might incure a loss of
+        information.
+
+        .. versionadded:: 0.15
+            Previously, this warning would always be raised.
+    warn_on_sign_loss : bool, optional
+        Issue a warning when converting from a signed format to an unsigned
+        format.
+
+        .. versionadded:: 0.15
+            Previously, this warning would always be raised.
 
     Returns
     -------
@@ -527,4 +630,6 @@ def img_as_bool(image, force_copy=False):
     half is False. All negative values (if present) are False.
 
     """
-    return convert(image, np.bool_, force_copy)
+    return convert(image, np.bool_, force_copy,
+                   warn_on_precision_loss=warn_on_precision_loss,
+                   warn_on_sign_loss=warn_on_sign_loss)

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -54,7 +54,8 @@ def dtype_limits(image, clip_negative=False):
     return imin, imax
 
 
-def convert(image, dtype, force_copy=False, uniform=False):
+def convert(image, dtype, force_copy=False, uniform=False, *,
+            warn_on_precision_loss=False, warn_on_sign_loss=False):
     """
     Convert an image to the requested data-type.
 
@@ -82,6 +83,25 @@ def convert(image, dtype, force_copy=False, uniform=False):
         By default (uniform=False) floating point values are scaled and
         rounded to the nearest integers, which minimizes back and forth
         conversion errors.
+    warn_on_precision_loss : bool, optional
+        Issue a warning when converting to a format might incure a loss of
+        information.
+
+        .. versionadded:: 0.15
+            Previously, this warning would always be raised.
+    warn_on_sign_loss : bool, optional
+        Issue a warning when converting from a signed format to an unsigned
+        format.
+
+        .. versionadded:: 0.15
+            Previously, this warning would always be raised.
+
+    Notes
+    -----
+    See discussions on these warnings at:
+    https://github.com/scikit-image/scikit-image/issues/2602
+    and:
+    https://github.com/scikit-image/scikit-image/issues/543#issuecomment-208202228
 
     References
     ----------

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -54,8 +54,7 @@ def dtype_limits(image, clip_negative=False):
     return imin, imax
 
 
-def convert(image, dtype, force_copy=False, uniform=False, *,
-            warn_on_precision_loss=False, warn_on_sign_loss=False):
+def convert(image, dtype, force_copy=False, uniform=False):
     """
     Convert an image to the requested data-type.
 
@@ -83,25 +82,6 @@ def convert(image, dtype, force_copy=False, uniform=False, *,
         By default (uniform=False) floating point values are scaled and
         rounded to the nearest integers, which minimizes back and forth
         conversion errors.
-    warn_on_precision_loss : bool, optional
-        Issue a warning when converting to a format might incure a loss of
-        information.
-
-        .. versionadded:: 0.15
-            Previously, this warning would always be raised.
-    warn_on_sign_loss : bool, optional
-        Issue a warning when converting from a signed format to an unsigned
-        format.
-
-        .. versionadded:: 0.15
-            Previously, this warning would always be raised.
-
-    Notes
-    -----
-    See discussions on these warnings at:
-    https://github.com/scikit-image/scikit-image/issues/2602
-    and:
-    https://github.com/scikit-image/scikit-image/issues/543#issuecomment-208202228
 
     .. versionchanged :: 0.15
         ``convert`` no longer warns about possible precision or sign

--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -39,8 +39,7 @@ def test_range(dtype, f_and_dt):
 
     f, dt = f_and_dt
 
-    with expected_warnings([r'precision loss|sign loss|\A\Z']):
-        y = f(x)
+    y = f(x)
 
     omin, omax = dtype_range[dt]
 
@@ -72,8 +71,7 @@ def test_range_extra_dtypes(dtype_in, dt):
     imin, imax = dtype_range_extra[dtype_in]
     x = np.linspace(imin, imax, 10).astype(dtype_in)
 
-    with expected_warnings([r'precision loss|sign loss|\A\Z']):
-        y = convert(x, dt, warn_on_precision_loss=True, warn_on_sign_loss=True)
+    y = convert(x, dt)
 
     omin, omax = dtype_range_extra[dt]
     _verify_range("From %s to %s" % (np.dtype(dtype_in), np.dtype(dt)),
@@ -132,12 +130,9 @@ def test_clobber():
         for func_output_type in img_funcs:
             img = np.random.rand(5, 5)
 
-            # UserWarning for possible precision loss, expected
-            with expected_warnings([r'Possible precision loss|\A\Z',
-                                    r'Possible sign loss|\A\Z']):
-                img_in = func_input_type(img)
-                img_in_before = img_in.copy()
-                img_out = func_output_type(img_in)
+            img_in = func_input_type(img)
+            img_in_before = img_in.copy()
+            img_out = func_output_type(img_in)
 
             assert_equal(img_in, img_in_before)
 

--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -73,7 +73,7 @@ def test_range_extra_dtypes(dtype_in, dt):
     x = np.linspace(imin, imax, 10).astype(dtype_in)
 
     with expected_warnings([r'precision loss|sign loss|\A\Z']):
-        y = convert(x, dt)
+        y = convert(x, dt, warn_on_precision_loss=True, warn_on_sign_loss=True)
 
     omin, omax = dtype_range_extra[dt]
     _verify_range("From %s to %s" % (np.dtype(dtype_in), np.dtype(dt)),

--- a/skimage/util/tests/test_montage.py
+++ b/skimage/util/tests/test_montage.py
@@ -1,6 +1,6 @@
 from skimage._shared import testing
-from skimage._shared.testing import (assert_equal, assert_array_equal,
-                                     expected_warnings)
+from skimage._shared.testing import assert_equal, assert_array_equal
+from skimage._shared._warnings import expected_warnings
 
 import numpy as np
 from skimage.util import montage

--- a/skimage/viewer/tests/test_plugins.py
+++ b/skimage/viewer/tests/test_plugins.py
@@ -1,5 +1,6 @@
 import numpy as np
 import skimage
+from skimage import util
 import skimage.data as data
 from skimage.filters.rank import median
 from skimage.morphology import disk
@@ -13,11 +14,10 @@ from skimage.viewer.plugins import (
 from skimage._shared import testing
 from skimage._shared.testing import (assert_equal, assert_allclose,
                                      assert_almost_equal)
-from skimage._shared._warnings import expected_warnings
 
 
 def setup_line_profile(image, limits='image'):
-    viewer = ImageViewer(skimage.img_as_float(image))
+    viewer = ImageViewer(util.img_as_float(image))
     plugin = LineProfile(limits=limits)
     viewer += plugin
     return plugin
@@ -56,7 +56,7 @@ def test_line_profile_rgb():
 def test_line_profile_dynamic():
     """Test a line profile updating after an image transform"""
     image = data.coins()[:-50, :]  # shave some off to make the line lower
-    image = skimage.img_as_float(image)
+    image = util.img_as_float(image)
     viewer = ImageViewer(image)
 
     lp = LineProfile(limits='dtype')
@@ -68,9 +68,7 @@ def test_line_profile_dynamic():
     assert_almost_equal(np.std(line), 0.229, 3)
     assert_almost_equal(np.max(line) - np.min(line), 0.725, 1)
 
-    with expected_warnings(['precision loss']):
-        viewer.image = skimage.img_as_float(median(image,
-                                                   selem=disk(radius=3)))
+    viewer.image = util.img_as_float(median(image, selem=disk(radius=3)))
 
     line = lp.get_profiles()[-1][0]
     assert_almost_equal(np.std(viewer.image), 0.198, 3)
@@ -134,7 +132,7 @@ def test_crop():
 
 @testing.skipif(not has_qt, reason="Qt not installed")
 def test_color_histogram():
-    image = skimage.img_as_float(data.load('color.png'))
+    image = util.img_as_float(data.load('color.png'))
     viewer = ImageViewer(image)
     ch = ColorHistogram(dock='right')
     viewer += ch
@@ -158,12 +156,11 @@ def test_plot_plugin():
 
 @testing.skipif(not has_qt, reason="Qt not installed")
 def test_plugin():
-    img = skimage.img_as_float(data.moon())
+    img = util.img_as_float(data.moon())
     viewer = ImageViewer(img)
 
     def median_filter(img, radius=3):
-        with expected_warnings(['precision loss']):
-            return median(img, selem=disk(radius=radius))
+        return median(img, selem=disk(radius=radius))
 
     plugin = Plugin(image_filter=median_filter)
     viewer += plugin

--- a/skimage/viewer/tests/test_widgets.py
+++ b/skimage/viewer/tests/test_widgets.py
@@ -8,7 +8,6 @@ from skimage.viewer.widgets import (
     Slider, OKCancelButtons, SaveButtons, ComboBox, CheckBox, Text)
 from skimage.viewer.plugins.base import Plugin
 
-from skimage._shared._warnings import expected_warnings
 from skimage._shared import testing
 from skimage._shared.testing import assert_almost_equal, assert_equal
 
@@ -108,13 +107,11 @@ def test_save_buttons():
 
     # call the save functions directly
     sv.save_to_stack()
-    with expected_warnings(['precision loss']):
-        sv.save_to_file(filename)
+    sv.save_to_file(filename)
 
     img = data.imread(filename)
 
-    with expected_warnings(['precision loss']):
-        assert_almost_equal(img, img_as_uint(viewer.image))
+    assert_almost_equal(img, img_as_uint(viewer.image))
 
     img = io.pop()
     assert_almost_equal(img, viewer.image)

--- a/skimage/viewer/widgets/history.py
+++ b/skimage/viewer/widgets/history.py
@@ -3,8 +3,8 @@ from textwrap import dedent
 from ..qt import QtGui, QtCore, QtWidgets
 import numpy as np
 
-import skimage
-from ... import io, img_as_ubyte
+from ... import io
+from ...util import img_as_ubyte
 from .core import BaseWidget
 from ..utils import dialogs
 


### PR DESCRIPTION
## Description
See discussions:
#543 (comment)
#2602

Specifically, @stefanv said [1]_:

> Why don't we just remove this warning entirely? It seemed like the
> proper thing to do at the time, but it's never been useful.

Therefore, I set the default to False, but leave the option for warning
there since it's potentially useful to some. When and if we stop doing
automatic dtype conversions (see #3009), we might be able to remove
warnings altogether.

..[1]: #2602 (comment) 

The PR touches a lot of lines so I suggest looking at individual commits when reviewing. Thanks @scikit-image/core!


## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests

## References
Closes #2602 

## For reviewers

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
