### PR TITLE
docs update for downscale_local_mean and N-dimensional images

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -20,9 +20,9 @@ def resize(image, output_shape, order=1, mode='reflect', cval=0, clip=True,
            preserve_range=False, anti_aliasing=True, anti_aliasing_sigma=None):
     """Resize image to match a certain size.
 
-    Performs interpolation to up-size or down-size images. Note that anti-
+    Performs interpolation to up-size or down-size N-dimensional images. Note that anti-
     aliasing should be enabled when down-sizing images to avoid aliasing
-    artifacts. For down-sampling N-dimensional images with an integer factor
+    artifacts. For down-sampling with an integer factor
     also see `skimage.transform.downscale_local_mean`.
 
     Parameters
@@ -189,9 +189,9 @@ def rescale(image, scale, order=1, mode='reflect', cval=0, clip=True,
             anti_aliasing=True, anti_aliasing_sigma=None):
     """Scale image by a certain factor.
 
-    Performs interpolation to up-scale or down-scale images. Note that anti-
+    Performs interpolation to up-scale or down-scale N-dimensional images. Note that anti-
     aliasing should be enabled when down-sizing images to avoid aliasing
-    artifacts. For down-sampling N-dimensional images with an integer factor
+    artifacts. For down-sampling with an integer factor
     also see `skimage.transform.downscale_local_mean`.
 
     Parameters
@@ -393,10 +393,9 @@ def downscale_local_mean(image, factors, cval=0, clip=True):
     The image is padded with `cval` if it is not perfectly divisible by the
     integer factors.
 
-    In contrast to the 2-D interpolation in `skimage.transform.resize` and
-    `skimage.transform.rescale` this function may be applied to N-dimensional
-    images and calculates the local mean of elements in each block of size
-    `factors` in the input image.
+    In contrast to interpolation in `skimage.transform.resize` and
+    `skimage.transform.rescale` this function calculates the local mean of
+    elements in each block of size `factors` in the input image.
 
     Parameters
     ----------

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -20,10 +20,10 @@ def resize(image, output_shape, order=1, mode='reflect', cval=0, clip=True,
            preserve_range=False, anti_aliasing=True, anti_aliasing_sigma=None):
     """Resize image to match a certain size.
 
-    Performs interpolation to up-size or down-size N-dimensional images. Note that anti-
-    aliasing should be enabled when down-sizing images to avoid aliasing
-    artifacts. For down-sampling with an integer factor
-    also see `skimage.transform.downscale_local_mean`.
+    Performs interpolation to up-size or down-size N-dimensional images. Note
+    that anti-aliasing should be enabled when down-sizing images to avoid
+    aliasing artifacts. For down-sampling with an integer factor also see
+    `skimage.transform.downscale_local_mean`.
 
     Parameters
     ----------
@@ -189,10 +189,10 @@ def rescale(image, scale, order=1, mode='reflect', cval=0, clip=True,
             anti_aliasing=True, anti_aliasing_sigma=None):
     """Scale image by a certain factor.
 
-    Performs interpolation to up-scale or down-scale N-dimensional images. Note that anti-
-    aliasing should be enabled when down-sizing images to avoid aliasing
-    artifacts. For down-sampling with an integer factor
-    also see `skimage.transform.downscale_local_mean`.
+    Performs interpolation to up-scale or down-scale N-dimensional images.
+    Note that anti-aliasing should be enabled when down-sizing images to avoid
+    aliasing artifacts. For down-sampling with an integer factor also see
+    `skimage.transform.downscale_local_mean`.
 
     Parameters
     ----------


### PR DESCRIPTION
## Description
Currently:
* `downscale_local_mean` documentation [says](https://github.com/scikit-image/scikit-image/blob/87830b081516b93dcb2e4a883483b4d895232066/skimage/transform/_warps.py#L396):
   >  In contrast to the 2-D interpolation in `skimage.transform.resize`

  which looks like `skimage.transform.resize` only actually works for 2D images. (Actually, higher-dimensional interpolation is possible since about 3b67c8204255757391b3a4f76e4cc778a6ad5072 .)

* `resize` & `rescale` documentation, effectively, only explicitly [mentions](https://github.com/scikit-image/scikit-image/blob/87830b081516b93dcb2e4a883483b4d895232066/skimage/transform/_warps.py#L25-L26) N-dimensional images when sending user to `downscale_local_mean` :
  > For down-sampling N-dimensional images with an integer factor also see `skimage.transform.downscale_local_mean`.  

   (I'm not saying this part is is not correct, but... This proved to be a bit misleading for a new user looking for a 3D image resize method, at the first glance.)

The minor changes, suggested here aim to resolve these ambiguities.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
