### PR TITLE
[WIP] MAINT activating test against nightly cpython build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,6 @@ matrix:
       python: 3.5
       env: QT=PyQt5 MINIMUM_REQUIREMENTS=1
     - os: linux
-      python: 3.5
-      env: QT=PyQt5 OPTIONAL_DEPS=1 MINIMUM_REQUIREMENTS=1
-    - os: linux
       python: 3.6
       env: QT=PyQt5 OPTIONAL_DEPS=1 BUILD_DOCS=1 DEPLOY_DOCS=1
     - os: linux
@@ -53,6 +50,15 @@ matrix:
       dist: xenial # Required for Python 3.7
       sudo: true   # travis-ci/travis-ci#9069
       env: QT=PyQt5 OPTIONAL_DEPS=1 BUILD_DOCS=1
+    - os: linux
+      python: "nightly"
+      env: QT=PyQt5 OPTIONAL_DEPS=1 MINIMUM_REQUIREMENTS=1
+      addons:
+        apt:
+          packages:
+            - liblapack-dev
+            - libblas-dev
+            - gfortran
     - os: linux
       python: 3.6
       env: QT=PyQt5 OPTIONAL_DEPS=1 PIP_FLAGS="--pre"
@@ -68,6 +74,8 @@ matrix:
       osx_image: xcode10.1
       language: objective-c
       env: TRAVIS_PYTHON_VERSION=3.7
+  allow_failures:
+    - python: "nightly"
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then


### PR DESCRIPTION
## Description
This is work in progress.

This pull request activates the tests against travis' nightly build of CPython (3.8 is in pre-release right now). As per the suggestion of @stefanv , I switched things around to keep the same number of matrix entries.

This PR will probably not work out of the box.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
