### PR TITLE
WIP: Allow regionprops to reuse objects

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -488,8 +488,9 @@ def _props_to_dict(regions, properties=('label', 'bbox'), separator='-'):
     return out
 
 
-def regionprops_table(label_image, intensity_image=None, cache=True,
-                      properties=('label', 'bbox'), separator='-'):
+def regionprops_table(label_image, intensity_image=None, *, cache=True,
+                      properties=('label', 'bbox'), separator='-',
+                      objects=None):
     """Find image properties and convert them into a dictionary
 
     Parameters
@@ -519,6 +520,10 @@ def regionprops_table(label_image, intensity_image=None, cache=True,
         Object columns are those that cannot be split in this way because the
         number of columns would change depending on the object. For example,
         ``image`` and ``coords``.
+    objects : list of slices, optional
+        Precomputed objects as given by :func:``scipy.ndimage.find_objects``.
+        This will accelerate calculation of regionprops when properties are
+        measured for different channels for the same objects.
 
     Returns
     -------
@@ -579,7 +584,7 @@ def regionprops_table(label_image, intensity_image=None, cache=True,
 
     """
     regions = regionprops(label_image, intensity_image=intensity_image,
-                          cache=cache)
+                          cache=cache, objects=objects)
     return _props_to_dict(regions, properties=properties, separator=separator)
 
 

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -583,7 +583,8 @@ def regionprops_table(label_image, intensity_image=None, cache=True,
     return _props_to_dict(regions, properties=properties, separator=separator)
 
 
-def regionprops(label_image, intensity_image=None, cache=True):
+def regionprops(label_image, intensity_image=None, cache=True,
+                *, objects=None):
     """Measure properties of labeled image regions.
 
     Parameters
@@ -604,6 +605,10 @@ def regionprops(label_image, intensity_image=None, cache=True):
         Determine whether to cache calculated properties. The computation is
         much faster for cached properties, whereas the memory consumption
         increases.
+    objects : list of slices, optional
+        Precomputed objects as given by :func:``scipy.ndimage.find_objects``.
+        This will accelerate calculation of regionprops when properties are
+        measured for different channels for the same objects.
 
     Returns
     -------
@@ -785,7 +790,9 @@ def regionprops(label_image, intensity_image=None, cache=True):
 
     regions = []
 
-    objects = ndi.find_objects(label_image)
+    if objects is None:
+        objects = ndi.find_objects(label_image)
+
     for i, sl in enumerate(objects):
         if sl is None:
             continue


### PR DESCRIPTION
## Description

If we want to measure regionprops with the same objects over multiple channels, it is wasteful to run `ndimage.find_objects` for each channel. The long term fix would be to add multichannel support, but this is more general anyway and raises fewer API issues.

CC @VolkerH

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
