### PR TITLE
Canny: same output regardless of dtype

### DIFF
--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -157,12 +157,12 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None, mask=None,
     dtype_max = dtype_limits(image, clip_negative=False)[1]
 
     if low_threshold is None:
-        low_threshold = 0.1 * dtype_max
+        low_threshold = 0.1
     else:
         low_threshold = low_threshold / dtype_max
 
     if high_threshold is None:
-        high_threshold = 0.2 * dtype_max
+        high_threshold = 0.2
     else:
         high_threshold = high_threshold / dtype_max
 

--- a/skimage/feature/tests/test_canny.py
+++ b/skimage/feature/tests/test_canny.py
@@ -104,3 +104,13 @@ class TestCanny(unittest.TestCase):
 
         self.assertRaises(ValueError, F.canny, image, use_quantiles=True,
                           low_threshold=0.5, high_threshold=-100)
+
+    def test_dtype(self):
+        """Check that the same output is produced regardless of image dtype."""
+        image_uint8 = data.camera()
+        image_float = img_as_float(image_uint8)
+
+        result_uint8 = F.canny(image_uint8)
+        result_float = F.canny(image_float)
+
+        assert_equal(result_uint8, result_float)


### PR DESCRIPTION
## Description

The same image will produce different outputs depending on the dtype of the input image. This is due to the thresholds, which are not scaled to the dtype of the image, but is compared with the magnitude which is always converted to a float image. This seems correct to me, but I'm not an expert at this, so please let me know if I'm missing some implications of this change.

I added a unit test which asserts that the output should be the same for the same input image regardless if the dtype is uint8 or float. I don't know if there is a better way to test this?


<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
 I think this closes #3913

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
