### PR TITLE
Fix Frangi artefacts around the image

### DIFF
--- a/doc/examples/edges/plot_ridge_filter.py
+++ b/doc/examples/edges/plot_ridge_filter.py
@@ -65,7 +65,7 @@ for i, black_ridges in enumerate([1, 0]):
     for j, func in enumerate([identity, meijering, sato, frangi, hessian]):
         kwargs['black_ridges'] = black_ridges
         result = func(image, **kwargs)
-        if func in (meijering, frangi):
+        if func in (meijering):
             # Crop by 4 pixels for rendering purpose.
             result = result[4:-4, 4:-4]
         axes[i, j].imshow(result, cmap=cmap, aspect='auto')

--- a/doc/examples/edges/plot_ridge_filter.py
+++ b/doc/examples/edges/plot_ridge_filter.py
@@ -65,7 +65,7 @@ for i, black_ridges in enumerate([1, 0]):
     for j, func in enumerate([identity, meijering, sato, frangi, hessian]):
         kwargs['black_ridges'] = black_ridges
         result = func(image, **kwargs)
-        if func in (meijering):
+        if func is meijering:
             # Crop by 4 pixels for rendering purpose.
             result = result[4:-4, 4:-4]
         axes[i, j].imshow(result, cmap=cmap, aspect='auto')

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -5,9 +5,9 @@ from scipy import ndimage as ndi
 from scipy import stats
 
 from ..util import img_as_float
-from ..feature import peak_local_max
-from ..feature.util import _prepare_grayscale_input_2D
-from ..feature.corner_cy import _corner_fast
+from .peak import peak_local_max
+from .util import _prepare_grayscale_input_2D
+from .corner_cy import _corner_fast
 from ._hessian_det_appx import _hessian_matrix_det
 from ..transform import integral_image
 from .._shared.utils import safe_as_int

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -428,6 +428,10 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
                                                         sorting='abs',
                                                         mode='reflect')
 
+        # Compute sensitivity to deviation from a plate-like
+        # structure see equations (11) and (15) in reference [1]_
+        r_a = np.inf if ndim == 2 else _divide_nonzero(*lambdas) ** 2
+
         # Compute sensitivity to deviation from a blob-like structure,
         # see equations (10) and (15) in reference [1]_,
         # np.abs(lambda2) in 2D, np.sqrt(np.abs(lambda2 * lambda3)) in 3D
@@ -440,13 +444,9 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
 
         # Compute output image for given (sigma) scale and store results in
         # (n+1)D matrices, see equations (13) and (15) in reference [1]_
