### PR TITLE
compare_ssim: fix window size of Gaussian filter

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -84,6 +84,13 @@ Bugfixes
 - ``skimage.morphology.local_maxima`` and ``skimage.morphology.local_minima``
   will return a boolean array instead of an array of 0s and 1s if the
   parameter ``indices`` was false.
+- When `compare_ssim` is used with `gaussian_weights` set to True, the boundary
+  crop used when computing the mean structural similarity will now exactly
+  match the width of the Gaussian used. The Gaussian filter window is also now
+  truncated at 3.5 rather than 4.0 standard deviations to exactly match the
+  original publication on the SSIM. These changes should produce only a very
+  small change in the computed SSIM value. There is no change to the existing
+  behavior when `gaussian_weights` is False.
 
 
 Deprecations

--- a/skimage/measure/_structural_similarity.py
+++ b/skimage/measure/_structural_similarity.py
@@ -153,11 +153,11 @@ def compare_ssim(X, Y, win_size=None, gradient=False,
     ndim = X.ndim
 
     if gaussian_weights:
-        # sigma = 1.5 to approximately match filter in Wang et. al. 2004
-        # this ends up giving a 13-tap rather than 11-tap Gaussian
+        # sigma = 1.5 as used in Wang et. al. 2004. Setting truncate to
+        # 3.5 gives an 11-tap filter as used in the publication.
         filter_func = gaussian_filter
-        filter_args = {'sigma': sigma}
-
+        truncate = 3.5
+        filter_args = {'sigma': sigma, 'truncate': truncate}
     else:
         filter_func = uniform_filter
         filter_args = {'size': win_size}

--- a/skimage/measure/_structural_similarity.py
+++ b/skimage/measure/_structural_similarity.py
@@ -17,16 +17,16 @@ def compare_ssim(X, Y, win_size=None, gradient=False,
     Parameters
     ----------
     X, Y : ndarray
-        Image.  Any dimensionality.
+        Image. Any dimensionality.
     win_size : int or None
-        The side-length of the sliding window used in comparison.  Must be an
-        odd value.  If `gaussian_weights` is True, this is ignored and the
+        The side-length of the sliding window used in comparison. Must be an
+        odd value. If `gaussian_weights` is True, this is ignored and the
         window size will depend on `sigma`.
     gradient : bool, optional
         If True, also return the gradient with respect to Y.
     data_range : float, optional
         The data range of the input image (distance between minimum and
-        maximum possible values).  By default, this is estimated from the image
+        maximum possible values). By default, this is estimated from the image
         data-type.
     multichannel : bool, optional
         If True, treat the last dimension of the array as channels. Similarity
@@ -41,14 +41,14 @@ def compare_ssim(X, Y, win_size=None, gradient=False,
     Other Parameters
     ----------------
     use_sample_covariance : bool
-        if True, normalize covariances by N-1 rather than, N where N is the
+        If True, normalize covariances by N-1 rather than, N where N is the
         number of pixels within the sliding window.
     K1 : float
-        algorithm parameter, K1 (small constant, see [1]_)
+        Algorithm parameter, K1 (small constant, see [1]_).
     K2 : float
-        algorithm parameter, K2 (small constant, see [1]_)
+        Algorithm parameter, K2 (small constant, see [1]_).
     sigma : float
-        sigma for the Gaussian when `gaussian_weights` is True.
+        Standard deviation for the Gaussian when `gaussian_weights` is True.
 
     Returns
     -------

--- a/skimage/measure/_structural_similarity.py
+++ b/skimage/measure/_structural_similarity.py
@@ -129,9 +129,16 @@ def compare_ssim(X, Y, win_size=None, gradient=False,
         raise ValueError("sigma must be positive")
     use_sample_covariance = kwargs.pop('use_sample_covariance', True)
 
+    if gaussian_weights:
+        # Set to give an 11-tap filter with the default sigma of 1.5 to match
+        # Wang et. al. 2004.
+        truncate = 3.5
+
     if win_size is None:
         if gaussian_weights:
-            win_size = 11  # 11 to match Wang et. al. 2004
+            # set win_size used by crop to match the filter size
+            r = int(truncate * sigma + 0.5)  # radius as in ndimage
+            win_size = 2 * r + 1
         else:
             win_size = 7   # backwards compatibility
 
@@ -153,10 +160,7 @@ def compare_ssim(X, Y, win_size=None, gradient=False,
     ndim = X.ndim
 
     if gaussian_weights:
-        # sigma = 1.5 as used in Wang et. al. 2004. Setting truncate to
-        # 3.5 gives an 11-tap filter as used in the publication.
         filter_func = gaussian_filter
-        truncate = 3.5
         filter_args = {'sigma': sigma, 'truncate': truncate}
     else:
         filter_func = uniform_filter

--- a/skimage/measure/tests/test_structural_similarity.py
+++ b/skimage/measure/tests/test_structural_similarity.py
@@ -176,7 +176,7 @@ def test_gaussian_mssim_vs_author_ref():
     mssim_matlab = 0.327314295673357
     mssim = ssim(cam, cam_noisy, gaussian_weights=True,
                  use_sample_covariance=False)
-    assert_almost_equal(mssim, mssim_matlab, decimal=3)
+    assert_almost_equal(mssim, mssim_matlab, decimal=10)
 
 
 def test_gaussian_mssim_and_gradient_vs_Matlab():


### PR DESCRIPTION
## Description

This PR has minor fixes to `compare_ssim` when `gaussian_filter` is set to True.  There is no change in the output for the default settings of `compare_ssim` and should only be very small changes with `gaussian_filter=True` for realistic image sizes. (A difference was seen at the fourth significant digit for an example given in #3652).

1.) Sets the truncate argument to `gaussian_filter` to get the same 11 sample window width as in the SSIM publication. It was previously using the default of truncate=4.0 which gives a 13 sample window instead.

2.) Sets `win_size` to match the Gaussian size at a user-specified `sigma` rather than relying on a hard-coded value of 11.

closes #3652 

I think the second item is technically a bug, but not a high priority one as the impact is fairly minor for most images (usually I only see SSIM comparisons up to 3 digits in publications).

## Checklist

- [x] Unit tests

The existing IPOL comparison still agree to 3 significant digits. The Matlab one now agrees to 12 digits on my machine, so I tightened the tolerance for that test.

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
