### PR TITLE
Fix float32 promotion in cubic interpolation

### DIFF
--- a/skimage/_shared/interpolation.pxd
+++ b/skimage/_shared/interpolation.pxd
@@ -203,11 +203,17 @@ cdef inline np_floats cubic_interpolation(np_floats x, np_real_numeric[4] f) nog
         Interpolated value to be used in bicubic_interpolation.
 
     """
-    return (\
-        f[1] + 0.5 * x * \
-            (f[2] - f[0] + x * \
-                (2.0 * f[0] - 5.0 * f[1] + 4.0 * f[2] - f[3] + x * \
-                    (3.0 * (f[1] - f[2]) + f[3] - f[0]))))
+    return (
+        f[1] + <np_floats>0.5 * x * (
+            f[2] - f[0] + x * (
+                <np_floats>2.0 * f[0] -
+                <np_floats>5.0 * f[1] +
+                <np_floats>4.0 * f[2] - f[3] + x * (
+                    <np_floats>3.0 * (f[1] - f[2]) + f[3] - f[0]
+                )
+            )
+        )
+    )
 
 
 cdef inline void bicubic_interpolation(np_real_numeric* image,

--- a/skimage/_shared/interpolation.pxd
+++ b/skimage/_shared/interpolation.pxd
@@ -205,6 +205,9 @@ cdef inline np_floats cubic_interpolation(np_floats x, np_real_numeric[4] f) nog
         Interpolated value to be used in bicubic_interpolation.
 
     """
+
+    # Explicitly cast a floating point literal to the other operand's type
+    # to prevent promoting operands unnecessarily to double precision
     return (
         f[1] + <np_floats>0.5 * x * (
             f[2] - f[0] + x * (

--- a/skimage/_shared/interpolation.pxd
+++ b/skimage/_shared/interpolation.pxd
@@ -23,7 +23,9 @@ cimport numpy as np
 from .fused_numerics cimport np_real_numeric, np_floats
 
 cdef inline Py_ssize_t round(np_floats r) nogil:
-    return <Py_ssize_t>((r + 0.5) if (r > 0.0) else (r - 0.5))
+    return <Py_ssize_t>(
+        (r + <np_floats>0.5) if (r > <np_floats>0.0) else (r - <np_floats>0.5)
+    )
 
 cdef inline Py_ssize_t fmax(Py_ssize_t one, Py_ssize_t two) nogil:
     return one if one > two else two


### PR DESCRIPTION
## Description

This PR fixes a problem where floats get promoted to doubles in cubic interpolation, yielding in performance degradation.

Disassembling generated bicubic_interpolation for float32 in _warps_cy.so I noticed that a lot of conversions are done from float32 to float64 and all operations are done in float64 then converted back to float32, that's mainly due to mixing operations with floating-point literals that are of type float64.

``` python
from math import radians
from timeit import timeit

import numpy as np
from skimage.data import astronaut
from skimage.transform import AffineTransform, warp


astro = astronaut()
astrof = astro.astype(np.float32)
astrod = astro.astype(np.float64)


def transform(image, angle, scale):
    center = np.array(image.shape[:2]) / 2. - 0.5
    tform1 = AffineTransform(translation=center)
    tform2 = AffineTransform(rotation=radians(angle), scale=(scale, scale))
    tform3 = AffineTransform(translation=-center)
    tform = tform3 + tform2 + tform1
    warped = warp(image, tform, order=3, preserve_range=True)
    return warped


timeit_globals = {'transform': transform, 'astrof': astrof, 'astrod': astrod}


if __name__ == '__main__':
    print(timeit('transform(astrof, 20, 1.2)', number=1000, globals=timeit_globals))
    print(timeit('transform(astrod, 20, 1.2)', number=1000, globals=timeit_globals))
```

Running this quick benchmark shows the following results:
```
    Old float32 = 72.4
    New float32 = 66.9
    float64 = 74.5
```

The fix offers a 10.2% improvement instead of originally 2.8% when switching from float64 to float32.

Any comments, changes are welcome.

## Checklist

- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)


## For reviewers

- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
