### PR TITLE
Replace np.einsum with np.tensordot in _upsampled_dft

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -269,3 +269,6 @@
 - Mark Harfouche
   Enabled GIL free operation of many algorithms implemented in Cython.
   Maintenance of the build and test infrastructure.
+
+- Taylor D. Scott
+  Simplified _upsampled_dft and extended register_translation to nD images.

--- a/benchmarks/benchmark_feature.py
+++ b/benchmarks/benchmark_feature.py
@@ -2,7 +2,8 @@
 # https://asv.readthedocs.io/en/latest/writing_benchmarks.html
 import numpy as np
 from scipy import ndimage as ndi
-from skimage import feature, util
+from skimage import feature, util, img_as_float
+from skimage.data import binary_blobs
 
 
 class FeatureSuite:
@@ -24,3 +25,41 @@ class FeatureSuite:
         pi = np.pi
         result = feature.greycomatrix(self.image_ubyte, distances=[1, 2],
                                       angles=[0, pi/4, pi/2, 3*pi/4])
+
+
+class RegisterTranslation:
+    """Benchmarks for feature.register_translation in scikit-image"""
+    param_names = ["ndims", "image_size", "upscale_factor"]
+    params = [(2, 3), (32, 100), (1, 5, 10)]
+
+    def setup(self, ndims, image_size, upscale_factor, *args):
+        shifts = (-2.3, 1.7, 5.4, -3.2)[:ndims]
+        phantom = img_as_float(binary_blobs(length=image_size, n_dim=ndims))
+        self.reference_image = np.fft.fftn(phantom)
+        self.shifted_image = ndi.fourier_shift(self.reference_image, shifts)
+
+    def time_register_translation(self, ndims, image_size, upscale_factor):
+        result = feature.register_translation(self.reference_image,
+                                              self.shifted_image,
+                                              upscale_factor,
+                                              space="fourier")
+
+    def peakmem_reference(self, *args):
+        """Provide reference for memory measurement with empty benchmark.
+        Peakmem benchmarks measure the maximum amount of RAM used by a
+        function. However, this maximum also includes the memory used
+        during the setup routine (as of asv 0.2.1; see [1]_).
+        Measuring an empty peakmem function might allow us to disambiguate
+        between the memory used by setup and the memory used by target (see
+        other ``peakmem_`` functions below).
+        References
+        ----------
+        .. [1]: https://asv.readthedocs.io/en/stable/writing_benchmarks.html#peak-memory
+        """
+        pass
+
+    def peakmem_register_translation(self, ndims, image_size, upscale_factor):
+        result = feature.register_translation(self.reference_image,
+                                              self.shifted_image,
+                                              upscale_factor,
+                                              space="fourier")

