### PR TITLE
Add missing argument to docstring of PaintTool

### DIFF
--- a/skimage/viewer/canvastools/painttool.py
+++ b/skimage/viewer/canvastools/painttool.py
@@ -18,8 +18,10 @@ class PaintTool(CanvasToolBase):
         Skimage viewer or plot plugin object.
     overlay_shape : shape tuple
         2D shape tuple used to initialize overlay image.
+    radius : int
+        The size of the paint cursor.
     alpha : float (between [0, 1])
-        Opacity of overlay
+        Opacity of overlay.
     on_move : function
         Function called whenever a control handle is moved.
         This function must accept the end points of line as the only argument.


### PR DESCRIPTION
## Description

While investigating an SO question, I found that this argument was missing in the PaintTool docstring. Even though the viewer is mostly neglected, this was an easy fix so I thought I'd add it in!

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] ~~Gallery example in `./doc/examples` (new features only)~~
- [ ] ~~Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark~~
- [ ] ~~Unit tests~~
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
