### PR TITLE
Cleanup plugin utilization in data.load and testsuite

### DIFF
--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -10,7 +10,7 @@ import os as _os
 
 import numpy as _np
 
-from ..io import imread, use_plugin
+from ..io import imread
 from .._shared._warnings import expected_warnings, warn
 from ..util.dtype import img_as_bool
 from ._binary_blobs import binary_blobs
@@ -59,8 +59,7 @@ def load(f, as_gray=False):
     img : ndarray
         Image loaded from ``skimage.data_dir``.
     """
-    use_plugin('pil')
-    return imread(_os.path.join(data_dir, f), as_gray=as_gray)
+    return imread(_os.path.join(data_dir, f), plugin='pil', as_gray=as_gray)
 
 
 def camera():

--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -417,7 +417,8 @@ class MultiImage(ImageCollection):
         from ._io import imread
 
         def load_func(fname, **kwargs):
-            kwargs.setdefault('dtype', dtype)
+            if dtype is not None:
+                kwargs.setdefault('dtype', dtype)
             return imread(fname, **kwargs)
 
         self._filename = filename

--- a/skimage/io/tests/test_imageio.py
+++ b/skimage/io/tests/test_imageio.py
@@ -9,26 +9,20 @@ from skimage._shared import testing
 from skimage._shared.testing import (assert_array_almost_equal, TestCase,
                                      expected_warnings)
 
+from pytest import importorskip
 
-try:
-    import imageio as _imageio
-except ImportError:
-    imageio_available = False
-else:
-    imageio_available = True
+importorskip('imageio')
 
 
 def setup():
-    if imageio_available:
-        np.random.seed(0)
-        use_plugin('imageio')
+    np.random.seed(0)
+    use_plugin('imageio')
 
 
 def teardown():
     reset_plugins()
 
 
-@testing.skipif(not imageio_available, reason="imageio not installed")
 def test_imageio_as_gray():
     img = imread(os.path.join(data_dir, 'color.png'), as_gray=True)
     assert img.ndim == 2
@@ -38,13 +32,11 @@ def test_imageio_as_gray():
     assert np.sctype2char(img.dtype) in np.typecodes['AllInteger']
 
 
-@testing.skipif(not imageio_available, reason="imageio not installed")
 def test_imageio_palette():
     img = imread(os.path.join(data_dir, 'palette_color.png'))
     assert img.ndim == 3
 
 
-@testing.skipif(not imageio_available, reason="imageio not installed")
 def test_imageio_truncated_jpg():
     # imageio>2.0 uses Pillow / PIL to try and load the file.
     # Oddly, PIL explicitly raises a SyntaxError when the file read fails.
@@ -63,7 +55,6 @@ class TestSave(TestCase):
 
         assert_array_almost_equal((x * scaling).astype(np.int32), y)
 
-    @testing.skipif(not imageio_available, reason="imageio not installed")
     def test_imsave_roundtrip(self):
         dtype = np.uint8
         for shape in [(10, 10), (10, 10, 3), (10, 10, 4)]:

--- a/skimage/io/tests/test_imageio.py
+++ b/skimage/io/tests/test_imageio.py
@@ -9,10 +9,6 @@ from skimage._shared import testing
 from skimage._shared.testing import (assert_array_almost_equal, TestCase,
                                      expected_warnings)
 
-from pytest import importorskip
-
-importorskip('imageio')
-
 
 def setup():
     use_plugin('imageio')

--- a/skimage/io/tests/test_imageio.py
+++ b/skimage/io/tests/test_imageio.py
@@ -15,7 +15,6 @@ importorskip('imageio')
 
 
 def setup():
-    np.random.seed(0)
     use_plugin('imageio')
 
 
@@ -57,6 +56,7 @@ class TestSave(TestCase):
 
     def test_imsave_roundtrip(self):
         dtype = np.uint8
+        np.random.seed(0)
         for shape in [(10, 10), (10, 10, 3), (10, 10, 4)]:
             x = np.ones(shape, dtype=dtype) * np.random.rand(*shape)
 

--- a/skimage/io/tests/test_imread.py
+++ b/skimage/io/tests/test_imread.py
@@ -14,7 +14,6 @@ from pytest import importorskip
 importorskip('imread')
 
 def setup():
-    np.random.seed(0)
     use_plugin('imread')
 
 
@@ -61,6 +60,7 @@ class TestSave(TestCase):
 
     def test_imsave_roundtrip(self):
         dtype = np.uint8
+        np.random.seed(0)
         for shape in [(10, 10), (10, 10, 3), (10, 10, 4)]:
             x = np.ones(shape, dtype=dtype) * np.random.rand(*shape)
 

--- a/skimage/io/tests/test_imread.py
+++ b/skimage/io/tests/test_imread.py
@@ -9,25 +9,19 @@ from skimage._shared import testing
 from skimage._shared.testing import (TestCase, assert_array_equal,
                                      assert_array_almost_equal)
 
-try:
-    import imread as _imread
-except ImportError:
-    imread_available = False
-else:
-    imread_available = True
+from pytest import importorskip
 
+importorskip('imread')
 
 def setup():
-    if imread_available:
-        np.random.seed(0)
-        use_plugin('imread')
+    np.random.seed(0)
+    use_plugin('imread')
 
 
 def teardown():
     reset_plugins()
 
 
-@testing.skipif(not imread_available, reason="imageread not installed")
 def test_imread_as_gray():
     img = imread(os.path.join(data_dir, 'color.png'), as_gray=True)
     assert img.ndim == 2
@@ -37,19 +31,16 @@ def test_imread_as_gray():
     assert np.sctype2char(img.dtype) in np.typecodes['AllInteger']
 
 
-@testing.skipif(not imread_available, reason="imageread not installed")
 def test_imread_palette():
     img = imread(os.path.join(data_dir, 'palette_color.png'))
     assert img.ndim == 3
 
 
-@testing.skipif(not imread_available, reason="imageread not installed")
 def test_imread_truncated_jpg():
     with testing.raises(RuntimeError):
         io.imread(os.path.join(data_dir, 'truncated.jpg'))
 
 
-@testing.skipif(not imread_available, reason="imageread not installed")
 def test_bilevel():
     expected = np.zeros((10, 10), bool)
     expected[::2] = 1
@@ -68,7 +59,6 @@ class TestSave(TestCase):
 
         assert_array_almost_equal((x * scaling).astype(np.int32), y)
 
-    @testing.skipif(not imread_available, reason="imageread not installed")
     def test_imsave_roundtrip(self):
         dtype = np.uint8
         for shape in [(10, 10), (10, 10, 3), (10, 10, 4)]:

--- a/skimage/io/tests/test_multi_image.py
+++ b/skimage/io/tests/test_multi_image.py
@@ -8,17 +8,13 @@ from skimage.io.collection import MultiImage, ImageCollection
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_allclose, TestCase
 
-def setup():
-    use_plugin('pil')
-
-def teardown():
-    reset_plugins()
-
 
 class TestMultiImage(TestCase):
     def setUp(self):
         # This multipage TIF file was created with imagemagick:
         # convert im1.tif im2.tif -adjoin multipage.tif
+        use_plugin('pil')
+        use_plugin('simpleitk')
         paths = [os.path.join(data_dir, 'multipage_rgb.tif'),
                  os.path.join(data_dir, 'no_time_for_that_tiny.gif')]
         self.imgs = [MultiImage(paths[0]),
@@ -28,6 +24,7 @@ class TestMultiImage(TestCase):
                      ImageCollection(paths[0]),
                      ImageCollection(paths[1], conserve_memory=False),
                      ImageCollection(os.pathsep.join(paths))]
+        reset_plugins()
 
     def test_shapes(self):
         img = self.imgs[-1]

--- a/skimage/io/tests/test_multi_image.py
+++ b/skimage/io/tests/test_multi_image.py
@@ -14,7 +14,6 @@ class TestMultiImage(TestCase):
         # This multipage TIF file was created with imagemagick:
         # convert im1.tif im2.tif -adjoin multipage.tif
         use_plugin('pil')
-        use_plugin('simpleitk')
         paths = [os.path.join(data_dir, 'multipage_rgb.tif'),
                  os.path.join(data_dir, 'no_time_for_that_tiny.gif')]
         self.imgs = [MultiImage(paths[0]),

--- a/skimage/io/tests/test_multi_image.py
+++ b/skimage/io/tests/test_multi_image.py
@@ -2,18 +2,23 @@ import os
 
 import numpy as np
 from skimage import data_dir
-from skimage.io import use_plugin
+from skimage.io import use_plugin, reset_plugins
 from skimage.io.collection import MultiImage, ImageCollection
 
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_allclose, TestCase
+
+def setup():
+    use_plugin('pil')
+
+def teardown():
+    reset_plugins()
 
 
 class TestMultiImage(TestCase):
     def setUp(self):
         # This multipage TIF file was created with imagemagick:
         # convert im1.tif im2.tif -adjoin multipage.tif
-        use_plugin('pil')
         paths = [os.path.join(data_dir, 'multipage_rgb.tif'),
                  os.path.join(data_dir, 'no_time_for_that_tiny.gif')]
         self.imgs = [MultiImage(paths[0]),

--- a/skimage/io/tests/test_multi_image.py
+++ b/skimage/io/tests/test_multi_image.py
@@ -8,85 +8,86 @@ from skimage.io.collection import MultiImage, ImageCollection
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_allclose, TestCase
 
+from pytest import fixture
 
-class TestMultiImage(TestCase):
-    def setUp(self):
-        # This multipage TIF file was created with imagemagick:
-        # convert im1.tif im2.tif -adjoin multipage.tif
-        use_plugin('pil')
-        paths = [os.path.join(data_dir, 'multipage_rgb.tif'),
-                 os.path.join(data_dir, 'no_time_for_that_tiny.gif')]
-        self.imgs = [MultiImage(paths[0]),
-                     MultiImage(paths[0], conserve_memory=False),
-                     MultiImage(paths[1]),
-                     MultiImage(paths[1], conserve_memory=False),
-                     ImageCollection(paths[0]),
-                     ImageCollection(paths[1], conserve_memory=False),
-                     ImageCollection(os.pathsep.join(paths))]
-        reset_plugins()
+@fixture
+def imgs():
+    use_plugin('pil')
+    paths = [os.path.join(data_dir, 'multipage_rgb.tif'),
+             os.path.join(data_dir, 'no_time_for_that_tiny.gif')]
+    imgs = [MultiImage(paths[0]),
+            MultiImage(paths[0], conserve_memory=False),
+            MultiImage(paths[1]),
+            MultiImage(paths[1], conserve_memory=False),
+            ImageCollection(paths[0]),
+            ImageCollection(paths[1], conserve_memory=False),
+            ImageCollection(os.pathsep.join(paths))]
+    yield imgs
 
-    def test_shapes(self):
-        img = self.imgs[-1]
-        imgs = img[:]
-        assert imgs[0].shape == imgs[1].shape
-        assert imgs[0].shape == (10, 10, 3)
+    reset_plugins()
 
-    def test_len(self):
-        assert len(self.imgs[0]) == len(self.imgs[1]) == 2
-        assert len(self.imgs[2]) == len(self.imgs[3]) == 24
-        assert len(self.imgs[4]) == 2
-        assert len(self.imgs[5]) == 24
-        assert len(self.imgs[6]) == 26, len(self.imgs[6])
+def test_shapes(imgs):
+    img = imgs[-1]
+    imgs = img[:]
+    assert imgs[0].shape == imgs[1].shape
+    assert imgs[0].shape == (10, 10, 3)
 
-    def test_slicing(self):
-        img = self.imgs[-1]
-        assert type(img[:]) is ImageCollection
-        assert len(img[:]) == 26, len(img[:])
-        assert len(img[:1]) == 1
-        assert len(img[1:]) == 25
-        assert_allclose(img[0], img[:1][0])
-        assert_allclose(img[1], img[1:][0])
-        assert_allclose(img[-1], img[::-1][0])
-        assert_allclose(img[0], img[::-1][-1])
+def test_len(imgs):
+    assert len(imgs[0]) == len(imgs[1]) == 2
+    assert len(imgs[2]) == len(imgs[3]) == 24
+    assert len(imgs[4]) == 2
+    assert len(imgs[5]) == 24
+    assert len(imgs[6]) == 26, len(imgs[6])
 
-    def test_getitem(self):
-        for img in self.imgs:
-            num = len(img)
+def test_slicing(imgs):
+    img = imgs[-1]
+    assert type(img[:]) is ImageCollection
+    assert len(img[:]) == 26, len(img[:])
+    assert len(img[:1]) == 1
+    assert len(img[1:]) == 25
+    assert_allclose(img[0], img[:1][0])
+    assert_allclose(img[1], img[1:][0])
+    assert_allclose(img[-1], img[::-1][0])
+    assert_allclose(img[0], img[::-1][-1])
 
-            for i in range(-num, num):
-                assert type(img[i]) is np.ndarray
-            assert_allclose(img[0], img[-num])
+def test_getitem(imgs):
+    for img in imgs:
+        num = len(img)
 
-            with testing.raises(AssertionError):
-                assert_allclose(img[0], img[1])
+        for i in range(-num, num):
+            assert type(img[i]) is np.ndarray
+        assert_allclose(img[0], img[-num])
 
-            with testing.raises(IndexError):
-                img[num]
-            with testing.raises(IndexError):
-                img[-num - 1]
+        with testing.raises(AssertionError):
+            assert_allclose(img[0], img[1])
 
-    def test_files_property(self):
-        for img in self.imgs:
-            if isinstance(img, ImageCollection):
-                continue
+        with testing.raises(IndexError):
+            img[num]
+        with testing.raises(IndexError):
+            img[-num - 1]
 
-            assert isinstance(img.filename, str)
+def test_files_property(imgs):
+    for img in imgs:
+        if isinstance(img, ImageCollection):
+            continue
 
-            with testing.raises(AttributeError):
-                img.filename = "newfile"
+        assert isinstance(img.filename, str)
 
-    def test_conserve_memory_property(self):
-        for img in self.imgs:
-            assert isinstance(img.conserve_memory, bool)
+        with testing.raises(AttributeError):
+            img.filename = "newfile"
 
-            with testing.raises(AttributeError):
-                img.conserve_memory = True
+def test_conserve_memory_property(imgs):
+    for img in imgs:
+        assert isinstance(img.conserve_memory, bool)
 
-    def test_concatenate(self):
-        for img in self.imgs:
-            if img[0].shape != img[-1].shape:
-                with testing.raises(ValueError):
-                    img.concatenate()
-                continue
-            array = img.concatenate()
-            assert_equal(array.shape, (len(img),) + img[0].shape)
+        with testing.raises(AttributeError):
+            img.conserve_memory = True
+
+def test_concatenate(imgs):
+    for img in imgs:
+        if img[0].shape != img[-1].shape:
+            with testing.raises(ValueError):
+                img.concatenate()
+            continue
+        array = img.concatenate()
+        assert_equal(array.shape, (len(img),) + img[0].shape)

--- a/skimage/io/tests/test_plugin.py
+++ b/skimage/io/tests/test_plugin.py
@@ -7,8 +7,10 @@ from skimage._shared import testing
 from skimage._shared.testing import assert_equal
 
 
-io.use_plugin('pil')
+
 priority_plugin = 'pil'
+def setup():
+    io.use_plugin('pil')
 
 
 def teardown_module():

--- a/skimage/io/tests/test_plugin.py
+++ b/skimage/io/tests/test_plugin.py
@@ -9,6 +9,8 @@ from skimage._shared.testing import assert_equal
 
 
 priority_plugin = 'pil'
+
+
 def setup():
     io.use_plugin('pil')
 

--- a/skimage/io/tests/test_simpleitk.py
+++ b/skimage/io/tests/test_simpleitk.py
@@ -8,16 +8,11 @@ from skimage import data_dir
 from skimage.io import imread, imsave, use_plugin, reset_plugins
 from skimage._shared import testing
 
-try:
-    import SimpleITK as sitk
-    use_plugin('simpleitk')
-except ImportError:
-    sitk_available = False
-else:
-    sitk_available = True
+from pytest import importorskip
+
+importorskip('SimpleITK')
 
 np.random.seed(0)
-
 
 def teardown():
     reset_plugins()
@@ -25,16 +20,13 @@ def teardown():
 
 def setup_module(self):
     """The effect of the `plugin.use` call may be overridden by later imports.
