### PR TITLE
Tighten the PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,27 @@
 ## Description
-[Tell us about your new feature, improvement, or fix! If relevant, please supplement the PR with images.]
+
+<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
+<!-- If this is a new feature, reference what paper it implements. -->
 
 
 ## Checklist
-[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
-- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
+<!-- It's fine to submit PRs which are a work in progress! -->
+<!-- But before they are merged, all PRs should provide: -->
 - [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
 - [ ] Gallery example in `./doc/examples` (new features only)
 - [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
   existing benchmark
 - [ ] Unit tests
+- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
 
-[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]
+<!-- For detailed information on these and other aspects see -->
+<!-- the scikit-image contribution guidelines. -->
+<!-- https://scikit-image.org/docs/dev/contribute.html -->
+
+## For reviewersreviewers
 
 
-## References
-[If this is a bug-fix or enhancement, it closes issue # ]
-[If this is a new feature, it implements the following paper: ]
-
-## For reviewers
-
-(Don't remove the checklist below.)
-
+<!-- Don't remove the checklist below. -->
 - [ ] Check that the PR title is short, concise, and will make sense 1 year
   later.
 - [ ] Check that new functions are imported in corresponding `__init__.py`.


### PR DESCRIPTION
## Description
In the spirit of https://github.com/scikit-image/scikit-image/pull/3697, I'm also requesting that the PR template be tightened.

Specifially:
- Description and reference secctions can likely be merged.
- HTML comments can be used instead of `[` `]`.
- Mentionning Pep8 can be moved down, since it is much more minor compared to other things (and the bot will just complain if it isn't pep8 compliant.

I know that most of the time I delete everything because I don't want to see the square bracket comments in my final PR.

## Checklist
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests


## For reviewers

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
