### PR TITLE
Fix typo in `compare_images` docstring

### DIFF
--- a/skimage/util/compare.py
+++ b/skimage/util/compare.py
@@ -29,7 +29,7 @@ def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
     Notes
     -----
     `diff` computes the absolute difference between the two images.
-    `bend` computes the mean value.
+    `blend` computes the mean value.
     `checkerboard` makes tiles of dimension `n_tiles` that display
     alternatively the first and the second image.
     """


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
