### PR TITLE
Fix float32 support in denoise_bilateral and denoise_tv_bregman

### DIFF
--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -10,21 +10,21 @@ import skimage.color as color
 import numbers
 
 
-def _gaussian_weight(sigma_sqr, value):
-    return np.exp(-0.5 * value * value / sigma_sqr)
+def _gaussian_weight(sigma_sqr, value, *, dtype=float):
+    return np.exp(-0.5 * value * value / sigma_sqr, dtype=dtype)
 
 
-def _compute_color_lut(bins, sigma, max_value, dtype):
-    color_lut = _gaussian_weight(sigma**2, np.linspace(0, max_value/bins, bins,
-                                                       endpoint=False))
+def _compute_color_lut(bins, sigma, max_value, *, dtype=float):
+    values = np.linspace(0, max_value / bins, bins, endpoint=False)
+    color_lut = _gaussian_weight(sigma**2, values, dtype=dtype)
     return color_lut
 
 
-def _compute_range_lut(win_size, sigma):
+def _compute_range_lut(win_size, sigma, *, dtype=float):
     grid_points = np.arange(-win_size, win_size + 1)
     rr, cc = np.meshgrid(grid_points, grid_points, indexing='ij')
     d = np.hypot(rr, cc)
-    range_lut = _gaussian_weight(sigma**2, d).ravel()
+    range_lut = _gaussian_weight(sigma**2, d, dtype=dtype).ravel()
     return range_lut
 
 
@@ -148,9 +148,10 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
 
     sigma_color = sigma_color or image.std()
 
-    color_lut = _compute_color_lut(bins, sigma_color, max_value, image.dtype)
+    color_lut = _compute_color_lut(bins, sigma_color, max_value,
+                                   dtype=image.dtype)
 
-    range_lut = _compute_range_lut(win_size, sigma_spatial)
+    range_lut = _compute_range_lut(win_size, sigma_spatial, dtype=image.dtype)
 
     out = np.empty(image.shape, dtype=image.dtype)
 

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -222,7 +222,8 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True):
     shape_ext = (rows + 2, cols + 2, dims)
 
     out = np.zeros(shape_ext, image.dtype)
-    _denoise_tv_bregman(image, weight, max_iter, eps, isotropic, out)
+    _denoise_tv_bregman(image, image.dtype.type(weight), max_iter, eps,
+                        isotropic, out)
     return np.squeeze(out[1:-1, 1:-1])
 
 

--- a/skimage/restoration/_denoise_cy.pyx
+++ b/skimage/restoration/_denoise_cy.pyx
@@ -96,7 +96,7 @@ def _denoise_bilateral(np_floats[:, :, ::1] image, double max_value,
 
 
 def _denoise_tv_bregman(np_floats[:, :, ::1] image, np_floats weight,
-                        int max_iter, np_floats eps,
+                        int max_iter, double eps,
                         char isotropic, np_floats[:, :, ::1] out):
     cdef:
         Py_ssize_t rows = image.shape[0]
@@ -119,7 +119,7 @@ def _denoise_tv_bregman(np_floats[:, :, ::1] image, np_floats weight,
         np_floats ux, uy, uprev, unew, bxx, byy, dxx, dyy, s, tx, ty
         int i = 0
         np_floats lam = 2 * weight
-        np_floats rmse = DBL_MAX
+        double rmse = DBL_MAX
         np_floats norm = (weight + 4 * lam)
 
         Py_ssize_t out_rows, out_cols
@@ -169,7 +169,7 @@ def _denoise_tv_bregman(np_floats[:, :, ::1] image, np_floats weight,
 
                     # update root mean square error
                     tx = unew - uprev
-                    rmse += tx * tx
+                    rmse += <double>(tx * tx)
 
                     bxx = bx[r, c, k]
                     byy = by[r, c, k]

--- a/skimage/restoration/_denoise_cy.pyx
+++ b/skimage/restoration/_denoise_cy.pyx
@@ -18,10 +18,10 @@ cdef inline Py_ssize_t Py_ssize_t_min(Py_ssize_t value1, Py_ssize_t value2):
         return value2
 
 
-def _denoise_bilateral(np_floats[:, :, ::1] image, np_floats max_value,
-                       Py_ssize_t win_size, np_floats sigma_color,
-                       np_floats sigma_spatial, Py_ssize_t bins, mode,
-                       np_floats cval, np_floats[::1] color_lut,
+def _denoise_bilateral(np_floats[:, :, ::1] image, double max_value,
+                       Py_ssize_t win_size, double sigma_color,
+                       double sigma_spatial, Py_ssize_t bins, mode,
+                       double cval, np_floats[::1] color_lut,
                        np_floats[::1] range_lut, np_floats[::1] empty_dims,
                        np_floats[:, :, ::1] out):
     cdef:

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -190,7 +190,7 @@ def test_denoise_bilateral_2d():
     assert_(out1[30:45, 5:15].std() > out2[30:45, 5:15].std())
 
 
-@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.double])
+@pytest.mark.parametrize('dtype', [np.float32, np.double])
 def test_denoise_bilateral_types(dtype):
     img = checkerboard_gray.copy()[:50, :50]
     # add some random noise

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -202,6 +202,18 @@ def test_denoise_bilateral_types(dtype):
                                         sigma_spatial=10, multichannel=False)
 
 
+@pytest.mark.parametrize('dtype', [np.float32, np.double])
+def test_denoise_bregman_types(dtype):
+    img = checkerboard_gray.copy()[:50, :50]
+    # add some random noise
+    img += 0.5 * img.std() * np.random.rand(*img.shape)
+    img = np.clip(img, 0, 1).astype(dtype)
+
+    # check that we can process multiple float types
+    out = restoration.denoise_bilateral(img, sigma_color=0.1,
+                                        sigma_spatial=10, multichannel=False)
+
+
 def test_denoise_bilateral_zeros():
     img = np.zeros((10, 10))
     assert_equal(img, restoration.denoise_bilateral(img, multichannel=False))

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -195,7 +195,7 @@ def test_denoise_bilateral_types(dtype):
     img = checkerboard_gray.copy()[:50, :50]
     # add some random noise
     img += 0.5 * img.std() * np.random.rand(*img.shape)
-    img = np.clip(img, 0, 1)
+    img = np.clip(img, 0, 1).astype(dtype)
 
     # check that we can process multiple float types
     out = restoration.denoise_bilateral(img, sigma_color=0.1,


### PR DESCRIPTION
## Description

Fixes #3449, again.

See https://github.com/scikit-image/scikit-image/issues/3449#issuecomment-495669637 and subsequent replies for details.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] ~~[Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)~~
- [ ] ~~Gallery example in `./doc/examples` (new features only)~~
- [ ] ~~Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark~~
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
