### PR TITLE
Build tools: Refactor check_sdist so that it takes a filename as a parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,9 @@ before_install:
     - which python; python --version
     - pip list
     - tools/build_versions.py
-    - tools/check_sdist.py
+    - python setup.py sdist
+    - SDIST_NAME=dist/`python setup.py --fullname`.tar.gz
+    - tools/check_sdist.py $SDIST_NAME
 
 install:
     - python setup.py develop

--- a/tools/check_sdist.py
+++ b/tools/check_sdist.py
@@ -1,21 +1,24 @@
-#!/usr/bin/env python
-
-
+#!/usr/bin/env python3
 import os
-import subprocess
 import sys
+from argparse import ArgumentParser
+from pathlib import Path
+import tarfile
 
-base_dir = os.path.join(os.path.dirname(__file__), '..')
-os.chdir(base_dir)
+parser = ArgumentParser(description='Check a created sdist')
+parser.add_argument('sdist_name', type=str, nargs=1,
+                    help='The name of the sdist file to check')
+args = parser.parse_args()
+sdist_name = args.sdist_name[0]
 
-p = subprocess.Popen("python setup.py sdist".split(),
-                     stdout=subprocess.PIPE)
-out, err = p.communicate()
+with tarfile.open(sdist_name) as tar:
+    members = tar.getmembers()
 
-data = out.decode('utf-8').split('\n')
-data = [l for l in data if l.startswith('hard linking')]
-data = [l.replace('hard linking ', '') for l in data]
-data = ['./' + l.split(' ->')[0] for l in data]
+# The very first item contains the name of the archive
+top_parent = Path(members[0].name)
+
+filenames = ['./' + str(Path(m.name).relative_to(top_parent))
+             for m in members[1:]]
 
 ignore_exts = ['.pyc', '.so', '.o', '#', '~', '.gitignore', '.o.d']
 ignore_dirs = ['./build', './dist', './tools', './doc', './viewer_examples',
@@ -51,7 +54,7 @@ for root, dirs, files in os.walk('./'):
             else:
                 fn = os.path.join(root, fn)
 
-                if not (fn in data or fn in ignore_files):
+                if not (fn in filenames or fn in ignore_files):
                     missing.append(fn)
 
 if missing:


### PR DESCRIPTION
@jni XREF https://github.com/scikit-image/scikit-image/pull/3311#discussion_r238650519

This refactors the `check_sdist` script so that it takes in the filename of the sdist script that it needs to check.

This is to make it clear that in the build process, we are issuing an
`python setup.py sdist` command and that it is not hidden in the `check_sdist` script itself.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
