### PR TITLE
Add border conditions to ridge filters

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -46,6 +46,8 @@ Version 0.19
   in flood_fill() ``inplace`` with ``in_place`` and update the tests.
 * Remove the definition of `skimage.util.pad` and
   skimage/util/tests/test_arraypad.py.
+* Remove the warnings in ``skimage/filters/ridges.py`` from sato and hessian
+  functions.
 
 
 Other

--- a/doc/examples/edges/plot_ridge_filter.py
+++ b/doc/examples/edges/plot_ridge_filter.py
@@ -57,17 +57,13 @@ def identity(image, **kwargs):
 image = color.rgb2gray(data.retina())[300:700, 700:900]
 cmap = plt.cm.gray
 
-kwargs = {}
-kwargs['sigmas'] = [1]
+kwargs = {'sigmas': [1], 'mode': 'reflect'}
 
 fig, axes = plt.subplots(2, 5)
 for i, black_ridges in enumerate([1, 0]):
     for j, func in enumerate([identity, meijering, sato, frangi, hessian]):
         kwargs['black_ridges'] = black_ridges
         result = func(image, **kwargs)
-        if func is meijering:
-            # Crop by 4 pixels for rendering purpose.
-            result = result[4:-4, 4:-4]
         axes[i, j].imshow(result, cmap=cmap, aspect='auto')
         if i == 0:
             axes[i, j].set_title(['Original\nimage', 'Meijering\nneuriteness',

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -478,7 +478,7 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None,
 
 def hessian(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
             beta1=None, beta2=None, alpha=0.5, beta=0.5, gamma=15,
-            black_ridges=True, mode='reflect', cval=0):
+            black_ridges=True, mode='constant', cval=0):
     """Filter an image with the Hybrid Hessian filter.
 
     This filter can be used to detect continuous edges, e.g. vessels,

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -478,7 +478,7 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None,
 
 def hessian(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
             beta1=None, beta2=None, alpha=0.5, beta=0.5, gamma=15,
-            black_ridges=True):
+            black_ridges=True, mode='reflect', cval=0):
     """Filter an image with the Hybrid Hessian filter.
 
     This filter can be used to detect continuous edges, e.g. vessels,
@@ -538,7 +538,7 @@ def hessian(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
     filtered = frangi(image, sigmas=sigmas, scale_range=scale_range,
                       scale_step=scale_step, beta1=beta1, beta2=beta2,
                       alpha=alpha, beta=beta, gamma=gamma,
-                      black_ridges=black_ridges)
+                      black_ridges=black_ridges, mode=mode, cval=cval)
 
     filtered[filtered <= 0] = 1
     return filtered

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -140,7 +140,7 @@ def compute_hessian_eigenvalues(image, sigma, sorting='none',
 
 
 def meijering(image, sigmas=range(1, 10, 2), alpha=None,
-              black_ridges=True):
+              black_ridges=True, mode='reflect', cval=0):
     """
     Filter an image with the Meijering neuriteness filter.
 
@@ -163,6 +163,11 @@ def meijering(image, sigmas=range(1, 10, 2), alpha=None,
     black_ridges : boolean, optional
         When True (the default), the filter detects black ridges; when
         False, it detects white ridges.
+    mode : {'constant', 'reflect', 'wrap', 'nearest', 'mirror'}, optional
+        How to handle values outside the image borders.
+    cval : float, optional
+        Used in conjunction with mode 'constant', the value outside
+        the image boundaries.
 
     Returns
     -------
@@ -208,7 +213,8 @@ def meijering(image, sigmas=range(1, 10, 2), alpha=None,
     for i, sigma in enumerate(sigmas):
 
         # Calculate (sorted) eigenvalues
-        eigenvalues = compute_hessian_eigenvalues(image, sigma, sorting='abs')
+        eigenvalues = compute_hessian_eigenvalues(image, sigma, sorting='abs',
+                                                  mode=mode, cval=cval)
 
         if ndim > 1:
 

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -243,7 +243,7 @@ def meijering(image, sigmas=range(1, 10, 2), alpha=None,
 
 
 def sato(image, sigmas=range(1, 10, 2), black_ridges=True,
-         mode='reflect', cval=0):
+         mode='constant', cval=0):
     """
     Filter an image with the Sato tubeness filter.
 

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -509,6 +509,11 @@ def hessian(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
     black_ridges : boolean, optional
         When True (the default), the filter detects black ridges; when
         False, it detects white ridges.
+    mode : {'constant', 'reflect', 'wrap', 'nearest', 'mirror'}, optional
+        How to handle values outside the image borders.
+    cval : float, optional
+        Used in conjunction with mode 'constant', the value outside
+        the image boundaries.
 
     Returns
     -------

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -242,7 +242,8 @@ def meijering(image, sigmas=range(1, 10, 2), alpha=None,
     return np.max(filtered_array, axis=0)
 
 
-def sato(image, sigmas=range(1, 10, 2), black_ridges=True):
+def sato(image, sigmas=range(1, 10, 2), black_ridges=True,
+         mode='reflect', cval=0):
     """
     Filter an image with the Sato tubeness filter.
 
@@ -263,6 +264,11 @@ def sato(image, sigmas=range(1, 10, 2), black_ridges=True):
     black_ridges : boolean, optional
         When True (the default), the filter detects black ridges; when
         False, it detects white ridges.
+    mode : {'constant', 'reflect', 'wrap', 'nearest', 'mirror'}, optional
+        How to handle values outside the image borders.
+    cval : float, optional
+        Used in conjunction with mode 'constant', the value outside
+        the image boundaries.
 
     Returns
     -------
@@ -305,7 +311,8 @@ def sato(image, sigmas=range(1, 10, 2), black_ridges=True):
 
         # Calculate (sorted) eigenvalues
         lamba1, *lambdas = compute_hessian_eigenvalues(image, sigma,
-                                                       sorting='val')
+                                                       sorting='val',
+                                                       mode=mode, cval=cval)
 
         # Compute tubeness, see  equation (9) in reference [1]_.
         # np.abs(lambda2) in 2D, np.sqrt(np.abs(lambda2 * lambda3)) in 3D

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -81,6 +81,30 @@ def _sortbyabs(array, axis=0):
     return array[tuple(index)]
 
 
+def _check_sigmas(sigmas):
+    """Check sigma values for ridges filters.
+
+    Parameters
+    ----------
+    sigmas : iterable of floats
+        Sigmas argument to be checked
+
+    Returns
+    -------
+    sigmas : ndarray
+        input iterable converted to ndarray
+
+    Raises
+    ------
+    ValueError if any input value is negative
+
+    """
+    sigmas = np.asarray(sigmas).ravel()
+    if np.any(sigmas < 0.0):
+        raise ValueError('Sigma values should be greater than zero.')
+    return sigmas
+
+
 def compute_hessian_eigenvalues(image, sigma, sorting='none',
                                 mode='constant', cval=0):
     """
@@ -190,9 +214,7 @@ def meijering(image, sigmas=range(1, 10, 2), alpha=None,
     """
 
     # Check (sigma) scales
-    sigmas = np.asarray(sigmas)
-    if np.any(sigmas < 0.0):
-        raise ValueError('Sigma values less than zero are not valid')
+    sigmas = _check_sigmas(sigmas)
 
     # Get image dimensions
     ndim = image.ndim
@@ -294,15 +316,13 @@ def sato(image, sigmas=range(1, 10, 2), black_ridges=True,
     check_nD(image, [2, 3])
 
     # Check (sigma) scales
-    sigmas = np.asarray(sigmas)
-    if np.any(sigmas < 0.0):
-        raise ValueError('Sigma values less than zero are not valid')
+    sigmas = _check_sigmas(sigmas)
 
     if mode is None:
         warn("Previously, sato implicitly used 'constant' as the "
              "border mode when dealing with the edge of the array. The new "
              "behavior is 'reflect'. To recover the old behavior, use "
-             "mode='constant'. To avoid this warning, please explicitely "
+             "mode='constant'. To avoid this warning, please explicitly "
              "set the mode.", category=FutureWarning, stacklevel=2)
         mode = 'reflect'
 
@@ -426,9 +446,7 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None,
     check_nD(image, [2, 3])
 
     # Check (sigma) scales
-    sigmas = np.asarray(sigmas).ravel()
-    if np.any(sigmas < 0.0):
-        raise ValueError('Sigma values less than zero are not valid')
+    sigmas = _check_sigmas(sigmas)
 
     # Rescale filter parameters
     alpha_sq = 2 * alpha ** 2
@@ -552,7 +570,7 @@ def hessian(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
         warn("Previously, hessian implicitly used 'constant' as the "
              "border mode when dealing with the edge of the array. The new "
              "behavior is 'reflect'. To recover the old behavior, use "
-             "mode='constant'. To avoid this warning, please explicitely "
+             "mode='constant'. To avoid this warning, please explicitly "
              "set the mode.", category=FutureWarning, stacklevel=2)
         mode = 'reflect'
 

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -299,11 +299,12 @@ def sato(image, sigmas=range(1, 10, 2), black_ridges=True,
         raise ValueError('Sigma values less than zero are not valid')
 
     if mode is None:
-        warn("'constant' borders handling mode is deprecated and will be "
-             "replaced by 'reflect' mode in version 0.19. To avoid this "
-             "warning, please explicitely set the mode argument.",
-             category=FutureWarning, stacklevel=2)
-        mode = 'constant'
+        warn("Previously, sato implicitly used 'constant' as the "
+             "border mode when dealing with the edge of the array. The new "
+             "behavior is 'reflect'. To recover the old behavior, use "
+             "mode='constant'. To avoid this warning, please explicitely "
+             "set the mode.", category=FutureWarning, stacklevel=2)
+        mode = 'reflect'
 
     # Invert image to detect bright ridges on dark background
     if not black_ridges:
@@ -548,11 +549,12 @@ def hessian(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
     """
 
     if mode is None:
-        warn("'constant' borders handling mode is deprecated and will be "
-             "replaced by 'reflect' mode in version 0.19. To avoid this "
-             "warning, please explicitely set the mode argument.",
-             category=FutureWarning, stacklevel=2)
-        mode = 'constant'
+        warn("Previously, hessian implicitly used 'constant' as the "
+             "border mode when dealing with the edge of the array. The new "
+             "behavior is 'reflect'. To recover the old behavior, use "
+             "mode='constant'. To avoid this warning, please explicitely "
+             "set the mode.", category=FutureWarning, stacklevel=2)
+        mode = 'reflect'
 
     filtered = frangi(image, sigmas=sigmas, scale_range=scale_range,
                       scale_step=scale_step, beta1=beta1, beta2=beta2,

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -243,7 +243,7 @@ def meijering(image, sigmas=range(1, 10, 2), alpha=None,
 
 
 def sato(image, sigmas=range(1, 10, 2), black_ridges=True,
-         mode='constant', cval=0):
+         mode=None, cval=0):
     """
     Filter an image with the Sato tubeness filter.
 
@@ -297,6 +297,13 @@ def sato(image, sigmas=range(1, 10, 2), black_ridges=True,
     sigmas = np.asarray(sigmas)
     if np.any(sigmas < 0.0):
         raise ValueError('Sigma values less than zero are not valid')
+
+    if mode is None:
+        warn("'constant' borders handling mode is deprecated and will be "
+             "replaced by 'reflect' mode in version 0.19. To avoid this "
+             "warning, please explicitely set the mode argument.",
+             category=FutureWarning, stacklevel=2)
+        mode = 'constant'
 
     # Invert image to detect bright ridges on dark background
     if not black_ridges:
@@ -478,7 +485,7 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None,
 
 def hessian(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
             beta1=None, beta2=None, alpha=0.5, beta=0.5, gamma=15,
-            black_ridges=True, mode='constant', cval=0):
+            black_ridges=True, mode=None, cval=0):
     """Filter an image with the Hybrid Hessian filter.
 
     This filter can be used to detect continuous edges, e.g. vessels,
@@ -539,6 +546,13 @@ def hessian(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,
         :DOI:`10.1007/978-3-319-16811-1_40`
     .. [2] Kroon, D. J.: Hessian based Frangi vesselness filter.
     """
+
+    if mode is None:
+        warn("'constant' borders handling mode is deprecated and will be "
+             "replaced by 'reflect' mode in version 0.19. To avoid this "
+             "warning, please explicitely set the mode argument.",
+             category=FutureWarning, stacklevel=2)
+        mode = 'constant'
 
     filtered = frangi(image, sigmas=sigmas, scale_range=scale_range,
                       scale_step=scale_step, beta1=beta1, beta2=beta2,

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -101,7 +101,8 @@ def _check_sigmas(sigmas):
     """
     sigmas = np.asarray(sigmas).ravel()
     if np.any(sigmas < 0.0):
-        raise ValueError('Sigma values should be greater than zero.')
+        raise ValueError('Sigma values should be equal to or greater '
+                         'than zero.')
     return sigmas
 
 

--- a/skimage/filters/tests/test_ridges.py
+++ b/skimage/filters/tests/test_ridges.py
@@ -18,14 +18,14 @@ def test_2d_null_matrix():
     assert_equal(meijering(a_black, black_ridges=True), zeros)
     assert_equal(meijering(a_white, black_ridges=False), zeros)
 
-    assert_equal(sato(a_black, black_ridges=True), zeros)
-    assert_equal(sato(a_white, black_ridges=False), zeros)
+    assert_equal(sato(a_black, black_ridges=True, mode='reflect'), zeros)
+    assert_equal(sato(a_white, black_ridges=False, mode='reflect'), zeros)
 
     assert_allclose(frangi(a_black, black_ridges=True), zeros, atol=1e-3)
     assert_allclose(frangi(a_white, black_ridges=False), zeros, atol=1e-3)
 
-    assert_equal(hessian(a_black, black_ridges=False), ones)
-    assert_equal(hessian(a_white, black_ridges=True), ones)
+    assert_equal(hessian(a_black, black_ridges=False, mode='reflect'), ones)
+    assert_equal(hessian(a_white, black_ridges=True, mode='reflect'), ones)
 
 
 def test_3d_null_matrix():
@@ -39,14 +39,14 @@ def test_3d_null_matrix():
     assert_allclose(meijering(a_black, black_ridges=True), zeros, atol=1e-1)
     assert_allclose(meijering(a_white, black_ridges=False), zeros, atol=1e-1)
 
-    assert_equal(sato(a_black, black_ridges=True), zeros)
-    assert_equal(sato(a_white, black_ridges=False), zeros)
+    assert_equal(sato(a_black, black_ridges=True, mode='reflect'), zeros)
+    assert_equal(sato(a_white, black_ridges=False, mode='reflect'), zeros)
 
     assert_allclose(frangi(a_black, black_ridges=True), zeros, atol=1e-3)
     assert_allclose(frangi(a_white, black_ridges=False), zeros, atol=1e-3)
 
-    assert_equal(hessian(a_black, black_ridges=False), ones)
-    assert_equal(hessian(a_white, black_ridges=True), ones)
+    assert_equal(hessian(a_black, black_ridges=False, mode='reflect'), ones)
+    assert_equal(hessian(a_white, black_ridges=True, mode='reflect'), ones)
 
 
 def test_2d_energy_decrease():
@@ -60,18 +60,20 @@ def test_2d_energy_decrease():
     assert_array_less(meijering(a_white, black_ridges=False).std(),
                       a_white.std())
 
-    assert_array_less(sato(a_black, black_ridges=True).std(), a_black.std())
-    assert_array_less(sato(a_white, black_ridges=False).std(), a_white.std())
+    assert_array_less(sato(a_black, black_ridges=True, mode='reflect').std(),
+                      a_black.std())
+    assert_array_less(sato(a_white, black_ridges=False, mode='reflect').std(),
+                      a_white.std())
 
     assert_array_less(frangi(a_black, black_ridges=True).std(),
                       a_black.std())
     assert_array_less(frangi(a_white, black_ridges=False).std(),
                       a_white.std())
 
-    assert_array_less(hessian(a_black, black_ridges=True).std(),
-                      a_black.std())
-    assert_array_less(hessian(a_white, black_ridges=False).std(),
-                      a_white.std())
+    assert_array_less(hessian(a_black, black_ridges=True,
+                              mode='reflect').std(), a_black.std())
+    assert_array_less(hessian(a_white, black_ridges=False,
+                              mode='reflect').std(), a_white.std())
 
 
 def test_3d_energy_decrease():
@@ -85,18 +87,20 @@ def test_3d_energy_decrease():
     assert_array_less(meijering(a_white, black_ridges=False).std(),
                       a_white.std())
 
-    assert_array_less(sato(a_black, black_ridges=True).std(), a_black.std())
-    assert_array_less(sato(a_white, black_ridges=False).std(), a_white.std())
+    assert_array_less(sato(a_black, black_ridges=True, mode='reflect').std(),
+                      a_black.std())
+    assert_array_less(sato(a_white, black_ridges=False, mode='reflect').std(),
+                      a_white.std())
 
     assert_array_less(frangi(a_black, black_ridges=True).std(),
                       a_black.std())
     assert_array_less(frangi(a_white, black_ridges=False).std(),
                       a_white.std())
 
-    assert_array_less(hessian(a_black, black_ridges=True).std(),
-                      a_black.std())
-    assert_array_less(hessian(a_white, black_ridges=False).std(),
-                      a_white.std())
+    assert_array_less(hessian(a_black, black_ridges=True,
+                              mode='reflect').std(), a_black.std())
+    assert_array_less(hessian(a_white, black_ridges=False,
+                              mode='reflect').std(), a_white.std())
 
 
 def test_2d_linearity():
@@ -109,20 +113,24 @@ def test_2d_linearity():
     assert_allclose(meijering(1 * a_white, black_ridges=False),
                     meijering(10 * a_white, black_ridges=False), atol=1e-3)
 
-    assert_allclose(sato(1 * a_black, black_ridges=True),
-                    sato(10 * a_black, black_ridges=True), atol=1e-3)
-    assert_allclose(sato(1 * a_white, black_ridges=False),
-                    sato(10 * a_white, black_ridges=False), atol=1e-3)
+    assert_allclose(sato(1 * a_black, black_ridges=True, mode='reflect'),
+                    sato(10 * a_black, black_ridges=True, mode='reflect'),
+                    atol=1e-3)
+    assert_allclose(sato(1 * a_white, black_ridges=False, mode='reflect'),
+                    sato(10 * a_white, black_ridges=False, mode='reflect'),
+                    atol=1e-3)
 
     assert_allclose(frangi(1 * a_black, black_ridges=True),
                     frangi(10 * a_black, black_ridges=True), atol=1e-3)
     assert_allclose(frangi(1 * a_white, black_ridges=False),
                     frangi(10 * a_white, black_ridges=False), atol=1e-3)
 
-    assert_allclose(hessian(1 * a_black, black_ridges=True),
-                    hessian(10 * a_black, black_ridges=True), atol=1e-3)
-    assert_allclose(hessian(1 * a_white, black_ridges=False),
-                    hessian(10 * a_white, black_ridges=False), atol=1e-3)
+    assert_allclose(hessian(1 * a_black, black_ridges=True, mode='reflect'),
+                    hessian(10 * a_black, black_ridges=True, mode='reflect'),
+                    atol=1e-3)
+    assert_allclose(hessian(1 * a_white, black_ridges=False, mode='reflect'),
+                    hessian(10 * a_white, black_ridges=False, mode='reflect'),
+                    atol=1e-3)
 
 
 def test_3d_linearity():
@@ -135,20 +143,24 @@ def test_3d_linearity():
     assert_allclose(meijering(1 * a_white, black_ridges=False),
                     meijering(10 * a_white, black_ridges=False), atol=1e-3)
 
-    assert_allclose(sato(1 * a_black, black_ridges=True),
-                    sato(10 * a_black, black_ridges=True), atol=1e-3)
-    assert_allclose(sato(1 * a_white, black_ridges=False),
-                    sato(10 * a_white, black_ridges=False), atol=1e-3)
+    assert_allclose(sato(1 * a_black, black_ridges=True, mode='reflect'),
+                    sato(10 * a_black, black_ridges=True, mode='reflect'),
+                    atol=1e-3)
+    assert_allclose(sato(1 * a_white, black_ridges=False, mode='reflect'),
+                    sato(10 * a_white, black_ridges=False, mode='reflect'),
+                    atol=1e-3)
 
     assert_allclose(frangi(1 * a_black, black_ridges=True),
                     frangi(10 * a_black, black_ridges=True), atol=1e-3)
     assert_allclose(frangi(1 * a_white, black_ridges=False),
                     frangi(10 * a_white, black_ridges=False), atol=1e-3)
 
-    assert_allclose(hessian(1 * a_black, black_ridges=True),
-                    hessian(10 * a_black, black_ridges=True), atol=1e-3)
-    assert_allclose(hessian(1 * a_white, black_ridges=False),
-                    hessian(10 * a_white, black_ridges=False), atol=1e-3)
+    assert_allclose(hessian(1 * a_black, black_ridges=True, mode='reflect'),
+                    hessian(10 * a_black, black_ridges=True, mode='reflect'),
+                    atol=1e-3)
+    assert_allclose(hessian(1 * a_white, black_ridges=False, mode='reflect'),
+                    hessian(10 * a_white, black_ridges=False, mode='reflect'),
+                    atol=1e-3)
 
 
 def test_2d_cropped_camera_image():
@@ -162,14 +174,16 @@ def test_2d_cropped_camera_image():
     assert_allclose(meijering(a_black, black_ridges=True),
                     meijering(a_white, black_ridges=False))
 
-    assert_allclose(sato(a_black, black_ridges=True),
-                    sato(a_white, black_ridges=False))
+    assert_allclose(sato(a_black, black_ridges=True, mode='reflect'),
+                    sato(a_white, black_ridges=False, mode='reflect'))
 
     assert_allclose(frangi(a_black, black_ridges=True), zeros, atol=1e-3)
     assert_allclose(frangi(a_white, black_ridges=False), zeros, atol=1e-3)
 
-    assert_allclose(hessian(a_black, black_ridges=True), ones, atol=1 - 1e-7)
-    assert_allclose(hessian(a_white, black_ridges=False), ones, atol=1 - 1e-7)
+    assert_allclose(hessian(a_black, black_ridges=True, mode='reflect'),
+                    ones, atol=1 - 1e-7)
+    assert_allclose(hessian(a_white, black_ridges=False, mode='reflect'),
+                    ones, atol=1 - 1e-7)
 
 
 def test_3d_cropped_camera_image():
@@ -184,23 +198,25 @@ def test_3d_cropped_camera_image():
     assert_allclose(meijering(a_black, black_ridges=True),
                     meijering(a_white, black_ridges=False))
 
-    assert_allclose(sato(a_black, black_ridges=True),
-                    sato(a_white, black_ridges=False))
+    assert_allclose(sato(a_black, black_ridges=True, mode='reflect'),
+                    sato(a_white, black_ridges=False, mode='reflect'))
 
     assert_allclose(frangi(a_black, black_ridges=True), zeros, atol=1e-3)
     assert_allclose(frangi(a_white, black_ridges=False), zeros, atol=1e-3)
 
-    assert_allclose(hessian(a_black, black_ridges=True), ones, atol=1 - 1e-7)
-    assert_allclose(hessian(a_white, black_ridges=False), ones, atol=1 - 1e-7)
+    assert_allclose(hessian(a_black, black_ridges=True, mode='reflect'),
+                    ones, atol=1 - 1e-7)
+    assert_allclose(hessian(a_white, black_ridges=False, mode='reflect'),
+                    ones, atol=1 - 1e-7)
 
 
 @pytest.mark.parametrize('func, tol', [(frangi, 1e-7),
                                        (meijering, 1e-2),
-                                       (sato, 1e-3),
-                                       (hessian, 0.55)])
+                                       (sato, 1e-4),
+                                       (hessian, 2e-2)])
 def test_border_management(func, tol):
     img = rgb2gray(retina()[300:500, 700:900])
-    out = func(img, sigmas=[1])
+    out = func(img, sigmas=[1], mode='reflect')
 
     full_std = out.std()
     full_mean = out.mean()

--- a/skimage/filters/tests/test_ridges.py
+++ b/skimage/filters/tests/test_ridges.py
@@ -5,6 +5,7 @@ from skimage.filters import meijering, sato, frangi, hessian
 from skimage.data import camera, retina
 from skimage.util import crop, invert
 from skimage.color import rgb2gray
+from skimage._shared._warnings import expected_warnings
 
 
 def test_2d_null_matrix():
@@ -233,6 +234,14 @@ def test_border_management(func, tol):
     assert abs(full_mean - inside_mean) < tol
     assert abs(full_mean - border_mean) < tol
     assert abs(inside_mean - border_mean) < tol
+
+
+@pytest.mark.parametrize('func', [sato, hessian])
+def test_border_warning(func):
+    img = rgb2gray(retina()[300:500, 700:900])
+
+    with expected_warnings(["implicitly used 'constant' as the border mode"]):
+        func(img, sigmas=[1])
 
 
 if __name__ == "__main__":

--- a/skimage/filters/tests/test_ridges.py
+++ b/skimage/filters/tests/test_ridges.py
@@ -212,7 +212,7 @@ def test_3d_cropped_camera_image():
 
 @pytest.mark.parametrize('func, tol', [(frangi, 1e-7),
                                        (meijering, 1e-2),
-                                       (sato, 1e-4),
+                                       (sato, 1e-3),
                                        (hessian, 2e-2)])
 def test_border_management(func, tol):
     img = rgb2gray(retina()[300:500, 700:900])

--- a/skimage/filters/tests/test_ridges.py
+++ b/skimage/filters/tests/test_ridges.py
@@ -194,7 +194,7 @@ def test_3d_cropped_camera_image():
     assert_allclose(hessian(a_white, black_ridges=False), ones, atol=1 - 1e-7)
 
 
-@pytest.mark.parametrize('func', [frangi, meijering])
+@pytest.mark.parametrize('func', [frangi, meijering, sato])
 def test_border_management(func):
     img = rgb2gray(retina()[300:500, 700:900])
     out = func(img, sigmas=[1])

--- a/skimage/filters/tests/test_ridges.py
+++ b/skimage/filters/tests/test_ridges.py
@@ -196,7 +196,7 @@ def test_3d_cropped_camera_image():
 
 @pytest.mark.parametrize('func, tol', [(frangi, 1e-7),
                                        (meijering, 1e-2),
-                                       (sato, 1e-4),
+                                       (sato, 1e-3),
                                        (hessian, 2e-2)])
 def test_border_management(func, tol):
     img = rgb2gray(retina()[300:500, 700:900])

--- a/skimage/filters/tests/test_ridges.py
+++ b/skimage/filters/tests/test_ridges.py
@@ -194,8 +194,11 @@ def test_3d_cropped_camera_image():
     assert_allclose(hessian(a_white, black_ridges=False), ones, atol=1 - 1e-7)
 
 
-@pytest.mark.parametrize('func', [frangi, meijering, sato])
-def test_border_management(func):
+@pytest.mark.parametrize('func, tol', [(frangi, 1e-7),
+                                       (meijering, 1e-2),
+                                       (sato, 1e-4),
+                                       (hessian, 2e-2)])
+def test_border_management(func, tol):
     img = rgb2gray(retina()[300:500, 700:900])
     out = func(img, sigmas=[1])
 
@@ -207,8 +210,6 @@ def test_border_management(func):
                            out[:, :4].T, out[:, -4:].T]).std()
     border_mean = np.stack([out[:4, :], out[-4:, :],
                             out[:, :4].T, out[:, -4:].T]).mean()
-
-    tol = 1e-2
 
     assert abs(full_std - inside_std) < tol
     assert abs(full_std - border_std) < tol

--- a/skimage/filters/tests/test_ridges.py
+++ b/skimage/filters/tests/test_ridges.py
@@ -197,7 +197,7 @@ def test_3d_cropped_camera_image():
 @pytest.mark.parametrize('func, tol', [(frangi, 1e-7),
                                        (meijering, 1e-2),
                                        (sato, 1e-3),
-                                       (hessian, 2e-2)])
+                                       (hessian, 0.55)])
 def test_border_management(func, tol):
     img = rgb2gray(retina()[300:500, 700:900])
     out = func(img, sigmas=[1])

