### PR TITLE
Add histogram matching test

### DIFF
--- a/skimage/exposure/tests/test_histogram_matching.py
+++ b/skimage/exposure/tests/test_histogram_matching.py
@@ -27,8 +27,6 @@ class TestMatchHistogram:
     image_rgb = data.chelsea()
     template_rgb = data.astronaut()
 
-    # To handle with mutlichannel ==False
-    #(image_rgb[:, :, 0], template_rgb[:, :, 0]),
     @pytest.mark.parametrize('image, reference', [
         (image_rgb, template_rgb)
     ])
@@ -37,7 +35,8 @@ class TestMatchHistogram:
         all channels and all values of matched"""
 
         # when
-        matched = exposure.match_histograms(image, reference, multichannel=True)
+        matched = exposure.match_histograms(image, reference,
+                                            multichannel=True)
 
         matched_pdf = self._calculate_image_empirical_pdf(matched)
         reference_pdf = self._calculate_image_empirical_pdf(reference)
@@ -48,9 +47,39 @@ class TestMatchHistogram:
             matched_values, matched_quantiles = matched_pdf[channel]
 
             for i, matched_value in enumerate(matched_values):
-                closest_id = (np.abs(reference_values - matched_value)).argmin()
+                closest_id = (
+                    np.abs(reference_values - matched_value)
+                ).argmin()
                 assert_almost_equal(matched_quantiles[i],
-                                    reference_quantiles[closest_id], decimal=1)
+                                    reference_quantiles[closest_id],
+                                    decimal=1)
+
+    @pytest.mark.parametrize('image, reference', [
+        (image_rgb[:, :, 0], template_rgb[:, :, 0])
+    ])
+    def test_match_histograms_unichannel(self, image, reference):
+        """Assert that pdf of matched image is close to the reference's pdf for
+        all values of matched"""
+
+        # when
+        matched = exposure.match_histograms(image, reference,
+                                            multichannel=False)
+
+        matched_pdf = self._calculate_image_empirical_pdf(matched)
+        reference_pdf = self._calculate_image_empirical_pdf(reference)
+
+        # then
+        for channel in range(len(matched_pdf)):
+            reference_values, reference_quantiles = reference_pdf[channel]
+            matched_values, matched_quantiles = matched_pdf[channel]
+
+            for i, matched_value in enumerate(matched_values):
+                closest_id = (
+                    np.abs(reference_values - matched_value)
+                ).argmin()
+                assert_almost_equal(matched_quantiles[i],
+                                    reference_quantiles[closest_id],
+                                    decimal=1)
 
     @pytest.mark.parametrize('image, reference', [
         (image_rgb, template_rgb[:, :, 0]),

--- a/skimage/exposure/tests/test_histogram_matching.py
+++ b/skimage/exposure/tests/test_histogram_matching.py
@@ -27,43 +27,18 @@ class TestMatchHistogram:
     image_rgb = data.chelsea()
     template_rgb = data.astronaut()
 
-    @pytest.mark.parametrize('image, reference', [
-        (image_rgb, template_rgb)
+    @pytest.mark.me
+    @pytest.mark.parametrize('image, reference, multichannel', [
+        (image_rgb, template_rgb, True),
+        (image_rgb[:, :, 0], template_rgb[:, :, 0], False)
     ])
-    def test_match_histograms(self, image, reference):
+    def test_match_histograms(self, image, reference, multichannel):
         """Assert that pdf of matched image is close to the reference's pdf for
         all channels and all values of matched"""
 
         # when
         matched = exposure.match_histograms(image, reference,
-                                            multichannel=True)
-
-        matched_pdf = self._calculate_image_empirical_pdf(matched)
-        reference_pdf = self._calculate_image_empirical_pdf(reference)
-
-        # then
-        for channel in range(len(matched_pdf)):
-            reference_values, reference_quantiles = reference_pdf[channel]
-            matched_values, matched_quantiles = matched_pdf[channel]
-
-            for i, matched_value in enumerate(matched_values):
-                closest_id = (
-                    np.abs(reference_values - matched_value)
-                ).argmin()
-                assert_almost_equal(matched_quantiles[i],
-                                    reference_quantiles[closest_id],
-                                    decimal=1)
-
-    @pytest.mark.parametrize('image, reference', [
-        (image_rgb[:, :, 0], template_rgb[:, :, 0])
-    ])
-    def test_match_histograms_unichannel(self, image, reference):
-        """Assert that pdf of matched image is close to the reference's pdf for
-        all values of matched"""
-
-        # when
-        matched = exposure.match_histograms(image, reference,
-                                            multichannel=False)
+                                            multichannel=multichannel)
 
         matched_pdf = self._calculate_image_empirical_pdf(matched)
         reference_pdf = self._calculate_image_empirical_pdf(reference)

--- a/skimage/exposure/tests/test_histogram_matching.py
+++ b/skimage/exposure/tests/test_histogram_matching.py
@@ -27,7 +27,6 @@ class TestMatchHistogram:
     image_rgb = data.chelsea()
     template_rgb = data.astronaut()
 
-    @pytest.mark.me
     @pytest.mark.parametrize('image, reference, multichannel', [
         (image_rgb, template_rgb, True),
         (image_rgb[:, :, 0], template_rgb[:, :, 0], False)


### PR DESCRIPTION
## Description

This commit fixes #4106 by adding a testcase for match_histograms parameter.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
