### PR TITLE
 Make dtype consistent in filters.rank functions

### DIFF
--- a/skimage/filters/_median.py
+++ b/skimage/filters/_median.py
@@ -7,7 +7,6 @@ from scipy import ndimage as ndi
 from .rank import generic
 
 
-@generic._default_selem
 def median(image, selem=None, out=None, mask=None, shift_x=False,
            shift_y=False, mode='nearest', cval=0.0, behavior='ndimage'):
     """Return local median of an image.
@@ -93,5 +92,7 @@ def median(image, selem=None, out=None, mask=None, shift_x=False,
         warn("Change 'behavior' to 'rank' if you want to use the "
              "parameters 'mask', 'shift_x', 'shift_y'. They will be "
              "discarded otherwise.")
+    if selem is None:
+        selem = ndi.generate_binary_structure(image.ndim, image.ndim)
     return ndi.median_filter(image, footprint=selem, output=out, mode=mode,
                              cval=cval)

--- a/skimage/filters/rank/_percentile.py
+++ b/skimage/filters/rank/_percentile.py
@@ -27,7 +27,6 @@ from ..._shared.utils import check_nD
 from . import percentile_cy
 from .generic import _handle_input
 
-
 __all__ = ['autolevel_percentile', 'gradient_percentile',
            'mean_percentile', 'subtract_mean_percentile',
            'enhance_contrast_percentile', 'percentile', 'pop_percentile',
@@ -36,7 +35,6 @@ __all__ = ['autolevel_percentile', 'gradient_percentile',
 
 def _apply(func, image, selem, out, mask, shift_x, shift_y, p0, p1,
            out_dtype=None):
-
     check_nD(image, 2)
     image, selem, out, mask, n_bins = _handle_input(image, selem, out, mask,
                                                     out_dtype)

--- a/skimage/filters/rank/_percentile.py
+++ b/skimage/filters/rank/_percentile.py
@@ -25,7 +25,7 @@ References
 from ..._shared.utils import check_nD
 
 from . import percentile_cy
-from .generic import _handle_input
+from .generic import _preprocess_input
 
 __all__ = ['autolevel_percentile', 'gradient_percentile',
            'mean_percentile', 'subtract_mean_percentile',
@@ -36,7 +36,7 @@ __all__ = ['autolevel_percentile', 'gradient_percentile',
 def _apply(func, image, selem, out, mask, shift_x, shift_y, p0, p1,
            out_dtype=None):
     check_nD(image, 2)
-    image, selem, out, mask, n_bins = _handle_input(image, selem, out, mask,
+    image, selem, out, mask, n_bins = _preprocess_input(image, selem, out, mask,
                                                     out_dtype)
 
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,

--- a/skimage/filters/rank/bilateral.py
+++ b/skimage/filters/rank/bilateral.py
@@ -29,13 +29,11 @@ from ..._shared.utils import check_nD
 from . import bilateral_cy
 from .generic import _handle_input
 
-
 __all__ = ['mean_bilateral', 'pop_bilateral', 'sum_bilateral']
 
 
 def _apply(func, image, selem, out, mask, shift_x, shift_y, s0, s1,
            out_dtype=None):
-
     check_nD(image, 2)
     image, selem, out, mask, n_bins = _handle_input(image, selem, out, mask,
                                                     out_dtype)

--- a/skimage/filters/rank/bilateral.py
+++ b/skimage/filters/rank/bilateral.py
@@ -27,7 +27,7 @@ import numpy as np
 
 from ..._shared.utils import check_nD
 from . import bilateral_cy
-from .generic import _handle_input
+from .generic import _preprocess_input
 
 __all__ = ['mean_bilateral', 'pop_bilateral', 'sum_bilateral']
 
@@ -35,7 +35,7 @@ __all__ = ['mean_bilateral', 'pop_bilateral', 'sum_bilateral']
 def _apply(func, image, selem, out, mask, shift_x, shift_y, s0, s1,
            out_dtype=None):
     check_nD(image, 2)
-    image, selem, out, mask, n_bins = _handle_input(image, selem, out, mask,
+    image, selem, out, mask, n_bins = _preprocess_input(image, selem, out, mask,
                                                     out_dtype)
 
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -1,4 +1,4 @@
-r"""
+"""
 
 General Description
 -------------------
@@ -25,11 +25,10 @@ histogram computation. By default the entire image is filtered.
 
 This implementation outperforms grey.dilation for large structuring elements.
 
-Input image can be 8-bit or 16-bit, for 16-bit input images, the number of
-histogram bins is determined from the maximum value present in the image.
-
-Result image is 8-/16-bit or double with respect to the input image and the
-rank filter operation.
+Input images will be cast in unsigned 8-bit integer or unsigned 16-bit integer
+if necessary. The number of histogram bins is then determined from the maximum
+value present in the image. Eventually, the output image is cast in the desired
+dtype.
 
 To do
 -----
@@ -64,8 +63,44 @@ __all__ = ['autolevel', 'bottomhat', 'equalize', 'gradient', 'maximum', 'mean',
 
 
 def _handle_input(image, selem, out, mask, out_dtype=None, pixel_size=1):
+    """Preprocess and verify input for filters.rank methods.
 
