### PR TITLE
Add rescale local mean

### DIFF
--- a/benchmarks/benchmark_transform_warp.py
+++ b/benchmarks/benchmark_transform_warp.py
@@ -1,5 +1,5 @@
 import numpy as np
-from skimage.transform import SimilarityTransform, warp
+from skimage.transform import SimilarityTransform, warp, resize_local_mean
 from skimage.util.dtype import convert
 import warnings
 import functools
@@ -48,3 +48,24 @@ class WarpSuite:
         transformations."""
         result = warp(self.image, self.tform, order=self.order,
                       preserve_range=True)
+
+
+class ResizeLocalMeanSuite:
+    params = ([np.uint8, np.uint16, np.float32, np.float64],
+              [128, 512, 1024, 2048],
+              [128, 512, 1024],
+              [2, 3],
+              [2, 3],
+              [True, False]
+              )
+    param_names = ['dtype', 'shape_in', 'shape_out', 'ndim_in',
+                   'ndim_out', 'grid_mode']
+
+    def setup(self, dtype, shape_in, shape_out, ndim_in, ndim_out, grid_mode):
+        self.shape_in = ndim_in * (shape_in, )
+        self.image = np.zeros(self.shape_in, dtype=dtype)
+        self.shape_out = ndim_out * (shape_out, )
+        self.grid_mode = grid_mode
+
+    def time_resize_local_mean(self):
+        resize_local_mean(self.image, self.shape_out, self.grid_mode)

--- a/skimage/transform/__init__.py
+++ b/skimage/transform/__init__.py
@@ -13,7 +13,8 @@ from ._geometric import (estimate_transform,
                          EssentialMatrixTransform, PolynomialTransform,
                          PiecewiseAffineTransform)
 from ._warps import (swirl, resize, rotate, rescale,
-                     downscale_local_mean, warp, warp_coords, warp_polar)
+                     downscale_local_mean, warp, warp_coords, warp_polar,
+                     resize_local_mean)
 from .pyramids import (pyramid_reduce, pyramid_expand,
                        pyramid_gaussian, pyramid_laplacian)
 
@@ -48,6 +49,7 @@ __all__ = ['match_histograms',
            'PiecewiseAffineTransform',
            'swirl',
            'resize',
+           'resize_local_mean',
            'rotate',
            'rescale',
            'downscale_local_mean',

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -1070,3 +1070,84 @@ def warp_polar(image, center=None, *, radius=None, output_shape=None,
                   output_shape=output_shape, **kwargs)
 
     return warped
+
+
+def _resize_weights(old_size, new_size, reflect=False):
+    """Create a weight matrix for resizing with the local mean along an axis.
+
+    Parameters
+    ----------
+    old_size: int
+        Old size.
+    new_size: int
+        New size.
+    reflect: bool
+        Whether to use reflecting boundary conditions or not.
+
+    Returns
+    -------
+    NumPy array with shape (new_size, old_size). Rows sum to 1.
+    """
+    if reflect:
+        old, new = old_size - 1, new_size - 1
+        old_breaks = np.pad(np.linspace(0.5, old-0.5, old),
+                            1, 'constant', constant_values=(0, old))
+        val = 0.5 * old / new
+        new_breaks = np.pad(np.linspace(val, old-val, new),
+                            1, 'constant', constant_values=(0, old))
+    else:
+        old_breaks = np.linspace(0, old_size, num=old_size + 1)
+        new_breaks = np.linspace(0, old_size, num=new_size + 1)
+
+    upper = np.minimum(new_breaks[1:, np.newaxis], old_breaks[np.newaxis, 1:])
+    lower = np.maximum(new_breaks[:-1, np.newaxis],
+                       old_breaks[np.newaxis, :-1])
+
+    weights = np.maximum(upper - lower, 0)
+    weights /= np.sum(weights, axis=1, keepdims=True)
+
+    return weights
+
+
+def resize_local_mean(image, output_shape, reflect_axes=None):
+    """Resize an array with the local mean / bilinear scaling.
+
+    Works for both upsampling and downsampling in a fashion equivalent
+    to block_mean and zoom, but allows for resizing by non-integer
+    multiples. Prefer block_mean and zoom when possible, as this
+    implementation is probably slower.
+
+    Parameters
+    ----------
+    image : ndarray
+        Input image.
+    output_shape : tuple or ndarray
+        Size of the generated output image `(rows, cols[, ...][, dim])`. If
+        `dim` is not provided, the number of channels is preserved. In case the
+        number of input channels does not equal the number of output channels a
+        n-dimensional interpolation is applied.
+
+    Returns
+    -------
+    Array resized to shape.
+
+    Raises:
+      ValueError: if any values in reflect_axes fall outside the interval
+        [-array.ndim, array.ndim).
+
+    """
+    reflect_axes_set = set()
+    for axis in reflect_axes:
+        if not -image.ndim <= axis < image.ndim:
+            raise ValueError('invalid axis: {}'.format(axis))
+        reflect_axes_set.add(axis % image.ndim)
+
+    output = image
+    for axis, (old_size, new_size) in enumerate(zip(image.shape,
+                                                    output_shape)):
+        reflect = axis in reflect_axes_set
+        weights = _resize_weights(old_size, new_size, reflect=reflect)
+        product = np.tensordot(output, weights, [[axis], [-1]])
+        output = np.moveaxis(product, -1, axis)
+
+    return output


### PR DESCRIPTION
## Description

Close #2827.

Based on @shoyer [gist](https://gist.github.com/shoyer/c0f1ddf409667650a076c058f9a17276), I implemented the `resize_local_mean` functionality.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
