### PR TITLE
Enable computing a full image tree with quickshift

### DIFF
--- a/doc/examples/segmentation/plot_quickshift_full_tree.py
+++ b/doc/examples/segmentation/plot_quickshift_full_tree.py
@@ -51,6 +51,7 @@ top_level = segments_quick[0]
 parents = np.array(segments_quick[1]).astype('uint32')
 dist_to_parent = np.array(segments_quick[2]).astype('uint32')
 
+# compute a partial tree of the image
 segments_quick_partial = quickshift(img, kernel_size=3, max_dist=1000,
                                     ratio=0.5, return_tree=True,
                                     full_search=False)
@@ -59,6 +60,9 @@ parents_partial = np.array(segments_quick_partial[1]).astype('uint32')
 dist_to_parent_partial = np.array(segments_quick_partial[2]).astype('uint32')
 
 fig, ax = plt.subplots(3, 2, figsize=(20, 20), sharex=True, sharey=True)
+fig.suptitle('This figure shows the outputs from the quickshift function.\n'
+             'The left column uses fullsearch=True while the right column '
+             'does not.', fontsize=12)
 
 ax[0, 0].imshow(segments_quick[0])
 ax[0, 0].set_title("top level full search")
@@ -82,7 +86,7 @@ plt.tight_layout()
 plt.show()
 
 
-# perform multilevel segmentation
+# perform multilevel segmentation i.e. segment based on the tree hierarchy
 def multilevel_segment(parents):
     parents_display = parents.copy()
     parents_display_old = np.zeros_like(parents_display)
@@ -105,6 +109,9 @@ plt.set_cmap('viridis')
 fig, ax = plt.subplots(max(nb_levels, nb_levels_partial), 2, figsize=(20,
                        max(nb_levels, nb_levels_partial) * 10),
                        sharex=True, sharey=True)
+fig.suptitle('Segment the image based on the tree hierachy levels. \nThe left '
+             'column uses fullsearch=True while the right column does not.',
+             fontsize=12)
 for i in range(nb_levels):
     ax[i, 0].imshow(ims[i])
     ax[i, 0].set_title("full search level " + str(i))
@@ -119,7 +126,7 @@ plt.tight_layout()
 plt.show()
 
 
-# perform multiscale segmentation
+# perform multiscale segmentation i.e. segment based on the distance to parent
 def multiscale_segment(segments_quick, nb_scales, min_scale):
     ims = []
     last_scale = 0
@@ -147,6 +154,9 @@ plt.set_cmap('viridis')
 fig, ax = plt.subplots(max(len(ims), len(ims_partial)), 2,
                        figsize=(20, max(len(ims), len(ims_partial)) * 10),
                        sharex=True, sharey=True)
+fig.suptitle('Segment the image based on the distance to parent (scale). \n'
+             'The left column uses fullsearch=True while the right column '
+             'does not.', fontsize=12)
 for i in range(len(ims)):
     ax[i, 0].imshow(ims[i])
     ax[i, 0].set_title("full search scale " + str(2**(min_scale+i)))

