### PR TITLE
Readme: Remove expectation for future fix from matplotlib

### DIFF
--- a/requirements/README.md
+++ b/requirements/README.md
@@ -34,4 +34,4 @@ $ pip install -U -r requirements/test.txt
 
 * Cython 0.28.2 was empircally found to fail tests while other patch-releases 0.28.x do not
 * Cython 0.29.0 erroneously sets the `__path__` to `None`. See https://github.com/cython/cython/issues/2662
-* matplotlib 3.0.0 is not used because of a bug that collapses 3D axes (see https://github.com/scikit-image/scikit-image/pull/3474 and https://github.com/matplotlib/matplotlib/issues/12239). We expect this issue to be resolved in the next matplotlib release.
+* matplotlib 3.0.0 is not used because of a bug that collapses 3D axes (see https://github.com/scikit-image/scikit-image/pull/3474 and https://github.com/matplotlib/matplotlib/issues/12239).


### PR DESCRIPTION
## Description

This line is not necessary anymore.


## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
