### PR TITLE
Deprecate neighbors parameter in convex_hull_object

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -31,8 +31,10 @@ Version 0.18
 * `skimage/measure/tests/test_simple_metrics.py` should also be removed
 * make coordinates='rc' the default in ``segmentation.active_contour``
 * remove deprecated ``bc`` argument in ``segmentation.active_contour``
-* In ``skimage/meausre/_ccomp.label_cython`` remove the deprecated parameter
-  ``neighbors``.
+* In ``skimage/measure/_ccomp.label_cython`` remove the deprecated parameter
+  ``neighbors`` and update the tests.
+* In ``skimage/morphology/convex_hull.py`` remove the deprecated parameter
+  ``neighbors`` and update the tests.
 
 Other
 -----

--- a/TODO.txt
+++ b/TODO.txt
@@ -32,9 +32,11 @@ Version 0.18
 * make coordinates='rc' the default in ``segmentation.active_contour``
 * remove deprecated ``bc`` argument in ``segmentation.active_contour``
 * In ``skimage/measure/_ccomp.label_cython`` remove the deprecated parameter
-  ``neighbors`` and update the tests.
+  ``neighbors`` and update the tests. Set the default value of ``connectivity``
+  to 2.
 * In ``skimage/morphology/convex_hull.py`` remove the deprecated parameter
-  ``neighbors`` and update the tests.
+  ``neighbors`` and update the tests. Set the default value of ``connectivity``
+  to 2.
 
 Other
 -----

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -64,6 +64,8 @@ Bugfixes
 
 Deprecations
 ------------
