### PR TITLE
Morphological snakes

### DIFF
--- a/skimage/segmentation/__init__.py
+++ b/skimage/segmentation/__init__.py
@@ -11,6 +11,7 @@ from ._chan_vese import chan_vese
 from .morphsnakes import (morphological_geodesic_active_contour,
                           morphological_chan_vese, inverse_gaussian_gradient,
                           circle_level_set, checkerboard_level_set)
+from .morphosnakes_fm import morphological_chan_vese_fm
 from ..morphology import flood, flood_fill
 
 
@@ -29,6 +30,7 @@ __all__ = ['random_walker',
            'chan_vese',
            'morphological_geodesic_active_contour',
            'morphological_chan_vese',
+           'morphological_chan_vese_fm',
            'inverse_gaussian_gradient',
            'circle_level_set',
            'checkerboard_level_set',

--- a/skimage/segmentation/_morphosnakes.h
+++ b/skimage/segmentation/_morphosnakes.h
@@ -1,0 +1,920 @@
+#pragma once
+
+#include "snakes2d_operators.h"
+#include "snakes2d_operators_bidir.h"
+#include "snakes3d_operators.h"
+#include "snakes3d_operators_bidir.h"
+#include <algorithm>
+#include <cassert>
+#include <omp.h>
+#include <vector>
+
+#include <algorithm>
+#include <omp.h>
+
+typedef struct point3d {
+  int x, y, z;
+} point3d;
+
+typedef struct point2d {
+  int x, y;
+} point2d;
+
+bool is_inside(int t_xi, int t_L) { return (t_xi >= 0) && (t_xi < t_L); }
+bool is_central(int t_xi, int t_L) { return (t_xi > 0) && (t_xi < t_L - 1); }
+
+bool SId_2d_borders(int xi, int yi, uint8_t *levelset, int nx, int ny) {
+  // All diagonal elements for the borders are zero
+  // only non-diagonal masks are relevant
+  int const stride_x = 1;
+  int const stride_y = nx;
+  int const index = xi + stride_y * yi;
+
+  if (is_central(xi, nx)) {
+    // mask along x is valid
+    return SId_2d_1(levelset, index, stride_x, stride_y);
+  }
+  if (is_central(yi, ny)) {
+    // mask along y is valid
+    return SId_2d_3(levelset, index, stride_x, stride_y);
+  }
+  return false;
+}
+
+bool SId_3d_borders(int xi, int yi, int zi, uint8_t *levelset, int nx, int ny, int nz) {
+  // All diagonal elements for the borders are zero
+  // only non-diagonal masks are relevant
+  int const stride_x = 1;
+  int const stride_y = nx;
+  int const stride_z = nx * ny;
+  int const index = xi + stride_y * yi + stride_z * zi;
+
+  if (is_central(xi, nx) && is_central(yi, ny)) {
+    // mask along x is valid
+    return SId_3d_2(levelset, index, stride_x, stride_y, stride_z);
+  }
+  if (is_central(yi, ny) && is_central(zi, nz)) {
+    // mask along y is valid
+    return SId_3d_0(levelset, index, stride_x, stride_y, stride_z);
+  }
+  if (is_central(zi, nz) && is_central(xi, nx)) {
+    // mask along z is valid
+    return SId_3d_1(levelset, index, stride_x, stride_y, stride_z);
+  }
+  return false;
+}
+
+bool ISd_2d_borders(int xi, int yi, uint8_t *levelset, int nx, int ny) {
+  // I defined a bidirectional macro for the dilations,
+  // outside coordinates are mapped back to INDEX, i.e. constant
+  // boundary conditions with value = levelset[index]
+  int stride_x = 1;
+  int stride_y = nx;
+  int nstride_x = 1;
+  int nstride_y = nx;
+  int const index = xi + stride_y * yi;
+
+  if (xi == 0) {
+    nstride_x = 0;
+  }
+  if (yi == 0) {
+    nstride_y = 0;
+  }
+  if (xi == nx - 1) {
+    stride_x = 0;
+  }
+  if (yi == ny - 1) {
+    stride_y = 0;
+  }
+  return ISd_2d_any_bidir(levelset, index, nstride_x, stride_x, nstride_y, stride_y);
+}
+bool ISd_3d_borders(int xi, int yi, int zi, uint8_t *levelset, int nx, int ny, int nz) {
+  // I defined a bidirectional macro for the dilations,
+  // outside coordinates are mapped back to INDEX, i.e. constant
+  // boundary conditions with value = levelset[index]
+  int stride_x = 1;
+  int stride_y = nx;
+  int stride_z = nx * ny;
+  int nstride_x = 1;
+  int nstride_y = nx;
+  int nstride_z = nx * ny;
+  int const index = xi + stride_y * yi + stride_z * zi;
+
+  if (xi == 0) {
+    nstride_x = 0;
+  }
+  if (yi == 0) {
+    nstride_y = 0;
+  }
+  if (zi == 0) {
+    nstride_z = 0;
+  }
+  if (xi == nx - 1) {
+    stride_x = 0;
+  }
+  if (yi == ny - 1) {
+    stride_y = 0;
+  }
+  if (zi == nz - 1) {
+    stride_z = 0;
+  }
+  // printf("ISd_3d_borders (%d,%d,%d)/(%d,%d,%d)\n", xi, yi, zi, nx, ny, nz);
+  // printf("strides (%d,%d,%d)/(%d,%d,%d)\n", nstride_x, nstride_y, nstride_z,
+  // stride_x,
+  //       stride_y, stride_z);
+
+  return ISd_3d_any_bidir(levelset, index, nstride_x, stride_x, nstride_y, stride_y,
+                          nstride_z, stride_z);
+}
+
+template <unsigned int N>
+double masked_average(double *image, uint8_t *mask, int size) {
+  double cumulative_sum = 0;
+  int counter = 0;
+  for (int i = 0; i < size; i++) {
+    if (mask[i] == N) {
+      cumulative_sum += image[i];
+      counter++;
+    }
+  }
+  if (counter == 0) {
+    return {0};
+  }
+  return cumulative_sum / counter;
+}
+
+template <class T> void reduce(std::vector<T> *v1, int begin, int end) {
+  if (end - begin == 1)
+    return;
+  int pivot = (begin + end) / 2;
+  // not uspported in MSVC
+  //#pragma omp task
+  reduce(v1, begin, pivot);
+  reduce(v1, pivot, end);
+  // not uspported in MSVC
+  // #pragma omp taskwait
+  v1[begin].insert(v1[begin].end(), v1[pivot].begin(), v1[pivot].end());
+}
+
+namespace pysnakes2d {
+
+bool is_edge(uint8_t *levelset, point2d point, int nx, int ny) {
+  int const xi = point.x;
+  int const yi = point.y;
+
+  int const stride_x = 1;
+  int const stride_y = nx;
+
+  // Edges are only inside image
+  if (xi < 0 || yi < 0 || xi > nx - 1 || yi > ny - 1) {
+    return false;
+  }
+
+  int const index = xi + stride_y * yi;
+  // Define border as a not 1 valued voxel with an 6 connected active neighbour
+  if (levelset[index] == 1) {
+    return false;
+  }
+
+  int const index_left = index - (xi > 0) * stride_x;
+  int const index_right = index + (xi < (nx - 1)) * stride_x;
+  int const index_down = index - (yi > 0) * stride_y;
+  int const index_up = index + (yi < (ny - 1)) * stride_y;
+  if (levelset[index_left] == 1 || levelset[index_right] == 1 ||
+      levelset[index_down] == 1 || levelset[index_up] == 1) {
+    return true;
+  }
+
+  return false;
+}
+
+void update_edge(uint8_t *levelset, int *counter, std::vector<point2d> &edge_points,
+                 int nx, int ny) {
+
+  counter[0] += 1;
+  int current_iteration = counter[0];
+
+  int const stride_x = 1;
+  int const stride_y = nx;
+
+  std::vector<point2d> new_edge;
+  for (const point2d &point : edge_points) {
+    int const index = point.x + stride_y * point.y;
+    if (counter[index] != current_iteration) {
+      counter[index] = current_iteration;
+      if (is_edge(levelset, point, nx, ny)) {
+        new_edge.push_back(point);
+      }
+    }
+  }
+  edge_points = new_edge;
+}
+
+void check_and_add_edges(std::vector<point2d> &edge_points,
+                         std::vector<point2d> &unchecked_points, uint8_t *levelset,
+                         int *counter, int nx, int ny) {
+
+  // counter[0] += 1;
+  int current_iteration = counter[0];
+
+  int const stride_x = 1;
+  int const stride_y = nx;
+
+  for (const point2d &p : unchecked_points) {
+    for (int yi = p.y - 1; yi < p.y + 2; yi++) {
+      if (is_inside(yi, ny)) {
+        for (int xi = p.x - 1; xi < p.x + 2; xi++) {
+          if (is_inside(xi, nx)) {
+            int index = xi + stride_y * yi;
+            if (counter[index] != current_iteration) {
+              counter[index] = current_iteration;
+
+              int index_left = index - (xi > 0) * stride_x;
+              int index_right = index + (xi < (nx - 1)) * stride_x;
+              int index_down = index - (yi > 0) * stride_y;
+              int index_up = index + (yi < (ny - 1)) * stride_y;
+
+              if (levelset[index] != 1 &&
+                  (levelset[index_left] == 1 || levelset[index_right] == 1 ||
+                   levelset[index_down] == 1 || levelset[index_up] == 1)) {
+                point2d edge = {xi, yi};
+                edge_points.push_back(edge);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return;
+}
+} // namespace pysnakes2d
+
+void evolve_edge_2d(double *image, uint8_t *levelset, int *counter,
+                    std::vector<point2d> &edge_points, int nx, int ny, double lambda1,
+                    double lambda2) {
+
+  int const stride_x = 1;
+  int const stride_y = nx;
+
+  double c0 = masked_average<0>(image, levelset, nx * ny);
+  double c1 = masked_average<1>(image, levelset, nx * ny);
+
+  counter[0] += 1;
+  int current_iteration = counter[0];
+
+  std::vector<point2d> changed_add, changed_remove;
+  std::vector<point2d> *changed_add_p, *changed_remove_p;
+
+#pragma omp parallel
+  {
+#pragma omp single
+    {
+      changed_add_p = new std::vector<point2d>[omp_get_num_threads()];
+      changed_remove_p = new std::vector<point2d>[omp_get_num_threads()];
+    }
+
+    // cast to int to be compatible with OpenMP 2.0
+    assert(edge_points.size() < INT_MAX / 2);
+#pragma omp for
+    for (int pi = 0; pi < static_cast<int>(edge_points.size()); pi++) {
+      point2d p = edge_points[pi];
+      for (int yi = p.y - 1; yi < p.y + 2; yi++) {
+        if (is_central(yi, ny)) {
+          for (int xi = p.x - 1; xi < p.x + 2; xi++) {
+            if (is_central(xi, nx)) {
+              int const index = xi + stride_y * yi;
+
+              if (counter[index] != current_iteration) {
+                // possible race
+                counter[index] = current_iteration;
+
+                double gx =
+                    0.5 * (levelset[index + stride_x] - levelset[index - stride_x]);
+                double gy =
+                    0.5 * (levelset[index + stride_y] - levelset[index - stride_y]);
+
+                double abs_grad = fabs(gx) + fabs(gy);
+                double value = image[index];
+                double aux = abs_grad * (lambda1 * pow(value - c1, 2) -
+                                         lambda2 * pow(value - c0, 2));
+
+                if (aux < 0 && levelset[index] == 0) {
+                  point2d point = {xi, yi};
+                  changed_add_p[omp_get_thread_num()].push_back(point);
+                }
+                if (aux > 0 && levelset[index] == 1) {
+                  point2d point = {xi, yi};
+                  changed_remove_p[omp_get_thread_num()].push_back(point);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+#pragma omp single
+    {
+      reduce(changed_add_p, 0, omp_get_num_threads());
+      reduce(changed_remove_p, 0, omp_get_num_threads());
+    }
+  }
+  changed_add = changed_add_p[0], changed_remove = changed_remove_p[0];
+  delete[] changed_add_p;
+  delete[] changed_remove_p;
+
+  for (const point2d &point : changed_add) {
+    levelset[point.x + stride_y * point.y] = 1;
+  }
+  for (const point2d &point : changed_remove) {
+    levelset[point.x + stride_y * point.y] = 0;
+  }
+
+  pysnakes2d::update_edge(levelset, counter, edge_points, nx, ny);
+  pysnakes2d::check_and_add_edges(edge_points, changed_remove, levelset, counter, nx,
+                                  ny);
+  pysnakes2d::check_and_add_edges(edge_points, changed_add, levelset, counter, nx, ny);
+  return;
+}
+
+std::vector<point2d> get_edge_list_2d(uint8_t *levelset, int nx, int ny) {
+
+  int const stride_x = 1;
+  int const stride_y = nx;
+
+  std::vector<point2d> retval;
+  for (int yi = 0; yi < ny; yi++) {
+    for (int xi = 0; xi < nx; xi++) {
+
+      int index = xi + stride_y * yi;
+      int index_left = index - (xi > 0) * stride_x;
+      int index_right = index + (xi < (nx - 1)) * stride_x;
+      int index_down = index - (yi > 0) * stride_y;
+      int index_up = index + (yi < (ny - 1)) * stride_y;
+      if (levelset[index] != 1 &&
+          (levelset[index_left] == 1 || levelset[index_right] == 1 ||
+           levelset[index_down] == 1 || levelset[index_up] == 1)) {
+        point2d edge = {xi, yi};
+        retval.push_back(edge);
+      }
+    }
+  }
+
+  return retval;
+}
+
+void fast_marching_erosion_2d(std::vector<point2d> &edge_points, uint8_t *levelset,
+                              int *counter, int nx, int ny) {
+
+  int const stride_x = 1;
+  int const stride_y = nx;
+
+  counter[0] += 1;
+  int current_iteration = counter[0];
+
+  std::vector<point2d> changed;
+  std::vector<point2d> *changed_p;
+
+#pragma omp parallel
+  {
+#pragma omp single
+    { changed_p = new std::vector<point2d>[omp_get_num_threads()]; }
+
+    // cast to int to be compatible with OpenMP 2.0
+    assert(edge_points.size() < INT_MAX / 2);
+
+#pragma omp for
+    for (int pi = 0; pi < static_cast<int>(edge_points.size()); pi++) {
+      point2d p = edge_points[pi];
+      for (int yi = p.y - 1; yi < p.y + 2; yi++) {
+        if (is_inside(yi, ny)) {
+          for (int xi = p.x - 1; xi < p.x + 2; xi++) {
+            if (is_inside(xi, nx)) {
+              int const index = xi + stride_y * yi;
+              if (counter[index] != current_iteration) {
+                counter[index] = current_iteration;
+                // // apply erosion only on 1
+                if (levelset[index] == 1) {
+
+                  if (is_central(xi, nx) && is_central(yi, ny)) {
+                    // normal case
+                    if (SId_2d_any(levelset, index, stride_x, stride_y) == 0) {
+                      point2d point = {xi, yi};
+                      changed_p[omp_get_thread_num()].push_back(point);
+                    }
+                  } else if (SId_2d_borders(xi, yi, levelset, nx, ny) == 0) {
+                    point2d point = {xi, yi};
+                    changed_p[omp_get_thread_num()].push_back(point);
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+#pragma omp single
+    { reduce(changed_p, 0, omp_get_num_threads()); }
+  }
+  changed = changed_p[0];
+  delete[] changed_p;
+
+  if (changed.size() == 0)
+    return;
+
+  for (const point2d &point : changed) {
+    levelset[point.x + stride_y * point.y] = 0;
+  }
+
+  pysnakes2d::update_edge(levelset, counter, edge_points, nx, ny);
+  pysnakes2d::check_and_add_edges(edge_points, changed, levelset, counter, nx, ny);
+  return;
+}
+
+void fast_marching_dilation_2d(std::vector<point2d> &edge_points, uint8_t *levelset,
+                               int *counter, int nx, int ny) {
+  int const stride_x = 1;
+  int const stride_y = nx;
+
+  counter[0] += 1;
+  int current_iteration = counter[0];
+
+  std::vector<point2d> changed;
+  std::vector<point2d> *changed_p;
+
+#pragma omp parallel
+  {
+#pragma omp single
+    { changed_p = new std::vector<point2d>[omp_get_num_threads()]; }
+
+    // cast to int to be compatible with OpenMP 2.0
+    assert(edge_points.size() < INT_MAX / 2);
+#pragma omp for
+    for (int pi = 0; pi < static_cast<int>(edge_points.size()); pi++) {
+      point2d p = edge_points[pi];
+      for (int yi = p.y - 1; yi < p.y + 2; yi++) {
+        if (is_inside(yi, ny)) {
+          for (int xi = p.x - 1; xi < p.x + 2; xi++) {
+            if (is_inside(xi, nx)) {
+              int const index = xi + stride_y * yi;
+              if (counter[index] != current_iteration) {
+                counter[index] = current_iteration;
+                // apply dilation only on 0
+                if (levelset[index] == 0) {
+                  if (is_central(xi, nx) && is_central(yi, ny)) {
+                    // normal case
+                    if (ISd_2d_any(levelset, index, stride_x, stride_y) == 1) {
+                      point2d point = {xi, yi};
+                      changed_p[omp_get_thread_num()].push_back(point);
+                    }
+                  } else if (ISd_2d_borders(xi, yi, levelset, nx, ny) == 1) {
+                    point2d point = {xi, yi};
+                    changed_p[omp_get_thread_num()].push_back(point);
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+#pragma omp single
+    { reduce(changed_p, 0, omp_get_num_threads()); }
+  }
+  changed = changed_p[0];
+  delete[] changed_p;
+
+  if (changed.size() == 0)
+    return;
+
+  for (const point2d &point : changed) {
+    levelset[point.x + stride_y * point.y] = 1;
+  }
+
+  pysnakes2d::update_edge(levelset, counter, edge_points, nx, ny);
+  pysnakes2d::check_and_add_edges(edge_points, changed, levelset, counter, nx, ny);
+  return;
+}
+
+namespace pysnakes3d {
+
+bool is_edge(uint8_t *levelset, point3d point, int nx, int ny, int nz) {
+  int const xi = point.x;
+  int const yi = point.y;
+  int const zi = point.z;
+
+  int const stride_x = 1;
+  int const stride_y = nx;
+  int const stride_z = nx * ny;
+
+  int const index = xi + stride_y * yi + stride_z * zi;
+
+  // Keep level sed padded from border
+  if (xi < 0 || yi < 0 || zi < 0 || xi > nx - 1 || yi > ny - 1 || zi > nz - 1) {
+    return false;
+  }
+
+  // Define border as a not 1 valued voxel with an 6 connected active neighbour
+  if (levelset[index] == 1) {
+    return false;
+  }
+  int const index_x0 = index - (xi > 0) * stride_x;
+  int const index_x1 = index + (xi < (nx - 1)) * stride_x;
+  int const index_y0 = index - (yi > 0) * stride_y;
+  int const index_y1 = index + (yi < (ny - 1)) * stride_y;
+  int const index_z0 = index - (zi > 0) * stride_z;
+  int const index_z1 = index + (zi < (nz - 1)) * stride_z;
+  if ((levelset[index_x0] == 1) || (levelset[index_x1] == 1) ||
+      (levelset[index_y0] == 1) || (levelset[index_y1] == 1) ||
+      (levelset[index_z0] == 1) || (levelset[index_z1] == 1)) {
+    return true;
+  }
+
+  return false;
+}
+
+void update_edge(uint8_t *levelset, int *counter, std::vector<point3d> &edge_points,
+                 int nx, int ny, int nz) {
+  counter[0] += 1;
+  int current_iteration = counter[0];
+
+  int const stride_x = 1;
+  int const stride_y = nx;
+  int const stride_z = nx * ny;
+
+  std::vector<point3d> new_edge;
+  new_edge.reserve(edge_points.size());
+
+  for (const point3d &point : edge_points) {
+    int const index = point.x + stride_y * point.y + stride_z * point.z;
+    if (counter[index] != current_iteration) {
+      counter[index] = current_iteration;
+      if (is_edge(levelset, point, nx, ny, nz)) {
+        new_edge.push_back(point);
+      }
+    }
+  }
+  edge_points = new_edge;
+}
+
+void check_and_add_edges(std::vector<point3d> &edge_points,
+                         std::vector<point3d> &unchecked_points, uint8_t *levelset,
+                         int *counter, int nx, int ny, int nz) {
+
+  counter[0] += 1;
+  int current_iteration = counter[0];
+
+  int const stride_x = 1;
+  int const stride_y = nx;
+  int const stride_z = nx * ny;
+
+  if (edge_points.capacity() < edge_points.size() + unchecked_points.size()) {
+    edge_points.reserve(edge_points.size() + unchecked_points.size());
+  }
+
+  for (const point3d &p : unchecked_points) {
+    for (int zi = p.z - 1; zi < p.z + 2; zi++) {
+      if (is_inside(zi, nz)) {
+        for (int yi = p.y - 1; yi < p.y + 2; yi++) {
+          if (is_inside(yi, ny)) {
+            for (int xi = p.x - 1; xi < p.x + 2; xi++) {
+              if (is_inside(xi, nx)) {
+                int const index = xi + stride_y * yi + stride_z * zi;
+                if (counter[index] != current_iteration) {
+                  counter[index] = current_iteration;
+
+                  int const index_x0 = index - (xi > 0) * stride_x;
+                  int const index_x1 = index + (xi < (nx - 1)) * stride_x;
+                  int const index_y0 = index - (yi > 0) * stride_y;
+                  int const index_y1 = index + (yi < (ny - 1)) * stride_y;
+                  int const index_z0 = index - (zi > 0) * stride_z;
+                  int const index_z1 = index + (zi < (nz - 1)) * stride_z;
+                  if (levelset[index] != 1 &&
+                      (levelset[index_x0] == 1 || levelset[index_x1] == 1 ||
+                       levelset[index_y0] == 1 || levelset[index_y1] == 1 ||
+                       levelset[index_z0] == 1 || levelset[index_z1] == 1)) {
+
+                    point3d edge = {xi, yi, zi};
+                    edge_points.push_back(edge);
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return;
+}
+
+} // namespace pysnakes3d
+
+void evolve_edge_3d(double *image, uint8_t *levelset, int *counter,
+                    std::vector<point3d> &edge_points, int nx, int ny, int nz,
+                    double lambda1, double lambda2) {
+
+  int const stride_x = 1;
+  int const stride_y = nx;
+  int const stride_z = nx * ny;
+
+  double c0 = masked_average<0>(image, levelset, nx * ny * nz);
+  double c1 = masked_average<1>(image, levelset, nx * ny * nz);
+
+  counter[0] += 1;
+  int current_iteration = counter[0];
+
+  std::vector<point3d> changed_add, changed_remove;
+  std::vector<point3d> *changed_add_p, *changed_remove_p;
+
+#pragma omp parallel
+  {
+#pragma omp single
+    {
+      changed_add_p = new std::vector<point3d>[omp_get_num_threads()];
+      changed_remove_p = new std::vector<point3d>[omp_get_num_threads()];
+    }
+
+    // cast to int to be compatible with OpenMP 2.0
+    assert(edge_points.size() < INT_MAX / 2);
+#pragma omp for
+    for (int pi = 0; pi < static_cast<int>(edge_points.size()); pi++) {
+      point3d p = edge_points[pi];
+      for (int zi = p.z - 1; zi < p.z + 2; zi++) {
+        if (is_central(zi, nz)) {
+          for (int yi = p.y - 1; yi < p.y + 2; yi++) {
+            if (is_central(yi, ny)) {
+              for (int xi = p.x - 1; xi < p.x + 2; xi++) {
+                if (is_central(xi, nx)) {
+                  int const index = xi + stride_y * yi + stride_z * zi;
+
+                  if (counter[index] != current_iteration) {
+                    // possible race ges cleared up at at check_and_add_edges
+                    counter[index] = current_iteration;
+
+                    double gx =
+                        0.5 * (levelset[index + stride_x] - levelset[index - stride_x]);
+                    double gy =
+                        0.5 * (levelset[index + stride_y] - levelset[index - stride_y]);
+                    double gz =
+                        0.5 * (levelset[index + stride_z] - levelset[index - stride_z]);
+
+                    double abs_grad = fabs(gx) + fabs(gy) + fabs(gz);
+                    double value = image[index];
+                    double aux = abs_grad * (lambda1 * pow(value - c1, 2) -
+                                             lambda2 * pow(value - c0, 2));
+
+                    if (aux < 0 && levelset[index] == 0) {
+                      point3d point = {xi, yi, zi};
+                      changed_add_p[omp_get_thread_num()].push_back(point);
+                    }
+                    if (aux > 0 && levelset[index] == 1) {
+                      point3d point = {xi, yi, zi};
+                      changed_remove_p[omp_get_thread_num()].push_back(point);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+#pragma omp single
+    {
+      reduce(changed_add_p, 0, omp_get_num_threads());
+      reduce(changed_remove_p, 0, omp_get_num_threads());
+    }
+  }
+  changed_add = changed_add_p[0], changed_remove = changed_remove_p[0];
+  delete[] changed_add_p;
+  delete[] changed_remove_p;
+
+  for (const point3d &point : changed_add) {
+    levelset[point.x + stride_y * point.y + stride_z * point.z] = 1;
+  }
+  for (const point3d &point : changed_remove) {
+    levelset[point.x + stride_y * point.y + stride_z * point.z] = 0;
+  }
+
+  pysnakes3d::update_edge(levelset, counter, edge_points, nx, ny, nz);
+  pysnakes3d::check_and_add_edges(edge_points, changed_remove, levelset, counter, nx,
+                                  ny, nz);
+  pysnakes3d::check_and_add_edges(edge_points, changed_add, levelset, counter, nx, ny,
+                                  nz);
+  return;
+}
+
+void fast_marching_erosion_3d(std::vector<point3d> &edge_points, uint8_t *levelset,
+                              int *counter, int nx, int ny, int nz) {
+
+  int const stride_x = 1;
+  int const stride_y = nx;
+  int const stride_z = nx * ny;
+
+  counter[0] += 1;
+  int current_iteration = counter[0];
+
+  std::vector<point3d> changed;
+  std::vector<point3d> *changed_p;
+
+#pragma omp parallel
+  {
+#pragma omp single
+    { changed_p = new std::vector<point3d>[omp_get_num_threads()]; }
+
+    // cast to int to be compatible with OpenMP 2.0
+    assert(edge_points.size() < INT_MAX / 2);
+#pragma omp for
+    for (int pi = 0; pi < static_cast<int>(edge_points.size()); pi++) {
+      point3d point = edge_points[pi];
+      for (int k = -1; k < 2; k++) {
+        int zi = point.z + k;
+        if (is_inside(zi, nz)) {
+          for (int j = -1; j < 2; j++) {
+            int yi = point.y + j;
+            if (is_inside(yi, ny)) {
+              for (int i = -1; i < 2; i++) {
+                int xi = point.x + i;
+                if (is_inside(xi, nx)) {
+                  int const index = xi + stride_y * yi + stride_z * zi;
+                  if (counter[index] != current_iteration) {
+                    counter[index] = current_iteration;
+                    // // apply erosion only on 1
+                    if (levelset[index] == 1) {
+                      if (is_central(xi, nx) && is_central(yi, ny) &&
+                          is_central(zi, nz)) {
+                        // normal case
+                        if (SId_3d_any(levelset, index, stride_x, stride_y, stride_z) ==
+                            0) {
+                          point3d point = {xi, yi, zi};
+                          changed_p[omp_get_thread_num()].push_back(point);
+                        }
+                      } else if (SId_3d_borders(xi, yi, zi, levelset, nx, ny, nz) ==
+                                 0) {
+                        point3d point = {xi, yi, zi};
+                        changed_p[omp_get_thread_num()].push_back(point);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+#pragma omp single
+    { reduce(changed_p, 0, omp_get_num_threads()); }
+  }
+  changed = changed_p[0];
+  delete[] changed_p;
+
+  if (changed.size() == 0)
+    return;
+
+  for (const point3d &point : changed) {
+    levelset[point.x + stride_y * point.y + stride_z * point.z] = 0;
+  }
+
+  pysnakes3d::update_edge(levelset, counter, edge_points, nx, ny, nz);
+  pysnakes3d::check_and_add_edges(edge_points, changed, levelset, counter, nx, ny, nz);
+  return;
+}
+
+void fast_marching_dilation_3d(std::vector<point3d> &edge_points, uint8_t *levelset,
+                               int *counter, int nx, int ny, int nz) {
+  int const stride_x = 1;
+  int const stride_y = nx;
+  int const stride_z = nx * ny;
+
+  counter[0] += 1;
+  int current_iteration = counter[0];
+
+  std::vector<point3d> changed;
+  std::vector<point3d> *changed_p;
+
+#pragma omp parallel
+  {
+#pragma omp single
+    { changed_p = new std::vector<point3d>[omp_get_num_threads()]; }
+    // cast to int to be compatible with OpenMP 2.0
+    assert(edge_points.size() < INT_MAX / 2);
+#pragma omp for
+    for (int pi = 0; pi < static_cast<int>(edge_points.size()); pi++) {
+      point3d p = edge_points[pi];
+      for (int zi = p.z - 1; zi < p.z + 2; zi++) {
+        if (is_inside(zi, nz)) {
+          for (int yi = p.y - 1; yi < p.y + 2; yi++) {
+            if (is_inside(yi, ny)) {
+              for (int xi = p.x - 1; xi < p.x + 2; xi++) {
+                if (is_inside(xi, nx)) {
+
+                  int const index = xi + stride_y * yi + stride_z * zi;
+                  if (counter[index] != current_iteration) {
+                    counter[index] = current_iteration;
+
+                    // apply dilation only on 0
+                    if (levelset[index] == 0) {
+                      if (is_central(xi, nx) && is_central(yi, ny) &&
+                          is_central(zi, nz)) {
+
+                        // normal case
+                        if (ISd_3d_any(levelset, index, stride_x, stride_y, stride_z) ==
+                            1) {
+                          point3d point = {xi, yi, zi};
+                          changed_p[omp_get_thread_num()].push_back(point);
+                        }
+                      } else if (ISd_3d_borders(xi, yi, zi, levelset, nx, ny, nz) ==
+                                 1) {
+                        point3d point = {xi, yi, zi};
+                        changed_p[omp_get_thread_num()].push_back(point);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+#pragma omp single
+    { reduce(changed_p, 0, omp_get_num_threads()); }
+  }
+  changed = changed_p[0];
+  delete[] changed_p;
+
+  if (changed.size() == 0)
+    return;
+
+  for (const point3d &point : changed) {
+    levelset[point.x + stride_y * point.y + stride_z * point.z] = 1;
+  }
+
+  pysnakes3d::update_edge(levelset, counter, edge_points, nx, ny, nz);
+  pysnakes3d::check_and_add_edges(edge_points, changed, levelset, counter, nx, ny, nz);
+  return;
+}
+
+std::vector<point3d> get_edge_list_3d(uint8_t *levelset, int nx, int ny, int nz) {
+
+  int const stride_x = 1;
+  int const stride_y = nx;
+  int const stride_z = nx * ny;
+
+  std::vector<point3d> retval;
+  for (int zi = 0; zi < nz; zi++) {
+    for (int yi = 0; yi < ny; yi++) {
+      for (int xi = 0; xi < nx; xi++) {
+        int index = xi + stride_y * yi + stride_z * zi;
+        int const index_x0 = index - (xi > 0) * stride_x;
+        int const index_x1 = index + (xi < (nx - 1)) * stride_x;
+        int const index_y0 = index - (yi > 0) * stride_y;
+        int const index_y1 = index + (yi < (ny - 1)) * stride_y;
+        int const index_z0 = index - (zi > 0) * stride_z;
+        int const index_z1 = index + (zi < (nz - 1)) * stride_z;
+        if (levelset[index] != 1 &&
+            (levelset[index_x0] == 1 || levelset[index_x1] == 1 ||
+             levelset[index_y0] == 1 || levelset[index_y1] == 1 ||
+             levelset[index_z0] == 1 || levelset[index_z1] == 1)) {
+          point3d edge = {xi, yi, zi};
+          retval.push_back(edge);
+        }
+      }
+    }
+  }
+  return retval;
+}
+
+struct sortfunc {
+  bool operator()(const point2d &left, const point2d &right) const {
+    if (left.y != right.y) {
+      return left.y < right.y;
+    }
+    return left.x < right.x;
+  }
+  bool operator()(const point3d &left, const point3d &right) const {
+    if (left.z != right.z) {
+      return left.z < right.z;
+    }
+    if (left.y != right.y) {
+      return left.y < right.y;
+    }
+    return left.x < right.x;
+  }
+};
+
+void sort_edge2d(std::vector<point2d> &edge) {
+  std::sort(edge.begin(), edge.end(), sortfunc());
+
+  return;
+}
+void sort_edge3d(std::vector<point3d> &edge) {
+  std::sort(edge.begin(), edge.end(), sortfunc());
+
+  return;
+}

--- a/skimage/segmentation/_morphosnakes.h
+++ b/skimage/segmentation/_morphosnakes.h
@@ -230,8 +230,8 @@ void update_edge(uint8_t *levelset, long *counter, std::vector<point2d> &edge_po
                  int nx, int ny)
 {
 
-  counter[0] += 1;
-  int current_iteration = counter[0];
+  counter[nx * ny] += 1;
+  int current_iteration = counter[nx * ny];
 
   int const stride_x = 1;
   int const stride_y = nx;
@@ -257,8 +257,8 @@ void check_and_add_edges(std::vector<point2d> &edge_points,
                          long *counter, int nx, int ny)
 {
 
-  // counter[0] += 1;
-  int current_iteration = counter[0];
+  // counter[nx*ny*nz] += 1;
+  int current_iteration = counter[nx * ny];
 
   int const stride_x = 1;
   int const stride_y = nx;
@@ -311,8 +311,8 @@ void evolve_edge_2d(double *image, uint8_t *levelset, long *counter,
   double c0 = masked_average<0>(image, levelset, nx * ny);
   double c1 = masked_average<1>(image, levelset, nx * ny);
 
-  counter[0] += 1;
-  int current_iteration = counter[0];
+  counter[nx * ny] += 1;
+  int current_iteration = counter[nx * ny];
 
   std::vector<point2d> changed_add, changed_remove;
   std::vector<point2d> *changed_add_p, *changed_remove_p;
@@ -435,8 +435,8 @@ void fast_marching_erosion_2d(std::vector<point2d> &edge_points, uint8_t *levels
   int const stride_x = 1;
   int const stride_y = nx;
 
-  counter[0] += 1;
-  int current_iteration = counter[0];
+  counter[nx * ny] += 1;
+  int current_iteration = counter[nx * ny];
 
   std::vector<point2d> changed;
   std::vector<point2d> *changed_p;
@@ -520,8 +520,8 @@ void fast_marching_dilation_2d(std::vector<point2d> &edge_points, uint8_t *level
   int const stride_x = 1;
   int const stride_y = nx;
 
-  counter[0] += 1;
-  int current_iteration = counter[0];
+  counter[nx * ny] += 1;
+  int current_iteration = counter[nx * ny];
 
   std::vector<point2d> changed;
   std::vector<point2d> *changed_p;
@@ -642,8 +642,8 @@ bool is_edge(uint8_t *levelset, point3d point, int nx, int ny, int nz)
 void update_edge(uint8_t *levelset, long *counter, std::vector<point3d> &edge_points,
                  int nx, int ny, int nz)
 {
-  counter[0] += 1;
-  int current_iteration = counter[0];
+  counter[nx * ny * nz] += 1;
+  int current_iteration = counter[nx * ny * nz];
 
   int const stride_x = 1;
   int const stride_y = nx;
@@ -672,8 +672,8 @@ void check_and_add_edges(std::vector<point3d> &edge_points,
                          long *counter, int nx, int ny, int nz)
 {
 
-  counter[0] += 1;
-  int current_iteration = counter[0];
+  counter[nx * ny * nz] += 1;
+  int current_iteration = counter[nx * ny * nz];
 
   int const stride_x = 1;
   int const stride_y = nx;
@@ -743,8 +743,8 @@ void evolve_edge_3d(double *image, uint8_t *levelset, long *counter,
   double c0 = masked_average<0>(image, levelset, nx * ny * nz);
   double c1 = masked_average<1>(image, levelset, nx * ny * nz);
 
-  counter[0] += 1;
-  int current_iteration = counter[0];
+  counter[nx * ny * nz] += 1;
+  int current_iteration = counter[nx * ny * nz];
 
   std::vector<point3d> changed_add, changed_remove;
   std::vector<point3d> *changed_add_p, *changed_remove_p;
@@ -845,8 +845,8 @@ void fast_marching_erosion_3d(std::vector<point3d> &edge_points, uint8_t *levels
   int const stride_y = nx;
   int const stride_z = nx * ny;
 
-  counter[0] += 1;
-  int current_iteration = counter[0];
+  counter[nx * ny * nz] += 1;
+  int current_iteration = counter[nx * ny * nz];
 
   std::vector<point3d> changed;
   std::vector<point3d> *changed_p;
@@ -941,8 +941,8 @@ void fast_marching_dilation_3d(std::vector<point3d> &edge_points, uint8_t *level
   int const stride_y = nx;
   int const stride_z = nx * ny;
 
-  counter[0] += 1;
-  int current_iteration = counter[0];
+  counter[nx * ny * nz] += 1;
+  int current_iteration = counter[nx * ny * nz];
 
   std::vector<point3d> changed;
   std::vector<point3d> *changed_p;

--- a/skimage/segmentation/_morphosnakes.h
+++ b/skimage/segmentation/_morphosnakes.h
@@ -12,36 +12,42 @@
 #include <algorithm>
 #include <omp.h>
 
-typedef struct point3d {
+typedef struct point3d
+{
   int x, y, z;
 } point3d;
 
-typedef struct point2d {
+typedef struct point2d
+{
   int x, y;
 } point2d;
 
 bool is_inside(int t_xi, int t_L) { return (t_xi >= 0) && (t_xi < t_L); }
 bool is_central(int t_xi, int t_L) { return (t_xi > 0) && (t_xi < t_L - 1); }
 
-bool SId_2d_borders(int xi, int yi, uint8_t *levelset, int nx, int ny) {
+bool SId_2d_borders(int xi, int yi, uint8_t *levelset, int nx, int ny)
+{
   // All diagonal elements for the borders are zero
   // only non-diagonal masks are relevant
   int const stride_x = 1;
   int const stride_y = nx;
   int const index = xi + stride_y * yi;
 
-  if (is_central(xi, nx)) {
+  if (is_central(xi, nx))
+  {
     // mask along x is valid
     return SId_2d_1(levelset, index, stride_x, stride_y);
   }
-  if (is_central(yi, ny)) {
+  if (is_central(yi, ny))
+  {
     // mask along y is valid
     return SId_2d_3(levelset, index, stride_x, stride_y);
   }
   return false;
 }
 
-bool SId_3d_borders(int xi, int yi, int zi, uint8_t *levelset, int nx, int ny, int nz) {
+bool SId_3d_borders(int xi, int yi, int zi, uint8_t *levelset, int nx, int ny, int nz)
+{
   // All diagonal elements for the borders are zero
   // only non-diagonal masks are relevant
   int const stride_x = 1;
@@ -49,22 +55,26 @@ bool SId_3d_borders(int xi, int yi, int zi, uint8_t *levelset, int nx, int ny, i
   int const stride_z = nx * ny;
   int const index = xi + stride_y * yi + stride_z * zi;
 
-  if (is_central(xi, nx) && is_central(yi, ny)) {
+  if (is_central(xi, nx) && is_central(yi, ny))
+  {
     // mask along x is valid
     return SId_3d_2(levelset, index, stride_x, stride_y, stride_z);
   }
-  if (is_central(yi, ny) && is_central(zi, nz)) {
+  if (is_central(yi, ny) && is_central(zi, nz))
+  {
     // mask along y is valid
     return SId_3d_0(levelset, index, stride_x, stride_y, stride_z);
   }
-  if (is_central(zi, nz) && is_central(xi, nx)) {
+  if (is_central(zi, nz) && is_central(xi, nx))
+  {
     // mask along z is valid
     return SId_3d_1(levelset, index, stride_x, stride_y, stride_z);
   }
   return false;
 }
 
-bool ISd_2d_borders(int xi, int yi, uint8_t *levelset, int nx, int ny) {
+bool ISd_2d_borders(int xi, int yi, uint8_t *levelset, int nx, int ny)
+{
   // I defined a bidirectional macro for the dilations,
   // outside coordinates are mapped back to INDEX, i.e. constant
   // boundary conditions with value = levelset[index]
@@ -74,21 +84,26 @@ bool ISd_2d_borders(int xi, int yi, uint8_t *levelset, int nx, int ny) {
   int nstride_y = nx;
   int const index = xi + stride_y * yi;
 
-  if (xi == 0) {
+  if (xi == 0)
+  {
     nstride_x = 0;
   }
-  if (yi == 0) {
+  if (yi == 0)
+  {
     nstride_y = 0;
   }
-  if (xi == nx - 1) {
+  if (xi == nx - 1)
+  {
     stride_x = 0;
   }
-  if (yi == ny - 1) {
+  if (yi == ny - 1)
+  {
     stride_y = 0;
   }
   return ISd_2d_any_bidir(levelset, index, nstride_x, stride_x, nstride_y, stride_y);
 }
-bool ISd_3d_borders(int xi, int yi, int zi, uint8_t *levelset, int nx, int ny, int nz) {
+bool ISd_3d_borders(int xi, int yi, int zi, uint8_t *levelset, int nx, int ny, int nz)
+{
   // I defined a bidirectional macro for the dilations,
   // outside coordinates are mapped back to INDEX, i.e. constant
   // boundary conditions with value = levelset[index]
@@ -100,22 +115,28 @@ bool ISd_3d_borders(int xi, int yi, int zi, uint8_t *levelset, int nx, int ny, i
   int nstride_z = nx * ny;
   int const index = xi + stride_y * yi + stride_z * zi;
 
-  if (xi == 0) {
+  if (xi == 0)
+  {
     nstride_x = 0;
   }
-  if (yi == 0) {
+  if (yi == 0)
+  {
     nstride_y = 0;
   }
-  if (zi == 0) {
+  if (zi == 0)
+  {
     nstride_z = 0;
   }
-  if (xi == nx - 1) {
+  if (xi == nx - 1)
+  {
     stride_x = 0;
   }
-  if (yi == ny - 1) {
+  if (yi == ny - 1)
+  {
     stride_y = 0;
   }
-  if (zi == nz - 1) {
+  if (zi == nz - 1)
+  {
     stride_z = 0;
   }
   // printf("ISd_3d_borders (%d,%d,%d)/(%d,%d,%d)\n", xi, yi, zi, nx, ny, nz);
@@ -128,22 +149,28 @@ bool ISd_3d_borders(int xi, int yi, int zi, uint8_t *levelset, int nx, int ny, i
 }
 
 template <unsigned int N>
-double masked_average(double *image, uint8_t *mask, int size) {
+double masked_average(double *image, uint8_t *mask, int size)
+{
   double cumulative_sum = 0;
   int counter = 0;
-  for (int i = 0; i < size; i++) {
-    if (mask[i] == N) {
+  for (int i = 0; i < size; i++)
+  {
+    if (mask[i] == N)
+    {
       cumulative_sum += image[i];
       counter++;
     }
   }
-  if (counter == 0) {
+  if (counter == 0)
+  {
     return {0};
   }
   return cumulative_sum / counter;
 }
 
-template <class T> void reduce(std::vector<T> *v1, int begin, int end) {
+template <class T>
+void reduce(std::vector<T> *v1, int begin, int end)
+{
   if (end - begin == 1)
     return;
   int pivot = (begin + end) / 2;
@@ -156,9 +183,11 @@ template <class T> void reduce(std::vector<T> *v1, int begin, int end) {
   v1[begin].insert(v1[begin].end(), v1[pivot].begin(), v1[pivot].end());
 }
 
-namespace pysnakes2d {
+namespace pysnakes2d
+{
 
-bool is_edge(uint8_t *levelset, point2d point, int nx, int ny) {
+bool is_edge(uint8_t *levelset, point2d point, int nx, int ny)
+{
   int const xi = point.x;
   int const yi = point.y;
 
@@ -166,13 +195,15 @@ bool is_edge(uint8_t *levelset, point2d point, int nx, int ny) {
   int const stride_y = nx;
 
   // Edges are only inside image
-  if (xi < 0 || yi < 0 || xi > nx - 1 || yi > ny - 1) {
+  if (xi < 0 || yi < 0 || xi > nx - 1 || yi > ny - 1)
+  {
     return false;
   }
 
   int const index = xi + stride_y * yi;
   // Define border as a not 1 valued voxel with an 6 connected active neighbour
-  if (levelset[index] == 1) {
+  if (levelset[index] == 1)
+  {
     return false;
   }
 
@@ -181,7 +212,8 @@ bool is_edge(uint8_t *levelset, point2d point, int nx, int ny) {
   int const index_down = index - (yi > 0) * stride_y;
   int const index_up = index + (yi < (ny - 1)) * stride_y;
   if (levelset[index_left] == 1 || levelset[index_right] == 1 ||
-      levelset[index_down] == 1 || levelset[index_up] == 1) {
+      levelset[index_down] == 1 || levelset[index_up] == 1)
+  {
     return true;
   }
 
@@ -189,7 +221,8 @@ bool is_edge(uint8_t *levelset, point2d point, int nx, int ny) {
 }
 
 void update_edge(uint8_t *levelset, int *counter, std::vector<point2d> &edge_points,
-                 int nx, int ny) {
+                 int nx, int ny)
+{
 
   counter[0] += 1;
   int current_iteration = counter[0];
@@ -198,11 +231,14 @@ void update_edge(uint8_t *levelset, int *counter, std::vector<point2d> &edge_poi
   int const stride_y = nx;
 
   std::vector<point2d> new_edge;
-  for (const point2d &point : edge_points) {
+  for (const point2d &point : edge_points)
+  {
     int const index = point.x + stride_y * point.y;
-    if (counter[index] != current_iteration) {
+    if (counter[index] != current_iteration)
+    {
       counter[index] = current_iteration;
-      if (is_edge(levelset, point, nx, ny)) {
+      if (is_edge(levelset, point, nx, ny))
+      {
         new_edge.push_back(point);
       }
     }
@@ -212,7 +248,8 @@ void update_edge(uint8_t *levelset, int *counter, std::vector<point2d> &edge_poi
 
 void check_and_add_edges(std::vector<point2d> &edge_points,
                          std::vector<point2d> &unchecked_points, uint8_t *levelset,
-                         int *counter, int nx, int ny) {
+                         int *counter, int nx, int ny)
+{
 
   // counter[0] += 1;
   int current_iteration = counter[0];
@@ -220,13 +257,19 @@ void check_and_add_edges(std::vector<point2d> &edge_points,
   int const stride_x = 1;
   int const stride_y = nx;
 
-  for (const point2d &p : unchecked_points) {
-    for (int yi = p.y - 1; yi < p.y + 2; yi++) {
-      if (is_inside(yi, ny)) {
-        for (int xi = p.x - 1; xi < p.x + 2; xi++) {
-          if (is_inside(xi, nx)) {
+  for (const point2d &p : unchecked_points)
+  {
+    for (int yi = p.y - 1; yi < p.y + 2; yi++)
+    {
+      if (is_inside(yi, ny))
+      {
+        for (int xi = p.x - 1; xi < p.x + 2; xi++)
+        {
+          if (is_inside(xi, nx))
+          {
             int index = xi + stride_y * yi;
-            if (counter[index] != current_iteration) {
+            if (counter[index] != current_iteration)
+            {
               counter[index] = current_iteration;
 
               int index_left = index - (xi > 0) * stride_x;
@@ -236,7 +279,8 @@ void check_and_add_edges(std::vector<point2d> &edge_points,
 
               if (levelset[index] != 1 &&
                   (levelset[index_left] == 1 || levelset[index_right] == 1 ||
-                   levelset[index_down] == 1 || levelset[index_up] == 1)) {
+                   levelset[index_down] == 1 || levelset[index_up] == 1))
+              {
                 point2d edge = {xi, yi};
                 edge_points.push_back(edge);
               }
@@ -252,7 +296,8 @@ void check_and_add_edges(std::vector<point2d> &edge_points,
 
 void evolve_edge_2d(double *image, uint8_t *levelset, int *counter,
                     std::vector<point2d> &edge_points, int nx, int ny, double lambda1,
-                    double lambda2) {
+                    double lambda2)
+{
 
   int const stride_x = 1;
   int const stride_y = nx;
@@ -277,33 +322,41 @@ void evolve_edge_2d(double *image, uint8_t *levelset, int *counter,
     // cast to int to be compatible with OpenMP 2.0
     assert(edge_points.size() < INT_MAX / 2);
 #pragma omp for
-    for (int pi = 0; pi < static_cast<int>(edge_points.size()); pi++) {
+    for (int pi = 0; pi < static_cast<int>(edge_points.size()); pi++)
+    {
       point2d p = edge_points[pi];
-      for (int yi = p.y - 1; yi < p.y + 2; yi++) {
-        if (is_central(yi, ny)) {
-          for (int xi = p.x - 1; xi < p.x + 2; xi++) {
-            if (is_central(xi, nx)) {
+      for (int yi = p.y - 1; yi < p.y + 2; yi++)
+      {
+        if (is_central(yi, ny))
+        {
+          for (int xi = p.x - 1; xi < p.x + 2; xi++)
+          {
+            if (is_central(xi, nx))
+            {
               int const index = xi + stride_y * yi;
 
-              if (counter[index] != current_iteration) {
+              if (counter[index] != current_iteration)
+              {
                 // possible race
                 counter[index] = current_iteration;
 
-                double gx =
-                    0.5 * (levelset[index + stride_x] - levelset[index - stride_x]);
-                double gy =
-                    0.5 * (levelset[index + stride_y] - levelset[index - stride_y]);
+                bool gx = levelset[index + stride_x] != levelset[index - stride_x];
+                bool gy = levelset[index + stride_y] != levelset[index - stride_y];
 
-                double abs_grad = fabs(gx) + fabs(gy);
+                bool abs_grad = (gx || gy);
                 double value = image[index];
-                double aux = abs_grad * (lambda1 * pow(value - c1, 2) -
-                                         lambda2 * pow(value - c0, 2));
+                double aux =
+                    abs_grad
+                        ? (lambda1 * pow(value - c1, 2) - lambda2 * pow(value - c0, 2))
+                        : 0.0;
 
-                if (aux < 0 && levelset[index] == 0) {
+                if (aux < 0 && levelset[index] == 0)
+                {
                   point2d point = {xi, yi};
                   changed_add_p[omp_get_thread_num()].push_back(point);
                 }
-                if (aux > 0 && levelset[index] == 1) {
+                if (aux > 0 && levelset[index] == 1)
+                {
                   point2d point = {xi, yi};
                   changed_remove_p[omp_get_thread_num()].push_back(point);
                 }
@@ -323,10 +376,12 @@ void evolve_edge_2d(double *image, uint8_t *levelset, int *counter,
   delete[] changed_add_p;
   delete[] changed_remove_p;
 
-  for (const point2d &point : changed_add) {
+  for (const point2d &point : changed_add)
+  {
     levelset[point.x + stride_y * point.y] = 1;
   }
-  for (const point2d &point : changed_remove) {
+  for (const point2d &point : changed_remove)
+  {
     levelset[point.x + stride_y * point.y] = 0;
   }
 
@@ -337,14 +392,17 @@ void evolve_edge_2d(double *image, uint8_t *levelset, int *counter,
   return;
 }
 
-std::vector<point2d> get_edge_list_2d(uint8_t *levelset, int nx, int ny) {
+std::vector<point2d> get_edge_list_2d(uint8_t *levelset, int nx, int ny)
+{
 
   int const stride_x = 1;
   int const stride_y = nx;
 
   std::vector<point2d> retval;
-  for (int yi = 0; yi < ny; yi++) {
-    for (int xi = 0; xi < nx; xi++) {
+  for (int yi = 0; yi < ny; yi++)
+  {
+    for (int xi = 0; xi < nx; xi++)
+    {
 
       int index = xi + stride_y * yi;
       int index_left = index - (xi > 0) * stride_x;
@@ -353,7 +411,8 @@ std::vector<point2d> get_edge_list_2d(uint8_t *levelset, int nx, int ny) {
       int index_up = index + (yi < (ny - 1)) * stride_y;
       if (levelset[index] != 1 &&
           (levelset[index_left] == 1 || levelset[index_right] == 1 ||
-           levelset[index_down] == 1 || levelset[index_up] == 1)) {
+           levelset[index_down] == 1 || levelset[index_up] == 1))
+      {
         point2d edge = {xi, yi};
         retval.push_back(edge);
       }
@@ -364,7 +423,8 @@ std::vector<point2d> get_edge_list_2d(uint8_t *levelset, int nx, int ny) {
 }
 
 void fast_marching_erosion_2d(std::vector<point2d> &edge_points, uint8_t *levelset,
-                              int *counter, int nx, int ny) {
+                              int *counter, int nx, int ny)
+{
 
   int const stride_x = 1;
   int const stride_y = nx;
@@ -378,31 +438,44 @@ void fast_marching_erosion_2d(std::vector<point2d> &edge_points, uint8_t *levels
 #pragma omp parallel
   {
 #pragma omp single
-    { changed_p = new std::vector<point2d>[omp_get_num_threads()]; }
+    {
+      changed_p = new std::vector<point2d>[omp_get_num_threads()];
+    }
 
     // cast to int to be compatible with OpenMP 2.0
     assert(edge_points.size() < INT_MAX / 2);
 
 #pragma omp for
-    for (int pi = 0; pi < static_cast<int>(edge_points.size()); pi++) {
+    for (int pi = 0; pi < static_cast<int>(edge_points.size()); pi++)
+    {
       point2d p = edge_points[pi];
-      for (int yi = p.y - 1; yi < p.y + 2; yi++) {
-        if (is_inside(yi, ny)) {
-          for (int xi = p.x - 1; xi < p.x + 2; xi++) {
-            if (is_inside(xi, nx)) {
+      for (int yi = p.y - 1; yi < p.y + 2; yi++)
+      {
+        if (is_inside(yi, ny))
+        {
+          for (int xi = p.x - 1; xi < p.x + 2; xi++)
+          {
+            if (is_inside(xi, nx))
+            {
               int const index = xi + stride_y * yi;
-              if (counter[index] != current_iteration) {
+              if (counter[index] != current_iteration)
+              {
                 counter[index] = current_iteration;
                 // // apply erosion only on 1
-                if (levelset[index] == 1) {
+                if (levelset[index] == 1)
+                {
 
-                  if (is_central(xi, nx) && is_central(yi, ny)) {
+                  if (is_central(xi, nx) && is_central(yi, ny))
+                  {
                     // normal case
-                    if (SId_2d_any(levelset, index, stride_x, stride_y) == 0) {
+                    if (SId_2d_any(levelset, index, stride_x, stride_y) == 0)
+                    {
                       point2d point = {xi, yi};
                       changed_p[omp_get_thread_num()].push_back(point);
                     }
-                  } else if (SId_2d_borders(xi, yi, levelset, nx, ny) == 0) {
+                  }
+                  else if (SId_2d_borders(xi, yi, levelset, nx, ny) == 0)
+                  {
                     point2d point = {xi, yi};
                     changed_p[omp_get_thread_num()].push_back(point);
                   }
@@ -415,7 +488,9 @@ void fast_marching_erosion_2d(std::vector<point2d> &edge_points, uint8_t *levels
     }
 
 #pragma omp single
-    { reduce(changed_p, 0, omp_get_num_threads()); }
+    {
+      reduce(changed_p, 0, omp_get_num_threads());
+    }
   }
   changed = changed_p[0];
   delete[] changed_p;
@@ -423,7 +498,8 @@ void fast_marching_erosion_2d(std::vector<point2d> &edge_points, uint8_t *levels
   if (changed.size() == 0)
     return;
 
-  for (const point2d &point : changed) {
+  for (const point2d &point : changed)
+  {
     levelset[point.x + stride_y * point.y] = 0;
   }
 
@@ -433,7 +509,8 @@ void fast_marching_erosion_2d(std::vector<point2d> &edge_points, uint8_t *levels
 }
 
 void fast_marching_dilation_2d(std::vector<point2d> &edge_points, uint8_t *levelset,
-                               int *counter, int nx, int ny) {
+                               int *counter, int nx, int ny)
+{
   int const stride_x = 1;
   int const stride_y = nx;
 
@@ -446,29 +523,42 @@ void fast_marching_dilation_2d(std::vector<point2d> &edge_points, uint8_t *level
 #pragma omp parallel
   {
 #pragma omp single
-    { changed_p = new std::vector<point2d>[omp_get_num_threads()]; }
+    {
+      changed_p = new std::vector<point2d>[omp_get_num_threads()];
+    }
 
     // cast to int to be compatible with OpenMP 2.0
     assert(edge_points.size() < INT_MAX / 2);
 #pragma omp for
-    for (int pi = 0; pi < static_cast<int>(edge_points.size()); pi++) {
+    for (int pi = 0; pi < static_cast<int>(edge_points.size()); pi++)
+    {
       point2d p = edge_points[pi];
-      for (int yi = p.y - 1; yi < p.y + 2; yi++) {
-        if (is_inside(yi, ny)) {
-          for (int xi = p.x - 1; xi < p.x + 2; xi++) {
-            if (is_inside(xi, nx)) {
+      for (int yi = p.y - 1; yi < p.y + 2; yi++)
+      {
+        if (is_inside(yi, ny))
+        {
+          for (int xi = p.x - 1; xi < p.x + 2; xi++)
+          {
+            if (is_inside(xi, nx))
+            {
               int const index = xi + stride_y * yi;
-              if (counter[index] != current_iteration) {
+              if (counter[index] != current_iteration)
+              {
                 counter[index] = current_iteration;
                 // apply dilation only on 0
-                if (levelset[index] == 0) {
-                  if (is_central(xi, nx) && is_central(yi, ny)) {
+                if (levelset[index] == 0)
+                {
+                  if (is_central(xi, nx) && is_central(yi, ny))
+                  {
                     // normal case
-                    if (ISd_2d_any(levelset, index, stride_x, stride_y) == 1) {
+                    if (ISd_2d_any(levelset, index, stride_x, stride_y) == 1)
+                    {
                       point2d point = {xi, yi};
                       changed_p[omp_get_thread_num()].push_back(point);
                     }
-                  } else if (ISd_2d_borders(xi, yi, levelset, nx, ny) == 1) {
+                  }
+                  else if (ISd_2d_borders(xi, yi, levelset, nx, ny) == 1)
+                  {
                     point2d point = {xi, yi};
                     changed_p[omp_get_thread_num()].push_back(point);
                   }
@@ -481,7 +571,9 @@ void fast_marching_dilation_2d(std::vector<point2d> &edge_points, uint8_t *level
     }
 
 #pragma omp single
-    { reduce(changed_p, 0, omp_get_num_threads()); }
+    {
+      reduce(changed_p, 0, omp_get_num_threads());
+    }
   }
   changed = changed_p[0];
   delete[] changed_p;
@@ -489,7 +581,8 @@ void fast_marching_dilation_2d(std::vector<point2d> &edge_points, uint8_t *level
   if (changed.size() == 0)
     return;
 
-  for (const point2d &point : changed) {
+  for (const point2d &point : changed)
+  {
     levelset[point.x + stride_y * point.y] = 1;
   }
 
@@ -498,9 +591,11 @@ void fast_marching_dilation_2d(std::vector<point2d> &edge_points, uint8_t *level
   return;
 }
 
-namespace pysnakes3d {
+namespace pysnakes3d
+{
 
-bool is_edge(uint8_t *levelset, point3d point, int nx, int ny, int nz) {
+bool is_edge(uint8_t *levelset, point3d point, int nx, int ny, int nz)
+{
   int const xi = point.x;
   int const yi = point.y;
   int const zi = point.z;
@@ -512,12 +607,14 @@ bool is_edge(uint8_t *levelset, point3d point, int nx, int ny, int nz) {
   int const index = xi + stride_y * yi + stride_z * zi;
 
   // Keep level sed padded from border
-  if (xi < 0 || yi < 0 || zi < 0 || xi > nx - 1 || yi > ny - 1 || zi > nz - 1) {
+  if (xi < 0 || yi < 0 || zi < 0 || xi > nx - 1 || yi > ny - 1 || zi > nz - 1)
+  {
     return false;
   }
 
   // Define border as a not 1 valued voxel with an 6 connected active neighbour
-  if (levelset[index] == 1) {
+  if (levelset[index] == 1)
+  {
     return false;
   }
   int const index_x0 = index - (xi > 0) * stride_x;
@@ -528,7 +625,8 @@ bool is_edge(uint8_t *levelset, point3d point, int nx, int ny, int nz) {
   int const index_z1 = index + (zi < (nz - 1)) * stride_z;
   if ((levelset[index_x0] == 1) || (levelset[index_x1] == 1) ||
       (levelset[index_y0] == 1) || (levelset[index_y1] == 1) ||
-      (levelset[index_z0] == 1) || (levelset[index_z1] == 1)) {
+      (levelset[index_z0] == 1) || (levelset[index_z1] == 1))
+  {
     return true;
   }
 
@@ -536,7 +634,8 @@ bool is_edge(uint8_t *levelset, point3d point, int nx, int ny, int nz) {
 }
 
 void update_edge(uint8_t *levelset, int *counter, std::vector<point3d> &edge_points,
-                 int nx, int ny, int nz) {
+                 int nx, int ny, int nz)
+{
   counter[0] += 1;
   int current_iteration = counter[0];
 
@@ -547,11 +646,14 @@ void update_edge(uint8_t *levelset, int *counter, std::vector<point3d> &edge_poi
   std::vector<point3d> new_edge;
   new_edge.reserve(edge_points.size());
 
-  for (const point3d &point : edge_points) {
+  for (const point3d &point : edge_points)
+  {
     int const index = point.x + stride_y * point.y + stride_z * point.z;
-    if (counter[index] != current_iteration) {
+    if (counter[index] != current_iteration)
+    {
       counter[index] = current_iteration;
-      if (is_edge(levelset, point, nx, ny, nz)) {
+      if (is_edge(levelset, point, nx, ny, nz))
+      {
         new_edge.push_back(point);
       }
     }
@@ -561,7 +663,8 @@ void update_edge(uint8_t *levelset, int *counter, std::vector<point3d> &edge_poi
 
 void check_and_add_edges(std::vector<point3d> &edge_points,
                          std::vector<point3d> &unchecked_points, uint8_t *levelset,
-                         int *counter, int nx, int ny, int nz) {
+                         int *counter, int nx, int ny, int nz)
+{
 
   counter[0] += 1;
   int current_iteration = counter[0];
@@ -570,19 +673,28 @@ void check_and_add_edges(std::vector<point3d> &edge_points,
   int const stride_y = nx;
   int const stride_z = nx * ny;
 
-  if (edge_points.capacity() < edge_points.size() + unchecked_points.size()) {
+  if (edge_points.capacity() < edge_points.size() + unchecked_points.size())
+  {
     edge_points.reserve(edge_points.size() + unchecked_points.size());
   }
 
-  for (const point3d &p : unchecked_points) {
-    for (int zi = p.z - 1; zi < p.z + 2; zi++) {
-      if (is_inside(zi, nz)) {
-        for (int yi = p.y - 1; yi < p.y + 2; yi++) {
-          if (is_inside(yi, ny)) {
-            for (int xi = p.x - 1; xi < p.x + 2; xi++) {
-              if (is_inside(xi, nx)) {
+  for (const point3d &p : unchecked_points)
+  {
+    for (int zi = p.z - 1; zi < p.z + 2; zi++)
+    {
+      if (is_inside(zi, nz))
+      {
+        for (int yi = p.y - 1; yi < p.y + 2; yi++)
+        {
+          if (is_inside(yi, ny))
+          {
+            for (int xi = p.x - 1; xi < p.x + 2; xi++)
+            {
+              if (is_inside(xi, nx))
+              {
                 int const index = xi + stride_y * yi + stride_z * zi;
-                if (counter[index] != current_iteration) {
+                if (counter[index] != current_iteration)
+                {
                   counter[index] = current_iteration;
 
                   int const index_x0 = index - (xi > 0) * stride_x;
@@ -594,7 +706,8 @@ void check_and_add_edges(std::vector<point3d> &edge_points,
                   if (levelset[index] != 1 &&
                       (levelset[index_x0] == 1 || levelset[index_x1] == 1 ||
                        levelset[index_y0] == 1 || levelset[index_y1] == 1 ||
-                       levelset[index_z0] == 1 || levelset[index_z1] == 1)) {
+                       levelset[index_z0] == 1 || levelset[index_z1] == 1))
+                  {
 
                     point3d edge = {xi, yi, zi};
                     edge_points.push_back(edge);
@@ -614,7 +727,8 @@ void check_and_add_edges(std::vector<point3d> &edge_points,
 
 void evolve_edge_3d(double *image, uint8_t *levelset, int *counter,
                     std::vector<point3d> &edge_points, int nx, int ny, int nz,
-                    double lambda1, double lambda2) {
+                    double lambda1, double lambda2)
+{
 
   int const stride_x = 1;
   int const stride_y = nx;
@@ -640,37 +754,45 @@ void evolve_edge_3d(double *image, uint8_t *levelset, int *counter,
     // cast to int to be compatible with OpenMP 2.0
     assert(edge_points.size() < INT_MAX / 2);
 #pragma omp for
-    for (int pi = 0; pi < static_cast<int>(edge_points.size()); pi++) {
+    for (int pi = 0; pi < static_cast<int>(edge_points.size()); pi++)
+    {
       point3d p = edge_points[pi];
-      for (int zi = p.z - 1; zi < p.z + 2; zi++) {
-        if (is_central(zi, nz)) {
-          for (int yi = p.y - 1; yi < p.y + 2; yi++) {
-            if (is_central(yi, ny)) {
-              for (int xi = p.x - 1; xi < p.x + 2; xi++) {
-                if (is_central(xi, nx)) {
+      for (int zi = p.z - 1; zi < p.z + 2; zi++)
+      {
+        if (is_central(zi, nz))
+        {
+          for (int yi = p.y - 1; yi < p.y + 2; yi++)
+          {
+            if (is_central(yi, ny))
+            {
+              for (int xi = p.x - 1; xi < p.x + 2; xi++)
+              {
+                if (is_central(xi, nx))
+                {
                   int const index = xi + stride_y * yi + stride_z * zi;
 
-                  if (counter[index] != current_iteration) {
-                    // possible race ges cleared up at at check_and_add_edges
+                  if (counter[index] != current_iteration)
+                  {
+                    // possible race gets cleared up at at check_and_add_edges
                     counter[index] = current_iteration;
 
-                    double gx =
-                        0.5 * (levelset[index + stride_x] - levelset[index - stride_x]);
-                    double gy =
-                        0.5 * (levelset[index + stride_y] - levelset[index - stride_y]);
-                    double gz =
-                        0.5 * (levelset[index + stride_z] - levelset[index - stride_z]);
+                    bool gx = levelset[index + stride_x] != levelset[index - stride_x];
+                    bool gy = levelset[index + stride_y] != levelset[index - stride_y];
+                    bool gz = levelset[index + stride_z] != levelset[index - stride_z];
 
-                    double abs_grad = fabs(gx) + fabs(gy) + fabs(gz);
+                    double abs_grad = (gx || gy || gz);
                     double value = image[index];
-                    double aux = abs_grad * (lambda1 * pow(value - c1, 2) -
-                                             lambda2 * pow(value - c0, 2));
+                    double aux = abs_grad ? (lambda1 * pow(value - c1, 2) -
+                                             lambda2 * pow(value - c0, 2))
+                                          : 0.0;
 
-                    if (aux < 0 && levelset[index] == 0) {
+                    if (aux < 0 && levelset[index] == 0)
+                    {
                       point3d point = {xi, yi, zi};
                       changed_add_p[omp_get_thread_num()].push_back(point);
                     }
-                    if (aux > 0 && levelset[index] == 1) {
+                    if (aux > 0 && levelset[index] == 1)
+                    {
                       point3d point = {xi, yi, zi};
                       changed_remove_p[omp_get_thread_num()].push_back(point);
                     }
@@ -692,10 +814,12 @@ void evolve_edge_3d(double *image, uint8_t *levelset, int *counter,
   delete[] changed_add_p;
   delete[] changed_remove_p;
 
-  for (const point3d &point : changed_add) {
+  for (const point3d &point : changed_add)
+  {
     levelset[point.x + stride_y * point.y + stride_z * point.z] = 1;
   }
-  for (const point3d &point : changed_remove) {
+  for (const point3d &point : changed_remove)
+  {
     levelset[point.x + stride_y * point.y + stride_z * point.z] = 0;
   }
 
@@ -708,7 +832,8 @@ void evolve_edge_3d(double *image, uint8_t *levelset, int *counter,
 }
 
 void fast_marching_erosion_3d(std::vector<point3d> &edge_points, uint8_t *levelset,
-                              int *counter, int nx, int ny, int nz) {
+                              int *counter, int nx, int ny, int nz)
+{
 
   int const stride_x = 1;
   int const stride_y = nx;
@@ -723,37 +848,52 @@ void fast_marching_erosion_3d(std::vector<point3d> &edge_points, uint8_t *levels
 #pragma omp parallel
   {
 #pragma omp single
-    { changed_p = new std::vector<point3d>[omp_get_num_threads()]; }
+    {
+      changed_p = new std::vector<point3d>[omp_get_num_threads()];
+    }
 
     // cast to int to be compatible with OpenMP 2.0
     assert(edge_points.size() < INT_MAX / 2);
 #pragma omp for
-    for (int pi = 0; pi < static_cast<int>(edge_points.size()); pi++) {
+    for (int pi = 0; pi < static_cast<int>(edge_points.size()); pi++)
+    {
       point3d point = edge_points[pi];
-      for (int k = -1; k < 2; k++) {
+      for (int k = -1; k < 2; k++)
+      {
         int zi = point.z + k;
-        if (is_inside(zi, nz)) {
-          for (int j = -1; j < 2; j++) {
+        if (is_inside(zi, nz))
+        {
+          for (int j = -1; j < 2; j++)
+          {
             int yi = point.y + j;
-            if (is_inside(yi, ny)) {
-              for (int i = -1; i < 2; i++) {
+            if (is_inside(yi, ny))
+            {
+              for (int i = -1; i < 2; i++)
+              {
                 int xi = point.x + i;
-                if (is_inside(xi, nx)) {
+                if (is_inside(xi, nx))
+                {
                   int const index = xi + stride_y * yi + stride_z * zi;
-                  if (counter[index] != current_iteration) {
+                  if (counter[index] != current_iteration)
+                  {
                     counter[index] = current_iteration;
                     // // apply erosion only on 1
-                    if (levelset[index] == 1) {
+                    if (levelset[index] == 1)
+                    {
                       if (is_central(xi, nx) && is_central(yi, ny) &&
-                          is_central(zi, nz)) {
+                          is_central(zi, nz))
+                      {
                         // normal case
                         if (SId_3d_any(levelset, index, stride_x, stride_y, stride_z) ==
-                            0) {
+                            0)
+                        {
                           point3d point = {xi, yi, zi};
                           changed_p[omp_get_thread_num()].push_back(point);
                         }
-                      } else if (SId_3d_borders(xi, yi, zi, levelset, nx, ny, nz) ==
-                                 0) {
+                      }
+                      else if (SId_3d_borders(xi, yi, zi, levelset, nx, ny, nz) ==
+                               0)
+                      {
                         point3d point = {xi, yi, zi};
                         changed_p[omp_get_thread_num()].push_back(point);
                       }
@@ -768,7 +908,9 @@ void fast_marching_erosion_3d(std::vector<point3d> &edge_points, uint8_t *levels
     }
 
 #pragma omp single
-    { reduce(changed_p, 0, omp_get_num_threads()); }
+    {
+      reduce(changed_p, 0, omp_get_num_threads());
+    }
   }
   changed = changed_p[0];
   delete[] changed_p;
@@ -776,7 +918,8 @@ void fast_marching_erosion_3d(std::vector<point3d> &edge_points, uint8_t *levels
   if (changed.size() == 0)
     return;
 
-  for (const point3d &point : changed) {
+  for (const point3d &point : changed)
+  {
     levelset[point.x + stride_y * point.y + stride_z * point.z] = 0;
   }
 
@@ -786,7 +929,8 @@ void fast_marching_erosion_3d(std::vector<point3d> &edge_points, uint8_t *levels
 }
 
 void fast_marching_dilation_3d(std::vector<point3d> &edge_points, uint8_t *levelset,
-                               int *counter, int nx, int ny, int nz) {
+                               int *counter, int nx, int ny, int nz)
+{
   int const stride_x = 1;
   int const stride_y = nx;
   int const stride_z = nx * ny;
@@ -800,36 +944,51 @@ void fast_marching_dilation_3d(std::vector<point3d> &edge_points, uint8_t *level
 #pragma omp parallel
   {
 #pragma omp single
-    { changed_p = new std::vector<point3d>[omp_get_num_threads()]; }
+    {
+      changed_p = new std::vector<point3d>[omp_get_num_threads()];
+    }
     // cast to int to be compatible with OpenMP 2.0
     assert(edge_points.size() < INT_MAX / 2);
 #pragma omp for
-    for (int pi = 0; pi < static_cast<int>(edge_points.size()); pi++) {
+    for (int pi = 0; pi < static_cast<int>(edge_points.size()); pi++)
+    {
       point3d p = edge_points[pi];
-      for (int zi = p.z - 1; zi < p.z + 2; zi++) {
-        if (is_inside(zi, nz)) {
-          for (int yi = p.y - 1; yi < p.y + 2; yi++) {
-            if (is_inside(yi, ny)) {
-              for (int xi = p.x - 1; xi < p.x + 2; xi++) {
-                if (is_inside(xi, nx)) {
+      for (int zi = p.z - 1; zi < p.z + 2; zi++)
+      {
+        if (is_inside(zi, nz))
+        {
+          for (int yi = p.y - 1; yi < p.y + 2; yi++)
+          {
+            if (is_inside(yi, ny))
+            {
+              for (int xi = p.x - 1; xi < p.x + 2; xi++)
+              {
+                if (is_inside(xi, nx))
+                {
 
                   int const index = xi + stride_y * yi + stride_z * zi;
-                  if (counter[index] != current_iteration) {
+                  if (counter[index] != current_iteration)
+                  {
                     counter[index] = current_iteration;
 
                     // apply dilation only on 0
-                    if (levelset[index] == 0) {
+                    if (levelset[index] == 0)
+                    {
                       if (is_central(xi, nx) && is_central(yi, ny) &&
-                          is_central(zi, nz)) {
+                          is_central(zi, nz))
+                      {
 
                         // normal case
                         if (ISd_3d_any(levelset, index, stride_x, stride_y, stride_z) ==
-                            1) {
+                            1)
+                        {
                           point3d point = {xi, yi, zi};
                           changed_p[omp_get_thread_num()].push_back(point);
                         }
-                      } else if (ISd_3d_borders(xi, yi, zi, levelset, nx, ny, nz) ==
-                                 1) {
+                      }
+                      else if (ISd_3d_borders(xi, yi, zi, levelset, nx, ny, nz) ==
+                               1)
+                      {
                         point3d point = {xi, yi, zi};
                         changed_p[omp_get_thread_num()].push_back(point);
                       }
@@ -843,7 +1002,9 @@ void fast_marching_dilation_3d(std::vector<point3d> &edge_points, uint8_t *level
       }
     }
 #pragma omp single
-    { reduce(changed_p, 0, omp_get_num_threads()); }
+    {
+      reduce(changed_p, 0, omp_get_num_threads());
+    }
   }
   changed = changed_p[0];
   delete[] changed_p;
@@ -851,7 +1012,8 @@ void fast_marching_dilation_3d(std::vector<point3d> &edge_points, uint8_t *level
   if (changed.size() == 0)
     return;
 
-  for (const point3d &point : changed) {
+  for (const point3d &point : changed)
+  {
     levelset[point.x + stride_y * point.y + stride_z * point.z] = 1;
   }
 
@@ -860,16 +1022,20 @@ void fast_marching_dilation_3d(std::vector<point3d> &edge_points, uint8_t *level
   return;
 }
 
-std::vector<point3d> get_edge_list_3d(uint8_t *levelset, int nx, int ny, int nz) {
+std::vector<point3d> get_edge_list_3d(uint8_t *levelset, int nx, int ny, int nz)
+{
 
   int const stride_x = 1;
   int const stride_y = nx;
   int const stride_z = nx * ny;
 
   std::vector<point3d> retval;
-  for (int zi = 0; zi < nz; zi++) {
-    for (int yi = 0; yi < ny; yi++) {
-      for (int xi = 0; xi < nx; xi++) {
+  for (int zi = 0; zi < nz; zi++)
+  {
+    for (int yi = 0; yi < ny; yi++)
+    {
+      for (int xi = 0; xi < nx; xi++)
+      {
         int index = xi + stride_y * yi + stride_z * zi;
         int const index_x0 = index - (xi > 0) * stride_x;
         int const index_x1 = index + (xi < (nx - 1)) * stride_x;
@@ -880,7 +1046,8 @@ std::vector<point3d> get_edge_list_3d(uint8_t *levelset, int nx, int ny, int nz)
         if (levelset[index] != 1 &&
             (levelset[index_x0] == 1 || levelset[index_x1] == 1 ||
              levelset[index_y0] == 1 || levelset[index_y1] == 1 ||
-             levelset[index_z0] == 1 || levelset[index_z1] == 1)) {
+             levelset[index_z0] == 1 || levelset[index_z1] == 1))
+        {
           point3d edge = {xi, yi, zi};
           retval.push_back(edge);
         }
@@ -890,30 +1057,38 @@ std::vector<point3d> get_edge_list_3d(uint8_t *levelset, int nx, int ny, int nz)
   return retval;
 }
 
-struct sortfunc {
-  bool operator()(const point2d &left, const point2d &right) const {
-    if (left.y != right.y) {
+struct sortfunc
+{
+  bool operator()(const point2d &left, const point2d &right) const
+  {
+    if (left.y != right.y)
+    {
       return left.y < right.y;
     }
     return left.x < right.x;
   }
-  bool operator()(const point3d &left, const point3d &right) const {
-    if (left.z != right.z) {
+  bool operator()(const point3d &left, const point3d &right) const
+  {
+    if (left.z != right.z)
+    {
       return left.z < right.z;
     }
-    if (left.y != right.y) {
+    if (left.y != right.y)
+    {
       return left.y < right.y;
     }
     return left.x < right.x;
   }
 };
 
-void sort_edge2d(std::vector<point2d> &edge) {
+void sort_edge2d(std::vector<point2d> &edge)
+{
   std::sort(edge.begin(), edge.end(), sortfunc());
 
   return;
 }
-void sort_edge3d(std::vector<point3d> &edge) {
+void sort_edge3d(std::vector<point3d> &edge)
+{
   std::sort(edge.begin(), edge.end(), sortfunc());
 
   return;

--- a/skimage/segmentation/_morphosnakes.h
+++ b/skimage/segmentation/_morphosnakes.h
@@ -15,7 +15,7 @@
 #else
 typedef int omp_int_t;
 inline omp_int_t omp_get_thread_num() { return 0; }
-inline omp_int_t omp_get_max_threads() { return 1; }
+inline omp_int_t omp_get_num_threads() { return 1; }
 #endif
 
 typedef struct point3d

--- a/skimage/segmentation/_morphosnakes.h
+++ b/skimage/segmentation/_morphosnakes.h
@@ -6,7 +6,6 @@
 #include "snakes3d_operators_bidir.h"
 #include <algorithm>
 #include <cassert>
-#include <omp.h>
 #include <vector>
 
 #include <algorithm>

--- a/skimage/segmentation/_morphosnakes.h
+++ b/skimage/segmentation/_morphosnakes.h
@@ -10,7 +10,14 @@
 #include <vector>
 
 #include <algorithm>
+
+#if defined(_OPENMP)
 #include <omp.h>
+#else
+typedef int omp_int_t;
+inline omp_int_t omp_get_thread_num() { return 0; }
+inline omp_int_t omp_get_max_threads() { return 1; }
+#endif
 
 typedef struct point3d
 {

--- a/skimage/segmentation/_morphosnakes.h
+++ b/skimage/segmentation/_morphosnakes.h
@@ -220,7 +220,7 @@ bool is_edge(uint8_t *levelset, point2d point, int nx, int ny)
   return false;
 }
 
-void update_edge(uint8_t *levelset, int *counter, std::vector<point2d> &edge_points,
+void update_edge(uint8_t *levelset, long *counter, std::vector<point2d> &edge_points,
                  int nx, int ny)
 {
 
@@ -248,7 +248,7 @@ void update_edge(uint8_t *levelset, int *counter, std::vector<point2d> &edge_poi
 
 void check_and_add_edges(std::vector<point2d> &edge_points,
                          std::vector<point2d> &unchecked_points, uint8_t *levelset,
-                         int *counter, int nx, int ny)
+                         long *counter, int nx, int ny)
 {
 
   // counter[0] += 1;
@@ -294,7 +294,7 @@ void check_and_add_edges(std::vector<point2d> &edge_points,
 }
 } // namespace pysnakes2d
 
-void evolve_edge_2d(double *image, uint8_t *levelset, int *counter,
+void evolve_edge_2d(double *image, uint8_t *levelset, long *counter,
                     std::vector<point2d> &edge_points, int nx, int ny, double lambda1,
                     double lambda2)
 {
@@ -423,7 +423,7 @@ std::vector<point2d> get_edge_list_2d(uint8_t *levelset, int nx, int ny)
 }
 
 void fast_marching_erosion_2d(std::vector<point2d> &edge_points, uint8_t *levelset,
-                              int *counter, int nx, int ny)
+                              long *counter, int nx, int ny)
 {
 
   int const stride_x = 1;
@@ -509,7 +509,7 @@ void fast_marching_erosion_2d(std::vector<point2d> &edge_points, uint8_t *levels
 }
 
 void fast_marching_dilation_2d(std::vector<point2d> &edge_points, uint8_t *levelset,
-                               int *counter, int nx, int ny)
+                               long *counter, int nx, int ny)
 {
   int const stride_x = 1;
   int const stride_y = nx;
@@ -633,7 +633,7 @@ bool is_edge(uint8_t *levelset, point3d point, int nx, int ny, int nz)
   return false;
 }
 
-void update_edge(uint8_t *levelset, int *counter, std::vector<point3d> &edge_points,
+void update_edge(uint8_t *levelset, long *counter, std::vector<point3d> &edge_points,
                  int nx, int ny, int nz)
 {
   counter[0] += 1;
@@ -663,7 +663,7 @@ void update_edge(uint8_t *levelset, int *counter, std::vector<point3d> &edge_poi
 
 void check_and_add_edges(std::vector<point3d> &edge_points,
                          std::vector<point3d> &unchecked_points, uint8_t *levelset,
-                         int *counter, int nx, int ny, int nz)
+                         long *counter, int nx, int ny, int nz)
 {
 
   counter[0] += 1;
@@ -725,7 +725,7 @@ void check_and_add_edges(std::vector<point3d> &edge_points,
 
 } // namespace pysnakes3d
 
-void evolve_edge_3d(double *image, uint8_t *levelset, int *counter,
+void evolve_edge_3d(double *image, uint8_t *levelset, long *counter,
                     std::vector<point3d> &edge_points, int nx, int ny, int nz,
                     double lambda1, double lambda2)
 {
@@ -832,7 +832,7 @@ void evolve_edge_3d(double *image, uint8_t *levelset, int *counter,
 }
 
 void fast_marching_erosion_3d(std::vector<point3d> &edge_points, uint8_t *levelset,
-                              int *counter, int nx, int ny, int nz)
+                              long *counter, int nx, int ny, int nz)
 {
 
   int const stride_x = 1;
@@ -929,7 +929,7 @@ void fast_marching_erosion_3d(std::vector<point3d> &edge_points, uint8_t *levels
 }
 
 void fast_marching_dilation_3d(std::vector<point3d> &edge_points, uint8_t *levelset,
-                               int *counter, int nx, int ny, int nz)
+                               long *counter, int nx, int ny, int nz)
 {
   int const stride_x = 1;
   int const stride_y = nx;

--- a/skimage/segmentation/_morphosnakes_fm.pyx
+++ b/skimage/segmentation/_morphosnakes_fm.pyx
@@ -48,7 +48,7 @@ cdef extern from "_morphosnakes.h":
 @cython.wraparound(False)
 def _morphological_chan_vese_2d(double[:, ::1] image,
                             unsigned char[:, ::1] u,
-                            long[:,  ::1] counter,
+                            long[::1] counter,
                             int iterations, 
                             int smoothing=1, 
                             double lambda1=1, 
@@ -63,19 +63,19 @@ def _morphological_chan_vese_2d(double[:, ::1] image,
     for i in range(iterations):
         evolve_edge_2d(&image[0,0],
                     &u[0,0], 
-                    &counter[0,0], 
+                    &counter[0], 
                     edge_points, u.shape[1],u.shape[0],lambda1,lambda2) 
 
                  
         # Smoothing
         for _ in range(smoothing):
             if smooth_counter % 2 == 0:
-                fast_marching_dilation_2d(edge_points, &u[ 0,0], &counter[ 0,0], u.shape[1],u.shape[0])
-                fast_marching_erosion_2d(edge_points, &u[ 0,0], &counter[ 0,0], u.shape[1],u.shape[0])
+                fast_marching_dilation_2d(edge_points, &u[ 0,0], &counter[ 0], u.shape[1],u.shape[0])
+                fast_marching_erosion_2d(edge_points, &u[ 0,0], &counter[ 0], u.shape[1],u.shape[0])
 
             else:
-                fast_marching_erosion_2d(edge_points, &u[ 0,0], &counter[ 0,0], u.shape[1],u.shape[0])
-                fast_marching_dilation_2d(edge_points, &u[ 0,0], &counter[ 0,0], u.shape[1],u.shape[0])
+                fast_marching_erosion_2d(edge_points, &u[ 0,0], &counter[ 0], u.shape[1],u.shape[0])
+                fast_marching_dilation_2d(edge_points, &u[ 0,0], &counter[ 0], u.shape[1],u.shape[0])
 
             smooth_counter=smooth_counter+1
         sort_edge2d(edge_points)   
@@ -90,7 +90,7 @@ def _morphological_chan_vese_2d(double[:, ::1] image,
 @cython.wraparound(False)
 def _morphological_chan_vese_3d(double[:, :, ::1] image,
                             unsigned char[:, :, ::1] u,
-                            long[:, :, ::1] counter,
+                            long[::1] counter,
                             int iterations, 
                             int smoothing=1, 
                             double lambda1=1, 
@@ -106,7 +106,7 @@ def _morphological_chan_vese_3d(double[:, :, ::1] image,
     for _ in range(iterations):
         evolve_edge_3d(&image[0,0,0],
                     &u[0,0,0], 
-                    &counter[0,0,0],  
+                    &counter[0],  
                     edge_points,u.shape[2], u.shape[1],u.shape[0],lambda1,lambda2) 
 
 
@@ -114,21 +114,14 @@ def _morphological_chan_vese_3d(double[:, :, ::1] image,
         for _ in range(smoothing):
         
             if smooth_counter % 2 == 0:
-                fast_marching_dilation_3d(edge_points, &u[0, 0,0], &counter[0, 0,0],u.shape[2], u.shape[1],u.shape[0])
-                fast_marching_erosion_3d(edge_points, &u[0, 0,0], &counter[0, 0,0],u.shape[2], u.shape[1],u.shape[0])
+                fast_marching_dilation_3d(edge_points, &u[0, 0,0], &counter[0],u.shape[2], u.shape[1],u.shape[0])
+                fast_marching_erosion_3d(edge_points, &u[0, 0,0], &counter[0],u.shape[2], u.shape[1],u.shape[0])
             else:
-                fast_marching_erosion_3d(edge_points, &u[0, 0,0], &counter[0, 0,0],u.shape[2], u.shape[1],u.shape[0])
-                fast_marching_dilation_3d(edge_points, &u[0, 0,0], &counter[0, 0,0],u.shape[2], u.shape[1],u.shape[0])
+                fast_marching_erosion_3d(edge_points, &u[0, 0,0], &counter[0],u.shape[2], u.shape[1],u.shape[0])
+                fast_marching_dilation_3d(edge_points, &u[0, 0,0], &counter[0],u.shape[2], u.shape[1],u.shape[0])
             smooth_counter+=1
         
         sort_edge3d(edge_points)        
         iter_callback(to_numpy(u))
 
     return to_numpy(u)
-
-
-
-
-
-
-

--- a/skimage/segmentation/_morphosnakes_fm.pyx
+++ b/skimage/segmentation/_morphosnakes_fm.pyx
@@ -1,0 +1,129 @@
+# distutils: language = c++
+cimport cython
+from libcpp.vector cimport vector
+cimport numpy as cnp
+import numpy as np
+
+
+def to_numpy(x):
+    return np.asarray(x,dtype = np.int8)
+
+cdef extern from "_morphosnakes.h":
+    ctypedef struct point2d
+    vector[point2d] get_edge_list_2d(unsigned char* levelset,
+                                     int nx, int ny)
+    void evolve_edge_2d(double *image, 
+                        unsigned char* levelset, 
+                        int *counter,
+                        vector[point2d] &edge_points, 
+                        int nx, int ny,
+                        double lambda2, double lambda2)
+    void fast_marching_dilation_2d(vector[point2d] &edge, 
+                                   unsigned char* levelset, 
+                                   int *counter,
+                                   int nx, int ny) 
+    void fast_marching_erosion_2d(vector[point2d] &edge, 
+                                  unsigned char* levelset, 
+                                  int *counter,
+                                  int nx, int ny) 
+    void sort_edge2d(vector[point2d] &edge)  
+    void sort_edge3d(vector[point3d] &edge)      
+
+    ctypedef struct point3d
+    vector[point3d] get_edge_list_3d(unsigned char* levelset, int nx, int ny, int nz)
+    void evolve_edge_3d(double *image, unsigned char* levelset, int *counter,
+                 vector[point3d] &edge_points, int nx, int ny, int nz,double lambda2, double lambda2)
+    void fast_marching_dilation_3d(vector[point3d] &edge, unsigned char* levelset, int *counter,
+                          int nx, int ny, int nz)
+    void fast_marching_erosion_3d(vector[point3d] &edge, unsigned char* levelset, int *counter,
+                          int nx, int ny, int nz)
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def _morphological_chan_vese_2d(double[:, ::1] image,
+                            unsigned char[:, ::1] u,
+                            int[:,  ::1] counter,
+                            int iterations, 
+                            int smoothing=1, 
+                            double lambda1=1, 
+                            double lambda2=1,
+                            iter_callback=lambda x: None):
+
+    cdef int smooth_counter = 0
+
+    cdef vector[point2d] edge_points = get_edge_list_2d(&u[0, 0],
+                  u.shape[1],u.shape[0])
+    iter_callback(to_numpy(u))
+    for i in range(iterations):
+        evolve_edge_2d(&image[0,0],
+                    &u[0,0], 
+                    &counter[0,0], 
+                    edge_points, u.shape[1],u.shape[0],lambda1,lambda2) 
+
+                 
+        # Smoothing
+        for _ in range(smoothing):
+            if smooth_counter % 2 == 0:
+                fast_marching_dilation_2d(edge_points, &u[ 0,0], &counter[ 0,0], u.shape[1],u.shape[0])
+                fast_marching_erosion_2d(edge_points, &u[ 0,0], &counter[ 0,0], u.shape[1],u.shape[0])
+
+            else:
+                fast_marching_erosion_2d(edge_points, &u[ 0,0], &counter[ 0,0], u.shape[1],u.shape[0])
+                fast_marching_dilation_2d(edge_points, &u[ 0,0], &counter[ 0,0], u.shape[1],u.shape[0])
+
+            smooth_counter=smooth_counter+1
+        sort_edge2d(edge_points)   
+
+        iter_callback(to_numpy(u))
+
+    return to_numpy(u)
+
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def _morphological_chan_vese_3d(double[:, :, ::1] image,
+                            unsigned char[:, :, ::1] u,
+                            int[:, :, ::1] counter,
+                            int iterations, 
+                            int smoothing=1, 
+                            double lambda1=1, 
+                            double lambda2=1,
+                            iter_callback=lambda x: None):
+
+    cdef int smooth_counter = 0
+
+    cdef vector[point3d] edge_points = get_edge_list_3d(&u[0, 0,0],
+                 u.shape[2], u.shape[1],u.shape[0])    
+       
+    iter_callback(to_numpy(u))
+    for _ in range(iterations):
+        evolve_edge_3d(&image[0,0,0],
+                    &u[0,0,0], 
+                    &counter[0,0,0],  
+                    edge_points,u.shape[2], u.shape[1],u.shape[0],lambda1,lambda2) 
+
+
+        # Smoothing
+        for _ in range(smoothing):
+        
+            if smooth_counter % 2 == 0:
+                fast_marching_dilation_3d(edge_points, &u[0, 0,0], &counter[0, 0,0],u.shape[2], u.shape[1],u.shape[0])
+                fast_marching_erosion_3d(edge_points, &u[0, 0,0], &counter[0, 0,0],u.shape[2], u.shape[1],u.shape[0])
+            else:
+                fast_marching_erosion_3d(edge_points, &u[0, 0,0], &counter[0, 0,0],u.shape[2], u.shape[1],u.shape[0])
+                fast_marching_dilation_3d(edge_points, &u[0, 0,0], &counter[0, 0,0],u.shape[2], u.shape[1],u.shape[0])
+            smooth_counter+=1
+        
+        sort_edge3d(edge_points)        
+        iter_callback(to_numpy(u))
+
+    return to_numpy(u)
+
+
+
+
+
+
+

--- a/skimage/segmentation/_morphosnakes_fm.pyx
+++ b/skimage/segmentation/_morphosnakes_fm.pyx
@@ -4,7 +4,6 @@ from libcpp.vector cimport vector
 cimport numpy as cnp
 import numpy as np
 
-ctypedef cnp.int32_t INT_T
 
 def to_numpy(x):
     return np.asarray(x,dtype = np.int8)
@@ -15,17 +14,17 @@ cdef extern from "_morphosnakes.h":
                                      int nx, int ny)
     void evolve_edge_2d(double *image, 
                         unsigned char* levelset, 
-                        INT_T *counter,
+                        long *counter,
                         vector[point2d] &edge_points, 
                         int nx, int ny,
                         double lambda2, double lambda2)
     void fast_marching_dilation_2d(vector[point2d] &edge, 
                                    unsigned char* levelset, 
-                                   INT_T *counter,
+                                   long *counter,
                                    int nx, int ny) 
     void fast_marching_erosion_2d(vector[point2d] &edge, 
                                   unsigned char* levelset, 
-                                  INT_T *counter,
+                                  long *counter,
                                   int nx, int ny) 
     void sort_edge2d(vector[point2d] &edge)  
     void sort_edge3d(vector[point3d] &edge)      
@@ -35,13 +34,13 @@ cdef extern from "_morphosnakes.h":
                                      int nx, int ny, int nz)
     void evolve_edge_3d(double *image, 
                         unsigned char* levelset, 
-                        INT_T *counter,
+                        long *counter,
                         vector[point3d] &edge_points, 
                         int nx, int ny, int nz,
                         double lambda2, double lambda2)
-    void fast_marching_dilation_3d(vector[point3d] &edge, unsigned char* levelset, INT_T *counter,
+    void fast_marching_dilation_3d(vector[point3d] &edge, unsigned char* levelset, long *counter,
                           int nx, int ny, int nz)
-    void fast_marching_erosion_3d(vector[point3d] &edge, unsigned char* levelset, INT_T *counter,
+    void fast_marching_erosion_3d(vector[point3d] &edge, unsigned char* levelset, long *counter,
                           int nx, int ny, int nz)
 
 
@@ -49,7 +48,7 @@ cdef extern from "_morphosnakes.h":
 @cython.wraparound(False)
 def _morphological_chan_vese_2d(double[:, ::1] image,
                             unsigned char[:, ::1] u,
-                            INT_T[:,  ::1] counter,
+                            long[:,  ::1] counter,
                             int iterations, 
                             int smoothing=1, 
                             double lambda1=1, 
@@ -91,7 +90,7 @@ def _morphological_chan_vese_2d(double[:, ::1] image,
 @cython.wraparound(False)
 def _morphological_chan_vese_3d(double[:, :, ::1] image,
                             unsigned char[:, :, ::1] u,
-                            INT_T[:, :, ::1] counter,
+                            long[:, :, ::1] counter,
                             int iterations, 
                             int smoothing=1, 
                             double lambda1=1, 

--- a/skimage/segmentation/_morphosnakes_fm.pyx
+++ b/skimage/segmentation/_morphosnakes_fm.pyx
@@ -4,6 +4,7 @@ from libcpp.vector cimport vector
 cimport numpy as cnp
 import numpy as np
 
+ctypedef cnp.int32_t INT_T
 
 def to_numpy(x):
     return np.asarray(x,dtype = np.int8)
@@ -14,28 +15,33 @@ cdef extern from "_morphosnakes.h":
                                      int nx, int ny)
     void evolve_edge_2d(double *image, 
                         unsigned char* levelset, 
-                        int *counter,
+                        INT_T *counter,
                         vector[point2d] &edge_points, 
                         int nx, int ny,
                         double lambda2, double lambda2)
     void fast_marching_dilation_2d(vector[point2d] &edge, 
                                    unsigned char* levelset, 
-                                   int *counter,
+                                   INT_T *counter,
                                    int nx, int ny) 
     void fast_marching_erosion_2d(vector[point2d] &edge, 
                                   unsigned char* levelset, 
-                                  int *counter,
+                                  INT_T *counter,
                                   int nx, int ny) 
     void sort_edge2d(vector[point2d] &edge)  
     void sort_edge3d(vector[point3d] &edge)      
 
     ctypedef struct point3d
-    vector[point3d] get_edge_list_3d(unsigned char* levelset, int nx, int ny, int nz)
-    void evolve_edge_3d(double *image, unsigned char* levelset, int *counter,
-                 vector[point3d] &edge_points, int nx, int ny, int nz,double lambda2, double lambda2)
-    void fast_marching_dilation_3d(vector[point3d] &edge, unsigned char* levelset, int *counter,
+    vector[point3d] get_edge_list_3d(unsigned char* levelset, 
+                                     int nx, int ny, int nz)
+    void evolve_edge_3d(double *image, 
+                        unsigned char* levelset, 
+                        INT_T *counter,
+                        vector[point3d] &edge_points, 
+                        int nx, int ny, int nz,
+                        double lambda2, double lambda2)
+    void fast_marching_dilation_3d(vector[point3d] &edge, unsigned char* levelset, INT_T *counter,
                           int nx, int ny, int nz)
-    void fast_marching_erosion_3d(vector[point3d] &edge, unsigned char* levelset, int *counter,
+    void fast_marching_erosion_3d(vector[point3d] &edge, unsigned char* levelset, INT_T *counter,
                           int nx, int ny, int nz)
 
 
@@ -43,7 +49,7 @@ cdef extern from "_morphosnakes.h":
 @cython.wraparound(False)
 def _morphological_chan_vese_2d(double[:, ::1] image,
                             unsigned char[:, ::1] u,
-                            int[:,  ::1] counter,
+                            INT_T[:,  ::1] counter,
                             int iterations, 
                             int smoothing=1, 
                             double lambda1=1, 
@@ -85,7 +91,7 @@ def _morphological_chan_vese_2d(double[:, ::1] image,
 @cython.wraparound(False)
 def _morphological_chan_vese_3d(double[:, :, ::1] image,
                             unsigned char[:, :, ::1] u,
-                            int[:, :, ::1] counter,
+                            INT_T[:, :, ::1] counter,
                             int iterations, 
                             int smoothing=1, 
                             double lambda1=1, 

--- a/skimage/segmentation/morphosnakes_fm.py
+++ b/skimage/segmentation/morphosnakes_fm.py
@@ -1,0 +1,96 @@
+import numpy as np
+from .morphsnakes import _init_level_set, _check_input
+from ._morphosnakes_fm import _morphological_chan_vese_2d
+from ._morphosnakes_fm import _morphological_chan_vese_3d
+
+
+def morphological_chan_vese_fm(image, iterations, init_level_set='checkerboard',
+                               smoothing=1, lambda1=1, lambda2=1,
+                               iter_callback=lambda x: None):
+    """Morphological Active Contours without Edges (MorphACWE)
+
+    Active contours without edges implemented with morphological operators. It
+    can be used to segment objects in images and volumes without well defined
+    borders. It is required that the inside of the object looks different on
+    average than the outside (i.e., the inner area of the object should be
+    darker or lighter than the outer area on average). This is a faster version
+    of morphological_chan_vese, based on
+
+    Luis Alvarez, Luis Baumela, Pablo Márquez-Neila, and Pedro Henríquez,
+    A Real Time Morphological Snakes Algorithm, Image Processing On Line,
+    2 (2012), pp. 1–7. https://doi.org/10.5201/ipol.2012.abmh-rtmsa
+
+    Parameters
+    ----------
+    image : (M, N) or (L, M, N) array
+        Grayscale image or volume to be segmented.
+    iterations : uint
+        Number of iterations to run
+    init_level_set : str, (M, N) array, or (L, M, N) array
+        Initial level set. If an array is given, it will be binarized and used
+        as the initial level set. If a string is given, it defines the method
+        to generate a reasonable initial level set with the shape of the
+        `image`. Accepted values are 'checkerboard' and 'circle'. See the
+        documentation of `checkerboard_level_set` and `circle_level_set`
+        respectively for details about how these level sets are created.
+    smoothing : uint, optional
+        Number of times the smoothing operator is applied per iteration.
+        Reasonable values are around 1-4. Larger values lead to smoother
+        segmentations.
+    lambda1 : float, optional
+        Weight parameter for the outer region. If `lambda1` is larger than
+        `lambda2`, the outer region will contain a larger range of values than
+        the inner region.
+    lambda2 : float, optional
+        Weight parameter for the inner region. If `lambda2` is larger than
+        `lambda1`, the inner region will contain a larger range of values than
+        the outer region.
+    iter_callback : function, optional
+        If given, this function is called once per iteration with the current
+        level set as the only argument. This is useful for debugging or for
+        plotting intermediate results during the evolution.
+
+    Returns
+    -------
+    out : (M, N) or (L, M, N) array
+        Final segmentation (i.e., the final level set)
+
+    See also
+    --------
+    circle_level_set, checkerboard_level_set
+
+    Notes
+    -----
+
+    This is a version of the Chan-Vese algorithm that uses morphological
+    operators instead of solving a partial differential equation (PDE) for the
+    evolution of the contour. The set of morphological operators used in this
+    algorithm are proved to be infinitesimally equivalent to the Chan-Vese PDE
+    (see [1]_). However, morphological operators are do not suffer from the
+    numerical stability issues typically found in PDEs (it is not necessary to
+    find the right time step for the evolution), and are computationally
+    faster.
+
+    The algorithm and its theoretical derivation are described in [1]_.
+
+    References
+    ----------
+    .. [1] A Morphological Approach to Curvature-based Evolution of Curves and
+            Surfaces, Pablo Márquez-Neila, Luis Baumela, Luis Álvarez. In IEEE
+            Transactions on Pattern Analysis and Machine Intelligence (PAMI),
+            2014, :DOI:`10.1109/TPAMI.2013.106`
+    """
+
+    init_level_set = _init_level_set(init_level_set, image.shape)
+    _check_input(image, init_level_set)
+    u = np.uint8(init_level_set > 0)
+    counter = np.zeros(image.shape, dtype=np.int)
+
+    if image.ndim == 2:
+        return _morphological_chan_vese_2d(
+            image, u, counter, iterations, smoothing, lambda1, lambda2, iter_callback
+        )
+    if image.ndim == 3:
+        return _morphological_chan_vese_3d(
+            image, u, counter, iterations, smoothing, lambda1, lambda2, iter_callback
+        )

--- a/skimage/segmentation/morphosnakes_fm.py
+++ b/skimage/segmentation/morphosnakes_fm.py
@@ -84,7 +84,7 @@ def morphological_chan_vese_fm(image, iterations, init_level_set='checkerboard',
     init_level_set = _init_level_set(init_level_set, image.shape)
     _check_input(image, init_level_set)
     u = np.uint8(init_level_set > 0)
-    counter = np.zeros(np.prod(u.shape)+1, dtype=np.int_)
+    counter = np.zeros(np.prod(u.shape) + 1, dtype=np.int_)
 
     if image.ndim == 2:
         return _morphological_chan_vese_2d(

--- a/skimage/segmentation/morphosnakes_fm.py
+++ b/skimage/segmentation/morphosnakes_fm.py
@@ -14,7 +14,7 @@ def morphological_chan_vese_fm(image, iterations, init_level_set='checkerboard',
     borders. It is required that the inside of the object looks different on
     average than the outside (i.e., the inner area of the object should be
     darker or lighter than the outer area on average). This is a faster version
-    of morphological_chan_vese, based on
+    of morphological_chan_vese, based on:
 
     Luis Alvarez, Luis Baumela, Pablo Márquez-Neila, and Pedro Henríquez,
     A Real Time Morphological Snakes Algorithm, Image Processing On Line,

--- a/skimage/segmentation/morphosnakes_fm.py
+++ b/skimage/segmentation/morphosnakes_fm.py
@@ -84,7 +84,7 @@ def morphological_chan_vese_fm(image, iterations, init_level_set='checkerboard',
     init_level_set = _init_level_set(init_level_set, image.shape)
     _check_input(image, init_level_set)
     u = np.uint8(init_level_set > 0)
-    counter = np.zeros(image.shape, dtype=np.int)
+    counter = np.zeros(np.prod(u.shape)+1, dtype=np.int_)
 
     if image.ndim == 2:
         return _morphological_chan_vese_2d(

--- a/skimage/segmentation/morphosnakes_fm.py
+++ b/skimage/segmentation/morphosnakes_fm.py
@@ -4,7 +4,8 @@ from ._morphosnakes_fm import _morphological_chan_vese_2d
 from ._morphosnakes_fm import _morphological_chan_vese_3d
 
 
-def morphological_chan_vese_fm(image, iterations, init_level_set='checkerboard',
+def morphological_chan_vese_fm(image, iterations,
+                               init_level_set='checkerboard',
                                smoothing=1, lambda1=1, lambda2=1,
                                iter_callback=lambda x: None):
     """Morphological Active Contours without Edges (MorphACWE)
@@ -83,14 +84,16 @@ def morphological_chan_vese_fm(image, iterations, init_level_set='checkerboard',
 
     init_level_set = _init_level_set(init_level_set, image.shape)
     _check_input(image, init_level_set)
-    u = np.uint8(init_level_set > 0)
-    counter = np.zeros(np.prod(u.shape) + 1, dtype=np.int_)
+    init_level_set = np.uint8(init_level_set > 0)
+    counter = np.zeros(np.prod(init_level_set.shape) + 1, dtype=np.int_)
 
     if image.ndim == 2:
         return _morphological_chan_vese_2d(
-            image, u, counter, iterations, smoothing, lambda1, lambda2, iter_callback
+            image, init_level_set, counter, iterations, smoothing,
+            lambda1, lambda2, iter_callback
         )
     if image.ndim == 3:
         return _morphological_chan_vese_3d(
-            image, u, counter, iterations, smoothing, lambda1, lambda2, iter_callback
+            image, init_level_set, counter, iterations, smoothing,
+            lambda1, lambda2, iter_callback
         )

--- a/skimage/segmentation/setup.py
+++ b/skimage/segmentation/setup.py
@@ -20,7 +20,8 @@ def configuration(parent_package='', top_path=None):
     config.add_extension('_felzenszwalb_cy', sources=['_felzenszwalb_cy.c'],
                          include_dirs=[get_numpy_include_dirs()])
     config.add_extension('_morphosnakes_fm', sources=['_morphosnakes_fm.cpp'],
-                         include_dirs=[get_numpy_include_dirs()], language="c++",
+                         include_dirs=[get_numpy_include_dirs()],
+                         language="c++",
                          extra_compile_args=["-std=c++11"],
                          extra_link_args=["-std=c++11"])
     config.add_extension('_quickshift_cy', sources=['_quickshift_cy.c'],

--- a/skimage/segmentation/setup.py
+++ b/skimage/segmentation/setup.py
@@ -20,7 +20,9 @@ def configuration(parent_package='', top_path=None):
     config.add_extension('_felzenszwalb_cy', sources=['_felzenszwalb_cy.c'],
                          include_dirs=[get_numpy_include_dirs()])
     config.add_extension('_morphosnakes_fm', sources=['_morphosnakes_fm.cpp'],
-                         include_dirs=[get_numpy_include_dirs()], language="c++")
+                         include_dirs=[get_numpy_include_dirs()], language="c++",
+                         extra_compile_args=["-std=c++11"],
+                         extra_link_args=["-std=c++11"])
     config.add_extension('_quickshift_cy', sources=['_quickshift_cy.c'],
                          include_dirs=[get_numpy_include_dirs()])
     config.add_extension('_slic', sources=['_slic.c'],

--- a/skimage/segmentation/setup.py
+++ b/skimage/segmentation/setup.py
@@ -14,14 +14,20 @@ def configuration(parent_package='', top_path=None):
     cython(['_felzenszwalb_cy.pyx',
             '_quickshift_cy.pyx',
             '_slic.pyx'], working_path=base_path)
+    # _morphosnakes_fm uses c++, so it must be cythonized separately
+    cython(['_morphosnakes_fm.pyx',
+            ], working_path=base_path)
     config.add_extension('_felzenszwalb_cy', sources=['_felzenszwalb_cy.c'],
                          include_dirs=[get_numpy_include_dirs()])
+    config.add_extension('_morphosnakes_fm', sources=['_morphosnakes_fm.cpp'],
+                         include_dirs=[get_numpy_include_dirs()], language="c++")
     config.add_extension('_quickshift_cy', sources=['_quickshift_cy.c'],
                          include_dirs=[get_numpy_include_dirs()])
     config.add_extension('_slic', sources=['_slic.c'],
                          include_dirs=[get_numpy_include_dirs()])
 
     return config
+
 
 if __name__ == '__main__':
     from numpy.distutils.core import setup

--- a/skimage/segmentation/snakes2d_operators.h
+++ b/skimage/segmentation/snakes2d_operators.h
@@ -1,0 +1,31 @@
+// diagonal
+#define SId_2d_0(cont_, idx_, si_, sj_)                                                \
+  (cont_[idx_ - si_ - sj_] == 1 && cont_[idx_] == 1 && cont_[idx_ + si_ + sj_] == 1)
+#define ISd_2d_0(cont_, idx_, si_, sj_)                                                \
+  (!(cont_[idx_ - si_ - sj_] == 1 || cont_[idx_] == 1 || cont_[idx_ + si_ + sj_] == 1))
+
+// const y
+#define SId_2d_1(cont_, idx_, si_, sj_)                                                \
+  (cont_[idx_ - si_] == 1 && cont_[idx_] == 1 && cont_[idx_ + si_] == 1)
+#define ISd_2d_1(cont_, idx_, si_, sj_)                                                \
+  (!(cont_[idx_ - si_] == 1 || cont_[idx_] == 1 || cont_[idx_ + si_] == 1))
+
+// diagonal
+#define SId_2d_2(cont_, idx_, si_, sj_)                                                \
+  (cont_[idx_ - si_ + sj_] == 1 && cont_[idx_] == 1 && cont_[idx_ + si_ - sj_] == 1)
+#define ISd_2d_2(cont_, idx_, si_, sj_)                                                \
+  (!(cont_[idx_ - si_ + sj_] == 1 || cont_[idx_] == 1 || cont_[idx_ + si_ - sj_] == 1))
+
+// const x
+#define SId_2d_3(cont_, idx_, si_, sj_)                                                \
+  (cont_[idx_ - sj_] == 1 && cont_[idx_] == 1 && cont_[idx_ + sj_] == 1)
+#define ISd_2d_3(cont_, idx_, si_, sj_)                                                \
+  (!(cont_[idx_ - sj_] == 1 || cont_[idx_] == 1 || cont_[idx_ + sj_] == 1))
+
+#define SId_2d_any(cont_, idx_, si_, sj_)                                              \
+  (SId_2d_0(cont_, idx_, si_, sj_) || SId_2d_1(cont_, idx_, si_, sj_) ||               \
+   SId_2d_2(cont_, idx_, si_, sj_) || SId_2d_3(cont_, idx_, si_, sj_))
+
+#define ISd_2d_any(cont_, idx_, si_, sj_)                                              \
+  (!(ISd_2d_0(cont_, idx_, si_, sj_) || ISd_2d_1(cont_, idx_, si_, sj_) ||             \
+     ISd_2d_2(cont_, idx_, si_, sj_) || ISd_2d_3(cont_, idx_, si_, sj_)))

--- a/skimage/segmentation/snakes2d_operators_bidir.h
+++ b/skimage/segmentation/snakes2d_operators_bidir.h
@@ -1,0 +1,23 @@
+// diagonal
+#define ISd_2d_0_bidir(cont_, idx_, nsi_, si_, nsj_, sj_)                              \
+  (!(cont_[idx_ - nsi_ - nsj_] == 1 || cont_[idx_] == 1 ||                             \
+     cont_[idx_ + si_ + sj_] == 1))
+
+// const y
+#define ISd_2d_1_bidir(cont_, idx_, nsi_, si_, nsj_, sj_)                              \
+  (!(cont_[idx_ - nsi_] == 1 || cont_[idx_] == 1 || cont_[idx_ + si_] == 1))
+
+// diagonal
+#define ISd_2d_2_bidir(cont_, idx_, nsi_, si_, nsj_, sj_)                              \
+  (!(cont_[idx_ - nsi_ + sj_] == 1 || cont_[idx_] == 1 ||                              \
+     cont_[idx_ + si_ - nsj_] == 1))
+
+// const x
+#define ISd_2d_3_bidir(cont_, idx_, nsi_, si_, nsj_, sj_)                              \
+  (!(cont_[idx_ - nsj_] == 1 || cont_[idx_] == 1 || cont_[idx_ + sj_] == 1))
+
+#define ISd_2d_any_bidir(cont_, idx_, nsi_, si_, nsj_, sj_)                            \
+  (!(ISd_2d_0_bidir(cont_, idx_, nsi_, si_, nsj_, sj_) ||                              \
+     ISd_2d_1_bidir(cont_, idx_, nsi_, si_, nsj_, sj_) ||                              \
+     ISd_2d_2_bidir(cont_, idx_, nsi_, si_, nsj_, sj_) ||                              \
+     ISd_2d_3_bidir(cont_, idx_, nsi_, si_, nsj_, sj_)))

--- a/skimage/segmentation/snakes3d_operators.h
+++ b/skimage/segmentation/snakes3d_operators.h
@@ -1,0 +1,145 @@
+// flat surfaces
+#define SId_3d_0(cont_, index_, si_, sj_, sk_)                                         \
+  (cont_[index_ - sj_ - sk_] == 1 && cont_[index_ - sj_] == 1 &&                       \
+   cont_[index_ - sj_ + sk_] == 1 && cont_[index_ - sk_] == 1 && cont_[index_] == 1 && \
+   cont_[index_ + sk_] == 1 && cont_[index_ + sj_ - sk_] == 1 &&                       \
+   cont_[index_ + sj_] == 1 && cont_[index_ + sj_ + sk_] == 1)
+
+#define SId_3d_1(cont_, index_, si_, sj_, sk_)                                         \
+  (cont_[index - si_ - sk_] == 1 && cont_[index - si_] == 1 &&                         \
+   cont_[index - si_ + sk_] == 1 && cont_[index_ - sk_] == 1 && cont_[index_] == 1 &&  \
+   cont_[index_ + sk_] == 1 && cont_[index + si_ - sk_] == 1 &&                        \
+   cont_[index + si_] == 1 && cont_[index + si_ + sk_] == 1)
+
+#define SId_3d_2(cont_, index_, si_, sj_, sk_)                                         \
+  (cont_[index - si_ - sj_] == 1 && cont_[index - si_] == 1 &&                         \
+   cont_[index - si_ + sj_] == 1 && cont_[index - sj_] == 1 && cont_[index_] == 1 &&   \
+   cont_[index_ + sj_] == 1 && cont_[index + si_ - sj_] == 1 &&                        \
+   cont_[index + si_] == 1 && cont_[index + si_ + sj_] == 1)
+
+// diagonals loop i
+#define SId_3d_3(cont_, index_, si_, sj_, sk_)                                         \
+  (cont_[index - si_ - sj_ - sk_] == 1 && cont_[index - si_] == 1 &&                   \
+   cont_[index - si_ + sj_ + sk_] == 1 && cont_[index - sj_ - sk_] == 1 &&             \
+   cont_[index_] == 1 && cont_[index_ + sj_ + sk_] == 1 &&                             \
+   cont_[index + si_ - sj_ - sk_] == 1 && cont_[index + si_] == 1 &&                   \
+   cont_[index + si_ + sj_ + sk_] == 1)
+
+#define SId_3d_4(cont_, index_, si_, sj_, sk_)                                         \
+  (cont_[index - si_ - sj_ + sk_] == 1 && cont_[index - si_] == 1 &&                   \
+   cont_[index - si_ + sj_ - sk_] == 1 && cont_[index - sj_ + sk_] == 1 &&             \
+   cont_[index_] == 1 && cont_[index_ + sj_ - sk_] == 1 &&                             \
+   cont_[index + si_ - sj_ + sk_] == 1 && cont_[index + si_] == 1 &&                   \
+   cont_[index + si_ + sj_ - sk_] == 1)
+
+// diagonals loop j_
+#define SId_3d_5(cont_, index_, si_, sj_, sk_)                                         \
+  (cont_[index - si_ - sj_ - sk_] == 1 && cont_[index - sj_] == 1 &&                   \
+   cont_[index + si_ - sj_ + sk_] == 1 && cont_[index - si_ - sk_] == 1 &&             \
+   cont_[index_] == 1 && cont_[index + si_ + sk_] == 1 &&                              \
+   cont_[index - si_ + sj_ - sk_] == 1 && cont_[index_ + sj_] == 1 &&                  \
+   cont_[index + si_ + sj_ + sk_] == 1)
+
+#define SId_3d_6(cont_, index_, si_, sj_, sk_)                                         \
+  (cont_[index - si_ - sj_ + sk_] == 1 && cont_[index - sj_] == 1 &&                   \
+   cont_[index + si_ - sj_ - sk_] == 1 && cont_[index - si_ + sk_] == 1 &&             \
+   cont_[index_] == 1 && cont_[index + si_ - sk_] == 1 &&                              \
+   cont_[index - si_ + sj_ + sk_] == 1 && cont_[index_ + sj_] == 1 &&                  \
+   cont_[index + si_ + sj_ - sk_] == 1)
+
+// diagonals loop
+#define SId_3d_7(cont_, index_, si_, sj_, sk_)                                         \
+  (cont_[index - si_ - sj_ - sk_] == 1 && cont_[index_ - sk_] == 1 &&                  \
+   cont_[index + si_ + sj_ - sk_] == 1 && cont_[index - si_ - sj_] == 1 &&             \
+   cont_[index_] == 1 && cont_[index + si_ + sj_] == 1 &&                              \
+   cont_[index - si_ - sj_ + sk_] == 1 && cont_[index_ + sk_] == 1 &&                  \
+   cont_[index + si_ + sj_ + sk_] == 1)
+
+#define SId_3d_8(cont_, index_, si_, sj_, sk_)                                         \
+  (cont_[index - si_ + sj_ - sk_] == 1 && cont_[index_ - sk_] == 1 &&                  \
+   cont_[index + si_ - sj_ - sk_] == 1 && cont_[index - si_ + sj_] == 1 &&             \
+   cont_[index_] == 1 && cont_[index + si_ - sj_] == 1 &&                              \
+   cont_[index - si_ + sj_ + sk_] == 1 && cont_[index_ + sk_] == 1 &&                  \
+   cont_[index + si_ - sj_ + sk_] == 1)
+
+#define SId_3d_any(cont_, index_, si_, sj_, sk_)                                       \
+  (SId_3d_0(cont_, index_, si_, sj_, sk_) || SId_3d_1(cont_, index_, si_, sj_, sk_) || \
+   SId_3d_2(cont_, index_, si_, sj_, sk_) || SId_3d_3(cont_, index_, si_, sj_, sk_) || \
+   SId_3d_4(cont_, index_, si_, sj_, sk_) || SId_3d_5(cont_, index_, si_, sj_, sk_) || \
+   SId_3d_6(cont_, index_, si_, sj_, sk_) || SId_3d_7(cont_, index_, si_, sj_, sk_) || \
+   SId_3d_8(cont_, index_, si_, sj_, sk_))
+
+// flat surfaces
+#define ISd_3d_0(cont_, index_, si_, sj_, sk_)                                         \
+  (!(cont_[index - sj_ - sk_] == 1 || cont_[index - sj_] == 1 ||                       \
+     cont_[index - sj_ + sk_] == 1 || cont_[index_ - sk_] == 1 ||                      \
+     cont_[index_] == 1 || cont_[index_ + sk_] == 1 ||                                 \
+     cont_[index_ + sj_ - sk_] == 1 || cont_[index_ + sj_] == 1 ||                     \
+     cont_[index_ + sj_ + sk_] == 1))
+#define ISd_3d_1(cont_, index_, si_, sj_, sk_)                                         \
+  (!(cont_[index - si_ - sk_] == 1 || cont_[index - si_] == 1 ||                       \
+     cont_[index - si_ + sk_] == 1 || cont_[index_ - sk_] == 1 ||                      \
+     cont_[index_] == 1 || cont_[index_ + sk_] == 1 ||                                 \
+     cont_[index + si_ - sk_] == 1 || cont_[index + si_] == 1 ||                       \
+     cont_[index + si_ + sk_] == 1))
+#define ISd_3d_2(cont_, index_, si_, sj_, sk_)                                         \
+  (!(cont_[index - si_ - sj_] == 1 || cont_[index - si_] == 1 ||                       \
+     cont_[index - si_ + sj_] == 1 || cont_[index - sj_] == 1 || cont_[index_] == 1 || \
+     cont_[index_ + sj_] == 1 || cont_[index + si_ - sj_] == 1 ||                      \
+     cont_[index + si_] == 1 || cont_[index + si_ + sj_] == 1))
+
+// diagonals loop i
+#define ISd_3d_3(cont_, index_, si_, sj_, sk_)                                         \
+  (!(cont_[index - si_ - sj_ - sk_] == 1 || cont_[index - si_] == 1 ||                 \
+     cont_[index - si_ + sj_ + sk_] == 1 || cont_[index - sj_ - sk_] == 1 ||           \
+     cont_[index_] == 1 || cont_[index_ + sj_ + sk_] == 1 ||                           \
+     cont_[index + si_ - sj_ - sk_] == 1 || cont_[index + si_] == 1 ||                 \
+     cont_[index + si_ + sj_ + sk_] == 1))
+
+#define ISd_3d_4(cont_, index_, si_, sj_, sk_)                                         \
+  (!(cont_[index - si_ - sj_ + sk_] == 1 || cont_[index - si_] == 1 ||                 \
+     cont_[index - si_ + sj_ - sk_] == 1 || cont_[index - sj_ + sk_] == 1 ||           \
+     cont_[index_] == 1 || cont_[index_ + sj_ - sk_] == 1 ||                           \
+     cont_[index + si_ - sj_ + sk_] == 1 || cont_[index + si_] == 1 ||                 \
+     cont_[index + si_ + sj_ - sk_] == 1))
+
+// diagonals loop j
+#define ISd_3d_5(cont_, index_, si_, sj_, sk_)                                         \
+  (!(cont_[index - si_ - sj_ - sk_] == 1 || cont_[index - sj_] == 1 ||                 \
+     cont_[index + si_ - sj_ + sk_] == 1 || cont_[index - si_ - sk_] == 1 ||           \
+     cont_[index_] == 1 || cont_[index + si_ + sk_] == 1 ||                            \
+     cont_[index - si_ + sj_ - sk_] == 1 || cont_[index_ + sj_] == 1 ||                \
+     cont_[index + si_ + sj_ + sk_] == 1))
+
+#define ISd_3d_6(cont_, index_, si_, sj_, sk_)                                         \
+  (!(cont_[index - si_ - sj_ + sk_] == 1 || cont_[index - sj_] == 1 ||                 \
+     cont_[index + si_ - sj_ - sk_] == 1 || cont_[index - si_ + sk_] == 1 ||           \
+     cont_[index_] == 1 || cont_[index + si_ - sk_] == 1 ||                            \
+     cont_[index - si_ + sj_ + sk_] == 1 || cont_[index_ + sj_] == 1 ||                \
+     cont_[index + si_ + sj_ - sk_] == 1))
+
+// diagonals loop k
+#define ISd_3d_7(cont_, index_, si_, sj_, sk_)                                         \
+  (!(cont_[index - si_ - sj_ - sk_] == 1 || cont_[index_ - sk_] == 1 ||                \
+     cont_[index + si_ + sj_ - sk_] == 1 || cont_[index - si_ - sj_] == 1 ||           \
+     cont_[index_] == 1 || cont_[index + si_ + sj_] == 1 ||                            \
+     cont_[index - si_ - sj_ + sk_] == 1 || cont_[index_ + sk_] == 1 ||                \
+     cont_[index + si_ + sj_ + sk_] == 1))
+
+#define ISd_3d_8(cont_, index_, si_, sj_, sk_)                                         \
+  (!(cont_[index - si_ + sj_ - sk_] == 1 || cont_[index_ - sk_] == 1 ||                \
+     cont_[index + si_ - sj_ - sk_] == 1 || cont_[index - si_ + sj_] == 1 ||           \
+     cont_[index_] == 1 || cont_[index + si_ - sj_] == 1 ||                            \
+     cont_[index - si_ + sj_ + sk_] == 1 || cont_[index_ + sk_] == 1 ||                \
+     cont_[index + si_ - sj_ + sk_] == 1))
+
+#define ISd_3d_any(cont_, index_, si_, sj_, sk_)                                       \
+  (!(ISd_3d_0(cont_, index_, si_, sj_, sk_) ||                                         \
+     ISd_3d_1(cont_, index_, si_, sj_, sk_) ||                                         \
+     ISd_3d_2(cont_, index_, si_, sj_, sk_) ||                                         \
+     ISd_3d_3(cont_, index_, si_, sj_, sk_) ||                                         \
+     ISd_3d_4(cont_, index_, si_, sj_, sk_) ||                                         \
+     ISd_3d_5(cont_, index_, si_, sj_, sk_) ||                                         \
+     ISd_3d_6(cont_, index_, si_, sj_, sk_) ||                                         \
+     ISd_3d_7(cont_, index_, si_, sj_, sk_) ||                                         \
+     ISd_3d_8(cont_, index_, si_, sj_, sk_)))

--- a/skimage/segmentation/snakes3d_operators_bidir.h
+++ b/skimage/segmentation/snakes3d_operators_bidir.h
@@ -1,0 +1,75 @@
+// flat surfaces
+#define ISd_3d_0_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_)                 \
+  (!(cont_[index - nsj_ - nsk_] == 1 || cont_[index - nsj_] == 1 ||                    \
+     cont_[index - nsj_ + sk_] == 1 || cont_[index_ - nsk_] == 1 ||                    \
+     cont_[index_] == 1 || cont_[index_ + sk_] == 1 ||                                 \
+     cont_[index_ + sj_ - nsk_] == 1 || cont_[index_ + sj_] == 1 ||                    \
+     cont_[index_ + sj_ + sk_] == 1))
+#define ISd_3d_1_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_)                 \
+  (!(cont_[index - nsi_ - nsk_] == 1 || cont_[index - nsi_] == 1 ||                    \
+     cont_[index - nsi_ + sk_] == 1 || cont_[index_ - nsk_] == 1 ||                    \
+     cont_[index_] == 1 || cont_[index_ + sk_] == 1 ||                                 \
+     cont_[index + si_ - nsk_] == 1 || cont_[index + si_] == 1 ||                      \
+     cont_[index + si_ + sk_] == 1))
+#define ISd_3d_2_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_)                 \
+  (!(cont_[index - nsi_ - nsj_] == 1 || cont_[index - nsi_] == 1 ||                    \
+     cont_[index - nsi_ + sj_] == 1 || cont_[index - nsj_] == 1 ||                     \
+     cont_[index_] == 1 || cont_[index_ + sj_] == 1 ||                                 \
+     cont_[index + si_ - nsj_] == 1 || cont_[index + si_] == 1 ||                      \
+     cont_[index + si_ + sj_] == 1))
+
+// diagonals loop i
+#define ISd_3d_3_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_)                 \
+  (!(cont_[index - nsi_ - nsj_ - nsk_] == 1 || cont_[index - nsi_] == 1 ||             \
+     cont_[index - nsi_ + sj_ + sk_] == 1 || cont_[index - nsj_ - nsk_] == 1 ||        \
+     cont_[index_] == 1 || cont_[index_ + sj_ + sk_] == 1 ||                           \
+     cont_[index + si_ - nsj_ - nsk_] == 1 || cont_[index + si_] == 1 ||               \
+     cont_[index + si_ + sj_ + sk_] == 1))
+
+#define ISd_3d_4_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_)                 \
+  (!(cont_[index - nsi_ - nsj_ + sk_] == 1 || cont_[index - nsi_] == 1 ||              \
+     cont_[index - nsi_ + sj_ - nsk_] == 1 || cont_[index - nsj_ + sk_] == 1 ||        \
+     cont_[index_] == 1 || cont_[index_ + sj_ - nsk_] == 1 ||                          \
+     cont_[index + si_ - nsj_ + sk_] == 1 || cont_[index + si_] == 1 ||                \
+     cont_[index + si_ + sj_ - nsk_] == 1))
+
+// diagonals loop j
+#define ISd_3d_5_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_)                 \
+  (!(cont_[index - nsi_ - nsj_ - nsk_] == 1 || cont_[index - nsj_] == 1 ||             \
+     cont_[index + si_ - nsj_ + sk_] == 1 || cont_[index - nsi_ - nsk_] == 1 ||        \
+     cont_[index_] == 1 || cont_[index + si_ + sk_] == 1 ||                            \
+     cont_[index - nsi_ + sj_ - nsk_] == 1 || cont_[index_ + sj_] == 1 ||              \
+     cont_[index + si_ + sj_ + sk_] == 1))
+
+#define ISd_3d_6_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_)                 \
+  (!(cont_[index - nsi_ - nsj_ + sk_] == 1 || cont_[index - nsj_] == 1 ||              \
+     cont_[index + si_ - nsj_ - nsk_] == 1 || cont_[index - nsi_ + sk_] == 1 ||        \
+     cont_[index_] == 1 || cont_[index + si_ - nsk_] == 1 ||                           \
+     cont_[index - nsi_ + sj_ + sk_] == 1 || cont_[index_ + sj_] == 1 ||               \
+     cont_[index + si_ + sj_ - nsk_] == 1))
+
+// diagonals loop k
+#define ISd_3d_7_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_)                 \
+  (!(cont_[index - nsi_ - nsj_ - nsk_] == 1 || cont_[index_ - nsk_] == 1 ||            \
+     cont_[index + si_ + sj_ - nsk_] == 1 || cont_[index - nsi_ - nsj_] == 1 ||        \
+     cont_[index_] == 1 || cont_[index + si_ + sj_] == 1 ||                            \
+     cont_[index - nsi_ - nsj_ + sk_] == 1 || cont_[index_ + sk_] == 1 ||              \
+     cont_[index + si_ + sj_ + sk_] == 1))
+
+#define ISd_3d_8_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_)                 \
+  (!(cont_[index - nsi_ + sj_ - nsk_] == 1 || cont_[index_ - nsk_] == 1 ||             \
+     cont_[index + si_ - nsj_ - nsk_] == 1 || cont_[index - nsi_ + sj_] == 1 ||        \
+     cont_[index_] == 1 || cont_[index + si_ - nsj_] == 1 ||                           \
+     cont_[index - nsi_ + sj_ + sk_] == 1 || cont_[index_ + sk_] == 1 ||               \
+     cont_[index + si_ - nsj_ + sk_] == 1))
+
+#define ISd_3d_any_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_)               \
+  (!(ISd_3d_0_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_) ||                 \
+     ISd_3d_1_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_) ||                 \
+     ISd_3d_2_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_) ||                 \
+     ISd_3d_3_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_) ||                 \
+     ISd_3d_4_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_) ||                 \
+     ISd_3d_5_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_) ||                 \
+     ISd_3d_6_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_) ||                 \
+     ISd_3d_7_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_) ||                 \
+     ISd_3d_8_bidir(cont_, index_, nsi_, si_, nsj_, sj_, nsk_, sk_)))

--- a/skimage/segmentation/tests/test_morphosnakes_fm.py
+++ b/skimage/segmentation/tests/test_morphosnakes_fm.py
@@ -1,0 +1,98 @@
+import numpy as np
+from skimage.segmentation import (
+    morphological_chan_vese_fm,
+    inverse_gaussian_gradient,
+    circle_level_set,
+)
+
+from skimage._shared import testing
+from skimage._shared.testing import assert_array_equal
+
+
+def gaussian_blob():
+    coords = np.mgrid[-5:6, -5:6]
+    sqrdistances = (coords ** 2).sum(0)
+    return np.exp(-sqrdistances / 10)
+
+
+def test_morphsnakes_incorrect_image_shape():
+    img = np.zeros((10, 10, 3))
+    ls = np.zeros((10, 9))
+
+    with testing.raises(ValueError):
+        morphological_chan_vese_fm(img, iterations=1, init_level_set=ls)
+
+
+def test_morphsnakes_incorrect_ndim():
+    img = np.zeros((4, 4, 4, 4))
+    ls = np.zeros((4, 4, 4, 4))
+
+    with testing.raises(ValueError):
+        morphological_chan_vese_fm(img, iterations=1, init_level_set=ls)
+
+
+def test_morphsnakes_black():
+    img = np.zeros((11, 11))
+    ls = circle_level_set(img.shape, (5, 5), 3)
+
+    ref_zeros = np.zeros(img.shape, dtype=np.int8)
+    ref_ones = np.ones(img.shape, dtype=np.int8)
+
+    acwe_ls = morphological_chan_vese_fm(img, iterations=6, init_level_set=ls)
+    assert_array_equal(acwe_ls, ref_zeros)
+
+    assert acwe_ls.dtype == np.int8
+
+
+def test_morphsnakes_simple_shape_chan_vese():
+    img = gaussian_blob()
+    ls1 = circle_level_set(img.shape, (5, 5), 3)
+    ls2 = circle_level_set(img.shape, (5, 5), 6)
+
+    acwe_ls1 = morphological_chan_vese_fm(
+        img, iterations=10, init_level_set=ls1)
+    acwe_ls2 = morphological_chan_vese_fm(
+        img, iterations=10, init_level_set=ls2)
+
+    assert_array_equal(acwe_ls1, acwe_ls2)
+
+    assert acwe_ls1.dtype == acwe_ls2.dtype == np.int8
+
+
+def test_init_level_sets():
+    image = np.zeros((6, 6))
+    checkerboard_ls = morphological_chan_vese_fm(image, 0, "checkerboard")
+    checkerboard_ref = np.array(
+        [
+            [0, 0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0, 1],
+            [0, 0, 0, 0, 0, 1],
+            [1, 1, 1, 1, 1, 0],
+        ],
+        dtype=np.int8,
+    )
+
+    assert_array_equal(checkerboard_ls, checkerboard_ref)
+
+
+def test_morphsnakes_3d():
+    image = np.zeros((7, 7, 7))
+
+    evolution = []
+
+    def callback(x):
+        evolution.append(x.sum())
+
+    ls = morphological_chan_vese_fm(image, 5, "circle", iter_callback=callback)
+
+    # Check that the initial circle level set is correct
+    assert evolution[0] == 81
+
+    # Check that the final level set is correct
+    assert ls.sum() == 0
+
+    # Check that the contour is shrinking at every iteration
+    for v1, v2 in zip(evolution[:-1], evolution[1:]):
+        assert v1 >= v2


### PR DESCRIPTION
## Description

This PR contains a fast marching version of morphological_chan_vese based on propagation a vector of edge pixels/voxels. It is implemented as a parallel module
`skimake.segmentation.morphological_chan_vese_fm`
with the same interface as the original.

Credit where credit is due: design is heavily based on the source from:
>    Luis Alvarez, Luis Baumela, Pablo Márquez-Neila, and Pedro Henríquez,
    A Real Time Morphological Snakes Algorithm, Image Processing On Line,
    2 (2012), pp. 1–7. https://doi.org/10.5201/ipol.2012.abmh-rtmsa

This version extends it to 3D and has modified boundary conditions to conform with the scipy defaults for the morphologgical operators.

Extension to the existing version:
All the boolean operators are based on level_set==1 comparison, so passing an initial mask with value \notin {0,1} removes this region from the propagation and averages.

A quick and dirty benchmark on use-cases resulted in:

>  === 2d case ===
data.camera() (512, 512) 35 iterations (scikit image example)
init_ls = checkerboard_level_set(image.shape, 6)
Reference:           calls: 5          elapsed: 7.772 s       ms/call: 1554.4 ms
Edge propagation:    calls: 5          elapsed: 0.431 s       ms/call: 86.1 ms
    Overhead (iterations==0)
Reference:           calls: 5          elapsed: 0.001 s       ms/call: 0.2 ms
Edge propagation:    calls: 5          elapsed: 0.009 s       ms/call: 1.8 ms

> === 3d case ===
confocal.npy (60, 120, 160) 15 iterations (from the [morphsnakes ](https://github.com/pmneila/morphsnakes)repo)
init_ls = circle_level_set(image.shape, (30, 50, 80), 25)
Reference:           calls: 4          elapsed: 22.310 s       ms/call: 5577.6 ms
Edge propagation:    calls: 5          elapsed: 0.627 s       ms/call: 125.4 ms
    Overhead (iterations==0)
Reference:           calls: 5          elapsed: 0.009 s       ms/call: 1.8 ms
Edge propagation:    calls: 5          elapsed: 0.052 s       ms/call: 10.4 ms


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
