### PR TITLE
Initialize starting vector for `scipy.sparse.linalg.eigsh` to ensure reproducibility in graph_cut

### DIFF
--- a/skimage/future/graph/graph_cut.py
+++ b/skimage/future/graph/graph_cut.py
@@ -268,7 +268,9 @@ def _ncut_relabel(rag, thresh, num_cuts):
         d2.data = np.reciprocal(np.sqrt(d2.data, out=d2.data), out=d2.data)
 
         # Refer Shi & Malik 2001, Equation 7, Page 891
-        vals, vectors = linalg.eigsh(d2 * (d - w) * d2, which='SM',
+        A = d2 * (d - w) * d2
+        v0 = np.random.rand(min(A.shape))
+        vals, vectors = linalg.eigsh(A, which='SM', v0=v0,
                                      k=min(100, m - 2))
 
         # Pick second smallest eigenvector.

--- a/skimage/future/graph/graph_cut.py
+++ b/skimage/future/graph/graph_cut.py
@@ -76,6 +76,7 @@ def cut_threshold(labels, rag, thresh, in_place=True):
 
 def cut_normalized(labels, rag, thresh=0.001, num_cuts=10, in_place=True,
                    max_edge=1.0,
+                   *,
                    random_state=None,
                    ):
     """Perform Normalized Graph cut on the Region Adjacency Graph.

--- a/skimage/future/graph/graph_cut.py
+++ b/skimage/future/graph/graph_cut.py
@@ -109,7 +109,7 @@ def cut_normalized(labels, rag, thresh=0.001, num_cuts=10, in_place=True,
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
         by `np.random`. The random state is used for the starting point
-        of `scipy.sparse.linalg.eighsh`
+        of `scipy.sparse.linalg.eigsh`.
 
     Returns
     -------

--- a/skimage/future/graph/graph_cut.py
+++ b/skimage/future/graph/graph_cut.py
@@ -264,7 +264,7 @@ def _ncut_relabel(rag, thresh, num_cuts, random_state):
     num_cuts : int
         The number or N-cuts to perform before determining the optimal one.
     random_state: RandomState instance
-        Provides initial values for eigenvalue solver
+        Provides initial values for eigenvalue solver.
     """
     d, w = _ncut.DW_matrices(rag)
     m = w.shape[0]

--- a/skimage/future/graph/graph_cut.py
+++ b/skimage/future/graph/graph_cut.py
@@ -245,8 +245,6 @@ def _ncut_relabel(rag, thresh, num_cuts):
 
     Parameters
     ----------
-    labels : ndarray
-        The array of labels.
     rag : RAG
         The region adjacency graph.
     thresh : float
@@ -254,9 +252,6 @@ def _ncut_relabel(rag, thresh, num_cuts):
         value of the N-cut exceeds `thresh`.
     num_cuts : int
         The number or N-cuts to perform before determining the optimal one.
-    map_array : array
-        The array which maps old labels to new ones. This is modified inside
-        the function.
     """
     d, w = _ncut.DW_matrices(rag)
     m = w.shape[0]

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -157,20 +157,6 @@ class RAG(nx.Graph):
                                   strides=((0,) * label_image.ndim)),
                 extra_arguments=(self,))
 
-    def __eq__(self, other):
-        if set(self.nodes) != set(other.nodes):
-            return False
-        for node in self.nodes:
-            for key, this_val in self.nodes[node].items():
-                other_val = other.nodes[node][key]
-                if isinstance(this_val, np.ndarray):
-                    equal = (this_val == other_val).all()
-                else:
-                    equal = (this_val == other_val)
-                if not equal:
-                    return False
-        return True
-
     def merge_nodes(self, src, dst, weight_func=min_weight, in_place=True,
                     extra_arguments=[], extra_keywords={}):
         """Merge node `src` and `dst`.

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -157,6 +157,21 @@ class RAG(nx.Graph):
                                   strides=((0,) * label_image.ndim)),
                 extra_arguments=(self,))
 