--- a/doc/examples/segmentation/plot_quickshift_full_tree.py
+++ b/doc/examples/segmentation/plot_quickshift_full_tree.py
@@ -1,0 +1,148 @@
+"""
+====================================================
+Comparison of segmentation and superpixel algorithms
+====================================================
+
+This example compares the computation of a complete superpixel hierarchy
+with the default which is to limit the parent to a local neighborhood
+of each pixel. When using ``full_search=True``the algorithm will return
+a single tree for the whole image provided that ``max_dist`` is large enough
+or that ``return_tree=True``.
+
+Since computing a full hierarchy requires searching the
+whole image it is also slower.
+
+
+Quickshift image segmentation
+-----------------------------
+
+Quickshift is a relatively recent 2D image segmentation algorithm, based on an
+approximation of kernelized mean-shift. Therefore it belongs to the family of
+local mode-seeking algorithms and is applied to the 5D space consisting of
+color information and image location [2]_.
+
+One of the benefits of quickshift is that it actually computes a
+hierarchical segmentation on multiple scales simultaneously.
+
+Quickshift has two main parameters: ``sigma`` controls the scale of the local
+density approximation, ``max_dist`` selects a level in the hierarchical
+segmentation that is produced. There is also a trade-off between distance in
+color-space and distance in image-space, given by ``ratio``.
+
+.. [2] Quick shift and kernel methods for mode seeking,
+       Vedaldi, A. and Soatto, S.
+       European Conference on Computer Vision, 2008
+
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from skimage.data import astronaut
+from skimage.segmentation import quickshift
+from skimage.util import img_as_float
+
+img = img_as_float(astronaut()[::2, ::2])
+
+#compute a complete tree of the image
+segments_quick = quickshift(img, kernel_size=3, max_dist=1000, ratio=0.5, return_tree=True, full_search=True)
+top_level = segments_quick[0]
+parents = np.array(segments_quick[1]).astype('uint32')
+dist_to_parent = np.array(segments_quick[2]).astype('uint32')
+
+segments_quick_partial = quickshift(img, kernel_size=3, max_dist=1000, ratio=0.5, return_tree=True, full_search=False)
+top_level_partial = segments_quick_partial[0]
+parents_partial = np.array(segments_quick_partial[1]).astype('uint32')
+dist_to_parent_partial = np.array(segments_quick_partial[2]).astype('uint32')
+
+fig, ax = plt.subplots(3, 2, figsize=(20, 20), sharex=True, sharey=True)
+
+ax[0,0].imshow(segments_quick[0])
+ax[0,0].set_title("top level full search")
+ax[1,0].imshow(np.array(segments_quick[1]).astype('uint32'))
+ax[1,0].set_title('parents full search')
+ax[2,0].imshow(np.array(segments_quick[2]).astype('uint32'))
+ax[2,0].set_title('distance to parent full search')
+
+
+ax[0,1].imshow(segments_quick_partial[0])
+ax[0,1].set_title("top level partial search")
+ax[1,1].imshow(np.array(segments_quick_partial[1]).astype('uint32'))
+ax[1,1].set_title('parents partial search')
+ax[2,1].imshow(np.array(segments_quick_partial[2]).astype('uint32'))
+ax[2,1].set_title('distance to parent partial search')
+
+for a in ax.ravel():
+    a.set_axis_off()
+
+plt.tight_layout()
+plt.show()
+
+# perform multilevel segmentation
+def multilevel_segment(parents):
+    parents_display = parents.copy()
+    parents_display_old = np.zeros_like(parents_display)
+    ims = []
+    nb_levels = 0
+    while np.any(parents_display_old!=parents_display):
+        parents_display_old = parents_display.copy()
+        parents_display = np.squeeze(parents_display[np.unravel_index([parents_display], parents_display.shape)])
+        ims.append(parents_display)
+        nb_levels = nb_levels+1
+    nb_levels = nb_levels-1
+    return ims, nb_levels
+ims, nb_levels = multilevel_segment(parents)
+ims_partial, nb_levels_partial = multilevel_segment(parents_partial)
+
+plt.set_cmap('viridis')
+fig, ax = plt.subplots(max(nb_levels, nb_levels_partial), 2, figsize=(20, max(nb_levels, nb_levels_partial)*10), sharex=True, sharey=True)
+for i in range(nb_levels):
+    ax[i,0].imshow(ims[i])
+    ax[i,0].set_title("full search level "+str(i))
+for i in range(nb_levels_partial):
+    ax[i,1].imshow(ims_partial[i])
+    ax[i,1].set_title("partial search level "+str(i))
+
+for a in ax.ravel():
+    a.set_axis_off()
+
+plt.tight_layout()
+plt.show()
+
+# perform multiscale segmentation
+def multiscale_segment(segments_quick, nb_scales, min_scale):
+    ims = []
+    for i in range(min_scale,nb_scales+min_scale,1):
+        max_dist = 2**i
+        # remove parents with distance > max_dist
+        parent_flat = np.array(segments_quick[1]).astype('uint32').ravel()
+        old = np.zeros(parent_flat.shape).astype('uint32')
+        too_far = np.array(segments_quick[2]).ravel() > max_dist
+        parent_flat[too_far] = np.arange(parent_flat.shape[0])[too_far]
+        while np.any(old!=parent_flat):
+            old=parent_flat
+            parent_flat=parent_flat[parent_flat]
+        ims.append(np.reshape(parent_flat, segments_quick[0].shape))
+        if len(ims)>=2:
+            if np.all(ims[-1]==ims[-2]):
+                break
+    return ims
+nb_scales = 8
+min_scale = 2
+ims = multiscale_segment(segments_quick, nb_scales, min_scale)
+ims_partial = multiscale_segment(segments_quick_partial, nb_scales, min_scale)
+
+plt.set_cmap('viridis')
+fig, ax = plt.subplots(max(len(ims)-1, len(ims_partial)-1), 2, figsize=(20, max(len(ims)-1, len(ims_partial)-1)*10), sharex=True, sharey=True)
+for i in range(len(ims)-1):
+    ax[i,0].imshow(ims[i])
+    ax[i,0].set_title("full search scale "+str(2**(min_scale+i)))
+for i in range(len(ims_partial)-1):
+    ax[i,1].imshow(ims_partial[i])
+    ax[i,1].set_title("partial search scale "+str(2**(min_scale+i)))
+
+for a in ax.ravel():
+    a.set_axis_off()
+
+plt.tight_layout()
+plt.show()

--- a/doc/examples/segmentation/plot_quickshift_full_tree.py
+++ b/doc/examples/segmentation/plot_quickshift_full_tree.py
@@ -30,8 +30,8 @@ segmentation that is produced. There is also a trade-off between distance in
 color-space and distance in image-space, given by ``ratio``.
 
 .. [2] Quick shift and kernel methods for mode seeking,
-       Vedaldi, A. and Soatto, S.
-       European Conference on Computer Vision, 2008
+    Vedaldi, A. and Soatto, S.
+    European Conference on Computer Vision, 2008
 
 """
 
