### PR TITLE
Remove code that tries to avoid upgrading large dependencies from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -166,14 +166,6 @@ if __name__ == "__main__":
     try:
         from numpy.distutils.core import setup
         extra = {'configuration': configuration}
-        # Do not try and upgrade larger dependencies
-        for lib in ['scipy', 'numpy', 'matplotlib', 'pillow']:
-            try:
-                __import__(lib)
-                INSTALL_REQUIRES = [i for i in INSTALL_REQUIRES
-                                    if lib not in i]
-            except ImportError:
-                pass
     except ImportError:
         if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or
                                    sys.argv[1] in ('--help-commands',


### PR DESCRIPTION
This was identified as strange by @Cadair I agree with them.

Probably best to just keep the dependencies as metadata for python.


## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
