### PR TITLE
Add warning on pillow version if reading a MPO image

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -69,6 +69,9 @@ Other
   the minimum supported version of ``scipy`` reaches 1.4.
 * When ``numpy`` is set to >= 1.16, simplify ``draw.line_nd`` by using the
   vectorized version of ``np.linspace``.
-* Monitor when multibuild devel gets merged into master for python 3.8 compatibility
-  https://github.com/matthew-brett/multibuild/issues/284
+* Monitor when multibuild devel gets merged into master for python 3.8
+  compatibility https://github.com/matthew-brett/multibuild/issues/284
   and update osx_install to point to the correct branch
+* Remove pillow version related warning for MPO file format in
+  `io._plugins.pil_plugin.imread` when upgrading pillow min version to
+  6.0.0

--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -40,7 +40,7 @@ def imread(fname, dtype=None, img_num=None, **kwargs):
         if im.format == 'MPO' and Image.__version__ < '6.0.0':
             warnings.warn("You are trying to read a MPO image. "
                           "To ensure a good support of this format, "
-                          "please upgrade pillow to 6.0.0 version.")
+                          "please upgrade pillow to 6.0.0 version or later.")
         return pil_to_ndarray(im, dtype=dtype, img_num=img_num)
 
 

--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -1,5 +1,6 @@
 __all__ = ['imread', 'imsave']
 
+import warnings
 import numpy as np
 from PIL import Image
 
@@ -36,6 +37,10 @@ def imread(fname, dtype=None, img_num=None, **kwargs):
             return pil_to_ndarray(im, dtype=dtype, img_num=img_num)
     else:
         im = Image.open(fname)
+        if im.format == 'MPO' and Image.__version__ < '6.0.0':
+            warnings.warn("You are trying to read a MPO image. "
+                          "To ensure a good support of this format, "
+                          "please upgrade pillow to 6.0.0 version.")
         return pil_to_ndarray(im, dtype=dtype, img_num=img_num)
 
 

--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -40,7 +40,8 @@ def imread(fname, dtype=None, img_num=None, **kwargs):
         if im.format == 'MPO' and Image.__version__ < '6.0.0':
             warnings.warn("You are trying to read a MPO image. "
                           "To ensure a good support of this format, "
-                          "please upgrade pillow to 6.0.0 version or later.")
+                          "please upgrade pillow to 6.0.0 version or later.",
+                          stacklevel=2)
         return pil_to_ndarray(im, dtype=dtype, img_num=img_num)
 
 

--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -3,7 +3,7 @@ __all__ = ['imread', 'imsave']
 from distutils.version import LooseVersion
 import warnings
 import numpy as np
-from PIL import Image
+from PIL import Image, __version__ as pil_version
 
 from ...util import img_as_ubyte, img_as_uint
 
@@ -38,8 +38,7 @@ def imread(fname, dtype=None, img_num=None, **kwargs):
             return pil_to_ndarray(im, dtype=dtype, img_num=img_num)
     else:
         im = Image.open(fname)
-        pil_version = LooseVersion(Image.__version__)
-        if im.format == 'MPO' and pil_version < '6.0.0':
+        if im.format == 'MPO' and LooseVersion(pil_version) < '6.0.0':
             warnings.warn("You are trying to read a MPO image. "
                           "To ensure a good support of this format, "
                           "please upgrade pillow to 6.0.0 version or later.",

--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -39,7 +39,7 @@ def imread(fname, dtype=None, img_num=None, **kwargs):
     else:
         im = Image.open(fname)
         pil_version = LooseVersion(Image.__version__)
-        if im.format == 'MPO' and pil_version < LooseVersion('6.0.0'):
+        if im.format == 'MPO' and pil_version < '6.0.0':
             warnings.warn("You are trying to read a MPO image. "
                           "To ensure a good support of this format, "
                           "please upgrade pillow to 6.0.0 version or later.",

--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -1,5 +1,6 @@
 __all__ = ['imread', 'imsave']
 
+from distutils.version import LooseVersion
 import warnings
 import numpy as np
 from PIL import Image
@@ -37,7 +38,8 @@ def imread(fname, dtype=None, img_num=None, **kwargs):
             return pil_to_ndarray(im, dtype=dtype, img_num=img_num)
     else:
         im = Image.open(fname)
-        if im.format == 'MPO' and Image.__version__ < '6.0.0':
+        pil_version = LooseVersion(Image.__version__)
+        if im.format == 'MPO' and pil_version < LooseVersion('6.0.0'):
             warnings.warn("You are trying to read a MPO image. "
                           "To ensure a good support of this format, "
                           "please upgrade pillow to 6.0.0 version or later.",


### PR DESCRIPTION
## Description

Fixes #2445 based on @sciunto [comment](https://github.com/scikit-image/scikit-image/issues/2445#issuecomment-543537856).

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
