### PR TITLE
win_size checks dims except last

### DIFF
--- a/skimage/measure/_structural_similarity.py
+++ b/skimage/measure/_structural_similarity.py
@@ -142,7 +142,7 @@ def compare_ssim(X, Y, win_size=None, gradient=False,
         else:
             win_size = 7   # backwards compatibility
 
-    if np.any((np.asarray(X.shape) - win_size) < 0):
+    if np.any((np.asarray(X.shape)[:-1] - win_size) < 0):
         raise ValueError(
             "win_size exceeds image extent.  If the input is a multichannel "
             "(color) image, set multichannel=True.")


### PR DESCRIPTION
## Description

Previously, win_size was checked against all the dimensions (including the last dimension, ie. pixel channel) of the input image. This PR fixes it by checking the size against all dimensions but the last one.

PS: I have made a few assumptions about how the function works. Please do let me know if I have misunderstood something.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
