### PR TITLE
Add support for anisotropic blob detection in blob_log and blob_dog

### DIFF
--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -259,7 +259,7 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
     if isinstance(max_sigma, (int, float)):
         max_sigma = np.full(len(image.shape), max_sigma, dtype=np.float)
     if isinstance(min_sigma, (int, float)):
-        min_sigma = np.full(len(image.shape), min_sigma, dtype=np.float)
+        min_sigma = np.full(image.ndim, min_sigma, dtype=float)
 
     # Convert sequence types to array
     min_sigma = np.asarray(min_sigma, dtype=np.float)

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -257,7 +257,7 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
     # Gaussian filter requires that sequence-type sigmas have same
     # dimensionality as image. This broadcasts scalar kernels
     if isinstance(max_sigma, (int, float)):
-        max_sigma = np.full(len(image.shape), max_sigma, dtype=np.float)
+        max_sigma = np.full(image.ndim, max_sigma, dtype=float)
     if isinstance(min_sigma, (int, float)):
         min_sigma = np.full(image.ndim, min_sigma, dtype=float)
 

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -309,7 +309,7 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
 
 
 def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
-             overlap=.5, log_scale=False, exclude_border=False):
+             overlap=.5, log_scale=False, *, exclude_border=False):
     r"""Finds blobs in the given grayscale image.
 
     Blobs are found using the Laplacian of Gaussian (LoG) method [1]_.

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -166,7 +166,7 @@ def _prune_blobs(blobs_array, overlap):
 
 
 def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
-             overlap=.5,):
+             overlap=.5, exclude_border=False):
     r"""Finds blobs in the given grayscale image.
 
     Blobs are found using the Difference of Gaussian (DoG) method [1]_.
@@ -178,12 +178,16 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
     image : 2D or 3D ndarray
         Input grayscale image, blobs are assumed to be light on dark
         background (white on black).
-    min_sigma : float, optional
-        The minimum standard deviation for Gaussian Kernel. Keep this low to
-        detect smaller blobs.
-    max_sigma : float, optional
-        The maximum standard deviation for Gaussian Kernel. Keep this high to
-        detect larger blobs.
+    min_sigma : scalar or sequence of scalars, optional
+        the minimum standard deviation for Gaussian kernel. Keep this low to
+        detect smaller blobs. The standard deviations of the Gaussian filter
+        are given for each axis as a sequence, or as a single number, in
+        which case it is equal for all axes.
+    max_sigma : scalar or sequence of scalars, optional
+        The maximum standard deviation for Gaussian kernel. Keep this high to
+        detect larger blobs. The standard deviations of the Gaussian filter
+        are given for each axis as a sequence, or as a single number, in
+        which case it is equal for all axes.
     sigma_ratio : float, optional
         The ratio between the standard deviation of Gaussian Kernels used for
         computing the Difference of Gaussians
@@ -194,15 +198,21 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
     overlap : float, optional
         A value between 0 and 1. If the area of two blobs overlaps by a
         fraction greater than `threshold`, the smaller blob is eliminated.
+    exclude_border : int or bool, optional
+        If nonzero int, `exclude_border` excludes blobs from
+        within `exclude_border`-pixels of the border of the image.
 
     Returns
     -------
-    A : (n, image.ndim + 1) ndarray
-        A 2d array with each row representing 3 values for a 2D image,
-        and 4 values for a 3D image: ``(r, c, sigma)`` or ``(p, r, c, sigma)``
-        where ``(r, c)`` or ``(p, r, c)`` are coordinates of the blob and
-        ``sigma`` is the standard deviation of the Gaussian kernel which
-        detected the blob.
+    A : (n, image.ndim + sigma) ndarray
+        A 2d array with each row representing 2 coordinate values for a 2D
+        image, and 3 coordinate values for a 3D image, plus the sigma(s) used.
+        When a single sigma is passed, outputs are:
+        ``(r, c, sigma)`` or ``(p, r, c, sigma)`` where ``(r, c)`` or
+        ``(p, r, c)`` are coordinates of the blob and ``sigma`` is the standard
+        deviation of the Gaussian kernel which detected the blob. When an
+        anisotropic gaussian is used (sigmas per dimension), the detected sigma
+        is returned for each dimension.
 
     References
     ----------