+- Parameter ``neighbors`` in ``skimage.measure.convex_hull_object`` has been
+  deprecated in favor of ``connectivity`` and will be removed in version 0.18.0.
 
 
 Contributors to this release

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -10,12 +10,12 @@ def label(input, neighbors=None, background=None, return_num=False,
     The value refers to the maximum number of orthogonal hops to consider a
     pixel/voxel a neighbor::
 
-      1-connectivity      2-connectivity     diagonal connection close-up
+      1-connectivity     2-connectivity     diagonal connection close-up
 
-           [ ]           [ ]  [ ]  [ ]         [ ]
-            |               \  |  /             |  <- hop 2
-      [ ]--[x]--[ ]      [ ]--[x]--[ ]    [x]--[ ]
-            |               /  |  \         hop 1
+           [ ]           [ ]  [ ]  [ ]             [ ]
+            |               \  |  /                 |  <- hop 2
+      [ ]--[x]--[ ]      [ ]--[x]--[ ]        [x]--[ ]
+            |               /  |  \             hop 1
            [ ]           [ ]  [ ]  [ ]
 
     Parameters
@@ -26,7 +26,7 @@ def label(input, neighbors=None, background=None, return_num=False,
         Whether to use 4- or 8-"connectivity".
         In 3D, 4-"connectivity" means connected pixels have to share face,
         whereas with 8-"connectivity", they have to share only edge or vertex.
-        **Deprecated, use ``connectivity`` instead.**
+        **Deprecated, use** ``connectivity`` **instead.**
     background : int, optional
         Consider all pixels with this value as background pixels, and label
         them as 0. By default, 0-valued pixels are considered as background

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -93,7 +93,7 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10):
     return mask
 
 
-def convex_hull_object(image, neighbors=None, connectivity=None):
+def convex_hull_object(image, neighbors=None, *, connectivity=None):
     r"""Compute the convex hull image of individual objects in a binary image.
 
     The convex hull is the set of pixels included in the smallest convex

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -103,10 +103,10 @@ def convex_hull_object(image, neighbors=None, connectivity=None):
     ----------
     image : (M, N) ndarray
         Binary input image.
-    neighbors : {4, 8}, int
+    neighbors : {4, 8}, int, optional
         Whether to use 4 or 8 adjacent pixels as neighbors.
         If ``None``, set to 8. **Deprecated, use** ``connectivity`` **instead.**
-    connectivity : {1, 2}, int
+    connectivity : {1, 2}, int, optional
         Determines the neighbors of each pixel. Adjacent elements
         within a squared distance of ``connectivity`` from pixel center
         are considered neighbors. If ``None``, set to 2::
@@ -125,7 +125,7 @@ def convex_hull_object(image, neighbors=None, connectivity=None):
 
     Notes
     -----
-    This function uses `skimage.morphology.label` to define unique objects,
+    This function uses ``skimage.morphology.label`` to define unique objects,
     finds the convex hull of each using ``convex_hull_image``, and combines
     these regions with logical OR. Be aware the convex hulls of unconnected
     objects may overlap in the result. If this is suspected, consider using

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -93,40 +93,66 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10):
     return mask
 
 
-def convex_hull_object(image, neighbors=8):
-    """Compute the convex hull image of individual objects in a binary image.
+def convex_hull_object(image, neighbors=None, connectivity=None):
+    r"""Compute the convex hull image of individual objects in a binary image.
 
     The convex hull is the set of pixels included in the smallest convex
     polygon that surround all white pixels in the input image.
 
     Parameters
     ----------
-    image : (M, N) array
+    image : (M, N) ndarray
         Binary input image.
     neighbors : {4, 8}, int
-        Whether to use 4- or 8-connectivity.
+        Whether to use 4 or 8 adjacent pixels as neighbors.
+        If ``None``, set to 8. **Deprecated, use** ``connectivity`` **instead.**
+    connectivity : {1, 2}, int
+        Determines the neighbors of each pixel. Adjacent elements
+        within a squared distance of ``connectivity`` from pixel center
+        are considered neighbors. If ``None``, set to 2::
+
+            1-connectivity      2-connectivity
+                  [ ]           [ ]  [ ]  [ ]
+                   |               \  |  /
+             [ ]--[x]--[ ]      [ ]--[x]--[ ]
+                   |               /  |  \
+                  [ ]           [ ]  [ ]  [ ]
 
     Returns
     -------
     hull : ndarray of bool
-        Binary image with pixels in convex hull set to True.
+        Binary image with pixels inside convex hull set to ``True``.
 
     Notes
     -----
-    This function uses skimage.morphology.label to define unique objects,
-    finds the convex hull of each using convex_hull_image, and combines
+    This function uses `skimage.morphology.label` to define unique objects,
+    finds the convex hull of each using ``convex_hull_image``, and combines
     these regions with logical OR. Be aware the convex hulls of unconnected
     objects may overlap in the result. If this is suspected, consider using
-    convex_hull_image separately on each object.
-
+    convex_hull_image separately on each object or adjust ``connectivity``.
     """
     if image.ndim > 2:
         raise ValueError("Input must be a 2D image")
 
-    if neighbors != 4 and neighbors != 8:
-        raise ValueError('Neighbors must be either 4 or 8.')
+    if neighbors is None and connectivity is None:
+        connectivity = 2
+    elif neighbors is not None:
+        # Backward-compatibility
+        if neighbors == 4:
+            connectivity = 1
+        elif neighbors == 8:
+            connectivity = 2
+        else:
+            raise ValueError('`neighbors` must be either 4 or 8.')
+        warn("The argument `neighbors` is deprecated and will be removed in "
+             "scikit-image 0.18, use `connectivity` instead. "
+             "For neighbors={neighbors}, use connectivity={connectivity}"
+             "".format(neighbors=neighbors, connectivity=connectivity),
+             stacklevel=2)
+    else:
+        if connectivity not in (1, 2):
+            raise ValueError('`connectivity` must be either 1 or 2.')
 
-    connectivity = neighbors // 4
     labeled_im = label(image, connectivity=connectivity, background=0)
     convex_obj = np.zeros(image.shape, dtype=bool)
     convex_img = np.zeros(image.shape, dtype=bool)

--- a/skimage/morphology/tests/test_convex_hull.py
+++ b/skimage/morphology/tests/test_convex_hull.py
@@ -137,7 +137,7 @@ def test_object():
     with testing.raises(ValueError):
         convex_hull_object(image, connectivity=3)
 
-    with expected_warnings('`neighbors` is deprecated'):
+    with expected_warnings(['`neighbors` is deprecated']):
         convex_hull_object(image, neighbors=4)
 
 

--- a/skimage/morphology/tests/test_convex_hull.py
+++ b/skimage/morphology/tests/test_convex_hull.py
@@ -119,7 +119,7 @@ def test_object():
          [1, 0, 0, 0, 0, 0, 0, 0, 0],
          [0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=bool)
 
-    assert_array_equal(convex_hull_object(image, 4), expected4)
+    assert_array_equal(convex_hull_object(image, connectivity=1), expected4)
 
     expected8 = np.array(
         [[0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -132,10 +132,13 @@ def test_object():
          [1, 0, 0, 0, 0, 0, 0, 0, 0],
          [0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=bool)
 
-    assert_array_equal(convex_hull_object(image, 8), expected8)
+    assert_array_equal(convex_hull_object(image, connectivity=2), expected8)
 
     with testing.raises(ValueError):
-        convex_hull_object(image, 7)
+        convex_hull_object(image, connectivity=3)
+
+    with expected_warnings('`neighbors` is deprecated'):
+        convex_hull_object(image, neighbors=4)
 
 
 def test_non_c_contiguous():

--- a/skimage/morphology/tests/test_convex_hull.py
+++ b/skimage/morphology/tests/test_convex_hull.py
@@ -108,7 +108,7 @@ def test_object():
          [1, 0, 0, 0, 0, 0, 0, 0, 0],
          [0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=bool)
 
-    expected4 = np.array(
+    expected_conn_1 = np.array(
         [[0, 0, 0, 0, 0, 0, 0, 0, 0],
          [1, 0, 0, 0, 0, 0, 0, 0, 0],
          [1, 1, 0, 0, 0, 0, 0, 0, 0],
@@ -119,9 +119,10 @@ def test_object():
          [1, 0, 0, 0, 0, 0, 0, 0, 0],
          [0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=bool)
 
-    assert_array_equal(convex_hull_object(image, connectivity=1), expected4)
+    assert_array_equal(convex_hull_object(image, connectivity=1),
+                       expected_conn_1)
 
-    expected8 = np.array(
+    expected_conn_2 = np.array(
         [[0, 0, 0, 0, 0, 0, 0, 0, 0],
          [1, 0, 0, 0, 0, 0, 0, 0, 0],
          [1, 1, 0, 0, 0, 0, 0, 0, 0],
@@ -132,13 +133,15 @@ def test_object():
          [1, 0, 0, 0, 0, 0, 0, 0, 0],
          [0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=bool)
 
-    assert_array_equal(convex_hull_object(image, connectivity=2), expected8)
+    assert_array_equal(convex_hull_object(image, connectivity=2),
+                       expected_conn_2)
 
     with testing.raises(ValueError):
         convex_hull_object(image, connectivity=3)
 
     with expected_warnings(['`neighbors` is deprecated']):
-        convex_hull_object(image, neighbors=4)
+        out = convex_hull_object(image, neighbors=4)
+    assert_array_equal(out, expected_conn_1)
 
 
 def test_non_c_contiguous():


### PR DESCRIPTION
## Description

Closes #4075.
With this PR:
![image](https://user-images.githubusercontent.com/1315589/63649286-4fadbb00-c744-11e9-97c9-96bd30f55ab8.png)

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
