### PR TITLE
Rename internal function called assert_* -> check_*

### DIFF
--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -52,13 +52,6 @@ def assert_greater(a, b, msg=None):
     assert a > b, message
 
 
-def assert_shape_equal(im1, im2):
-    """Raise an error if the shape and dtype do not match."""
-    if not im1.shape == im2.shape:
-        raise ValueError('Input images must have the same dimensions.')
-    return
-
-
 def doctest_skip_parser(func):
     """ Decorator replaces custom skip test markup in doctests
 

--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -1,14 +1,14 @@
-from skimage._shared.utils import (copy_func, assert_nD)
+from skimage._shared.utils import (copy_func, check_nD)
 import numpy.testing as npt
 import numpy as np
 from skimage._shared import testing
 
 
-def test_assert_nD():
+def test_check_nD():
     z = np.random.random(200**2).reshape((200, 200))
     x = z[10:30, 30:10]
     with testing.raises(ValueError):
-        assert_nD(x, 2)
+        check_nD(x, 2)
 
 
 def test_copyfunc():

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -9,7 +9,7 @@ from ..util import img_as_float
 from ._warnings import all_warnings, warn
 
 __all__ = ['deprecated', 'get_bound_method_class', 'all_warnings',
-           'safe_as_int', 'assert_nD', 'assert_shape_equal', 'warn']
+           'safe_as_int', 'assert_nD', 'check_shape_equality', 'warn']
 
 
 class skimage_deprecation(Warning):
@@ -151,7 +151,7 @@ def safe_as_int(val, atol=1e-3):
     return np.round(val).astype(np.int64)
 
 
-def assert_shape_equal(im1, im2):
+def check_shape_equality(im1, im2):
     """Raise an error if the shape and dtype do not match."""
     if not im1.shape == im2.shape:
         raise ValueError('Input images must have the same dimensions.')

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -9,7 +9,7 @@ from ..util import img_as_float
 from ._warnings import all_warnings, warn
 
 __all__ = ['deprecated', 'get_bound_method_class', 'all_warnings',
-           'safe_as_int', 'assert_nD', 'warn']
+           'safe_as_int', 'assert_nD', 'assert_shape_equal', 'warn']
 
 
 class skimage_deprecation(Warning):
@@ -149,6 +149,13 @@ def safe_as_int(val, atol=1e-3):
                          "{0}, check inputs.".format(val))
 
     return np.round(val).astype(np.int64)
+
+
+def assert_shape_equal(im1, im2):
+    """Raise an error if the shape and dtype do not match."""
+    if not im1.shape == im2.shape:
+        raise ValueError('Input images must have the same dimensions.')
+    return
 
 
 def assert_nD(array, ndim, arg_name='image'):

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -9,7 +9,7 @@ from ..util import img_as_float
 from ._warnings import all_warnings, warn
 
 __all__ = ['deprecated', 'get_bound_method_class', 'all_warnings',
-           'safe_as_int', 'assert_nD', 'check_shape_equality', 'warn']
+           'safe_as_int', 'check_nD', 'check_shape_equality', 'warn']
 
 
 class skimage_deprecation(Warning):
@@ -158,7 +158,7 @@ def check_shape_equality(im1, im2):
     return
 
 
-def assert_nD(array, ndim, arg_name='image'):
+def check_nD(array, ndim, arg_name='image'):
     """
     Verify an array meets the desired ndims and array isn't empty.
 

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -152,7 +152,7 @@ def safe_as_int(val, atol=1e-3):
 
 
 def check_shape_equality(im1, im2):
-    """Raise an error if the shape and dtype do not match."""
+    """Raise an error if the shape do not match."""
     if not im1.shape == im2.shape:
         raise ValueError('Input images must have the same dimensions.')
     return

--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -17,7 +17,7 @@ import scipy.ndimage as ndi
 from scipy.ndimage import generate_binary_structure, binary_erosion, label
 from ..filters import gaussian
 from .. import dtype_limits, img_as_float
