### PR TITLE
MAINT: cycle_spin cleanup

### DIFF
--- a/skimage/restoration/_cycle_spin.py
+++ b/skimage/restoration/_cycle_spin.py
@@ -34,7 +34,7 @@ def _generate_shifts(ndim, multichannel, max_shifts, shift_steps=1):
     elif len(shift_steps) != ndim:
         raise ValueError("max_shifts should have length ndim")
 
-    if np.any(np.asarray(shift_steps) < 1):
+    if any(s < 1 for s in shift_steps):
         raise ValueError("shift_steps must all be >= 1")
 
     if multichannel and max_shifts[-1] != 0:
@@ -42,7 +42,7 @@ def _generate_shifts(ndim, multichannel, max_shifts, shift_steps=1):
             "Multichannel cycle spinning should not have shifts along the "
             "last axis.")
 
-    return product(*[range(0, s+1, t) for
+    return product(*[range(0, s + 1, t) for
                      s, t in zip(max_shifts, shift_steps)])
 
 
@@ -121,7 +121,7 @@ def cycle_spin(x, func, max_shifts, shift_steps=1, num_workers=None,
         # shift, apply function, inverse shift
         xs = np.roll(x, shift, axis=roll_axes)
         tmp = func(xs, **func_kw)
-        return np.roll(tmp, -np.asarray(shift), axis=roll_axes)
+        return np.roll(tmp, tuple(-s for s in shift), axis=roll_axes)
 
     if not dask_available and (num_workers is None or num_workers > 1):
         num_workers = 1


### PR DESCRIPTION

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->
This PR is just a minor refactoring of cycle_spin to replace `_roll_axes` with numpy's own `roll` (this is possible now that our minimum support NumPy is >= 1.12).

This is purely a maintenance PR and does not change the existing behaviour.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
~- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)~
~- [ ] Gallery example in `./doc/examples` (new features only)~
~- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark~
~- [ ] Unit tests~
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
