### PR TITLE
Modify ProjectiveTransform.__nice__ formatting

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1,6 +1,7 @@
 import math
 import numpy as np
 from scipy import spatial
+import textwrap
 
 from .._shared.utils import get_bound_method_class, safe_as_int
 
@@ -728,12 +729,7 @@ class ProjectiveTransform(GeometricTransform):
         >>> print(ProjectiveTransform(np.random.rand(3, 3)))
         """
         npstring = np.array2string(self.params, separator=', ')
-        lines = npstring.split('\n ')
-        # Initial indentation
-        lines = ['    ' + p for p in lines]
-        # Add an extra space to every non-first line for alignment
-        lines[1:] = [' ' + p for p in lines[1:]]
-        paramstr = 'matrix=\n' + '\n'.join(lines)
+        paramstr = 'matrix=\n' + textwrap.indent(npstring, '    ')
         return paramstr
 
     def __repr__(self):

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -721,13 +721,7 @@ class ProjectiveTransform(GeometricTransform):
                             "types.")
 
     def __nice__(self):
-        """common 'paramstr' used by __str__ and __repr__
-
-        Examples
-        --------
-        >>> print(ProjectiveTransform())
-        >>> print(ProjectiveTransform(np.random.rand(3, 3)))
-        """
+        """common 'paramstr' used by __str__ and __repr__"""
         npstring = np.array2string(self.params, separator=', ')
         paramstr = 'matrix=\n' + textwrap.indent(npstring, '    ')
         return paramstr

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -720,24 +720,31 @@ class ProjectiveTransform(GeometricTransform):
                             "types.")
 
     def __nice__(self):
-        """ common 'paramstr' used by __str__ and __repr__ """
+        """common 'paramstr' used by __str__ and __repr__
+
+        Examples
+        --------
+        >>> print(ProjectiveTransform())
+        >>> print(ProjectiveTransform(np.random.rand(3, 3)))
+        """
         npstring = np.array2string(self.params, separator=', ')
-        # add a newline and indentation after the first square braket to ensure
-        # the columns of the params matrix are aligned in the repr
-        lines = npstring[1:].split('\n ')
-        indented_lines = ['    ' + p for p in lines]
-        paramstr = 'matrix=[\n' + '\n'.join(indented_lines)
+        lines = npstring.split('\n ')
+        # Initial indentation
+        lines = ['    ' + p for p in lines]
+        # Add an extra space to every non-first line for alignment
+        lines[1:] = [' ' + p for p in lines[1:]]
+        paramstr = 'matrix=\n' + '\n'.join(lines)
         return paramstr
 
     def __repr__(self):
-        """ Add standard repr formatting around a nice string """
+        """Add standard repr formatting around a __nice__ string"""
         paramstr = self.__nice__()
         classname = self.__class__.__name__
         classstr = classname
         return '<{}({}) at {}>'.format(classstr, paramstr, hex(id(self)))
 
     def __str__(self):
-        """ Add standard str formatting around a nice string """
+        """Add standard str formatting around a __nice__ string"""
         paramstr = self.__nice__()
         classname = self.__class__.__name__
         classstr = classname

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -478,10 +478,10 @@ def test_projective_repr():
     tform = ProjectiveTransform()
     want = re.escape(textwrap.dedent(
         '''
-        <ProjectiveTransform(matrix=[
-            [1., 0., 0.],
-            [0., 1., 0.],
-            [0., 0., 1.]]) at
+        <ProjectiveTransform(matrix=
+            [[1., 0., 0.],
+             [0., 1., 0.],
+             [0., 0., 1.]]) at
         ''').strip()) + ' 0x[a-f0-9]+' + re.escape('>')
     # Hack the escaped regex to allow whitespace before each number for
     # compatibility with different numpy versions.
@@ -494,10 +494,10 @@ def test_projective_str():
     tform = ProjectiveTransform()
     want = re.escape(textwrap.dedent(
         '''
-        <ProjectiveTransform(matrix=[
-            [1., 0., 0.],
-            [0., 1., 0.],
-            [0., 0., 1.]])>
+        <ProjectiveTransform(matrix=
+            [[1., 0., 0.],
+             [0., 1., 0.],
+             [0., 0., 1.]])>
         ''').strip())
     # Hack the escaped regex to allow whitespace before each number for
     # compatibility with different numpy versions.


### PR DESCRIPTION
Logical extension to #3525

In the previous merged PR there was more support for an alternate matrix format. This PR implements that format. 

I also fixed a small inconsistency in the docstrings and added a doctest. I originally created the doctest for debugging, but I think doctests generally improve code quality --- even for simple things like this --- so I opted to keep it in.  

Advertisement: This doctest can be run using the [xdoctest](https://github.com/Erotemic/xdoctest) CLI:  `xdoctest -m skimage.transform._geometric ProjectiveTransform.__nice__`. Any doctest can theoretically be run this way: e.g. `xdoctest -m skimage.morphology.selem ellipse`. 
