### PR TITLE
Use integer division in examples when using transform.resize

### DIFF
--- a/doc/examples/transform/plot_rescale.py
+++ b/doc/examples/transform/plot_rescale.py
@@ -27,8 +27,8 @@ from skimage.transform import rescale, resize, downscale_local_mean
 
 image = color.rgb2gray(data.astronaut())
 
-image_rescaled = rescale(image, 1.0 / 4.0, anti_aliasing=False)
-image_resized = resize(image, (image.shape[0] / 4, image.shape[1] / 4),
+image_rescaled = rescale(image, 1.0 // 4.0, anti_aliasing=False)
+image_resized = resize(image, (image.shape[0] // 4, image.shape[1] // 4),
                        anti_aliasing=True)
 image_downscaled = downscale_local_mean(image, (4, 3))
 


### PR DESCRIPTION
solves "ValueError: Integer argument required but received (817.8, 516.8, 3), check inputs."

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
