### PR TITLE
Fix CSS styling of Sphinx 2.0.1 + numpydoc 0.9 rendered docs

### DIFF
--- a/doc/source/themes/scikit-image/static/css/custom.css
+++ b/doc/source/themes/scikit-image/static/css/custom.css
@@ -1,7 +1,5 @@
 body {
     font-family: "Lato", sans-serif;
-    letter-spacing: 0.02em;
-    font-size: 102%;
     line-height: 23px;
 }
 a {
@@ -322,14 +320,77 @@ a.copybtn {
     z-index: 100 !important;
 }
 
-dl.glossary dt { 
+dl.glossary dt {
     font-weight: bold;
     font-size: 1.1em;
 }
 
 
-dl.glossary dd { 
+dl.glossary dd {
   margin-bottom: 0.5em;
 }
 
 
+.classifier:before {
+    content: " : ";
+}
+
+.classifier {
+    font-weight: normal;
+}
+
+dl .field-list > dt {
+    padding-top: 0.1em;
+    font-size: 19px;
+}
+
+.seealso .admonition-title {
+    font-size: 19px;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.seealso > dl {
+    margin-bottom: 0;
+}
+
+/* No padding at bottom of See Also */
+
+.seealso > dl > dd {
+    padding-bottom: 0;
+}
+
+dl .field-list > dd {
+    border-left: solid 10px #eee;
+    padding-bottom: 0;
+    margin-left: 0;
+    margin-top: 0.5em;
+}
+
+.field-list p {
+    margin-bottom: 0;
+}
+
+dl.citation {
+    padding: 0em 1em 1em 1em;
+    margin: 0em;
+}
+
+.citation * {
+    display: inline;
+}
+
+.citation > dt {
+    background: none;
+    color: black;
+}
+
+.citation > dt:before {
+    display: block;
+    white-space: pre;
+    content: "\A";
+}
+
+.citation > dt:first-child:before {
+    display: inline;
+}

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,7 @@
 # Sphinx 1.7.8 has a bug when building on cached envs
 # https://github.com/sphinx-doc/sphinx/issues/5361
 sphinx>=1.3,!=1.7.8
-numpydoc>=0.7,<0.8
+numpydoc>=0.9
 sphinx-gallery
 sphinx-copybutton
 pytest-runner


### PR DESCRIPTION
Sphinx 2.0.1 renders parameter listings as description lists instead of
tables.  This CSS, while not perfect, brings us close to what we were
rendering before.

xref: https://github.com/numpy/numpydoc/issues/215