@@ -44,39 +44,43 @@ from skimage.util import img_as_float
 
 img = img_as_float(astronaut()[::2, ::2])
 
-#compute a complete tree of the image
-segments_quick = quickshift(img, kernel_size=3, max_dist=1000, ratio=0.5, return_tree=True, full_search=True)
+# compute a complete tree of the image
+segments_quick = quickshift(img, kernel_size=3, max_dist=1000,
+                            ratio=0.5, return_tree=True, full_search=True)
 top_level = segments_quick[0]
 parents = np.array(segments_quick[1]).astype('uint32')
 dist_to_parent = np.array(segments_quick[2]).astype('uint32')
 
-segments_quick_partial = quickshift(img, kernel_size=3, max_dist=1000, ratio=0.5, return_tree=True, full_search=False)
+segments_quick_partial = quickshift(img, kernel_size=3, max_dist=1000,
+                                    ratio=0.5, return_tree=True,
+                                    full_search=False)
 top_level_partial = segments_quick_partial[0]
 parents_partial = np.array(segments_quick_partial[1]).astype('uint32')
 dist_to_parent_partial = np.array(segments_quick_partial[2]).astype('uint32')
 
 fig, ax = plt.subplots(3, 2, figsize=(20, 20), sharex=True, sharey=True)
 
-ax[0,0].imshow(segments_quick[0])
-ax[0,0].set_title("top level full search")
-ax[1,0].imshow(np.array(segments_quick[1]).astype('uint32'))
-ax[1,0].set_title('parents full search')
-ax[2,0].imshow(np.array(segments_quick[2]).astype('uint32'))
-ax[2,0].set_title('distance to parent full search')
+ax[0, 0].imshow(segments_quick[0])
+ax[0, 0].set_title("top level full search")
+ax[1, 0].imshow(np.array(segments_quick[1]).astype('uint32'))
+ax[1, 0].set_title('parents full search')
+ax[2, 0].imshow(np.array(segments_quick[2]).astype('uint32'))
+ax[2, 0].set_title('distance to parent full search')
 
 
-ax[0,1].imshow(segments_quick_partial[0])
-ax[0,1].set_title("top level partial search")
-ax[1,1].imshow(np.array(segments_quick_partial[1]).astype('uint32'))
-ax[1,1].set_title('parents partial search')
-ax[2,1].imshow(np.array(segments_quick_partial[2]).astype('uint32'))
-ax[2,1].set_title('distance to parent partial search')
+ax[0, 1].imshow(segments_quick_partial[0])
+ax[0, 1].set_title("top level partial search")
+ax[1, 1].imshow(np.array(segments_quick_partial[1]).astype('uint32'))
+ax[1, 1].set_title('parents partial search')
+ax[2, 1].imshow(np.array(segments_quick_partial[2]).astype('uint32'))
+ax[2, 1].set_title('distance to parent partial search')
 
 for a in ax.ravel():
     a.set_axis_off()
 
 plt.tight_layout()
 plt.show()