+    Parameters
+    ----------
+    image : 2-D array (integer, float or boolean)
+        Input image.
+    selem : 2-D array (integer, float or boolean)
+        The neighborhood expressed as a 2-D array of 1's and 0's.
+    out : 2-D array (integer, float or boolean)
+        If None, a new array is allocated.
+    mask : ndarray (integer, float or boolean)
+        Mask array that defines (>0) area of the image included in the local
+        neighborhood. If None, the complete image is used (default).
+    out_dtype : data-type
+        Desired output data-type. Default is None, which means we cast output
+        in input dtype.
+    pixel_size : int
+        Dimension of each pixel. Default value is 1.
+
+    Returns
+    -------
+    image : 2-D array (np.uint8 or np.uint16)
+    selem : 2-D array (np.uint8)
+        The neighborhood expressed as a binary 2-D array.
+    out : 3-D array (same dtype out_dtype or as input)
+        Output array. The two first dimensions are the spatial ones, the third
+        one is the pixel vector (length 1 by default).
+    mask : 2-D array (np.uint8)
+        Mask array that defines (>0) area of the image included in the local
+        neighborhood.
+    n_bins : int
+        Number of histogram bins.
+    out_dtype : data-type
+        Output data-type.
+
+    """
     check_nD(image, 2)
+    input_dtype = image.dtype
     if image.dtype not in (np.uint8, np.uint16):
         message = ('Possible precision loss converting image of type {} to '
                    'uint8 as required by rank filters. Convert manually using '
@@ -74,9 +109,13 @@ def _handle_input(image, selem, out, mask, out_dtype=None, pixel_size=1):
         warn(message, stacklevel=2)
         image = img_as_ubyte(image)
 
-    selem = np.ascontiguousarray(img_as_ubyte(selem > 0))
+    # make `image` contiguous in memory
     image = np.ascontiguousarray(image)
 
+    # cast `selem` as an unsigned 8-bit array and make it contiguous in memory
+    selem = np.ascontiguousarray(img_as_ubyte(selem > 0))
+
+    # idem with `mask`
     if mask is None:
         mask = np.ones(image.shape, dtype=np.uint8)
     else:
@@ -86,17 +125,20 @@ def _handle_input(image, selem, out, mask, out_dtype=None, pixel_size=1):
     if image is out:
         raise NotImplementedError("Cannot perform rank operation in place.")
 
+    # allocate a new output array if necessary
     if out is None:
-        if out_dtype is None:
-            out_dtype = image.dtype
-        out = np.empty(image.shape+(pixel_size,), dtype=out_dtype)
+        out = np.empty(image.shape + (pixel_size,))
     else:
         if len(out.shape) == 2:
             out = out.reshape(out.shape+(pixel_size,))
+    out = out.astype(image.dtype)
 
-    is_8bit = image.dtype in (np.uint8, np.int8)
+    # cast output in the desired dtype
+    if out_dtype is None:
+        out_dtype = input_dtype
 
-    if is_8bit:
+    # compute the number of bins in the histogram from `image` dtype
+    if image.dtype in (np.uint8, np.int8):
         n_bins = 256
     else:
         # Convert to a Python int to avoid the potential overflow when we add
@@ -109,32 +151,105 @@ def _handle_input(image, selem, out, mask, out_dtype=None, pixel_size=1):
              "bitdepth of {:.1f}.".format(n_bins, np.log2(n_bins)),
              stacklevel=2)
 
-    return image, selem, out, mask, n_bins
+    return image, selem, out, mask, n_bins, out_dtype
 
 
 def _apply_scalar_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
                             out_dtype=None):
+    """Process the specific cython function to the image.
 
