### PR TITLE
Fix conversion to float32 dtype

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-numpy>=1.13.3
+numpy>=1.14
 scipy>=0.19.0
 matplotlib>=2.0.0,!=3.0.0
 networkx>=2.0

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-numpy>=1.14
+numpy>=1.14.1
 scipy>=0.19.0
 matplotlib>=2.0.0,!=3.0.0
 networkx>=2.0

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -95,7 +95,7 @@ def moments_coords_central(coords, center=None, order=3):
 
     >>> coords2 = np.concatenate((coords, [[17, 17]]), axis=0)
     >>> np.round(moments_coords_central(coords2),
-    ...          decimals=2)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    ...          decimals=2)  # doctest: +NORMALIZE_WHITESPACE
     array([[ 17.  ,   0.  ,  22.12,  -2.49],
            [  0.  ,   3.53,   1.73,   7.4 ],
            [ 25.88,   6.02,  36.63,   8.83],

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -95,7 +95,7 @@ def moments_coords_central(coords, center=None, order=3):
 
     >>> coords2 = np.concatenate((coords, [[17, 17]]), axis=0)
     >>> np.round(moments_coords_central(coords2),
-                 decimals=2)  # doctest: +NORMALIZE_WHITESPACE
+    ...          decimals=2)  # doctest: +NORMALIZE_WHITESPACE
     array([[17.  ,  0.  , 22.12, -2.49],
            [ 0.  ,  3.53,  1.73,  7.4 ],
            [25.88,  6.02, 36.63,  8.83],

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -95,10 +95,10 @@ def moments_coords_central(coords, center=None, order=3):
 
     >>> coords2 = np.concatenate((coords, [[17, 17]]), axis=0)
     >>> np.round(moments_coords_central(coords2), 2)
-    array([[ 17.  ,   0.  ,  22.12,  -2.49],
-           [  0.  ,   3.53,   1.73,   7.4 ],
-           [ 25.88,   6.02,  36.63,   8.83],
-           [  4.15,  19.17,  14.8 ,  39.6 ]])
+    array([[17.  ,  0.  , 22.12, -2.49],
+           [ 0.  ,  3.53,  1.73,  7.4 ],
+           [25.88,  6.02, 36.63,  8.83],
+           [ 4.15, 19.17, 14.8 , 39.6 ]])
 
     Image moments and central image moments are equivalent (by definition)
     when the center is (0, 0):

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -96,10 +96,10 @@ def moments_coords_central(coords, center=None, order=3):
     >>> coords2 = np.concatenate((coords, [[17, 17]]), axis=0)
     >>> np.round(moments_coords_central(coords2),
     ...          decimals=2)  # doctest: +NORMALIZE_WHITESPACE
-    array([[17.  ,  0.  , 22.12, -2.49],
-           [ 0.  ,  3.53,  1.73,  7.4 ],
-           [25.88,  6.02, 36.63,  8.83],
-           [ 4.15, 19.17, 14.8 , 39.6 ]])
+    array([[ 17.  ,   0.  ,  22.12,  -2.49],
+           [  0.  ,   3.53,   1.73,   7.4 ],
+           [ 25.88,   6.02,  36.63,   8.83],
+           [  4.15,  19.17,  14.8 ,  39.6 ]])
 
     Image moments and central image moments are equivalent (by definition)
     when the center is (0, 0):

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -94,8 +94,7 @@ def moments_coords_central(coords, center=None, order=3):
     point, this no longer holds:
 
     >>> coords2 = np.concatenate((coords, [[17, 17]]), axis=0)
-    >>> np.round(moments_coords_central(coords2),
-    ...          decimals=2)  # doctest: +NORMALIZE_WHITESPACE
+    >>> np.round(moments_coords_central(coords2), decimals=2)  # doctest: +NORMALIZE_WHITESPACE
     array([[ 17.  ,   0.  ,  22.12,  -2.49],
            [  0.  ,   3.53,   1.73,   7.4 ],
            [ 25.88,   6.02,  36.63,   8.83],

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -94,7 +94,8 @@ def moments_coords_central(coords, center=None, order=3):
     point, this no longer holds:
 
     >>> coords2 = np.concatenate((coords, [[17, 17]]), axis=0)
-    >>> np.round(moments_coords_central(coords2), decimals=2)  # doctest: +NORMALIZE_WHITESPACE
+    >>> np.round(moments_coords_central(coords2),
+    ...          decimals=2)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     array([[ 17.  ,   0.  ,  22.12,  -2.49],
            [  0.  ,   3.53,   1.73,   7.4 ],
            [ 25.88,   6.02,  36.63,   8.83],

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -94,7 +94,8 @@ def moments_coords_central(coords, center=None, order=3):
     point, this no longer holds:
 
     >>> coords2 = np.concatenate((coords, [[17, 17]]), axis=0)
-    >>> np.round(moments_coords_central(coords2), 2)
+    >>> np.round(moments_coords_central(coords2),
+                 decimals=2)  # doctest: +NORMALIZE_WHITESPACE
     array([[17.  ,  0.  , 22.12, -2.49],
            [ 0.  ,  3.53,  1.73,  7.4 ],
            [25.88,  6.02, 36.63,  8.83],

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -95,9 +95,8 @@ def _dtype_bits(kind, bits, itemsize=1):
 
     """
 
-    compare_bits_to = bits.__le__ if kind == 'u' else bits.__lt__
-
-    s = next(i for i in (itemsize, ) + (2, 4, 8) if compare_bits_to(i * 8))
+    s = next(i for i in (itemsize, ) + (2, 4, 8) if
+             bits < (i * 8) or (bits == (i * 8) and kind == 'u'))
 
     return np.dtype(kind + str(s))
 

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -241,9 +241,7 @@ def convert(image, dtype, force_copy=False, uniform=False):
     #   is a subclass of that type (e.g. `np.floating` will allow
     #   `float32` and `float64` arrays through)
 
-    type_out = dtype if isinstance(dtype, type) else dtypeobj_out
-
-    if np.issubdtype(dtypeobj_in, type_out):
+    if np.issubdtype(dtype_in, np.obj2sctype(dtype)):
         if force_copy:
             image = image.copy()
         return image

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -54,6 +54,126 @@ def dtype_limits(image, clip_negative=False):
     return imin, imax
 
 
+def _dtype_itemsize(itemsize, *dtypes):
+    """Return first of `dtypes` with itemsize greater than `itemsize`
+
+    Parameters
+    ----------
+    itemsize: int
+        The data type object element size.
+
+    Other Parameters
+    ----------------
+    *dtypes:
+        Any Object accepted by `np.dtype` to be converted to a data
+        type object
+
+    Returns
+    -------
+    dtype: data type object
+        First of `dtypes` with itemsize greater than `itemsize`.
+
+    """
+    return next(dt for dt in dtypes if np.dtype(dt).itemsize >= itemsize)
+
+
+def _dtype_bits(kind, bits, itemsize=1):
+    """Return dtype of `kind` that can store a `bits` wide unsigned int
+
+    Parameters:
+    kind: str
+        Data type kind.
+    bits: int
+        Desired number of bits.
+    itemsize: int
+        The data type object element size.
+
+    Returns
+    -------
+    dtype: data type object
+        Data type of `kind` that can store a `bits` wide unsigned int
+
+    """
+
+    compare_bits_to = bits.__le__ if kind == 'u' else bits.__lt__
+
+    s = next(i for i in (itemsize, ) + (2, 4, 8) if compare_bits_to(i * 8))
+
+    return np.dtype(kind + str(s))
+
+
+def _scale(a, n, m, copy=True):
+    """Scale an array of unsigned/positive integers from `n` to `m` bits.
+
+    Numbers can be represented exactly only if `m` is a multiple of `n`.
+
+    Parameters
+    ----------
+    a : ndarray
+        Input image array.
+    n : int
+        Number of bits currently used to encode the values in `a`.
+    m : int
+        Desired number of bits to encode the values in `out`.
+    copy : bool, optional
+        If True, allocates and returns new array. Otherwise, modifies
+        `a` in place.
+
+    Returns
+    -------
+    out : array
+        Output image array. Has the same kind as `a`.
+    """
+    kind = a.dtype.kind
+    if n > m and a.max() < 2 ** m:
+        mnew = int(np.ceil(m / 2) * 2)
+        if mnew > m:
+            dtype = "int{}".format(mnew)
+        else:
+            dtype = "uint{}".format(mnew)
+        n = int(np.ceil(n / 2) * 2)
+        warn("Downcasting {} to {} without scaling because max "
+             "value {} fits in {}".format(a.dtype, dtype, a.max(), dtype),
+             stacklevel=3)
+        return a.astype(_dtype_bits(kind, m))
+    elif n == m:
+        return a.copy() if copy else a
+    elif n > m:
+        # downscale with precision loss
+        if copy:
+            b = np.empty(a.shape, _dtype_bits(kind, m))
+            np.floor_divide(a, 2**(n - m), out=b, dtype=a.dtype,
+                            casting='unsafe')
+            return b
+        else:
+            a //= 2**(n - m)
+            return a
+    elif m % n == 0:
+        # exact upscale to a multiple of `n` bits
+        if copy:
+            b = np.empty(a.shape, _dtype_bits(kind, m))
+            np.multiply(a, (2**m - 1) // (2**n - 1), out=b, dtype=b.dtype)
+            return b
+        else:
+            a = a.astype(_dtype_bits(kind, m, a.dtype.itemsize), copy=False)
+            a *= (2**m - 1) // (2**n - 1)
+            return a
+    else:
+        # upscale to a multiple of `n` bits,
+        # then downscale with precision loss
+        o = (m // n + 1) * n
+        if copy:
+            b = np.empty(a.shape, _dtype_bits(kind, o))
+            np.multiply(a, (2**o - 1) // (2**n - 1), out=b, dtype=b.dtype)
+            b //= 2**(o - m)
+            return b
+        else:
+            a = a.astype(_dtype_bits(kind, o, a.dtype.itemsize), copy=False)
+            a *= (2**o - 1) // (2**n - 1)
+            a //= 2**(o - m)
+            return a
+
+
 def convert(image, dtype, force_copy=False, uniform=False):
     """
     Convert an image to the requested data-type.
@@ -131,93 +251,6 @@ def convert(image, dtype, force_copy=False, uniform=False):
     if not (dtype_in in _supported_types and dtype_out in _supported_types):
         raise ValueError("Can not convert from {} to {}."
                          .format(dtypeobj_in, dtypeobj_out))
-
-    def _dtype_itemsize(itemsize, *dtypes):
-        # Return first of `dtypes` with itemsize greater than `itemsize`
-        return next(dt for dt in dtypes if np.dtype(dt).itemsize >= itemsize)
-
-    def _dtype_bits(kind, bits, itemsize=1):
-        # Return dtype of `kind` that can store a `bits` wide unsigned int
-        def compare(x, y, kind='u'):
-            if kind == 'u':
-                return x <= y
-            else:
-                return x < y
-
-        s = next(i for i in (itemsize, ) + (2, 4, 8) if compare(bits, i * 8,
-                                                                kind=kind))
-        return np.dtype(kind + str(s))
-
-    def _scale(a, n, m, copy=True):
-        """Scale an array of unsigned/positive integers from `n` to `m` bits.
-
-        Numbers can be represented exactly only if `m` is a multiple of `n`.
-
-        Parameters
-        ----------
-        a : ndarray
-            Input image array.
-        n : int
-            Number of bits currently used to encode the values in `a`.
-        m : int
-            Desired number of bits to encode the values in `out`.
-        copy : bool, optional
-            If True, allocates and returns new array. Otherwise, modifies
-            `a` in place.
-
-        Returns
-        -------
-        out : array
-            Output image array. Has the same kind as `a`.
-        """
-        kind = a.dtype.kind
-        if n > m and a.max() < 2 ** m:
-            mnew = int(np.ceil(m / 2) * 2)
-            if mnew > m:
-                dtype = "int{}".format(mnew)
-            else:
-                dtype = "uint{}".format(mnew)
-            n = int(np.ceil(n / 2) * 2)
-            warn("Downcasting {} to {} without scaling because max "
-                 "value {} fits in {}".format(a.dtype, dtype, a.max(), dtype),
-                 stacklevel=3)
-            return a.astype(_dtype_bits(kind, m))
-        elif n == m:
-            return a.copy() if copy else a
-        elif n > m:
-            # downscale with precision loss
-            if copy:
-                b = np.empty(a.shape, _dtype_bits(kind, m))
-                np.floor_divide(a, 2**(n - m), out=b, dtype=a.dtype,
-                                casting='unsafe')
-                return b
-            else:
-                a //= 2**(n - m)
-                return a
-        elif m % n == 0:
-            # exact upscale to a multiple of `n` bits
-            if copy:
-                b = np.empty(a.shape, _dtype_bits(kind, m))
-                np.multiply(a, (2**m - 1) // (2**n - 1), out=b, dtype=b.dtype)
-                return b
-            else:
-                a = a.astype(_dtype_bits(kind, m, a.dtype.itemsize), copy=False)
-                a *= (2**m - 1) // (2**n - 1)
-                return a
-        else:
-            # upscale to a multiple of `n` bits,
-            # then downscale with precision loss
-            o = (m // n + 1) * n
-            if copy:
-                b = np.empty(a.shape, _dtype_bits(kind, o))
-                np.multiply(a, (2**o - 1) // (2**n - 1), out=b, dtype=b.dtype)
-                b //= 2**(o - m)
-                return b
-            else:
-                a = a.astype(_dtype_bits(kind, o, a.dtype.itemsize), copy=False)
-                a *= (2**o - 1) // (2**n - 1)
-                a //= 2**(o - m)
-                return a
 
     if kind_in in 'ui':
         imin_in = np.iinfo(dtype_in).min

--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -150,7 +150,7 @@ def test_float32_passthrough():
 
 
 float_dtype_list = [float, np.float, np.double, np.single, np.float32,
-                    'float32', 'float64']
+                    np.float64, 'float32', 'float64']
 
 
 def test_float_conversion_dtype():

--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -132,16 +132,46 @@ def test_clobber():
 
             img_in = func_input_type(img)
             img_in_before = img_in.copy()
-            img_out = func_output_type(img_in)
+            func_output_type(img_in)
 
             assert_equal(img_in, img_in_before)
+
 
 def test_signed_scaling_float32():
     x = np.array([-128,  127], dtype=np.int8)
     y = img_as_float32(x)
     assert_equal(y.max(), 1)
 
+
 def test_float32_passthrough():
     x = np.array([-1, 1], dtype=np.float32)
     y = img_as_float(x)
     assert_equal(y.dtype, x.dtype)
+
+
+float_dtype_list = [float, np.float, np.double, np.single, np.float32,
+                    'float32', 'float64']
+
+
+def test_float_conversion_dtype():
+    """Test any convertion from a float dtype to an other."""
+    x = np.array([-1, 1])
+
+    # Test all combinations of dtypes convertions
+    dtype_combin = np.array(np.meshgrid(float_dtype_list,
+                                        float_dtype_list)).T.reshape(-1, 2)
+
+    for dtype_in, dtype_out in dtype_combin:
+        x = x.astype(dtype_in)
+        y = convert(x, dtype_out)
+        assert y.dtype == np.dtype(dtype_out)
+
+
+def test_subclass_conversion():
+    """Check subclass conversion behavior"""
+    x = np.array([-1, 1])
+
+    for dtype in float_dtype_list:
+        x = x.astype(dtype)
+        y = convert(x, np.floating)
+        assert y.dtype == x.dtype


### PR DESCRIPTION
## Description

Closes #4189.

This PR consists in:

- refactoring `skimage.util.convert`: defining annex functions (`_scale`, `_dtype_bits`, `_dtype_itemsize`) outside the body of the `convert` function to make it more readable,
- refactoring of `_dtype_bits`: removing the definition of `compare` function,
- using `np.obj2sctype(dtype)` instead of `type_out` to fix the conversion to `float32` whatever is `numpy` version,
- adding tests for conversion from any combination of floating data type definition (`float32`, np.float, float, etc...)
- adding tests for conversion from a subclass of the desired output datatype (check for no regression).

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
