### PR TITLE
scipy stopped emitting a warnings for the matrix subclass in 1.3

### DIFF
--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -15,7 +15,7 @@ SCIPY_RANK_WARNING = r'numpy.linalg.matrix_rank|\A\Z'
 PYAMG_MISSING_WARNING = r'pyamg|\A\Z'
 PYAMG_OR_SCIPY_WARNING = SCIPY_RANK_WARNING + '|' + PYAMG_MISSING_WARNING
 
-if (Version(np.__version__) >= '1.15.0'):
+if Version(np.__version__) >= '1.15.0' and Version(scipy.__version__) < '1.3':
     NUMPY_MATRIX_WARNING = 'matrix subclass'
 else:
     NUMPY_MATRIX_WARNING = None
@@ -352,7 +352,7 @@ def test_trivial_cases():
             output_labels = random_walker(img, markers)
     assert np.all(output_labels[markers == 1] == 1)
     # Here 0-labeled pixels could not be determined (no connexion to seed)
-    assert np.all(output_labels[markers == 0] == -1) 
+    assert np.all(output_labels[markers == 0] == -1)
     with expected_warnings(["Returning provided labels"]):
         test = random_walker(img, markers, return_full_prob=True)
 


### PR DESCRIPTION
## Description

It seems that scipy removed the warning in 1.13. Maybe also in some version of 1.12 since they are considering backporting it.
https://github.com/scipy/scipy/pull/9764


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
