### PR TITLE
Critical: address internal warnings in test suite related to metrics 4025

### DIFF
--- a/skimage/io/tests/test_pil.py
+++ b/skimage/io/tests/test_pil.py
@@ -9,7 +9,6 @@ from .. import imread, imsave, use_plugin, reset_plugins
 from PIL import Image
 from .._plugins.pil_plugin import (
     pil_to_ndarray, ndarray_to_pil, _palette_is_grayscale)
-from ...measure import compare_ssim as ssim
 from ...color import rgb2lab
 
 from skimage._shared import testing
@@ -19,6 +18,8 @@ from skimage._shared.testing import (mono_check, color_check,
                                      assert_allclose)
 from skimage._shared._warnings import expected_warnings
 from skimage._shared._tempfile import temporary_file
+
+from skimage.metrics import structural_similarity
 
 
 def setup():
@@ -139,8 +140,9 @@ def test_jpg_quality_arg():
     with temporary_file(suffix='.jpg') as jpg:
         imsave(jpg, chessboard, quality=95)
         im = imread(jpg)
-        sim = ssim(chessboard, im,
-                   data_range=chessboard.max() - chessboard.min())
+        sim = structural_similarity(
+            chessboard, im,
+            data_range=chessboard.max() - chessboard.min())
         assert sim > 0.99
 
 
@@ -285,7 +287,8 @@ def test_cmyk():
     for i in range(3):
         newi = np.ascontiguousarray(new_lab[:, :, i])
         refi = np.ascontiguousarray(ref_lab[:, :, i])
-        sim = ssim(refi, newi, data_range=refi.max() - refi.min())
+        sim = structural_similarity(refi, newi,
+                                    data_range=refi.max() - refi.min())
         assert sim > 0.99
 
 

--- a/skimage/measure/_structural_similarity.py
+++ b/skimage/measure/_structural_similarity.py
@@ -14,14 +14,19 @@ def compare_ssim(X, Y, win_size=None, gradient=False,
                                  data_range, multichannel,
                                  gaussian_weights, full, **kwargs)
 
+
 if structural_similarity.__doc__ is not None:
     compare_ssim.__doc__ = structural_similarity.__doc__ + """
+
     Warns
     -----
     Deprecated:
-        As of scikit-image 0.16, this function is deprecated and will be removed
-        in scikit-image 0.18. Please use the function named
+        .. versionadded:: 0.16
+
+        This function is deprecated and will be
+        removed in scikit-image 0.18. Please use the function named
         ``structural_similarity`` from the ``metrics`` module instead.
+
 
     See also
     --------

--- a/skimage/measure/_structural_similarity.py
+++ b/skimage/measure/_structural_similarity.py
@@ -7,76 +7,23 @@ __all__ = ['compare_ssim']
 def compare_ssim(X, Y, win_size=None, gradient=False,
                  data_range=None, multichannel=False, gaussian_weights=False,
                  full=False, **kwargs):
-    """Compute the mean structural similarity index between two images.
-
-    Parameters
-    ----------
-    X, Y : ndarray
-        Image. Any dimensionality.
-    win_size : int or None
-        The side-length of the sliding window used in comparison. Must be an
-        odd value. If `gaussian_weights` is True, this is ignored and the
-        window size will depend on `sigma`.
-    gradient : bool, optional
-        If True, also return the gradient with respect to Y.
-    data_range : float, optional
-        The data range of the input image (distance between minimum and
-        maximum possible values). By default, this is estimated from the image
-        data-type.
-    multichannel : bool, optional
-        If True, treat the last dimension of the array as channels. Similarity
-        calculations are done independently for each channel then averaged.
-    gaussian_weights : bool, optional
-        If True, each patch has its mean and variance spatially weighted by a
-        normalized Gaussian kernel of width sigma=1.5.
-    full : bool, optional
-        If True, also return the full structural similarity image.
-
-    Other Parameters
-    ----------------
-    use_sample_covariance : bool
-        If True, normalize covariances by N-1 rather than, N where N is the
-        number of pixels within the sliding window.
-    K1 : float
-        Algorithm parameter, K1 (small constant, see [1]_).
-    K2 : float
-        Algorithm parameter, K2 (small constant, see [1]_).
-    sigma : float
-        Standard deviation for the Gaussian when `gaussian_weights` is True.
-
-    Returns
-    -------
-    mssim : float
-        The mean structural similarity over the image.
-    grad : ndarray
-        The gradient of the structural similarity index between X and Y [2]_.
-        This is only returned if `gradient` is set to True.
-    S : ndarray
-        The full SSIM image.  This is only returned if `full` is set to True.
-
-    Notes
-    -----
-    To match the implementation of Wang et. al. [1]_, set `gaussian_weights`
-    to True, `sigma` to 1.5, and `use_sample_covariance` to False.
-
-    References
-    ----------
-    .. [1] Wang, Z., Bovik, A. C., Sheikh, H. R., & Simoncelli, E. P.
-       (2004). Image quality assessment: From error visibility to
-       structural similarity. IEEE Transactions on Image Processing,
-       13, 600-612.
-       https://ece.uwaterloo.ca/~z70wang/publications/ssim.pdf,
-       :DOI:`10.1109/TIP.2003.819861`
-
-    .. [2] Avanaki, A. N. (2009). Exact global histogram specification
-       optimized for structural similarity. Optical Review, 16, 613-621.
-       :arXiv:`0901.0065`
-       :DOI:`10.1007/s10043-009-0119-z`
-
-    """
     warn('DEPRECATED: skimage.measure.compare_ssim has been moved to '
          'skimage.metrics.structural_similarity. It will be removed from '
          'skimage.measure in version 0.18.', stacklevel=2)
     return structural_similarity(X, Y, win_size, gradient,
                                  data_range, multichannel,
                                  gaussian_weights, full, **kwargs)
+
+if structural_similarity.__doc__ is not None:
+    compare_ssim.__doc__ = structural_similarity.__doc__ + """
+    Warns
+    -----
+    Deprecated:
+        As of scikit-image 0.16, this function is deprecated and will be removed
+        in scikit-image 0.18. Please use the function named
+        ``structural_similarity`` from the ``metrics`` module instead.
+
+    See also
+    --------
+    skimage.metrics.structural_similarity
+    """

--- a/skimage/measure/_structural_similarity.py
+++ b/skimage/measure/_structural_similarity.py
@@ -1,5 +1,5 @@
+from warnings import warn
 from ..metrics._structural_similarity import structural_similarity
-from .._shared.utils import warn
 
 __all__ = ['compare_ssim']
 
@@ -76,7 +76,7 @@ def compare_ssim(X, Y, win_size=None, gradient=False,
     """
     warn('DEPRECATED: skimage.measure.compare_ssim has been moved to '
          'skimage.metrics.structural_similarity. It will be removed from '
-         'skimage.measure in version 0.18.')
+         'skimage.measure in version 0.18.', stacklevel=2)
     return structural_similarity(X, Y, win_size, gradient,
                                  data_range, multichannel,
                                  gaussian_weights, full, **kwargs)

