### PR TITLE
Missing parameter description in `morphology.reconstruction() docstring #3581

### DIFF
--- a/skimage/morphology/greyreconstruct.py
+++ b/skimage/morphology/greyreconstruct.py
@@ -146,7 +146,7 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
         offset = np.array([d // 2 for d in selem.shape])
     else:
         if offset.ndim != selem.ndim:
-            raise ValueError("offset and selem ndims must be identical")
+            raise ValueError("Offset and selem ndims must be equal.")
         if not all([(0 <= o < d) for o, d in zip(offset, selem.shape)]):
             raise ValueError("Offset must be included inside selem")
 

--- a/skimage/morphology/greyreconstruct.py
+++ b/skimage/morphology/greyreconstruct.py
@@ -54,7 +54,8 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
         (i.e. a 3x3 square for 2D images, a 3x3x3 cube for 3D images, etc.)
     offset : ndarray, optional
         The coordinates of the center of the structuring element.
-        Default is located on the real center of the selem, in that case selem dimensions must be odd.
+        Default is located on the real center of the selem, in that case
+        selem dimensions must be odd.
 
     Returns
     -------
@@ -206,5 +207,6 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
 
     # Reshape reconstructed image to original image shape and remove padding.
     rec_img = value_map[value_rank[:image_stride]]
-    rec_img.shape = np.array(seed.shape) + (np.array(selem.shape) - 1).astype(int)
+    rec_img.shape = np.array(seed.shape) + (np.array(selem.shape) - 1) \
+        .astype(int)
     return rec_img[inside_slices]

--- a/skimage/morphology/greyreconstruct.py
+++ b/skimage/morphology/greyreconstruct.py
@@ -47,10 +47,13 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
         erosion), the seed image is dilated (or eroded) until limited by the
         mask image. For dilation, each seed value must be less than or equal
         to the corresponding mask value; for erosion, the reverse is true.
-    selem : ndarray
+    selem : ndarray, optional
         The neighborhood expressed as an n-D array of 1's and 0's.
         Default is the ball of radius 1 according to the maximum norm
         (i.e. a 3x3 square for 2D images, a 3x3x3 cube for 3D images, etc.)
+    offset : ndarray, optional
+        The coordinates of the center of the structuring element.
+        Default is located on the real center of the selem, in that case selem dimensions must be odd.
 
     Returns
     -------
@@ -139,15 +142,20 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
         if not all([d % 2 == 1 for d in selem.shape]):
             raise ValueError("Footprint dimensions must all be odd")
         offset = np.array([d // 2 for d in selem.shape])
+    else:
+        if offset.ndim != selem.ndim:
+            raise ValueError("offset and selem ndims must be identical")
+        if not all([(0 <= o < d) for o, d in zip(offset, selem.shape)]):
+            raise ValueError("Offset must be included inside selem")
+
     # Cross out the center of the selem
     selem[tuple(slice(d, d + 1) for d in offset)] = False
 
     # Make padding for edges of reconstructed image so we can ignore boundaries
-    padding = (np.array(selem.shape) / 2).astype(int)
     dims = np.zeros(seed.ndim + 1, dtype=int)
-    dims[1:] = np.array(seed.shape) + 2 * padding
+    dims[1:] = np.array(seed.shape) + (np.array(selem.shape) - 1).astype(int)
     dims[0] = 2
-    inside_slices = tuple(slice(p, -p) for p in padding)
+    inside_slices = tuple(slice(o, o + s) for o, s in zip(offset, seed.shape))
     # Set padded region to minimum image intensity and mask along first axis so
     # we can interleave image and mask pixels when sorting.
     if method == 'dilation':
@@ -197,5 +205,5 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
 
     # Reshape reconstructed image to original image shape and remove padding.
     rec_img = value_map[value_rank[:image_stride]]
-    rec_img.shape = np.array(seed.shape) + 2 * padding
+    rec_img.shape = np.array(seed.shape) + (np.array(selem.shape) - 1).astype(int)
     return rec_img[inside_slices]

--- a/skimage/morphology/greyreconstruct.py
+++ b/skimage/morphology/greyreconstruct.py
@@ -155,7 +155,7 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
 
     # Make padding for edges of reconstructed image so we can ignore boundaries
     dims = np.zeros(seed.ndim + 1, dtype=int)
-    dims[1:] = np.array(seed.shape) + (np.array(selem.shape) - 1).astype(int)
+    dims[1:] = np.array(seed.shape) + (np.array(selem.shape) - 1)
     dims[0] = 2
     inside_slices = tuple(slice(o, o + s) for o, s in zip(offset, seed.shape))
     # Set padded region to minimum image intensity and mask along first axis so
@@ -207,6 +207,5 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
 
     # Reshape reconstructed image to original image shape and remove padding.
     rec_img = value_map[value_rank[:image_stride]]
-    rec_img.shape = np.array(seed.shape) + (np.array(selem.shape) - 1) \
-        .astype(int)
+    rec_img.shape = np.array(seed.shape) + (np.array(selem.shape) - 1)
     return rec_img[inside_slices]

--- a/skimage/morphology/greyreconstruct.py
+++ b/skimage/morphology/greyreconstruct.py
@@ -42,11 +42,12 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
         are dilated or eroded.
     mask : ndarray
         The maximum (dilation) / minimum (erosion) allowed value at each pixel.
-    method : {'dilation'|'erosion'}
+    method : {'dilation'|'erosion'}, optional
         Perform reconstruction by dilation or erosion. In dilation (or
         erosion), the seed image is dilated (or eroded) until limited by the
         mask image. For dilation, each seed value must be less than or equal
         to the corresponding mask value; for erosion, the reverse is true.
+        Default is 'dilation'.
     selem : ndarray, optional
         The neighborhood expressed as an n-D array of 1's and 0's.
         Default is the ball of radius 1 according to the maximum norm

--- a/skimage/morphology/greyreconstruct.py
+++ b/skimage/morphology/greyreconstruct.py
@@ -50,11 +50,11 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
         Default is 'dilation'.
     selem : ndarray, optional
         The neighborhood expressed as an n-D array of 1's and 0's.
-        Default is the ball of radius 1 according to the maximum norm
-        (i.e. a 3x3 square for 2D images, a 3x3x3 cube for 3D images, etc.)
+        Default is the n-D square of radius equal to 1 (i.e. a 3x3 square
+        for 2D images, a 3x3x3 cube for 3D images, etc.)
     offset : ndarray, optional
         The coordinates of the center of the structuring element.
-        Default is located on the real center of the selem, in that case
+        Default is located on the geometrical center of the selem, in that case
         selem dimensions must be odd.
 
     Returns

--- a/skimage/morphology/tests/test_reconstruction.py
+++ b/skimage/morphology/tests/test_reconstruction.py
@@ -108,3 +108,32 @@ def test_invalid_method():
     mask = np.array([0, 3, 6, 2, 1, 1, 1, 4, 2, 0])
     with testing.raises(ValueError):
         reconstruction(seed, mask, method='foo')
+
+
+def test_invalid_offset_not_none():
+    """Test reconstruction with invalid not None offset parameter"""
+    image = np.array([[1, 1, 1, 1, 1, 1, 1, 1],
+                      [1, 2, 1, 1, 1, 1, 1, 1],
+                      [1, 1, 1, 1, 1, 1, 1, 1],
+                      [1, 1, 1, 1, 1, 1, 1, 1],
+                      [1, 1, 1, 1, 1, 1, 3, 1],
+                      [1, 1, 1, 1, 1, 1, 1, 1]])
+
+    mask = np.array([[4, 4, 4, 1, 1, 1, 1, 1],
+                     [4, 4, 4, 1, 1, 1, 1, 1],
+                     [4, 4, 4, 1, 1, 1, 1, 1],
+                     [1, 1, 1, 1, 1, 4, 4, 4],
+                     [1, 1, 1, 1, 1, 4, 4, 4],
+                     [1, 1, 1, 1, 1, 4, 4, 4]])
+    with testing.raises(ValueError):
+        reconstruction(image, mask, method='dilation', selem=np.ones((3, 3)), offset=np.array([3, 0]))
+
+
+def test_offset_not_none():
+    """Test reconstruction with valid offset parameter"""
+    seed = np.array([0, 3, 6, 2, 1, 1, 1, 4, 2, 0])
+    mask = np.array([0, 8, 6, 8, 8, 8, 8, 4, 4, 0])
+    expected = np.array([0, 3, 6, 6, 6, 6, 6, 4, 4, 0])
+
+    assert_array_almost_equal(
+        reconstruction(seed, mask, method='dilation', selem=np.ones(3), offset=np.array([0])), expected)

--- a/skimage/morphology/tests/test_reconstruction.py
+++ b/skimage/morphology/tests/test_reconstruction.py
@@ -126,7 +126,8 @@ def test_invalid_offset_not_none():
                      [1, 1, 1, 1, 1, 4, 4, 4],
                      [1, 1, 1, 1, 1, 4, 4, 4]])
     with testing.raises(ValueError):
-        reconstruction(image, mask, method='dilation', selem=np.ones((3, 3)), offset=np.array([3, 0]))
+        reconstruction(image, mask, method='dilation',
+                       selem=np.ones((3, 3)), offset=np.array([3, 0]))
 
 
 def test_offset_not_none():
@@ -136,4 +137,5 @@ def test_offset_not_none():
     expected = np.array([0, 3, 6, 6, 6, 6, 6, 4, 4, 0])
 
     assert_array_almost_equal(
-        reconstruction(seed, mask, method='dilation', selem=np.ones(3), offset=np.array([0])), expected)
+        reconstruction(seed, mask, method='dilation',
+                       selem=np.ones(3), offset=np.array([0])), expected)


### PR DESCRIPTION
## Description
[Missing parameter description in `morphology.reconstruction() docstring #3581
_I have completed the description for parameters 'method' and 'offset'.
_I have added 2 conditions that seems to be fulfilled for the 'offset' parameter when not default.
_On the previous revision when 'offset' was not default, nothing prevented 'selem' to be non-odd and the padding could also possibly not be symmetric but seemed to be not handled. I have added a generic way to handle the padding.
_ Two tests were added: one for checking a non-valid offset and one for checking the vailidity of a result with a non-symmetric padding.
_Travis build is ok on the branch  ]


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
