### PR TITLE
[MRG] EHN: median filters will accept floating image

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -31,6 +31,14 @@ Version 0.16
 * In ``skimage.measure.moments_central``, remove ``cc`` and ``**kwargs``
   arguments.
 * In ``skimage.morphology.remove_small_holes``, remove ``min_size`` argument.
+* In ``skimage.filters.median``, change default from ``behavior='rank'`` to
+  ``behavior='ndimage'``.
+
+Version 0.17
+------------
+
+* In ``skimage.filters.median``, remove the parameters ``mask``, ``shift_x``,
+  and ``shift_y``.
 
 Other
 -----

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -19,7 +19,7 @@ New Features
 - unsharp mask filtering (#2772)
 - New options ``connectivity``, ``indices`` and ``allow_borders`` for
   ``skimage.morphology.local_maxima`` and ``.local_minima``. #3022
-- Image translation registration for masked data 
+- Image translation registration for masked data
   (``skimage.feature.masked_register_translation``)
 
 
@@ -95,6 +95,11 @@ Deprecations
   row-column coordinates.
 - ``skimage.morphology.remove_small_holes`` ``min_size`` argument is deprecated
   and will be removed in 0.16. Use ``area_threshold`` instead.
+- ``skimage.filters.median`` will change behavior in the future to have an
+  identical behavior as ``scipy.ndimage.median_filter``. This behavior can be
+  set already using ``behavior='new'``. In 0.17, it will be the default
+  behavior and in 0.19, the parameter of the previous behavior (i.e., ``mask``,
+  ``shift_x``, ``shift_y``) will be removed.
 
 
 Contributors to this release

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -97,8 +97,8 @@ Deprecations
   and will be removed in 0.16. Use ``area_threshold`` instead.
 - ``skimage.filters.median`` will change behavior in the future to have an
   identical behavior as ``scipy.ndimage.median_filter``. This behavior can be
-  set already using ``behavior='new'``. In 0.17, it will be the default
-  behavior and in 0.19, the parameter of the previous behavior (i.e., ``mask``,
+  set already using ``behavior='ndimage'``. In 0.16, it will be the default
+  behavior and in 0.17, the parameter of the previous behavior (i.e., ``mask``,
   ``shift_x``, ``shift_y``) will be removed.
 
 

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -98,8 +98,8 @@ Deprecations
 - ``skimage.filters.median`` will change behavior in the future to have an
   identical behavior as ``scipy.ndimage.median_filter``. This behavior can be
   set already using ``behavior='ndimage'``. In 0.16, it will be the default
-  behavior and in 0.17, the parameter of the previous behavior (i.e., ``mask``,
-  ``shift_x``, ``shift_y``) will be removed.
+  behavior and removed in 0.17 as well as the parameter of the previous
+  behavior (i.e., ``mask``, ``shift_x``, ``shift_y``) will be removed.
 
 
 Contributors to this release

--- a/skimage/filters/__init__.py
+++ b/skimage/filters/__init__.py
@@ -14,7 +14,7 @@ from .thresholding import (threshold_local, threshold_otsu, threshold_yen,
                            threshold_niblack, threshold_sauvola,
                            try_all_threshold, apply_hysteresis_threshold)
 from . import rank
-from .rank import median
+from ._median import median
 from ._unsharp_mask import unsharp_mask
 
 

--- a/skimage/filters/_median.py
+++ b/skimage/filters/_median.py
@@ -9,7 +9,7 @@ from .rank import generic
 
 @generic._default_selem
 def median(image, selem=None, out=None, mask=None, shift_x=False,
-           shift_y=False, mode='nearest', cval=0.0, behavior='old'):
+           shift_y=False, mode='nearest', cval=0.0, behavior='rank'):
     """Return local median of an image.
 
     Parameters
@@ -17,8 +17,8 @@ def median(image, selem=None, out=None, mask=None, shift_x=False,
     image : array-like
         Input image.
     selem : ndarray
-        If ``behavior=='old'``, ``selem`` is a 2-D array of 1's and 0's.
-        If ``behavior=='new'``, ``selem`` is a N-D array of 1's and 0's with
+        If ``behavior=='rank'``, ``selem`` is a 2-D array of 1's and 0's.
+        If ``behavior=='ndimage'``, ``selem`` is a N-D array of 1's and 0's with
         the same number of dimension than ``image``.
         If None, ``selem`` will be a N-D array with 3 elements for each
         dimension (e.g., vector, square, cube, etc.)
@@ -27,38 +27,44 @@ def median(image, selem=None, out=None, mask=None, shift_x=False,
     mask : ndarray
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default). Only valid
-        when ``behavior='old'``
-        .. deprecated:: 0.17
-           ``mask`` is deprecated in 0.17 and will be removed 0.19.
+        when ``behavior='rank'``
+        .. deprecated:: 0.16
+           ``mask`` is deprecated in 0.16 and will be removed 0.17.
     shift_x, shift_y : int
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
-        structuring element). Only valid when ``behavior='new'``.
-        .. deprecated:: 0.17
-           ``shift_x`` and ``shift_y`` are deprecated in 0.17 and will be
-           removed in 0.19.
+        structuring element). Only valid when ``behavior='ndimage'``.
+        .. deprecated:: 0.16
+           ``shift_x`` and ``shift_y`` are deprecated in 0.16 and will be
+           removed in 0.17.
     mode : {'reflect', 'constant', 'nearest', 'mirror','‘wrap'}, optional
         The mode parameter determines how the array borders are handled, where
         ``cval`` is the value when mode is equal to 'constant'.
         Default is 'nearest'.
         .. versionadded:: 0.15
-           ``mode`` is used when ``behavior='new'``.
+           ``mode`` is used when ``behavior='ndimage'``.
     cval : scalar, optional
         Value to fill past edges of input if mode is 'constant'. Default is 0.0
         .. versionadded:: 0.15
-           ``cval`` was added in 0.15is used when ``behavior='new'``.
-    behavior : {'old', 'new'}, optional
+           ``cval`` was added in 0.15 is used when ``behavior='ndimage'``.
+    behavior : {'rank', 'ndimage'}, optional
         Either to use the old behavior (i.e., < 0.15) or the new behavior.
         The new behavior will call the :func:`scipy.ndimage.median_filter`.
-        Default is 'old'.
+        Default is 'rank'.
         .. versionadded:: 0.15
            ``behavior`` is introduced in 0.15
         .. deprecated:: 0.15
-           Default ``behavior`` will change from 'old' to 'new' in 0.17
+           Default ``behavior`` will change from 'rank' to 'ndimage' in 0.16
+
     Returns
     -------
     out : 2-D array (same dtype as input image)
         Output image.
+
+    See also
+    --------
+    skimage.filters.rank.median : Rank-based implementation of the median
+        filtering offering more flexibility.
 
     Examples
     --------
@@ -69,17 +75,17 @@ def median(image, selem=None, out=None, mask=None, shift_x=False,
     >>> med = median(img, disk(5))
 
     """
-    if behavior == 'old':
-        warn("Default 'behavior' will change from 'old' to 'new' in 0.17",
+    if behavior == 'rank':
+        warn("Default 'behavior' will change from 'rank' to 'ndimage' in 0.16",
              DeprecationWarning)
         if mode != 'nearest' or not np.isclose(cval, 0.0):
-            warn("Change 'behavior' to 'new' if you want to use the "
+            warn("Change 'behavior' to 'ndimage' if you want to use the "
                  "parameters 'mode' or 'cval'. They will be discarded "
                  "otherwise.")
         return generic.median(image, selem=selem, out=out, mask=mask,
                               shift_x=shift_x, shift_y=shift_y)
     if mask is not None or shift_x or shift_y:
-        warn("Change 'behavior' to 'old' if you want to use the "
+        warn("Change 'behavior' to 'rank' if you want to use the "
              "parameters 'mask', 'shift_x', 'shift_y'. They will be "
              "discarded otherwise.")
     return ndi.median_filter(image, footprint=selem, output=out, mode=mode,

--- a/skimage/filters/_median.py
+++ b/skimage/filters/_median.py
@@ -1,0 +1,86 @@
+
+from warnings import warn
+
+import numpy as np
+from scipy import ndimage as ndi
+
+from .rank import generic
+
+
+@generic._default_selem
+def median(image, selem=None, out=None, mask=None, shift_x=False,
+           shift_y=False, mode='nearest', cval=0.0, behavior='old'):
+    """Return local median of an image.
+
+    Parameters
+    ----------
+    image : array-like
+        Input image.
+    selem : ndarray
+        If ``behavior=='old'``, ``selem`` is a 2-D array of 1's and 0's.
+        If ``behavior=='new'``, ``selem`` is a N-D array of 1's and 0's with
+        the same number of dimension than ``image``.
+        If None, ``selem`` will be a N-D array with 3 elements for each
+        dimension (e.g., vector, square, cube, etc.)
+    out : ndarray, (same dtype as image)
+        If None, a new array is allocated.
+    mask : ndarray
+        Mask array that defines (>0) area of the image included in the local
+        neighborhood. If None, the complete image is used (default). Only valid
+        when ``behavior='old'``
+        .. deprecated:: 0.17
+           ``mask`` is deprecated in 0.17 and will be removed 0.19.
+    shift_x, shift_y : int
+        Offset added to the structuring element center point. Shift is bounded
+        to the structuring element sizes (center must be inside the given
+        structuring element). Only valid when ``behavior='new'``.
+        .. deprecated:: 0.17
+           ``shift_x`` and ``shift_y`` are deprecated in 0.17 and will be
+           removed in 0.19.
+    mode : {'reflect', 'constant', 'nearest', 'mirror','‘wrap'}, optional
+        The mode parameter determines how the array borders are handled, where
+        ``cval`` is the value when mode is equal to 'constant'.
+        Default is 'nearest'.
+        .. versionadded:: 0.15
+           ``mode`` is used when ``behavior='new'``.
+    cval : scalar, optional
+        Value to fill past edges of input if mode is 'constant'. Default is 0.0
+        .. versionadded:: 0.15
+           ``cval`` was added in 0.15is used when ``behavior='new'``.
+    behavior : {'old', 'new'}, optional
+        Either to use the old behavior (i.e., < 0.15) or the new behavior.
+        The new behavior will call the :func:`scipy.ndimage.median_filter`.
+        Default is 'old'.
+        .. versionadded:: 0.15
+           ``behavior`` is introduced in 0.15
+        .. deprecated:: 0.15
+           Default ``behavior`` will change from 'old' to 'new' in 0.17
+    Returns
+    -------
+    out : 2-D array (same dtype as input image)
+        Output image.
+
+    Examples
+    --------
+    >>> from skimage import data
+    >>> from skimage.morphology import disk
+    >>> from skimage.filters import median
+    >>> img = data.camera()
+    >>> med = median(img, disk(5))
+
+    """
+    if behavior == 'old':
+        warn("Default 'behavior' will change from 'old' to 'new' in 0.17",
+             DeprecationWarning)
+        if mode != 'nearest' or not np.isclose(cval, 0.0):
+            warn("Change 'behavior' to 'new' if you want to use the "
+                 "parameters 'mode' or 'cval'. They will be discarded "
+                 "otherwise.")
+        return generic.median(image, selem=selem, out=out, mask=mask,
+                              shift_x=shift_x, shift_y=shift_y)
+    if mask is not None or shift_x or shift_y:
+        warn("Change 'behavior' to 'old' if you want to use the "
+             "parameters 'mask', 'shift_x', 'shift_y'. They will be "
+             "discarded otherwise.")
+    return ndi.median_filter(image, footprint=selem, output=out, mode=mode,
+                             cval=cval)

--- a/skimage/filters/_median.py
+++ b/skimage/filters/_median.py
@@ -18,8 +18,8 @@ def median(image, selem=None, out=None, mask=None, shift_x=False,
         Input image.
     selem : ndarray
         If ``behavior=='rank'``, ``selem`` is a 2-D array of 1's and 0's.
-        If ``behavior=='ndimage'``, ``selem`` is a N-D array of 1's and 0's with
-        the same number of dimension than ``image``.
+        If ``behavior=='ndimage'``, ``selem`` is a N-D array of 1's and 0's
+        with the same number of dimension than ``image``.
         If None, ``selem`` will be a N-D array with 3 elements for each
         dimension (e.g., vector, square, cube, etc.)
     out : ndarray, (same dtype as image)

--- a/skimage/filters/_median.py
+++ b/skimage/filters/_median.py
@@ -16,25 +16,25 @@ def median(image, selem=None, out=None, mask=None, shift_x=False,
     ----------
     image : array-like
         Input image.
-    selem : ndarray
+    selem : ndarray, optional
         If ``behavior=='rank'``, ``selem`` is a 2-D array of 1's and 0's.
         If ``behavior=='ndimage'``, ``selem`` is a N-D array of 1's and 0's
         with the same number of dimension than ``image``.
         If None, ``selem`` will be a N-D array with 3 elements for each
         dimension (e.g., vector, square, cube, etc.)
-    out : ndarray, (same dtype as image)
+    out : ndarray, (same dtype as image), optional
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray, optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default). Only valid
         when ``behavior='rank'``
 
         .. deprecated:: 0.16
            ``mask`` is deprecated in 0.16 and will be removed 0.17.
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
-        to the structuring element sizes (center must be inside the given
-        structuring element). Only valid when ``behavior='ndimage'``.
+        by the structuring element sizes (center must be inside the given
+        structuring element). Only valid when ``behavior='rank'``.
 
         .. deprecated:: 0.16
            ``shift_x`` and ``shift_y`` are deprecated in 0.16 and will be
@@ -70,7 +70,8 @@ def median(image, selem=None, out=None, mask=None, shift_x=False,
     See also
     --------
     skimage.filters.rank.median : Rank-based implementation of the median
-        filtering offering more flexibility.
+        filtering offering more flexibility with additional parameters but
+        dedicated for unsigned integer images.
 
     Examples
     --------

--- a/skimage/filters/_median.py
+++ b/skimage/filters/_median.py
@@ -28,12 +28,14 @@ def median(image, selem=None, out=None, mask=None, shift_x=False,
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default). Only valid
         when ``behavior='rank'``
+
         .. deprecated:: 0.16
            ``mask`` is deprecated in 0.16 and will be removed 0.17.
     shift_x, shift_y : int
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element). Only valid when ``behavior='ndimage'``.
+
         .. deprecated:: 0.16
            ``shift_x`` and ``shift_y`` are deprecated in 0.16 and will be
            removed in 0.17.
@@ -41,16 +43,20 @@ def median(image, selem=None, out=None, mask=None, shift_x=False,
         The mode parameter determines how the array borders are handled, where
         ``cval`` is the value when mode is equal to 'constant'.
         Default is 'nearest'.
+
         .. versionadded:: 0.15
            ``mode`` is used when ``behavior='ndimage'``.
     cval : scalar, optional
         Value to fill past edges of input if mode is 'constant'. Default is 0.0
+
         .. versionadded:: 0.15
            ``cval`` was added in 0.15 is used when ``behavior='ndimage'``.
     behavior : {'rank', 'ndimage'}, optional
         Either to use the old behavior (i.e., < 0.15) or the new behavior.
+        The old behavior will call the :func:`skimage.filters.rank.median`.
         The new behavior will call the :func:`scipy.ndimage.median_filter`.
         Default is 'rank'.
+
         .. versionadded:: 0.15
            ``behavior`` is introduced in 0.15
         .. deprecated:: 0.15

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -514,6 +514,11 @@ def median(image, selem=None, out=None, mask=None,
     out : 2-D array (same dtype as input image)
         Output image.
 
+    See also
+    --------
+    skimage.filters.median : Implementation of a median filtering which handles
+        images with floating precision.
+
     Examples
     --------
     >>> from skimage import data

--- a/skimage/filters/tests/test_median.py
+++ b/skimage/filters/tests/test_median.py
@@ -20,14 +20,14 @@ def image():
 
 @pytest.mark.parametrize(
     "mask, shift_x, shift_y, mode, cval, behavior, n_warning, warning_type",
-    [(True, None, None, 'nearest', 0.0, 'new', 1, (UserWarning,)),
-     (None, 1, None, 'nearest', 0.0, 'new', 1, (UserWarning,)),
-     (None, None, 1, 'nearest', 0.0, 'new', 1, (UserWarning,)),
-     (True, 1, 1, 'nearest', 0.0, 'new', 1, (UserWarning,)),
-     (None, False, False, 'constant', 0.0, 'old', 2, (DeprecationWarning,
+    [(True, None, None, 'nearest', 0.0, 'ndimage', 1, (UserWarning,)),
+     (None, 1, None, 'nearest', 0.0, 'ndimage', 1, (UserWarning,)),
+     (None, None, 1, 'nearest', 0.0, 'ndimage', 1, (UserWarning,)),
+     (True, 1, 1, 'nearest', 0.0, 'ndimage', 1, (UserWarning,)),
+     (None, False, False, 'constant', 0.0, 'rank', 2, (DeprecationWarning,
                                                       UserWarning,)),
-     (None, False, False, 'nearest', 0.0, 'old', 1, (DeprecationWarning,)),
-     (None, False, False, 'nearest', 0.0, 'new', 0, [])]
+     (None, False, False, 'nearest', 0.0, 'rank', 1, (DeprecationWarning,)),
+     (None, False, False, 'nearest', 0.0, 'ndimage', 0, [])]
 )
 def test_median_warning(image, mask, shift_x, shift_y, mode, cval, behavior,
                         n_warning, warning_type):
@@ -45,8 +45,8 @@ def test_median_warning(image, mask, shift_x, shift_y, mode, cval, behavior,
 
 @pytest.mark.parametrize(
     "behavior, func, params",
-    [('new', ndimage.median_filter, {'size': (3, 3)}),
-     ('old', rank.median, {'selem': np.ones((3, 3), dtype=np.uint8)})]
+    [('ndimage', ndimage.median_filter, {'size': (3, 3)}),
+     ('rank', rank.median, {'selem': np.ones((3, 3), dtype=np.uint8)})]
 )
 @pytest.mark.filterwarnings("ignore:Default 'behavior' will change")
 def test_median_behavior(image, behavior, func, params):

--- a/skimage/filters/tests/test_median.py
+++ b/skimage/filters/tests/test_median.py
@@ -51,3 +51,29 @@ def test_median_warning(image, mask, shift_x, shift_y, mode, cval, behavior,
 @pytest.mark.filterwarnings("ignore:Default 'behavior' will change")
 def test_median_behavior(image, behavior, func, params):
     assert_allclose(median(image, behavior=behavior), func(image, **params))
+
+
+@pytest.mark.parametrize(
+    "dtype", [np.uint8, np.uint16, np.float32, np.float64]
+)
+def test_median_preserve_dtype(image, dtype):
+    median_image = median(image.astype(dtype), behavior='ndimage')
+    assert median_image.dtype == dtype
+
+
+@pytest.mark.filterwarnings("ignore:Default 'behavior' will change")
+def test_median_error_ndim():
+    img = np.random.randint(0, 10, size=(5, 5, 5), dtype=np.uint8)
+    with pytest.raises(ValueError):
+        median(img, behavior='rank')
+
+
+@pytest.mark.parametrize(
+    "img, behavior",
+    [(np.random.randint(0, 10, size=(3, 3), dtype=np.uint8), 'rank'),
+     (np.random.randint(0, 10, size=(3, 3), dtype=np.uint8), 'ndimage'),
+     (np.random.randint(0, 10, size=(3, 3, 3), dtype=np.uint8), 'ndimage')]
+)
+@pytest.mark.filterwarnings("ignore:Default 'behavior' will change")
+def test_median(img, behavior):
+    median(img, behavior=behavior)

--- a/skimage/filters/tests/test_median.py
+++ b/skimage/filters/tests/test_median.py
@@ -25,7 +25,7 @@ def image():
      (None, None, 1, 'nearest', 0.0, 'ndimage', 1, (UserWarning,)),
      (True, 1, 1, 'nearest', 0.0, 'ndimage', 1, (UserWarning,)),
      (None, False, False, 'constant', 0.0, 'rank', 2, (DeprecationWarning,
-                                                      UserWarning,)),
+                                                       UserWarning,)),
      (None, False, False, 'nearest', 0.0, 'rank', 1, (DeprecationWarning,)),
      (None, False, False, 'nearest', 0.0, 'ndimage', 0, [])]
 )

--- a/skimage/filters/tests/test_median.py
+++ b/skimage/filters/tests/test_median.py
@@ -1,2 +1,53 @@
-def test_median_in_filters():
-    from skimage.filters import median
+import pytest
+
+import numpy as np
+from scipy import ndimage
+
+from skimage.filters import median
+from skimage.filters import rank
+from skimage._shared.testing import assert_allclose
+
+
+@pytest.fixture
+def image():
+    return np.array([[1, 2, 3, 2, 1],
+                     [1, 1, 2, 2, 3],
+                     [3, 2, 1, 2, 1],
+                     [3, 2, 1, 1, 1],
+                     [1, 2, 1, 2, 3]],
+                    dtype=np.uint8)
+
+
+@pytest.mark.parametrize(
+    "mask, shift_x, shift_y, mode, cval, behavior, n_warning, warning_type",
+    [(True, None, None, 'nearest', 0.0, 'new', 1, (UserWarning,)),
+     (None, 1, None, 'nearest', 0.0, 'new', 1, (UserWarning,)),
+     (None, None, 1, 'nearest', 0.0, 'new', 1, (UserWarning,)),
+     (True, 1, 1, 'nearest', 0.0, 'new', 1, (UserWarning,)),
+     (None, False, False, 'constant', 0.0, 'old', 2, (DeprecationWarning,
+                                                      UserWarning,)),
+     (None, False, False, 'nearest', 0.0, 'old', 1, (DeprecationWarning,)),
+     (None, False, False, 'nearest', 0.0, 'new', 0, [])]
+)
+def test_median_warning(image, mask, shift_x, shift_y, mode, cval, behavior,
+                        n_warning, warning_type):
+    if mask:
+        mask = np.ones((image.shape), dtype=np.bool_)
+
+    with pytest.warns(None) as records:
+        median(image, mask=mask, shift_x=shift_x, shift_y=shift_y, mode=mode,
+               behavior=behavior)
+
+    assert len(records) == n_warning
+    for rec in records:
+        assert isinstance(rec.message, warning_type)
+
+
+@pytest.mark.parametrize(
+    "behavior, func, params",
+    [('new', ndimage.median_filter, {'size': (3, 3)}),
+     ('old', rank.median, {'selem': np.ones((3, 3), dtype=np.uint8)})]
+)
+@pytest.mark.filterwarnings("ignore:Default 'behavior' will change")
+def test_median_behavior(image, behavior, func, params):
+    assert_allclose(median(image, behavior=behavior), func(image, **params))


### PR DESCRIPTION
## Description
Support floating image in `skimage.filters.median`. This PR will controversial, but let's start with a potential solution.

Things to considered:

* Floating images cannot be handled by `skimage.filters.rank.median`
* `scipy.ndimage.median_filter` would be a good candidate for this use case

However,

* `scipy.ndimage.median_filter` does not accept parameter such as `mask` or `shift_*`
* there is no way to go back to the behavior of `skimage.filters.rank.median` using `scipy.ndimage.median_filter`: (i) skimage discard the pixel outside of the structural element when computing the median while scipy will pad the image beforehand and (ii) the tie breaking is done differently --- floor for skimage and ceiling for scipy.

Therefore my proposal is the following: introduce a parameter `behavior` allowing to switch to the scipy implementation using all the available parameters. By default, we will fall back on the previous behavior for 2 releases. In 2 releases, the scipy function will be the default and in 4 releases, the parameters of the old behavior will be removed at the same time than the `behavior` parameter.

I could not come with a cleaner design than those deprecation cycles.

## Checklist

- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests


## References
closes #1419 
closes #1422
closes #2943

## For reviewers

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