--- a/skimage/measure/simple_metrics.py
+++ b/skimage/measure/simple_metrics.py
@@ -10,105 +10,65 @@ __all__ = ['compare_mse',
            ]
 
 
-def _as_floats(im1, im2):
-    """Promote im1, im2 to nearest appropriate floating point precision."""
-    float_type = np.result_type(im1.dtype, im2.dtype, np.float32)
-    im1 = np.asarray(im1, dtype=float_type)
-    im2 = np.asarray(im2, dtype=float_type)
-    return im1, im2
-
-
 def compare_mse(im1, im2):
-    """Compute the mean-squared error between two images.
-
-    Parameters
-    ----------
-    im_true : ndarray
-        Ground-truth image, same shape as im_test.
-    im_test : ndarray
-        Test image.
-
-    Returns
-    -------
-    mse : float
-        The mean-squared error (MSE) metric.
-
-    """
     warn('DEPRECATED: skimage.measure.compare_mse has been moved to '
          'skimage.metrics.mean_squared_error. It will be removed from '
          'skimage.measure in version 0.18.', stacklevel=2)
     return mean_squared_error(im1, im2)
 
+if mean_squared_error.__doc__ is not None:
+    compare_mse.__doc__ = mean_squared_error.__doc__ + """
+    Warns
+    -----
+    Deprecated:
+        As of scikit-image 0.16, this function is deprecated and will be removed
+        in scikit-image 0.18. Please use the function named
+        ``mean_squared_error`` from the ``metrics`` module instead.
+
+    See also
+    --------
+    skimage.metrics.mean_squared_error
+    """
+
 
 def compare_nrmse(im_true, im_test, norm_type='euclidean'):
-    """Compute the normalized root mean-squared error (NRMSE) between two
-    images.
-
-    Parameters
-    ----------
-    im_true : ndarray
-        Ground-truth image, same shape as im_test.
-    im_test : ndarray
-        Test image.
-    norm_type : {'euclidean', 'min-max', 'mean'}
-        Controls the normalization method to use in the denominator of the
-        NRMSE.  There is no standard method of normalization across the
-        literature [1]_.  The methods available here are as follows:
-
-        - 'euclidean' : normalize by the averaged Euclidean norm of
-          ``im_true``::
-
-              NRMSE = RMSE * sqrt(N) / || im_true ||
-
-          where || . || denotes the Frobenius norm and ``N = im_true.size``.
-          This result is equivalent to::
-
-              NRMSE = || im_true - im_test || / || im_true ||.
-
-        - 'min-max'   : normalize by the intensity range of ``im_true``.
-        - 'mean'      : normalize by the mean of ``im_true``
-
-    Returns
-    -------
-    nrmse : float
-        The NRMSE metric.
-
-    References
-    ----------
-    .. [1] https://en.wikipedia.org/wiki/Root-mean-square_deviation
-
-    """
     warn('DEPRECATED: skimage.measure.compare_nrmse has been moved to '
          'skimage.metrics.normalized_root_mse. It will be removed from '
          'skimage.measure in version 0.18.', stacklevel=2)
     return normalized_root_mse(im_true, im_test, norm_type=norm_type)
 
+if normalized_root_mse.__doc__ is not None:
+    compare_nrmse.__doc__ = normalized_root_mse.__doc__ + """
+    Warns
+    -----
+    Deprecated:
+        As of scikit-image 0.16, this function is deprecated and will be removed
+        in scikit-image 0.18. Please use the function named
+        ``normalized_root_mse`` from the ``metrics`` module instead.
+
+    See also
+    --------
+    skimage.metrics.normalized_root_mse
+    """
+
+
 
 def compare_psnr(im_true, im_test, data_range=None):
-    """ Compute the peak signal to noise ratio (PSNR) for an image.
-
-    Parameters
-    ----------
-    im_true : ndarray
-        Ground-truth image, same shape as im_test.
-    im_test : ndarray
-        Test image.
-    data_range : int
-        The data range of the input image (distance between minimum and
-        maximum possible values).  By default, this is estimated from the image
-        data-type.
-
-    Returns
-    -------
-    psnr : float
-        The PSNR metric.
-
-    References
-    ----------
-    .. [1] https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio
-
-    """
     warn('DEPRECATED: skimage.measure.compare_psnr has been moved to '
          'skimage.metrics.peak_signal_noise_ratio. It will be removed from '
          'skimage.measure in version 0.18.', stacklevel=2)
     return peak_signal_noise_ratio(im_true, im_test, data_range=data_range)
+
+if peak_signal_noise_ratio.__doc__ is not None:
+    compare_psnr.__doc__ = peak_signal_noise_ratio.__doc__ + """
+    Warns
+    -----
+    Deprecated:
+        As of scikit-image 0.16, this function is deprecated and will be removed
+        in scikit-image 0.18. Please use the function named
+        ``peak_signal_noise_ratio`` from the ``metrics`` module instead.
+
+    See also
+    --------
+    skimage.metrics.peak_signal_noise_ratio
+    """

