### PR TITLE
Fix peak finding for empty images when indices=True

### DIFF
--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -165,7 +165,7 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
     # no peak for a trivial image
     if np.all(image == image.flat[0]):
         if indices is True:
-            return np.empty((0, 2), np.int)
+            return np.empty((0, image.ndim), np.int)
         else:
             return out
 

--- a/skimage/feature/tests/test_peak.py
+++ b/skimage/feature/tests/test_peak.py
@@ -234,8 +234,7 @@ class TestPeakLocalMax():
                                      footprint=np.ones((3, 3), bool),
                                      min_distance=1, threshold_rel=0,
                                      indices=True, exclude_border=False)
-        assert result.shape[0] == 0
-        assert result.shape[1] == image.ndim
+        assert result.shape == (0, image.ndim)
 
     def test_one_point(self):
         image = np.zeros((10, 20))

--- a/skimage/feature/tests/test_peak.py
+++ b/skimage/feature/tests/test_peak.py
@@ -228,6 +228,15 @@ class TestPeakLocalMax():
                                      indices=False, exclude_border=False)
         assert np.all(~ result)
 
+    def test_empty_non2d_indices(self):
+        image = np.zeros((10, 10, 10))
+        result = peak.peak_local_max(image,
+                                     footprint=np.ones((3, 3), bool),
+                                     min_distance=1, threshold_rel=0,
+                                     indices=True, exclude_border=False)
+        assert result.shape[0] == 0
+        assert result.shape[1] == image.ndim
+
     def test_one_point(self):
         image = np.zeros((10, 20))
         labels = np.zeros((10, 20), int)


### PR DESCRIPTION
## Description

#3984 adds an optimization where a flat image immediately returns.  However, it returns an array where the shape is incorrectly set to always be 2D when indices=True.  A test is added to catch this scenario, and a fix is introduced where we set the output array's shape based on the input array's shape.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
