### PR TITLE
Handle case in which NamedTemporaryFile fails

### DIFF
--- a/skimage/io/tests/test_io.py
+++ b/skimage/io/tests/test_io.py
@@ -67,6 +67,16 @@ def _named_tempfile_func(error_class):
     -------
     named_temp_file : callable
         A function that always raises the desired error.
+
+    Notes
+    -----
+    Although this function has general utility for raising errors, it is
+    expected to be used to raise errors that ``tempfile.NamedTemporaryFile``
+    from the Python standard library could raise. As of this writing, these
+    are ``FileNotFoundError``, ``FileExistsError``, ``PermissionError``, and
+    ``BaseException``. See
+    `this comment <https://github.com/scikit-image/scikit-image/issues/3785#issuecomment-486598307>`__
+    for more information.
     """
     def named_temp_file(*args, **kwargs):
         raise error_class()

--- a/skimage/io/tests/test_io.py
+++ b/skimage/io/tests/test_io.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 
 import numpy as np
 from skimage import io, data_dir
@@ -52,3 +53,39 @@ def test_imread_http_url(httpserver):
     # by extension
     image = io.imread(httpserver.url + '/test.jpg' + '?' + 's' * 266)
     assert image.shape == (1, 1)
+
+
+def _named_tempfile_func(error_class):
+    """Create a mock function for NamedTemporaryFile that always raises.
+
+    Parameters
+    ----------
+    error_class : exception class
+        The error that should be raised when asking for a NamedTemporaryFile.
+
+    Returns
+    -------
+    named_temp_file : callable
+        A function that always raises the desired error.
+    """
+    def named_temp_file(*args, **kwargs):
+        raise error_class()
+    return named_temp_file
+
+
+@testing.parametrize(
+    'error_class', [
+        FileNotFoundError, FileExistsError, PermissionError, BaseException
+    ]
+)
+def test_failed_temporary_file(monkeypatch, error_class):
+    # tweak data path so that file URI works on both unix and windows.
+    data_path = data_dir.lstrip(os.path.sep)
+    data_path = data_path.replace(os.path.sep, '/')
+    image_url = 'file:///{0}/camera.png'.format(data_path)
+    with monkeypatch.context():
+        monkeypatch.setattr(
+            tempfile, 'NamedTemporaryFile', _named_tempfile_func(error_class)
+        )
+        with testing.raises(error_class):
+            image = io.imread(image_url)

--- a/skimage/io/util.py
+++ b/skimage/io/util.py
@@ -1,5 +1,6 @@
 import urllib.parse
 import urllib.request
+from urllib.error import URLError, HTTPError
 
 import os
 import re
@@ -28,7 +29,15 @@ def file_or_url_context(resource_name):
                 f.write(u.read())
             # f must be closed before yielding
             yield f.name
-        finally:
+        except (URLError, HTTPError):
+            # could not open URL
+            os.remove(f.name)
+            raise
+        except (FileNotFoundError, FileExistsError,
+                PermissionError, BaseException):
+            # could not create temporary file
+            raise
+        else:
             os.remove(f.name)
     else:
         yield resource_name


### PR DESCRIPTION
Fixes #3785

Currently I just re-raise the exceptions, which I think is the least ambiguous way of handling them. Other alternatives welcome!

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
