### PR TITLE
sphinx gallery configuration (inspect_global_variables)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -56,6 +56,7 @@ sphinx_gallery_conf = {
     'gallery_dirs': 'auto_examples',
     'backreferences_dir': 'api',
     'reference_url': {'skimage': None},
+    'inspect_global_variables'  : False,
     'subsection_order': ExplicitOrder([
         '../examples/data',
         '../examples/numpy_operations',


### PR DESCRIPTION
Sphinx-gallery 0.5 has introduced a new feature: it introduces links also for class instances (see the note block in https://sphinx-gallery.github.io/stable/configuration.html#references-to-examples). This results in very busy gallery pages with a lot of links, since we have intersphinx enabled for numpy and matplotlib so most lines are bright orange :-) (see for example https://scikit-image.org/docs/dev/auto_examples/color_exposure/plot_rgb_to_hsv.html).

This PR reverts this behaviour (I think it'd be better, but let's discuss about it).

Relevant links:
- the issue I opened on sphinx-gallery https://github.com/sphinx-gallery/sphinx-gallery/issues/580
- scikit-learn's corresponding issue and PR https://github.com/scikit-learn/scikit-learn/issues/15812 and https://github.com/scikit-learn/scikit-learn/pull/15844
