### PR TITLE
Update optical flow functions API

### DIFF
--- a/skimage/registration/_optical_flow.py
+++ b/skimage/registration/_optical_flow.py
@@ -137,7 +137,7 @@ def _tvl1(image0, image1, flow0, attachment, tightness, nwarp, niter,
 
 def optical_flow_tvl1(image0, image1, *, attachment=15, tightness=0.3,
                       nwarp=5, niter=10, tol=1e-4, prefilter=False,
-                      dtype='float32'):
+                      single_precision=True):
     r"""Coarse to fine optical flow estimator.
 
     The TV-L1 solver is applied at each level of the image
@@ -167,10 +167,11 @@ def optical_flow_tvl1(image0, image1, *, attachment=15, tightness=0.3,
     prefilter : bool
         Whether to prefilter the estimated optical flow before each
         image warp. This helps to remove the potential outliers.
-    dtype : dtype
-        Output data type: must be floating point. Single precision
-        provides good results and saves memory usage and computation
-        time compared to double precision.
+    single_precision : bool
+        If True, single precision float is used. Double precision
+        float is used otherwise. Single precision provides good
+        results and saves memory usage and computation time compared
+        to double precision.
 
     Returns
     -------
@@ -212,4 +213,5 @@ def optical_flow_tvl1(image0, image1, *, attachment=15, tightness=0.3,
                      tightness=tightness, nwarp=nwarp, niter=niter,
                      tol=tol, prefilter=prefilter)
 
-    return coarse_to_fine(image0, image1, solver, dtype=dtype)
+    return coarse_to_fine(image0, image1, solver,
+                          single_precision=single_precision)

--- a/skimage/registration/_optical_flow_utils.py
+++ b/skimage/registration/_optical_flow_utils.py
@@ -76,7 +76,7 @@ def get_pyramid(I, downscale=2.0, nlevel=10, min_size=16):
 
 
 def coarse_to_fine(I0, I1, solver, downscale=2, nlevel=10, min_size=16,
-                   dtype='float32'):
+                   single_precision=True):
     """Generic coarse to fine solver.
 
     Parameters
@@ -93,8 +93,9 @@ def coarse_to_fine(I0, I1, solver, downscale=2, nlevel=10, min_size=16,
         The maximum number of pyramid levels.
     min_size : int
         The minimum size for any dimension of the pyramid levels.
-    dtype : dtype
-        Output data type.
+    single_precision : bool
+        If True, single precision float is used. Double precision
+        float is used otherwise.
 
     Returns
     -------
@@ -106,9 +107,10 @@ def coarse_to_fine(I0, I1, solver, downscale=2, nlevel=10, min_size=16,
     if I0.shape != I1.shape:
         raise ValueError("Input images should have the same shape")
 
-    if np.dtype(dtype).char not in 'efdg':
-        raise ValueError("Only floating point data type are valid"
-                         " for optical flow")
+    if single_precision:
+        dtype = np.float32
+    else:
+        dtype = np.float64
 
     pyramid = list(zip(get_pyramid(convert(I0, dtype),
                                    downscale, nlevel, min_size),

--- a/skimage/registration/tests/test_tvl1.py
+++ b/skimage/registration/tests/test_tvl1.py
@@ -77,12 +77,14 @@ def test_optical_flow_dtype():
     image0 = rnd.normal(size=(256, 256))
     gt_flow, image1 = _sin_flow_gen(image0)
     # Estimate the flow at double precision
-    flow_f64 = optical_flow_tvl1(image0, image1, attachment=5, dtype='float64')
+    flow_f64 = optical_flow_tvl1(image0, image1, attachment=5,
+                                 single_precision=False)
 
     assert flow_f64.dtype == 'float64'
 
     # Estimate the flow at single precision
-    flow_f32 = optical_flow_tvl1(image0, image1, attachment=5, dtype='float32')
+    flow_f32 = optical_flow_tvl1(image0, image1, attachment=5,
+                                 single_precision=True)
 
     assert flow_f32.dtype == 'float32'
 
@@ -98,10 +100,3 @@ def test_incompatible_shapes():
     I1 = rnd.normal(size=(255, 256))
     with testing.raises(ValueError):
         u, v = optical_flow_tvl1(I0, I1)
-
-
-def test_wrong_dtype():
-    rnd = np.random.RandomState(0)
-    img = rnd.normal(size=(256, 256))
-    with testing.raises(ValueError):
-        u, v = optical_flow_tvl1(img, img, dtype='int')


### PR DESCRIPTION
## Description

Here is the  implementation of my [suggestion](https://github.com/scikit-image/scikit-image/pull/4187#issuecomment-536025590) concerning the modification of optical flow API: `dtype` argument is replaced by `single_precision`.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
