### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,4 @@ If you find this project useful, please cite:
 > François Boulogne, Joshua D. Warner, Neil Yager, Emmanuelle
 > Gouillart, Tony Yu, and the scikit-image contributors.
 > *scikit-image: Image processing in Python*. PeerJ 2:e453 (2014)
-> http://dx.doi.org/10.7717/peerj.453
+> https://doi.org/10.7717/peerj.453

--- a/skimage/_shared/fast_exp.h
+++ b/skimage/_shared/fast_exp.h
@@ -1,6 +1,6 @@
 /* A fast approximation of the exponential function.
  * Reference [1]: https://schraudolph.org/pubs/Schraudolph99.pdf
- * Reference [2]: http://dx.doi.org/10.1162/089976600300015033
+ * Reference [2]: https://doi.org/10.1162/089976600300015033
  * Additional improvements by Leonid Bloch. */
 
 /* use just EXP_A = 1512775 for integer version, to avoid FP calculations */


### PR DESCRIPTION
## Description

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

I'd simply like to suggest to update all static DOI links and the code that generates new DOI links accordingly.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## ~~References~~

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
