### PR TITLE
MIN: docstring improvements in canny functions

### DIFF
--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -21,7 +21,7 @@ from .._shared.utils import assert_nD
 
 
 def smooth_with_function_and_mask(image, function, mask):
-    """Smooth an image with a linear function, ignoring masked pixels
+    """Smooth an image with a linear function, ignoring masked pixels.
 
     Parameters
     ----------
@@ -58,12 +58,12 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None, mask=None,
     -----------
     image : 2D array
         Grayscale input image to detect edges on; can be of any dtype.
-    sigma : float
+    sigma : float, optional
         Standard deviation of the Gaussian filter.
-    low_threshold : float
+    low_threshold : float, optional
         Lower bound for hysteresis thresholding (linking edges).
         If None, low_threshold is set to 10% of dtype's max.
-    high_threshold : float
+    high_threshold : float, optional
         Upper bound for hysteresis thresholding (linking edges).
         If None, high_threshold is set to 20% of dtype's max.
     mask : array, dtype=bool, optional
@@ -108,6 +108,7 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None, mask=None,
     -----------
     .. [1] Canny, J., A Computational Approach To Edge Detection, IEEE Trans.
            Pattern Analysis and Machine Intelligence, 8:679-714, 1986
+           :DOI:`10.1109/TPAMI.1986.4767851`
     .. [2] William Green's Canny tutorial
            http://dasl.unlv.edu/daslDrexel/alumni/bGreen/www.pages.drexel.edu/_weg22/can_tut.html
 


### PR DESCRIPTION
## Description

A short PR to follow my review of the PR on the recently introduced bug in canny.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
