### PR TITLE
Update the joblib link in tutorial_parallelization.rst

### DIFF
--- a/doc/source/user_guide/tutorial_parallelization.rst
+++ b/doc/source/user_guide/tutorial_parallelization.rst
@@ -4,7 +4,7 @@ How to parallelize loops
 
 In image processing, we frequently apply the same algorithm
 on a large batch of images. In this paragraph, we propose to
-use `joblib <https://pythonhosted.org/joblib/>`_ to parallelize
+use `joblib <https://joblib.readthedocs.io>`_ to parallelize
 loops. Here is an example of such repetitive tasks:
 
 .. code-block:: python


### PR DESCRIPTION
The original link to joblib is no longer valid. This change proposes to use the new doc link of joblib.

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
