### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,6 @@
 
 environment:
   matrix:
-    - PYTHON: C:\Python35-x64
     - PYTHON: C:\Python36
     - PYTHON: C:\Python36-x64
     - PYTHON: C:\Python37

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,5 @@
 # AppVeyor.com is a Continuous Integration service to build and run tests under
 # Windows
-
 environment:
   matrix:
     - PYTHON: C:\Python36

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,27 +43,33 @@ notifications:
 matrix:
   include:
     - os: linux
-      python: 3.5
+      python: 3.6
       env: OPTIONAL_DEPS=1 WITH_PYSIDE=1 BUILD_DOCS=1 INSTALL_FROM_SDIST=1
     - os: linux
-      python: 3.5
+      python: 3.6
       env: QT=PyQt5 MINIMUM_REQUIREMENTS=1
     - os: linux
-      python: 3.5
+      python: 3.6
       env: QT=PyQt5 OPTIONAL_DEPS=1 MINIMUM_REQUIREMENTS=1
     - os: linux
-      python: 3.6
-      env: QT=PyQt5 OPTIONAL_DEPS=1 BUILD_DOCS=1 DEPLOY_DOCS=1
-    - os: linux
       python: 3.7
-      dist: xenial # Required for Python 3.7
+      env: QT=PyQt5 OPTIONAL_DEPS=1 BUILD_DOCS=1 DEPLOY_DOCS=1
       sudo: true   # travis-ci/travis-ci#9069
-      env: QT=PyQt5 OPTIONAL_DEPS=1 BUILD_DOCS=1
       services:
         - xvfb
     - os: linux
-      python: 3.6
+      python: 3.8-dev
+      env: QT=PyQt5 OPTIONAL_DEPS=1 BUILD_DOCS=1
+      dist: xenial # Required for Python 3.7
+      sudo: true   # travis-ci/travis-ci#9069
+      services:
+        - xvfb
+    - os: linux
+      python: 3.7
       env: QT=PyQt5 OPTIONAL_DEPS=1 PIP_FLAGS="--pre"
+      sudo: true   # travis-ci/travis-ci#9069
+      services:
+        - xvfb
     # For smooth deployment, the osx_image here should match
     # what we set in the wheel generation travis images.
     # If not set, it will use the default version from Travis
@@ -71,14 +77,15 @@ matrix:
     - os: osx
       osx_image: xcode9.4
       language: objective-c
-      env: TRAVIS_PYTHON_VERSION=3.5
+      env: TRAVIS_PYTHON_VERSION=3.6
     - os: osx
       osx_image: xcode9.4
       language: objective-c
-      env: TRAVIS_PYTHON_VERSION=3.6 OPTIONAL_DEPS=1 EXTRA_DEPS=0
+      env: TRAVIS_PYTHON_VERSION=3.7 OPTIONAL_DEPS=1 EXTRA_DEPS=0
     - os: osx
       osx_image: xcode9.4
       language: objective-c
+      # Update this one to 3.8 when it becomes easier to install 3.8 on OSX
       env: TRAVIS_PYTHON_VERSION=3.7
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,19 +54,23 @@ matrix:
     - os: linux
       python: 3.7
       env: QT=PyQt5 OPTIONAL_DEPS=1 BUILD_DOCS=1 DEPLOY_DOCS=1
-      sudo: true   # travis-ci/travis-ci#9069
-      services:
-        - xvfb
-    - os: linux
-      python: 3.8-dev
-      env: QT=PyQt5 OPTIONAL_DEPS=1 BUILD_DOCS=1
       dist: xenial # Required for Python 3.7
       sudo: true   # travis-ci/travis-ci#9069
       services:
         - xvfb
+    # When 3.8 gets released, and dependencies have built wheels, enable
+    # this build
+    # - os: linux
+    #   python: 3.8
+    #   env: QT=PyQt5 OPTIONAL_DEPS=1 BUILD_DOCS=1
+    #   dist: xenial # Required for Python 3.7
+    #   sudo: true   # travis-ci/travis-ci#9069
+    #   services:
+    #     - xvfb
     - os: linux
       python: 3.7
       env: QT=PyQt5 OPTIONAL_DEPS=1 PIP_FLAGS="--pre"
+      dist: xenial # Required for Python 3.7
       sudo: true   # travis-ci/travis-ci#9069
       services:
         - xvfb
