### PR TITLE
Fix doc building issues with SKIPs

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -55,17 +55,17 @@ Sections
 
        Usage guidelines.
 
-   * - `Glossary <glossary.html>`_
+     - `Glossary <glossary.html>`_
 
        Definitions of common terms.
 
-     - `Contribute <contribute.html>`_
+   * - `Contribute <contribute.html>`_
 
        Take part in development.  Core developers, please `read your guide
        <core_developer.html>`_.
 
 
-   * - `Examples <auto_examples/index.html>`_
+     - `Examples <auto_examples/index.html>`_
 
        Introductory examples
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -39,19 +39,19 @@ Sections
 
        Documentation for the functions included in scikit-image.
 
-   * - `Mission statement <values.html>`_
+     - `Mission statement <values.html>`_
 
        Our mission, vision and values.
 
-     - `Governance <skips/0-governance.html>`_
+     - `Governance <skips/1-governance.html>`_
 
        How decisions are made in scikit-image.
 
-   * - `Installation Steps <install.html>`_
+     - `Installation Steps <install.html>`_
 
        How to install scikit-image.
 
-     - `User Guide <user_guide.html>`_
+   * - `User Guide <user_guide.html>`_
 
        Usage guidelines.
 
@@ -59,7 +59,7 @@ Sections
 
        Definitions of common terms.
 
-   * - `Contribute <contribute.html>`_
+     - `Contribute <contribute.html>`_
 
        Take part in development.  Core developers, please `read your guide
        <core_developer.html>`_.

--- a/doc/source/skips/0-skip-process.rst
+++ b/doc/source/skips/0-skip-process.rst
@@ -13,7 +13,7 @@ SKIP 0 — Purpose and Process
 
 
 What is a SKIP?
---------------
+---------------
 
 SKIP stands for SciKit-Image Proposal. A SKIP is a design document providing
 information to the community, or describing a new feature for