-from .._shared.utils import assert_nD
+from .._shared.utils import check_nD
 
 
 def smooth_with_function_and_mask(image, function, mask):
@@ -154,7 +154,7 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None, mask=None,
     # mask by one and then mask the output. We also mask out the border points
     # because who knows what lies beyond the edge of the image?
     #
-    assert_nD(image, 2)
+    check_nD(image, 2)
     dtype_max = dtype_limits(image, clip_negative=False)[1]
 
     if low_threshold is None:

--- a/skimage/feature/_daisy.py
+++ b/skimage/feature/_daisy.py
@@ -3,7 +3,7 @@ from scipy import sqrt, pi, arctan2, cos, sin, exp
 from scipy.ndimage import gaussian_filter
 from .. import img_as_float, draw
 from ..color import gray2rgb
-from .._shared.utils import assert_nD
+from .._shared.utils import check_nD
 
 
 def daisy(image, step=4, radius=15, rings=3, histograms=8, orientations=8,
@@ -94,7 +94,7 @@ def daisy(image, step=4, radius=15, rings=3, histograms=8, orientations=8,
     .. [2] http://cvlab.epfl.ch/software/daisy
     '''
 
-    assert_nD(image, 2, 'img')
+    check_nD(image, 2, 'img')
 
     image = img_as_float(image)
 

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -7,7 +7,7 @@ from ..util import img_as_float
 from .peak import peak_local_max
 from ._hessian_det_appx import _hessian_matrix_det
 from ..transform import integral_image
-from .._shared.utils import assert_nD
+from .._shared.utils import check_nD
 
 
 # This basic blob detection algorithm is based on:
@@ -542,7 +542,7 @@ def blob_doh(image, min_sigma=1, max_sigma=30, num_sigma=10, threshold=0.01,
     this method can't be used for detecting blobs of radius less than `3px`
     due to the box filters used in the approximation of Hessian Determinant.
     """
-    assert_nD(image, 2)
+    check_nD(image, 2)
 
     image = img_as_float(image)
     image = integral_image(image)

--- a/skimage/feature/brief.py
+++ b/skimage/feature/brief.py
@@ -5,7 +5,7 @@ from .util import (DescriptorExtractor, _mask_border_keypoints,
                    _prepare_grayscale_input_2D)
 
 from .brief_cy import _brief_loop
-from .._shared.utils import assert_nD
+from .._shared.utils import check_nD
 
 
 class BRIEF(DescriptorExtractor):
@@ -138,7 +138,7 @@ class BRIEF(DescriptorExtractor):
             Keypoint coordinates as ``(row, col)``.
 
         """
-        assert_nD(image, 2)
+        check_nD(image, 2)
 
         random = np.random.RandomState()
         random.seed(self.sample_seed)

--- a/skimage/feature/censure.py
+++ b/skimage/feature/censure.py
@@ -7,7 +7,7 @@ from ..morphology import octagon, star
 from ..feature.censure_cy import _censure_dob_loop
 from ..feature.util import (FeatureDetector, _prepare_grayscale_input_2D,
                             _mask_border_keypoints)
-from .._shared.utils import assert_nD
+from .._shared.utils import check_nD
 
 # The paper(Reference [1]) mentions the sizes of the Octagon shaped filter
 # kernel for the first seven scales only. The sizes of the later scales
@@ -238,7 +238,7 @@ class CENSURE(FeatureDetector):
         # (4) Finally, we remove the border keypoints and return the keypoints
         # along with its corresponding scale.
 
-        assert_nD(image, 2)
+        check_nD(image, 2)
 
         num_scales = self.max_scale - self.min_scale
 

--- a/skimage/feature/orb.py
+++ b/skimage/feature/orb.py
@@ -7,7 +7,7 @@ from ..feature.util import (FeatureDetector, DescriptorExtractor,
 from ..feature import (corner_fast, corner_orientations, corner_peaks,
                        corner_harris)
 from ..transform import pyramid_gaussian
-from .._shared.utils import assert_nD
+from .._shared.utils import check_nD
 
 from .orb_cy import _orb_loop
 
@@ -168,7 +168,7 @@ class ORB(FeatureDetector, DescriptorExtractor):
             Input image.
 
         """
-        assert_nD(image, 2)
+        check_nD(image, 2)
 
         pyramid = self._build_pyramid(image)
 
@@ -240,7 +240,7 @@ class ORB(FeatureDetector, DescriptorExtractor):
             Corresponding orientations in radians.
 
         """
-        assert_nD(image, 2)
+        check_nD(image, 2)
 
         pyramid = self._build_pyramid(image)
 
@@ -286,7 +286,7 @@ class ORB(FeatureDetector, DescriptorExtractor):
             Input image.
 
         """
-        assert_nD(image, 2)
+        check_nD(image, 2)
 
         pyramid = self._build_pyramid(image)
 

--- a/skimage/feature/template.py
+++ b/skimage/feature/template.py
@@ -1,7 +1,7 @@
 import numpy as np
 from scipy.signal import fftconvolve
 
-from .._shared.utils import assert_nD
+from .._shared.utils import check_nD
 
 
 def _window_sum_2d(image, window_shape):
@@ -110,7 +110,7 @@ def match_template(image, template, pad_input=False, mode='constant',
            [ 0.   ,  0.   ,  0.   ,  0.125, -1.   ,  0.125],
            [ 0.   ,  0.   ,  0.   ,  0.125,  0.125,  0.125]])
     """
-    assert_nD(image, (2, 3))
+    check_nD(image, (2, 3))
 
     if image.ndim < template.ndim:
         raise ValueError("Dimensionality of template must be less than or "

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -4,7 +4,7 @@ Methods to characterize image textures.
 
 import numpy as np
 import warnings
-from .._shared.utils import assert_nD
+from .._shared.utils import check_nD
 from ..util import img_as_float
 from ..color import gray2rgb
 from ._texture import (_glcm_loop,
@@ -99,9 +99,9 @@ def greycomatrix(image, distances, angles, levels=None, symmetric=False,
            [0, 0, 0, 0]], dtype=uint32)
 
     """
-    assert_nD(image, 2)
-    assert_nD(distances, 1, 'distances')
-    assert_nD(angles, 1, 'angles')
+    check_nD(image, 2)
+    check_nD(distances, 1, 'distances')
+    check_nD(angles, 1, 'angles')
 
     image = np.ascontiguousarray(image)
 
@@ -210,7 +210,7 @@ def greycoprops(P, prop='contrast'):
            [ 1.25      ,  2.75      ]])
 
     """
-    assert_nD(P, 4, 'P')
+    check_nD(P, 4, 'P')
 
     (num_level, num_level2, num_dist, num_angle) = P.shape
     if num_level != num_level2:
@@ -319,7 +319,7 @@ def local_binary_pattern(image, P, R, method='default'):
            http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.214.6851,
            2004.
     """
-    assert_nD(image, 2)
+    check_nD(image, 2)
 
     methods = {
         'default': ord('D'),

--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from ..util import img_as_float
-from .._shared.utils import assert_nD
+from .._shared.utils import check_nD
 
 
 class FeatureDetector(object):
@@ -139,7 +139,7 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
 
 def _prepare_grayscale_input_2D(image):
     image = np.squeeze(image)
-    assert_nD(image, 2)
+    check_nD(image, 2)
     return img_as_float(image)
 
 

--- a/skimage/filters/_gabor.py
+++ b/skimage/filters/_gabor.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy import ndimage as ndi
-from .._shared.utils import assert_nD
+from .._shared.utils import check_nD
 
 
 __all__ = ['gabor_kernel', 'gabor']
@@ -165,7 +165,7 @@ def gabor(image, frequency, theta=0, bandwidth=1, sigma_x=None,
     >>> io.imshow(filt_real)    # doctest: +SKIP
     >>> io.show()               # doctest: +SKIP
     """
-    assert_nD(image, 2)
+    check_nD(image, 2)
     g = gabor_kernel(frequency, theta, bandwidth, sigma_x, sigma_y, n_stds,
                      offset)
 

--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -11,7 +11,7 @@ Original author: Lee Kamentsky
 """
 import numpy as np
 from .. import img_as_float
-from .._shared.utils import assert_nD
+from .._shared.utils import check_nD
 from scipy.ndimage import convolve, binary_erosion, generate_binary_structure
 
 from ..restoration.uft import laplacian
@@ -110,7 +110,7 @@ def sobel(image, mask=None):
     >>> from skimage import filters
     >>> edges = filters.sobel(camera)
     """
-    assert_nD(image, 2)
+    check_nD(image, 2)
     out = np.sqrt(sobel_h(image, mask) ** 2 + sobel_v(image, mask) ** 2)
     out /= np.sqrt(2)
     return out
@@ -142,7 +142,7 @@ def sobel_h(image, mask=None):
      -1  -2  -1
 
     """
-    assert_nD(image, 2)
+    check_nD(image, 2)
     image = img_as_float(image)
     result = convolve(image, HSOBEL_WEIGHTS)
     return _mask_filter_result(result, mask)
@@ -174,7 +174,7 @@ def sobel_v(image, mask=None):
       1   0  -1
 
     """
-    assert_nD(image, 2)
+    check_nD(image, 2)
     image = img_as_float(image)
     result = convolve(image, VSOBEL_WEIGHTS)
     return _mask_filter_result(result, mask)
@@ -258,7 +258,7 @@ def scharr_h(image, mask=None):
            Optimization of Kernel Based Image Derivatives.
 
     """
-    assert_nD(image, 2)
+    check_nD(image, 2)
     image = img_as_float(image)
     result = convolve(image, HSCHARR_WEIGHTS)
     return _mask_filter_result(result, mask)
@@ -295,7 +295,7 @@ def scharr_v(image, mask=None):
            Optimization of Kernel Based Image Derivatives.
 
     """
-    assert_nD(image, 2)
+    check_nD(image, 2)
     image = img_as_float(image)
     result = convolve(image, VSCHARR_WEIGHTS)
     return _mask_filter_result(result, mask)
@@ -339,7 +339,7 @@ def prewitt(image, mask=None):
     >>> from skimage import filters
     >>> edges = filters.prewitt(camera)
     """
-    assert_nD(image, 2)
+    check_nD(image, 2)
     out = np.sqrt(prewitt_h(image, mask) ** 2 + prewitt_v(image, mask) ** 2)
     out /= np.sqrt(2)
     return out
@@ -371,7 +371,7 @@ def prewitt_h(image, mask=None):
      -1  -1  -1
 
     """
-    assert_nD(image, 2)
+    check_nD(image, 2)
     image = img_as_float(image)
     result = convolve(image, HPREWITT_WEIGHTS)
     return _mask_filter_result(result, mask)
@@ -403,7 +403,7 @@ def prewitt_v(image, mask=None):
       1   0  -1
 
     """
-    assert_nD(image, 2)
+    check_nD(image, 2)
     image = img_as_float(image)
     result = convolve(image, VPREWITT_WEIGHTS)
     return _mask_filter_result(result, mask)
@@ -438,7 +438,7 @@ def roberts(image, mask=None):
     >>> edges = filters.roberts(camera)
 
     """
-    assert_nD(image, 2)
+    check_nD(image, 2)
     out = np.sqrt(roberts_pos_diag(image, mask) ** 2 +
                   roberts_neg_diag(image, mask) ** 2)
     out /= np.sqrt(2)
@@ -473,7 +473,7 @@ def roberts_pos_diag(image, mask=None):
       0  -1
 
     """
-    assert_nD(image, 2)
+    check_nD(image, 2)
     image = img_as_float(image)
     result = convolve(image, ROBERTS_PD_WEIGHTS)
     return _mask_filter_result(result, mask)
@@ -507,7 +507,7 @@ def roberts_neg_diag(image, mask=None):
      -1   0
 
     """
-    assert_nD(image, 2)
+    check_nD(image, 2)
     image = img_as_float(image)
     result = convolve(image, ROBERTS_ND_WEIGHTS)
     return _mask_filter_result(result, mask)
@@ -590,7 +590,7 @@ def farid(image, mask=None):
     >>> from skimage import filters
     >>> edges = filters.farid(camera)
     """
-    assert_nD(image, 2)
+    check_nD(image, 2)
     out = np.sqrt(farid_h(image, mask) ** 2 + farid_v(image, mask) ** 2)
     out /= np.sqrt(2)
     return out
@@ -626,7 +626,7 @@ def farid_h(image, mask=None):
            directional derivative kernels", In: 7th International Conference on
            Computer Analysis of Images and Patterns, Kiel, Germany. Sep, 1997.
     """
-    assert_nD(image, 2)
+    check_nD(image, 2)
     image = img_as_float(image)
     result = convolve(image, HFARID_WEIGHTS)
     return _mask_filter_result(result, mask)
@@ -659,7 +659,7 @@ def farid_v(image, mask=None):
            multidimensional signals", IEEE Transactions on Image Processing
            13(4): 496-508, 2004. :DOI:`10.1109/TIP.2004.823819`
     """
-    assert_nD(image, 2)
+    check_nD(image, 2)
     image = img_as_float(image)
     result = convolve(image, VFARID_WEIGHTS)
     return _mask_filter_result(result, mask)

--- a/skimage/filters/lpi_filter.py
+++ b/skimage/filters/lpi_filter.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 from scipy.fftpack import ifftshift
-from .._shared.utils import assert_nD
+from .._shared.utils import check_nD
 
 eps = np.finfo(float).eps
 
@@ -120,7 +120,7 @@ class LPIFilter2D(object):
         data : (M,N) ndarray
 
         """
-        assert_nD(data, 2, 'data')
+        check_nD(data, 2, 'data')
         F, G = self._prepare(data)
         out = np.dual.ifftn(F * G)
         out = np.abs(_centre(out, data.shape))
@@ -158,7 +158,7 @@ def forward(data, impulse_response=None, filter_params={},
     >>> filtered = forward(data.coins(), filt_func)
 
     """
-    assert_nD(data, 2, 'data')
+    check_nD(data, 2, 'data')
     if predefined_filter is None:
         predefined_filter = LPIFilter2D(impulse_response, **filter_params)
     return predefined_filter(data)
@@ -188,7 +188,7 @@ def inverse(data, impulse_response=None, filter_params={}, max_gain=2,
         images, construct the LPIFilter2D and specify it here.
 
     """
-    assert_nD(data, 2, 'data')
+    check_nD(data, 2, 'data')
     if predefined_filter is None:
         filt = LPIFilter2D(impulse_response, **filter_params)
     else:
@@ -227,10 +227,10 @@ def wiener(data, impulse_response=None, filter_params={}, K=0.25,
         images, construct the LPIFilter2D and specify it here.
 
     """
-    assert_nD(data, 2, 'data')
+    check_nD(data, 2, 'data')
 
     if not isinstance(K, float):
-        assert_nD(K, 2, 'K')
+        check_nD(K, 2, 'K')
 
     if predefined_filter is None:
         filt = LPIFilter2D(impulse_response, **filter_params)

--- a/skimage/filters/rank/_percentile.py
+++ b/skimage/filters/rank/_percentile.py
@@ -22,7 +22,7 @@ References
 
 """
 
-from ..._shared.utils import assert_nD
+from ..._shared.utils import check_nD
 
 from . import percentile_cy
 from .generic import _handle_input
@@ -37,7 +37,7 @@ __all__ = ['autolevel_percentile', 'gradient_percentile',
 def _apply(func, image, selem, out, mask, shift_x, shift_y, p0, p1,
            out_dtype=None):
 
-    assert_nD(image, 2)
+    check_nD(image, 2)
     image, selem, out, mask, n_bins = _handle_input(image, selem, out, mask,
                                                     out_dtype)
 

--- a/skimage/filters/rank/bilateral.py
+++ b/skimage/filters/rank/bilateral.py
@@ -25,7 +25,7 @@ References
 
 import numpy as np
 
-from ..._shared.utils import assert_nD
+from ..._shared.utils import check_nD
 from . import bilateral_cy
 from .generic import _handle_input
 
@@ -36,7 +36,7 @@ __all__ = ['mean_bilateral', 'pop_bilateral', 'sum_bilateral']
 def _apply(func, image, selem, out, mask, shift_x, shift_y, s0, s1,
            out_dtype=None):
 
-    assert_nD(image, 2)
+    check_nD(image, 2)
     image, selem, out, mask, n_bins = _handle_input(image, selem, out, mask,
                                                     out_dtype)
 

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -52,7 +52,7 @@ import functools
 import numpy as np
 from scipy import ndimage as ndi
 from ...util import img_as_ubyte
-from ..._shared.utils import assert_nD, warn
+from ..._shared.utils import check_nD, warn
 
 from . import generic_cy
 
@@ -65,7 +65,7 @@ __all__ = ['autolevel', 'bottomhat', 'equalize', 'gradient', 'maximum', 'mean',
 
 def _handle_input(image, selem, out, mask, out_dtype=None, pixel_size=1):
 
-    assert_nD(image, 2)
+    check_nD(image, 2)
     if image.dtype not in (np.uint8, np.uint16):
         message = ('Possible precision loss converting image of type {} to '
                    'uint8 as required by rank filters. Convert manually using '

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -14,7 +14,7 @@ from warnings import warn
 import numpy as np
 
 from ..util import img_as_float, invert
-from .._shared.utils import assert_nD
+from .._shared.utils import check_nD
 
 
 def _divide_nonzero(array1, array2, cval=1e-10):
@@ -274,7 +274,7 @@ def sato(image, sigmas=range(1, 10, 2), black_ridges=True):
     """
 
     # Check image dimensions
-    assert_nD(image, [2, 3])
+    check_nD(image, [2, 3])
 
     # Check (sigma) scales
     sigmas = np.asarray(sigmas)
@@ -390,7 +390,7 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
         sigmas = np.arange(scale_range[0], scale_range[1], scale_step)
 
     # Check image dimensions
-    assert_nD(image, [2, 3])
+    check_nD(image, [2, 3])
 
     # Check (sigma) scales
     sigmas = np.asarray(sigmas)

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -5,7 +5,7 @@ from scipy import ndimage as ndi
 from collections import OrderedDict
 from collections.abc import Iterable
 from ..exposure import histogram
-from .._shared.utils import assert_nD, warn, deprecated
+from .._shared.utils import check_nD, warn, deprecated
 from ..transform import integral_image
 from ..util import crop, dtype_limits
 from ..filters._multiotsu import _find_threshold_multiotsu
@@ -203,7 +203,7 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
     if block_size % 2 == 0:
         raise ValueError("The kwarg ``block_size`` must be odd! Given "
                          "``block_size`` {0} is even.".format(block_size))
-    assert_nD(image, 2)
+    check_nD(image, 2)
     thresh_image = np.zeros(image.shape, 'double')
     if method == 'generic':
         ndi.generic_filter(image, param, block_size,

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -1,5 +1,5 @@
 import numpy as np
-from .._shared.utils import assert_nD
+from .._shared.utils import check_nD
 from . import _moments_cy
 import itertools
 
@@ -112,7 +112,7 @@ def moments_coords_central(coords, center=None, order=3):
         # e.g. np.nonzero: (row_coords, column_coords).
         # We represent them as an npoints x ndim array.
         coords = np.transpose(coords)
-    assert_nD(coords, 2)
+    check_nD(coords, 2)
     ndim = coords.shape[1]
     if center is None:
         center = np.mean(coords, axis=0)

--- a/skimage/metrics/_adapted_rand_error.py
+++ b/skimage/metrics/_adapted_rand_error.py
@@ -1,4 +1,4 @@
-from .._shared.testing import assert_shape_equal
+from .._shared.utils import assert_shape_equal
 from ._contingency_table import contingency_table
 
 __all__ = ['adapted_rand_error']

--- a/skimage/metrics/_adapted_rand_error.py
+++ b/skimage/metrics/_adapted_rand_error.py
@@ -1,4 +1,4 @@
-from .._shared.utils import assert_shape_equal
+from .._shared.utils import check_shape_equality
 from ._contingency_table import contingency_table
 
 __all__ = ['adapted_rand_error']
@@ -50,7 +50,7 @@ def adapted_rand_error(im_true=None, im_test=None, *, table=None,
            for connectomics. Front. Neuroanat. 9:142.
            :DOI:`10.3389/fnana.2015.00142`
     """
-    assert_shape_equal(im_true, im_test)
+    check_shape_equality(im_true, im_test)
 
     if table is None:
         p_ij = contingency_table(im_true, im_test, ignore_labels=[

--- a/skimage/metrics/_structural_similarity.py
+++ b/skimage/metrics/_structural_similarity.py
@@ -4,7 +4,7 @@ from scipy.ndimage import uniform_filter, gaussian_filter
 
 from ..util.dtype import dtype_range
 from ..util.arraycrop import crop
-from .._shared.utils import warn, assert_shape_equal
+from .._shared.utils import warn, check_shape_equality
 
 __all__ = ['structural_similarity']
 
@@ -80,7 +80,7 @@ def structural_similarity(im1, im2, win_size=None, gradient=False,
        :DOI:`10.1007/s10043-009-0119-z`
 
     """
-    assert_shape_equal(im1, im2)
+    check_shape_equality(im1, im2)
 
     if multichannel:
         # loop over channels

--- a/skimage/metrics/_structural_similarity.py
+++ b/skimage/metrics/_structural_similarity.py
@@ -4,8 +4,7 @@ from scipy.ndimage import uniform_filter, gaussian_filter
 
 from ..util.dtype import dtype_range
 from ..util.arraycrop import crop
-from .._shared.utils import warn
-from .._shared.testing import assert_shape_equal
+from .._shared.utils import warn, assert_shape_equal
 
 __all__ = ['structural_similarity']
 

--- a/skimage/metrics/_variation_of_information.py
+++ b/skimage/metrics/_variation_of_information.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy.sparse as sparse
 from ._contingency_table import contingency_table
-from .._shared.utils import assert_shape_equal
+from .._shared.utils import check_shape_equality
 
 __all__ = ['variation_of_information']
 
@@ -89,7 +89,7 @@ def _vi_tables(im_true, im_test, table=None, ignore_labels=[],
         Per-segment conditional entropies of ``im_true`` given ``im_test`` and
         vice-versa.
     """
-    assert_shape_equal(im_true, im_test)
+    check_shape_equality(im_true, im_test)
 
     if table is None:
         # normalize, since it is an identity op if already done

--- a/skimage/metrics/_variation_of_information.py
+++ b/skimage/metrics/_variation_of_information.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy.sparse as sparse
 from ._contingency_table import contingency_table
-from .._shared.testing import assert_shape_equal
+from .._shared.utils import assert_shape_equal
 
 __all__ = ['variation_of_information']
 

--- a/skimage/metrics/simple_metrics.py
+++ b/skimage/metrics/simple_metrics.py
@@ -1,7 +1,6 @@
 import numpy as np
 from ..util.dtype import dtype_range
-from .._shared.utils import warn
-from .._shared.testing import assert_shape_equal
+from .._shared.utils import warn, assert_shape_equal
 
 __all__ = ['mean_squared_error',
            'normalized_root_mse',

--- a/skimage/metrics/simple_metrics.py
+++ b/skimage/metrics/simple_metrics.py
@@ -1,6 +1,6 @@
 import numpy as np
 from ..util.dtype import dtype_range
-from .._shared.utils import warn, assert_shape_equal
+from .._shared.utils import warn, check_shape_equality
 
 __all__ = ['mean_squared_error',
            'normalized_root_mse',
@@ -33,7 +33,7 @@ def mean_squared_error(im1, im2):
         The mean-squared error (MSE) metric.
 
     """
-    assert_shape_equal(im1, im2)
+    check_shape_equality(im1, im2)
     im1, im2 = _as_floats(im1, im2)
     return np.mean((im1 - im2) ** 2, dtype=np.float64)
 
@@ -77,7 +77,7 @@ def normalized_root_mse(im_true, im_test, norm_type='euclidean'):
     .. [1] https://en.wikipedia.org/wiki/Root-mean-square_deviation
 
     """
-    assert_shape_equal(im_true, im_test)
+    check_shape_equality(im_true, im_test)
     im_true, im_test = _as_floats(im_true, im_test)
 
     norm_type = norm_type.lower()
@@ -117,7 +117,7 @@ def peak_signal_noise_ratio(im_true, im_test, data_range=None):
     .. [1] https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio
 
     """
-    assert_shape_equal(im_true, im_test)
+    check_shape_equality(im_true, im_test)
 
     if data_range is None:
         if im_true.dtype != im_test.dtype:

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -7,7 +7,7 @@ import numpy as np
 from ..util import img_as_ubyte, crop
 from scipy import ndimage as ndi
 
-from .._shared.utils import assert_nD
+from .._shared.utils import check_nD
 from ._skeletonize_cy import (_fast_skeletonize, _skeletonize_loop,
                               _table_lookup_index)
 from ._skeletonize_3d_cy import _compute_thin_image
@@ -324,7 +324,7 @@ def thin(image, max_iter=None):
            [0, 0, 0, 0, 0, 0, 0]], dtype=uint8)
     """
     # check that image is 2d
-    assert_nD(image, 2)
+    check_nD(image, 2)
 
     # convert image to uint8 with values in {0, 1}
     skel = np.asanyarray(image, dtype=bool).astype(np.uint8)

--- a/skimage/segmentation/morphsnakes.py
+++ b/skimage/segmentation/morphsnakes.py
@@ -3,7 +3,7 @@ from itertools import cycle
 import numpy as np
 from scipy import ndimage as ndi
 
-from .._shared.utils import assert_nD
+from .._shared.utils import check_nD
 
 __all__ = ['morphological_chan_vese',
            'morphological_geodesic_active_contour',
@@ -84,7 +84,7 @@ _curvop = _fcycle([lambda u: sup_inf(inf_sup(u)),   # SIoIS
 
 def _check_input(image, init_level_set):
     """Check that shapes of `image` and `init_level_set` match."""
-    assert_nD(image, [2, 3])
+    check_nD(image, [2, 3])
 
     if len(image.shape) != len(init_level_set.shape):
         raise ValueError("The dimensions of the initial level set do not "


### PR DESCRIPTION
## Description

This follows the discussion we had [here](https://github.com/scikit-image/scikit-image/pull/4025#discussion_r305571144) and [here](https://github.com/scikit-image/scikit-image/pull/4025#discussion_r305571018).

Basically, I believe it is important to name assert_* functions that call `assert`, like numpy does, and other functions that do *not* call assert, to name them differently. The reason is explained in #4006 
A proper name will help to remember the behavior of these functions.

No need for deprecation, these functions are private.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
