### PR TITLE
fix wrong argument parsing in structural_similarity

### DIFF
--- a/skimage/measure/_structural_similarity.py
+++ b/skimage/measure/_structural_similarity.py
@@ -10,9 +10,11 @@ def compare_ssim(X, Y, win_size=None, gradient=False,
     warn('DEPRECATED: skimage.measure.compare_ssim has been moved to '
          'skimage.metrics.structural_similarity. It will be removed from '
          'skimage.measure in version 0.18.', stacklevel=2)
-    return structural_similarity(X, Y, win_size, gradient,
-                                 data_range, multichannel,
-                                 gaussian_weights, full, **kwargs)
+    return structural_similarity(X, Y, win_size=win_size, gradient=gradient,
+                                 data_range=data_range,
+                                 multichannel=multichannel,
+                                 gaussian_weights=gaussian_weights, full=full,
+                                 **kwargs)
 
 
 if structural_similarity.__doc__ is not None:


### PR DESCRIPTION
## Description

Because of commit dd43834, most of the arguments for the function `metrics.structural_similarity` are keyword-only. However, the call of the function from the deprecated function `measure.compare_ssim` was not reflecting this and the code was falling in a `TypeError`. This patch fixes it. 

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
