### PR TITLE
Fix docstring for Threshold Niblack

### DIFF
--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -905,8 +905,10 @@ def threshold_niblack(image, window_size=15, k=0.2):
     The Bradley threshold is a particular case of the Niblack
     one, being equivalent to
 
+    >>> from skimage import data
+    >>> image = data.page()
     >>> q = 1
-    >>> threshold_niblack(image, k=0) * q
+    >>> threshold_image = threshold_niblack(image, k=0) * q
 
     for some value ``q``. By default, Bradley and Roth use ``q=1``.
 
@@ -923,7 +925,7 @@ def threshold_niblack(image, window_size=15, k=0.2):
     --------
     >>> from skimage import data
     >>> image = data.page()
-    >>> binary_image = threshold_niblack(image, window_size=7, k=0.1)
+    >>> threshold_image = threshold_niblack(image, window_size=7, k=0.1)
     """
     m, s = _mean_std(image, window_size)
     return m - k * s


### PR DESCRIPTION
## Description

This should fix the broken docstring from #3891. Additionally, the name of the variable in the example is misleading so I fixed it. ;)

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