--- a/skimage/measure/simple_metrics.py
+++ b/skimage/measure/simple_metrics.py
@@ -58,7 +58,6 @@ if normalized_root_mse.__doc__ is not None:
     """
 
 
-
 def compare_psnr(im_true, im_test, data_range=None):
     warn('DEPRECATED: skimage.measure.compare_psnr has been moved to '
          'skimage.metrics.peak_signal_noise_ratio. It will be removed from '

--- a/skimage/measure/simple_metrics.py
+++ b/skimage/measure/simple_metrics.py
@@ -1,9 +1,8 @@
-
+from warnings import warn
 import numpy as np
 from ..metrics.simple_metrics import (mean_squared_error,
                                        peak_signal_noise_ratio,
                                        normalized_root_mse)
-from .._shared.utils import warn
 
 __all__ = ['compare_mse',
            'compare_nrmse',
@@ -37,7 +36,7 @@ def compare_mse(im1, im2):
     """
     warn('DEPRECATED: skimage.measure.compare_mse has been moved to '
          'skimage.metrics.mean_squared_error. It will be removed from '
-         'skimage.measure in version 0.18.')
+         'skimage.measure in version 0.18.', stacklevel=2)
     return mean_squared_error(im1, im2)
 
 
@@ -81,7 +80,7 @@ def compare_nrmse(im_true, im_test, norm_type='euclidean'):
     """
     warn('DEPRECATED: skimage.measure.compare_nrmse has been moved to '
          'skimage.metrics.normalized_root_mse. It will be removed from '
-         'skimage.measure in version 0.18.')
+         'skimage.measure in version 0.18.', stacklevel=2)
     return normalized_root_mse(im_true, im_test, norm_type=norm_type)
 
 
@@ -111,5 +110,5 @@ def compare_psnr(im_true, im_test, data_range=None):
     """
     warn('DEPRECATED: skimage.measure.compare_psnr has been moved to '
          'skimage.metrics.peak_signal_noise_ratio. It will be removed from '
-         'skimage.measure in version 0.18.')
+         'skimage.measure in version 0.18.', stacklevel=2)
     return peak_signal_noise_ratio(im_true, im_test, data_range=data_range)

--- a/skimage/measure/simple_metrics.py
+++ b/skimage/measure/simple_metrics.py
@@ -16,14 +16,17 @@ def compare_mse(im1, im2):
          'skimage.measure in version 0.18.', stacklevel=2)
     return mean_squared_error(im1, im2)
 
+
 if mean_squared_error.__doc__ is not None:
     compare_mse.__doc__ = mean_squared_error.__doc__ + """
     Warns
     -----
     Deprecated:
-        As of scikit-image 0.16, this function is deprecated and will be removed
-        in scikit-image 0.18. Please use the function named
-        ``mean_squared_error`` from the ``metrics`` module instead.
+        .. versionadded:: 0.16
+
+        This function is deprecated and will be removed in scikit-image 0.18.
+        Please use the function named ``mean_squared_error`` from the
+        ``metrics`` module instead.
 
     See also
     --------
@@ -37,14 +40,17 @@ def compare_nrmse(im_true, im_test, norm_type='euclidean'):
          'skimage.measure in version 0.18.', stacklevel=2)
     return normalized_root_mse(im_true, im_test, norm_type=norm_type)
 
+
 if normalized_root_mse.__doc__ is not None:
     compare_nrmse.__doc__ = normalized_root_mse.__doc__ + """
     Warns
     -----
     Deprecated:
-        As of scikit-image 0.16, this function is deprecated and will be removed
-        in scikit-image 0.18. Please use the function named
-        ``normalized_root_mse`` from the ``metrics`` module instead.
+        .. versionadded:: 0.16
+
+        This function is deprecated and will be removed in scikit-image 0.18.
+        Please use the function named ``normalized_root_mse`` from the
+        ``metrics`` module instead.
 
     See also
     --------
@@ -59,14 +65,17 @@ def compare_psnr(im_true, im_test, data_range=None):
          'skimage.measure in version 0.18.', stacklevel=2)
     return peak_signal_noise_ratio(im_true, im_test, data_range=data_range)
 