-    image, selem, out, mask, n_bins = _handle_input(image, selem, out, mask,
-                                                    out_dtype)
+    Parameters
+    ----------
+    func : function
+        Cython function to apply.
+    image : 2-D array (integer, float or boolean)
+        Input image.
+    selem : 2-D array (integer, float or boolean)
+        The neighborhood expressed as a 2-D array of 1's and 0's.
+    out : 2-D array (integer, float or boolean)
+        If None, a new array is allocated.
+    mask : ndarray (integer, float or boolean)
+        Mask array that defines (>0) area of the image included in the local
+        neighborhood. If None, the complete image is used (default).
+    shift_x, shift_y : int
+        Offset added to the structuring element center point. Shift is bounded
+        to the structuring element sizes (center must be inside the given
+        structuring element).
+    out_dtype : data-type, optional
+        Desired output data-type. Default is None, which means we cast output
+        in input dtype.
 
+    Returns
+    -------
+    out : 2-D array (same dtype as out_dtype or same as input image)
+        Output image.
+
+    """
+    # preprocess and verify the input
+    image, selem, out, mask, n_bins, out_dtype = _handle_input(image,
+                                                               selem,
+                                                               out,
+                                                               mask,
+                                                               out_dtype)
+
+    # apply cython function
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
          out=out, n_bins=n_bins)
 
-    return out.reshape(out.shape[:2])
+    return out.reshape(out.shape[:2]).astype(out_dtype)
 
 
 def _apply_vector_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
                             out_dtype=None, pixel_size=1):
+    """
 
-    image, selem, out, mask, n_bins = _handle_input(image, selem, out, mask,
-                                                    out_dtype,
-                                                    pixel_size=pixel_size)
+    Parameters
+    ----------
+    func : function
+        Cython function to apply.
+    image : 2-D array (integer, float or boolean)
+        Input image.
+    selem : 2-D array (integer, float or boolean)
+        The neighborhood expressed as a 2-D array of 1's and 0's.
+    out : 2-D array (integer, float or boolean)
+        If None, a new array is allocated.
+    mask : ndarray (integer, float or boolean)
+        Mask array that defines (>0) area of the image included in the local
+        neighborhood. If None, the complete image is used (default).
+    shift_x, shift_y : int
+        Offset added to the structuring element center point. Shift is bounded
+        to the structuring element sizes (center must be inside the given
+        structuring element).
+    out_dtype : data-type, optional
+        Desired output data-type. Default is None, which means we cast output
+        in input dtype.
+    pixel_size : int
+        Dimension of each pixel. Default value is 1.
 
+    Returns
+    -------
+    out : 3-D array with float dtype of dimensions (H,W,N), where (H,W) are
+        the dimensions of the input image and N is n_bins or
+        ``image.max() + 1`` if no value is provided as a parameter.
+        Effectively, each pixel is a N-D feature vector that is the histogram.
+        The sum of the elements in the feature vector will be 1, unless no
+        pixels in the window were covered by both selem and mask, in which
+        case all elements will be 0.
+
+    """
+    # preprocess and verify the input
+    image, selem, out, mask, n_bins, out_dtype = _handle_input(image,
+                                                               selem,
+                                                               out,
+                                                               mask,
+                                                               out_dtype,
+                                                               pixel_size)
+
+    # apply cython function
     func(image, selem, shift_x=shift_x, shift_y=shift_y, mask=mask,
          out=out, n_bins=n_bins)
 
-    return out
+    return out.astype(out_dtype)
 
 
 def _default_selem(func):
@@ -164,18 +279,18 @@ def _default_selem(func):
 def autolevel(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
     """Auto-level image using local histogram.
 
