### PR TITLE
Update link to NumPy docstring standard in Contribution Guide (replaces #4191)

### DIFF
--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -219,7 +219,7 @@ Guidelines
 
 * All code should have tests (see `test coverage`_ below for more details).
 * All code should be documented, to the same
-  `standard <https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt#docstring-standard>`_ as NumPy and SciPy.
+  `standard <https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard>`_ as NumPy and SciPy.
 * For new functionality, always add an example to the gallery.
 * No changes are ever committed without review and approval by two core
   team members.  Ask on the


### PR DESCRIPTION
## Description

The old link is no longer up to date after NumPy moved that document into the repository for numpydoc.

Replaces #4191 where I unintentionally created a new branch in the scikit-image repository.

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
