### PR TITLE
fix URL encoding for wikipedia references in filters.rank.entropy and filters.rank.shannon_entropy docstring

### DIFF
--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -947,7 +947,7 @@ def entropy(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     References
     ----------
-    .. [1] https://en.wikipedia.org/wiki/Entropy_%28information_theory%29
+    .. [1] `https://en.wikipedia.org/wiki/Entropy_(information_theory) <https://en.wikipedia.org/wiki/Entropy_(information_theory)>`_
 
     Examples
     --------

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -947,7 +947,7 @@ def entropy(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     References
     ----------
-    .. [1] https://en.wikipedia.org/wiki/Entropy_(information_theory)
+    .. [1] https://en.wikipedia.org/wiki/Entropy_%28information_theory%29
 
     Examples
     --------

--- a/skimage/measure/entropy.py
+++ b/skimage/measure/entropy.py
@@ -26,7 +26,7 @@ def shannon_entropy(image, base=2):
 
     References
     ----------
-    .. [1] https://en.wikipedia.org/wiki/Entropy_(information_theory)
+    .. [1] https://en.wikipedia.org/wiki/Entropy_%28information_theory%29
     .. [2] https://en.wiktionary.org/wiki/Shannon_entropy
 
     Examples

--- a/skimage/measure/entropy.py
+++ b/skimage/measure/entropy.py
@@ -26,7 +26,7 @@ def shannon_entropy(image, base=2):
 
     References
     ----------
-    .. [1] https://en.wikipedia.org/wiki/Entropy_%28information_theory%29
+    .. [1] `https://en.wikipedia.org/wiki/Entropy_(information_theory) <https://en.wikipedia.org/wiki/Entropy_(information_theory)>`_
     .. [2] https://en.wiktionary.org/wiki/Shannon_entropy
 
     Examples


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
