### PR TITLE
Fix broken import of rgb2gray in benchmark suite

### DIFF
--- a/benchmarks/benchmark_registration.py
+++ b/benchmarks/benchmark_registration.py
@@ -1,5 +1,5 @@
 from skimage.data import stereo_motorcycle
-from skimage import rgb2gray
+from skimage.color import rgb2gray
 from skimage import registration
 
 


### PR DESCRIPTION
## Description

Running the benchmark suite seems to fail with an ImportError after in 17d6347ae260319b2de654a8983fb6ab9d81a6ee (#3265). I'm not sure if `rgb2gray` was intentionally left out or forgotten.The module docstring seems to indicate the former.

Benchmark suite passes on my local machine with `asv check`. Might be useful to add this to the CI somewhere. Maybe as a periodical job for the master? 

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
