### PR TITLE
EHN: allow tuple to define kernel in threshold_niblack and threshold_sauvola

### DIFF
--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -2,7 +2,10 @@ Version 0.15
 ------------
 - ``skimage.feature.canny`` now uses a more accurate Gaussian filter
   internally; output values will be different from 0.14.
-
+- ``skimage.filters.threshold_niblack`` and
+  ``skimage.filters.threshold_sauvola``
+  now accepts a tuple as ``window_size`` besides integers.
+  
 Version 0.14
 ------------
 - ``skimage.filters.gaussian_filter`` has been removed. Use

--- a/doc/source/api_changes.rst
+++ b/doc/source/api_changes.rst
@@ -4,7 +4,7 @@ Version 0.15
   internally; output values will be different from 0.14.
 - ``skimage.filters.threshold_niblack`` and
   ``skimage.filters.threshold_sauvola``
-  now accepts a tuple as ``window_size`` besides integers.
+  now accept a tuple as ``window_size`` besides integers.
   
 Version 0.14
 ------------

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -187,6 +187,30 @@ class TestSimpleImage():
         out = self.image > thres
         assert_equal(ref, out)
 
+    def test_threshold_niblack_tuple_window_size(self):
+        ref = np.array(
+            [[False, False, False, True, True],
+             [False, True, True, True, True],
+             [False, True, True, True, False],
+             [False, True, True, True, True],
+             [True, True, False, False, False]]
+        )
+        thres = threshold_niblack(self.image, window_size=(3, 3), k=0.5)
+        out = self.image > thres
+        assert_equal(ref, out)
+
+    def test_threshold_sauvola_tuple_window_size(self):
+        ref = np.array(
+            [[False, False, False, True, True],
+             [False, False, True, True, True],
+             [False, False, True, True, False],
+             [False, True, True, True, False],
+             [True, True, False, False, False]]
+        )
+        thres = threshold_sauvola(self.image, window_size=(3, 3), k=0.2, r=128)
+        out = self.image > thres
+        assert_equal(ref, out)
+
 
 def test_otsu_camera_image():
     camera = skimage.img_as_ubyte(data.camera())

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 from scipy import ndimage as ndi
-
+from collections import Iterable
 import skimage
 from skimage import data
 from skimage._shared._warnings import expected_warnings
@@ -188,27 +188,27 @@ class TestSimpleImage():
         out = self.image > thres
         assert_equal(ref, out)
 
-    def test_threshold_niblack_tuple_window_size(self):
+    def test_threshold_niblack_iterable_window_size(self):
         ref = np.array(
-            [[False, False, False, True, True],
-             [False, True, True, True, True],
-             [False, True, True, True, False],
-             [False, True, True, True, True],
-             [True, True, False, False, False]]
+            [[False, False, False,  True,  True],
+             [False, False,  True,  True,  True],
+             [False,  True,  True,  True, False],
+             [False,  True,  True,  True, False],
+             [True,  True, False, False, False]]
         )
-        thres = threshold_niblack(self.image, window_size=(3, 3), k=0.5)
+        thres = threshold_niblack(self.image, window_size=[3, 5], k=0.5)
         out = self.image > thres
         assert_array_equal(ref, out)
 
-    def test_threshold_sauvola_tuple_window_size(self):
+    def test_threshold_sauvola_iterable_window_size(self):
         ref = np.array(
-            [[False, False, False, True, True],
-             [False, False, True, True, True],
-             [False, False, True, True, False],
-             [False, True, True, True, False],
-             [True, True, False, False, False]]
+            [[False, False, False,  True,  True],
+             [False, False,  True,  True,  True],
+             [False, False,  True,  True, False],
+             [False,  True,  True,  True, False],
+             [True,  True, False, False, False]]
         )
-        thres = threshold_sauvola(self.image, window_size=(3, 3), k=0.2, r=128)
+        thres = threshold_sauvola(self.image, window_size=(3, 5), k=0.2, r=128)
         out = self.image > thres
         assert_array_equal(ref, out)
 
@@ -456,11 +456,16 @@ def test_triangle_flip():
     assert(len(unequal_pos[0]) / t_img.size < 1e-2)
 
 
