### PR TITLE
Add toggle for prompts in docstring examples next to copybutton

### DIFF
--- a/doc/source/themes/scikit-image/layout.html
+++ b/doc/source/themes/scikit-image/layout.html
@@ -17,6 +17,7 @@
 {%- macro script() %}
     <script src="https://code.jquery.com/jquery-latest.js"></script>
     <script src="{{ pathto('_static/', 1) }}js/bootstrap.min.js"></script>
+    <script src="{{ pathto('_static/', 1) }}js/togglebutton.js"></script>
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '{{ url_root }}',

--- a/doc/source/themes/scikit-image/static/css/custom.css
+++ b/doc/source/themes/scikit-image/static/css/custom.css
@@ -297,6 +297,30 @@ p.sphx-glr-signature a.reference.external {
   display: none !important;
 }
 
+
+span.togglebutton {
+    cursor: pointer;
+    position: absolute;
+    top: 6px;
+    right: 25px;
+    font-family: "monospace";
+    line-height: 100%;
+    border-style: solid;
+    border-width: 1px;
+    border-radius: 2px;
+    padding-left: 0.2em;
+    padding-right: 0.2em;
+    margin: 0.5px;
+    color: #777777;  /* Matches sphinx_copybutton */
+    opacity: 0.3;
+    transition: opacity 0.5s;
+}
+
+.highlight:hover .togglebutton {
+    opacity: 1;
+}
+
+
 a.copybtn {
     background: transparent no-repeat none;
     border: none;

--- a/doc/source/themes/scikit-image/static/js/togglebutton.js
+++ b/doc/source/themes/scikit-image/static/js/togglebutton.js
@@ -1,0 +1,64 @@
+/*!
+ * togglebutton.js
+ *
+ * Modified version of
+ * https://github.com/python/python-docs-theme/blob/b862f1159388ed3134818e56b065e18b835d652c/python_docs_theme/static/copybutton.js *
+ * The modifications utilize the tooltip included by sphinx_copybutton for consistence.
+ *
+ * Copyright 2019 PSF
+ * Licensed under the PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+ * https://github.com/python/python-docs-theme/blob/b862f1159388ed3134818e56b065e18b835d652c/LICENSE
+ */
+
+$(document).ready(function() {
+    /* Add a [>>>] button on the top-right corner of code samples to hide
+     * the >>> and ... prompts and the output and thus make the code
+     * copyable. */
+    var div = $('.highlight-python .highlight,' +
+                '.highlight-python3 .highlight,' +
+                '.highlight-pycon .highlight,' +
+                '.highlight-default .highlight');
+    var pre = div.find('pre');
+
+    // get the styles from the current theme
+    pre.parent().parent().css('position', 'relative');
+    var hide_text = 'Hide prompts and output';
+    var show_text = 'Show prompts and output';
+
+    // create and add the button to all the code blocks that contain >>>
+    div.each(function(index) {
+        var jthis = $(this);
+        if (jthis.find('.gp').length > 0) {
+            var button = $('<span class="togglebutton o-tooltip--left">&gt;&gt;&gt;</span>');
+            button.attr('data-tooltip', hide_text);
+            button.data('hidden', 'false');
+            jthis.prepend(button);
+        }
+        // tracebacks (.gt) contain bare text elements that need to be
+        // wrapped in a span to work with .nextUntil() (see later)
+        jthis.find('pre:has(.gt)').contents().filter(function() {
+            return ((this.nodeType == 3) && (this.data.trim().length > 0));
+        }).wrap('<span>');
+    });
+
+    // define the behavior of the button when it's clicked
+    $('.togglebutton').click(function(e){
+        e.preventDefault();
+        var button = $(this);
+        if (button.data('hidden') === 'false') {
+            // hide the code output
+            button.parent().find('.go, .gp, .gt').hide();
+            button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'hidden');
+            button.css('text-decoration', 'line-through');
+            button.attr('data-tooltip', show_text);
+            button.data('hidden', 'true');
+        } else {
+            // show the code output
+            button.parent().find('.go, .gp, .gt').show();
+            button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'visible');
+            button.css('text-decoration', 'none');
+            button.attr('data-tooltip', hide_text);
+            button.data('hidden', 'false');
+        }
+    });
+});

