### PR TITLE
Improve import time

### DIFF
--- a/benchmarks/benchmark_import_time.py
+++ b/benchmarks/benchmark_import_time.py
@@ -3,14 +3,18 @@ from sys import executable
 
 class ImportSuite:
     """Benchmark the time it takes to import various modules"""
-    def setup(self):
+    params = [
+        'numpy',
+        'skimage',
+        'skimage.feature',
+        'skimage.morphology',
+        'skimage.color',
+    ]
+    param_names = ["package_name"]
+    def setup(self, package_name):
         pass
 
-    def time_import_numpy(self):
-        results = run(executable + ' -c "import numpy"',
-            stdout=PIPE, stderr=PIPE, stdin=PIPE, shell=True)
-
-    def time_import_skimage(self):
-        results = run(executable + ' -c "import skimage"',
+    def time_import(self, package_name):
+        results = run(executable + ' -c "import ' + package_name + '"',
             stdout=PIPE, stderr=PIPE, stdin=PIPE, shell=True)
 

--- a/benchmarks/benchmark_import_time.py
+++ b/benchmarks/benchmark_import_time.py
@@ -1,0 +1,16 @@
+from subprocess import run, PIPE
+from sys import executable
+
+class ImportSuite:
+    """Benchmark the time it takes to import various modules"""
+    def setup(self):
+        pass
+
+    def time_import_numpy(self):
+        results = run(executable + ' -c "import numpy"',
+            stdout=PIPE, stderr=PIPE, stdin=PIPE, shell=True)
+
+    def time_import_skimage(self):
+        results = run(executable + ' -c "import skimage"',
+            stdout=PIPE, stderr=PIPE, stdin=PIPE, shell=True)
+

--- a/skimage/_shared/_warnings.py
+++ b/skimage/_shared/_warnings.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 import sys
 import warnings
-import inspect
 import re
 
 __all__ = ['all_warnings', 'expected_warnings', 'warn']
@@ -44,7 +43,9 @@ def all_warnings():
     >>> with all_warnings():
     ...     assert_warns(RuntimeWarning, foo)
     """
-
+    # _warnings.py is on the critical import path.
+    # Since this is a testing only function, we lazy import inspect.
+    import inspect
     # Whenever a warning is triggered, Python adds a __warningregistry__
     # member to the *calling* module.  The exercize here is to find
     # and eradicate all those breadcrumbs that were left lying around.

--- a/skimage/_shared/version_requirements.py
+++ b/skimage/_shared/version_requirements.py
@@ -1,7 +1,3 @@
-from distutils.version import LooseVersion
-from platform import python_version
-import functools
-import re
 import sys
 
 
@@ -9,6 +5,10 @@ def ensure_python_version(min_version):
     if not isinstance(min_version, tuple):
         min_version = (min_version, )
     if sys.version_info < min_version:
+        # since ensure_python_version is in the critical import path,
+        # we lazy import it.
+        from platform import python_version
+
         raise ImportError("""
 
 You are running scikit-image on an unsupported version of Python.
@@ -43,6 +43,10 @@ def _check_version(actver, version, cmp_op):
 
     Distributed under the terms of the BSD License.
     """
+    # since version_requirements.py is in the critical import path, we
+    # lazy import it
+    from distutils.version import LooseVersion
+
     try:
         if cmp_op == '>':
             return LooseVersion(actver) > LooseVersion(version)
@@ -98,6 +102,10 @@ def is_installed(name, version=None):
     if version is None:
         return True
     else:
+        # since version_requirements is in the critical import path,
+        # we lazy import re
+        import re
+
         match = re.search('[0-9]', version)
         assert match is not None, "Invalid version number"
         symb = version[:match.start()]
@@ -128,6 +136,10 @@ def require(name, version=None):
         A decorator that raises an ImportError if a function is run
         in the absence of the input dependency.
     """
+    # since version_requirements is in the critical import path, we lazy import
+    # functools
+    import functools
+
     def decorator(obj):
         @functools.wraps(obj)
         def func_wrapped(*args, **kwargs):

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -10,7 +10,6 @@ import os as _os
 
 import numpy as _np
 
-from ..io import imread
 from .._shared._warnings import expected_warnings, warn
 from ..util.dtype import img_as_bool
 from ._binary_blobs import binary_blobs
@@ -65,6 +64,9 @@ def load(f, as_gray=False):
     img : ndarray
         Image loaded from ``skimage.data_dir``.
     """
+    # importing io is quite slow since it scans all the backends
+    # we lazy import it here
+    from ..io import imread
     return imread(_os.path.join(data_dir, f), plugin='pil', as_gray=as_gray)
 
 

--- a/skimage/data/_binary_blobs.py
+++ b/skimage/data/_binary_blobs.py
@@ -1,5 +1,4 @@
 import numpy as np
-from ..filters import gaussian
 
 
 def binary_blobs(length=512, blob_size_fraction=0.1, n_dim=2,
@@ -43,6 +42,10 @@ def binary_blobs(length=512, blob_size_fraction=0.1, n_dim=2,
     >>> # Blobs cover a smaller volume fraction of the image
     >>> blobs = data.binary_blobs(length=256, volume_fraction=0.3)
     """
+    # filters is quite an expensive import since it imports all of scipy.signal
+    # We lazy import here
+    from ..filters import gaussian
+
     rs = np.random.RandomState(seed)
     shape = tuple([length] * n_dim)
     mask = np.zeros(shape)

--- a/skimage/util/_montage.py
+++ b/skimage/util/_montage.py
@@ -1,5 +1,4 @@
 import numpy as np
-from .. import exposure
 
 
 __all__ = ['montage']
@@ -85,6 +84,10 @@ def montage(arr_in, fill='mean', rescale_intensity=False, grid_shape=None,
     (2, 6)
     """
 
+    # exposure imports scipy.linalg which is quite expensive.
+    # Since skimage.util is in the critical import path, we lazy import
+    # exposure to improve import time
+    from .. import exposure
     if multichannel:
         arr_in = np.asarray(arr_in)
     else:

--- a/skimage/util/apply_parallel.py
+++ b/skimage/util/apply_parallel.py
@@ -4,13 +4,6 @@ from multiprocessing import cpu_count
 __all__ = ['apply_parallel']
 
 
-try:
-    import dask.array as da
-    dask_available = True
-except ImportError:
-    dask_available = False
-
-
 def _get_chunks(shape, ncpu):
     """Split the array into equal sized chunks based on the number of
     available processors. The last chunk in each dimension absorbs the
@@ -51,6 +44,7 @@ def _get_chunks(shape, ncpu):
 
 
 def _ensure_dask_array(array, chunks=None):
+    import dask.array as da
     if isinstance(array, da.Array):
         return array
 
@@ -111,7 +105,11 @@ def apply_parallel(function, array, chunks=None, depth=0, mode=None,
     to disk instead of loading in memory.
 
     """
-    if not dask_available:
+    try:
+        # Importing dask takes time. since apply_parallel is on the
+        # minimum import path of skimage, we lazy attempt to import dask
+        import dask.array as da
+    except ImportError:
         raise RuntimeError("Could not import 'dask'.  Please install "
                            "using 'pip install dask'")
 

--- a/skimage/util/apply_parallel.py
+++ b/skimage/util/apply_parallel.py
@@ -1,6 +1,3 @@
-from math import ceil
-from multiprocessing import cpu_count
-
 __all__ = ['apply_parallel']
 
 
@@ -21,6 +18,10 @@ def _get_chunks(shape, ncpu):
     >>> _get_chunks((2, 4), 2)
     ((1, 1), (4,))
     """
+    # since apply_parallel is in the critical import path, we lazy import
+    # math just when we need it.
+    from math import ceil
+
     chunks = []
     nchunks_per_dim = int(ceil(ncpu ** (1./len(shape))))
 
@@ -119,6 +120,9 @@ def apply_parallel(function, array, chunks=None, depth=0, mode=None,
     if chunks is None:
         shape = array.shape
         try:
+            # since apply_parallel is in the critical import path, we lazy
+            # import multiprocessing just when we need it.
+            from multiprocessing import cpu_count
             ncpu = cpu_count()
         except NotImplementedError:
             ncpu = 4

--- a/skimage/util/arraycrop.py
+++ b/skimage/util/arraycrop.py
@@ -5,15 +5,6 @@ n-dimensional array.
 
 import numpy as np
 
-# After numpy 1.15, a new backward compatible function have been implemented.
-# See https://github.com/numpy/numpy/pull/11966
-from distutils.version import LooseVersion as Version
-old_numpy = Version(np.__version__) < Version('1.16')
-if old_numpy:
-    from numpy.lib.arraypad import _validate_lengths
-else:
-    from numpy.lib.arraypad import _as_pairs
-
 __all__ = ['crop']
 
 
@@ -46,6 +37,18 @@ def crop(ar, crop_width, copy=False, order='K'):
         The cropped array. If ``copy=False`` (default), this is a sliced
         view of the input array.
     """
+    # Since arraycrop is in the critical import path, we lazy import distutils
+    # to check the version of numpy
+    # After numpy 1.15, a new backward compatible function have been
+    # implemented.
+    # See https://github.com/numpy/numpy/pull/11966
+    from distutils.version import LooseVersion as Version
+    old_numpy = Version(np.__version__) < Version('1.16')
+    if old_numpy:
+        from numpy.lib.arraypad import _validate_lengths
+    else:
+        from numpy.lib.arraypad import _as_pairs
+
     ar = np.array(ar, copy=False)
     if old_numpy:
         crops = _validate_lengths(ar, crop_width)

--- a/skimage/util/tests/test_apply_parallel.py
+++ b/skimage/util/tests/test_apply_parallel.py
@@ -1,16 +1,14 @@
-
 import numpy as np
 
-from skimage._shared import testing
 from skimage._shared.testing import assert_array_almost_equal
 from skimage.filters import threshold_local, gaussian
-from skimage.util.apply_parallel import apply_parallel, dask_available
+from skimage.util.apply_parallel import apply_parallel
+
+import pytest
+da = pytest.importorskip('dask.array')
 
 
-@testing.skipif(not dask_available, reason="dask not installed")
 def test_apply_parallel():
-    import dask.array as da
-
     # data
     a = np.arange(144).reshape(12, 12).astype(float)
 
@@ -39,10 +37,7 @@ def test_apply_parallel():
     assert_array_almost_equal(result3, expected3)
 
 
-@testing.skipif(not dask_available, reason="dask not installed")
 def test_apply_parallel_lazy():
-    import dask.array as da
-
     # data
     a = np.arange(144).reshape(12, 12).astype(float)
     d = da.from_array(a, chunks=(6, 6))
@@ -68,7 +63,6 @@ def test_apply_parallel_lazy():
     assert_array_almost_equal(result2.compute(), expected1)
 
 
-@testing.skipif(not dask_available, reason="dask not installed")
 def test_no_chunks():
     a = np.ones(1 * 4 * 8 * 9).reshape(1, 4, 8, 9)
 
@@ -81,7 +75,6 @@ def test_no_chunks():
     assert_array_almost_equal(result, expected)
 
 
-@testing.skipif(not dask_available, reason="dask not installed")
 def test_apply_parallel_wrap():
     def wrapped(arr):
         return gaussian(arr, 1, mode='wrap')
@@ -92,7 +85,6 @@ def test_apply_parallel_wrap():
     assert_array_almost_equal(result, expected)
 
 
-@testing.skipif(not dask_available, reason="dask not installed")
 def test_apply_parallel_nearest():
     def wrapped(arr):
         return gaussian(arr, 1, mode='nearest')


### PR DESCRIPTION
## Description
This delays almost all imports from the critical import path of scikit image.

Now, on a "good" install, only numpy is imported, all other libraries are now lazy imported and only used when the user needs them in their code.

This decreases the total import time from 0.7 s to 0.13 s. Most of this is due to importing numpy.
Before:
![image](https://user-images.githubusercontent.com/90008/61596678-a3bd0100-abd4-11e9-9d6e-0777114e2ba3.png)

After:
![image](https://user-images.githubusercontent.com/90008/61596672-97d13f00-abd4-11e9-9ec5-470ec90a11b7.png)


Ref: #4038

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
