### PR TITLE
Add example to highlight regionprops_table

### DIFF
--- a/doc/examples/segmentation/plot_regionprops_table.py
+++ b/doc/examples/segmentation/plot_regionprops_table.py
@@ -26,7 +26,7 @@ fractions = np.linspace(0.05, 0.5, 10)
 
 #####################################################################
 # 2D images
-# ========
+# =========
 
 images = [data.binary_blobs(volume_fraction=f) for f in fractions]
 
@@ -68,14 +68,13 @@ Python library dedicated to statistical data visualization) with argument
 sns_fig, sns_ax = plt.subplots()
 sns.stripplot(x='volume fraction', y='area', data=areas, jitter=True,
               ax=sns_ax)
-x_format = sns_ax.xaxis.get_major_formatter()
-x_format.seq = ['{:0.2f}'.format(float(s)) for s in x_format.seq]
-sns_ax.xaxis.set_major_formatter(x_format)
+# Fix floating point rendering
+sns_ax.set_xticklabels([f'{frac:.2f}' for frac in fractions])
 plt.show()
 
 #####################################################################
 # 3D images
-# ========
+# =========
 # Doing the same analysis in 3D, we find a much more dramatic behaviour: blobs
 # coalesce into a single, giant piece as the volume fraction crosses ~0.25.
 
@@ -98,8 +97,7 @@ blob_volumes = pd.concat(tables, axis=0)
 d3_fig, d3_ax = plt.subplots()
 sns.stripplot(x='volume fraction', y='area', data=blob_volumes, jitter=True,
               ax=d3_ax)
-x_format = d3_ax.xaxis.get_major_formatter()
-x_format.seq = ['{:0.2f}'.format(float(s)) for s in x_format.seq]
-d3_ax.xaxis.set_major_formatter(x_format)
 d3_ax.set_ylabel('blob size (3D)')
+# Fix floating point rendering
+d3_ax.set_xticklabels([f'{frac:.2f}' for frac in fractions])
 plt.show()

--- a/doc/examples/segmentation/plot_regionprops_table.py
+++ b/doc/examples/segmentation/plot_regionprops_table.py
@@ -1,10 +1,10 @@
 """
-=========================
-Tabulate areas of regions
-=========================
+===================================================
+Explore and visualize region properties with pandas
+===================================================
 
 This toy example shows how to compute the area of every labelled region in a
-series of 3D images. The blob-like regions are generated synthetically. As the
+series of 10 images. The blob-like regions are generated synthetically. As the
 fraction of image pixels covered by the blobs increases, the number of blobs
 (regions) decreases, and the size (area) of a single region can get larger and
 larger. The area values are available in a pandas-compatible format, which
@@ -16,15 +16,13 @@ Beyond area, many other region properties are available.
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import seaborn as sns
 
 from skimage import data, measure
 
 
 fractions = np.linspace(0.05, 0.5, 10)
 
-images = [data.binary_blobs(length=128, n_dim=3, volume_fraction=f)
-          for f in fractions]
+images = [data.binary_blobs(volume_fraction=f) for f in fractions]
 
 labeled_images = [measure.label(image) for image in images]
 
@@ -39,8 +37,5 @@ for fraction, table in zip(fractions, tables):
 
 areas = pd.concat(tables, axis=0)
 
-ax = sns.stripplot(data=areas, x='volume fraction', y='area', jitter=0.2)
-x_format = ax.xaxis.get_major_formatter()
-x_format.seq = ["{:0.2f}".format(float(s)) for s in x_format.seq]
-ax.xaxis.set_major_formatter(x_format)
+areas.plot(x='volume fraction', y='area', kind='scatter')
 plt.show()

--- a/doc/examples/segmentation/plot_regionprops_table.py
+++ b/doc/examples/segmentation/plot_regionprops_table.py
@@ -50,3 +50,21 @@ ax1.imshow(images[0])
 ax2 = fig.add_subplot(222)
 ax2.imshow(images[-1])
 plt.show()
+
+"""
+In the scatterplot, many points seem to be overlapping at low area values.
+To get a better sense of the distribution, we may want to add some 'jitter'
+to the visualization. To this end, we import `seaborn`, the Python library
+dedicated to statistical data visualization, and use `stripplot` with
+argument `jitter=True`.
+"""
+
+import seaborn as sns
+
+sns_fig, sns_ax = plt.subplots()
+sns.stripplot(x='volume fraction', y='area', data=areas, jitter=True,
+              ax=sns_ax)
+x_format = sns_ax.xaxis.get_major_formatter()
+x_format.seq = ['{:0.2f}'.format(float(s)) for s in x_format.seq]
+sns_ax.xaxis.set_major_formatter(x_format)
+plt.show()

--- a/doc/examples/segmentation/plot_regionprops_table.py
+++ b/doc/examples/segmentation/plot_regionprops_table.py
@@ -1,0 +1,46 @@
+"""
+=========================
+Tabulate areas of regions
+=========================
+
+This toy example shows how to compute the area of every labelled region in a
+series of 3D images. The blob-like regions are generated synthetically. As the
+fraction of image pixels covered by the blobs increases, the number of blobs
+(regions) decreases, and the size (area) of a single region can get larger and
+larger. The area values are available in a pandas-compatible format, which
+makes for convenient data analysis and visualization.
+
+Beyond area, many other region properties are available.
+
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+
+from skimage import data, measure
+
+
+fractions = np.linspace(0.05, 0.5, 10)
+
+images = [data.binary_blobs(length=128, n_dim=3, volume_fraction=f)
+          for f in fractions]
+
+labeled_images = [measure.label(image) for image in images]
+
+properties = ['label', 'area']
+
+tables = [measure.regionprops_table(image, properties=properties)
+          for image in labeled_images]
+tables = [pd.DataFrame(table) for table in tables]
+
+for fraction, table in zip(fractions, tables):
+    table['volume fraction'] = fraction
+
+areas = pd.concat(tables, axis=0)
+
+ax = sns.stripplot(data=areas, x='volume fraction', y='area', jitter=0.2)
+x_format = ax.xaxis.get_major_formatter()
+x_format.seq = ["{:0.2f}".format(float(s)) for s in x_format.seq]
+ax.xaxis.set_major_formatter(x_format)
+plt.show()