@@ -244,8 +254,19 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
     """
     image = img_as_float(image)
 
+    # Gaussian filter requires that sequence-type sigmas have same
+    # dimensionality as image. This broadcasts scalar kernels
+    if isinstance(max_sigma, (int, float)):
+        max_sigma = np.full(len(image.shape), max_sigma, dtype=np.float)
+    if isinstance(min_sigma, (int, float)):
+        min_sigma = np.full(len(image.shape), min_sigma, dtype=np.float)
+
+    # Convert sequence types to array
+    min_sigma = np.asarray(min_sigma, dtype=np.float)
+    max_sigma = np.asarray(max_sigma, dtype=np.float)
+
     # k such that min_sigma*(sigma_ratio**k) > max_sigma
-    k = int(log(float(max_sigma) / min_sigma, sigma_ratio)) + 1
+    k = int(np.mean(np.log(max_sigma / min_sigma) / np.log(sigma_ratio) + 1))
 
     # a geometric progression of standard deviations for gaussian kernels
     sigma_list = np.array([min_sigma * (sigma_ratio ** i)
@@ -254,9 +275,9 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
     gaussian_images = [gaussian_filter(image, s) for s in sigma_list]
 
     # computing difference between two successive Gaussian blurred images
-    # multiplying with standard deviation provides scale invariance
+    # multiplying with average standard deviation provides scale invariance
     dog_images = [(gaussian_images[i] - gaussian_images[i + 1])
-                  * sigma_list[i] for i in range(k)]
+                  * np.mean(sigma_list[i]) for i in range(k)]
 
     image_cube = np.stack(dog_images, axis=-1)
 
@@ -264,19 +285,31 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
     local_maxima = peak_local_max(image_cube, threshold_abs=threshold,
                                   footprint=np.ones((3,) * (image.ndim + 1)),
                                   threshold_rel=0.0,
-                                  exclude_border=False)
+                                  exclude_border=exclude_border)
     # Catch no peaks
     if local_maxima.size == 0:
         return np.empty((0, 3))
+
     # Convert local_maxima to float64
     lm = local_maxima.astype(np.float64)
-    # Convert the last index to its corresponding scale value
-    lm[:, -1] = sigma_list[local_maxima[:, -1]]
+
+    # translate final column of lm, which contains the index of the
+    # sigma that produced the maximum intensity value, into the sigma
+    sigmas_of_peaks = sigma_list[local_maxima[:, -1]]
+
+    # if the gaussian is isotropic, the stdev across dimensions are
+    # identical, so return only the stdev deviation of the first dimension
+    if np.unique(min_sigma).shape == (1,) and np.unique(max_sigma).shape == (1,):
+        sigmas_of_peaks = sigmas_of_peaks[:, 0][:, None]
+
+    # Remove sigma index and replace with sigmas
+    lm = np.hstack([lm[:, :-1], sigmas_of_peaks])
+
     return _prune_blobs(lm, overlap)
 
 
 def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
-             overlap=.5, log_scale=False):
+             overlap=.5, log_scale=False, exclude_border=False):
     r"""Finds blobs in the given grayscale image.
 
     Blobs are found using the Laplacian of Gaussian (LoG) method [1]_.
@@ -288,12 +321,16 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
     image : 2D or 3D ndarray
         Input grayscale image, blobs are assumed to be light on dark
         background (white on black).
-    min_sigma : float, optional
-        The minimum standard deviation for Gaussian Kernel. Keep this low to
-        detect smaller blobs.
-    max_sigma : float, optional
-        The maximum standard deviation for Gaussian Kernel. Keep this high to
-        detect larger blobs.
+    min_sigma : scalar or sequence of scalars, optional
+        the minimum standard deviation for Gaussian kernel. Keep this low to
+        detect smaller blobs. The standard deviations of the Gaussian filter
+        are given for each axis as a sequence, or as a single number, in
+        which case it is equal for all axes.
+    max_sigma : scalar or sequence of scalars, optional
+        The maximum standard deviation for Gaussian kernel. Keep this high to
+        detect larger blobs. The standard deviations of the Gaussian filter
+        are given for each axis as a sequence, or as a single number, in
+        which case it is equal for all axes.
     num_sigma : int, optional
         The number of intermediate values of standard deviations to consider
         between `min_sigma` and `max_sigma`.
