### PR TITLE
Enable OpenMP for msvc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,9 +56,12 @@ import builtins
 builtins.__SKIMAGE_SETUP__ = True
 
 # Support for openmp
-
-compile_flags = ['-fopenmp']
-link_flags = ['-fopenmp']
+if sys.platform == 'win32':
+    compile_flags = ['/openmp']
+    link_flags = []
+else:
+    compile_flags = ['-fopenmp']
+    link_flags = ['-fopenmp']
 
 code = """#include <omp.h>
 int main(int argc, char** argv) { return(0); }"""


### PR DESCRIPTION
msvc uses the '/openmp' compiler flag to enable OpenMP.

Two potential issues:

1) Extension modules using OpenMP will depend on VCOMP*.DLL, which either needs to be shipped with the wheel or installed by the user using a matching Visual C++ Redistributable.

2) This patch probably does not work if skimage is compiled with mingw.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
