### PR TITLE
Fix numpy 117 rc and dask in thresholding filters

### DIFF
--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -666,7 +666,7 @@ def threshold_minimum(image, nbins=256, max_iter=10000):
 
     hist, bin_centers = histogram(image.ravel(), nbins, source_range='image')
 
-    smooth_hist = np.copy(hist).astype(np.float64)
+    smooth_hist = hist.astype(np.float64, copy=False)
 
     for counter in range(max_iter):
         smooth_hist = ndi.uniform_filter1d(smooth_hist, 3)

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -422,7 +422,7 @@ def threshold_isodata(image, nbins=256, return_all=False):
     # csuml and csumh contain the count of pixels in that bin or lower, and
     # in all bins strictly higher than that bin, respectively
     csuml = np.cumsum(hist)
-    csumh = np.cumsum(hist[::-1])[::-1] - hist
+    csumh = csuml[-1] - csuml
 
     # intensity_sum contains the total pixel intensity from each bin
     intensity_sum = hist * bin_centers
@@ -437,8 +437,9 @@ def threshold_isodata(image, nbins=256, return_all=False):
     # can be in the top bin. So we just patch up csumh[-1] to not cause 0/0
     # errors.
     csumh[-1] = 1
-    l = np.cumsum(intensity_sum) / csuml
-    h = (np.cumsum(intensity_sum[::-1])[::-1] - intensity_sum) / csumh
+    csum_intensity = np.cumsum(intensity_sum)
+    l = csum_intensity / csuml
+    h = (csum_intensity[-1] - csum_intensity) / csumh
 
     # isodata finds threshold values that meet the criterion t = (l + m)/2
     # where l is the mean of all pixels <= t and h is the mean of all pixels

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -434,12 +434,12 @@ def threshold_isodata(image, nbins=256, return_all=False):
     # last bin of csumh, which is zero by construction.
     # So no worries about division by zero in the following lines, except
     # for the last bin, but we can ignore that because no valid threshold
-    # can be in the top bin. So we just patch up csumh[-1] to not cause 0/0
-    # errors.
-    csumh[-1] = 1
+    # can be in the top bin.
+    # To avoid the division by zero, we simply skip over the last element in
+    # all future computation.
     csum_intensity = np.cumsum(intensity_sum)
-    l = csum_intensity / csuml
-    h = (csum_intensity[-1] - csum_intensity) / csumh
+    lower = csum_intensity[:-1] / csuml[:-1]
+    higher = (csum_intensity[-1] - csum_intensity[:-1]) / csumh[:-1]
 
     # isodata finds threshold values that meet the criterion t = (l + m)/2
     # where l is the mean of all pixels <= t and h is the mean of all pixels
@@ -448,7 +448,7 @@ def threshold_isodata(image, nbins=256, return_all=False):
     # were calculated -- which is, of course, the histogram bin centers.
     # We only require this equality to be within the precision of the bin
     # width, of course.
-    all_mean = (l + h) / 2.0
+    all_mean = (lower + higher) / 2.0
     bin_width = bin_centers[1] - bin_centers[0]
 
     # Look only at thresholds that are below the actual all_mean value,
@@ -456,8 +456,8 @@ def threshold_isodata(image, nbins=256, return_all=False):
     # group. Otherwise can get thresholds that are not actually fixed-points
     # of the isodata algorithm. For float images, this matters less, since
     # there really can't be any guarantees anymore anyway.
-    distances = all_mean - bin_centers
-    thresholds = bin_centers[(distances >= 0) & (distances < bin_width)]
+    distances = all_mean - bin_centers[:-1]
+    thresholds = bin_centers[:-1][(distances >= 0) & (distances < bin_width)]
 
     if return_all:
         return thresholds


### PR DESCRIPTION
## Description

Fixes tests for numpy 1.17 and dask.

I get a really strange warning from dask and true divide, but I'm note sure where it is from.

As far as I can tell, the warning is reproduced by

```python
import numpy as np
import skimage
import dask
from skimage.exposure import histogram
from dask import array as da
from skimage import data
print(f"numpy version {np.__version__}")
print(f"scikit-image version {skimage.__version__}")
print(f"dask version {dask.__version__}")
image = da.from_array(data.camera(), chunks=(256, 256))
nbins = 256

hist, bin_centers = histogram(image.ravel(), nbins, source_range='image')
nbins = len(hist)

# Find peak, lowest and highest gray levels.
arg_peak_height = np.argmax(hist)
peak_height = hist[arg_peak_height]
arg_low_level, arg_high_level = np.where(hist>0)[0][[0, -1]]



# Find peak, lowest and highest gray levels.
arg_peak_height = np.argmax(hist)
peak_height = hist[arg_peak_height]
arg_low_level, arg_high_level = np.where(hist>0)[0][[0, -1]]


# Flip is True if left tail is shorter.
flip = (arg_peak_height - arg_low_level) < (arg_high_level - arg_peak_height)
if flip:
    hist = hist[::-1]
    arg_low_level = nbins - arg_high_level - 1
    arg_peak_height = nbins - arg_peak_height - 1


# If flip == True, arg_high_level becomes incorrect
# but we don't need it anymore.
del(arg_high_level)



# Set up the coordinate system.
width = arg_peak_height - arg_low_level
x1 = np.arange(width)
y1 = hist[x1 + arg_low_level]


norm = np.sqrt(peak_height**2 + width**2)

peak_height / norm

"""
/home/mark/miniconda3/envs/skdev/lib/python3.7/site-packages/dask/array/core.py:3808: RuntimeWarning: invalid value encountered in true_divide
  result = function(*args, **kwargs)
dask.array<truediv, shape=(), dtype=float64, chunksize=()>
"""

norm

norm.compute()
"""6216.711992685522"""

peak_height.compute()
"""6212"""
```

Should open an issue upstream

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
