### PR TITLE
API updates before 0.16

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -17,6 +17,7 @@ Version 0.17
 * Remove deprecated arguments ``beta1`` and ``beta2`` from function ``skimage.filters.hessian``
 * Remove unused arguments ``dtype`` in ``imread`` functions. See #3918.
 * Remove ``rough_wall`` from ``skimage.data.__init__``.
+* Remove parameter ``img`` from skimage.morphology.skeletonize_3d.
 
 Version 0.18
 ------------

--- a/skimage/exposure/histogram_matching.py
+++ b/skimage/exposure/histogram_matching.py
@@ -19,7 +19,7 @@ def _match_cumulative_cdf(source, template):
     return interp_a_values[src_unique_indices].reshape(source.shape)
 
 
-def match_histograms(image, reference, multichannel=False):
+def match_histograms(image, reference, *, multichannel=False):
     """Adjust an image so that its cumulative histogram matches that of another.
 
     The adjustment is applied separately for each channel.

--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -547,7 +547,7 @@ def laplace(image, ksize=3, mask=None):
     return _mask_filter_result(result, mask)
 
 
-def farid(image, mask=None):
+def farid(image, *, mask=None):
     """Find the edge magnitude using the Farid transform.
 
     Parameters
@@ -591,12 +591,12 @@ def farid(image, mask=None):
     >>> edges = filters.farid(camera)
     """
     check_nD(image, 2)
-    out = np.sqrt(farid_h(image, mask) ** 2 + farid_v(image, mask) ** 2)
+    out = np.sqrt(farid_h(image, mask=mask) ** 2 + farid_v(image, mask=mask) ** 2)
     out /= np.sqrt(2)
     return out
 
 
-def farid_h(image, mask=None):
+def farid_h(image, *, mask=None):
     """Find the horizontal edges of an image using the Farid transform.
 
     Parameters
@@ -632,7 +632,7 @@ def farid_h(image, mask=None):
     return _mask_filter_result(result, mask)
 
 
-def farid_v(image, mask=None):
+def farid_v(image, *, mask=None):
     """Find the vertical edges of an image using the Farid transform.
 
     Parameters

--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -591,7 +591,8 @@ def farid(image, *, mask=None):
     >>> edges = filters.farid(camera)
     """
     check_nD(image, 2)
-    out = np.sqrt(farid_h(image, mask=mask) ** 2 + farid_v(image, mask=mask) ** 2)
+    out = np.sqrt(farid_h(image, mask=mask) ** 2
+                  + farid_v(image, mask=mask) ** 2)
     out /= np.sqrt(2)
     return out
 

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -1062,7 +1062,9 @@ def windowed_histogram(image, selem, out=None, mask=None,
                                    pixel_size=n_bins)
 
 
