### PR TITLE
gallery: Fix typo + reduce the angle to a reasonable value

### DIFF
--- a/doc/examples/applications/plot_image_comparison.py
+++ b/doc/examples/applications/plot_image_comparison.py
@@ -18,7 +18,7 @@ from skimage.util import compare_images
 
 img1 = data.coins()
 img1_equalized = exposure.equalize_hist(img1)
-img2 = transform.rotate(img1, 5)
+img2 = transform.rotate(img1, 2)
 
 
 comp_equalized = compare_images(img1, img1_equalized, method='checkerboard')
@@ -66,7 +66,7 @@ ax2 = fig.add_subplot(gs[1:, :])
 
 ax0.imshow(img1, cmap='gray')
 ax0.set_title('Original')
-ax1.imshow(img1_equalized, cmap='gray')
+ax1.imshow(img2, cmap='gray')
 ax1.set_title('Rotated')
 ax2.imshow(diff_rotated, cmap='gray')
 ax2.set_title('Diff comparison')
@@ -90,7 +90,7 @@ ax2 = fig.add_subplot(gs[1:, :])
 
 ax0.imshow(img1, cmap='gray')
 ax0.set_title('Original')
-ax1.imshow(img1_equalized, cmap='gray')
+ax1.imshow(img2, cmap='gray')
 ax1.set_title('Rotated')
 ax2.imshow(blend_rotated, cmap='gray')
 ax2.set_title('Blend comparison')


### PR DESCRIPTION
## Description

While I was preparing my lecture, I discovered I made a typo in the two last examples. The 2nd image was incorrect regarding the plotted comparison.

I adjusted the angle to a smaller value to get closer images and give a better demonstration of the sensitivity.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