--- a/skimage/filters/tests/test_ridges.py
+++ b/skimage/filters/tests/test_ridges.py
@@ -1,4 +1,4 @@
-
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_less, assert_equal
 from skimage.filters import meijering, sato, frangi, hessian
@@ -15,8 +15,8 @@ def test_2d_null_matrix():
     zeros = np.zeros((3, 3))
     ones = np.ones((3, 3))
 
-    assert_equal(meijering(a_black, black_ridges=True), ones)
-    assert_equal(meijering(a_white, black_ridges=False), ones)
+    assert_equal(meijering(a_black, black_ridges=True), zeros)
+    assert_equal(meijering(a_white, black_ridges=False), zeros)
 
     assert_equal(sato(a_black, black_ridges=True), zeros)
     assert_equal(sato(a_white, black_ridges=False), zeros)
@@ -36,8 +36,8 @@ def test_3d_null_matrix():
     zeros = np.zeros((3, 3, 3))
     ones = np.ones((3, 3, 3))
 
-    assert_allclose(meijering(a_black, black_ridges=True), ones, atol=1e-1)
-    assert_allclose(meijering(a_white, black_ridges=False), ones, atol=1e-1)
+    assert_allclose(meijering(a_black, black_ridges=True), zeros, atol=1e-1)
+    assert_allclose(meijering(a_white, black_ridges=False), zeros, atol=1e-1)
 
     assert_equal(sato(a_black, black_ridges=True), zeros)
     assert_equal(sato(a_white, black_ridges=False), zeros)
