### PR TITLE
WIP: Use a n-dimensional Bresenham algorithm in draw_nd

### DIFF
--- a/skimage/draw/_draw_nd.pyx
+++ b/skimage/draw/_draw_nd.pyx
@@ -1,19 +1,22 @@
-import numpy as np
-cimport numpy as np
 cimport cython
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def _line_nd_cy(Py_ssize_t[::1] cur, Py_ssize_t[::1] stop, Py_ssize_t[::1] step,
-                *, Py_ssize_t[::1] delta, Py_ssize_t x_dim,
-                bint endpoint, Py_ssize_t[::1] error, Py_ssize_t[:, ::1] coords):
+def _line_nd_cy(
+        Py_ssize_t[::1] cur,
+        Py_ssize_t[::1] step,
+        Py_ssize_t[::1] delta,
+        *,
+        Py_ssize_t x_dim,
+        Py_ssize_t[::1] error,
+        Py_ssize_t[:, ::1] coords
+):
 
-    ndim = error.shape[0]
-    n_points = coords.shape[1]
-
+    cdef int n_dim = error.shape[0]
+    cdef int n_points = coords.shape[1]
     cdef int i_pt
     for i_pt in range(n_points):
-        for i_dim in range(ndim):
+        for i_dim in range(n_dim):
             coords[i_dim, i_pt] = cur[i_dim]
             if error[i_dim] > 0:
                 coords[i_dim, i_pt] += step[i_dim]

--- a/skimage/draw/_draw_nd.pyx
+++ b/skimage/draw/_draw_nd.pyx
@@ -1,0 +1,48 @@
+import numpy as np
+cimport numpy as np
+cimport cython
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def my_line_nd_cython(long[::1] start, long[::1] stop, bint endpoint=False, bint integer=True):
+    # TODO currently ignoring the decimal part of the number
+    if stop.shape[0] != start.shape[0]:
+        raise ValueError("Different lengths")
+    cdef int n = stop.shape[0]
+    cdef int[::1] delta = np.empty(n, dtype=np.intc)
+    cdef int[::1] steps = np.empty(n, dtype=np.intc)
+    cdef int n_points = 0
+    cdef int x_dim = -1
+    cdef int i_dim
+    for i_dim in range(n):
+        if stop[i_dim] >= start[i_dim]:
+            delta[i_dim] = stop[i_dim] - start[i_dim]
+            steps[i_dim] = +1
+        else:
+            delta[i_dim] = start[i_dim] - stop[i_dim]
+            steps[i_dim] = -1
+        
+        if abs(delta[i_dim]) > n_points:
+            n_points = delta[i_dim]
+            x_dim = i_dim
+    
+    if endpoint:
+        n_points += 1
+
+    cdef int[::1] cum_error = np.empty(n, dtype=np.intc)
+    cdef int[:, ::1] coords = np.empty([n_points, n], dtype=np.intc)
+    
+    for i_dim in range(n):
+        cum_error[i_dim] = 4 * delta[i_dim] - delta[x_dim]
+        coords[0, i_dim] = start[i_dim]
+    
+    cdef int i_pt
+    for i_pt in range(1, n_points):
+        for i_dim in range(n):
+            coords[i_pt, i_dim] = coords[i_pt-1, i_dim]
+            if cum_error[i_dim] > 0:
+                coords[i_pt, i_dim] += steps[i_dim]
+                cum_error[i_dim] -= 2 * delta[x_dim]
+            cum_error[i_dim] += 2 * delta[i_dim]
+        
+    return np.asarray(coords)

--- a/skimage/draw/_draw_nd.pyx
+++ b/skimage/draw/_draw_nd.pyx
@@ -4,45 +4,19 @@ cimport cython
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def my_line_nd_cython(long[::1] start, long[::1] stop, bint endpoint=False, bint integer=True):
-    # TODO currently ignoring the decimal part of the number
-    if stop.shape[0] != start.shape[0]:
-        raise ValueError("Different lengths")
-    cdef int n = stop.shape[0]
-    cdef int[::1] delta = np.empty(n, dtype=np.intc)
-    cdef int[::1] steps = np.empty(n, dtype=np.intc)
-    cdef int n_points = 0
-    cdef int x_dim = -1
-    cdef int i_dim
-    for i_dim in range(n):
-        if stop[i_dim] >= start[i_dim]:
-            delta[i_dim] = stop[i_dim] - start[i_dim]
-            steps[i_dim] = +1
-        else:
-            delta[i_dim] = start[i_dim] - stop[i_dim]
-            steps[i_dim] = -1
-        
-        if abs(delta[i_dim]) > n_points:
-            n_points = delta[i_dim]
-            x_dim = i_dim
-    
-    if endpoint:
-        n_points += 1
+def _line_nd_cy(Py_ssize_t[::1] cur, Py_ssize_t[::1] stop, Py_ssize_t[::1] step,
+                *, Py_ssize_t[::1] delta, Py_ssize_t x_dim,
+                bint endpoint, Py_ssize_t[::1] error, Py_ssize_t[:, ::1] coords):
 
