### PR TITLE
Backport: Reduce default tolerance in threshold_li (#3622)

### DIFF
--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 import itertools
 import math
 import numpy as np

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -529,11 +529,6 @@ def threshold_li(image):
     image : ndarray
         Input image.
 
-    tolerance : float, optional
-        Finish the computation when the change in the threshold in an iteration
-        is less than this value. By default, this is half of the range of the
-        input image, divided by 256.
-
     Returns
     -------
     threshold : float
@@ -582,8 +577,7 @@ def threshold_li(image):
     # Li's algorithm requires positive image (because of log(mean))
     image_min = np.min(image)
     image -= image_min
-    image_range = np.max(image)
-    tolerance = 0.5 * image_range / 256
+    tolerance = np.min(np.diff(np.unique(image))) / 2
 
     # Initial estimate
     t_curr = np.mean(image)


### PR DESCRIPTION
* Reduce the default tolerance in threshold_li

Fixes #3605

In that issue, I found that a tolerance of `range / 2**15` was
sufficient. However, the only thing that guarantees convergence is the
smallest intensity difference in the image (it's impossible for the
update to change if the threshold doesn't change). I've set this as the
new default, as the only downside is that it might take a long time to
converge, but that seems preferable to finding an incorrect threshold.

* Fix documentation of tolerance in threshold_li

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
