### PR TITLE
Fix ValueError: not enough values to unpack

### DIFF
--- a/skimage/measure/mc_meta/visual_test.py
+++ b/skimage/measure/mc_meta/visual_test.py
@@ -53,11 +53,11 @@ elif SELECT == 4:
 
 # Get surface meshes
 t0 = time.time()
-vertices1, faces1, _ = marching_cubes_lewiner(vol, isovalue, gradient_direction=gradient_dir, use_classic=False)
+vertices1, faces1, _, _ = marching_cubes_lewiner(vol, isovalue, gradient_direction=gradient_dir, use_classic=False)
 print('finding surface lewiner took %1.0f ms' % (1000*(time.time()-t0)) )
 
 t0 = time.time()
-vertices2, faces2, _ = marching_cubes_classic(vol, isovalue, gradient_direction=gradient_dir)
+vertices2, faces2 = marching_cubes_classic(vol, isovalue, gradient_direction=gradient_dir)
 print('finding surface classic took %1.0f ms' % (1000*(time.time()-t0)) )
 
 # Show


### PR DESCRIPTION
`marching_cubes_lewiner` returns 4 values, `marching_cubes_classic` returns 2 values.

Using current git master branch on Windows.

## Checklist
[It's fine to submit PRs which are a work in progress! But before they are merged, all PRs should provide:]
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests

[For detailed information on these and other aspects see [scikit-image contribution guidelines](https://scikit-image.org/docs/dev/contribute.html)]


## References
[If this is a bug-fix or enhancement, it closes issue # ]
[If this is a new feature, it implements the following paper: ]

## For reviewers

(Don't remove the checklist below.)

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
