### PR TITLE
Use float32 when warping when provided by the user.

### DIFF
--- a/benchmarks/benchmark_transform_warp.py
+++ b/benchmarks/benchmark_transform_warp.py
@@ -30,8 +30,15 @@ class WarpSuite:
             warp, inverse_map=tform,
             order=order, preserve_range=True)
 
-    # def time_same_type(self, dtype_in, N, order, dtype_tform):
     def time_warp(self, dtype_in, N, order):
+        """Test the case where the users wants to preserve their same low
+        precision data type."""
+        result = self.warp(self.image)
+
+        # convert back to input type, no-op if same type
+        result = result.astype(dtype_in, copy=False)
+
+    def peakmem_warp(self, dtype_in, N, order):
         """Test the case where the users wants to preserve their same low
         precision data type."""
         result = self.warp(self.image)

--- a/benchmarks/benchmark_transform_warp.py
+++ b/benchmarks/benchmark_transform_warp.py
@@ -20,9 +20,10 @@ class WarpSuite:
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", "Possible precision loss")
             self.image = convert(np.random.random((N, N)), dtype=dtype_in)
+
         tform = SimilarityTransform(scale=1, rotation=np.pi / 10,
                                     translation=(0, 4))
-        tform.params = tform.params.astype('float32')
+        tform.params = tform.params.astype(dtype_in)
         order = order
 
         self.warp = functools.partial(

--- a/benchmarks/benchmark_transform_warp.py
+++ b/benchmarks/benchmark_transform_warp.py
@@ -30,7 +30,7 @@ class WarpSuite:
             order=order, preserve_range=True)
 
     # def time_same_type(self, dtype_in, N, order, dtype_tform):
-    def time_same_type(self, dtype_in, N, order):
+    def time_warp(self, dtype_in, N, order):
         """Test the case where the users wants to preserve their same low
         precision data type."""
         result = self.warp(self.image)
@@ -38,8 +38,3 @@ class WarpSuite:
         # convert back to input type, no-op if same type
         result = result.astype(dtype_in, copy=False)
 
-    # def time_to_float64(self, dtype_in, N, order, dtype_form):
-    def time_to_float64(self, dtype_in, N, order):
-        """Test the case where want to upvert to float64 for continued
-        transformations."""
-        result = self.warp(self.image)

