### PR TITLE
MNT: remove extreneous matplotlib warning

### DIFF
--- a/skimage/viewer/plugins/overlayplugin.py
+++ b/skimage/viewer/plugins/overlayplugin.py
@@ -1,4 +1,3 @@
-from warnings import warn
 
 from ...util.dtype import dtype_range
 from .base import Plugin
@@ -32,9 +31,6 @@ class OverlayPlugin(Plugin):
               'cyan': (0, 1, 1)}
 
     def __init__(self, **kwargs):
-        if not is_installed('matplotlib', '>=1.2'):
-            msg = "Matplotlib >= 1.2 required for OverlayPlugin."
-            warn(RuntimeWarning(msg))
         super(OverlayPlugin, self).__init__(**kwargs)
         self._overlay_plot = None
         self._overlay = None


### PR DESCRIPTION
## Description

We depend on newer matplotlib version.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