-def test_mean_std_2d():
+@pytest.mark.parametrize(
+    "window_size, mean_kernel",
+    [(11, np.full((11,) * 2,  1 / 11 ** 2)),
+     ((11, 11), np.full((11, 11), 1 / 11 ** 2)),
+     ((9, 13), np.full((9, 13), 1 / np.prod((9, 13)))),
+     ((13, 9), np.full((13, 9), 1 / np.prod((13, 9))))]
+)
+def test_mean_std_2d(window_size, mean_kernel):
     image = np.random.rand(256, 256)
-    window_size = 11
     m, s = _mean_std(image, w=window_size)
-    mean_kernel = np.full((window_size,) * 2,  1 / window_size**2)
     expected_m = ndi.convolve(image, mean_kernel, mode='mirror')
     np.testing.assert_allclose(m, expected_m)
     expected_s = ndi.generic_filter(image, np.std, size=window_size,
@@ -468,10 +473,14 @@ def test_mean_std_2d():
     np.testing.assert_allclose(s, expected_s)
 
 
-def test_mean_std_3d():
+@pytest.mark.parametrize(
+    "window_size, mean_kernel", [
+        (5, np.full((5,) * 3, 1 / 5 ** 3)),
+        ((5, 5, 5), np.full((5, 5, 5), 1 / 5 ** 3)),
+        ((3, 5, 7), np.full((3, 5, 7), 1 / np.prod((3, 5, 7))))]
+)
+def test_mean_std_3d(window_size, mean_kernel):
     image = np.random.rand(40, 40, 40)
-    window_size = 5
-    mean_kernel = np.full((window_size,) * 3, 1 / window_size**3)
     m, s = _mean_std(image, w=window_size)
     expected_m = ndi.convolve(image, mean_kernel, mode='mirror')
     np.testing.assert_allclose(m, expected_m)

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -1,7 +1,6 @@
 import pytest
 import numpy as np
 from scipy import ndimage as ndi
-from collections import Iterable
 import skimage
 from skimage import data
 from skimage._shared._warnings import expected_warnings
@@ -475,7 +474,7 @@ def test_mean_std_2d(window_size, mean_kernel):
 
 @pytest.mark.parametrize(
     "window_size, mean_kernel", [
-        (5, np.full((5,) * 3, 1 / 5 ** 3)),
+        (5, np.full((5,) * 3, 1 / 5) ** 3),
         ((5, 5, 5), np.full((5, 5, 5), 1 / 5 ** 3)),
         ((3, 5, 7), np.full((3, 5, 7), 1 / np.prod((3, 5, 7))))]
 )

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -189,11 +189,11 @@ class TestSimpleImage():
 
     def test_threshold_niblack_iterable_window_size(self):
         ref = np.array(
-            [[False, False, False,  True,  True],
-             [False, False,  True,  True,  True],
-             [False,  True,  True,  True, False],
-             [False,  True,  True,  True, False],
-             [True,  True, False, False, False]]
+            [[False, False, False, True, True],
+             [False, False, True, True, True],
+             [False, True, True, True, False],
+             [False, True, True, True, False],
+             [True, True, False, False, False]]
         )
         thres = threshold_niblack(self.image, window_size=[3, 5], k=0.5)
         out = self.image > thres
@@ -201,11 +201,11 @@ class TestSimpleImage():
 
     def test_threshold_sauvola_iterable_window_size(self):
         ref = np.array(
-            [[False, False, False,  True,  True],
-             [False, False,  True,  True,  True],
-             [False, False,  True,  True, False],
-             [False,  True,  True,  True, False],
-             [True,  True, False, False, False]]
+            [[False, False, False, True, True],
+             [False, False, True, True, True],
+             [False, False, True, True, False],
+             [False, True, True, True, False],
+             [True, True, False, False, False]]
         )
         thres = threshold_sauvola(self.image, window_size=(3, 5), k=0.2, r=128)
         out = self.image > thres

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -20,6 +20,7 @@ from skimage.filters.thresholding import (threshold_local,
                                           _cross_entropy)
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_almost_equal
+from skimage._shared.testing import assert_array_equal
 
 
 class TestSimpleImage():
@@ -197,7 +198,7 @@ class TestSimpleImage():
         )
         thres = threshold_niblack(self.image, window_size=(3, 3), k=0.5)
         out = self.image > thres
