### PR TITLE
pypi: explicitly exclude Python 3.1, 3.2, and 3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ if __name__ == "__main__":
         ],
         install_requires=INSTALL_REQUIRES,
         requires=REQUIRES,
-        python_requires='>=2.7',
+        python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
         packages=setuptools.find_packages(exclude=['doc']),
         include_package_data=True,
         zip_safe=False,  # the package can run out of an .egg file


### PR DESCRIPTION
See also: https://github.com/scikit-image/scikit-image/issues/3713