### PR TITLE
Suppress warnings in test_rank due to type conversion

### DIFF
--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -59,7 +59,8 @@ class TestRank():
         @test_parallel()
         def check():
             expected = self.refs[filter]
-            result = getattr(rank, filter)(self.image, self.selem)
+            with expected_warnings(['Possible precision loss']):
+                result = getattr(rank, filter)(self.image, self.selem)
             if filter == "entropy":
                 # There may be some arch dependent rounding errors
                 # See the discussions in
@@ -289,7 +290,8 @@ class TestRank():
         for method in methods:
             func = getattr(rank, method)
             out_u = func(image_uint, disk(3))
-            out_f = func(image_float, disk(3))
+            with expected_warnings(["Possible precision loss"]):
+                out_f = func(image_float, disk(3))
             assert_equal(out_u, out_f)
 
 
@@ -311,7 +313,8 @@ class TestRank():
         for method in methods:
             func = getattr(rank, method)
             out_u = func(image_u, disk(3))
-            out_s = func(image_s, disk(3))
+            with expected_warnings(["Possible precision loss"]):
+                out_s = func(image_s, disk(3))
             assert_equal(out_u, out_s)
 
     @parametrize('method',


### PR DESCRIPTION
##  Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
