### PR TITLE
Numerous backports to 0.14.x to avoid warnings in tests and python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ addons:
     - texlive-latex-extra
     - dvipng
     - python-qt4
-services:
-  - xvfb
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,12 +92,7 @@ install:
     # Install testing requirements
     - pip install --retries 3 -q $PIP_FLAGS -r requirements/test.txt
     # Matplotlib settings - do not show figures during doc examples
-    - |
-      if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-        export MPL_DIR=${HOME}/.matplotlib
-      else
-        export MPL_DIR=${HOME}/.config/matplotlib
-      fi
+    - export MPL_DIR=`python -c 'import matplotlib; print(matplotlib.get_configdir())'`
     - mkdir -p ${MPL_DIR}
     - touch ${MPL_DIR}/matplotlibrc
     # Install most of the optional packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,8 @@ matrix:
       dist: xenial # Required for Python 3.7
       sudo: true   # travis-ci/travis-ci#9069
       env: QT=PyQt5 WITH_PYAMG=1 OPTIONAL_DEPS=1 BUILD_DOCS=1
+      services:
+        - xvfb
     - os: linux
       python: 3.6
       env: QT=PyQt5 WITH_PYAMG=1 OPTIONAL_DEPS=1 PIP_FLAGS="--pre"
@@ -70,10 +72,6 @@ matrix:
       osx_image: xcode9
       language: objective-c
       env: TRAVIS_PYTHON_VERSION=3.7
-  allow_failures:
-    # python 3.7 is failing and it is out of our control for now.
-    # remove when scikit-image tests actually start running.
-    - python: 3.7
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,10 @@ matrix:
       osx_image: xcode9
       language: objective-c
       env: TRAVIS_PYTHON_VERSION=3.7
