### PR TITLE
`view_as_windows` incorrectly assumes that a contiguous array is needed 

### DIFF
--- a/skimage/util/shape.py
+++ b/skimage/util/shape.py
@@ -22,8 +22,7 @@ def view_as_blocks(arr_in, block_shape):
     Returns
     -------
     arr_out : ndarray
-        Block view of the input array.  If `arr_in` is non-contiguous, a copy
-        is made.
+        Block view of the input array.
 
     Examples
     --------
@@ -88,13 +87,6 @@ def view_as_blocks(arr_in, block_shape):
         raise ValueError("'block_shape' is not compatible with 'arr_in'")
 
     # -- restride the array to build the block view
-
-    if not arr_in.flags.contiguous:
-        warn(RuntimeWarning("Cannot provide views on a non-contiguous input "
-                            "array without copying."), stacklevel=2)
-
-    arr_in = np.ascontiguousarray(arr_in)
-
     new_shape = tuple(arr_shape // block_shape) + tuple(block_shape)
     new_strides = tuple(arr_in.strides * block_shape) + arr_in.strides
 
@@ -125,8 +117,7 @@ def view_as_windows(arr_in, window_shape, step=1):
     Returns
     -------
     arr_out : ndarray
-        (rolling) window view of the input array.   If `arr_in` is
-        non-contiguous, a copy is made.
+        (rolling) window view of the input array.
 
     Notes
     -----
@@ -242,12 +233,6 @@ def view_as_windows(arr_in, window_shape, step=1):
         raise ValueError("`window_shape` is too small")
 
     # -- build rolling window view
-    if not arr_in.flags.contiguous:
-        warn(RuntimeWarning("Cannot provide views on a non-contiguous input "
-                            "array without copying."), stacklevel=2)
-
-    arr_in = np.ascontiguousarray(arr_in)
-
     slices = tuple(slice(None, None, st) for st in step)
     window_strides = np.array(arr_in.strides)
 

--- a/skimage/util/tests/test_shape.py
+++ b/skimage/util/tests/test_shape.py
@@ -147,8 +147,25 @@ def test_views_non_contiguous():
     A = np.arange(16).reshape((4, 4))
     A = A[::2, :]
 
-    assert_warns(RuntimeWarning, view_as_blocks, A, (2, 2))
-    assert_warns(RuntimeWarning, view_as_windows, A, (2, 2))
+    res_b = view_as_blocks(A, (2, 2))
+    res_w = view_as_windows(A, (2, 2))
+    print(res_b)
+    print(res_w)
+
+    expected_b = [[[[0,  1],
+                    [8,  9]],
+                   [[2,  3],
+                    [10, 11]]]]
+
+    expected_w = [[[[ 0,  1],
+                    [ 8,  9]],
+                   [[ 1,  2],
+                    [ 9, 10]],
+                   [[ 2,  3],
+                    [10, 11]]]]
+
+    assert_equal(res_b, expected_b)
+    assert_equal(res_w, expected_w)
 
 
 def test_view_as_windows_step_tuple():

--- a/skimage/util/tests/test_shape.py
+++ b/skimage/util/tests/test_shape.py
@@ -143,14 +143,6 @@ def test_view_as_windows_with_skip():
     assert_equal(C.shape, (1, 1, 2, 2))
 
 
-def test_views_non_contiguous():
-    A = np.arange(16).reshape((4, 4))
-    A = A[::2, :]
-
-    assert_warns(RuntimeWarning, view_as_blocks, A, (2, 2))
-    assert_warns(RuntimeWarning, view_as_windows, A, (2, 2))
-
-
 def test_view_as_windows_step_tuple():
     A = np.arange(24).reshape((6, 4))
     B = view_as_windows(A, (3, 2), step=3)

--- a/skimage/util/tests/test_shape.py
+++ b/skimage/util/tests/test_shape.py
@@ -143,6 +143,14 @@ def test_view_as_windows_with_skip():
     assert_equal(C.shape, (1, 1, 2, 2))
 
 
+def test_views_non_contiguous():
+    A = np.arange(16).reshape((4, 4))
+    A = A[::2, :]
+
+    assert_warns(RuntimeWarning, view_as_blocks, A, (2, 2))
+    assert_warns(RuntimeWarning, view_as_windows, A, (2, 2))
+
+
 def test_view_as_windows_step_tuple():
     A = np.arange(24).reshape((6, 4))
     B = view_as_windows(A, (3, 2), step=3)


### PR DESCRIPTION
## Description

Fix #3088 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