--- a/skimage/_shared/interpolation.pxd
+++ b/skimage/_shared/interpolation.pxd
@@ -103,17 +103,14 @@ cdef inline void bilinear_interpolation(
     dr = r - minr
     dc = c - minc
 
-    cdef np.float64_t top
-    cdef np.float64_t bottom
-
     cdef np_real_numeric top_left = get_pixel2d(image, rows, cols, minr, minc, mode, cval)
     cdef np_real_numeric top_right = get_pixel2d(image, rows, cols, minr, maxc, mode, cval)
     cdef np_real_numeric bottom_left = get_pixel2d(image, rows, cols, maxr, minc, mode, cval)
     cdef np_real_numeric bottom_right = get_pixel2d(image, rows, cols, maxr, maxc, mode, cval)
 
-    top = (1 - dc) * top_left + dc * top_right
-    bottom = (1 - dc) * bottom_left + dc * bottom_right
-    out[0] = <np_real_numeric_out> ((1 - dr) * top + dr * bottom)
+    out[0] = <np_real_numeric_out> (
+        (1 - dr) * ((1 - dc) * top_left + dc * top_right) +
+        dr * ((1 - dc) * bottom_left + dc * bottom_right))
 
 cdef inline np_floats quadratic_interpolation(np_floats x,
                                               np_real_numeric[3] f) nogil:

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -860,15 +860,17 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=1,
         if matrix is not None:
             matrix = matrix.astype(np.double)
             if image.ndim == 2:
-                warped = _warp_fast(image, matrix,
-                                    output_shape=output_shape,
-                                    order=order, mode=mode, cval=cval)
+                warped = np.empty(shape=output_shape, dtype=image.dtype)
+                _warp_fast(image, matrix,
+                           out=warped, order=order, mode=mode, cval=cval)
             elif image.ndim == 3:
                 dims = []
                 for dim in range(image.shape[2]):
-                    dims.append(_warp_fast(image[..., dim], matrix,
-                                           output_shape=output_shape,
-                                           order=order, mode=mode, cval=cval))
+                    warped = np.empty(shape=output_shape[:2],
+                                      dtype=image.dtype)
+                    _warp_fast(image[..., dim], matrix,
+                               out=warped, order=order, mode=mode, cval=cval)
+                    dims.append(warped)
                 warped = np.dstack(dims)
 
     if warped is None:

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -858,7 +858,8 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=1,
             matrix = np.linalg.inv(inverse_map.__self__.params)
 
         if matrix is not None:
-            matrix = matrix.astype(np.double)
+            if not np.issubdtype(image.dtype, np.floating):
+                matrix = matrix.astype(np.double)
             if image.ndim == 2:
                 warped = np.empty(shape=output_shape, dtype=image.dtype)
                 _warp_fast(image, matrix,

--- a/skimage/transform/_warps_cy.pyx
+++ b/skimage/transform/_warps_cy.pyx
@@ -8,19 +8,19 @@ from .._shared.interpolation cimport (nearest_neighbour_interpolation,
                                       bilinear_interpolation,
                                       biquadratic_interpolation,
                                       bicubic_interpolation)
+from .._shared.fused_numerics cimport np_real_numeric, np_floats
 
-
-cdef inline void _transform_metric(double x, double y, double* H,
-                                   double *x_, double *y_) nogil:
+cdef inline void _transform_metric(np_floats x, np_floats y, np_floats* H,
+                                   np_floats *x_, np_floats *y_) nogil:
     """Apply a metric transformation to a coordinate.
 
     Parameters
     ----------
-    x, y : double
+    x, y : float32 or float64
         Input coordinate.
-    H : (3,3) *double
+    H : (3,3) *float32 or *float64
         Transformation matrix.
-    x_, y_ : *double
+    x_, y_ : *float32 or *float64
         Output coordinate.
 
     """
@@ -28,17 +28,17 @@ cdef inline void _transform_metric(double x, double y, double* H,
     y_[0] = H[4] * y + H[5]
 
 
-cdef inline void _transform_affine(double x, double y, double* H,
-                                   double *x_, double *y_) nogil:
+cdef inline void _transform_affine(np_floats x, np_floats y, np_floats* H,
+                                   np_floats *x_, np_floats *y_) nogil:
     """Apply an affine transformation to a coordinate.
 
     Parameters
     ----------
-    x, y : double
+    x, y : float32 or float64
         Input coordinate.
-    H : (3,3) *double
+    H : (3,3) *float32 or *float64
         Transformation matrix.
-    x_, y_ : *double
+    x_, y_ : *float32 or *float64
         Output coordinate.
 
     """
@@ -46,28 +46,34 @@ cdef inline void _transform_affine(double x, double y, double* H,
     y_[0] = H[3] * x + H[4] * y + H[5]
 
 
-cdef inline void _transform_projective(double x, double y, double* H,
-                                       double *x_, double *y_) nogil:
+cdef inline void _transform_projective(np_floats x, np_floats y, np_floats* H,
+                                       np_floats *x_, np_floats *y_) nogil:
     """Apply a homography to a coordinate.
 
     Parameters
     ----------
-    x, y : double
+    x, y : float32 or float64
         Input coordinate.
-    H : (3,3) *double
+    H : (3,3) *float32 or *float64
         Transformation matrix.
-    x_, y_ : *double
+    x_, y_ : *float32 or *float64
         Output coordinate.
 
     """
-    cdef double z_
+    cdef np_floats z_
     z_ = H[6] * x + H[7] * y + H[8]
     x_[0] = (H[0] * x + H[1] * y + H[2]) / z_
     y_[0] = (H[3] * x + H[4] * y + H[5]) / z_
 
 
-def _warp_fast(cnp.ndarray image, cnp.ndarray H, output_shape=None,
-               int order=1, mode='constant', double cval=0):
+# Without these definitions, it assumes that
+# H, and out have the same dtype
+ctypedef fused np_floats_H:
+    np_floats
+
+def _warp_fast(np_floats[:, :] image, np_floats_H[:, :] H,
+               np_floats[:, ::1] out,
+               int order=1, mode='constant', np_floats cval=0):
     """Projective transformation (homography).
 
     Perform a projective transformation (homography) of a
@@ -90,12 +96,12 @@ def _warp_fast(cnp.ndarray image, cnp.ndarray H, output_shape=None,
 
     Parameters
     ----------
-    image : 2-D array
+    image : 2-D array (float32 or float64)
         Input image.
     H : array of shape ``(3, 3)``
         Transformation matrix H that defines the homography.
-    output_shape : tuple (rows, cols), optional
-        Shape of the output image generated (default None).
+    out : 2-D array (float32 or float64)
+        THe buffer where to store the output image.
     order : {0, 1, 2, 3}, optional
         Order of interpolation::
         * 0: Nearest-neighbor
@@ -105,7 +111,7 @@ def _warp_fast(cnp.ndarray image, cnp.ndarray H, output_shape=None,
     mode : {'constant', 'edge', 'symmetric', 'reflect', 'wrap'}, optional
         Points outside the boundaries of the input are filled according
         to the given mode.  Modes match the behaviour of `numpy.pad`.
-    cval : string, optional (default 0)
+    cval : np_floats_out, optional (default 0)
         Used in conjunction with mode 'C' (constant), the value
         outside the image boundaries.
 
@@ -119,30 +125,23 @@ def _warp_fast(cnp.ndarray image, cnp.ndarray H, output_shape=None,
 
     """
 
-    cdef double[:, ::1] img = np.ascontiguousarray(image, dtype=np.double)
-    cdef double[:, ::1] M = np.ascontiguousarray(H)
+    cdef np_floats[:, ::1] img = np.ascontiguousarray(image)
+    cdef np_floats_H[:, ::1] M = np.ascontiguousarray(H)
 
     if mode not in ('constant', 'wrap', 'symmetric', 'reflect', 'edge'):
         raise ValueError("Invalid mode specified.  Please use `constant`, "
                          "`edge`, `wrap`, `reflect` or `symmetric`.")
     cdef char mode_c = ord(mode[0].upper())
 
-    cdef Py_ssize_t out_r, out_c
-    if output_shape is None:
-        out_r = int(img.shape[0])
-        out_c = int(img.shape[1])
-    else:
-        out_r = int(output_shape[0])
-        out_c = int(output_shape[1])
-
-    cdef double[:, ::1] out = np.zeros((out_r, out_c), dtype=np.double)
+    cdef Py_ssize_t out_r = out.shape[0]
+    cdef Py_ssize_t out_c = out.shape[1]
 
     cdef Py_ssize_t tfr, tfc
-    cdef double r, c
+    cdef np_floats_H r, c
     cdef Py_ssize_t rows = img.shape[0]
     cdef Py_ssize_t cols = img.shape[1]
 
-    cdef void (*transform_func)(double, double, double*, double*, double*) nogil
+    cdef void (*transform_func)(np_floats_H, np_floats_H, np_floats_H*, np_floats_H*, np_floats_H*) nogil
     if M[2, 0] == 0 and M[2, 1] == 0 and M[2, 2] == 1:
         if M[0, 1] == 0 and M[1, 0] == 0:
             transform_func = _transform_metric
@@ -151,16 +150,19 @@ def _warp_fast(cnp.ndarray image, cnp.ndarray H, output_shape=None,
     else:
         transform_func = _transform_projective
 
-    cdef void (*interp_func)(double*, Py_ssize_t , Py_ssize_t ,
-                             double, double, char, double, double*) nogil
+    cdef void (*interp_func)(np_floats*,
+                             Py_ssize_t , Py_ssize_t ,
+                             np_floats_H, np_floats_H,
+                             char,
+                             np_floats, np_floats*) nogil
     if order == 0:
-        interp_func = nearest_neighbour_interpolation[cnp.float64_t, double, double]
+        interp_func = nearest_neighbour_interpolation
     elif order == 1:
-        interp_func = bilinear_interpolation[cnp.float64_t, double, double]
+        interp_func = bilinear_interpolation
     elif order == 2:
-        interp_func = biquadratic_interpolation[cnp.float64_t, double, double]
+        interp_func = biquadratic_interpolation
     elif order == 3:
-        interp_func = bicubic_interpolation[cnp.float64_t, double, double]
+        interp_func = bicubic_interpolation
     else:
         raise ValueError("Unsupported interpolation order", order)
 
@@ -170,5 +172,3 @@ def _warp_fast(cnp.ndarray image, cnp.ndarray H, output_shape=None,
                 transform_func(tfc, tfr, &M[0, 0], &c, &r)
                 interp_func(&img[0, 0], rows, cols, r, c,
                             mode_c, cval, &out[tfr, tfc])
-
-    return np.asarray(out)

--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -103,7 +103,8 @@ def radon(image, theta=None, circle=True):
         return shift1.dot(R).dot(shift0)
 
     for i in range(len(theta)):
-        rotated = _warp_fast(padded_image, build_rotation(theta[i]))
+        rotated = np.zeros_like(padded_image)
+        _warp_fast(padded_image, build_rotation(theta[i]), out=rotated)
         radon_image[:, i] = rotated.sum(0)
     return radon_image
 

--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -4,6 +4,7 @@ from scipy.interpolate import interp1d
 from ._warps_cy import _warp_fast
 from ._radon_transform import sart_projection_update
 from warnings import warn
+from .._shared.utils import convert_to_float
 
 
 __all__ = ['radon', 'order_angles_golden_ratio', 'iradon', 'iradon_sart']
@@ -103,6 +104,12 @@ def radon(image, theta=None, circle=True):
         return shift1.dot(R).dot(shift0)
 
     for i in range(len(theta)):
+        if not np.issubdtype(padded_image.dtype, np.floating):
+            # prior to this, img_as_float was never called.
+            # Numpy casting means that preserve_range was implicitely
+            # set to True
+            # https://github.com/scikit-image/scikit-image/issues/3799
+            padded_image = convert_to_float(padded_image, preserve_range=True)
         rotated = np.zeros_like(padded_image)
         _warp_fast(padded_image, build_rotation(theta[i]), out=rotated)
         radon_image[:, i] = rotated.sum(0)

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -12,7 +12,7 @@ from skimage.color import rgb2gray
 
 from skimage._shared import testing
 from skimage._shared.testing import (assert_almost_equal, assert_equal,
-                                     test_parallel)
+                                     test_parallel, parametrize)
 from skimage._shared._warnings import expected_warnings
 
 
@@ -523,3 +523,12 @@ def test_zero_image_size():
     with testing.raises(ValueError):
         warp(np.zeros((10, 10, 0)),
              SimilarityTransform())
+
+
+@parametrize('dtype', [np.float32, np.float64])
+def test_warp_floats(dtype):
+    x = np.zeros((5, 5), dtype=dtype)
+    tform = SimilarityTransform(scale=1)
+
+    x_tform = warp(x, tform, order=1)
+    assert x_tform.dtype == x.dtype

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -14,6 +14,7 @@ from skimage._shared import testing
 from skimage._shared.testing import (assert_almost_equal, assert_equal,
                                      test_parallel, parametrize)
 from skimage._shared._warnings import expected_warnings
+from numpy.testing import assert_allclose
 
 
 np.random.seed(0)
@@ -528,7 +529,18 @@ def test_zero_image_size():
 @parametrize('dtype', [np.float32, np.float64])
 def test_warp_floats(dtype):
     x = np.zeros((5, 5), dtype=dtype)
+    x[0, 0] = 1
     tform = SimilarityTransform(scale=1)
 
     x_tform = warp(x, tform, order=1)
     assert x_tform.dtype == x.dtype
+    assert_allclose(x, x_tform)
+
+@parametrize('dtype', [np.uint8, np.uint16, np.uint32,
+                       np.int8, np.int16, np.int32])
+def test_warp_ints(dtype):
+    x = np.zeros((5, 5), dtype=dtype)
+    x[0, 0] = 1
+    tform = SimilarityTransform(scale=1)
+    x_tform = warp(x, tform, order=1)
+    assert_allclose(img_as_float(x), x_tform)


### PR DESCRIPTION
## Description

I don't want to enable integer warping right away, but this is at least a good start.

I probably need to write a failer for iradon
xref: https://github.com/scikit-image/scikit-image/pull/3486

```python
pytest skimage/transform/tests/test_warps.py                                  
============================= test session starts ==============================
platform linux -- Python 3.7.1, pytest-4.3.0, py-1.8.0, pluggy-0.9.0
rootdir: /home/mark/git/scikit-image/skimage/transform, inifile:
plugins: xdist-1.26.1, localserver-0.5.0, forked-1.0.2, faulthandler-1.5.0
collected 41 items                                                             

skimage/transform/tests/test_warps.py .................................. [ 82%]
.....F.                                                                  [100%]

=================================== FAILURES ===================================
__________________________ test_warp_floats[float32] ___________________________

dtype = <class 'numpy.float32'>

    @parametrize('dtype', [np.float32, np.float64])
    def test_warp_floats(dtype):
        x = np.zeros((5, 5), dtype=dtype)
        tform = SimilarityTransform(scale=1)
    
        x_tform = warp(x, tform, order=1)
>       assert x_tform.dtype == x.dtype
E       AssertionError: assert dtype('float64') == dtype('float32')
E        +  where dtype('float64') = array([[ 0.,  0.,  0.,  0.,  0.],\n       [ 0.,  0.,  0.,  0.,  0.],\n       [ 0.,  0.,  0.,  0.,  0.],\n       [ 0.,  0.,  0.,  0.,  0.],\n       [ 0.,  0.,  0.,  0.,  0.]]).dtype
E        +  and   dtype('float32') = array([[ 0.,  0.,  0.,  0.,  0.],\n       [ 0.,  0.,  0.,  0.,  0.],\n       [ 0.,  0.,  0.,  0.,  0.],\n       [ 0.,  0.,  0.,  0.,  0.],\n       [ 0.,  0.,  0.,  0.,  0.]], dtype=float32).dtype

skimage/transform/tests/test_warps.py:533: AssertionError
===================== 1 failed, 40 passed in 0.29 seconds ======
```


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
