### PR TITLE
ENH: doc of ridge functions

### DIFF
--- a/doc/examples/edges/plot_ridge_filter.py
+++ b/doc/examples/edges/plot_ridge_filter.py
@@ -40,7 +40,8 @@ References
        :DOI:`10.1007/978-3-319-16811-1_40`
 """
 
-from skimage.data import page
+from skimage import data
+from skimage import color
 from skimage.filters import meijering, sato, frangi, hessian
 import matplotlib.pyplot as plt
 
@@ -50,7 +51,7 @@ def identity(image, **kwargs):
     return image
 
 
-image = page()
+image = color.rgb2gray(data.retina())[300:700, 700:900]
 cmap = plt.cm.gray
 
 kwargs = {}

--- a/doc/examples/edges/plot_ridge_filter.py
+++ b/doc/examples/edges/plot_ridge_filter.py
@@ -13,6 +13,9 @@ The present class of ridge filters relies on the eigenvalues of
 the Hessian matrix of image intensities to detect ridge structures where the
 intensity changes perpendicular but not along the structure.
 
+Note that, due to edge effects, results for Meijering and Frangi filters
+are cropped by 4 pixels on each edge to get a proper rendering.
+
 References
 ----------
 
@@ -61,7 +64,11 @@ fig, axes = plt.subplots(2, 5)
 for i, black_ridges in enumerate([1, 0]):
     for j, func in enumerate([identity, meijering, sato, frangi, hessian]):
         kwargs['black_ridges'] = black_ridges
-        axes[i, j].imshow(func(image, **kwargs), cmap=cmap, aspect='auto')
+        result = func(image, **kwargs)
+        if func in (meijering, frangi):
+            # Crop by 4 pixels for rendering purpose.
+            result = result[4:-4, 4:-4]
+        axes[i, j].imshow(result, cmap=cmap, aspect='auto')
         if i == 0:
             axes[i, j].set_title(['Original\nimage', 'Meijering\nneuriteness',
                                   'Sato\ntubeness', 'Frangi\nvesselness',

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -164,6 +164,12 @@ def meijering(image, sigmas=range(1, 10, 2), alpha=None,
     out : (N, M[, ..., P]) ndarray
         Filtered image (maximum of pixels across all scales).
 
+    See also
+    --------
+    sato
+    frangi
+    hessian
+
     References
     ----------
     .. [1] Meijering, E., Jacob, M., Sarria, J. C., Steiner, P., Hirling, H.,
@@ -251,6 +257,12 @@ def sato(image, sigmas=range(1, 10, 2), black_ridges=True):
     -------
     out : (N, M[, P]) ndarray
         Filtered image (maximum of pixels across all scales).
+
+    See also
+    --------
+    meijering
+    frangi
+    hessian
 
     References
     ----------
@@ -343,6 +355,12 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
     Written by Marc Schrijver, November 2001
     Re-Written by D. J. Kroon, University of Twente, May 2009, [2]_
     Adoption of 3D version from D. G. Ellis, Januar 20017, [3]_
+
+    See also
+    --------
+    meijering
+    sato
+    hessian
 
     References
     ----------
@@ -474,6 +492,12 @@ def hessian(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
     -----
     Written by Marc Schrijver (November 2001)
     Re-Written by D. J. Kroon University of Twente (May 2009) [2]_
+
+    See also
+    --------
+    meijering
+    sato
+    frangi
 
     References
     ----------


### PR DESCRIPTION
## Description

This PR aims at improving the doc of #3515   as these functions are designed for processing on vessels, I changed the image for a crop of retina. I added see also sections as well.
![Figure_1](https://user-images.githubusercontent.com/335370/58366708-afdb5980-7ed6-11e9-9d45-841da095af1b.png)


Cc @DavidBreuer 


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