+
 if peak_signal_noise_ratio.__doc__ is not None:
     compare_psnr.__doc__ = peak_signal_noise_ratio.__doc__ + """
     Warns
     -----
     Deprecated:
-        As of scikit-image 0.16, this function is deprecated and will be removed
-        in scikit-image 0.18. Please use the function named
-        ``peak_signal_noise_ratio`` from the ``metrics`` module instead.
+        .. versionadded:: 0.16
+
+        This function is deprecated and will be removed in scikit-image 0.18.
+        Please use the function named ``peak_signal_noise_ratio`` from the
+        ``metrics`` module instead.
 
     See also
     --------

--- a/skimage/measure/tests/test_simple_metrics.py
+++ b/skimage/measure/tests/test_simple_metrics.py
@@ -1,7 +1,9 @@
 import numpy as np
 
 import skimage.data
-from skimage.measure import compare_psnr, compare_nrmse, compare_mse
+from skimage.metrics import peak_signal_noise_ratio
+from skimage.metrics import normalized_root_mse
+from skimage.metrics import mean_squared_error
 
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_almost_equal
@@ -19,62 +21,59 @@ def test_PSNR_vs_IPOL():
     # Tests vs. imdiff result from the following IPOL article and code:
     # https://www.ipol.im/pub/art/2011/g_lmii/
     p_IPOL = 22.4497
-    p = compare_psnr(cam, cam_noisy)
+    p = peak_signal_noise_ratio(cam, cam_noisy)
     assert_almost_equal(p, p_IPOL, decimal=4)
 
 
 def test_PSNR_float():
-    p_uint8 = compare_psnr(cam, cam_noisy)
-    p_float64 = compare_psnr(cam / 255., cam_noisy / 255.,
-                             data_range=1)
+    p_uint8 = peak_signal_noise_ratio(cam, cam_noisy)
+    p_float64 = peak_signal_noise_ratio(cam / 255., cam_noisy / 255.,
+                                        data_range=1)
     assert_almost_equal(p_uint8, p_float64, decimal=5)
 
     # mixed precision inputs
-    p_mixed = compare_psnr(cam / 255., np.float32(cam_noisy / 255.),
-                           data_range=1)
+    p_mixed = peak_signal_noise_ratio(cam / 255., np.float32(cam_noisy / 255.),
+                                      data_range=1)
     assert_almost_equal(p_mixed, p_float64, decimal=5)
 
     # mismatched dtype results in a warning if data_range is unspecified
-    with expected_warnings(['Inputs have mismatched dtype', ''.join([
-            'DEPRECATED: skimage.measure.compare_psnr has been moved to ',
-            'skimage.metrics.peak_signal_noise_ratio. It will be removed ',
-            'from skimage.measure in version 0.18.'])]):
-        p_mixed = compare_psnr(cam / 255., np.float32(cam_noisy / 255.))
+    with expected_warnings(['Inputs have mismatched dtype']):
+        p_mixed = peak_signal_noise_ratio(cam / 255., np.float32(cam_noisy / 255.))
     assert_almost_equal(p_mixed, p_float64, decimal=5)
 
 
 def test_PSNR_errors():
     # shape mismatch
     with testing.raises(ValueError):
-        compare_psnr(cam, cam[:-1, :])
+        peak_signal_noise_ratio(cam, cam[:-1, :])
 
 
 def test_NRMSE():
     x = np.ones(4)
     y = np.asarray([0., 2., 2., 2.])
-    assert_equal(compare_nrmse(y, x, 'mean'), 1/np.mean(y))
-    assert_equal(compare_nrmse(y, x, 'Euclidean'), 1/np.sqrt(3))
-    assert_equal(compare_nrmse(y, x, 'min-max'), 1/(y.max()-y.min()))
+    assert_equal(normalized_root_mse(y, x, 'mean'), 1/np.mean(y))
+    assert_equal(normalized_root_mse(y, x, 'Euclidean'), 1/np.sqrt(3))
+    assert_equal(normalized_root_mse(y, x, 'min-max'), 1/(y.max()-y.min()))
 
     # mixed precision inputs are allowed
-    assert_almost_equal(compare_nrmse(y, np.float32(x), 'min-max'),
+    assert_almost_equal(normalized_root_mse(y, np.float32(x), 'min-max'),
                         1 / (y.max() - y.min()))
 
 
 def test_NRMSE_no_int_overflow():
     camf = cam.astype(np.float32)
     cam_noisyf = cam_noisy.astype(np.float32)
-    assert_almost_equal(compare_mse(cam, cam_noisy),
-                        compare_mse(camf, cam_noisyf))
-    assert_almost_equal(compare_nrmse(cam, cam_noisy),
-                        compare_nrmse(camf, cam_noisyf))
+    assert_almost_equal(mean_squared_error(cam, cam_noisy),
+                        mean_squared_error(camf, cam_noisyf))
+    assert_almost_equal(normalized_root_mse(cam, cam_noisy),
+                        normalized_root_mse(camf, cam_noisyf))
 
 
 def test_NRMSE_errors():
     x = np.ones(4)
     # shape mismatch
     with testing.raises(ValueError):
-        compare_nrmse(x[:-1], x)
+        normalized_root_mse(x[:-1], x)
     # invalid normalization name
     with testing.raises(ValueError):
-        compare_nrmse(x, x, 'foo')
+        normalized_root_mse(x, x, 'foo')

--- a/skimage/measure/tests/test_simple_metrics.py
+++ b/skimage/measure/tests/test_simple_metrics.py
@@ -38,7 +38,8 @@ def test_PSNR_float():
 
     # mismatched dtype results in a warning if data_range is unspecified
     with expected_warnings(['Inputs have mismatched dtype']):
-        p_mixed = peak_signal_noise_ratio(cam / 255., np.float32(cam_noisy / 255.))
+        p_mixed = peak_signal_noise_ratio(cam / 255.,
+                                          np.float32(cam_noisy / 255.))
     assert_almost_equal(p_mixed, p_float64, decimal=5)
 
 
@@ -51,9 +52,9 @@ def test_PSNR_errors():
 def test_NRMSE():
     x = np.ones(4)
     y = np.asarray([0., 2., 2., 2.])
-    assert_equal(normalized_root_mse(y, x, 'mean'), 1/np.mean(y))
-    assert_equal(normalized_root_mse(y, x, 'Euclidean'), 1/np.sqrt(3))
-    assert_equal(normalized_root_mse(y, x, 'min-max'), 1/(y.max()-y.min()))
+    assert_equal(normalized_root_mse(y, x, 'mean'), 1 / np.mean(y))
+    assert_equal(normalized_root_mse(y, x, 'Euclidean'), 1 / np.sqrt(3))
+    assert_equal(normalized_root_mse(y, x, 'min-max'), 1 / (y.max() - y.min()))
 
     # mixed precision inputs are allowed
     assert_almost_equal(normalized_root_mse(y, np.float32(x), 'min-max'),

--- a/skimage/measure/tests/test_structural_similarity.py
+++ b/skimage/measure/tests/test_structural_similarity.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 
 from skimage import data, data_dir
-from skimage.measure import compare_ssim as ssim
+from skimage.metrics import structural_similarity
 
 from skimage._shared import testing
 from skimage._shared._warnings import expected_warnings
@@ -18,42 +18,42 @@ cam_noisy = cam_noisy.astype(cam.dtype)
 np.random.seed(1234)
 
 
-def test_ssim_patch_range():
+def test_structural_similarity_patch_range():
     N = 51
     X = (np.random.rand(N, N) * 255).astype(np.uint8)
     Y = (np.random.rand(N, N) * 255).astype(np.uint8)
 
-    assert(ssim(X, Y, win_size=N) < 0.1)
-    assert_equal(ssim(X, X, win_size=N), 1)
+    assert(structural_similarity(X, Y, win_size=N) < 0.1)
+    assert_equal(structural_similarity(X, X, win_size=N), 1)
 
 
-def test_ssim_image():
+def test_structural_similarity_image():
     N = 100
     X = (np.random.rand(N, N) * 255).astype(np.uint8)
     Y = (np.random.rand(N, N) * 255).astype(np.uint8)
 
-    S0 = ssim(X, X, win_size=3)
+    S0 = structural_similarity(X, X, win_size=3)
     assert_equal(S0, 1)
 
-    S1 = ssim(X, Y, win_size=3)
+    S1 = structural_similarity(X, Y, win_size=3)
     assert(S1 < 0.3)
 
-    S2 = ssim(X, Y, win_size=11, gaussian_weights=True)
+    S2 = structural_similarity(X, Y, win_size=11, gaussian_weights=True)
     assert(S2 < 0.3)
 
-    mssim0, S3 = ssim(X, Y, full=True)
+    mssim0, S3 = structural_similarity(X, Y, full=True)
     assert_equal(S3.shape, X.shape)
-    mssim = ssim(X, Y)
+    mssim = structural_similarity(X, Y)
     assert_equal(mssim0, mssim)
 
     # ssim of image with itself should be 1.0
-    assert_equal(ssim(X, X), 1.0)
+    assert_equal(structural_similarity(X, X), 1.0)
 
 
 # Because we are forcing a random seed state, it is probably good to test
 # against a few seeds in case on seed gives a particularly bad example
 @testing.parametrize('seed', [1, 2, 3, 5, 8, 13])
-def test_ssim_grad(seed):
+def test_structural_similarity_grad(seed):
     N = 30
     # NOTE: This test is known to randomly fail on some systems (Mac OS X 10.6)
     #       And when testing tests in parallel. Therefore, we choose a few
@@ -67,66 +67,67 @@ def test_ssim_grad(seed):
     X = rnd.rand(N, N) * 255
     Y = rnd.rand(N, N) * 255
 
-    f = ssim(X, Y, data_range=255)
-    g = ssim(X, Y, data_range=255, gradient=True)
+    f = structural_similarity(X, Y, data_range=255)
+    g = structural_similarity(X, Y, data_range=255, gradient=True)
 
     assert f < 0.05
 
     assert g[0] < 0.05
     assert np.all(g[1] < 0.05)
 
-    mssim, grad, s = ssim(X, Y, data_range=255, gradient=True, full=True)
+    mssim, grad, s = structural_similarity(X, Y, data_range=255,
+                                           gradient=True, full=True)
     assert np.all(grad < 0.05)
 
 
-def test_ssim_dtype():
+def test_structural_similarity_dtype():
     N = 30
     X = np.random.rand(N, N)
     Y = np.random.rand(N, N)
 
-    S1 = ssim(X, Y)
+    S1 = structural_similarity(X, Y)
 
     X = (X * 255).astype(np.uint8)
     Y = (X * 255).astype(np.uint8)
 
-    S2 = ssim(X, Y)
+    S2 = structural_similarity(X, Y)
 
     assert S1 < 0.1
     assert S2 < 0.1
 
 
-def test_ssim_multichannel():
+def test_structural_similarity_multichannel():
     N = 100
     X = (np.random.rand(N, N) * 255).astype(np.uint8)
     Y = (np.random.rand(N, N) * 255).astype(np.uint8)
 
-    S1 = ssim(X, Y, win_size=3)
+    S1 = structural_similarity(X, Y, win_size=3)
 
     # replicate across three channels.  should get identical value
     Xc = np.tile(X[..., np.newaxis], (1, 1, 3))
     Yc = np.tile(Y[..., np.newaxis], (1, 1, 3))
-    S2 = ssim(Xc, Yc, multichannel=True, win_size=3)
+    S2 = structural_similarity(Xc, Yc, multichannel=True, win_size=3)
     assert_almost_equal(S1, S2)
 
     # full case should return an image as well
-    m, S3 = ssim(Xc, Yc, multichannel=True, full=True)
+    m, S3 = structural_similarity(Xc, Yc, multichannel=True, full=True)
     assert_equal(S3.shape, Xc.shape)
 
     # gradient case
-    m, grad = ssim(Xc, Yc, multichannel=True, gradient=True)
+    m, grad = structural_similarity(Xc, Yc, multichannel=True, gradient=True)
     assert_equal(grad.shape, Xc.shape)
 
     # full and gradient case
-    m, grad, S3 = ssim(Xc, Yc, multichannel=True, full=True, gradient=True)
+    m, grad, S3 = structural_similarity(Xc, Yc, multichannel=True, full=True, gradient=True)
     assert_equal(grad.shape, Xc.shape)
     assert_equal(S3.shape, Xc.shape)
 
     # fail if win_size exceeds any non-channel dimension
     with testing.raises(ValueError):
-        ssim(Xc, Yc, win_size=7, multichannel=False)
+        structural_similarity(Xc, Yc, win_size=7, multichannel=False)
 
 
-def test_ssim_nD():
+def test_structural_similarity_nD():
     # test 1D through 4D on small random arrays
     N = 10
     for ndim in range(1, 5):
@@ -134,11 +135,11 @@ def test_ssim_nD():
         X = (np.random.rand(*xsize) * 255).astype(np.uint8)
         Y = (np.random.rand(*xsize) * 255).astype(np.uint8)
 
-        mssim = ssim(X, Y, win_size=3)
+        mssim = structural_similarity(X, Y, win_size=3)
         assert mssim < 0.05
 
 
-def test_ssim_multichannel_chelsea():
+def test_structural_similarity_multichannel_chelsea():
     # color image example
     Xc = data.chelsea()
     sigma = 15.0
@@ -146,20 +147,21 @@ def test_ssim_multichannel_chelsea():
     Yc = Yc.astype(Xc.dtype)
 
     # multichannel result should be mean of the individual channel results
-    mssim = ssim(Xc, Yc, multichannel=True)
-    mssim_sep = [ssim(Yc[..., c], Xc[..., c]) for c in range(Xc.shape[-1])]
+    mssim = structural_similarity(Xc, Yc, multichannel=True)
+    mssim_sep = [structural_similarity(Yc[..., c], Xc[..., c])
+                 for c in range(Xc.shape[-1])]
     assert_almost_equal(mssim, np.mean(mssim_sep))
 
     # ssim of image with itself should be 1.0
-    assert_equal(ssim(Xc, Xc, multichannel=True), 1.0)
+    assert_equal(structural_similarity(Xc, Xc, multichannel=True), 1.0)
 
 
 def test_gaussian_mssim_vs_IPOL():
     # Tests vs. imdiff result from the following IPOL article and code:
     # https://www.ipol.im/pub/art/2011/g_lmii/
     mssim_IPOL = 0.327309966087341
-    mssim = ssim(cam, cam_noisy, gaussian_weights=True,
-                 use_sample_covariance=False)
+    mssim = structural_similarity(cam, cam_noisy, gaussian_weights=True,
+                                  use_sample_covariance=False)
     assert_almost_equal(mssim, mssim_IPOL, decimal=3)
 
 
@@ -174,8 +176,8 @@ def test_gaussian_mssim_vs_author_ref():
        mssim = ssim_index(img1, img2)
     """
     mssim_matlab = 0.327314295673357
