### PR TITLE
Backport: use fused types in denoise, warp (#3486)

### DIFF
--- a/benchmarks/benchmark_transform_warp.py
+++ b/benchmarks/benchmark_transform_warp.py
@@ -1,0 +1,50 @@
+import numpy as np
+from skimage.transform import SimilarityTransform, warp
+from skimage.util.dtype import convert
+import warnings
+import functools
+import inspect
+
+
+class WarpSuite:
+    params = ([np.uint8, np.uint16, np.float32, np.float64],
+              [128, 1024, 4096],
+              [0, 1, 3],
+              # [np.float32, np.float64]
+              )
+    # param_names = ['dtype_in', 'N', 'order', 'dtype_tform']
+    param_names = ['dtype_in', 'N', 'order']
+
+    # def setup(self, dtype_in, N, order, dtype_tform):
+    def setup(self, dtype_in, N, order):
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "Possible precision loss")
+            self.image = convert(np.random.random((N, N)), dtype=dtype_in)
+        self.tform = SimilarityTransform(scale=1, rotation=np.pi / 10,
+                                         translation=(0, 4))
+        self.tform.params = self.tform.params.astype('float32')
+        self.order = order
+
+        if 'dtype' in inspect.signature(warp).parameters:
+            self.warp = functools.partial(warp, dtype=self.image.dtype)
+        else:
+            # Keep a call to functools to have the same number of python
+            # function calls
+            self.warp = functools.partial(warp)
+
+    # def time_same_type(self, dtype_in, N, order, dtype_tform):
+    def time_same_type(self, dtype_in, N, order):
+        """Test the case where the users wants to preserve their same low
+        precision data type."""
+        result = self.warp(self.image, self.tform, order=self.order,
+                           preserve_range=True)
+
+        # convert back to input type, no-op if same type
+        result = result.astype(dtype_in, copy=False)
+
+    # def time_to_float64(self, dtype_in, N, order, dtype_form):
+    def time_to_float64(self, dtype_in, N, order):
+        """Test the case where want to upvert to float64 for continued
+        transformations."""
+        result = warp(self.image, self.tform, order=self.order,
+                      preserve_range=True)

--- a/skimage/_shared/fused_numerics.pxd
+++ b/skimage/_shared/fused_numerics.pxd
@@ -1,0 +1,34 @@
+cimport numpy as cnp
+import numpy as np
+
+ctypedef fused np_ints:
+    cnp.int8_t
+    cnp.int16_t
+    cnp.int32_t
+    cnp.int64_t
+
+ctypedef fused np_uints:
+    cnp.uint8_t
+    cnp.uint16_t
+    cnp.uint32_t
+    cnp.uint64_t
+
+ctypedef fused np_anyint:
+    np_uints
+    np_ints
+
+ctypedef fused np_floats:
+    cnp.float32_t
+    cnp.float64_t
+
+ctypedef fused np_complexes:
+    cnp.complex64_t
+    cnp.complex128_t
+
+ctypedef fused np_real_numeric:
+    np_anyint
+    np_floats
+
+ctypedef fused np_numeric:
+    np_real_numeric
+    np_complexes

--- a/skimage/_shared/interpolation.pxd
+++ b/skimage/_shared/interpolation.pxd
@@ -18,66 +18,78 @@ by 4 values on each side:
 """
 from libc.math cimport ceil, floor
 
+import numpy as np
+cimport numpy as np
+from .fused_numerics cimport np_real_numeric, np_floats
 
-cdef inline Py_ssize_t round(double r) nogil:
+
+cdef inline Py_ssize_t round(np_floats r) nogil:
     return <Py_ssize_t>((r + 0.5) if (r > 0.0) else (r - 0.5))
 
 
-cdef inline double nearest_neighbour_interpolation(double* image,
-                                                   Py_ssize_t rows,
-                                                   Py_ssize_t cols, double r,
-                                                   double c, char mode,
-                                                   double cval) nogil:
+# Redefine np_real_numeric to force cross type compilation
+# this allows the output type to be different than the input dtype
+# https://cython.readthedocs.io/en/latest/src/userguide/fusedtypes.html#fused-types-and-arrays
+ctypedef fused np_real_numeric_out:
+    np_real_numeric
+
+
+cdef inline void nearest_neighbour_interpolation(
+        np_real_numeric* image, Py_ssize_t rows, Py_ssize_t cols,
+        np_floats r, np_floats c, char mode, np_real_numeric cval,
+        np_real_numeric_out* out) nogil:
     """Nearest neighbour interpolation at a given position in the image.
 
     Parameters
     ----------
