### PR TITLE
don't cast integer to float before using it as integer in numpy logspace

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -41,3 +41,5 @@ Other
   #3486 fused types is merged.
 * Check whether imread wheels are available, then re-enable testing imread
   on macOS. See https://github.com/scikit-image/scikit-image/pull/3898
+* When ``numpy`` is set to > 1.16, one may simplify the implementation of
+  of `feature.blob_log` using the vectorized version of ``np.logspace``.

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -417,9 +417,7 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
     if log_scale:
         start = np.log10(min_sigma)
         stop = np.log10(max_sigma)
-        sigma_list = np.stack([np.logspace(_start, _stop, num_sigma)
-                               for _start, _stop in zip(start, stop)],
-                              axis=1)
+        sigma_list = np.logspace(start, stop, num_sigma)
     else:
         scale = np.linspace(0, 1, num_sigma)[:, None]
         sigma_list = scale * (max_sigma - min_sigma) + min_sigma

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -417,7 +417,12 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
     if log_scale:
         start = np.log10(min_sigma)
         stop = np.log10(max_sigma)
-        sigma_list = np.logspace(start, stop, num_sigma)
+        sigma_list = np.stack([np.logspace(_start, _stop, num_sigma)
+                               for _start, _stop in zip(start, stop)],
+                              axis=1)
+        # The line below may only be used with numpy 1.16 and above
+        # https://github.com/numpy/numpy/commit/58ebb6a7d77cf89afeb888a70aff23e03d213788
+        # sigma_list = np.logspace(start, stop, num_sigma)
     else:
         scale = np.linspace(0, 1, num_sigma)[:, None]
         sigma_list = scale * (max_sigma - min_sigma) + min_sigma

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -415,10 +415,11 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
     max_sigma = np.asarray(max_sigma, dtype=float)
 
     if log_scale:
-        start, stop = np.log10(min_sigma)[:, None], np.log10(max_sigma)[:, None]
-        space = np.concatenate(
-            [start, stop, np.full_like(start, num_sigma)], axis=1)
-        sigma_list = np.stack([np.logspace(*s) for s in space], axis=1)
+        start = np.log10(min_sigma)
+        stop = np.log10(max_sigma)
+        sigma_list = np.stack([np.logspace(_start, _stop, num_sigma)
+                               for _start, _stop in zip(start, stop)],
+                              axis=1)
     else:
         scale = np.linspace(0, 1, num_sigma)[:, None]
         sigma_list = scale * (max_sigma - min_sigma) + min_sigma


### PR DESCRIPTION
by putting everything in an array, `num` is cast to an float, then it gets passes as the `num` parameter which expects to be an integers. Numpy is warning us that this behaviour is deprecated.

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
