### PR TITLE
State Bradley threshold equivalence in Niblack docstring

### DIFF
--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -905,14 +905,19 @@ def threshold_niblack(image, window_size=15, k=0.2):
     The Bradley threshold is a particular case of the Niblack
     one, being equivalent to
 
-    >>> threshold_niblack(image, k=0)
+    >>> q = 1
+    >>> threshold_niblack(image, k=0) * q
+
+    for some value ``q``. By default, Bradley and Roth use ``q=1``.
+
 
     References
     ----------
-    .. [1] Niblack, W (1986), An introduction to Digital Image
-           Processing, Prentice-Hall.
-    .. [2] D. Bradley and G. Roth, "Adaptive thresholding using Integral Image"
-           Journal of Graphics Tools 12(2), pp. 13-21, 2007.
+    .. [1] W. Niblack, An introduction to Digital Image Processing,
+           Prentice-Hall, 1986.
+    .. [2] D. Bradley and G. Roth, "Adaptive thresholding using Integral
+           Image", Journal of Graphics Tools 12(2), pp. 13-21, 2007.
+           :DOI:`10.1080/2151237X.2007.10129236`
 
     Examples
     --------

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -902,10 +902,17 @@ def threshold_niblack(image, window_size=15, k=0.2):
     -----
     This algorithm is originally designed for text recognition.
 
+    The Bradley threshold is a particular case of the Niblack
+    one, being equivalent to
+    >>> threshold_niblack(image, k=0) * (1-q)
+    where q is a quantile. Bradley and Roth use q=100 [2]_.
+
     References
     ----------
     .. [1] Niblack, W (1986), An introduction to Digital Image
            Processing, Prentice-Hall.
+    .. [2] D. Bradley and G. Roth, "Adaptive thresholding using Integral Image"
+           Journal of Graphics Tools 12(2), pp. 13-21, 2007.
 
     Examples
     --------

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -904,8 +904,8 @@ def threshold_niblack(image, window_size=15, k=0.2):
 
     The Bradley threshold is a particular case of the Niblack
     one, being equivalent to
-    >>> threshold_niblack(image, k=0) * (1-q)
-    where q is a quantile. Bradley and Roth use q=100 [2]_.
+
+    >>> threshold_niblack(image, k=0)
 
     References
     ----------


### PR DESCRIPTION
## Description

Some info on Bradley and Niblack's thresholds equivalence (see #3877 @jni comments).

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
~~- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)~~
~~- [ ] Gallery example in `./doc/examples` (new features only)~~
~~- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark~~
~~- [ ] Unit tests~~
~~- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)~~

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
