### PR TITLE
Visual image comparison

### DIFF
--- a/doc/examples/applications/plot_image_comparison.py
+++ b/doc/examples/applications/plot_image_comparison.py
@@ -6,7 +6,7 @@ Visual image comparison
 
 """
 import matplotlib.pyplot as plt
-
+from matplotlib.gridspec import GridSpec
 
 from skimage import data, transform, exposure
 from skimage.util import compare_images
@@ -29,14 +29,20 @@ blend_rotated = compare_images(img1, img2, method='blend')
 # The checkerboard method alternates tiles from the first and the second
 # images.
 
-fig, ax = plt.subplots(ncols=3, figsize=(15, 5))
-ax[0].imshow(img1, cmap='gray')
-ax[0].set_title('Original')
-ax[1].imshow(img1_equalized, cmap='gray')
-ax[1].set_title('Equalized')
-ax[2].imshow(comp_equalized, cmap='gray')
-ax[2].set_title('Checkerboard comparison')
-for a in ax:
+fig = plt.figure(figsize=(8, 9))
+
+gs = GridSpec(3, 2)
+ax0 = fig.add_subplot(gs[0, 0])
+ax1 = fig.add_subplot(gs[0, 1])
+ax2 = fig.add_subplot(gs[1:, :])
+
+ax0.imshow(img1, cmap='gray')
+ax0.set_title('Original')
+ax1.imshow(img1_equalized, cmap='gray')
+ax1.set_title('Equalized')
+ax2.imshow(comp_equalized, cmap='gray')
+ax2.set_title('Checkerboard comparison')
+for a in (ax0, ax1, ax2):
     a.axis('off')
 plt.tight_layout()
 plt.plot()
@@ -46,7 +52,22 @@ plt.plot()
 # ====
 #
 
-plt.imshow(diff_rotated, cmap='gray')
+fig = plt.figure(figsize=(8, 9))
+
+gs = GridSpec(3, 2)
+ax0 = fig.add_subplot(gs[0, 0])
+ax1 = fig.add_subplot(gs[0, 1])
+ax2 = fig.add_subplot(gs[1:, :])
+
+ax0.imshow(img1, cmap='gray')
+ax0.set_title('Original')
+ax1.imshow(img1_equalized, cmap='gray')
+ax1.set_title('Rotated')
+ax2.imshow(diff_rotated, cmap='gray')
+ax2.set_title('Diff comparison')
+for a in (ax0, ax1, ax2):
+    a.axis('off')
+plt.tight_layout()
 plt.plot()
 
 ######################################################################
@@ -54,5 +75,20 @@ plt.plot()
 # =====
 #
 
-plt.imshow(blend_rotated, cmap='gray')
+fig = plt.figure(figsize=(8, 9))
+
+gs = GridSpec(3, 2)
+ax0 = fig.add_subplot(gs[0, 0])
+ax1 = fig.add_subplot(gs[0, 1])
+ax2 = fig.add_subplot(gs[1:, :])
+
+ax0.imshow(img1, cmap='gray')
+ax0.set_title('Original')
+ax1.imshow(img1_equalized, cmap='gray')
+ax1.set_title('Rotated')
+ax2.imshow(blend_rotated, cmap='gray')
+ax2.set_title('Blend comparison')
+for a in (ax0, ax1, ax2):
+    a.axis('off')
+plt.tight_layout()
 plt.plot()

--- a/doc/examples/applications/plot_image_comparison.py
+++ b/doc/examples/applications/plot_image_comparison.py
@@ -3,6 +3,10 @@
 Visual image comparison
 =======================
 
+Image comparison is particularly useful when performing image processing tasks
+such as exposure manipulations, filtering, and restauration.
+
+This example shows how to easily compare two images with various approaches.
 
 """
 import matplotlib.pyplot as plt
@@ -26,7 +30,7 @@ blend_rotated = compare_images(img1, img2, method='blend')
 # Checkerboard
 # ============
 #
-# The checkerboard method alternates tiles from the first and the second
+# The `checkerboard` method alternates tiles from the first and the second
 # images.
 
 fig = plt.figure(figsize=(8, 9))
@@ -51,6 +55,7 @@ plt.plot()
 # Diff
 # ====
 #
+# The `diff` method computes the absolute difference between the two images.
 
 fig = plt.figure(figsize=(8, 9))
 
@@ -74,6 +79,7 @@ plt.plot()
 # Blend
 # =====
 #
+# `blend` is the result of the average of the two images.
 
 fig = plt.figure(figsize=(8, 9))
 

