### PR TITLE
[WIP] Make dtype consistent in filters.rank fonctions

### DIFF
--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -1,4 +1,4 @@
-r"""
+"""
 
 General Description
 -------------------
@@ -25,11 +25,10 @@ histogram computation. By default the entire image is filtered.
 
 This implementation outperforms grey.dilation for large structuring elements.
 
-Input image can be 8-bit or 16-bit, for 16-bit input images, the number of
-histogram bins is determined from the maximum value present in the image.
-
-Result image is 8-/16-bit or double with respect to the input image and the
-rank filter operation.
+Input images will be cast in unsigned 8-bit integer or unsigned 16-bit integer
+if necessary. The number of histogram bins is then determined from the maximum
+value present in the image. Eventually, the output image is cast in the desired
+dtype.
 
 To do
 -----
@@ -64,14 +63,55 @@ __all__ = ['autolevel', 'bottomhat', 'equalize', 'gradient', 'maximum', 'mean',
 
 
 def _handle_input(image, selem, out, mask, out_dtype=None, pixel_size=1):
+    """Preprocess and verify input for filters.rank methods.
 
+    Parameters
+    ----------
+    image : 2-D array (integer, float or boolean)
+        Input image.
+    selem : 2-D array (integer, float or boolean)
+        The neighborhood expressed as a 2-D array of 1's and 0's.
+    out : 2-D array (integer, float or boolean)
+        If None, a new array is allocated.
+    mask : ndarray (integer, float or boolean)
+        Mask array that defines (>0) area of the image included in the local
+        neighborhood. If None, the complete image is used (default).
+    out_dtype : data-type, optional
+        Desired output data-type. Default is None, which means we cast output
+        in input dtype.
+    pixel_size : int
+        Dimension of each pixel. Default value is 1.
+
+    Returns
+    -------
+    image : 2-D array (np.uint8 or np.uint16)
+    selem : 2-D array (np.uint8)
+        The neighborhood expressed as a binary 2-D array.
+    out : 3-D array (same dtype out_dtype or as input)
+        Output array. The two first dimensions are the spatial ones, the third
+        one is the pixel vector (length 1 by default).
+    mask : 2-D array (np.uint8)
+        Mask array that defines (>0) area of the image included in the local
+        neighborhood.
+    n_bins : int
+        Number of histogram bins.
+
+    """
+    # check `image` is 2D
     assert_nD(image, 2)
+
+    # if `image` is not an integer 8-bit/16-bit or a boolean, we cast it as
+    # an unsigned 8-bit image.
     if image.dtype not in (np.uint8, np.uint16, np.bool_):
         image = img_as_ubyte(image)
 
-    selem = np.ascontiguousarray(img_as_ubyte(selem > 0))
+    # make `image` contiguous in memory
     image = np.ascontiguousarray(image)
 
+    # cast `selem` as an unsigned 8-bit array and make it contiguous in memory
+    selem = np.ascontiguousarray(img_as_ubyte(selem > 0))
+
+    # idem with `mask`
     if mask is None:
         mask = np.ones(image.shape, dtype=np.uint8)
     else:
@@ -81,17 +121,20 @@ def _handle_input(image, selem, out, mask, out_dtype=None, pixel_size=1):
     if image is out:
         raise NotImplementedError("Cannot perform rank operation in place.")
 
+    # allocate a new output array if necessary
     if out is None:
-        if out_dtype is None:
-            out_dtype = image.dtype
-        out = np.empty(image.shape+(pixel_size,), dtype=out_dtype)
+        out = np.empty(image.shape+(pixel_size,))
     else:
         if len(out.shape) == 2:
             out = out.reshape(out.shape+(pixel_size,))
 
-    is_8bit = image.dtype in (np.uint8, np.int8)
+    # cast output in the desired dtype
+    if out_dtype is None:
+        out_dtype = image.dtype
+    out = out.astype(out_dtype)
 
-    if is_8bit:
+    # compute the number of bins in the histogram from `image` dtype
+    if image.dtype in (np.uint8, np.int8):
         n_bins = 256
     else:
         # Convert to a Python int to avoid the potential overflow when we add
@@ -108,10 +151,40 @@ def _handle_input(image, selem, out, mask, out_dtype=None, pixel_size=1):
 
 def _apply_scalar_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
                             out_dtype=None):
