### PR TITLE
Pin numpydoc to pre-0.8 to fix dev docs formatting

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,7 @@
 # Sphinx 1.7.8 has a bug when building on cached envs
 # https://github.com/sphinx-doc/sphinx/issues/5361
 sphinx>=1.3,!=1.7.8
-numpydoc>=0.6
+numpydoc>=0.7,<0.8
 sphinx-gallery
 sphinx-copybutton
 pytest-runner


### PR DESCRIPTION
See https://github.com/numpy/numpydoc/issues/215#issuecomment-487664426
for more.

## Description

Our documentation rendering for the dev branch is broken: the types are all smushed up together with the parameter names, see e.g. https://scikit-image.org/docs/dev/api/skimage.feature.html#skimage.feature.canny

This pin fixes that until https://github.com/numpy/numpydoc/issues/215 is closed.