### PR TITLE
WIP: force single axis shift from xy translation shift

### DIFF
--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -106,7 +106,7 @@ def _compute_error(cross_correlation_max, src_amp, target_amp):
 
 
 def register_translation(src_image, target_image, upsample_factor=1,
-                         space="real", return_error=True):
+                         space="real", return_error=True, axis=None):
     """
     Efficient subpixel image translation registration by cross-correlation.
 
@@ -134,6 +134,9 @@ def register_translation(src_image, target_image, upsample_factor=1,
     return_error : bool, optional
         Returns error and phase difference if on,
         otherwise only shifts are returned
+    axis : int, optional
+        The `axis` to which the translation shift is limited. Useful if the
+        user knows the translation shift should only be along one axis.
 
     Returns
     -------
@@ -228,6 +231,19 @@ def register_translation(src_image, target_image, upsample_factor=1,
     for dim in range(src_freq.ndim):
         if shape[dim] == 1:
             shifts[dim] = 0
+
+    if axis is not None:
+        if 0 in (shifts):
+            print('One of the shifts is already 0, '
+                  'returning the shifts array as is.')
+        else:
+            x_shift, y_shift = float(shifts[1]), float(shifts[0])
+            if axis == 0:  # y
+                shifts = np.array([y_shift + (x_shift**2 / y_shift), 0],
+                                  dtype=np.float64)
+            elif axis == 1:  # x
+                shifts = np.array([0, x_shift + (y_shift**2 / x_shift)],
+                                  dtype=np.float64)
 
     if return_error:
         return shifts, _compute_error(CCmax, src_amp, target_amp),\

--- a/skimage/feature/tests/test_register_translation.py
+++ b/skimage/feature/tests/test_register_translation.py
@@ -46,6 +46,19 @@ def test_real_input():
     assert_allclose(result[:2], -np.array(subpixel_shift), atol=0.05)
 
 
+def test_real_input_single_axis():
+    reference_image = camera()
+    subpixel_shift = (3, 4)
+    shifted_image = fourier_shift(fft.fftn(reference_image), subpixel_shift)
+    shifted_image = fft.ifftn(shifted_image)
+
+    # subpixel precision
+    result, error, diffphase = register_translation(reference_image,
+                                                    shifted_image,
+                                                    axis=1)
+    assert_allclose(result[:2], [0, -6.25], atol=0.05)
+
+
 def test_size_one_dimension_input():
     # take a strip of the input image
     reference_image = fft.fftn(camera()[:, 15]).reshape((-1, 1))


### PR DESCRIPTION
## Description

This change to `register_translation` is a possible solution for [this stack overflow question](https://stackoverflow.com/questions/58388392/measuring-shift-between-two-images-along-one-direction-only), and situations where the user knows the image shift should be constrained to one axis, but where `register_translation` is "incorrectly" returning an xy shift. Essentially, it takes the xy shift translation, and forces it to just one axis with some triangles. It's limited to two dimensions right now.

I'm not sure if this "fits" into this function, or whether it's useful. Perhaps it could be its own function, or maybe people should do the maths themselves, any advice is greatly appreciated.

Also, maybe `axis` isn't the best param name here. `limit_to_axis` might be better.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
