### PR TITLE
Manage iradon_sart input and output data type

### DIFF
--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -383,11 +383,11 @@ def iradon_sart(radon_image, theta=None, image=None, projection_shifts=None,
     theta : 1D array, optional
         Reconstruction angles (in degrees). Default: m angles evenly spaced
         between 0 and 180 (if the shape of `radon_image` is (N, M)).
-    image : 2D array, dtype=float, optional
+    image : 2D array, optional
         Image containing an initial reconstruction estimate. Shape of this
         array should be ``(radon_image.shape[0], radon_image.shape[0])``. The
         default is an array of zeros.
-    projection_shifts : 1D array, dtype=float, optional
+    projection_shifts : 1D array, optional
         Shift the projections contained in ``radon_image`` (the sinogram) by
         this many pixels before reconstructing the image. The i'th value
         defines the shift of the i'th column of ``radon_image``.
@@ -398,6 +398,10 @@ def iradon_sart(radon_image, theta=None, image=None, projection_shifts=None,
         Relaxation parameter for the update step. A higher value can
         improve the convergence rate, but one runs the risk of instabilities.
         Values close to or higher than 1 are not recommended.
+    dtype : dtype, optional
+        Output data type, must be floating point. By default, if input
+        data type is not float, input is cast to double, otherwise
+        dtype is set to input data type.
 
     Returns
     -------

--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -366,7 +366,7 @@ def order_angles_golden_ratio(theta):
 
 
 def iradon_sart(radon_image, theta=None, image=None, projection_shifts=None,
-                clip=None, relaxation=0.15):
+                clip=None, relaxation=0.15, dtype=None):
     """Inverse radon transform.
 
     Reconstruct an image from the radon transform, using a single iteration of
@@ -374,13 +374,13 @@ def iradon_sart(radon_image, theta=None, image=None, projection_shifts=None,
 
     Parameters
     ----------
-    radon_image : 2D array, dtype=float
+    radon_image : 2D array
         Image containing radon transform (sinogram). Each column of
         the image corresponds to a projection along a different angle. The
         tomography rotation axis should lie at the pixel index
         ``radon_image.shape[0] // 2`` along the 0th dimension of
         ``radon_image``.
-    theta : 1D array, dtype=float, optional
+    theta : 1D array, optional
         Reconstruction angles (in degrees). Default: m angles evenly spaced
         between 0 and 180 (if the shape of `radon_image` is (N, M)).
     image : 2D array, dtype=float, optional
@@ -440,30 +440,58 @@ def iradon_sart(radon_image, theta=None, image=None, projection_shifts=None,
     """
     if radon_image.ndim != 2:
         raise ValueError('radon_image must be two dimensional')
+
+    if dtype is None:
+        if radon_image.dtype.char in 'fd':
+            dtype = radon_image.dtype
+        else:
+            warn("Only floating point data type are valid for SART inverse "
+                 "radon transform. Input data is cast to float. To disable "
+                 "this warning, please cast image_radon to float.")
+            dtype = np.dtype(float)
+    elif np.dtype(dtype).char not in 'fd':
+        raise ValueError("Only floating point data type are valid for inverse "
+                         "radon transform.")
+
+    dtype = np.dtype(dtype)
+    radon_image = radon_image.astype(dtype, copy=False)
+
     reconstructed_shape = (radon_image.shape[0], radon_image.shape[0])
+
     if theta is None:
-        theta = np.linspace(0, 180, radon_image.shape[1], endpoint=False)
-    elif theta.shape != (radon_image.shape[1],):
+        theta = np.linspace(0, 180, radon_image.shape[1],
+                            endpoint=False, dtype=dtype)
+    elif len(theta) != radon_image.shape[1]:
         raise ValueError('Shape of theta (%s) does not match the '
                          'number of projections (%d)'
-                         % (projection_shifts.shape, radon_image.shape[1]))
+                         % (len(theta), radon_image.shape[1]))
+    else:
+        theta = np.asarray(theta, dtype=dtype)
+
     if image is None:
-        image = np.zeros(reconstructed_shape, dtype=np.float)
+        image = np.zeros(reconstructed_shape, dtype=dtype)
     elif image.shape != reconstructed_shape:
         raise ValueError('Shape of image (%s) does not match first dimension '
                          'of radon_image (%s)'
                          % (image.shape, reconstructed_shape))
+    elif image.dtype != dtype:
+        warn("image dtype does not match output dtype: "
+             "image is cast to {}".format(dtype))
+
+    image = np.asarray(image, dtype=dtype)
+
     if projection_shifts is None:
-        projection_shifts = np.zeros((radon_image.shape[1],), dtype=np.float)
-    elif projection_shifts.shape != (radon_image.shape[1],):
+        projection_shifts = np.zeros((radon_image.shape[1],), dtype=dtype)
+    elif len(projection_shifts) != radon_image.shape[1]:
         raise ValueError('Shape of projection_shifts (%s) does not match the '
                          'number of projections (%d)'
-                         % (projection_shifts.shape, radon_image.shape[1]))
+                         % (len(projection_shifts), radon_image.shape[1]))
+    else:
+        projection_shifts = np.asarray(projection_shifts, dtype=dtype)
     if clip is not None:
         if len(clip) != 2:
             raise ValueError('clip must be a length-2 sequence')
-        clip = (float(clip[0]), float(clip[1]))
-    relaxation = float(relaxation)
+        clip = np.asarray(clip, dtype=dtype)
 
     for angle_index in order_angles_golden_ratio(theta):
         image_update = sart_projection_update(image, theta[angle_index],

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -435,3 +435,23 @@ def test_iradon_sart():
         delta = np.mean(np.abs(reconstructed - image))
         print('delta (1 iteration, shifted sinogram) =', delta)
         assert delta < 0.022 * error_factor
+
+
+def test_iradon_sart_dtype():
+    sinogram = np.zeros((16, 1), dtype=int)
+    sinogram[8, 0] = 1.
+    sinogram64 = sinogram.astype('float64')
+    sinogram32 = sinogram.astype('float32')
+
+    with expected_warnings(['Input data is cast to float']):
+        assert iradon_sart(sinogram, theta=[0]).dtype == 'float64'
+
+    assert iradon_sart(sinogram64, theta=[0]).dtype == sinogram64.dtype
+    assert iradon_sart(sinogram32, theta=[0]).dtype == sinogram32.dtype
+
+
+def test_iradon_wrong_dtype():
+    sinogram = np.zeros((16, 1))
+
+    with testing.raises(ValueError):
+        iradon_sart(sinogram, dtype=int)


### PR DESCRIPTION
## Description

In the same spirit of #4298, the input and output data type of `iradon_sart` is managed.

In this PR, a `dtype` parameter is added do `iradon_sart` and set to `None` by default and corresponds to the desired output data type:
By default, if input data type is not float, a warning is raised and input is cast to double, otherwise dtype is set to input data type.
If dtype is set to non floating point, a ValueError is raised.
The fused type `np_floats` is used to add single precision support in `_radon_transform` Cython module (see #3111).
Tests asserting correct output datatype is also added.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
