### PR TITLE
Gallery hough line transform

### DIFF
--- a/doc/examples/edges/plot_line_hough_transform.py
+++ b/doc/examples/edges/plot_line_hough_transform.py
@@ -23,9 +23,10 @@ the length of that segment, :math:`r`, and the angle it makes with the x-axis,
 The Hough transform constructs a histogram array representing the parameter
 space (i.e., an :math:`M \\times N` matrix, for :math:`M` different values of
 the radius and :math:`N` different values of :math:`\\theta`).  For each
-parameter combination, :math:`r` and :math:`\\theta`, we then find the number of
-non-zero pixels in the input image that would fall close to the corresponding
-line, and increment the array at position :math:`(r, \\theta)` appropriately.
+parameter combination, :math:`r` and :math:`\\theta`, we then find the number
+of non-zero pixels in the input image that would fall close to the
+corresponding line, and increment the array at position :math:`(r, \\theta)`
+appropriately.
 
 We can think of each non-zero pixel "voting" for potential line candidates. The
 local maxima in the resulting histogram indicates the parameters of the most
@@ -55,10 +56,14 @@ References
        Conference on Computer Vision and Pattern Recognition, 1999.
 
 """
+
+######################
+# Line Hough Transform
+# ====================
+
 import numpy as np
 
-from skimage.transform import (hough_line, hough_line_peaks,
-                               probabilistic_hough_line)
+from skimage.transform import hough_line, hough_line_peaks
 from skimage.feature import canny
 from skimage import data
 
@@ -103,6 +108,13 @@ ax[2].set_title('Detected lines')
 
 plt.tight_layout()
 plt.show()
+
+
+###############################
+# Probabilistic Hough Transform
+# =============================
+
+from skimage.transform import probabilistic_hough_line
 
 # Line finding using the Probabilistic Hough Transform
 image = data.camera()

--- a/doc/examples/edges/plot_line_hough_transform.py
+++ b/doc/examples/edges/plot_line_hough_transform.py
@@ -78,7 +78,8 @@ image[idx[::-1], idx] = 255
 image[idx, idx] = 255
 
 # Classic straight-line Hough transform
-h, theta, d = hough_line(image)
+tested_angles = np.linspace(-np.pi / 2, np.pi / 2, 360)
+h, theta, d = hough_line(image, theta=tested_angles)
 
 # Generating figure 1
 fig, axes = plt.subplots(1, 3, figsize=(15, 6))
@@ -98,10 +99,10 @@ ax[1].axis('image')
 
 ax[2].imshow(image, cmap=cm.gray)
 for _, angle, dist in zip(*hough_line_peaks(h, theta, d)):
-    y0 = (dist - 0 * np.cos(angle)) / np.sin(angle)
-    y1 = (dist - image.shape[1] * np.cos(angle)) / np.sin(angle)
-    ax[2].plot((0, image.shape[1]), (y0, y1), '-r')
-ax[2].set_xlim((0, image.shape[1]))
+    origin = np.array((0, image.shape[1]))
+    y0, y1 = (dist - origin * np.cos(angle)) / np.sin(angle)
+    ax[2].plot(origin, (y0, y1), '-r')
+ax[2].set_xlim(origin)
 ax[2].set_ylim((image.shape[0], 0))
 ax[2].set_axis_off()
 ax[2].set_title('Detected lines')

--- a/doc/examples/edges/plot_line_hough_transform.py
+++ b/doc/examples/edges/plot_line_hough_transform.py
@@ -72,12 +72,13 @@ from matplotlib import cm
 
 
 # Constructing test image
-image = np.zeros((100, 100))
-idx = np.arange(25, 75)
+image = np.zeros((200, 200))
+idx = np.arange(25, 175)
 image[idx[::-1], idx] = 255
 image[idx, idx] = 255
 
 # Classic straight-line Hough transform
+# Set a precision of 0.5 degree.
 tested_angles = np.linspace(-np.pi / 2, np.pi / 2, 360)
 h, theta, d = hough_line(image, theta=tested_angles)
 

--- a/doc/examples/edges/plot_line_hough_transform.py
+++ b/doc/examples/edges/plot_line_hough_transform.py
@@ -99,8 +99,8 @@ ax[1].set_ylabel('Distance (pixels)')
 ax[1].axis('image')
 
 ax[2].imshow(image, cmap=cm.gray)
+origin = np.array((0, image.shape[1]))
 for _, angle, dist in zip(*hough_line_peaks(h, theta, d)):
-    origin = np.array((0, image.shape[1]))
     y0, y1 = (dist - origin * np.cos(angle)) / np.sin(angle)
     ax[2].plot(origin, (y0, y1), '-r')
 ax[2].set_xlim(origin)


### PR DESCRIPTION
## Description

I made some edits to improve the examples:

* sections to split hough line and prob hough line
* change the default value of the hlt, often people have problems with the accuracy and ignore after reading the example that it's possible to change it.
* increase a bit the image resolution. No  significant impact on the processing time.
* Simplify the notations for the origin in the plot. The example is less verbose.
* PEP8

New version below

![Straight line Hough transform — skimage v0 16 dev0 docs](https://user-images.githubusercontent.com/335370/63927414-f00a2500-ca4d-11e9-8641-bc71370fa83b.png)
