### PR TITLE
ENHANCEMENT: Compatibility with dask for image thresholding methods

### DIFF
--- a/benchmarks/benchmark_filters.py
+++ b/benchmarks/benchmark_filters.py
@@ -15,3 +15,39 @@ class FiltersSuite:
         result = filters.sobel(self.image)
 
 
+class ThresholdingSuite:
+    """Benchmark for image thresholding routines in scikit-image."""
+    def setup(self):
+        self.image = np.random.random((4000, 4000))
+        self.image[:2000, :2000] += 1
+        self.image[3000:, 3000] += 0.5
+
+    def time_threshold_local(self):
+        result = filters.threshold_local(self.image, 11)
+
+    def time_threshold_otsu(self):
+        result = filters.threshold_otsu(self.image)
+
+    def time_threshold_yen(self):
+        result = filters.threshold_yen(self.image)
+
+    def time_threshold_isodata(self):
+        result = filters.threshold_isodata(self.image)
+
+    def time_threshold_li(self):
+        result = filters.threshold_li(self.image)
+
+    def time_threshold_minimum(self):
+        result = filters.threshold_minimum(self.image)
+
+    def time_threshold_mean(self):
+        result = filters.threshold_mean(self.image)
+
+    def time_threshold_triangle(self):
+        result = filters.threshold_triangle(self.image)
+
+    def time_threshold_niblack(self):
+        result = filters.threshold_niblack(self.image)
+
+    def time_threshold_sauvola(self):
+        result = filters.threshold_sauvola(self.image)

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -66,7 +66,8 @@ def _bincount_histogram(image, source_range):
     elif source_range == 'dtype':
         image_min, image_max = dtype_limits(image, clip_negative=False)
     image, offset = _offset_array(image, image_min, image_max)
-    hist = np.bincount(image.ravel(), minlength=image_max - image_min + 1)
+    hist = np.bincount(image.ravel(),
+                       minlength=int(image_max) - int(image_min) + 1)
     bin_centers = np.arange(image_min, image_max + 1)
     if source_range == 'image':
         idx = max(image_min, 0)

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -61,13 +61,12 @@ def _bincount_histogram(image, source_range):
     if source_range not in ['image', 'dtype']:
         raise ValueError('Incorrect value for `source_range` argument: {}'.format(source_range))
     if source_range == 'image':
-        image_min = np.min(image).astype(np.int64)
-        image_max = np.max(image).astype(np.int64)
+        image_min = int(np.min(image).astype(np.int64))
+        image_max = int(np.max(image).astype(np.int64))
     elif source_range == 'dtype':
         image_min, image_max = dtype_limits(image, clip_negative=False)
     image, offset = _offset_array(image, image_min, image_max)
-    hist = np.bincount(image.ravel(),
-                       minlength=int(image_max) - int(image_min) + 1)
+    hist = np.bincount(image.ravel(), minlength=image_max - image_min + 1)
     bin_centers = np.arange(image_min, image_max + 1)
     if source_range == 'image':
         idx = max(image_min, 0)

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -231,7 +231,7 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
     return thresh_image - offset
 
 
-def threshold_otsu(image, nbins=256):
+def threshold_otsu(image, nbins=256, source_range='image'):
     """Return threshold value based on Otsu's method.
 
     Parameters
@@ -241,6 +241,11 @@ def threshold_otsu(image, nbins=256):
     nbins : int, optional
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
+    source_range : 'image' or 'dtype' (default value is 'image').
+    source_range : string, optional
+        'image' (default) determines the histogram range from the input image.
+        'dtype' determines the histogram range from the expected range of the
+        images of that data type.
 
     Returns
     -------
@@ -279,7 +284,8 @@ def threshold_otsu(image, nbins=256):
                          "having more than one color. The input image seems "
                          "to have just one color {0}.".format(image.min()))
 
-    hist, bin_centers = histogram(image.ravel(), nbins, source_range='image')
+    hist, bin_centers = histogram(image.ravel(), nbins,
+                                  source_range=source_range)
     hist = hist.astype(float)
 
     # class probabilities for all possible thresholds
@@ -299,7 +305,7 @@ def threshold_otsu(image, nbins=256):
     return threshold
 
 
-def threshold_yen(image, nbins=256):
+def threshold_yen(image, nbins=256, source_range='image'):
     """Return threshold value based on Yen's method.
 
     Parameters
@@ -309,6 +315,10 @@ def threshold_yen(image, nbins=256):
     nbins : int, optional
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
+    source_range : string, optional
+        'image' (default) determines the histogram range from the input image.
+        'dtype' determines the histogram range from the expected range of the
+        images of that data type.
 
     Returns
     -------
@@ -334,7 +344,8 @@ def threshold_yen(image, nbins=256):
     >>> thresh = threshold_yen(image)
     >>> binary = image <= thresh
     """
-    hist, bin_centers = histogram(image.ravel(), nbins, source_range='image')
+    hist, bin_centers = histogram(image.ravel(), nbins,
+                                  source_range=source_range)
     # On blank images (e.g. filled with 0) with int dtype, `histogram()`
     # returns `bin_centers` containing only one value. Speed up with it.
     if bin_centers.size == 1:
@@ -353,7 +364,7 @@ def threshold_yen(image, nbins=256):
     return bin_centers[crit.argmax()]
 
 
-def threshold_isodata(image, nbins=256, return_all=False):
+def threshold_isodata(image, nbins=256, source_range='image', return_all=False):
     """Return threshold value(s) based on ISODATA method.
 
     Histogram-based threshold, known as Ridler-Calvard method or inter-means.
