### PR TITLE
 Make dtype consistent in filters.rank functions

### DIFF
--- a/skimage/filters/_median.py
+++ b/skimage/filters/_median.py
@@ -7,7 +7,6 @@ from scipy import ndimage as ndi
 from .rank import generic
 
 
-@generic._default_selem
 def median(image, selem=None, out=None, mask=None, shift_x=False,
            shift_y=False, mode='nearest', cval=0.0, behavior='ndimage'):
     """Return local median of an image.
@@ -93,5 +92,7 @@ def median(image, selem=None, out=None, mask=None, shift_x=False,
         warn("Change 'behavior' to 'rank' if you want to use the "
              "parameters 'mask', 'shift_x', 'shift_y'. They will be "
              "discarded otherwise.")
+    if selem is None:
+        selem = ndi.generate_binary_structure(image.ndim, image.ndim)
     return ndi.median_filter(image, footprint=selem, output=out, mode=mode,
                              cval=cval)

--- a/skimage/filters/rank/_percentile.py
+++ b/skimage/filters/rank/_percentile.py
@@ -36,9 +36,8 @@ __all__ = ['autolevel_percentile', 'gradient_percentile',
 def _apply(func, image, selem, out, mask, shift_x, shift_y, p0, p1,
            out_dtype=None):
     assert_nD(image, 2)
-    image, selem, out, mask, n_bins = _handle_input(image, selem,
-                                                               out, mask,
-                                                               out_dtype)
+    image, selem, out, mask, n_bins = _handle_input(image, selem, out, mask,
+                                                    out_dtype)
 
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
          out=out, n_bins=n_bins, p0=p0, p1=p1)

--- a/skimage/filters/rank/_percentile.py
+++ b/skimage/filters/rank/_percentile.py
@@ -42,7 +42,7 @@ def _apply(func, image, selem, out, mask, shift_x, shift_y, p0, p1,
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
          out=out, n_bins=n_bins, p0=p0, p1=p1)
 
-    return out.reshape(out.shape[:2])
+    return out.reshape(out.shape[:2]).astype(out_dtype)
 
 
 def autolevel_percentile(image, selem, out=None, mask=None, shift_x=False,

--- a/skimage/filters/rank/_percentile.py
+++ b/skimage/filters/rank/_percentile.py
@@ -36,7 +36,7 @@ __all__ = ['autolevel_percentile', 'gradient_percentile',
 def _apply(func, image, selem, out, mask, shift_x, shift_y, p0, p1,
            out_dtype=None):
     assert_nD(image, 2)
-    image, selem, out, mask, n_bins, out_dtype = _handle_input(image, selem,
+    image, selem, out, mask, n_bins = _handle_input(image, selem,
                                                                out, mask,
                                                                out_dtype)
 

--- a/skimage/filters/rank/_percentile.py
+++ b/skimage/filters/rank/_percentile.py
@@ -43,7 +43,7 @@ def _apply(func, image, selem, out, mask, shift_x, shift_y, p0, p1,
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
          out=out, n_bins=n_bins, p0=p0, p1=p1)
 
-    return out.reshape(out.shape[:2]).astype(out_dtype)
+    return out.reshape(out.shape[:2])
 
 
 def autolevel_percentile(image, selem, out=None, mask=None, shift_x=False,

--- a/skimage/filters/rank/_percentile.py
+++ b/skimage/filters/rank/_percentile.py
@@ -36,7 +36,8 @@ __all__ = ['autolevel_percentile', 'gradient_percentile',
 def _apply(func, image, selem, out, mask, shift_x, shift_y, p0, p1,
            out_dtype=None):
     assert_nD(image, 2)
-    image, selem, out, mask, n_bins, out_dtype = _handle_input(image, selem, out, mask,
+    image, selem, out, mask, n_bins, out_dtype = _handle_input(image, selem,
+                                                               out, mask,
                                                                out_dtype)
 
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,

--- a/skimage/filters/rank/_percentile.py
+++ b/skimage/filters/rank/_percentile.py
@@ -27,7 +27,6 @@ from ..._shared.utils import assert_nD
 from . import percentile_cy
 from .generic import _handle_input
 
-
 __all__ = ['autolevel_percentile', 'gradient_percentile',
            'mean_percentile', 'subtract_mean_percentile',
            'enhance_contrast_percentile', 'percentile', 'pop_percentile',
@@ -36,10 +35,9 @@ __all__ = ['autolevel_percentile', 'gradient_percentile',
 
 def _apply(func, image, selem, out, mask, shift_x, shift_y, p0, p1,
            out_dtype=None):
-
     assert_nD(image, 2)
-    image, selem, out, mask, n_bins = _handle_input(image, selem, out, mask,
-                                                    out_dtype)
+    image, selem, out, mask, n_bins, out_dtype = _handle_input(image, selem, out, mask,
+                                                               out_dtype)
 
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
          out=out, n_bins=n_bins, p0=p0, p1=p1)

--- a/skimage/filters/rank/bilateral.py
+++ b/skimage/filters/rank/bilateral.py
@@ -41,7 +41,7 @@ def _apply(func, image, selem, out, mask, shift_x, shift_y, s0, s1,
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
          out=out, n_bins=n_bins, s0=s0, s1=s1)
 
-    return out.reshape(out.shape[:2])
+    return out.reshape(out.shape[:2]).astype(out_dtype)
 
 
 def mean_bilateral(image, selem, out=None, mask=None, shift_x=False,

--- a/skimage/filters/rank/bilateral.py
+++ b/skimage/filters/rank/bilateral.py
@@ -35,9 +35,8 @@ __all__ = ['mean_bilateral', 'pop_bilateral', 'sum_bilateral']
 def _apply(func, image, selem, out, mask, shift_x, shift_y, s0, s1,
            out_dtype=None):
     assert_nD(image, 2)
-    image, selem, out, mask, n_bins = _handle_input(image, selem,
-                                                               out, mask,
-                                                               out_dtype)
+    image, selem, out, mask, n_bins = _handle_input(image, selem, out, mask,
+                                                    out_dtype)
 
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
          out=out, n_bins=n_bins, s0=s0, s1=s1)

--- a/skimage/filters/rank/bilateral.py
+++ b/skimage/filters/rank/bilateral.py
@@ -29,16 +29,14 @@ from ..._shared.utils import assert_nD
 from . import bilateral_cy
 from .generic import _handle_input
 
-
 __all__ = ['mean_bilateral', 'pop_bilateral', 'sum_bilateral']
 
 
 def _apply(func, image, selem, out, mask, shift_x, shift_y, s0, s1,
            out_dtype=None):
-
     assert_nD(image, 2)
-    image, selem, out, mask, n_bins = _handle_input(image, selem, out, mask,
-                                                    out_dtype)
+    image, selem, out, mask, n_bins, out_dtype = _handle_input(image, selem, out, mask,
+                                                               out_dtype)
 
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
          out=out, n_bins=n_bins, s0=s0, s1=s1)

--- a/skimage/filters/rank/bilateral.py
+++ b/skimage/filters/rank/bilateral.py
@@ -35,7 +35,8 @@ __all__ = ['mean_bilateral', 'pop_bilateral', 'sum_bilateral']
 def _apply(func, image, selem, out, mask, shift_x, shift_y, s0, s1,
            out_dtype=None):
     assert_nD(image, 2)
-    image, selem, out, mask, n_bins, out_dtype = _handle_input(image, selem, out, mask,
+    image, selem, out, mask, n_bins, out_dtype = _handle_input(image, selem,
+                                                               out, mask,
                                                                out_dtype)
 
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,

--- a/skimage/filters/rank/bilateral.py
+++ b/skimage/filters/rank/bilateral.py
@@ -42,7 +42,7 @@ def _apply(func, image, selem, out, mask, shift_x, shift_y, s0, s1,
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
          out=out, n_bins=n_bins, s0=s0, s1=s1)
 
-    return out.reshape(out.shape[:2]).astype(out_dtype)
+    return out.reshape(out.shape[:2])
 
 
 def mean_bilateral(image, selem, out=None, mask=None, shift_x=False,

--- a/skimage/filters/rank/bilateral.py
+++ b/skimage/filters/rank/bilateral.py
@@ -35,7 +35,7 @@ __all__ = ['mean_bilateral', 'pop_bilateral', 'sum_bilateral']
 def _apply(func, image, selem, out, mask, shift_x, shift_y, s0, s1,
            out_dtype=None):
     assert_nD(image, 2)
-    image, selem, out, mask, n_bins, out_dtype = _handle_input(image, selem,
+    image, selem, out, mask, n_bins = _handle_input(image, selem,
                                                                out, mask,
                                                                out_dtype)
 

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -62,7 +62,7 @@ __all__ = ['autolevel', 'bottomhat', 'equalize', 'gradient', 'maximum', 'mean',
            'entropy', 'otsu']
 
 
-def _handle_input(image, selem, out=None, mask=None, out_dtype=None,
+def _handle_input(image, selem=None, out=None, mask=None, out_dtype=None,
                   pixel_size=1):
     """Preprocess and verify input for filters.rank methods.
 
