### PR TITLE
Clarify return values in _overlap docstrings in feature/blob.py

### DIFF
--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -17,8 +17,8 @@ from .._shared.utils import assert_nD
 
 def _compute_disk_overlap(d, r1, r2):
     """
-    Compute surface overlap between two disks of radii ``r1`` and ``r2``,
-    with centers separated by a distance ``d``.
+    Compute fraction of surface overlap between two disks of radii 
+    ``r1`` and ``r2``, with centers separated by a distance ``d``.
 
     Parameters
     ----------
@@ -31,8 +31,8 @@ def _compute_disk_overlap(d, r1, r2):
 
     Returns
     -------
-    vol: float
-        Volume of the overlap between the two disks.
+    area: float
+        Fraction of area of the overlap between the two disks.
     """
 
     ratio1 = (d ** 2 + r1 ** 2 - r2 ** 2) / (2 * d * r1)
@@ -54,7 +54,7 @@ def _compute_disk_overlap(d, r1, r2):
 
 def _compute_sphere_overlap(d, r1, r2):
     """
-    Compute volume overlap between two spheres of radii ``r1`` and ``r2``,
+    Compute volume overlap fraction between two spheres of radii ``r1`` and ``r2``,
     with centers separated by a distance ``d``.
 
     Parameters
@@ -69,7 +69,7 @@ def _compute_sphere_overlap(d, r1, r2):
     Returns
     -------
     vol: float
-        Volume of the overlap between the two spheres.
+        Fraction of volume of the overlap between the two spheres.
 
     Notes
     -----

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -17,7 +17,7 @@ from .._shared.utils import assert_nD
 
 def _compute_disk_overlap(d, r1, r2):
     """
-    Compute fraction of surface overlap between two disks of radii 
+    Compute fraction of surface overlap between two disks of radii
     ``r1`` and ``r2``, with centers separated by a distance ``d``.
 
     Parameters
@@ -54,8 +54,8 @@ def _compute_disk_overlap(d, r1, r2):
 
 def _compute_sphere_overlap(d, r1, r2):
     """
-    Compute volume overlap fraction between two spheres of radii ``r1`` and ``r2``,
-    with centers separated by a distance ``d``.
+    Compute volume overlap fraction between two spheres of radii
+    ``r1`` and ``r2``, with centers separated by a distance ``d``.
 
     Parameters
     ----------

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -31,7 +31,7 @@ def _compute_disk_overlap(d, r1, r2):
 
     Returns
     -------
-    area: float
+    fraction: float
         Fraction of area of the overlap between the two disks.
     """
 
@@ -68,7 +68,7 @@ def _compute_sphere_overlap(d, r1, r2):
 
     Returns
     -------
-    vol: float
+    fraction: float
         Fraction of volume of the overlap between the two spheres.
 
     Notes


### PR DESCRIPTION
One typo for `vol` instead of area for the 2d case, both say they return a volume but really return fraction

## Description
Fixing typos to clarify overlap functions in blob.py


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References


## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
