### PR TITLE
enable multichannel images in drawing module using shape

### DIFF
--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -20,7 +20,8 @@ def _coords_inside_image(rr, cc, shape, val=None):
         Indices of pixels.
     shape : tuple
         Image shape which is used to determine the maximum extent of output
-        pixel coordinates.
+        pixel coordinates.  Must be at least length 2. Only the first two values
+        are used to determine the extent of the input image.
     val : (N, D) ndarray of float, optional
         Values of pixels at coordinates ``[rr, cc]``.
 

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -792,8 +792,9 @@ def rectangle(start, end=None, extent=None, shape=None):
     tl, br = _rectangle_slice(start=start, end=end, extent=extent)
 
     if shape is not None:
-        br = np.minimum(shape, br)
-        tl = np.maximum(np.zeros_like(shape), tl)
+        n_dim = len(start)
+        br = np.minimum(shape[0:n_dim], br)
+        tl = np.maximum(np.zeros_like(shape[0:n_dim]), tl)
     coords = np.meshgrid(*[np.arange(st, en) for st, en in zip(tuple(tl),
                                                                tuple(br))])
     return coords

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -13,7 +13,8 @@ def _ellipse_in_shape(shape, center, radii, rotation=0.):
     Parameters
     ----------
     shape :  iterable of ints
-        Shape of the input image.  Must be length 2.
+        Shape of the input image.  Must be at least length 2. Only the first
+        two values are used to determine the extent of the input image.
     center : iterable of floats
         (row, column) position of center inside the given shape.
     radii : iterable of floats
@@ -53,7 +54,8 @@ def ellipse(r, c, r_radius, c_radius, shape=None, rotation=0.):
     shape : tuple, optional
         Image shape which is used to determine the maximum extent of output pixel
         coordinates. This is useful for ellipses which exceed the image size.
-        By default the full extent of the ellipse are used.
+        By default the full extent of the ellipse are used. Must be at least
+        length 2. Only the first two values are used to determine the extent.
     rotation : float, optional (default 0.)
         Set the ellipse rotation (rotation) in range (-PI, PI)
         in contra clock wise direction, so PI/2 degree means swap ellipse axis
@@ -152,7 +154,9 @@ def circle(r, c, radius, shape=None):
     shape : tuple, optional
         Image shape which is used to determine the maximum extent of output
         pixel coordinates. This is useful for circles that exceed the image
-        size. If None, the full extent of the circle is used.
+        size. If None, the full extent of the circle is used.  Must be at least
+        length 2. Only the first two values are used to determine the extent of
+        the input image.
 
     Returns
     -------
@@ -194,7 +198,9 @@ def polygon_perimeter(r, c, shape=None, clip=False):
     shape : tuple, optional
         Image shape which is used to determine maximum extents of output pixel
         coordinates. This is useful for polygons that exceed the image size.
-        If None, the full extents of the polygon is used.
+        If None, the full extents of the polygon is used.  Must be at least
+        length 2. Only the first two values are used to determine the extent of
+        the input image.
     clip : bool, optional
         Whether to clip the polygon to the provided shape.  If this is set
         to True, the drawn figure will always be a closed polygon with all
@@ -419,7 +425,9 @@ def polygon(r, c, shape=None):
     shape : tuple, optional
         Image shape which is used to determine the maximum extent of output
         pixel coordinates. This is useful for polygons that exceed the image
-        size. If None, the full extent of the polygon is used.
+        size. If None, the full extent of the polygon is used.  Must be at
+        least length 2. Only the first two values are used to determine the
+        extent of the input image.
 
     Returns
     -------
@@ -467,7 +475,9 @@ def circle_perimeter(r, c, radius, method='bresenham', shape=None):
     shape : tuple, optional
         Image shape which is used to determine the maximum extent of output
         pixel coordinates. This is useful for circles that exceed the image
-        size. If None, the full extent of the circle is used.
+        size. If None, the full extent of the circle is used.  Must be at least
+        length 2. Only the first two values are used to determine the extent of
+        the input image.
 
     Returns
     -------