-    This filter locally stretches the histogram of greyvalues to cover the
+    This filter locally stretches the histogram of grey values to cover the
     entire range of values from "white" to "black".
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -211,13 +326,13 @@ def bottomhat(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : 2-D array
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -250,13 +365,13 @@ def equalize(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -289,13 +404,13 @@ def gradient(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -328,13 +443,13 @@ def maximum(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -376,13 +491,13 @@ def mean(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -415,13 +530,13 @@ def geometric_mean(image, selem, out=None, mask=None,
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -459,13 +574,13 @@ def subtract_mean(image, selem, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -500,14 +615,14 @@ def median(image, selem=None, out=None, mask=None,
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array, optional
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's. If None, a
         full square of size 3 is used.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -545,13 +660,13 @@ def minimum(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -595,13 +710,13 @@ def modal(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -639,13 +754,13 @@ def enhance_contrast(image, selem, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -656,7 +771,7 @@ def enhance_contrast(image, selem, out=None, mask=None, shift_x=False,
     Returns
     -------
     out : 2-D array (same dtype as input image)
-        The result of the local enhance_contrast.
+        Output image
 
     Examples
     --------
@@ -681,13 +796,13 @@ def pop(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -731,13 +846,13 @@ def sum(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -781,13 +896,13 @@ def threshold(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -831,13 +946,13 @@ def tophat(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -871,13 +986,13 @@ def noise_filter(image, selem, out=None, mask=None, shift_x=False,
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -926,13 +1041,13 @@ def entropy(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : 2-D array (uint8, uint16)
+    image : 2-D array (integer, float or boolean)
         Input image.
-    selem : 2-D array
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : 2-D array (same dtype as input)
+    out : 2-D array (integer, float or boolean)
         If None, a new array is allocated.
-    mask : ndarray
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -942,7 +1057,7 @@ def entropy(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Returns
     -------
-    out : ndarray (double)
+    out : ndarray (float)
         Output image.
 
     References
@@ -970,13 +1085,13 @@ def otsu(image, selem, out=None, mask=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-    image : ndarray
-        Image array (uint8 array).
-    selem : 2-D array
+    image : 2-D array (integer, float or boolean)
+        Input image.
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : ndarray
-        If None, a new array will be allocated.
-    mask : ndarray
+    out : 2-D array (integer, float or boolean)
+        If None, a new array is allocated.
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -1015,13 +1130,13 @@ def windowed_histogram(image, selem, out=None, mask=None,
 
     Parameters
     ----------
-    image : ndarray
-        Image array (uint8 array).
-    selem : 2-D array
+    image : 2-D array (integer, float or boolean)
+        Input image.
+    selem : 2-D array (integer, float or boolean)
         The neighborhood expressed as a 2-D array of 1's and 0's.
-    out : ndarray
-        If None, a new array will be allocated.
-    mask : ndarray
+    out : 2-D array (integer, float or boolean)
+        If None, a new array is allocated.
+    mask : ndarray (integer, float or boolean)
         Mask array that defines (>0) area of the image included in the local
         neighborhood. If None, the complete image is used (default).
     shift_x, shift_y : int
@@ -1034,13 +1149,13 @@ def windowed_histogram(image, selem, out=None, mask=None,
 
     Returns
     -------
-    out : 3-D array with float dtype of dimensions (H,W,N), where (H,W) are
-        the dimensions of the input image and N is n_bins or
-        ``image.max() + 1`` if no value is provided as a parameter.
-        Effectively, each pixel is a N-D feature vector that is the histogram.
-        The sum of the elements in the feature vector will be 1, unless no
-        pixels in the window were covered by both selem and mask, in which
-        case all elements will be 0.
+    out : 3-D array (float)
+        Array of dimensions (H,W,N), where (H,W) are the dimensions of the
+        input image and N is n_bins or ``image.max() + 1`` if no value is
+        provided as a parameter. Effectively, each pixel is a N-D feature
+        vector that is the histogram. The sum of the elements in the feature
+        vector will be 1, unless no pixels in the window were covered by both
+        selem and mask, in which case all elements will be 0.
 
     Examples
     --------

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -1,4 +1,4 @@
-"""
+r"""
 
 General Description
 -------------------
@@ -99,14 +99,14 @@ def _handle_input(image, selem=None, out=None, mask=None, out_dtype=None,
     """
     check_nD(image, 2)
     input_dtype = image.dtype
-    if (image_dtype in (bool, np.bool, np.bool_)
+    if (input_dtype in (bool, np.bool, np.bool_)
             or out_dtype in (bool, np.bool, np.bool_)):
         raise ValueError('dtype cannot be bool.')
-    if image_dtype not in (np.uint8, np.uint16):
+    if input_dtype not in (np.uint8, np.uint16):
         message = ('Possible precision loss converting image of type {} to '
                    'uint8 as required by rank filters. Convert manually using '
                    'skimage.util.img_as_ubyte to silence this warning.'
-                   .format(image.dtype))
+                   .format(input_dtype))
         warn(message, stacklevel=5)
         image = img_as_ubyte(image)
 

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -23,12 +23,13 @@ adjusted accordingly. The user may provide a mask image (same size as input
 image) where non zero values are the part of the image participating in the
 histogram computation. By default the entire image is filtered.
 
-This implementation outperforms gray.dilation for large structuring elements.
+This implementation outperforms :func:`skimage.morphology.dilation`
+for large structuring elements.
 
 Input images will be cast in unsigned 8-bit integer or unsigned 16-bit integer
 if necessary. The number of histogram bins is then determined from the maximum
-value present in the image. Eventually, the output image is cast in the desired
-dtype.
+value present in the image. Eventually, the output image is cast in the input
+dtype, or the `output_dtype` if set.
 
 To do
 -----
@@ -61,7 +62,7 @@ __all__ = ['autolevel', 'bottomhat', 'equalize', 'gradient', 'maximum', 'mean',
            'entropy', 'otsu']
 
 
-def _handle_input(image, selem=None, out=None, mask=None, out_dtype=None,
+def _preprocess_input(image, selem=None, out=None, mask=None, out_dtype=None,
                   pixel_size=1):
     """Preprocess and verify input for filters.rank methods.
 
@@ -178,7 +179,7 @@ def _apply_scalar_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
 
     """
     # preprocess and verify the input
-    image, selem, out, mask, n_bins = _handle_input(image,
+    image, selem, out, mask, n_bins = _preprocess_input(image,
                                                     selem,
                                                     out,
                                                     mask,
@@ -230,7 +231,7 @@ def _apply_vector_per_pixel(func, image, selem, out, mask, shift_x, shift_y,
 
     """
     # preprocess and verify the input
-    image, selem, out, mask, n_bins = _handle_input(image,
+    image, selem, out, mask, n_bins = _preprocess_input(image,
                                                     selem,
                                                     out,
                                                     mask,

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -509,7 +509,7 @@ class TestRank:
         image[2, 3] = 128
         image[1, 2] = 16
 
-        for dtype in (np.uint8, np.uint16, np.int32, np.int64,
+        for dtype in (np.bool_, np.uint8, np.uint16, np.int32, np.int64,
                       np.float32, np.float64):
             elem = np.array([[0, 0, 0], [0, 1, 0], [0, 0, 0]], dtype=dtype)
             rank.mean(image=image, selem=elem, out=out, mask=mask,
@@ -686,10 +686,23 @@ class TestRank:
         assert rank.median(a)[1, 1] == 0
         assert rank.median(a, disk(1))[1, 1] == 1
 
-
     def test_majority(self):
         img = data.camera()
         elem = np.ones((3, 3), dtype=np.uint8)
         expected = rank.windowed_histogram(
             img, elem).argmax(-1).astype(np.uint8)
         assert_equal(expected, rank.majority(img, elem))
+
+    def test_output_same_dtype(self):
+        image = (np.random.rand(100, 100) * 256).astype(np.uint8)
+        out = np.empty_like(image)
+        mask = np.ones(image.shape, dtype=np.uint8)
+        elem = np.ones((3, 3), dtype=np.uint8)
+        rank.maximum(image=image, selem=elem, out=out, mask=mask)
+        assert_equal(image.dtype, out.dtype)
+
+    def test_input_boolean_dtype(self):
+        image = (np.random.rand(100, 100) * 256).astype(np.bool_)
+        elem = np.ones((3, 3), dtype=np.bool_)
+        with testing.raises(ValueError):
+            rank.maximum(image=image, selem=elem)

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -41,8 +41,7 @@ def test_otsu_edge_case():
     assert result[1, 1] in [141, 172]
 
 
-
-class TestRank():
+class TestRank:
     def setup(self):
         np.random.seed(0)
         # This image is used along with @test_parallel
@@ -84,7 +83,6 @@ class TestRank():
                 assert_array_equal(expected, result)
 
         check()
-
 
     def test_random_sizes(self):
         # make sure the size is not a problem
@@ -132,7 +130,6 @@ class TestRank():
                                  selem=elem, shift_x=+1, shift_y=+1, p0=.1, p1=.9)
             assert_equal(image16.shape, out16.shape)
 
-
     def test_compare_with_grey_dilation(self):
         # compare the result of maximum filter with dilate
 
@@ -146,7 +143,6 @@ class TestRank():
             cm = grey.dilation(image=image, selem=elem)
             assert_equal(out, cm)
 
-
     def test_compare_with_grey_erosion(self):
         # compare the result of maximum filter with erode
 
@@ -159,7 +155,6 @@ class TestRank():
             rank.minimum(image=image, selem=elem, out=out, mask=mask)
             cm = grey.erosion(image=image, selem=elem)
             assert_equal(out, cm)
-
 
     def test_bitdepth(self):
         # test the different bit depth for rank16
@@ -179,7 +174,6 @@ class TestRank():
                 rank.mean_percentile(image=image, selem=elem, mask=mask,
                                      out=out, shift_x=0, shift_y=0, p0=.1, p1=.9)
 
-
     def test_population(self):
         # check the number of valid pixels in the neighborhood
 
@@ -195,7 +189,6 @@ class TestRank():
                       [6, 9, 9, 9, 6],
                       [4, 6, 6, 6, 4]])
         assert_equal(r, out)
-
 
     def test_structuring_element8(self):
         # check the output for a custom structuring element
@@ -227,7 +220,6 @@ class TestRank():
                      shift_x=1, shift_y=1)
         assert_equal(r, out)
 
-
     def test_pass_on_bitdepth(self):
         # should pass because data bitdepth is not too high for the function
 
@@ -238,7 +230,6 @@ class TestRank():
         with expected_warnings(["Bad rank filter performance"]):
             rank.maximum(image=image, selem=elem, out=out, mask=mask)
 
-
     def test_inplace_output(self):
         # rank filters are not supposed to filter inplace
 
@@ -247,7 +238,6 @@ class TestRank():
         out = image
         with testing.raises(NotImplementedError):
             rank.mean(image, selem, out=out)
-
 
     def test_compare_autolevels(self):
         # compare autolevel and percentile autolevel with p0=0.0 and p1=1.0
@@ -262,10 +252,9 @@ class TestRank():
 
         assert_equal(loc_autolevel, loc_perc_autolevel)
 
-
     def test_compare_autolevels_16bit(self):
-        # compare autolevel(16-bit) and percentile autolevel(16-bit) with p0=0.0
-        # and p1=1.0 should returns the same arrays
+        # compare autolevel(16-bit) and percentile autolevel(16-bit) with
+        # p0=0.0 and p1=1.0 should returns the same arrays
 
         image = data.camera().astype(np.uint16) * 4
 
@@ -275,7 +264,6 @@ class TestRank():
                                                        p0=.0, p1=1.)
 
         assert_equal(loc_autolevel, loc_perc_autolevel)
-
 
     def test_compare_ubyte_vs_float(self):
 
@@ -292,7 +280,6 @@ class TestRank():
             with expected_warnings(["Possible precision loss"]):
                 out_f = func(image_float, disk(3))
             assert_equal(out_u, out_f)
-
 
     def test_compare_8bit_unsigned_vs_signed(self):
         # filters applied on 8-bit image ore 16-bit image (having only real 8-bit
@@ -332,7 +319,6 @@ class TestRank():
         f16 = func(image16, disk(3))
         assert_equal(f8, f16)
 
-
     def test_trivial_selem8(self):
         # check that min, max and mean returns identity if structuring element
         # contains only central pixel
@@ -357,7 +343,6 @@ class TestRank():
         rank.maximum(image=image, selem=elem, out=out, mask=mask,
                      shift_x=0, shift_y=0)
         assert_equal(image, out)
-
 
     def test_trivial_selem16(self):
         # check that min, max and mean returns identity if structuring element
@@ -384,7 +369,6 @@ class TestRank():
                      shift_x=0, shift_y=0)
         assert_equal(image, out)
 
-
     def test_smallest_selem8(self):
         # check that min, max and mean returns identity if structuring element
         # contains only central pixel
@@ -406,7 +390,6 @@ class TestRank():
         rank.maximum(image=image, selem=elem, out=out, mask=mask,
                      shift_x=0, shift_y=0)
         assert_equal(image, out)
-
 
     def test_smallest_selem16(self):
         # check that min, max and mean returns identity if structuring element
@@ -432,7 +415,6 @@ class TestRank():
         rank.maximum(image=image, selem=elem, out=out, mask=mask,
                      shift_x=0, shift_y=0)
         assert_equal(image, out)
-
 
     def test_empty_selem(self):
         # check that min, max and mean returns zeros if structuring element is
@@ -461,7 +443,6 @@ class TestRank():
                      shift_x=0, shift_y=0)
         assert_equal(res, out)
 
-
     def test_otsu(self):
         # test the local Otsu segmentation on a synthetic image
         # (left to right ramp * sinus)
@@ -474,7 +455,6 @@ class TestRank():
         selem = np.ones((6, 6), dtype=np.uint8)
         th = 1 * (test >= rank.otsu(test, selem))
         assert_equal(th, res)
-
 
     def test_entropy(self):
         #  verify that entropy is coherent with bitdepth of the input data
@@ -520,7 +500,6 @@ class TestRank():
             out = rank.entropy(data, np.ones((16, 16), dtype=np.uint8))
         assert out.dtype == np.double
 
-
     def test_selem_dtypes(self):
 
         image = np.zeros((5, 5), dtype=np.uint8)
@@ -543,7 +522,6 @@ class TestRank():
                                  shift_x=0, shift_y=0)
             assert_equal(image, out)
 
-
     def test_16bit(self):
         image = np.zeros((21, 21), dtype=np.uint16)
         selem = np.ones((3, 3), dtype=np.uint8)
@@ -560,7 +538,6 @@ class TestRank():
                 assert rank.maximum(image, selem)[10, 10] == value
                 assert rank.mean(image, selem)[10, 10] == int(value / selem.size)
 
-
     def test_bilateral(self):
         image = np.zeros((21, 21), dtype=np.uint16)
         selem = np.ones((3, 3), dtype=np.uint8)
@@ -573,7 +550,6 @@ class TestRank():
         assert rank.pop_bilateral(image, selem, s0=1, s1=1)[10, 10] == 1
         assert rank.mean_bilateral(image, selem, s0=11, s1=11)[10, 10] == 1005
         assert rank.pop_bilateral(image, selem, s0=11, s1=11)[10, 10] == 2
-
 
     def test_percentile_min(self):
         # check that percentile p0 = 0 is identical to local min
@@ -589,7 +565,6 @@ class TestRank():
         img_min = rank.minimum(img16, selem=selem)
         assert_equal(img_p0, img_min)
 
-
     def test_percentile_max(self):
         # check that percentile p0 = 1 is identical to local max
         img = data.camera()
@@ -604,7 +579,6 @@ class TestRank():
         img_max = rank.maximum(img16, selem=selem)
         assert_equal(img_p0, img_max)
 
-
     def test_percentile_median(self):
         # check that percentile p0 = 0.5 is identical to local median
         img = data.camera()
@@ -618,7 +592,6 @@ class TestRank():
         img_p0 = rank.percentile(img16, selem=selem, p0=.5)
         img_max = rank.median(img16, selem=selem)
         assert_equal(img_p0, img_max)
-
 
     def test_sum(self):
         # check the number of valid pixels in the neighborhood
@@ -666,7 +639,6 @@ class TestRank():
             image=image16, selem=elem, out=out16, mask=mask, s0=1000, s1=1000)
         assert_equal(r, out16)
 
-
     def test_windowed_histogram(self):
         # check the number of valid pixels in the neighborhood
 
@@ -705,7 +677,6 @@ class TestRank():
         larger_output = rank.windowed_histogram(image=image8, selem=elem,
                                                 mask=mask, n_bins=5)
         assert larger_output.shape[2] == 5
-
 
     def test_median_default_value(self):
         a = np.zeros((3, 3), dtype=np.uint8)


### PR DESCRIPTION
## Description

    Added default arg to selem to make consistent with docs
    Removed default_selem decorator and bool image dtype support
    Made selem=None default argument for all rank functions

Closes #3981 @clementkng @sciunto @lagru @soupault

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