-        assert_equal(ref, out)
+        assert_array_equal(ref, out)
 
     def test_threshold_sauvola_tuple_window_size(self):
         ref = np.array(
@@ -209,7 +210,7 @@ class TestSimpleImage():
         )
         thres = threshold_sauvola(self.image, window_size=(3, 3), k=0.2, r=128)
         out = self.image > thres
-        assert_equal(ref, out)
+        assert_array_equal(ref, out)
 
 
 def test_otsu_camera_image():

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -460,7 +460,9 @@ def test_triangle_flip():
     [(11, np.full((11,) * 2,  1 / 11 ** 2)),
      ((11, 11), np.full((11, 11), 1 / 11 ** 2)),
      ((9, 13), np.full((9, 13), 1 / np.prod((9, 13)))),
-     ((13, 9), np.full((13, 9), 1 / np.prod((13, 9))))]
+     ((13, 9), np.full((13, 9), 1 / np.prod((13, 9)))),
+     ((1, 9), np.full((1, 9), 1 / np.prod((1, 9))))
+     ]
 )
 def test_mean_std_2d(window_size, mean_kernel):
     image = np.random.rand(256, 256)
@@ -476,6 +478,7 @@ def test_mean_std_2d(window_size, mean_kernel):
     "window_size, mean_kernel", [
         (5, np.full((5,) * 3, 1 / 5) ** 3),
         ((5, 5, 5), np.full((5, 5, 5), 1 / 5 ** 3)),
+        ((1, 5, 5), np.full((1, 5, 5), 1 / 5 ** 2)),
         ((3, 5, 7), np.full((3, 5, 7), 1 / np.prod((3, 5, 7))))]
 )
 def test_mean_std_3d(window_size, mean_kernel):

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -2,7 +2,8 @@ import itertools
 import math
 import numpy as np
 from scipy import ndimage as ndi
-from collections import OrderedDict, Iterable
+from collections import OrderedDict
+from collections.abc import Iterable
 from ..exposure import histogram
 from .._shared.utils import assert_nD, warn, deprecated
 from ..transform import integral_image

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -951,7 +951,7 @@ def threshold_sauvola(image, window_size=15, k=0.2, r=None):
 
     References
     ----------
-    .. [1] J. Sauvola and M". Pietikainen, Adaptive document image
+    .. [1] J. Sauvola and M. Pietikainen, "Adaptive document image
            binarization," Pattern Recognition 33(2),
            pp. 225-236, 2000.
            :DOI:`10.1016/S0031-3203(99)00055-2`

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -802,8 +802,9 @@ def _mean_std(image, w):
     image : ndarray
         Input image.
     w : int, tuple
-        window size of the kernel (e.g. odd integers or tuple of odd number 5,
-        (3, 5)).
+        Odd size window specified as a single integer (e.g., 3, 5,
+        etc.) or a tuple of the same dimension than ``image``
+        containing odd integers (e.g., (3, 5)).
 
     Returns
     -------
@@ -877,7 +878,9 @@ def threshold_niblack(image, window_size=15, k=0.2):
     image: (N, M) ndarray
         Grayscale input image.
     window_size : int, optional
-        Odd size of pixel neighborhood window (e.g. 3, 5, 7...).
+        Odd size window specified as a single integer (e.g., 3, 5,
+        etc.) or a tuple of the same dimension than ``image``
+        containing odd integers (e.g., (3, 5)).
     k : float, optional
         Value of parameter k in threshold formula.
 
@@ -926,7 +929,9 @@ def threshold_sauvola(image, window_size=15, k=0.2, r=None):
     image: (N, M) ndarray
         Grayscale input image.
     window_size : int, optional
-        Odd size of pixel neighborhood window (e.g. 3, 5, 7...).
+        Odd size window specified as a single integer (e.g., 3, 5,
+        etc.) or a tuple of the same dimension than ``image``
+        containing odd integers (e.g., (3, 5)).
     k : float, optional
         Value of the positive parameter k.
     r : float, optional

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -2,7 +2,7 @@ import itertools
 import math
 import numpy as np
 from scipy import ndimage as ndi