-        filtered_array[i] = (np.exp(-r_b / beta_sq)
+        filtered_array[i] = ((1 - np.exp(-r_a / alpha_sq))
+                             * np.exp(-r_b / beta_sq)
                              * (1 - np.exp(-r_g / gamma_sq)))
-        if ndim == 3:
-            # Compute sensitivity to deviation from a plate-like
-            # structure see equations (11) and (15) in reference [1]_
-            r_a = _divide_nonzero(*lambdas) ** 2
-            filtered_array[i] *= (1 - np.exp(-r_a / alpha_sq))
 
         lambdas_array[i] = np.max(lambdas, axis=0)
 

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -117,7 +117,7 @@ def compute_hessian_eigenvalues(image, sigma, sorting='none',
 
     # Make nD hessian
     hessian_elements = hessian_matrix(image, sigma=sigma, order='rc',
-                                      mode=mode)
+                                      mode=mode, cval=cval)
 
     # Correct for scale
     hessian_elements = [(sigma ** 2) * e for e in hessian_elements]
@@ -312,9 +312,10 @@ def sato(image, sigmas=range(1, 10, 2), black_ridges=True):
     return np.max(filtered_array, axis=0)
 
 
-def frangi(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
-           beta1=None, beta2=None, alpha=0.5, beta=0.5, gamma=15,
-           black_ridges=True):
+def frangi(image, sigmas=range(1, 10, 2), scale_range=None,
+           scale_step=None, beta1=None, beta2=None, alpha=0.5,
+           beta=0.5, gamma=15, black_ridges=True, mode='reflect',
+           cval=0):
     """
     Filter an image with the Frangi vesselness filter.
 
@@ -349,6 +350,11 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
     black_ridges : boolean, optional
         When True (the default), the filter detects black ridges; when
         False, it detects white ridges.
+    mode : {'constant', 'reflect', 'wrap', 'nearest', 'mirror'}, optional
+        How to handle values outside the image borders.
+    cval : float, optional
+        Used in conjunction with mode 'constant', the value outside
+        the image boundaries.
 
     Returns
     -------
@@ -426,7 +432,7 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
         # Calculate (abs sorted) eigenvalues
         lambda1, *lambdas = compute_hessian_eigenvalues(image, sigma,
                                                         sorting='abs',
-                                                        mode='reflect')
+                                                        mode=mode, cval=cval)
 
         # Compute sensitivity to deviation from a plate-like
         # structure see equations (11) and (15) in reference [1]_

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from ..util import img_as_float, invert
 from .._shared.utils import check_nD
-from ..feature import hessian_matrix, hessian_matrix_eigvals
+from ..feature.corner import hessian_matrix, hessian_matrix_eigvals
 
 
 def _divide_nonzero(array1, array2, cval=1e-10):

--- a/skimage/filters/tests/test_ridges.py
+++ b/skimage/filters/tests/test_ridges.py
@@ -208,7 +208,7 @@ def test_border_management():
                             out[:, :4].T, out[:, -4:].T]).mean()
 
     assert abs(full_std - inside_std) < 1e-7
-    assert abs(full_std -  border_std) < 1e-7
+    assert abs(full_std - border_std) < 1e-7
     assert abs(inside_std - border_std) < 1e-7
     assert abs(full_mean - inside_mean) < 1e-7
     assert abs(full_mean - border_mean) < 1e-7

--- a/skimage/filters/tests/test_ridges.py
+++ b/skimage/filters/tests/test_ridges.py
@@ -207,12 +207,12 @@ def test_border_management():
     border_mean = np.stack([out[:4, :], out[-4:, :],
                             out[:, :4].T, out[:, -4:].T]).mean()
 
-    assert abs(full_std-inside_std) < 1e-7
-    assert abs(full_std- border_std) < 1e-7
-    assert abs(inside_std-border_std) < 1e-7
-    assert abs(full_mean-inside_mean) < 1e-7
-    assert abs(full_mean- border_mean) < 1e-7
-    assert abs(inside_mean-border_mean) < 1e-7
+    assert abs(full_std - inside_std) < 1e-7
+    assert abs(full_std -  border_std) < 1e-7
+    assert abs(inside_std - border_std) < 1e-7
+    assert abs(full_mean - inside_mean) < 1e-7
+    assert abs(full_mean - border_mean) < 1e-7
+    assert abs(inside_mean - border_mean) < 1e-7
 
 
 if __name__ == "__main__":

--- a/skimage/filters/tests/test_ridges.py
+++ b/skimage/filters/tests/test_ridges.py
@@ -2,8 +2,9 @@
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_less, assert_equal
 from skimage.filters import meijering, sato, frangi, hessian
-from skimage.data import camera
+from skimage.data import camera, retina
 from skimage.util import crop, invert
+from skimage.color import rgb2gray
 
 
 def test_2d_null_matrix():
@@ -191,6 +192,27 @@ def test_3d_cropped_camera_image():
 
     assert_allclose(hessian(a_black, black_ridges=True), ones, atol=1 - 1e-7)
     assert_allclose(hessian(a_white, black_ridges=False), ones, atol=1 - 1e-7)
+
+
+def test_border_management():
+    img = rgb2gray(retina()[300:500, 700:900])
+    out = frangi(img, sigmas=[1])
+
+    full_std = out.std()
+    full_mean = out.mean()
+    inside_std = out[4:-4, 4:-4].std()
+    inside_mean = out[4:-4, 4:-4].mean()
+    border_std = np.stack([out[:4, :], out[-4:, :],
+                           out[:, :4].T, out[:, -4:].T]).std()
+    border_mean = np.stack([out[:4, :], out[-4:, :],
+                            out[:, :4].T, out[:, -4:].T]).mean()
+
+    assert abs(full_std-inside_std) < 1e-7
+    assert abs(full_std- border_std) < 1e-7
+    assert abs(inside_std-border_std) < 1e-7
+    assert abs(full_mean-inside_mean) < 1e-7
+    assert abs(full_mean- border_mean) < 1e-7
+    assert abs(inside_mean-border_mean) < 1e-7
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Closes #4249.

This PR fixes this issue by adding adding border conditions to `compute_hessian_eigenvalues` and setting it to `'reflect'` in `frangi`. Here is the output of @wimthiels's example:

![frangi](https://user-images.githubusercontent.com/3438227/70340735-a6518780-1851-11ea-94f4-4f25beb33cdb.png)


<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
