### PR TITLE
Replacing pyfits with Astropy to read FITS

### DIFF
--- a/skimage/io/_plugins/fits_plugin.py
+++ b/skimage/io/_plugins/fits_plugin.py
@@ -3,15 +3,12 @@ __all__ = ['imread', 'imread_collection']
 import skimage.io as io
 
 try:
-    from astropy.io import fits as pyfits
+    from astropy.io import fits
 except ImportError:
-    try:
-        import pyfits
-    except ImportError:
-        raise ImportError(
-            "PyFITS could not be found. Please refer to\n"
-            "http://www.stsci.edu/resources/software_hardware/pyfits\n"
-            "for further instructions.")
+    raise ImportError(
+        "Astropy could not be found. It is needed to read FITS files.\n"
+        "Please refer to http://www.astropy.org for installation\n"
+        "instructions.")
 
 
 def imread(fname, dtype=None):
@@ -44,14 +41,14 @@ def imread(fname, dtype=None):
 
     """
 
-    hdulist = pyfits.open(fname)
+    hdulist = fits.open(fname)
 
     # Iterate over FITS image extensions, ignoring any other extension types
     # such as binary tables, and get the first image data array:
     img_array = None
     for hdu in hdulist:
-        if isinstance(hdu, pyfits.ImageHDU) or \
-           isinstance(hdu, pyfits.PrimaryHDU):
+        if isinstance(hdu, fits.ImageHDU) or \
+           isinstance(hdu, fits.PrimaryHDU):
             if hdu.data is not None:
                 img_array = hdu.data
                 break
@@ -92,16 +89,16 @@ def imread_collection(load_pattern, conserve_memory=True):
     # files and finding the image extensions in each one:
     ext_list = []
     for filename in load_pattern:
-        hdulist = pyfits.open(filename)
+        hdulist = fits.open(filename)
         for n, hdu in zip(range(len(hdulist)), hdulist):
-            if isinstance(hdu, pyfits.ImageHDU) or \
-               isinstance(hdu, pyfits.PrimaryHDU):
+            if isinstance(hdu, fits.ImageHDU) or \
+               isinstance(hdu, fits.PrimaryHDU):
                 # Ignore (primary) header units with no data (use '.size'
                 # rather than '.data' to avoid actually loading the image):
                 try:
+                    data_size = hdu.size  # size is int in Astropy 3.1.2
+                except TypeError:
                     data_size = hdu.size()
-                except TypeError:  # (size changed to int in PyFITS 3.1)
-                    data_size = hdu.size
                 if data_size > 0:
                     ext_list.append((filename, n))
         hdulist.close()
@@ -138,7 +135,7 @@ def FITSFactory(image_ext):
     if type(filename) is not str or type(extnum) is not int:
         raise ValueError("Expected a (filename, extension) tuple")
 
-    hdulist = pyfits.open(filename)
+    hdulist = fits.open(filename)
 
     data = hdulist[extnum].data
 

--- a/skimage/io/tests/test_fits.py
+++ b/skimage/io/tests/test_fits.py
@@ -5,53 +5,50 @@ from skimage import data_dir
 from skimage._shared import testing
 
 
-pyfits_available = True
+fits_available = True
 
 try:
-    from astropy.io import fits as pyfits
+    from astropy.io import fits
 except ImportError:
-    try:
-        import pyfits
-    except ImportError:
-        pyfits_available = False
+    fits_available = False
 
-if pyfits_available:
+if fits_available:
     import skimage.io._plugins.fits_plugin as fplug
 
 
 def test_fits_plugin_import():
-    # Make sure we get an import exception if PyFITS isn't there
+    # Make sure we get an import exception if Astropy isn't there
     # (not sure how useful this is, but it ensures there isn't some other
     # error when trying to load the plugin)
     try:
         io.use_plugin('fits')
     except ImportError:
-        assert not pyfits_available
+        assert not fits_available
     else:
-        assert pyfits_available
+        assert fits_available
 
 
 def teardown():
     io.reset_plugins()
 
 
-@testing.skipif(not pyfits_available, reason="pyfits not installed")
+@testing.skipif(not fits_available, reason="fits not installed")
 def test_imread_MEF():
     io.use_plugin('fits')
     testfile = os.path.join(data_dir, 'multi.fits')
     img = io.imread(testfile)
-    assert np.all(img == pyfits.getdata(testfile, 1))
+    assert np.all(img == fits.getdata(testfile, 1))
 
 
-@testing.skipif(not pyfits_available, reason="pyfits not installed")
+@testing.skipif(not fits_available, reason="fits not available")
 def test_imread_simple():
     io.use_plugin('fits')
     testfile = os.path.join(data_dir, 'simple.fits')
     img = io.imread(testfile)
-    assert np.all(img == pyfits.getdata(testfile, 0))
+    assert np.all(img == fits.getdata(testfile, 0))
 
 
-@testing.skipif(not pyfits_available, reason="pyfits not installed")
+@testing.skipif(not fits_available, reason="fits not available")
 def test_imread_collection_single_MEF():
     io.use_plugin('fits')
     testfile = os.path.join(data_dir, 'multi.fits')
@@ -62,7 +59,7 @@ def test_imread_collection_single_MEF():
     assert _same_ImageCollection(ic1, ic2)
 
 
-@testing.skipif(not pyfits_available, reason="pyfits not installed")
+@testing.skipif(not fits_available, reason="fits not available")
 def test_imread_collection_MEF_and_simple():
     io.use_plugin('fits')
     testfile1 = os.path.join(data_dir, 'multi.fits')

--- a/skimage/io/tests/test_fits.py
+++ b/skimage/io/tests/test_fits.py
@@ -4,9 +4,9 @@ import skimage.io as io
 from skimage import data_dir
 from skimage._shared import testing
 
-if testing.pytest.importorskip('astropy'):
-    from astropy.io import fits
-    import skimage.io._plugins.fits_plugin as fplug
+testing.pytest.importorskip('astropy')
+from astropy.io import fits
+import skimage.io._plugins.fits_plugin as fplug
 
 
 def test_fits_plugin_import():

--- a/skimage/io/tests/test_fits.py
+++ b/skimage/io/tests/test_fits.py
@@ -4,15 +4,8 @@ import skimage.io as io
 from skimage import data_dir
 from skimage._shared import testing
 
-
-fits_available = True
-
-try:
+if testing.pytest.importorskip('astropy'):
     from astropy.io import fits
-except ImportError:
-    fits_available = False
-
-if fits_available:
     import skimage.io._plugins.fits_plugin as fplug
 
 
@@ -23,16 +16,13 @@ def test_fits_plugin_import():
     try:
         io.use_plugin('fits')
     except ImportError:
-        assert not fits_available
-    else:
-        assert fits_available
+        raise()
 
 
 def teardown():
     io.reset_plugins()
 
 
-@testing.skipif(not fits_available, reason="fits not installed")
 def test_imread_MEF():
     io.use_plugin('fits')
     testfile = os.path.join(data_dir, 'multi.fits')
@@ -40,7 +30,6 @@ def test_imread_MEF():
     assert np.all(img == fits.getdata(testfile, 1))
 
 
-@testing.skipif(not fits_available, reason="fits not available")
 def test_imread_simple():
     io.use_plugin('fits')
     testfile = os.path.join(data_dir, 'simple.fits')
@@ -48,7 +37,6 @@ def test_imread_simple():
     assert np.all(img == fits.getdata(testfile, 0))
 
 
-@testing.skipif(not fits_available, reason="fits not available")
 def test_imread_collection_single_MEF():
     io.use_plugin('fits')
     testfile = os.path.join(data_dir, 'multi.fits')
@@ -59,7 +47,6 @@ def test_imread_collection_single_MEF():
     assert _same_ImageCollection(ic1, ic2)
 
 
-@testing.skipif(not fits_available, reason="fits not available")
 def test_imread_collection_MEF_and_simple():
     io.use_plugin('fits')
     testfile1 = os.path.join(data_dir, 'multi.fits')


### PR DESCRIPTION
## Description

Closes #3002.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [X] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
