### PR TITLE
Fix active contour gallery example after change to rc coordinates

### DIFF
--- a/doc/examples/edges/plot_active_contours.py
+++ b/doc/examples/edges/plot_active_contours.py
@@ -47,8 +47,8 @@ snake = active_contour(gaussian(img, 3),
 
 fig, ax = plt.subplots(figsize=(7, 7))
 ax.imshow(img, cmap=plt.cm.gray)
-ax.plot(init[:, 0], init[:, 1], '--r', lw=3)
-ax.plot(snake[:, 0], snake[:, 1], '-b', lw=3)
+ax.plot(init[:, 1], init[:, 0], '--r', lw=3)
+ax.plot(snake[:, 1], snake[:, 0], '-b', lw=3)
 ax.set_xticks([]), ax.set_yticks([])
 ax.axis([0, img.shape[1], img.shape[0], 0])
 
@@ -72,8 +72,8 @@ snake = active_contour(gaussian(img, 1), init, boundary_condition='fixed',
 
 fig, ax = plt.subplots(figsize=(9, 5))
 ax.imshow(img, cmap=plt.cm.gray)
-ax.plot(init[:, 0], init[:, 1], '--r', lw=3)
-ax.plot(snake[:, 0], snake[:, 1], '-b', lw=3)
+ax.plot(init[:, 1], init[:, 0], '--r', lw=3)
+ax.plot(snake[:, 1], snake[:, 0], '-b', lw=3)
 ax.set_xticks([]), ax.set_yticks([])
 ax.axis([0, img.shape[1], img.shape[0], 0])
 


### PR DESCRIPTION
## Description

PR #4035 changed the active contour example to use rc coordinates rather than xy, but it did not update the matplotlib code, resulting in transposed contours. This change fixes that oversight.

Fixes #4253


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
