### PR TITLE
Fix tifffile and __array_function__ failures in our CI

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -61,8 +61,8 @@ def _bincount_histogram(image, source_range):
     if source_range not in ['image', 'dtype']:
         raise ValueError('Incorrect value for `source_range` argument: {}'.format(source_range))
     if source_range == 'image':
-        image_min = int(np.min(image).astype(np.int64))
-        image_max = int(np.max(image).astype(np.int64))
+        image_min = int(np.amin(image).astype(np.int64))
+        image_max = int(np.amax(image).astype(np.int64))
     elif source_range == 'dtype':
         image_min, image_max = dtype_limits(image, clip_negative=False)
     image, offset = _offset_array(image, image_min, image_max)

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -61,8 +61,8 @@ def _bincount_histogram(image, source_range):
     if source_range not in ['image', 'dtype']:
         raise ValueError('Incorrect value for `source_range` argument: {}'.format(source_range))
     if source_range == 'image':
-        image_min = int(np.amin(image).astype(np.int64))
-        image_max = int(np.amax(image).astype(np.int64))
+        image_min = int(image.min().astype(np.int64))
+        image_max = int(image.max().astype(np.int64))
     elif source_range == 'dtype':
         image_min, image_max = dtype_limits(image, clip_negative=False)
     image, offset = _offset_array(image, image_min, image_max)

--- a/skimage/io/_plugins/tifffile_plugin.py
+++ b/skimage/io/_plugins/tifffile_plugin.py
@@ -41,7 +41,7 @@ def imread(fname, dtype=None, **kwargs):
 
     # parse_kwargs will extract keyword arguments intended for the TiffFile
     # class and remove them from the kwargs dictionary in-place
-    tiff_keys = ['multifile', 'multifile_close', 'pages', 'fastij', 'is_ome']
+    tiff_keys = ['multifile', 'multifile_close', 'fastij', 'is_ome']
     kwargs_tiff = parse_kwargs(kwargs, *tiff_keys)
 
     # read and return tiff as numpy array

--- a/skimage/io/tests/test_tifffile.py
+++ b/skimage/io/tests/test_tifffile.py
@@ -38,7 +38,7 @@ def test_imread_multipage_rgb_tif():
     assert img.shape == (2, 10, 10, 3), img.shape
 
 def test_tifffile_kwarg_passthrough ():
-    img = imread(os.path.join(data_dir, 'multipage.tif'), pages=[1], 
+    img = imread(os.path.join(data_dir, 'multipage.tif'),
                  multifile=False, multifile_close=True, fastij=True, 
                  is_ome=True)
     assert img.shape == (15, 10), img.shape

--- a/skimage/io/tests/test_tifffile.py
+++ b/skimage/io/tests/test_tifffile.py
@@ -38,7 +38,7 @@ def test_imread_multipage_rgb_tif():
     assert img.shape == (2, 10, 10, 3), img.shape
 
 def test_tifffile_kwarg_passthrough ():
-    img = imread(os.path.join(data_dir, 'multipage.tif'),
+    img = imread(os.path.join(data_dir, 'multipage.tif'), key=[1],
                  multifile=False, multifile_close=True, fastij=True, 
                  is_ome=True)
     assert img.shape == (15, 10), img.shape

--- a/skimage/util/tests/test_arraypad.py
+++ b/skimage/util/tests/test_arraypad.py
@@ -1,5 +1,7 @@
+from distutils.version import LooseVersion
 
 import numpy as np
+# note: skimage.util.pad is just numpy.pad
 from skimage.util import pad
 
 from skimage._shared import testing
@@ -989,6 +991,8 @@ class ValueError3(TestCase):
         with testing.raises(ValueError):
             pad(arr, 4, mode='mean', reflect_type='odd')
 
+    @testing.skipif(LooseVersion(np.__version__) >= LooseVersion('1.17'),
+                    reason='Error removed in NumPy 1.17')
     def test_mode_not_set(self):
         arr = np.arange(30).reshape(5, 6)
         with testing.raises(TypeError):


### PR DESCRIPTION
## Description

Fixes #3985 #3991 

- Use new `key` keyword argument in Tifffile to replace `pages`
- Use `np.amin` and `np.amax` instead of `min` and `max` to ensure compatibility between NumPy 1.17 (with default `__array_function__` protocol) and various versions of dask.

## Checklist

- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] ~~Gallery example in `./doc/examples` (new features only)~~
- [ ] ~~Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark~~
- [x] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
