### PR TITLE
Fix equalize_adapthist border artifacts

### DIFF
--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -146,7 +146,7 @@ def _clahe(image, kernel_size, clip_limit, nbins=128):
 
             hist = lut[sub_img.ravel()]
             hist = np.bincount(hist)
-            hist = np.append(hist, np.zeros(nbins - hist.size, dtype=int))
+            hist = np.pad(hist, (0, nbins - hist.size))
             hist = clip_histogram(hist, clim)
             hist = map_histogram(hist, 0, NR_OF_GREY - 1, sub_img.size)
             map_array[r, c] = hist

--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -116,6 +116,8 @@ def _clahe(image, kernel_size, clip_limit, nbins=128):
     if clip_limit == 1.0:
         return image  # is OK, immediately returns original image.
 
+    clip_limit /= nbins
+
     row_step = int(image.shape[0] // np.ceil(image.shape[0] / kernel_size[0]))
     col_step = int(image.shape[1] // np.ceil(image.shape[1] / kernel_size[1]))
 
@@ -138,9 +140,7 @@ def _clahe(image, kernel_size, clip_limit, nbins=128):
             sub_img = image[i0:i1, j0:j1]
 
             if clip_limit > 0.0:  # Calculate actual cliplimit
-                clim = int(clip_limit * sub_img.size / nbins)
-                if clim < 1:
-                    clim = 1
+                clim = max(int(clip_limit * sub_img.size), 1)
             else:
                 clim = NR_OF_GREY  # Large value, do not clip (AHE)
 

--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -129,10 +129,13 @@ def _clahe(image, kernel_size, clip_limit, nbins=128):
     map_array = np.zeros((nr, nc, nbins), dtype=int)
 
     # Calculate greylevel mappings for each contextual region
+    i0 = 0
     for r in range(nr):
+        i1 = i0 + row_step
+        j0 = 0
         for c in range(nc):
-            sub_img = image[r * row_step: (r + 1) * row_step,
-                            c * col_step: (c + 1) * col_step]
+            j1 = j0 + col_step
+            sub_img = image[i0:i1, j0:j1]
 
             if clip_limit > 0.0:  # Calculate actual cliplimit
                 clim = int(clip_limit * sub_img.size / nbins)
@@ -147,9 +150,10 @@ def _clahe(image, kernel_size, clip_limit, nbins=128):
             hist = clip_histogram(hist, clim)
             hist = map_histogram(hist, 0, NR_OF_GREY - 1, sub_img.size)
             map_array[r, c] = hist
+            j0 = j1
+        i0 = i1
 
     # Interpolate greylevel mappings to get CLAHE image
-
     rstart = 0
     for r in range(nr + 1):
         cstart = 0

--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -146,7 +146,7 @@ def _clahe(image, kernel_size, clip_limit, nbins=128):
 
             hist = lut[sub_img.ravel()]
             hist = np.bincount(hist)
-            hist = np.pad(hist, (0, nbins - hist.size))
+            hist = np.pad(hist, (0, nbins - hist.size), mode='constant')
             hist = clip_histogram(hist, clim)
             hist = map_histogram(hist, 0, NR_OF_GREY - 1, sub_img.size)
             map_array[r, c] = hist

--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -165,7 +165,7 @@ def _clahe(image, kernel_size, clip_limit, nbins=128):
         for c in range(nc + 1):
             cL = max(0, c - 1)
             cR = min(nc - 1, c)
-            if c in [0, nc]:  # special case: left and right rows
+            if c in [0, nc]:  # special case: left and right columns
                 c_offset = col_step // 2
             else:  # default values
                 c_offset = col_step

--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -116,11 +116,11 @@ def _clahe(image, kernel_size, clip_limit, nbins=128):
     if clip_limit == 1.0:
         return image  # is OK, immediately returns original image.
 
-    nr = int(np.ceil(image.shape[0] / kernel_size[0]))
-    nc = int(np.ceil(image.shape[1] / kernel_size[1]))
+    row_step = int(image.shape[0] // np.ceil(image.shape[0] / kernel_size[0]))
+    col_step = int(image.shape[1] // np.ceil(image.shape[1] / kernel_size[1]))
 
-    row_step = int(np.floor(image.shape[0] / nr))
-    col_step = int(np.floor(image.shape[1] / nc))
+    nr = image.shape[0] // row_step
+    nc = image.shape[1] // col_step
 
     bin_size = 1 + NR_OF_GREY // nbins
     lut = np.arange(NR_OF_GREY)
@@ -149,43 +149,33 @@ def _clahe(image, kernel_size, clip_limit, nbins=128):
             map_array[r, c] = hist
 
     # Interpolate greylevel mappings to get CLAHE image
+
     rstart = 0
     for r in range(nr + 1):
         cstart = 0
-        if r == 0:  # special case: top row
-            r_offset = row_step / 2.0
-            rU = 0
-            rB = 0
-        elif r == nr:  # special case: bottom row
-            r_offset = row_step / 2.0
-            rU = nr - 1
-            rB = rU
+        rU = max(0, r - 1)
+        rB = min(nr - 1, r)
+        if r in [0, nr]:  # special case: top and bottom rows
+            r_offset = row_step // 2
         else:  # default values
             r_offset = row_step
-            rU = r - 1
-            rB = rB + 1
+
+        rslice = np.arange(rstart, rstart + r_offset)
 
         for c in range(nc + 1):
-            if c == 0:  # special case: left column
-                c_offset = col_step / 2.0
-                cL = 0
-                cR = 0
-            elif c == nc:  # special case: right column
-                c_offset = col_step / 2.0
-                cL = nc - 1
-                cR = cL
+            cL = max(0, c - 1)
+            cR = min(nc - 1, c)
+            if c in [0, nc]:  # special case: left and right rows
+                c_offset = col_step // 2
             else:  # default values
                 c_offset = col_step
-                cL = c - 1
-                cR = cL + 1
+
+            cslice = np.arange(cstart, cstart + c_offset)
 
             mapLU = map_array[rU, cL]
             mapRU = map_array[rU, cR]
             mapLB = map_array[rB, cL]
             mapRB = map_array[rB, cR]
-
-            cslice = np.arange(cstart, cstart + c_offset)
-            rslice = np.arange(rstart, rstart + r_offset)
 
             interpolate(image, cslice, rslice,
                         mapLU, mapRU, mapLB, mapRB, lut)

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -331,6 +331,17 @@ def test_adapthist_alpha():
     assert_almost_equal(norm_brightness_err(full_scale, adapted), 0.0248, 3)
 
 
+def test_adapthist_borders():
+    """Test border processing
+    """
+    img = np.random.rand(35, 35)
+    adapted = exposure.equalize_adapthist(img, kernel_size=3)
+    # Check last column is procesed
+    assert np.any(adapted[:, -1] != img[:, -1])
+    # Check last row is procesed
+    assert np.any(adapted[-1, :] != img[-1, :])
+
+
 def peak_snr(img1, img2):
     """Peak signal to noise ratio of two images
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -334,12 +334,13 @@ def test_adapthist_alpha():
 def test_adapthist_borders():
     """Test border processing
     """
-    img = np.random.rand(35, 35)
-    adapted = exposure.equalize_adapthist(img, kernel_size=3)
-    # Check last column is procesed
-    assert np.any(adapted[:, -1] != img[:, -1])
-    # Check last row is procesed
-    assert np.any(adapted[-1, :] != img[-1, :])
+    img = rgb2gray(util.img_as_float(data.astronaut()))
+    adapted = exposure.equalize_adapthist(img, 11)
+    width = 42
+    # Check last columns are procesed
+    assert norm_brightness_err(adapted[:, -width], img[:, -width]) > 1e-3
+    # Check last rows are procesed
+    assert norm_brightness_err(adapted[-width, :], img[-width, :]) > 1e-3
 
 
 def peak_snr(img1, img2):


### PR DESCRIPTION
## Description

Closes #4160.

The artifacts comes from round-off errors in `map_array` shape computation in `_clahe` function ([here](https://github.com/scikit-image/scikit-image/blob/master/skimage/exposure/_adapthist.py#L119)).

Here is the result using the example of @VasylVaskivskyi in #4160:

![adapt_hist_1](https://user-images.githubusercontent.com/3438227/70445011-199a0a00-1a9b-11ea-9c44-94e336c6bb55.png)

and prettier with `clip_lim=0.1`

![adapt_hist_2](https://user-images.githubusercontent.com/3438227/70445134-56fe9780-1a9b-11ea-968c-014c9f29d306.png)

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