-    image : double array
+    image : numeric array
         Input image.
     rows, cols : int
         Shape of image.
-    r, c : double
+    r, c : np_float
         Position at which to interpolate.
     mode : {'C', 'W', 'S', 'E', 'R'}
         Wrapping mode. Constant, Wrap, Symmetric, Edge or Reflect.
-    cval : double
+    cval : numeric
         Constant value to use for constant mode.
 
     Returns
     -------
-    value : double
+    value : np_float
         Interpolated value.
 
     """
 
-    return get_pixel2d(image, rows, cols, round(r), round(c), mode, cval)
+    out[0] = <np_real_numeric_out>get_pixel2d(
+        image, rows, cols, round(r), round(c), mode, cval)
 
 
-cdef inline double bilinear_interpolation(double* image, Py_ssize_t rows,
-                                          Py_ssize_t cols, double r, double c,
-                                          char mode, double cval) nogil:
+cdef inline void bilinear_interpolation(
+        np_real_numeric* image, Py_ssize_t rows, Py_ssize_t cols,
+        np_floats r, np_floats c, char mode, np_real_numeric cval,
+        np_real_numeric_out* out) nogil:
     """Bilinear interpolation at a given position in the image.
 
     Parameters
     ----------
-    image : double array
+    image : numeric array
         Input image.
     rows, cols : int
         Shape of image.
-    r, c : double
+    r, c : np_float
         Position at which to interpolate.
     mode : {'C', 'W', 'S', 'E', 'R'}
         Wrapping mode. Constant, Wrap, Symmetric, Edge or Reflect.
-    cval : double
+    cval : numeric
         Constant value to use for constant mode.
 
     Returns
     -------
-    value : double
+    value : numeric
         Interpolated value.
 
     """
-    cdef double dr, dc
+    cdef np_floats dr, dc
     cdef long minr, minc, maxr, maxc
 
     minr = <long>floor(r)
@@ -86,30 +98,36 @@ cdef inline double bilinear_interpolation(double* image, Py_ssize_t rows,
     maxc = <long>ceil(c)
     dr = r - minr
     dc = c - minc
-    top = (1 - dc) * get_pixel2d(image, rows, cols, minr, minc, mode, cval) \
-          + dc * get_pixel2d(image, rows, cols, minr, maxc, mode, cval)
-    bottom = (1 - dc) * get_pixel2d(image, rows, cols, maxr, minc, mode,
-                                    cval) \
-             + dc * get_pixel2d(image, rows, cols, maxr, maxc, mode, cval)
-    return (1 - dr) * top + dr * bottom
 
+    cdef np.float64_t top
+    cdef np.float64_t bottom
 
-cdef inline double quadratic_interpolation(double x, double[3] f) nogil:
+    cdef np_real_numeric top_left = get_pixel2d(image, rows, cols, minr, minc, mode, cval)
+    cdef np_real_numeric top_right = get_pixel2d(image, rows, cols, minr, maxc, mode, cval)
+    cdef np_real_numeric bottom_left = get_pixel2d(image, rows, cols, maxr, minc, mode, cval)
+    cdef np_real_numeric bottom_right = get_pixel2d(image, rows, cols, maxr, maxc, mode, cval)
+
+    top = (1 - dc) * top_left + dc * top_right
+    bottom = (1 - dc) * bottom_left + dc * bottom_right
+    out[0] = <np_real_numeric_out> ((1 - dr) * top + dr * bottom)
+
+cdef inline np_floats quadratic_interpolation(np_floats x,
+                                              np_real_numeric[3] f) nogil:
     """WARNING: Do not use, not implemented correctly.
 
     Quadratic interpolation.
 
     Parameters
     ----------
-    x : double
+    x : np_float
         Position in the interval [0, 2].
-    f : double[3]
+    f : real numeric[3]
         Function values at positions [0, 2].
 
     Returns
     -------
-    value : double
-        Interpolated value.
+    value : np_float
+        Interpolated value to be used in biquadratic_interpolation.
 
     """
     return (x * f[2] * (x - 1)) / 2 - \
@@ -117,30 +135,30 @@ cdef inline double quadratic_interpolation(double x, double[3] f) nogil:
                     (f[0] * (x - 1) * (x - 2)) / 2
 
 
-cdef inline double biquadratic_interpolation(double* image, Py_ssize_t rows,
-                                             Py_ssize_t cols, double r,
-                                             double c, char mode,
-                                             double cval) nogil:
+cdef inline void biquadratic_interpolation(
+        np_real_numeric* image, Py_ssize_t rows, Py_ssize_t cols,
+        np_floats r, np_floats c, char mode, np_real_numeric cval,
+        np_real_numeric_out* out) nogil:
     """WARNING: Do not use, not implemented correctly.
 
     Biquadratic interpolation at a given position in the image.
 
     Parameters
     ----------
