### PR TITLE
MAINT: remove workaround for next_fast_len

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -52,9 +52,6 @@ Other
   moves away from using ``np.matrix`` in a future version too.
 * Remove the conditional import and function call when ``numpy`` is set
   to > 1.15.x in ``skimage/util/arraycrop.py``.
-* When minimum supported version of ``scipy`` reaches 0.18, use
-  ``scipy.fftpack.next_fast_len`` directly in
-  ``skimage._shared.fft``.
 * Remove custom fused type in ``skimage/filters/_max_tree.pyx`` once
   #3486 fused types is merged.
 * Check whether imread wheels are available, then re-enable testing imread

--- a/skimage/_shared/fft.py
+++ b/skimage/_shared/fft.py
@@ -2,7 +2,7 @@
 
 Otherwise fall back to numpy.fft.
 
-Like numpy 1.15+ scipy 1.3+ is also using pocketfft, but a newer 
+Like numpy 1.15+ scipy 1.3+ is also using pocketfft, but a newer
 C++/pybind11 version called pypocketfft
 """
 try:
@@ -12,14 +12,6 @@ try:
 except ImportError:
     import numpy.fft
     fftmodule = numpy.fft
-
-    try:
-        from scipy.fftpack import next_fast_len
-    except ImportError:
-        # next_fast_len was implemented in scipy 0.18
-        # In case it cannot be imported, we use the id function
-        def next_fast_len(size):
-            """Dummy next_fast_len that returns size unmodified."""
-            return size
+    from scipy.fftpack import next_fast_len
 
 __all__ = ['fftmodule', 'next_fast_len']


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