@@ -82,11 +86,12 @@ matrix:
       osx_image: xcode9.4
       language: objective-c
       env: TRAVIS_PYTHON_VERSION=3.7 OPTIONAL_DEPS=1 EXTRA_DEPS=0
-    - os: osx
-      osx_image: xcode9.4
-      language: objective-c
-      # Update this one to 3.8 when it becomes easier to install 3.8 on OSX
-      env: TRAVIS_PYTHON_VERSION=3.7
+    # When 3.8 gets released, and dependencies have built wheels, enable
+    # this build
+    # - os: osx
+    #   osx_image: xcode9.4
+    #   language: objective-c
+    #   env: TRAVIS_PYTHON_VERSION=3.8
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/TODO.txt
+++ b/TODO.txt
@@ -60,3 +60,7 @@ Other
   of `feature.blob_log` using the vectorized version of ``np.logspace``.
 * Remove conditional import of ``scipy.fft`` in ``skimage._shared.fft`` once
   the minimum supported version of ``scipy`` reaches 1.4.
+* When Python 3.8 is released, increment the version number on the last OSX
+  build to use Python 3.8 instead of 3.7.
+* When Python 3.8 is released, add entries to the build matrix in appveyor.
+* When Python 3.8 is released, add entries to the build matrix in azure.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,10 +8,6 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      Python35-x64:
-        PYTHON_VERSION: '3.5'
-        ARCH: 'x64'
-        PIP_FLAGS: ''
       Python36:
         PYTHON_VERSION: '3.6'
         ARCH: 'x86'

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -13,7 +13,7 @@ https://scikit-image.org
 
 
 This release of scikit-image drops support for Python 3.5.
-This release of scikit-image officially supports for Python 3.6 and 3.7.
+This release of scikit-image officially supports Python 3.6 and 3.7.
 
 New Features
 ------------

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -12,6 +12,8 @@ For more information, examples, and documentation, please visit our website:
 https://scikit-image.org
 
 
+This release of scikit-image drops support for Python 3.5.
+This release of scikit-image officially supports for Python 3.6 and 3.7.
 
 New Features
 ------------

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -11,8 +11,10 @@ For more information, examples, and documentation, please visit our website:
 
 https://scikit-image.org
 
-
-This release of scikit-image drops support for Python 3.5.
+Starting from this release, scikit-image will follow the spirit of the recently
+introduced numpy deprecation policy -- NEP 29
+(https://github.com/numpy/numpy/blob/master/doc/neps/nep-0029-deprecation_policy.rst). 
+Accordingly, scikit-image 0.16 drops the support for Python 3.5.
 This release of scikit-image officially supports Python 3.6 and 3.7.
 
 New Features

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,5 @@
 numpy>=1.13.3
-scipy>=0.17.0
+scipy>=0.19.0
 matplotlib>=2.0.0,!=3.0.0
 networkx>=2.0
 pillow>=4.3.0

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ if sys.version_info < (3, 6):
 
     error = """Python {py} detected.
 
-scikit-image 0.16+ support only Python 3.6 and above.
+scikit-image 0.16+ supports only Python 3.6 and above.
 
 For Python 2.7, please install the 0.14.x Long Term Support using:
 

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,11 @@ from distutils.errors import CompileError, LinkError
 from numpy.distutils.command.build_ext import build_ext
 
 
-if sys.version_info < (3, 5):
+if sys.version_info < (3, 6):
 
     error = """Python {py} detected.
 
-scikit-image 0.15+ support only Python 3.5 and above.
+scikit-image 0.16+ support only Python 3.6 and above.
 
 For Python 2.7, please install the 0.14.x Long Term Support using:
 
@@ -215,7 +215,6 @@ if __name__ == "__main__":
             'Programming Language :: C',
             'Programming Language :: Python',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3 :: Only',
@@ -228,7 +227,7 @@ if __name__ == "__main__":
         install_requires=INSTALL_REQUIRES,
         requires=REQUIRES,
         extras_require=extras_require,
-        python_requires='>=3.5',
+        python_requires='>=3.6',
         packages=setuptools.find_packages(exclude=['doc', 'benchmarks']),
         include_package_data=True,
         zip_safe=False,  # the package can run out of an .egg file


### PR DESCRIPTION
## Description

xref: https://github.com/numpy/numpy/pull/14086
closes https://github.com/scikit-image/scikit-image/issues/4100

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
