### PR TITLE
FIX #4166: maintain shape for 1x1 input array in exposure.

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -416,7 +416,7 @@ def adjust_gamma(image, gamma=1, gain=1):
     scale = float(dtype_limits(image, True)[1] - dtype_limits(image, True)[0])
 
     out = ((image / scale) ** gamma) * scale * gain
-    return dtype(out)
+    return out.astype(dtype)
 
 
 def adjust_log(image, gain=1, inv=False):
@@ -459,7 +459,7 @@ def adjust_log(image, gain=1, inv=False):
         return dtype(out)
 
     out = np.log2(1 + image / scale) * scale * gain
-    return dtype(out)
+    return out.astype(dtype)
 
 
 def adjust_sigmoid(image, cutoff=0.5, gain=10, inv=False):
@@ -508,7 +508,7 @@ def adjust_sigmoid(image, cutoff=0.5, gain=10, inv=False):
         return dtype(out)
 
     out = (1 / (1 + np.exp(gain * (cutoff - image / scale)))) * scale
-    return dtype(out)
+    return out.astype(dtype)
 
 
 def is_low_contrast(image, fraction_threshold=0.05, lower_percentile=1,

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -445,7 +445,7 @@ def test_adjust_gamma_neggative():
 
 def test_adjust_log_1x1_shape():
     """Check that the shape is maintained"""
-    img = np.ones([1,1])
+    img = np.ones([1, 1])
     result = exposure.adjust_log(img, 1)
     assert img.shape == result.shape
 
@@ -491,7 +491,7 @@ def test_adjust_inv_log():
 
 def test_adjust_sigmoid_1x1_shape():
     """Check that the shape is maintained"""
-    img = np.ones([1,1])
+    img = np.ones([1, 1])
     result = exposure.adjust_sigmoid(img, 1, 5)
     assert img.shape == result.shape
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -376,6 +376,12 @@ def norm_brightness_err(img1, img2):
 # Test Gamma Correction
 # =====================
 
+def test_adjust_gamma_1x1_shape():
+    """Check that the shape is maintained"""
+    img = np.ones([1,1])
+    result = exposure.adjust_gamma(img, 1.5)
+    assert img.shape == result.shape
+
 
 def test_adjust_gamma_one():
     """Same image should be returned for gamma equal to one"""
@@ -437,6 +443,13 @@ def test_adjust_gamma_neggative():
 # Test Logarithmic Correction
 # ===========================
 
+def test_adjust_log_1x1_shape():
+    """Check that the shape is maintained"""
+    img = np.ones([1,1])
+    result = exposure.adjust_log(img, 1)
+    assert img.shape == result.shape
+
+
 def test_adjust_log():
     """Verifying the output with expected results for logarithmic
     correction with multiplier constant multiplier equal to unity"""
@@ -475,6 +488,13 @@ def test_adjust_inv_log():
 
 # Test Sigmoid Correction
 # =======================
+
+def test_adjust_sigmoid_1x1_shape():
+    """Check that the shape is maintained"""
+    img = np.ones([1,1])
+    result = exposure.adjust_sigmoid(img, 1, 5)
+    assert img.shape == result.shape
+
 
 def test_adjust_sigmoid_cutoff_one():
     """Verifying the output with expected results for sigmoid correction


### PR DESCRIPTION
## Description

Closes #4166

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
