### PR TITLE
BLD: pin cython's language_level

### DIFF
--- a/skimage/_build.py
+++ b/skimage/_build.py
@@ -54,7 +54,7 @@ def cython(pyx_files, working_path=''):
                 process_tempita_pyx(pyxfile)
                 pyxfile = pyxfile.replace('.pyx.in', '.pyx')
 
-            cythonize(pyxfile, language_level='2')
+            cythonize(pyxfile, language_level=2)
 
 
 def _md5sum(f):

--- a/skimage/_build.py
+++ b/skimage/_build.py
@@ -54,7 +54,7 @@ def cython(pyx_files, working_path=''):
                 process_tempita_pyx(pyxfile)
                 pyxfile = pyxfile.replace('.pyx.in', '.pyx')
 
-            cythonize(pyxfile)
+            cythonize(pyxfile, language_level='2')
 
 
 def _md5sum(f):


### PR DESCRIPTION
Pin to language_level '2'

The next version of cython will change the default level to '3str'
under which the skimage cython files fail to cythonize.


## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`