### PR TITLE
Fix CI failures caused by incompatible imagecodec minimum requirement 

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,3 +1,3 @@
 Cython>=0.29.13
 wheel
-numpy>=1.14.1
+numpy>=1.14.6

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-numpy>=1.14.1
+numpy>=1.14.6
 scipy>=0.19.0
 matplotlib>=2.0.0,!=3.0.0
 networkx>=2.0


### PR DESCRIPTION
## Description

NumPy version is bumped to 1.14.6 to fix the following CI failures:

>ERROR: imagecodecs-lite 2019.12.2 has requirement numpy>=1.14.6, but you'll have numpy 1.14.1 which is incompatible.
> ERROR: tifffile 2019.7.26.2 has requirement numpy>=1.14.6, but you'll have numpy 1.14.1 which is incompatible.

