### PR TITLE
Add a benchmark for img_as

### DIFF
--- a/benchmarks/.ipynb_checkpoints/Untitled-checkpoint.ipynb
+++ b/benchmarks/.ipynb_checkpoints/Untitled-checkpoint.ipynb
@@ -1,0 +1,45 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from skimage import img_as_ubyte, img_as_float64\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_uint8 = np.full((1024, 1024), fill_value=51, dtype=np.uint8)\n",
+    "image_float64 = np.full((1024, 1024), fill_value=0.2, dtype=np.float64)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/benchmarks/Untitled.ipynb
+++ b/benchmarks/Untitled.ipynb
@@ -1,0 +1,583 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from skimage import img_as_ubyte, img_as_float64\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_uint8 = np.full((1024, 1024), fill_value=51, dtype=np.uint8)\n",
+    "image_float64 = np.full((1024, 1024), fill_value=0.2, dtype=np.float64)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(225)convert()\n",
+      "-> image = np.asarray(image)\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  n\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(226)convert()\n",
+      "-> dtypeobj_in = image.dtype\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(227)convert()\n",
+      "-> dtypeobj_out = np.dtype(dtype)\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(228)convert()\n",
+      "-> dtype_in = dtypeobj_in.type\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(229)convert()\n",
+      "-> dtype_out = dtypeobj_out.type\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(230)convert()\n",
+      "-> kind_in = dtypeobj_in.kind\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(231)convert()\n",
+      "-> kind_out = dtypeobj_out.kind\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(232)convert()\n",
+      "-> itemsize_in = dtypeobj_in.itemsize\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(233)convert()\n",
+      "-> itemsize_out = dtypeobj_out.itemsize\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(244)convert()\n",
+      "-> if np.issubdtype(dtype_in, np.obj2sctype(dtype)):\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(249)convert()\n",
+      "-> if not (dtype_in in _supported_types and dtype_out in _supported_types):\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(253)convert()\n",
+      "-> if kind_in in 'ui':\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(256)convert()\n",
+      "-> if kind_out in 'ui':\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(257)convert()\n",
+      "-> imin_out = np.iinfo(dtype_out).min\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(258)convert()\n",
+      "-> imax_out = np.iinfo(dtype_out).max\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(261)convert()\n",
+      "-> if kind_out == 'b':\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(265)convert()\n",
+      "-> if kind_in == 'b':\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(272)convert()\n",
+      "-> if kind_in == 'f':\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(273)convert()\n",
+      "-> if kind_out == 'f':\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(281)convert()\n",
+      "-> computation_type = _dtype_itemsize(itemsize_out, dtype_in,\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(282)convert()\n",
+      "-> np.float32, np.float64)\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(284)convert()\n",
+      "-> if not uniform:\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(285)convert()\n",
+      "-> if kind_out == 'u':\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(286)convert()\n",
+      "-> image_out = np.multiply(image, imax_out,\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  image\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "array([[0.2, 0.2, 0.2, ..., 0.2, 0.2, 0.2],\n",
+      "       [0.2, 0.2, 0.2, ..., 0.2, 0.2, 0.2],\n",
+      "       [0.2, 0.2, 0.2, ..., 0.2, 0.2, 0.2],\n",
+      "       ...,\n",
+      "       [0.2, 0.2, 0.2, ..., 0.2, 0.2, 0.2],\n",
+      "       [0.2, 0.2, 0.2, ..., 0.2, 0.2, 0.2],\n",
+      "       [0.2, 0.2, 0.2, ..., 0.2, 0.2, 0.2]])\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  imax_out\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "255\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  n\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(287)convert()\n",
+      "-> dtype=computation_type)\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  computation_type\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'numpy.float64'>\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  n\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(303)convert()\n",
+      "-> return image_out.astype(dtype_out)\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  n\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--Return--\n",
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(303)convert()->array([[51, 5..., dtype=uint8)\n",
+      "-> return image_out.astype(dtype_out)\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  n\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--Return--\n",
+      "> /home/mark/git/scikit-image/skimage/util/dtype.py(504)img_as_ubyte()->array([[51, 5..., dtype=uint8)\n",
+      "-> return convert(image, np.uint8, force_copy)\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  n\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--Call--\n",
+      "> /home/mark/miniconda3/envs/skdev/lib/python3.7/site-packages/IPython/core/displayhook.py(252)__call__()\n",
+      "-> def __call__(self, result=None):\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "(Pdb)  c\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "array([[51, 51, 51, ..., 51, 51, 51],\n",
+       "       [51, 51, 51, ..., 51, 51, 51],\n",
+       "       [51, 51, 51, ..., 51, 51, 51],\n",
+       "       ...,\n",
+       "       [51, 51, 51, ..., 51, 51, 51],\n",
+       "       [51, 51, 51, ..., 51, 51, 51],\n",
+       "       [51, 51, 51, ..., 51, 51, 51]], dtype=uint8)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "img_as_ubyte(image_float64)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.2 ms ± 35.7 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "(image_float64 * 255).astype(np.uint8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/benchmarks/benchmark_img_as.py
+++ b/benchmarks/benchmark_img_as.py
@@ -1,0 +1,64 @@
+import numpy as np
+from skimage.util.dtype import convert
+
+class ImgAsSuite:
+    param_names = ["dtype_in", "dtype_out", "shape", "mode"]
+    params = [
+        [np.uint8, np.uint16, np.float32, np.float64],
+        [np.uint8, np.uint16, np.float32, np.float64],
+        [
+            (32, 32),
+            (256, 256),
+            (1024, 1024),
+            (4096, 4096),
+        ],
+        ["library", "unsafe"]
+    ]
+
+    def setup(self, dtype_in, dtype_out, shape, mode):
+        if np.issubdtype(dtype_in, np.floating):
+            fill_value = 0.2
+        else:
+            fill_value = 51
+        self.image = np.full(shape, fill_value=fill_value, dtype=dtype_in)
+
+    def _time_noop(self, *args):
+        # As array isn't as cheap as a "pass", and therefore, I want to time
+        # The cost of this operation.
+        np.asarray(self.image)
+
+    def time_img_as_(self, dtype_in, dtype_out, shape, mode):
+        if mode == "library":
+            convert(self.image, dtype_out)
+        else:
+            self.img_as_manual(dtype_in, dtype_out)
+
+    def img_as_manual(self, dtype_in, dtype_out):
+        # naive implementations of img_as to compare the performance of the
+        # library
+        if dtype_in == dtype_out:
+            return np.asarray(self.image)
+
+        elif (np.issubdtype(dtype_in, np.integer) and
+                np.issubdtype(dtype_out, np.integer)):
+
+            max_in = np.iinfo(dtype_in).max
+            max_out = np.iinfo(dtype_out).max
+
+            result_float = np.multiply(self.image, max_out / max_in)
+            return result_float.astype(dtype_out)
+
+        elif (np.issubdtype(dtype_in, np.integer) and
+                np.issubdtype(dtype_out, np.floating)):
+            imax = np.iinfo(dtype_in).max
+            return np.multiply(self.image, 1 / imax, dtype=dtype_out)
+
+        elif (np.issubdtype(dtype_in, np.floating) and
+                np.issubdtype(dtype_out, np.floating)):
+            return self.image.astype(dtype_out)
+        elif (np.issubdtype(dtype_in, np.floating) and
+                np.issubdtype(dtype_out, np.integer)):
+            imax = np.iinfo(dtype_out).max
+            return np.multiply(self.image, imax).astype(dtype_out)
+
+        raise NotImplementedError()


### PR DESCRIPTION
## Description

I included naive implementations below. They probably aren't the best, but they would be what I would use if I were to roll my own.

xref: https://github.com/scikit-image/scikit-image/issues/4268

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
