### PR TITLE
Migrate to networkx 2.x

### DIFF
--- a/doc/examples/segmentation/plot_rag.py
+++ b/doc/examples/segmentation/plot_rag.py
@@ -67,7 +67,7 @@ g.add_edge(1, 3, weight=50)
 
 # Assigning dummy labels.
 for n in g.nodes():
-    g.node[n]['labels'] = [n]
+    g.nodes[n]['labels'] = [n]
 
 gc = g.copy()
 

--- a/doc/examples/segmentation/plot_rag_merge.py
+++ b/doc/examples/segmentation/plot_rag_merge.py
@@ -36,7 +36,7 @@ def _weight_mean_color(graph, src, dst, n):
         difference of the mean color between node `dst` and `n`.
     """
 
-    diff = graph.node[dst]['mean color'] - graph.node[n]['mean color']
+    diff = graph.nodes[dst]['mean color'] - graph.nodes[n]['mean color']
     diff = np.linalg.norm(diff)
     return {'weight': diff}
 
@@ -53,10 +53,10 @@ def merge_mean_color(graph, src, dst):
     src, dst : int
         The vertices in `graph` to be merged.
     """
-    graph.node[dst]['total color'] += graph.node[src]['total color']
-    graph.node[dst]['pixel count'] += graph.node[src]['pixel count']
-    graph.node[dst]['mean color'] = (graph.node[dst]['total color'] /
-                                     graph.node[dst]['pixel count'])
+    graph.nodes[dst]['total color'] += graph.nodes[src]['total color']
+    graph.nodes[dst]['pixel count'] += graph.nodes[src]['pixel count']
+    graph.nodes[dst]['mean color'] = (graph.nodes[dst]['total color'] /
+                                      graph.nodes[dst]['pixel count'])
 
 
 img = data.coffee()

--- a/skimage/future/graph/graph_cut.py
+++ b/skimage/future/graph/graph_cut.py
@@ -67,7 +67,7 @@ def cut_threshold(labels, rag, thresh, in_place=True):
     map_array = np.arange(labels.max() + 1, dtype=labels.dtype)
     for i, nodes in enumerate(comps):
         for node in nodes:
-            for label in rag.node[node]['labels']:
+            for label in rag.nodes[node]['labels']:
                 map_array[label] = i
 
     return map_array[labels]