-def majority(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
+def majority(image, selem,
+             *,
+             out=None, mask=None, shift_x=False, shift_y=False):
     """Majority filter assign to each pixel the most occuring value within
     its neighborhood.
 

--- a/skimage/filters/tests/test_edges.py
+++ b/skimage/filters/tests/test_edges.py
@@ -362,14 +362,15 @@ def test_laplace_mask():
 
 def test_farid_zeros():
     """Farid on an array of all zeros."""
-    result = filters.farid(np.zeros((10, 10)), np.ones((10, 10), dtype=bool))
+    result = filters.farid(np.zeros((10, 10)),
+                           mask=np.ones((10, 10), dtype=bool))
     assert (np.all(result == 0))
 
 
 def test_farid_mask():
     """Farid on a masked array should be zero."""
     result = filters.farid(np.random.uniform(size=(10, 10)),
-                           np.zeros((10, 10), dtype=bool))
+                           mask=np.zeros((10, 10), dtype=bool))
     assert (np.all(result == 0))
 
 
@@ -396,14 +397,15 @@ def test_farid_vertical():
 
 def test_farid_h_zeros():
     """Horizontal Farid on an array of all zeros."""
-    result = filters.farid_h(np.zeros((10, 10)), np.ones((10, 10), dtype=bool))
+    result = filters.farid_h(np.zeros((10, 10)),
+                             mask=np.ones((10, 10), dtype=bool))
     assert (np.all(result == 0))
 
 
 def test_farid_h_mask():
     """Horizontal Farid on a masked array should be zero."""
     result = filters.farid_h(np.random.uniform(size=(10, 10)),
-                             np.zeros((10, 10), dtype=bool))
+                             mask=np.zeros((10, 10), dtype=bool))
     assert (np.all(result == 0))
 
 
@@ -428,14 +430,15 @@ def test_farid_h_vertical():
 
 def test_farid_v_zeros():
     """Vertical Farid on an array of all zeros."""
-    result = filters.farid_v(np.zeros((10, 10)), np.ones((10, 10), dtype=bool))
+    result = filters.farid_v(np.zeros((10, 10)),
+                             mask=np.ones((10, 10), dtype=bool))
     assert_allclose(result, 0, atol=1e-10)
 
 
 def test_farid_v_mask():
     """Vertical Farid on a masked array should be zero."""
     result = filters.farid_v(np.random.uniform(size=(10, 10)),
-                             np.zeros((10, 10), dtype=bool))
+                             mask=np.zeros((10, 10), dtype=bool))
     assert_allclose(result, 0)
 
 

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -525,8 +525,10 @@ def _props_to_dict(regions, properties=('label', 'bbox'), separator='-'):
     return out
 
 
-def regionprops_table(label_image, intensity_image=None, cache=True,
-                      properties=('label', 'bbox'), separator='-'):
+def regionprops_table(label_image, intensity_image=None,
+                      properties=('label', 'bbox'),
+                      *,
+                      cache=True, separator='-'):
     """Find image properties and convert them into a dictionary
 
     Parameters
@@ -536,15 +538,15 @@ def regionprops_table(label_image, intensity_image=None, cache=True,
     intensity_image : (N, M) ndarray, optional
         Intensity (i.e., input) image with same size as labeled image.
         Default is None.
-    cache : bool, optional
-        Determine whether to cache calculated properties. The computation is
-        much faster for cached properties, whereas the memory consumption
-        increases.
     properties : tuple or list of str, optional
         Properties that will be included in the resulting dictionary
         For a list of available properties, please see :func:`regionprops`.
         Users should remember to add "label" to keep track of region
         identities.
+    cache : bool, optional
+        Determine whether to cache calculated properties. The computation is
+        much faster for cached properties, whereas the memory consumption
+        increases.
     separator : str, optional
         For non-scalar properties not listed in OBJECT_COLUMNS, each element
         will appear in its own column, with the index of that element separated

--- a/skimage/measure/simple_metrics.py
+++ b/skimage/measure/simple_metrics.py
@@ -38,7 +38,7 @@ def compare_nrmse(im_true, im_test, norm_type='euclidean'):
     warn('DEPRECATED: skimage.measure.compare_nrmse has been moved to '
          'skimage.metrics.normalized_root_mse. It will be removed from '
          'skimage.measure in version 0.18.', stacklevel=2)
-    return normalized_root_mse(im_true, im_test, norm_type=norm_type)
+    return normalized_root_mse(im_true, im_test, normalization=norm_type)
 
 
 if normalized_root_mse.__doc__ is not None:

--- a/skimage/measure/tests/test_simple_metrics.py
+++ b/skimage/measure/tests/test_simple_metrics.py
@@ -1,9 +1,7 @@
 import numpy as np
 
 import skimage.data
-from skimage.metrics import peak_signal_noise_ratio
-from skimage.metrics import normalized_root_mse
-from skimage.metrics import mean_squared_error
+from skimage.measure import compare_nrmse, compare_psnr, compare_mse
 
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_almost_equal
@@ -21,60 +19,66 @@ def test_PSNR_vs_IPOL():
     # Tests vs. imdiff result from the following IPOL article and code:
     # https://www.ipol.im/pub/art/2011/g_lmii/
     p_IPOL = 22.4497
-    p = peak_signal_noise_ratio(cam, cam_noisy)
+    with expected_warnings(['DEPRECATED']):
+        p = compare_psnr(cam, cam_noisy)
     assert_almost_equal(p, p_IPOL, decimal=4)
 
 
 def test_PSNR_float():
-    p_uint8 = peak_signal_noise_ratio(cam, cam_noisy)
-    p_float64 = peak_signal_noise_ratio(cam / 255., cam_noisy / 255.,
-                                        data_range=1)
+    with expected_warnings(['DEPRECATED']):
+        p_uint8 = compare_psnr(cam, cam_noisy)
+        p_float64 = compare_psnr(cam / 255., cam_noisy / 255.,
+                                 data_range=1)
     assert_almost_equal(p_uint8, p_float64, decimal=5)
 
     # mixed precision inputs
-    p_mixed = peak_signal_noise_ratio(cam / 255., np.float32(cam_noisy / 255.),
-                                      data_range=1)
+    with expected_warnings(['DEPRECATED']):
+        p_mixed = compare_psnr(cam / 255., np.float32(cam_noisy / 255.),
+                               data_range=1)
     assert_almost_equal(p_mixed, p_float64, decimal=5)
 
     # mismatched dtype results in a warning if data_range is unspecified
-    with expected_warnings(['Inputs have mismatched dtype']):
-        p_mixed = peak_signal_noise_ratio(cam / 255.,
-                                          np.float32(cam_noisy / 255.))
+    with expected_warnings(['Inputs have mismatched dtype', 'DEPRECATED']):
+        p_mixed = compare_psnr(cam / 255., np.float32(cam_noisy / 255.))
     assert_almost_equal(p_mixed, p_float64, decimal=5)
 
 
 def test_PSNR_errors():
-    # shape mismatch
-    with testing.raises(ValueError):
-        peak_signal_noise_ratio(cam, cam[:-1, :])
+    with expected_warnings(['DEPRECATED']):
+        # shape mismatch
+        with testing.raises(ValueError):
+            compare_psnr(cam, cam[:-1, :])
 
 
 def test_NRMSE():
     x = np.ones(4)
     y = np.asarray([0., 2., 2., 2.])
-    assert_equal(normalized_root_mse(y, x), 1 / np.mean(y))
-    assert_equal(normalized_root_mse(y, x), 1 / np.sqrt(3))
-    assert_equal(normalized_root_mse(y, x), 1 / (y.max() - y.min()))
+    with expected_warnings(['DEPRECATED']):
+        assert_equal(compare_nrmse(y, x, 'mean'), 1 / np.mean(y))
+        assert_equal(compare_nrmse(y, x, 'Euclidean'), 1 / np.sqrt(3))
+        assert_equal(compare_nrmse(y, x, 'min-max'), 1 / (y.max() - y.min()))
 
-    # mixed precision inputs are allowed
-    assert_almost_equal(normalized_root_mse(y, np.float32(x)),
-                        1 / (y.max() - y.min()))
+        # mixed precision inputs are allowed
+        assert_almost_equal(compare_nrmse(y, np.float32(x), 'min-max'),
+                            1 / (y.max() - y.min()))
 
 
 def test_NRMSE_no_int_overflow():
     camf = cam.astype(np.float32)
     cam_noisyf = cam_noisy.astype(np.float32)
-    assert_almost_equal(mean_squared_error(cam, cam_noisy),
-                        mean_squared_error(camf, cam_noisyf))
-    assert_almost_equal(normalized_root_mse(cam, cam_noisy),
-                        normalized_root_mse(camf, cam_noisyf))
+    with expected_warnings(['DEPRECATED']):
+        assert_almost_equal(compare_mse(cam, cam_noisy),
+                            compare_mse(camf, cam_noisyf))
+        assert_almost_equal(compare_nrmse(cam, cam_noisy),
+                            compare_nrmse(camf, cam_noisyf))
 
 
 def test_NRMSE_errors():
     x = np.ones(4)
-    # shape mismatch
-    with testing.raises(ValueError):
-        normalized_root_mse(x[:-1], x)
-    # invalid normalization name
-    with testing.raises(ValueError):
-        normalized_root_mse(x, x)
+    with expected_warnings(['DEPRECATED']):
+        # shape mismatch
+        with testing.raises(ValueError):
+            compare_nrmse(x[:-1], x)
+        # invalid normalization name
+        with testing.raises(ValueError):
+            compare_nrmse(x, x, norm_type='foo')

--- a/skimage/measure/tests/test_simple_metrics.py
+++ b/skimage/measure/tests/test_simple_metrics.py
@@ -52,12 +52,12 @@ def test_PSNR_errors():
 def test_NRMSE():
     x = np.ones(4)
     y = np.asarray([0., 2., 2., 2.])
-    assert_equal(normalized_root_mse(y, x, 'mean'), 1 / np.mean(y))
-    assert_equal(normalized_root_mse(y, x, 'Euclidean'), 1 / np.sqrt(3))
-    assert_equal(normalized_root_mse(y, x, 'min-max'), 1 / (y.max() - y.min()))
+    assert_equal(normalized_root_mse(y, x), 1 / np.mean(y))
+    assert_equal(normalized_root_mse(y, x), 1 / np.sqrt(3))
+    assert_equal(normalized_root_mse(y, x), 1 / (y.max() - y.min()))
 
     # mixed precision inputs are allowed
-    assert_almost_equal(normalized_root_mse(y, np.float32(x), 'min-max'),
+    assert_almost_equal(normalized_root_mse(y, np.float32(x)),
                         1 / (y.max() - y.min()))
 
 
@@ -77,4 +77,4 @@ def test_NRMSE_errors():
         normalized_root_mse(x[:-1], x)
     # invalid normalization name
     with testing.raises(ValueError):
-        normalized_root_mse(x, x, 'foo')
+        normalized_root_mse(x, x)

--- a/skimage/metrics/_adapted_rand_error.py
+++ b/skimage/metrics/_adapted_rand_error.py
@@ -4,16 +4,15 @@ from ._contingency_table import contingency_table
 __all__ = ['adapted_rand_error']
 
 
-def adapted_rand_error(label_image_true=None, label_image_test=None,
-                       *,
-                       table=None, ignore_labels=(0,)):
+def adapted_rand_error(image_true=None, image_test=None, *, table=None,
+                       ignore_labels=(0,)):
     r"""Compute Adapted Rand error as defined by the SNEMI3D contest. [1]_
 
     Parameters
     ----------
-    label_image_true : ndarray of int
+    image_true : ndarray of int
         Ground-truth label image, same shape as im_test.
-    label_image_test : ndarray of int
+    image_test : ndarray of int
         Test image.
     table : scipy.sparse array in crs format, optional
         A contingency table built with skimage.evaluate.contingency_table.
@@ -47,11 +46,11 @@ def adapted_rand_error(label_image_true=None, label_image_test=None,
            for connectomics. Front. Neuroanat. 9:142.
            :DOI:`10.3389/fnana.2015.00142`
     """
-    if label_image_test is not None and label_image_true is not None:
-        check_shape_equality(label_image_true, label_image_test)
+    if image_test is not None and image_true is not None:
+        check_shape_equality(image_true, image_test)
 
     if table is None:
-        p_ij = contingency_table(label_image_true, label_image_test,
+        p_ij = contingency_table(image_true, image_test,
                                  ignore_labels=ignore_labels, normalize=False)
     else:
         p_ij = table

--- a/skimage/metrics/_adapted_rand_error.py
+++ b/skimage/metrics/_adapted_rand_error.py
@@ -4,26 +4,23 @@ from ._contingency_table import contingency_table
 __all__ = ['adapted_rand_error']
 
 
-def adapted_rand_error(im_true=None, im_test=None, *, table=None,
-                       ignore_labels=None, normalize=False):
-    r"""
-    Compute Adapted Rand error as defined by the SNEMI3D contest. [1]_
+def adapted_rand_error(label_image_true=None, label_image_test=None,
+                       *,
+                       table=None, ignore_labels=(0,)):
+    r"""Compute Adapted Rand error as defined by the SNEMI3D contest. [1]_
 
     Parameters
     ----------
-    im_true : ndarray of int
+    label_image_true : ndarray of int
         Ground-truth label image, same shape as im_test.
-    im_test : ndarray of int
+    label_image_test : ndarray of int
         Test image.
     table : scipy.sparse array in crs format, optional
         A contingency table built with skimage.evaluate.contingency_table.
         If None, it will be computed on the fly.
-    ignore_labels : list of int, optional
+    ignore_labels : sequence of int, optional
         Labels to ignore. Any part of the true image labeled with any of these
         values will not be counted in the score.
-    normalize : bool, optional
-        If True, normalizes contigency table by the number of pixels of
-        each value.
 
     Returns
     -------
@@ -50,11 +47,12 @@ def adapted_rand_error(im_true=None, im_test=None, *, table=None,
            for connectomics. Front. Neuroanat. 9:142.
            :DOI:`10.3389/fnana.2015.00142`
     """
-    check_shape_equality(im_true, im_test)
+    if label_image_test is not None and label_image_true is not None:
+        check_shape_equality(label_image_true, label_image_test)
 
     if table is None:
-        p_ij = contingency_table(im_true, im_test, ignore_labels=[
-                                 0], normalize=normalize)
+        p_ij = contingency_table(label_image_true, label_image_test,
+                                 ignore_labels=ignore_labels, normalize=False)
     else:
         p_ij = table
 

--- a/skimage/metrics/_contingency_table.py
+++ b/skimage/metrics/_contingency_table.py
@@ -4,7 +4,7 @@ import numpy as np
 __all__ = ['contingency_table']
 
 
-def contingency_table(im_true, im_test, ignore_labels=[], normalize=False):
+def contingency_table(im_true, im_test, *, ignore_labels=[], normalize=False):
     """
     Return the contingency table for all regions in matched segmentations.
 

--- a/skimage/metrics/_contingency_table.py
+++ b/skimage/metrics/_contingency_table.py
@@ -4,7 +4,7 @@ import numpy as np
 __all__ = ['contingency_table']
 
 
-def contingency_table(im_true, im_test, *, ignore_labels=[], normalize=False):
+def contingency_table(im_true, im_test, *, ignore_labels=(), normalize=False):
     """
     Return the contingency table for all regions in matched segmentations.
 
@@ -14,7 +14,7 @@ def contingency_table(im_true, im_test, *, ignore_labels=[], normalize=False):
         Ground-truth label image, same shape as im_test.
     im_test : ndarray of int
         Test image.
-    ignore_labels : list of int, optional
+    ignore_labels : sequence of int, optional
         Labels to ignore. Any part of the true image labeled with any of these
         values will not be counted in the score.
     normalize : bool

--- a/skimage/metrics/_structural_similarity.py
+++ b/skimage/metrics/_structural_similarity.py
@@ -9,9 +9,11 @@ from .._shared.utils import warn, check_shape_equality
 __all__ = ['structural_similarity']
 
 
-def structural_similarity(im1, im2, win_size=None, gradient=False,
-                          data_range=None, multichannel=False,
-                          gaussian_weights=False, full=False, **kwargs):
+def structural_similarity(im1, im2,
+                          *,
+                          win_size=None, gradient=False, data_range=None,
+                          multichannel=False, gaussian_weights=False,
+                          full=False, **kwargs):
     """
     Compute the mean structural similarity index between two images.
 

--- a/skimage/metrics/_variation_of_information.py
+++ b/skimage/metrics/_variation_of_information.py
@@ -7,7 +7,7 @@ __all__ = ['variation_of_information']
 
 
 def variation_of_information(im_true=None, im_test=None, *, table=None,
-                             ignore_labels=[], normalize=False):
+                             ignore_labels=(), normalize=False):
     """Return symmetric conditional entropies associated with the VI. [1]_
 
     The variation of information is defined as VI(X,Y) = H(X|Y) + H(Y|X).
@@ -23,7 +23,7 @@ def variation_of_information(im_true=None, im_test=None, *, table=None,
     table : scipy.sparse array in crs format, optional
         A contingency table built with skimage.evaluate.contingency_table.
         If None, it will be computed with skimage.evaluate.contingency_table.
-    ignore_labels : list of int, optional
+    ignore_labels : sequence of int, optional
         Labels to ignore. Any part of the true image labeled with any of these
         values will not be counted in the score.
     normalize : bool, optional
@@ -72,8 +72,7 @@ def _xlogx(x):
     return y
 
 
-def _vi_tables(im_true, im_test, table=None, ignore_labels=[],
-               normalize=False):
+def _vi_tables(im_true, im_test, table=None, ignore_labels=()):
     """
     Compute probability tables used for calculating VI.
 
@@ -94,7 +93,7 @@ def _vi_tables(im_true, im_test, table=None, ignore_labels=[],
         # normalize, since it is an identity op if already done
         pxy = contingency_table(
             im_true, im_test,
-            ignore_labels=ignore_labels, normalize=normalize
+            ignore_labels=ignore_labels, normalize=True
         )
 
     else:

--- a/skimage/metrics/_variation_of_information.py
+++ b/skimage/metrics/_variation_of_information.py
@@ -20,9 +20,11 @@ def variation_of_information(im_true=None, im_test=None, *, table=None,
     ----------
     im_true, im_test : ndarray of int
         Label images / segmentations, must have same shape.
-    table : scipy.sparse array in crs format, optional
+    table : scipy.sparse array in csr format, optional
         A contingency table built with skimage.evaluate.contingency_table.
         If None, it will be computed with skimage.evaluate.contingency_table.
+        If given, the entropies will be computed from this table and any images
+        will be ignored.
     ignore_labels : sequence of int, optional
         Labels to ignore. Any part of the true image labeled with any of these
         values will not be counted in the score.
@@ -48,8 +50,8 @@ def variation_of_information(im_true=None, im_test=None, *, table=None,
 
 
 def _xlogx(x):
-    """
-    Compute x * log_2(x).
+    """Compute x * log_2(x).
+
     We define 0 * log_2(0) = 0
 
     Parameters
@@ -73,13 +75,16 @@ def _xlogx(x):
 
 
 def _vi_tables(im_true, im_test, table=None, ignore_labels=()):
-    """
-    Compute probability tables used for calculating VI.
+    """Compute probability tables used for calculating VI.
 
     Parameters
     ----------
     im_true, im_test : ndarray of int
         Input label images, any dimensionality.
+    table : csr matrix, optional
+        Pre-computed contingency table.
+    ignore_labels : sequence of int, optional
+        Labels to ignore when computing scores.
 
     Returns
     -------
@@ -116,8 +121,7 @@ def _vi_tables(im_true, im_test, table=None, ignore_labels=()):
 
 
 def _invert_nonzero(arr):
-    """
-    Compute the inverse of the non-zero elements of arr, not changing 0.
+    """Compute the inverse of the non-zero elements of arr, not changing 0.
 
     Parameters
     ----------

--- a/skimage/metrics/_variation_of_information.py
+++ b/skimage/metrics/_variation_of_information.py
@@ -8,8 +8,7 @@ __all__ = ['variation_of_information']
 
 def variation_of_information(im_true=None, im_test=None, *, table=None,
                              ignore_labels=[], normalize=False):
-    """
-    Return symmetric conditional entropies associated with the VI. [1]_
+    """Return symmetric conditional entropies associated with the VI. [1]_
 
     The variation of information is defined as VI(X,Y) = H(X|Y) + H(Y|X).
     If Y is the ground-truth segmentation, then H(Y|X) can be interpreted
@@ -94,7 +93,9 @@ def _vi_tables(im_true, im_test, table=None, ignore_labels=[],
     if table is None:
         # normalize, since it is an identity op if already done
         pxy = contingency_table(
-            im_true, im_test, ignore_labels, normalize=normalize)
+            im_true, im_test,
+            ignore_labels=ignore_labels, normalize=normalize
+        )
 
     else:
         pxy = table

--- a/skimage/metrics/_variation_of_information.py
+++ b/skimage/metrics/_variation_of_information.py
@@ -41,7 +41,7 @@ def variation_of_information(image0=None, image1=None, *, table=None,
         Pages 873-895, ISSN 0047-259X, :DOI:`10.1016/j.jmva.2006.11.013`.
     """
     h0g1, h1g0 = _vi_tables(image0, image1, table=table,
-                            ignore_labels=ignore_labels, normalize=True)
+                            ignore_labels=ignore_labels)
     # false splits, false merges
     return np.array([h1g0.sum(), h0g1.sum()])
 

--- a/skimage/metrics/_variation_of_information.py
+++ b/skimage/metrics/_variation_of_information.py
@@ -6,19 +6,19 @@ from .._shared.utils import check_shape_equality
 __all__ = ['variation_of_information']
 
 
-def variation_of_information(im_true=None, im_test=None, *, table=None,
-                             ignore_labels=(), normalize=False):
+def variation_of_information(image0=None, image1=None, *, table=None,
+                             ignore_labels=()):
     """Return symmetric conditional entropies associated with the VI. [1]_
 
     The variation of information is defined as VI(X,Y) = H(X|Y) + H(Y|X).
-    If Y is the ground-truth segmentation, then H(Y|X) can be interpreted
-    as the amount of under-segmentation of Y and H(X|Y) as the amount
+    If X is the ground-truth segmentation, then H(X|Y) can be interpreted
+    as the amount of under-segmentation and H(X|Y) as the amount
     of over-segmentation. In other words, a perfect over-segmentation
-    will have H(Y|X)=0 and a perfect under-segmentation will have H(X|Y)=0.
+    will have H(X|Y)=0 and a perfect under-segmentation will have H(Y|X)=0.
 
     Parameters
     ----------
-    im_true, im_test : ndarray of int
+    image0, image1 : ndarray of int
         Label images / segmentations, must have same shape.
     table : scipy.sparse array in csr format, optional
         A contingency table built with skimage.evaluate.contingency_table.
@@ -28,14 +28,11 @@ def variation_of_information(im_true=None, im_test=None, *, table=None,
     ignore_labels : sequence of int, optional
         Labels to ignore. Any part of the true image labeled with any of these
         values will not be counted in the score.
-    normalize : bool, optional
-        If True, normalizes contigency table by the number of pixels of
-        each value.
 
     Returns
     -------
     vi : ndarray of float, shape (2,)
-        The conditional entropies of im_test|im_true and im_true|im_test.
+        The conditional entropies of image1|image0 and image0|image1.
 
     References
     ----------
@@ -43,10 +40,10 @@ def variation_of_information(im_true=None, im_test=None, *, table=None,
         distance, Journal of Multivariate Analysis, Volume 98, Issue 5,
         Pages 873-895, ISSN 0047-259X, :DOI:`10.1016/j.jmva.2006.11.013`.
     """
-    hxgy, hygx = _vi_tables(im_true, im_test, table,
-                            ignore_labels, normalize=normalize)
+    h0g1, h1g0 = _vi_tables(image0, image1, table=table,
+                            ignore_labels=ignore_labels, normalize=True)
     # false splits, false merges
-    return np.array([hygx.sum(), hxgy.sum()])
+    return np.array([h1g0.sum(), h0g1.sum()])
 
 
 def _xlogx(x):

--- a/skimage/metrics/simple_metrics.py
+++ b/skimage/metrics/simple_metrics.py
@@ -8,23 +8,23 @@ __all__ = ['mean_squared_error',
            ]
 
 
-def _as_floats(im1, im2):
+def _as_floats(image0, image1):
     """
     Promote im1, im2 to nearest appropriate floating point precision.
     """
-    float_type = np.result_type(im1.dtype, im2.dtype, np.float32)
-    im1 = np.asarray(im1, dtype=float_type)
-    im2 = np.asarray(im2, dtype=float_type)
-    return im1, im2
+    float_type = np.result_type(image0.dtype, image1.dtype, np.float32)
+    image0 = np.asarray(image0, dtype=float_type)
+    image1 = np.asarray(image1, dtype=float_type)
+    return image0, image1
 
 
-def mean_squared_error(im1, im2):
+def mean_squared_error(image0, image1):
     """
     Compute the mean-squared error between two images.
 
     Parameters
     ----------
-    im1, im2 : ndarray
+    image0, image1 : ndarray
         Images.  Any dimensionality, must have same shape.
 
     Returns
@@ -39,23 +39,23 @@ def mean_squared_error(im1, im2):
         ``skimage.metrics.mean_squared_error``.
 
     """
-    check_shape_equality(im1, im2)
-    im1, im2 = _as_floats(im1, im2)
-    return np.mean((im1 - im2) ** 2, dtype=np.float64)
+    check_shape_equality(image0, image1)
+    image0, image1 = _as_floats(image0, image1)
+    return np.mean((image0 - image1) ** 2, dtype=np.float64)
 
 
-def normalized_root_mse(im_true, im_test, norm_type='euclidean'):
+def normalized_root_mse(image_true, image_test, *, normalization='euclidean'):
     """
     Compute the normalized root mean-squared error (NRMSE) between two
     images.
 
     Parameters
     ----------
-    im_true : ndarray
+    image_true : ndarray
         Ground-truth image, same shape as im_test.
-    im_test : ndarray
+    image_test : ndarray
         Test image.
-    norm_type : {'euclidean', 'min-max', 'mean'}, optional
+    normalization : {'euclidean', 'min-max', 'mean'}, optional
         Controls the normalization method to use in the denominator of the
         NRMSE.  There is no standard method of normalization across the
         literature [1]_.  The methods available here are as follows:
@@ -89,31 +89,31 @@ def normalized_root_mse(im_true, im_test, norm_type='euclidean'):
     .. [1] https://en.wikipedia.org/wiki/Root-mean-square_deviation
 
     """
-    check_shape_equality(im_true, im_test)
-    im_true, im_test = _as_floats(im_true, im_test)
+    check_shape_equality(image_true, image_test)
+    image_true, image_test = _as_floats(image_true, image_test)
 
     # Ensure that both 'Euclidean' and 'euclidean' match
-    norm_type = norm_type.lower()
-    if norm_type == 'euclidean':
-        denom = np.sqrt(np.mean((im_true * im_true), dtype=np.float64))
-    elif norm_type == 'min-max':
-        denom = im_true.max() - im_true.min()
-    elif norm_type == 'mean':
-        denom = im_true.mean()
+    normalization = normalization.lower()
+    if normalization == 'euclidean':
+        denom = np.sqrt(np.mean((image_true * image_true), dtype=np.float64))
+    elif normalization == 'min-max':
+        denom = image_true.max() - image_true.min()
+    elif normalization == 'mean':
+        denom = image_true.mean()
     else:
         raise ValueError("Unsupported norm_type")
-    return np.sqrt(mean_squared_error(im_true, im_test)) / denom
+    return np.sqrt(mean_squared_error(image_true, image_test)) / denom
 
 
-def peak_signal_noise_ratio(im_true, im_test, data_range=None):
+def peak_signal_noise_ratio(image_true, image_test, *, data_range=None):
     """
     Compute the peak signal to noise ratio (PSNR) for an image.
 
     Parameters
     ----------
-    im_true : ndarray
+    image_true : ndarray
         Ground-truth image, same shape as im_test.
-    im_test : ndarray
+    image_test : ndarray
         Test image.
     data_range : int, optional
         The data range of the input image (distance between minimum and
@@ -136,14 +136,14 @@ def peak_signal_noise_ratio(im_true, im_test, data_range=None):
     .. [1] https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio
 
     """
-    check_shape_equality(im_true, im_test)
+    check_shape_equality(image_true, image_test)
 
     if data_range is None:
-        if im_true.dtype != im_test.dtype:
+        if image_true.dtype != image_test.dtype:
             warn("Inputs have mismatched dtype.  Setting data_range based on "
                  "im_true.", stacklevel=2)
-        dmin, dmax = dtype_range[im_true.dtype.type]
-        true_min, true_max = np.min(im_true), np.max(im_true)
+        dmin, dmax = dtype_range[image_true.dtype.type]
+        true_min, true_max = np.min(image_true), np.max(image_true)
         if true_max > dmax or true_min < dmin:
             raise ValueError(
                 "im_true has intensity values outside the range expected for "
@@ -154,7 +154,7 @@ def peak_signal_noise_ratio(im_true, im_test, data_range=None):
         else:
             data_range = dmax - dmin
 
-    im_true, im_test = _as_floats(im_true, im_test)
+    image_true, image_test = _as_floats(image_true, image_test)
 
-    err = mean_squared_error(im_true, im_test)
+    err = mean_squared_error(image_true, image_test)
     return 10 * np.log10((data_range ** 2) / err)

--- a/skimage/metrics/tests/test_segmentation_metrics.py
+++ b/skimage/metrics/tests/test_segmentation_metrics.py
@@ -26,12 +26,11 @@ def test_contingency_table():
 def test_vi():
     im_true = np.array([1, 2, 3, 4])
     im_test = np.array([1, 1, 8, 8])
-    assert_equal(np.sum(variation_of_information(
-        im_true, im_test, normalize=True)), 1)
+    assert_equal(np.sum(variation_of_information(im_true, im_test)), 1)
 
 
 def test_are():
     im_true = np.array([[2, 1], [1, 2]])
     im_test = np.array([[1, 2], [3, 1]])
-    assert_almost_equal(adapted_rand_error(im_true, im_test, normalize=False),
+    assert_almost_equal(adapted_rand_error(im_true, im_test),
                         (0.3333333, 0.5, 1.0))

--- a/skimage/metrics/tests/test_simple_metrics.py
+++ b/skimage/metrics/tests/test_simple_metrics.py
@@ -36,8 +36,8 @@ def test_PSNR_float():
 
     # mismatched dtype results in a warning if data_range is unspecified
     with expected_warnings(['Inputs have mismatched dtype']):
-        p_mixed = peak_signal_noise_ratio(
-            cam / 255., np.float32(cam_noisy / 255.))
+        p_mixed = peak_signal_noise_ratio(cam / 255.,
+                                          np.float32(cam_noisy / 255.))
     assert_almost_equal(p_mixed, p_float64, decimal=5)
 
 
@@ -50,12 +50,16 @@ def test_PSNR_errors():
 def test_NRMSE():
     x = np.ones(4)
     y = np.asarray([0., 2., 2., 2.])
-    assert_equal(normalized_root_mse(y, x, 'mean'), 1 / np.mean(y))
-    assert_equal(normalized_root_mse(y, x, 'Euclidean'), 1 / np.sqrt(3))
-    assert_equal(normalized_root_mse(y, x, 'min-max'), 1 / (y.max() - y.min()))
+    assert_equal(normalized_root_mse(y, x, normalization='mean'),
+                 1 / np.mean(y))
+    assert_equal(normalized_root_mse(y, x, normalization='euclidean'),
+                 1 / np.sqrt(3))
+    assert_equal(normalized_root_mse(y, x, normalization='min-max'),
+                 1 / (y.max() - y.min()))
 
     # mixed precision inputs are allowed
-    assert_almost_equal(normalized_root_mse(y, np.float32(x), 'min-max'),
+    assert_almost_equal(normalized_root_mse(y, np.float32(x),
+                                            normalization='min-max'),
                         1 / (y.max() - y.min()))
 
 
@@ -75,4 +79,4 @@ def test_NRMSE_errors():
         normalized_root_mse(x[:-1], x)
     # invalid normalization name
     with testing.raises(ValueError):
-        normalized_root_mse(x, x, 'foo')
+        normalized_root_mse(x, x, normalization='foo')

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -7,7 +7,7 @@ import numpy as np
 from ..util import img_as_ubyte, crop
 from scipy import ndimage as ndi
 
-from .._shared.utils import check_nD
+from .._shared.utils import check_nD, warn
 from ._skeletonize_cy import (_fast_skeletonize, _skeletonize_loop,
                               _table_lookup_index)
 from ._skeletonize_3d_cy import _compute_thin_image
@@ -576,7 +576,7 @@ def _table_lookup(image, table):
     return image
 
 
-def skeletonize_3d(image):
+def skeletonize_3d(image, *, img=None):
     """Compute the skeleton of a binary image.
 
     Thinning is used to reduce each connected component in a binary image
@@ -587,6 +587,14 @@ def skeletonize_3d(image):
     image : ndarray, 2D or 3D
         A binary image containing the objects to be skeletonized. Zeros
         represent background, nonzero values are foreground.
+
+    Other Parameters
+    ----------------
+    img : DEPRECATED
+        Synonym for `image`.
+
+        .. deprecated:: 0.16
+           Will be removed in 0.17.
 
     Returns
     -------
@@ -617,11 +625,14 @@ def skeletonize_3d(image):
            Computer Vision, Graphics, and Image Processing, 56(6):462-478, 1994.
 
     """
+    if img is not None:
+        image = img
+        warn('Using img as a keyword argument to skeletonize_3d is deprecated.'
+             ' Use image instead.')
     # make sure the image is 3D or 2D
     if image.ndim < 2 or image.ndim > 3:
         raise ValueError("skeletonize_3d can only handle 2D or 3D images; "
                          "got image.ndim = %s instead." % image.ndim)
-
     image = np.ascontiguousarray(image)
     image = img_as_ubyte(img, force_copy=False)
 

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -576,7 +576,7 @@ def _table_lookup(image, table):
     return image
 
 
-def skeletonize_3d(img):
+def skeletonize_3d(image):
     """Compute the skeleton of a binary image.
 
     Thinning is used to reduce each connected component in a binary image
@@ -584,7 +584,7 @@ def skeletonize_3d(img):
 
     Parameters
     ----------
-    img : ndarray, 2D or 3D
+    image : ndarray, 2D or 3D
         A binary image containing the objects to be skeletonized. Zeros
         represent background, nonzero values are foreground.
 
@@ -618,31 +618,31 @@ def skeletonize_3d(img):
 
     """
     # make sure the image is 3D or 2D
-    if img.ndim < 2 or img.ndim > 3:
+    if image.ndim < 2 or image.ndim > 3:
         raise ValueError("skeletonize_3d can only handle 2D or 3D images; "
-                         "got img.ndim = %s instead." % img.ndim)
+                         "got image.ndim = %s instead." % image.ndim)
 
-    img = np.ascontiguousarray(img)
-    img = img_as_ubyte(img, force_copy=False)
+    image = np.ascontiguousarray(image)
+    image = img_as_ubyte(img, force_copy=False)
 
     # make an in image 3D and pad it w/ zeros to simplify dealing w/ boundaries
     # NB: careful here to not clobber the original *and* minimize copying
-    img_o = img
-    if img.ndim == 2:
-        img_o = img[np.newaxis, ...]
-    img_o = np.pad(img_o, pad_width=1, mode='constant')
+    image_o = image
+    if image.ndim == 2:
+        image_o = image[np.newaxis, ...]
+    image_o = np.pad(image_o, pad_width=1, mode='constant')
 
     # normalize to binary
-    maxval = img_o.max()
-    img_o[img_o != 0] = 1
+    maxval = image_o.max()
+    image_o[image_o != 0] = 1
 
     # do the computation
-    img_o = np.asarray(_compute_thin_image(img_o))
+    image_o = np.asarray(_compute_thin_image(image_o))
 
     # crop it back and restore the original intensity range
-    img_o = crop(img_o, crop_width=1)
-    if img.ndim == 2:
-        img_o = img_o[0]
-    img_o *= maxval
+    image_o = crop(image_o, crop_width=1)
+    if image.ndim == 2:
+        image_o = image_o[0]
+    image_o *= maxval
 
-    return img_o
+    return image_o

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -634,7 +634,7 @@ def skeletonize_3d(image, *, img=None):
         raise ValueError("skeletonize_3d can only handle 2D or 3D images; "
                          "got image.ndim = %s instead." % image.ndim)
     image = np.ascontiguousarray(image)
-    image = img_as_ubyte(img, force_copy=False)
+    image = img_as_ubyte(image, force_copy=False)
 
     # make an in image 3D and pad it w/ zeros to simplify dealing w/ boundaries
     # NB: careful here to not clobber the original *and* minimize copying

--- a/skimage/registration/_optical_flow.py
+++ b/skimage/registration/_optical_flow.py
@@ -139,7 +139,7 @@ def _tvl1(reference_image, moving_image, flow0, attachment, tightness,
 def optical_flow_tvl1(reference_image, moving_image,
                       *,
                       attachment=15, tightness=0.3, num_warp=5, num_iter=10,
-                      tol=1e-4, prefilter=False, dtype='float32'):
+                      tol=1e-4, prefilter=False, dtype=np.float32):
     r"""Coarse to fine optical flow estimator.
 
     The TV-L1 solver is applied at each level of the image

--- a/skimage/registration/_optical_flow.py
+++ b/skimage/registration/_optical_flow.py
@@ -11,15 +11,15 @@ from skimage.transform import warp
 from ._optical_flow_utils import coarse_to_fine
 
 
-def _tvl1(image0, image1, flow0, attachment, tightness, nwarp, niter,
-          tol, prefilter):
+def _tvl1(reference_image, moving_image, flow0, attachment, tightness, nwarp,
+          niter, tol, prefilter):
     """TV-L1 solver for optical flow estimation.
 
     Parameters
     ----------
-    image0 : ndarray, shape (M, N[, P[, ...]])
+    reference_image : ndarray, shape (M, N[, P[, ...]])
         The first gray scale image of the sequence.
-    image1 : ndarray, shape (M, N[, P[, ...]])
+    moving_image : ndarray, shape (M, N[, P[, ...]])
         The second gray scale image of the sequence.
     flow0 : ndarray, shape (image0.ndim, M, N[, P[, ...]])
         Initialization for the vector field.
@@ -48,21 +48,22 @@ def _tvl1(image0, image1, flow0, attachment, tightness, nwarp, niter,
 
     """
 
-    dtype = image0.dtype
-    grid = np.meshgrid(*[np.arange(n, dtype=dtype) for n in image0.shape],
+    dtype = reference_image.dtype
+    grid = np.meshgrid(*[np.arange(n, dtype=dtype)
+                         for n in reference_image.shape],
                        indexing='ij')
 
-    dt = 0.5/image0.ndim
+    dt = 0.5 / reference_image.ndim
     reg_niter = 2
     f0 = attachment * tightness
     f1 = dt / tightness
-    tol *= image0.size
+    tol *= reference_image.size
 
     flow_current = flow_previous = flow0
 
-    g = np.zeros((image0.ndim, ) + image0.shape, dtype=dtype)
-    proj = np.zeros((image0.ndim, image0.ndim, ) + image0.shape,
-                    dtype=dtype)
+    g = np.zeros((reference_image.ndim,) + reference_image.shape, dtype=dtype)
+    proj = np.zeros((reference_image.ndim, reference_image.ndim,)
+                    + reference_image.shape, dtype=dtype)
 
     s_g = [slice(None), ] * g.ndim
     s_p = [slice(None), ] * proj.ndim
@@ -71,14 +72,14 @@ def _tvl1(image0, image1, flow0, attachment, tightness, nwarp, niter,
     for _ in range(nwarp):
         if prefilter:
             flow_current = ndi.median_filter(flow_current,
-                                             [1]+image0.ndim*[3])
+                                             [1] + reference_image.ndim * [3])
 
-        image1_warp = warp(image1, grid+flow_current, mode='nearest')
+        image1_warp = warp(moving_image, grid + flow_current, mode='nearest')
         grad = np.array(np.gradient(image1_warp))
         NI = (grad*grad).sum(0)
         NI[NI == 0] = 1
 
-        rho_0 = image1_warp - image0 - (grad*flow_current).sum(0)
+        rho_0 = image1_warp - reference_image - (grad * flow_current).sum(0)
 
         for _ in range(niter):
 
@@ -99,10 +100,10 @@ def _tvl1(image0, image1, flow0, attachment, tightness, nwarp, niter,
             # Regularization term
             flow_current = flow_auxiliary.copy()
 
-            for idx in range(image0.ndim):
+            for idx in range(reference_image.ndim):
                 s_p[0] = idx
                 for _ in range(reg_niter):
-                    for ax in range(image0.ndim):
+                    for ax in range(reference_image.ndim):
                         s_g[0] = ax
                         s_g[ax+1] = slice(0, -1)
                         g[tuple(s_g)] = np.diff(flow_current[idx], axis=ax)
@@ -116,7 +117,7 @@ def _tvl1(image0, image1, flow0, attachment, tightness, nwarp, niter,
 
                     # d will be the (negative) divergence of proj[idx]
                     d = -proj[idx].sum(0)
-                    for ax in range(image0.ndim):
+                    for ax in range(reference_image.ndim):
                         s_p[1] = ax
                         s_p[ax+2] = slice(0, -1)
                         s_d[ax] = slice(1, None)
@@ -135,9 +136,10 @@ def _tvl1(image0, image1, flow0, attachment, tightness, nwarp, niter,
     return flow_current
 
 
-def optical_flow_tvl1(image0, image1, *, attachment=15, tightness=0.3,
-                      nwarp=5, niter=10, tol=1e-4, prefilter=False,
-                      dtype='float32'):
+def optical_flow_tvl1(reference_image, moving_image,
+                      *,
+                      attachment=15, tightness=0.3, nwarp=5, niter=10,
+                      tol=1e-4, prefilter=False, dtype='float32'):
     r"""Coarse to fine optical flow estimator.
 
     The TV-L1 solver is applied at each level of the image
@@ -146,9 +148,9 @@ def optical_flow_tvl1(image0, image1, *, attachment=15, tightness=0.3,
 
     Parameters
     ----------
-    image0 : ndarray, shape (M, N[, P[, ...]])
+    reference_image : ndarray, shape (M, N[, P[, ...]])
         The first gray scale image of the sequence.
-    image1 : ndarray, shape (M, N[, P[, ...]])
+    moving_image : ndarray, shape (M, N[, P[, ...]])
         The second gray scale image of the sequence.
     attachment : float
         Attachment parameter (:math:`\lambda` in [1]_). The smaller
@@ -212,4 +214,4 @@ def optical_flow_tvl1(image0, image1, *, attachment=15, tightness=0.3,
                      tightness=tightness, nwarp=nwarp, niter=niter,
                      tol=tol, prefilter=prefilter)
 
-    return coarse_to_fine(image0, image1, solver, dtype=dtype)
+    return coarse_to_fine(reference_image, moving_image, solver, dtype=dtype)

--- a/skimage/registration/_optical_flow_utils.py
+++ b/skimage/registration/_optical_flow_utils.py
@@ -76,7 +76,7 @@ def get_pyramid(I, downscale=2.0, nlevel=10, min_size=16):
 
 
 def coarse_to_fine(I0, I1, solver, downscale=2, nlevel=10, min_size=16,
-                   dtype='float32'):
+                   dtype=np.float32):
     """Generic coarse to fine solver.
 
     Parameters

--- a/skimage/registration/tests/test_tvl1.py
+++ b/skimage/registration/tests/test_tvl1.py
@@ -77,25 +77,25 @@ def test_optical_flow_dtype():
     image0 = rnd.normal(size=(256, 256))
     gt_flow, image1 = _sin_flow_gen(image0)
     # Estimate the flow at double precision
-    flow_f64 = optical_flow_tvl1(image0, image1, attachment=5, dtype='float64')
+    flow_f64 = optical_flow_tvl1(image0, image1, attachment=5, dtype=np.float64)
 
-    assert flow_f64.dtype == 'float64'
+    assert flow_f64.dtype == np.float64
 
     # Estimate the flow at single precision
-    flow_f32 = optical_flow_tvl1(image0, image1, attachment=5, dtype='float32')
+    flow_f32 = optical_flow_tvl1(image0, image1, attachment=5, dtype=np.float32)
 
-    assert flow_f32.dtype == 'float32'
+    assert flow_f32.dtype == np.float32
 
     # Assert that floating point precision does not affect the quality
     # of the estimated flow
 
-    assert abs(flow_f64 - flow_f32) .mean() < 1e-3
+    assert np.abs(flow_f64 - flow_f32).mean() < 1e-3
 
 
 def test_incompatible_shapes():
     rnd = np.random.RandomState(0)
     I0 = rnd.normal(size=(256, 256))
-    I1 = rnd.normal(size=(255, 256))
+    I1 = rnd.normal(size=(128, 256))
     with testing.raises(ValueError):
         u, v = optical_flow_tvl1(I0, I1)
 
@@ -104,4 +104,4 @@ def test_wrong_dtype():
     rnd = np.random.RandomState(0)
     img = rnd.normal(size=(256, 256))
     with testing.raises(ValueError):
-        u, v = optical_flow_tvl1(img, img, dtype='int')
+        u, v = optical_flow_tvl1(img, img, dtype=np.int64)

--- a/skimage/util/compare.py
+++ b/skimage/util/compare.py
@@ -28,9 +28,9 @@ def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
 
     Notes
     -----
-    `diff` computes the absolute difference between the two images.
-    `blend` computes the mean value.
-    `checkerboard` makes tiles of dimension `n_tiles` that display
+    ``'diff'`` computes the absolute difference between the two images.
+    ``'blend'`` computes the mean value.
+    ``'checkerboard'`` makes tiles of dimension `n_tiles` that display
     alternatively the first and the second image.
     """
     if image1.shape != image2.shape:


### PR DESCRIPTION
## Description

Using @Carreau's great tool [frappuccino](https://github.com/Carreau/frappuccino), I went through all the new APIs we are releasing in 0.16 and checked that they were where we want them to be. Mostly it was a matter of making some arguments keyword-only.

The only thing missing right now is in the new `metrics` and `registration` modules, and also in the new `util.compare_images` function, some functions use `im1, im2`, others use `im_true, im_test`, while `compare_images` uses `image1, image2` and the new optical flow uses `image0, image1`. Needless to say this is a mess and we should aim to rectify it. Suggestions welcome! My preference is `reference_image, target_image`.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
