### PR TITLE
Edit rescale_intensity to return original image instead of nans

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -341,6 +341,9 @@ def rescale_intensity(image, in_range='image', out_range='dtype'):
     array([  0,  63, 127], dtype=int8)
 
     """
+    if image.min() == image.max():
+        return image
+
     dtype = image.dtype.type
 
     imin, imax = intensity_range(image, in_range)

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -351,6 +351,8 @@ def rescale_intensity(image, in_range='image', out_range='dtype'):
 
     image = np.clip(image, imin, imax)
 
+    if imin == imax:
+        return image
     image = (image - imin) / float(imax - imin)
     return np.array(image * (omax - omin) + omin, dtype=dtype)
 

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -348,10 +348,9 @@ def rescale_intensity(image, in_range='image', out_range='dtype'):
 
     image = np.clip(image, imin, imax)
 
-    if imin == imax:
-        return np.asarray(image)
-    image = (image - imin) / float(imax - imin)
-    return np.array(image * (omax - omin) + omin, dtype=dtype)
+    if imin != imax:
+        image = (image - imin) / float(imax - imin)
+    return np.asarray(image * (omax - omin) + omin, dtype=dtype)
 
 
 def _assert_non_negative(image):

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -341,9 +341,6 @@ def rescale_intensity(image, in_range='image', out_range='dtype'):
     array([  0,  63, 127], dtype=int8)
 
     """
-    if image.min() == image.max():
-        return image
-
     dtype = image.dtype.type
 
     imin, imax = intensity_range(image, in_range)

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -349,7 +349,7 @@ def rescale_intensity(image, in_range='image', out_range='dtype'):
     image = np.clip(image, imin, imax)
 
     if imin == imax:
-        return image
+        return np.asarray(image)
     image = (image - imin) / float(imax - imin)
     return np.array(image * (omax - omin) + omin, dtype=dtype)
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -268,7 +268,7 @@ def test_rescale_uint14_limits():
 
 
 def test_rescale_same_values():
-    image = np.zeros((2,2), dtype=np.uint8)
+    image = np.zeros((2, 2), dtype=np.uint8)
     out = exposure.rescale_intensity(image)
     assert_array_almost_equal(out, image)
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -267,6 +267,12 @@ def test_rescale_uint14_limits():
     assert_array_almost_equal(out, [0, uint14_max])
 
 
+def test_rescale_same_values():
+    image = np.zeros((2,2), dtype=np.uint8)
+    out = exposure.rescale_intensity(image)
+    assert_array_almost_equal(out, image)
+
+
 # Test adaptive histogram equalization
 # ====================================
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -271,12 +271,14 @@ def test_rescale_all_zeros():
     image = np.zeros((2, 2), dtype=np.uint8)
     out = exposure.rescale_intensity(image)
     assert ~np.isnan(out).all()
+    assert_array_almost_equal(out, image)
 
 
 def test_rescale_same_values():
     image = np.ones((2, 2), dtype=np.uint8)
     out = exposure.rescale_intensity(image)
     assert ~np.isnan(out).all()
+    assert_array_almost_equal(out, image)
 
 
 # Test adaptive histogram equalization

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -275,7 +275,7 @@ def test_rescale_all_zeros():
 
 
 def test_rescale_same_values():
-    image = np.ones((2, 2), dtype=np.uint8)
+    image = np.ones((2, 2))
     out = exposure.rescale_intensity(image)
     assert ~np.isnan(out).all()
     assert_array_almost_equal(out, image)

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -270,8 +270,7 @@ def test_rescale_uint14_limits():
 def test_rescale_same_values():
     image = np.zeros((2, 2), dtype=np.uint8)
     out = exposure.rescale_intensity(image)
-    assert_array_almost_equal(out, image)
-
+    assert ~np.isnan(out).all()
 
 # Test adaptive histogram equalization
 # ====================================

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -267,10 +267,17 @@ def test_rescale_uint14_limits():
     assert_array_almost_equal(out, [0, uint14_max])
 
 
-def test_rescale_same_values():
+def test_rescale_all_zeros():
     image = np.zeros((2, 2), dtype=np.uint8)
     out = exposure.rescale_intensity(image)
     assert ~np.isnan(out).all()
+
+
+def test_rescale_same_values():
+    image = np.ones((2, 2), dtype=np.uint8)
+    out = exposure.rescale_intensity(image)
+    assert ~np.isnan(out).all()
+
 
 # Test adaptive histogram equalization
 # ====================================


### PR DESCRIPTION
## Description
This PR was originally addressing issue stated in #3773, which requests CLAHE to return numpy of zeros instead of nans when the input is np.zeros(n,n). 

Further examining the code indicates that the problem stems from the rescale_intensity() function in equalize_adapthist(), which returns np.array of nans if all values in the input image are the same. This PR edits rescale_intensity() to return the original image if the max and min of the image is the same. 

## Checklist

- [X ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [X ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
