### PR TITLE
Add todo item for imread plugin testing

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -47,3 +47,5 @@ Other
   environment variable ``PYTHONOPTIMIZE=2`` to one of the builds.
 * Remove custom fused type in ``skimage/filters/_max_tree.pyx`` once
   #3486 fused types is merged.
+* Check whether imread wheels are available, then re-enable testing imread
+  on macOS. See https://github.com/scikit-image/scikit-image/pull/3898


### PR DESCRIPTION
## Description

Follow-up for https://github.com/scikit-image/scikit-image/pull/3898

More info:

#3898 removed testing of extra dependencies on macOS because we were having trouble compiling imread on travis. We should periodically check whether imread wheels are available and then re-enable this testing (revert #3898).

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
