### PR TITLE
clarify register_translation example description

### DIFF
--- a/doc/examples/transform/plot_register_translation.py
+++ b/doc/examples/transform/plot_register_translation.py
@@ -1,9 +1,9 @@
 """
 =====================================
-Cross-Correlation (Phase Correlation)
+Image Registration
 =====================================
 
-In this example, we use phase correlation to identify the relative shift
+In this example, we use cross-correlation to identify the relative shift
 between two similar-sized images.
 
 The ``register_translation`` function uses cross-correlation in Fourier space,


### PR DESCRIPTION
## Description

The `register_translation()` example [here](https://scikit-image.org/docs/dev/auto_examples/transform/plot_register_translation.html#sphx-glr-auto-examples-transform-plot-register-translation-py) claims to use phase correlation when it is actually using cross correlation implemented via FFTs.  

Phase correlation yields different results and is not simply an alternative implementation of cross correlation. (see [here](https://dsp.stackexchange.com/questions/31919/phase-correlation-vs-normalized-cross-correlation) for a comparison).

The relevant lines in `register_translation.py` are [here](https://github.com/scikit-image/scikit-image/blob/b1ed36a33be0a8da4be985aa89e24b37e5a34c76/doc/examples/transform/plot_register_translation.py#L51-L52).  Note the absence of elementwise normalization.

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