--- a/doc/examples/applications/plot_image_comparison.py
+++ b/doc/examples/applications/plot_image_comparison.py
@@ -1,0 +1,58 @@
+"""
+=======================
+Visual image comparison
+=======================
+
+
+"""
+import matplotlib.pyplot as plt
+
+
+from skimage import data, transform, exposure
+from skimage.util import compare_images
+
+
+img1 = data.coins()
+img1_equalized = exposure.equalize_hist(img1)
+img2 = transform.rotate(img1, 5)
+
+
+comp_equalized = compare_images(img1, img1_equalized, method='checkerboard')
+diff_rotated = compare_images(img1, img2, method='diff')
+blend_rotated = compare_images(img1, img2, method='blend')
+
+
+######################################################################
+# Checkerboard
+# ============
+#
+# The checkerboard method alternates tiles from the first and the second
+# images.
+
+fig, ax = plt.subplots(ncols=3, figsize=(15, 5))
+ax[0].imshow(img1, cmap='gray')
+ax[0].set_title('Original')
+ax[1].imshow(img1_equalized, cmap='gray')
+ax[1].set_title('Equalized')
+ax[2].imshow(comp_equalized, cmap='gray')
+ax[2].set_title('Checkerboard comparison')
+for a in ax:
+    a.axis('off')
+plt.tight_layout()
+plt.plot()
+
+######################################################################
+# Diff
+# ====
+#
+
+plt.imshow(diff_rotated, cmap='gray')
+plt.plot()
+
+######################################################################
+# Blend
+# =====
+#
+
+plt.imshow(blend_rotated, cmap='gray')
+plt.plot()

--- a/skimage/util/__init__.py
+++ b/skimage/util/__init__.py
@@ -6,6 +6,7 @@ from .noise import random_noise
 from .apply_parallel import apply_parallel
 
 from .arraycrop import crop
+from .compare import compare_images
 from ._regular_grid import regular_grid, regular_seeds
 from .unique import unique_rows
 from ._invert import invert
