### PR TITLE
Delay matplotlib import in skimage/future/manual_segmentation.py

### DIFF
--- a/skimage/future/manual_segmentation.py
+++ b/skimage/future/manual_segmentation.py
@@ -1,8 +1,5 @@
 from functools import reduce
 import numpy as np
-import matplotlib
-from matplotlib.patches import Polygon
-from matplotlib.collections import PatchCollection
 from ..draw import polygon
 
 
@@ -64,6 +61,9 @@ def manual_polygon_segmentation(image, alpha=0.4, return_all=False):
     >>> io.imshow(mask)  # doctest: +SKIP
     >>> io.show()  # doctest: +SKIP
     """
+    import matplotlib
+    from matplotlib.patches import Polygon
+    from matplotlib.collections import PatchCollection
     import matplotlib.pyplot as plt
 
     list_of_vertex_lists = []
@@ -176,6 +176,9 @@ def manual_lasso_segmentation(image, alpha=0.4, return_all=False):
     >>> io.imshow(mask)  # doctest: +SKIP
     >>> io.show()  # doctest: +SKIP
     """
+    import matplotlib
+    from matplotlib.patches import Polygon
+    from matplotlib.collections import PatchCollection
     import matplotlib.pyplot as plt
 
     list_of_vertex_lists = []

--- a/skimage/future/manual_segmentation.py
+++ b/skimage/future/manual_segmentation.py
@@ -1,5 +1,6 @@
 from functools import reduce
 import numpy as np
+import matplotlib
 from matplotlib.patches import Polygon
 from matplotlib.collections import PatchCollection
 from ..draw import polygon

--- a/skimage/future/manual_segmentation.py
+++ b/skimage/future/manual_segmentation.py
@@ -17,6 +17,8 @@ def _mask_from_vertices(vertices, shape, label):
 
 
 def _draw_polygon(ax, vertices, alpha=0.4):
+    from matplotlib.patches import Polygon
+    from matplotlib.collections import PatchCollection
     import matplotlib.pyplot as plt
 
     polygon = Polygon(vertices, closed=True)


### PR DESCRIPTION
## Description
Bugfix for missing matplotlib import error in `skimage.future.manual_segmentation.py`.

Currently if you try to run the docstring examples from the `manual_polygon_segmentaion` or `manual_lasso_segmentation` functions, this error is produced (also verified independently by @jni):
```
File '...\scikit-image\skimage\future\manual_segmentation.py", line 92, in manual_polygon_segmentation
    undo_button = matplotlib.widgets.Button(undo_pos, u'\u27F2')
NameError: name 'matplotlib' is not defined
```

It seems that as part of the larger effort to remove matplotlib as a dependency (https://github.com/scikit-image/scikit-image/pull/3129), the line `import matplotlib` inadvertently got dropped in PR https://github.com/scikit-image/scikit-image/pull/3533, commit https://github.com/scikit-image/scikit-image/commit/fb81456bf527f93ec0ad7a968b02de6eba0ad8cb. It's necessary for the undo buttons, but flew under the radar because pytest skips these docstring examples.

@hmaarrfk 
Mark, is this the right place to add that line back in, or should it go next to the `import matplotlib.pyplot as plt` lines inside the manual segmentation functions? You've spent a lot more time thinking about how to handle this.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
PR https://github.com/scikit-image/scikit-image/pull/3533, commit https://github.com/scikit-image/scikit-image/commit/fb81456bf527f93ec0ad7a968b02de6eba0ad8cb

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
