### PR TITLE
Removed non-existent parameter in docstring

### DIFF
--- a/skimage/morphology/_flood_fill_cy.pyx
+++ b/skimage/morphology/_flood_fill_cy.pyx
@@ -105,8 +105,6 @@ cpdef inline void _flood_fill_tolerance(dtype_t[::1] image,
     neighbor_offsets : ndarray
         A one-dimensional array that contains the offsets to find the
         connected neighbors for any index in `image`.
-    queue_ptr :
-        Pointer to initialized queue.
     start_index : int
         Start position for the flood-fill.
     seed_value :


### PR DESCRIPTION
## Description

Removed argument `queue_ptr` from the docstring of `flood_fill` cython file since it does not appear in the argument list of the function

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
