### PR TITLE
Make hough_circle_peaks respect min_xdistance, min_ydistance

### DIFF
--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -362,6 +362,10 @@ def hough_circle_peaks(hspaces, radii, min_xdistance=1, min_ydistance=1,
             cx.append(x)
             cy.append(y)
             r.append(ra)
+    accum = np.array(accum)
+    cx = np.array(cx)
+    cy = np.array(cy)
+    r = np.array(r)
 
     if total_num_peaks != np.inf:
         tnp = total_num_peaks

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -343,9 +343,25 @@ def hough_circle_peaks(hspaces, radii, min_xdistance=1, min_ydistance=1,
     else:
         s = np.argsort(accum)
 
+    # For circles with centers too close, only keep the one with
+    # the highest peak
+    accum_sorted, cx_sorted, cy_sorted, r_sorted = \
+        accum[s][::-1], cx[s][::-1], cy[s][::-1], r[s][::-1]
+    accum = []
+    cx = []
+    cy = []
+    r = []
+    for ac, x, y, ra in zip(accum_sorted, cx_sorted, cy_sorted, r_sorted):
+        close_in_x = [abs(i - x) <= min_xdistance for i in cx]
+        close_in_y = [abs(j - y) <= min_ydistance for j in cy]
+        if (True not in close_in_x) and (True not in close_in_y):
+            accum.append(ac)
+            cx.append(x)
+            cy.append(y)
+            r.append(ra)
+
     if total_num_peaks != np.inf:
         tnp = total_num_peaks
-        return (accum[s][::-1][:tnp], cx[s][::-1][:tnp], cy[s][::-1][:tnp],
-                r[s][::-1][:tnp])
+        return (accum[:tnp], cx[:tnp], cy[:tnp], r[:tnp])
 
-    return (accum[s][::-1], cx[s][::-1], cy[s][::-1], r[s][::-1])
+    return (accum, cx, cy, r)

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -379,6 +379,9 @@ def hough_circle_peaks(hspaces, radii, min_xdistance=1, min_ydistance=1,
 def label_distant_points(xs, ys, min_xdistance, min_ydistance, max_points):
     """Keep points that are separated by certain distance in each dimension.
 
+    The first point is always accpeted and all subsequent points are selected
+    so that they are distant from all their preceding ones.
+
     Parameters
     ----------
     xs : array

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -404,9 +404,12 @@ def label_distant_points(xs, ys, min_xdistance, min_ydistance, max_points):
     coordinates = np.stack([xs, ys], axis=1)
     # Use a KDTree to search for neighboring points effectively
     kd_tree = cKDTree(coordinates)
-    i = 0
-    while i < max_points:
-        if not is_neighbor[i]:
+    n_pts = 0
+    for i in range(len(xs)):
+        if n_pts >= max_points:
+            # Ignore the point if points to keep reaches maximum
+            is_neighbor[i] = True
+        elif not is_neighbor[i]:
             # Find a short list of candidates to remove
             # by searching within a circle
             neighbors_i = kd_tree.query_ball_point(
@@ -419,7 +422,6 @@ def label_distant_points(xs, ys, min_xdistance, min_ydistance, max_points):
                 y_close = abs(ys[ni] - ys[i]) <= min_ydistance
                 if (x_close or y_close) and (ni > i):
                     is_neighbor[ni] = True
-        i += 1
+            n_pts += 1
     should_keep = ~is_neighbor
-    should_keep[max_points:] = False
     return should_keep

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -271,10 +271,11 @@ def hough_circle_peaks(hspaces, radii, min_xdistance=1, min_ydistance=1,
                        total_num_peaks=np.inf, normalize=False):
     """Return peaks in a circle Hough transform.
 
-    Identifies most prominent circles separated by certain distances in a
-    Hough space. Non-maximum suppression with different sizes is applied
+    Identifies most prominent circles separated by certain distances in given
+    Hough spaces. Non-maximum suppression with different sizes is applied
     separately in the first and second dimension of the Hough space to
-    identify peaks.
+    identify peaks. For circles with different radius but close in distance,
+    only the one with highest peak is kept.
 
     Parameters
     ----------

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -420,7 +420,7 @@ def label_distant_points(xs, ys, min_xdistance, min_ydistance, max_points):
             for ni in neighbors_i:
                 x_close = abs(xs[ni] - xs[i]) <= min_xdistance
                 y_close = abs(ys[ni] - ys[i]) <= min_ydistance
-                if (x_close or y_close) and (ni > i):
+                if x_close and y_close and ni > i:
                     is_neighbor[ni] = True
             n_pts += 1
     should_keep = ~is_neighbor

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -353,9 +353,11 @@ def hough_circle_peaks(hspaces, radii, min_xdistance=1, min_ydistance=1,
     cy = []
     r = []
     for ac, x, y, ra in zip(accum_sorted, cx_sorted, cy_sorted, r_sorted):
-        close_in_x = [abs(i - x) <= min_xdistance for i in cx]
-        close_in_y = [abs(j - y) <= min_ydistance for j in cy]
-        if (True not in close_in_x) and (True not in close_in_y):
+        far_from_kept_circle = [
+            abs(i - x) > min_xdistance or abs(j - y) > min_ydistance
+            for i, j in zip(cx, cy)
+        ]
+        if all(far_from_kept_circle):
             accum.append(ac)
             cx.append(x)
             cy.append(y)

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -322,7 +322,8 @@ def hough_circle_peaks(hspaces, radii, min_xdistance=1, min_ydistance=1,
     -----
     Circles with bigger radius have higher peaks in Hough space. If larger
     circles are preferred over smaller ones, `normalize` should be False.
-    Otherwise, circles will be returned in the order of decreasing perfectness.
+    Otherwise, circles will be returned in the order of decreasing voting
+    number.
     """
     from ..feature.peak import _prominent_peaks
 
@@ -388,7 +389,7 @@ def hough_circle_peaks(hspaces, radii, min_xdistance=1, min_ydistance=1,
             cx_kept.append(cx_sorted[i])
             cy_kept.append(cy_sorted[i])
             r_kept.append(r_sorted[i])
-            # Find a shrot list of candidates to remove
+            # Find a short list of candidates to remove
             # by searching within a radius of sqrt(2) in scaled space
             neighbors_i = kd_tree.query_ball_point(
                 (scaled_cx_sorted[i], scaled_cy_sorted[i]), np.sqrt(2)

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -375,7 +375,13 @@ def hough_circle_peaks(hspaces, radii, min_xdistance=1, min_ydistance=1,
     # Use a KDTree to search for neighboring circles effectively
     scaled_cx_sorted = cx_sorted / float(min_xdistance)
     scaled_cy_sorted = cy_sorted / float(min_ydistance)
-    kd_tree = cKDTree(np.stack([scaled_cx_sorted, scaled_cy_sorted], axis=1))
+    scaled_coordinates = np.stack([scaled_cx_sorted, scaled_cy_sorted], axis=1)
+    if scaled_coordinates.size == 0:
+        # Return empty arrays early
+        # as cKDTree throws an error given zero-sized data
+        return (np.array(accum_kept), np.array(cx_kept),
+                np.array(cy_kept), np.array(r_kept))
+    kd_tree = cKDTree(scaled_coordinates)
     while i < tnp:
         if not removed[i]:
             accum_kept.append(accum_sorted[i])

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -317,6 +317,12 @@ def hough_circle_peaks(hspaces, radii, min_xdistance=1, min_ydistance=1,
     >>> img[x, y] = 1
     >>> hspaces = transform.hough_circle(img, radius)
     >>> accum, cx, cy, rad = hough_circle_peaks(hspaces, [radius,])
+
+    Notes
+    -----
+    Circles with bigger radius have higher peaks in Hough space. If larger
+    circles are preferred over smaller ones, `normalize` should be False.
+    Otherwise, circles will be returned in the order of decreasing perfectness.
     """
     from ..feature.peak import _prominent_peaks
 

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -260,6 +260,68 @@ def test_hough_circle_peaks_total_peak():
     assert_equal(out[3][0], np.array([rad_1, ]))
 
 
+def test_hough_circle_peaks_min_distance():
+    x_0, y_0, rad_0 = (50, 50, 20)
+    img = np.zeros((120, 100), dtype=int)
+    y, x = circle_perimeter(y_0, x_0, rad_0)
+    img[x, y] = 1
+
+    x_1, y_1, rad_1 = (60, 60, 30)
+    y, x = circle_perimeter(y_1, x_1, rad_1)
+    # Add noise and create an imperfect circle to lower the peak in Hough space
+    y[::2] += 1
+    x[::2] += 1
+    img[x, y] = 1
+
+    x_2, y_2, rad_2 = (70, 70, 20)
+    y, x = circle_perimeter(y_2, x_2, rad_2)
+    # Add noise and create an imperfect circle to lower the peak in Hough space
+    y[::2] += 1
+    x[::2] += 1
+    img[x, y] = 1
+
+
+    radii = [rad_0, rad_1, rad_2]
+    hspaces = transform.hough_circle(img, radii)
+    out = transform.hough_circle_peaks(hspaces, radii, min_xdistance=15,
+                                       min_ydistance=15, threshold=None,
+                                       num_peaks=np.inf,
+                                       total_num_peaks=np.inf,
+                                       normalize=True)
+
+    # The second circle is too close to the first one
+    # and has a weaker peak in Hough space due to imperfectness.
+    # Therefore it got removed.
+    assert_equal(out[1], np.array([y_0, y_2]))
+    assert_equal(out[2], np.array([x_0, x_2]))
+    assert_equal(out[3], np.array([rad_0, rad_2]))
+
+
+def test_hough_circle_peaks_normalize():
+    x_0, y_0, rad_0 = (50, 50, 20)
+    img = np.zeros((120, 100), dtype=int)
+    y, x = circle_perimeter(y_0, x_0, rad_0)
+    img[x, y] = 1
+
+    x_1, y_1, rad_1 = (60, 60, 30)
+    y, x = circle_perimeter(y_1, x_1, rad_1)
+    img[x, y] = 1
+
+    radii = [rad_0, rad_1]
+    hspaces = transform.hough_circle(img, radii)
+    out = transform.hough_circle_peaks(hspaces, radii, min_xdistance=15,
+                                       min_ydistance=15, threshold=None,
+                                       num_peaks=np.inf,
+                                       total_num_peaks=np.inf,
+                                       normalize=False)
+
+    # Two perfect circles are close but the second one is bigger.
+    # Therefore, it is picked due to its high peak.
+    assert_equal(out[1], np.array([y_1]))
+    assert_equal(out[2], np.array([x_1]))
+    assert_equal(out[3], np.array([rad_1]))
+
+
 def test_hough_ellipse_zero_angle():
     img = np.zeros((25, 25), dtype=int)
     rx = 6

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -280,7 +280,6 @@ def test_hough_circle_peaks_min_distance():
     x[::2] += 1
     img[x, y] = 1
 
-
     radii = [rad_0, rad_1, rad_2]
     hspaces = transform.hough_circle(img, radii)
     out = transform.hough_circle_peaks(hspaces, radii, min_xdistance=15,

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -295,6 +295,16 @@ def test_hough_circle_peaks_min_distance():
     assert_equal(out[2], np.array([x_0, x_2]))
     assert_equal(out[3], np.array([rad_0, rad_2]))
 
+    out = transform.hough_circle_peaks(hspaces, radii, min_xdistance=15,
+                                       min_ydistance=15, threshold=None,
+                                       num_peaks=np.inf,
+                                       total_num_peaks=1,
+                                       normalize=True)
+
+    assert_equal(out[1], np.array([y_0]))
+    assert_equal(out[2], np.array([x_0]))
+    assert_equal(out[3], np.array([rad_0]))
+
 
 def test_hough_circle_peaks_normalize():
     x_0, y_0, rad_0 = (50, 50, 20)

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -295,15 +295,27 @@ def test_hough_circle_peaks_min_distance():
     assert_equal(out[2], np.array([x_0, x_2]))
     assert_equal(out[3], np.array([rad_0, rad_2]))
 
+
+def test_hough_circle_peaks_total_peak_and_min_distance():
+    img = np.zeros((120, 120), dtype=int)
+    cx = cy = [40, 50, 60, 70, 80]
+    radii = range(20, 30, 2)
+    for i in range(len(cx)):
+        y, x = circle_perimeter(cy[i], cx[i], radii[i])
+        img[x, y] = 1
+
+    hspaces = transform.hough_circle(img, radii)
     out = transform.hough_circle_peaks(hspaces, radii, min_xdistance=15,
                                        min_ydistance=15, threshold=None,
                                        num_peaks=np.inf,
-                                       total_num_peaks=1,
+                                       total_num_peaks=2,
                                        normalize=True)
 
-    assert_equal(out[1], np.array([y_0]))
-    assert_equal(out[2], np.array([x_0]))
-    assert_equal(out[3], np.array([rad_0]))
+    # 2nd (4th) circle is removed as it is close to 1st (3rd) oneself.
+    # 5th is removed as total_num_peaks = 2
+    assert_equal(out[1], np.array(cy[:4:2]))
+    assert_equal(out[2], np.array(cx[:4:2]))
+    assert_equal(out[3], np.array(radii[:4:2]))
 
 
 def test_hough_circle_peaks_normalize():

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -178,8 +178,8 @@ def test_hough_line_peaks_zero_input():
     hspace, angles, dists = transform.hough_line(img, theta)
     h, a, d = transform.hough_line_peaks(hspace, angles, dists)
     assert_equal(a, np.array([]))
-    
-    
+
+
 @test_parallel()
 def test_hough_circle():
     # Prepare picture


### PR DESCRIPTION
## Description

Closes issue #2728 
For circles with different radius but close in distance, only keeping the one with highest peak intensity.

Using the [example code](https://gist.github.com/xiaoyu-wu/7116c5d133f01718e601365532fe03a6) in the issue, now only one circle is drawn per coin.
![hough_circle_peaks](https://user-images.githubusercontent.com/12037335/70481907-a946b500-1aa9-11ea-9796-243f9b1214eb.png)

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
