### PR TITLE
Improve visual_test.py

### DIFF
--- a/skimage/measure/mc_meta/visual_test.py
+++ b/skimage/measure/mc_meta/visual_test.py
@@ -77,27 +77,21 @@ def donuts():
     b = -1.25 * 8.0
     c = 16.0 - 1.85 * 1.85
     d = 64.0
-    vol = np.empty((n, n, n), 'float32')
-    for iz in range(n):
-        z = iz * a + b
-        z *= z
-        zc = z + c
-        for iy in range(n):
-            y = iy * a + b
-            y1 = y - 2
-            y1 *= y1
-            y2 = y + 2
-            y2 *= y2
-            for ix in range(n):
-                x = ix * a + b
-                x *= x
-                x1 = x + y1 + zc
-                x1 *= x1
-                x2 = x + y2 + zc
-                x2 *= x2
-                vol[iz, iy, ix] = ((x1 - d * (x + y1)) * (x2 - d * (z + y2)))
-    vol += 1025.0
-    return vol
+    
+    i = np.arange(n, dtype=int)
+    ia_plus_b = i * a + b
+    ia_plus_b_square = ia_plus_b ** 2
+    z = ia_plus_b_square[:, np.newaxis, np.newaxis]
+    zc = z + c
+    
+    y1 = ((ia_plus_b - 2) ** 2)[np.newaxis, :, np.newaxis]
+    y2 = ((ia_plus_b + 2) ** 2)[np.newaxis, :, np.newaxis]
+    
+    x = ia_plus_b_square[np.newaxis, np.newaxis, :]
+    x1 = (x + y1 + zc) ** 2
+    x2 = (x + y2 + zc) ** 2
+    
+    return ((x1 - d * (x + y1)) * (x2 - d * (z + y2))) + 1025
 
 
 @contextmanager

--- a/skimage/measure/mc_meta/visual_test.py
+++ b/skimage/measure/mc_meta/visual_test.py
@@ -6,6 +6,7 @@ data.
 from __future__ import print_function
 
 import time
+from contextlib import contextmanager
 
 import numpy as np
 
@@ -33,7 +34,7 @@ def main(select=3, **kwargs):
         vol = vv.aVolume(20, 128)
         isovalue = kwargs.pop('level', 0.2)
     elif select == 3:
-        with Timer('computing donuts'):
+        with timer('computing donuts'):
             vol = donuts()
         isovalue = kwargs.pop('level', 0.0)
         # Uncommenting the line below will yield different results for
@@ -46,10 +47,10 @@ def main(select=3, **kwargs):
         raise ValueError('invalid selection')
 
     # Get surface meshes
-    with Timer('finding surface lewiner'):
+    with timer('finding surface lewiner'):
         vertices1, faces1 = marching_cubes_lewiner(vol, isovalue, **kwargs)[:2]
 
-    with Timer('finding surface classic'):
+    with timer('finding surface classic'):
         vertices2, faces2 = marching_cubes_classic(vol, isovalue, **kwargs)
 
     # Show
@@ -99,21 +100,13 @@ def donuts():
     return vol
 
 
-class Timer(object):
+@contextmanager
+def timer(message):
     """Context manager for timing execution speed of body."""
-
-    def __init__(self, message):
-        """Initialize timer."""
-        print(message, end=' ')
-        self.start = 0
-
-    def __enter__(self):
-        """Enter timer context."""
-        self.start = time.time()
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        """Exit timer context."""
-        print('took %1.0f ms' % (1000 * (time.time() - self.start)))
+    print(message, end=' ')
+    start = time.time()
+    yield
+    print('took {:1.0f} ms'.format(1000 * (time.time() - start)))
 
 
 if __name__ == '__main__':

--- a/skimage/measure/mc_meta/visual_test.py
+++ b/skimage/measure/mc_meta/visual_test.py
@@ -77,20 +77,20 @@ def donuts():
     b = -1.25 * 8.0
     c = 16.0 - 1.85 * 1.85
     d = 64.0
-    
+
     i = np.arange(n, dtype=int)
     ia_plus_b = i * a + b
     ia_plus_b_square = ia_plus_b ** 2
     z = ia_plus_b_square[:, np.newaxis, np.newaxis]
     zc = z + c
-    
+
     y1 = ((ia_plus_b - 2) ** 2)[np.newaxis, :, np.newaxis]
     y2 = ((ia_plus_b + 2) ** 2)[np.newaxis, :, np.newaxis]
-    
+
     x = ia_plus_b_square[np.newaxis, np.newaxis, :]
     x1 = (x + y1 + zc) ** 2
     x2 = (x + y2 + zc) ** 2
-    
+
     return ((x1 - d * (x + y1)) * (x2 - d * (z + y2))) + 1025
 
 

--- a/skimage/measure/mc_meta/visual_test.py
+++ b/skimage/measure/mc_meta/visual_test.py
@@ -3,70 +3,118 @@ Script to show the results of the two marching cubes algorithms on different
 data.
 """
 
+from __future__ import print_function
+
 import time
 
 import numpy as np
-import visvis as vv
 
 from skimage.measure import marching_cubes_classic, marching_cubes_lewiner
 from skimage.draw import ellipsoid
 
 
-# Create test volume
-SELECT = 3
-gradient_dir = 'descent'  # ascent or descent
+def main(select=3, **kwargs):
+    """Script main function.
 
-if SELECT == 1:
-    # Medical data
-    vol = vv.volread('stent')
-    isovalue = 800
+    select: int
+        1: Medical data
+        2: Blocky data, different every time
+        3: Two donuts
+        4: Ellipsoid
 
