### PR TITLE
Set minimum version for imread so that it compiles from source on linux in test builds

### DIFF
--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,1 +1,1 @@
-imread
+imread>=0.5.1


### PR DESCRIPTION
## Description

Seems  like imread is broken on python 3.5.

I have a feeling that this is because imread releases wheels for manylinux2010
https://www.python.org/dev/peps/pep-0571/

I don't understand why pip is choosing the manylinux2010 wheels

https://pypi.org/project/imread/#files



## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