@@ -70,7 +70,7 @@ def _handle_input(image, selem, out=None, mask=None, out_dtype=None,
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -244,7 +244,7 @@ def _apply_vector_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
     return out
 
 
-def autolevel(image, selem=None, out=None, mask=None, shift_x=False,
+def autolevel(image, selem, out=None, mask=None, shift_x=False,
               shift_y=False):
     """Auto-level image using local histogram.
 
@@ -255,7 +255,7 @@ def autolevel(image, selem=None, out=None, mask=None, shift_x=False,
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -287,7 +287,7 @@ def autolevel(image, selem=None, out=None, mask=None, shift_x=False,
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def bottomhat(image, selem=None, out=None, mask=None, shift_x=False,
+def bottomhat(image, selem, out=None, mask=None, shift_x=False,
               shift_y=False):
     """Local bottom-hat of an image.
 
@@ -298,7 +298,7 @@ def bottomhat(image, selem=None, out=None, mask=None, shift_x=False,
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -330,15 +330,14 @@ def bottomhat(image, selem=None, out=None, mask=None, shift_x=False,
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def equalize(image, selem=None, out=None, mask=None, shift_x=False,
-             shift_y=False):
+def equalize(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     """Equalize image using local histogram.
 
     Parameters
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -370,7 +369,7 @@ def equalize(image, selem=None, out=None, mask=None, shift_x=False,
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def gradient(image, selem=None, out=None, mask=None, shift_x=False,
+def gradient(image, selem, out=None, mask=None, shift_x=False,
              shift_y=False):
     """Return local gradient of an image (i.e. local maximum - local minimum).
 
@@ -378,7 +377,7 @@ def gradient(image, selem=None, out=None, mask=None, shift_x=False,
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -410,7 +409,7 @@ def gradient(image, selem=None, out=None, mask=None, shift_x=False,
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def maximum(image, selem=None, out=None, mask=None, shift_x=False,
+def maximum(image, selem, out=None, mask=None, shift_x=False,
             shift_y=False):
     """Return local maximum of an image.
 
@@ -418,7 +417,7 @@ def maximum(image, selem=None, out=None, mask=None, shift_x=False,
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -459,14 +458,14 @@ def maximum(image, selem=None, out=None, mask=None, shift_x=False,
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def mean(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
+def mean(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     """Return local mean of an image.
 
     Parameters
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -497,7 +496,7 @@ def mean(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
                                    mask=mask, shift_x=shift_x, shift_y=shift_y)
 
 
-def geometric_mean(image, selem=None, out=None, mask=None,
+def geometric_mean(image, selem, out=None, mask=None,
                    shift_x=False, shift_y=False):
     """Return local geometric mean of an image.
 
@@ -505,7 +504,7 @@ def geometric_mean(image, selem=None, out=None, mask=None,
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -542,7 +541,7 @@ def geometric_mean(image, selem=None, out=None, mask=None,
                                    shift_y=shift_y)
 
 
-def subtract_mean(image, selem=None, out=None, mask=None, shift_x=False,
+def subtract_mean(image, selem, out=None, mask=None, shift_x=False,
                   shift_y=False):
     """Return image subtracted from its local mean.
 
@@ -550,7 +549,7 @@ def subtract_mean(image, selem=None, out=None, mask=None, shift_x=False,
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -630,7 +629,7 @@ def median(image, selem=None, out=None, mask=None,
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def minimum(image, selem=None, out=None, mask=None, shift_x=False,
+def minimum(image, selem, out=None, mask=None, shift_x=False,
             shift_y=False):
     """Return local minimum of an image.
 
@@ -638,7 +637,7 @@ def minimum(image, selem=None, out=None, mask=None, shift_x=False,
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -679,7 +678,7 @@ def minimum(image, selem=None, out=None, mask=None, shift_x=False,
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def modal(image, selem=None, out=None, mask=None, shift_x=False,
+def modal(image, selem, out=None, mask=None, shift_x=False,
           shift_y=False):
     """Return local mode of an image.
 
@@ -689,7 +688,7 @@ def modal(image, selem=None, out=None, mask=None, shift_x=False,
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -721,7 +720,7 @@ def modal(image, selem=None, out=None, mask=None, shift_x=False,
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def enhance_contrast(image, selem=None, out=None, mask=None, shift_x=False,
+def enhance_contrast(image, selem, out=None, mask=None, shift_x=False,
                      shift_y=False):
     """Enhance contrast of an image.
 
@@ -733,7 +732,7 @@ def enhance_contrast(image, selem=None, out=None, mask=None, shift_x=False,
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -765,7 +764,7 @@ def enhance_contrast(image, selem=None, out=None, mask=None, shift_x=False,
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def pop(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
+def pop(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     """Return the local number (population) of pixels.
 
     The number of pixels is defined as the number of pixels which are included
@@ -775,7 +774,7 @@ def pop(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -815,7 +814,7 @@ def pop(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
                                    shift_y=shift_y)
 
 
-def sum(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
+def sum(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     """Return the local sum of pixels.
 
     Note that the sum may overflow depending on the data type of the input
@@ -825,7 +824,7 @@ def sum(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -865,7 +864,7 @@ def sum(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
                                    shift_y=shift_y)
 
 
-def threshold(image, selem=None, out=None, mask=None, shift_x=False,
+def threshold(image, selem, out=None, mask=None, shift_x=False,
               shift_y=False):
     """Local threshold of an image.
 
@@ -876,7 +875,7 @@ def threshold(image, selem=None, out=None, mask=None, shift_x=False,
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -916,7 +915,7 @@ def threshold(image, selem=None, out=None, mask=None, shift_x=False,
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def tophat(image, selem=None, out=None, mask=None, shift_x=False,
+def tophat(image, selem, out=None, mask=None, shift_x=False,
            shift_y=False):
     """Local top-hat of an image.
 
@@ -927,7 +926,7 @@ def tophat(image, selem=None, out=None, mask=None, shift_x=False,
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -959,7 +958,7 @@ def tophat(image, selem=None, out=None, mask=None, shift_x=False,
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def noise_filter(image, selem=None, out=None, mask=None, shift_x=False,
+def noise_filter(image, selem, out=None, mask=None, shift_x=False,
                  shift_y=False):
     """Noise feature.
 
@@ -967,7 +966,7 @@ def noise_filter(image, selem=None, out=None, mask=None, shift_x=False,
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -1011,7 +1010,7 @@ def noise_filter(image, selem=None, out=None, mask=None, shift_x=False,
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def entropy(image, selem=None, out=None, mask=None, shift_x=False,
+def entropy(image, selem, out=None, mask=None, shift_x=False,
             shift_y=False):
     """Local entropy.
 
@@ -1023,7 +1022,7 @@ def entropy(image, selem=None, out=None, mask=None, shift_x=False,
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -1060,14 +1059,14 @@ def entropy(image, selem=None, out=None, mask=None, shift_x=False,
                                    out_dtype=np.double)
 
 
-def otsu(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
+def otsu(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     """Local Otsu's threshold value for each pixel.
 
     Parameters
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -1104,7 +1103,7 @@ def otsu(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
                                    shift_y=shift_y)
 
 
-def windowed_histogram(image, selem=None, out=None, mask=None,
+def windowed_histogram(image, selem, out=None, mask=None,
                        shift_x=False, shift_y=False, n_bins=None):
     """Normalized sliding window histogram
 
@@ -1112,7 +1111,7 @@ def windowed_histogram(image, selem=None, out=None, mask=None,
     ----------
     image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : 2-D array (integer or float), optional
         If None, a new array is allocated.
@@ -1157,7 +1156,7 @@ def windowed_histogram(image, selem=None, out=None, mask=None,
                                    pixel_size=n_bins)
 
 
-def majority(image, selem=None, out=None, mask=None, shift_x=False,
+def majority(image, selem, out=None, mask=None, shift_x=False,
              shift_y=False):
     """Majority filter assign to each pixel the most occuring value within
     its neighborhood.
@@ -1166,7 +1165,7 @@ def majority(image, selem=None, out=None, mask=None, shift_x=False,
     ----------
     image : ndarray
         Image array (uint8, uint16 array).
-    selem : 2-D array (integer or float), optional
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
     out : ndarray (integer or float), optional
         If None, a new array will be allocated.

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -273,7 +273,7 @@ def _default_selem(func):
     return func_out
 
 
-def autolevel(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
+def autolevel(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
     """Auto-level image using local histogram.
 
     This filter locally stretches the histogram of gray values to cover the
@@ -315,7 +315,7 @@ def autolevel(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def bottomhat(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
+def bottomhat(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
     """Local bottom-hat of an image.
 
     This filter computes the morphological closing of the image and then
@@ -357,7 +357,7 @@ def bottomhat(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def equalize(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
+def equalize(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
     """Equalize image using local histogram.
 
     Parameters
@@ -396,7 +396,7 @@ def equalize(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def gradient(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
+def gradient(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
     """Return local gradient of an image (i.e. local maximum - local minimum).
 
     Parameters
@@ -435,7 +435,7 @@ def gradient(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def maximum(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
+def maximum(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
     """Return local maximum of an image.
 
     Parameters
@@ -483,7 +483,7 @@ def maximum(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def mean(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
+def mean(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
     """Return local mean of an image.
 
     Parameters
@@ -521,7 +521,7 @@ def mean(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
                                    mask=mask, shift_x=shift_x, shift_y=shift_y)
 
 
-def geometric_mean(image, selem, out=None, mask=None,
+def geometric_mean(image, selem=None, out=None, mask=None,
                    shift_x=False, shift_y=False):
     """Return local geometric mean of an image.
 
@@ -565,7 +565,7 @@ def geometric_mean(image, selem, out=None, mask=None,
                                    mask=mask, shift_x=shift_x, shift_y=shift_y)
 
 
-def subtract_mean(image, selem, out=None, mask=None, shift_x=False,
+def subtract_mean(image, selem=None, out=None, mask=None, shift_x=False,
                   shift_y=False):
     """Return image subtracted from its local mean.
 
@@ -652,7 +652,7 @@ def median(image, selem=None, out=None, mask=None,
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def minimum(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
+def minimum(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
     """Return local minimum of an image.
 
     Parameters
@@ -700,7 +700,7 @@ def minimum(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def modal(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
+def modal(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
     """Return local mode of an image.
 
     The mode is the value that appears most often in the local histogram.
@@ -741,7 +741,7 @@ def modal(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def enhance_contrast(image, selem, out=None, mask=None, shift_x=False,
+def enhance_contrast(image, selem=None, out=None, mask=None, shift_x=False,
                      shift_y=False):
     """Enhance contrast of an image.
 
@@ -785,7 +785,7 @@ def enhance_contrast(image, selem, out=None, mask=None, shift_x=False,
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def pop(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
+def pop(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
     """Return the local number (population) of pixels.
 
     The number of pixels is defined as the number of pixels which are included
@@ -835,7 +835,7 @@ def pop(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
                                    shift_y=shift_y)
 
 
-def sum(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
+def sum(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
     """Return the local sum of pixels.
 
     Note that the sum may overflow depending on the data type of the input
@@ -885,7 +885,7 @@ def sum(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
                                    shift_y=shift_y)
 
 
-def threshold(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
+def threshold(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
     """Local threshold of an image.
 
     The resulting binary mask is True if the gray value of the center pixel is
@@ -935,7 +935,7 @@ def threshold(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def tophat(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
+def tophat(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
     """Local top-hat of an image.
 
     This filter computes the morphological opening of the image and then
@@ -977,7 +977,7 @@ def tophat(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def noise_filter(image, selem, out=None, mask=None, shift_x=False,
+def noise_filter(image, selem=None, out=None, mask=None, shift_x=False,
                  shift_y=False):
     """Noise feature.
 
@@ -1029,7 +1029,7 @@ def noise_filter(image, selem, out=None, mask=None, shift_x=False,
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def entropy(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
+def entropy(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
     """Local entropy.
 
     The entropy is computed using base 2 logarithm i.e. the filter returns the
@@ -1077,7 +1077,7 @@ def entropy(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
                                    out_dtype=np.double)
 
 
-def otsu(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
+def otsu(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
     """Local Otsu's threshold value for each pixel.
 
     Parameters
@@ -1121,7 +1121,7 @@ def otsu(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
                                    shift_y=shift_y)
 
 
-def windowed_histogram(image, selem, out=None, mask=None,
+def windowed_histogram(image, selem=None, out=None, mask=None,
                        shift_x=False, shift_y=False, n_bins=None):
     """Normalized sliding window histogram
 
@@ -1174,7 +1174,7 @@ def windowed_histogram(image, selem, out=None, mask=None,
                                    pixel_size=n_bins)
 
 
-def majority(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
+def majority(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
     """Majority filter assign to each pixel the most occuring value within
     its neighborhood.
 

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -62,7 +62,8 @@ __all__ = ['autolevel', 'bottomhat', 'equalize', 'gradient', 'maximum', 'mean',
            'entropy', 'otsu']
 
 
-def _handle_input(image, selem, out=None, mask=None, out_dtype=None, pixel_size=1):
+def _handle_input(image, selem, out=None, mask=None, out_dtype=None,
+                  pixel_size=1):
     """Preprocess and verify input for filters.rank methods.
 
     Parameters
@@ -100,7 +101,8 @@ def _handle_input(image, selem, out=None, mask=None, out_dtype=None, pixel_size=
 
     """
     assert_nD(image, 2)
-    if image.dtype in (bool, np.bool, np.bool_) or out_dtype in (bool, np.bool, np.bool_):
+    if (image.dtype in (bool, np.bool, np.bool_) or
+            out_dtype in (bool, np.bool, np.bool_)):
         raise ValueError('dtype cannot be bool.')
     if image.dtype not in (np.uint8, np.uint16):
         message = ('Possible precision loss converting image of type {} to '
@@ -245,7 +247,8 @@ def _apply_vector_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
     return out
 
 
-def autolevel(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
+def autolevel(image, selem=None, out=None, mask=None, shift_x=False,
+              shift_y=False):
     """Auto-level image using local histogram.
 
     This filter locally stretches the histogram of gray values to cover the
@@ -287,7 +290,8 @@ def autolevel(image, selem=None, out=None, mask=None, shift_x=False, shift_y=Fal
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def bottomhat(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
+def bottomhat(image, selem=None, out=None, mask=None, shift_x=False,
+              shift_y=False):
     """Local bottom-hat of an image.
 
     This filter computes the morphological closing of the image and then
@@ -329,7 +333,8 @@ def bottomhat(image, selem=None, out=None, mask=None, shift_x=False, shift_y=Fal
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def equalize(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
+def equalize(image, selem=None, out=None, mask=None, shift_x=False,
+             shift_y=False):
     """Equalize image using local histogram.
 
     Parameters
@@ -368,7 +373,8 @@ def equalize(image, selem=None, out=None, mask=None, shift_x=False, shift_y=Fals
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def gradient(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
+def gradient(image, selem=None, out=None, mask=None, shift_x=False,
+             shift_y=False):
     """Return local gradient of an image (i.e. local maximum - local minimum).
 
     Parameters
@@ -407,7 +413,8 @@ def gradient(image, selem=None, out=None, mask=None, shift_x=False, shift_y=Fals
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def maximum(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
+def maximum(image, selem=None, out=None, mask=None, shift_x=False,
+            shift_y=False):
     """Return local maximum of an image.
 
     Parameters
@@ -533,8 +540,9 @@ def geometric_mean(image, selem=None, out=None, mask=None,
 
     """
 
-    return _apply_scalar_per_pixel(generic_cy._geometric_mean, image, selem, out=out,
-                                   mask=mask, shift_x=shift_x, shift_y=shift_y)
+    return _apply_scalar_per_pixel(generic_cy._geometric_mean, image, selem,
+                                   out=out, mask=mask, shift_x=shift_x,
+                                   shift_y=shift_y)
 
 
 def subtract_mean(image, selem=None, out=None, mask=None, shift_x=False,
@@ -625,7 +633,8 @@ def median(image, selem=None, out=None, mask=None,
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def minimum(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
+def minimum(image, selem=None, out=None, mask=None, shift_x=False,
+            shift_y=False):
     """Return local minimum of an image.
 
     Parameters
@@ -673,7 +682,8 @@ def minimum(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def modal(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
+def modal(image, selem=None, out=None, mask=None, shift_x=False,
+          shift_y=False):
     """Return local mode of an image.
 
     The mode is the value that appears most often in the local histogram.
@@ -858,7 +868,8 @@ def sum(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
                                    shift_y=shift_y)
 
 
-def threshold(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
+def threshold(image, selem=None, out=None, mask=None, shift_x=False,
+              shift_y=False):
     """Local threshold of an image.
 
     The resulting binary mask is True if the gray value of the center pixel is
@@ -908,7 +919,8 @@ def threshold(image, selem=None, out=None, mask=None, shift_x=False, shift_y=Fal
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def tophat(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
+def tophat(image, selem=None, out=None, mask=None, shift_x=False,
+           shift_y=False):
     """Local top-hat of an image.
 
     This filter computes the morphological opening of the image and then
@@ -1002,7 +1014,8 @@ def noise_filter(image, selem=None, out=None, mask=None, shift_x=False,
                                    shift_x=shift_x, shift_y=shift_y)
 
 
-def entropy(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
+def entropy(image, selem=None, out=None, mask=None, shift_x=False,
+            shift_y=False):
     """Local entropy.
 
     The entropy is computed using base 2 logarithm i.e. the filter returns the
@@ -1147,7 +1160,8 @@ def windowed_histogram(image, selem=None, out=None, mask=None,
                                    pixel_size=n_bins)
 
 
-def majority(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
+def majority(image, selem=None, out=None, mask=None, shift_x=False,
+             shift_y=False):
     """Majority filter assign to each pixel the most occuring value within
     its neighborhood.
 

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -55,7 +55,6 @@ from ..._shared.utils import assert_nD, warn
 
 from . import generic_cy
 
-
 __all__ = ['autolevel', 'bottomhat', 'equalize', 'gradient', 'maximum', 'mean',
            'geometric_mean', 'subtract_mean', 'median', 'minimum', 'modal',
            'enhance_contrast', 'pop', 'threshold', 'tophat', 'noise_filter',
@@ -128,7 +127,7 @@ def _handle_input(image, selem=None, out=None, mask=None, out_dtype=None,
         out = np.empty(image.shape + (pixel_size,), dtype=out_dtype)
     else:
         if len(out.shape) == 2:
-            out = out.reshape(out.shape+(pixel_size,))
+            out = out.reshape(out.shape + (pixel_size,))
 
     if image.dtype in (np.uint8, np.int8):
         n_bins = 256
@@ -137,7 +136,7 @@ def _handle_input(image, selem=None, out=None, mask=None, out_dtype=None,
         # 1 to the maximum of the image.
         n_bins = int(max(3, image.max())) + 1
 
-    if n_bins > 2**10:
+    if n_bins > 2 ** 10:
         warn("Bad rank filter performance is expected due to a "
              "large number of bins ({}), equivalent to an approximate "
              "bitdepth of {:.1f}.".format(n_bins, np.log2(n_bins)),
@@ -179,10 +178,10 @@ def _apply_scalar_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
     """
     # preprocess and verify the input
     image, selem, out, mask, n_bins = _handle_input(image,
-                                                               selem,
-                                                               out,
-                                                               mask,
-                                                               out_dtype)
+                                                    selem,
+                                                    out,
+                                                    mask,
+                                                    out_dtype)
 
     # apply cython function
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
@@ -231,11 +230,11 @@ def _apply_vector_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
     """
     # preprocess and verify the input
     image, selem, out, mask, n_bins = _handle_input(image,
-                                                               selem,
-                                                               out,
-                                                               mask,
-                                                               out_dtype,
-                                                               pixel_size)
+                                                    selem,
+                                                    out,
+                                                    mask,
+                                                    out_dtype,
+                                                    pixel_size)
 
     # apply cython function
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -105,7 +105,10 @@ def _handle_input(image, selem, out=None, mask=None, out_dtype=None, pixel_size=
                    'uint8 as required by rank filters. Convert manually using '
                    'skimage.util.img_as_ubyte to silence this warning.'
                    .format(image.dtype))
-        warn(message, stacklevel=3)
+        warn(message, stacklevel=5)
+        image = img_as_ubyte(image)
+
+    if image.dtype not in (np.uint8, np.uint16):
         image = img_as_ubyte(image)
 
     if out_dtype is None:
@@ -126,6 +129,9 @@ def _handle_input(image, selem, out=None, mask=None, out_dtype=None, pixel_size=
     if out is None:
         out = np.empty(image.shape + (pixel_size,), dtype=out_dtype)
     else:
+        if out.dtype == np.dtype(np.bool_):
+            # So much hackery,
+            out = out.view(np.uint8)
         if len(out.shape) == 2:
             out = out.reshape(out.shape+(pixel_size,))
 

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -23,7 +23,7 @@ adjusted accordingly. The user may provide a mask image (same size as input
 image) where non zero values are the part of the image participating in the
 histogram computation. By default the entire image is filtered.
 
-This implementation outperforms grey.dilation for large structuring elements.
+This implementation outperforms gray.dilation for large structuring elements.
 
 Input images will be cast in unsigned 8-bit integer or unsigned 16-bit integer
 if necessary. The number of histogram bins is then determined from the maximum
@@ -62,7 +62,7 @@ __all__ = ['autolevel', 'bottomhat', 'equalize', 'gradient', 'maximum', 'mean',
            'entropy', 'otsu']
 
 
-def _handle_input(image, selem, out, mask, out_dtype=None, pixel_size=1):
+def _handle_input(image, selem, out=None, mask=None, out_dtype=None, pixel_size=1):
     """Preprocess and verify input for filters.rank methods.
 
     Parameters
@@ -71,15 +71,15 @@ def _handle_input(image, selem, out, mask, out_dtype=None, pixel_size=1):
         Input image.
     selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    out_dtype : data-type
+    out_dtype : data-type, optional
         Desired output data-type. Default is None, which means we cast output
         in input dtype.
-    pixel_size : int
+    pixel_size : int, optional
         Dimension of each pixel. Default value is 1.
 
     Returns
@@ -105,7 +105,7 @@ def _handle_input(image, selem, out, mask, out_dtype=None, pixel_size=1):
                    'uint8 as required by rank filters. Convert manually using '
                    'skimage.util.img_as_ubyte to silence this warning.'
                    .format(image.dtype))
-        warn(message, stacklevel=2)
+        warn(message, stacklevel=3)
         image = img_as_ubyte(image)
 
     if out_dtype is None:
@@ -214,8 +214,8 @@ def _apply_vector_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
     out_dtype : data-type, optional
         Desired output data-type. Default is None, which means we cast output
         in input dtype.
-    pixel_size : int
-        Dimension of each pixel. Default value is 1.
+    pixel_size : int, optional
+        Dimension of each pixel.
 
     Returns
     -------
@@ -270,21 +270,21 @@ def _default_selem(func):
 def autolevel(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     """Auto-level image using local histogram.
 
-    This filter locally stretches the histogram of grey values to cover the
+    This filter locally stretches the histogram of gray values to cover the
     entire range of values from "white" to "black".
 
     Parameters
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -319,14 +319,14 @@ def bottomhat(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -358,14 +358,14 @@ def equalize(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -397,14 +397,14 @@ def gradient(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -436,14 +436,14 @@ def maximum(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -484,14 +484,14 @@ def mean(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -523,14 +523,14 @@ def geometric_mean(image, selem, out=None, mask=None,
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -567,14 +567,14 @@ def subtract_mean(image, selem, out=None, mask=None, shift_x=False,
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -608,15 +608,15 @@ def median(image, selem=None, out=None, mask=None,
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's. If None, a
         full square of size 3 is used.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -653,14 +653,14 @@ def minimum(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -703,14 +703,14 @@ def modal(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -739,7 +739,7 @@ def enhance_contrast(image, selem, out=None, mask=None, shift_x=False,
                      shift_y=False):
     """Enhance contrast of an image.
 
-    This replaces each pixel by the local maximum if the pixel greyvalue is
+    This replaces each pixel by the local maximum if the pixel gray value is
     closer to the local maximum than the local minimum. Otherwise it is
     replaced by the local minimum.
 
@@ -747,14 +747,14 @@ def enhance_contrast(image, selem, out=None, mask=None, shift_x=False,
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -789,14 +789,14 @@ def pop(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -839,14 +839,14 @@ def sum(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -882,21 +882,21 @@ def sum(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 def threshold(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     """Local threshold of an image.
 
-    The resulting binary mask is True if the greyvalue of the center pixel is
+    The resulting binary mask is True if the gray value of the center pixel is
     greater than the local mean.
 
     Parameters
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -939,14 +939,14 @@ def tophat(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -979,14 +979,14 @@ def noise_filter(image, selem, out=None, mask=None, shift_x=False,
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -1027,21 +1027,21 @@ def entropy(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     """Local entropy.
 
     The entropy is computed using base 2 logarithm i.e. the filter returns the
-    minimum number of bits needed to encode the local greylevel
+    minimum number of bits needed to encode the local gray level
     distribution.
 
     Parameters
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -1078,14 +1078,14 @@ def otsu(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -1123,14 +1123,14 @@ def windowed_histogram(image, selem, out=None, mask=None,
     ----------
     image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer, float, boolean or optional)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).
@@ -1176,14 +1176,14 @@ def majority(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     ----------
     image : ndarray
         Image array (uint8, uint16 array).
-    selem : 2-D array
+    selem : 2-D array (integer, float, boolean or optional)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : ndarray
+    out : ndarray (integer, float, boolean or optional)
         If None, a new array will be allocated.
-    mask : ndarray
+    mask : ndarray (integer, float, boolean or optional)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
-    shift_x, shift_y : int
+    shift_x, shift_y : int, optional
         Offset added to the structuring element center point. Shift is bounded
         to the structuring element sizes (center must be inside the given
         structuring element).

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -101,8 +101,8 @@ def _handle_input(image, selem, out=None, mask=None, out_dtype=None,
 
     """
     assert_nD(image, 2)
-    if (image.dtype in (bool, np.bool, np.bool_) or
-            out_dtype in (bool, np.bool, np.bool_)):
+    if (image.dtype in (bool, np.bool, np.bool_)
+            or out_dtype in (bool, np.bool, np.bool_)):
         raise ValueError('dtype cannot be bool.')
     if image.dtype not in (np.uint8, np.uint16):
         message = ('Possible precision loss converting image of type {} to '

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -68,13 +68,13 @@ def _handle_input(image, selem, out=None, mask=None, out_dtype=None,
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     out_dtype : data-type, optional
@@ -96,8 +96,6 @@ def _handle_input(image, selem, out=None, mask=None, out_dtype=None,
         neighborhood.
     n_bins : int
         Number of histogram bins.
-    out_dtype : data-type
-        Output data-type.
 
     """
     assert_nD(image, 2)
@@ -112,9 +110,6 @@ def _handle_input(image, selem, out=None, mask=None, out_dtype=None,
         warn(message, stacklevel=5)
         image = img_as_ubyte(image)
 
-    if out_dtype is None:
-        out_dtype = image.dtype
-
     selem = np.ascontiguousarray(img_as_ubyte(selem > 0))
     image = np.ascontiguousarray(image)
 
@@ -128,6 +123,8 @@ def _handle_input(image, selem, out=None, mask=None, out_dtype=None,
         raise NotImplementedError("Cannot perform rank operation in place.")
 
     if out is None:
+        if out_dtype is None:
+            out_dtype = image.dtype
         out = np.empty(image.shape + (pixel_size,), dtype=out_dtype)
     else:
         if len(out.shape) == 2:
@@ -146,7 +143,7 @@ def _handle_input(image, selem, out=None, mask=None, out_dtype=None,
              "bitdepth of {:.1f}.".format(n_bins, np.log2(n_bins)),
              stacklevel=2)
 
-    return image, selem, out, mask, n_bins, out_dtype
+    return image, selem, out, mask, n_bins
 
 
 def _apply_scalar_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
@@ -157,13 +154,13 @@ def _apply_scalar_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
     ----------
     func : function
         Cython function to apply.
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer or float)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer or float)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -181,7 +178,7 @@ def _apply_scalar_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
 
     """
     # preprocess and verify the input
-    image, selem, out, mask, n_bins, out_dtype = _handle_input(image,
+    image, selem, out, mask, n_bins = _handle_input(image,
                                                                selem,
                                                                out,
                                                                mask,
@@ -202,13 +199,13 @@ def _apply_vector_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
     ----------
     func : function
         Cython function to apply.
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float or boolean)
+    selem : 2-D array (integer or float)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float or boolean)
+    out : 2-D array (integer or float)
         If None, a new array is allocated.
-    mask : ndarray (integer, float or boolean)
+    mask : ndarray (integer or float)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -233,7 +230,7 @@ def _apply_vector_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
 
     """
     # preprocess and verify the input
-    image, selem, out, mask, n_bins, out_dtype = _handle_input(image,
+    image, selem, out, mask, n_bins = _handle_input(image,
                                                                selem,
                                                                out,
                                                                mask,
@@ -256,13 +253,13 @@ def autolevel(image, selem=None, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -299,13 +296,13 @@ def bottomhat(image, selem=None, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -339,13 +336,13 @@ def equalize(image, selem=None, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -379,13 +376,13 @@ def gradient(image, selem=None, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -419,13 +416,13 @@ def maximum(image, selem=None, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -467,13 +464,13 @@ def mean(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -506,13 +503,13 @@ def geometric_mean(image, selem=None, out=None, mask=None,
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -551,13 +548,13 @@ def subtract_mean(image, selem=None, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -591,14 +588,14 @@ def median(image, selem=None, out=None, mask=None,
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's. If None, a
         full square of size 3 is used.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -639,13 +636,13 @@ def minimum(image, selem=None, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -690,13 +687,13 @@ def modal(image, selem=None, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -734,13 +731,13 @@ def enhance_contrast(image, selem=None, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -776,13 +773,13 @@ def pop(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -826,13 +823,13 @@ def sum(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -877,13 +874,13 @@ def threshold(image, selem=None, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -928,13 +925,13 @@ def tophat(image, selem=None, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -968,13 +965,13 @@ def noise_filter(image, selem=None, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -1024,13 +1021,13 @@ def entropy(image, selem=None, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -1068,13 +1065,13 @@ def otsu(image, selem=None, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -1113,13 +1110,13 @@ def windowed_histogram(image, selem=None, out=None, mask=None,
 
     Parameters
     ----------
-    image : 2-D array (integer, float or boolean)
+    image : 2-D array (integer or float)
         Input image.
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (integer, float, boolean or optional)
+    out : 2-D array (integer or float), optional
         If None, a new array is allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional
@@ -1169,11 +1166,11 @@ def majority(image, selem=None, out=None, mask=None, shift_x=False,
     ----------
     image : ndarray
         Image array (uint8, uint16 array).
-    selem : 2-D array (integer, float, boolean or optional)
+    selem : 2-D array (integer or float), optional
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : ndarray (integer, float, boolean or optional)
+    out : ndarray (integer or float), optional
         If None, a new array will be allocated.
-    mask : ndarray (integer, float, boolean or optional)
+    mask : ndarray (integer or float), optional
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int, optional

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -124,7 +124,7 @@ def _handle_input(image, selem, out, mask, out_dtype=None, pixel_size=1):
         raise NotImplementedError("Cannot perform rank operation in place.")
 
     if out is None:
-        out = np.empty(image.shape + (pixel_size,))
+        out = np.empty(image.shape + (pixel_size,), dtype=out_dtype)
     else:
         if len(out.shape) == 2:
             out = out.reshape(out.shape+(pixel_size,))
@@ -187,7 +187,7 @@ def _apply_scalar_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
          out=out, n_bins=n_bins)
 
-    return out.reshape(out.shape[:2]).astype(out_dtype)
+    return out.reshape(out.shape[:2])
 
 
 def _apply_vector_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
@@ -240,7 +240,7 @@ def _apply_vector_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
          out=out, n_bins=n_bins)
 
-    return out.astype(out_dtype).astype(out_dtype)
+    return out
 
 
 def _default_selem(func):

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -507,7 +507,7 @@ class TestRank:
         image[2, 3] = 128
         image[1, 2] = 16
 
-        for dtype in (np.uint8, np.uint16, np.int32, np.int64,
+        for dtype in (np.bool_, np.uint8, np.uint16, np.int32, np.int64,
                       np.float32, np.float64):
             elem = np.array([[0, 0, 0], [0, 1, 0], [0, 0, 0]], dtype=dtype)
             rank.mean(image=image, selem=elem, out=out, mask=mask,
@@ -691,3 +691,19 @@ class TestRank:
         expected = rank.windowed_histogram(
             img, elem).argmax(-1).astype(np.uint8)
         assert_equal(expected, rank.majority(img, elem))
+
+    def test_output_same_dtype(self):
+        image = (np.random.rand(100, 100) * 256).astype(np.uint8)
+        out = np.empty_like(image)
+        mask = np.ones(image.shape, dtype=np.uint8)
+        elem = np.ones((3, 3), dtype=np.uint8)
+        rank.maximum(image=image, selem=elem, out=out, mask=mask)
+        assert_equal(image.dtype, out.dtype)
+
+    def test_input_boolean_dtype(self):
+        image = (np.random.rand(100, 100) * 256).astype(np.bool_)
+        out = np.empty_like(image)
+        mask = np.ones(image.shape, dtype=np.bool_)
+        elem = np.ones((3, 3), dtype=np.bool_)
+        # rank.maximum(image=image, selem=elem, out=out, mask=mask)
+        # assert_equal(image.dtype, out.dtype)

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -41,8 +41,7 @@ def test_otsu_edge_case():
     assert result[1, 1] in [141, 172]
 
 
-
-class TestRank():
+class TestRank:
     def setup(self):
         np.random.seed(0)
         # This image is used along with @test_parallel
@@ -84,7 +83,6 @@ class TestRank():
                 assert_array_equal(expected, result)
 
         check()
-
 
     def test_random_sizes(self):
         # make sure the size is not a problem
@@ -132,7 +130,6 @@ class TestRank():
                                  selem=elem, shift_x=+1, shift_y=+1, p0=.1, p1=.9)
             assert_equal(image16.shape, out16.shape)
 
-
     def test_compare_with_grey_dilation(self):
         # compare the result of maximum filter with dilate
 
@@ -146,7 +143,6 @@ class TestRank():
             cm = grey.dilation(image=image, selem=elem)
             assert_equal(out, cm)
 
-
     def test_compare_with_grey_erosion(self):
         # compare the result of maximum filter with erode
 
@@ -159,7 +155,6 @@ class TestRank():
             rank.minimum(image=image, selem=elem, out=out, mask=mask)
             cm = grey.erosion(image=image, selem=elem)
             assert_equal(out, cm)
-
 
     def test_bitdepth(self):
         # test the different bit depth for rank16
@@ -179,7 +174,6 @@ class TestRank():
                 rank.mean_percentile(image=image, selem=elem, mask=mask,
                                      out=out, shift_x=0, shift_y=0, p0=.1, p1=.9)
 
-
     def test_population(self):
         # check the number of valid pixels in the neighborhood
 
@@ -195,7 +189,6 @@ class TestRank():
                       [6, 9, 9, 9, 6],
                       [4, 6, 6, 6, 4]])
         assert_equal(r, out)
-
 
     def test_structuring_element8(self):
         # check the output for a custom structuring element
@@ -227,7 +220,6 @@ class TestRank():
                      shift_x=1, shift_y=1)
         assert_equal(r, out)
 
-
     def test_pass_on_bitdepth(self):
         # should pass because data bitdepth is not too high for the function
 
@@ -238,7 +230,6 @@ class TestRank():
         with expected_warnings(["Bad rank filter performance"]):
             rank.maximum(image=image, selem=elem, out=out, mask=mask)
 
-
     def test_inplace_output(self):
         # rank filters are not supposed to filter inplace
 
@@ -247,7 +238,6 @@ class TestRank():
         out = image
         with testing.raises(NotImplementedError):
             rank.mean(image, selem, out=out)
-
 
     def test_compare_autolevels(self):
         # compare autolevel and percentile autolevel with p0=0.0 and p1=1.0
@@ -262,10 +252,9 @@ class TestRank():
 
         assert_equal(loc_autolevel, loc_perc_autolevel)
 
-
     def test_compare_autolevels_16bit(self):
-        # compare autolevel(16-bit) and percentile autolevel(16-bit) with p0=0.0
-        # and p1=1.0 should returns the same arrays
+        # compare autolevel(16-bit) and percentile autolevel(16-bit) with
+        # p0=0.0 and p1=1.0 should returns the same arrays
 
         image = data.camera().astype(np.uint16) * 4
 
@@ -275,7 +264,6 @@ class TestRank():
                                                        p0=.0, p1=1.)
 
         assert_equal(loc_autolevel, loc_perc_autolevel)
-
 
     def test_compare_ubyte_vs_float(self):
 
@@ -291,7 +279,6 @@ class TestRank():
             out_u = func(image_uint, disk(3))
             out_f = func(image_float, disk(3))
             assert_equal(out_u, out_f)
-
 
     def test_compare_8bit_unsigned_vs_signed(self):
         # filters applied on 8-bit image ore 16-bit image (having only real 8-bit
@@ -330,7 +317,6 @@ class TestRank():
         f16 = func(image16, disk(3))
         assert_equal(f8, f16)
 
-
     def test_trivial_selem8(self):
         # check that min, max and mean returns identity if structuring element
         # contains only central pixel
@@ -355,7 +341,6 @@ class TestRank():
         rank.maximum(image=image, selem=elem, out=out, mask=mask,
                      shift_x=0, shift_y=0)
         assert_equal(image, out)
-
 
     def test_trivial_selem16(self):
         # check that min, max and mean returns identity if structuring element
@@ -382,7 +367,6 @@ class TestRank():
                      shift_x=0, shift_y=0)
         assert_equal(image, out)
 
-
     def test_smallest_selem8(self):
         # check that min, max and mean returns identity if structuring element
         # contains only central pixel
@@ -404,7 +388,6 @@ class TestRank():
         rank.maximum(image=image, selem=elem, out=out, mask=mask,
                      shift_x=0, shift_y=0)
         assert_equal(image, out)
-
 
     def test_smallest_selem16(self):
         # check that min, max and mean returns identity if structuring element
@@ -430,7 +413,6 @@ class TestRank():
         rank.maximum(image=image, selem=elem, out=out, mask=mask,
                      shift_x=0, shift_y=0)
         assert_equal(image, out)
-
 
     def test_empty_selem(self):
         # check that min, max and mean returns zeros if structuring element is
@@ -459,7 +441,6 @@ class TestRank():
                      shift_x=0, shift_y=0)
         assert_equal(res, out)
 
-
     def test_otsu(self):
         # test the local Otsu segmentation on a synthetic image
         # (left to right ramp * sinus)
@@ -472,7 +453,6 @@ class TestRank():
         selem = np.ones((6, 6), dtype=np.uint8)
         th = 1 * (test >= rank.otsu(test, selem))
         assert_equal(th, res)
-
 
     def test_entropy(self):
         #  verify that entropy is coherent with bitdepth of the input data
@@ -518,7 +498,6 @@ class TestRank():
             out = rank.entropy(data, np.ones((16, 16), dtype=np.uint8))
         assert out.dtype == np.double
 
-
     def test_selem_dtypes(self):
 
         image = np.zeros((5, 5), dtype=np.uint8)
@@ -541,7 +520,6 @@ class TestRank():
                                  shift_x=0, shift_y=0)
             assert_equal(image, out)
 
-
     def test_16bit(self):
         image = np.zeros((21, 21), dtype=np.uint16)
         selem = np.ones((3, 3), dtype=np.uint8)
@@ -558,7 +536,6 @@ class TestRank():
                 assert rank.maximum(image, selem)[10, 10] == value
                 assert rank.mean(image, selem)[10, 10] == int(value / selem.size)
 
-
     def test_bilateral(self):
         image = np.zeros((21, 21), dtype=np.uint16)
         selem = np.ones((3, 3), dtype=np.uint8)
@@ -571,7 +548,6 @@ class TestRank():
         assert rank.pop_bilateral(image, selem, s0=1, s1=1)[10, 10] == 1
         assert rank.mean_bilateral(image, selem, s0=11, s1=11)[10, 10] == 1005
         assert rank.pop_bilateral(image, selem, s0=11, s1=11)[10, 10] == 2
-
 
     def test_percentile_min(self):
         # check that percentile p0 = 0 is identical to local min
@@ -587,7 +563,6 @@ class TestRank():
         img_min = rank.minimum(img16, selem=selem)
         assert_equal(img_p0, img_min)
 
-
     def test_percentile_max(self):
         # check that percentile p0 = 1 is identical to local max
         img = data.camera()
@@ -602,7 +577,6 @@ class TestRank():
         img_max = rank.maximum(img16, selem=selem)
         assert_equal(img_p0, img_max)
 
-
     def test_percentile_median(self):
         # check that percentile p0 = 0.5 is identical to local median
         img = data.camera()
@@ -616,7 +590,6 @@ class TestRank():
         img_p0 = rank.percentile(img16, selem=selem, p0=.5)
         img_max = rank.median(img16, selem=selem)
         assert_equal(img_p0, img_max)
-
 
     def test_sum(self):
         # check the number of valid pixels in the neighborhood
@@ -664,7 +637,6 @@ class TestRank():
             image=image16, selem=elem, out=out16, mask=mask, s0=1000, s1=1000)
         assert_equal(r, out16)
 
-
     def test_windowed_histogram(self):
         # check the number of valid pixels in the neighborhood
 
@@ -703,7 +675,6 @@ class TestRank():
         larger_output = rank.windowed_histogram(image=image8, selem=elem,
                                                 mask=mask, n_bins=5)
         assert larger_output.shape[2] == 5
-
 
     def test_median_default_value(self):
         a = np.zeros((3, 3), dtype=np.uint8)

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -684,7 +684,6 @@ class TestRank:
         assert rank.median(a)[1, 1] == 0
         assert rank.median(a, disk(1))[1, 1] == 1
 
-
     def test_majority(self):
         img = data.camera()
         elem = np.ones((3, 3), dtype=np.uint8)

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -705,5 +705,5 @@ class TestRank:
         out = np.empty_like(image)
         mask = np.ones(image.shape, dtype=np.bool_)
         elem = np.ones((3, 3), dtype=np.bool_)
-        # rank.maximum(image=image, selem=elem, out=out, mask=mask)
-        # assert_equal(image.dtype, out.dtype)
+        rank.maximum(image=image, selem=elem, out=out, mask=mask)
+        assert_equal(image.dtype, out.dtype)

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -705,5 +705,5 @@ class TestRank:
         out = np.empty_like(image)
         mask = np.ones(image.shape, dtype=np.bool_)
         elem = np.ones((3, 3), dtype=np.bool_)
-        rank.maximum(image=image, selem=elem, out=out, mask=mask)
-        assert_equal(image.dtype, out.dtype)
+        with testing.raises(ValueError):
+            rank.maximum(image=image, selem=elem, out=out, mask=mask)

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -701,8 +701,6 @@ class TestRank:
 
     def test_input_boolean_dtype(self):
         image = (np.random.rand(100, 100) * 256).astype(np.bool_)
-        out = np.empty_like(image)
-        mask = np.ones(image.shape, dtype=np.bool_)
         elem = np.ones((3, 3), dtype=np.bool_)
         with testing.raises(ValueError):
-            rank.maximum(image=image, selem=elem, out=out, mask=mask)
+            rank.maximum(image=image, selem=elem)


### PR DESCRIPTION
## Description
Supersedes gh-3615. Fixed test behavior locally and added new tests to ensure that `dtypes` remain the same in the output of the `filter.rank` functions. For now, the `test_input_boolean_dtype` in `test_rank` is currently commented out because a `TypeError: No matching signature found` error is raised when the `filter.rank.maximum` function is called w/ a `dtype np.bool_` arguments. I have no experience w/ Cython, but I assume that means we need to add Cython support somehow for `np.bool_` dtypes. Before I explore this further, does anyone know off the top of their heads how to do this? 

Closes #3577
May address some, but perhaps not all, issues in #1010

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