-elif SELECT == 2:
-    # Blocky data
-    vol = vv.aVolume(20, 128) # Different every time
-    isovalue = 0.2
+    """
+    import visvis as vv  # noqa: delay import visvis and GUI libraries
 
-elif SELECT == 3:
-    # Generate two donuts using a formula by Thomas Lewiner
+    # Create test volume
+    if select == 1:
+        vol = vv.volread('stent')
+        isovalue = kwargs.pop('level', 800)
+    elif select == 2:
+        vol = vv.aVolume(20, 128)
+        isovalue = kwargs.pop('level', 0.2)
+    elif select == 3:
+        with Timer('computing donuts'):
+            vol = donuts()
+        isovalue = kwargs.pop('level', 0.0)
+        # Uncommenting the line below will yield different results for
+        # classic MC
+        # vol *= -1
+    elif select == 4:
+        vol = ellipsoid(4, 3, 2, levelset=True)
+        isovalue = kwargs.pop('level', 0.0)
+    else:
+        raise ValueError('invalid selection')
+
+    # Get surface meshes
+    with Timer('finding surface lewiner'):
+        vertices1, faces1 = marching_cubes_lewiner(vol, isovalue, **kwargs)[:2]
+
+    with Timer('finding surface classic'):
+        vertices2, faces2 = marching_cubes_classic(vol, isovalue, **kwargs)
+
+    # Show
+    vv.figure(1)
+    vv.clf()
+    a1 = vv.subplot(121)
+    vv.title('Lewiner')
+    m1 = vv.mesh(np.fliplr(vertices1), faces1)
+    a2 = vv.subplot(122)
+    vv.title('Classic')
+    m2 = vv.mesh(np.fliplr(vertices2), faces2)
+    a1.camera = a2.camera
+
+    # visvis uses right-hand rule, gradient_direction param uses left-hand rule
+    m1.cullFaces = m2.cullFaces = 'front'  # None, front or back
+
+    vv.use().Run()
+
+
+def donuts():
+    """Return volume of two donuts based on a formula by Thomas Lewiner."""
     n = 48
-    a, b = 2.5 / n, -1.25
-    isovalue = 0.0
-    #
+    a = 2.5 / n * 8.0
+    b = -1.25 * 8.0
+    c = 16.0 - 1.85 * 1.85
+    d = 64.0
     vol = np.empty((n, n, n), 'float32')
-    for iz in range(vol.shape[0]):
-        for iy in range(vol.shape[1]):
-            for ix in range(vol.shape[2]):
-                z, y, x = float(iz)*a+b, float(iy)*a+b, float(ix)*a+b
-                vol[iz, iy, ix] = ( (
-                    (8*x)**2 + (8*y-2)**2 + (8*z)**2 + 16 - 1.85*1.85 ) * ( (8*x)**2 +
-                    (8*y-2)**2 + (8*z)**2 + 16 - 1.85*1.85 ) - 64 * ( (8*x)**2 + (8*y-2)**2 )
-                    ) * ( ( (8*x)**2 + ((8*y-2)+4)*((8*y-2)+4) + (8*z)**2 + 16 - 1.85*1.85 )
-                    * ( (8*x)**2 + ((8*y-2)+4)*((8*y-2)+4) + (8*z)**2 + 16 - 1.85*1.85 ) -
-                    64 * ( ((8*y-2)+4)*((8*y-2)+4) + (8*z)**2
-                    ) ) + 1025
-    # Uncommenting the line below will yield different results for classic MC
-    #vol = -vol
+    for iz in range(n):
+        z = iz * a + b
+        z *= z
+        zc = z + c
+        for iy in range(n):
+            y = iy * a + b
+            y1 = y - 2
+            y1 *= y1
+            y2 = y + 2
+            y2 *= y2
+            for ix in range(n):
+                x = ix * a + b
+                x *= x
+                x1 = x + y1 + zc
+                x1 *= x1
+                x2 = x + y2 + zc
+                x2 *= x2
+                vol[iz, iy, ix] = ((x1 - d * (x + y1)) * (x2 - d * (z + y2)))
+    vol += 1025.0
+    return vol
 
-elif SELECT == 4:
-    vol = ellipsoid(4, 3, 2, levelset=True)
-    isovalue = 0
 
-# Get surface meshes
-t0 = time.time()
-vertices1, faces1, _, _ = marching_cubes_lewiner(vol, isovalue, gradient_direction=gradient_dir, use_classic=False)
-print('finding surface lewiner took %1.0f ms' % (1000*(time.time()-t0)) )
+class Timer(object):
+    """Context manager for timing execution speed of body."""
 
-t0 = time.time()
-vertices2, faces2 = marching_cubes_classic(vol, isovalue, gradient_direction=gradient_dir)
-print('finding surface classic took %1.0f ms' % (1000*(time.time()-t0)) )
+    def __init__(self, message):
+        """Initialize timer."""
+        print(message, end=' ')
+        self.start = 0
 
-# Show
-vv.figure(1); vv.clf()
-a1 = vv.subplot(121); m1 = vv.mesh(np.fliplr(vertices1), faces1)
-a2 = vv.subplot(122); m2 = vv.mesh(np.fliplr(vertices2), faces2)
-a1.camera = a2.camera
+    def __enter__(self):
+        """Enter timer context."""
+        self.start = time.time()
 
-# visvis uses right-hand rule, gradient_direction param uses left-hand rule
-m1.cullFaces = m2.cullFaces = 'front'  # None, front or back
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Exit timer context."""
+        print('took %1.0f ms' % (1000 * (time.time() - self.start)))
 
-vv.use().Run()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Description

Do not run the script when running pytest on an inplace build.
Clean-up and speed-up (10x) calculations of the donuts volume.
Many style fixes, passing flake8.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [x] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
