### PR TITLE
FIX generate_release_note when contributor_set contains None

### DIFF
--- a/tools/generate_release_notes.py
+++ b/tools/generate_release_notes.py
@@ -215,7 +215,7 @@ for section, pull_request_dicts in highlights.items():
 contributors = OrderedDict()
 
 contributors['authors'] = authors
-#contributors['committers'] = committers
+# contributors['committers'] = committers
 contributors['reviewers'] = reviewers
 
 for section_name, contributor_set in contributors.items():
@@ -224,6 +224,11 @@ for section_name, contributor_set in contributors.items():
                      'release [alphabetical by first name or login]')
     print(committer_str)
     print('-' * len(committer_str))
+
+    # Remove None from contributor set if it's in there.
+    if None in contributor_set:
+        contributor_set.remove(None)
+
     for c in sorted(contributor_set, key=str.lower):
         print(f'- {c}')
     print()


### PR DESCRIPTION
## Description

contributor_set sometimes includes None (not quite sure why…). That creates problems when trying to sort the set using the key str.lower. Removing the culprit from the set fixes the problem.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
