### PR TITLE
Undo lazy import in arraycrop

### DIFF
--- a/skimage/util/arraycrop.py
+++ b/skimage/util/arraycrop.py
@@ -7,6 +7,13 @@ import numpy as np
 
 __all__ = ['crop']
 
+from distutils.version import LooseVersion as Version
+old_numpy = Version(np.__version__) < Version('1.16')
+if old_numpy:
+    from numpy.lib.arraypad import _validate_lengths
+else:
+    from numpy.lib.arraypad import _as_pairs
+
 
 def crop(ar, crop_width, copy=False, order='K'):
     """Crop array `ar` by `crop_width` along each dimension.
@@ -37,18 +44,6 @@ def crop(ar, crop_width, copy=False, order='K'):
         The cropped array. If ``copy=False`` (default), this is a sliced
         view of the input array.
     """
-    # Since arraycrop is in the critical import path, we lazy import distutils
-    # to check the version of numpy
-    # After numpy 1.15, a new backward compatible function have been
-    # implemented.
-    # See https://github.com/numpy/numpy/pull/11966
-    from distutils.version import LooseVersion as Version
-    old_numpy = Version(np.__version__) < Version('1.16')
-    if old_numpy:
-        from numpy.lib.arraypad import _validate_lengths
-    else:
-        from numpy.lib.arraypad import _as_pairs
-
     ar = np.array(ar, copy=False)
     if old_numpy:
         crops = _validate_lengths(ar, crop_width)


### PR DESCRIPTION
## Description

@stefanv sorry, for this one, @jni was right that some of these were probably a little frivolous and added much  stylistic noise.

You merged as soon as I tried to push this change ;)

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
