### PR TITLE
Improve imports in Cython modules

### DIFF
--- a/skimage/_shared/interpolation.pyx
+++ b/skimage/_shared/interpolation.pyx
@@ -1,4 +1,4 @@
-from interpolation cimport coord_map
+from .interpolation cimport coord_map
 
 
 def coord_map_py(dim, coord, mode):

--- a/skimage/feature/_cascade.pyx
+++ b/skimage/feature/_cascade.pyx
@@ -16,8 +16,8 @@ from skimage._shared.transform cimport integrate
 from skimage._shared.interpolation cimport round, fmax, fmin
 
 from cython.parallel import prange
-from skimage.color import rgb2gray
-from skimage.transform import integral_image
+from ..color import rgb2gray
+from ..transform import integral_image
 import xml.etree.ElementTree as ET
 from ._texture cimport _multiblock_lbp
 import math

--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -7,7 +7,6 @@ cimport numpy as cnp
 from libc.math cimport sin, cos, abs
 from .._shared.interpolation cimport bilinear_interpolation, round
 from .._shared.transform cimport integrate
-import cython
 
 cdef extern from "numpy/npy_math.h":
     double NAN "NPY_NAN"

--- a/skimage/io/_plugins/_colormixer.pyx
+++ b/skimage/io/_plugins/_colormixer.pyx
@@ -11,7 +11,6 @@ integers, so currently the only way to clip results efficiently
 one.
 
 """
-import cython
 
 cimport numpy as cnp
 from libc.math cimport exp, pow

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -5,7 +5,6 @@
 
 import numpy as np
 cimport numpy as np
-cimport cython
 
 ctypedef np.float64_t IMGDTYPE
 

--- a/skimage/segmentation/_felzenszwalb_cy.pyx
+++ b/skimage/segmentation/_felzenszwalb_cy.pyx
@@ -5,7 +5,6 @@
 import numpy as np
 from scipy import ndimage as ndi
 
-cimport cython
 cimport numpy as cnp
 from ..measure._ccomp cimport find_root, join_trees
 

--- a/skimage/segmentation/_slic.pyx
+++ b/skimage/segmentation/_slic.pyx
@@ -3,7 +3,6 @@
 #cython: nonecheck=False
 #cython: wraparound=False
 from libc.float cimport DBL_MAX
-from cpython cimport bool
 
 import numpy as np
 cimport numpy as cnp

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -5,7 +5,6 @@
 import numpy as np
 
 cimport numpy as cnp
-cimport cython
 
 from cpython.mem cimport PyMem_Malloc, PyMem_Free
 from libc.stdlib cimport abs


### PR DESCRIPTION
## Description
Cleans up some cython imports to help future devs with annoying cython errors that might crop up.

@jni just hit a cython import that was annoying enough.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
