### PR TITLE
pyramid functions take preserve_range kwarg

### DIFF
--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -11,7 +11,7 @@ def _smooth(image, sigma, mode, cval, multichannel=None):
 
     # apply Gaussian filter to all channels independently
     if multichannel:
-        sigma = (sigma, )*(image.ndim - 1) + (0, )
+        sigma = (sigma, ) * (image.ndim - 1) + (0, )
     ndi.gaussian_filter(image, sigma, output=smoothed,
                         mode=mode, cval=cval)
     return smoothed
@@ -110,7 +110,7 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
-    
+
     Returns
     -------
     out : array
@@ -180,7 +180,7 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
-    
+
     Returns
     -------
     pyramid : generator

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -2,7 +2,7 @@ import math
 import numpy as np
 from scipy import ndimage as ndi
 from ..transform import resize
-from ..util import img_as_float
+from .._shared.utils import convert_to_float
 
 
 def _smooth(image, sigma, mode, cval, multichannel=None):
@@ -23,7 +23,7 @@ def _check_factor(factor):
 
 
 def pyramid_reduce(image, downscale=2, sigma=None, order=1,
-                   mode='reflect', cval=0, multichannel=False):
+                   mode='reflect', cval=0, multichannel=False, preserve_range=False):
     """Smooth and then downsample image.
 
     Parameters
@@ -47,6 +47,10 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
     multichannel : bool, optional
         Whether the last axis of the image is to be interpreted as multiple
         channels or another spatial dimension.
+    preserve_range : bool, optional
+        Whether to keep the original range of values. Otherwise, the input
+        image is converted according to the conventions of `img_as_float`.
+        Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Returns
     -------
@@ -60,7 +64,7 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
     """
     _check_factor(downscale)
 
-    image = img_as_float(image)
+    image = convert_to_float(image, preserve_range)
 
     out_shape = tuple([math.ceil(d / float(downscale)) for d in image.shape])
     if multichannel:
@@ -78,7 +82,7 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
 
 
 def pyramid_expand(image, upscale=2, sigma=None, order=1,
-                   mode='reflect', cval=0, multichannel=False):
+                   mode='reflect', cval=0, multichannel=False, preserve_range=False):
     """Upsample and then smooth image.
 
     Parameters
@@ -102,7 +106,11 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
     multichannel : bool, optional
         Whether the last axis of the image is to be interpreted as multiple
         channels or another spatial dimension.
-
+    preserve_range : bool, optional
+        Whether to keep the original range of values. Otherwise, the input
+        image is converted according to the conventions of `img_as_float`.
+        Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
+    
     Returns
     -------
     out : array
@@ -115,7 +123,7 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
     """
     _check_factor(upscale)
 
-    image = img_as_float(image)
+    image = convert_to_float(image, preserve_range)
 
     out_shape = tuple([math.ceil(upscale * d) for d in image.shape])
     if multichannel:
@@ -133,7 +141,7 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
 
 
 def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
-                     mode='reflect', cval=0, multichannel=False):
+                     mode='reflect', cval=0, multichannel=False, preserve_range=False):
     """Yield images of the Gaussian pyramid formed by the input image.
 
     Recursively applies the `pyramid_reduce` function to the image, and yields
@@ -168,7 +176,11 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
     multichannel : bool, optional
         Whether the last axis of the image is to be interpreted as multiple
         channels or another spatial dimension.
-
+    preserve_range : bool, optional
+        Whether to keep the original range of values. Otherwise, the input
+        image is converted according to the conventions of `img_as_float`.
+        Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
+    
     Returns
     -------
     pyramid : generator
@@ -182,7 +194,7 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
     _check_factor(downscale)
 
     # cast to float for consistent data type in pyramid
-    image = img_as_float(image)
+    image = convert_to_float(image, preserve_range)
 
     layer = 0
     current_shape = image.shape
@@ -210,7 +222,7 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
 
 
 def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
-                      mode='reflect', cval=0, multichannel=False):
+                      mode='reflect', cval=0, multichannel=False, preserve_range=False):
     """Yield images of the laplacian pyramid formed by the input image.
 
     Each layer contains the difference between the downsampled and the
