### PR TITLE
MNT: remove unused import `deprecated` from filters.threasholding

### DIFF
--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -5,7 +5,7 @@ from scipy import ndimage as ndi
 from collections import OrderedDict
 from collections.abc import Iterable
 from ..exposure import histogram
-from .._shared.utils import check_nD, warn, deprecated
+from .._shared.utils import check_nD, warn
 from ..transform import integral_image
 from ..util import crop, dtype_limits
 from ..filters._multiotsu import _find_threshold_multiotsu


### PR DESCRIPTION
## Description
xref https://github.com/scikit-image/scikit-image/pull/3467/

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
