### PR TITLE
[WIP] Add axes argument to register_translation

### DIFF
--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -76,7 +76,7 @@ def _upsampled_dft(data, upsampled_region_size,
 
         shifts = -ax_offset * np.fft.fftfreq(n_items, upsample_factor)[:, None]
         shifts = np.squeeze(np.exp(-im2pi * shifts.T))
-        data *= shifts.reshape(*shifts.shape, *(1, )*(nreg - 1))
+        data *= shifts.reshape(*shifts.shape, *(1, ) * (nreg - 1))
 
         # Equivalent to:
         #   data[i, j, k] = kernel[i, :] @ data[j, k].T
@@ -240,7 +240,7 @@ def register_translation(src_image, target_image, upsample_factor=1,
         flat_maxima = np.argmax(flat_CC, axis=-1)
         CCmax = flat_CC[..., flat_maxima]
         maxima = np.stack(np.unravel_index(flat_maxima,
-                                           (upsampled_region_size,)*axes),
+                                           (upsampled_region_size,) * axes),
                           axis=-1)
 
         shifts = shifts + (maxima - dftshift) / upsample_factor

--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -191,20 +191,20 @@ def register_translation(src_image, target_image, upsample_factor=1,
     cross_correlation = np.fft.ifftn(image_product, axes=register_axes)
 
     # Locate maximum
-    flattened_CC = np.abs(cross_correlation).reshape(*broadcast_shape,
-                                                    np.product(register_shape))
-    maxima = np.unravel_index(np.argmax(flattened_CC, axis=-1), register_shape)
-    maxima = np.stack(maxima, axis=-1)
+    flat_CC = np.abs(cross_correlation).reshape(*broadcast_shape,
+                                                np.product(register_shape))
+    flat_maxima = np.argmax(flat_CC, axis=-1)
+    maxima = np.stack(np.unravel_index(flat_maxima, register_shape), axis=-1)
     midpoints = np.array([np.fix(axis_size / 2) for axis_size in register_shape])
 
     shifts = maxima - np.array(register_shape) * (maxima > midpoints)
     if upsample_factor == 1:
         if return_error:
             src_amp = np.sum(np.abs(src_freq) ** 2, axis=register_axes) \
-                             / src_freq.size
+                / np.product(register_shape)
             target_amp = np.sum(np.abs(target_freq) ** 2, axis=register_axes) \
-                                / target_freq.size
-            CCmax = cross_correlation[maxima]
+                / np.product(register_shape)
+            CCmax = flat_CC[..., flat_maxima]
     # If upsampling > 1, then refine estimate with matrix multiply DFT
     else:
         # Initial shift estimate in upsampled grid

--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -181,6 +181,7 @@ def register_translation(src_image, target_image, upsample_factor=1,
 
     register_axes = np.arange(image_dim - axes, image_dim)
     register_shape = image_shape[register_axes]
+    register_size = np.product(register_shape)
     broadcast_shape = image_shape[:image_dim - axes]
     register_axes = tuple(register_axes)
 
@@ -202,8 +203,7 @@ def register_translation(src_image, target_image, upsample_factor=1,
     cross_correlation = np.fft.ifftn(image_product, axes=register_axes)
 
     # Locate maximum
-    flat_CC = np.abs(cross_correlation).reshape(*broadcast_shape,
-                                                np.product(register_shape))
+    flat_CC = np.abs(cross_correlation).reshape(*broadcast_shape, register_size)
     flat_maxima = np.argmax(flat_CC, axis=-1)
     maxima = np.stack(np.unravel_index(flat_maxima, register_shape), axis=-1)
     midpoints = np.array([np.fix(axis_size / 2) for axis_size in register_shape])
@@ -212,9 +212,9 @@ def register_translation(src_image, target_image, upsample_factor=1,
     if upsample_factor == 1:
         if return_error:
             src_amp = np.sum(np.abs(src_freq) ** 2, axis=register_axes) \
-                / np.product(register_shape)
+                / register_size
             target_amp = np.sum(np.abs(target_freq) ** 2, axis=register_axes) \
-                / np.product(register_shape)
+                / register_size
             CCmax = flat_CC[..., flat_maxima]
     # If upsampling > 1, then refine estimate with matrix multiply DFT
     else:

--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -105,7 +105,7 @@ def _compute_error(cross_correlation_max, src_amp, target_amp):
 
 
 def register_translation(src_image, target_image, upsample_factor=1,
-                         space="real", return_error=True):
+                         space="real", return_error=True, axes=None):
     """
     Efficient subpixel image translation registration by cross-correlation.
 
@@ -133,6 +133,10 @@ def register_translation(src_image, target_image, upsample_factor=1,
     return_error : bool, optional
         Returns error and phase difference if on,
         otherwise only shifts are returned
+    axes : int or tuple of int, optional
+        Register the first (or last) ``n`` axes of the images. If positive,
+        register the first ``n`` axes. If negative, register the last ``n`` axes.
+        Default None (regiseter all axes)
 
     Returns
     -------

--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -134,9 +134,8 @@ def register_translation(src_image, target_image, upsample_factor=1,
         Returns error and phase difference if on,
         otherwise only shifts are returned
     axes : int or tuple of int, optional
-        Register the first (or last) ``n`` axes of the images. If positive,
-        register the first ``n`` axes. If negative, register the last ``n`` axes.
-        Default None (regiseter all axes)
+        Register the last ``n`` axes of the images. Default None (register all
+         axes)
 
     Returns
     -------
@@ -162,6 +161,16 @@ def register_translation(src_image, target_image, upsample_factor=1,
     if src_image.shape != target_image.shape:
         raise ValueError("Error: images must be same size for "
                          "register_translation")
+
+    image_dim = src_image.ndim
+    image_shape = np.array(src_image.shape)
+
+    if axes is None:
+        axes = image_dim
+
+    register_axes = np.arange(image_dim - axes, image_dim)
+    register_shape = image_shape[register_axes]
+    broadcast_shape = image_shape[:image_dim - axes]
 
     # assume complex data is already in Fourier space
     if space.lower() == 'fourier':

--- a/skimage/feature/tests/test_register_translation.py
+++ b/skimage/feature/tests/test_register_translation.py
@@ -165,3 +165,16 @@ def test_axes_subpixel():
                                                     space="fourier",
                                                     axes=2)
     assert_allclose(result, shifts, atol=0.05)
+
+
+def test_length_1_unregistered_axis_subpixel():
+    reference_image = np.fft.fftn(camera())
+    shift = np.array([[2.7, -15.3]])
+    image_stack = reference_image[None, :, :]
+    shifted_image_stack = fourier_shift(reference_image, shift[0])[None, :, :]
+    result, error, diffphase = register_translation(shifted_image_stack,
+                                                    image_stack,
+                                                    10,
+                                                    space="fourier",
+                                                    axes=2)
+    assert_allclose(result, shift, atol=0.05)

--- a/skimage/feature/tests/test_register_translation.py
+++ b/skimage/feature/tests/test_register_translation.py
@@ -150,3 +150,18 @@ def test_axes_pixel():
                                                     space="fourier",
                                                     axes=2)
     assert_allclose(result, shifts)
+
+
+def test_axes_subpixel():
+    reference_image = np.fft.fftn(camera())
+    shifts = np.array([[2.7, -15.3], [20.1, -5.9], [-7.5, -10.4]])
+    image_stack = np.tile(reference_image, (3, 1, 1))
+    shifted_image_stack = np.zeros_like(image_stack)
+    for i, shift in enumerate(shifts):
+        shifted_image_stack[i] = fourier_shift(reference_image, shift)
+    result, error, diffphase = register_translation(shifted_image_stack,
+                                                    image_stack,
+                                                    10,
+                                                    space="fourier",
+                                                    axes=2)
+    assert_allclose(result, shifts, atol=0.05)

--- a/skimage/feature/tests/test_register_translation.py
+++ b/skimage/feature/tests/test_register_translation.py
@@ -149,4 +149,4 @@ def test_axes_pixel():
                                                     image_stack,
                                                     space="fourier",
                                                     axes=2)
-    assert_allclose(result, shifts)                                            
+    assert_allclose(result, shifts)

--- a/skimage/feature/tests/test_register_translation.py
+++ b/skimage/feature/tests/test_register_translation.py
@@ -138,7 +138,7 @@ def test_mismatch_offsets_size():
                        axis_offsets=[3, 2, 1, 4])
 
 
-def test_negative_axes_pixel():
+def test_axes_pixel():
     reference_image = np.fft.fftn(camera())
     shifts = np.array([[2, -15], [20, -5], [-7, -10]])
     image_stack = np.tile(reference_image, (3, 1, 1))
@@ -148,5 +148,5 @@ def test_negative_axes_pixel():
     result, error, diffphase = register_translation(shifted_image_stack,
                                                     image_stack,
                                                     space="fourier",
-                                                    axes=-2)
+                                                    axes=2)
     assert_allclose(result, shifts)                                            

--- a/skimage/feature/tests/test_register_translation.py
+++ b/skimage/feature/tests/test_register_translation.py
@@ -136,3 +136,17 @@ def test_mismatch_offsets_size():
     with testing.raises(ValueError):
         _upsampled_dft(np.ones((4, 4)), 3,
                        axis_offsets=[3, 2, 1, 4])
+
+
+def test_negative_axes_pixel():
+    reference_image = np.fft.fftn(camera())
+    shifts = np.array([[2, -15], [20, -5], [-7, -10]])
+    image_stack = np.tile(reference_image, (3, 1, 1))
+    shifted_image_stack = np.zeros_like(image_stack)
+    for i, shift in enumerate(shifts):
+        shifted_image_stack[i] = fourier_shift(reference_image, shift)
+    result, error, diffphase = register_translation(shifted_image_stack,
+                                                    image_stack,
+                                                    space="fourier",
+                                                    axes=-2)
+    assert_allclose(result, shifts)                                            


### PR DESCRIPTION
## Description

Add optional argument `axes` to `register_translation` that allows users to register over a subset of the axes in their image. 

The use case I have in mind is stabilizing a time lapse by registering each frame to the previous:

```python
# image.shape = (t, r, c)
shifts, _, _ = register_translation(image[:-1], image[1:], axes=2)
# shifts.shape = (t, 2)
```

While I'm working on this, `axes=n` will register the last `n` axes of the image. Once I get the logic figured out, I'll make it so `n > 0` registers the first `n`  axes and `n < 0` registers the last `n` frames.

I'll also add an example (especially if #3745 gets merged before this one!).

## To do
- [ ] Subpixel registration
- [ ] Write tests for error and phase calculation
- [ ] Positive and negative axes arguments
- [ ] Example in documentation

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
