### PR TITLE
Deprecate xy coordinates in segmentation.active_contours

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -28,6 +28,8 @@ Version 0.18
   `skimage.measure.compare_pnsr`
   `skimage.measure.compare_ssim`
 * `skimage/measure/tests/test_simple_metrics.py` should also be removed
+* make coordinates='rc' the default in ``segmentation.active_contour``
+* remove deprecated ``bc`` argument in ``segmentation.active_contour``
 
 Other
 -----

--- a/doc/examples/edges/plot_active_contours.py
+++ b/doc/examples/edges/plot_active_contours.py
@@ -37,12 +37,13 @@ img = data.astronaut()
 img = rgb2gray(img)
 
 s = np.linspace(0, 2*np.pi, 400)
-x = 220 + 100*np.cos(s)
-y = 100 + 100*np.sin(s)
-init = np.array([x, y]).T
+r = 100 + 100*np.sin(s)
+c = 220 + 100*np.cos(s)
+init = np.array([r, c]).T
 
 snake = active_contour(gaussian(img, 3),
-                       init, alpha=0.015, beta=10, gamma=0.001)
+                       init, alpha=0.015, beta=10, gamma=0.001,
+                       coordinates='rc')
 
 fig, ax = plt.subplots(figsize=(7, 7))
 ax.imshow(img, cmap=plt.cm.gray)
@@ -61,12 +62,13 @@ plt.show()
 
 img = data.text()
 
-x = np.linspace(5, 424, 100)
-y = np.linspace(136, 50, 100)
-init = np.array([x, y]).T
+r = np.linspace(136, 50, 100)
+c = np.linspace(5, 424, 100)
+init = np.array([r, c]).T
 
-snake = active_contour(gaussian(img, 1), init, bc='fixed',
-                       alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1)
+snake = active_contour(gaussian(img, 1), init, boundary_condition='fixed',
+                       alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1,
+                       coordinates='rc')
 
 fig, ax = plt.subplots(figsize=(9, 5))
 ax.imshow(img, cmap=plt.cm.gray)

--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -9,7 +9,8 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
                    w_line=0, w_edge=1, gamma=0.01,
                    bc=None, max_px_move=1.0,
                    max_iterations=2500, convergence=0.1, *,
-                   boundary_condition='periodic'):
+                   boundary_condition='periodic',
+                   coordinates=None):
     """Active contour model.
 
     Active contours by fitting snakes to features of images. Supports single
@@ -55,6 +56,9 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
         be combined by parsing 'fixed-free', 'free-fixed'. Parsing
         'fixed-fixed' or 'free-free' yields same behaviour as 'fixed' and
         'free', respectively.
+    coordinates : {'rc' or 'xy'}, optional
+        Whether to use rc or xy coordinates. The default will change from xy
+        to rc in scikit-image v0.18.
 
     Returns
     -------
@@ -98,6 +102,12 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
                    'removed in scikit-image v0.18.')
         warn(message, category=DeprecationWarning)
         boundary_condition = bc
+    if coordinates is None:
+        message = ('The coordinates returned by `active_contour` will change '
+                   'from xy coordinates (transposed from image dimensions) to '
+                   'rc coordinates in scikit-image 0.18.')
+        warn(message, category=FutureWarning)
+        coordinates = 'xy'
     max_iterations = int(max_iterations)
     if max_iterations <= 0:
         raise ValueError("max_iterations should be >0.")
@@ -227,4 +237,7 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
             if dist < convergence:
                 break
 
-    return np.array([x, y]).T
+    if coordinates == 'xy':
+        x, y = y, x
+
+    return np.stack([y, x], axis=1)

--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -70,7 +70,7 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
     ----------
     .. [1]  Kass, M.; Witkin, A.; Terzopoulos, D. "Snakes: Active contour
             models". International Journal of Computer Vision 1 (4): 321
-            (1988). DOI:`10.1007/BF00133570`
+            (1988). :DOI:`10.1007/BF00133570`
 
     Examples
     --------

--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -87,13 +87,13 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
     Initialize spline:
 
     >>> s = np.linspace(0, 2*np.pi, 100)
-    >>> init = 50 * np.array([np.cos(s), np.sin(s)]).T + 50
+    >>> init = 50 * np.array([np.sin(s), np.cos(s)]).T + 50
 
     Fit spline to image:
 
-    >>> snake = active_contour(img, init, w_edge=0, w_line=1) #doctest: +SKIP
-    >>> dist = np.sqrt((45-snake[:, 0])**2 + (35-snake[:, 1])**2) #doctest: +SKIP
-    >>> int(np.mean(dist)) #doctest: +SKIP
+    >>> snake = active_contour(img, init, w_edge=0, w_line=1, coordinates='rc')  # doctest: +SKIP
+    >>> dist = np.sqrt((45-snake[:, 0])**2 + (35-snake[:, 1])**2)  # doctest: +SKIP
+    >>> int(np.mean(dist))  # doctest: +SKIP
     25
 
     """
