### PR TITLE
Refactor/optimize threshold_multiotsu

### DIFF
--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -1158,10 +1158,10 @@ def threshold_multiotsu(image, classes=3, nbins=256):
 
     momP[2:, 2:][upper_tri] = (momP[1, 2:][upper_tri[1]]
                                - np.repeat(momP[1, 1:-2],
-                                           np.arange(nbins-3, 0, -1)))
+                                           np.arange(nbins - 3, 0, -1)))
     momS[2:, 2:][upper_tri] = (momS[1, 2:][upper_tri[1]]
                                - np.repeat(momS[1, 1:-2],
-                                           np.arange(nbins-3, 0, -1)))
+                                           np.arange(nbins - 3, 0, -1)))
 
     # step 4: calculating the between class variance.
     var_btwcls = np.zeros_like(momP)

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -1146,6 +1146,7 @@ def threshold_multiotsu(image, classes=3, nbins=256):
 
     # building the lookup tables.
     # step 1: calculating the diagonal.
+    prob[0] = 0
     momP = np.diagflat(prob)
     momS = np.diagflat(np.arange(nbins) * prob)
 
@@ -1153,7 +1154,8 @@ def threshold_multiotsu(image, classes=3, nbins=256):
     momP[1, 2:] = np.cumsum(prob[2:])
     momS[1, 2:] = np.cumsum(np.arange(2, nbins) * prob[2:])
 
-    # step 3: calculating the other rows recursively.
+    # step 3: the other rows are recursively computed as:
+    # A[i, j] = A[1, j] - A[1, i-1] for A in {momP, momS};  i > 1 and j > i.
     upper_tri = np.triu_indices_from(momP[2:, 2:], 1)
 
     momP[2:, 2:][upper_tri] = (momP[1, 2:][upper_tri[1]]

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -1147,7 +1147,7 @@ def threshold_multiotsu(image, classes=3, nbins=256):
     # building the lookup tables.
     # step 1: calculating the diagonal.
     momP = np.diagflat(prob)
-    momS = np.diagflat(np.arange(nbins)*prob)
+    momS = np.diagflat(np.arange(nbins) * prob)
 
     # step 2: calculating the first row.
     momP[1, 2:] = np.cumsum(prob[2:])


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

This PR basically consists in getting rid of python for loops in the `threshold_multiotsu` function.

This optimization improves dramatically the performance of this function when the number of classes is less then 5:

### Setup

```python
In [1]: from skimage.filters import threshold_multiotsu, threshold_otsu                                 

In [2]: from skimage.data import moon                                                                   

In [3]: img = moon()                              

In [4]: %timeit threshold_otsu(img)                                                                     
1.21 ms ± 444 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)

```

### Before optimization

```python

In [5]: %timeit threshold_multiotsu(img, 2)                                                             
62.4 ms ± 1.21 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [6]: %timeit threshold_multiotsu(img, 3)                                                             
61.8 ms ± 918 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [7]: %timeit threshold_multiotsu(img, 4)                                                             
79.9 ms ± 1.51 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [8]: %timeit threshold_multiotsu(img, 5)                                                             
1.39 s ± 42.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

```

### After optimization

```python

In [5]: %timeit threshold_multiotsu(img, 2)                                                             
2.07 ms ± 3.44 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [6]: %timeit threshold_multiotsu(img, 3)                                                             
2.27 ms ± 3.96 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [7]: %timeit threshold_multiotsu(img, 4)                                                             
19.4 ms ± 3.84 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [8]: %timeit threshold_multiotsu(img, 5)                                                             
1.3 s ± 704 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)

```

This optimization make the computation time of `threshold_multiotsu` comparable with `threshold_otsu`. This is may be an opportunity to deprecate the actual implementation of `threshold_otsu` and replace it by a call to  `threshold_multiotsu` with `classes=2` to fix the issue #3980.

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
