### PR TITLE
Add dtype keyword argument to block reduce and small documentation changes

### DIFF
--- a/skimage/measure/block.py
+++ b/skimage/measure/block.py
@@ -3,9 +3,9 @@ from ..util import view_as_blocks
 
 
 def block_reduce(image, block_size, func=np.sum, cval=0, **func_kwargs):
-    """
-    Down-sample image by applying function to local blocks. Able to do
-    max and mean pooling.
+    """Downsample image by applying function `func` to local blocks.
+
+    This function is useful for max and mean pooling, for example.
 
     Parameters
     ----------

--- a/skimage/measure/block.py
+++ b/skimage/measure/block.py
@@ -78,4 +78,5 @@ def block_reduce(image, block_size, func=np.sum, cval=0, dtype=None):
 
     blocked = view_as_blocks(image, block_size)
 
-    return func(blocked, axis=tuple(range(image.ndim, blocked.ndim)), dtype=dtype)
+    return func(blocked, axis=tuple(range(image.ndim, blocked.ndim)),
+                dtype=dtype)

--- a/skimage/measure/block.py
+++ b/skimage/measure/block.py
@@ -2,7 +2,7 @@ import numpy as np
 from ..util import view_as_blocks
 
 
-def block_reduce(image, block_size, func=np.sum, cval=0, dtype=None):
+def block_reduce(image, block_size, func=np.sum, cval=0, **func_kwargs):
     """
     Down-sample image by applying function to local blocks. Able to do
     max and mean pooling.
@@ -15,14 +15,15 @@ def block_reduce(image, block_size, func=np.sum, cval=0, dtype=None):
         Array containing down-sampling integer factor along each axis.
     func : callable
         Function object which is used to calculate the return value for each
-        local block. This function must implement an ``axis`` parameter such
-        as ``numpy.sum``, ``numpy.min``, or ``numpy.mean``.
+        local block. This function must implement an ``axis`` parameter.
+        Primary functions are ``numpy.sum``, ``numpy.min``, ``numpy.max``,
+        ``numpy.mean`` and ``numpy.median``.
     cval : float
         Constant padding value if image is not perfectly divisible by the
         block size.
-    dtype : string
-        Dtype argument passed to passed numpy function. Defaults to default
-        for function. Especially useful when using ``np.mean``.
+    **func_kwargs :
+        Flag arguments passed to func. Noteably useful for passing dtype
+        argument to ``np.mean``.
 
     Returns
     -------
@@ -78,4 +79,5 @@ def block_reduce(image, block_size, func=np.sum, cval=0, dtype=None):
 
     blocked = view_as_blocks(image, block_size)
 
-    return func(blocked, axis=tuple(range(image.ndim, blocked.ndim)), dtype=dtype)
+    return func(blocked, axis=tuple(range(image.ndim, blocked.ndim)),
+                **func_kwargs)

--- a/skimage/measure/block.py
+++ b/skimage/measure/block.py
@@ -2,8 +2,10 @@ import numpy as np
 from ..util import view_as_blocks
 
 
-def block_reduce(image, block_size, func=np.sum, cval=0):
-    """Down-sample image by applying function to local blocks.
+def block_reduce(image, block_size, func=np.sum, cval=0, dtype=None):
+    """
+    Down-sample image by applying function to local blocks. Able to do
+    max and mean pooling.
 
     Parameters
     ----------
@@ -14,10 +16,13 @@ def block_reduce(image, block_size, func=np.sum, cval=0):
     func : callable
         Function object which is used to calculate the return value for each
         local block. This function must implement an ``axis`` parameter such
-        as ``numpy.sum`` or ``numpy.min``.
+        as ``numpy.sum``, ``numpy.min``, or ``numpy.mean``.
     cval : float
         Constant padding value if image is not perfectly divisible by the
         block size.
+    dtype : string
+        Dtype argument passed to passed numpy function. Defaults to default
+        for function. Especially useful when using ``np.mean``.
 
     Returns
     -------
@@ -73,4 +78,4 @@ def block_reduce(image, block_size, func=np.sum, cval=0):
 
     blocked = view_as_blocks(image, block_size)
 
-    return func(blocked, axis=tuple(range(image.ndim, blocked.ndim)))
+    return func(blocked, axis=tuple(range(image.ndim, blocked.ndim)), dtype=dtype)

--- a/skimage/measure/block.py
+++ b/skimage/measure/block.py
@@ -22,7 +22,7 @@ def block_reduce(image, block_size, func=np.sum, cval=0, **func_kwargs):
         Constant padding value if image is not perfectly divisible by the
         block size.
     **func_kwargs :
-        Flag arguments passed to func. Noteably useful for passing dtype
+        Keyword arguments passed to `func`. Notably useful for passing dtype
         argument to ``np.mean``.
 
     Returns

--- a/skimage/measure/tests/test_block.py
+++ b/skimage/measure/tests/test_block.py
@@ -86,3 +86,30 @@ def test_invalid_block_size():
         block_reduce(image, [1, 2, 3])
     with testing.raises(ValueError):
         block_reduce(image, [1, 0.5])
+
+
+def test_func_kwargs_same_dtype():
+    image = np.array([[97, 123, 173, 227],
+                     [217, 241, 221, 214],
+                     [211,  11, 170,  53],
+                     [214, 205, 101,  57]], dtype=np.uint8)
+
+    out = block_reduce(image, (2, 2), func=np.mean, dtype=np.uint8)
+    excepted = np.array([[41, 16], [32, 31]], dtype=np.uint8)
+
+    assert np.array_equal(out, excepted)
+    assert out.dtype == excepted.dtype
+
+
+def test_func_kwargs_different_dtype():
+    image = np.array([[0.45745366, 0.67479345, 0.20949775, 0.3147348],
+                      [0.7209286, 0.88915504, 0.66153409, 0.07919526],
+                      [0.04640037, 0.54008495, 0.34664343, 0.56152301],
+                      [0.58085003, 0.80144708, 0.87844473, 0.29811511]],
+                     dtype=np.float64)
+
+    out = block_reduce(image, (2, 2), func=np.mean, dtype=np.float16)
+    excepted = np.array([[0.6855, 0.3164], [0.4922, 0.521]], dtype=np.float16)
+
+    assert np.is_close(out, excepted)
+    assert out.dtype == excepted.dtype

--- a/skimage/measure/tests/test_block.py
+++ b/skimage/measure/tests/test_block.py
@@ -95,10 +95,10 @@ def test_func_kwargs_same_dtype():
                      [214, 205, 101,  57]], dtype=np.uint8)
 
     out = block_reduce(image, (2, 2), func=np.mean, dtype=np.uint8)
-    excepted = np.array([[41, 16], [32, 31]], dtype=np.uint8)
+    expected = np.array([[41, 16], [32, 31]], dtype=np.uint8)
 
-    assert_equal(out, excepted)
-    assert out.dtype == excepted.dtype
+    assert_equal(out, expected)
+    assert out.dtype == expected.dtype
 
 
 def test_func_kwargs_different_dtype():
@@ -109,7 +109,7 @@ def test_func_kwargs_different_dtype():
                      dtype=np.float64)
 
     out = block_reduce(image, (2, 2), func=np.mean, dtype=np.float16)
-    excepted = np.array([[0.6855, 0.3164], [0.4922, 0.521]], dtype=np.float16)
+    expected = np.array([[0.6855, 0.3164], [0.4922, 0.521]], dtype=np.float16)
 
-    assert_equal(out, excepted)
-    assert out.dtype == excepted.dtype
+    assert_equal(out, expected)
+    assert out.dtype == expected.dtype

--- a/skimage/measure/tests/test_block.py
+++ b/skimage/measure/tests/test_block.py
@@ -97,7 +97,7 @@ def test_func_kwargs_same_dtype():
     out = block_reduce(image, (2, 2), func=np.mean, dtype=np.uint8)
     excepted = np.array([[41, 16], [32, 31]], dtype=np.uint8)
 
-    assert np.array_equal(out, excepted)
+    assert_equal(out, excepted)
     assert out.dtype == excepted.dtype
 
 
@@ -111,5 +111,5 @@ def test_func_kwargs_different_dtype():
     out = block_reduce(image, (2, 2), func=np.mean, dtype=np.float16)
     excepted = np.array([[0.6855, 0.3164], [0.4922, 0.521]], dtype=np.float16)
 
-    assert np.is_close(out, excepted)
+    assert_equal(out, excepted)
     assert out.dtype == excepted.dtype


### PR DESCRIPTION
## Description

For a project I'm doing, I needed to implement a mean pooling operation, which is supported with block reduce by passing np.mean through. This is a relatively normal use case for down sampling images. It turns out that when np.mean is passed integer arguments, by default it outputs float64 to preserve as much information as possible. When working with images, they're usually integers, and having them not come out as integers again is a problem in many cases. To change this, you simply pass a dtype= flag to np.mean. 

Because this block reduce function passes another keyword argument (axis) to whatever numpy function it's given, this can't be accomplished with creating a lambda function like `meanuint8 = lambda x: np.mean(x, dtype='uint8')`. Having to use a lambda function for what seems like a fairly normal use case is also ineloquent.

Just recasting the output is also undesirable, because it's slower than passing the argument and I, for example, call this function a few thousand times per second per server.

So I created a pull request just to add this keyword argument to the block reduce because it's the only solution to a fairly reasonable problem. The dtype defaults to None, so the change will have no impact on existing codebases or default functionality.

I also changed the description to mention that this can do max/mean pooling, which is the term the deep learning community uses for what this function does, and "numpy/scipy max pooling" doesn't return anything on Google.

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
