### PR TITLE
Add shape= to circle perimeter in hough_circle example

### DIFF
--- a/doc/examples/edges/plot_circular_elliptical_hough_transform.py
+++ b/doc/examples/edges/plot_circular_elliptical_hough_transform.py
@@ -61,7 +61,8 @@ accums, cx, cy, radii = hough_circle_peaks(hough_res, hough_radii,
 fig, ax = plt.subplots(ncols=1, nrows=1, figsize=(10, 4))
 image = color.gray2rgb(image)
 for center_y, center_x, radius in zip(cy, cx, radii):
-    circy, circx = circle_perimeter(center_y, center_x, radius)
+    circy, circx = circle_perimeter(center_y, center_x, radius,
+                                    shape=image.shape)
     image[circy, circx] = (220, 20, 20)
 
 ax.imshow(image, cmap=plt.cm.gray)


### PR DESCRIPTION
When the code is used with circles that are not entirely contained in
the image, users can see wrap-around effects, or worse, IndexErrors,
when replicating the example on their own data.

## Checklist

- [ ] ~~[Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)~~
- [ ] ~~Gallery example in `./doc/examples` (new features only)~~
- [ ] ~~Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark~~
- [ ] ~~Unit tests~~
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
