### PR TITLE
Clarify merge policy in core contributor guide

### DIFF
--- a/doc/source/core_developer.rst
+++ b/doc/source/core_developer.rst
@@ -91,12 +91,16 @@ or using GitHub’s `suggestion
 (The latter is preferred because it gives the contributor a choice in
 whether to accept the changes.)
 
-Unless you know that a contributor is experienced with git, don’t
-ask for a rebase when merge conflicts arise. Instead, rebase the
-branch yourself, force-push to their branch, and advise the contributor to force-pull.  If the contributor is
-no longer active, you may take over their branch by submitting a new pull
-request and closing the original. In doing so, ensure you communicate
-that you are not throwing the contributor's work away!
+Our default merge policy is to squash all PR commits into a single
+commit. Users who wish to bring the latest changes from ``master``
+into their branch should be advised to merge, not to rebase.  Even
+when merge conflicts arise, don’t ask for a rebase unless you know
+that a contributor is experienced with git. Instead, rebase the branch
+yourself, force-push to their branch, and advise the contributor on
+how to force-pull.  If the contributor is no longer active, you may
+take over their branch by submitting a new pull request and closing
+the original. In doing so, ensure you communicate that you are not
+throwing the contributor's work away!
 
 Please add a note to a pull request after you push new changes; GitHub
 does not send out notifications for these.


### PR DESCRIPTION
This updates some language around how to merge PRs and how to update PRs in the core contributor guide.