### PR TITLE
DOC: Improve downscale_local_mean() docstring

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -406,11 +406,18 @@ def downscale_local_mean(image, factors, cval=0, clip=True):
     cval : float, optional
         Constant padding value if image is not perfectly divisible by the
         integer factors.
+    clip : bool, optional
+        Unused, but kept here for API consistency with the other transforms
+        in this module. (The local mean will never fall outside the range
+        of values in the input image, assuming the provided `cval` also
+        falls within that range.)
 
     Returns
     -------
     image : ndarray
         Down-sampled image with same number of dimensions as input image.
+        For integer inputs, the output dtype will be ``float64``.
+        See :func:`numpy.mean` for details.
 
     Examples
     --------


### PR DESCRIPTION
The `downscale_local_mean()` function takes an argument `clip` which is unused.  Looks like it was introduced intentionally, years ago in 0ae8c4a74bc99cb9de7229e961eacee1c7da0840.

Assuming we want to keep it, it would be nice to mention it in the docstring.  While I was at it, I also added a note about the returned dtype.

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
