### PR TITLE
WIP: Update Sobel, Scharr, and Prewitt filters to nD

### DIFF
--- a/benchmarks/benchmark_filters.py
+++ b/benchmarks/benchmark_filters.py
@@ -11,7 +11,7 @@ class FiltersSuite:
         self.image[:2000, :2000] += 1
         self.image[3000:, 3000] += 0.5
 
-        self.image3d = data.binary_blobs(length=128, n_dim=3).astype(float)
+        self.image3d = data.binary_blobs(length=256, n_dim=3).astype(float)
 
     def time_sobel(self):
         filters.sobel(self.image)

--- a/benchmarks/benchmark_filters.py
+++ b/benchmarks/benchmark_filters.py
@@ -11,9 +11,13 @@ class FiltersSuite:
         self.image[:2000, :2000] += 1
         self.image[3000:, 3000] += 0.5
 
+        self.image3d = data.binary_blobs(length=128, n_dim=3).astype(float)
+
     def time_sobel(self):
         filters.sobel(self.image)
 
+    def time_sobel_3d(self):
+        _ = filters.sobel(self.image3d)
 
 class MultiOtsu(object):
     """Benchmarks for MultiOtsu threshold."""

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -35,7 +35,8 @@ API Changes
   no longer set the boundary pixels to 0 when a mask is not supplied. This was
   changed because the boundary mode for `scipy.ndimage.convolve` is now
   ``'reflect'``, which allows meaningful values at the borders for these
