### PR TITLE
Fix plot_edge_filter.py references

### DIFF
--- a/doc/examples/edges/plot_edge_filter.py
+++ b/doc/examples/edges/plot_edge_filter.py
@@ -54,6 +54,7 @@ plt.show()
 #        1999.
 #
 # .. [3] https://en.wikipedia.org/wiki/Prewitt_operator
+#
 
 x, y = np.ogrid[:100, :100]
 # Rotation-invariant image with different spatial frequencies
@@ -96,15 +97,15 @@ plt.show()
 # The other two rows contain the difference between the different gradient
 # approximations (Sobel, Prewitt, Scharr & Farid) and analytical gradient.
 #
-# Farid & Simoncelli derivative filters have the closest to rotationall
-# invariance, but require a 5x5 kernel, which is computationall more intensive.
+# The Farid & Simoncelli derivative filters [4]_, [5]_  are the most
+# rotationally invariant, but require a 5x5 kernel, which is computationally
+# more intensive than a 3x3 kernel.
 #
 # .. [4] Farid, Hany, and Eero P. Simoncelli. "Differentiation of discrete
 #     multidimensional signals."
 #     IEEE Transactions on image processing 13.4 (2004): 496-508.
 #
 # .. [5] https://en.wikipedia.org/wiki/Image_derivatives
-# #Farid_and_Simoncelli_Derivatives
 
 
 x, y = np.mgrid[-10:10:255j, -10:10:255j]

--- a/doc/examples/edges/plot_edge_filter.py
+++ b/doc/examples/edges/plot_edge_filter.py
@@ -54,7 +54,6 @@ plt.show()
 #        1999.
 #
 # .. [3] https://en.wikipedia.org/wiki/Prewitt_operator
-#
 
 x, y = np.ogrid[:100, :100]
 # Rotation-invariant image with different spatial frequencies


### PR DESCRIPTION
## Description

Having that `# ` section was breaking things.

Not referring to 4 and 5 was also breaking things.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
