### PR TITLE
Downgrade Xcode to 9.4 on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,16 +58,20 @@ matrix:
     - os: linux
       python: 3.6
       env: QT=PyQt5 OPTIONAL_DEPS=1 PIP_FLAGS="--pre"
+    # For smooth deployment, the osx_image here should match
+    # what we set in the wheel generation travis images.
+    # If not set, it will use the default version from Travis
+    # https://docs.travis-ci.com/user/reference/osx/#xcode-version
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode9.4
       language: objective-c
       env: TRAVIS_PYTHON_VERSION=3.5
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode9.4
       language: objective-c
       env: TRAVIS_PYTHON_VERSION=3.6 OPTIONAL_DEPS=1
     - os: osx
-      osx_image: xcode10.1
+      osx_image: xcode9.4
       language: objective-c
       env: TRAVIS_PYTHON_VERSION=3.7
 


### PR DESCRIPTION
## Description

This is the default version from travis which seems to be used by the wheel builder.

Should be merged in conjunction with https://github.com/scikit-image/scikit-image/pull/3724

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
