### PR TITLE
Add space in 'ValueError' output of `skimage.measure.regionprops`

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -104,7 +104,7 @@ class _RegionProperties(object):
         if intensity_image is not None:
             if not intensity_image.shape == label_image.shape:
                 raise ValueError('Label and intensity image must have the'
-                                 'same shape.')
+                                 ' same shape.')
 
         self.label = label
 


### PR DESCRIPTION
## Description
I've seen the error pop up (see screenshot below).
I think the output should have a space between 'the' and 'same'.

![Screenshot from 2019-05-01 16-11-08](https://user-images.githubusercontent.com/1651235/57021194-d71e6e00-6c2b-11e9-9283-12ff8ec7d820.png)

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