+
 
 # perform multilevel segmentation
 def multilevel_segment(parents):
@@ -84,24 +88,29 @@ def multilevel_segment(parents):
     parents_display_old = np.zeros_like(parents_display)
     ims = []
     nb_levels = 0
-    while np.any(parents_display_old!=parents_display):
+    while np.any(parents_display_old != parents_display):
         parents_display_old = parents_display.copy()
-        parents_display = np.squeeze(parents_display[np.unravel_index([parents_display], parents_display.shape)])
+        parents_display = np.squeeze(parents_display[
+                                            np.unravel_index([parents_display],
+                                            parents_display.shape)])
         ims.append(parents_display)
-        nb_levels = nb_levels+1
-    nb_levels = nb_levels-1
-    return ims, nb_levels
+        nb_levels = nb_levels + 1
+    nb_levels = nb_levels - 1
+    return ims[:-1], nb_levels
+
 ims, nb_levels = multilevel_segment(parents)
 ims_partial, nb_levels_partial = multilevel_segment(parents_partial)
 
 plt.set_cmap('viridis')
-fig, ax = plt.subplots(max(nb_levels, nb_levels_partial), 2, figsize=(20, max(nb_levels, nb_levels_partial)*10), sharex=True, sharey=True)
+fig, ax = plt.subplots(max(nb_levels, nb_levels_partial), 2, figsize=(20,
+                       max(nb_levels, nb_levels_partial) * 10),
+                       sharex=True, sharey=True)
 for i in range(nb_levels):
-    ax[i,0].imshow(ims[i])
-    ax[i,0].set_title("full search level "+str(i))
+    ax[i, 0].imshow(ims[i])
+    ax[i, 0].set_title("full search level " + str(i))
 for i in range(nb_levels_partial):
-    ax[i,1].imshow(ims_partial[i])
-    ax[i,1].set_title("partial search level "+str(i))
+    ax[i, 1].imshow(ims_partial[i])
+    ax[i, 1].set_title("partial search level " + str(i))
 
 for a in ax.ravel():
     a.set_axis_off()
@@ -109,37 +118,41 @@ for a in ax.ravel():
 plt.tight_layout()
 plt.show()
 
+
 # perform multiscale segmentation
 def multiscale_segment(segments_quick, nb_scales, min_scale):
     ims = []
-    for i in range(min_scale,nb_scales+min_scale,1):
+    last_scale = 0
+    for i in range(min_scale, nb_scales + min_scale, 1):
         max_dist = 2**i
         # remove parents with distance > max_dist
         parent_flat = np.array(segments_quick[1]).astype('uint32').ravel()
         old = np.zeros(parent_flat.shape).astype('uint32')
         too_far = np.array(segments_quick[2]).ravel() > max_dist
         parent_flat[too_far] = np.arange(parent_flat.shape[0])[too_far]
-        while np.any(old!=parent_flat):
-            old=parent_flat
-            parent_flat=parent_flat[parent_flat]
+        while np.any(old != parent_flat):
+            old = parent_flat
+            parent_flat = parent_flat[parent_flat]
         ims.append(np.reshape(parent_flat, segments_quick[0].shape))
-        if len(ims)>=2:
-            if np.all(ims[-1]==ims[-2]):
-                break
-    return ims
+        if len(ims) >= 2:
+            if np.any(ims[-1] != ims[last_scale-1]) or last_scale == 0:
+                last_scale = len(ims)
+    return ims[:last_scale]
 nb_scales = 8
 min_scale = 2
 ims = multiscale_segment(segments_quick, nb_scales, min_scale)
 ims_partial = multiscale_segment(segments_quick_partial, nb_scales, min_scale)
 
 plt.set_cmap('viridis')