@@ -308,15 +345,21 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
         If set intermediate values of standard deviations are interpolated
         using a logarithmic scale to the base `10`. If not, linear
         interpolation is used.
+    exclude_border : int or bool, optional
+        If nonzero int, `exclude_border` excludes blobs from
+        within `exclude_border`-pixels of the border of the image.
 
     Returns
     -------
-    A : (n, image.ndim + 1) ndarray
-        A 2d array with each row representing 3 values for a 2D image,
-        and 4 values for a 3D image: ``(r, c, sigma)`` or ``(p, r, c, sigma)``
-        where ``(r, c)`` or ``(p, r, c)`` are coordinates of the blob and
-        ``sigma`` is the standard deviation of the Gaussian kernel which
-        detected the blob.
+    A : (n, image.ndim + sigma) ndarray
+        A 2d array with each row representing 2 coordinate values for a 2D
+        image, and 3 coordinate values for a 3D image, plus the sigma(s) used.
+        When a single sigma is passed, outputs are:
+        ``(r, c, sigma)`` or ``(p, r, c, sigma)`` where ``(r, c)`` or
+        ``(p, r, c)`` are coordinates of the blob and ``sigma`` is the standard
+        deviation of the Gaussian kernel which detected the blob. When an
+        anisotropic gaussian is used (sigmas per dimension), the detected sigma
+        is returned for each dimension.
 
     References
     ----------
@@ -353,30 +396,57 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
     """
     image = img_as_float(image)
 
+    # Gaussian filter requires that sequence-type sigmas have same
+    # dimensionality as image. This broadcasts scalar kernels
+    if isinstance(max_sigma, (int, float)):
+        max_sigma = np.full(len(image.shape), max_sigma, dtype=np.float)
+    if isinstance(min_sigma, (int, float)):
+        min_sigma = np.full(len(image.shape), min_sigma, dtype=np.float)
+
+    # Convert sequence types to array
+    min_sigma = np.asarray(min_sigma, dtype=np.float)
+    max_sigma = np.asarray(max_sigma, dtype=np.float)
+
     if log_scale:
-        start, stop = log(min_sigma, 10), log(max_sigma, 10)
-        sigma_list = np.logspace(start, stop, num_sigma)
+        start, stop = np.log10(min_sigma)[:, None], np.log10(max_sigma)[:, None]
+        space = np.concatenate(
+            [start, stop, np.full_like(start, num_sigma)], axis=1)
+        sigma_list = np.stack([np.logspace(*s) for s in space], axis=1)
     else:
-        sigma_list = np.linspace(min_sigma, max_sigma, num_sigma)
+        scale = np.linspace(0, 1, num_sigma)[:, None]
+        sigma_list = scale * (max_sigma - min_sigma) + min_sigma
 
     # computing gaussian laplace
-    # s**2 provides scale invariance
-    gl_images = [-gaussian_laplace(image, s) * s ** 2 for s in sigma_list]
+    # average s**2 provides scale invariance
+    gl_images = [-gaussian_laplace(image, s) * s ** 2
+                 for s in np.mean(sigma_list, axis=1)]
 
     image_cube = np.stack(gl_images, axis=-1)
 
     local_maxima = peak_local_max(image_cube, threshold_abs=threshold,
                                   footprint=np.ones((3,) * (image.ndim + 1)),
                                   threshold_rel=0.0,
-                                  exclude_border=False)
+                                  exclude_border=exclude_border)
 
     # Catch no peaks
     if local_maxima.size == 0:
         return np.empty((0, 3))
+
     # Convert local_maxima to float64
     lm = local_maxima.astype(np.float64)
-    # Convert the last index to its corresponding scale value
-    lm[:, -1] = sigma_list[local_maxima[:, -1]]
+
+    # translate final column of lm, which contains the index of the
+    # sigma that produced the maximum intensity value, into the sigma
+    sigmas_of_peaks = sigma_list[local_maxima[:, -1]]
+
+    # if the gaussian is isotropic, the stdev across dimensions are
+    # identical, so return only the stdev deviation of the first dimension
+    if np.unique(min_sigma).shape == (1,) and np.unique(max_sigma).shape == (1,):
+        sigmas_of_peaks = sigmas_of_peaks[:, 0][:, None]
+
+    # Remove sigma index and replace with sigmas
+    lm = np.hstack([lm[:, :-1], sigmas_of_peaks])
+
     return _prune_blobs(lm, overlap)
 
 

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -179,7 +179,7 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
         Input grayscale image, blobs are assumed to be light on dark
         background (white on black).
     min_sigma : scalar or sequence of scalars, optional
-        the minimum standard deviation for Gaussian kernel. Keep this low to
+        The minimum standard deviation for Gaussian kernel. Keep this low to
         detect smaller blobs. The standard deviations of the Gaussian filter
         are given for each axis as a sequence, or as a single number, in
         which case it is equal for all axes.

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -166,7 +166,7 @@ def _prune_blobs(blobs_array, overlap):
 
 
 def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
-             overlap=.5, exclude_border=False):
+             overlap=.5, *, exclude_border=False):
     r"""Finds blobs in the given grayscale image.
 
     Blobs are found using the Difference of Gaussian (DoG) method [1]_.

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -255,9 +255,7 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
     image = img_as_float(image)
 
     # if both min and max sigma are scalar, function returns only one sigma
