### PR TITLE
Update to the new way of generating Sphinx search box

### DIFF
--- a/doc/source/themes/scikit-image/search.html
+++ b/doc/source/themes/scikit-image/search.html
@@ -14,7 +14,9 @@
     <script type="text/javascript" src="{{ pathto('_static/searchtools.js', 1) }}"></script>
 {%- endblock %}
 {%- block extrahead %}
-  <script type="text/javascript" src="{{ pathto('searchindex.js', 1) }}" defer></script>
+  <script type="text/javascript">
+    jQuery(function() { Search.loadIndex("searchindex.js"); });
+  </script>
   {{ super() }}
 {% endblock %}
 {%- block body %}


### PR DESCRIPTION
## Description

This basically applies [`matplotlib/715ac1d`](https://github.com/matplotlib/matplotlib/commit/715ac1df9e27ce21059a089aeca9f7a8e51a9960) to skimage and resolves the same problem as described in matplotlib/matplotlib#820:
It switches to a more modern way to load `searchindex.js`, which is required by our `dh_sphinxdoc` tool to identify it.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
