### PR TITLE
Fix Travis linux build by moving from Ubuntu trusty to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@
 
 # See tools/travis/notes.txt for some guidelines
 
-# If this is ever changed to xenial (Ubuntu 16.04), make sure to enable the
-# xvfb service
-dist: trusty
+dist: xenial
+services:
+  - xvfb
 language: python
 cache:
   # See https://docs.travis-ci.com/user/caching/#pip-cache
@@ -56,29 +56,17 @@ matrix:
     - os: linux
       python: 3.7
       env: QT=PyQt5 OPTIONAL_DEPS=1 BUILD_DOCS=1 DEPLOY_DOCS=1
-      dist: xenial # Required for Python 3.7
-      services:
-        - xvfb
     - os: linux
       python: 3.7
-      dist: xenial # Required for Python 3.7
       env: QT=PyQt5 OPTIONAL_DEPS=1 BUILD_DOCS=1
-      services:
-        - xvfb
     # When 3.8 gets released, and dependencies have built wheels, enable
     # this build
     # - os: linux
     #   python: 3.8
     #   env: QT=PyQt5 OPTIONAL_DEPS=1 BUILD_DOCS=1
-    #   dist: xenial # Required for Python 3.7
-    #   services:
-    #     - xvfb
     - os: linux
       python: 3.7
       env: QT=PyQt5 OPTIONAL_DEPS=1 PIP_FLAGS="--pre"
-      dist: xenial # Required for Python 3.7
-      services:
-        - xvfb
     # For smooth deployment, the osx_image here should match
     # what we set in the wheel generation travis images.
     # If not set, it will use the default version from Travis


### PR DESCRIPTION
## Description

Ubuntu trusty having [reached the end of its LTS window](https://ubuntu.com/blog/ubuntu-14-04-trusty-tahr), I think that it is time to move to xenial!
This may solve the issues with Travis CI.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