@@ -29,6 +30,7 @@ __all__ = ['img_as_float32',
            'view_as_windows',
            'pad',
            'crop',
+           'compare_images',
            'montage',
            'random_noise',
            'regular_grid',

--- a/skimage/util/compare.py
+++ b/skimage/util/compare.py
@@ -49,7 +49,7 @@ def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
         stepx = int(shapex / n_tiles[0])
         stepy = int(shapey / n_tiles[1])
         for i, j in product(range(n_tiles[0]), range(n_tiles[1])):
-            if (i+j) % 2 == 0:
+            if (i + j) % 2 == 0:
                 mask[i*stepx:(i+1)*stepx, j*stepy:(j+1)*stepy] = True
         comparison = np.zeros_like(img1)
         comparison[mask] = img1[mask]

--- a/skimage/util/compare.py
+++ b/skimage/util/compare.py
@@ -1,5 +1,5 @@
 import numpy as np
-from skimage import img_as_float64
+from ..util import img_as_float64
 from itertools import product
 
 

--- a/skimage/util/compare.py
+++ b/skimage/util/compare.py
@@ -15,7 +15,8 @@ def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
         Images to process, must be of the same shape.
     method : string, optional
         Method used for the comparison.
-        Valid values are {'diff', 'blend', 'checkerboard'}
+        Valid values are {'diff', 'blend', 'checkerboard'}.
+        Details are provided in the note section.
     n_tiles : tuple, optional
         Used only for the `checkerboard` method. Specifies the number
         of tiles (row, column) to divide the image.
@@ -24,6 +25,13 @@ def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
     -------
     comparison : 2-D array
         Image showing the differences.
+
+    Notes
+    -----
+    `diff` computes the absolute difference between the two images.
+    `bend` computes the mean value.
+    `checkerboard` makes tiles of dimension `n_tiles` that display
+    alternatively the first and the second image.
     """
     img1 = img_as_float64(image1)
     img2 = img_as_float64(image2)

--- a/skimage/util/compare.py
+++ b/skimage/util/compare.py
@@ -1,5 +1,5 @@
 import numpy as np
-from ..util import img_as_float64
+from ..util import img_as_float
 from itertools import product
 
 
@@ -38,8 +38,8 @@ def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
     if image1.dtype != image2.dtype:
         raise ValueError('Images must have the same dtype.')
 
-    img1 = img_as_float64(image1)
-    img2 = img_as_float64(image2)
+    img1 = img_as_float(image1)
+    img2 = img_as_float(image2)
 
     if method == 'diff':
         comparison = np.abs(img2 - img1)

--- a/skimage/util/compare.py
+++ b/skimage/util/compare.py
@@ -3,7 +3,7 @@ from ..util import img_as_float64
 from itertools import product
 
 
-def compare_images(image1, image2, method='diff'):
+def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
     """
     Return an image showing the differences between two images.
 
@@ -14,6 +14,9 @@ def compare_images(image1, image2, method='diff'):
     method : string, optional
         Method used for the comparison.
         Valid values are {'diff', 'blend', 'checkerboard'}
+    n_tiles : tuple, optional
+        Used only for the `checkerboard` method. Specifies the number
+        of tiles (row, column) to divide the image.
 
     Returns
     -------
@@ -28,12 +31,11 @@ def compare_images(image1, image2, method='diff'):
     elif method == 'blend':
         comparison = 0.5 * (img2 + img1)
     elif method == 'checkerboard':
-        num_box = 9
         shapex, shapey = img1.shape
         mask = np.full((shapex, shapey), False)
-        stepx = int(shapex / num_box)
-        stepy = int(shapey / num_box)
-        for i, j in product(range(num_box), range(num_box)):
+        stepx = int(shapex / n_tiles[0])
+        stepy = int(shapey / n_tiles[1])
+        for i, j in product(range(n_tiles[0]), range(n_tiles[1])):
             if (i+j) % 2 == 0:
                 mask[i*stepx:(i+1)*stepx, j*stepy:(j+1)*stepy] = True
         comparison = np.zeros_like(img1)

--- a/skimage/util/compare.py
+++ b/skimage/util/compare.py
@@ -50,7 +50,7 @@ def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
         stepy = int(shapey / n_tiles[1])
         for i, j in product(range(n_tiles[0]), range(n_tiles[1])):
             if (i + j) % 2 == 0:
-                mask[i*stepx:(i+1)*stepx, j*stepy:(j+1)*stepy] = True
+                mask[i * stepx:(i + 1)*stepx, j * stepy:(j + 1) * stepy] = True
         comparison = np.zeros_like(img1)
         comparison[mask] = img1[mask]
         comparison[~mask] = img2[~mask]

--- a/skimage/util/compare.py
+++ b/skimage/util/compare.py
@@ -7,6 +7,8 @@ def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
     """
     Return an image showing the differences between two images.
 
+    .. versionadded:: 0.16
+
     Parameters
     ----------
     image1, image2 : 2-D array

--- a/skimage/util/compare.py
+++ b/skimage/util/compare.py
@@ -1,0 +1,45 @@
+import numpy as np
+from skimage import img_as_float64
+from itertools import product
+
+
+def compare_images(image1, image2, method='diff'):
+    """
+    Return an image showing the differences between two images.
+
+    Parameters
+    ----------
+    image1, image2 : 2-D array
+        Images to process, must be of the same shape.
+    method : string, optional
+        Method used for the comparison.
+        Valid values are {'diff', 'blend', 'checkerboard'}
+
+    Returns
+    -------
+    comparison : 2-D array
+        Image showing the differences.
+    """
+    img1 = img_as_float64(image1)
+    img2 = img_as_float64(image2)
+
+    if method == 'diff':
+        comparison = np.abs(img2 - img1)
+    elif method == 'blend':
+        comparison = 0.5 * (img2 + img1)
+    elif method == 'checkerboard':
+        num_box = 9
+        shapex, shapey = img1.shape
+        mask = np.full((shapex, shapey), False)
+        stepx = int(shapex / num_box)
+        stepy = int(shapey / num_box)
+        for i, j in product(range(num_box), range(num_box)):
+            if (i+j) % 2 == 0:
+                mask[i*stepx:(i+1)*stepx, j*stepy:(j+1)*stepy] = True
+        comparison = np.zeros_like(img1)
+        comparison[mask] = img1[mask]
+        comparison[~mask] = img2[~mask]
+    else:
+        raise ValueError('Wrong value for `method`. '
+                         'Must be either "diff", "blend" or "checkerboard".')
+    return comparison

--- a/skimage/util/compare.py
+++ b/skimage/util/compare.py
@@ -12,7 +12,7 @@ def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
     Parameters
     ----------
     image1, image2 : 2-D array
-        Images to process, must be of the same shape and dtype.
+        Images to process, must be of the same shape.
     method : string, optional
         Method used for the comparison.
         Valid values are {'diff', 'blend', 'checkerboard'}.
@@ -35,8 +35,6 @@ def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
     """
     if image1.shape != image2.shape:
         raise ValueError('Images must have the same shape.')
-    if image1.dtype != image2.dtype:
-        raise ValueError('Images must have the same dtype.')
 
     img1 = img_as_float(image1)
     img2 = img_as_float(image2)

--- a/skimage/util/compare.py
+++ b/skimage/util/compare.py
@@ -12,7 +12,7 @@ def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
     Parameters
     ----------
     image1, image2 : 2-D array
-        Images to process, must be of the same shape.
+        Images to process, must be of the same shape and dtype.
     method : string, optional
         Method used for the comparison.
         Valid values are {'diff', 'blend', 'checkerboard'}.
@@ -33,6 +33,11 @@ def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
     `checkerboard` makes tiles of dimension `n_tiles` that display
     alternatively the first and the second image.
     """
+    if image1.shape != image2.shape:
+        raise ValueError('Images must have the same shape.')
+    if image1.dtype != image2.dtype:
+        raise ValueError('Images must have the same dtype.')
+
     img1 = img_as_float64(image1)
     img2 = img_as_float64(image2)
 

--- a/skimage/util/tests/test_compare.py
+++ b/skimage/util/tests/test_compare.py
@@ -5,11 +5,11 @@ from skimage.util.compare import compare_images
 
 
 def test_compare_images_diff():
-    img1 = np.zeros((10, 10), dtype=np.uint)
-    img1[3:8, 3:8] = 1
+    img1 = np.zeros((10, 10), dtype=np.uint8)
+    img1[3:8, 3:8] = 255
     img2 = np.zeros_like(img1)
-    img2[3:8, 0:8] = 1
-    expected_result = np.zeros_like(img1)
+    img2[3:8, 0:8] = 255
+    expected_result = np.zeros_like(img1, dtype=np.float64)
     expected_result[3:8, 0:3] = 1
     result = compare_images(img1, img2, method='diff')
     assert_array_equal(result, expected_result)

--- a/skimage/util/tests/test_compare.py
+++ b/skimage/util/tests/test_compare.py
@@ -53,7 +53,9 @@ def test_compare_images_checkerboard_tuple():
     img2 = np.full(img1.shape, fill_value=255, dtype=np.uint8)
     res = compare_images(img1, img2, method='checkerboard', n_tiles=(4, 8))
     exp_row1 = np.array([0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1.])
-    exp_row2 = np.array([1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0.])
+    exp_row2 = np.array(
+        [1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0.]
+    )
     for i in (0, 1, 2, 3, 8, 9, 10, 11):
         assert_array_equal(res[i, :], exp_row1)
     for i in (4, 5, 6, 7, 12, 13, 14, 15):

--- a/skimage/util/tests/test_compare.py
+++ b/skimage/util/tests/test_compare.py
@@ -13,13 +13,6 @@ def test_compate_images_ValueError_shape():
         compare_images(img1, img2)
 
 
-def test_compate_images_ValueError_dtype():
-    img1 = np.zeros((10, 10), dtype=np.uint8)
-    img2 = np.zeros((10, 10), dtype=np.uint16)
-    with testing.raises(ValueError):
-        compare_images(img1, img2)
-
-
 def test_compare_images_diff():
     img1 = np.zeros((10, 10), dtype=np.uint8)
     img1[3:8, 3:8] = 255

--- a/skimage/util/tests/test_compare.py
+++ b/skimage/util/tests/test_compare.py
@@ -52,7 +52,9 @@ def test_compare_images_checkerboard_tuple():
     img1 = np.zeros((2**4, 2**4), dtype=np.uint8)
     img2 = np.full(img1.shape, fill_value=255, dtype=np.uint8)
     res = compare_images(img1, img2, method='checkerboard', n_tiles=(4, 8))
-    exp_row1 = np.array([0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1.])
+    exp_row1 = np.array(
+        [0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1.]
+    )
     exp_row2 = np.array(
         [1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0.]
     )

--- a/skimage/util/tests/test_compare.py
+++ b/skimage/util/tests/test_compare.py
@@ -1,7 +1,23 @@
 import numpy as np
+
 from skimage._shared.testing import assert_array_equal
+from skimage._shared import testing
 
 from skimage.util.compare import compare_images
+
+
+def test_compate_images_ValueError_shape():
+    img1 = np.zeros((10, 10), dtype=np.uint8)
+    img2 = np.zeros((10, 1), dtype=np.uint8)
+    with testing.raises(ValueError):
+        compare_images(img1, img2)
+
+
+def test_compate_images_ValueError_dtype():
+    img1 = np.zeros((10, 10), dtype=np.uint8)
+    img2 = np.zeros((10, 10), dtype=np.uint16)
+    with testing.raises(ValueError):
+        compare_images(img1, img2)
 
 
 def test_compare_images_diff():
@@ -14,6 +30,7 @@ def test_compare_images_diff():
     result = compare_images(img1, img2, method='diff')
     assert_array_equal(result, expected_result)
 
+
 def test_compare_images_blend():
     img1 = np.zeros((10, 10), dtype=np.uint8)
     img1[3:8, 3:8] = 255
@@ -25,6 +42,7 @@ def test_compare_images_blend():
     result = compare_images(img1, img2, method='blend')
     assert_array_equal(result, expected_result)
 
+
 def test_compare_images_checkerboard_default():
     img1 = np.zeros((2**4, 2**4), dtype=np.uint8)
     img2 = np.full(img1.shape, fill_value=255, dtype=np.uint8)
@@ -35,6 +53,7 @@ def test_compare_images_checkerboard_default():
         assert_array_equal(res[i, :], exp_row1)
     for i in (2, 3, 6, 7, 10, 11, 14, 15):
         assert_array_equal(res[i, :], exp_row2)
+
 
 def test_compare_images_checkerboard_tuple():
     img1 = np.zeros((2**4, 2**4), dtype=np.uint8)

--- a/skimage/util/tests/test_compare.py
+++ b/skimage/util/tests/test_compare.py
@@ -13,3 +13,25 @@ def test_compare_images_diff():
     expected_result[3:8, 0:3] = 1
     result = compare_images(img1, img2, method='diff')
     assert_array_equal(result, expected_result)
+
+def test_compare_images_checkerboard_default():
+    img1 = np.zeros((2**4, 2**4), dtype=np.uint8)
+    img2 = np.full(img1.shape, fill_value=255, dtype=np.uint8)
+    res = compare_images(img1, img2, method='checkerboard')
+    exp_row1 = np.array([0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1.])
+    exp_row2 = np.array([1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0.])
+    for i in (0, 1, 4, 5, 8, 9, 12, 13):
+        assert_array_equal(res[i, :], exp_row1)
+    for i in (2, 3, 6, 7, 10, 11, 14, 15):
+        assert_array_equal(res[i, :], exp_row2)
+
+def test_compare_images_checkerboard_tuple():
+    img1 = np.zeros((2**4, 2**4), dtype=np.uint8)
+    img2 = np.full(img1.shape, fill_value=255, dtype=np.uint8)
+    res = compare_images(img1, img2, method='checkerboard', n_tiles=(4, 8))
+    exp_row1 = np.array([0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1.])
+    exp_row2 = np.array([1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0.])
+    for i in (0, 1, 2, 3, 8, 9, 10, 11):
+        assert_array_equal(res[i, :], exp_row1)
+    for i in (4, 5, 6, 7, 12, 13, 14, 15):
+        assert_array_equal(res[i, :], exp_row2)

--- a/skimage/util/tests/test_compare.py
+++ b/skimage/util/tests/test_compare.py
@@ -1,0 +1,15 @@
+import numpy as np
+from skimage._shared.testing import assert_array_equal
+
+from skimage.util.compare import compare_images
+
+
+def test_compare_images_diff():
+    img1 = np.zeros((10, 10), dtype=np.uint)
+    img1[3:8, 3:8] = 1
+    img2 = np.zeros_like(img1)
+    img2[3:8, 0:8] = 1
+    expected_result = np.zeros_like(img1)
+    expected_result[3:8, 0:3] = 1
+    result = compare_images(img1, img2, method='diff')
+    assert_array_equal(result, expected_result)

--- a/skimage/util/tests/test_compare.py
+++ b/skimage/util/tests/test_compare.py
@@ -14,6 +14,17 @@ def test_compare_images_diff():
     result = compare_images(img1, img2, method='diff')
     assert_array_equal(result, expected_result)
 
+def test_compare_images_blend():
+    img1 = np.zeros((10, 10), dtype=np.uint8)
+    img1[3:8, 3:8] = 255
+    img2 = np.zeros_like(img1)
+    img2[3:8, 0:8] = 255
+    expected_result = np.zeros_like(img1, dtype=np.float64)
+    expected_result[3:8, 3:8] = 1
+    expected_result[3:8, 0:3] = 0.5
+    result = compare_images(img1, img2, method='blend')
+    assert_array_equal(result, expected_result)
+
 def test_compare_images_checkerboard_default():
     img1 = np.zeros((2**4, 2**4), dtype=np.uint8)
     img2 = np.full(img1.shape, fill_value=255, dtype=np.uint8)


### PR DESCRIPTION
## Description

See #3736 for details.

Closes #3736

@lagru If you have any improvement from your version, feel free to make a PR on my branch.

![Visual image comparison — skimage v0 16 dev0 docs](https://user-images.githubusercontent.com/335370/63092188-34cb9180-bf61-11e9-9b2c-8c05307c1bd4.png)




## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