-    cdef int[::1] cum_error = np.empty(n, dtype=np.intc)
-    cdef int[:, ::1] coords = np.empty([n_points, n], dtype=np.intc)
-    
-    for i_dim in range(n):
-        cum_error[i_dim] = 4 * delta[i_dim] - delta[x_dim]
-        coords[0, i_dim] = start[i_dim]
-    
+    ndim = error.shape[0]
+    n_points = coords.shape[1]
+
     cdef int i_pt
-    for i_pt in range(1, n_points):
-        for i_dim in range(n):
-            coords[i_pt, i_dim] = coords[i_pt-1, i_dim]
-            if cum_error[i_dim] > 0:
-                coords[i_pt, i_dim] += steps[i_dim]
-                cum_error[i_dim] -= 2 * delta[x_dim]
-            cum_error[i_dim] += 2 * delta[i_dim]
-        
-    return np.asarray(coords)
+    for i_pt in range(n_points):
+        for i_dim in range(ndim):
+            coords[i_dim, i_pt] = cur[i_dim]
+            if error[i_dim] > 0:
+                coords[i_dim, i_pt] += step[i_dim]
+                error[i_dim] -= 2 * delta[x_dim]
+            error[i_dim] += 2 * delta[i_dim]
+            cur[i_dim] = coords[i_dim, i_pt]

--- a/skimage/draw/draw_nd.py
+++ b/skimage/draw/draw_nd.py
@@ -173,6 +173,7 @@ def my_line_nd(start, stop, *, endpoint=False, integer=True):
     delta_abs = np.abs(delta)
     x_dim = np.argmax(delta_abs)
 
+    m = (stop - start) / (stop[x_dim] - start[x_dim])
     q = (stop[x_dim] * start - start[x_dim] * stop) / delta[x_dim]
 
     start_int = np.round(start).astype(int)
@@ -186,13 +187,13 @@ def my_line_nd(start, stop, *, endpoint=False, integer=True):
 
     step = np.sign(delta).astype(int)
 
-    error = (q - 1) * delta_abs_int[x_dim]
+    error = (2 * (m * start_int[x_dim] + q - start_int) - 1) * delta_abs_int[x_dim]
     error[x_dim] = 0
     error_int = error.astype(int)
     coords = np.zeros([len(start), n_points], dtype=np.intp)
 
