### PR TITLE
morphology.rectangle() dimensions swapped, Fixes Issue #4125

### DIFF
--- a/skimage/morphology/selem.py
+++ b/skimage/morphology/selem.py
@@ -54,7 +54,7 @@ def rectangle(width, height, dtype=np.uint8):
         pixel belongs to the neighborhood.
 
     """
-    return np.ones((width, height), dtype=dtype)
+    return np.ones((height, width), dtype=dtype)
 
 
 def diamond(radius, dtype=np.uint8):


### PR DESCRIPTION
## Description
Issue required that the parameters to build the rectangle were inverted.

Fixes #4125

## Checklist

- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
