### PR TITLE
Add urllib.request again

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,6 +2,7 @@
 # https://github.com/pytest-dev/pytest/issues/3888
 pytest!=3.7.3
 pytest-cov
+pytest-localserver
 flake8
 codecov
 pytest-faulthandler

--- a/skimage/io/tests/test_io.py
+++ b/skimage/io/tests/test_io.py
@@ -8,29 +8,20 @@ from skimage._shared import testing
 from skimage._shared.testing import assert_array_equal
 
 
-@pytest.fixture
-def urllib_urlopen(monkeypatch):
-    def mockopen(resource_name):
-        class MockOpen:
-            @staticmethod
-            def read():
-                # bytes of a 1x1 jpg
-                return (b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01'
-                        b'\x00\x01\x00\x00\xff\xdb\x00C\x00\x03\x02\x02\x02\x02'
-                        b'\x02\x03\x02\x02\x02\x03\x03\x03\x03\x04\x06\x04\x04'
-                        b'\x04\x04\x04\x08\x06\x06\x05\x06\t\x08\n\n\t\x08\t\t'
-                        b'\n\x0c\x0f\x0c\n\x0b\x0e\x0b\t\t\r\x11\r\x0e\x0f\x10'
-                        b'\x10\x11\x10\n\x0c\x12\x13\x12\x10\x13\x0f\x10\x10'
-                        b'\x10\xff\xc0\x00\x0b\x08\x00\x01\x00\x01\x01\x01\x11'
-                        b'\x00\xff\xc4\x00\x14\x00\x01\x00\x00\x00\x00\x00\x00'
-                        b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\t\xff\xc4\x00'
-                        b'\x14\x10\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                        b'\x00\x00\x00\x00\x00\x00\xff\xda\x00\x08\x01\x01\x00'
-                        b'\x00?\x00*\x9f\xff\xd9')
-        return MockOpen
-
-    monkeypatch.setattr('urllib.request.urlopen', mockopen)
-
+one_by_one_jpeg = (
+    b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01'
+    b'\x00\x01\x00\x00\xff\xdb\x00C\x00\x03\x02\x02\x02\x02'
+    b'\x02\x03\x02\x02\x02\x03\x03\x03\x03\x04\x06\x04\x04'
+    b'\x04\x04\x04\x08\x06\x06\x05\x06\t\x08\n\n\t\x08\t\t'
+    b'\n\x0c\x0f\x0c\n\x0b\x0e\x0b\t\t\r\x11\r\x0e\x0f\x10'
+    b'\x10\x11\x10\n\x0c\x12\x13\x12\x10\x13\x0f\x10\x10'
+    b'\x10\xff\xc0\x00\x0b\x08\x00\x01\x00\x01\x01\x01\x11'
+    b'\x00\xff\xc4\x00\x14\x00\x01\x00\x00\x00\x00\x00\x00'
+    b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\t\xff\xc4\x00'
+    b'\x14\x10\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    b'\x00\x00\x00\x00\x00\x00\xff\xda\x00\x08\x01\x01\x00'
+    b'\x00?\x00*\x9f\xff\xd9'
+)
 
 def test_stack_basic():
     x = np.arange(12).reshape(3, 4)
@@ -53,8 +44,12 @@ def test_imread_file_url():
     assert image.shape == (512, 512)
 
 
-def test_imread_http_url(urllib_urlopen):
-    query_string = '?' + 's' * 266
-    image_url = 'https://image.com/camera.jpg{}'.format(query_string)
-    image = io.imread(image_url)
+def test_imread_http_url(httpserver):
+    # httpserver is a fixture provided by pytest-localserver
+    # https://bitbucket.org/pytest-dev/pytest-localserver/
+    httpserver.serve_content(one_by_one_jpeg)
+    # it will serve anything you provide to it on its url.
+    # we add a /test.jpg so that we can identify the content
+    # by extension
+    image = io.imread(httpserver.url + '/test.jpg' + '?' + 's' * 266)
     assert image.shape == (1, 1)

--- a/skimage/io/util.py
+++ b/skimage/io/util.py
@@ -1,4 +1,5 @@
 import urllib.parse
+import urllib.request
 
 import os
 import re


### PR DESCRIPTION
## Description

Not too sure why or how the tests pass without this line in there :/.

Seems to have been removed in a recent PR.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