-    mssim = ssim(cam, cam_noisy, gaussian_weights=True,
-                 use_sample_covariance=False)
+    mssim = structural_similarity(cam, cam_noisy, gaussian_weights=True,
+                                  use_sample_covariance=False)
     assert_almost_equal(mssim, mssim_matlab, decimal=10)
 
 
@@ -188,8 +190,9 @@ def test_gaussian_mssim_and_gradient_vs_Matlab():
     grad_matlab = ref['grad_matlab']
     mssim_matlab = float(ref['mssim_matlab'])
 
-    mssim, grad = ssim(cam, cam_noisy, gaussian_weights=True, gradient=True,
-                       use_sample_covariance=False)
+    mssim, grad = structural_similarity(cam, cam_noisy, gaussian_weights=True,
+                                        gradient=True,
+                                        use_sample_covariance=False)
 
     assert_almost_equal(mssim, mssim_matlab, decimal=3)
 
@@ -200,21 +203,18 @@ def test_gaussian_mssim_and_gradient_vs_Matlab():
 def test_mssim_vs_legacy():
     # check that ssim with default options matches skimage 0.11 result
     mssim_skimage_0pt11 = 0.34192589699605191
-    mssim = ssim(cam, cam_noisy)
+    mssim = structural_similarity(cam, cam_noisy)
     assert_almost_equal(mssim, mssim_skimage_0pt11)
 
 
 def test_mssim_mixed_dtype():
