### PR TITLE
Speed up skimage.feature.peak_local_max

### DIFF
--- a/benchmarks/benchmark_peak_local_max.py
+++ b/benchmarks/benchmark_peak_local_max.py
@@ -13,9 +13,9 @@ class PeakLocalMaxSuite(object):
         y_c = y // 20 * 20 + 10
         mask[(x - x_c)**2 + (y - y_c)**2 < 8**2] = True
 
-        # create a mask, label each disk, create distance image for peak
-        # searching
+        # create a mask, label each disk,
         self.labels, num_objs = ndi.label(mask)
+        # create distance image for peak searching
         self.dist = ndi.distance_transform_edt(mask)
 
     def time_peak_local_max(self):

--- a/benchmarks/benchmark_peak_local_max.py
+++ b/benchmarks/benchmark_peak_local_max.py
@@ -3,7 +3,9 @@ import numpy as np
 from scipy import ndimage as ndi
 from skimage.feature import peak_local_max
 
+
 class PeakLocalMaxSuite(object):
+
     def setup(self):
         mask = np.zeros([500, 500], dtype=bool)
         x, y = np.indices((500, 500))
@@ -11,7 +13,8 @@ class PeakLocalMaxSuite(object):
         y_c = y // 20 * 20 + 10
         mask[(x - x_c)**2 + (y - y_c)**2 < 8**2] = True
 
-        # create a mask, label each disk, create distance image for peak searching
+        # create a mask, label each disk, create distance image for peak
+        # searching
         self.labels, num_objs = ndi.label(mask)
         self.dist = ndi.distance_transform_edt(mask)
 

