### PR TITLE
Relax overly-stringent check in threshold_multiotsu

### DIFF
--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -561,8 +561,15 @@ def test_multiotsu_output():
     for coor, val in zip(coords, values):
         rr, cc = circle(coor[1], coor[0], 20)
         image[rr, cc] = val
-    thresholds = [64, 128]
-    assert np.array_equal(thresholds, threshold_multiotsu(image))
+    t1, t2 = threshold_multiotsu(image)
+    # since the image only contains values 64, 128, 192, and the image is
+    # compared to the threshold with a strictly greater than check, thresholds
+    # 64, 65, ..., 127 are all equivalent, and thresholds 128, 129, ..., 191
+    # are all equivalent. The overly stringent check of t1 == 64 was causing
+    # some 32-bit builds to fail. See e.g.
+    # https://travis-ci.org/scikit-image/scikit-image-wheels/jobs/595911861#L3896-L3911
+    assert t1 in range(64, 128)
+    assert t2 in range(128, 192)
 
     image = color.rgb2gray(data.astronaut())
     assert_almost_equal(threshold_multiotsu(image, 2), 0.43945312)


### PR DESCRIPTION
## Description

Cherrypicks the fix for the 32bit multi-otsu failing test from the v0.16.x branch.
Travis will not pick up the failing test, as there is no 32 bit here. 


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