-    mssim = ssim(cam, cam_noisy)
-    with expected_warnings(['Inputs have mismatched dtype', ''.join([
-                    'DEPRECATED: skimage.measure.compare_ssim has been moved ',
-                    'to skimage.metrics.structural_similarity. It will be ',
-                    'removed from skimage.measure in version 0.18.'])]):
-        mssim_mixed = ssim(cam, cam_noisy.astype(np.float32))
+    mssim = structural_similarity(cam, cam_noisy)
+    with expected_warnings(['Inputs have mismatched dtype']):
+        mssim_mixed = structural_similarity(cam, cam_noisy.astype(np.float32))
     assert_almost_equal(mssim, mssim_mixed)
 
     # no warning when user supplies data_range
-    mssim_mixed = ssim(cam, cam_noisy.astype(np.float32), data_range=255)
+    mssim_mixed = structural_similarity(cam, cam_noisy.astype(np.float32), data_range=255)
     assert_almost_equal(mssim, mssim_mixed)
 
 
@@ -223,14 +223,15 @@ def test_invalid_input():
     X = np.zeros((9, 9), dtype=np.double)
     Y = np.zeros((8, 8), dtype=np.double)
     with testing.raises(ValueError):
-        ssim(X, Y)
+        structural_similarity(X, Y)
     # win_size exceeds image extent
     with testing.raises(ValueError):
-        ssim(X, X, win_size=X.shape[0] + 1)
+        structural_similarity(X, X, win_size=X.shape[0] + 1)
     # some kwarg inputs must be non-negative
     with testing.raises(ValueError):
-        ssim(X, X, K1=-0.1)
+        structural_similarity(X, X, K1=-0.1)
     with testing.raises(ValueError):
-        ssim(X, X, K2=-0.1)
+        structural_similarity(X, X, K2=-0.1)
     with testing.raises(ValueError):
-        ssim(X, X, sigma=-1.0)
+        structural_similarity(X, X, sigma=-1.0)
+

--- a/skimage/measure/tests/test_structural_similarity.py
+++ b/skimage/measure/tests/test_structural_similarity.py
@@ -118,7 +118,10 @@ def test_structural_similarity_multichannel():
     assert_equal(grad.shape, Xc.shape)
 
     # full and gradient case
-    m, grad, S3 = structural_similarity(Xc, Yc, multichannel=True, full=True, gradient=True)
+    m, grad, S3 = structural_similarity(Xc, Yc,
+                                        multichannel=True,
+                                        full=True,
+                                        gradient=True)
     assert_equal(grad.shape, Xc.shape)
     assert_equal(S3.shape, Xc.shape)
 
@@ -214,7 +217,8 @@ def test_mssim_mixed_dtype():
     assert_almost_equal(mssim, mssim_mixed)
 
     # no warning when user supplies data_range
-    mssim_mixed = structural_similarity(cam, cam_noisy.astype(np.float32), data_range=255)
+    mssim_mixed = structural_similarity(cam, cam_noisy.astype(np.float32),
+                                        data_range=255)
     assert_almost_equal(mssim, mssim_mixed)
 
 