-    image : double array
+    image : numeric array
         Input image.
     rows, cols : int
         Shape of image.
-    r, c : double
+    r, c : np_float
         Position at which to interpolate.
     mode : {'C', 'W', 'S', 'E', 'R'}
         Wrapping mode. Constant, Wrap, Symmetric, Edge or Reflect.
-    cval : double
+    cval : numeric
         Constant value to use for constant mode.
 
     Returns
     -------
-    value : double
+    out : np_real_numeric
         Interpolated value.
 
     """
@@ -148,11 +166,11 @@ cdef inline double biquadratic_interpolation(double* image, Py_ssize_t rows,
     cdef long r0 = <long>round(r) - 1
     cdef long c0 = <long>round(c) - 1
 
-    cdef double xr = r - r0
-    cdef double xc = c - c0
+    cdef np_floats xr = r - r0
+    cdef np_floats xc = c - c0
 
-    cdef double fc[3]
-    cdef double fr[3]
+    cdef np_real_numeric fc[3]
+    cdef np_floats fr[3]
 
     cdef long pr, pc
 
@@ -163,36 +181,37 @@ cdef inline double biquadratic_interpolation(double* image, Py_ssize_t rows,
                                  r0 + pr, c0 + pc, mode, cval)
         fr[pr] = quadratic_interpolation(xc, fc)
 
-    # cubic interpolation for interpolated values of each row
-    return quadratic_interpolation(xr, fr)
+    out[0] = <np_real_numeric_out>quadratic_interpolation(xr, fr)
 
 
-cdef inline double cubic_interpolation(double x, double[4] f) nogil:
+cdef inline np_floats cubic_interpolation(np_floats x, np_real_numeric[4] f) nogil:
     """Cubic interpolation.
 
     Parameters
     ----------
-    x : double
+    x : np_float
         Position in the interval [0, 1].
-    f : double[4]
+    f : real numeric[4]
         Function values at positions [-1, 0, 1, 2].
 
     Returns
     -------
-    value : double
-        Interpolated value.
+    value : np_float
+        Interpolated value to be used in bicubic_interpolation.
 
     """
-    return \
+    return (\
         f[1] + 0.5 * x * \
             (f[2] - f[0] + x * \
                 (2.0 * f[0] - 5.0 * f[1] + 4.0 * f[2] - f[3] + x * \
-                    (3.0 * (f[1] - f[2]) + f[3] - f[0])))
+                    (3.0 * (f[1] - f[2]) + f[3] - f[0]))))
 
 
-cdef inline double bicubic_interpolation(double* image, Py_ssize_t rows,
-                                         Py_ssize_t cols, double r, double c,
-                                         char mode, double cval) nogil:
+cdef inline void bicubic_interpolation(np_real_numeric* image,
+                                       Py_ssize_t rows, Py_ssize_t cols,
+                                       np_floats r, np_floats c, char mode,
+                                       np_real_numeric cval,
+                                       np_real_numeric_out* out) nogil:
     """Bicubic interpolation at a given position in the image.
 
     Interpolation using Catmull-Rom splines, based on the bicubic convolution
