### PR TITLE
WIP: Reduce the default tolerance in threshold_li

### DIFF
--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -527,8 +527,8 @@ def threshold_li(image, *, tolerance=None):
 
     tolerance : float, optional
         Finish the computation when the change in the threshold in an iteration
-        is less than this value. By default, this is the smallest difference
-        between intensity values in ``image``.
+        is less than this value. By default, this is half the smallest
+        difference between intensity values in ``image``.
 
     Returns
     -------

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -527,8 +527,8 @@ def threshold_li(image, *, tolerance=None):
 
     tolerance : float, optional
         Finish the computation when the change in the threshold in an iteration
-        is less than this value. By default, this is half of the range of the
-        input image, divided by 256.
+        is less than this value. By default, this is the smallest difference
+        between intensity values in ``image``.
 
     Returns
     -------
@@ -578,8 +578,7 @@ def threshold_li(image, *, tolerance=None):
     # Li's algorithm requires positive image (because of log(mean))
     image_min = np.min(image)
     image -= image_min
-    image_range = np.max(image)
-    tolerance = tolerance or 0.5 * image_range / 256
+    tolerance = tolerance or np.min(np.diff(np.unique(image))) / 2
 
     # Initial estimate
     t_curr = np.mean(image)


### PR DESCRIPTION
Fixes #3605

In that issue, I found that a tolerance of `range / 2**15` was
sufficient.  However, I don't know whether this is generally true, so an
extra factor of 2 is probably a good margin, and gets us to a nice
round number.

Still to do:

- [ ] Find an appropriate test case. I might end up using pooch/external data for this, so that I can use the example image from that issue.
- [ ] Update the release notes both for dev and 0.14.1.
- [ ] Write a dev gallery example about `threshold_li`. Possibly after merging `attribute_operators`.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

## For reviewers

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
