### PR TITLE
Use ssize_t in denoise cython

### DIFF
--- a/skimage/restoration/_denoise_cy.pyx
+++ b/skimage/restoration/_denoise_cy.pyx
@@ -122,7 +122,8 @@ def _denoise_tv_bregman(np_floats[:, :, ::1] image, np_floats weight,
         np_floats rmse = DBL_MAX
         np_floats norm = (weight + 4 * lam)
 
-    Py_ssize_t out_rows, out_cols = out.shape[:2]
+    Py_ssize_t out_rows, out_cols
+    out_rows, out_cols = out.shape[:2]
     out[1:out_rows-1, 1:out_cols-1] = image
 
     # reflect image

--- a/skimage/restoration/_denoise_cy.pyx
+++ b/skimage/restoration/_denoise_cy.pyx
@@ -122,7 +122,7 @@ def _denoise_tv_bregman(np_floats[:, :, ::1] image, np_floats weight,
         np_floats rmse = DBL_MAX
         np_floats norm = (weight + 4 * lam)
 
-    out_rows, out_cols = out.shape[:2]
+    Py_ssize_t out_rows, out_cols = out.shape[:2]
     out[1:out_rows-1, 1:out_cols-1] = image
 
     # reflect image

--- a/skimage/restoration/_denoise_cy.pyx
+++ b/skimage/restoration/_denoise_cy.pyx
@@ -122,7 +122,7 @@ def _denoise_tv_bregman(np_floats[:, :, ::1] image, np_floats weight,
         np_floats rmse = DBL_MAX
         np_floats norm = (weight + 4 * lam)
 
-    Py_ssize_t out_rows, out_cols
+        Py_ssize_t out_rows, out_cols
     out_rows, out_cols = out.shape[:2]
     out[1:out_rows-1, 1:out_cols-1] = image
 


### PR DESCRIPTION
## Description

Cython warns that it can go faster if you specify the dtype

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