@@ -248,6 +260,11 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
     multichannel : bool, optional
         Whether the last axis of the image is to be interpreted as multiple
         channels or another spatial dimension.
+    preserve_range : bool, optional
+        Whether to keep the original range of values. Otherwise, the input
+        image is converted according to the conventions of `img_as_float`.
+        Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
+
 
     Returns
     -------
@@ -263,7 +280,7 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
     _check_factor(downscale)
 
     # cast to float for consistent data type in pyramid
-    image = img_as_float(image)
+    image = convert_to_float(image, preserve_range)
 
     if sigma is None:
         # automatically determine sigma which covers > 99% of distribution

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -23,7 +23,8 @@ def _check_factor(factor):
 
 
 def pyramid_reduce(image, downscale=2, sigma=None, order=1,
-                   mode='reflect', cval=0, multichannel=False, preserve_range=False):
+                   mode='reflect', cval=0, multichannel=False,
+                   preserve_range=False):
     """Smooth and then downsample image.
 
     Parameters
@@ -82,7 +83,8 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
 
 
 def pyramid_expand(image, upscale=2, sigma=None, order=1,
-                   mode='reflect', cval=0, multichannel=False, preserve_range=False):
+                   mode='reflect', cval=0, multichannel=False,
+                   preserve_range=False):
     """Upsample and then smooth image.
 
     Parameters
@@ -141,7 +143,8 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
 
 
 def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
-                     mode='reflect', cval=0, multichannel=False, preserve_range=False):
+                     mode='reflect', cval=0, multichannel=False,
+                     preserve_range=False):
     """Yield images of the Gaussian pyramid formed by the input image.
 
     Recursively applies the `pyramid_reduce` function to the image, and yields
@@ -222,7 +225,8 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
 
 
 def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
-                      mode='reflect', cval=0, multichannel=False, preserve_range=False):
+                      mode='reflect', cval=0, multichannel=False,
+                      preserve_range=False):
     """Yield images of the laplacian pyramid formed by the input image.
 
     Each layer contains the difference between the downsampled and the

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -4,7 +4,8 @@ from skimage import data
 from skimage.transform import pyramids
 
 from skimage._shared import testing
-from skimage._shared.testing import assert_array_equal, assert_, assert_equal
+from skimage._shared.testing import (assert_array_equal, assert_, assert_equal,
+                                     assert_almost_equal)
 from skimage._shared._warnings import expected_warnings
 
 
@@ -20,9 +21,13 @@ def test_pyramid_reduce_rgb():
 
 def test_pyramid_reduce_gray():
     rows, cols = image_gray.shape
-    out = pyramids.pyramid_reduce(image_gray, downscale=2,
-                                  multichannel=False)
-    assert_array_equal(out.shape, (rows / 2, cols / 2))
+    out1 = pyramids.pyramid_reduce(image_gray, downscale=2,
+                                   multichannel=False)
+    assert_array_equal(out1.shape, (rows / 2, cols / 2))
+    assert_almost_equal(out1.ptp(), 1.0, decimal=2)
+    out2 = pyramids.pyramid_reduce(image_gray, downscale=2,
+                                   multichannel=False, preserve_range=True)
+    assert_almost_equal(out2.ptp()/image_gray.ptp(), 1.0, decimal=2)
 
 
 def test_pyramid_reduce_nd():

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -27,7 +27,7 @@ def test_pyramid_reduce_gray():
     assert_almost_equal(out1.ptp(), 1.0, decimal=2)
     out2 = pyramids.pyramid_reduce(image_gray, downscale=2,
                                    multichannel=False, preserve_range=True)
-    assert_almost_equal(out2.ptp()/image_gray.ptp(), 1.0, decimal=2)
+    assert_almost_equal(out2.ptp() / image_gray.ptp(), 1.0, decimal=2)
 
 
 def test_pyramid_reduce_nd():


### PR DESCRIPTION
## Description

None of the pyramid functions had the `preserve_range` kwarg, so I added it, and replaced the previous cast to float with a call to `convert_to_float`. 

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
