### PR TITLE
Fix mpl deprecation on grid()

### DIFF
--- a/doc/examples/filters/plot_cycle_spinning.py
+++ b/doc/examples/filters/plot_cycle_spinning.py
@@ -73,7 +73,7 @@ for n, s in enumerate(max_shifts):
 ax[5].plot(max_shifts, all_psnr, 'k.-')
 ax[5].set_ylabel('PSNR (dB)')
 ax[5].set_xlabel('max cycle shift along each axis')
-ax[5].grid('on')
+ax[5].grid(True)
 plt.subplots_adjust(wspace=0.35, hspace=0.35)
 
 # Annotate with a cyan arrow on the 6x6 case vs. no cycle shift case to


### PR DESCRIPTION
## Description

Matplotlib through a warning concerning a future deprecation related to [this change](https://matplotlib.org/2.2.4/api/api_changes.html#changed-function-signatures)

Building the doc leads to a warning like:

"Passing one of 'on', 'true', 'off', 'false' as a boolean is deprecated; use an actual boolean (True/False) instead.
  warn_deprecated("2.2", "Passing one of 'on', 'true', 'off', 'false' as a "
"

The fix works for me with matplotlib==2.0.0. Seems that we don't need to upgrade the min req.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
