### PR TITLE
Remove pytest-faulthandler from test dependencies

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,4 +5,3 @@ pytest-cov
 pytest-localserver
 flake8
 codecov
-pytest-faulthandler


### PR DESCRIPTION
pytest-faulthandler is included in pytest as of pytest 5.0 and
including it in requirements raises a packaging error with 5.0.

Fixes #3986

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
