### PR TITLE
Refactor radon transform module

### DIFF
--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -324,28 +324,29 @@ def order_angles_golden_ratio(theta):
     """
     interval = 180
 
-    def angle_distance(a, b):
-        difference = a - b
-        return min(abs(difference % interval), abs(difference % -interval))
-
-    remaining = list(np.argsort(theta))   # indices into theta
+    remaining_indices = list(np.argsort(theta))   # indices into theta
     # yield an arbitrary angle to start things off
-    index = remaining.pop(0)
-    angle = theta[index]
-    yield index
+    angle = theta[remaining_indices[0]]
+    yield remaining_indices.pop(0)
     # determine subsequent angles using the golden ratio method
     angle_increment = interval * (1 - (np.sqrt(5) - 1) / 2)
-    while remaining:
+    while remaining_indices:
+        remaining_angles = theta[remaining_indices]
         angle = (angle + angle_increment) % interval
-        insert_point = np.searchsorted(theta[remaining], angle)
-        index_below = insert_point - 1
-        index_above = 0 if insert_point == len(remaining) else insert_point
-        distance_below = angle_distance(angle, theta[remaining[index_below]])
-        distance_above = angle_distance(angle, theta[remaining[index_above]])
+        index_above = np.searchsorted(remaining_angles, angle)
+        index_below = index_above - 1
+        index_above %= len(remaining_indices)
+
+        diff_below = abs(angle - remaining_angles[index_below])
+        distance_below = min(diff_below % interval, diff_below % -interval)
+
+        diff_above = abs(angle - remaining_angles[index_above])
+        distance_above = min(diff_above % interval, diff_above % -interval)
+
         if distance_below < distance_above:
-            yield remaining.pop(index_below)
+            yield remaining_indices.pop(index_below)
         else:
-            yield remaining.pop(index_above)
+            yield remaining_indices.pop(index_above)
 
 
 def iradon_sart(radon_image, theta=None, image=None, projection_shifts=None,

--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -93,8 +93,7 @@ def radon(image, theta=None, circle=True):
     center = padded_image.shape[0] // 2
     radon_image = np.zeros((padded_image.shape[0], len(theta)))
 
-    for i, angle in enumerate(theta):
-        T = np.deg2rad(angle)
+    for i, T in enumerate(np.deg2rad(theta)):
         cos_T, sin_T = np.cos(T), np.sin(T)
         R = np.array([[cos_T, sin_T, -center * (cos_T + sin_T - 1)],
                       [-sin_T, cos_T, -center * (cos_T - sin_T - 1)],

--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -6,6 +6,7 @@ from ._warps import warp
 from ._radon_transform import sart_projection_update
 from .._shared.fft import fftmodule
 from warnings import warn
+from functools import partial
 
 if fftmodule is np.fft:
     # fallback from scipy.fft to scipy.fftpack instead of numpy.fft
@@ -277,11 +278,11 @@ def iradon(radon_image, theta=None, output_size=None,
     for col, angle in zip(radon_filtered.T, np.deg2rad(theta)):
         t = ypr * np.cos(angle) - xpr * np.sin(angle)
         if interpolation == 'linear':
-            reconstructed += np.interp(t, x, col, left=0, right=0)
+            interpolant = partial(np.interp, xp=x, fp=col, left=0, right=0)
         else:
             interpolant = interp1d(x, col, kind=interpolation,
                                    bounds_error=False, fill_value=0)
-            reconstructed += interpolant(t)
+        reconstructed += interpolant(t)
 
     if circle:
         out_reconstruction_circle = (xpr ** 2 + ypr ** 2) > radius ** 2


### PR DESCRIPTION
## Description

The major changes introduced by this PR are:

- use `warp` instead of `_warp_fast` to ease the maintenance when an enhancement/fix is introduced to `_warp_cy` (`_warp_fast` is now called only by the `warp` function),
- remove unnecessary inner functions (`build_rotation` in `radon` and `angle_distance` in `order_angles_golden_ratio`),
- define `_get_fourier_filter` function to improve `iradon` readability,
- replace double dot product by a direct array definition for the creation of the rotation matrix in `radon`,
- simplify some `if` statements,
- use `scipy.ndimage.measurements.find_objects` to find reconstruction circle area instead of a hand made loop,
- use `functools.partial` to make `np.interp` call consistent with `scipy.interpolate.interp1d` call in `iradon`

This results in some lines drop and no API change is introduced.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