@@ -75,7 +75,7 @@ way to do this.
 The proposal should be submitted as a draft SKIP via a `GitHub pull
 request`_ to the ``doc/source/skips`` directory with the name
 ``skip-<n>.rst`` where ``<n>`` is an appropriately assigned number (e.g.,
-``skip-35.rst``). The draft must use the :ref:`skip-template` file.
+``skip-35.rst``). The draft must use the :ref:`skip_template` file.
 
 Once the PR is in place, the SKIP should be announced on the mailing
 list for discussion (comments on the PR itself should be restricted to
@@ -152,7 +152,7 @@ meant to be completed, e.g. SKIP 0 (this SKIP).
 
 
 How a SKIP becomes Accepted
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A SKIP is ``Accepted`` by consensus of all interested contributors. We
 need a concrete way to tell whether consensus has been reached. When
@@ -224,7 +224,7 @@ Format and Template
 -------------------
 
 SKIPs are UTF-8 encoded text files using the reStructuredText_ format.  Please
-see the :ref:`skip-template` file and the reStructuredTextPrimer_ for more
+see the :ref:`skip_template` file and the reStructuredTextPrimer_ for more
 information.  We use Sphinx_ to convert SKIPs to HTML for viewing on the web
 [2]_.
 

--- a/doc/source/skips/1-governance.rst
+++ b/doc/source/skips/1-governance.rst
@@ -53,7 +53,7 @@ project in concrete ways, such as:
   `tutorials <https://github.com/scikit-image/skimage-tutorials>`_ via a
   GitHub pull request;
 - discussing the design of the library, website, or tutorials on the
-  `mailing list <https://mail.python.org/mailman3/lists/scikit-image.python.org/>`_,
+  `mailing list <https://mail.python.org/mailman3/lists/scikit-image.python.org>`_,
   in the
   `project chat room <skimage.zulipchat.com/>`_, or in existing issues and pull
   requests; or
@@ -117,7 +117,8 @@ Decision Making Process
 
 Decisions about the future of the project are made through discussion with all
 members of the community. All non-sensitive project management discussion takes
-place on the project `mailing list <mailto:scikit-image@python.org>`_
+place on the project
+`mailing list <https://mail.python.org/mailman3/lists/scikit-image.python.org>`_
 and the `issue tracker <https://github.com/scikit-image/scikit-image/issues>`_.
 Occasionally, sensitive discussion may occur on a private list.
 

--- a/doc/source/skips/1-governance.rst
+++ b/doc/source/skips/1-governance.rst
@@ -154,8 +154,8 @@ are made according to the following rules:
   *unless* there is unanimous agreement from core developers on the change.
 
 If a veto is cast on a lazy consensus, the proposer can appeal to the
-community and core developers and the change can be approved or rejected using
-the decision making procedure outlined above.
+community and core developers and the change can be approved or rejected by
+escalating to the SC, and if necessary, a SKIP (see below).
 
 .. _skip:
 

--- a/doc/source/skips/1-governance.rst
+++ b/doc/source/skips/1-governance.rst
@@ -1,5 +1,9 @@
 .. _governance:
 
+====================================================
+SKIP 1 — scikit-image governance and decision-making
+====================================================
+
 :Author: Juan Nunez-Iglesias <juan.nunez-iglesias@monash.edu>
 :Author: Stéfan van der Walt <stefanv@berkeley.edu>
 :Author: Josh Warner
@@ -15,9 +19,8 @@
 :Resolution:
 :skimage-Version: 0.16
 
-===========================================
-scikit-image governance and decision-making
-===========================================
+Abstract
+========
 
 The purpose of this document is to formalize the governance process used by the
 scikit-image project, to clarify how decisions are made and how the various
@@ -111,6 +114,7 @@ then admission to the SC by consensus.
 
 Decision Making Process
 =======================
+
 Decisions about the future of the project are made through discussion with all
 members of the community. All non-sensitive project management discussion takes
 place on the project `mailing list <mailto:scikit-image@python.org>`_

--- a/doc/source/skips/1-governance.rst
+++ b/doc/source/skips/1-governance.rst
@@ -67,7 +67,7 @@ Contributors are encouraged to read the
 Core developers
 ---------------
 Core developers are community members that have demonstrated continued
-commitment to the project through ongoing engagement with the community. They
+commitment to the project through ongoing contributions. They
 have shown they can be trusted to maintain scikit-image with care. Becoming a
 core developer allows contributors to merge approved pull requests, cast votes
 for and against merging a pull-request, and be involved in deciding major

--- a/doc/source/skips/1-governance.rst
+++ b/doc/source/skips/1-governance.rst
@@ -12,11 +12,11 @@ SKIP 1 — scikit-image governance and decision-making
 :Author: Mark Harfouche
 :Author: Lars Grüter
 :Author: Egor Panfilov
-:Status: Draft
+:Status: Final
 :Type: Process
 :Created: 2019-07-02
-:Resolved:
-:Resolution:
+:Resolved: 2019-07-25
+:Resolution: https://github.com/scikit-image/scikit-image/pull/4182
 :skimage-Version: 0.16
 
 Abstract

--- a/doc/source/skips/2-values.rst
+++ b/doc/source/skips/2-values.rst
@@ -1,7 +1,7 @@
 .. _values:
 
 ======================================
-SKIP-1: scikit-image mission statement
+SKIP-2: scikit-image mission statement
 ======================================
 
 :Author: Juan Nunez-Iglesias <juan.nunez-iglesias@monash.edu>
@@ -18,7 +18,7 @@ SKIP-1: scikit-image mission statement
 :Created: 2018-12-08
 :Resolved:
 :Resolution:
-:Version effective: 0.16
+:skimage-Version: 0.16
 
 Abstract
 --------

--- a/doc/source/skips/template.rst
+++ b/doc/source/skips/template.rst
@@ -1,4 +1,4 @@
-.. _skip-template::
+.. _skip_template:
 
 ==================================
 SKIP X — Template and Instructions

--- a/doc/source/skips/template.rst
+++ b/doc/source/skips/template.rst
@@ -1,8 +1,8 @@
 .. _skip-template::
 
-==============================
-SKIP Template and Instructions
-==============================
+==================================
+SKIP X — Template and Instructions
+==================================
 
 :Author: <list of authors' real names and, optionally, email addresses>
 :Status: <Draft | Active | Accepted | Deferred | Rejected | Withdrawn |
@@ -31,11 +31,16 @@ proposed change.
 Detailed description
 --------------------
 
-This section describes the need for the SKIP. It should describe the
-existing problem that it is trying to solve and why this SKIP makes the
-situation better. It should include examples of how the new functionality
-would be used and perhaps some real-world use cases.
+This section should provide a detailed description of the proposed change. It
+should include examples of how the new functionality would be used, intended
+use-cases, and pseudocode illustrating its use.
 
+Related Work
+------------
+
+This section should list relevant and/or similar technologies, possibly in
+other libraries. It does not need to be comprehensive, just list the major
+examples of prior and relevant art.
 
 Implementation
 --------------


### PR DESCRIPTION
## Description

#3585 was ultimately merged optimistically, as the SKIP process dictates, but the documentation building was actually failing. This PR changes the build. It also changes the status of the Values SKIP (2) to Draft, pending approval using the SKIP process.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
