### PR TITLE
Fix the data scaling and clipping behavior of denoise_wavelet

### DIFF
--- a/doc/examples/filters/plot_cycle_spinning.py
+++ b/doc/examples/filters/plot_cycle_spinning.py
@@ -51,7 +51,8 @@ ax[0].set_title('Noisy\nPSNR={:0.4g}'.format(psnr_noisy))
 # max_shift = 3 -> shifts of (0, 1, 2, 3) along each axis
 # etc...
 
-denoise_kwargs = dict(multichannel=True, convert2ycbcr=True, wavelet='db1')
+denoise_kwargs = dict(multichannel=True, convert2ycbcr=True, wavelet='db1',
+                      rescale_sigma=True)
 
 all_psnr = []
 max_shifts = [0, 1, 3, 5]

--- a/doc/examples/filters/plot_denoise.py
+++ b/doc/examples/filters/plot_denoise.py
@@ -72,7 +72,7 @@ ax[0, 2].imshow(denoise_bilateral(noisy, sigma_color=0.05, sigma_spatial=15,
                 multichannel=True))
 ax[0, 2].axis('off')
 ax[0, 2].set_title('Bilateral')
-ax[0, 3].imshow(denoise_wavelet(noisy, multichannel=True))
+ax[0, 3].imshow(denoise_wavelet(noisy, multichannel=True, rescale_sigma=True))
 ax[0, 3].axis('off')
 ax[0, 3].set_title('Wavelet denoising')
 
@@ -83,7 +83,8 @@ ax[1, 2].imshow(denoise_bilateral(noisy, sigma_color=0.1, sigma_spatial=15,
                 multichannel=True))
 ax[1, 2].axis('off')
 ax[1, 2].set_title('(more) Bilateral')
-ax[1, 3].imshow(denoise_wavelet(noisy, multichannel=True, convert2ycbcr=True))
+ax[1, 3].imshow(denoise_wavelet(noisy, multichannel=True, convert2ycbcr=True,
+                                rescale_sigma=True))
 ax[1, 3].axis('off')
 ax[1, 3].set_title('Wavelet denoising\nin YCbCr colorspace')
 ax[1, 0].imshow(original)

--- a/doc/examples/filters/plot_denoise_wavelet.py
+++ b/doc/examples/filters/plot_denoise_wavelet.py
@@ -52,20 +52,21 @@ sigma_est = estimate_sigma(noisy, multichannel=True, average_sigmas=True)
 print(f"Estimated Gaussian noise standard deviation = {sigma_est}")
 
 im_bayes = denoise_wavelet(noisy, multichannel=True, convert2ycbcr=True,
-                           method='BayesShrink', mode='soft')
+                           method='BayesShrink', mode='soft',
+                           rescale_sigma=True)
 im_visushrink = denoise_wavelet(noisy, multichannel=True, convert2ycbcr=True,
                                 method='VisuShrink', mode='soft',
-                                sigma=sigma_est)
+                                sigma=sigma_est, rescale_sigma=True)
 
 # VisuShrink is designed to eliminate noise with high probability, but this
 # results in a visually over-smooth appearance.  Repeat, specifying a reduction
 # in the threshold by factors of 2 and 4.
 im_visushrink2 = denoise_wavelet(noisy, multichannel=True, convert2ycbcr=True,
                                  method='VisuShrink', mode='soft',
-                                 sigma=sigma_est/2)
+                                 sigma=sigma_est/2, rescale_sigma=True)
 im_visushrink4 = denoise_wavelet(noisy, multichannel=True, convert2ycbcr=True,
                                  method='VisuShrink', mode='soft',
-                                 sigma=sigma_est/4)
+                                 sigma=sigma_est/4, rescale_sigma=True)
 
 # Compute PSNR as an indication of image quality
 psnr_noisy = peak_signal_noise_ratio(original, noisy)

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -66,7 +66,8 @@ Bugfixes
 --------
 - ``denoise_wavelet``: For user-supplied `sigma`, if the input image gets
   rescaled via ``img_as_float``, the same scaling will be applied to `sigma` to
-  preserve the relative scale of the noise estimate.
+  preserve the relative scale of the noise estimate. To restore the old,
+  behaviour, the user can manually specify ``rescale_sigma=False``.
 
 
 Deprecations

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -56,10 +56,17 @@ API Changes
 - Default value of ``order`` parameter has been set to ``rc`` in
   ``skimage.feature.hessian_matrix``.
 - ``skimage.util.img_as_*`` functions no longer raise precision and/or loss warnings.
+- When used with floating point inputs, ``denoise_wavelet`` no longer rescales
+  the range of the data or clips the output to the range [0, 1] or [-1, 1].
+  For non-float inputs, rescaling and clipping still occurs as in prior
+  releases (although with a bugfix related to the scaling of ``sigma``).
 
 
 Bugfixes
 --------