-    scalar_sigma = (
-        True if np.isscalar(max_sigma) and np.isscalar(min_sigma) else False
-    )
+    scalar_sigma = np.isscalar(max_sigma) and np.isscalar(min_sigma)
 
     # Gaussian filter requires that sequence-type sigmas have same
     # dimensionality as image. This broadcasts scalar kernels
@@ -302,10 +300,9 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
     # sigma that produced the maximum intensity value, into the sigma
     sigmas_of_peaks = sigma_list[local_maxima[:, -1]]
 
-    # if the gaussian is isotropic, the stdev across dimensions are
-    # identical, so return only the stdev deviation of the first dimension
     if scalar_sigma:
-        sigmas_of_peaks = sigmas_of_peaks[:, 0][:, None]
+        # select one sigma column, keeping dimension
+        sigmas_of_peaks = sigmas_of_peaks[:, 0:1]
 
     # Remove sigma index and replace with sigmas
     lm = np.hstack([lm[:, :-1], sigmas_of_peaks])
@@ -449,10 +446,9 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
     # sigma that produced the maximum intensity value, into the sigma
     sigmas_of_peaks = sigma_list[local_maxima[:, -1]]
 
-    # if the gaussian is isotropic, the stdev across dimensions are
-    # identical, so return only the stdev deviation of the first dimension
     if scalar_sigma:
-        sigmas_of_peaks = sigmas_of_peaks[:, 0][:, None]
+        # select one sigma column, keeping dimension
+        sigmas_of_peaks = sigmas_of_peaks[:, 0:1]
 
     # Remove sigma index and replace with sigmas
     lm = np.hstack([lm[:, :-1], sigmas_of_peaks])

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -254,16 +254,21 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
     """
     image = img_as_float(image)
 
+    # if both min and max sigma are scalar, function returns only one sigma
+    scalar_sigma = (
+        True if np.isscalar(max_sigma) and np.isscalar(min_sigma) else False
+    )
+
     # Gaussian filter requires that sequence-type sigmas have same
     # dimensionality as image. This broadcasts scalar kernels
-    if isinstance(max_sigma, (int, float)):
+    if np.isscalar(max_sigma):
         max_sigma = np.full(image.ndim, max_sigma, dtype=float)
-    if isinstance(min_sigma, (int, float)):
+    if np.isscalar(min_sigma):
         min_sigma = np.full(image.ndim, min_sigma, dtype=float)
 
     # Convert sequence types to array
     min_sigma = np.asarray(min_sigma, dtype=float)
-    max_sigma = np.asarray(max_sigma, dtype=np.float)
+    max_sigma = np.asarray(max_sigma, dtype=float)
 
     # k such that min_sigma*(sigma_ratio**k) > max_sigma
     k = int(np.mean(np.log(max_sigma / min_sigma) / np.log(sigma_ratio) + 1))
@@ -299,7 +304,7 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
 
     # if the gaussian is isotropic, the stdev across dimensions are
     # identical, so return only the stdev deviation of the first dimension
-    if np.unique(min_sigma).shape == (1,) and np.unique(max_sigma).shape == (1,):
+    if scalar_sigma:
         sigmas_of_peaks = sigmas_of_peaks[:, 0][:, None]
 
     # Remove sigma index and replace with sigmas
@@ -396,16 +401,21 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
     """
     image = img_as_float(image)
 
