### PR TITLE
[WIP] Use PEP 517 Build Isolation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm", "wheel", "numpy==1.14.5", "cython==0.29.0"]
+requires = ["setuptools", "wheel", "numpy==1.14.5", "cython==0.29.0"]
 build-backend = 'setuptools.build_meta'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools_scm", "wheel", "numpy==1.14.5", "cython==0.29.0"]
+build-backend = 'setuptools.build_meta'

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,9 @@ For Python 2.7, please install the 0.14.x Long Term Support using:
     sys.stderr.write(error + "\n")
     sys.exit(1)
 
+# Add the current directory to the path to allow import of skimage
+sys.path.append(os.path.abspath("."))
+
 import builtins
 
 # This is a bit (!) hackish: we are setting a global variable so that the main
@@ -163,39 +166,16 @@ def configuration(parent_package='', top_path=None):
 
 
 if __name__ == "__main__":
-    try:
-        from numpy.distutils.core import setup
-        extra = {'configuration': configuration}
-        # Do not try and upgrade larger dependencies
-        for lib in ['scipy', 'numpy', 'matplotlib', 'pillow']:
-            try:
-                __import__(lib)
-                INSTALL_REQUIRES = [i for i in INSTALL_REQUIRES
-                                    if lib not in i]
-            except ImportError:
-                pass
-    except ImportError:
-        if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or
-                                   sys.argv[1] in ('--help-commands',
-                                                   '--version',
-                                                   'clean',
-                                                   'egg_info',
-                                                   'install_egg_info',
-                                                   'rotate')):
-            # For these actions, NumPy is not required.
-            #
-            # They are required to succeed without Numpy for example when
-            # pip is used to install scikit-image when Numpy is not yet
-            # present in the system.
-            from setuptools import setup
-            extra = {}
-        else:
-            print('To install scikit-image from source, you will need numpy.\n' +
-                  'Install numpy with pip:\n' +
-                  'pip install numpy\n'
-                  'Or use your operating system package manager. For more\n' +
-                  'details, see https://scikit-image.org/docs/stable/install.html')
-            sys.exit(1)
+    from numpy.distutils.core import setup
+    extra = {'configuration': configuration}
+    # Do not try and upgrade larger dependencies
+    for lib in ['scipy', 'numpy', 'matplotlib', 'pillow']:
+        try:
+            __import__(lib)
+            INSTALL_REQUIRES = [i for i in INSTALL_REQUIRES
+                                if lib not in i]
+        except ImportError:
+            pass
 
     setup(
         name=DISTNAME,


### PR DESCRIPTION
## Description

This is following on from a discussion in #4261 

This works for me currently when installing from a checkout in a completely clean venv. What I am unclear on at this point is how the C files are generated for the sdist, I am proposing that we remove that behaviour and have people generate the C files during build (with a pinned known version of Cython).

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
