### PR TITLE
Change `measure.block_reduce` to accept explicit `func_kwargs` kwd

### DIFF
--- a/skimage/measure/block.py
+++ b/skimage/measure/block.py
@@ -2,7 +2,7 @@ import numpy as np
 from ..util import view_as_blocks
 
 
-def block_reduce(image, block_size, func=np.sum, cval=0, **func_kwargs):
+def block_reduce(image, block_size, func=np.sum, cval=0, func_kwargs=None):
     """Downsample image by applying function `func` to local blocks.
 
     This function is useful for max and mean pooling, for example.
@@ -17,11 +17,11 @@ def block_reduce(image, block_size, func=np.sum, cval=0, **func_kwargs):
         Function object which is used to calculate the return value for each
         local block. This function must implement an ``axis`` parameter.
         Primary functions are ``numpy.sum``, ``numpy.min``, ``numpy.max``,
-        ``numpy.mean`` and ``numpy.median``.
+        ``numpy.mean`` and ``numpy.median``.  See also `func_kwargs`.
     cval : float
         Constant padding value if image is not perfectly divisible by the
         block size.
-    **func_kwargs :
+    func_kwargs : dict
         Keyword arguments passed to `func`. Notably useful for passing dtype
         argument to ``np.mean``.
 
@@ -61,6 +61,9 @@ def block_reduce(image, block_size, func=np.sum, cval=0, **func_kwargs):
     if len(block_size) != image.ndim:
         raise ValueError("`block_size` must have the same length "
                          "as `image.shape`.")
+
+    if func_kwargs is None:
+        func_kwargs = {}
 
     pad_width = []
     for i in range(len(block_size)):

--- a/skimage/measure/tests/test_block.py
+++ b/skimage/measure/tests/test_block.py
@@ -94,7 +94,8 @@ def test_func_kwargs_same_dtype():
                      [211,  11, 170,  53],
                      [214, 205, 101,  57]], dtype=np.uint8)
 
-    out = block_reduce(image, (2, 2), func=np.mean, dtype=np.uint8)
+    out = block_reduce(image, (2, 2), func=np.mean,
+                       func_kwargs={'dtype': np.uint8})
     expected = np.array([[41, 16], [32, 31]], dtype=np.uint8)
 
     assert_equal(out, expected)
@@ -108,7 +109,8 @@ def test_func_kwargs_different_dtype():
                       [0.58085003, 0.80144708, 0.87844473, 0.29811511]],
                      dtype=np.float64)
 
-    out = block_reduce(image, (2, 2), func=np.mean, dtype=np.float16)
+    out = block_reduce(image, (2, 2), func=np.mean,
+                       func_kwargs={'dtype': np.float16})
     expected = np.array([[0.6855, 0.3164], [0.4922, 0.521]], dtype=np.float16)
 
     assert_equal(out, expected)


### PR DESCRIPTION
As per the discussion on #4334