+    """Process the specific cython function to the image.
 
+    Parameters
+    ----------
+    func : function
+        Cython function to apply.
+    image : 2-D array (integer, float or boolean)
+        Input image.
+    selem : 2-D array (integer, float or boolean)
+        The neighborhood expressed as a 2-D array of 1's and 0's.
+    out : 2-D array (integer, float or boolean)
+        If None, a new array is allocated.
+    mask : ndarray (integer, float or boolean)
+        Mask array that defines (>0) area of the image included in the local
+        neighborhood. If None, the complete image is used (default).
+    shift_x, shift_y : int
+        Offset added to the structuring element center point. Shift is bounded
+        to the structuring element sizes (center must be inside the given
+        structuring element).
+    out_dtype : data-type, optional
+        Desired output data-type. Default is None, which means we cast output
+        in input dtype.
+
+    Returns
+    -------
+    out : 2-D array (same dtype as out_dtype or same as input image)
+        Output image.
+
+    """
+    # preprocess and verify the input
     image, selem, out, mask, n_bins = _handle_input(image, selem, out, mask,
                                                     out_dtype)
 
+    # apply cython function
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
          out=out, n_bins=n_bins)
 
@@ -120,11 +193,48 @@ def _apply_scalar_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
 
 def _apply_vector_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
                             out_dtype=None, pixel_size=1):
+    """
 
+    Parameters
+    ----------
+    func : function
+        Cython function to apply.
+    image : 2-D array (integer, float or boolean)
+        Input image.
+    selem : 2-D array (integer, float or boolean)
+        The neighborhood expressed as a 2-D array of 1's and 0's.
+    out : 2-D array (integer, float or boolean)
+        If None, a new array is allocated.
+    mask : ndarray (integer, float or boolean)
+        Mask array that defines (>0) area of the image included in the local
+        neighborhood. If None, the complete image is used (default).
+    shift_x, shift_y : int
+        Offset added to the structuring element center point. Shift is bounded
+        to the structuring element sizes (center must be inside the given
+        structuring element).
+    out_dtype : data-type, optional
+        Desired output data-type. Default is None, which means we cast output
+        in input dtype.
+    pixel_size : int
+        Dimension of each pixel. Default value is 1.
+
+    Returns
+    -------
+    out : 3-D array with float dtype of dimensions (H,W,N), where (H,W) are
+        the dimensions of the input image and N is n_bins or
+        ``image.max() + 1`` if no value is provided as a parameter.
+        Effectively, each pixel is a N-D feature vector that is the histogram.
+        The sum of the elements in the feature vector will be 1, unless no
+        pixels in the window were covered by both selem and mask, in which
+        case all elements will be 0.
+
+    """
+    # preprocess and verify the input
     image, selem, out, mask, n_bins = _handle_input(image, selem, out, mask,
                                                     out_dtype,
                                                     pixel_size=pixel_size)
 
+    # apply cython function
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
          out=out, n_bins=n_bins)
 