+    def __eq__(self, other):
+        if set(self.nodes) != set(other.nodes):
+            return False
+        for node in self.nodes:
+            for key, this_val in self.nodes[node].items():
+                other_val = other.nodes[node][key]
+                if isinstance(this_val, np.ndarray):
+                    equal = (this_val == other_val).all()
+                else:
+                    equal = (this_val == other_val)
+                if not equal:
+                    print(f"Unequal! {node}/'{key}':{this_val} != {other_val}")
+                    return False
+        return True
+
     def merge_nodes(self, src, dst, weight_func=min_weight, in_place=True,
                     extra_arguments=[], extra_keywords={}):
         """Merge node `src` and `dst`.

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -168,7 +168,6 @@ class RAG(nx.Graph):
                 else:
                     equal = (this_val == other_val)
                 if not equal:
-                    print(f"Unequal! {node}/'{key}':{this_val} != {other_val}")
                     return False
         return True
 

--- a/skimage/future/graph/tests/test_rag.py
+++ b/skimage/future/graph/tests/test_rag.py
@@ -187,6 +187,19 @@ def test_ncut_stable_subgraph():
     assert new_labels.max() == 0
 
 
+def test_inplace():
+    """Make sure normalized cuts does not modify arguments
+    when in_place=False"""
+    img = data.coffee()
+    labels1 = segmentation.slic(img, compactness=30, n_segments=400)
+    g = graph.rag_mean_color(img, labels1, mode='similarity')
+    backup_labels = deepcopy(labels1)
+    backup_g = deepcopy(g)
+    _ = graph.cut_normalized(labels1, g, in_place=False, thresh=1e-8)
+    assert_array_equal(backup_labels, labels1)
+    assert backup_g == g
+
+
 def test_random_seed():
     img = data.coffee()
     labels1 = segmentation.slic(img, compactness=30, n_segments=400)

--- a/skimage/future/graph/tests/test_rag.py
+++ b/skimage/future/graph/tests/test_rag.py
@@ -1,7 +1,10 @@
+from copy import deepcopy
+
+from numpy.testing import assert_array_equal
 import numpy as np
 from skimage.future import graph
 from skimage._shared.version_requirements import is_installed
-from skimage import segmentation
+from skimage import segmentation, data
 from skimage._shared import testing
 
 
@@ -182,6 +185,19 @@ def test_ncut_stable_subgraph():
     new_labels, _, _ = segmentation.relabel_sequential(new_labels)
 
     assert new_labels.max() == 0
+
+
+def test_random_seed():
+    img = data.coffee()
+    labels1 = segmentation.slic(img, compactness=30, n_segments=400)
+    g = graph.rag_mean_color(img, labels1, mode='similarity')
+    results = [None] * 10
+    for i in range(len(results)):
+        np.random.seed(1234)
+        results[i] = graph.cut_normalized(labels1, g, in_place=False, thresh=1e-3)
+
+    for i in range(len(results) - 1):
+        assert_array_equal(results[i], results[i + 1])
 
 
 def test_generic_rag_2d():

--- a/skimage/future/graph/tests/test_rag.py
+++ b/skimage/future/graph/tests/test_rag.py
@@ -210,7 +210,8 @@ def test_random_seed():
     results = [None] * 10
     for i in range(len(results)):
         np.random.seed(1234)
-        results[i] = graph.cut_normalized(labels1, g, in_place=False, thresh=1e-3)
+        results[i] = graph.cut_normalized(
+            labels1, g, in_place=False, thresh=1e-3)
 
     for i in range(len(results) - 1):
         assert_array_equal(results[i], results[i + 1])

--- a/skimage/future/graph/tests/test_rag.py
+++ b/skimage/future/graph/tests/test_rag.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 from numpy.testing import assert_array_equal
 import numpy as np
 from skimage.future import graph
@@ -185,19 +183,6 @@ def test_ncut_stable_subgraph():
     new_labels, _, _ = segmentation.relabel_sequential(new_labels)
 
     assert new_labels.max() == 0
-
-
-def test_inplace():
-    """Make sure normalized cuts does not modify arguments
-    when in_place=False"""
-    img = data.coffee()
-    labels1 = segmentation.slic(img, compactness=30, n_segments=400)
-    g = graph.rag_mean_color(img, labels1, mode='similarity')
-    backup_labels = deepcopy(labels1)
-    backup_g = deepcopy(g)
-    _ = graph.cut_normalized(labels1, g, in_place=False, thresh=1e-8)
-    assert_array_equal(backup_labels, labels1)
-    assert backup_g == g
 
 
 def test_reproducibility():

--- a/skimage/future/graph/tests/test_rag.py
+++ b/skimage/future/graph/tests/test_rag.py
@@ -201,6 +201,9 @@ def test_inplace():
 
 
 def test_random_seed():
+    """ensure cut_normalized returns the same output for the same input,
+    when setting numpy random seed
+    """
     img = data.coffee()
     labels1 = segmentation.slic(img, compactness=30, n_segments=400)
     g = graph.rag_mean_color(img, labels1, mode='similarity')

--- a/skimage/future/graph/tests/test_rag.py
+++ b/skimage/future/graph/tests/test_rag.py
@@ -200,18 +200,17 @@ def test_inplace():
     assert backup_g == g
 
 
-def test_random_seed():
+def test_reproducibility():
     """ensure cut_normalized returns the same output for the same input,
-    when setting numpy random seed
+    when specifying random_state
     """
     img = data.coffee()
     labels1 = segmentation.slic(img, compactness=30, n_segments=400)
     g = graph.rag_mean_color(img, labels1, mode='similarity')
     results = [None] * 10
     for i in range(len(results)):
-        np.random.seed(1234)
         results[i] = graph.cut_normalized(
-            labels1, g, in_place=False, thresh=1e-3)
+            labels1, g, in_place=False, thresh=1e-3, random_state=1234)
 
     for i in range(len(results) - 1):
         assert_array_equal(results[i], results[i + 1])


### PR DESCRIPTION
## Description

Addresses issue #4245, and adds unit tests to cover `inplace` argument to `cut_normalized`


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (NOT APPLICABLE)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)



## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
