### PR TITLE
Updated painttool to work with color images and properly scale labels.

### DIFF
--- a/skimage/viewer/canvastools/painttool.py
+++ b/skimage/viewer/canvastools/painttool.py
@@ -69,7 +69,7 @@ class PaintTool(CanvasToolBase):
         self.alpha = alpha
         self.cmap = LABELS_CMAP
         self._overlay_plot = None
-        self.shape = overlay_shape
+        self.shape = overlay_shape[:2]
 
         self._cursor = plt.Rectangle((0, 0), 0, 0, **props)
         self._cursor.set_visible(False)
@@ -118,7 +118,8 @@ class PaintTool(CanvasToolBase):
             self._overlay_plot = None
         elif self._overlay_plot is None:
             props = dict(cmap=self.cmap, alpha=self.alpha,
-                         norm=mcolors.NoNorm(), animated=True)
+                         norm=mcolors.NoNorm(vmin=0, vmax=self.cmap.N),
+                         animated=True)
             self._overlay_plot = self.ax.imshow(image, **props)
         else:
             self._overlay_plot.set_data(image)

--- a/skimage/viewer/tests/test_tools.py
+++ b/skimage/viewer/tests/test_tools.py
@@ -8,7 +8,7 @@ from skimage.viewer.canvastools import (
 from skimage.viewer.canvastools.base import CanvasToolBase
 
 from skimage._shared import testing
-from skimage._shared.testing import assert_equal
+from skimage._shared.testing import assert_equal, parametrize
 
 try:
     from matplotlib.testing.decorators import cleanup
@@ -160,8 +160,8 @@ def test_rect_tool():
 
 @cleanup
 @testing.skipif(not has_qt, reason="Qt not installed")
-def test_paint_tool():
-    img = data.astronaut()
+@parametrize('img', [data.moon(), data.astronaut()])
+def test_paint_tool(img):
     viewer = ImageViewer(img)
 
     tool = PaintTool(viewer, img.shape)

--- a/skimage/viewer/tests/test_tools.py
+++ b/skimage/viewer/tests/test_tools.py
@@ -190,7 +190,6 @@ def test_paint_tool(img):
 
     tool.overlay = tool.overlay * 0
     assert_equal(tool.overlay.sum(), 0)
-
     assert_equal(tool.cmap.N, tool._overlay_plot.norm.vmax)
 
 

--- a/skimage/viewer/tests/test_tools.py
+++ b/skimage/viewer/tests/test_tools.py
@@ -161,7 +161,7 @@ def test_rect_tool():
 @cleanup
 @testing.skipif(not has_qt, reason="Qt not installed")
 def test_paint_tool():
-    img = data.moon()
+    img = data.astronaut()
     viewer = ImageViewer(img)
 
     tool = PaintTool(viewer, img.shape)
@@ -170,7 +170,7 @@ def test_paint_tool():
     assert_equal(tool.radius, 10)
     tool.label = 2
     assert_equal(tool.label, 2)
-    assert_equal(tool.shape, img.shape)
+    assert_equal(tool.shape, img.shape[:2])
 
     do_event(viewer, 'mouse_press', xdata=100, ydata=100)
     do_event(viewer, 'move', xdata=110, ydata=110)
@@ -190,6 +190,8 @@ def test_paint_tool():
 
     tool.overlay = tool.overlay * 0
     assert_equal(tool.overlay.sum(), 0)
+
+    assert_equal(tool.cmap.N, tool._overlay_plot.norm.vmax)
 
 
 @cleanup


### PR DESCRIPTION
## Description

PaintTool and LabelPlugin are handy for labelling data, but when I tried to use them, they weren't actually painting the labels onto the image. It looks like there are a couple of factors.

For color images, the overlay shape is getting set as MxNx3 instead of MxN. This causes an exception when the points are assigned to scalar values. I updated the code to just use the first two dimensions and  updated the unit tests.

The matplotlib.colors.NoNorm used for scaling the label layer has some subtle behavior. It is supposed to be a "dummy replacement for Normalize." However, the documentation (https://matplotlib.org/api/_as_gen/matplotlib.colors.NoNorm.html) states that it "returns 0 if vmin==vmax." The parameters vmin and vmax were being set from the initial label layer (all zeros), causing the label layer to always get mapped to zero. I updated the NoNorm call to explicitly set vmin and vmax to span the range of the colormap, and updated the unit tests.

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
