### PR TITLE
fix #4014 gaussian filter output and add test

### DIFF
--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -129,6 +129,12 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
             sigma = [sigma] * (image.ndim - 1)
         if len(sigma) != image.ndim:
             sigma = np.concatenate((np.asarray(sigma), [0]))
+    if output is not None and not preserve_range:
+        if isinstance(output, np.ndarray):
+            if issubclass(output.dtype.type, np.integer):
+                preserve_range = True
+        elif issubclass(output, np.integer):
+            preserve_range = True
     image = convert_to_float(image, preserve_range)
-    return ndi.gaussian_filter(image, sigma, mode=mode, cval=cval,
-                               truncate=truncate)
+    return ndi.gaussian_filter(image, sigma, output=output, mode=mode,
+                               cval=cval, truncate=truncate)

--- a/skimage/filters/tests/test_gaussian.py
+++ b/skimage/filters/tests/test_gaussian.py
@@ -68,3 +68,13 @@ def test_4d_ok():
     img[2, 2, 2, 2] = 1
     res = gaussian(img, 1, mode='reflect')
     assert np.allclose(res.sum(), 1)
+
+
+def test_output_type():
+    img = np.arange(16, dtype=np.uint8).reshape((4, 4))
+    output_type = np.uint8
+    gaussian_img = gaussian(img, 1, output=output_type)
+    assert gaussian_img.dtype == output_type
+    output_image = np.zeros_like(img, dtype=output_type)
+    gaussian_img = gaussian(img, 1, output=output_image)
+    assert gaussian_img.dtype == output_type


### PR DESCRIPTION
## Description
Closes #4014
`skimage.filters.gaussian` didn't use the value of `output` parameter. It returned only the image of float64 dtype, even if explicitly specify the output dtype. Fix it and add test.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
