### PR TITLE
Fix blob_log/blob_dog and their corresponding tests

### DIFF
--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -208,7 +208,8 @@ def _format_exclude_border(img_ndim, exclude_border):
         return (0,) * (img_ndim + 1)
     else:
         raise ValueError(
-            "Unsupported value ({}) for exclude_border".format(exclude_border))
+            f"Unsupported value ({exclude_border}) for exclude_border"
+        )
 
 
 def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -206,6 +206,9 @@ def _format_exclude_border(img_ndim, exclude_border):
         raise ValueError("exclude_border cannot be True")
     elif exclude_border is False:
         return (0,) * (img_ndim + 1)
+    else:
+        raise ValueError(
+            "Unsupported value ({}) for exclude_border".format(exclude_border))
 
 
 def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,

--- a/skimage/feature/tests/test_blob.py
+++ b/skimage/feature/tests/test_blob.py
@@ -110,7 +110,7 @@ def test_blob_dog_excl_border():
         min_sigma=1.5,
         max_sigma=5,
         sigma_ratio=1.2,
-        exclude_border=5
+        exclude_border=6,
     )
     msg = "zero blobs should be detected, as only blob is 5 px from border"
     assert blobs.shape[0] == 0, msg
@@ -246,11 +246,11 @@ def test_blob_log_exclude_border():
     b = blobs[0]
     assert b[0] == b[1] == 5, "blob should be 5 px from x and y borders"
 
-    blobs = blob_dog(
+    blobs = blob_log(
         img,
         min_sigma=1.5,
         max_sigma=5,
-        exclude_border=5
+        exclude_border=6,
     )
     msg = "zero blobs should be detected, as only blob is 5 px from border"
     assert blobs.shape[0] == 0, msg


### PR DESCRIPTION
## Description

1. With the change in https://github.com/scikit-image/scikit-image/pull/4325, it's now possible to specify the excluded region on a per-dimension basis.  We can therefore explicitly exclude the borders for the image dimensions as needed.
2. test_blob_log_excl_border was calling blob_dog and not blob_log.  Whoops copy pasta.
3. exclude_border is set to 6.  If the circle is centered at (5, 5), one needs to chop off 6 pixels to remove the circle's center.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
