### PR TITLE
corner_peaks prevent negative index locations

### DIFF
--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -968,8 +968,8 @@ def corner_peaks(image, min_distance=1, threshold_abs=None, threshold_rel=0.1,
         coords = np.transpose(peaks.nonzero())
         for r, c in coords:
             if peaks[r, c]:
-                peaks[r - min_distance:r + min_distance + 1,
-                      c - min_distance:c + min_distance + 1] = False
+                peaks[max((r - min_distance), 0):r + min_distance + 1,
+                      max((c - min_distance), 0):c + min_distance + 1] = False
                 peaks[r, c] = True
 
     if indices is True:

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -351,17 +351,22 @@ def test_num_peaks():
 def test_corner_peaks():
     response = np.zeros((10, 10))
     response[2:5, 2:5] = 1
+    response[8:10, 0:2] = 1
 
     corners = corner_peaks(response, exclude_border=False, min_distance=10,
                            threshold_rel=0)
     assert len(corners) == 1
 
+    corners = corner_peaks(response, exclude_border=False, min_distance=5,
+                           threshold_rel=0)
+    assert len(corners) == 2
+
     corners = corner_peaks(response, exclude_border=False, min_distance=1)
-    assert len(corners) == 4
+    assert len(corners) == 5
 
     corners = corner_peaks(response, exclude_border=False, min_distance=1,
                            indices=False)
-    assert np.sum(corners) == 4
+    assert np.sum(corners) == 5
 
 
 def test_blank_image_nans():

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -355,14 +355,14 @@ def test_corner_peaks():
 
     corners = corner_peaks(response, exclude_border=False, min_distance=10,
                            threshold_rel=0)
-    assert len(corners) == 1
+    assert corners.shape == (1, 2)
 
     corners = corner_peaks(response, exclude_border=False, min_distance=5,
                            threshold_rel=0)
-    assert len(corners) == 2
+    assert corners.shape == (2, 2)
 
     corners = corner_peaks(response, exclude_border=False, min_distance=1)
-    assert len(corners) == 5
+    assert corners.shape == (5, 2)
 
     corners = corner_peaks(response, exclude_border=False, min_distance=1,
                            indices=False)


### PR DESCRIPTION
This is a fix for the following issue:
#4200 

Corrects how corner_peaks handles image borders. The issue results in too many peaks being returned. 

If one end of the index range is negative, array values cannot be set to false and no error is thrown. Unit test was also updated to check for this. 



Example Unit Test Output:

Check 1:
```
    corners = corner_peaks(response, exclude_border=False, min_distance=10,
                           threshold_rel=0)
    assert len(corners) == 1
```
![test1](https://user-images.githubusercontent.com/16522814/66238280-3560e880-e6c5-11e9-8308-2e213220db0d.png)

Check 2:
```
    corners = corner_peaks(response, exclude_border=False, min_distance=5,
                           threshold_rel=0)
    assert len(corners) == 2
```
![test2](https://user-images.githubusercontent.com/16522814/66238315-50cbf380-e6c5-11e9-8856-488a16d0b987.png)

Check 3:
```
    corners = corner_peaks(response, exclude_border=False, min_distance=1)
    assert len(corners) == 5
```
![test3](https://user-images.githubusercontent.com/16522814/66238335-604b3c80-e6c5-11e9-804b-1636462c561e.png)

Check 4:
```
    corners = corner_peaks(response, exclude_border=False, min_distance=1,
                           indices=False)
    assert np.sum(corners) == 5
```
![image](https://user-images.githubusercontent.com/16522814/66238086-bcfa2780-e6c4-11e9-824a-ba0c9629276c.png)


## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