--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -63,13 +63,12 @@ def _upsampled_dft(data, upsampled_region_size,
     dim_properties = list(zip(data.shape, upsampled_region_size, axis_offsets))
 
     for (n_items, ups_size, ax_offset) in dim_properties[::-1]:
-        kernel = np.exp(np.dot(
-                (-im2pi / (n_items * upsample_factor)) *
-                (np.arange(upsampled_region_size[0])[:, None] - ax_offset),
-                (np.fft.ifftshift(np.arange(n_items))[None, :] - n_items // 2)))
+        kernel = np.fft.fftfreq(n_items, upsample_factor)[:, None] *\
+                 (np.arange(upsampled_region_size[0]) - ax_offset)
+        kernel = np.exp(-im2pi * kernel)
         # Equivalent to:
-        #   data[i, j, k] = (kernel[i, :] * data[j, k, :]).sum()
-        data = np.tensordot(kernel, data, axes=(1, -1))
+        #   data[i, j, k] = kernel[:, i] @ data[j, k].T
+        data = np.tensordot(kernel, data, axes=(0, -1))
     return data
 
 

--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -27,7 +27,7 @@ def _upsampled_dft(data, upsampled_region_size,
 
     Parameters
     ----------
-    data : nD ndarray
+    data : array
         The input data array (DFT of original data) to upsample.
     upsampled_region_size : integer or tuple of integers, optional
         The size of the region to be sampled.  If one integer is provided, it
@@ -40,7 +40,7 @@ def _upsampled_dft(data, upsampled_region_size,
 
     Returns
     -------
-    output : nD ndarray
+    output : ndarray
             The upsampled DFT of the specified region.
     """
     # if people pass in an integer, expand it to a list of equal-sized sections
@@ -117,9 +117,9 @@ def register_translation(src_image, target_image, upsample_factor=1,
 
     Parameters
     ----------
-    src_image : ndarray
+    src_image : array
         Reference image.
-    target_image : ndarray
+    target_image : array
         Image to register.  Must be same dimensionality as ``src_image``.
     upsample_factor : int, optional
         Upsampling factor. Images will be registered to within

--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -27,7 +27,7 @@ def _upsampled_dft(data, upsampled_region_size,
 
     Parameters
     ----------
-    data : 2D or 3D ndarray
+    data : nD ndarray
         The input data array (DFT of original data) to upsample.
     upsampled_region_size : integer or tuple of integers, optional
         The size of the region to be sampled.  If one integer is provided, it
@@ -40,7 +40,7 @@ def _upsampled_dft(data, upsampled_region_size,
 
     Returns
     -------
-    output : 2D or 3D ndarray
+    output : nD ndarray
             The upsampled DFT of the specified region.
     """
     # if people pass in an integer, expand it to a list of equal-sized sections
@@ -77,14 +77,15 @@ def _upsampled_dft(data, upsampled_region_size,
 
         return row_kernel.dot(data).dot(col_kernel)
 
+    # For the general nD case, use sequential calls to tensordot to calculate
+    # the DFT
     elif data.ndim > 2:
         im2pi = 1j * 2 * np.pi
 
-        # To compute the upsampled DFT across all spatial dimensions,
-        # a tensor product is computed
         dim_properties = list(zip(data.shape,
                                   upsampled_region_size,
                                   axis_offsets))
+
         for (n_items, ups_size, ax_offset) in dim_properties[::-1]:
             kernel = np.exp(np.dot(
                     (-im2pi / (n_items * upsample_factor)) *

--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -187,7 +187,7 @@ def register_translation(src_image, target_image, upsample_factor=1,
         if return_error:
             src_amp = np.sum(np.abs(src_freq) ** 2) / src_freq.size
             target_amp = np.sum(np.abs(target_freq) ** 2) / target_freq.size
-            CCmax = cross_correlation.max()
+            CCmax = cross_correlation[maxima]
     # If upsampling > 1, then refine estimate with matrix multiply DFT
     else:
         # Initial shift estimate in upsampled grid
@@ -205,16 +205,15 @@ def register_translation(src_image, target_image, upsample_factor=1,
                                            sample_region_offset).conj()
         cross_correlation /= normalization
         # Locate maximum and map back to original pixel grid
-        maxima = np.array(np.unravel_index(
-                              np.argmax(np.abs(cross_correlation)),
-                              cross_correlation.shape),
-                          dtype=np.float64)
-        maxima -= dftshift
+        maxima = np.unravel_index(np.argmax(np.abs(cross_correlation)),
+                                  cross_correlation.shape)
+        CCmax = cross_correlation[maxima]
+
+        maxima = np.array(maxima, dtype=np.float64) - dftshift
 
         shifts = shifts + maxima / upsample_factor
 
         if return_error:
-            CCmax = cross_correlation.max()
             src_amp = _upsampled_dft(src_freq * src_freq.conj(),
                                      1, upsample_factor)[0, 0]
             src_amp /= normalization

--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -63,9 +63,10 @@ def _upsampled_dft(data, upsampled_region_size,
     dim_properties = list(zip(data.shape, upsampled_region_size, axis_offsets))
 
     for (n_items, ups_size, ax_offset) in dim_properties[::-1]:
-        kernel = ((np.arange(upsampled_region_size[0]) - ax_offset)[:, None] *
-                  np.fft.fftfreq(n_items, upsample_factor))
+        kernel = ((np.arange(upsampled_region_size[0]) - ax_offset)[:, None]
+                  * np.fft.fftfreq(n_items, upsample_factor))
         kernel = np.exp(-im2pi * kernel)
+
         # Equivalent to:
         #   data[i, j, k] = kernel[i, :] @ data[j, k].T
         data = np.tensordot(kernel, data, axes=(1, -1))

--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -63,7 +63,7 @@ def _upsampled_dft(data, upsampled_region_size,
     dim_properties = list(zip(data.shape, upsampled_region_size, axis_offsets))
 
     for (n_items, ups_size, ax_offset) in dim_properties[::-1]:
-        kernel = ((np.arange(upsampled_region_size[0]) - ax_offset)[:, None]
+        kernel = ((np.arange(ups_size) - ax_offset)[:, None]
                   * np.fft.fftfreq(n_items, upsample_factor))
         kernel = np.exp(-im2pi * kernel)
 

--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -63,12 +63,12 @@ def _upsampled_dft(data, upsampled_region_size,
     dim_properties = list(zip(data.shape, upsampled_region_size, axis_offsets))
 
     for (n_items, ups_size, ax_offset) in dim_properties[::-1]:
-        kernel = np.fft.fftfreq(n_items, upsample_factor)[:, None] *\
-                 (np.arange(upsampled_region_size[0]) - ax_offset)
+        kernel = ((np.arange(upsampled_region_size[0]) - ax_offset)[:, None] *
+                  np.fft.fftfreq(n_items, upsample_factor))
         kernel = np.exp(-im2pi * kernel)
         # Equivalent to:
-        #   data[i, j, k] = kernel[:, i] @ data[j, k].T
-        data = np.tensordot(kernel, data, axes=(0, -1))
+        #   data[i, j, k] = kernel[i, :] @ data[j, k].T
+        data = np.tensordot(kernel, data, axes=(1, -1))
     return data
 
 

--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -77,7 +77,7 @@ def _upsampled_dft(data, upsampled_region_size,
 
         return row_kernel.dot(data).dot(col_kernel)
 
-    elif data.ndim == 3:
+    elif data.ndim > 2:
         im2pi = 1j * 2 * np.pi
 
         # To compute the upsampled DFT across all spatial dimensions,
@@ -91,14 +91,10 @@ def _upsampled_dft(data, upsampled_region_size,
                     (np.arange(upsampled_region_size[0])[:, None] - ax_offset),
                     (np.fft.ifftshift(np.arange(n_items))[None, :]
                      - n_items // 2)))
-            # Equivalent to
+            # Equivalent to:
             #   data[i, j, k] = (kernel[i, :] * data[j, k, :]).sum()
             data = np.tensordot(kernel, data, axes=(1, -1))
         return data
-
-    else:
-        raise NotImplementedError("Upsampled registration for images of more"
-                                  " than 3 dimensions is not implemented")
 
 
 def _compute_phasediff(cross_correlation_max):
@@ -186,11 +182,6 @@ def register_translation(src_image, target_image, upsample_factor=1,
     if src_image.shape != target_image.shape:
         raise ValueError("Error: images must be same size for "
                          "register_translation")
-
-    # only 2D data makes sense right now
-    if src_image.ndim > 3 and upsample_factor > 1:
-        raise NotImplementedError("Error: register_translation only supports "
-                                  "subpixel registration for 2D and 3D images")
 
     # assume complex data is already in Fourier space
     if space.lower() == 'fourier':

--- a/skimage/feature/tests/test_register_translation.py
+++ b/skimage/feature/tests/test_register_translation.py
@@ -115,6 +115,19 @@ def test_4d_input_pixel():
                                                     space="fourier")
     assert_allclose(result, -np.array(shift), atol=0.05)
 
+
+def test_4d_input_subpixel():
+    phantom = img_as_float(binary_blobs(length=32, n_dim=4))
+    reference_image = np.fft.fftn(phantom)
+    subpixel_shift = (-2.3, 1.7, 5.4, -3.2)
+    shifted_image = fourier_shift(reference_image, subpixel_shift)
+    result, error, diffphase = register_translation(reference_image,
+                                                    shifted_image,
+                                                    10,
+                                                    space="fourier")
+    assert_allclose(result, -np.array(subpixel_shift), atol=0.05)
+
+
 def test_no_4D():
     # Dimensionality mismatch
     image = np.ones((5, 5, 5, 5))

--- a/skimage/feature/tests/test_register_translation.py
+++ b/skimage/feature/tests/test_register_translation.py
@@ -10,6 +10,7 @@ from skimage._shared import testing
 
 from distutils.version import LooseVersion
 
+
 def test_correlation():
     reference_image = np.fft.fftn(camera())
     shift = (-7, 12)
@@ -105,6 +106,7 @@ def test_wrong_input():
     with testing.raises(ValueError):
         register_translation(template, image)
 
+
 def test_4d_input_pixel():
     phantom = img_as_float(binary_blobs(length=32, n_dim=4))
     reference_image = np.fft.fftn(phantom)
@@ -126,6 +128,7 @@ def test_4d_input_subpixel():
                                                     10,
                                                     space="fourier")
     assert_allclose(result, -np.array(subpixel_shift), atol=0.05)
+
 
 def test_mismatch_upsampled_region_size():
     with testing.raises(ValueError):

--- a/skimage/feature/tests/test_register_translation.py
+++ b/skimage/feature/tests/test_register_translation.py
@@ -8,8 +8,6 @@ from scipy.ndimage import fourier_shift
 from skimage import img_as_float
 from skimage._shared import testing
 
-from distutils.version import LooseVersion
-
 
 def test_correlation():
     reference_image = np.fft.fftn(camera())
@@ -73,16 +71,13 @@ def test_3d_input():
 
     # subpixel precision now available for 3-D data
 
-    # skip the test for numpy older than 1.12, which does not have
-    # einsum optimization
-    if LooseVersion(np.__version__) >= LooseVersion("1.12"):
-        subpixel_shift = (-2.3, 1.7, 5.4)
-        shifted_image = fourier_shift(reference_image, subpixel_shift)
-        result, error, diffphase = register_translation(reference_image,
-                                                        shifted_image,
-                                                        100,
-                                                        space="fourier")
-        assert_allclose(result, -np.array(subpixel_shift), atol=0.05)
+    subpixel_shift = (-2.3, 1.7, 5.4)
+    shifted_image = fourier_shift(reference_image, subpixel_shift)
+    result, error, diffphase = register_translation(reference_image,
+                                                    shifted_image,
+                                                    100,
+                                                    space="fourier")
+    assert_allclose(result, -np.array(subpixel_shift), atol=0.05)
 
 
 def test_unknown_space_input():

--- a/skimage/feature/tests/test_register_translation.py
+++ b/skimage/feature/tests/test_register_translation.py
@@ -105,6 +105,15 @@ def test_wrong_input():
     with testing.raises(ValueError):
         register_translation(template, image)
 
+def test_4d_input_pixel():
+    phantom = img_as_float(binary_blobs(length=32, n_dim=4))
+    reference_image = np.fft.fftn(phantom)
+    shift = (-2., 1., 5., -3)
+    shifted_image = fourier_shift(reference_image, shift)
+    result, error, diffphase = register_translation(reference_image,
+                                                    shifted_image,
+                                                    space="fourier")
+    assert_allclose(result, -np.array(shift), atol=0.05)
 
 def test_no_4D():
     # Dimensionality mismatch

--- a/skimage/feature/tests/test_register_translation.py
+++ b/skimage/feature/tests/test_register_translation.py
@@ -127,15 +127,6 @@ def test_4d_input_subpixel():
                                                     space="fourier")
     assert_allclose(result, -np.array(subpixel_shift), atol=0.05)
 
-
-def test_no_4D():
-    # Dimensionality mismatch
-    image = np.ones((5, 5, 5, 5))
-    template = np.ones((5, 5, 5, 5))
-    with testing.raises(NotImplementedError):
-        register_translation(template, image, upsample_factor=5)
-
-
 def test_mismatch_upsampled_region_size():
     with testing.raises(ValueError):
         _upsampled_dft(


### PR DESCRIPTION
## Description

In feature/register_translation.py, _upsampled_dft uses np.einsum to compute the upsampled DFT of an image. This is not easily generalizable and in numpy 1.11 is (extremely) slow because no optimize flag is available.

np.einsum can be replaced with sequential calls to np.tensordot which (should) generalize to higher dimensions.

E.g.,

    import numpy as np
    image = np.random.uniform(10, size=(10, 15, 20))
    kernels = [np.random.uniform(10, size=(2*i, i)) for i in image.shape]
    einsum_result = np.einsum('ijk,li,mj,nk->lmn', image, *kernels, optimize=True)
    tensordot_result = np.copy(image)
    for kernel in kernels[::-1]:
        tensordot_result = np.tensordot(kernel, tensordot_result, axes=(1, -1))
    
    print(np.abs(tensordot_result - einsum_result).max()) # 0.0

It should also be faster in numpy 1.11 and, from testing on my latptop, not slower than np.einsum in numpy 1.16. It seems to be slightly faster for some inputs. 

Is there a standard way to benchmark functions? I see there's a benchmarks folder but I'm not sure how to use it.

## Todo
- [x] Benchmark in numpy 1.16 (current) ~and numpy 1.11~
- [x] Extend to nD images
- [x] Write tests for nD images
- [x] Clean up kernel statement

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] ~Gallery example in `./doc/examples` (new features only)~
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
