### PR TITLE
Enable packagers to disable failures on warnings.

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -140,3 +140,17 @@ Testing Requirements
 
 .. include:: ../../requirements/test.txt
    :literal:
+
+Warnings during testing phase
+-----------------------------
+
+Scikit-image tries to catch all warnings in its development builds to ensure
+that crucial warnings from dependencies are not missed.  This might cause
+certain tests to fail if you are building scikit-image with versions of
+dependencies that were not tested at the time of the release. To disable
+failures on warnings, export the environment variable
+``SKIMAGE_TEST_STRICT_WARNINGS`` with a value of `0` or `False` and run the
+tests::
+
+   export SKIMAGE_TEST_STRICT_WARNINGS=False
+   pytest --pyargs skimage

--- a/skimage/_shared/_warnings.py
+++ b/skimage/_shared/_warnings.py
@@ -3,6 +3,7 @@ import sys
 import warnings
 import inspect
 import re
+import os
 
 __all__ = ['all_warnings', 'expected_warnings', 'warn']
 
@@ -109,6 +110,15 @@ def expected_warnings(matching):
     if isinstance(matching, str):
         raise ValueError('``matching`` should be a list of strings and not '
                          'a string itself.')
+
+    strict_warnings = os.environ.get('SKIMAGE_TEST_STRICT_WARNINGS', '1')
+    if strict_warnings.lower() == 'true':
+        strict_warnings = True
+    elif strict_warnings.lower() == 'false':
+        strict_warnings = False
+    else:
+        strict_warnings = bool(int(strict_warnings))
+
     with all_warnings() as w:
         # enter context
         yield w
@@ -124,8 +134,8 @@ def expected_warnings(matching):
                     found = True
                     if match in remaining:
                         remaining.remove(match)
-            if not found:
+            if strict_warnings and not found:
                 raise ValueError('Unexpected warning: %s' % str(warn.message))
-        if len(remaining) > 0:
+        if strict_warnings and (len(remaining) > 0):
             msg = 'No warning raised matching:\n%s' % '\n'.join(remaining)
             raise ValueError(msg)

--- a/skimage/_shared/tests/test_warnings.py
+++ b/skimage/_shared/tests/test_warnings.py
@@ -19,12 +19,14 @@ def test_strict_warnigns_default(setup):
         with expected_warnings(['some warnings']):
             pass
 
+
 @pytest.mark.parametrize('strictness', ['1', 'true', 'True', 'TRUE'])
 def test_strict_warning_true(setup, strictness):
     os.environ['SKIMAGE_TEST_STRICT_WARNINGS'] = strictness
     with pytest.raises(ValueError):
         with expected_warnings(['some warnings']):
             pass
+
 
 @pytest.mark.parametrize('strictness', ['0', 'false', 'False', 'FALSE'])
 def test_strict_warning_false(setup, strictness):

--- a/skimage/_shared/tests/test_warnings.py
+++ b/skimage/_shared/tests/test_warnings.py
@@ -1,0 +1,35 @@
+import os
+from skimage._shared._warnings import expected_warnings
+import pytest
+
+
+@pytest.fixture(scope='function')
+def setup():
+    # Remove any environment variable if it exists
+    old_strictness = os.environ.pop('SKIMAGE_TEST_STRICT_WARNINGS', None)
+    yield
+    # Add the user's desired strictness
+    if old_strictness is not None:
+        os.environ['SKIMAGE_TEST_STRICT_WARNINGS'] = old_strictness
+
+
+def test_strict_warnigns_default(setup):
+    # By default we should fail on missing expected warnings
+    with pytest.raises(ValueError):
+        with expected_warnings(['some warnings']):
+            pass
+
+@pytest.mark.parametrize('strictness', ['1', 'true', 'True', 'TRUE'])
+def test_strict_warning_true(setup, strictness):
+    os.environ['SKIMAGE_TEST_STRICT_WARNINGS'] = strictness
+    with pytest.raises(ValueError):
+        with expected_warnings(['some warnings']):
+            pass
+
+@pytest.mark.parametrize('strictness', ['0', 'false', 'False', 'FALSE'])
+def test_strict_warning_false(setup, strictness):
+    # If the user doesnn't wish to be strict about warnigns
+    # the following shouldn't raise any error
+    os.environ['SKIMAGE_TEST_STRICT_WARNINGS'] = strictness
+    with expected_warnings(['some warnings']):
+        pass


### PR DESCRIPTION
## Description
The `SKIMAGE_TEST_STRICT_WARNINGS` now enables packagers to avoid failures due to warnings. This often happens when warnings pop up due to newer versions of dependencies.

I added a few tests for this functionality too.

As somebody who maintains the conda-forge package, I would like this backported to both 0.15 and 0.14.

I couldn't find where the `expected_warnings` context manager was tested, so I created new tests that test this added functionality.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
