### PR TITLE
matplotlib: remove interpolation=nearest, none in our examples

### DIFF
--- a/doc/examples/applications/plot_coins_segmentation.py
+++ b/doc/examples/applications/plot_coins_segmentation.py
@@ -18,7 +18,7 @@ coins = data.coins()
 hist, hist_centers = histogram(coins)
 
 fig, axes = plt.subplots(1, 2, figsize=(8, 3))
-axes[0].imshow(coins, cmap=plt.cm.gray, interpolation='nearest')
+axes[0].imshow(coins, cmap=plt.cm.gray)
 axes[0].axis('off')
 axes[1].plot(hist_centers, hist, lw=2)
 axes[1].set_title('histogram of gray values')
@@ -35,10 +35,10 @@ axes[1].set_title('histogram of gray values')
 
 fig, axes = plt.subplots(1, 2, figsize=(8, 3), sharey=True)
 
-axes[0].imshow(coins > 100, cmap=plt.cm.gray, interpolation='nearest')
+axes[0].imshow(coins > 100, cmap=plt.cm.gray)
 axes[0].set_title('coins > 100')
 
-axes[1].imshow(coins > 150, cmap=plt.cm.gray, interpolation='nearest')
+axes[1].imshow(coins > 150, cmap=plt.cm.gray)
 axes[1].set_title('coins > 150')
 
 for a in axes:
@@ -59,7 +59,7 @@ from skimage.feature import canny
 edges = canny(coins)
 
 fig, ax = plt.subplots(figsize=(4, 3))
-ax.imshow(edges, cmap=plt.cm.gray, interpolation='nearest')
+ax.imshow(edges, cmap=plt.cm.gray)
 ax.set_title('Canny detector')
 ax.axis('off')
 
@@ -71,7 +71,7 @@ from scipy import ndimage as ndi
 fill_coins = ndi.binary_fill_holes(edges)
 
 fig, ax = plt.subplots(figsize=(4, 3))
-ax.imshow(fill_coins, cmap=plt.cm.gray, interpolation='nearest')
+ax.imshow(fill_coins, cmap=plt.cm.gray)
 ax.set_title('filling the holes')
 ax.axis('off')
 
@@ -85,7 +85,7 @@ from skimage import morphology
 coins_cleaned = morphology.remove_small_objects(fill_coins, 21)
 
 fig, ax = plt.subplots(figsize=(4, 3))
-ax.imshow(coins_cleaned, cmap=plt.cm.gray, interpolation='nearest')
+ax.imshow(coins_cleaned, cmap=plt.cm.gray)
 ax.set_title('removing small objects')
 ax.axis('off')
 
@@ -105,7 +105,7 @@ from skimage.filters import sobel
 elevation_map = sobel(coins)
 
 fig, ax = plt.subplots(figsize=(4, 3))
-ax.imshow(elevation_map, cmap=plt.cm.gray, interpolation='nearest')
+ax.imshow(elevation_map, cmap=plt.cm.gray)
 ax.set_title('elevation map')
 ax.axis('off')
 
@@ -118,7 +118,7 @@ markers[coins < 30] = 1
 markers[coins > 150] = 2
 
 fig, ax = plt.subplots(figsize=(4, 3))
-ax.imshow(markers, cmap=plt.cm.nipy_spectral, interpolation='nearest')
+ax.imshow(markers, cmap=plt.cm.nipy_spectral)
 ax.set_title('markers')
 ax.axis('off')
 
@@ -129,7 +129,7 @@ ax.axis('off')
 segmentation = morphology.watershed(elevation_map, markers)
 
 fig, ax = plt.subplots(figsize=(4, 3))
-ax.imshow(segmentation, cmap=plt.cm.gray, interpolation='nearest')
+ax.imshow(segmentation, cmap=plt.cm.gray)
 ax.set_title('segmentation')
 ax.axis('off')
 
@@ -144,9 +144,9 @@ labeled_coins, _ = ndi.label(segmentation)
 image_label_overlay = label2rgb(labeled_coins, image=coins)
 
 fig, axes = plt.subplots(1, 2, figsize=(8, 3), sharey=True)
-axes[0].imshow(coins, cmap=plt.cm.gray, interpolation='nearest')
+axes[0].imshow(coins, cmap=plt.cm.gray)
 axes[0].contour(segmentation, [0.5], linewidths=1.2, colors='y')
