### PR TITLE
Bump scipy minimum version to 1.0.1

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,5 @@
 numpy>=1.14.1
-scipy>=0.19.0
+scipy>=1.0.1
 matplotlib>=2.0.0,!=3.0.0
 networkx>=2.0
 pillow>=4.3.0


### PR DESCRIPTION
## Description
Fixes https://github.com/scikit-image/scikit-image/issues/4371

This supports 2 years of scipy from today.
Rather conservative, but gets us to the 1.0 mark, which I'm really excited about.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