--- a/doc/examples/segmentation/plot_regionprops_table.py
+++ b/doc/examples/segmentation/plot_regionprops_table.py
@@ -3,12 +3,13 @@
 Explore and visualize region properties with pandas
 ===================================================
 
-This toy example shows how to compute the area of every labelled region in a
-series of 10 images. The blob-like regions are generated synthetically. As the
-fraction of image pixels covered by the blobs increases, the number of blobs
-(regions) decreases, and the size (area) of a single region can get larger and
-larger. The area values are available in a pandas-compatible format, which
-makes for convenient data analysis and visualization.
+This toy example shows how to compute the size of every labelled region in a
+series of 10 images. We use 2D images and then 3D images. The blob-like
+regions are generated synthetically. As the volume fraction (i.e., number of
+pixels or voxels covered by the blobs) increases, the number of blobs
+(regions) decreases, and the size (area or volume) of a single region can get
+larger and larger. The area (size) values are available in a pandas-compatible
+format, which makes for convenient data analysis and visualization.
 
 Beyond area, many other region properties are available.
 
@@ -16,11 +17,17 @@ Beyond area, many other region properties are available.
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import seaborn as sns
 
 from skimage import data, measure
 
 
 fractions = np.linspace(0.05, 0.5, 10)
+
+"""
+2D images
+---------
+"""
 
 images = [data.binary_blobs(volume_fraction=f) for f in fractions]
 
@@ -54,12 +61,10 @@ plt.show()
 """
 In the scatterplot, many points seem to be overlapping at low area values.
 To get a better sense of the distribution, we may want to add some 'jitter'
-to the visualization. To this end, we import `seaborn`, the Python library
-dedicated to statistical data visualization, and use `stripplot` with
-argument `jitter=True`.
+to the visualization. To this end, we use `stripplot` (from `seaborn`, the
+Python library dedicated to statistical data visualization) with argument
+`jitter=True`.
 """