-axes[1].imshow(image_label_overlay, interpolation='nearest')
+axes[1].imshow(image_label_overlay)
 
 for a in axes:
     a.axis('off')

--- a/doc/examples/applications/plot_rank_filters.py
+++ b/doc/examples/applications/plot_rank_filters.py
@@ -46,7 +46,7 @@ hist, hist_centers = histogram(noisy_image)
 
 fig, ax = plt.subplots(ncols=2, figsize=(10, 5))
 
-ax[0].imshow(noisy_image, interpolation='nearest', cmap=plt.cm.gray)
+ax[0].imshow(noisy_image, cmap=plt.cm.gray)
 ax[0].axis('off')
 
 ax[1].plot(hist_centers, hist, lw=2)
@@ -193,19 +193,19 @@ loc_hist = np.histogram(loc, bins=np.arange(0, 256))
 fig, axes = plt.subplots(nrows=3, ncols=2, figsize=(12, 12))
 ax = axes.ravel()
 
-ax[0].imshow(noisy_image, interpolation='nearest', cmap=plt.cm.gray)
+ax[0].imshow(noisy_image, cmap=plt.cm.gray)
 ax[0].axis('off')
 
 ax[1].plot(hist[1][:-1], hist[0], lw=2)
 ax[1].set_title('Histogram of gray values')
 
-ax[2].imshow(glob, interpolation='nearest', cmap=plt.cm.gray)
+ax[2].imshow(glob, cmap=plt.cm.gray)
 ax[2].axis('off')
 
 ax[3].plot(glob_hist[1][:-1], glob_hist[0], lw=2)
 ax[3].set_title('Histogram of gray values')
 
-ax[4].imshow(loc, interpolation='nearest', cmap=plt.cm.gray)
+ax[4].imshow(loc, cmap=plt.cm.gray)
 ax[4].axis('off')
 
 ax[5].plot(loc_hist[1][:-1], loc_hist[0], lw=2)