+  allow_failures:
+    # python 3.7 is failing and it is out of our control for now.
+    # remove when scikit-image tests actually start running.
+    - python: 3.7
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -27,3 +27,8 @@ $ pip install -U -r requirements/default.txt
 $ pip install -U -r requirements/default.txt
 $ pip install -U -r requirements/test.txt
 ```
+
+## Blacklist justification
+
+  * cython 0.28.2 was empircally found to fail tests.
+  * cython 0.29.0 eroneously sets the the `__path__` to `none`. See https://github.com/cython/cython/issues/2662

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -30,5 +30,5 @@ $ pip install -U -r requirements/test.txt
 
 ## Blacklist justification
 
-  * cython 0.28.2 was empircally found to fail tests.
-  * cython 0.29.0 eroneously sets the the `__path__` to `none`. See https://github.com/cython/cython/issues/2662
+  * Cython 0.28.2 was empirically found to fail tests.
+  * Cython 0.29.0 erroneously sets the `__path__` to `None`. See https://github.com/cython/cython/issues/2662

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,4 +1,4 @@
-Cython>=0.23.4,<0.28.2
+Cython>=0.23.4,!=0.28.2,!=0.29.0
 wheel
 numpy>=1.11
 requirements-parser

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -2,3 +2,6 @@ sphinx>=1.3
 numpydoc>=0.6
 sphinx-gallery
 scikit-learn
+dask[array]>=1.0.0
+# cloudpickle is necessary to provide the 'processes' scheduler for dask
+cloudpickle>=0.2.1

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -2,6 +2,11 @@ sphinx>=1.3
 numpydoc>=0.6
 sphinx-gallery
 scikit-learn
-dask[array]>=1.0.0
+dask[array]>=1.0.0; python_version >= '3.5'
+dask[array]>=1.0.0; python_version == '2.7'
+# Dask 1.0 is only required for better numpy 1.16 compatibility.
+# That said, numpy 1.16 isn't released on pypi for Python 3.4
+# And we still support 3.4 on the LTS branch
+dask[array]>=0.9.0; python_version == '3.4'
 # cloudpickle is necessary to provide the 'processes' scheduler for dask
 cloudpickle>=0.2.1

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,4 +1,3 @@
-dask[array]>=1.0.0
 PySide; python_version <= '3.4'
 imread
 SimpleITK; python_version < '3.7'
@@ -6,3 +5,6 @@ astropy
 tifffile
 imageio
 qtpy
+dask[array]>=1.0.0
+# cloudpickle is necessary to provide the 'processes' scheduler for dask
+cloudpickle>=0.2.1

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,10 +1,15 @@
 PySide; python_version <= '3.4'
 imread
-SimpleITK; python_version < '3.7'
+SimpleITK
 astropy
 tifffile
 imageio
 qtpy
-dask[array]>=1.0.0
+dask[array]>=1.0.0; python_version >= '3.5'
+dask[array]>=1.0.0; python_version == '2.7'
+# Dask 1.0 is only required for better numpy 1.16 compatibility.
+# That said, numpy 1.16 isn't released on pypi for Python 3.4
+# And we still support 3.4
+dask[array]>=0.9.0; python_version == '3.4'
 # cloudpickle is necessary to provide the 'processes' scheduler for dask
 cloudpickle>=0.2.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,3 +2,4 @@ pytest
 pytest-cov
 flake8
 codecov
+pytest-faulthandler

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -13,6 +13,7 @@ from skimage._shared import testing
 from skimage._shared.testing import (assert_array_equal,
                                      assert_array_almost_equal,
                                      assert_almost_equal)
+from skimage._shared.testing import xfail
 
 
 # Test integer histograms
@@ -191,6 +192,8 @@ def test_rescale_uint14_limits():
 # Test adaptive histogram equalization
 # ====================================
 
+@xfail(reason='This raises a divide by 0 error sometimes. '
+              'See: https://github.com/scikit-image/scikit-image/issues/3684')
 def test_adapthist_grayscale():
     """Test a grayscale float image
     """
@@ -205,6 +208,8 @@ def test_adapthist_grayscale():
     assert_almost_equal(norm_brightness_err(img, adapted), 0.0529, 3)
 
 
+@xfail(reason='This raises a divide by 0 error sometimes. '
+              'See: https://github.com/scikit-image/scikit-image/issues/3684')
 def test_adapthist_color():
     """Test an RGB color uint16 image
     """
@@ -225,6 +230,8 @@ def test_adapthist_color():
     return data, adapted
 
 
+@xfail(reason='This raises a divide by 0 error sometimes. '
+              'See: https://github.com/scikit-image/scikit-image/issues/3684')
 def test_adapthist_alpha():
     """Test an RGBA color image
     """

--- a/skimage/external/tifffile/tifffile.py
+++ b/skimage/external/tifffile/tifffile.py
@@ -72,6 +72,10 @@ Revisions
 ---------
 2018.10.08
     No longer use numpy.fromstring just use numpy.frombuffer.
+    Note that this has been fixed upstream in 2018.02.18.
+    Unfortunately, upstream code claims to depend on Numpy 1.14.
+    To not bump the minimum version requirements of scikit-image,
+    this targetted fix was added to the vendored version.
 2017.01.12
     Read Zeiss SEM metadata.
     Read OME-TIFF with invalid references to external files.

--- a/skimage/external/tifffile/tifffile.py
+++ b/skimage/external/tifffile/tifffile.py
@@ -70,6 +70,8 @@ Requirements
 
 Revisions
 ---------
+2018.10.08
+    No longer use numpy.fromstring just use numpy.frombuffer.
 2017.01.12
     Read Zeiss SEM metadata.
     Read OME-TIFF with invalid references to external files.
@@ -2540,13 +2542,13 @@ class TiffPage(object):
                         # needs the raw byte order
                         typecode = dtype
                     try:
-                        return numpy.fromstring(x, typecode)
+                        return numpy.frombuffer(x, typecode)
                     except ValueError as e:
                         # strips may be missing EOI
                         warnings.warn("unpack: %s" % e)
                         xlen = ((len(x) // (bits_per_sample // 8)) *
                                 (bits_per_sample // 8))
-                        return numpy.fromstring(x[:xlen], typecode)
+                        return numpy.frombuffer(x[:xlen], typecode)
 
             elif isinstance(bits_per_sample, tuple):
                 def unpack(x):
@@ -3601,7 +3603,7 @@ class FileHandle(object):
                             offset=self._offset + offset,
                             shape=shape, order=order)
 
-    def read_array(self, dtype, count=-1, sep=""):
+    def read_array(self, dtype, count=-1):
         """Return numpy array from file.
 
         Work around numpy issue #2230, "numpy.fromfile does not accept
@@ -3609,14 +3611,14 @@ class FileHandle(object):
 
         """
         try:
-            return numpy.fromfile(self._fh, dtype, count, sep)
+            return numpy.fromfile(self._fh, dtype, count)
         except IOError:
             if count < 0:
                 size = self._size
             else:
                 size = count * numpy.dtype(dtype).itemsize
             data = self._fh.read(size)
-            return numpy.fromstring(data, dtype, count, sep)
+            return numpy.frombuffer(data, dtype, count)
 
     def read_record(self, dtype, shape=1, byteorder=None):
         """Return numpy record from file."""
@@ -4144,7 +4146,7 @@ def imagej_metadata(data, bytecounts, byteorder):
 
     def read_bytes(data, byteorder):
         #return struct.unpack('b' * len(data), data)
-        return numpy.fromstring(data, 'uint8')
+        return numpy.frombuffer(data, 'uint8')
 
     metadata_types = {  # big endian
         b'info': ('info', read_string),
@@ -4535,7 +4537,7 @@ def unpack_ints(data, dtype, itemsize, runlen=0):
 
     """
     if itemsize == 1:  # bitarray
-        data = numpy.fromstring(data, '|B')
+        data = numpy.frombuffer(data, '|B')
         data = numpy.unpackbits(data)
         if runlen % 8:
             data = data.reshape(-1, runlen + (8 - runlen % 8))
@@ -4544,7 +4546,7 @@ def unpack_ints(data, dtype, itemsize, runlen=0):
 
     dtype = numpy.dtype(dtype)
     if itemsize in (8, 16, 32, 64):
-        return numpy.fromstring(data, dtype)
+        return numpy.frombuffer(data, dtype)
     if itemsize < 1 or itemsize > 32:
         raise ValueError("itemsize out of range: %i" % itemsize)
     if dtype.kind not in "biu":
@@ -4620,7 +4622,7 @@ def unpack_rgb(data, dtype='<B', bitspersample=(5, 6, 5), rescale=True):
     if not (bits <= 32 and all(i <= dtype.itemsize*8 for i in bitspersample)):
         raise ValueError("sample size not supported %s" % str(bitspersample))
     dt = next(i for i in 'BHI' if numpy.dtype(i).itemsize*8 >= bits)
-    data = numpy.fromstring(data, dtype.byteorder+dt)
+    data = numpy.frombuffer(data, dtype.byteorder+dt)
     result = numpy.empty((data.size, len(bitspersample)), dtype.char)
     for i, bps in enumerate(bitspersample):
         t = data >> int(numpy.sum(bitspersample[i+1:]))
@@ -4664,7 +4666,7 @@ def reverse_bitorder(data):
         b'\xef\x1f\x9f_\xdf?\xbf\x7f\xff')
     try:
         view = data.view('uint8')
-        numpy.take(numpy.fromstring(table, dtype='uint8'), view, out=view)
+        numpy.take(numpy.frombuffer(table, dtype='uint8'), view, out=view)
     except AttributeError:
         return data.translate(table)
     except ValueError:

--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -65,8 +65,8 @@ def _glcm_loop(any_int[:, ::1] image, double[:] distances,
                         i = image[r, c]
 
                         # compute the location of the offset pixel
-                        row = r + <int>round(sin(angle) * distance)
-                        col = c + <int>round(cos(angle) * distance)
+                        row = r + round(sin(angle) * distance)
+                        col = c + round(cos(angle) * distance)
 
                         # make sure the offset is within bounds
                         if row >= 0 and row < rows and \

--- a/skimage/feature/match.py
+++ b/skimage/feature/match.py
@@ -16,23 +16,23 @@ def match_descriptors(descriptors1, descriptors2, metric=None, p=2,
         Binary descriptors of size P about M keypoints in the first image.
     descriptors2 : (N, P) array
         Binary descriptors of size P about N keypoints in the second image.
-    metric : {'euclidean', 'cityblock', 'minkowski', 'hamming', ...}
+    metric : {'euclidean', 'cityblock', 'minkowski', 'hamming', ...} , optional
         The metric to compute the distance between two descriptors. See
         `scipy.spatial.distance.cdist` for all possible types. The hamming
         distance should be used for binary descriptors. By default the L2-norm
         is used for all descriptors of dtype float or double and the Hamming
         distance is used for binary descriptors automatically.
-    p : int
+    p : int, optional
         The p-norm to apply for ``metric='minkowski'``.
-    max_distance : float
+    max_distance : float, optional
         Maximum allowed distance between descriptors of two keypoints
         in separate images to be regarded as a match.
-    cross_check : bool
+    cross_check : bool, optional
         If True, the matched keypoints are returned after cross checking i.e. a
         matched pair (keypoint1, keypoint2) is returned if keypoint2 is the
         best match for keypoint1 in second image and keypoint1 is the best
         match for keypoint2 in first image.
-    max_ratio : float
+    max_ratio : float, optional
         Maximum ratio of distances between first and second closest descriptor
         in the second set of descriptors. This threshold is useful to filter
         ambiguous matches between the two descriptor sets. The choice of this
@@ -59,7 +59,12 @@ def match_descriptors(descriptors1, descriptors2, metric=None, p=2,
         else:
             metric = 'euclidean'
 
-    distances = cdist(descriptors1, descriptors2, metric=metric, p=p)
+    kwargs = {}
+    # Scipy raises an error if p is passed as an extra argument when it isn't
+    # necessary for the chosen metric.
+    if metric == 'minkowski':
+        kwargs['p'] = p
+    distances = cdist(descriptors1, descriptors2, metric=metric, **kwargs)
 
     indices1 = np.arange(descriptors1.shape[0])
     indices2 = np.argmin(distances, axis=1)

--- a/skimage/feature/tests/test_peak.py
+++ b/skimage/feature/tests/test_peak.py
@@ -13,7 +13,7 @@ class TestPeakLocalMax():
         trivial = np.zeros((25, 25))
         peak_indices = peak.peak_local_max(trivial, min_distance=1, indices=True)
         assert type(peak_indices) is np.ndarray
-        assert not peak_indices     # inherent boolean-ness of empty list
+        assert peak_indices.size == 0
         peaks = peak.peak_local_max(trivial, min_distance=1, indices=False)
         assert (peaks.astype(np.bool) == trivial).all()
 

--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -1,4 +1,7 @@
-import collections.abc as coll
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 import numpy as np
 from scipy import ndimage as ndi
 
@@ -111,7 +114,7 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
         raise ValueError("Sigma values less than zero are not valid")
     if multichannel:
         # do not filter across channels
-        if not isinstance(sigma, coll.Iterable):
+        if not isinstance(sigma, Iterable):
             sigma = [sigma] * (image.ndim - 1)
         if len(sigma) != image.ndim:
             sigma = np.concatenate((np.asarray(sigma), [0]))

--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -1,4 +1,4 @@
-import collections as coll
+import collections.abc as coll
 import numpy as np
 from scipy import ndimage as ndi
 

--- a/skimage/graph/heap.pyx
+++ b/skimage/graph/heap.pyx
@@ -107,6 +107,7 @@ cdef class BinaryHeap:
     references, this implementation will probably be slower. If you need
     references (and maybe cross references to be kept up to date) this
     implementation will be faster.
+
     """
 
     ## Basic methods
@@ -127,6 +128,7 @@ cdef class BinaryHeap:
     #
     # To calculate the capacity at a certain level:
     # 2**l
+
     def __cinit__(self, INDEX_T initial_capacity=128, *args, **kws):
         # calc levels from the default capacity
         cdef LEVELS_T levels = 0
@@ -140,7 +142,7 @@ cdef class BinaryHeap:
 
         # allocate arrays
         cdef INDEX_T number = 2**self.levels
-        self._values = <VALUE_T *>malloc( 2*number * sizeof(VALUE_T))
+        self._values = <VALUE_T *>malloc(2 * number * sizeof(VALUE_T))
         self._references = <REFERENCE_T *>malloc(number * sizeof(REFERENCE_T))
 
     def __init__(self, INDEX_T initial_capacity=128):
@@ -150,42 +152,40 @@ cdef class BinaryHeap:
 
         Takes an optional parameter 'initial_capacity' so that
         if the required heap capacity is known or can be estimated in advance,
-        there will need to be fewer resize operations on the heap."""
+        there will need to be fewer resize operations on the heap.
+
+        """
         if self._values is NULL or self._references is NULL:
-          raise MemoryError()
+            raise MemoryError()
         self.reset()
 
     def reset(self):
         """reset()
 
         Reset the heap to default, empty state.
+
         """
         cdef INDEX_T number = 2**self.levels
         cdef INDEX_T i
         cdef VALUE_T *values = self._values
-        for i in range(number*2):
+        for i in range(number * 2):
             values[i] = inf
 
-
     def __dealloc__(self):
-        if self._values is not NULL:
-            free(self._values)
-        if self._references is not NULL:
-            free(self._references)
+        free(self._values)
+        free(self._references)
 
     def __str__(self):
         s = ''
-        for level in range(1,self.levels+1):
-            i0 = 2**level-1 # LevelStart
-            s+= 'level %i: ' % level
-            for i in range(i0,i0+2**level):
+        for level in range(1, self.levels + 1):
+            i0 = 2**level - 1  # LevelStart
+            s += 'level %i: ' % level
+            for i in range(i0, i0 + 2**level):
                 s += '%g, ' % self._values[i]
             s = s[:-1] + '\n'
         return s
 
-
-    ## C Maintanance methods
-
+    ## C Maintenance methods
     cdef void _add_or_remove_level(self, LEVELS_T add_or_remove) nogil:
         # init indexing ints
         cdef INDEX_T i, i1, i2, n
@@ -197,11 +197,15 @@ cdef class BinaryHeap:
         cdef INDEX_T number = 2**new_levels
         cdef VALUE_T *values
         cdef REFERENCE_T *references
-        values = <VALUE_T *>malloc(number*2 * sizeof(VALUE_T))
+        values = <VALUE_T *>malloc(number * 2 * sizeof(VALUE_T))
         references = <REFERENCE_T *>malloc(number * sizeof(REFERENCE_T))
+        if values is NULL or references is NULL:
+            free(values)
+            free(references)
+            raise MemoryError()
 
         # init arrays
-        for i in range(number*2):
+        for i in range(number * 2):
             values[i] = inf
         for i in range(number):
             references[i] = -1
@@ -210,8 +214,8 @@ cdef class BinaryHeap:
         cdef VALUE_T *old_values = self._values
         cdef REFERENCE_T *old_references = self._references
         if self.count:
-            i1 = 2**new_levels-1 # LevelStart
-            i2 = 2**self.levels-1 # LevelStart
+            i1 = 2**new_levels - 1  # LevelStart
+            i2 = 2**self.levels - 1  # LevelStart
             n = index_min(2**new_levels, 2**self.levels)
             for i in range(n):
                 values[i1+i] = old_values[i2+i]
@@ -228,11 +232,12 @@ cdef class BinaryHeap:
         self.levels = new_levels
         self._update()
 
-
     cdef void _update(self) nogil:
         """Update the full tree from the bottom up.
-        This should be done after resizing. """
 
+        This should be done after resizing.
+
+        """
         # shorter name for values
         cdef VALUE_T *values = self._values
 
@@ -241,32 +246,30 @@ cdef class BinaryHeap:
         cdef LEVELS_T level
 
         # track tree
-        for level in range(self.levels,1,-1):
-            i0 = (1 << level) - 1 #2**level-1 = LevelStart
-            n = i0 + 1 #2**level
-            for i in range(i0,i0+n,2):
-                ii = (i-1)//2 # CalcPrevAbs
+        for level in range(self.levels, 1, -1):
+            i0 = (1 << level) - 1  # 2**level-1 = LevelStart
+            n = i0 + 1  # 2**level
+            for i in range(i0, i0+n, 2):
+                ii = (i-1) // 2  # CalcPrevAbs
                 if values[i] < values[i+1]:
                     values[ii] = values[i]
                 else:
                     values[ii] = values[i+1]
 
-
     cdef void _update_one(self, INDEX_T i) nogil:
         """Update the tree for one value."""
-
         # shorter name for values
         cdef VALUE_T *values = self._values
 
         # make index uneven
-        if i % 2==0:
-            i = i-1
+        if i % 2 == 0:
+            i -= 1
 
         # track tree
         cdef INDEX_T ii
         cdef LEVELS_T level
-        for level in range(self.levels,1,-1):
-            ii = (i-1)//2 # CalcPrevAbs
+        for level in range(self.levels, 1, -1):
+            ii = (i-1) // 2  # CalcPrevAbs
 
             # test
             if values[i] < values[i+1]:
@@ -277,16 +280,14 @@ cdef class BinaryHeap:
             if ii % 2:
                 i = ii
             else:
-                i = ii-1
-
+                i = ii - 1
 
     cdef void _remove(self, INDEX_T i1) nogil:
         """Remove a value from the heap. By index."""
-
         cdef LEVELS_T levels = self.levels
         cdef INDEX_T count = self.count
         # get indices
-        cdef INDEX_T i0 = (1 << levels) - 1  #2**self.levels - 1 # LevelStart
+        cdef INDEX_T i0 = (1 << levels) - 1  # 2**self.levels - 1 # LevelStart
         cdef INDEX_T i2 = i0 + count - 1
 
         # get relative indices
@@ -306,28 +307,29 @@ cdef class BinaryHeap:
         # update
         self.count -= 1
         count -= 1
-        if (levels>self.min_levels) & (count < (1 << (levels-2))):
+        if (levels > self.min_levels) and (count < (1 << (levels-2))):
             self._add_or_remove_level(-1)
         else:
             self._update_one(i1)
             self._update_one(i2)
-
 
     ## C Public methods
 
     cdef INDEX_T push_fast(self, VALUE_T value, REFERENCE_T reference) nogil:
         """The c-method for fast pushing.
 
-        Returns the index relative to the start of the last level in the heap."""
+        Returns the index relative to the start of the last level in the heap.
+
+        """
         # We need to resize if currently it just fits.
         cdef LEVELS_T levels = self.levels
         cdef INDEX_T count = self.count
-        if count >= (1 << levels):#2**self.levels:
-            self._add_or_remove_level(+1)
+        if count >= (1 << levels):  # 2**self.levels:
+            self._add_or_remove_level(1)
             levels += 1
 
         # insert new value
-        cdef INDEX_T i = ((1 << levels) - 1) + count # LevelStart + n
+        cdef INDEX_T i = ((1 << levels) - 1) + count  # LevelStart + n
         self._values[i] = value
         self._references[count] = reference
 
@@ -338,12 +340,12 @@ cdef class BinaryHeap:
         # return
         return count
 
-
     cdef VALUE_T pop_fast(self) nogil:
         """The c-method for fast popping.
 
-        Returns the minimum value. The reference is put in self._popped_ref"""
+        Returns the minimum value. The reference is put in self._popped_ref.
 
+        """
         # shorter name for values
         cdef VALUE_T *values = self._values
 
@@ -354,18 +356,19 @@ cdef class BinaryHeap:
         # search tree (using absolute indices)
         for level in range(1, levels):
             if values[i] <= values[i+1]:
-                i = i*2+1 # CalcNextAbs
+                i = i * 2 + 1  # CalcNextAbs
             else:
-                i = (i+1)*2+1 # CalcNextAbs
+                i = (i+1) * 2 + 1  # CalcNextAbs
 
         # select best one in last level
         if values[i] <= values[i+1]:
             i = i
         else:
-            i = i+1
+            i += 1
 
         # get values
-        cdef INDEX_T ir = i - ((1 << levels) - 1) #(2**self.levels-1) # LevelStart
+        cdef INDEX_T ir = i - ((1 << levels) - 1) # (2**self.levels-1)
+                                                  # LevelStart
         cdef VALUE_T value = values[i]
         self._popped_ref = self._references[ir]
 
@@ -375,7 +378,6 @@ cdef class BinaryHeap:
 
         # return
         return value
-
 
     ## Python Public methods (that do not need to be VERY fast)
 
@@ -390,9 +392,9 @@ cdef class BinaryHeap:
             Value to push onto the heap
         reference : int, optional
             Reference to associate with the given value.
+
         """
         self.push_fast(value, reference)
-
 
     def min_val(self):
         """min_val()
@@ -400,6 +402,7 @@ cdef class BinaryHeap:
         Get the minimum value on the heap.
 
         Returns only the value, and does not remove it from the heap.
+
         """
         # shorter name for values
         cdef VALUE_T *values = self._values
@@ -410,31 +413,22 @@ cdef class BinaryHeap:
         else:
             return values[2]
 
-
     def values(self):
         """values()
 
         Get the values in the heap as a list.
-        """
-        out = []
-        cdef INDEX_T i, i0
-        i0 = 2**self.levels-1  # LevelStart
-        for i in range(self.count):
-            out.append(self._values[i0+i])
-        return out
 
+        """
+        cdef INDEX_T i0 = 2**self.levels - 1  # LevelStart
+        return [self._values[i] for i in range(i0, i0+self.count)]
 
     def references(self):
         """references()
 
         Get the references in the heap as a list.
-        """
-        out = []
-        cdef INDEX_T i
-        for i in range(self.count):
-            out.append(self._references[i])
-        return out
 
+        """
+        return [self._references[i] for i in range(self.count)]
 
     def pop(self):
         """pop()
@@ -451,13 +445,13 @@ cdef class BinaryHeap:
         ------
         IndexError
             On attempt to pop from an empty heap
+
         """
         if self.count == 0:
-          raise IndexError('pop from an empty heap')
+            raise IndexError('pop from an empty heap')
         value = self.pop_fast()
         ref = self._popped_ref
         return value, ref
-
 
 
 cdef class FastUpdateBinaryHeap(BinaryHeap):
@@ -511,46 +505,49 @@ cdef class FastUpdateBinaryHeap(BinaryHeap):
     the given reference is not in the heap, or if it is and the provided value
     is lower than the current value in the heap. This is again useful for
     pathfinding algorithms.
+
     """
+
     def __cinit__(self, INDEX_T initial_capacity=128, max_reference=None):
-      if max_reference is None:
-        max_reference = initial_capacity - 1
-      self.max_reference = max_reference
-      self._crossref = <INDEX_T *>malloc((self.max_reference+1) * \
-                                      sizeof(INDEX_T))
+        if max_reference is None:
+            max_reference = initial_capacity - 1
+        self.max_reference = max_reference
+        self._crossref = <INDEX_T *>malloc((self.max_reference + 1) *
+                                           sizeof(INDEX_T))
 
     def __init__(self, INDEX_T initial_capacity=128, max_reference=None):
         """__init__(initial_capacity=128, max_reference=None)
 
         Class constructor.
+
         """
+        if self._crossref is NULL:
+            raise MemoryError()
         # below will call self.reset
         BinaryHeap.__init__(self, initial_capacity)
 
-
     def __dealloc__(self):
-        if self._crossref is not NULL:
-            free(self._crossref)
+        free(self._crossref)
 
     def reset(self):
         """reset()
 
         Reset the heap to default, empty state.
+
         """
         BinaryHeap.reset(self)
         # set default values of crossrefs
         cdef INDEX_T i
-        for i in range(self.max_reference+1):
+        for i in range(self.max_reference + 1):
             self._crossref[i] = -1
 
-
     cdef void _remove(self, INDEX_T i1) nogil:
-        """ Remove a value from the heap. By index. """
+        """Remove a value from the heap. By index."""
         cdef LEVELS_T levels = self.levels
         cdef INDEX_T count = self.count
 
         # get indices
-        cdef INDEX_T i0 = (1 << levels) - 1  #2**self.levels - 1 # LevelStart
+        cdef INDEX_T i0 = (1 << levels) - 1  # 2**self.levels - 1 # LevelStart
         cdef INDEX_T i2 = i0 + count - 1
 
         # get relative indices
@@ -562,8 +559,8 @@ cdef class FastUpdateBinaryHeap(BinaryHeap):
         cdef INDEX_T *crossref = self._crossref
 
         # update cross reference
-        crossref[references[r2]]=r1
-        crossref[references[r1]]=-1  # disable removed item
+        crossref[references[r2]] = r1
+        crossref[references[r1]] = -1  # disable removed item
 
         # swap with last
         values[i1] = values[i2]
@@ -581,7 +578,6 @@ cdef class FastUpdateBinaryHeap(BinaryHeap):
             self._update_one(i1)
             self._update_one(i2)
 
-
     cdef INDEX_T push_fast(self, VALUE_T value, REFERENCE_T reference) nogil:
         """The c method for fast pushing.
 
@@ -589,9 +585,11 @@ cdef class FastUpdateBinaryHeap(BinaryHeap):
         will append it.
 
         If -1 is returned, the provided reference was out-of-bounds and no
-        value was pushed to the heap."""
+        value was pushed to the heap.
+
+        """
         if not (0 <= reference <= self.max_reference):
-          return -1
+            return -1
 
         # init variable to store the index-in-the-heap
         cdef INDEX_T i
@@ -621,6 +619,7 @@ cdef class FastUpdateBinaryHeap(BinaryHeap):
 
         If -1 is returned, the provided reference was out-of-bounds and no
         value was pushed to the heap.
+
         """
         if not (0 <= reference <= self.max_reference):
             return -1
@@ -648,14 +647,15 @@ cdef class FastUpdateBinaryHeap(BinaryHeap):
         self._crossref[reference] = ir
         return ir
 
-
     cdef VALUE_T value_of_fast(self, REFERENCE_T reference):
-        """Return the value corresponding to the given reference. If inf
-        is returned, the reference may be invalid: check the _invaild_ref
-        field in this case."""
+        """Return the value corresponding to the given reference.
 
+        If inf is returned, the reference may be invalid: check the
+        _invaild_ref field in this case.
+
+        """
         if not (0 <= reference <= self.max_reference):
-            self.invalid_ref = 1
+            self._invalid_ref = 1
             return inf
 
         # init variable to store the index-in-the-heap
@@ -670,7 +670,6 @@ cdef class FastUpdateBinaryHeap(BinaryHeap):
             return inf
         i = (1 << self.levels) - 1 + ir
         return self._values[i]
-
 
     def push(self, double value, int reference):
         """push(value, reference)
@@ -689,9 +688,10 @@ cdef class FastUpdateBinaryHeap(BinaryHeap):
         ------
         ValueError
             On pushing a reference outside the range [0, max_reference].
+
         """
         if self.push_fast(value, reference) == -1:
-            raise ValueError("reference outside of range [0, max_reference]")
+            raise ValueError('reference outside of range [0, max_reference]')
 
     def push_if_lower(self, double value, int reference):
         """push_if_lower(value, reference)
@@ -719,9 +719,10 @@ cdef class FastUpdateBinaryHeap(BinaryHeap):
         ------
         ValueError
             On pushing a reference outside the range [0, max_reference].
+
         """
         if self.push_if_lower_fast(value, reference) == -1:
-          raise ValueError("reference outside of range [0, max_reference]")
+            raise ValueError('reference outside of range [0, max_reference]')
         return self._pushed == 1
 
     def value_of(self, int reference):
@@ -743,6 +744,7 @@ cdef class FastUpdateBinaryHeap(BinaryHeap):
         ValueError
             On querying a reference outside the range [0, max_reference], or
             not already pushed to the heap.
+
         """
         value = self.value_of_fast(reference)
         if self._invalid_ref:
@@ -751,8 +753,4 @@ cdef class FastUpdateBinaryHeap(BinaryHeap):
 
     def cross_references(self):
         """Get the cross references in the heap as a list."""
-        out = []
-        cdef INDEX_T i
-        for i in range(self.max_reference+1):
-            out.append( self._crossref[i] )
-        return out
+        return [self._crossref[i] for i in range(self.max_reference + 1)]

--- a/skimage/graph/heap.pyx
+++ b/skimage/graph/heap.pyx
@@ -202,7 +202,8 @@ cdef class BinaryHeap:
         if values is NULL or references is NULL:
             free(values)
             free(references)
-            raise MemoryError()
+            with gil:
+                raise MemoryError()
 
         # init arrays
         for i in range(number * 2):

--- a/skimage/graph/tests/test_heap.py
+++ b/skimage/graph/tests/test_heap.py
@@ -17,7 +17,7 @@ def _test_heap(n, fast_update):
     a = [random.uniform(1.0, 100.0) for i in range(n // 2)]
     a = a + a
 
-    t0 = time.clock()
+    t0 = time.perf_counter()
 
     # insert in heap with random removals
     if fast_update:
@@ -41,7 +41,7 @@ def _test_heap(n, fast_update):
         except IndexError:
             break
 
-    t1 = time.clock()
+    t1 = time.perf_counter()
 
     # verify
     for i in range(1, len(b)):

--- a/skimage/graph/tests/test_heap.py
+++ b/skimage/graph/tests/test_heap.py
@@ -5,6 +5,15 @@ import skimage.graph.heap as heap
 from skimage._shared.testing import test_parallel
 
 
+# Lower versions of python don't have perf_counter
+# Python 3.7 will issue a warning if clock is used as it was
+# considered deprecated in 3.3
+try:
+    from time import perf_counter
+except ImportError:
+    from time import clock as perf_counter
+
+
 @test_parallel()
 def test_heap():
     _test_heap(100000, True)
@@ -17,7 +26,7 @@ def _test_heap(n, fast_update):
     a = [random.uniform(1.0, 100.0) for i in range(n // 2)]
     a = a + a
 
-    t0 = time.perf_counter()
+    t0 = perf_counter()
 
     # insert in heap with random removals
     if fast_update:
@@ -41,7 +50,7 @@ def _test_heap(n, fast_update):
         except IndexError:
             break
 
-    t1 = time.perf_counter()
+    t1 = perf_counter()
 
     # verify
     for i in range(1, len(b)):

--- a/skimage/measure/mc_meta/visual_test.py
+++ b/skimage/measure/mc_meta/visual_test.py
@@ -53,11 +53,11 @@ elif SELECT == 4:
 
 # Get surface meshes
 t0 = time.time()
-vertices1, faces1, _ = marching_cubes_lewiner(vol, isovalue, gradient_direction=gradient_dir, use_classic=False)
+vertices1, faces1, _, _ = marching_cubes_lewiner(vol, isovalue, gradient_direction=gradient_dir, use_classic=False)
 print('finding surface lewiner took %1.0f ms' % (1000*(time.time()-t0)) )
 
 t0 = time.time()
-vertices2, faces2, _ = marching_cubes_classic(vol, isovalue, gradient_direction=gradient_dir)
+vertices2, faces2 = marching_cubes_classic(vol, isovalue, gradient_direction=gradient_dir)
 print('finding surface classic took %1.0f ms' % (1000*(time.time()-t0)) )
 
 # Show

--- a/skimage/measure/profile.py
+++ b/skimage/measure/profile.py
@@ -100,7 +100,7 @@ def _line_profile_coordinates(src, dst, linewidth=1):
     d_row, d_col = dst - src
     theta = np.arctan2(d_row, d_col)
 
-    length = np.ceil(np.hypot(d_row, d_col) + 1)
+    length = int(np.ceil(np.hypot(d_row, d_col) + 1))
     # we add one above because we include the last point in the profile
     # (in contrast to standard numpy indexing)
     line_col = np.linspace(src_col, dst_col, length)

--- a/skimage/measure/tests/test_marching_cubes.py
+++ b/skimage/measure/tests/test_marching_cubes.py
@@ -4,6 +4,7 @@ from skimage.measure import (marching_cubes_classic, marching_cubes_lewiner,
                              mesh_surface_area, correct_mesh_orientation)
 from skimage._shared import testing
 from skimage._shared.testing import assert_array_equal
+from skimage._shared._warnings import expected_warnings
 
 
 def test_marching_cubes_isotropic():
@@ -94,10 +95,11 @@ def test_correct_mesh_orientation():
                       [5, 4, 3]])
 
     # Correct mesh orientation - descent
-    corrected_faces1 = correct_mesh_orientation(sphere_small, verts, faces,
-                                                gradient_direction='descent')
-    corrected_faces2 = correct_mesh_orientation(sphere_small, verts, faces,
-                                                gradient_direction='ascent')
+    with expected_warnings(['`correct_mesh_orientation` is deprecated']):
+        corrected_faces1 = correct_mesh_orientation(
+            sphere_small, verts, faces, gradient_direction='descent')
+        corrected_faces2 = correct_mesh_orientation(
+            sphere_small, verts, faces, gradient_direction='ascent')
 
     # Ensure ascent is opposite of descent for all faces
     assert_array_equal(corrected_faces1, corrected_faces2[:, ::-1])

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -236,10 +236,10 @@ def _set_edge_values_inplace(image, value):
         sl = [slice(None)] * image.ndim
         # Set edge in front
         sl[axis] = 0
-        image[sl] = value
+        image[tuple(sl)] = value
         # Set edge to the end
         sl[axis] = -1
-        image[sl] = value
+        image[tuple(sl)] = value
 
 
 def _fast_pad(image, value):

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -625,7 +625,8 @@ def test_cycle_spinning_multichannel():
             assert_(compare_psnr(img, dn_cc) > compare_psnr(img, dn))
 
         for shift_steps in valid_steps:
-            with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
+            with expected_warnings([PYWAVELET_ND_INDEXING_WARNING,
+                                    DASK_NOT_FOUND_WARNING]):
                 dn_cc = restoration.cycle_spin(noisy, denoise_func,
                                                max_shifts=2,
                                                shift_steps=shift_steps,

--- a/skimage/viewer/tests/test_plugins.py
+++ b/skimage/viewer/tests/test_plugins.py
@@ -69,7 +69,10 @@ def test_line_profile_dynamic():
     assert_almost_equal(np.std(line), 0.229, 3)
     assert_almost_equal(np.max(line) - np.min(line), 0.725, 1)
 
-    with expected_warnings(['precision loss']):
+    # Maptlotlib 2.2.3 seems to use np.asscalar which issues a warning
+    # with numpy 1.16
+    # Matplotlib 2.2.3 is the last supported version for python 2.7
+    with expected_warnings(['precision loss', r'np.asscalar|\A\Z']):
         viewer.image = skimage.img_as_float(median(image,
                                                    selem=disk(radius=3)))
 

--- a/skimage/viewer/tests/test_plugins.py
+++ b/skimage/viewer/tests/test_plugins.py
@@ -69,9 +69,9 @@ def test_line_profile_dynamic():
     assert_almost_equal(np.std(line), 0.229, 3)
     assert_almost_equal(np.max(line) - np.min(line), 0.725, 1)
 
-    # Maptlotlib 2.2.3 seems to use np.asscalar which issues a warning
+    # Matplotlib 2.2.3 seems to use np.asscalar which issues a warning
     # with numpy 1.16
-    # Matplotlib 2.2.3 is the last supported version for python 2.7
+    # Matplotlib 2.2.3 is the last supported version for Python 2.7
     with expected_warnings(['precision loss', r'np.asscalar|\A\Z']):
         viewer.image = skimage.img_as_float(median(image,
                                                    selem=disk(radius=3)))

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -12,6 +12,7 @@ EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.
 WHEELHOUSE="--find-links=$EXTRA_WHEELS"
 
 if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
+    sh -e /etc/init.d/xvfb start
     # This one is for wheels we can only build on the travis precise container.
     # As of 14 Jan 2017, this is only pyside.  Also on Rackspace, see above.
     # To build new wheels for this container, consider using:

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -11,8 +11,17 @@ export PIP_DEFAULT_TIMEOUT=60
 EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
 WHEELHOUSE="--find-links=$EXTRA_WHEELS"
 
-if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
+
+# Starting xvfb this way is only valid for ubuntu 14.04
+# On ubuntu 16.04 (xenial), the appropriate command is
+#   sudo systemctl start xvfb
+# which is done by travis with `services: -xvfb` in .travis.yml
+if [[ -f /etc/init.d/xvfb ]]; then
     sh -e /etc/init.d/xvfb start
+    export DISPLAY=:99.0
+fi
+
+if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
     # This one is for wheels we can only build on the travis precise container.
     # As of 14 Jan 2017, this is only pyside.  Also on Rackspace, see above.
     # To build new wheels for this container, consider using:
@@ -26,7 +35,6 @@ if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
 fi
 export WHEELHOUSE
 
-export DISPLAY=:99.0
 # This causes way too many internal warnings within python.
 # export PYTHONWARNINGS="d,all:::skimage"
 export TEST_ARGS="--doctest-modules"


### PR DESCRIPTION
## Description
This backport removes many nuisance warnings in the tests, and potentially for users when they use scikit-image.

This also includes preemptive backports of 
-  Enable the faulthandler module during testing #3708 
-  Fix 3.7 builds on travis #3709 

## References
xref:  #3684
xref:  #3687

## For reviewers
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
