### PR TITLE
pytest.importorskip doesn't take a reason parameter

### DIFF
--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -564,7 +564,7 @@ def test_is_low_contrast():
 # =======================
 
 def test_dask_histogram():
-    pytest.importorskip('dask', reason="dask python library is not installed")
+    pytest.importorskip('dask')
     import dask.array as da
     dask_array = da.from_array(np.array([[0, 1], [1, 2]]), chunks=(1, 2))
     output_hist, output_bins = exposure.histogram(dask_array)

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -530,7 +530,7 @@ def test_check_multiotsu_results():
     (threshold_minimum, 75, 77),
 ])
 def test_thresholds_dask_compatibility(thresholding, lower, upper):
-    pytest.importorskip('dask', reason="dask python library is not installed")
+    pytest.importorskip('dask')
     import dask.array as da
     dask_camera = da.from_array(skimage.data.camera(), chunks=(256, 256))
     assert lower < float(thresholding(dask_camera)) < upper


### PR DESCRIPTION
## Description

don't know why this didn't get caught. Maybe cuz tests have been broken these past few weeks.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
