### PR TITLE
Deprecate CONTRIBUTORS.txt and replace by git shortlog command

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,4 +1,30 @@
-﻿- Stefan van der Walt
+﻿# Acknowledgements
+
+scikit-image is a joint effort, created by a large community of contributors.
+For a full list of contributors, please visit
+[our GitHub repo](https://github.com/scikit-image/scikit-image/graphs/contributors)
+or use `git` in the source repository as follows:
+
+```
+git shortlog --summary --numbered
+
+```
+
+Previously, we asked authors to add their names to this file whenever
+they made a contribution.  Because these additions were not made
+consistently, we now refer to the git commit log as the ultimate
+record of code contribution.
+
+Please note that, on a project as large as this, there are *many*
+different ways to contribute, of which code is only one.  Other
+contributions include community & project management, code review,
+answering questions on forums, and web design.  We are grateful for
+each and every contributor, regardless of their role.
+
+
+## Historical credits list
+
+- Stefan van der Walt
   Project coordination
 
 - Nicolas Pinto


### PR DESCRIPTION
The CONTRIBUTORS.txt file was not being consistently updated, so there's
not much sense in keeping it around as a mechanism of credit.