-
-import seaborn as sns
 
 sns_fig, sns_ax = plt.subplots()
 sns.stripplot(x='volume fraction', y='area', data=areas, jitter=True,
@@ -67,4 +72,34 @@ sns.stripplot(x='volume fraction', y='area', data=areas, jitter=True,
 x_format = sns_ax.xaxis.get_major_formatter()
 x_format.seq = ['{:0.2f}'.format(float(s)) for s in x_format.seq]
 sns_ax.xaxis.set_major_formatter(x_format)
+plt.show()
+
+"""
+3D images
+---------
+"""
+
+images = [data.binary_blobs(length=128, n_dim=3, volume_fraction=f)
+          for f in fractions]
+
+labeled_images = [measure.label(image) for image in images]
+
+properties = ['label', 'area']
+
+tables = [measure.regionprops_table(image, properties=properties)
+          for image in labeled_images]
+tables = [pd.DataFrame(table) for table in tables]
+
+for fraction, table in zip(fractions, tables):
+    table['volume fraction'] = fraction
+
+blob_volumes = pd.concat(tables, axis=0)
+
+d3_fig, d3_ax = plt.subplots()
+sns.stripplot(x='volume fraction', y='area', data=blob_volumes, jitter=True,
+              ax=d3_ax)
+x_format = d3_ax.xaxis.get_major_formatter()
+x_format.seq = ['{:0.2f}'.format(float(s)) for s in x_format.seq]
+d3_ax.xaxis.set_major_formatter(x_format)
+d3_ax.set_ylabel('blob size (3D)')
 plt.show()

--- a/doc/examples/segmentation/plot_regionprops_table.py
+++ b/doc/examples/segmentation/plot_regionprops_table.py
@@ -51,10 +51,14 @@ im.axis('off')
 areas.plot(x='volume fraction', y='area', kind='scatter', ax=ax)
 # Show image with lowest volume fraction
 ax1 = fig.add_subplot(221)
-ax1.imshow(images[0])
+ax1.imshow(images[0], cmap='gray_r')
+ax1.set_axis_off()
+ax1.set_title(f'fraction {fractions[0]}')
 # Show image with highest volume fraction
 ax2 = fig.add_subplot(222)
-ax2.imshow(images[-1])
+ax2.imshow(images[-1], cmap='gray_r')
+ax2.set_axis_off()
+ax2.set_title(f'fraction {fractions[-1]}')
 plt.show()
 
 """

--- a/doc/examples/segmentation/plot_regionprops_table.py
+++ b/doc/examples/segmentation/plot_regionprops_table.py
@@ -68,11 +68,11 @@ plt.show()
 # Python library dedicated to statistical data visualization) with argument
 # `jitter=True`.
 
-sns_fig, sns_ax = plt.subplots()
+fig, ax = plt.subplots()
 sns.stripplot(x='volume fraction', y='area', data=areas, jitter=True,
-              ax=sns_ax)
+              ax=ax)
 # Fix floating point rendering
-sns_ax.set_xticklabels([f'{frac:.2f}' for frac in fractions])
+ax.set_xticklabels([f'{frac:.2f}' for frac in fractions])
 plt.show()
 
 #####################################################################
@@ -97,10 +97,10 @@ for fraction, table in zip(fractions, tables):
 
 blob_volumes = pd.concat(tables, axis=0)
 
-d3_fig, d3_ax = plt.subplots()
+fig, ax = plt.subplots()
 sns.stripplot(x='volume fraction', y='area', data=blob_volumes, jitter=True,
-              ax=d3_ax)
-d3_ax.set_ylabel('blob size (3D)')
+              ax=ax)
+ax.set_ylabel('blob size (3D)')
 # Fix floating point rendering
-d3_ax.set_xticklabels([f'{frac:.2f}' for frac in fractions])
+ax.set_xticklabels([f'{frac:.2f}' for frac in fractions])
 plt.show()

--- a/doc/examples/segmentation/plot_regionprops_table.py
+++ b/doc/examples/segmentation/plot_regionprops_table.py
@@ -43,22 +43,21 @@ for fraction, table in zip(fractions, tables):
 
 areas = pd.concat(tables, axis=0)
 
-# Divide the figure into a 2x1 grid
-fig, (im, ax) = plt.subplots(2, 1)
-# Turn off axes for top subplot
-im.axis('off')
-# Plot area vs volume fraction
-areas.plot(x='volume fraction', y='area', kind='scatter', ax=ax)
+# Create custom grid of subplots
+grid = plt.GridSpec(2, 2)
+ax1 = plt.subplot(grid[0, 0])
+ax2 = plt.subplot(grid[0, 1])
+ax = plt.subplot(grid[1, :])
 # Show image with lowest volume fraction
-ax1 = fig.add_subplot(221)
 ax1.imshow(images[0], cmap='gray_r')
 ax1.set_axis_off()
 ax1.set_title(f'fraction {fractions[0]}')
 # Show image with highest volume fraction
-ax2 = fig.add_subplot(222)
 ax2.imshow(images[-1], cmap='gray_r')
 ax2.set_axis_off()
 ax2.set_title(f'fraction {fractions[-1]}')
+# Plot area vs volume fraction
+areas.plot(x='volume fraction', y='area', kind='scatter', ax=ax)
 plt.show()
 
 #####################################################################

--- a/doc/examples/segmentation/plot_regionprops_table.py
+++ b/doc/examples/segmentation/plot_regionprops_table.py
@@ -37,5 +37,16 @@ for fraction, table in zip(fractions, tables):
 
 areas = pd.concat(tables, axis=0)
 
-areas.plot(x='volume fraction', y='area', kind='scatter')
+# Divide the figure into a 2x1 grid
+fig, (im, ax) = plt.subplots(2, 1)
+# Turn off axes for top subplot
+im.axis('off')
+# Plot area vs volume fraction
+areas.plot(x='volume fraction', y='area', kind='scatter', ax=ax)
+# Show image with lowest volume fraction
+ax1 = fig.add_subplot(221)
+ax1.imshow(images[0])
+# Show image with highest volume fraction
+ax2 = fig.add_subplot(222)
+ax2.imshow(images[-1])
 plt.show()

--- a/doc/examples/segmentation/plot_regionprops_table.py
+++ b/doc/examples/segmentation/plot_regionprops_table.py
@@ -79,6 +79,9 @@ plt.show()
 # =========
 # Doing the same analysis in 3D, we find a much more dramatic behaviour: blobs
 # coalesce into a single, giant piece as the volume fraction crosses ~0.25.
+# This corresponds to the `percolation threshold
+# <https://en.wikipedia.org/wiki/Percolation_threshold>`_ in statistical
+# physics and graph theory.
 
 images = [data.binary_blobs(length=128, n_dim=3, volume_fraction=f)
           for f in fractions]

--- a/doc/examples/segmentation/plot_regionprops_table.py
+++ b/doc/examples/segmentation/plot_regionprops_table.py
@@ -24,10 +24,9 @@ from skimage import data, measure
 
 fractions = np.linspace(0.05, 0.5, 10)
 
-"""
-2D images
----------
-"""
+#####################################################################
+# 2D images
+# ========
 
 images = [data.binary_blobs(volume_fraction=f) for f in fractions]
 
@@ -74,10 +73,11 @@ x_format.seq = ['{:0.2f}'.format(float(s)) for s in x_format.seq]
 sns_ax.xaxis.set_major_formatter(x_format)
 plt.show()
 
-"""
-3D images
----------
-"""
+#####################################################################
+# 3D images
+# ========
+# Doing the same analysis in 3D, we find a much more dramatic behaviour: blobs
+# coalesce into a single, giant piece as the volume fraction crosses ~0.25.
 
 images = [data.binary_blobs(length=128, n_dim=3, volume_fraction=f)
           for f in fractions]

--- a/doc/examples/segmentation/plot_regionprops_table.py
+++ b/doc/examples/segmentation/plot_regionprops_table.py
@@ -61,13 +61,12 @@ ax2.set_axis_off()
 ax2.set_title(f'fraction {fractions[-1]}')
 plt.show()
 
-"""
-In the scatterplot, many points seem to be overlapping at low area values.
-To get a better sense of the distribution, we may want to add some 'jitter'
-to the visualization. To this end, we use `stripplot` (from `seaborn`, the
-Python library dedicated to statistical data visualization) with argument
-`jitter=True`.
-"""
+#####################################################################
+# In the scatterplot, many points seem to be overlapping at low area values.
+# To get a better sense of the distribution, we may want to add some 'jitter'
+# to the visualization. To this end, we use `stripplot` (from `seaborn`, the
+# Python library dedicated to statistical data visualization) with argument
+# `jitter=True`.
 
 sns_fig, sns_ax = plt.subplots()
 sns.stripplot(x='volume fraction', y='area', data=areas, jitter=True,

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -11,4 +11,3 @@ dask[array]>=0.15.0
 # cloudpickle is necessary to provide the 'processes' scheduler for dask
 cloudpickle>=0.2.1
 pandas
-seaborn

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -10,3 +10,5 @@ matplotlib>=3.0.1
 dask[array]>=0.15.0
 # cloudpickle is necessary to provide the 'processes' scheduler for dask
 cloudpickle>=0.2.1
+pandas
+seaborn

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -11,3 +11,4 @@ dask[array]>=0.15.0
 # cloudpickle is necessary to provide the 'processes' scheduler for dask
 cloudpickle>=0.2.1
 pandas
+seaborn

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -10,5 +10,5 @@ matplotlib>=3.0.1
 dask[array]>=0.15.0
 # cloudpickle is necessary to provide the 'processes' scheduler for dask
 cloudpickle>=0.2.1
-pandas
-seaborn
+pandas>=0.23.0
+seaborn>=0.7.1


### PR DESCRIPTION
## Description

This PR addresses #4335 and follows up with conversation at #4346.

I hardly modified @jni's proposal. I included a slightly verbose description to contextualize and motivate the example. In the visualization, I used `jitter=0.2` instead of the default `jitter=True` to scatter the dots a tiny bit more.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