@@ -194,9 +194,10 @@ def test_3d_cropped_camera_image():
     assert_allclose(hessian(a_white, black_ridges=False), ones, atol=1 - 1e-7)
 
 
-def test_border_management():
+@pytest.mark.parametrize('func', [frangi, meijering])
+def test_border_management(func):
     img = rgb2gray(retina()[300:500, 700:900])
-    out = frangi(img, sigmas=[1])
+    out = func(img, sigmas=[1])
 
     full_std = out.std()
     full_mean = out.mean()
@@ -207,12 +208,14 @@ def test_border_management():
     border_mean = np.stack([out[:4, :], out[-4:, :],
                             out[:, :4].T, out[:, -4:].T]).mean()
 
-    assert abs(full_std - inside_std) < 1e-7
-    assert abs(full_std - border_std) < 1e-7
-    assert abs(inside_std - border_std) < 1e-7
-    assert abs(full_mean - inside_mean) < 1e-7
-    assert abs(full_mean - border_mean) < 1e-7
-    assert abs(inside_mean - border_mean) < 1e-7
+    tol = 1e-2
+
+    assert abs(full_std - inside_std) < tol
+    assert abs(full_std - border_std) < tol
+    assert abs(inside_std - border_std) < tol
+    assert abs(full_mean - inside_mean) < tol
+    assert abs(full_mean - border_mean) < tol
+    assert abs(inside_mean - border_mean) < tol
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Closes #4394.

- Border condition handling is added to the `meijering`, `sato` and `hessian` filters,
- border artifact in `meijering` are removed using the 'reflect' mode,
- implicit 'constant' mode used in `sato` and `hessian` are deprecated in favor of 'reflect' mode.

This PR comes from a suggestion of @shenker https://github.com/scikit-image/scikit-image/pull/4343#pullrequestreview-337754448.

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