+- ``denoise_wavelet``: For user-supplied `sigma`, if the input image gets
+  rescaled via ``img_as_float``, the same scaling will be applied to `sigma` to
+  preserve the relative scale of the noise estimate.
 
 
 Deprecations

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -767,13 +767,15 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
             ('Invalid method: {}. The currently supported methods are '
              '"BayesShrink" and "VisuShrink"').format(method))
 
-    image, sigma = _scale_sigma_and_image_consistently(image, sigma,
-                                                       multichannel,
-                                                       convert2ycbcr)
-
     # floating-point inputs are not rescaled, so don't clip their output.
     clip_output = image.dtype.kind != 'f'
 
+    if convert2ycbcr and not multichannel:
+        raise ValueError("convert2ycbcr requires multichannel == True")
+
+    image, sigma = _scale_sigma_and_image_consistently(image, sigma,
+                                                       multichannel,
+                                                       convert2ycbcr)
     if multichannel:
         if convert2ycbcr:
             out = color.rgb2ycbcr(image)

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -6,6 +6,7 @@ from ._denoise_cy import _denoise_bilateral, _denoise_tv_bregman
 from .._shared.utils import warn
 import pywt
 import skimage.color as color
+from skimage.color.colorconv import ycbcr_from_rgb
 import numbers
 
 
