### PR TITLE
Improved documentation/test in `flood()`

### DIFF
--- a/skimage/morphology/_flood_fill.py
+++ b/skimage/morphology/_flood_fill.py
@@ -173,8 +173,9 @@ def flood(image, seed_point, *, selem=None, connectivity=None, tolerance=None):
     Fill connected ones with 5, with full connectivity (diagonals included):
 
     >>> mask = flood(image, (1, 1))
-    >>> image[mask] = 5
-    >>> image
+    >>> image_flooded = image.copy()
+    >>> image_flooded[mask] = 5
+    >>> image_flooded
     array([[0, 0, 0, 0, 0, 0, 0],
            [0, 5, 5, 0, 2, 2, 0],
            [0, 5, 5, 0, 2, 2, 0],
@@ -183,18 +184,20 @@ def flood(image, seed_point, *, selem=None, connectivity=None, tolerance=None):
     Fill connected ones with 5, excluding diagonal points (connectivity 1):
 
     >>> mask = flood(image, (1, 1), connectivity=1)
-    >>> image[mask] = 1
-    >>> image
+    >>> image_flooded = image.copy()
+    >>> image_flooded[mask] = 5
+    >>> image_flooded
     array([[0, 0, 0, 0, 0, 0, 0],
-           [0, 1, 1, 0, 2, 2, 0],
-           [0, 1, 1, 0, 2, 2, 0],
-           [5, 0, 0, 0, 0, 0, 3]])
+           [0, 5, 5, 0, 2, 2, 0],
+           [0, 5, 5, 0, 2, 2, 0],
+           [1, 0, 0, 0, 0, 0, 3]])
 
     Fill with a tolerance:
 
     >>> mask = flood(image, (0, 0), tolerance=1)
-    >>> image[mask] = 5
-    >>> image
+    >>> image_flooded = image.copy()
+    >>> image_flooded[mask] = 5
+    >>> image_flooded
     array([[5, 5, 5, 5, 5, 5, 5],
            [5, 5, 5, 5, 2, 2, 5],
            [5, 5, 5, 5, 2, 2, 5],


### PR DESCRIPTION
## Improved documentation of the `flood()` function

The examples in `flood()` [documentation](http://scikit-image.org/docs/dev/api/skimage.morphology.html?highlight=flood#skimage.morphology.flood) only give the suggested outputs if they are run in sequence. As a documentation, it might be better to have examples that can be understood independently. Suggested some changes for doing that

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
