### PR TITLE
allow python 3.7 to fail, but travis to continue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,10 @@ matrix:
       osx_image: xcode10.1
       language: objective-c
       env: TRAVIS_PYTHON_VERSION=3.7
+  allow_failures:
+    # python 3.7 is failing and it is out of our control for now.
+    # remove when scikit-image tests actually start running.
+    - python: 3.7
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then


### PR DESCRIPTION
## Description
[Tell us about your new feature, improvement, or fix! If relevant, please supplement the PR with images.]


## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