-fig, ax = plt.subplots(max(len(ims)-1, len(ims_partial)-1), 2, figsize=(20, max(len(ims)-1, len(ims_partial)-1)*10), sharex=True, sharey=True)
-for i in range(len(ims)-1):
-    ax[i,0].imshow(ims[i])
-    ax[i,0].set_title("full search scale "+str(2**(min_scale+i)))
-for i in range(len(ims_partial)-1):
-    ax[i,1].imshow(ims_partial[i])
-    ax[i,1].set_title("partial search scale "+str(2**(min_scale+i)))
+fig, ax = plt.subplots(max(len(ims), len(ims_partial)), 2,
+                       figsize=(20, max(len(ims), len(ims_partial)) * 10),
+                       sharex=True, sharey=True)
+for i in range(len(ims)):
+    ax[i, 0].imshow(ims[i])
+    ax[i, 0].set_title("full search scale " + str(2**(min_scale+i)))
+for i in range(len(ims_partial)):
+    ax[i, 1].imshow(ims_partial[i])
+    ax[i, 1].set_title("partial search scale " + str(2**(min_scale+i)))
 
 for a in ax.ravel():
     a.set_axis_off()

--- a/doc/examples/segmentation/plot_quickshift_full_tree.py
+++ b/doc/examples/segmentation/plot_quickshift_full_tree.py
@@ -1,11 +1,11 @@
 """
-====================================================
-Comparison of segmentation and superpixel algorithms
-====================================================
+=============================================================
+Comparison of quickshift with and without full_search enabled
+=============================================================
 
 This example compares the computation of a complete superpixel hierarchy
 with the default which is to limit the parent to a local neighborhood
-of each pixel. When using ``full_search=True``the algorithm will return
+of each pixel. When using ``full_search=True`` the algorithm will return
 a single tree for the whole image provided that ``max_dist`` is large enough
 or that ``return_tree=True``.
 

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -20,6 +20,7 @@ This release of scikit-image officially supports Python 3.6 and 3.7.
 New Features
 ------------
 - Added majority rank filter - ``filters.rank.majority``.
+- Added option to compute a single tree over the whole image for quickshift.
 
 
 Improvements

--- a/skimage/segmentation/_quickshift.py
+++ b/skimage/segmentation/_quickshift.py
@@ -9,7 +9,7 @@ from ._quickshift_cy import _quickshift_cython
 
 
 def quickshift(image, ratio=1.0, kernel_size=5, max_dist=10,
-               return_tree=False, sigma=0, convert2lab=True, random_seed=42, 
+               return_tree=False, sigma=0, convert2lab=True, random_seed=42,
                full_search=False):
     """Segments image using quickshift clustering in Color-(x,y) space.
     Produces an oversegmentation of the image using the quickshift mode-seeking