@@ -95,7 +95,7 @@ def cut_normalized(labels, rag, thresh=0.001, num_cuts=10, in_place=True,
         The number or N-cuts to perform before determining the optimal one.
     in_place : bool
         If set, modifies `rag` in place. For each node `n` the function will
-        set a new attribute ``rag.node[n]['ncut label']``.
+        set a new attribute ``rag.nodes[n]['ncut label']``.
     max_edge : float, optional
         The maximum possible value of an edge in the RAG. This corresponds to
         an edge between identical regions. This is used to put self
@@ -230,7 +230,7 @@ def _label_all(rag, attr_name):
         The attribute to which a unique integer is assigned.
     """
     node = min(rag.nodes())
-    new_label = rag.node[node]['labels'][0]
+    new_label = rag.nodes[node]['labels'][0]
     for n, d in rag.nodes(data=True):
         d[attr_name] = new_label
 

--- a/skimage/future/graph/graph_merge.py
+++ b/skimage/future/graph/graph_merge.py
@@ -42,7 +42,7 @@ def _rename_node(graph, node_id, copy_id):
     """ Rename `node_id` in `graph` to `copy_id`. """
 
     graph._add_node_silent(copy_id)
-    graph.node[copy_id].update(graph.node[node_id])
+    graph.nodes[copy_id].update(graph.nodes[node_id])
 
     for nbr in graph.neighbors(node_id):
         wt = graph[node_id][nbr]['weight']

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -210,8 +210,8 @@ class RAG(nx.Graph):
                                **extra_keywords)
             self.add_edge(neighbor, new, attr_dict=data)
 
-        self.node[new]['labels'] = (self.node[src]['labels'] +
-                                    self.node[dst]['labels'])
+        self.nodes[new]['labels'] = (self.nodes[src]['labels'] +
+                                     self.nodes[dst]['labels'])
         self.remove_node(src)
 
         if not in_place:
@@ -355,22 +355,22 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
     graph = RAG(labels, connectivity=connectivity)
 
     for n in graph:
-        graph.node[n].update({'labels': [n],
-                              'pixel count': 0,
-                              'total color': np.array([0, 0, 0],
+        graph.nodes[n].update({'labels': [n],
+                               'pixel count': 0,
+                               'total color': np.array([0, 0, 0],
                                                       dtype=np.double)})
 
     for index in np.ndindex(labels.shape):
         current = labels[index]
-        graph.node[current]['pixel count'] += 1
-        graph.node[current]['total color'] += image[index]
+        graph.nodes[current]['pixel count'] += 1
+        graph.nodes[current]['total color'] += image[index]
 
     for n in graph:
-        graph.node[n]['mean color'] = (graph.node[n]['total color'] /
-                                       graph.node[n]['pixel count'])
+        graph.nodes[n]['mean color'] = (graph.nodes[n]['total color'] /
+                                        graph.nodes[n]['pixel count'])
 
     for x, y, d in graph.edges(data=True):
-        diff = graph.node[x]['mean color'] - graph.node[y]['mean color']
+        diff = graph.nodes[x]['mean color'] - graph.nodes[y]['mean color']
         diff = np.linalg.norm(diff)
         if mode == 'similarity':
             d['weight'] = math.e ** (-(diff ** 2) / sigma)
@@ -441,7 +441,7 @@ def rag_boundary(labels, edge_map, connectivity=2):
                                 weight='count')
 
     for n in rag.nodes():
-        rag.node[n].update({'labels': [n]})
+        rag.nodes[n].update({'labels': [n]})
 
     return rag
 
@@ -474,7 +474,7 @@ def show_rag(labels, rag, image, border_color='black', edge_width=1.5,
         the image is drawn as it is.
     in_place : bool, optional
         If set, the RAG is modified in place. For each node `n` the function
-        will set a new attribute ``rag.node[n]['centroid']``.
+        will set a new attribute ``rag.nodes[n]['centroid']``.
     ax : :py:class:`matplotlib.axes.Axes`, optional
         The axes to draw on. If not specified, new axes are created and drawn
         on.
@@ -547,8 +547,8 @@ def show_rag(labels, rag, image, border_color='black', edge_width=1.5,
     # Defining the end points of the edges
     # The tuple[::-1] syntax reverses a tuple as matplotlib uses (x,y)
     # convention while skimage uses (row, column)
-    lines = [[rag.node[n1]['centroid'][::-1], rag.node[n2]['centroid'][::-1]]
-             for (n1, n2) in rag.edges()]
+    lines = [[rag.nodes[n1]['centroid'][::-1], rag.nodes[n2]['centroid'][::-1]]
+              for (n1, n2) in rag.edges()]
 
     lc = LineCollection(lines, linewidths=edge_width, cmap=edge_cmap)
     edge_weights = [d['weight'] for x, y, d in rag.edges(data=True)]

--- a/skimage/future/graph/tests/test_rag.py
+++ b/skimage/future/graph/tests/test_rag.py
@@ -44,7 +44,7 @@ def test_rag_merge():
     g.merge_nodes(1, 4)
     g.merge_nodes(2, 3)
     n = g.merge_nodes(3, 4, in_place=False)
-    assert sorted(g.node[n]['labels']) == list(range(5))
+    assert sorted(g.nodes[n]['labels']) == list(range(5))
     assert list(g.edges()) == []
 
 
@@ -115,16 +115,16 @@ def test_rag_error():
 
 
 def _weight_mean_color(graph, src, dst, n):
-    diff = graph.node[dst]['mean color'] - graph.node[n]['mean color']
+    diff = graph.nodes[dst]['mean color'] - graph.nodes[n]['mean color']
     diff = np.linalg.norm(diff)
     return {'weight': diff}
 
 
 def _pre_merge_mean_color(graph, src, dst):
-    graph.node[dst]['total color'] += graph.node[src]['total color']
-    graph.node[dst]['pixel count'] += graph.node[src]['pixel count']
-    graph.node[dst]['mean color'] = (graph.node[dst]['total color'] /
-                                     graph.node[dst]['pixel count'])
+    graph.nodes[dst]['total color'] += graph.nodes[src]['total color']
+    graph.nodes[dst]['pixel count'] += graph.nodes[src]['pixel count']
+    graph.nodes[dst]['mean color'] = (graph.nodes[dst]['total color'] /
+                                      graph.nodes[dst]['pixel count'])
 
 
 def merge_hierarchical_mean_color(labels, rag, thresh, rag_copy=True,


### PR DESCRIPTION
## Description

This should complete the migration from networkx 1.x to 2.x:
https://networkx.github.io/documentation/latest/release/migration_guide_from_1.x_to_2.0.html

In 2.4, we deleted several deprecated features:
https://networkx.github.io/documentation/latest/release/release_2.4.html

According to your `requirements/default.txt` file, you currently require `networkx>=2.0`, which should be fine as the new interface was introduced in 2.0.

See #4235.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
