### PR TITLE
Do not depend on test execution order for success

### DIFF
--- a/skimage/morphology/misc.py
+++ b/skimage/morphology/misc.py
@@ -212,7 +212,7 @@ def remove_small_holes(ar, area_threshold=64, connectivity=1, in_place=False):
 
     # Creating the inverse of ar
     if in_place:
-        out = np.logical_not(out, out)
+        np.logical_not(out, out=out)
     else:
         out = np.logical_not(out)
 
@@ -220,7 +220,7 @@ def remove_small_holes(ar, area_threshold=64, connectivity=1, in_place=False):
     out = remove_small_objects(out, area_threshold, connectivity, in_place)
 
     if in_place:
-        out = np.logical_not(out, out)
+        np.logical_not(out, out=out)
     else:
         out = np.logical_not(out)
 

--- a/skimage/morphology/tests/test_misc.py
+++ b/skimage/morphology/tests/test_misc.py
@@ -28,8 +28,9 @@ def test_two_connectivity():
 
 
 def test_in_place():
-    observed = remove_small_objects(test_image, min_size=6, in_place=True)
-    assert_equal(observed is test_image, True,
+    image = test_image.copy()
+    observed = remove_small_objects(image, min_size=6, in_place=True)
+    assert_equal(observed is image, True,
                  "remove_small_objects in_place argument failed.")
 
 
@@ -117,9 +118,9 @@ def test_two_connectivity_holes():
 
 
 def test_in_place_holes():
-    observed = remove_small_holes(test_holes_image, area_threshold=3,
-                                  in_place=True)
-    assert_equal(observed is test_holes_image, True,
+    image = test_holes_image.copy()
+    observed = remove_small_holes(image, area_threshold=3, in_place=True)
+    assert_equal(observed is image, True,
                  "remove_small_holes in_place argument failed.")
 
 


### PR DESCRIPTION
Currently, an in-place modification is the last test run.  If the tests
are swapped around, they would break.  That seems brittle, so now it
instead copies the test data before it is used in the in-place
test.