-from collections import OrderedDict
+from collections import OrderedDict, Iterable
 from ..exposure import histogram
 from .._shared.utils import assert_nD, warn, deprecated
 from ..transform import integral_image
@@ -793,15 +793,15 @@ def threshold_triangle(image, nbins=256):
 
 def _mean_std(image, w):
     """Return local mean and standard deviation of each pixel using a
-    neighborhood defined by a rectangular window with size w times w.
+    neighborhood defined by a rectangular window size ``w``.
     The algorithm uses integral images to speedup computation. This is
-    used by threshold_niblack and threshold_sauvola.
+    used by :func:`threshold_niblack` and :func:`threshold_sauvola`.
 
     Parameters
     ----------
     image : ndarray
         Input image.
-    w : int, tuple
+    w : int, tuple or list of integer
         Odd size window specified as a single integer (e.g., 3, 5,
         etc.) or a tuple of the same dimension than ``image``
         containing odd integers (e.g., (3, 5)).
@@ -827,7 +827,7 @@ def _mean_std(image, w):
                 .format(axis_size)
             )
 
-    if isinstance(w, tuple):
+    if isinstance(w, Iterable):
         for axis in w:
             _sanity_check_window_size(axis)
         kern_size = tuple(w_ + 1 for w_ in w)
@@ -875,9 +875,9 @@ def threshold_niblack(image, window_size=15, k=0.2):
 
     Parameters
     ----------
-    image: (N, M) ndarray
-        Grayscale input image.
-    window_size : int, optional
+    image: ndarray
+        Input image.
+    window_size : int, tuple or list of integer
         Odd size window specified as a single integer (e.g., 3, 5,
         etc.) or a tuple of the same dimension than ``image``
         containing odd integers (e.g., (3, 5)).
@@ -926,9 +926,9 @@ def threshold_sauvola(image, window_size=15, k=0.2, r=None):
 
     Parameters
     ----------
-    image: (N, M) ndarray
-        Grayscale input image.
-    window_size : int, optional
+    image: ndarray
+        Input image.
+    window_size : int, tuple or list of integer
         Odd size window specified as a single integer (e.g., 3, 5,
         etc.) or a tuple of the same dimension than ``image``
         containing odd integers (e.g., (3, 5)).
@@ -950,7 +950,7 @@ def threshold_sauvola(image, window_size=15, k=0.2, r=None):
 
     References
     ----------
-    .. [1] J. Sauvola and M. Pietikainen, "Adaptive document image
+    .. [1] J. Sauvola and M". Pietikainen, Adaptive document image
            binarization," Pattern Recognition 33(2),
            pp. 225-236, 2000.
            :DOI:`10.1016/S0031-3203(99)00055-2`

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -822,9 +822,9 @@ def _mean_std(image, w):
            :DOI:`10.1117/12.767755`
     """
     def _sanity_check_window_size(axis_size):
-        if axis_size == 1 or axis_size % 2 == 0:
+        if axis_size % 2 == 0:
             raise ValueError(
-                "Window size w = {} must be odd and greater than 1."
+                "Window size w = {} must be odd."
                 .format(axis_size)
             )
 
@@ -878,7 +878,7 @@ def threshold_niblack(image, window_size=15, k=0.2):
     ----------
     image: ndarray
         Input image.
-    window_size : int, tuple or list of integer
+    window_size : int, tuple or list of integer, optional
         Odd size window specified as a single integer (e.g., 3, 5,
         etc.) or a tuple of the same dimension than ``image``
         containing odd integers (e.g., (3, 5)).
@@ -929,7 +929,7 @@ def threshold_sauvola(image, window_size=15, k=0.2, r=None):
     ----------
     image: ndarray
         Input image.
-    window_size : int, tuple or list of integer
+    window_size : int, tuple or list of integer, optional
         Odd size window specified as a single integer (e.g., 3, 5,
         etc.) or a tuple of the same dimension than ``image``
         containing odd integers (e.g., (3, 5)).


### PR DESCRIPTION
## Description

Add support for `tuple` to specify the size of a kernel in functions `threshold_niblack` and `threshold_sauvola`


## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References

closes #2442 
superseded #2536

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
