### PR TITLE
remove unused dtype argument in IO plugins

### DIFF
--- a/skimage/io/_plugins/fits_plugin.py
+++ b/skimage/io/_plugins/fits_plugin.py
@@ -14,16 +14,13 @@ except ImportError:
             "for further instructions.")
 
 
-def imread(fname, dtype=None):
+def imread(fname):
     """Load an image from a FITS file.
 
     Parameters
     ----------
     fname : string
         Image file name, e.g. ``test.fits``.
-    dtype : dtype, optional
-        For FITS, this argument is ignored because Stefan is planning on
-        removing the dtype argument from imread anyway.
 
     Returns
     -------

--- a/skimage/io/_plugins/gdal_plugin.py
+++ b/skimage/io/_plugins/gdal_plugin.py
@@ -8,7 +8,7 @@ except ImportError:
                       "for further instructions.")
 
 
-def imread(fname, dtype=None):
+def imread(fname):
     """Load an image from file.
 
     """

--- a/skimage/io/_plugins/tifffile_plugin.py
+++ b/skimage/io/_plugins/tifffile_plugin.py
@@ -4,15 +4,13 @@ except ImportError:
     from ...external.tifffile import TiffFile, imsave, parse_kwargs
 
 
-def imread(fname, dtype=None, **kwargs):
+def imread(fname, **kwargs):
     """Load a tiff image from file.
 
     Parameters
     ----------
     fname : str or file
        File name or file-like-object.
-    dtype : numpy dtype object or string specifier
-       Specifies data type of array elements (Not currently used).
     kwargs : keyword pairs, optional
         Additional keyword arguments to pass through (see ``tifffile``'s
         ``imread`` function).

--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -416,13 +416,9 @@ class MultiImage(ImageCollection):
         """Load a multi-img."""
         from ._io import imread
 
-        def load_func(fname, **kwargs):
-            kwargs.setdefault('dtype', dtype)
-            return imread(fname, **kwargs)
-
         self._filename = filename
         super(MultiImage, self).__init__(filename, conserve_memory,
-                                         load_func=load_func, **imread_kwargs)
+                                         load_func=imread, **imread_kwargs)
 
     @property
     def filename(self):


### PR DESCRIPTION
## Description




## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
