### PR TITLE
Get rid of the requirements-parser dependency -- Backport of 3534

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,4 +1,3 @@
 Cython>=0.23.4,!=0.28.2,!=0.29.0
 wheel
 numpy>=1.11
-requirements-parser

--- a/tools/build_versions.py
+++ b/tools/build_versions.py
@@ -1,19 +1,28 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-
-import numpy as np
-import scipy as sp
-import matplotlib as mpl
-import six
-from PIL import Image
-import Cython
-import networkx
+import pkg_resources
+import re
+from os.path import dirname, abspath, basename
+from glob import glob
 
 
-for m in (np, sp, mpl, six, Image, networkx, Cython):
-    if m is Image:
-        version = m.VERSION
-    else:
-        version = m.__version__
-    print(m.__name__.rjust(10), ' ', version)
+def main():
+    requirements_dir = dirname(abspath(__file__)) + '/../requirements'
+    for requirement_file in glob(requirements_dir + '/*.txt'):
+        print(basename(requirement_file))
+        with open(str(requirement_file), 'r') as f:
+            for req in f:
+                req = req.strip()
+                if req[0] == '#':
+                    continue
+                req = re.split('<|>|=|!|;', req)[0]
+                try:
+                    version = pkg_resources.get_distribution(req).version
+                    print(req.rjust(20), version)
+                except pkg_resources.DistributionNotFound:
+                    print(req.rjust(20), 'is not installed')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Description
This is a backport of #3534 whereby we remove a superfluous dependency for the build system.

It took a while to backport because it needed some python 2.7 syntax to get written.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
