### PR TITLE
Avoid NumPy warning while stacking arrays.

### DIFF
--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -396,9 +396,9 @@ def test_iradon_sart():
         np.random.seed(1239867)
         shifts = np.random.uniform(-3, 3, sinogram.shape[1])
         x = np.arange(sinogram.shape[0])
-        sinogram_shifted = np.vstack(np.interp(x + shifts[i], x,
-                                               sinogram[:, i])
-                                     for i in range(sinogram.shape[1])).T
+        sinogram_shifted = np.vstack([np.interp(x + shifts[i], x,
+                                                sinogram[:, i])
+                                      for i in range(sinogram.shape[1])]).T
         reconstructed = iradon_sart(sinogram_shifted, theta,
                                     projection_shifts=shifts)
         if debug:


### PR DESCRIPTION
Newer versions of NumPy require that a list/tuple is passed in, and here we are using a generator.