### PR TITLE
DOC unusused im3d_t in example

### DIFF
--- a/doc/source/user_guide/numpy_images.rst
+++ b/doc/source/user_guide/numpy_images.rst
@@ -218,9 +218,6 @@ is the same::
     >>> t0 = time.time(); x = in_order_multiply(im3d, 5); t1 = time.time()
     >>> print("%.2f seconds" % (t1 - t0))  # doctest: +SKIP
     0.14 seconds
-    >>> im3d_t = np.transpose(im3d).copy()  # place "planes" dimension at end
-    >>> im3d_t.shape
-    (1024, 1024, 100)
     >>> s0 = time.time(); x = out_of_order_multiply(im3d, 5); s1 = time.time()
     >>> print("%.2f seconds" % (s1 - s0))  # doctest: +SKIP
     1.18 seconds


### PR DESCRIPTION
The example in the "Notes on the order of array dimensions" defined the
transpose of a matrix `im3d_t` that isn't used in the example.

On a side note, the whole example seems out of date. Neither @jni nor I could get a difference in timing between the in order versus out of order multiply.