### PR TITLE
Add explicit use of 32-bit int in fast_exp

### DIFF
--- a/skimage/_shared/fast_exp.h
+++ b/skimage/_shared/fast_exp.h
@@ -4,7 +4,7 @@
  * Additional improvements by Leonid Bloch. */
 
 /* use just EXP_A = 1512775 for integer version, to avoid FP calculations */
-#define EXP_A (1512775.3951951856938)  /* 2^20*ln2 */
+#define EXP_A (1512775.3951951856938)  /* 2^20/ln2 */
 /* For min. RMS error */
 #define EXP_BC 1072632447              /* 1023*2^20 - 60801 */
 /* For min. max. relative error */

--- a/skimage/_shared/fast_exp.h
+++ b/skimage/_shared/fast_exp.h
@@ -3,6 +3,8 @@
  * Reference [2]: https://doi.org/10.1162/089976600300015033
  * Additional improvements by Leonid Bloch. */
 
+#include <stdint.h>
+
 /* use just EXP_A = 1512775 for integer version, to avoid FP calculations */
 #define EXP_A (1512775.3951951856938)  /* 2^20/ln2 */
 /* For min. RMS error */
@@ -17,7 +19,7 @@ __inline double fast_exp (double y)
     union
     {
         double d;
-        struct { int i, j; } n;
+        struct { int32_t i, j; } n;
         char t[8];
     } _eco;
 
@@ -26,12 +28,12 @@ __inline double fast_exp (double y)
     switch(_eco.t[0]) {
         case 1:
             /* Little endian */
-            _eco.n.j = (int)(EXP_A*(y)) + EXP_BC;
+            _eco.n.j = (int32_t)(EXP_A*(y)) + EXP_BC;
             _eco.n.i = 0;
             break;
         case 0:
             /* Big endian */
-            _eco.n.i = (int)(EXP_A*(y)) + EXP_BC;
+            _eco.n.i = (int32_t)(EXP_A*(y)) + EXP_BC;
             _eco.n.j = 0;
             break;
     }


### PR DESCRIPTION
## Description

Implements @blochl [advice](https://github.com/scikit-image/scikit-image/pull/4322#discussion_r353567366).

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
