### PR TITLE
Rename the 0.14.3 release notes as 0.14.4

### DIFF
--- a/doc/release/release_0.14.rst
+++ b/doc/release/release_0.14.rst
@@ -1,9 +1,11 @@
-Announcement: scikit-image 0.14.3
+Announcement: scikit-image 0.14.4
 =================================
 
 As a reminder, 0.14.x is the final version of scikit-image with support for
 Python 2.7, and will receive critical bug fixes until Jan 1, 2020. If you
 are using Python 3.5 or later, you should upgrade to scikit-image 0.15.x.
+
+The 0.14.3 release was skipped for a last minute bugfix.
 
 This is a bugfix release, and contains the following changes from v0.14.2:
 
@@ -19,7 +21,7 @@ Bug Fixes
 - Fix potential use of NULL pointer (#3696)
 - pypi: explicitly exclude Python 3.1, 3.2, and 3.3 (#3726)
 - Reduce default tolerance in threshold_li (#3622) (#3781)
-- Denoising functions now accept float32 images (#3449) (#3486) (#3880)
+- Denoising functions now accept float32 images (#3449) (#3486) (#3880) (#3936)
 
 Other Pull Requests
 -------------------
@@ -41,6 +43,7 @@ Other Pull Requests
 
 12 authors added to this release [alphabetical by first name]
 -------------------------------------------------------------
+- Alexandre de Siqueira
 - Andrew Murray
 - Christoph Gohlke
 - Egor Panfilov


### PR DESCRIPTION
## Description

@scikit-image/core 
@jni and I think it is best to skip 0.14.3 and merge the release notes into 0.14.4
Thoughts?

Uploading was delayed to better understand how to upload docs to the website.

I'm still confused as to why the website still points to 0.14.2 for the 0.14.x branch.

xref: https://github.com/scikit-image/scikit-image/pull/3937

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
