### PR TITLE
backport: _marching_cubes_lewiner_cy: mark char as signed #3587 

### DIFF
--- a/skimage/measure/_marching_cubes_lewiner_cy.pyx
+++ b/skimage/measure/_marching_cubes_lewiner_cy.pyx
@@ -746,9 +746,9 @@ cdef class Lut:
     The tables are initially defined as numpy arrays. On initialization,
     this class converts them to a C array for fast access.
     This class defines functions to look up values using 1, 2 or 3 indices.
-    """ 
-    
-    cdef char* VALUES
+    """
+
+    cdef signed char* VALUES
     cdef int L0 # Length
     cdef int L1 # size of tuple
     cdef int L2 # size of tuple in tuple (if any)
@@ -769,7 +769,7 @@ cdef class Lut:
         array = array.ravel()
         cdef int n, N
         N = self.L0 * self.L1 * self.L2
-        self.VALUES = <char *> malloc(N * sizeof(char)) 
+        self.VALUES = <signed char *> malloc(N * sizeof(signed char))
         for n in range(N):
             self.VALUES[n] = array[n]
     


### PR DESCRIPTION
Fix marching_cubes_lewiner on ppc64le

Closes gh-2982.

## Description
[Tell us about your new feature, improvement, or fix! If relevant, please supplement the PR with images.]


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
