### PR TITLE
remove warning filter, fix doc wrt r,c

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -1,5 +1,4 @@
 from math import sqrt, atan2, pi as PI
-import warnings
 import numpy as np
 from scipy import ndimage as ndi
 

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -196,9 +196,7 @@ class RegionProperties:
 
     @only2d
     def eccentricity(self):
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', 'regionprops and image moments')
-            l1, l2 = self.inertia_tensor_eigvals
+        l1, l2 = self.inertia_tensor_eigvals
         if l1 == 0:
             return 0
         return sqrt(1 - l2 / l1)
@@ -264,15 +262,11 @@ class RegionProperties:
         return np.min(self.intensity_image[self.image])
 
     def major_axis_length(self):
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', 'regionprops and image moments')
-            l1 = self.inertia_tensor_eigvals[0]
+        l1 = self.inertia_tensor_eigvals[0]
         return 4 * sqrt(l1)
 
     def minor_axis_length(self):
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', 'regionprops and image moments')
-            l2 = self.inertia_tensor_eigvals[-1]
+        l2 = self.inertia_tensor_eigvals[-1]
         return 4 * sqrt(l2)
 
     @_cached
@@ -510,9 +504,6 @@ def regionprops_table(label_image, intensity_image=None, cache=True,
         Determine whether to cache calculated properties. The computation is
         much faster for cached properties, whereas the memory consumption
         increases.
-    coordinates : 'rc' or 'xy', optional
-        Coordinate conventions for 2D images. (Only 'rc' coordinates are
-        supported for 3D images.)
     properties : tuple or list of str, optional
         Properties that will be included in the resulting dictionary
         For a list of available properties, please see :func:`regionprops`.


### PR DESCRIPTION
This PR removes warnings filter that turned out to be unnecessary for region props (eccentricity, major_axis_length, minor_axis_length), and updated documentation to remove ref to r,c 

## Checklist
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
