### PR TITLE
WIP:  Add minimal distance argument to local_maxima

### DIFF
--- a/skimage/morphology/_extrema_cy.pyx
+++ b/skimage/morphology/_extrema_cy.pyx
@@ -231,15 +231,15 @@ cdef inline cnp.float64_t _sq_euclidean_distance(
     Py_ssize_t p2,
     Py_ssize_t[::1] unravel_factors
 ) nogil:
-    """Calculate the squared euclidean distance between two points in a raveled array.
+    """Calculate the squared euclidean distance between two points.
 
     Parameters
     ----------
     p1, p2 :
         Two raveled coordinates (indices to a raveled array). 
     unravel_factors :
-        An array of factors for all dimensions except the first one. E.g. if the
-        unraveled array has the shape ``(1, 2, 3, 4)`` this should be 
+        An array of factors for all dimensions except the first one. E.g. if
+        the unraveled array has the shape ``(1, 2, 3, 4)`` this should be 
         ``np.array([2 * 3 * 4, 3 * 4, 4])``.
 
     Returns
@@ -283,8 +283,8 @@ def _remove_close_maxima(
         A one-dimensional array that contains the offsets to find the
         connected neighbors for any index in `image`.
     priority : ndarray, one-dimensional
-        A one-dimensional array of indices indicating the order in which conflicting
-        maxima are kept.
+        A one-dimensional array of indices indicating the order in which
+        conflicting maxima are kept.
     minimal_distance : float
         The minimal euclidean distance allowed between non-conflicting maxima.
     """
@@ -318,8 +318,8 @@ def _remove_close_maxima(
                 if queue_count[start_index] == 1:
                     continue
                 if maxima[start_index] == 0:
-                    # This should never be the case and hints either at faulty values in
-                    # `priority` or a bug in this algorithm
+                    # This should never be the case and hints either at faulty
+                    # values in `priority` or a bug in this algorithm
                     with gil:
                         raise ValueError(
                             "value {} in priority does not point to maxima"
@@ -331,8 +331,9 @@ def _remove_close_maxima(
                 queue_clear(&to_search)
                 queue_clear(&to_delete)
 
-                # Find all points of the current maximum and queue in `current_maximum`,
-                # queue the points surrounding the maximum in `to_search`
+                # Find all points of the current maximum and queue in
+                # `current_maximum`, queue the points surrounding the maximum
+                # in `to_search`
                 queue_push(&current_maximum, &start_index)
                 queue_count[start_index] = 1
                 while queue_pop(&current_maximum, &current_index):
@@ -349,7 +350,8 @@ def _remove_close_maxima(
                             queue_push(&to_search, &neighbor)
                             queue_count[neighbor] = 1
 
-                # Evaluate the space within the minimal distance of the current maximum
+                # Evaluate the space within the minimal distance of the current
+                # maximum
                 while queue_pop(&to_search, &current_index):
                     # Check if `current_index` is in range of any point
                     # in `current_maximum`
@@ -362,10 +364,11 @@ def _remove_close_maxima(
                             break
                     else:
                         # Didn't find any point close enough
-                        # -> we aren't in range anymore and can ignore this point
+                        # -> not in range anymore and can ignore this point
                         continue
 
-                    # If another maximum is at `current_index`, queue it in `to_delete`
+                    # If another maximum is at `current_index`, queue it in
+                    # `to_delete`
                     if maxima[current_index] == 1:
                         queue_push(&to_delete, &current_index)
                         # Set flag to 2, to indicate that it was queued twice:
@@ -384,8 +387,8 @@ def _remove_close_maxima(
                 # Restore empty range surrounding the current_maximum
                 queue_restore(&to_search)
                 while queue_pop(&to_search, &current_index):
-                    # Decrease queue count to honor points which are queued a second
-                    # time in `to_delete`
+                    # Decrease queue count to honor points which are queued a
+                    # second time in `to_delete`
                     queue_count[current_index] -= 1
 
                 # Remove maxima that are to close
@@ -396,7 +399,10 @@ def _remove_close_maxima(
                         neighbor = current_index + neighbor_offsets[i]
                         if not 0 <= neighbor < maxima.shape[0]:
                             continue
-                        if queue_count[neighbor] == 0 and maxima[neighbor] == 1:
+                        if (
+                            queue_count[neighbor] == 0
+                            and maxima[neighbor] == 1
+                        ):
                             queue_push(&to_delete, &neighbor)
                             queue_count[neighbor] = 1
 

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -358,8 +358,8 @@ def local_maxima(image, selem=None, connectivity=None, indices=False,
     allow_borders : bool, optional
         If true, plateaus that touch the image border are valid maxima.
     distance : float, optional
-        The minimal euclidean distance allowed between maxima. In case of a conflict,
-        the maximum with the smaller value is dismissed.
+        The minimal euclidean distance allowed between maxima. In case of a
+        conflict, the maximum with the smaller value is dismissed.
 
     Returns
     -------
@@ -488,12 +488,13 @@ def local_maxima(image, selem=None, connectivity=None, indices=False,
         # No padding was performed but set edge values back to 0
         _set_edge_values_inplace(flags, value=0)
 
-    # Ensure contiguity which might be broken due to cropping and is required in case
-    # maxima are selected based on their distance to each other
+    # Ensure contiguity which might be broken due to cropping and is required
+    # in case maxima are selected based on their distance to each other
     flags = np.ascontiguousarray(flags)
 
     if distance:
-        # Reconstruct offsets in case flags was padded during earlier construction
+        # Reconstruct offsets in case flags was padded during earlier
+        # construction
         neighbor_offsets = _offsets_to_raveled_neighbors(
             flags.shape, selem, center=((1,) * flags.ndim)
         )
@@ -545,8 +546,8 @@ def local_minima(image, selem=None, connectivity=None, indices=False,
     allow_borders : bool, optional
         If true, plateaus that touch the image border are valid minima.
     distance : float, optional
-        The minimal euclidean distance allowed between minima. In case of a conflict,
-        the minima with the larger value is dismissed.
+        The minimal euclidean distance allowed between minima. In case of a
+        conflict, the minima with the larger value is dismissed.
 
     Returns
     -------


### PR DESCRIPTION
## Description

Closes #3816. 

Adds the optional keyword `distance` to [local_maxima](https://scikit-image.org/docs/dev/api/skimage.morphology.html#skimage.morphology.local_maxima) (and local_minima) to specify the minimal euclidean distance allowed between maxima. In case of a conflict, the maximum with the smaller value is dismissed.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
