### PR TITLE
Fix gallery after deprecation from #4025

### DIFF
--- a/doc/examples/filters/plot_cycle_spinning.py
+++ b/doc/examples/filters/plot_cycle_spinning.py
@@ -27,7 +27,7 @@ import matplotlib.pyplot as plt
 from skimage.restoration import denoise_wavelet, cycle_spin
 from skimage import data, img_as_float
 from skimage.util import random_noise
-from skimage.measure import compare_psnr
+from skimage.metrics import peak_signal_noise_ratio
 
 
 original = img_as_float(data.chelsea()[100:250, 50:300])
@@ -39,7 +39,7 @@ fig, ax = plt.subplots(nrows=2, ncols=3, figsize=(10, 4),
                        sharex=False, sharey=False)
 ax = ax.ravel()
 
-psnr_noisy = compare_psnr(original, noisy)
+psnr_noisy = peak_signal_noise_ratio(original, noisy)
 ax[0].imshow(noisy)
 ax[0].axis('off')
 ax[0].set_title('Noisy\nPSNR={:0.4g}'.format(psnr_noisy))
@@ -60,7 +60,7 @@ for n, s in enumerate(max_shifts):
                             func_kw=denoise_kwargs, multichannel=True)
     ax[n+1].imshow(im_bayescs)
     ax[n+1].axis('off')
-    psnr = compare_psnr(original, im_bayescs)
+    psnr = peak_signal_noise_ratio(original, im_bayescs)
     if s == 0:
         ax[n+1].set_title(
             "Denoised: no cycle shifts\nPSNR={:0.4g}".format(psnr))

--- a/doc/examples/filters/plot_denoise_wavelet.py
+++ b/doc/examples/filters/plot_denoise_wavelet.py
@@ -32,7 +32,7 @@ import matplotlib.pyplot as plt
 from skimage.restoration import (denoise_wavelet, estimate_sigma)
 from skimage import data, img_as_float
 from skimage.util import random_noise
-from skimage.measure import compare_psnr
+from skimage.metrics import peak_signal_noise_ratio
 
 
 original = img_as_float(data.chelsea()[100:250, 50:300])
@@ -68,11 +68,11 @@ im_visushrink4 = denoise_wavelet(noisy, multichannel=True, convert2ycbcr=True,
                                  sigma=sigma_est/4)
 
 # Compute PSNR as an indication of image quality
-psnr_noisy = compare_psnr(original, noisy)
-psnr_bayes = compare_psnr(original, im_bayes)
-psnr_visushrink = compare_psnr(original, im_visushrink)
-psnr_visushrink2 = compare_psnr(original, im_visushrink2)
-psnr_visushrink4 = compare_psnr(original, im_visushrink4)
+psnr_noisy = peak_signal_noise_ratio(original, noisy)
+psnr_bayes = peak_signal_noise_ratio(original, im_bayes)
+psnr_visushrink = peak_signal_noise_ratio(original, im_visushrink)
+psnr_visushrink2 = peak_signal_noise_ratio(original, im_visushrink2)
+psnr_visushrink4 = peak_signal_noise_ratio(original, im_visushrink4)
 
 ax[0, 0].imshow(noisy)
 ax[0, 0].axis('off')

--- a/doc/examples/filters/plot_nonlocal_means.py
+++ b/doc/examples/filters/plot_nonlocal_means.py
@@ -35,7 +35,7 @@ import matplotlib.pyplot as plt
 
 from skimage import data, img_as_float
 from skimage.restoration import denoise_nl_means, estimate_sigma
-from skimage.measure import compare_psnr
+from skimage.metrics import peak_signal_noise_ratio
 from skimage.util import random_noise
 
 
@@ -94,11 +94,11 @@ ax[1, 2].set_title('non-local means\n(fast, using $\sigma_{est}$)')
 fig.tight_layout()
 
 # print PSNR metric for each case
-psnr_noisy = compare_psnr(astro, noisy)
-psnr = compare_psnr(astro, denoise)
-psnr2 = compare_psnr(astro, denoise2)
-psnr_fast = compare_psnr(astro, denoise_fast)
-psnr2_fast = compare_psnr(astro, denoise2_fast)
+psnr_noisy = peak_signal_noise_ratio(astro, noisy)
+psnr = peak_signal_noise_ratio(astro, denoise)
+psnr2 = peak_signal_noise_ratio(astro, denoise2)
+psnr_fast = peak_signal_noise_ratio(astro, denoise_fast)
+psnr2_fast = peak_signal_noise_ratio(astro, denoise2_fast)
 
 print("PSNR (noisy) = {:0.2f}".format(psnr_noisy))
 print("PSNR (slow) = {:0.2f}".format(psnr))

--- a/doc/examples/transform/plot_ssim.py
+++ b/doc/examples/transform/plot_ssim.py
@@ -25,7 +25,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from skimage import data, img_as_float
-from skimage.measure import compare_ssim as ssim
+from skimage.metrics import structural_similarity as ssim
 
 
 img = img_as_float(data.camera())


### PR DESCRIPTION
## Description

Before merging #4025, we forgot to change the related examples in the gallery.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
