### PR TITLE
Pass parameters through tifffile plugin

### DIFF
--- a/skimage/external/tifffile/__init__.py
+++ b/skimage/external/tifffile/__init__.py
@@ -1,5 +1,5 @@
-from .tifffile import imsave, imread, imshow, TiffFile, TiffWriter, TiffSequence
+from .tifffile import imsave, imread, imshow, TiffFile, TiffWriter, TiffSequence, parse_kwargs
 
 __version__ = '0.6.2'
 __all__ = ('imsave', 'imread', 'imshow', 'TiffFile', 'TiffWriter',
-           'TiffSequence')
+           'TiffSequence','parse_kwargs')

--- a/skimage/external/tifffile/__init__.py
+++ b/skimage/external/tifffile/__init__.py
@@ -1,5 +1,6 @@
-from .tifffile import imsave, imread, imshow, TiffFile, TiffWriter, TiffSequence, parse_kwargs
+from .tifffile import imsave, imread, imshow, TiffFile, TiffWriter, \
+    TiffSequence, parse_kwargs
 
 __version__ = '0.6.2'
 __all__ = ('imsave', 'imread', 'imshow', 'TiffFile', 'TiffWriter',
-           'TiffSequence','parse_kwargs')
+           'TiffSequence', 'parse_kwargs')

--- a/skimage/io/_plugins/tifffile_plugin.py
+++ b/skimage/io/_plugins/tifffile_plugin.py
@@ -1,6 +1,6 @@
 from ...external.tifffile import TiffFile, imsave, parse_kwargs
 
-                 
+
 def imread(fname, **kwargs):
     """Load a tiff image from file.
 
@@ -24,17 +24,17 @@ def imread(fname, **kwargs):
     .. [1] http://www.lfd.uci.edu/~gohlke/code/tifffile.py
 
     """
-    
+
     if 'img_num' in kwargs:
         kwargs['key'] = kwargs.pop('img_num')
-        
+
     # separate TiffFile kwargs from other kwargs
     tiff_keys = ['multifile', 'multifile_close', 'pages', 'fastij', 'is_ome',
                  'pattern']
     kwargs_tiff = parse_kwargs(kwargs, *tiff_keys)
     for key in tiff_keys:
         kwargs.pop(key, None)
-    
+
     # read and return tiff as numpy array
     with TiffFile(fname, **kwargs_tiff) as tif:
         return tif.asarray(**kwargs)

--- a/skimage/io/_plugins/tifffile_plugin.py
+++ b/skimage/io/_plugins/tifffile_plugin.py
@@ -28,11 +28,10 @@ def imread(fname, dtype=None, **kwargs):
     if 'img_num' in kwargs:
         kwargs['key'] = kwargs.pop('img_num')
 
-    # separate TiffFile kwargs from other kwargs
+    # parse_kwargs will extract keyword arguments intended for the TiffFile 
+    # class and remove them from the kwargs dictionary in-place
     tiff_keys = ['multifile', 'multifile_close', 'pages', 'fastij', 'is_ome']
     kwargs_tiff = parse_kwargs(kwargs, *tiff_keys)
-    for key in tiff_keys:
-        kwargs.pop(key, None)
 
     # read and return tiff as numpy array
     with TiffFile(fname, **kwargs_tiff) as tif:

--- a/skimage/io/_plugins/tifffile_plugin.py
+++ b/skimage/io/_plugins/tifffile_plugin.py
@@ -24,6 +24,7 @@ def imread(fname, **kwargs):
     .. [1] http://www.lfd.uci.edu/~gohlke/code/tifffile.py
 
     """
+    
     if 'img_num' in kwargs:
         kwargs['key'] = kwargs.pop('img_num')
         
@@ -32,7 +33,8 @@ def imread(fname, **kwargs):
                  'pattern']
     kwargs_tiff = parse_kwargs(kwargs, *tiff_keys)
     for key in tiff_keys:
-        kwargs.pop(key,None)
-
+        kwargs.pop(key, None)
+    
+    # read and return tiff as numpy array
     with TiffFile(fname, **kwargs_tiff) as tif:
         return tif.asarray(**kwargs)

--- a/skimage/io/_plugins/tifffile_plugin.py
+++ b/skimage/io/_plugins/tifffile_plugin.py
@@ -1,7 +1,7 @@
-from ...external.tifffile import TiffFile, imsave
+from ...external.tifffile import TiffFile, imsave, parse_kwargs
 
-
-def imread(fname, dtype=None, **kwargs):
+                 
+def imread(fname, **kwargs):
     """Load a tiff image from file.
 
     Parameters
@@ -26,5 +26,13 @@ def imread(fname, dtype=None, **kwargs):
     """
     if 'img_num' in kwargs:
         kwargs['key'] = kwargs.pop('img_num')
-    with TiffFile(fname) as tif:
+        
+    # separate TiffFile kwargs from other kwargs
+    tiff_keys = ['multifile', 'multifile_close', 'pages', 'fastij', 'is_ome',
+                 'pattern']
+    kwargs_tiff = parse_kwargs(kwargs, *tiff_keys)
+    for key in tiff_keys:
+        kwargs.pop(key,None)
+
+    with TiffFile(fname, **kwargs_tiff) as tif:
         return tif.asarray(**kwargs)

--- a/skimage/io/_plugins/tifffile_plugin.py
+++ b/skimage/io/_plugins/tifffile_plugin.py
@@ -29,8 +29,7 @@ def imread(fname, dtype=None, **kwargs):
         kwargs['key'] = kwargs.pop('img_num')
 
     # separate TiffFile kwargs from other kwargs
-    tiff_keys = ['multifile', 'multifile_close', 'pages', 'fastij', 'is_ome',
-                 'pattern']
+    tiff_keys = ['multifile', 'multifile_close', 'pages', 'fastij', 'is_ome']
     kwargs_tiff = parse_kwargs(kwargs, *tiff_keys)
     for key in tiff_keys:
         kwargs.pop(key, None)

--- a/skimage/io/_plugins/tifffile_plugin.py
+++ b/skimage/io/_plugins/tifffile_plugin.py
@@ -1,7 +1,7 @@
 from ...external.tifffile import TiffFile, imsave, parse_kwargs
 
 
-def imread(fname, **kwargs):
+def imread(fname, dtype=None, **kwargs):
     """Load a tiff image from file.
 
     Parameters

--- a/skimage/io/tests/test_tifffile.py
+++ b/skimage/io/tests/test_tifffile.py
@@ -37,6 +37,11 @@ def test_imread_multipage_rgb_tif():
     img = imread(os.path.join(data_dir, 'multipage_rgb.tif'))
     assert img.shape == (2, 10, 10, 3), img.shape
 
+def test_tifffile_kwarg_passthrough ():
+    img = imread(os.path.join(data_dir, 'multipage.tif'), pages=[1], 
+                 multifile=False, multifile_close=True, fastij=True, 
+                 is_ome=True)
+    assert img.shape == (15, 10), img.shape
 
 def test_imread_handle():
     expected = np.load(os.path.join(data_dir, 'chessboard_GRAY_U8.npy'))


### PR DESCRIPTION
## Description
This fixes the bug that, contrary to the documentation, arguments such as 'pages' were not passed to the TiffFile reader.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests


## References
closes #3674 

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