@@ -619,29 +620,21 @@ def _wavelet_threshold(image, wavelet, method=None, threshold=None,
     return pywt.waverecn(denoised_coeffs, wavelet)[original_extent]
 
 
-def _scale_sigma_and_image_consistently(image, sigma, multichannel,
-                                        convert2ycbcr):
-    """If the ``image`` is to be rescaled, also rescale ``sigma`` consistently.
+def _scale_sigma_and_image_consistently(image, sigma, multichannel):
+    """If the ``image`` is rescaled, also rescale ``sigma`` consistently.
 
     Images that are not floating point will be rescaled via ``img_as_float``.
-
-    Unless ``convert2ycbcr`` is ``True``, sigma gets rescaled by the same
-    amount.
-
-    When convert2ycbcr is True, there is a separate rescaling of each channel
-    to the range [0, 1] within ``denoise_wavelet`` and the user must specify a
-    sigma appropriate to that range.
     """
     if multichannel:
         if isinstance(sigma, numbers.Number) or sigma is None:
             sigma = [sigma] * image.shape[-1]
-
+        elif len(sigma) != image.shape[-1]:
+            raise ValueError(
+                "When multichannel is True, sigma must be a scalar or have "
+                "length equal to the number of channels")
     if image.dtype.kind != 'f':
         range_pre = image.max() - image.min()
         image = img_as_float(image)
-        if convert2ycbcr:
-            # do not rescale sigma in convert2ycbcr case
-            return image, sigma
         range_post = image.max() - image.min()
         # apply the same magnitude scaling to sigma
         scale_factor = range_post / range_pre
@@ -649,8 +642,29 @@ def _scale_sigma_and_image_consistently(image, sigma, multichannel,
             sigma = [s * scale_factor if s is not None else s for s in sigma]
         elif sigma is not None:
             sigma *= scale_factor
-
     return image, sigma
+
+
+def _rescale_sigma_rgb2ycbcr(sigmas):
+    """Convert user-provided noise standard deviations to YCbCr space.
+
+    Notes
+    -----
+    If R, G, B are linearly independent random variables and a1, a2, a3 are
+    scalars, then random variable C:
+        C = a1 * R + a2 * G + a3 * B
+    has variance, var_C, given by:
+        var_C = a1**2 * var_R + a2**2 * var_G + a3**2 * var_B
+    """
+    if sigmas[0] is None:
+        return sigmas
+    sigmas = np.asarray(sigmas)
+    rgv_variances = sigmas * sigmas
+    for i in range(3):
+        scalars = ycbcr_from_rgb[i, :]
+        var_channel = np.sum(scalars * scalars * rgv_variances)
+        sigmas[i] = np.sqrt(var_channel)
+    return sigmas
 
 
 def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
@@ -712,15 +726,7 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
     to a floating point value in the range [-1, 1] or [0, 1] depending on the
     input image range. Any rescaling applied to the `image` will also be
     applied to `sigma` to maintain the same relative amplitude for the supplied
-    noise standard deviation. he only exception to this automated `sigma`
-    scaling is when ``convert2ycbcr`` is set to ``True`` (see below).
-
-    When YCbCr conversion is enabled, every color channel is scaled between 0
-    and 1, and ``sigma`` values are applied to these scaled color channels.
-    Thus, some care needs to be taken to compute any user-provided ``sigma``
-    using a signal in the range [0, 1]. For example, if ``estimate_sigma`` is
-    used, the user should first rescale floating point data to the range
-    [0, 1].
+    noise standard deviation.
 
     Many wavelet coefficient thresholding approaches have been proposed. By
     default, ``denoise_wavelet`` applies BayesShrink, which is an adaptive
@@ -774,11 +780,13 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
         raise ValueError("convert2ycbcr requires multichannel == True")
 
     image, sigma = _scale_sigma_and_image_consistently(image, sigma,
-                                                       multichannel,
-                                                       convert2ycbcr)
+                                                       multichannel)
+
     if multichannel:
         if convert2ycbcr:
             out = color.rgb2ycbcr(image)
+            # convert user-supplied sigmas to the new colorspase as well
+            sigma = _rescale_sigma_rgb2ycbcr(sigma)
             for i in range(3):
                 # renormalizing this color channel to live in [0, 1]
                 _min, _max = out[..., i].min(), out[..., i].max()
@@ -788,8 +796,13 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
                     continue
                 channel = out[..., i] - _min
                 channel /= scale_factor
-                out[..., i] = denoise_wavelet(channel, wavelet=wavelet,
-                                              method=method, sigma=sigma[i],
+                sigma_channel = sigma[i]
+                if sigma_channel is not None:
+                    sigma_channel /= scale_factor
+                out[..., i] = denoise_wavelet(channel,
+                                              wavelet=wavelet,
+                                              method=method,
+                                              sigma=sigma_channel,
                                               mode=mode,
                                               wavelet_levels=wavelet_levels)
                 out[..., i] = out[..., i] * scale_factor

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -776,7 +776,7 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
     >>> img = color.rgb2gray(img)
     >>> img += 0.1 * np.random.randn(*img.shape)
     >>> img = np.clip(img, 0, 1)
-    >>> denoised_img = denoise_wavelet(img, sigma=0.1)
+    >>> denoised_img = denoise_wavelet(img, sigma=0.1, rescale_sigma=True)
 
     """
     if method not in ["BayesShrink", "VisuShrink"]:

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -713,7 +713,10 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
         performed. The default of ``None`` rescales sigma appropriately if the
         image is rescaled internally. A ``DeprecationWarning`` is raised to
         warn the user about this new behaviour. This warning can be avoided
-        by setting ``rescale_sigma=True`.
+        by setting ``rescale_sigma=True``.
+
+        .. versionadded:: 0.16
+           ``rescale_sigma`` was introduced in 0.16
 
     Returns
     -------
@@ -732,12 +735,13 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
     If the input is 3D, this function performs wavelet denoising on each color
     plane separately.
 
-    For floating point inputs, the original input range is maintained and there
-    is no clipping applied to the output. Other input types will be converted
-    to a floating point value in the range [-1, 1] or [0, 1] depending on the
-    input image range. Any rescaling applied to the `image` will also be
-    applied to `sigma` to maintain the same relative amplitude for the supplied
-    noise standard deviation.
+    .. versionchanged:: 0.16
+       For floating point inputs, the original input range is maintained and
+       there is no clipping applied to the output. Other input types will be
+       converted to a floating point value in the range [-1, 1] or [0, 1]
+       depending on the input image range. Unless ``rescale_sigma = False``,
+       any internal rescaling applied to the ``image`` will also be applied
+       to ``sigma`` to maintain the same relative amplitude.
 
     Many wavelet coefficient thresholding approaches have been proposed. By
     default, ``denoise_wavelet`` applies BayesShrink, which is an adaptive

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -404,8 +404,8 @@ def test_wavelet_denoising(img, multichannel, convert2ycbcr):
                                                multichannel=multichannel,
                                                convert2ycbcr=convert2ycbcr,
                                                rescale_sigma=True)
-    psnr_noisy = compare_psnr(img, noisy)
-    psnr_denoised = compare_psnr(img, denoised)
+    psnr_noisy = peak_signal_noise_ratio(img, noisy)
+    psnr_denoised = peak_signal_noise_ratio(img, denoised)
     assert_(psnr_denoised > psnr_noisy)
 
     # Verify that SNR is improved with internally estimated sigma
@@ -414,8 +414,8 @@ def test_wavelet_denoising(img, multichannel, convert2ycbcr):
                                                multichannel=multichannel,
                                                convert2ycbcr=convert2ycbcr,
                                                rescale_sigma=True)
-    psnr_noisy = compare_psnr(img, noisy)
-    psnr_denoised = compare_psnr(img, denoised)
+    psnr_noisy = peak_signal_noise_ratio(img, noisy)
+    psnr_denoised = peak_signal_noise_ratio(img, denoised)
     assert_(psnr_denoised > psnr_noisy)
 
     # SNR is improved less with 1 wavelet level than with the default.
@@ -426,7 +426,7 @@ def test_wavelet_denoising(img, multichannel, convert2ycbcr):
             wavelet_levels=1,
             convert2ycbcr=convert2ycbcr,
             rescale_sigma=True)
-    psnr_denoised_1 = compare_psnr(img, denoised_1)
+    psnr_denoised_1 = peak_signal_noise_ratio(img, denoised_1)
     assert_(psnr_denoised > psnr_denoised_1)
     assert_(psnr_denoised_1 > psnr_noisy)
 
@@ -498,10 +498,11 @@ def test_wavelet_denoising_scaling(case, dtype, convert2ycbcr,
                                                rescale_sigma=True)
 
     data_range = x.max() - x.min()
-    psnr_noisy = compare_psnr(x, noisy, data_range=data_range)
+    psnr_noisy = peak_signal_noise_ratio(x, noisy, data_range=data_range)
     clipped = np.dtype(dtype).kind != 'f'
     if not clipped:
-        psnr_denoised = compare_psnr(x, denoised, data_range=data_range)
+        psnr_denoised = peak_signal_noise_ratio(x, denoised,
+                                                data_range=data_range)
 
         # output's max value is not substantially smaller than x's
         assert_(denoised.max() > 0.9 * x.max())
@@ -509,8 +510,8 @@ def test_wavelet_denoising_scaling(case, dtype, convert2ycbcr,
         # have to compare to x_as_float in integer input cases
         x_as_float = img_as_float(x)
         f_data_range = x_as_float.max() - x_as_float.min()
-        psnr_denoised = compare_psnr(x_as_float, denoised,
-                                     data_range=f_data_range)
+        psnr_denoised = peak_signal_noise_ratio(x_as_float, denoised,
+                                                data_range=f_data_range)
 
         # output has been clipped to expected range
         assert_(denoised.max() <= 1.0)
@@ -583,8 +584,8 @@ def test_wavelet_denoising_nd(rescale_sigma, method, ndim):
         denoised = restoration.denoise_wavelet(
             noisy, method=method,
             rescale_sigma=rescale_sigma)
-    psnr_noisy = compare_psnr(img, noisy)
-    psnr_denoised = compare_psnr(img, denoised)
+    psnr_noisy = peak_signal_noise_ratio(img, noisy)
+    psnr_denoised = peak_signal_noise_ratio(img, denoised)
     assert_(psnr_denoised > psnr_noisy)
 
 
@@ -619,9 +620,9 @@ def test_wavelet_denoising_levels(rescale_sigma):
         denoised_1 = restoration.denoise_wavelet(noisy, wavelet=wavelet,
                                                  wavelet_levels=1,
                                                  rescale_sigma=rescale_sigma)
-    psnr_noisy = compare_psnr(img, noisy)
-    psnr_denoised = compare_psnr(img, denoised)
-    psnr_denoised_1 = compare_psnr(img, denoised_1)
+    psnr_noisy = peak_signal_noise_ratio(img, noisy)
+    psnr_denoised = peak_signal_noise_ratio(img, denoised)
+    psnr_denoised_1 = peak_signal_noise_ratio(img, denoised_1)
 
     # multi-level case should outperform single level case
     assert_(psnr_denoised > psnr_denoised_1 > psnr_noisy)

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -1,6 +1,7 @@
 import itertools
 import numpy as np
 import pytest
+from pytest import warns
 
 from skimage import restoration, data, color, img_as_float
 from skimage.metrics import structural_similarity
@@ -36,6 +37,9 @@ astro = img_as_float(data.astronaut()[:128, :128])
 astro_gray = color.rgb2gray(astro)
 checkerboard_gray = img_as_float(data.checkerboard())
 checkerboard = color.gray2rgb(checkerboard_gray)
+# versions with one odd-sized dimension
+astro_gray_odd = astro_gray[:, :-1]
+astro_odd = astro[:, :-1]
 
 
 def test_denoise_tv_chambolle_2d():
@@ -381,59 +385,64 @@ def test_no_denoising_for_small_h():
     assert_(np.allclose(denoised, img))
 
 
-def test_wavelet_denoising():
+@pytest.mark.parametrize(
+    'img, multichannel, convert2ycbcr',
+    [(astro_gray, False, False),
+     (astro_gray_odd, False, False),
+     (astro_odd, True, False),
+     (astro_odd, True, True)]
+)
+def test_wavelet_denoising(img, multichannel, convert2ycbcr):
     rstate = np.random.RandomState(1234)
+    sigma = 0.1
+    noisy = img + sigma * rstate.randn(*(img.shape))
+    noisy = np.clip(noisy, 0, 1)
 
-    # version with one odd-sized dimension
-    astro_gray_odd = astro_gray[:, :-1]
-    astro_odd = astro[:, :-1]
+    # Verify that SNR is improved when true sigma is used
+    with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
+        denoised = restoration.denoise_wavelet(noisy, sigma=sigma,
+                                               multichannel=multichannel,
+                                               convert2ycbcr=convert2ycbcr,
+                                               rescale_sigma=True)
+    psnr_noisy = compare_psnr(img, noisy)
+    psnr_denoised = compare_psnr(img, denoised)
+    assert_(psnr_denoised > psnr_noisy)
 
-    for img, multichannel, convert2ycbcr in [(astro_gray, False, False),
-                                             (astro_gray_odd, False, False),
-                                             (astro_odd, True, False),
-                                             (astro_odd, True, True)]:
-        sigma = 0.1
-        noisy = img + sigma * rstate.randn(*(img.shape))
-        noisy = np.clip(noisy, 0, 1)
+    # Verify that SNR is improved with internally estimated sigma
+    with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
+        denoised = restoration.denoise_wavelet(noisy,
+                                               multichannel=multichannel,
+                                               convert2ycbcr=convert2ycbcr,
+                                               rescale_sigma=True)
+    psnr_noisy = compare_psnr(img, noisy)
+    psnr_denoised = compare_psnr(img, denoised)
+    assert_(psnr_denoised > psnr_noisy)
 
-        # Verify that SNR is improved when true sigma is used
-        with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
-            denoised = restoration.denoise_wavelet(noisy, sigma=sigma,
-                                                   multichannel=multichannel,
-                                                   convert2ycbcr=convert2ycbcr)
-        psnr_noisy = peak_signal_noise_ratio(img, noisy)
-        psnr_denoised = peak_signal_noise_ratio(img, denoised)
-        assert_(psnr_denoised > psnr_noisy)
+    # SNR is improved less with 1 wavelet level than with the default.
+    with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
+        denoised_1 = restoration.denoise_wavelet(
+            noisy,
+            multichannel=multichannel,
+            wavelet_levels=1,
+            convert2ycbcr=convert2ycbcr,
+            rescale_sigma=True)
+    psnr_denoised_1 = compare_psnr(img, denoised_1)
+    assert_(psnr_denoised > psnr_denoised_1)
+    assert_(psnr_denoised_1 > psnr_noisy)
 
-        # Verify that SNR is improved with internally estimated sigma
-        with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
-            denoised = restoration.denoise_wavelet(noisy,
-                                                   multichannel=multichannel,
-                                                   convert2ycbcr=convert2ycbcr)
-        psnr_noisy = peak_signal_noise_ratio(img, noisy)
-        psnr_denoised = peak_signal_noise_ratio(img, denoised)
-        assert_(psnr_denoised > psnr_noisy)
-
-        # SNR is improved less with 1 wavelet level than with the default.
-        denoised_1 = restoration.denoise_wavelet(noisy,
-                                                 multichannel=multichannel,
-                                                 wavelet_levels=1,
-                                                 convert2ycbcr=convert2ycbcr)
-        psnr_denoised_1 = peak_signal_noise_ratio(img, denoised_1)
-        assert_(psnr_denoised > psnr_denoised_1)
-        assert_(psnr_denoised_1 > psnr_noisy)
-
-        # Test changing noise_std (higher threshold, so less energy in signal)
-        with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
-            res1 = restoration.denoise_wavelet(noisy, sigma=2 * sigma,
-                                               multichannel=multichannel)
-        with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
-            res2 = restoration.denoise_wavelet(noisy, sigma=sigma,
-                                               multichannel=multichannel)
-        assert_(np.sum(res1**2) <= np.sum(res2**2))
+    # Test changing noise_std (higher threshold, so less energy in signal)
+    with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
+        res1 = restoration.denoise_wavelet(noisy, sigma=2 * sigma,
+                                           multichannel=multichannel,
+                                           rescale_sigma=True)
+    with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
+        res2 = restoration.denoise_wavelet(noisy, sigma=sigma,
+                                           multichannel=multichannel,
+                                           rescale_sigma=True)
+    assert_(np.sum(res1**2) <= np.sum(res2**2))
 
 
-@testing.parametrize(
+@pytest.mark.parametrize(
     'case, dtype, convert2ycbcr, estimate_sigma',
     itertools.product(
         ['1d', '2d multichannel'],
@@ -463,8 +472,9 @@ def test_wavelet_denoising_scaling(case, dtype, convert2ycbcr,
     multichannel = x.shape[-1] == 3
 
     if estimate_sigma:
-        sigma_est = restoration.estimate_sigma(noisy,
-                                               multichannel=multichannel)
+        with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
+            sigma_est = restoration.estimate_sigma(noisy,
+                                                   multichannel=multichannel)
     else:
         sigma_est = None
 
@@ -475,14 +485,17 @@ def test_wavelet_denoising_scaling(case, dtype, convert2ycbcr,
                                                    sigma=sigma_est,
                                                    wavelet='sym4',
                                                    multichannel=multichannel,
-                                                   convert2ycbcr=convert2ycbcr)
+                                                   convert2ycbcr=convert2ycbcr,
+                                                   rescale_sigma=True)
         return
 
-    denoised = restoration.denoise_wavelet(noisy,
-                                           sigma=sigma_est,
-                                           wavelet='sym4',
-                                           multichannel=multichannel,
-                                           convert2ycbcr=convert2ycbcr)
+    with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
+        denoised = restoration.denoise_wavelet(noisy,
+                                               sigma=sigma_est,
+                                               wavelet='sym4',
+                                               multichannel=multichannel,
+                                               convert2ycbcr=convert2ycbcr,
+                                               rescale_sigma=True)
 
     data_range = x.max() - x.min()
     psnr_noisy = compare_psnr(x, noisy, data_range=data_range)
@@ -536,43 +549,58 @@ def test_wavelet_threshold():
                            threshold=sigma)
 
 
-def test_wavelet_denoising_nd():
+@pytest.mark.parametrize(
+    'rescale_sigma, method, ndim',
+    itertools.product(
+        [True, False],
+        ['VisuShrink', 'BayesShrink'],
+        range(1, 5)
+    )
+)
+def test_wavelet_denoising_nd(rescale_sigma, method, ndim):
     rstate = np.random.RandomState(1234)
-    for method in ['VisuShrink', 'BayesShrink']:
-        for ndim in range(1, 5):
-            # Generate a very simple test image
-            if ndim < 3:
-                img = 0.2*np.ones((128, )*ndim)
-            else:
-                img = 0.2*np.ones((16, )*ndim)
-            img[(slice(5, 13), ) * ndim] = 0.8
+    # Generate a very simple test image
+    if ndim < 3:
+        img = 0.2*np.ones((128, )*ndim)
+    else:
+        img = 0.2*np.ones((16, )*ndim)
+    img[(slice(5, 13), ) * ndim] = 0.8
 
-            sigma = 0.1
-            noisy = img + sigma * rstate.randn(*(img.shape))
-            noisy = np.clip(noisy, 0, 1)
+    sigma = 0.1
+    noisy = img + sigma * rstate.randn(*(img.shape))
+    noisy = np.clip(noisy, 0, 1)
 
-            # Mark H. 2018.08:
-            #   The issue arises because when ndim in [1, 2]
-            #   ``waverecn`` calls ``_match_coeff_dims``
-            #   Which includes a numpy 1.15 deprecation.
-            #   for larger number of dimensions _match_coeff_dims isn't called
-            #   for some reason.
-            anticipated_warnings = (PYWAVELET_ND_INDEXING_WARNING
-                                    if ndim < 3 else None)
-            with expected_warnings([anticipated_warnings]):
-                # Verify that SNR is improved with internally estimated sigma
-                denoised = restoration.denoise_wavelet(noisy, method=method)
-            psnr_noisy = peak_signal_noise_ratio(img, noisy)
-            psnr_denoised = peak_signal_noise_ratio(img, denoised)
-            assert_(psnr_denoised > psnr_noisy)
+    # Mark H. 2018.08:
+    #   The issue arises because when ndim in [1, 2]
+    #   ``waverecn`` calls ``_match_coeff_dims``
+    #   Which includes a numpy 1.15 deprecation.
+    #   for larger number of dimensions _match_coeff_dims isn't called
+    #   for some reason.
+    anticipated_warnings = (PYWAVELET_ND_INDEXING_WARNING
+                            if ndim < 3 else None)
+    with expected_warnings([anticipated_warnings]):
+        # Verify that SNR is improved with internally estimated sigma
+        denoised = restoration.denoise_wavelet(
+            noisy, method=method,
+            rescale_sigma=rescale_sigma)
+    psnr_noisy = compare_psnr(img, noisy)
+    psnr_denoised = compare_psnr(img, denoised)
+    assert_(psnr_denoised > psnr_noisy)
 
 
 def test_wavelet_invalid_method():
     with testing.raises(ValueError):
-        restoration.denoise_wavelet(np.ones(16), method='Unimplemented')
+        restoration.denoise_wavelet(np.ones(16), method='Unimplemented',
+                                    rescale_sigma=True)
 
 
-def test_wavelet_denoising_levels():
+def test_wavelet_rescale_sigma_deprecation():
+    # No specifying rescale_sigma results in a DeprecationWarning
+    assert_warns(DeprecationWarning, restoration.denoise_wavelet, np.ones(16))
+
+
+@pytest.mark.parametrize('rescale_sigma', [True, False])
+def test_wavelet_denoising_levels(rescale_sigma):
     rstate = np.random.RandomState(1234)
     ndim = 2
     N = 256
@@ -586,12 +614,14 @@ def test_wavelet_denoising_levels():
     noisy = np.clip(noisy, 0, 1)
 
     with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
-        denoised = restoration.denoise_wavelet(noisy, wavelet=wavelet)
-    denoised_1 = restoration.denoise_wavelet(noisy, wavelet=wavelet,
-                                             wavelet_levels=1)
-    psnr_noisy = peak_signal_noise_ratio(img, noisy)
-    psnr_denoised = peak_signal_noise_ratio(img, denoised)
-    psnr_denoised_1 = peak_signal_noise_ratio(img, denoised_1)
+        denoised = restoration.denoise_wavelet(noisy, wavelet=wavelet,
+                                               rescale_sigma=rescale_sigma)
+        denoised_1 = restoration.denoise_wavelet(noisy, wavelet=wavelet,
+                                                 wavelet_levels=1,
+                                                 rescale_sigma=rescale_sigma)
+    psnr_noisy = compare_psnr(img, noisy)
+    psnr_denoised = compare_psnr(img, denoised)
+    psnr_denoised_1 = compare_psnr(img, denoised_1)
 
     # multi-level case should outperform single level case
     assert_(psnr_denoised > psnr_denoised_1 > psnr_noisy)
@@ -604,19 +634,22 @@ def test_wavelet_denoising_levels():
         with testing.raises(ValueError):
             with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
                 restoration.denoise_wavelet(
-                    noisy, wavelet=wavelet, wavelet_levels=max_level + 1)
+                    noisy, wavelet=wavelet, wavelet_levels=max_level + 1,
+                    rescale_sigma=rescale_sigma)
     else:
         # exceeding max_level raises a UserWarning in PyWavelets >= 1.0.0
         with expected_warnings([
                 'all coefficients will experience boundary effects']):
             restoration.denoise_wavelet(
-                noisy, wavelet=wavelet, wavelet_levels=max_level + 1)
+                noisy, wavelet=wavelet, wavelet_levels=max_level + 1,
+                rescale_sigma=rescale_sigma)
 
     with testing.raises(ValueError):
         with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
             restoration.denoise_wavelet(
                 noisy,
-                wavelet=wavelet, wavelet_levels=-1)
+                wavelet=wavelet, wavelet_levels=-1,
+                rescale_sigma=rescale_sigma)
 
 
 def test_estimate_sigma_gray():
@@ -669,7 +702,8 @@ def test_estimate_sigma_color():
     assert_warns(UserWarning, restoration.estimate_sigma, img)
 
 
-def test_wavelet_denoising_args():
+@pytest.mark.parametrize('rescale_sigma', [True, False])
+def test_wavelet_denoising_args(rescale_sigma):
     """
     Some of the functions inside wavelet denoising throw an error the wrong
     arguments are passed. This protects against that and verifies that all
@@ -684,7 +718,8 @@ def test_wavelet_denoising_args():
                 with testing.raises(ValueError):
                     restoration.denoise_wavelet(noisy,
                                                 convert2ycbcr=convert2ycbcr,
-                                                multichannel=multichannel)
+                                                multichannel=multichannel,
+                                                rescale_sigma=rescale_sigma)
                 continue
             anticipated_warnings = (PYWAVELET_ND_INDEXING_WARNING
                                     if multichannel else None)
@@ -695,17 +730,21 @@ def test_wavelet_denoising_args():
                 with expected_warnings([anticipated_warnings]):
                     restoration.denoise_wavelet(noisy, sigma=sigma,
                                                 convert2ycbcr=convert2ycbcr,
-                                                multichannel=multichannel)
+                                                multichannel=multichannel,
+                                                rescale_sigma=rescale_sigma)
 
 
-def test_denoise_wavelet_biorthogonal():
+@pytest.mark.parametrize('rescale_sigma', [True, False])
+def test_denoise_wavelet_biorthogonal(rescale_sigma):
     """Biorthogonal wavelets should raise a warning during thresholding."""
     img = astro_gray
     assert_warns(UserWarning, restoration.denoise_wavelet, img,
-                 wavelet='bior2.2', multichannel=False)
+                 wavelet='bior2.2', multichannel=False,
+                 rescale_sigma=rescale_sigma)
 
 
-def test_cycle_spinning_multichannel():
+@pytest.mark.parametrize('rescale_sigma', [True, False])
+def test_cycle_spinning_multichannel(rescale_sigma):
     sigma = 0.1
     rstate = np.random.RandomState(1234)
 
@@ -730,7 +769,8 @@ def test_cycle_spinning_multichannel():
         noisy = img.copy() + 0.1 * rstate.randn(*(img.shape))
 
         denoise_func = restoration.denoise_wavelet
-        func_kw = dict(sigma=sigma, multichannel=multichannel)
+        func_kw = dict(sigma=sigma, multichannel=multichannel,
+                       rescale_sigma=rescale_sigma)
 
         # max_shifts=0 is equivalent to just calling denoise_func
         with expected_warnings([PYWAVELET_ND_INDEXING_WARNING,
@@ -787,7 +827,7 @@ def test_cycle_spinning_num_workers():
     noisy = img.copy() + 0.1 * rstate.randn(*(img.shape))
 
     denoise_func = restoration.denoise_wavelet
-    func_kw = dict(sigma=sigma, multichannel=True)
+    func_kw = dict(sigma=sigma, multichannel=True, rescale_sigma=True)
 
     # same results are expected whether using 1 worker or multiple workers
     with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -442,7 +442,7 @@ def test_wavelet_denoising_scaling(dtype):
 
     # add noise and clip to original signal range
     sigma = 25.
-    noisy = x + sigma*rstate.randn(x.size)
+    noisy = x + sigma * rstate.randn(x.size)
     noisy = np.clip(noisy, x.min(), x.max())
     noisy = noisy.astype(x.dtype)
 

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -463,13 +463,8 @@ def test_wavelet_denoising_scaling(case, dtype, convert2ycbcr,
     multichannel = x.shape[-1] == 3
 
     if estimate_sigma:
-        if convert2ycbcr:
-            # YCbCr expects a sigma appropriate to data in the range [0, 1]
-            sigma_est = restoration.estimate_sigma(noisy/x.max(),
-                                                   multichannel=multichannel)
-        else:
-            sigma_est = restoration.estimate_sigma(noisy,
-                                                   multichannel=multichannel)
+        sigma_est = restoration.estimate_sigma(noisy,
+                                               multichannel=multichannel)
     else:
         sigma_est = None
 

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -1,7 +1,6 @@
 import itertools
 import numpy as np
 import pytest
-from pytest import warns
 
 from skimage import restoration, data, color, img_as_float
 from skimage.metrics import structural_similarity

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -432,47 +432,48 @@ def test_wavelet_denoising():
         assert_(np.sum(res1**2) <= np.sum(res2**2))
 
 
-def test_wavelet_denoising_scaling():
+@testing.parametrize('dtype',
+                     [np.float16, np.float32, np.float64, np.int16, np.uint8])
+def test_wavelet_denoising_scaling(dtype):
     """Test case for floating point input outside the [-1, 1] range."""
     rstate = np.random.RandomState(1234)
-    for dtype in [np.float16, np.float32, np.float64, np.int16, np.uint8]:
-        # clean signal in range [0, 255]
-        x = np.linspace(0, 255, 1024, dtype=dtype)
+    # clean signal in range [0, 255]
+    x = np.linspace(0, 255, 1024, dtype=dtype)
 
-        # add noise and clip to original signal range
-        sigma = 25.
-        noisy = x + sigma*rstate.randn(x.size)
-        noisy = np.clip(noisy, x.min(), x.max())
-        noisy = noisy.astype(x.dtype)
+    # add noise and clip to original signal range
+    sigma = 25.
+    noisy = x + sigma*rstate.randn(x.size)
+    noisy = np.clip(noisy, x.min(), x.max())
+    noisy = noisy.astype(x.dtype)
 
-        sigma_est = restoration.estimate_sigma(noisy)
-        denoised = restoration.denoise_wavelet(noisy,
-                                               sigma=sigma_est,
-                                               wavelet='sym4',
-                                               multichannel=False)
+    sigma_est = restoration.estimate_sigma(noisy)
+    denoised = restoration.denoise_wavelet(noisy,
+                                           sigma=sigma_est,
+                                           wavelet='sym4',
+                                           multichannel=False)
 
-        data_range = x.max() - x.min()
-        psnr_noisy = compare_psnr(x, noisy, data_range=data_range)
-        if np.dtype(dtype).kind == 'f':
-            psnr_denoised = compare_psnr(x, denoised, data_range=data_range)
+    data_range = x.max() - x.min()
+    psnr_noisy = compare_psnr(x, noisy, data_range=data_range)
+    if np.dtype(dtype).kind == 'f':
+        psnr_denoised = compare_psnr(x, denoised, data_range=data_range)
 
-            # output's max value is not substantially smaller than signal's
-            assert_(denoised.max() > 0.9 * x.max())
+        # output's max value is not substantially smaller than signal's
+        assert_(denoised.max() > 0.9 * x.max())
+    else:
+        # have to compare to x_as_float in integer input cases
+        x_as_float = img_as_float(x)
+        f_data_range = x_as_float.max() - x_as_float.min()
+        psnr_denoised = compare_psnr(x_as_float, denoised,
+                                     data_range=f_data_range)
+
+        # output has been clipped to expected range
+        assert_(denoised.max() <= 1.0)
+        if np.dtype(dtype).kind == 'u':
+            assert_(denoised.min() >= 0)
         else:
-            # have to compare to x_as_float in integer input cases
-            x_as_float = img_as_float(x)
-            f_data_range = x_as_float.max() - x_as_float.min()
-            psnr_denoised = compare_psnr(x_as_float, denoised,
-                                         data_range=f_data_range)
+            assert_(denoised.min() >= -1)
 
-            # output has been clipped to expected range
-            assert_(denoised.max() <= 1.0)
-            if np.dtype(dtype).kind == 'u':
-                assert_(denoised.min() >= 0)
-            else:
-                assert_(denoised.min() >= -1)
-
-        assert_(psnr_denoised > psnr_noisy)
+    assert_(psnr_denoised > psnr_noisy)
 
 
 def test_wavelet_threshold():


### PR DESCRIPTION
## Description

This PR fixes two separate issues with data scaling in `denoise_wavelet`.

- The changes in #3052 (see also #3373), mean that floating point inputs will no longer be automatically rescaled to the range [0, 1] or [-1, 1]. I think this is desirable, but it means that it is no longer appropriate to clip the output to this range when the input is a float.

- In cases where `img_as_float` does rescale the image, the same rescaling should also be applied to `sigma`, but this was not previously being done. This was okay for the default `sigma=None` as the scaling occurs prior to the internal call to `estimate_sigma`. 

I added some test cases that check both PSNR and the output range for various dtypes.  All of these test cases fail without the changes in this PR.

The previously existing tests were passing because the inputs had already been scaled via `img_as_float` prior to calling `denoise_wavelet`.



## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
