### PR TITLE
DOC: enhance the result display in ransac gallery example

### DIFF
--- a/doc/examples/transform/plot_matching.py
+++ b/doc/examples/transform/plot_matching.py
@@ -114,9 +114,24 @@ outliers = inliers == False
 
 
 # compare "true" and estimated transform parameters
-print(tform.scale, tform.translation, tform.rotation)
-print(model.scale, model.translation, model.rotation)
-print(model_robust.scale, model_robust.translation, model_robust.rotation)
+print("Ground truth:")
+print(f"Scale: ({tform.scale[1]:.4f}, {tform.scale[0]:.4f}), "
+      f"Translation: ({tform.translation[1]:.4f}, "
+      f"{tform.translation[0]:.4f}), "
+      f"Rotation: {-tform.rotation:.4f}"
+      )
+print("Affine transform:")
+print(f"Scale: ({model.scale[0]:.4f}, {model.scale[1]:.4f}), "
+      f"Translation: ({model.translation[0]:.4f}, "
+      f"{model.translation[1]:.4f}), "
+      f"Rotation: {model.rotation:.4f}"
+      )
+print("RANSAC:")
+print(f"Scale: ({model_robust.scale[0]:.4f}, {model_robust.scale[1]:.4f}), "
+      f"Translation: ({model_robust.translation[0]:.4f}, "
+      f"{model_robust.translation[1]:.4f}), "
+      f"Rotation: {model_robust.rotation:.4f}"
+      )
 
 # visualize correspondence
 fig, ax = plt.subplots(nrows=2, ncols=1)

--- a/doc/examples/transform/plot_matching.py
+++ b/doc/examples/transform/plot_matching.py
@@ -118,20 +118,17 @@ print("Ground truth:")
 print(f"Scale: ({tform.scale[1]:.4f}, {tform.scale[0]:.4f}), "
       f"Translation: ({tform.translation[1]:.4f}, "
       f"{tform.translation[0]:.4f}), "
-      f"Rotation: {-tform.rotation:.4f}"
-      )
+      f"Rotation: {-tform.rotation:.4f}")
 print("Affine transform:")
 print(f"Scale: ({model.scale[0]:.4f}, {model.scale[1]:.4f}), "
       f"Translation: ({model.translation[0]:.4f}, "
       f"{model.translation[1]:.4f}), "
-      f"Rotation: {model.rotation:.4f}"
-      )
+      f"Rotation: {model.rotation:.4f}")
 print("RANSAC:")
 print(f"Scale: ({model_robust.scale[0]:.4f}, {model_robust.scale[1]:.4f}), "
       f"Translation: ({model_robust.translation[0]:.4f}, "
       f"{model_robust.translation[1]:.4f}), "
-      f"Rotation: {model_robust.rotation:.4f}"
-      )
+      f"Rotation: {model_robust.rotation:.4f}")
 
 # visualize correspondence
 fig, ax = plt.subplots(nrows=2, ncols=1)


### PR DESCRIPTION
## Description

[This](https://scikit-image.org/docs/stable/auto_examples/transform/plot_matching.html#sphx-glr-auto-examples-transform-plot-matching-py) is now changed into this:
![Robust matching using RANSAC — skimage v0 16 dev0 docs](https://user-images.githubusercontent.com/335370/63633953-b0f46200-c650-11e9-96a3-ada40d53a5e5.png)


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
