### PR TITLE
Move conftest

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -67,7 +67,7 @@ test_script:
   -  echo backend:Agg > matplotlibrc
 
   # Run unit tests with pytest
-  - pytest -v --pyargs skimage
+  - pytest --doctest-modules -v --pyargs skimage
 
 #artifacts:
 #  # Archive the generated wheel package in the ci.appveyor.com build report.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -67,7 +67,7 @@ test_script:
   -  echo backend:Agg > matplotlibrc
 
   # Run unit tests with pytest
-  - pytest -v --pyargs skimage
+  - pytest -v --pyargs skimage --doctest-modules
 
 #artifacts:
 #  # Archive the generated wheel package in the ci.appveyor.com build report.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -67,7 +67,7 @@ test_script:
   -  echo backend:Agg > matplotlibrc
 
   # Run unit tests with pytest
-  - pytest -v --pyargs skimage --doctest-modules
+  - pytest --doctest-modules -v --pyargs skimage
 
 #artifacts:
 #  # Archive the generated wheel package in the ci.appveyor.com build report.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -67,7 +67,7 @@ test_script:
   -  echo backend:Agg > matplotlibrc
 
   # Run unit tests with pytest
-  - pytest --doctest-modules -v --pyargs skimage
+  - pytest -v --pyargs skimage
 
 #artifacts:
 #  # Archive the generated wheel package in the ci.appveyor.com build report.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include setup*.py
-include conftest.py
 include MANIFEST.in
 include *.txt
 include *.rst

--- a/skimage/conftest.py
+++ b/skimage/conftest.py
@@ -8,7 +8,7 @@ if Version(np.__version__) >= Version('1.14'):
     np.set_printoptions(legacy='1.13')
 
 # List of files that pytest should ignore
-collect_ignore = ["io/_plugins",]
+collect_ignore = ["io/_plugins"]
 try:
     import visvis
 except ImportError:

--- a/skimage/conftest.py
+++ b/skimage/conftest.py
@@ -8,15 +8,11 @@ if Version(np.__version__) >= Version('1.14'):
     np.set_printoptions(legacy='1.13')
 
 # List of files that pytest should ignore
-collect_ignore = ["setup.py",
-                  "skimage/io/_plugins",
-                  "doc/",
-                  "tools/",
-                  "viewer_examples"]
+collect_ignore = ["io/_plugins",]
 try:
     import visvis
 except ImportError:
-    collect_ignore.append("skimage/measure/mc_meta/visual_test.py")
+    collect_ignore.append("measure/mc_meta/visual_test.py")
 
 # importing skimage.novice issues some warnings. Without these lines,
 # pytest issues numerous warnings when crawling the package.

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -17,7 +17,7 @@ section_end "List.installed.dependencies"
 
 section "Test"
 # Change to a random directory for testing
-tmp_test_dir=`mkdir -d`
+tmp_test_dir=`mktemp -d`
 (cd %{tmp_test_dir} && pytest $TEST_ARGS --pyargs skimage)
 section_end "Test"
 

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -16,7 +16,9 @@ tools/build_versions.py
 section_end "List.installed.dependencies"
 
 section "Test"
-pytest $TEST_ARGS skimage
+# Change to a random directory for testing
+tmp_test_dir=`mkdir -d`
+(cd %{tmp_test_dir} && pytest $TEST_ARGS --pyargs skimage)
 section_end "Test"
 
 section "Flake8.test"

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -18,7 +18,7 @@ section_end "List.installed.dependencies"
 section "Test"
 # Change to a random directory for testing
 tmp_test_dir=`mktemp -d`
-(cd %{tmp_test_dir} && pytest $TEST_ARGS --pyargs skimage)
+(cd ${tmp_test_dir} && pytest $TEST_ARGS --pyargs skimage)
 section_end "Test"
 
 section "Flake8.test"


### PR DESCRIPTION
Moving conftest allows users to run the doctests themselves.

this is proven because now appveyor can run the doctests without having conftest.py in the same directory where pytest is executed. 

@jni 

part of breaking up #3129
## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
