### PR TITLE
_marching_cubes_lewiner_cy: mark char as signed

### DIFF
--- a/skimage/measure/_marching_cubes_lewiner_cy.pyx
+++ b/skimage/measure/_marching_cubes_lewiner_cy.pyx
@@ -746,7 +746,7 @@ cdef class Lut:
     This class defines functions to look up values using 1, 2 or 3 indices.
     """
 
-    cdef char* VALUES
+    cdef signed char* VALUES
     cdef int L0 # Length
     cdef int L1 # size of tuple
     cdef int L2 # size of tuple in tuple (if any)
@@ -767,7 +767,7 @@ cdef class Lut:
         array = array.ravel()
         cdef int n, N
         N = self.L0 * self.L1 * self.L2
-        self.VALUES = <char *> malloc(N * sizeof(char))
+        self.VALUES = <signed char *> malloc(N * sizeof(signed char))
         for n in range(N):
             self.VALUES[n] = array[n]
 


### PR DESCRIPTION
Fixes marching_cubes_lewiner on ppc64le

xref: https://github.com/scikit-image/scikit-image/issues/2982

## Description
Running marching_cubes_lewiner on ppc64le throws:  "OverflowError: can't convert negative value to char"

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

## References
[If this is a bug-fix or enhancement, it closes issue # ] 2982

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
