### PR TITLE
Use Travis-CI's xvfb service, instead of firing it up manually

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ addons:
     - texlive
     - texlive-latex-extra
     - dvipng
+services:
+  - xvfb
 
 env:
   global:

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -12,7 +12,6 @@ EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.
 WHEELHOUSE="--find-links=$EXTRA_WHEELS"
 
 if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
-    sh -e /etc/init.d/xvfb start
     # This one is for wheels we can only build on the travis precise container.
     # As of 14 Jan 2017, this is only pyside.  Also on Rackspace, see above.
     # To build new wheels for this container, consider using:


### PR DESCRIPTION
Backport of patch made on the v0.14.x branch: https://github.com/scikit-image/scikit-image/commit/5751e4ead9fdc16a89c84b8a372339c49c73af27