### PR TITLE
New threshold_tpoint function

### DIFF
--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -620,9 +620,11 @@ def test_multiotsu_lut():
 
             assert np.array_equal(result_lut, result)
 
+
 def test_tpoint_tail():
     img = rgb2gray(data.retina())[210:-210, 210:-210]
     assert 0.56 < threshold_tpoint(img, tail=True) < 0.58
+
 
 def test_tpoint_foot():
     img = rgb2gray(data.retina())[210:-210, 210:-210]

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -19,6 +19,7 @@ from skimage.filters.thresholding import (threshold_local,
                                           threshold_triangle,
                                           threshold_minimum,
                                           threshold_multiotsu,
+                                          threshold_tpoint,
                                           try_all_threshold,
                                           _mean_std,
                                           _cross_entropy)
@@ -129,7 +130,7 @@ class TestSimpleImage():
              [False, False,  True, False,  True],
              [False, False,  True,  True, False],
              [False,  True,  True, False, False],
-             [ True,  True, False, False, False]]
+             [True,  True, False, False, False]]
         )
         out = threshold_local(self.image, 3, method='gaussian')
         assert_equal(ref, self.image > out)
@@ -144,7 +145,7 @@ class TestSimpleImage():
              [False, False,  True, False,  True],
              [False, False,  True,  True, False],
              [False,  True,  True, False, False],
-             [ True,  True, False, False, False]]
+             [True,  True, False, False, False]]
         )
         out = threshold_local(self.image, 3, method='mean')
         assert_equal(ref, self.image > out)
@@ -164,10 +165,10 @@ class TestSimpleImage():
         out = threshold_local(self.image, 3, method='median',
                               mode='constant', cval=20)
         expected = np.array([[20.,  1.,  3.,  4., 20.],
-                            [ 1.,  1.,  3.,  4.,  4.],
-                            [ 2.,  2.,  4.,  4.,  4.],
-                            [ 4.,  4.,  4.,  1.,  2.],
-                            [20.,  5.,  5.,  2., 20.]])
+                             [1.,  1.,  3.,  4.,  4.],
+                             [2.,  2.,  4.,  4.,  4.],
+                             [4.,  4.,  4.,  1.,  2.],
+                             [20.,  5.,  5.,  2., 20.]])
         assert_equal(expected, out)
 
     def test_threshold_niblack(self):
@@ -618,3 +619,11 @@ def test_multiotsu_lut():
             result = _get_multiotsu_thresh_indices(prob, classes - 1)
 
             assert np.array_equal(result_lut, result)
+
+def test_tpoint_tail():
+    img = rgb2gray(data.retina())[210:-210, 210:-210]
+    assert 0.56 < threshold_tpoint(img, tail=True) < 0.58
+
+def test_tpoint_foot():
+    img = rgb2gray(data.retina())[210:-210, 210:-210]
+    assert 0.33 < threshold_tpoint(img, tail=False) < 0.45

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -1,7 +1,7 @@
 import itertools
 import math
 import numpy as np
-from scipy import ndimage as ndi
+from scipy import ndimage as ndi, stats
 from collections import OrderedDict
 from collections.abc import Iterable
 from ..exposure import histogram
@@ -1177,3 +1177,69 @@ def threshold_multiotsu(image, classes=3, nbins=256):
     thresh = bin_centers[thresh_idx]
 
     return thresh
+
+
+def threshold_tpoint(image, nbins=256, tail=True):
+    """
+    T-point algorithm for thresholding unimodal images.
+    The image histogram is assumed to be unimodal with a small tail.
+    Two line segments are fitted to the sharply descending slope near the 
+    histogram peak and to the histogram tail. The optimal threshold minimises 
+    the residuals between the two fitted line segments and the histogram.
+
+    Parameters
+    ----------
+    image: (M, N) ndarray
+        Image to threshold.
+    nbins: int, default is 256
+        Number of bins in image histogram.
+    tail: bool, default is True
+        If True consider the histogram tail for thresholding.
+        Otherwise consider the histogram foot.
+
+    Returns
+    -------
+    threshold: float
+        Calculated threshold value.
+
+    References
+    ----------
+    [1] doi.org/10.1016/j.patrec.2009.12.025
+
+    """
+
+    hist, bin_centers = histogram(image.ravel(), nbins=nbins)
+    hist = hist.astype(np.float)
+
+    if not tail:
+        hist = hist[::-1]
+        bin_centers = bin_centers[::-1]
+
+    # get histogram peak index
+    M = np.argmax(hist)
+
+    # need at least two data points to fit a line
+    offset = 2
+    # start and stop indices for threshold testing
+    levels = np.arange(M + offset, hist.size - offset)
+    residuals = np.empty_like(levels, dtype=np.float)
+
+    for index, k in enumerate(levels):
+        # line 1: steeply descending slope
+        D1 = stats.linregress(bin_centers[M:k], hist[M:k])
+        # line 2: shallow tail
+        D2 = stats.linregress(
+            bin_centers[k + 1: hist.size], hist[k + 1: hist.size])
+
+        # calculate sum of residuals
+        err1 = np.square(
+            hist[M:k] - (D1.slope * bin_centers[M:k] + D1.intercept))
+        err2 = np.square(
+            hist[k + 1: hist.size]
+            - (D2.slope * bin_centers[k + 1: hist.size] + D2.intercept)
+        )
+        residuals[index] = err1.sum() + err2.sum()
+
+    # get minimum errors as threshold point
+    threshold = bin_centers[:-offset][-(residuals.size - np.argmin(residuals))]
+    return threshold


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

Hi there,

I have implemented the T-Point threshold from the paper: "Robust threshold estimation for images with unimodal histograms." [1](https://www.doi.org/10.1016/j.patrec.2009.12.025) It's implementation is useful for thresholding unimodal histograms in a similar fashion to the triangle algorithm, however I prefer its results in many cases, such as for electron microscopy images. It is only dependent on the image histogram and can threshold histograms with positive or negative skew.

Cheers!

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [X] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [X] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