--- a/benchmarks/benchmark_peak_local_max.py
+++ b/benchmarks/benchmark_peak_local_max.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from scipy import ndimage as ndi
+from skimage.feature import peak_local_max
+
+class PeakLocalMaxSuite(object):
+    def setup(self):
+        mask = np.zeros([500, 500], dtype=bool)
+        x, y = np.indices((500, 500))
+        x_c = x // 20 * 20 + 10
+        y_c = y // 20 * 20 + 10
+        mask[(x - x_c)**2 + (y - y_c)**2 < 8**2] = True
+
+        # create a mask, label each disk, create distance image for peak searching
+        self.labels, num_objs = ndi.label(mask)
+        self.dist = ndi.distance_transform_edt(mask)
+
+    def time_peak_local_max(self):
+        local_max = peak_local_max(
+            self.dist, labels=self.labels,
+            min_distance=20, indices=False, exclude_border=False)

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -44,7 +44,7 @@ def _get_peak_mask(image, min_distance, footprint, threshold_abs,
 
 def _exclude_border(mask, footprint, exclude_border):
     """
-    Remove peaks round the borders
+    Remove peaks near the borders
     """
     # zero out the image borders
     for i in range(mask.ndim):
@@ -189,10 +189,16 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
             mask[nd_indices] = True
             out[obj] += mask
 
+        if not indices and np.isinf(num_peaks):
+            return out
+
         coordinates = _get_high_intensity_peaks(image, out, num_peaks)
-        if indices is True:
+        if indices:
             return coordinates
         else:
+            out.fill(False)
+            nd_indices = tuple(coordinates.T)
+            out[nd_indices] = True
             return out
 
     # Non maximum filter

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -25,7 +25,7 @@ def _get_high_intensity_peaks(image, mask, num_peaks):
 def _get_peak_mask(image, min_distance, footprint, threshold_abs,
                    threshold_rel):
     """
-    Return the mask containing all peak candidates above thresholds
+    Return the mask containing all peak candidates above thresholds.
     """
     if footprint is not None:
         image_max = ndi.maximum_filter(image, footprint=footprint,
@@ -44,7 +44,7 @@ def _get_peak_mask(image, min_distance, footprint, threshold_abs,
 
 def _exclude_border(mask, footprint, exclude_border):
     """
-    Remove peaks round the borders
+    Remove peaks round the borders.
     """
     # zero out the image borders
     for i in range(mask.ndim):
@@ -152,9 +152,6 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
     array([[10, 10, 10]])
 
     """
-    if type(exclude_border) == bool:
-        exclude_border = min_distance if exclude_border else 0
-
     out = np.zeros_like(image, dtype=np.bool)
 
     # no peak for a trivial image
@@ -166,8 +163,10 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
 
     threshold_abs = threshold_abs if threshold_abs is not None else image.min()
 
-    # In the case of labels, recursively build and return an output
-    # operating on each label separately
+    if type(exclude_border) == bool:
+        exclude_border = min_distance if exclude_border else 0
+
+    # In the case of labels, call ndi on each label
     if labels is not None:
         label_values = np.unique(labels)
         # Reorder label values to have consecutive integers (no gaps)
@@ -181,10 +180,8 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
             inner_mask = _exclude_border(np.ones_like(labels, dtype=bool),
                                          footprint, exclude_border)
 
-        for i, obj in enumerate(ndi.find_objects(labels)):
-            label = i + 1
-            # print("Label>", label)
-            img = image[obj] * (labels[obj] == label)
+        for label_idx, obj in enumerate(ndi.find_objects(labels)):
+            img = image[obj] * (labels[obj] == label_idx + 1)
             mask = _get_peak_mask(img, min_distance, footprint, threshold_abs,
                                   threshold_rel)
             if exclude_border:

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -158,6 +158,13 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
     if type(exclude_border) == bool:
         exclude_border = min_distance if exclude_border else 0
 
+    # no peak for a trivial image
+    if np.all(image == image.flat[0]):
+        if indices is True:
+            return np.empty((0, 2), np.int)
+        else:
+            return out
+
     # In the case of labels, call ndi on each label
     if labels is not None:
         label_values = np.unique(labels)

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -180,14 +180,17 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
             inner_mask = _exclude_border(np.ones_like(labels, dtype=bool),
                                          footprint, exclude_border)
 
+        # For each label, extract a smaller image enclosing the object of
+        # interest, identify num_peaks_per_label peaks and mark them in
+        # variable out.
         for label_idx, obj in enumerate(ndi.find_objects(labels)):
-            img = image[obj] * (labels[obj] == label_idx + 1)
-            mask = _get_peak_mask(img, min_distance, footprint, threshold_abs,
+            img_object = image[obj] * (labels[obj] == label_idx + 1)
+            mask = _get_peak_mask(img_object, min_distance, footprint, threshold_abs,
                                   threshold_rel)
             if exclude_border:
                 # remove peaks fall in the exclude region
                 mask &= inner_mask[obj]
-            coordinates = _get_high_intensity_peaks(img, mask,
+            coordinates = _get_high_intensity_peaks(img_object, mask,
                                                     num_peaks_per_label)
             nd_indices = tuple(coordinates.T)
             mask.fill(False)

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -185,8 +185,8 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
         # variable out.
         for label_idx, obj in enumerate(ndi.find_objects(labels)):
             img_object = image[obj] * (labels[obj] == label_idx + 1)
-            mask = _get_peak_mask(img_object, min_distance, footprint, threshold_abs,
-                                  threshold_rel)
+            mask = _get_peak_mask(img_object, min_distance, footprint,
+                                  threshold_abs, threshold_rel)
             if exclude_border:
                 # remove peaks fall in the exclude region
                 mask &= inner_mask[obj]

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -22,6 +22,39 @@ def _get_high_intensity_peaks(image, mask, num_peaks):
     return coord[::-1]
 
 
+def _get_peak_mask(image, min_distance, footprint, threshold_abs, threshold_rel):
+    """
+    Return the mask containing all peak candidates above thresholds
+    """
+    if footprint is not None:
+        image_max = ndi.maximum_filter(image, footprint=footprint,
+                                       mode='constant')
+    else:
+        size = 2 * min_distance + 1
+        image_max = ndi.maximum_filter(image, size=size, mode='constant')
+    mask = image == image_max
+    if threshold_rel is not None:
+        threshold=max(threshold_abs, threshold_rel * image.max())
+    else:
+        threshold=threshold_abs
+    mask &= image > threshold
+    return mask
+
+
+def _exclude_border(mask, footprint, exclude_border):
+    """
+    Remove peaks round the borders
+    """
+    # zero out the image borders
+    for i in range(mask.ndim):
+        mask = mask.swapaxes(0, i)
+        remove = (footprint.shape[i] if footprint is not None
+                  else 2 * exclude_border)
+        mask[:remove // 2] = mask[-remove // 2:] = False
+        mask = mask.swapaxes(0, i)
+    return mask
+
+
 def peak_local_max(image, min_distance=1, threshold_abs=None,
                    threshold_rel=None, exclude_border=True, indices=True,
                    num_peaks=np.inf, footprint=None, labels=None,
@@ -123,6 +156,15 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
 
     out = np.zeros_like(image, dtype=np.bool)
 
+    # no peak for a trivial image
+    if np.all(image == image.flat[0]):
+        if indices is True:
+            return np.empty((0, 2), np.int)
+        else:
+            return out
+
+    threshold_abs = threshold_abs if threshold_abs is not None else image.min()
+
     # In the case of labels, recursively build and return an output
     # operating on each label separately
     if labels is not None:
@@ -134,19 +176,35 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
         labels = labels.astype(np.int32)
 
         # New values for new ordering
-        label_values = np.unique(labels)
-        for label in label_values[label_values != 0]:
-            maskim = (labels == label)
-            out += peak_local_max(image * maskim, min_distance=min_distance,
-                                  threshold_abs=threshold_abs,
-                                  threshold_rel=threshold_rel,
-                                  exclude_border=exclude_border,
-                                  indices=False, num_peaks=num_peaks_per_label,
-                                  footprint=footprint, labels=None)
+        # for label in label_values[label_values != 0]:
+        #    maskim = (labels == label)
+        #    out += peak_local_max(image * maskim, min_distance=min_distance,
+        #                          threshold_abs=threshold_abs,
+        #                          threshold_rel=threshold_rel,
+        #                          exclude_border=exclude_border,
+        #                          indices=False, num_peaks=num_peaks_per_label,
+        #                          footprint=footprint, labels=None)
+        # modify to speed it up, as the original code passes the full image for each label
+        # too slow, more so for 3D images and many objects
+        if exclude_border:
+            # create a mask for the non-exclude region
+            inner_mask = _exclude_border(np.ones_like(labels, dtype=bool), footprint, exclude_border)
 
-        # Select highest intensities (num_peaks)
+        for i, obj in enumerate(ndi.find_objects(labels)):
+            label = i + 1
+            # print("Label>", label)
+            img = image[obj] * (labels[obj] == label)
+            mask = _get_peak_mask(img, min_distance, footprint, threshold_abs, threshold_rel)
+            if exclude_border:
+                # remove peaks fall in the exclude region
+                mask &= inner_mask[obj]
+            coordinates = _get_high_intensity_peaks(img, mask, num_peaks_per_label)
+            nd_indices = tuple(coordinates.T)
+            mask.fill(False)
+            mask[nd_indices] = True
+            out[obj] += mask
+
         coordinates = _get_high_intensity_peaks(image, out, num_peaks)
-
         if indices is True:
             return coordinates
         else:
@@ -154,39 +212,11 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
             out[nd_indices] = True
             return out
 
-    if np.all(image == image.flat[0]):
-        if indices is True:
-            return np.empty((0, 2), np.int)
-        else:
-            return out
-
     # Non maximum filter
-    if footprint is not None:
-        image_max = ndi.maximum_filter(image, footprint=footprint,
-                                       mode='constant')
-    else:
-        size = 2 * min_distance + 1
-        image_max = ndi.maximum_filter(image, size=size, mode='constant')
-    mask = image == image_max
+    mask = _get_peak_mask(image, min_distance, footprint, threshold_abs, threshold_rel)
 
     if exclude_border:
-        # zero out the image borders
-        for i in range(mask.ndim):
-            mask = mask.swapaxes(0, i)
-            remove = (footprint.shape[i] if footprint is not None
-                      else 2 * exclude_border)
-            mask[:remove // 2] = mask[-remove // 2:] = False
-            mask = mask.swapaxes(0, i)
-
-    # find top peak candidates above a threshold
-    thresholds = []
-    if threshold_abs is None:
-        threshold_abs = image.min()
-    thresholds.append(threshold_abs)
-    if threshold_rel is not None:
-        thresholds.append(threshold_rel * image.max())
-    if thresholds:
-        mask &= image > max(thresholds)
+        mask = _exclude_border(mask, footprint, exclude_border)
 
     # Select highest intensities (num_peaks)
     coordinates = _get_high_intensity_peaks(image, mask, num_peaks)

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -88,9 +88,9 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
     exclude_border : int or bool, optional
         If nonzero int, `exclude_border` excludes peaks from
         within `exclude_border`-pixels of the border of the image.
-	If True, takes the `min_distance` parameter as value.
-	If zero or False, peaks are identified regardless of their
-	distance from the border.
+        If True, takes the `min_distance` parameter as value.
+        If zero or False, peaks are identified regardless of their
+        distance from the border.
     indices : bool, optional
         If True, the output will be an array representing peak
         coordinates.  If False, the output will be a boolean array shaped as

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -22,7 +22,8 @@ def _get_high_intensity_peaks(image, mask, num_peaks):
     return coord[::-1]
 
 
-def _get_peak_mask(image, min_distance, footprint, threshold_abs, threshold_rel):
+def _get_peak_mask(image, min_distance, footprint, threshold_abs,
+                   threshold_rel):
     """
     Return the mask containing all peak candidates above thresholds
     """
@@ -34,9 +35,9 @@ def _get_peak_mask(image, min_distance, footprint, threshold_abs, threshold_rel)
         image_max = ndi.maximum_filter(image, size=size, mode='constant')
     mask = image == image_max
     if threshold_rel is not None:
-        threshold=max(threshold_abs, threshold_rel * image.max())
+        threshold = max(threshold_abs, threshold_rel * image.max())
     else:
-        threshold=threshold_abs
+        threshold = threshold_abs
     mask &= image > threshold
     return mask
 
@@ -175,30 +176,22 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
             labels[mask] = 1 + rank_order(labels[mask])[0].astype(labels.dtype)
         labels = labels.astype(np.int32)
 
-        # New values for new ordering
-        # for label in label_values[label_values != 0]:
-        #    maskim = (labels == label)
-        #    out += peak_local_max(image * maskim, min_distance=min_distance,
-        #                          threshold_abs=threshold_abs,
-        #                          threshold_rel=threshold_rel,
-        #                          exclude_border=exclude_border,
-        #                          indices=False, num_peaks=num_peaks_per_label,
-        #                          footprint=footprint, labels=None)
-        # modify to speed it up, as the original code passes the full image for each label
-        # too slow, more so for 3D images and many objects
         if exclude_border:
             # create a mask for the non-exclude region
-            inner_mask = _exclude_border(np.ones_like(labels, dtype=bool), footprint, exclude_border)
+            inner_mask = _exclude_border(np.ones_like(labels, dtype=bool),
+                                         footprint, exclude_border)
 
         for i, obj in enumerate(ndi.find_objects(labels)):
             label = i + 1
             # print("Label>", label)
             img = image[obj] * (labels[obj] == label)
-            mask = _get_peak_mask(img, min_distance, footprint, threshold_abs, threshold_rel)
+            mask = _get_peak_mask(img, min_distance, footprint, threshold_abs,
+                                  threshold_rel)
             if exclude_border:
                 # remove peaks fall in the exclude region
                 mask &= inner_mask[obj]
-            coordinates = _get_high_intensity_peaks(img, mask, num_peaks_per_label)
+            coordinates = _get_high_intensity_peaks(img, mask,
+                                                    num_peaks_per_label)
             nd_indices = tuple(coordinates.T)
             mask.fill(False)
             mask[nd_indices] = True
@@ -213,7 +206,8 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
             return out
 
     # Non maximum filter
-    mask = _get_peak_mask(image, min_distance, footprint, threshold_abs, threshold_rel)
+    mask = _get_peak_mask(image, min_distance, footprint, threshold_abs,
+                          threshold_rel)
 
     if exclude_border:
         mask = _exclude_border(mask, footprint, exclude_border)

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -44,16 +44,14 @@ def _get_peak_mask(image, min_distance, footprint, threshold_abs,
 
 def _exclude_border(mask, footprint, exclude_border):
     """
-    Remove peaks round the borders.
+    Remove peaks round the borders
     """
     # zero out the image borders
     for i in range(mask.ndim):
-        mask = mask.swapaxes(0, i)
         remove = (footprint.shape[i] if footprint is not None
                   else 2 * exclude_border)
-        mask[:remove // 2] = False
-        mask[-remove // 2:] = False
-        mask = mask.swapaxes(0, i)
+        mask[(slice(None),) * i + (slice(None, remove // 2),)] = False
+        mask[(slice(None),) * i + (slice(-remove // 2, None),)] = False
     return mask
 
 

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -51,7 +51,8 @@ def _exclude_border(mask, footprint, exclude_border):
         mask = mask.swapaxes(0, i)
         remove = (footprint.shape[i] if footprint is not None
                   else 2 * exclude_border)
-        mask[:remove // 2] = mask[-remove // 2:] = False
+        mask[:remove // 2] = False
+        mask[-remove // 2:] = False
         mask = mask.swapaxes(0, i)
     return mask
 
@@ -154,13 +155,6 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
     """
     out = np.zeros_like(image, dtype=np.bool)
 
-    # no peak for a trivial image
-    if np.all(image == image.flat[0]):
-        if indices is True:
-            return np.empty((0, 2), np.int)
-        else:
-            return out
-
     threshold_abs = threshold_abs if threshold_abs is not None else image.min()
 
     if type(exclude_border) == bool:
@@ -201,8 +195,6 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
         if indices is True:
             return coordinates
         else:
-            nd_indices = tuple(coordinates.T)
-            out[nd_indices] = True
             return out
 
     # Non maximum filter

--- a/skimage/feature/tests/test_peak.py
+++ b/skimage/feature/tests/test_peak.py
@@ -445,3 +445,15 @@ class TestProminentPeaks(unittest.TestCase):
                                      min_distance=1, threshold_rel=0,
                                      indices=False, exclude_border=False)
         assert np.all(labels == labelsin)
+
+    def test_many_objects(self):
+        mask = np.zeros([500, 500], dtype=bool)
+        x, y = np.indices((500, 500))
+        x_c = x // 20 * 20 + 10
+        y_c = y // 20 * 20 + 10
+        mask[(x - x_c) ** 2 + (y - y_c) ** 2 < 8 ** 2] = True
+        labels, num_objs = ndi.label(mask)
+        dist = ndi.distance_transform_edt(mask)
+        local_max = peak.peak_local_max(dist, min_distance=20, indices=True,
+                                        exclude_border=False, labels=labels)
+        assert (len(local_max) == 625)

--- a/skimage/feature/tests/test_peak.py
+++ b/skimage/feature/tests/test_peak.py
@@ -456,4 +456,4 @@ class TestProminentPeaks(unittest.TestCase):
         dist = ndi.distance_transform_edt(mask)
         local_max = peak.peak_local_max(dist, min_distance=20, indices=True,
                                         exclude_border=False, labels=labels)
-        assert (len(local_max) == 625)
+        assert len(local_max) == 625


### PR DESCRIPTION
## Description

@brownmk's proposal to modify the `peak_local_max` algorithm to recursively pass a small image enclosing each object rather than an image of the same size, improving algorithm performance.

Fixes gh-3974

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
~- [ ] Gallery example in `./doc/examples` (new features only)~
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