@@ -376,6 +387,10 @@ def threshold_isodata(image, nbins=256, return_all=False):
     nbins : int, optional
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
+    source_range : string, optional
+        'image' (default) determines the histogram range from the input image.
+        'dtype' determines the histogram range from the expected range of the
+        images of that data type.
     return_all: bool, optional
         If False (default), return only the lowest threshold that satisfies
         the above equality. If True, return all valid thresholds.
@@ -406,7 +421,8 @@ def threshold_isodata(image, nbins=256, return_all=False):
     >>> thresh = threshold_isodata(image)
     >>> binary = image > thresh
     """
-    hist, bin_centers = histogram(image.ravel(), nbins, source_range='image')
+    hist, bin_centers = histogram(image.ravel(), nbins,
+                                  source_range=source_range)
 
     # image only contains one unique value
     if len(bin_centers) == 1:
@@ -599,7 +615,7 @@ def threshold_li(image, *, tolerance=None):
     return threshold
 
 
-def threshold_minimum(image, nbins=256, max_iter=10000):
+def threshold_minimum(image, nbins=256, source_range='image', max_iter=10000):
     """Return threshold value based on minimum method.
 
     The histogram of the input `image` is computed and smoothed until there are
@@ -612,6 +628,10 @@ def threshold_minimum(image, nbins=256, max_iter=10000):
     nbins : int, optional
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
+    source_range : string, optional
+        'image' (default) determines the histogram range from the input image.
+        'dtype' determines the histogram range from the expected range of the
+        images of that data type.
     max_iter: int, optional
         Maximum number of iterations to smooth the histogram.
 
@@ -661,7 +681,8 @@ def threshold_minimum(image, nbins=256, max_iter=10000):
 
         return maximum_idxs
 
-    hist, bin_centers = histogram(image.ravel(), nbins, source_range='image')
+    hist, bin_centers = histogram(image.ravel(), nbins,
+                                  source_range=source_range)
 
     smooth_hist = np.copy(hist).astype(np.float64)
 
@@ -714,7 +735,7 @@ def threshold_mean(image):
     return np.mean(image)
 
 
-def threshold_triangle(image, nbins=256):
+def threshold_triangle(image, nbins=256, source_range='image'):
     """Return threshold value based on the triangle algorithm.
 
     Parameters
@@ -724,6 +745,10 @@ def threshold_triangle(image, nbins=256):
     nbins : int, optional
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
+    source_range : string, optional
+        'image' (default) determines the histogram range from the input image.
+        'dtype' determines the histogram range from the expected range of the
+        images of that data type.
 
     Returns
     -------
@@ -749,7 +774,8 @@ def threshold_triangle(image, nbins=256):
     """
     # nbins is ignored for integer arrays
     # so, we recalculate the effective nbins.
-    hist, bin_centers = histogram(image.ravel(), nbins, source_range='image')
+    hist, bin_centers = histogram(image.ravel(), nbins,
+                                  source_range=source_range)
     nbins = len(hist)
 
     # Find peak, lowest and highest gray levels.

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -364,7 +364,8 @@ def threshold_yen(image, nbins=256, source_range='image'):
     return bin_centers[crit.argmax()]
 
 
-def threshold_isodata(image, nbins=256, source_range='image', return_all=False):
+def threshold_isodata(image, nbins=256, source_range='image',
+                      return_all=False):
     """Return threshold value(s) based on ISODATA method.
 
     Histogram-based threshold, known as Ridler-Calvard method or inter-means.


### PR DESCRIPTION
## Description

We can make most of the scikit-image thresholding functions compatible with dask with a very small change. These functions are now compatible with dask arrays:
* threshold_isodata
* threshold_mean
* threshold_minimum
* threshold_otsu
* threshold_triangle
* threshold_yen

### Details
I wrap two  integer values with `int()` in the `__bincount_histogram()` from `skimage/exposure/exposure.py`. 

1. If the input is a numpy array, this is redundant and has no effect. 
2. If the input is a dask array it will force computation & let us avoid the error that happens when you pass a dask object in as a keyword argument to `numpy.bincount()` a few lines later.

I also allow users to control the histogram keyword argument  `source_range` from the thresholding functions (something we already do for the keyword argument controlling the number of histogram bins). This is of particular importance to dask users, who are likely to want to use `source_range='dtype'` as a way to keep computations as lazy as possible.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] ~~[Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py) (no new functions here)~~
- [ ] ~~Gallery example in `./doc/examples` (new features only)~~
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark (I've given this a go, any feedback here? It's the first time I've written benchmarks for scikit-image)
- [ ] Unit tests (Should I write some that explicitly include dask arrays? What's the stance on compatibility between libraries and the scikit-image test suite?)
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
