### PR TITLE
added positivity constraint to Chambolle-Pock TV

### DIFF
--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -220,8 +220,8 @@ def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, n_iter_max=200,
             out = out_nopos
         else:
             out = np.maximum(0, out_nopos)
-            removed = np.minimum(out_nopos, 0) 
-            d = d-removed
+            removed = np.minimum(out_nopos, 0)
+            d = d - removed
 
         E = (d ** 2).sum()
 

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -160,7 +160,8 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True):
     return _denoise_tv_bregman(image, weight, max_iter, eps, isotropic)
 
 
-def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, n_iter_max=200, positivity=False):
+def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, n_iter_max=200,
+                             positivity=False):
     """Perform total-variation denoising on n-dimensional images.
 
     Parameters
@@ -214,15 +215,14 @@ def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, n_iter_max=200, posit
             out_nopos = image + d
         else:
             out_nopos = image
-            
+
         if not positivity:
             out = out_nopos
         else:
-            out     = np.maximum (0 ,out_nopos)
-            removed = np.minimum (out_nopos, 0) 
-            d       = d-removed
+            out = np.maximum(0, out_nopos)
+            removed = np.minimum(out_nopos, 0) 
+            d = d-removed
 
-            
         E = (d ** 2).sum()
 
         # g stores the gradients of out along each axis
@@ -334,9 +334,11 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, n_iter_max=200,
         out = np.zeros_like(image)
         for c in range(image.shape[-1]):
             out[..., c] = _denoise_tv_chambolle_nd(image[..., c], weight, eps,
-                                                   n_iter_max, positivity=positivity)
+                                                   n_iter_max,
+                                                   positivity=positivity)
     else:
-        out = _denoise_tv_chambolle_nd(image, weight, eps, n_iter_max, positivity=positivity)
+        out = _denoise_tv_chambolle_nd(image, weight, eps, n_iter_max,
+                                       positivity=positivity)
     return out
 
 

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -46,6 +46,23 @@ def test_denoise_tv_chambolle_2d():
     assert_(grad_denoised.dtype == np.float)
     assert_(np.sqrt((grad_denoised**2).sum()) < np.sqrt((grad**2).sum()))
 
+def test_denoise_tv_chambolle_2d_positivity():
+    # astronaut image
+    img = astro_gray.copy()
+    # add noise to astronaut
+    img += 0.5 * img.std() * np.random.rand(*img.shape)
+    img = np.clip(img, img.min(), 1)
+    # denoise
+    denoised_astro = restoration.denoise_tv_chambolle(img, weight=0.1, positivity=True)
+    # which dtype?
+    assert_(denoised_astro.dtype in [np.float, np.float32, np.float64])
+    from scipy import ndimage as ndi
+    grad = ndi.morphological_gradient(img, size=((3, 3)))
+    grad_denoised = ndi.morphological_gradient(denoised_astro, size=((3, 3)))
+    # test if the total variation has decreased
+    assert_(grad_denoised.dtype == np.float)
+    assert_(np.sqrt((grad_denoised**2).sum()) < np.sqrt((grad**2).sum()))
+
 
 def test_denoise_tv_chambolle_multichannel():
     denoised0 = restoration.denoise_tv_chambolle(astro[..., 0], weight=0.1)

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -46,6 +46,7 @@ def test_denoise_tv_chambolle_2d():
     assert_(grad_denoised.dtype == np.float)
     assert_(np.sqrt((grad_denoised**2).sum()) < np.sqrt((grad**2).sum()))
 
+
 def test_denoise_tv_chambolle_2d_positivity():
     # astronaut image
     img = astro_gray.copy()
@@ -53,7 +54,8 @@ def test_denoise_tv_chambolle_2d_positivity():
     img += 0.5 * img.std() * np.random.rand(*img.shape)
     img = np.clip(img, img.min(), 1)
     # denoise
-    denoised_astro = restoration.denoise_tv_chambolle(img, weight=0.1, positivity=True)
+    denoised_astro = restoration.denoise_tv_chambolle(img, weight=0.1,
+                                                      positivity=True)
     # which dtype?
     assert_(denoised_astro.dtype in [np.float, np.float32, np.float64])
     from scipy import ndimage as ndi


### PR DESCRIPTION
## Description
Positivity constraint in Chambolle-Pock TV
(min max -> max min and  the positivity indicator function disappears during the implicit resolution of min). 

