### PR TITLE
Turn single backquotes to double backquotes in filters

### DIFF
--- a/skimage/filters/_gabor.py
+++ b/skimage/filters/_gabor.py
@@ -31,13 +31,12 @@ def gabor_kernel(frequency, theta=0, bandwidth=1, sigma_x=None, sigma_y=None,
     theta : float, optional
         Orientation in radians. If 0, the harmonic is in the x-direction.
     bandwidth : float, optional
-        The bandwidth captured by the filter. For fixed bandwidth, `sigma_x`
-        and `sigma_y` will decrease with increasing frequency. This value is
-        ignored if `sigma_x` and `sigma_y` are set by the user.
+        The bandwidth captured by the filter. For fixed bandwidth, ``sigma_x``         and ``sigma_y`` will decrease with increasing frequency. This value is
+        ignored if ``sigma_x`` and `sigma_y` are set by the user.
     sigma_x, sigma_y : float, optional
         Standard deviation in x- and y-directions. These directions apply to
         the kernel *before* rotation. If `theta = pi/2`, then the kernel is
-        rotated 90 degrees so that `sigma_x` controls the *vertical* direction.
+        rotated 90 degrees so that ``sigma_x`` controls the *vertical* direction.
     n_stds : scalar, optional
         The linear size of the kernel is n_stds (3 by default) standard
         deviations
@@ -117,13 +116,12 @@ def gabor(image, frequency, theta=0, bandwidth=1, sigma_x=None,
     theta : float, optional
         Orientation in radians. If 0, the harmonic is in the x-direction.
     bandwidth : float, optional
-        The bandwidth captured by the filter. For fixed bandwidth, `sigma_x`
-        and `sigma_y` will decrease with increasing frequency. This value is
-        ignored if `sigma_x` and `sigma_y` are set by the user.
+        The bandwidth captured by the filter. For fixed bandwidth, ``sigma_x``         and ``sigma_y`` will decrease with increasing frequency. This value is
+        ignored if ``sigma_x`` and `sigma_y` are set by the user.
     sigma_x, sigma_y : float, optional
         Standard deviation in x- and y-directions. These directions apply to
         the kernel *before* rotation. If `theta = pi/2`, then the kernel is
-        rotated 90 degrees so that `sigma_x` controls the *vertical* direction.
+        rotated 90 degrees so that ``sigma_x`` controls the *vertical* direction.
     n_stds : scalar, optional
         The linear size of the kernel is n_stds (3 by default) standard
         deviations.
@@ -132,7 +130,7 @@ def gabor(image, frequency, theta=0, bandwidth=1, sigma_x=None,
     mode : {'constant', 'nearest', 'reflect', 'mirror', 'wrap'}, optional
         Mode used to convolve image with a kernel, passed to `ndi.convolve`
     cval : scalar, optional
-        Value to fill past edges of input if `mode` of convolution is
+        Value to fill past edges of input if ``mode`` of convolution is
         'constant'. The parameter is passed to `ndi.convolve`.
 
     Returns

--- a/skimage/filters/_gabor.py
+++ b/skimage/filters/_gabor.py
@@ -31,12 +31,14 @@ def gabor_kernel(frequency, theta=0, bandwidth=1, sigma_x=None, sigma_y=None,
     theta : float, optional
         Orientation in radians. If 0, the harmonic is in the x-direction.
     bandwidth : float, optional
-        The bandwidth captured by the filter. For fixed bandwidth, ``sigma_x``         and ``sigma_y`` will decrease with increasing frequency. This value is
-        ignored if ``sigma_x`` and `sigma_y` are set by the user.
+        The bandwidth captured by the filter. For fixed bandwidth, ``sigma_x``
+        and ``sigma_y`` will decrease with increasing frequency. This value is
+        ignored if ``sigma_x`` and ``sigma_y`` are set by the user.
     sigma_x, sigma_y : float, optional
         Standard deviation in x- and y-directions. These directions apply to
         the kernel *before* rotation. If `theta = pi/2`, then the kernel is
-        rotated 90 degrees so that ``sigma_x`` controls the *vertical* direction.
+        rotated 90 degrees so that ``sigma_x`` controls the *vertical*
+        direction.
     n_stds : scalar, optional
         The linear size of the kernel is n_stds (3 by default) standard
         deviations
@@ -116,12 +118,14 @@ def gabor(image, frequency, theta=0, bandwidth=1, sigma_x=None,
     theta : float, optional
         Orientation in radians. If 0, the harmonic is in the x-direction.
     bandwidth : float, optional
-        The bandwidth captured by the filter. For fixed bandwidth, ``sigma_x``         and ``sigma_y`` will decrease with increasing frequency. This value is
-        ignored if ``sigma_x`` and `sigma_y` are set by the user.
+        The bandwidth captured by the filter. For fixed bandwidth, ``sigma_x``
+        and ``sigma_y`` will decrease with increasing frequency. This value is
+        ignored if ``sigma_x`` and ``sigma_y`` are set by the user.
     sigma_x, sigma_y : float, optional
         Standard deviation in x- and y-directions. These directions apply to
         the kernel *before* rotation. If `theta = pi/2`, then the kernel is
-        rotated 90 degrees so that ``sigma_x`` controls the *vertical* direction.
+        rotated 90 degrees so that ``sigma_x`` controls the *vertical*
+        direction.
     n_stds : scalar, optional
         The linear size of the kernel is n_stds (3 by default) standard
         deviations.

--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -35,12 +35,12 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
     multichannel : bool, optional (default: None)
         Whether the last axis of the image is to be interpreted as multiple
         channels. If True, each channel is filtered separately (channels are
-        not mixed together). Only 3 channels are supported. If `None`,
+        not mixed together). Only 3 channels are supported. If ``None``,
         the function will attempt to guess this, and raise a warning if
         ambiguous, when the array has shape (M, N, 3).
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `img_as_float`.
+        image is converted according to the conventions of ``img_as_float``.
         Also see
         https://scikit-image.org/docs/dev/user_guide/data_types.html
     truncate : float, optional
@@ -128,7 +128,7 @@ def _guess_spatial_dimensions(image):
     Returns
     -------
     spatial_dims : int or None
-        The number of spatial dimensions of `image`. If ambiguous, the value
+        The number of spatial dimensions of ``image``. If ambiguous, the value
         is ``None``.
 
     Raises

--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -26,11 +26,11 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
         The ``output`` parameter passes an array in which to store the
         filter output.
     mode : {'reflect', 'constant', 'nearest', 'mirror', 'wrap'}, optional
-        The `mode` parameter determines how the array borders are
-        handled, where `cval` is the value when mode is equal to
+        The ``mode`` parameter determines how the array borders are
+        handled, where ``cval`` is the value when mode is equal to
         'constant'. Default is 'nearest'.
     cval : scalar, optional
-        Value to fill past edges of input if `mode` is 'constant'. Default
+        Value to fill past edges of input if ``mode`` is 'constant'. Default
         is 0.0
     multichannel : bool, optional (default: None)
         Whether the last axis of the image is to be interpreted as multiple

--- a/skimage/filters/_rank_order.py
+++ b/skimage/filters/_rank_order.py
@@ -29,8 +29,7 @@ def rank_order(image):
         `image`.
 
     original_values: 1-D ndarray
-        Unique original values of `image`
-
+        Unique original values of ``image`` 
     Examples
     --------
     >>> a = np.array([[1, 4, 5], [4, 4, 1], [5, 1, 1]])

--- a/skimage/filters/_rank_order.py
+++ b/skimage/filters/_rank_order.py
@@ -29,7 +29,7 @@ def rank_order(image):
         ``image``.
 
     original_values: 1-D ndarray
-        Unique original values of ``image`` 
+        Unique original values of ``image``
     Examples
     --------
     >>> a = np.array([[1, 4, 5], [4, 4, 1], [5, 1, 1]])

--- a/skimage/filters/_rank_order.py
+++ b/skimage/filters/_rank_order.py
@@ -14,7 +14,7 @@ import numpy as np
 def rank_order(image):
     """Return an image of the same shape where each pixel is the
     index of the pixel value in the ascending order of the unique
-    values of `image`, aka the rank-order value.
+    values of ``image``, aka the rank-order value.
 
     Parameters
     ----------
@@ -24,9 +24,9 @@ def rank_order(image):
     -------
     labels: ndarray of type np.uint32, of shape image.shape
         New array where each pixel has the rank-order value of the
-        corresponding pixel in `image`. Pixel values are between 0 and
+        corresponding pixel in ``image``. Pixel values are between 0 and
         n - 1, where n is the number of distinct unique values in
-        `image`.
+        ``image``.
 
     original_values: 1-D ndarray
         Unique original values of ``image`` 

--- a/skimage/filters/_rank_order.py
+++ b/skimage/filters/_rank_order.py
@@ -18,18 +18,18 @@ def rank_order(image):
 
     Parameters
     ----------
-    image: ndarray
+    image : ndarray
 
     Returns
     -------
-    labels: ndarray of type np.uint32, of shape image.shape
+    labels : ndarray of type np.uint32, of shape image.shape
         New array where each pixel has the rank-order value of the
         corresponding pixel in ``image``. Pixel values are between 0 and
         n - 1, where n is the number of distinct unique values in
         ``image``.
-
-    original_values: 1-D ndarray
+    original_values : 1-D ndarray
         Unique original values of ``image``
+
     Examples
     --------
     >>> a = np.array([[1, 4, 5], [4, 4, 1], [5, 1, 1]])

--- a/skimage/filters/_unsharp_mask.py
+++ b/skimage/filters/_unsharp_mask.py
@@ -39,7 +39,7 @@ def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
         The details will be amplified with this factor. The factor could be 0
         or negative. Typically, it is a small positive number, e.g. 1.0.
     multichannel : bool, optional
-        If True, the last `image` dimension is considered as a color channel,
+        If True, the last ``image`` dimension is considered as a color channel,
         otherwise as spatial. Color channels are processed individually.
     preserve_range: bool, optional
         Whether to keep the original range of values. Otherwise, the input

--- a/skimage/filters/_unsharp_mask.py
+++ b/skimage/filters/_unsharp_mask.py
@@ -43,7 +43,7 @@ def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
         otherwise as spatial. Color channels are processed individually.
     preserve_range: bool, optional
         Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `img_as_float`.
+        image is converted according to the conventions of ``img_as_float``.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Returns

--- a/skimage/filters/lpi_filter.py
+++ b/skimage/filters/lpi_filter.py
@@ -49,12 +49,12 @@ class LPIFilter2D(object):
         Parameters
         ----------
         impulse_response : callable `f(r, c, **filter_params)`
-            Function that yields the impulse response.  `r` and `c` are
+            Function that yields the impulse response.  ``r`` and `c` are
             1-dimensional vectors that represent row and column positions, in
             other words coordinates are (r[0],c[0]),(r[0],c[1]) etc.
             `**filter_params` are passed through.
 
-            In other words, `impulse_response` would be called like this:
+            In other words, ``impulse_response`` would be called like this:
 
             >>> def impulse_response(r, c, **filter_params):
             ...     pass

--- a/skimage/filters/lpi_filter.py
+++ b/skimage/filters/lpi_filter.py
@@ -49,7 +49,7 @@ class LPIFilter2D(object):
         Parameters
         ----------
         impulse_response : callable `f(r, c, **filter_params)`
-            Function that yields the impulse response.  ``r`` and `c` are
+            Function that yields the impulse response.  ``r`` and ``c`` are
             1-dimensional vectors that represent row and column positions, in
             other words coordinates are (r[0],c[0]),(r[0],c[1]) etc.
             `**filter_params` are passed through.

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -380,7 +380,7 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
         beta = beta1
 
     if beta2:
-        warn('Use keyword parameter ``gamma`` instead of ``beta2`` which '
+        warn('Use keyword parameter `gamma` instead of `beta2` which '
              'will be removed in version 0.17.', stacklevel=2)
         gamma = beta2
 

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -375,7 +375,7 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
 
     # Check deprecated keyword parameters
     if beta1:
-        warn('Use keyword parameter ``beta`` instead of ``beta1`` which '
+        warn('Use keyword parameter `beta` instead of `beta1` which '
              'will be removed in version 0.17.', stacklevel=2)
         beta = beta1
 

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -385,7 +385,7 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
         gamma = beta2
 
     if scale_range and scale_step:
-        warn('Use keyword parameter ``sigmas`` instead of ``scale_range`` and '
+        warn('Use keyword parameter `sigmas` instead of `scale_range` and '
              '`scale_range` which will be removed in version 0.17.',
              stacklevel=2)
         sigmas = np.arange(scale_range[0], scale_range[1], scale_step)

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -375,17 +375,17 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
 
     # Check deprecated keyword parameters
     if beta1:
-        warn('Use keyword parameter `beta` instead of `beta1` which '
+        warn('Use keyword parameter ``beta`` instead of `beta1` which '
              'will be removed in version 0.17.', stacklevel=2)
         beta = beta1
 
     if beta2:
-        warn('Use keyword parameter `gamma` instead of `beta2` which '
+        warn('Use keyword parameter ``gamma`` instead of `beta2` which '
              'will be removed in version 0.17.', stacklevel=2)
         gamma = beta2
 
     if scale_range and scale_step:
-        warn('Use keyword parameter `sigmas` instead of `scale_range` and '
+        warn('Use keyword parameter ``sigmas`` instead of `scale_range` and '
              '`scale_range` which will be removed in version 0.17.',
              stacklevel=2)
         sigmas = np.arange(scale_range[0], scale_range[1], scale_step)

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -375,17 +375,17 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
 
     # Check deprecated keyword parameters
     if beta1:
-        warn('Use keyword parameter ``beta`` instead of `beta1` which '
+        warn('Use keyword parameter ``beta`` instead of ``beta1`` which '
              'will be removed in version 0.17.', stacklevel=2)
         beta = beta1
 
     if beta2:
-        warn('Use keyword parameter ``gamma`` instead of `beta2` which '
+        warn('Use keyword parameter ``gamma`` instead of ``beta2`` which '
              'will be removed in version 0.17.', stacklevel=2)
         gamma = beta2
 
     if scale_range and scale_step:
-        warn('Use keyword parameter ``sigmas`` instead of `scale_range` and '
+        warn('Use keyword parameter ``sigmas`` instead of ``scale_range`` and '
              '`scale_range` which will be removed in version 0.17.',
              stacklevel=2)
         sigmas = np.arange(scale_range[0], scale_range[1], scale_step)

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -613,7 +613,7 @@ def threshold_li(image, *, tolerance=None, initial_guess=None,
                    .format(initial_guess, image_min, image_max))
             raise ValueError(msg)
     else:
-        raise TypeError('Incorrect type for ``initial_guess``; should be '
+        raise TypeError('Incorrect type for `initial_guess`; should be '
                         'a floating point value, or a function mapping an '
                         'array to a floating point value.')
 

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -159,8 +159,8 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
         Method used to determine adaptive threshold for local neighbourhood in
         weighted mean image.
 
-        * 'generic': use custom function (see `param` parameter)
-        * 'gaussian': apply gaussian filter (see `param` parameter for custom\
+        * 'generic': use custom function (see ``param`` parameter)
+        * 'gaussian': apply gaussian filter (see ``param`` parameter for custom\
                       sigma value)
         * 'mean': apply arithmetic mean filter
         * 'median': apply median rank filter
@@ -253,7 +253,7 @@ def threshold_otsu(image, nbins=256):
     Raises
     ------
     ValueError
-         If `image` only contains a single grayscale value.
+         If ``image`` only contains a single grayscale value.
 
     References
     ----------
@@ -338,7 +338,7 @@ def threshold_yen(image, nbins=256):
     """
     hist, bin_centers = histogram(image.ravel(), nbins, source_range='image')
     # On blank images (e.g. filled with 0) with int dtype, `histogram()`
-    # returns `bin_centers` containing only one value. Speed up with it.
+    # returns ``bin_centers`` containing only one value. Speed up with it.
     if bin_centers.size == 1:
         return bin_centers[0]
 
@@ -494,8 +494,7 @@ def _cross_entropy(image, threshold, bins=_DEFAULT_ENTROPY_BINS):
 
     Notes
     -----
-    See Li and Lee, 1993 [1]_; this is the objective function `threshold_li`
-    minimizes. This function can be improved but this implementation most
+    See Li and Lee, 1993 [1]_; this is the objective function ``threshold_li``     minimizes. This function can be improved but this implementation most
     closely matches equation 8 in [1]_ and equations 1-3 in [2]_.
 
     References
@@ -647,7 +646,7 @@ def threshold_li(image, *, tolerance=None, initial_guess=None,
 def threshold_minimum(image, nbins=256, max_iter=10000):
     """Return threshold value based on minimum method.
 
-    The histogram of the input `image` is computed and smoothed until there are
+    The histogram of the input ``image`` is computed and smoothed until there are
     only two maxima. Then the minimum in between is the threshold value.
 
     Parameters
@@ -850,7 +849,7 @@ def _validate_window_size(axis_sizes):
     """
     for axis_size in axis_sizes:
         if axis_size % 2 == 0:
-            msg = ('Window size for `threshold_sauvola` or '
+            msg = ('Window size for ``threshold_sauvola`` or '
                    '`threshold_niblack` must not be even on any dimension. '
                    'Got {}'.format(axis_sizes))
             raise ValueError(msg)
@@ -1039,23 +1038,20 @@ def threshold_sauvola(image, window_size=15, k=0.2, r=None):
 def apply_hysteresis_threshold(image, low, high):
     """Apply hysteresis thresholding to `image`.
 
-    This algorithm finds regions where `image` is greater than `high`
-    OR `image` is greater than `low` *and* that region is connected to
+    This algorithm finds regions where ``image`` is greater than `high`
+    OR ``image`` is greater than `low` *and* that region is connected to
     a region greater than `high`.
 
     Parameters
     ----------
     image : array, shape (M,[ N, ..., P])
         Grayscale input image.
-    low : float, or array of same shape as `image`
-        Lower threshold.
-    high : float, or array of same shape as `image`
-        Higher threshold.
+    low : float, or array of same shape as ``image``         Lower threshold.
+    high : float, or array of same shape as ``image``         Higher threshold.
 
     Returns
     -------
-    thresholded : array of bool, same shape as `image`
-        Array in which `True` indicates the locations where `image`
+    thresholded : array of bool, same shape as ``image``         Array in which ``True`` indicates the locations where `image`
         was above the hysteresis threshold.
 
     Examples

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -227,8 +227,8 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
         ndi.median_filter(image, block_size, output=thresh_image, mode=mode,
                           cval=cval)
     else:
-        raise ValueError("Invalid method specified. Please use `generic`, "
-                         "`gaussian`, `mean`, or `median`.")
+        raise ValueError("Invalid method specified. Please use ``generic``, "
+                         "`gaussian`, ``mean``, or `median`.")
 
     return thresh_image - offset
 
@@ -292,8 +292,8 @@ def threshold_otsu(image, nbins=256):
     mean2 = (np.cumsum((hist * bin_centers)[::-1]) / weight2[::-1])[::-1]
 
     # Clip ends to align class 1 and class 2 variables:
-    # The last value of `weight1`/`mean1` should pair with zero values in
-    # `weight2`/`mean2`, which do not exist.
+    # The last value of ``weight1``/``mean1`` should pair with zero values in
+    # ``weight2``/`mean2`, which do not exist.
     variance12 = weight1[:-1] * weight2[1:] * (mean1[:-1] - mean2[1:]) ** 2
 
     idx = np.argmax(variance12)
@@ -612,7 +612,7 @@ def threshold_li(image, *, tolerance=None, initial_guess=None,
                    .format(initial_guess, image_min, image_max))
             raise ValueError(msg)
     else:
-        raise TypeError('Incorrect type for `initial_guess`; should be '
+        raise TypeError('Incorrect type for ``initial_guess``; should be '
                         'a floating point value, or a function mapping an '
                         'array to a floating point value.')
 
@@ -1036,11 +1036,11 @@ def threshold_sauvola(image, window_size=15, k=0.2, r=None):
 
 
 def apply_hysteresis_threshold(image, low, high):
-    """Apply hysteresis thresholding to `image`.
+    """Apply hysteresis thresholding to ``image``.
 
-    This algorithm finds regions where ``image`` is greater than `high`
-    OR ``image`` is greater than `low` *and* that region is connected to
-    a region greater than `high`.
+    This algorithm finds regions where ``image`` is greater than ``high``
+    OR ``image`` is greater than ``low`` *and* that region is connected to
+    a region greater than ``high``.
 
     Parameters
     ----------
@@ -1051,7 +1051,7 @@ def apply_hysteresis_threshold(image, low, high):
 
     Returns
     -------
-    thresholded : array of bool, same shape as ``image``         Array in which ``True`` indicates the locations where `image`
+    thresholded : array of bool, same shape as ``image``         Array in which ``True`` indicates the locations where ``image``
         was above the hysteresis threshold.
 
     Examples

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -293,7 +293,7 @@ def threshold_otsu(image, nbins=256):
 
     # Clip ends to align class 1 and class 2 variables:
     # The last value of ``weight1``/``mean1`` should pair with zero values in
-    # ``weight2``/`mean2`, which do not exist.
+    # ``weight2``/``mean2``, which do not exist.
     variance12 = weight1[:-1] * weight2[1:] * (mean1[:-1] - mean2[1:]) ** 2
 
     idx = np.argmax(variance12)

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -348,8 +348,8 @@ def threshold_yen(image, nbins=256):
     P1_sq = np.cumsum(pmf ** 2)
     # Get cumsum calculated from end of squared array:
     P2_sq = np.cumsum(pmf[::-1] ** 2)[::-1]
-    # P2_sq indexes is shifted +1. I assume, with P1[:-1] it's help avoid '-inf'
-    # in crit. ImageJ Yen implementation replaces those values by zero.
+    # P2_sq indexes is shifted +1. I assume, with P1[:-1] it's help avoid
+    # '-inf' in crit. ImageJ Yen implementation replaces those values by zero.
     crit = np.log(((P1_sq[:-1] * P2_sq[1:]) ** -1) *
                   (P1[:-1] * (1.0 - P1[:-1])) ** 2)
     return bin_centers[crit.argmax()]
@@ -494,7 +494,8 @@ def _cross_entropy(image, threshold, bins=_DEFAULT_ENTROPY_BINS):
 
     Notes
     -----
-    See Li and Lee, 1993 [1]_; this is the objective function ``threshold_li``     minimizes. This function can be improved but this implementation most
+    See Li and Lee, 1993 [1]_; this is the objective function ``threshold_li``
+    minimizes. This function can be improved but this implementation most
     closely matches equation 8 in [1]_ and equations 1-3 in [2]_.
 
     References
@@ -646,8 +647,9 @@ def threshold_li(image, *, tolerance=None, initial_guess=None,
 def threshold_minimum(image, nbins=256, max_iter=10000):
     """Return threshold value based on minimum method.
 
-    The histogram of the input ``image`` is computed and smoothed until there are
-    only two maxima. Then the minimum in between is the threshold value.
+    The histogram of the input ``image`` is computed and smoothed until
+    there are only two maxima. Then the minimum in between is the threshold
+    value.
 
     Parameters
     ----------
@@ -799,7 +801,7 @@ def threshold_triangle(image, nbins=256):
     # Find peak, lowest and highest gray levels.
     arg_peak_height = np.argmax(hist)
     peak_height = hist[arg_peak_height]
-    arg_low_level, arg_high_level = np.where(hist>0)[0][[0, -1]]
+    arg_low_level, arg_high_level = np.where(hist > 0)[0][[0, -1]]
 
     # Flip is True if left tail is shorter.
     flip = arg_peak_height - arg_low_level < arg_high_level - arg_peak_height
@@ -1046,12 +1048,15 @@ def apply_hysteresis_threshold(image, low, high):
     ----------
     image : array, shape (M,[ N, ..., P])
         Grayscale input image.
-    low : float, or array of same shape as ``image``         Lower threshold.
-    high : float, or array of same shape as ``image``         Higher threshold.
+    low : float, or array of same shape as ``image``
+        Lower threshold.
+    high : float, or array of same shape as ``image``
+        Higher threshold.
 
     Returns
     -------
-    thresholded : array of bool, same shape as ``image``         Array in which ``True`` indicates the locations where ``image``
+    thresholded : array of bool, same shape as ``image``
+        Array in which ``True`` indicates the locations where ``image``
         was above the hysteresis threshold.
 
     Examples

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -851,7 +851,7 @@ def _validate_window_size(axis_sizes):
     """
     for axis_size in axis_sizes:
         if axis_size % 2 == 0:
-            msg = ('Window size for ``threshold_sauvola`` or '
+            msg = ('Window size for `threshold_sauvola` or '
                    '`threshold_niblack` must not be even on any dimension. '
                    'Got {}'.format(axis_sizes))
             raise ValueError(msg)

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -227,7 +227,7 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
         ndi.median_filter(image, block_size, output=thresh_image, mode=mode,
                           cval=cval)
     else:
-        raise ValueError("Invalid method specified. Please use ``generic``, "
+        raise ValueError("Invalid method specified. Please use `generic`, "
                          "`gaussian`, ``mean``, or `median`.")
 
     return thresh_image - offset

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -228,7 +228,7 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
                           cval=cval)
     else:
         raise ValueError("Invalid method specified. Please use `generic`, "
-                         "`gaussian`, ``mean``, or `median`.")
+                         "`gaussian`, `mean`, or `median`.")
 
     return thresh_image - offset
 


### PR DESCRIPTION
## Description
See #4117 

I applied a regexp and checked the diff. So far, it's applied only on the filters submodule.
I would like to have your feedback first.

I think it is worth it: better documentation, less "bad" examples for future contributions.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
