### PR TITLE
Correction of typos after #4025

### DIFF
--- a/skimage/measure/simple_metrics.py
+++ b/skimage/measure/simple_metrics.py
@@ -56,7 +56,7 @@ def compare_nrmse(im_true, im_test, norm_type='euclidean'):
         NRMSE.  There is no standard method of normalization across the
         literature [1]_.  The methods available here are as follows:
 
-        - 'Euclidean' : normalize by the averaged Euclidean norm of
+        - 'euclidean' : normalize by the averaged Euclidean norm of
           ``im_true``::
 
               NRMSE = RMSE * sqrt(N) / || im_true ||

--- a/skimage/metrics/simple_metrics.py
+++ b/skimage/metrics/simple_metrics.py
@@ -50,12 +50,12 @@ def normalized_root_mse(im_true, im_test, norm_type='euclidean'):
         Ground-truth image, same shape as im_test.
     im_test : ndarray
         Test image.
-    norm_type : {'Euclidean', 'min-max', 'mean'}, optional
+    norm_type : {'euclidean', 'min-max', 'mean'}, optional
         Controls the normalization method to use in the denominator of the
         NRMSE.  There is no standard method of normalization across the
         literature [1]_.  The methods available here are as follows:
 
-        - 'Euclidean' : normalize by the averaged Euclidean norm of
+        - 'euclidean' : normalize by the averaged Euclidean norm of
           ``im_true``::
 
               NRMSE = RMSE * sqrt(N) / || im_true ||
@@ -81,6 +81,7 @@ def normalized_root_mse(im_true, im_test, norm_type='euclidean'):
     assert_shape_equal(im_true, im_test)
     im_true, im_test = _as_floats(im_true, im_test)
 
+    # Ensure that both 'Euclidean' and 'euclidean' match
     norm_type = norm_type.lower()
     if norm_type == 'euclidean':
         denom = np.sqrt(np.mean((im_true * im_true), dtype=np.float64))

--- a/skimage/morphology/selem.py
+++ b/skimage/morphology/selem.py
@@ -90,7 +90,7 @@ def diamond(radius, dtype=np.uint8):
 def disk(radius, dtype=np.uint8):
     """Generates a flat, disk-shaped structuring element.
 
-    A pixel is within the neighborhood if the euclidean distance between
+    A pixel is within the neighborhood if the Euclidean distance between
     it and the origin is no greater than radius.
 
     Parameters
@@ -222,7 +222,7 @@ def ball(radius, dtype=np.uint8):
     """Generates a ball-shaped structuring element.
 
     This is the 3D equivalent of a disk.
-    A pixel is within the neighborhood if the euclidean distance between
+    A pixel is within the neighborhood if the Euclidean distance between
     it and the origin is no greater than radius.
 
     Parameters

--- a/skimage/restoration/_denoise_cy.pyx
+++ b/skimage/restoration/_denoise_cy.pyx
@@ -68,7 +68,7 @@ def _denoise_bilateral(np_floats[:, :, ::1] image, double max_value,
                     cc = wc + c
                     kc = wc + window_ext
 
-                    # save pixel values for all dims and compute euclidian
+                    # save pixel values for all dims and compute euclidean
                     # distance between centre stack and current position
                     dist = 0
                     for d in range(dims):


### PR DESCRIPTION
## Description

xref: #4025

The choice was to use 'euclidean'. I homogenized the situation, added a comment.

I fixed few other typos as well.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
