### PR TITLE
mini-galleries for classes as well

### DIFF
--- a/doc/tools/apigen.py
+++ b/doc/tools/apigen.py
@@ -317,6 +317,8 @@ class ApiDocWriter(object):
                   '  :show-inheritance:\n' \
                   '\n' \
                   '  .. automethod:: __init__\n'
+            full_c = uri + '.' + c
+            ad += '\n.. include:: ' + full_c + '.examples\n\n'
         return ad
 
     def _survives_exclude(self, matchstr, match_type):


### PR DESCRIPTION
I noticed that only functions had their mini-galleries, not classes. This PR corrects this. 