### PR TITLE
Usage of util.apply_parallel in tutorial_parallelization.rst.

### DIFF
--- a/doc/source/user_guide/tutorial_parallelization.rst
+++ b/doc/source/user_guide/tutorial_parallelization.rst
@@ -61,3 +61,13 @@ The number of jobs can be specified.
         Parallel(n_jobs=4)(delayed(task)(i) for i in pics)
 
     %timeit joblib_loop()
+
+
+``apply_parallel`` Maps a function in parallel across an array.
+
+.. code-block:: python
+    
+    from skimage.util.apply_parallel import apply_parallel
+    apply_parallel(threshold_local, a, chunks=(6, 6), depth=5,
+                   extra_arguments=(3,),
+                   extra_keywords={'mode': 'reflect'})


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
