### PR TITLE
Add location for Sphinx 2.0.1 search results; clean up templates

### DIFF
--- a/doc/source/themes/scikit-image/layout.html
+++ b/doc/source/themes/scikit-image/layout.html
@@ -1,4 +1,4 @@
-{#
+{#-
     scikit-image/layout.html
     ~~~~~~~~~~~~~~~~~
 
@@ -6,16 +6,14 @@
     Johannes Schönberger.
 
 #}
-
 {%- set url_root = pathto('', 1) %}
-{# XXX necessary? #}
+{#- XXX necessary? #}
 {%- if url_root == '#' %}{% set url_root = '' %}{% endif %}
 {%- if not embedded and docstitle %}
   {%- set titlesuffix = " &mdash; "|safe + docstitle|e %}
 {%- else %}
   {%- set titlesuffix = "" %}
 {%- endif %}
-
 {%- macro script() %}
     <script src="https://code.jquery.com/jquery-latest.js"></script>
     <script src="{{ pathto('_static/', 1) }}js/bootstrap.min.js"></script>
@@ -28,11 +26,10 @@
         HAS_SOURCE:  {{ has_source|lower }}
       };
     </script>
-    {%- for scriptfile in script_files %}
-        <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
+    {%- for js in script_files %}
+    {{ js_tag(js) }}
     {%- endfor %}
 {%- endmacro %}
-
 {%- macro css() %}
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
     <link href="{{ pathto('_static/', 1) }}css/bootstrap.min.css" rel="stylesheet" type="text/css">
@@ -42,16 +39,19 @@
         <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />
     {%- endfor %}
 {%- endmacro %}
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
     {%- block htmltitle %}
         <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
     {%- endblock %}
-    {{ metatags }}
-    {{ css() }}
+    {{- metatags }}
+    {%- block css %}
+    {{- css() }}
+    {%- endblock %}
+    {%- block scripts %}
     {{ script() }}
+    {%- endblock %}
     {%- if hasdoc('about') %}
         <link rel="author" title="{{ _('About these documents') }}" href="{{ pathto('about') }}" />
     {%- endif %}
@@ -94,11 +94,11 @@
                 {%- include sidebartemplate %}
             {%- endfor %}
         </div>
-        <div class="span9">
+        <div class="span9" class="body" role="main">
             {% block body %}{% endblock %}
         </div>
     </div>
-    <div class="well footer">
+    <div class="well footer" role="contentinfo">
         <small>
             &copy; Copyright the scikit-image development team.
             Created using <a href="https://getbootstrap.com/">Bootstrap</a> and <a href="https://www.sphinx-doc.org/">Sphinx</a>.

--- a/doc/source/themes/scikit-image/search.html
+++ b/doc/source/themes/scikit-image/search.html
@@ -1,4 +1,4 @@
-{#
+{#-
     basic/search.html
     ~~~~~~~~~~~~~~~~~
 
@@ -7,15 +7,17 @@
     :copyright: Copyright 2007-2011 by the Sphinx team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 #}
-{% extends "layout.html" %}
-{% set title = _('Search') %}
-{% block extrahead %}
-  <script type="text/javascript" src="{{ pathto('_static/searchtools.js', 1) }}"></script>
+{%- extends "layout.html" %}
+{%- set title = _('Search') %}
+{%- block scripts %}
+    {{ super() }}
+    <script type="text/javascript" src="{{ pathto('_static/searchtools.js', 1) }}"></script>
+{%- endblock %}
+{%- block extrahead %}
   <script type="text/javascript" src="{{ pathto('searchindex.js', 1) }}" defer></script>
   {{ super() }}
 {% endblock %}
-
-{% block body %}
+{%- block body %}
   <h1 id="search-documentation">{{ _('Search') }}</h1>
   <div id="fallback" class="admonition warning">
   <script type="text/javascript">


### PR DESCRIPTION
In Sphinx 2.0.1, they search for the "role=main" specifier to know where
to put search results.  This is a strange hardcoded choice, but adding
it causes us no difficulties, and should fix some of the issues we've been
seeing with search results not showing up.