@@ -525,7 +535,9 @@ def circle_perimeter_aa(r, c, radius, shape=None):
     shape : tuple, optional
         Image shape which is used to determine the maximum extent of output
         pixel coordinates. This is useful for circles that exceed the image
-        size. If None, the full extent of the circle is used.
+        size. If None, the full extent of the circle is used.  Must be at least
+        length 2. Only the first two values are used to determine the extent of
+        the input image.
 
     Returns
     -------
@@ -578,7 +590,9 @@ def ellipse_perimeter(r, c, r_radius, c_radius, orientation=0, shape=None):
     shape : tuple, optional
         Image shape which is used to determine the maximum extent of output
         pixel coordinates. This is useful for ellipses that exceed the image
-        size. If None, the full extent of the ellipse is used.
+        size. If None, the full extent of the ellipse is used.  Must be at
+        least length 2. Only the first two values are used to determine the
+        extent of the input image.
 
     Returns
     -------
@@ -806,7 +820,9 @@ def rectangle_perimeter(start, end=None, extent=None, shape=None, clip=False):
     shape : tuple, optional
         Image shape used to determine the maximum bounds of the output
         coordinates. This is useful for clipping perimeters that exceed
-        the image size. By default, no clipping is done.
+        the image size. By default, no clipping is done.  Must be at least
+        length 2. Only the first two values are used to determine the extent of
+        the input image.
     clip : bool, optional
         Whether to clip the perimeter to the provided shape. If this is set
         to True, the drawn figure will always be a closed polygon with all

--- a/skimage/draw/tests/test_draw.py
+++ b/skimage/draw/tests/test_draw.py
@@ -515,6 +515,27 @@ def test_ellipse_with_shape():
 
     assert_array_equal(img, img_)
 
+    img = np.zeros((10, 9, 3), 'uint8')
+
+    rr, cc = ellipse(7, 7, 3, 10, shape=img.shape)
+    img[rr, cc, 0] = 1
+
+    img_ = np.zeros_like(img)
+    img_[..., 0] = np.array(
+        [[0, 0, 0, 0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0, 0, 0, 0, 0],
+         [1, 1, 1, 1, 1, 1, 1, 1, 1],
+         [1, 1, 1, 1, 1, 1, 1, 1, 1],
+         [1, 1, 1, 1, 1, 1, 1, 1, 1],
+         [1, 1, 1, 1, 1, 1, 1, 1, 1],
+         [1, 1, 1, 1, 1, 1, 1, 1, 1]],
+    )
+
+    assert_array_equal(img, img_)
+
 
 def test_ellipse_negative():
     rr, cc = ellipse(-3, -3, 1.7, 1.7)

--- a/skimage/draw/tests/test_draw.py
+++ b/skimage/draw/tests/test_draw.py
@@ -931,6 +931,13 @@ def test_rectangle_extent():
     img[rr, cc] = 1
     assert_array_equal(img, expected)
 
+    img = np.zeros((5, 5, 3), dtype=np.uint8)
+    rr, cc = rectangle(start, extent=extent, shape=img.shape)
+    img[rr, cc, 0] = 1
+    expected_2 = np.zeros_like(img)
+    expected_2[..., 0] = expected
+    assert_array_equal(img, expected_2)
+
 
 def test_rectangle_extent_negative():
     # These two tests should be done together.


### PR DESCRIPTION
## Description

Most of the `skimage.drawing` functions allow to pass a `shape` parameter in order to confine the output coordinates to a given shape. These functions assume 2D images. All functions, except `rectangle` would also gracefully handle images with a channel dimension.

In this PR I clarified how the `shape` parameter is interpreted in the drawing docstrings. Furthermore, this PR adds the same behavior to `skimage.drawing.rectangle`, such that it will properly handle 2D images with channel (but still, 3D images are handled by this as well. Dimensinality of the drawing area is determined via the `start` parameter).

I didn't bother opening an issue about this, since the fix is so small
<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

Not applicable checks:

- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
