### PR TITLE
Fix border removal in peak_local_max with footprints

### DIFF
--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -48,10 +48,14 @@ def _exclude_border(mask, footprint, exclude_border):
     """
     # zero out the image borders
     for i in range(mask.ndim):
-        remove = (footprint.shape[i] if footprint is not None
-                  else 2 * exclude_border)
-        mask[(slice(None),) * i + (slice(None, remove // 2),)] = False
-        mask[(slice(None),) * i + (slice(-remove // 2, None),)] = False
+        remove = (footprint.shape[i] // 2 if footprint is not None
+                  else exclude_border)
+        # if we want to remove 0 pixels, we need to bail.  otherwise
+        # slice(-0, None) will nuke the entire image.
+        if remove == 0:
+            continue
+        mask[(slice(None),) * i + (slice(None, remove),)] = False
+        mask[(slice(None),) * i + (slice(-remove, None),)] = False
     return mask
 
 

--- a/skimage/feature/tests/test_peak.py
+++ b/skimage/feature/tests/test_peak.py
@@ -1,4 +1,6 @@
+import itertools
 import numpy as np
+import pytest
 import unittest
 from skimage._shared.testing import assert_array_almost_equal
 from skimage._shared.testing import assert_equal
@@ -379,7 +381,6 @@ class TestPeakLocalMax():
                                           threshold_rel=0).tolist()) == \
             [[5, 5, 5, 5], [15, 15, 15, 15]]
 
-
     def test_threshold_rel_default(self):
         image = np.ones((5, 5))
 
@@ -391,6 +392,19 @@ class TestPeakLocalMax():
 
         image[2, 2] = 0
         assert len(peak.peak_local_max(image, min_distance=0)) == image.size - 1
+
+
+@pytest.mark.parametrize(
+    ["indices"],
+    [[indices] for indices in itertools.product(range(3), range(3))],
+)
+def test_footprint_1px(indices):
+    image = np.zeros((3, 3))
+    image[indices] = 1
+    footprint = np.ones((1, 1), dtype=np.bool)
+    assert len(peak.peak_local_max(
+        image, footprint=footprint, exclude_border=True)) == 1
+
 
 class TestProminentPeaks(unittest.TestCase):
     def test_isolated_peaks(self):


### PR DESCRIPTION
## Description

The current code will erroneously remove the last row of an image when the footprint is size 1 along any dimension.  This is because `remove` will be 1, and (-1 // 2) is -1, and we slice out (-1, None).

In this PR, we update the `remove` to actually reflect the number of pixels we want to trim on each side of the image, and if it is 0, then we continue the loop.

Added tests to put a peak in each pixel in a 3x3 image, and verified that the peaks are correctly detected in all locations.  Prior to the fix, it would fail on any of the last row and last column.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
