### PR TITLE
Add mask parameter to find_contours

### DIFF
--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -118,6 +118,8 @@ def find_contours(array, level,
         raise ValueError('Only 2D arrays are supported.')
     level = float(level)
     if mask is not None:
+        if not np.can_cast(mask.dtype, bool, casting='safe'):
+            raise TypeError('Parameter "mask" must be a binary array.')
         mask = np.asarray(mask, dtype=np.uint8)
         if mask.shape != array.shape:
             raise ValueError('Parameters "array" and "mask" must have same shape.')

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -120,7 +120,7 @@ def find_contours(array, level,
     if mask is not None:
         if not np.can_cast(mask.dtype, bool, casting='safe'):
             raise TypeError('Parameter "mask" must be a binary array.')
-        mask = np.asarray(mask, dtype=np.uint8)
+        mask = mask.view(np.uint8)
         if mask.shape != array.shape:
             raise ValueError('Parameters "array" and "mask"'
                              ' must have same shape.')

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -117,9 +117,7 @@ def find_contours(array, level,
     if array.ndim != 2:
         raise ValueError('Only 2D arrays are supported.')
     level = float(level)
-    if mask is None:
-        mask = np.ones_like(array, dtype=np.uint8)
-    else:
+    if mask is not None:
         mask = np.asarray(mask, dtype=np.uint8)
         if mask.shape != array.shape:
             raise ValueError('Parameters "array" and "mask" must have same shape.')

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -122,7 +122,8 @@ def find_contours(array, level,
             raise TypeError('Parameter "mask" must be a binary array.')
         mask = np.asarray(mask, dtype=np.uint8)
         if mask.shape != array.shape:
-            raise ValueError('Parameters "array" and "mask" must have same shape.')
+            raise ValueError('Parameters "array" and "mask"'
+                             ' must have same shape.')
     if (fully_connected not in _param_options or
        positive_orientation not in _param_options):
         raise ValueError('Parameters "fully_connected" and'

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -118,9 +118,9 @@ def find_contours(array, level,
         raise ValueError('Only 2D arrays are supported.')
     level = float(level)
     if mask is None:
-        mask = np.ones_like(array, dtype=bool)
+        mask = np.ones_like(array, dtype=np.uint8)
     else:
-        mask = np.asarray(mask, dtype=bool)
+        mask = np.asarray(mask, dtype=np.uint8)
         if mask.shape != array.shape:
             raise ValueError('Parameters "array" and "mask" must have same shape.')
     if (fully_connected not in _param_options or

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -8,7 +8,7 @@ _param_options = ('high', 'low')
 
 def find_contours(array, level,
                   fully_connected='low', positive_orientation='low',
-                  nodata=None):
+                  mask=None):
     """Find iso-valued contours in a 2D array for a given level value.
 
     Uses the "marching squares" method to compute a the iso-valued contours of
@@ -31,11 +31,10 @@ def find_contours(array, level,
          contours will wind counter- clockwise around elements below the
          iso-value. Alternately, this means that low-valued elements are always
          on the left of the contour. (See below for details.)
-    nodata : float
-        Value to treat as missing data. No contours will be drawn where *array*
-        has values equal to *nodata* (or where values are ``NaN`` if nodata is
-        ``NaN``).  Default value is ``None``, which disables this behaviour
-        entirely for backwards-compatibility.
+    mask : 2D ndarray of bool, or None
+        A boolean mask, True where we want to draw contours.
+        Note that NaN values are always excluded from the considered region (
+        i.e. mask=False is forced where where array is NaN).
 
     Returns
     -------
@@ -64,9 +63,10 @@ def find_contours(array, level,
     with the 'fully_connected' parameter.
 
     Output contours are not guaranteed to be closed: contours which intersect
-    the array edge or a region of missing data will be left open. All other
-    contours will be closed. (The closed-ness of a contours can be tested by
-    checking whether the beginning point is the same as the end point.)
+    the array edge or a masked-off region (either where mask is False or where
+    array is NaN) will be left open. All other contours will be closed. (The
+    closed-ness of a contours can be tested by checking whether the beginning
+    point is the same as the end point.)
 
     Contours are oriented. By default, array values lower than the contour
     value are to the left of the contour and values greater than the contour
@@ -117,15 +117,19 @@ def find_contours(array, level,
     if array.ndim != 2:
         raise ValueError('Only 2D arrays are supported.')
     level = float(level)
-    if nodata is not None:
-        nodata = np.double(nodata)
+    if mask is None:
+        mask = np.ones_like(array, dtype=bool)
+    else:
+        mask = np.asarray(mask, dtype=bool)
+        if mask.shape != array.shape:
+            raise ValueError('Parameters "array" and "mask" must have same shape.')
     if (fully_connected not in _param_options or
        positive_orientation not in _param_options):
         raise ValueError('Parameters "fully_connected" and'
         ' "positive_orientation" must be either "high" or "low".')
     point_list = _find_contours_cy.iterate_and_store(array, level,
                                                      fully_connected == 'high',
-                                                     nodata=nodata)
+                                                     mask=mask)
     contours = _assemble_contours(_take_2(point_list))
     if positive_orientation == 'high':
         contours = [c[::-1] for c in contours]

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -117,7 +117,8 @@ def find_contours(array, level,
     if array.ndim != 2:
         raise ValueError('Only 2D arrays are supported.')
     level = float(level)
-    if nodata is not None: nodata = float(nodata)
+    if nodata is not None:
+        nodata = float(nodata)
     if (fully_connected not in _param_options or
        positive_orientation not in _param_options):
         raise ValueError('Parameters "fully_connected" and'

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -118,7 +118,7 @@ def find_contours(array, level,
         raise ValueError('Only 2D arrays are supported.')
     level = float(level)
     if nodata is not None:
-        nodata = float(nodata)
+        nodata = np.double(nodata)
     if (fully_connected not in _param_options or
        positive_orientation not in _param_options):
         raise ValueError('Parameters "fully_connected" and'

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -7,7 +7,8 @@ _param_options = ('high', 'low')
 
 
 def find_contours(array, level,
-                  fully_connected='low', positive_orientation='low'):
+                  fully_connected='low', positive_orientation='low',
+                  nodata=None):
     """Find iso-valued contours in a 2D array for a given level value.
 
     Uses the "marching squares" method to compute a the iso-valued contours of
@@ -30,6 +31,11 @@ def find_contours(array, level,
          contours will wind counter- clockwise around elements below the
          iso-value. Alternately, this means that low-valued elements are always
          on the left of the contour. (See below for details.)
+    nodata : float
+        Value to treat as missing data. No contours will be drawn where *array*
+        has values equal to *nodata* (or where values are ``NaN`` if nodata is
+        ``NaN``).  Default value is ``None``, which disables this behaviour
+        entirely for backwards-compatibility.
 
     Returns
     -------
@@ -58,9 +64,9 @@ def find_contours(array, level,
     with the 'fully_connected' parameter.
 
     Output contours are not guaranteed to be closed: contours which intersect
-    the array edge will be left open. All other contours will be closed. (The
-    closed-ness of a contours can be tested by checking whether the beginning
-    point is the same as the end point.)
+    the array edge or a region of missing data will be left open. All other
+    contours will be closed. (The closed-ness of a contours can be tested by
+    checking whether the beginning point is the same as the end point.)
 
     Contours are oriented. By default, array values lower than the contour
     value are to the left of the contour and values greater than the contour
@@ -111,12 +117,14 @@ def find_contours(array, level,
     if array.ndim != 2:
         raise ValueError('Only 2D arrays are supported.')
     level = float(level)
+    if nodata is not None: nodata = float(nodata)
     if (fully_connected not in _param_options or
        positive_orientation not in _param_options):
         raise ValueError('Parameters "fully_connected" and'
         ' "positive_orientation" must be either "high" or "low".')
     point_list = _find_contours_cy.iterate_and_store(array, level,
-                                                     fully_connected == 'high')
+                                                     fully_connected == 'high',
+                                                     nodata=nodata)
     contours = _assemble_contours(_take_2(point_list))
     if positive_orientation == 'high':
         contours = [c[::-1] for c in contours]

--- a/skimage/measure/_find_contours_cy.pyx
+++ b/skimage/measure/_find_contours_cy.pyx
@@ -3,9 +3,8 @@
 #cython: nonecheck=False
 #cython: wraparound=False
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 
-ctypedef np.uint8_t DTYPE_BOOL_t
 cdef extern from "numpy/npy_math.h":
     bint npy_isnan(double x)
     double NAN "NPY_NAN"
@@ -19,7 +18,7 @@ cdef inline double _get_fraction(double from_value, double to_value,
 
 def iterate_and_store(double[:, :] array,
                       double level, Py_ssize_t vertex_connect_high,
-                      np.ndarray[DTYPE_BOOL_t, cast=True, ndim=2] mask):
+                      cnp.uint8_t[:, :] mask):
     """Iterate across the given array in a marching-squares fashion,
     looking for segments that cross 'level'. If such a segment is
     found, its coordinates are added to a growing list of segments,

--- a/skimage/measure/_find_contours_cy.pyx
+++ b/skimage/measure/_find_contours_cy.pyx
@@ -7,7 +7,6 @@ cimport numpy as cnp
 
 cdef extern from "numpy/npy_math.h":
     bint npy_isnan(double x)
-    double NAN "NPY_NAN"
 
 cdef inline double _get_fraction(double from_value, double to_value,
                                  double level):

--- a/skimage/measure/_find_contours_cy.pyx
+++ b/skimage/measure/_find_contours_cy.pyx
@@ -28,10 +28,9 @@ def iterate_and_store(double[:, :] array,
     if array.shape[0] < 2 or array.shape[1] < 2:
         raise ValueError("Input array must be at least 2x2.")
 
-    cdef bint _nodata_enabled
+    cdef bint _nodata_enabled = nodata is not None
     cdef double _nd = 0
 
-    _nodata_enabled = nodata is not None
     if _nodata_enabled:
         _nd = <double>nodata
 
@@ -105,7 +104,7 @@ def iterate_and_store(double[:, :] array,
 
         if _nodata_enabled:
             if npy_isnan(_nd):
-                if (npy_isnan(ul) or npy_isnan(ur) or npy_isnan(ll) or npy_isnan(lr)):
+                if npy_isnan(ul) or npy_isnan(ur) or npy_isnan(ll) or npy_isnan(lr):
                     continue
             else:
                 if ul == _nd or ur == _nd or ll == _nd or lr == _nd:

--- a/skimage/measure/_find_contours_cy.pyx
+++ b/skimage/measure/_find_contours_cy.pyx
@@ -100,8 +100,8 @@ def iterate_and_store(double[:, :] array,
             coords[1] = 0
 
         # Skip this square if any of the four input values are masked out.
-        if not (mask[r0, c0] and mask[r0, c1] and
-                mask[r1, c0] and mask[r1, c1]):
+        if mask is not None and not (mask[r0, c0] and mask[r0, c1] and
+                                     mask[r1, c0] and mask[r1, c1]):
             continue
 
         # Skip this square if any of the four input values are NaN.

--- a/skimage/measure/tests/test_find_contours.py
+++ b/skimage/measure/tests/test_find_contours.py
@@ -100,6 +100,12 @@ def test_mask_shape():
         find_contours(a, 0, mask=bad_mask)
 
 
+def test_mask_dtype():
+    bad_mask = np.ones((8,8), dtype=np.uint8)
+    with raises(TypeError, match='binary'):
+        find_contours(a, 0, mask=bad_mask)
+
+
 def test_float():
     contours = find_contours(r, 0.5)
     assert len(contours) == 1

--- a/skimage/measure/tests/test_find_contours.py
+++ b/skimage/measure/tests/test_find_contours.py
@@ -10,7 +10,7 @@ a[1:-1, 1] = 0
 a[1, 1:-1] = 0
 
 b = np.copy(a)
-b[7:,:] = np.nan
+b[7:, :] = np.nan
 
 x, y = np.mgrid[-1:1:5j, -1:1:5j]
 r = np.sqrt(x**2 + y**2)
@@ -47,6 +47,7 @@ def test_binary():
     assert len(contours) == 1
     assert_array_equal(contours[0][::-1], ref)
 
+
 def test_nodata():
     ref = [[6. ,  1.5],
            [5. ,  1.5],
@@ -71,9 +72,11 @@ def test_nodata():
            [4. ,  0.5],
            [5. ,  0.5],
            [6. ,  0.5]]
-    contours = find_contours(b, 0.5, positive_orientation='high', nodata=np.nan)
+    contours = find_contours(b, 0.5, positive_orientation='high',
+                             nodata=np.nan)
     assert len(contours) == 1
     assert_array_equal(contours[0][::-1], ref)
+
 
 def test_float():
     contours = find_contours(r, 0.5)

--- a/skimage/measure/tests/test_find_contours.py
+++ b/skimage/measure/tests/test_find_contours.py
@@ -3,6 +3,7 @@ from skimage.measure import find_contours
 
 from skimage._shared import testing
 from skimage._shared.testing import assert_array_equal
+from pytest import raises
 
 
 a = np.ones((8, 8), dtype=np.float32)
@@ -91,6 +92,12 @@ def test_mask():
     contours = find_contours(a, 0.5, positive_orientation='high', mask=mask)
     assert len(contours) == 1
     assert_array_equal(contours[0], mask_contour)
+
+
+def test_mask_shape():
+    bad_mask = np.ones((8, 7), dtype=bool)
+    with raises(ValueError, match='shape'):
+        find_contours(a, 0, mask=bad_mask)
 
 
 def test_float():

--- a/skimage/measure/tests/test_find_contours.py
+++ b/skimage/measure/tests/test_find_contours.py
@@ -73,12 +73,8 @@ mask_contour = [
 ]
 
 mask = np.ones((8, 8), dtype=bool)
-# Some missing data that should result in target hole in the contour:
+# Some missing data that should result in a hole in the contour:
 mask[7, 0:3] = False
-
-# Some missing data that shouldn't change anything:
-mask[0, 7] = False
-mask[2, 7] = False
 
 
 def test_nodata():

--- a/skimage/measure/tests/test_find_contours.py
+++ b/skimage/measure/tests/test_find_contours.py
@@ -9,6 +9,9 @@ a = np.ones((8, 8), dtype=np.float32)
 a[1:-1, 1] = 0
 a[1, 1:-1] = 0
 
+b = np.copy(a)
+b[7:,:] = np.nan
+
 x, y = np.mgrid[-1:1:5j, -1:1:5j]
 r = np.sqrt(x**2 + y**2)
 
@@ -44,6 +47,33 @@ def test_binary():
     assert len(contours) == 1
     assert_array_equal(contours[0][::-1], ref)
 
+def test_nodata():
+    ref = [[6. ,  1.5],
+           [5. ,  1.5],
+           [4. ,  1.5],
+           [3. ,  1.5],
+           [2. ,  1.5],
+           [1.5,  2. ],
+           [1.5,  3. ],
+           [1.5,  4. ],
+           [1.5,  5. ],
+           [1.5,  6. ],
+           [1. ,  6.5],
+           [0.5,  6. ],
+           [0.5,  5. ],
+           [0.5,  4. ],
+           [0.5,  3. ],
+           [0.5,  2. ],
+           [0.5,  1. ],
+           [1. ,  0.5],
+           [2. ,  0.5],
+           [3. ,  0.5],
+           [4. ,  0.5],
+           [5. ,  0.5],
+           [6. ,  0.5]]
+    contours = find_contours(b, 0.5, positive_orientation='high', nodata=np.nan)
+    assert len(contours) == 1
+    assert_array_equal(contours[0][::-1], ref)
 
 def test_float():
     contours = find_contours(r, 0.5)


### PR DESCRIPTION
## Description

Resolves #3006: Adds a `nodata` parameter to `measure.find_contours` which draws no contours in the region where the input array is equal to `nodata`.

`find_contours` currently misbehaves when handling input arrays containing `NaN` values: it attempts to linearly interpolate these values and ends up returning contours containing `NaN` coordinates. This PR allows avoiding this by passing `nodata=numpy.nan`. For now I've left the previous behaviour as the default (`nodata=None`) for backwards compatibility, in case anyone was relying on it.

The implementation is very simple - no lines are added in any squares with at least one `NaN` corner. This could be cleverer - for example, the square `[[1,NaN],[0,1]]` should probably result in the same segment as `[[1,1],[0,1]]` - but I didn't have time to think through all the possible combinations.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
