### PR TITLE
make the low contrast check optional when saving images

### DIFF
--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -104,7 +104,7 @@ def imread_collection(load_pattern, conserve_memory=True,
                        plugin=plugin, **plugin_args)
 
 
-def imsave(fname, arr, plugin=None, **plugin_args):
+def imsave(fname, arr, plugin=None, check_contrast=True, **plugin_args):
     """Save an image to file.
 
     Parameters
@@ -113,11 +113,13 @@ def imsave(fname, arr, plugin=None, **plugin_args):
         Target filename.
     arr : ndarray of shape (M,N) or (M,N,3) or (M,N,4)
         Image data.
-    plugin : str
+    plugin : str, optional
         Name of plugin to use.  By default, the different plugins are
         tried (starting with imageio) until a suitable
         candidate is found.  If not given and fname is a tiff file, the
         tifffile plugin will be used.
+    check_contrast : bool, optional
+        Check for low contrast and print warning (default: True).
 
     Other parameters
     ----------------
@@ -135,7 +137,7 @@ def imsave(fname, arr, plugin=None, **plugin_args):
     if plugin is None and hasattr(fname, 'lower'):
         if fname.lower().endswith(('.tiff', '.tif')):
             plugin = 'tifffile'
-    if is_low_contrast(arr):
+    if check_contrast and is_low_contrast(arr):
         warn('%s is a low contrast image' % fname)
     if arr.dtype == bool:
         warn('%s is a boolean image: setting True to 1 and False to 0' % fname)

--- a/skimage/io/tests/test_pil.py
+++ b/skimage/io/tests/test_pil.py
@@ -203,6 +203,10 @@ def test_imsave_incorrect_dimension():
         with testing.raises(ValueError):
             with expected_warnings([fname + ' is a low contrast image']):
                 imsave(fname, np.zeros((2, 3, 2)))
+        # test that low contrast check is ignored
+        with testing.raises(ValueError):
+            with expected_warnings([]):
+                imsave(fname, np.zeros((2, 3, 2)), check_contrast=False)
 
 
 def test_imsave_filelike():


### PR DESCRIPTION
## Description
This PR makes the low constrast check optional when saving images.
As described in https://github.com/scikit-image/scikit-image/issues/2531 the low contrast check delays the image export and is generally only useful for natural images.

## References
Fixe #2531 

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
