### PR TITLE
Add warning for future dtype kwarg removal

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -15,6 +15,7 @@ Version 0.17
   and ``shift_y``.
 * Remove deprecated arguments ``beta1`` and ``beta2`` from function ``skimage.filters.frangi``
 * Remove deprecated arguments ``beta1`` and ``beta2`` from function ``skimage.filters.hessian``
+* Remove unused arguments ``dtype`` in ``imread`` functions. See #3918.
 
 Other
 -----

--- a/skimage/io/_plugins/fits_plugin.py
+++ b/skimage/io/_plugins/fits_plugin.py
@@ -1,6 +1,7 @@
 __all__ = ['imread', 'imread_collection']
 
 import skimage.io as io
+from warnings import warn
 
 try:
     from astropy.io import fits as pyfits
@@ -22,8 +23,8 @@ def imread(fname, dtype=None):
     fname : string
         Image file name, e.g. ``test.fits``.
     dtype : dtype, optional
-        For FITS, this argument is ignored because Stefan is planning on
-        removing the dtype argument from imread anyway.
+        Was always silently ignored.
+        Will be removed from version 0.17.
 
     Returns
     -------
@@ -43,6 +44,11 @@ def imread(fname, dtype=None):
     lazy loading) to get all the extensions at once.
 
     """
+    if 'dtype' is not None:
+        warn('The dtype argument was always silently ignored. It will be '
+             'removed from scikit-image version 0.17. To avoid this '
+             'warning, do not specify it in your function call.',
+             UserWarning, stacklevel=2)
 
     hdulist = pyfits.open(fname)
 

--- a/skimage/io/_plugins/gdal_plugin.py
+++ b/skimage/io/_plugins/gdal_plugin.py
@@ -1,5 +1,7 @@
 __all__ = ['imread']
 
+from warnings import warn
+
 try:
     import osgeo.gdal as gdal
 except ImportError:
@@ -12,6 +14,12 @@ def imread(fname, dtype=None):
     """Load an image from file.
 
     """
+    if 'dtype' is not None:
+        warn('The dtype argument was always silently ignored. It will be '
+             'removed from scikit-image version 0.17. To avoid this '
+             'warning, do not specify it in your function call.',
+             UserWarning, stacklevel=2)
+
     ds = gdal.Open(fname)
 
     return ds.ReadAsArray().astype(dtype)

--- a/skimage/io/_plugins/tifffile_plugin.py
+++ b/skimage/io/_plugins/tifffile_plugin.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 try:
     from tifffile import TiffFile, imsave, parse_kwargs
 except ImportError:
@@ -12,7 +14,8 @@ def imread(fname, dtype=None, **kwargs):
     fname : str or file
        File name or file-like-object.
     dtype : numpy dtype object or string specifier
-       Specifies data type of array elements (Not currently used).
+       Specifies data type of array elements.
+       Will be removed from version 0.17.
     kwargs : keyword pairs, optional
         Additional keyword arguments to pass through (see ``tifffile``'s
         ``imread`` function).
@@ -27,11 +30,16 @@ def imread(fname, dtype=None, **kwargs):
     .. [1] http://www.lfd.uci.edu/~gohlke/code/tifffile.py
 
     """
+    if 'dtype' is not None:
+        warn('The dtype argument was always silently ignored. It will be '
+             'removed from scikit-image version 0.17. To avoid this '
+             'warning, do not specify it in your function call.',
+             UserWarning, stacklevel=2)
 
     if 'img_num' in kwargs:
         kwargs['key'] = kwargs.pop('img_num')
 
-    # parse_kwargs will extract keyword arguments intended for the TiffFile 
+    # parse_kwargs will extract keyword arguments intended for the TiffFile
     # class and remove them from the kwargs dictionary in-place
     tiff_keys = ['multifile', 'multifile_close', 'pages', 'fastij', 'is_ome']
     kwargs_tiff = parse_kwargs(kwargs, *tiff_keys)


### PR DESCRIPTION
## Description

Closes #3922

@hmaarrfk How about this?

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