--- a/doc/source/themes/scikit-image/static/js/togglebutton.js
+++ b/doc/source/themes/scikit-image/static/js/togglebutton.js
@@ -3,11 +3,59 @@
  *
  * Modified version of
  * https://github.com/python/python-docs-theme/blob/b862f1159388ed3134818e56b065e18b835d652c/python_docs_theme/static/copybutton.js *
- * The modifications utilize the tooltip included by sphinx_copybutton for consistence.
+ * The modifications utilize the tooltip included by sphinx_copybutton for consistence
+ * and omit the CSS.
  *
  * Copyright 2019 PSF
- * Licensed under the PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
- * https://github.com/python/python-docs-theme/blob/b862f1159388ed3134818e56b065e18b835d652c/LICENSE
+ *
+ * PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+ * --------------------------------------------
+ *
+ * 1. This LICENSE AGREEMENT is between the Python Software Foundation
+ * ("PSF"), and the Individual or Organization ("Licensee") accessing and
+ * otherwise using this software ("Python") in source or binary form and
+ * its associated documentation.
+ *
+ * 2. Subject to the terms and conditions of this License Agreement, PSF hereby
+ * grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+ * analyze, test, perform and/or display publicly, prepare derivative works,
+ * distribute, and otherwise use Python alone or in any derivative version,
+ * provided, however, that PSF's License Agreement and PSF's notice of copyright,
+ * i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+ * 2011, 2012, 2013, 2014, 2015, 2016, 2017 Python Software Foundation; All Rights
+ * Reserved" are retained in Python alone or in any derivative version prepared by
+ * Licensee.
+ *
+ * 3. In the event Licensee prepares a derivative work that is based on
+ * or incorporates Python or any part thereof, and wants to make
+ * the derivative work available to others as provided herein, then
+ * Licensee hereby agrees to include in any such work a brief summary of
+ * the changes made to Python.
+ *
+ * 4. PSF is making Python available to Licensee on an "AS IS"
+ * basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+ * IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+ * DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+ * INFRINGE ANY THIRD PARTY RIGHTS.
+ *
+ * 5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+ * FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+ * A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+ * OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+ *
+ * 6. This License Agreement will automatically terminate upon a material
+ * breach of its terms and conditions.
+ *
+ * 7. Nothing in this License Agreement shall be deemed to create any
+ * relationship of agency, partnership, or joint venture between PSF and
+ * Licensee.  This License Agreement does not grant permission to use PSF
+ * trademarks or trade name in a trademark sense to endorse or promote
+ * products or services of Licensee, or any third party.
+ *
+ * 8. By copying, installing or otherwise using Python, Licensee
+ * agrees to be bound by the terms and conditions of this License
+ * Agreement.
  */
 
 $(document).ready(function() {


### PR DESCRIPTION
## Description

As discussed in the [last meeting](https://github.com/scikit-image/meeting-notes/blob/master/2019/2019-10-28.markdown) sphinx_copybutton has the disadvantage that prefixes such as `>>> ` and output are copied as well. 

I propose to replace this with a simple javascript copied from [python/python-docs-theme](https://github.com/python/python-docs-theme/blob/b862f1159388ed3134818e56b065e18b835d652c/python_docs_theme/static/copybutton.js). The replacement allows to hide these and allows the user to select content by himself. This should make copying and running examples inside your own console a bit less tedious.

Not sure if I accommodated the license here in the right way. Do we need to include tools that are not included in the distribution archives in the license as well (e.g. as with tifffile)?

E.g. [skimage.exposure.histogram](https://scikit-image.org/docs/stable/api/skimage.exposure.html#histogram):

![image](https://user-images.githubusercontent.com/20140352/67779217-9f6e7280-fa64-11e9-8547-537b75c39f32.png)
after clicking the button
![image](https://user-images.githubusercontent.com/20140352/67779172-8ebdfc80-fa64-11e9-89c2-3eaac9e03a93.png)


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`

cc @jni, @alexdesiqueira 