### PR TITLE
Fix annotation of image licenses

### DIFF
--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -91,10 +91,8 @@ def astronaut():
     1995. She retired in 2006 after spending a total of 38 days, 8 hours
     and 10 minutes in outer space.
 
-    This image was downloaded from the NASA Great Images database
-    <https://flic.kr/p/r9qvLn>`__.
-
-    No known copyright restrictions, released into the public domain.
+    This image was downloaded from the NASA Great Images `database
+    <https://flic.kr/p/r9qvLn>`__ and falls under CC0 license by NASA.
 
     Returns
     -------
@@ -110,10 +108,9 @@ def text():
 
     Notes
     -----
-    This image was downloaded from Wikipedia
-    <https://en.wikipedia.org/wiki/File:Corner.png>`__.
-
-    No known copyright restrictions, released into the public domain.
+    This image was downloaded from `Wikipedia
+    <https://en.wikipedia.org/wiki/File:Corner.png>`__ and
+    falls under CC0 license.
 
     Returns
     -------
@@ -154,7 +151,7 @@ def coins():
     `Brooklyn Museum Collection
     <https://www.brooklynmuseum.org/opencollection/archives/image/51611>`__.
 
-    No known copyright restrictions.
+    This image probably falls under CC0 license.
 
     Returns
     -------
@@ -207,9 +204,9 @@ def horse():
     """Black and white silhouette of a horse.
 
     This image was downloaded from
-    `openclipart <http://openclipart.org/detail/158377/horse-by-marauder>`
+    `openclipart <http://openclipart.org/detail/158377/horse-by-marauder>`__
 
-    Released into public domain and drawn and uploaded by Andreas Preuss
+    Released under CC0 and drawn and uploaded by Andreas Preuss
     (marauder).
 
     Returns
@@ -228,7 +225,9 @@ def clock():
     aproximately horizontal direction.  It may be used to illustrate
     inverse filters and deconvolution.
 
-    Released into the public domain by the photographer (Stefan van der Walt).
+    Notes
+    -----
+    No copyright restrictions.  CC0 by the photographer (Stefan van der Walt).
 
     Returns
     -------
@@ -248,7 +247,7 @@ def immunohistochemistry():
     This image was acquired at the Center for Microscopy And Molecular Imaging
     (CMMI).
 
-    No known copyright restrictions.
+    This image probably falls under CC0 license.
 
     Returns
     -------
@@ -308,8 +307,10 @@ def hubble_deep_field():
     `HubbleSite
     <http://hubblesite.org/newscenter/archive/releases/2012/37/image/a/>`__.
 
-    The image was captured by NASA and `may be freely used in the public domain
-    <http://www.nasa.gov/audience/formedia/features/MP_Photo_Guidelines.html>`_.
+    The image was captured by `NASA
+    <http://www.nasa.gov/audience/formedia/features/MP_Photo_Guidelines.html>`__
+    and falls under CC0 license.
+
 
     Returns
     -------
@@ -331,8 +332,9 @@ def rocket():
     `SpaceX Photos
     <https://www.flickr.com/photos/spacexphotos/16511594820/in/photostream/>`__.
 
-    The image was captured by SpaceX and `released in the public domain
-    <http://arstechnica.com/tech-policy/2015/03/elon-musk-puts-spacex-photos-into-the-public-domain/>`_.
+    The image was captured by `SpaceX
+    <http://arstechnica.com/tech-policy/2015/03/elon-musk-puts-spacex-photos-into-the-public-domain/>`__
+    and falls under CC0 license.
 
     Returns
     -------


### PR DESCRIPTION
## Description
Close #3623.
Fix the annotation of images' license at `data` [documentation](http://scikit-image.org/docs/dev/api/skimage.data.html). 
* ~"public domain" be renamed to CC0~ Standardize the license info. 
* ~"no known copyright" be relabeled to "probably CC0"~ Keep as before but provide extra info if available

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
