### PR TITLE
silence r,c  warnings when property does not depend on r,c

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -195,9 +195,9 @@ class RegionProperties:
                           for i in range(self._ndim)]).T
 
     @only2d
-    def eccentricity(self): 
+    def eccentricity(self):
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore","regionprops and image moments")
+            warnings.filterwarnings('ignore', 'regionprops and image moments')
             l1, l2 = self.inertia_tensor_eigvals
         if l1 == 0:
             return 0
@@ -265,13 +265,13 @@ class RegionProperties:
 
     def major_axis_length(self):
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore","regionprops and image moments")
+            warnings.filterwarnings('ignore', 'regionprops and image moments')
             l1 = self.inertia_tensor_eigvals[0]
         return 4 * sqrt(l1)
 
     def minor_axis_length(self):
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore","regionprops and image moments")
+            warnings.filterwarnings('ignore', 'regionprops and image moments')
             l2 = self.inertia_tensor_eigvals[-1]
         return 4 * sqrt(l2)
 

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -195,8 +195,10 @@ class RegionProperties:
                           for i in range(self._ndim)]).T
 
     @only2d
-    def eccentricity(self): #suppress warning
-        l1, l2 = self.inertia_tensor_eigvals
+    def eccentricity(self): 
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore","regionprops and image moments")
+            l1, l2 = self.inertia_tensor_eigvals
         if l1 == 0:
             return 0
         return sqrt(1 - l2 / l1)

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -1,4 +1,5 @@
 from math import sqrt, atan2, pi as PI
+import warnings
 import numpy as np
 from scipy import ndimage as ndi
 
@@ -194,7 +195,7 @@ class RegionProperties:
                           for i in range(self._ndim)]).T
 
     @only2d
-    def eccentricity(self):
+    def eccentricity(self): #suppress warning
         l1, l2 = self.inertia_tensor_eigvals
         if l1 == 0:
             return 0
@@ -261,11 +262,15 @@ class RegionProperties:
         return np.min(self.intensity_image[self.image])
 
     def major_axis_length(self):
-        l1 = self.inertia_tensor_eigvals[0]
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore","regionprops and image moments")
+            l1 = self.inertia_tensor_eigvals[0]
         return 4 * sqrt(l1)
 
     def minor_axis_length(self):
-        l2 = self.inertia_tensor_eigvals[-1]
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore","regionprops and image moments")
+            l2 = self.inertia_tensor_eigvals[-1]
         return 4 * sqrt(l2)
 
     @_cached


### PR DESCRIPTION
Addresses issue #3667 by filtering r,c warning for region properties that don't depend on ordering of r,c (eccentricity, major_axis_length, and minor_axis_length). 
## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