-  filters. (#4347)
+  filters. To retain the old behavior, pass
+  ``mask=np.ones(image.shape, dtype=bool)`` (#4347)
 
 
 Bugfixes

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -11,11 +11,11 @@ For more information, examples, and documentation, please visit our website:
 
 https://scikit-image.org
 
-Starting from this release, scikit-image will follow the spirit of the recently
-introduced numpy deprecation policy -- NEP 29
+Starting from release 0.16, scikit-image follows the spirit of the recently
+introduced NumPy deprecation policy -- NEP 29
 (https://github.com/numpy/numpy/blob/master/doc/neps/nep-0029-deprecation_policy.rst). 
-Accordingly, scikit-image 0.16 drops the support for Python 3.5.
-This release of scikit-image officially supports Python 3.6 and 3.7.
+This release of scikit-image officially supports Python 3.6, 3.7, and
+3.8.
 
 New Features
 ------------

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -31,6 +31,11 @@ API Changes
   the range of the data or clips the output to the range [0, 1] or [-1, 1].
   For non-float inputs, rescaling and clipping still occurs as in prior
   releases (although with a bugfix related to the scaling of ``sigma``).
+- For 2D input, edge filters (Sobel, Scharr, Prewitt, Roberts, and Farid)
+  no longer set the boundary pixels to 0 when a mask is not supplied. This was
+  changed because the boundary mode for `scipy.ndimage.convolve` is now
+  ``'reflect'``, which allows meaningful values at the borders for these
+  filters. (#4347)
 
 
 Bugfixes

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -19,7 +19,6 @@ This release of scikit-image officially supports Python 3.6 and 3.7.
 
 New Features
 ------------
-- Added majority rank filter - ``filters.rank.majority``.
 
 
 Improvements
@@ -28,34 +27,6 @@ Improvements
 
 API Changes
 -----------
-- Deprecated subpackage ``skimage.novice`` has been removed.
-- Default value of ``multichannel`` parameters has been set to False in
-  ``skimage.transform.rescale``, ``skimage.transform.pyramid_reduce``,
-  ``skimage.transform.pyramid_laplacian``,
-  ``skimage.transform.pyramid_gaussian``, and
-  ``skimage.transform.pyramid_expand``. No guessing is performed for 3D arrays
-  anymore, so, please, make sure that the parameter is fixed to a proper value.
-- Deprecated argument ``visualise`` has been removed from
-  ``skimage.feature.hog``. Use ``visualize`` instead.¨
-- ``skimage.transform.seam_carve`` has been completely removed from the
-  library due to licensing restrictions.
-- Parameter ``as_grey`` has been removed from ``skimage.data.load`` and
-  ``skimage.io.imread``. Use ``as_gray`` instead.
-- Parameter ``min_size`` has been removed from
-  ``skimage.morphology.remove_small_holes``. Use ``area_threshold`` instead.
-- Deprecated ``correct_mesh_orientation`` in ``skimage.measure`` has been
-  removed.
-- ``skimage.measure._regionprops`` has been completely switched to using
-  row-column coordinates. Old x-y interface is not longer available.
-- Default value of ``behavior`` parameter has been set to ``ndimage`` in
-  ``skimage.filters.median``.
-- Parameter ``flatten`` in `skimage.io.imread` has been removed in
-  favor of ``as_gray``.
-- Parameters ``Hxx, Hxy, Hyy`` have been removed from
-  ``skimage.feature.corner.hessian_matrix_eigvals`` in favor of ``H_elems``.
-- Default value of ``order`` parameter has been set to ``rc`` in
-  ``skimage.feature.hessian_matrix``.
-- ``skimage.util.img_as_*`` functions no longer raise precision and/or loss warnings.
 - When used with floating point inputs, ``denoise_wavelet`` no longer rescales
   the range of the data or clips the output to the range [0, 1] or [-1, 1].
   For non-float inputs, rescaling and clipping still occurs as in prior
@@ -72,8 +43,6 @@ Bugfixes
 
 Deprecations
 ------------
-- Parameter ``neighbors`` in ``skimage.measure.convex_hull_object`` has been
-  deprecated in favor of ``connectivity`` and will be removed in version 0.18.0.
 - Parameter ``inplace`` in skimage.morphology.flood_fill has been deprecated
   in favor of ``in_place`` and will be removed in version scikit-image 0.19.0.
 

--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -207,8 +207,7 @@ def sobel(image, mask=None, *, axis=None, mode='reflect', cval=0.0):
     image = img_as_float(image)
     output = _generic_edge_filter(image, smooth_weights=SOBEL_SMOOTH,
                                   axis=axis, mode=mode, cval=cval)
-    if image.ndim == 2 and mask is not None:
-        output = _mask_filter_result(output, mask)
+    output = _mask_filter_result(output, mask)
     return output
 
 
@@ -329,8 +328,7 @@ def scharr(image, mask=None, *, axis=None, mode='reflect', cval=0.0):
     image = img_as_float(image)
     output = _generic_edge_filter(image, smooth_weights=SCHARR_SMOOTH,
                                   axis=axis, mode=mode, cval=cval)
-    if image.ndim == 2 and mask is not None:
-        output = _mask_filter_result(output, mask)
+    output = _mask_filter_result(output, mask)
     return output
 
 
@@ -457,8 +455,7 @@ def prewitt(image, mask=None, *, axis=None, mode='reflect', cval=0.0):
     image = img_as_float(image)
     output = _generic_edge_filter(image, smooth_weights=PREWITT_SMOOTH,
                                   axis=axis, mode=mode, cval=cval)
-    if image.ndim == 2 or mask is not None:
-        output = _mask_filter_result(output, mask)
+    output = _mask_filter_result(output, mask)
     return output
 
 

--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -145,9 +145,10 @@ def _generic_edge_filter(image, *, smooth_weights, edge_weights=[1, 0, -1],
         for smooth_dim in smooth_axes:
             kernel = kernel * np.reshape(smooth_weights,
                                          kernel_shape(ndim, smooth_dim))
-        output += ndi.convolve(image, kernel, mode='reflect')
+        ax_output = ndi.convolve(image, kernel, mode='reflect')
         if mag:
-            output *= output
+            ax_output *= ax_output
+        output += ax_output
 
     if mag:
         output = np.sqrt(output) / np.sqrt(ndim)

--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -57,14 +57,7 @@ def _mask_filter_result(result, mask):
     Input masks are eroded so that mask areas in the original image don't
     affect values in the result.
     """
-    if mask is None and result.ndim > 2:
-        pass
-    elif mask is None:
-        result[0, :] = 0
-        result[-1, :] = 0
-        result[:, 0] = 0
-        result[:, -1] = 0
-    else:
+    if mask is not None:
         erosion_selem = ndi.generate_binary_structure(mask.ndim, mask.ndim)
         mask = binary_erosion(mask, erosion_selem, border_value=0)
         result *= mask

--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -12,27 +12,29 @@ Original author: Lee Kamentsky
 import numpy as np
 from .. import img_as_float
 from .._shared.utils import check_nD
-from scipy.ndimage import convolve, binary_erosion, generate_binary_structure
+from scipy import ndimage as ndi
+from scipy.ndimage import convolve, binary_erosion
 
 from ..restoration.uft import laplacian
 
-EROSION_SELEM = generate_binary_structure(2, 2)
-
-HSOBEL_WEIGHTS = np.array([[1, 2, 1],
-                           [0, 0, 0],
-                           [-1, -2, -1]]) / 4.0
+# n-dimensional filter weights
+SOBEL_EDGE = np.array([1, 0, -1])
+SOBEL_SMOOTH = np.array([1, 2, 1]) / 4
+HSOBEL_WEIGHTS = SOBEL_EDGE.reshape((3, 1)) * SOBEL_SMOOTH.reshape((1, 3))
 VSOBEL_WEIGHTS = HSOBEL_WEIGHTS.T
 
-HSCHARR_WEIGHTS = np.array([[3, 10, 3],
-                            [0, 0, 0],
-                            [-3, -10, -3]]) / 16.0
+SCHARR_EDGE = np.array([1, 0, -1])
+SCHARR_SMOOTH = np.array([3, 10, 3]) / 16
+HSCHARR_WEIGHTS = SCHARR_EDGE.reshape((3, 1)) * SCHARR_SMOOTH.reshape((1, 3))
 VSCHARR_WEIGHTS = HSCHARR_WEIGHTS.T
 
-HPREWITT_WEIGHTS = np.array([[1, 1, 1],
-                             [0, 0, 0],
-                             [-1, -1, -1]]) / 3.0
+PREWITT_EDGE = np.array([1, 0, -1])
+PREWITT_SMOOTH = np.full((3,), 1/3)
+HPREWITT_WEIGHTS = (PREWITT_EDGE.reshape((3, 1))
+                    * PREWITT_SMOOTH.reshape((1, 3)))
 VPREWITT_WEIGHTS = HPREWITT_WEIGHTS.T
 
+# 2D-only filter weights
 ROBERTS_PD_WEIGHTS = np.array([[1, 0],
                                [0, -1]], dtype=np.double)
 ROBERTS_ND_WEIGHTS = np.array([[0, 1],
@@ -55,65 +57,165 @@ def _mask_filter_result(result, mask):
     Input masks are eroded so that mask areas in the original image don't
     affect values in the result.
     """
-    if mask is None:
+    if mask is None and result.ndim > 2:
+        pass
+    elif mask is None:
         result[0, :] = 0
         result[-1, :] = 0
         result[:, 0] = 0
         result[:, -1] = 0
-        return result
     else:
-        mask = binary_erosion(mask, EROSION_SELEM, border_value=0)
-        return result * mask
+        erosion_selem = ndi.generate_binary_structure(mask.ndim, mask.ndim)
+        mask = binary_erosion(mask, erosion_selem, border_value=0)
+        result *= mask
+    return result
 
 
-def sobel(image, mask=None):
-    """Find the edge magnitude using the Sobel transform.
+def kernel_shape(ndim, dim):
+    """Return list of `ndim` 1s except at position `dim`, where value is -1.
 
     Parameters
     ----------
-    image : 2-D array
-        Image to process.
-    mask : 2-D array, optional
-        An optional mask to limit the application to a certain area.
-        Note that pixels surrounding masked regions are also masked to
-        prevent masked regions from affecting the result.
+    ndim : int
+        The number of dimensions of the kernel shape.
+    dim : int
+        The axis of the kernel to expand to shape -1.
 
     Returns
     -------
-    output : 2-D array
+    shape : list of int
+        The requested shape.
+
+    Examples
+    --------
+    >>> kernel_shape(2, 0)
+    [-1, 1]
+    >>> kernel_shape(3, 1)
+    [1, -1, 1]
+    >>> kernel_shape(4, -1)
+    [1, 1, 1, -1]
+    """
+    shape = [1, ] * ndim
+    shape[dim] = -1
+    return shape
+
+
+def _generic_edge_filter(image, *, smooth_weights, edge_weights=[1, 0, -1],
+                         axis=None, mode='reflect', cval=0.0, mask=None):
+    """Apply a generic, n-dimensional edge filter.
+
+    The filter is computed by applying the edge weights along one dimension
+    and the smoothing weights along all other dimensions. If no axis is given,
+    or a tuple of axes is given the filter is computed along all axes in turn,
+    and the magnitude is computed as the square root of the average square
+    magnitude of all the axes.
+
+    Parameters
+    ----------
+    image : array
+        The input image.
+    smooth_weights : array of float
+        The smoothing weights for the filter. These are applied to dimensions
+        orthogonal to the edge axis.
+    edge_weights : 1D array of float, optional
+        The weights to compute the edge along the chosen axes.
+    axis : int or sequence of int, optional
+        Compute the edge filter along this axis. If not provided, the edge
+        magnitude is computed. This is defined as::
+
+            edge_mag = np.sqrt(sum([_generic_edge_filter(image, ..., axis=i)**2
+                                    for i in range(image.ndim)]) / image.ndim)
+
+        The magnitude is also computed if axis is a sequence.
+    mode : str or sequence of str, optional
+        The boundary mode for the convolution. See `scipy.ndimage.convolve`
+        for a description of the modes. This can be either a single boundary
+        mode or one boundary mode per axis.
+    cval : float, optional
+        When `mode` is ``'constant'``, this is the constant used in values
+        outside the boundary of the image data.
+    """
+    ndim = image.ndim
+    if axis is None:
+        axes = list(range(ndim))
+    elif np.isscalar(axis):
+        axes = [axis]
+    else:
+        axes = axis
+    mag = (len(axes) > 1)
+
+    output = np.zeros(image.shape, dtype=float)
+
+    for edge_dim in axes:
+        kernel = np.reshape(edge_weights, kernel_shape(ndim, edge_dim))
+        smooth_axes = list(set(range(ndim)) - {edge_dim})
+        for smooth_dim in smooth_axes:
+            kernel = kernel * np.reshape(smooth_weights,
+                                         kernel_shape(ndim, smooth_dim))
+        output += ndi.convolve(image, kernel, mode='reflect')
+        if mag:
+            output *= output
+
+    if mag:
+        output = np.sqrt(output) / np.sqrt(ndim)
+    return output
+
+
+def sobel(image, mask=None, *, axis=None, mode='reflect', cval=0.0):
+    """Find edges in an image using the Sobel filter.
+
+    Parameters
+    ----------
+    image : array
+        The input image.
+    mask : array of bool, optional
+        Clip the output image to this mask. (Values where mask=0 will be set
+        to 0.)
+    axis : int or sequence of int, optional
+        Compute the edge filter along this axis. If not provided, the edge
+        magnitude is computed. This is defined as::
+
+            sobel_mag = np.sqrt(sum([sobel(image, axis=i)**2
+                                     for i in range(image.ndim)]) / image.ndim)
+
+        The magnitude is also computed if axis is a sequence.
+    mode : str or sequence of str, optional
+        The boundary mode for the convolution. See `scipy.ndimage.convolve`
+        for a description of the modes. This can be either a single boundary
+        mode or one boundary mode per axis.
+    cval : float, optional
+        When `mode` is ``'constant'``, this is the constant used in values
+        outside the boundary of the image data.
+
+    Returns
+    -------
+    output : array of float
         The Sobel edge map.
 
     See also
     --------
-    scharr, prewitt, roberts, feature.canny
+    scharr, prewitt, canny
 
-    Notes
-    -----
-    Take the square root of the sum of the squares of the horizontal and
-    vertical Sobels to get a magnitude that's somewhat insensitive to
-    direction.
+    References
+    ----------
+    .. [1] D. Kroon, 2009, Short Paper University Twente, Numerical
+           Optimization of Kernel Based Image Derivatives.
 
-    The 3x3 convolution kernel used in the horizontal and vertical Sobels is
-    an approximation of the gradient of the image (with some slight blurring
-    since 9 pixels are used to compute the gradient at a given pixel). As an
-    approximation of the gradient, the Sobel operator is not completely
-    rotation-invariant. The Scharr operator should be used for a better
-    rotation invariance.
-
-    Note that ``scipy.ndimage.sobel`` returns a directional Sobel which
-    has to be further processed to perform edge detection.
+    .. [2] https://en.wikipedia.org/wiki/Sobel_operator
 
     Examples
     --------
     >>> from skimage import data
-    >>> camera = data.camera()
     >>> from skimage import filters
+    >>> camera = data.camera()
     >>> edges = filters.sobel(camera)
     """
-    check_nD(image, 2)
-    out = np.sqrt(sobel_h(image, mask) ** 2 + sobel_v(image, mask) ** 2)
-    out /= np.sqrt(2)
-    return out
+    image = img_as_float(image)
+    output = _generic_edge_filter(image, smooth_weights=SOBEL_SMOOTH,
+                                  axis=axis, mode=mode, cval=cval)
+    if image.ndim == 2 and mask is not None:
+        output = _mask_filter_result(output, mask)
+    return output
 
 
 def sobel_h(image, mask=None):
@@ -143,9 +245,7 @@ def sobel_h(image, mask=None):
 
     """
     check_nD(image, 2)
-    image = img_as_float(image)
-    result = convolve(image, HSOBEL_WEIGHTS)
-    return _mask_filter_result(result, mask)
+    return sobel(image, mask=mask, axis=0)
 
 
 def sobel_v(image, mask=None):
@@ -175,26 +275,38 @@ def sobel_v(image, mask=None):
 
     """
     check_nD(image, 2)
-    image = img_as_float(image)
-    result = convolve(image, VSOBEL_WEIGHTS)
-    return _mask_filter_result(result, mask)
+    return sobel(image, mask=mask, axis=1)
 
 
-def scharr(image, mask=None):
+def scharr(image, mask=None, *, axis=None, mode='reflect', cval=0.0):
     """Find the edge magnitude using the Scharr transform.
 
     Parameters
     ----------
-    image : 2-D array
-        Image to process.
-    mask : 2-D array, optional
-        An optional mask to limit the application to a certain area.
-        Note that pixels surrounding masked regions are also masked to
-        prevent masked regions from affecting the result.
+    image : array
+        The input image.
+    mask : array of bool, optional
+        Clip the output image to this mask. (Values where mask=0 will be set
+        to 0.)
+    axis : int or sequence of int, optional
+        Compute the edge filter along this axis. If not provided, the edge
+        magnitude is computed. This is defined as::
+
+            sch_mag = np.sqrt(sum([scharr(image, axis=i)**2
+                                   for i in range(image.ndim)]) / image.ndim)
+
+        The magnitude is also computed if axis is a sequence.
+    mode : str or sequence of str, optional
+        The boundary mode for the convolution. See `scipy.ndimage.convolve`
+        for a description of the modes. This can be either a single boundary
+        mode or one boundary mode per axis.
+    cval : float, optional
+        When `mode` is ``'constant'``, this is the constant used in values
+        outside the boundary of the image data.
 
     Returns
     -------
-    output : 2-D array
+    output : array of float
         The Scharr edge map.
 
     See also
@@ -203,9 +315,7 @@ def scharr(image, mask=None):
 
     Notes
     -----
-    Take the square root of the sum of the squares of the horizontal and
-    vertical Scharrs to get a magnitude that is somewhat insensitive to
-    direction. The Scharr operator has a better rotation invariance than
+    The Scharr operator has a better rotation invariance than
     other edge filters such as the Sobel or the Prewitt operators.
 
     References
@@ -218,13 +328,16 @@ def scharr(image, mask=None):
     Examples
     --------
     >>> from skimage import data
-    >>> camera = data.camera()
     >>> from skimage import filters
+    >>> camera = data.camera()
     >>> edges = filters.scharr(camera)
     """
-    out = np.sqrt(scharr_h(image, mask) ** 2 + scharr_v(image, mask) ** 2)
-    out /= np.sqrt(2)
-    return out
+    image = img_as_float(image)
+    output = _generic_edge_filter(image, smooth_weights=SCHARR_SMOOTH,
+                                  axis=axis, mode=mode, cval=cval)
+    if image.ndim == 2 and mask is not None:
+        output = _mask_filter_result(output, mask)
+    return output
 
 
 def scharr_h(image, mask=None):
@@ -259,9 +372,7 @@ def scharr_h(image, mask=None):
 
     """
     check_nD(image, 2)
-    image = img_as_float(image)
-    result = convolve(image, HSCHARR_WEIGHTS)
-    return _mask_filter_result(result, mask)
+    return scharr(image, mask=mask, axis=0)
 
 
 def scharr_v(image, mask=None):
@@ -293,29 +404,40 @@ def scharr_v(image, mask=None):
     ----------
     .. [1] D. Kroon, 2009, Short Paper University Twente, Numerical
            Optimization of Kernel Based Image Derivatives.
-
     """
     check_nD(image, 2)
-    image = img_as_float(image)
-    result = convolve(image, VSCHARR_WEIGHTS)
-    return _mask_filter_result(result, mask)
+    return scharr(image, mask=mask, axis=1)
 
 
-def prewitt(image, mask=None):
+def prewitt(image, mask=None, *, axis=None, mode='reflect', cval=0.0):
     """Find the edge magnitude using the Prewitt transform.
 
     Parameters
     ----------
-    image : 2-D array
-        Image to process.
-    mask : 2-D array, optional
-        An optional mask to limit the application to a certain area.
-        Note that pixels surrounding masked regions are also masked to
-        prevent masked regions from affecting the result.
+    image : array
+        The input image.
+    mask : array of bool, optional
+        Clip the output image to this mask. (Values where mask=0 will be set
+        to 0.)
+    axis : int or sequence of int, optional
+        Compute the edge filter along this axis. If not provided, the edge
+        magnitude is computed. This is defined as::
+
+            prw_mag = np.sqrt(sum([prewitt(image, axis=i)**2
+                                   for i in range(image.ndim)]) / image.ndim)
+
+        The magnitude is also computed if axis is a sequence.
+    mode : str or sequence of str, optional
+        The boundary mode for the convolution. See `scipy.ndimage.convolve`
+        for a description of the modes. This can be either a single boundary
+        mode or one boundary mode per axis.
+    cval : float, optional
+        When `mode` is ``'constant'``, this is the constant used in values
+        outside the boundary of the image data.
 
     Returns
     -------
-    output : 2-D array
+    output : array of float
         The Prewitt edge map.
 
     See also
@@ -324,25 +446,26 @@ def prewitt(image, mask=None):
 
     Notes
     -----
-    Return the square root of the sum of squares of the horizontal
-    and vertical Prewitt transforms. The edge magnitude depends slightly
-    on edge directions, since the approximation of the gradient operator by
-    the Prewitt operator is not completely rotation invariant. For a better
-    rotation invariance, the Scharr operator should be used. The Sobel operator
-    has a better rotation invariance than the Prewitt operator, but a worse
-    rotation invariance than the Scharr operator.
+    The edge magnitude depends slightly on edge directions, since the
+    approximation of the gradient operator by the Prewitt operator is not
+    completely rotation invariant. For a better rotation invariance, the Scharr
+    operator should be used. The Sobel operator has a better rotation
+    invariance than the Prewitt operator, but a worse rotation invariance than
+    the Scharr operator.
 
     Examples
     --------
     >>> from skimage import data
-    >>> camera = data.camera()
     >>> from skimage import filters
+    >>> camera = data.camera()
     >>> edges = filters.prewitt(camera)
     """
-    check_nD(image, 2)
-    out = np.sqrt(prewitt_h(image, mask) ** 2 + prewitt_v(image, mask) ** 2)
-    out /= np.sqrt(2)
-    return out
+    image = img_as_float(image)
+    output = _generic_edge_filter(image, smooth_weights=PREWITT_SMOOTH,
+                                  axis=axis, mode=mode, cval=cval)
+    if image.ndim == 2 or mask is not None:
+        output = _mask_filter_result(output, mask)
+    return output
 
 
 def prewitt_h(image, mask=None):
@@ -372,9 +495,7 @@ def prewitt_h(image, mask=None):
 
     """
     check_nD(image, 2)
-    image = img_as_float(image)
-    result = convolve(image, HPREWITT_WEIGHTS)
-    return _mask_filter_result(result, mask)
+    return prewitt(image, mask=mask, axis=0)
 
 
 def prewitt_v(image, mask=None):
@@ -404,9 +525,7 @@ def prewitt_v(image, mask=None):
 
     """
     check_nD(image, 2)
-    image = img_as_float(image)
-    result = convolve(image, VPREWITT_WEIGHTS)
-    return _mask_filter_result(result, mask)
+    return prewitt(image, mask=mask, axis=1)
 
 
 def roberts(image, mask=None):

--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -135,7 +135,7 @@ def _generic_edge_filter(image, *, smooth_weights, edge_weights=[1, 0, -1],
         axes = [axis]
     else:
         axes = axis
-    mag = (len(axes) > 1)
+    return_magnitude = (len(axes) > 1)
 
     output = np.zeros(image.shape, dtype=float)
 
@@ -146,11 +146,11 @@ def _generic_edge_filter(image, *, smooth_weights, edge_weights=[1, 0, -1],
             kernel = kernel * np.reshape(smooth_weights,
                                          kernel_shape(ndim, smooth_dim))
         ax_output = ndi.convolve(image, kernel, mode='reflect')
-        if mag:
+        if return_magnitude:
             ax_output *= ax_output
         output += ax_output
 
-    if mag:
+    if return_magnitude:
         output = np.sqrt(output) / np.sqrt(ndim)
     return output
 

--- a/skimage/filters/tests/test_edges.py
+++ b/skimage/filters/tests/test_edges.py
@@ -510,7 +510,7 @@ MAX_SOBEL_ND = np.array([
      [1, 1, 0]]
 ]).astype(float)
 
-# maximum Scharr 3D edge in magnitude This illustrates the better rotation
+# maximum Scharr 3D edge in magnitude. This illustrates the better rotation
 # invariance of the Scharr filter!
 MAX_SCHARR_ND = np.array([
     [[0, 0, 0],

--- a/skimage/filters/tests/test_edges.py
+++ b/skimage/filters/tests/test_edges.py
@@ -1,4 +1,5 @@
 import numpy as np
+from skimage import data
 from skimage import filters
 from skimage.filters.edges import _mask_filter_result
 
@@ -495,6 +496,42 @@ def test_vertical_mask_line(grad_func):
 
     result = grad_func(hgrad, mask)
     assert_allclose(result, expected)
+
+
+MAX_EDGE_0 = np.array([
+    [[0, 0, 0],
+     [0, 0, 0],
+     [0, 0, 0]],
+    [[0, 0, 0],
+     [0, 0, 0],
+     [0, 0, 0]],
+    [[1, 1, 1],
+     [1, 1, 1],
+     [1, 1, 1]],
+])
+
+MAX_EDGE_ND = np.array([
+    [[0, 0, 0],
+     [0, 0, 0],
+     [0, 0, 0]],
+    [[0, 0, 0],
+     [0, 1, 1],
+     [1, 1, 1]],
+    [[1, 1, 1],
+     [1, 1, 1],
+     [1, 1, 1]]
+]).astype(float)
+
+
+@testing.parametrize(
+    'func', (filters.sobel, filters.scharr, filters.prewitt)
+)
+def test_3d_edge_filters(func):
+    blobs = data.binary_blobs(length=128, n_dim=3)
+    edges = func(blobs)
+    edges0 = func(blobs, axis=0)
+    testing.assert_allclose(np.max(edges), func(MAX_EDGE_ND)[1, 1, 1])
+    testing.assert_allclose(np.max(edges0), 1.0)
 
 
 def test_range():

--- a/skimage/filters/tests/test_edges.py
+++ b/skimage/filters/tests/test_edges.py
@@ -493,7 +493,7 @@ MAX_SOBEL_0 = np.array([
     [[1, 1, 1],
      [1, 1, 1],
      [1, 1, 1]],
-])
+]).astype(float)
 
 # maximum Sobel 3D edge in magnitude
 MAX_SOBEL_ND = np.array([
@@ -525,7 +525,6 @@ MAX_SCHARR_ND = np.array([
 ]).astype(float)
 
 
-
 @testing.parametrize(
     ('func', 'max_edge'),
     [(filters.prewitt, MAX_SOBEL_ND),
@@ -535,10 +534,16 @@ MAX_SCHARR_ND = np.array([
 def test_3d_edge_filters(func, max_edge):
     blobs = data.binary_blobs(length=128, n_dim=3)
     edges = func(blobs)
-    edges0 = func(blobs, axis=0)
     testing.assert_allclose(np.max(edges), func(max_edge)[1, 1, 1])
-    testing.assert_allclose(np.max(edges0), 1.0)
 
+
+@testing.parametrize(
+    'func', (filters.prewitt, filters.sobel, filters.scharr)
+)
+def test_3d_edge_filters_single_axis(func):
+    blobs = data.binary_blobs(length=128, n_dim=3)
+    edges0 = func(blobs, axis=0)
+    testing.assert_allclose(np.max(edges0), func(MAX_SOBEL_0, axis=0)[1, 1, 1])
 
 
 def test_range():

--- a/skimage/filters/tests/test_edges.py
+++ b/skimage/filters/tests/test_edges.py
@@ -482,6 +482,11 @@ def test_vertical_mask_line(grad_func):
     assert_allclose(result, expected)
 
 
+# The below three constant 3x3x3 cubes were empirically found to maximise the
+# output of each of their respective filters. We use them to test that the
+# output of the filter on the blobs image matches expectation in terms of
+# scale.
+
 # maximum Sobel 3D edge on axis 0
 MAX_SOBEL_0 = np.array([
     [[0, 0, 0],

--- a/skimage/filters/tests/test_edges.py
+++ b/skimage/filters/tests/test_edges.py
@@ -482,7 +482,8 @@ def test_vertical_mask_line(grad_func):
     assert_allclose(result, expected)
 
 
-MAX_EDGE_0 = np.array([
+# maximum Sobel 3D edge on axis 0
+MAX_SOBEL_0 = np.array([
     [[0, 0, 0],
      [0, 0, 0],
      [0, 0, 0]],
@@ -494,28 +495,50 @@ MAX_EDGE_0 = np.array([
      [1, 1, 1]],
 ])
 
-MAX_EDGE_ND = np.array([
+# maximum Sobel 3D edge in magnitude
+MAX_SOBEL_ND = np.array([
+    [[1, 0, 0],
+     [1, 0, 0],
+     [1, 0, 0]],
+
+    [[1, 0, 0],
+     [1, 1, 0],
+     [1, 1, 0]],
+
+    [[1, 1, 0],
+     [1, 1, 0],
+     [1, 1, 0]]
+]).astype(float)
+
+# maximum Scharr 3D edge in magnitude This illustrates the better rotation
+# invariance of the Scharr filter!
+MAX_SCHARR_ND = np.array([
     [[0, 0, 0],
-     [0, 0, 0],
-     [0, 0, 0]],
-    [[0, 0, 0],
+     [0, 0, 1],
+     [0, 1, 1]],
+    [[0, 0, 1],
      [0, 1, 1],
-     [1, 1, 1]],
-    [[1, 1, 1],
-     [1, 1, 1],
+     [0, 1, 1]],
+    [[0, 0, 1],
+     [0, 1, 1],
      [1, 1, 1]]
 ]).astype(float)
 
 
+
 @testing.parametrize(
-    'func', (filters.sobel, filters.scharr, filters.prewitt)
+    ('func', 'max_edge'),
+    [(filters.prewitt, MAX_SOBEL_ND),
+     (filters.sobel, MAX_SOBEL_ND),
+     (filters.scharr, MAX_SCHARR_ND)]
 )
-def test_3d_edge_filters(func):
+def test_3d_edge_filters(func, max_edge):
     blobs = data.binary_blobs(length=128, n_dim=3)
     edges = func(blobs)
     edges0 = func(blobs, axis=0)
-    testing.assert_allclose(np.max(edges), func(MAX_EDGE_ND)[1, 1, 1])
+    testing.assert_allclose(np.max(edges), func(max_edge)[1, 1, 1])
     testing.assert_allclose(np.max(edges0), 1.0)
+
 
 
 def test_range():

--- a/skimage/filters/tests/test_edges.py
+++ b/skimage/filters/tests/test_edges.py
@@ -546,18 +546,18 @@ def test_3d_edge_filters_single_axis(func):
     testing.assert_allclose(np.max(edges0), func(MAX_SOBEL_0, axis=0)[1, 1, 1])
 
 
-def test_range():
+@testing.parametrize(
+    'detector',
+    [filters.sobel, filters.scharr, filters.prewitt,
+     filters.roberts, filters.farid]
+)
+def test_range(detector):
     """Output of edge detection should be in [0, 1]"""
     image = np.random.random((100, 100))
-    for detector in (filters.sobel, filters.scharr,
-                     filters.prewitt, filters.roberts,
-                     filters.farid):
-        out = detector(image)
-        assert_(out.min() >= 0,
-                "Minimum of `{0}` is smaller than zero".format(
-                    detector.__name__)
-                )
-        assert_(out.max() <= 1,
-                "Maximum of `{0}` is larger than 1".format(
-                    detector.__name__)
-                )
+    out = detector(image)
+    assert_(
+        out.min() >= 0, f'Minimum of `{detector.__name__}` is smaller than 0.'
+    )
+    assert_(
+        out.max() <= 1, f'Maximum of `{detector.__name__}` is larger than 1.'
+    )

--- a/skimage/filters/tests/test_edges.py
+++ b/skimage/filters/tests/test_edges.py
@@ -19,7 +19,7 @@ def test_roberts_diagonal1():
     image = np.tri(10, 10, 0)
     expected = ~(np.tri(10, 10, -1).astype(bool) |
                  np.tri(10, 10, -2).astype(bool).transpose())
-    expected = _mask_filter_result(expected, None)
+    expected[-1, -1] = 0  # due to 'reflect' & image shape, last pixel not edge
     result = filters.roberts(image).astype(bool)
     assert_array_almost_equal(result, expected)
 
@@ -53,7 +53,6 @@ def test_sobel_horizontal():
     image = (i >= 0).astype(float)
     result = filters.sobel(image) * np.sqrt(2)
     # Check if result match transform direction
-    i[np.abs(j) == 5] = 10000
     assert_allclose(result[i == 0], 1)
     assert (np.all(result[np.abs(i) > 1] == 0))
 
@@ -63,7 +62,6 @@ def test_sobel_vertical():
     i, j = np.mgrid[-5:6, -5:6]
     image = (j >= 0).astype(float)
     result = filters.sobel(image) * np.sqrt(2)
-    j[np.abs(i) == 5] = 10000
     assert (np.all(result[j == 0] == 1))
     assert (np.all(result[np.abs(j) > 1] == 0))
 
@@ -87,7 +85,6 @@ def test_sobel_h_horizontal():
     image = (i >= 0).astype(float)
     result = filters.sobel_h(image)
     # Check if result match transform direction
-    i[np.abs(j) == 5] = 10000
     assert (np.all(result[i == 0] == 1))
     assert (np.all(result[np.abs(i) > 1] == 0))
 
@@ -119,7 +116,6 @@ def test_sobel_v_vertical():
     image = (j >= 0).astype(float)
     result = filters.sobel_v(image)
     # Check if result match transform direction
-    j[np.abs(i) == 5] = 10000
     assert (np.all(result[j == 0] == 1))
     assert (np.all(result[np.abs(j) > 1] == 0))
 
@@ -151,7 +147,6 @@ def test_scharr_horizontal():
     image = (i >= 0).astype(float)
     result = filters.scharr(image) * np.sqrt(2)
     # Check if result match transform direction
-    i[np.abs(j) == 5] = 10000
     assert_allclose(result[i == 0], 1)
     assert (np.all(result[np.abs(i) > 1] == 0))
 
@@ -161,7 +156,6 @@ def test_scharr_vertical():
     i, j = np.mgrid[-5:6, -5:6]
     image = (j >= 0).astype(float)
     result = filters.scharr(image) * np.sqrt(2)
-    j[np.abs(i) == 5] = 10000
     assert_allclose(result[j == 0], 1)
     assert (np.all(result[np.abs(j) > 1] == 0))
 
@@ -186,7 +180,6 @@ def test_scharr_h_horizontal():
     image = (i >= 0).astype(float)
     result = filters.scharr_h(image)
     # Check if result match transform direction
-    i[np.abs(j) == 5] = 10000
     assert (np.all(result[i == 0] == 1))
     assert (np.all(result[np.abs(i) > 1] == 0))
 
@@ -219,7 +212,6 @@ def test_scharr_v_vertical():
     image = (j >= 0).astype(float)
     result = filters.scharr_v(image)
     # Check if result match transform direction
-    j[np.abs(i) == 5] = 10000
     assert (np.all(result[j == 0] == 1))
     assert (np.all(result[np.abs(j) > 1] == 0))
 
@@ -252,7 +244,6 @@ def test_prewitt_horizontal():
     image = (i >= 0).astype(float)
     result = filters.prewitt(image) * np.sqrt(2)
     # Check if result match transform direction
-    i[np.abs(j) == 5] = 10000
     assert (np.all(result[i == 0] == 1))
     assert_allclose(result[np.abs(i) > 1], 0, atol=1e-10)
 
@@ -262,7 +253,6 @@ def test_prewitt_vertical():
     i, j = np.mgrid[-5:6, -5:6]
     image = (j >= 0).astype(float)
     result = filters.prewitt(image) * np.sqrt(2)
-    j[np.abs(i) == 5] = 10000
     assert_allclose(result[j == 0], 1)
     assert_allclose(result[np.abs(j) > 1], 0, atol=1e-10)
 
@@ -287,7 +277,6 @@ def test_prewitt_h_horizontal():
     image = (i >= 0).astype(float)
     result = filters.prewitt_h(image)
     # Check if result match transform direction
-    i[np.abs(j) == 5] = 10000
     assert (np.all(result[i == 0] == 1))
     assert_allclose(result[np.abs(i) > 1], 0, atol=1e-10)
 
@@ -320,7 +309,6 @@ def test_prewitt_v_vertical():
     image = (j >= 0).astype(float)
     result = filters.prewitt_v(image)
     # Check if result match transform direction
-    j[np.abs(i) == 5] = 10000
     assert (np.all(result[j == 0] == 1))
     assert_allclose(result[np.abs(j) > 1], 0, atol=1e-10)
 
@@ -381,7 +369,6 @@ def test_farid_horizontal():
     image = (i >= 0).astype(float)
     result = filters.farid(image) * np.sqrt(2)
     # Check if result match transform direction
-    i[np.abs(j) == 5] = 10000
     assert (np.all(result[i == 0] == result[i == 0][0]))
     assert_allclose(result[np.abs(i) > 2], 0, atol=1e-10)
 
@@ -391,7 +378,6 @@ def test_farid_vertical():
     i, j = np.mgrid[-5:6, -5:6]
     image = (j >= 0).astype(float)
     result = filters.farid(image) * np.sqrt(2)
-    j[np.abs(i) == 5] = 10000
     assert (np.all(result[j == 0] == result[j == 0][0]))
     assert_allclose(result[np.abs(j) > 2], 0, atol=1e-10)
 
@@ -416,7 +402,6 @@ def test_farid_h_horizontal():
     image = (i >= 0).astype(float)
     result = filters.farid_h(image)
     # Check if result match transform direction
-    i[np.abs(j) == 5] = 10000
     assert np.all(result[i == 0] == result[i == 0][0])
     assert_allclose(result[np.abs(i) > 2], 0, atol=1e-10)
 
@@ -449,7 +434,6 @@ def test_farid_v_vertical():
     image = (j >= 0).astype(float)
     result = filters.farid_v(image)
     # Check if result match transform direction
-    j[np.abs(i) == 5] = 10000
     assert (np.all(result[j == 0] == result[j == 0][0]))
     assert_allclose(result[np.abs(j) > 2], 0, atol=1e-10)
 

--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -134,11 +134,6 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
                     sobel(img[:, :, 2])]
         else:
             edge = [sobel(img)]
-        for i in range(3 if RGB else 1):
-            edge[i][0, :] = edge[i][1, :]
-            edge[i][-1, :] = edge[i][-2, :]
-            edge[i][:, 0] = edge[i][:, 1]
-            edge[i][:, -1] = edge[i][:, -2]
     else:
         edge = [0]
 


### PR DESCRIPTION
This change is backwards compatible with previous versions, while supporting n-dimensional images, an axis= keyword argument, and boundary modes.

Currently, some tests are failing because the existing implementation clears all the borders to 0. Personally I think that behaviour is incorrect and we should remove it as a bug, but it *is* an API change so I'm happy to hear dissenting opinions!

Incidentally, the tests are failing *despite* my attempt to maintain the old, buggy behaviour (see `_mask_filter_result`), but it's bedtime, so I'll revisit in the morning. ;)

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