@@ -158,18 +268,18 @@ def _default_selem(func):
 def autolevel(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     """Auto-level image using local histogram.
 
-    This filter locally stretches the histogram of greyvalues to cover the
+    This filter locally stretches the histogram of grey values to cover the
     entire range of values from "white" to "black".
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -205,13 +315,13 @@ def bottomhat(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : 2-D array
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -244,13 +354,13 @@ def equalize(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -283,13 +393,13 @@ def gradient(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -322,13 +432,13 @@ def maximum(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -370,13 +480,13 @@ def mean(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -409,13 +519,13 @@ def geometric_mean(image, selem, out=None, mask=None,
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -453,13 +563,13 @@ def subtract_mean(image, selem, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -494,14 +604,14 @@ def median(image, selem=None, out=None, mask=None,
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array, optional
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's. If None, a
         full square of size 3 is used.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -534,13 +644,13 @@ def minimum(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -584,13 +694,13 @@ def modal(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -628,13 +738,13 @@ def enhance_contrast(image, selem, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -645,7 +755,7 @@ def enhance_contrast(image, selem, out=None, mask=None, shift_x=False,
     Returns
     -------
     out : 2-D array (same dtype as input image)
-        The result of the local enhance_contrast.
+        Output image
 
     Examples
     --------
@@ -670,13 +780,13 @@ def pop(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -720,13 +830,13 @@ def sum(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -770,13 +880,13 @@ def threshold(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -820,13 +930,13 @@ def tophat(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -860,13 +970,13 @@ def noise_filter(image, selem, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -915,13 +1025,13 @@ def entropy(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -931,7 +1041,7 @@ def entropy(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Returns
     -------
-    out : ndarray (double)
+    out : ndarray (float)
         Output image.
 
     References
@@ -959,13 +1069,13 @@ def otsu(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : ndarray
-        Image array (uint8 array).
-    selem : 2-D array
+    image : 2-D array (integer, float or boolean)
+        Input image.
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : ndarray
-        If None, a new array will be allocated.
-    mask : ndarray
+    out : 2-D array (integer, float or boolean)
+        If None, a new array is allocated.
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -1004,13 +1114,13 @@ def windowed_histogram(image, selem, out=None, mask=None,
 
     Parameters
     ----------
-    image : ndarray
-        Image array (uint8 array).
-    selem : 2-D array
+    image : 2-D array (integer, float or boolean)
+        Input image.
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : ndarray
-        If None, a new array will be allocated.
-    mask : ndarray
+    out : 2-D array (integer, float or boolean)
+        If None, a new array is allocated.
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -1023,13 +1133,13 @@ def windowed_histogram(image, selem, out=None, mask=None,
 
     Returns
     -------
-    out : 3-D array with float dtype of dimensions (H,W,N), where (H,W) are
-        the dimensions of the input image and N is n_bins or
-        ``image.max() + 1`` if no value is provided as a parameter.
-        Effectively, each pixel is a N-D feature vector that is the histogram.
-        The sum of the elements in the feature vector will be 1, unless no
-        pixels in the window were covered by both selem and mask, in which
-        case all elements will be 0.
+    out : 3-D array (float)
+        Array of dimensions (H,W,N), where (H,W) are the dimensions of the
+        input image and N is n_bins or ``image.max() + 1`` if no value is
+        provided as a parameter. Effectively, each pixel is a N-D feature
+        vector that is the histogram. The sum of the elements in the feature
+        vector will be 1, unless no pixels in the window were covered by both
+        selem and mask, in which case all elements will be 0.
 
     Examples
     --------

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -66,7 +66,7 @@ __all__ = ['autolevel', 'bottomhat', 'equalize', 'gradient', 'maximum', 'mean',
 def _handle_input(image, selem, out, mask, out_dtype=None, pixel_size=1):
 
     assert_nD(image, 2)
-    if image.dtype not in (np.uint8, np.uint16):
+    if image.dtype not in (np.uint8, np.uint16, np.bool_):
         image = img_as_ubyte(image)
 
     selem = np.ascontiguousarray(img_as_ubyte(selem > 0))

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -126,7 +126,7 @@ def _handle_input(image, selem, out, mask, out_dtype=None, pixel_size=1):
 
     # allocate a new output array if necessary
     if out is None:
-        out = np.empty(image.shape+(pixel_size,))
+        out = np.empty(image.shape + (pixel_size,))
     else:
         if len(out.shape) == 2:
             out = out.reshape(out.shape+(pixel_size,))

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -41,8 +41,7 @@ def test_otsu_edge_case():
     assert result[1, 1] in [141, 172]
 
 
-
-class TestRank():
+class TestRank:
     def setup(self):
         np.random.seed(0)
         # This image is used along with @test_parallel
@@ -85,7 +84,6 @@ class TestRank():
 
         with expected_warnings(['precision loss']):
             check()
-
 
     def test_random_sizes(self):
         # make sure the size is not a problem
@@ -133,7 +131,6 @@ class TestRank():
                                  selem=elem, shift_x=+1, shift_y=+1, p0=.1, p1=.9)
             assert_equal(image16.shape, out16.shape)
 
-
     def test_compare_with_grey_dilation(self):
         # compare the result of maximum filter with dilate
 
@@ -147,7 +144,6 @@ class TestRank():
             cm = grey.dilation(image=image, selem=elem)
             assert_equal(out, cm)
 
-
     def test_compare_with_grey_erosion(self):
         # compare the result of maximum filter with erode
 
@@ -160,7 +156,6 @@ class TestRank():
             rank.minimum(image=image, selem=elem, out=out, mask=mask)
             cm = grey.erosion(image=image, selem=elem)
             assert_equal(out, cm)
-
 
     def test_bitdepth(self):
         # test the different bit depth for rank16
@@ -180,7 +175,6 @@ class TestRank():
                 rank.mean_percentile(image=image, selem=elem, mask=mask,
                                      out=out, shift_x=0, shift_y=0, p0=.1, p1=.9)
 
-
     def test_population(self):
         # check the number of valid pixels in the neighborhood
 
@@ -196,7 +190,6 @@ class TestRank():
                       [6, 9, 9, 9, 6],
                       [4, 6, 6, 6, 4]])
         assert_equal(r, out)
-
 
     def test_structuring_element8(self):
         # check the output for a custom structuring element
@@ -228,7 +221,6 @@ class TestRank():
                      shift_x=1, shift_y=1)
         assert_equal(r, out)
 
-
     def test_pass_on_bitdepth(self):
         # should pass because data bitdepth is not too high for the function
 
@@ -239,7 +231,6 @@ class TestRank():
         with expected_warnings(["Bad rank filter performance"]):
             rank.maximum(image=image, selem=elem, out=out, mask=mask)
 
-
     def test_inplace_output(self):
         # rank filters are not supposed to filter inplace
 
@@ -248,7 +239,6 @@ class TestRank():
         out = image
         with testing.raises(NotImplementedError):
             rank.mean(image, selem, out=out)
-
 
     def test_compare_autolevels(self):
         # compare autolevel and percentile autolevel with p0=0.0 and p1=1.0
@@ -263,10 +253,9 @@ class TestRank():
 
         assert_equal(loc_autolevel, loc_perc_autolevel)
 
-
     def test_compare_autolevels_16bit(self):
-        # compare autolevel(16-bit) and percentile autolevel(16-bit) with p0=0.0
-        # and p1=1.0 should returns the same arrays
+        # compare autolevel(16-bit) and percentile autolevel(16-bit) with
+        # p0=0.0 and p1=1.0 should returns the same arrays
 
         image = data.camera().astype(np.uint16) * 4
 
@@ -276,7 +265,6 @@ class TestRank():
                                                        p0=.0, p1=1.)
 
         assert_equal(loc_autolevel, loc_perc_autolevel)
-
 
     def test_compare_ubyte_vs_float(self):
 
@@ -293,7 +281,6 @@ class TestRank():
             with expected_warnings(['precision loss']):
                 out_f = func(image_float, disk(3))
             assert_equal(out_u, out_f)
-
 
     def test_compare_8bit_unsigned_vs_signed(self):
         # filters applied on 8-bit image ore 16-bit image (having only real 8-bit
@@ -335,7 +322,6 @@ class TestRank():
         f16 = func(image16, disk(3))
         assert_equal(f8, f16)
 
-
     def test_trivial_selem8(self):
         # check that min, max and mean returns identity if structuring element
         # contains only central pixel
@@ -360,7 +346,6 @@ class TestRank():
         rank.maximum(image=image, selem=elem, out=out, mask=mask,
                      shift_x=0, shift_y=0)
         assert_equal(image, out)
-
 
     def test_trivial_selem16(self):
         # check that min, max and mean returns identity if structuring element
@@ -387,7 +372,6 @@ class TestRank():
                      shift_x=0, shift_y=0)
         assert_equal(image, out)
 
-
     def test_smallest_selem8(self):
         # check that min, max and mean returns identity if structuring element
         # contains only central pixel
@@ -409,7 +393,6 @@ class TestRank():
         rank.maximum(image=image, selem=elem, out=out, mask=mask,
                      shift_x=0, shift_y=0)
         assert_equal(image, out)
-
 
     def test_smallest_selem16(self):
         # check that min, max and mean returns identity if structuring element
@@ -435,7 +418,6 @@ class TestRank():
         rank.maximum(image=image, selem=elem, out=out, mask=mask,
                      shift_x=0, shift_y=0)
         assert_equal(image, out)
-
 
     def test_empty_selem(self):
         # check that min, max and mean returns zeros if structuring element is
@@ -464,7 +446,6 @@ class TestRank():
                      shift_x=0, shift_y=0)
         assert_equal(res, out)
 
-
     def test_otsu(self):
         # test the local Otsu segmentation on a synthetic image
         # (left to right ramp * sinus)
@@ -477,7 +458,6 @@ class TestRank():
         selem = np.ones((6, 6), dtype=np.uint8)
         th = 1 * (test >= rank.otsu(test, selem))
         assert_equal(th, res)
-
 
     def test_entropy(self):
         #  verify that entropy is coherent with bitdepth of the input data
@@ -523,7 +503,6 @@ class TestRank():
             out = rank.entropy(data, np.ones((16, 16), dtype=np.uint8))
         assert out.dtype == np.double
 
-
     def test_selem_dtypes(self):
 
         image = np.zeros((5, 5), dtype=np.uint8)
@@ -546,7 +525,6 @@ class TestRank():
                                  shift_x=0, shift_y=0)
             assert_equal(image, out)
 
-
     def test_16bit(self):
         image = np.zeros((21, 21), dtype=np.uint16)
         selem = np.ones((3, 3), dtype=np.uint8)
@@ -563,7 +541,6 @@ class TestRank():
                 assert rank.maximum(image, selem)[10, 10] == value
                 assert rank.mean(image, selem)[10, 10] == int(value / selem.size)
 
-
     def test_bilateral(self):
         image = np.zeros((21, 21), dtype=np.uint16)
         selem = np.ones((3, 3), dtype=np.uint8)
@@ -576,7 +553,6 @@ class TestRank():
         assert rank.pop_bilateral(image, selem, s0=1, s1=1)[10, 10] == 1
         assert rank.mean_bilateral(image, selem, s0=11, s1=11)[10, 10] == 1005
         assert rank.pop_bilateral(image, selem, s0=11, s1=11)[10, 10] == 2
-
 
     def test_percentile_min(self):
         # check that percentile p0 = 0 is identical to local min
@@ -592,7 +568,6 @@ class TestRank():
         img_min = rank.minimum(img16, selem=selem)
         assert_equal(img_p0, img_min)
 
-
     def test_percentile_max(self):
         # check that percentile p0 = 1 is identical to local max
         img = data.camera()
@@ -607,7 +582,6 @@ class TestRank():
         img_max = rank.maximum(img16, selem=selem)
         assert_equal(img_p0, img_max)
 
-
     def test_percentile_median(self):
         # check that percentile p0 = 0.5 is identical to local median
         img = data.camera()
@@ -621,7 +595,6 @@ class TestRank():
         img_p0 = rank.percentile(img16, selem=selem, p0=.5)
         img_max = rank.median(img16, selem=selem)
         assert_equal(img_p0, img_max)
-
 
     def test_sum(self):
         # check the number of valid pixels in the neighborhood
@@ -669,7 +642,6 @@ class TestRank():
             image=image16, selem=elem, out=out16, mask=mask, s0=1000, s1=1000)
         assert_equal(r, out16)
 
-
     def test_windowed_histogram(self):
         # check the number of valid pixels in the neighborhood
 
@@ -708,7 +680,6 @@ class TestRank():
         larger_output = rank.windowed_histogram(image=image8, selem=elem,
                                                 mask=mask, n_bins=5)
         assert larger_output.shape[2] == 5
-
 
     def test_median_default_value(self):
         a = np.zeros((3, 3), dtype=np.uint8)


### PR DESCRIPTION
## Description
Boolean inputs return uint8 output with `filters.rank.maximum` or `filters.rank.mean`for example. We want to keep the input and output dtypes identical.

## Checklist
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Test for boolean inputs
- [ ] Test for `_handle_input` in filters/rank/generic.py
- [x] Be sure to (re)cast the output properly (after the cython computation ?)

## References
Closes  #3577
Closes #1010

## For reviewers
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
