### PR TITLE
Fix fast_exp for gcc 8.3 with certain flags

### DIFF
--- a/skimage/_shared/fast_exp.h
+++ b/skimage/_shared/fast_exp.h
@@ -15,7 +15,7 @@
 // All these inline directives are necessary for us to stay compatible with
 // as many compilers as possible.
 // See discussion https://github.com/scikit-image/scikit-image/issues/3866
-__inline double inline __attribute__((always_inline)) fast_exp (double y)
+double inline __attribute__((always_inline)) fast_exp (double y)
 {
     union
     {

--- a/skimage/_shared/fast_exp.h
+++ b/skimage/_shared/fast_exp.h
@@ -15,7 +15,14 @@
 // All these inline directives are necessary for us to stay compatible with
 // as many compilers as possible.
 // See discussion https://github.com/scikit-image/scikit-image/issues/3866
-double inline __attribute__((always_inline)) fast_exp (double y)
+#ifdef _MSC_VER
+#define INLINE_PREFIX_DIRECTIVE __inline
+#define INLINE_SUFFIX_DIRECTIVE
+#else
+#define INLINE_PREFIX_DIRECTIVE
+#define INLINE_SUFFIX_DIRECTIVE inline __attribute__((always inline))
+#endif
+INLINE_PREFIX_DIRECTIVE double INLINE_SUFFIX_DIRECTIVE fast_exp (double y)
 {
     union
     {

--- a/skimage/_shared/fast_exp.h
+++ b/skimage/_shared/fast_exp.h
@@ -12,7 +12,10 @@
 /* For min. mean relative error */
 /* #define EXP_BC 1072625005 */        /* 1023*2^20 - 68243 */
 
-__inline double fast_exp (double y)
+// All these inline directives are necessary for us to stay compatible with
+// as many compilers as possible.
+// See discussion https://github.com/scikit-image/scikit-image/issues/3866
+__inline double inline __attribute__((always_inline)) fast_exp (double y)
 {
     union
     {


### PR DESCRIPTION
## Description

Not sure exactly what combination of things this helps
Closes https://github.com/scikit-image/scikit-image/issues/3866

But I think these flags are all necessary for some compilers with certain flags....

Who knows.... But it definitely helps one person
## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