-    Call `use_plugin` directly before the tests to ensure that sitk is used.
+    Call `use_plugin` directly before the tests to ensure that SimpleITK is
+    used.
 
     """
-    try:
-        use_plugin('simpleitk')
-    except ImportError:
-        pass
+    use_plugin('simpleitk')
 
 
-@testing.skipif(not sitk_available, reason="simpletk not installed")
 def test_imread_as_gray():
     img = imread(os.path.join(data_dir, 'color.png'), as_gray=True)
     assert img.ndim == 2
@@ -44,7 +36,6 @@ def test_imread_as_gray():
     assert np.sctype2char(img.dtype) in np.typecodes['AllInteger']
 
 
-@testing.skipif(not sitk_available, reason="simpletk not installed")
 def test_bilevel():
     expected = np.zeros((10, 10))
     expected[::2] = 255
@@ -54,7 +45,6 @@ def test_bilevel():
 
 """
 #TODO: This test causes a Segmentation fault
-@testing.skipif(not sitk_available)
 def test_imread_truncated_jpg():
     assert_raises((RuntimeError, ValueError),
                   imread,
@@ -62,7 +52,6 @@ def test_imread_truncated_jpg():
 """
 
 
-@testing.skipif(not sitk_available, reason="simpletk not installed")
 def test_imread_uint16():
     expected = np.load(os.path.join(data_dir, 'chessboard_GRAY_U8.npy'))
     img = imread(os.path.join(data_dir, 'chessboard_GRAY_U16.tif'))
@@ -70,7 +59,6 @@ def test_imread_uint16():
     np.testing.assert_array_almost_equal(img, expected)
 
 
-@testing.skipif(not sitk_available, reason="simpletk not installed")
 def test_imread_uint16_big_endian():
     expected = np.load(os.path.join(data_dir, 'chessboard_GRAY_U8.npy'))
     img = imread(os.path.join(data_dir, 'chessboard_GRAY_U16B.tif'))
@@ -87,7 +75,6 @@ class TestSave(unittest.TestCase):
 
         np.testing.assert_array_almost_equal(x, y)
 
-    @testing.skipif(not sitk_available, reason="simpletk not installed")
     def test_imsave_roundtrip(self):
         for shape in [(10, 10), (10, 10, 3), (10, 10, 4)]:
             for dtype in (np.uint8, np.uint16, np.float32, np.float64):

--- a/skimage/viewer/tests/test_viewer.py
+++ b/skimage/viewer/tests/test_viewer.py
@@ -9,7 +9,6 @@ from skimage.viewer.plugins import OverlayPlugin
 from skimage._shared.version_requirements import is_installed
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal
-from skimage._shared._warnings import expected_warnings
 
 
 @testing.skipif(not has_qt, reason="Qt not installed")
@@ -70,8 +69,7 @@ def test_viewer_with_overlay():
     ov.color = 3
     assert_equal(ov.color, 'yellow')
 
-    with expected_warnings(['precision loss']):
-        viewer.save_to_file(filename)
+    viewer.save_to_file(filename)
     ov.display_filtered_image(img)
     assert_equal(ov.overlay, img)
     ov.overlay = None


### PR DESCRIPTION
## Description


1. Calling `use_plugin` in `skimage.data.load` surely had some unintended consequences to the global state of the plugin in use.
2. I'm pretty sure this was causing all tests to use pil at one point or an other.
3. I went through man of the IO test to ensure that they reset the plugin after they finish.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