+    # if both min and max sigma are scalar, function returns only one sigma
+    scalar_sigma = (
+        True if np.isscalar(max_sigma) and np.isscalar(min_sigma) else False
+    )
+
     # Gaussian filter requires that sequence-type sigmas have same
     # dimensionality as image. This broadcasts scalar kernels
-    if isinstance(max_sigma, (int, float)):
-        max_sigma = np.full(len(image.shape), max_sigma, dtype=np.float)
-    if isinstance(min_sigma, (int, float)):
-        min_sigma = np.full(len(image.shape), min_sigma, dtype=np.float)
+    if np.isscalar(max_sigma):
+        max_sigma = np.full(image.ndim, max_sigma, dtype=float)
+    if np.isscalar(min_sigma):
+        min_sigma = np.full(image.ndim, min_sigma, dtype=float)
 
     # Convert sequence types to array
-    min_sigma = np.asarray(min_sigma, dtype=np.float)
-    max_sigma = np.asarray(max_sigma, dtype=np.float)
+    min_sigma = np.asarray(min_sigma, dtype=float)
+    max_sigma = np.asarray(max_sigma, dtype=float)
 
     if log_scale:
         start, stop = np.log10(min_sigma)[:, None], np.log10(max_sigma)[:, None]
@@ -441,7 +451,7 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
 
     # if the gaussian is isotropic, the stdev across dimensions are
     # identical, so return only the stdev deviation of the first dimension
-    if np.unique(min_sigma).shape == (1,) and np.unique(max_sigma).shape == (1,):
+    if scalar_sigma:
         sigmas_of_peaks = sigmas_of_peaks[:, 0][:, None]
 
     # Remove sigma index and replace with sigmas

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -262,7 +262,7 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
         min_sigma = np.full(image.ndim, min_sigma, dtype=float)
 
     # Convert sequence types to array
-    min_sigma = np.asarray(min_sigma, dtype=np.float)
+    min_sigma = np.asarray(min_sigma, dtype=float)
     max_sigma = np.asarray(max_sigma, dtype=np.float)
 
     # k such that min_sigma*(sigma_ratio**k) > max_sigma

--- a/skimage/feature/tests/test_blob.py
+++ b/skimage/feature/tests/test_blob.py
@@ -55,11 +55,34 @@ def test_blob_dog():
                           sigma_ratio=1.2, threshold=0.1)
     b = blobs[0]
 
+    assert b.shape == (4,)
     assert b[0] == r + pad + 1
     assert b[1] == r + pad + 1
     assert b[2] == r + pad + 1
     assert abs(math.sqrt(3) * b[3] - r) < 1
 
+    # Testing 3D anisotropic
+    r = 10
+    pad = 10
+    im3 = ellipsoid(r / 2, r, r)
+    im3 = util.pad(im3, pad, mode='constant')
+
+    blobs = blob_dog(
+        im3,
+        min_sigma=[1.5, 3, 3],
+        max_sigma=[5, 10, 10],
+        sigma_ratio=1.2,
+        threshold=0.1
+    )
+    b = blobs[0]
+
+    assert b.shape == (6,)
+    assert b[0] == r / 2 + pad + 1
+    assert b[1] == r + pad + 1
+    assert b[2] == r + pad + 1
+    assert abs(math.sqrt(3) * b[3] - r / 2) < 1
+    assert abs(math.sqrt(3) * b[4] - r) < 1
+    assert abs(math.sqrt(3) * b[5] - r) < 1
 
 def test_blob_log():
     r2 = math.sqrt(2)
@@ -144,11 +167,32 @@ def test_blob_log():
     blobs = blob_log(im3, min_sigma=3, max_sigma=10)
     b = blobs[0]
 
