### PR TITLE
compute image_cube in parallel for blob_dog

### DIFF
--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -362,13 +362,13 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
 
     pool = mp.Pool()
     filtered = []
-    for sigma in sigma_list:
-        filtered.append(pool.apply_async(gaussian_laplace, args=(image, sigma)))
+    for s in sigma_list:
+        filtered.append(pool.apply_async(gaussian_laplace, args=(image, s)))
 
     # computing gaussian laplace
     # s**2 provides scale invariance
-    image_cube = np.stack([-s ** 2 * result.get()
-                           for result, s in zip(filtered, sigma_list)], axis=-1)
+    image_cube = np.stack([-s ** 2 * res.get()
+                           for res, s in zip(filtered, sigma_list)], axis=-1)
 
     local_maxima = peak_local_max(image_cube, threshold_abs=threshold,
                                   footprint=np.ones((3,) * (image.ndim + 1)),


### PR DESCRIPTION
## Description
For large ranges of `sigma` in the `blog_log` function, building the `image_cube` is the slowest part usually (once `sigma` is large it and requires a very large image filter).

Submitting these in parallel with a `Pool()` speeds the function up considerably for me, especially on a computer with many cores.


## Checklist
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