@@ -104,12 +104,16 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
         warn(message, stacklevel=2)
         boundary_condition = bc
     if coordinates is None:
-        message = ('The coordinates returned by `active_contour` will change '
+        message = ('The coordinates used by `active_contour` will change '
                    'from xy coordinates (transposed from image dimensions) to '
                    'rc coordinates in scikit-image 0.18. Set '
-                   "`coordinates='rc'` to silence this warning.")
+                   "`coordinates='rc'` to silence this warning. "
+                   "`coordinates='xy'` will restore the old behavior until "
+                   '0.18, but will stop working thereafter.')
         warn(message, category=FutureWarning, stacklevel=2)
         coordinates = 'xy'
+    if coordinates == 'rc':
+        snake = snake[:, ::-1]
     max_iterations = int(max_iterations)
     if max_iterations <= 0:
         raise ValueError("max_iterations should be >0.")

--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -112,8 +112,9 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
                    '0.18, but will stop working thereafter.')
         warn(message, category=FutureWarning, stacklevel=2)
         coordinates = 'xy'
+        snake_xy = snake
     if coordinates == 'rc':
-        snake = snake[:, ::-1]
+        snake_xy = snake[:, ::-1]
     max_iterations = int(max_iterations)
     if max_iterations <= 0:
         raise ValueError("max_iterations should be >0.")
@@ -153,7 +154,7 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
                                np.arange(img.shape[0]),
                                img.T, kx=2, ky=2, s=0)
 
-    x, y = snake[:, 0].astype(np.float), snake[:, 1].astype(np.float)
+    x, y = snake_xy[:, 0].astype(np.float), snake_xy[:, 1].astype(np.float)
     n = len(x)
     xsave = np.empty((convergence_order, n))
     ysave = np.empty((convergence_order, n))
@@ -244,6 +245,6 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
                 break
 
     if coordinates == 'xy':
-        x, y = y, x
-
-    return np.stack([y, x], axis=1)
+        return np.stack([x, y], axis=1)
+    else:
+        return np.stack([y, x], axis=1)