+    assert b.shape == (4,)
     assert b[0] == r + pad + 1
     assert b[1] == r + pad + 1
     assert b[2] == r + pad + 1
     assert abs(math.sqrt(3) * b[3] - r) < 1
 
+    # Testing 3D anisotropic
+    r = 6
+    pad = 10
+    im3 = ellipsoid(r / 2, r, r)
+    im3 = util.pad(im3, pad, mode='constant')
+
+    blobs = blob_log(
+        im3,
+        min_sigma=[1, 2, 2],
+        max_sigma=[5, 10, 10],
+    )
+
+    b = blobs[0]
+    assert b.shape == (6,)
+    assert b[0] == r / 2 + pad + 1
+    assert b[1] == r + pad + 1
+    assert b[2] == r + pad + 1
+    assert abs(math.sqrt(3) * b[3] - r / 2) < 1
+    assert abs(math.sqrt(3) * b[4] - r) < 1
+    assert abs(math.sqrt(3) * b[5] - r) < 1
 
 def test_blob_doh():
     img = np.ones((512, 512), dtype=np.uint8)

--- a/skimage/feature/tests/test_blob.py
+++ b/skimage/feature/tests/test_blob.py
@@ -84,6 +84,34 @@ def test_blob_dog():
     assert abs(math.sqrt(3) * b[4] - r) < 1
     assert abs(math.sqrt(3) * b[5] - r) < 1
 
+    # Testing exclude border
+
+    # image where blob is 5 px from borders, radius 5
+    img = np.ones((512, 512))
+    xs, ys = circle(5, 5, 5)
+    img[xs, ys] = 255
+
+    blobs = blob_dog(
+        img,
+        min_sigma=1.5,
+        max_sigma=5,
+        sigma_ratio=1.2,
+    )
+    assert blobs.shape[0] == 1
+    b = blobs[0]
+    assert b[0] == b[1] == 5, "blob should be 5 px from x and y borders"
+
+    blobs = blob_dog(
+        img,
+        min_sigma=1.5,
+        max_sigma=5,
+        sigma_ratio=1.2,
+        exclude_border=5
+    )
+    msg = "zero blobs should be detected, as only blob is 5 px from border"
+    assert blobs.shape[0] == 0, msg
+
+
 def test_blob_log():
     r2 = math.sqrt(2)
     img = np.ones((256, 256))
@@ -193,6 +221,32 @@ def test_blob_log():
     assert abs(math.sqrt(3) * b[3] - r / 2) < 1
     assert abs(math.sqrt(3) * b[4] - r) < 1
     assert abs(math.sqrt(3) * b[5] - r) < 1
+
+    # Testing exclude border
+
+    # image where blob is 5 px from borders, radius 5
+    img = np.ones((512, 512))
+    xs, ys = circle(5, 5, 5)
+    img[xs, ys] = 255
+
+    blobs = blob_log(
+        img,
+        min_sigma=1.5,
+        max_sigma=5,
+    )
+    assert blobs.shape[0] == 1
+    b = blobs[0]
+    assert b[0] == b[1] == 5, "blob should be 5 px from x and y borders"
+
+    blobs = blob_dog(
+        img,
+        min_sigma=1.5,
+        max_sigma=5,
+        exclude_border=5
+    )
+    msg = "zero blobs should be detected, as only blob is 5 px from border"
+    assert blobs.shape[0] == 0, msg
+
 
 def test_blob_doh():
     img = np.ones((512, 512), dtype=np.uint8)


### PR DESCRIPTION
## Add support for anisotropic blob detection in blob_log and blob_dog

This PR enables a user to submit an anisotropic gaussian kernel to blob_log or blob_dog. 

During testing on real data, I noticed that the exclude_border functionality of peak_local_max is hard coded to "off", however in my data I see significant border effects within ~ 1 sigma of the image border. I've added that parameter to the `blob_log` and `blob_dog` methods with the default set to the existing functionality (no exclusion). 

I don't believe there are existing benchmarks for spot finding, but changing the kernel width should not affect the performance in any way, as gaussian convolution is implemented as a series of linear convolutions, and there is no performance gain from subsequent kernels having the same width.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests

## References
closes issue #3680 

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
