### PR TITLE
Add check to avoid import craching

### DIFF
--- a/skimage/io/manage_plugins.py
+++ b/skimage/io/manage_plugins.py
@@ -294,7 +294,7 @@ def _load(plugin):
     else:
         modname = plugin_module_name[plugin]
         plugin_module = __import__('skimage.io._plugins.' + modname,
-            fromlist=[modname])
+                                   fromlist=[modname])
 
     provides = plugin_provides[plugin]
     for p in provides:

--- a/skimage/io/manage_plugins.py
+++ b/skimage/io/manage_plugins.py
@@ -15,10 +15,9 @@ can be multiple states for a given plugin:
         loaded explicitly by the user.
 
 """
-import sys
-
-from configparser import ConfigParser
 import os.path
+import warnings
+from configparser import ConfigParser
 from glob import glob
 
 from .collection import imread_collection_wrapper
@@ -112,7 +111,8 @@ def _scan_plugins():
 
     for filename in config_files:
         name, meta_data = _parse_config_file(filename)
-        if 'providers' not in meta_data:
+        if 'provides' not in meta_data:
+            warnings.warn(f'file {filename} not recognized as a scikit-image io plugin, skipping.')
             continue
         plugin_meta_data[name] = meta_data
         provides = [s.strip() for s in meta_data['provides'].split(',')]

--- a/skimage/io/manage_plugins.py
+++ b/skimage/io/manage_plugins.py
@@ -23,10 +23,8 @@ from glob import glob
 
 from .collection import imread_collection_wrapper
 
-
 __all__ = ['use_plugin', 'call_plugin', 'plugin_info', 'plugin_order',
            'reset_plugins', 'find_available_plugins', 'available_plugins']
-
 
 # The plugin store will save a list of *loaded* io functions for each io type
 # (e.g. 'imread', 'imsave', etc.). Plugins are loaded as requested.
@@ -114,8 +112,9 @@ def _scan_plugins():
 
     for filename in config_files:
         name, meta_data = _parse_config_file(filename)
+        if 'providers' not in meta_data:
+            continue
         plugin_meta_data[name] = meta_data
-
         provides = [s.strip() for s in meta_data['provides'].split(',')]
         valid_provides = [p for p in provides if p in plugin_store]
 
@@ -295,7 +294,7 @@ def _load(plugin):
     else:
         modname = plugin_module_name[plugin]
         plugin_module = __import__('skimage.io._plugins.' + modname,
-                                   fromlist=[modname])
+            fromlist=[modname])
 
     provides = plugin_provides[plugin]
     for p in provides:


### PR DESCRIPTION
Some `.ini` files are automatically generated by windows, and downloaded when using Google Drive's Backup and Sync app. 
When scanning for plugins in each `.ini` file, if 'providers' is not found in the file (the `meta-data` dict parsed from the file), the import craches.