@@ -37,7 +37,7 @@ def quickshift(image, ratio=1.0, kernel_size=5, max_dist=10,
     random_seed : int, optional
         Random seed used for breaking ties.
     full_search : bool
-        Wether to extend search to always find the nearest node with higer 
+        Wether to extend search to always find the nearest node with higher
         density. Will return a single tree if max_dist is large enough.
     Returns
     -------
@@ -69,6 +69,6 @@ def quickshift(image, ratio=1.0, kernel_size=5, max_dist=10,
 
     segment_mask = _quickshift_cython(
         image, kernel_size=kernel_size, max_dist=max_dist,
-        return_tree=return_tree, random_seed=random_seed, 
+        return_tree=return_tree, random_seed=random_seed,
         full_search=full_search)
     return segment_mask

--- a/skimage/segmentation/_quickshift.py
+++ b/skimage/segmentation/_quickshift.py
@@ -12,8 +12,10 @@ def quickshift(image, ratio=1.0, kernel_size=5, max_dist=10,
                return_tree=False, sigma=0, convert2lab=True, random_seed=42,
                full_search=False):
     """Segments image using quickshift clustering in Color-(x,y) space.
+
     Produces an oversegmentation of the image using the quickshift mode-seeking
     algorithm.
+
     Parameters
     ----------
     image : (width, height, channels) ndarray
@@ -39,15 +41,18 @@ def quickshift(image, ratio=1.0, kernel_size=5, max_dist=10,
     full_search : bool
         Wether to extend search to always find the nearest node with higher
         density. Will return a single tree if max_dist is large enough.
+
     Returns
     -------
     segment_mask : (width, height) ndarray
         Integer mask indicating segment labels.
+
     Notes
     -----
     The authors advocate to convert the image to Lab color space prior to
     segmentation, though this is not strictly necessary. For this to work, the
     image must be given in RGB format.
+
     References
     ----------
     .. [1] Quick shift and kernel methods for mode seeking,

--- a/skimage/segmentation/_quickshift.py
+++ b/skimage/segmentation/_quickshift.py
@@ -9,12 +9,11 @@ from ._quickshift_cy import _quickshift_cython
 
 
 def quickshift(image, ratio=1.0, kernel_size=5, max_dist=10,
-               return_tree=False, sigma=0, convert2lab=True, random_seed=42):
+               return_tree=False, sigma=0, convert2lab=True, random_seed=42, 
+               full_search=False):
     """Segments image using quickshift clustering in Color-(x,y) space.
-
     Produces an oversegmentation of the image using the quickshift mode-seeking
     algorithm.
-
     Parameters
     ----------
     image : (width, height, channels) ndarray
@@ -37,18 +36,18 @@ def quickshift(image, ratio=1.0, kernel_size=5, max_dist=10,
         segmentation. For this purpose, the input is assumed to be RGB.
     random_seed : int, optional
         Random seed used for breaking ties.
-
+    full_search : bool
+        Wether to extend search to always find the nearest node with higer 
+        density. Will return a single tree if max_dist is large enough.
     Returns
     -------
     segment_mask : (width, height) ndarray
         Integer mask indicating segment labels.
-
     Notes
     -----
     The authors advocate to convert the image to Lab color space prior to
     segmentation, though this is not strictly necessary. For this to work, the
     image must be given in RGB format.
-
     References
     ----------
     .. [1] Quick shift and kernel methods for mode seeking,
@@ -70,5 +69,6 @@ def quickshift(image, ratio=1.0, kernel_size=5, max_dist=10,
 
     segment_mask = _quickshift_cython(
         image, kernel_size=kernel_size, max_dist=max_dist,
-        return_tree=return_tree, random_seed=random_seed)
+        return_tree=return_tree, random_seed=random_seed, 
+        full_search=full_search)
     return segment_mask

--- a/skimage/segmentation/_quickshift_cy.pyx
+++ b/skimage/segmentation/_quickshift_cy.pyx
@@ -9,7 +9,6 @@ cimport numpy as cnp
 from libc.math cimport exp, sqrt, ceil
 from libc.float cimport DBL_MAX
 
-
 def _quickshift_cython(double[:, :, ::1] image, double kernel_size,
                        double max_dist, bint return_tree, int random_seed,
                        bint full_search):
@@ -31,7 +30,7 @@ def _quickshift_cython(double[:, :, ::1] image, double kernel_size,
     random_seed : int
         Random seed used for breaking ties.
     full_search : bool
-        Wether to extend search to always find the nearest node with higer 
+        Wether to extend search to always find the nearest node with higher
         density. Will return a single tree if max_dist is large enough.
     Returns
     -------
@@ -40,12 +39,6 @@ def _quickshift_cython(double[:, :, ::1] image, double kernel_size,
     """
 
     random_state = np.random.RandomState(random_seed)
-
-    # TODO join orphaned roots?
-    # Some nodes might not have a point of higher density within the
-    # search window. We could do a global search over these in the end.
-    # Reference implementation doesn't do that, though, and it only has
-    # an effect for very high max_dist.
 
     # window size for neighboring pixels to consider
     cdef double inv_kernel_size_sqr = -0.5 / (kernel_size * kernel_size)
@@ -105,11 +98,11 @@ def _quickshift_cython(double[:, :, ::1] image, double kernel_size,
                 c_min = max(c - window_size, 0)
                 c_max = min(c + window_size + 1, width)
                 r_min = max(r - window_size, 0)
-                r_max = min(r + window_size + 1, height)  
+                r_max = min(r + window_size + 1, height)
                 c_min_old = 0
                 c_max_old = 0
                 r_min_old = 0
-                r_max_old = 0            
+                r_max_old = 0
                 # increase search window until you find a parent
                 # or until you have searched all the image
                 while closest == DBL_MAX and \

--- a/skimage/segmentation/_quickshift_cy.pyx
+++ b/skimage/segmentation/_quickshift_cy.pyx
@@ -14,8 +14,10 @@ def _quickshift_cython(double[:, :, ::1] image, double kernel_size,
                        double max_dist, bint return_tree, int random_seed,
                        bint full_search):
     """Segments image using quickshift clustering in Color-(x,y) space.
+
     Produces an oversegmentation of the image using the quickshift mode-seeking
     algorithm.
+
     Parameters
     ----------
     image : (width, height, channels) ndarray
@@ -33,6 +35,7 @@ def _quickshift_cython(double[:, :, ::1] image, double kernel_size,
     full_search : bool
         Wether to extend search to always find the nearest node with higher
         density. Will return a single tree if max_dist is large enough.
+
     Returns
     -------
     segment_mask : (width, height) ndarray

--- a/skimage/segmentation/tests/test_quickshift.py
+++ b/skimage/segmentation/tests/test_quickshift.py
@@ -47,3 +47,20 @@ def test_color():
     # still don't cross lines
     assert (seg2[9, :] != seg2[10, :]).all()
     assert (seg2[:, 9] != seg2[:, 10]).all()
+
+    # tests for full_search option
+    seg3 = quickshift(img, random_seed=0, max_dist=1000, kernel_size=10,
+                      sigma=0, full_search=True)
+    # we expect 1 segment:
+    assert_equal(len(np.unique(seg3)), 1)
+    assert_array_equal(seg, 0)
+
+    # tests for full_search option with the tree
+    seg4 = quickshift(img, random_seed=0, max_dist=1000, kernel_size=10,
+                      sigma=0, full_search=True, return_tree=True)
+    dist_to_parent = np.array(seg4[2]).astype('uint32')
+    # we expect 1 root, 3 root children and all the other pixels have a
+    # distance of 1:
+    assert_equal(np.sum(dist_to_parent == 0), 1)
+    assert_equal(np.sum(dist_to_parent > 1), 3)
+    assert_equal(np.sum(dist_to_parent == 1), 416)

--- a/skimage/segmentation/tests/test_quickshift.py
+++ b/skimage/segmentation/tests/test_quickshift.py
@@ -22,6 +22,14 @@ def test_grey():
         hist = np.histogram(img[seg == i], bins=[0, 0.1, 0.3, 0.5, 1])[0]
         assert_greater(hist[i], 20)
 
+    seg4 = quickshift(img, random_seed=0, max_dist=1000, kernel_size=10,
+                      sigma=0, ratio=0.5, full_search=True, return_tree=True,
+                      convert2lab=False)
+    dist_to_parent = np.array(seg4[2]).astype('uint32')
+    # we expect 1 root, all the other pixels have a distance of 1:
+    assert_equal(np.sum(dist_to_parent == 0), 1)
+    assert_equal(np.sum(dist_to_parent == 1), 419)
+
 
 def test_color():
     rnd = np.random.RandomState(0)

--- a/skimage/segmentation/tests/test_quickshift.py
+++ b/skimage/segmentation/tests/test_quickshift.py
@@ -53,7 +53,7 @@ def test_color():
                       sigma=0, full_search=True)
     # we expect 1 segment:
     assert_equal(len(np.unique(seg3)), 1)
-    assert_array_equal(seg, 0)
+    assert_array_equal(seg3, 0)
 
     # tests for full_search option with the tree
     seg4 = quickshift(img, random_seed=0, max_dist=1000, kernel_size=10,

--- a/skimage/segmentation/tests/test_quickshift.py
+++ b/skimage/segmentation/tests/test_quickshift.py
@@ -57,7 +57,7 @@ def test_color():
 
     # tests for full_search option with the tree
     seg4 = quickshift(img, random_seed=0, max_dist=1000, kernel_size=10,
-                      sigma=0, full_search=True, return_tree=True)
+                      sigma=0, ratio=0.5, full_search=True, return_tree=True)
     dist_to_parent = np.array(seg4[2]).astype('uint32')
     # we expect 1 root, 3 root children and all the other pixels have a
     # distance of 1:


### PR DESCRIPTION
Signed-off-by: Sebastien ESKENAZI <s.eskenaz@pixelz.com>

## Description

This pull requests adds the option `full_search` to the function `quickshift` in order to produce a complete hierarchy of the image superpixels as in the initial paper.

[1] Quick shift and kernel methods for mode seeking,
           Vedaldi, A. and Soatto, S.
           European Conference on Computer Vision, 2008

## Checklist

- [x] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
