### PR TITLE
cloudpickle is really a doc dependency, not a core one

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -5,4 +5,3 @@ networkx>=2.0
 pillow>=4.3.0
 imageio>=2.0.1
 PyWavelets>=0.4.0
-cloudpickle>=0.2.1

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,3 +7,5 @@ sphinx-copybutton
 pytest-runner
 scikit-learn
 dask[array]>=0.9.0
+# cloudpickle is necessary to provide the 'processes' scheduler for dask
+cloudpickle>=0.2.1

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,7 +1,9 @@
-dask[array]>=0.9.0
 imread
 SimpleITK
 astropy
 tifffile
 qtpy
 pyamg
+dask[array]>=0.9.0
+# cloudpickle is necessary to provide the 'processes' scheduler for dask
+cloudpickle>=0.2.1


### PR DESCRIPTION
I added a comment to the dependency since the dependency was missed when this was merged

https://github.com/scikit-image/scikit-image/pull/3582
