### PR TITLE
DOC: "feature.peak_local_max" : explanation of multiple same-intensity peaks returned by the function; added details on `exclude_border` parameter 

### DIFF
--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -55,9 +55,9 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
     exclude_border : int or bool, optional
         If nonzero int, `exclude_border` excludes peaks from
         within `exclude_border`-pixels of the border of the image.
-	If True, takes the `min_distance` parametar as value.
+	If True, takes the `min_distance` parameter as value.
 	If zero or False, peaks are identified regardless of their
-	distance from the border
+	distance from the border.
     indices : bool, optional
         If True, the output will be an array representing peak
         coordinates.  If False, the output will be a boolean array shaped as


### PR DESCRIPTION
## Description
- Explained the fact of the function returning all off the same intensity peaks from the region defined with min_distance.
- Added the details on the `exclude_border` parameter behavior and the bool vs. int parameter values.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
closes #2407

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
