### PR TITLE
fix boundary condition when calculating Haar features

### DIFF
--- a/skimage/feature/_haar.pyx
+++ b/skimage/feature/_haar.pyx
@@ -43,8 +43,8 @@ cdef vector[vector[Rectangle]] _haar_like_feature_coord(
 
     for y in range(height):
         for x in range(width):
-            for dy in range(1, height):
-                for dx in range(1, width):
+            for dy in range(1, height + 1):
+                for dx in range(1, width + 1):
                     # type -> 2 rectangles split along x axis
                     if (feature_type == 0 and
                             (y + dy <= height and x + 2 * dx <= width)):


### PR DESCRIPTION
## Description

Fix boundary condition when calculating Haar features

Current # of Haar features is wrong. It can be verified by 2 ways

1. check 2 rectangle horizontal.
https://en.wikipedia.org/wiki/Haar-like_feature
```
feature_types = ['type-2-x']
# Extract all possible features
feature_coord, feature_type = \
   haar_like_feature_coord(width=2, height=1,
                           feature_type=feature_types)
print('feature_coord.sahpe ', feature_coord.shape)
```
**Notice that we should have # = 1 for this case but get 0 now.**

2. 

```
# Extract all possible features
feature_coord, feature_type = \
   haar_like_feature_coord(width=2, height=24,
                           feature_type=None)
print('feature_coord.sahpe ', feature_coord.shape)
```

Please refer to:
https://stackoverflow.com/questions/1707620/viola-jones-face-detection-claims-180k-features
**The correct result should be 162,336.**
**However, current results is 161864,**

**The problem is we miss the largest height(or width) since for python,
for for dy in range(1, height) does NOT include height.**

## Result
Apply this fix, both test cases are correct.