--- a/skimage/metrics/_structural_similarity.py
+++ b/skimage/metrics/_structural_similarity.py
@@ -65,6 +65,10 @@ def structural_similarity(im1, im2, win_size=None, gradient=False,
     To match the implementation of Wang et. al. [1]_, set `gaussian_weights`
     to True, `sigma` to 1.5, and `use_sample_covariance` to False.
 
+    .. versionchanged:: 0.16
+        This function was renamed from ``skimage.measure.compare_ssim`` to
+        ``skimage.metrics.structural_similarity``.
+
     References
     ----------
     .. [1] Wang, Z., Bovik, A. C., Sheikh, H. R., & Simoncelli, E. P.

--- a/skimage/metrics/_structural_similarity.py
+++ b/skimage/metrics/_structural_similarity.py
@@ -1,4 +1,4 @@
-
+from warnings import warn
 import numpy as np
 from scipy.ndimage import uniform_filter, gaussian_filter
 
@@ -153,7 +153,7 @@ def structural_similarity(im1, im2, win_size=None, gradient=False,
     if data_range is None:
         if im1.dtype != im2.dtype:
             warn("Inputs have mismatched dtype.  Setting data_range based on "
-                 "im1.dtype.")
+                 "im1.dtype.", stacklevel=2)
         dmin, dmax = dtype_range[im1.dtype.type]
         data_range = dmax - dmin
 

--- a/skimage/metrics/simple_metrics.py
+++ b/skimage/metrics/simple_metrics.py
@@ -32,6 +32,12 @@ def mean_squared_error(im1, im2):
     mse : float
         The mean-squared error (MSE) metric.
 
+    Notes
+    -----
+    .. versionchanged:: 0.16
+        This function was renamed from ``skimage.measure.compare_mse`` to
+        ``skimage.metrics.mean_squared_error``.
+
     """
     check_shape_equality(im1, im2)
     im1, im2 = _as_floats(im1, im2)
@@ -71,6 +77,12 @@ def normalized_root_mse(im_true, im_test, norm_type='euclidean'):
     -------
     nrmse : float
         The NRMSE metric.
+
+    Notes
+    -----
+    .. versionchanged:: 0.16
+        This function was renamed from ``skimage.measure.compare_nrmse`` to
+        ``skimage.metrics.normalized_root_mse``.
 
     References
     ----------
@@ -112,6 +124,12 @@ def peak_signal_noise_ratio(im_true, im_test, data_range=None):
     -------
     psnr : float
         The PSNR metric.
+
+    Notes
+    -----
+    .. versionchanged:: 0.16
+        This function was renamed from ``skimage.measure.compare_psnr`` to
+        ``skimage.metrics.peak_singal_noise_ratio``.
 
     References
     ----------

--- a/skimage/metrics/simple_metrics.py
+++ b/skimage/metrics/simple_metrics.py
@@ -123,7 +123,7 @@ def peak_signal_noise_ratio(im_true, im_test, data_range=None):
     if data_range is None:
         if im_true.dtype != im_test.dtype:
             warn("Inputs have mismatched dtype.  Setting data_range based on "
-                 "im_true.")
+                 "im_true.", stacklevel=2)
         dmin, dmax = dtype_range[im_true.dtype.type]
         true_min, true_max = np.min(im_true), np.max(im_true)
         if true_max > dmax or true_min < dmin:

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -653,8 +653,9 @@ def test_cycle_spinning_multichannel():
                                                max_shifts=max_shifts,
                                                func_kw=func_kw,
                                                multichannel=multichannel)
-            assert_(peak_signal_noise_ratio(img, dn_cc) >
-                    peak_signal_noise_ratio(img, dn))
+            psnr = peak_signal_noise_ratio(img, dn)
+            psnr_cc = peak_signal_noise_ratio(img, dn_cc)
+            assert_(psnr_cc > psnr)
 
         for shift_steps in valid_steps:
             with expected_warnings([PYWAVELET_ND_INDEXING_WARNING,
@@ -664,8 +665,9 @@ def test_cycle_spinning_multichannel():
                                                shift_steps=shift_steps,
                                                func_kw=func_kw,
                                                multichannel=multichannel)
-            assert_(peak_signal_noise_ratio(img, dn_cc) >
-                    peak_signal_noise_ratio(img, dn))
+            psnr = peak_signal_noise_ratio(img, dn)
+            psnr_cc = peak_signal_noise_ratio(img, dn_cc)
+            assert_(psnr_cc > psnr)
 
         for max_shifts in invalid_shifts:
             with testing.raises(ValueError):

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -1,8 +1,9 @@
 import numpy as np
 import pytest
 
-from skimage import restoration, data, color, img_as_float, measure
-from skimage.measure import compare_psnr
+from skimage import restoration, data, color, img_as_float
+from skimage.metrics import structural_similarity
+from skimage.metrics import peak_signal_noise_ratio
 from skimage.restoration._denoise import _wavelet_threshold
 import pywt
 
@@ -130,8 +131,8 @@ def test_denoise_tv_chambolle_weighting():
     w = 0.2
     denoised_2d = restoration.denoise_tv_chambolle(img2d, weight=w)
     denoised_4d = restoration.denoise_tv_chambolle(img4d, weight=w)
-    assert_(measure.compare_ssim(denoised_2d,
-                                 denoised_4d[:, :, 0, 0]) > 0.99)
+    assert_(structural_similarity(denoised_2d,
+                                  denoised_4d[:, :, 0, 0]) > 0.99)
 
 
 def test_denoise_tv_bregman_2d():
@@ -300,15 +301,15 @@ def test_denoise_nl_means_2d_multichannel():
     for fast_mode in [True, False]:
         for s in [sigma, 0]:
             for n_channels in [2, 3, 6]:
-                psnr_noisy = compare_psnr(img[..., :n_channels],
-                                          imgn[..., :n_channels])
+                psnr_noisy = peak_signal_noise_ratio(img[..., :n_channels],
+                                                     imgn[..., :n_channels])
                 denoised = restoration.denoise_nl_means(imgn[..., :n_channels],
                                                         3, 5, h=0.75 * sigma,
                                                         fast_mode=fast_mode,
                                                         multichannel=True,
                                                         sigma=s)
-                psnr_denoised = compare_psnr(denoised[..., :n_channels],
-                                             img[..., :n_channels])
+                psnr_denoised = peak_signal_noise_ratio(
+                    denoised[..., :n_channels], img[..., :n_channels])
                 # make sure noise is reduced
                 assert_(psnr_denoised > psnr_noisy)
 
@@ -318,18 +319,18 @@ def test_denoise_nl_means_3d():
     img[5:-5, 5:-5, 2:-2] = 1.
     sigma = 0.3
     imgn = img + sigma * np.random.randn(*img.shape)
-    psnr_noisy = compare_psnr(img, imgn)
+    psnr_noisy = peak_signal_noise_ratio(img, imgn)
     for s in [sigma, 0]:
         denoised = restoration.denoise_nl_means(imgn, 3, 4, h=0.75 * sigma,
                                                 fast_mode=True,
                                                 multichannel=False, sigma=s)
         # make sure noise is reduced
-        assert_(compare_psnr(img, denoised) > psnr_noisy)
+        assert_(peak_signal_noise_ratio(img, denoised) > psnr_noisy)
         denoised = restoration.denoise_nl_means(imgn, 3, 4, h=0.75 * sigma,
                                                 fast_mode=False,
                                                 multichannel=False, sigma=s)
         # make sure noise is reduced
-        assert_(compare_psnr(img, denoised) > psnr_noisy)
+        assert_(peak_signal_noise_ratio(img, denoised) > psnr_noisy)
 
 
 def test_denoise_nl_means_multichannel():
@@ -342,8 +343,8 @@ def test_denoise_nl_means_multichannel():
         imgn, 3, 4, 0.6 * sigma, fast_mode=True, multichannel=True)
     denoised_ok_multichannel = restoration.denoise_nl_means(
         imgn, 3, 4, 0.6 * sigma, fast_mode=True, multichannel=False)
-    psnr_wrong = compare_psnr(img, denoised_wrong_multichannel)
-    psnr_ok = compare_psnr(img, denoised_ok_multichannel)
+    psnr_wrong = peak_signal_noise_ratio(img, denoised_wrong_multichannel)
+    psnr_ok = peak_signal_noise_ratio(img, denoised_ok_multichannel)
     assert_(psnr_ok > psnr_wrong)
 
 
@@ -386,8 +387,8 @@ def test_wavelet_denoising():
             denoised = restoration.denoise_wavelet(noisy, sigma=sigma,
                                                    multichannel=multichannel,
                                                    convert2ycbcr=convert2ycbcr)
-        psnr_noisy = compare_psnr(img, noisy)
-        psnr_denoised = compare_psnr(img, denoised)
+        psnr_noisy = peak_signal_noise_ratio(img, noisy)
+        psnr_denoised = peak_signal_noise_ratio(img, denoised)
         assert_(psnr_denoised > psnr_noisy)
 
         # Verify that SNR is improved with internally estimated sigma
@@ -395,8 +396,8 @@ def test_wavelet_denoising():
             denoised = restoration.denoise_wavelet(noisy,
                                                    multichannel=multichannel,
                                                    convert2ycbcr=convert2ycbcr)
-        psnr_noisy = compare_psnr(img, noisy)
-        psnr_denoised = compare_psnr(img, denoised)
+        psnr_noisy = peak_signal_noise_ratio(img, noisy)
+        psnr_denoised = peak_signal_noise_ratio(img, denoised)
         assert_(psnr_denoised > psnr_noisy)
 
         # SNR is improved less with 1 wavelet level than with the default.
@@ -404,7 +405,7 @@ def test_wavelet_denoising():
                                                  multichannel=multichannel,
                                                  wavelet_levels=1,
                                                  convert2ycbcr=convert2ycbcr)
-        psnr_denoised_1 = compare_psnr(img, denoised_1)
+        psnr_denoised_1 = peak_signal_noise_ratio(img, denoised_1)
         assert_(psnr_denoised > psnr_denoised_1)
         assert_(psnr_denoised_1 > psnr_noisy)
 
@@ -430,8 +431,8 @@ def test_wavelet_threshold():
     with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
         denoised = _wavelet_threshold(noisy, wavelet='db1', method=None,
                                       threshold=sigma)
-    psnr_noisy = compare_psnr(img, noisy)
-    psnr_denoised = compare_psnr(img, denoised)
+    psnr_noisy = peak_signal_noise_ratio(img, noisy)
+    psnr_denoised = peak_signal_noise_ratio(img, denoised)
     assert_(psnr_denoised > psnr_noisy)
 
     # either method or threshold must be defined
@@ -471,8 +472,8 @@ def test_wavelet_denoising_nd():
             with expected_warnings([anticipated_warnings]):
                 # Verify that SNR is improved with internally estimated sigma
                 denoised = restoration.denoise_wavelet(noisy, method=method)
-            psnr_noisy = compare_psnr(img, noisy)
-            psnr_denoised = compare_psnr(img, denoised)
+            psnr_noisy = peak_signal_noise_ratio(img, noisy)
+            psnr_denoised = peak_signal_noise_ratio(img, denoised)
             assert_(psnr_denoised > psnr_noisy)
 
 
@@ -498,9 +499,9 @@ def test_wavelet_denoising_levels():
         denoised = restoration.denoise_wavelet(noisy, wavelet=wavelet)
     denoised_1 = restoration.denoise_wavelet(noisy, wavelet=wavelet,
                                              wavelet_levels=1)
-    psnr_noisy = compare_psnr(img, noisy)
-    psnr_denoised = compare_psnr(img, denoised)
-    psnr_denoised_1 = compare_psnr(img, denoised_1)
+    psnr_noisy = peak_signal_noise_ratio(img, noisy)
+    psnr_denoised = peak_signal_noise_ratio(img, denoised)
+    psnr_denoised_1 = peak_signal_noise_ratio(img, denoised_1)
 
     # multi-level case should outperform single level case
     assert_(psnr_denoised > psnr_denoised_1 > psnr_noisy)
@@ -652,7 +653,8 @@ def test_cycle_spinning_multichannel():
                                                max_shifts=max_shifts,
                                                func_kw=func_kw,
                                                multichannel=multichannel)
-            assert_(compare_psnr(img, dn_cc) > compare_psnr(img, dn))
+            assert_(peak_signal_noise_ratio(img, dn_cc) >
+                    peak_signal_noise_ratio(img, dn))
 
         for shift_steps in valid_steps:
             with expected_warnings([PYWAVELET_ND_INDEXING_WARNING,
@@ -662,7 +664,8 @@ def test_cycle_spinning_multichannel():
                                                shift_steps=shift_steps,
                                                func_kw=func_kw,
                                                multichannel=multichannel)
-            assert_(compare_psnr(img, dn_cc) > compare_psnr(img, dn))
+            assert_(peak_signal_noise_ratio(img, dn_cc) >
+                    peak_signal_noise_ratio(img, dn))
 
         for max_shifts in invalid_shifts:
             with testing.raises(ValueError):


### PR DESCRIPTION
## Description
I think this PR should act as proof that we shouldn't hard deprecate the old names for these functions. 

It touches a ridiculous number of lines of code, just because we decided to change the name of a function.
It seems a little "flavor of the week" to me. If it is really just internal reorganization that we want, we shouldn't hard impose this on users...

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
