### PR TITLE
Force imageio reader to return NumPy arrays

### DIFF
--- a/skimage/io/_plugins/imageio_plugin.py
+++ b/skimage/io/_plugins/imageio_plugin.py
@@ -4,12 +4,6 @@ from functools import wraps
 import numpy as np
 from imageio import imread as imageio_imread, imsave
 
-
-def array_return(f):
-    @wraps(f)
-    def wrapper(*args, **kwargs):
-        return np.asarray(f(*args, **kwargs))
-    return wrapper
-
-
-imread = array_return(imageio_imread)
+@wraps(imageio_imread)
+def imread(*args, **kwargs):
+    return np.asarray(imageio_imread(*args, **kwargs))

--- a/skimage/io/_plugins/imageio_plugin.py
+++ b/skimage/io/_plugins/imageio_plugin.py
@@ -4,6 +4,7 @@ from functools import wraps
 import numpy as np
 from imageio import imread as imageio_imread, imsave
 
+
 @wraps(imageio_imread)
 def imread(*args, **kwargs):
     return np.asarray(imageio_imread(*args, **kwargs))

--- a/skimage/io/_plugins/imageio_plugin.py
+++ b/skimage/io/_plugins/imageio_plugin.py
@@ -1,3 +1,15 @@
 __all__ = ['imread', 'imsave']
 
-from imageio import imread, imsave
+from functools import wraps
+import numpy as np
+from imageio import imread as imageio_imread, imsave
+
+
+def array_return(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        return np.asarray(f(*args, **kwargs))
+    return wrapper
+
+
+imread = array_return(imageio_imread)

--- a/skimage/io/tests/test_imageio.py
+++ b/skimage/io/tests/test_imageio.py
@@ -77,3 +77,10 @@ class TestSave(TestCase):
             else:
                 x = (x * 255).astype(dtype)
                 yield self.roundtrip, x
+
+
+def test_return_class():
+    testing.assert_equal(
+        type(imread(os.path.join(data_dir, 'color.png'))),
+        np.ndarray
+    )


### PR DESCRIPTION
In newer versions of `imageio`, they now return an ndarray subclass with a `.meta` attribute.  We moved away from this kind of representation many years ago (yes, we used to have an Image object!), because these subclassed arrays do not survive computation through a typical pipeline.