### PR TITLE
Import Iterable from collections.abc in vendored tifffile code

### DIFF
--- a/skimage/external/tifffile/tifffile.py
+++ b/skimage/external/tifffile/tifffile.py
@@ -70,6 +70,8 @@ Requirements
 
 Revisions
 ---------
+2019.07.20
+    Importing Iterable from collections.abc is used to avoid a python warning.
 2018.10.08
     No longer use numpy.fromstring just use numpy.frombuffer.
     Note that this has been fixed upstream in 2018.02.18.
@@ -279,7 +281,7 @@ import struct
 import warnings
 import tempfile
 import datetime
-import collections
+from collections.abc import Iterable
 from fractions import Fraction
 from xml.etree import cElementTree as etree
 
@@ -1488,7 +1490,7 @@ class TiffFile(object):
             pages = [pages[key]]
         elif isinstance(key, slice):
             pages = pages[key]
-        elif isinstance(key, collections.Iterable):
+        elif isinstance(key, Iterable):
             pages = [pages[k] for k in key]
         else:
             raise TypeError("key must be an int, slice, or sequence")


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