-    _line_nd(start_int, step,
-                delta=delta_int, x_dim=x_dim,
+    _line_nd_cy(start_int, step,
+                delta=delta_abs_int, x_dim=x_dim,
                 error=error_int, coords=coords)
 
     return tuple(coords)

--- a/skimage/draw/draw_nd.py
+++ b/skimage/draw/draw_nd.py
@@ -1,6 +1,114 @@
 import numpy as np
 from ._draw_nd import _line_nd_cy
 
+
+def _round_safe(coords):
+    """Round coords while ensuring successive values are less than 1 apart.
+
+    When rounding coordinates for `line_nd`, we want coordinates that are less
+    than 1 apart (always the case, by design) to remain less than one apart.
+    However, NumPy rounds values to the nearest *even* integer, so:
+
+    >>> np.round([0.5, 1.5, 2.5, 3.5, 4.5])
+    array([0., 2., 2., 4., 4.])
+
+    So, for our application, we detect whether the above case occurs, and use
+    ``np.floor`` if so. It is sufficient to detect that the first coordinate
+    falls on 0.5 and that the second coordinate is 1.0 apart, since we assume
+    by construction that the inter-point distance is less than or equal to 1
+    and that all successive points are equidistant.
+
+    Parameters
+    ----------
+    coords : 1D array of float
+        The coordinates array. We assume that all successive values are
+        equidistant (``np.all(np.diff(coords) = coords[1] - coords[0])``)
+        and that this distance is no more than 1
+        (``np.abs(coords[1] - coords[0]) <= 1``).
+
+    Returns
+    -------
+    rounded : 1D array of int
+        The array correctly rounded for an indexing operation, such that no
+        successive indices will be more than 1 apart.
+
+    Examples
+    --------
+    >>> coords0 = np.array([0.5, 1.25, 2., 2.75, 3.5])
+    >>> _round_safe(coords0)
+    array([0, 1, 2, 3, 4])
+    >>> coords1 = np.arange(0.5, 8, 1)
+    >>> coords1
+    array([0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5])
+    >>> _round_safe(coords1)
+    array([0, 1, 2, 3, 4, 5, 6, 7])
+    """
+    if (len(coords) > 1
+            and coords[0] % 1 == 0.5
+            and coords[1] - coords[0] == 1):
+        _round_function = np.floor
+    else:
+        _round_function = np.round
+    return _round_function(coords).astype(int)
+
+
+def line_nd(start, stop, *, endpoint=False, integer=True):
+    """Draw a single-pixel thick line in n dimensions.
+
+    The line produced will be ndim-connected. That is, two subsequent
+    pixels in the line will be either direct or diagonal neighbours in
+    n dimensions.
+
+    Parameters
+    ----------
+    start : array-like, shape (N,)
+        The start coordinates of the line.
+    stop : array-like, shape (N,)
+        The end coordinates of the line.
+    endpoint : bool, optional
+        Whether to include the endpoint in the returned line. Defaults
+        to False, which allows for easy drawing of multi-point paths.
+    integer : bool, optional
+        Whether to round the coordinates to integer. If True (default),
+        the returned coordinates can be used to directly index into an
+        array. `False` could be used for e.g. vector drawing.
+
+    Returns
+    -------
+    coords : tuple of arrays
+        The coordinates of points on the line.
+
+    Examples
+    --------
+    >>> lin = line_nd((1, 1), (5, 2.5), endpoint=False)
+    >>> lin
+    (array([1, 2, 3, 4]), array([1, 1, 2, 2]))
+    >>> im = np.zeros((6, 5), dtype=int)
+    >>> im[lin] = 1
+    >>> im
+    array([[0, 0, 0, 0, 0],
+           [0, 1, 0, 0, 0],
+           [0, 1, 0, 0, 0],
+           [0, 0, 1, 0, 0],
+           [0, 0, 1, 0, 0],
+           [0, 0, 0, 0, 0]])
+    >>> line_nd([2, 1, 1], [5, 5, 2.5], endpoint=True)
+    (array([2, 3, 4, 4, 5]), array([1, 2, 3, 4, 5]), array([1, 1, 2, 2, 2]))
+    """
+    start = np.asarray(start)
+    stop = np.asarray(stop)
+    npoints = int(np.ceil(np.max(np.abs(stop - start))))
+    if endpoint:
+        npoints += 1
+    coords = []
+    for dim in range(len(start)):
+        dimcoords = np.linspace(start[dim], stop[dim], npoints, endpoint)
+        if integer:
+            dimcoords = _round_safe(dimcoords).astype(int)
+        coords.append(dimcoords)
+    return tuple(coords)
+
+
 def _line_nd_py(cur, stop, step, *, delta, x_dim, endpoint, error, coords):
 
     ndim = error.shape[0]
@@ -15,7 +123,8 @@ def _line_nd_py(cur, stop, step, *, delta, x_dim, endpoint, error, coords):
             error[i_dim] += 2 * delta[i_dim]
             cur[i_dim] = coords[i_dim, i_pt]
 
-def line_nd(start, stop, *, endpoint=False, integer=True):
+
+def my_line_nd(start, stop, *, endpoint=False, integer=True):
     """Draw a single-pixel thick line in n dimensions.
 
     The line produced will be ndim-connected. That is, two subsequent
@@ -68,6 +177,8 @@ def line_nd(start, stop, *, endpoint=False, integer=True):
 
     start_int = np.round(start).astype(int)
     stop_int = np.round(stop).astype(int)
+    delta_int = stop_int - start_int
+    delta_abs_int = np.abs(delta_int)
     
     n_points = abs(stop_int[x_dim] - start_int[x_dim])
     if endpoint:
@@ -75,36 +186,44 @@ def line_nd(start, stop, *, endpoint=False, integer=True):
 
     step = np.sign(delta).astype(int)
 
-    error = 2 * delta_abs - delta_abs[x_dim] + q * 2 * delta_abs[x_dim]
+    error = (q - 1) * delta_abs_int[x_dim]
     error[x_dim] = 0
-    cur = start_int
+    error_int = error.astype(int)
     coords = np.zeros([len(start), n_points], dtype=np.intp)
 
-    _line_nd_cy(cur, np.round(stop).astype(int), step, endpoint=endpoint,
-                delta=np.round(delta_abs).astype(int), x_dim=x_dim,
-                error=np.round(error).astype(int), coords=coords)
+    _line_nd(start_int, step,
+                delta=delta_int, x_dim=x_dim,
+                error=error_int, coords=coords)
 
     return tuple(coords)
 
 
-if __name__ == '__main__':
-    def test(draw_nd_fn):
-        lin = draw_nd_fn((1, 1), (5, 2.5), endpoint=False)
-        print(lin)
-        print((np.array([1, 2, 3, 4]), np.array([1, 1, 2, 2])))
-        im = np.zeros((6, 5), dtype=int)
-        im[lin] = 1
-        print(im)
-        print(np.array([[0, 0, 0, 0, 0],
-               [0, 1, 0, 0, 0],
-               [0, 1, 0, 0, 0],
-               [0, 0, 1, 0, 0],
-               [0, 0, 1, 0, 0],
-               [0, 0, 0, 0, 0]]))
-        print(draw_nd_fn([2, 1, 1], [5, 5, 2.5], endpoint=True))
-        print((np.array([2, 3, 4, 4, 5]), np.array([1, 2, 3, 4, 5]), np.array([1, 1, 2, 2, 2])))
+def _line_nd(cur, step, delta, x_dim, error, coords):
 
-    from _draw_nd import my_line_nd_cython
-    test(line_nd)
-    test(my_line_nd)
-    test(my_line_nd_cython)
+    n_dim = error.shape[0]
+    n_points = coords.shape[1]
+
+    for i_pt in range(n_points):
+        for i_dim in range(n_dim):
+            coords[i_dim, i_pt] = cur[i_dim]
+            if error[i_dim] > 0:
+                coords[i_dim, i_pt] += step[i_dim]
+                error[i_dim] -= 2 * delta[x_dim]
+            error[i_dim] += 2 * delta[i_dim]
+            cur[i_dim] = coords[i_dim, i_pt]
+
+
+tests = [
+    ((0, 0), (2, 2)),
+    ((1, 1), (3, 3)),
+    ((0, 0), (4, 2)),
+    ((1, 1), (5, 3)),
+    ((1, 1), (5, 2.5)),
+    ((2, 1, 1), (5, 5, 2.5)),
+]
+
+for start, stop in tests:
+    print(start, stop)
+    print(line_nd(start, stop, endpoint=True))
+    print(my_line_nd(start, stop, endpoint=True))
+    print()

--- a/skimage/draw/draw_nd.py
+++ b/skimage/draw/draw_nd.py
@@ -215,12 +215,21 @@ def _line_nd(cur, step, delta, x_dim, error, coords):
 
 
 tests = [
-    ((0, 0), (2, 2)),
-    ((1, 1), (3, 3)),
-    ((0, 0), (4, 2)),
-    ((1, 1), (5, 3)),
-    ((1, 1), (5, 2.5)),
-    ((2, 1, 1), (5, 5, 2.5)),
+    ((0, 0), (2, 2)), # m=1 (x0 is even)
+    ((1, 1), (3, 3)), # m=1 (x0 is odd)
+    ((0, 0), (4, 2)), # m=2 (x0 is even)
+    ((1, 1), (5, 3)), # m=2 (x0 is odd)
+    ((1, 1), (3, 5)), # x is the second coordinate
+    ((1, 1), (5, 2.5)), # y1 is decimal
+    ((1.1, 1.4), (5.3, 2.2)), # all decimals (this produces a bug - a repeated point in the original implementation, due to the call to np.ceil (maybe a -0.5 is due in there))
+    ((0, 0), (5, -3)), # m<0
+    ((0, 0), (3, -5)), # m<0, x is the second coordinate
+    ((2, 1, 1), (5, 5, 2.5)), # 3 dimensions
+    ((2, 1, 1), (5, 5, -2.5)), # 3 dimensions, m>0 and m<0
+    ((2, 1, 0), (5, 5, -1.5)), # 3 dimensions, m>0 and m<0, shifting causes different shape in the old implementation (compared to previous test)
+    ((2, 1, 1), (5, 5, -2.4)), # just need to tease out why the results are what they are in this and the next example
+    ((2, 1, 1), (5, 5, -2.6))
+
 ]
 
 for start, stop in tests:

--- a/skimage/draw/draw_nd.py
+++ b/skimage/draw/draw_nd.py
@@ -176,8 +176,8 @@ def my_line_nd(start, stop, *, endpoint=False, integer=True):
     m = (stop - start) / (stop[x_dim] - start[x_dim])
     q = (stop[x_dim] * start - start[x_dim] * stop) / delta[x_dim]
 
-    start_int = np.round(start).astype(int)
-    stop_int = np.round(stop).astype(int)
+    start_int = np.floor(start + 0.5).astype(int)
+    stop_int = np.floor(stop + 0.5).astype(int)
     delta_int = stop_int - start_int
     delta_abs_int = np.abs(delta_int)
     

--- a/skimage/draw/draw_nd.py
+++ b/skimage/draw/draw_nd.py
@@ -180,18 +180,23 @@ def my_line_nd(start, stop, *, endpoint=False, integer=True):
     return tuple(coords)
 
 if __name__ == '__main__':
-    line_nd = my_line_nd
-    lin = line_nd((1, 1), (5, 2.5), endpoint=False)
-    print(lin)
-    print((np.array([1, 2, 3, 4]), np.array([1, 1, 2, 2])))
-    im = np.zeros((6, 5), dtype=int)
-    im[lin] = 1
-    print(im)
-    print(np.array([[0, 0, 0, 0, 0],
-           [0, 1, 0, 0, 0],
-           [0, 1, 0, 0, 0],
-           [0, 0, 1, 0, 0],
-           [0, 0, 1, 0, 0],
-           [0, 0, 0, 0, 0]]))
-    print(line_nd([2, 1, 1], [5, 5, 2.5], endpoint=True))
-    print((np.array([2, 3, 4, 4, 5]), np.array([1, 2, 3, 4, 5]), np.array([1, 1, 2, 2, 2])))
+    def test(draw_nd_fn):
+        lin = draw_nd_fn((1, 1), (5, 2.5), endpoint=False)
+        print(lin)
+        print((np.array([1, 2, 3, 4]), np.array([1, 1, 2, 2])))
+        im = np.zeros((6, 5), dtype=int)
+        im[lin] = 1
+        print(im)
+        print(np.array([[0, 0, 0, 0, 0],
+               [0, 1, 0, 0, 0],
+               [0, 1, 0, 0, 0],
+               [0, 0, 1, 0, 0],
+               [0, 0, 1, 0, 0],
+               [0, 0, 0, 0, 0]]))
+        print(draw_nd_fn([2, 1, 1], [5, 5, 2.5], endpoint=True))
+        print((np.array([2, 3, 4, 4, 5]), np.array([1, 2, 3, 4, 5]), np.array([1, 1, 2, 2, 2])))
+
+    from _draw_nd import my_line_nd_cython
+    test(line_nd)
+    test(my_line_nd)
+    test(my_line_nd_cython)

--- a/skimage/draw/setup.py
+++ b/skimage/draw/setup.py
@@ -12,7 +12,7 @@ def configuration(parent_package='', top_path=None):
     config = Configuration('draw', parent_package, top_path)
     config.add_data_dir('tests')
 
-    cython(['_draw.pyx'], working_path=base_path)
+    cython(['_draw.pyx', '_draw_nd.pyx'], working_path=base_path)
 
     config.add_extension('_draw', sources=['_draw.c'],
                          include_dirs=[get_numpy_include_dirs(), '../_shared'])

--- a/skimage/draw/setup.py
+++ b/skimage/draw/setup.py
@@ -16,6 +16,8 @@ def configuration(parent_package='', top_path=None):
 
     config.add_extension('_draw', sources=['_draw.c'],
                          include_dirs=[get_numpy_include_dirs(), '../_shared'])
+    config.add_extension('_draw_nd', sources=['_draw_nd.c'],
+                         include_dirs=[get_numpy_include_dirs(), '../_shared'])
 
     return config
 


### PR DESCRIPTION
## Description

This is a possible enhancement of the `draw_nd` function that uses the Bresenham algorithm (extended to n dimensions).
I suppose its strongest advantage is that it is unaffected by floating point error.

The current proposed version is vectorized in the number of dimensions, while a Python loop iterates over the various points. I suppose the original implementation is faster in most use cases although I have not run any tests.

The current algorithm is a WIP because it works exclusively on integers (as did the original Bresenham. Ideas for how to handle floats are welcome (I am currently truncating them).

My idea I have is to use the decimal value to initialize the errors, but to do that I think I need to find the least common denominator of said decimals after converting them to fractions, which has two problems:
    a) it only works with fractional values (ok, on a computer no really real numbers exist, but then the LCD could have a huge denominator resulting in huge initial errors (think plotting from `(0,0)` to `(cos(30°), sin(30°))`, and
    b) computing the LCD sounds like extra work one might not want to do (but I guess we have the `integer` flag for that?).


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
