### PR TITLE
Rename docstring section in data.__init__

### DIFF
--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -65,8 +65,8 @@ def load(f, as_gray=False):
     img : ndarray
         Image loaded from ``skimage.data_dir``.
 
-    Note
-    ----
+    Notes
+    -----
     This functions is deprecated and will be removed in 0.18.
     """
     warn('This function is deprecated and will be removed in 0.18. '


### PR DESCRIPTION
## Description

```
UserWarning: Unknown section Note in the docstring of <function load at 0x7fa2d0a5f9d8> in /home/travis/venv/lib/python3.7/site-packages/skimage/data/__init__.py.
```

See https://travis-ci.org/scikit-image/scikit-image/jobs/576393523#L4004-L4007.
<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
