### PR TITLE
WIP: Avoid sphinx 2 (for now)

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,4 @@
-# Sphinx 1.7.8 has a bug when building on cached envs
-# https://github.com/sphinx-doc/sphinx/issues/5361
-sphinx>=1.3,!=1.7.8
+sphinx==1.8.5
 numpydoc>=0.6
 sphinx-gallery
 sphinx-copybutton


### PR DESCRIPTION
## Description

**This is just a test.**

It looks like your doc test build started failing when Sphinx 2 was released.  This is just to reduce the noise in the CI system until someone gets the docs building with Sphinx 2.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