@@ -200,20 +219,20 @@ cdef inline double bicubic_interpolation(double* image, Py_ssize_t rows,
 
     Parameters
     ----------
-    image : double array
+    image : numeric array
         Input image.
     rows, cols : int
         Shape of image.
-    r, c : double
+    r, c : np_float
         Position at which to interpolate.
     mode : {'C', 'W', 'S', 'E', 'R'}
         Wrapping mode. Constant, Wrap, Symmetric, Edge or Reflect.
-    cval : double
+    cval : numeric
         Constant value to use for constant mode.
 
     Returns
     -------
-    value : double
+    out : np_real_numeric
         Interpolated value.
 
     References
@@ -228,15 +247,14 @@ cdef inline double bicubic_interpolation(double* image, Py_ssize_t rows,
     cdef long c0 = <long>floor(c)
 
     # scale position to range [0, 1]
-    cdef double xr = r - r0
-    cdef double xc = c - c0
+    cdef np_floats xr = r - r0
+    cdef np_floats xc = c - c0
 
     r0 -= 1
     c0 -= 1
 
-    cdef double fc[4]
-    cdef double fr[4]
-
+    cdef np_real_numeric fc[4]
+    cdef np_floats fr[4]
     cdef long pr, pc
 
     # row-wise cubic interpolation
@@ -245,18 +263,17 @@ cdef inline double bicubic_interpolation(double* image, Py_ssize_t rows,
             fc[pc] = get_pixel2d(image, rows, cols, pr + r0, pc + c0, mode, cval)
         fr[pr] = cubic_interpolation(xc, fc)
 
-    # cubic interpolation for interpolated values of each row
-    return cubic_interpolation(xr, fr)
+    out[0] = <np_real_numeric_out>cubic_interpolation(xr, fr)
 
-
-cdef inline double get_pixel2d(double* image, Py_ssize_t rows, Py_ssize_t cols,
-                               long r, long c, char mode,
-                               double cval) nogil:
+cdef inline np_real_numeric get_pixel2d(np_real_numeric* image,
+                                        Py_ssize_t rows, Py_ssize_t cols,
+                                        long r, long c, char mode,
+                                        np_real_numeric cval) nogil:
     """Get a pixel from the image, taking wrapping mode into consideration.
 
     Parameters
     ----------
-    image : double array
+    image : numeric array
         Input image.
     rows, cols : int
         Shape of image.
@@ -264,12 +281,12 @@ cdef inline double get_pixel2d(double* image, Py_ssize_t rows, Py_ssize_t cols,
         Position at which to get the pixel.
     mode : {'C', 'W', 'S', 'E', 'R'}
         Wrapping mode. Constant, Wrap, Symmetric, Edge or Reflect.
-    cval : double
+    cval : numeric
         Constant value to use for constant mode.
 
     Returns
     -------
-    value : double
+    value : numeric
         Pixel value at given position.
 
     """
@@ -279,17 +296,20 @@ cdef inline double get_pixel2d(double* image, Py_ssize_t rows, Py_ssize_t cols,
         else:
             return image[r * cols + c]
     else:
-        return image[coord_map(rows, r, mode) * cols + coord_map(cols, c, mode)]
+        return <np_real_numeric>(image[coord_map(rows, r, mode) * cols +
+                                       coord_map(cols, c, mode)])
 
 
-cdef inline double get_pixel3d(double* image, Py_ssize_t rows, Py_ssize_t cols,
-                               Py_ssize_t dims, long r, long c,
-                               long d, char mode, double cval) nogil:
+cdef inline np_real_numeric get_pixel3d(np_real_numeric* image,
+                                        Py_ssize_t rows, Py_ssize_t cols,
+                                        Py_ssize_t dims, long r, long c,
+                                        long d, char mode,
+                                        np_real_numeric cval) nogil:
     """Get a pixel from the image, taking wrapping mode into consideration.
 
     Parameters
     ----------
-    image : double array
+    image : numeric array
         Input image.
     rows, cols, dims : int
         Shape of image.
@@ -297,12 +317,12 @@ cdef inline double get_pixel3d(double* image, Py_ssize_t rows, Py_ssize_t cols,
         Position at which to get the pixel.
     mode : {'C', 'W', 'S', 'E', 'R'}
         Wrapping mode. Constant, Wrap, Symmetric, Edge or Reflect.
-    cval : double
+    cval : numeric
         Constant value to use for constant mode.
 
     Returns
     -------
-    value : double
+    out : np_real_numeric
         Pixel value at given position.
 
     """
@@ -312,9 +332,9 @@ cdef inline double get_pixel3d(double* image, Py_ssize_t rows, Py_ssize_t cols,
         else:
             return image[r * cols * dims + c * dims + d]
     else:
-        return image[coord_map(rows, r, mode) * cols * dims
-                     + coord_map(cols, c, mode) * dims
-                     + coord_map(dims, d, mode)]
+        return image[coord_map(rows, r, mode) * cols * dims +
+                     coord_map(cols, c, mode) * dims +
+                     coord_map(dims, d, mode)]
 
 
 cdef inline Py_ssize_t coord_map(Py_ssize_t dim, long coord, char mode) nogil:

--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -12,15 +12,8 @@ import cython
 cdef extern from "numpy/npy_math.h":
     double NAN "NPY_NAN"
 
-ctypedef fused any_int:
-    cnp.uint8_t
-    cnp.uint16_t
-    cnp.uint32_t
-    cnp.uint64_t
-    cnp.int8_t
-    cnp.int16_t
-    cnp.int32_t
-    cnp.int64_t
+from .._shared.fused_numerics cimport np_anyint as any_int
+from .._shared.fused_numerics cimport np_real_numeric
 
 
 def _glcm_loop(any_int[:, ::1] image, double[:] distances,
@@ -153,9 +146,9 @@ def _local_binary_pattern(double[:, ::1] image,
         for r in range(image.shape[0]):
             for c in range(image.shape[1]):
                 for i in range(P):
-                    texture[i] = bilinear_interpolation(&image[0, 0], rows, cols,
-                                                        r + rp[i], c + cp[i],
-                                                        'C', 0)
+                    bilinear_interpolation[cnp.float64_t, double, double](
+                            &image[0, 0], rows, cols, r + rp[i], c + cp[i],
+                            b'C', 0, &texture[i])
                 # signed / thresholded texture
                 for i in range(P):
                     if texture[i] - image[r, c] >= 0:

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -1,13 +1,32 @@
 # coding: utf-8
+import itertools
 import scipy.stats
 import numpy as np
 from math import ceil
 from .. import img_as_float
-from ..restoration._denoise_cy import _denoise_bilateral, _denoise_tv_bregman
-from .._shared.utils import skimage_deprecation, warn
+from ._denoise_cy import _denoise_bilateral, _denoise_tv_bregman
+from .._shared.utils import warn
 import pywt
 import skimage.color as color
 import numbers
+
+
+def _gaussian_weight(sigma_sqr, value):
+    return np.exp(-0.5 * value * value / sigma_sqr)
+
+
+def _compute_color_lut(bins, sigma, max_value, dtype):
+    color_lut = _gaussian_weight(sigma**2, np.linspace(0, max_value/bins, bins,
+                                                       endpoint=False))
+    return color_lut
+
+
+def _compute_range_lut(win_size, sigma):
+    grid_points = np.arange(-win_size, win_size + 1)
+    rr, cc = np.meshgrid(grid_points, grid_points, indexing='ij')
+    d = np.hypot(rr, cc)
+    range_lut = _gaussian_weight(sigma**2, d).ravel()
+    return range_lut
 
 
 def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
@@ -113,8 +132,43 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
     if win_size is None:
         win_size = max(5, 2 * int(ceil(3 * sigma_spatial)) + 1)
 
-    return _denoise_bilateral(image, win_size, sigma_color, sigma_spatial,
-                              bins, mode, cval)
+    min_value = image.min()
+    max_value = image.max()
+
+    if min_value == max_value:
+        return image
+
+    # if image.max() is 0, then dist_scale can have an unverified value
+    # and color_lut[<int>(dist * dist_scale)] may cause a segmentation fault
+    # so we verify we have a positive image and that the max is not 0.0.
+    if min_value < 0.0:
+        raise ValueError("Image must contain only positive values")
+
+    if max_value == 0.0:
+        raise ValueError("The maximum value found in the image was 0.")
+
+    image = np.atleast_3d(img_as_float(image))
+    image = np.ascontiguousarray(image)
+
+    sigma_color = sigma_color or image.std()
+
+    color_lut = _compute_color_lut(bins, sigma_color, max_value, image.dtype)
+
+    range_lut = _compute_range_lut(win_size, sigma_spatial)
+
+    out = np.empty(image.shape, dtype=image.dtype)
+
+    dims = image.shape[2]
+
+    # There are a number of arrays needed in the Cython function.
+    # It's easier to allocate them outside of Cython so that all
+    # arrays are in the same type, then just copy the empty array
+    # where needed within Cython.
+    empty_dims = np.empty(dims, dtype=image.dtype)
+
+    return _denoise_bilateral(image, image.max(), win_size, sigma_color,
+                              sigma_spatial, bins, mode, cval, color_lut,
+                              range_lut, empty_dims, out)
 
 
 def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True):
@@ -161,7 +215,18 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True):
     .. [4] http://www.math.ucsb.edu/~cgarcia/UGProjects/BregmanAlgorithms_JacquelineBush.pdf
 
     """
-    return _denoise_tv_bregman(image, weight, max_iter, eps, isotropic)
+    image = np.atleast_3d(img_as_float(image))
+    image = np.ascontiguousarray(image)
+
+    rows = image.shape[0]
+    cols = image.shape[1]
+    dims = image.shape[2]
+
+    shape_ext = (rows + 2, cols + 2, dims)
+
+    out = np.zeros(shape_ext, image.dtype)
+    _denoise_tv_bregman(image, weight, max_iter, eps, isotropic, out)
+    return np.squeeze(out[1:-1, 1:-1])
 
 
 def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, n_iter_max=200):

--- a/skimage/restoration/_denoise_cy.pyx
+++ b/skimage/restoration/_denoise_cy.pyx
@@ -8,6 +8,7 @@ import numpy as np
 from libc.math cimport exp, fabs, sqrt
 from libc.float cimport DBL_MAX
 from .._shared.interpolation cimport get_pixel3d
+from .._shared.fused_numerics cimport np_floats
 from ..util import img_as_float
 
 
@@ -57,29 +58,12 @@ cdef inline Py_ssize_t Py_ssize_t_min(Py_ssize_t value1, Py_ssize_t value2):
         return value2
 
 
-def _denoise_bilateral(image, Py_ssize_t win_size, sigma_color,
-                      double sigma_spatial, Py_ssize_t bins,
-                      mode, double cval):
-    cdef:
-        double min_value, max_value
-
-    min_value = image.min()
-    max_value = image.max()
-
-    if min_value == max_value:
-        return image
-
-    # if image.max() is 0, then dist_scale can have an unverified value
-    # and color_lut[<int>(dist * dist_scale)] may cause a segmentation fault
-    # so we verify we have a positive image and that the max is not 0.0.
-    if min_value < 0.0:
-        raise ValueError("Image must contain only positive values")
-
-    if max_value == 0.0:
-        raise ValueError("The maximum value found in the image was 0.")
-
-    image = np.atleast_3d(img_as_float(image))
-
+def _denoise_bilateral(np_floats[:, :, ::1] image, np_floats max_value,
+                       Py_ssize_t win_size, np_floats sigma_color,
+                       np_floats sigma_spatial, Py_ssize_t bins, mode,
+                       np_floats cval, np_floats[::1] color_lut,
+                       np_floats[::1] range_lut, np_floats[::1] empty_dims,
+                       np_floats[:, :, ::1] out):
     cdef:
         Py_ssize_t rows = image.shape[0]
         Py_ssize_t cols = image.shape[1]
@@ -87,19 +71,13 @@ def _denoise_bilateral(image, Py_ssize_t win_size, sigma_color,
         Py_ssize_t window_ext = (win_size - 1) / 2
         Py_ssize_t max_color_lut_bin = bins - 1
 
-        double[:, :, ::1] cimage
-        double[:, :, ::1] out
-
-        double[:] color_lut
-        double[:] range_lut
-
         Py_ssize_t r, c, d, wr, wc, kr, kc, rr, cc, pixel_addr, color_lut_bin
-        double value, weight, dist, total_weight, csigma_color, color_weight, \
+        np_floats value, weight, dist, total_weight, csigma_color, color_weight, \
                range_weight, t
-        double dist_scale
-        double[:] values
-        double[:] centres
-        double[:] total_values
+        np_floats dist_scale
+        np_floats[:] values
+        np_floats[:] centres
+        np_floats[:] total_values
 
     if sigma_color is None:
         csigma_color = image.std()
@@ -111,22 +89,18 @@ def _denoise_bilateral(image, Py_ssize_t win_size, sigma_color,
                          "`edge`, `wrap`, `symmetric` or `reflect`.")
     cdef char cmode = ord(mode[0].upper())
 
-    cimage = np.ascontiguousarray(image)
 
-    out = np.zeros((rows, cols, dims), dtype=np.double)
-    color_lut = _compute_color_lut(bins, csigma_color, max_value)
-    range_lut = _compute_range_lut(win_size, sigma_spatial)
     dist_scale = bins / dims / max_value
-    values = np.empty(dims, dtype=np.double)
-    centres = np.empty(dims, dtype=np.double)
-    total_values = np.empty(dims, dtype=np.double)
+    values = empty_dims.copy()
+    centres = empty_dims.copy()
+    total_values = empty_dims.copy()
 
     for r in range(rows):
         for c in range(cols):
             total_weight = 0
             for d in range(dims):
                 total_values[d] = 0
-                centres[d] = cimage[r, c, d]
+                centres[d] = image[r, c, d]
             for wr in range(-window_ext, window_ext + 1):
                 rr = wr + r
                 kr = wr + window_ext
@@ -138,7 +112,7 @@ def _denoise_bilateral(image, Py_ssize_t win_size, sigma_color,
                     # distance between centre stack and current position
                     dist = 0
                     for d in range(dims):
-                        value = get_pixel3d(&cimage[0, 0, 0], rows, cols, dims,
+                        value = get_pixel3d(&image[0, 0, 0], rows, cols, dims,
                                             rr, cc, d, cmode, cval)
                         values[d] = value
                         t = centres[d] - value
@@ -161,10 +135,9 @@ def _denoise_bilateral(image, Py_ssize_t win_size, sigma_color,
     return np.squeeze(np.asarray(out))
 
 
-def _denoise_tv_bregman(image, double weight, int max_iter, double eps,
-                       char isotropic):
-    image = np.atleast_3d(img_as_float(image))
-
+def _denoise_tv_bregman(np_floats[:, :, ::1] image, np_floats weight,
+                        int max_iter, np_floats eps,
+                        char isotropic, np_floats[:, :, ::1] out):
     cdef:
         Py_ssize_t rows = image.shape[0]
         Py_ssize_t cols = image.shape[1]
@@ -176,52 +149,49 @@ def _denoise_tv_bregman(image, double weight, int max_iter, double eps,
         Py_ssize_t total = rows * cols * dims
 
     shape_ext = (rows2, cols2, dims)
-    u = np.zeros(shape_ext, dtype=np.double)
 
     cdef:
-        double[:, :, ::1] cimage = np.ascontiguousarray(image)
-        double[:, :, ::1] cu = u
+        np_floats[:, :, ::1] dx = out.copy()
+        np_floats[:, :, ::1] dy = out.copy()
+        np_floats[:, :, ::1] bx = out.copy()
+        np_floats[:, :, ::1] by = out.copy()
 
-        double[:, :, ::1] dx = np.zeros(shape_ext, dtype=np.double)
-        double[:, :, ::1] dy = np.zeros(shape_ext, dtype=np.double)
-        double[:, :, ::1] bx = np.zeros(shape_ext, dtype=np.double)
-        double[:, :, ::1] by = np.zeros(shape_ext, dtype=np.double)
-
-        double ux, uy, uprev, unew, bxx, byy, dxx, dyy, s, tx, ty
+        np_floats ux, uy, uprev, unew, bxx, byy, dxx, dyy, s, tx, ty
         int i = 0
-        double lam = 2 * weight
-        double rmse = DBL_MAX
-        double norm = (weight + 4 * lam)
+        np_floats lam = 2 * weight
+        np_floats rmse = DBL_MAX
+        np_floats norm = (weight + 4 * lam)
 
-    u[1:-1, 1:-1] = image
+    out_rows, out_cols = out.shape[:2]
+    out[1:out_rows-1, 1:out_cols-1] = image
 
     # reflect image
-    u[0, 1:-1] = image[1, :]
-    u[1:-1, 0] = image[:, 1]
-    u[-1, 1:-1] = image[-2, :]
-    u[1:-1, -1] = image[:, -2]
+    out[0, 1:out_cols-1] = image[1, :]
+    out[1:out_rows-1, 0] = image[:, 1]
+    out[out_rows-1, 1:out_cols-1] = image[rows-1, :]
+    out[1:out_rows-1, out_cols-1] = image[:, cols-1]
 
     while i < max_iter and rmse > eps:
 
         rmse = 0
 
-        for k in range(dims):
-            for r in range(1, rows + 1):
-                for c in range(1, cols + 1):
+        for r in range(1, rows + 1):
+            for c in range(1, cols + 1):
+                for k in range(dims):
 
-                    uprev = cu[r, c, k]
+                    uprev = out[r, c, k]
 
                     # forward derivatives
-                    ux = cu[r, c + 1, k] - uprev
-                    uy = cu[r + 1, c, k] - uprev
+                    ux = out[r, c + 1, k] - uprev
+                    uy = out[r + 1, c, k] - uprev
 
                     # Gauss-Seidel method
                     unew = (
                         lam * (
-                            + cu[r + 1, c, k]
-                            + cu[r - 1, c, k]
-                            + cu[r, c + 1, k]
-                            + cu[r, c - 1, k]
+                            + out[r + 1, c, k]
+                            + out[r - 1, c, k]
+                            + out[r, c + 1, k]
+                            + out[r, c - 1, k]
 
                             + dx[r, c - 1, k]
                             - dx[r, c, k]
@@ -232,9 +202,9 @@ def _denoise_tv_bregman(image, double weight, int max_iter, double eps,
                             + bx[r, c, k]
                             - by[r - 1, c, k]
                             + by[r, c, k]
-                        ) + weight * cimage[r - 1, c - 1, k]
+                        ) + weight * image[r - 1, c - 1, k]
                     ) / norm
-                    cu[r, c, k] = unew
+                    out[r, c, k] = unew
 
                     # update root mean square error
                     tx = unew - uprev
@@ -275,5 +245,3 @@ def _denoise_tv_bregman(image, double weight, int max_iter, double eps,
 
         rmse = sqrt(rmse / total)
         i += 1
-
-    return np.squeeze(np.asarray(u[1:-1, 1:-1]))

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from skimage import restoration, data, color, img_as_float, measure
 from skimage.measure import compare_psnr
@@ -181,6 +182,18 @@ def test_denoise_bilateral_2d():
     # make sure noise is reduced in the checkerboard cells
     assert_(img[30:45, 5:15].std() > out1[30:45, 5:15].std())
     assert_(out1[30:45, 5:15].std() > out2[30:45, 5:15].std())
+
+
+@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.double])
+def test_denoise_bilateral_types(dtype):
+    img = checkerboard_gray.copy()[:50, :50]
+    # add some random noise
+    img += 0.5 * img.std() * np.random.rand(*img.shape)
+    img = np.clip(img, 0, 1)
+
+    # check that we can process multiple float types
+    out = restoration.denoise_bilateral(img, sigma_color=0.1,
+                                        sigma_spatial=10, multichannel=False)
 
 
 def test_denoise_bilateral_zeros():

--- a/skimage/transform/_warps_cy.pyx
+++ b/skimage/transform/_warps_cy.pyx
@@ -151,16 +151,16 @@ def _warp_fast(cnp.ndarray image, cnp.ndarray H, output_shape=None,
     else:
         transform_func = _transform_projective
 
-    cdef double (*interp_func)(double*, Py_ssize_t, Py_ssize_t, double, double,
-                               char, double) nogil
+    cdef void (*interp_func)(double*, Py_ssize_t , Py_ssize_t ,
+                             double, double, char, double, double*) nogil
     if order == 0:
-        interp_func = nearest_neighbour_interpolation
+        interp_func = nearest_neighbour_interpolation[cnp.float64_t, double, double]
     elif order == 1:
-        interp_func = bilinear_interpolation
+        interp_func = bilinear_interpolation[cnp.float64_t, double, double]
     elif order == 2:
-        interp_func = biquadratic_interpolation
+        interp_func = biquadratic_interpolation[cnp.float64_t, double, double]
     elif order == 3:
-        interp_func = bicubic_interpolation
+        interp_func = bicubic_interpolation[cnp.float64_t, double, double]
     else:
         raise ValueError("Unsupported interpolation order", order)
 
@@ -168,7 +168,7 @@ def _warp_fast(cnp.ndarray image, cnp.ndarray H, output_shape=None,
         for tfr in range(out_r):
             for tfc in range(out_c):
                 transform_func(tfc, tfr, &M[0, 0], &c, &r)
-                out[tfr, tfc] = interp_func(&img[0, 0], rows, cols, r, c,
-                                            mode_c, cval)
+                interp_func(&img[0, 0], rows, cols, r, c,
+                            mode_c, cval, &out[tfr, tfc])
 
     return np.asarray(out)

--- a/tools/check_sdist.py
+++ b/tools/check_sdist.py
@@ -20,13 +20,12 @@ data = ['./' + l.split(' ->')[0] for l in data]
 
 ignore_exts = ['.pyc', '.so', '.o', '#', '~', '.gitignore']
 ignore_dirs = ['./dist', './tools', './doc', './viewer_examples',
-               './downloads', './scikit_image.egg-info']
+               './downloads', './scikit_image.egg-info', './benchmarks']
 ignore_files = ['./TODO.md', './README.md', './MANIFEST',
                 './.gitignore', './.travis.yml', './.gitmodules',
                 './.mailmap', './.coveragerc', './.appveyor.yml',
                 './.pep8speaks.yml', './asv.conf.json',
-                './skimage/filters/rank/README.rst', './.meeseeksdev.yml']
-
+                './skimage/filters/rank/README.rst']
 
 missing = []
 for root, dirs, files in os.walk('./'):


### PR DESCRIPTION
* MNT: Add a fused numeric type to make fused_types more constent.

* MNT: make the interpolation use fused types for any->any type interpolation of images.

* MNT: Move even more numpy function calls from Cython to Python.

* MNT: More explicit type specifying

* BUG: Use fused floats in denoise

Pull all denoise array allocation out into python
Function used in python should be def not cdef
Have the correct number of arguments

* MNT: Add additional type check for denoise, more docs

* PEP8 fixes

* Remove redundant array u and view cu

* Mutate output array in Cython and trim in Python

* Replace height and width with existing rows and cols

* Change iteration order to match array order

* Move range_lut and color_lut properly from Cy to Py

* Ravel range LUT which is expected to be 1D

* Update comment in denoise bilateral tests

* Fix relative import in interpolation.pyx

* BENCH: Benchmark for warping with many types

* Rename warp benchmark file

* Update pointer syntax

Co-Authored-By: Mark Harfouche <mark.harfouche@gmail.com>

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
