### PR TITLE
Fix 3861: Bad indentation on medial_axis (internal cython function)

### DIFF
--- a/skimage/morphology/_skeletonize_cy.pyx
+++ b/skimage/morphology/_skeletonize_cy.pyx
@@ -185,19 +185,19 @@ def _skeletonize_loop(cnp.uint8_t[:, ::1] result,
                     accumulator += 2
                 if jj < cols - 1 and result[ii - 1, jj + 1]:
                         accumulator += 4
-                if jj > 0 and result[ii, jj - 1]:
-                    accumulator += 8
-                if jj < cols - 1 and result[ii, jj + 1]:
-                    accumulator += 32
-                if ii < rows - 1:
-                    if jj > 0 and result[ii + 1, jj - 1]:
-                        accumulator += 64
-                    if result[ii + 1, jj]:
-                        accumulator += 128
-                    if jj < cols - 1 and result[ii + 1, jj + 1]:
-                        accumulator += 256
-                # Assign the value of table corresponding to the configuration
-                result[ii, jj] = table[accumulator]
+            if jj > 0 and result[ii, jj - 1]:
+                accumulator += 8
+            if jj < cols - 1 and result[ii, jj + 1]:
+                accumulator += 32
+            if ii < rows - 1:
+                if jj > 0 and result[ii + 1, jj - 1]:
+                    accumulator += 64
+                if result[ii + 1, jj]:
+                    accumulator += 128
+                if jj < cols - 1 and result[ii + 1, jj + 1]:
+                    accumulator += 256
+            # Assign the value of table corresponding to the configuration
+            result[ii, jj] = table[accumulator]
 
 
 

--- a/skimage/morphology/tests/test_skeletonize.py
+++ b/skimage/morphology/tests/test_skeletonize.py
@@ -181,6 +181,19 @@ class TestMedialAxis():
                              np.zeros((10, 10), bool))
         assert np.all(result == False)
 
+    def test_vertical_line(self):
+        '''Test a thick vertical line, issue #3861'''
+        img = np.zeros((9, 9))
+        img[:, 2] = 1
+        img[:, 3] = 1
+        img[:, 4] = 1
+
+        expected = np.full(img.shape, False)
+        expected[:, 3] = True
+
+        result = medial_axis(img)
+        assert_array_equal(result, expected)
+
     def test_01_01_rectangle(self):
         '''Test skeletonize on a rectangle'''
         image = np.zeros((9, 15), bool)


### PR DESCRIPTION
## Description

Fixes #3861

I added a test. Before fixing the code, the result was wrong and looked like a T shape. ( The first line was not reduced). After the fix, the result is ok (Like a I).


PS: if you zoom in like crazy, you can see a reddish line at the top: https://scikit-image.org/docs/0.15.x/_images/sphx_glr_plot_skeleton_003.png


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