@@ -419,7 +419,7 @@ fig, ax = plt.subplots(ncols=2, figsize=(10, 5),
 ax[0].imshow(m, cmap=plt.cm.gray)
 ax[0].set_title('Original')
 
-ax[1].imshow(m >= t, interpolation='nearest', cmap=plt.cm.gray)
+ax[1].imshow(m >= t, cmap=plt.cm.gray)
 ax[1].set_title('Local Otsu ($r=%d$)' % radius)
 
 for a in ax:

--- a/doc/examples/edges/plot_contours.py
+++ b/doc/examples/edges/plot_contours.py
@@ -30,7 +30,7 @@ contours = measure.find_contours(r, 0.8)
 
 # Display the image and plot all contours found
 fig, ax = plt.subplots()
-ax.imshow(r, interpolation='nearest', cmap=plt.cm.gray)
+ax.imshow(r, cmap=plt.cm.gray)
 
 for n, contour in enumerate(contours):
     ax.plot(contour[:, 1], contour[:, 0], linewidth=2)

--- a/doc/examples/edges/plot_convex_hull.py
+++ b/doc/examples/edges/plot_convex_hull.py
@@ -26,11 +26,11 @@ fig, axes = plt.subplots(1, 2, figsize=(8, 4))
 ax = axes.ravel()
 
 ax[0].set_title('Original picture')
-ax[0].imshow(image, cmap=plt.cm.gray, interpolation='nearest')
+ax[0].imshow(image, cmap=plt.cm.gray)
 ax[0].set_axis_off()
 
 ax[1].set_title('Transformed picture')
-ax[1].imshow(chull, cmap=plt.cm.gray, interpolation='nearest')
+ax[1].imshow(chull, cmap=plt.cm.gray)
 ax[1].set_axis_off()
 
 plt.tight_layout()
@@ -44,6 +44,6 @@ chull_diff = img_as_float(chull.copy())
 chull_diff[image] = 2
 
 fig, ax = plt.subplots()
-ax.imshow(chull_diff, cmap=plt.cm.gray, interpolation='nearest')
+ax.imshow(chull_diff, cmap=plt.cm.gray)
 ax.set_title('Difference')
 plt.show()

--- a/doc/examples/edges/plot_shapes.py
+++ b/doc/examples/edges/plot_shapes.py
@@ -90,7 +90,7 @@ rr, cc, val = circle_perimeter_aa(60, 40, 30)
 img[rr, cc] = val
 
 
-ax2.imshow(img, cmap=plt.cm.gray, interpolation='nearest')
+ax2.imshow(img, cmap=plt.cm.gray)
 ax2.set_title('Anti-aliasing')
 ax2.axis('off')
 

--- a/doc/examples/edges/plot_skeleton.py
+++ b/doc/examples/edges/plot_skeleton.py
@@ -84,15 +84,15 @@ skeleton_lee = skeletonize(data, method='lee')
 fig, axes = plt.subplots(1, 3, figsize=(8, 4), sharex=True, sharey=True)
 ax = axes.ravel()
 
-ax[0].imshow(data, cmap=plt.cm.gray, interpolation='nearest')
+ax[0].imshow(data, cmap=plt.cm.gray)
 ax[0].set_title('original')
 ax[0].axis('off')
 
-ax[1].imshow(skeleton, cmap=plt.cm.gray, interpolation='nearest')
+ax[1].imshow(skeleton, cmap=plt.cm.gray)
 ax[1].set_title('skeletonize')
 ax[1].axis('off')
 
-ax[2].imshow(skeleton_lee, cmap=plt.cm.gray, interpolation='nearest')
+ax[2].imshow(skeleton_lee, cmap=plt.cm.gray)
 ax[2].set_title('skeletonize (Lee 94)')
 ax[2].axis('off')
 
@@ -134,20 +134,20 @@ dist_on_skel = distance * skel
 fig, axes = plt.subplots(2, 2, figsize=(8, 8), sharex=True, sharey=True)
 ax = axes.ravel()
 
-ax[0].imshow(data, cmap=plt.cm.gray, interpolation='nearest')
+ax[0].imshow(data, cmap=plt.cm.gray)
 ax[0].set_title('original')
 ax[0].axis('off')
 
-ax[1].imshow(dist_on_skel, cmap='magma', interpolation='nearest')
+ax[1].imshow(dist_on_skel, cmap='magma')
 ax[1].contour(data, [0.5], colors='w')
 ax[1].set_title('medial_axis')
 ax[1].axis('off')
 
-ax[2].imshow(skeleton, cmap=plt.cm.gray, interpolation='nearest')
+ax[2].imshow(skeleton, cmap=plt.cm.gray)
 ax[2].set_title('skeletonize')
 ax[2].axis('off')
 
-ax[3].imshow(skeleton_lee, cmap=plt.cm.gray, interpolation='nearest')
+ax[3].imshow(skeleton_lee, cmap=plt.cm.gray)
 ax[3].set_title("skeletonize (Lee 94)")
 ax[3].axis('off')
 
@@ -177,19 +177,19 @@ thinned_partial = thin(image, max_iter=25)
 fig, axes = plt.subplots(2, 2, figsize=(8, 8), sharex=True, sharey=True)
 ax = axes.ravel()
 
-ax[0].imshow(image, cmap=plt.cm.gray, interpolation='nearest')
+ax[0].imshow(image, cmap=plt.cm.gray)
 ax[0].set_title('original')
 ax[0].axis('off')
 
-ax[1].imshow(skeleton, cmap=plt.cm.gray, interpolation='nearest')
+ax[1].imshow(skeleton, cmap=plt.cm.gray)
 ax[1].set_title('skeleton')
 ax[1].axis('off')
 
-ax[2].imshow(thinned, cmap=plt.cm.gray, interpolation='nearest')
+ax[2].imshow(thinned, cmap=plt.cm.gray)
 ax[2].set_title('thinned')
 ax[2].axis('off')
 
-ax[3].imshow(thinned_partial, cmap=plt.cm.gray, interpolation='nearest')
+ax[3].imshow(thinned_partial, cmap=plt.cm.gray)
 ax[3].set_title('partially thinned')
 ax[3].axis('off')
 

--- a/doc/examples/features_detection/plot_blob.py
+++ b/doc/examples/features_detection/plot_blob.py
@@ -68,7 +68,7 @@ ax = axes.ravel()
 
 for idx, (blobs, color, title) in enumerate(sequence):
     ax[idx].set_title(title)
-    ax[idx].imshow(image, interpolation='nearest')
+    ax[idx].imshow(image)
     for blob in blobs:
         y, x, r = blob
         c = plt.Circle((x, y), r, color=color, linewidth=2, fill=False)

--- a/doc/examples/features_detection/plot_corner.py
+++ b/doc/examples/features_detection/plot_corner.py
@@ -30,7 +30,7 @@ coords = corner_peaks(corner_harris(image), min_distance=5)
 coords_subpix = corner_subpix(image, coords, window_size=13)
 
 fig, ax = plt.subplots()
-ax.imshow(image, interpolation='nearest', cmap=plt.cm.gray)
+ax.imshow(image, cmap=plt.cm.gray)
 ax.plot(coords[:, 1], coords[:, 0], '.b', markersize=3)
 ax.plot(coords_subpix[:, 1], coords_subpix[:, 0], '+r', markersize=15)
 ax.axis((0, 350, 350, 0))

--- a/doc/examples/features_detection/plot_gabor.py
+++ b/doc/examples/features_detection/plot_gabor.py
@@ -115,7 +115,7 @@ for label, img, ax in zip(image_names, images, axes[0][1:]):
 for label, (kernel, powers), ax_row in zip(kernel_params, results, axes[1:]):
     # Plot Gabor kernel
     ax = ax_row[0]
-    ax.imshow(np.real(kernel), interpolation='nearest')
+    ax.imshow(np.real(kernel))
     ax.set_ylabel(label, fontsize=7)
     ax.set_xticks([])
     ax.set_yticks([])

--- a/doc/examples/features_detection/plot_gabors_from_astronaut.py
+++ b/doc/examples/features_detection/plot_gabors_from_astronaut.py
@@ -75,13 +75,13 @@ ax = axes.ravel()
 ax[0].imshow(astro, cmap=plt.cm.gray)
 ax[0].set_title("Image (original)")
 
-ax[1].imshow(fb1_montage, cmap=plt.cm.gray, interpolation='nearest')
+ax[1].imshow(fb1_montage, cmap=plt.cm.gray)
 ax[1].set_title("K-means filterbank (codebook)\non original image")
 
 ax[2].imshow(astro_dog, cmap=plt.cm.gray)
 ax[2].set_title("Image (LGN-like DoG)")
 
-ax[3].imshow(fb2_montage, cmap=plt.cm.gray, interpolation='nearest')
+ax[3].imshow(fb2_montage, cmap=plt.cm.gray)
 ax[3].set_title("K-means filterbank (codebook)\non LGN-like DoG image")
 
 for a in ax.ravel():

--- a/doc/examples/features_detection/plot_glcm.py
+++ b/doc/examples/features_detection/plot_glcm.py
@@ -56,7 +56,7 @@ fig = plt.figure(figsize=(8, 8))
 
 # display original image with locations of patches
 ax = fig.add_subplot(3, 2, 1)
-ax.imshow(image, cmap=plt.cm.gray, interpolation='nearest',
+ax.imshow(image, cmap=plt.cm.gray,
           vmin=0, vmax=255)
 for (y, x) in grass_locations:
     ax.plot(x + PATCH_SIZE / 2, y + PATCH_SIZE / 2, 'gs')
@@ -80,13 +80,13 @@ ax.legend()
 # display the image patches
 for i, patch in enumerate(grass_patches):
     ax = fig.add_subplot(3, len(grass_patches), len(grass_patches)*1 + i + 1)
-    ax.imshow(patch, cmap=plt.cm.gray, interpolation='nearest',
+    ax.imshow(patch, cmap=plt.cm.gray,
               vmin=0, vmax=255)
     ax.set_xlabel('Grass %d' % (i + 1))
 
 for i, patch in enumerate(sky_patches):
     ax = fig.add_subplot(3, len(sky_patches), len(sky_patches)*2 + i + 1)
-    ax.imshow(patch, cmap=plt.cm.gray, interpolation='nearest',
+    ax.imshow(patch, cmap=plt.cm.gray,
               vmin=0, vmax=255)
     ax.set_xlabel('Sky %d' % (i + 1))
 

--- a/doc/examples/features_detection/plot_multiblock_local_binary_pattern.py
+++ b/doc/examples/features_detection/plot_multiblock_local_binary_pattern.py
@@ -60,7 +60,7 @@ img = draw_multiblock_lbp(test_img, 0, 0, 90, 90,
                           lbp_code=lbp_code, alpha=0.5)
 
 
-plt.imshow(img, interpolation='nearest')
+plt.imshow(img)
 
 plt.show()
 

--- a/doc/examples/numpy_operations/plot_camera_numpy.py
+++ b/doc/examples/numpy_operations/plot_camera_numpy.py
@@ -24,6 +24,6 @@ outer_disk_mask = (X - l_x / 2)**2 + (Y - l_y / 2)**2 > (l_x / 2)**2
 camera[outer_disk_mask] = 0
 
 plt.figure(figsize=(4, 4))
-plt.imshow(camera, cmap='gray', interpolation='nearest')
+plt.imshow(camera, cmap='gray')
 plt.axis('off')
 plt.show()

--- a/doc/examples/numpy_operations/plot_view_as_blocks.py
+++ b/doc/examples/numpy_operations/plot_view_as_blocks.py
@@ -48,17 +48,17 @@ ax = axes.ravel()
 
 l_resized = ndi.zoom(l, 2, order=3)
 ax[0].set_title("Original rescaled with\n spline interpolation (order=3)")
-ax[0].imshow(l_resized, extent=(0, 128, 128, 0), interpolation='nearest',
+ax[0].imshow(l_resized, extent=(0, 128, 128, 0),
              cmap=cm.Greys_r)
 
 ax[1].set_title("Block view with\n local mean pooling")
-ax[1].imshow(mean_view, interpolation='nearest', cmap=cm.Greys_r)
+ax[1].imshow(mean_view, cmap=cm.Greys_r)
 
 ax[2].set_title("Block view with\n local max pooling")
-ax[2].imshow(max_view, interpolation='nearest', cmap=cm.Greys_r)
+ax[2].imshow(max_view, cmap=cm.Greys_r)
 
 ax[3].set_title("Block view with\n local median pooling")
-ax[3].imshow(median_view, interpolation='nearest', cmap=cm.Greys_r)
+ax[3].imshow(median_view, cmap=cm.Greys_r)
 
 for a in ax:
     a.set_axis_off()

--- a/doc/examples/segmentation/plot_extrema.py
+++ b/doc/examples/segmentation/plot_extrema.py
@@ -68,15 +68,15 @@ overlay_h = color.label2rgb(label_h_maxima, img, alpha=0.7, bg_label=0,
 # a new figure with 3 subplots
 fig, ax = plt.subplots(1, 3, figsize=(15, 5))
 
-ax[0].imshow(img, cmap='gray', interpolation='none')
+ax[0].imshow(img, cmap='gray')
 ax[0].set_title('Original image')
 ax[0].axis('off')
 
-ax[1].imshow(overlay, interpolation='none')
+ax[1].imshow(overlay)
 ax[1].set_title('Local Maxima')
 ax[1].axis('off')
 
-ax[2].imshow(overlay_h, interpolation='none')
+ax[2].imshow(overlay_h)
 ax[2].set_title('h maxima for h = %.2f' % h)
 ax[2].axis('off')
 plt.show()

--- a/doc/examples/segmentation/plot_floodfill.py
+++ b/doc/examples/segmentation/plot_floodfill.py
@@ -29,11 +29,11 @@ filled_checkers = flood_fill(checkers, (76, 76), 127)
 
 fig, ax = plt.subplots(ncols=2, figsize=(10, 5))
 
-ax[0].imshow(checkers, cmap=plt.cm.gray, interpolation='none')
+ax[0].imshow(checkers, cmap=plt.cm.gray)
 ax[0].set_title('Original')
 ax[0].axis('off')
 
-ax[1].imshow(filled_checkers, cmap=plt.cm.gray, interpolation='none')
+ax[1].imshow(filled_checkers, cmap=plt.cm.gray)
 ax[1].plot(76, 76, 'wo')  # seed point
 ax[1].set_title('After flood fill')
 ax[1].axis('off')

--- a/doc/examples/segmentation/plot_marked_watershed.py
+++ b/doc/examples/segmentation/plot_marked_watershed.py
@@ -49,17 +49,17 @@ fig, axes = plt.subplots(nrows=2, ncols=2, figsize=(8, 8),
                          sharex=True, sharey=True)
 ax = axes.ravel()
 
-ax[0].imshow(image, cmap=plt.cm.gray, interpolation='nearest')
+ax[0].imshow(image, cmap=plt.cm.gray)
 ax[0].set_title("Original")
 
-ax[1].imshow(gradient, cmap=plt.cm.nipy_spectral, interpolation='nearest')
+ax[1].imshow(gradient, cmap=plt.cm.nipy_spectral)
 ax[1].set_title("Local Gradient")
 
-ax[2].imshow(markers, cmap=plt.cm.nipy_spectral, interpolation='nearest')
+ax[2].imshow(markers, cmap=plt.cm.nipy_spectral)
 ax[2].set_title("Markers")
 
-ax[3].imshow(image, cmap=plt.cm.gray, interpolation='nearest')
-ax[3].imshow(labels, cmap=plt.cm.nipy_spectral, interpolation='nearest', alpha=.7)
+ax[3].imshow(image, cmap=plt.cm.gray)
+ax[3].imshow(labels, cmap=plt.cm.nipy_spectral, alpha=.7)
 ax[3].set_title("Segmented")
 
 for a in ax:

--- a/doc/examples/segmentation/plot_random_walker_segmentation.py
+++ b/doc/examples/segmentation/plot_random_walker_segmentation.py
@@ -47,13 +47,13 @@ labels = random_walker(data, markers, beta=10, mode='bf')
 # Plot results
 fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(8, 3.2),
                                     sharex=True, sharey=True)
-ax1.imshow(data, cmap='gray', interpolation='nearest')
+ax1.imshow(data, cmap='gray')
 ax1.axis('off')
 ax1.set_title('Noisy data')
-ax2.imshow(markers, cmap='magma', interpolation='nearest')
+ax2.imshow(markers, cmap='magma')
 ax2.axis('off')
 ax2.set_title('Markers')
-ax3.imshow(labels, cmap='gray', interpolation='nearest')
+ax3.imshow(labels, cmap='gray')
 ax3.axis('off')
 ax3.set_title('Segmentation')
 

--- a/doc/examples/segmentation/plot_watershed.py
+++ b/doc/examples/segmentation/plot_watershed.py
@@ -51,11 +51,11 @@ labels = watershed(-distance, markers, mask=image)
 fig, axes = plt.subplots(ncols=3, figsize=(9, 3), sharex=True, sharey=True)
 ax = axes.ravel()
 
-ax[0].imshow(image, cmap=plt.cm.gray, interpolation='nearest')
+ax[0].imshow(image, cmap=plt.cm.gray)
 ax[0].set_title('Overlapping objects')
-ax[1].imshow(-distance, cmap=plt.cm.gray, interpolation='nearest')
+ax[1].imshow(-distance, cmap=plt.cm.gray)
 ax[1].set_title('Distances')
-ax[2].imshow(labels, cmap=plt.cm.nipy_spectral, interpolation='nearest')
+ax[2].imshow(labels, cmap=plt.cm.nipy_spectral)
 ax[2].set_title('Separated objects')
 
 for a in ax:

--- a/doc/examples/transform/plot_edge_modes.py
+++ b/doc/examples/transform/plot_edge_modes.py
@@ -26,7 +26,7 @@ ax = axes.flatten()
 
 for n, mode in enumerate(modes):
     img_padded = pad(img, pad_width=img.shape[0], mode=mode)
-    ax[n].imshow(img_padded, cmap=plt.cm.gray, interpolation='nearest')
+    ax[n].imshow(img_padded, cmap=plt.cm.gray)
     ax[n].plot([15.5, 15.5, 31.5, 31.5, 15.5],
                [15.5, 31.5, 31.5, 15.5, 15.5], 'y--', linewidth=0.5)
     ax[n].set_title(mode)

--- a/doc/examples/transform/plot_swirl.py
+++ b/doc/examples/transform/plot_swirl.py
@@ -77,9 +77,9 @@ swirled = swirl(image, rotation=0, strength=10, radius=120)
 fig, (ax0, ax1) = plt.subplots(nrows=1, ncols=2, figsize=(8, 3),
                                sharex=True, sharey=True)
 
-ax0.imshow(image, cmap=plt.cm.gray, interpolation='none')
+ax0.imshow(image, cmap=plt.cm.gray)
 ax0.axis('off')
-ax1.imshow(swirled, cmap=plt.cm.gray, interpolation='none')
+ax1.imshow(swirled, cmap=plt.cm.gray)
 ax1.axis('off')
 
 plt.show()

--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -120,7 +120,7 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
         ax.scatter(keypoints2[:, 1] + offset[1], keypoints2[:, 0] + offset[0],
                    facecolors='none', edgecolors=keypoints_color)
 
-    ax.imshow(image, interpolation='nearest', cmap='gray')
+    ax.imshow(image, cmap='gray')
     ax.axis((0, image1.shape[1] + offset[1], image1.shape[0] + offset[0], 0))
 
     for i in range(matches.shape[0]):


### PR DESCRIPTION
## Description

Closes #3998


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
