### PR TITLE
DOC: Improve the documentation of transform.resize with respect to the anti_aliasing_sigma parameter

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -65,8 +65,8 @@ def resize(image, output_shape, order=1, mode='reflect', cval=0, clip=True,
         avoid aliasing artifacts.
     anti_aliasing_sigma : {float, tuple of floats}, optional
         Standard deviation for Gaussian filtering to avoid aliasing artifacts.
-        By default, this value is chosen as (1 - s) / 2 where s is the
-        down-scaling factor.
+        By default, this value is chosen as (s - 1) / 2 where s is the
+        down-scaling factor, assuming s > 1.
 
     Notes
     -----

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -66,7 +66,7 @@ def resize(image, output_shape, order=1, mode='reflect', cval=0, clip=True,
     anti_aliasing_sigma : {float, tuple of floats}, optional
         Standard deviation for Gaussian filtering to avoid aliasing artifacts.
         By default, this value is chosen as (s - 1) / 2 where s is the
-        down-scaling factor, assuming s > 1. If s < 1 (up-size), no
+        down-scaling factor, where s > 1. For the up-size case, s < 1, no
         anti-aliasing is performed prior to rescaling.
 
     Notes

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -66,7 +66,8 @@ def resize(image, output_shape, order=1, mode='reflect', cval=0, clip=True,
     anti_aliasing_sigma : {float, tuple of floats}, optional
         Standard deviation for Gaussian filtering to avoid aliasing artifacts.
         By default, this value is chosen as (s - 1) / 2 where s is the
-        down-scaling factor, assuming s > 1.
+        down-scaling factor, assuming s > 1. If s < 1 (up-size), no
+        anti-aliasing is performed prior to rescaling.
 
     Notes
     -----


### PR DESCRIPTION
## Description
Issue #3890 : fix the documentation of the [`skimage.transform.resize`](https://github.com/scikit-image/scikit-image/blob/51d4fd9294955deee48491a5ae4c01c1dfe0f48d/skimage/transform/_warps.py#L19) method.

## For reviewers
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