--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -8,7 +8,8 @@ from ..filters import sobel
 def active_contour(image, snake, alpha=0.01, beta=0.1,
                    w_line=0, w_edge=1, gamma=0.01,
                    bc=None, max_px_move=1.0,
-                   max_iterations=2500, convergence=0.1, *,
+                   max_iterations=2500, convergence=0.1,
+                   *,
                    boundary_condition='periodic',
                    coordinates=None):
     """Active contour model.

--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -101,13 +101,14 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
         message = ('The keyword argument `bc` to `active_contour` has been '
                    'renamed. Use `boundary_condition=` instead. `bc` will be '
                    'removed in scikit-image v0.18.')
-        warn(message, category=DeprecationWarning)
+        warn(message, stacklevel=2)
         boundary_condition = bc
     if coordinates is None:
         message = ('The coordinates returned by `active_contour` will change '
                    'from xy coordinates (transposed from image dimensions) to '
-                   'rc coordinates in scikit-image 0.18.')
-        warn(message, category=FutureWarning)
+                   'rc coordinates in scikit-image 0.18. Set '
+                   "`coordinates='rc'` to silence this warning.")
+        warn(message, category=FutureWarning, stacklevel=2)
         coordinates = 'xy'
     max_iterations = int(max_iterations)
     if max_iterations <= 0:

--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -58,8 +58,8 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
         'fixed-fixed' or 'free-free' yields same behaviour as 'fixed' and
         'free', respectively.
     coordinates : {'rc' or 'xy'}, optional
-        Whether to use rc or xy coordinates. The default will change from xy
-        to rc in scikit-image v0.18.
+        Whether to use rc or xy coordinates. The 'xy' option (current default)
+        will be removed in version 0.18.
 
     Returns
     -------

--- a/skimage/segmentation/tests/test_active_contour_model.py
+++ b/skimage/segmentation/tests/test_active_contour_model.py
@@ -18,10 +18,10 @@ def test_periodic_reference():
     init = np.array([r, c]).T
     snake = active_contour(gaussian(img, 3), init, alpha=0.015, beta=10,
                            w_line=0, w_edge=1, gamma=0.001, coordinates='rc')
-    refx = [299, 298, 298, 298, 298, 297, 297, 296, 296, 295]
-    refy = [98, 99, 100, 101, 102, 103, 104, 105, 106, 108]
-    assert_equal(np.array(snake[:10, 0], dtype=np.int32), refx)
-    assert_equal(np.array(snake[:10, 1], dtype=np.int32), refy)
+    refr = [98, 99, 100, 101, 102, 103, 104, 105, 106, 108]
+    refc = [299, 298, 298, 298, 298, 297, 297, 296, 296, 295]
+    assert_equal(np.array(snake[:10, 0], dtype=np.int32), refr)
+    assert_equal(np.array(snake[:10, 1], dtype=np.int32), refc)
 
 
 def test_fixed_reference():

--- a/skimage/segmentation/tests/test_active_contour_model.py
+++ b/skimage/segmentation/tests/test_active_contour_model.py
@@ -108,13 +108,15 @@ def test_end_points():
 
 def test_bad_input():
     img = np.zeros((10, 10))
-    x = np.linspace(5, 424, 100)
-    y = np.linspace(136, 50, 100)
-    init = np.array([x, y]).T
+    r = np.linspace(136, 50, 100)
+    c = np.linspace(5, 424, 100)
+    init = np.array([r, c]).T
     with testing.raises(ValueError):
-        active_contour(img, init, boundary_condition='wrong')
+        active_contour(img, init, boundary_condition='wrong',
+                       coordinates='rc')
     with testing.raises(ValueError):
-        active_contour(img, init, max_iterations=-15)
+        active_contour(img, init, max_iterations=-15,
+                       coordinates='rc')
 
 
 def test_bc_deprecation():

--- a/skimage/segmentation/tests/test_active_contour_model.py
+++ b/skimage/segmentation/tests/test_active_contour_model.py
@@ -6,6 +6,7 @@ from skimage.segmentation import active_contour
 
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_allclose
+from skimage._shared._warnings import expected_warnings
 
 
 def test_periodic_reference():
@@ -28,7 +29,7 @@ def test_fixed_reference():
     x = np.linspace(5, 424, 100)
     y = np.linspace(136, 50, 100)
     init = np.array([x, y]).T
-    snake = active_contour(gaussian(img, 1), init, bc='fixed',
+    snake = active_contour(gaussian(img, 1), init, boundary_condition='fixed',
                            alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1)
     refx = [5, 9, 13, 17, 21, 25, 30, 34, 38, 42]
     refy = [136, 135, 134, 133, 132, 131, 129, 128, 127, 125]
@@ -41,7 +42,7 @@ def test_free_reference():
     x = np.linspace(5, 424, 100)
     y = np.linspace(70, 40, 100)
     init = np.array([x, y]).T
-    snake = active_contour(gaussian(img, 3), init, bc='free',
+    snake = active_contour(gaussian(img, 3), init, boundary_condition='free',
                            alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1)
     refx = [10, 13, 16, 19, 23, 26, 29, 32, 36, 39]
     refy = [76, 76, 75, 74, 73, 72, 71, 70, 69, 69]
@@ -60,18 +61,19 @@ def test_RGB():
     x = np.linspace(5, 424, 100)
     y = np.linspace(136, 50, 100)
     init = np.array([x, y]).T
-    snake = active_contour(imgR, init, bc='fixed',
+    snake = active_contour(imgR, init, boundary_condition='fixed',
                            alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1)
     refx = [5, 9, 13, 17, 21, 25, 30, 34, 38, 42]
     refy = [136, 135, 134, 133, 132, 131, 129, 128, 127, 125]
     assert_equal(np.array(snake[:10, 0], dtype=np.int32), refx)
     assert_equal(np.array(snake[:10, 1], dtype=np.int32), refy)
-    snake = active_contour(imgG, init, bc='fixed',
+    snake = active_contour(imgG, init, boundary_condition='fixed',
                            alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1)
     assert_equal(np.array(snake[:10, 0], dtype=np.int32), refx)
     assert_equal(np.array(snake[:10, 1], dtype=np.int32), refy)
-    snake = active_contour(imgRGB, init, bc='fixed', alpha=0.1, beta=1.0,
-                           w_line=-5/3., w_edge=0, gamma=0.1)
+    snake = active_contour(imgRGB, init, boundary_condition='fixed',
+                           alpha=0.1, beta=1.0, w_line=-5/3., w_edge=0,
+                           gamma=0.1)
     assert_equal(np.array(snake[:10, 0], dtype=np.int32), refx)
     assert_equal(np.array(snake[:10, 1], dtype=np.int32), refy)
 
@@ -84,15 +86,15 @@ def test_end_points():
     y = 100 + 100*np.sin(s)
     init = np.array([x, y]).T
     snake = active_contour(gaussian(img, 3), init,
-                           bc='periodic', alpha=0.015, beta=10,
+                           boundary_condition='periodic', alpha=0.015, beta=10,
                            w_line=0, w_edge=1, gamma=0.001, max_iterations=100)
     assert np.sum(np.abs(snake[0, :]-snake[-1, :])) < 2
     snake = active_contour(gaussian(img, 3), init,
-                           bc='free', alpha=0.015, beta=10,
+                           boundary_condition='free', alpha=0.015, beta=10,
                            w_line=0, w_edge=1, gamma=0.001, max_iterations=100)
     assert np.sum(np.abs(snake[0, :]-snake[-1, :])) > 2
     snake = active_contour(gaussian(img, 3), init,
-                           bc='fixed', alpha=0.015, beta=10,
+                           boundary_condition='fixed', alpha=0.015, beta=10,
                            w_line=0, w_edge=1, gamma=0.001, max_iterations=100)
     assert_allclose(snake[0, :], [x[0], y[0]], atol=1e-5)
 
@@ -103,6 +105,19 @@ def test_bad_input():
     y = np.linspace(136, 50, 100)
     init = np.array([x, y]).T
     with testing.raises(ValueError):
-        active_contour(img, init, bc='wrong')
+        active_contour(img, init, boundary_condition='wrong')
     with testing.raises(ValueError):
         active_contour(img, init, max_iterations=-15)
+
+
+def test_bc_deprecation():
+    with expected_warnings(['boundary_condition']):
+        img = rgb2gray(data.astronaut())
+        s = np.linspace(0, 2*np.pi, 400)
+        x = 220 + 100*np.cos(s)
+        y = 100 + 100*np.sin(s)
+        init = np.array([x, y]).T
+        snake = active_contour(gaussian(img, 3), init,
+                               bc='periodic', alpha=0.015, beta=10,
+                               w_line=0, w_edge=1, gamma=0.001,
+                               max_iterations=100, coordinates='rc')

--- a/skimage/segmentation/tests/test_active_contour_model.py
+++ b/skimage/segmentation/tests/test_active_contour_model.py
@@ -121,10 +121,24 @@ def test_bc_deprecation():
     with expected_warnings(['boundary_condition']):
         img = rgb2gray(data.astronaut())
         s = np.linspace(0, 2*np.pi, 400)
-        x = 220 + 100*np.cos(s)
-        y = 100 + 100*np.sin(s)
-        init = np.array([x, y]).T
+        r = 100 + 100*np.sin(s)
+        c = 220 + 100*np.cos(s)
+        init = np.array([r, c]).T
         snake = active_contour(gaussian(img, 3), init,
                                bc='periodic', alpha=0.015, beta=10,
                                w_line=0, w_edge=1, gamma=0.001,
                                max_iterations=100, coordinates='rc')
+
+
+def test_xy_coord_warning():
+    # this should raise ValueError after 0.18.
+    with expected_warnings(['xy coordinates']):
+        img = rgb2gray(data.astronaut())
+        s = np.linspace(0, 2*np.pi, 400)
+        x = 100 + 100*np.sin(s)
+        y = 220 + 100*np.cos(s)
+        init = np.array([x, y]).T
+        snake = active_contour(gaussian(img, 3), init,
+                               bc='periodic', alpha=0.015, beta=10,
+                               w_line=0, w_edge=1, gamma=0.001,
+                               max_iterations=100)

--- a/skimage/segmentation/tests/test_active_contour_model.py
+++ b/skimage/segmentation/tests/test_active_contour_model.py
@@ -141,6 +141,6 @@ def test_xy_coord_warning():
         y = 220 + 100*np.cos(s)
         init = np.array([x, y]).T
         snake = active_contour(gaussian(img, 3), init,
-                               bc='periodic', alpha=0.015, beta=10,
-                               w_line=0, w_edge=1, gamma=0.001,
+                               boundary_condition='periodic', alpha=0.015,
+                               beta=10, w_line=0, w_edge=1, gamma=0.001,
                                max_iterations=100)

--- a/skimage/segmentation/tests/test_active_contour_model.py
+++ b/skimage/segmentation/tests/test_active_contour_model.py
@@ -13,11 +13,11 @@ def test_periodic_reference():
     img = data.astronaut()
     img = rgb2gray(img)
     s = np.linspace(0, 2*np.pi, 400)
-    x = 220 + 100*np.cos(s)
-    y = 100 + 100*np.sin(s)
-    init = np.array([x, y]).T
+    r = 100 + 100*np.sin(s)
+    c = 220 + 100*np.cos(s)
+    init = np.array([r, c]).T
     snake = active_contour(gaussian(img, 3), init, alpha=0.015, beta=10,
-                           w_line=0, w_edge=1, gamma=0.001)
+                           w_line=0, w_edge=1, gamma=0.001, coordinates='rc')
     refx = [299, 298, 298, 298, 298, 297, 297, 296, 296, 295]
     refy = [98, 99, 100, 101, 102, 103, 104, 105, 106, 108]
     assert_equal(np.array(snake[:10, 0], dtype=np.int32), refx)
@@ -26,28 +26,30 @@ def test_periodic_reference():
 
 def test_fixed_reference():
     img = data.text()
-    x = np.linspace(5, 424, 100)
-    y = np.linspace(136, 50, 100)
-    init = np.array([x, y]).T
+    r = np.linspace(136, 50, 100)
+    c = np.linspace(5, 424, 100)
+    init = np.array([r, c]).T
     snake = active_contour(gaussian(img, 1), init, boundary_condition='fixed',
-                           alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1)
-    refx = [5, 9, 13, 17, 21, 25, 30, 34, 38, 42]
-    refy = [136, 135, 134, 133, 132, 131, 129, 128, 127, 125]
-    assert_equal(np.array(snake[:10, 0], dtype=np.int32), refx)
-    assert_equal(np.array(snake[:10, 1], dtype=np.int32), refy)
+                           alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1,
+                           coordinates='rc')
+    refr = [136, 135, 134, 133, 132, 131, 129, 128, 127, 125]
+    refc = [5, 9, 13, 17, 21, 25, 30, 34, 38, 42]
+    assert_equal(np.array(snake[:10, 0], dtype=np.int32), refr)
+    assert_equal(np.array(snake[:10, 1], dtype=np.int32), refc)
 
 
 def test_free_reference():
     img = data.text()
-    x = np.linspace(5, 424, 100)
-    y = np.linspace(70, 40, 100)
-    init = np.array([x, y]).T
+    r = np.linspace(70, 40, 100)
+    c = np.linspace(5, 424, 100)
+    init = np.array([r, c]).T
     snake = active_contour(gaussian(img, 3), init, boundary_condition='free',
-                           alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1)
-    refx = [10, 13, 16, 19, 23, 26, 29, 32, 36, 39]
-    refy = [76, 76, 75, 74, 73, 72, 71, 70, 69, 69]
-    assert_equal(np.array(snake[:10, 0], dtype=np.int32), refx)
-    assert_equal(np.array(snake[:10, 1], dtype=np.int32), refy)
+                           alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1,
+                           coordinates='rc')
+    refr = [76, 76, 75, 74, 73, 72, 71, 70, 69, 69]
+    refc = [10, 13, 16, 19, 23, 26, 29, 32, 36, 39]
+    assert_equal(np.array(snake[:10, 0], dtype=np.int32), refr)
+    assert_equal(np.array(snake[:10, 1], dtype=np.int32), refc)
 
 
 def test_RGB():
@@ -58,45 +60,50 @@ def test_RGB():
     imgR[:, :, 0] = img
     imgG[:, :, 1] = img
     imgRGB[:, :, :] = img[:, :, None]
-    x = np.linspace(5, 424, 100)
-    y = np.linspace(136, 50, 100)
-    init = np.array([x, y]).T
+    r = np.linspace(136, 50, 100)
+    c = np.linspace(5, 424, 100)
+    init = np.array([r, c]).T
     snake = active_contour(imgR, init, boundary_condition='fixed',
-                           alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1)
-    refx = [5, 9, 13, 17, 21, 25, 30, 34, 38, 42]
-    refy = [136, 135, 134, 133, 132, 131, 129, 128, 127, 125]
-    assert_equal(np.array(snake[:10, 0], dtype=np.int32), refx)
-    assert_equal(np.array(snake[:10, 1], dtype=np.int32), refy)
+                           alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1,
+                           coordinates='rc')
+    refr = [136, 135, 134, 133, 132, 131, 129, 128, 127, 125]
+    refc = [5, 9, 13, 17, 21, 25, 30, 34, 38, 42]
+    assert_equal(np.array(snake[:10, 0], dtype=np.int32), refr)
+    assert_equal(np.array(snake[:10, 1], dtype=np.int32), refc)
     snake = active_contour(imgG, init, boundary_condition='fixed',
-                           alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1)
-    assert_equal(np.array(snake[:10, 0], dtype=np.int32), refx)
-    assert_equal(np.array(snake[:10, 1], dtype=np.int32), refy)
+                           alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1,
+                           coordinates='rc')
+    assert_equal(np.array(snake[:10, 0], dtype=np.int32), refr)
+    assert_equal(np.array(snake[:10, 1], dtype=np.int32), refc)
     snake = active_contour(imgRGB, init, boundary_condition='fixed',
                            alpha=0.1, beta=1.0, w_line=-5/3., w_edge=0,
-                           gamma=0.1)
-    assert_equal(np.array(snake[:10, 0], dtype=np.int32), refx)
-    assert_equal(np.array(snake[:10, 1], dtype=np.int32), refy)
+                           gamma=0.1, coordinates='rc')
+    assert_equal(np.array(snake[:10, 0], dtype=np.int32), refr)
+    assert_equal(np.array(snake[:10, 1], dtype=np.int32), refc)
 
 
 def test_end_points():
     img = data.astronaut()
     img = rgb2gray(img)
     s = np.linspace(0, 2*np.pi, 400)
-    x = 220 + 100*np.cos(s)
-    y = 100 + 100*np.sin(s)
-    init = np.array([x, y]).T
+    r = 100 + 100*np.sin(s)
+    c = 220 + 100*np.cos(s)
+    init = np.array([r, c]).T
     snake = active_contour(gaussian(img, 3), init,
                            boundary_condition='periodic', alpha=0.015, beta=10,
-                           w_line=0, w_edge=1, gamma=0.001, max_iterations=100)
+                           w_line=0, w_edge=1, gamma=0.001, max_iterations=100,
+                           coordinates='rc')
     assert np.sum(np.abs(snake[0, :]-snake[-1, :])) < 2
     snake = active_contour(gaussian(img, 3), init,
                            boundary_condition='free', alpha=0.015, beta=10,
-                           w_line=0, w_edge=1, gamma=0.001, max_iterations=100)
+                           w_line=0, w_edge=1, gamma=0.001, max_iterations=100,
+                           coordinates='rc')
     assert np.sum(np.abs(snake[0, :]-snake[-1, :])) > 2
     snake = active_contour(gaussian(img, 3), init,
                            boundary_condition='fixed', alpha=0.015, beta=10,
-                           w_line=0, w_edge=1, gamma=0.001, max_iterations=100)
-    assert_allclose(snake[0, :], [x[0], y[0]], atol=1e-5)
+                           w_line=0, w_edge=1, gamma=0.001, max_iterations=100,
+                           coordinates='rc')
+    assert_allclose(snake[0, :], [r[0], c[0]], atol=1e-5)
 
 
 def test_bad_input():


### PR DESCRIPTION
## Description

As I delivering @JDWarner's segmentation tutorial, someone asked how to go from the coordinate outputs to a segmentation masked, and I noticed that the coordinates returned by `active_contour` were actually in x/y format rather than rc. Our brand new poly2mask function produces a transposed mask from the output, for example.

This PR provides a keyword argument to reverse that convention, as well as a deprecation path to make rc the default. I also took the opportunity to clean up the API a little, replacing `bc` with `boundary_condition`. 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
