### PR TITLE
Fix 3.7 builds on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ matrix:
       dist: xenial # Required for Python 3.7
       sudo: true   # travis-ci/travis-ci#9069
       env: QT=PyQt5 OPTIONAL_DEPS=1 BUILD_DOCS=1
+      services:
+        - xvfb
     - os: linux
       python: 3.6
       env: QT=PyQt5 OPTIONAL_DEPS=1 PIP_FLAGS="--pre"
@@ -68,10 +70,6 @@ matrix:
       osx_image: xcode10.1
       language: objective-c
       env: TRAVIS_PYTHON_VERSION=3.7
-  allow_failures:
-    # python 3.7 is failing and it is out of our control for now.
-    # remove when scikit-image tests actually start running.
-    - python: 3.7
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -11,8 +11,17 @@ export PIP_DEFAULT_TIMEOUT=60
 EXTRA_WHEELS="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
 WHEELHOUSE="--find-links=$EXTRA_WHEELS"
 
-if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
+
+# Starting xvfb this way is only valid for ubuntu 14.04
+# On ubuntu 16.04 (xenial), the appropriate command is
+#   sudo systemctl start xvfb
+# which is done by travis with `services: -xvfb` in .travis.yml
+if [[ -f /etc/init.d/xvfb ]]; then
     sh -e /etc/init.d/xvfb start
+    export DISPLAY=:99.0
+fi
+
+if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
     # This one is for wheels we can only build on the travis precise container.
     # As of 14 Jan 2017, this is only pyside.  Also on Rackspace, see above.
     # To build new wheels for this container, consider using:
@@ -26,7 +35,6 @@ if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
 fi
 export WHEELHOUSE
 
-export DISPLAY=:99.0
 # This causes way too many internal warnings within python.
 # export PYTHONWARNINGS="d,all:::skimage"
 


### PR DESCRIPTION
## Description
3.7 uses a different image of ubuntu. I think we can just use their XVFB service on that one.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
