### PR TITLE
Explain use of num_peaks parameter in corner_peaks

### DIFF
--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -920,10 +920,11 @@ def corner_peaks(image, min_distance=1, threshold_abs=None, threshold_rel=0.1,
 
     This differs from `skimage.feature.peak_local_max` in that it suppresses
     multiple connected peaks with the same accumulator value.
-    
-    Note that the `num_peaks` limit is applied *before* suppression of connected
-    peaks. If you want to limit the number of peaks *after suppression*, you
-    should set `num_peaks=np.inf` and post-process the output of this function.
+
+    Note that the `num_peaks` limit is applied *before* suppression of 
+    connected peaks. If you want to limit the number of peaks 
+    *after suppression*, you should set `num_peaks=np.inf` and 
+    post-process the output of this function.
 
     Parameters
     ----------

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -921,9 +921,9 @@ def corner_peaks(image, min_distance=1, threshold_abs=None, threshold_rel=0.1,
     This differs from `skimage.feature.peak_local_max` in that it suppresses
     multiple connected peaks with the same accumulator value.
 
-    Note that the `num_peaks` limit is applied *before* suppression of 
-    connected peaks. If you want to limit the number of peaks 
-    *after suppression*, you should set `num_peaks=np.inf` and 
+    Note that the `num_peaks` limit is applied *before* suppression of
+    connected peaks. If you want to limit the number of peaks
+    *after suppression*, you should set `num_peaks=np.inf` and
     post-process the output of this function.
 
     Parameters

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -923,7 +923,7 @@ def corner_peaks(image, min_distance=1, threshold_abs=None, threshold_rel=0.1,
     
     Note that the `num_peaks` limit is applied *before* suppression of connected
     peaks. If you want to limit the number of peaks *after suppression*, you
-    must set `num_peaks=np.inf` and trim the list yourself.
+    should set `num_peaks=np.inf` and post-process the output of this function.
 
     Parameters
     ----------

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -920,6 +920,10 @@ def corner_peaks(image, min_distance=1, threshold_abs=None, threshold_rel=0.1,
 
     This differs from `skimage.feature.peak_local_max` in that it suppresses
     multiple connected peaks with the same accumulator value.
+    
+    Note that the `num_peaks` limit is applied *before* suppression of connected
+    peaks. If you want to limit the number of peaks *after suppression*, you
+    must set `num_peaks=np.inf` and trim the list yourself.
 
     Parameters
     ----------

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -921,11 +921,6 @@ def corner_peaks(image, min_distance=1, threshold_abs=None, threshold_rel=0.1,
     This differs from `skimage.feature.peak_local_max` in that it suppresses
     multiple connected peaks with the same accumulator value.
 
-    Note that the `num_peaks` limit is applied *before* suppression of
-    connected peaks. If you want to limit the number of peaks
-    *after suppression*, you should set `num_peaks=np.inf` and
-    post-process the output of this function.
-
     Parameters
     ----------
     * : *
@@ -934,6 +929,13 @@ def corner_peaks(image, min_distance=1, threshold_abs=None, threshold_rel=0.1,
     See also
     --------
     skimage.feature.peak_local_max
+
+    Notes
+    -----
+    The `num_peaks` limit is applied before suppression of
+    connected peaks. If you want to limit the number of peaks
+    after suppression, you should set `num_peaks=np.inf` and
+    post-process the output of this function.
 
     Examples
     --------


### PR DESCRIPTION
## Description

Adds a note in the documentation for `skimage.feature.corner_peaks` that explains how the `num_peaks` parameter is interpreted.

At present (without reading the source code) it is ambiguous whether the `num_peaks` limit applies *before* suppression of connected peaks, or *after*.

If a user assumes the latter behavior, then `corner_peaks` will appear broken when the `num_peaks` argument is used; `corner_peaks` will return far fewer than the expected number of results, and adding more peaks to an input image may increase *or decrease* the number of results that `corner_peaks` returns for that image.

This PR adds documentation that clarifies the meaning of the `num_peaks` parameter.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
