### PR TITLE
Fix the random Linux build fails in travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,9 @@ matrix:
     #   env: TRAVIS_PYTHON_VERSION=3.8
 
 before_install:
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 762E3157
+      fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         source tools/travis/osx_install.sh;
       else

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ matrix:
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 762E3157;
+        apt-key adv --list-public-keys --with-colons | grep '^pub' | cut -d':' -f 5 | egrep -o '.{8}$' | grep -wo 762E3157 > /dev/null 2>&1 || sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 762E3157;
       fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         source tools/travis/osx_install.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,8 @@ matrix:
     #   env: TRAVIS_PYTHON_VERSION=3.8
 
 before_install:
+    # Remove this line when the Ubuntu image is updated to Xenial
+    # https://travis-ci.community/t/then-sudo-apt-get-update-failed-public-key-is-not-available-no-pubkey-6b05f25d762e3157-in-ubuntu-xenial/1728/15
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         apt-key adv --list-public-keys --with-colons | grep '^pub' | cut -d':' -f 5 | egrep -o '.{8}$' | grep -wo 762E3157 > /dev/null 2>&1 || sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 762E3157;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ matrix:
 
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 762E3157
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 762E3157;
       fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         source tools/travis/osx_install.sh;


### PR DESCRIPTION
## Description

Travis CI fails randomly on Linux builds. We can see in the logs ([here](https://travis-ci.org/scikit-image/scikit-image/jobs/595317007#L574) for example)

```
Err:89 http://archive.ubuntu.com/ubuntu trusty-updates/main i386 Packages

  Writing more data than expected (1089393 > 1088989)

Fetched 38.4 MB in 6s (5,554 kB/s)

Reading package lists...

W: http://ppa.launchpad.net/couchdb/stable/ubuntu/dists/trusty/Release.gpg: Signature by key 15866BAFD9BCC4F3C1E0DFC7D69548E1C17EAB57 uses weak digest algorithm (SHA1)

W: GPG error: https://packagecloud.io/github/git-lfs/ubuntu trusty InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 6B05F25D762E3157

W: The repository 'https://packagecloud.io/github/git-lfs/ubuntu trusty InRelease' is not signed.

W: There is no public key available for the following key IDs:

6B05F25D762E3157  

E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/trusty-updates/main/binary-amd64/Packages.gz  Hash Sum mismatch

E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/trusty-updates/main/binary-i386/Packages  Writing more data than expected (1089393 > 1088989)

E: Some index files failed to download. They have been ignored, or old ones used instead.

The command "sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install ccache texlive texlive-latex-extra dvipng qtbase5-dev" failed and exited with 100 during .
```

Based on this [post](https://travis-ci.community/t/then-sudo-apt-get-update-failed-public-key-is-not-available-no-pubkey-6b05f25d762e3157-in-ubuntu-xenial/1728/13), this PR fixes this issue by importing the non available key.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
