### PR TITLE
Update image's luminance extraction to current recommendation.

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -751,8 +751,7 @@ def rgbcie2rgb(rgbcie):
 
 
 def rgb2gray(rgb):
-    """Compute luminance of an RGB image,
-    according to ITU-R BT.709-6 (2015) recommendation.
+    """Compute luminance of an RGB image.
 
     Parameters
     ----------
@@ -766,6 +765,10 @@ def rgb2gray(rgb):
     out : ndarray
         The luminance image - an array which is the same size as the input
         array, but with the channel dimension removed.
+
+        ..versionchanged:: 0.15.0
+            Now returns luminance according to the ITU-R BT.709-6 (2015)
+            recommendation instead of ITU-R BT.709-1 (1993).
 
     Raises
     ------
@@ -786,6 +789,8 @@ def rgb2gray(rgb):
         Y = 0.2126 R + 0.7152 G + 0.0722 B
 
     If there is an alpha channel present, it is ignored.
+    This luminance computation is defined in the ITU-R BT.709-6 (2015)
+    recommendation for true CIE luminance extraction from contemporary CRT phosphors.
 
     Examples
     --------

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -751,7 +751,8 @@ def rgbcie2rgb(rgbcie):
 
 
 def rgb2gray(rgb):
-    """Compute luminance of an RGB image, according to ITU-R BT.709-6 (2015) recommendation.
+    """Compute luminance of an RGB image, 
+    according to ITU-R BT.709-6 (2015) recommendation.
 
     Parameters
     ----------

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -751,7 +751,7 @@ def rgbcie2rgb(rgbcie):
 
 
 def rgb2gray(rgb):
-    """Compute luminance of an RGB image.
+    """Compute luminance of an RGB image, according to ITU-R BT.709-6 (2015) recommendation
 
     Parameters
     ----------
@@ -774,14 +774,15 @@ def rgb2gray(rgb):
 
     References
     ----------
-    .. [1] http://www.poynton.com/PDFs/ColorFAQ.pdf
+    .. [1] https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.709-6-201506-I!!PDF-E.pdf
+    .. [2] https://www.itu.int/rec/R-REC-BT.709/en
 
     Notes
     -----
     The weights used in this conversion are calibrated for contemporary
     CRT phosphors::
 
-        Y = 0.2125 R + 0.7154 G + 0.0721 B
+        Y = 0.2126 R + 0.7152 G + 0.0722 B
 
     If there is an alpha channel present, it is ignored.
 
@@ -797,7 +798,7 @@ def rgb2gray(rgb):
         return np.ascontiguousarray(rgb)
 
     rgb = _prepare_colorarray(rgb[..., :3])
-    coeffs = np.array([0.2125, 0.7154, 0.0721], dtype=rgb.dtype)
+    coeffs = np.array([0.2126, 0.7152, 0.0722], dtype=rgb.dtype)
     return rgb @ coeffs
 
 

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -791,6 +791,8 @@ def rgb2gray(rgb):
     If there is an alpha channel present, it is ignored.
     This luminance computation is defined in the ITU-R BT.709-6 (2015)
     recommendation for true CIE luminance extraction from contemporary CRT phosphors.
+    Prior to version 0.15.0, the luminance was computed by
+    `Y = 0.2125 R + 0.7154 G + 0.0721 B` (ITU-R BT.709-1 from 1993).
 
     Examples
     --------

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -751,7 +751,7 @@ def rgbcie2rgb(rgbcie):
 
 
 def rgb2gray(rgb):
-    """Compute luminance of an RGB image, according to ITU-R BT.709-6 (2015) recommendation
+    """Compute luminance of an RGB image, according to ITU-R BT.709-6 (2015) recommendation.
 
     Parameters
     ----------

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -751,7 +751,7 @@ def rgbcie2rgb(rgbcie):
 
 
 def rgb2gray(rgb):
-    """Compute luminance of an RGB image, 
+    """Compute luminance of an RGB image,
     according to ITU-R BT.709-6 (2015) recommendation.
 
     Parameters


### PR DESCRIPTION
## Description
[Tell us about your new feature, improvement, or fix! If relevant, please supplement the PR with images.]

The ITU-R BT.709-1 recommendation from 1993 (`Y = 0.2125 R + 0.7154 G + 0.0721  B`) is outdated and was replaced by BT.709-6 in 2015.
Adapt the rgb2gray conversion function accordingly to `Y = 0.2126 R + 0.7152 G + 0.0722 B`.

https://www.itu.int/rec/R-REC-BT.709-1-199311-S/en
https://www.itu.int/rec/R-REC-BT.709-6-201506-I/en
https://www.itu.int/rec/R-REC-BT.709/en

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
