### PR TITLE
Bugfix for documentation example: plot_active_contours.py

### DIFF
--- a/doc/examples/edges/plot_active_contours.py
+++ b/doc/examples/edges/plot_active_contours.py
@@ -39,11 +39,10 @@ img = rgb2gray(img)
 s = np.linspace(0, 2*np.pi, 400)
 r = 100 + 100*np.sin(s)
 c = 220 + 100*np.cos(s)
-init = np.array([r, c]).T
+init = np.array([c, r]).T
 
 snake = active_contour(gaussian(img, 3),
-                       init, alpha=0.015, beta=10, gamma=0.001,
-                       coordinates='rc')
+                       init, alpha=0.015, beta=10, gamma=0.001)
 
 fig, ax = plt.subplots(figsize=(7, 7))
 ax.imshow(img, cmap=plt.cm.gray)
@@ -64,11 +63,10 @@ img = data.text()
 
 r = np.linspace(136, 50, 100)
 c = np.linspace(5, 424, 100)
-init = np.array([r, c]).T
+init = np.array([c, r]).T
 
-snake = active_contour(gaussian(img, 1), init, boundary_condition='fixed',
-                       alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1,
-                       coordinates='rc')
+snake = active_contour(gaussian(img, 1), init, bc='fixed',
+                       alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1)
 
 fig, ax = plt.subplots(figsize=(9, 5))
 ax.imshow(img, cmap=plt.cm.gray)


### PR DESCRIPTION
Fixes the example at https://scikit-image.org/docs/dev/auto_examples/edges/plot_active_contours.html.

(I've tested it against 0.15.0; I don't know which version is used to generate the docs but I got the same incorrect result that is shown in the docs using 0.15.0 after fixing the keyword argument names.)

The inputs currently being used to generate the (linked) docs are transposed, causing the examples to look nonsensical at first. It looks like it is probably due to the removal of a `coordinates` argument.

The textual description already used the right argument names (which required changes), so no text needed updating.

## Description

Example bug fix

## Checklist

(Very few changes, so I'm assuming the below can all be checked.)
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
