### PR TITLE
Allow failures on --pre builds for travis and appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,6 +13,8 @@ environment:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - PIP_FLAGS: --pre
 
 install:
   - ECHO "Filesystem root:"

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,8 @@ matrix:
       osx_image: xcode9.4
       language: objective-c
       env: TRAVIS_PYTHON_VERSION=3.7
+   allow_failures:
+      env: QT=PyQt5 OPTIONAL_DEPS=1 PIP_FLAGS="--pre"
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ matrix:
       language: objective-c
       env: TRAVIS_PYTHON_VERSION=3.7
    allow_failures:
-      env: QT=PyQt5 OPTIONAL_DEPS=1 PIP_FLAGS="--pre"
+      - env: QT=PyQt5 OPTIONAL_DEPS=1 PIP_FLAGS="--pre"
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then


### PR DESCRIPTION
## Description
Apparently not yet possible for azure.
https://github.com/microsoft/azure-pipelines-tasks/issues/9302

At least we don't have *soooo* much red that it is super distracting.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
