### PR TITLE
Allow for f-contiguous 2D arrays in convex_hull_image

### DIFF
--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -56,7 +56,7 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10):
     # the starting or ending pixel of a row or column.  This vastly
     # limits the number of coordinates to examine for the virtual hull.
     if ndim == 2:
-        coords = possible_hull(image.astype(np.uint8))
+        coords = possible_hull(np.ascontiguousarray(image.astype(np.uint8)))
     else:
         coords = np.transpose(np.nonzero(image))
         if offset_coordinates:

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -56,7 +56,7 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10):
     # the starting or ending pixel of a row or column.  This vastly
     # limits the number of coordinates to examine for the virtual hull.
     if ndim == 2:
-        coords = possible_hull(np.ascontiguousarray(image.astype(np.uint8)))
+        coords = possible_hull(np.ascontiguousarray(image, dtype=np.uint8))
     else:
         coords = np.transpose(np.nonzero(image))
         if offset_coordinates:

--- a/skimage/morphology/tests/test_convex_hull.py
+++ b/skimage/morphology/tests/test_convex_hull.py
@@ -136,6 +136,9 @@ def test_object():
     with testing.raises(ValueError):
         convex_hull_object(image, 7)
 
+def test_f_contiguous():
+    image = np.ones((2,2), order='F', dtype=bool)
+    assert_array_equal(convex_hull_image(image), image)
 
 @testing.fixture
 def images2d3d():

--- a/skimage/morphology/tests/test_convex_hull.py
+++ b/skimage/morphology/tests/test_convex_hull.py
@@ -136,9 +136,11 @@ def test_object():
     with testing.raises(ValueError):
         convex_hull_object(image, 7)
 
+
 def test_f_contiguous():
-    image = np.ones((2,2), order='F', dtype=bool)
+    image = np.ones((2, 2), order='F', dtype=bool)
     assert_array_equal(convex_hull_image(image), image)
+
 
 @testing.fixture
 def images2d3d():

--- a/skimage/morphology/tests/test_convex_hull.py
+++ b/skimage/morphology/tests/test_convex_hull.py
@@ -137,8 +137,15 @@ def test_object():
         convex_hull_object(image, 7)
 
 
-def test_f_contiguous():
+def test_non_c_contiguous():
+    # 2D Fortran-contiguous
     image = np.ones((2, 2), order='F', dtype=bool)
+    assert_array_equal(convex_hull_image(image), image)
+    # 3D Fortran-contiguous
+    image = np.ones((2, 2, 2), order='F', dtype=bool)
+    assert_array_equal(convex_hull_image(image), image)
+    # 3D non-contiguous
+    image = np.transpose(np.ones((2, 2, 2), dtype=bool), [0, 2, 1])
     assert_array_equal(convex_hull_image(image), image)
 
 


### PR DESCRIPTION
## Description
This is the bug fix for issue #3758.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
