### PR TITLE
Fix computation of Meijering filter and avoid ZeroDivisionError

### DIFF
--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -185,7 +185,7 @@ def meijering(image, sigmas=range(1, 10, 2), alpha=None,
     if alpha is None:
         alpha = 1.0 / ndim
 
-    # Invert image to detect bright ridges on dark background
+    # Invert image to detect dark ridges on bright background
     if black_ridges:
         image = invert(image)
 
@@ -210,7 +210,7 @@ def meijering(image, sigmas=range(1, 10, 2), alpha=None,
                          for j in range(ndim)], axis=0) for i in range(ndim)]
 
             # Get maximum eigenvalues by magnitude
-            auxiliary = auxiliary[1]
+            auxiliary = auxiliary[-1]
 
             # Rescale image intensity and avoid ZeroDivisionError
             filtered = _divide_nonzero(auxiliary, np.min(auxiliary))

--- a/skimage/filters/tests/test_ridges.py
+++ b/skimage/filters/tests/test_ridges.py
@@ -14,8 +14,8 @@ def test_2d_null_matrix():
     zeros = np.zeros((3, 3))
     ones = np.ones((3, 3))
 
-    assert_equal(meijering(a_black, black_ridges=True), zeros)
-    assert_equal(meijering(a_white, black_ridges=False), zeros)
+    assert_equal(meijering(a_black, black_ridges=True), ones)
+    assert_equal(meijering(a_white, black_ridges=False), ones)
 
     assert_equal(sato(a_black, black_ridges=True), zeros)
     assert_equal(sato(a_white, black_ridges=False), zeros)
@@ -35,8 +35,8 @@ def test_3d_null_matrix():
     zeros = np.zeros((3, 3, 3))
     ones = np.ones((3, 3, 3))
 
-    assert_equal(meijering(a_black, black_ridges=True), zeros)
-    assert_equal(meijering(a_white, black_ridges=False), zeros)
+    assert_allclose(meijering(a_black, black_ridges=True), ones, atol=1e-1)
+    assert_allclose(meijering(a_white, black_ridges=False), ones, atol=1e-1)
 
     assert_equal(sato(a_black, black_ridges=True), zeros)
     assert_equal(sato(a_white, black_ridges=False), zeros)


### PR DESCRIPTION
Fix computation of Meijering filter in accordance with cited reference and adjust tests.

## Description

This PR avoids a potential ZeroDivisionError discussed in PR #3951.

Moreover, it fixes the actual computation of the Meijering filter whose previous implementation in PR #3515 deviates from the formulas given in the original paper [1], see discussion of PR #3951 and https://github.com/scikit-image/scikit-image/pull/3951#issuecomment-498627182.

Unit tests were adjusted to deal with edge effects of (corrected) Meijering filter, similar to those of the Frangi ridge filter, see e.g. discussion in PR #3933.

The respective gallery example did not require any changes.

[1] Meijering, E., Jacob, M., Sarria, J. C., Steiner, P., Hirling, H., Unser,
M. (2004). Design and validation of a tool for neurite tracing and analysis in
fluorescence microscopy images. Cytometry Part A, 58(2), 167-176.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [not changed] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [not changed] Gallery example in `./doc/examples` (new features only)
- [not changed] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [X] Unit tests
- [X] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
