### PR TITLE
Documentation fixes for transform (rescale, warp_polar)

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -236,7 +236,7 @@ def rescale(image, scale, order=1, mode='reflect', cval=0, clip=True,
         avoid aliasing artifacts.
     anti_aliasing_sigma : {float, tuple of floats}, optional
         Standard deviation for Gaussian filtering to avoid aliasing artifacts.
-        By default, this value is chosen as (1 - s) / 2 where s is the
+        By default, this value is chosen as (s - 1) / 2 where s is the
         down-scaling factor.
 
     Notes
@@ -910,7 +910,7 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=1,
 
 
 def _linear_polar_mapping(output_coords, k_angle, k_radius, center):
-    """Inverse mapping function to convert from cartesion to polar coordinates
+    """Inverse mapping function to convert from cartesian to polar coordinates
 
     Parameters
     ----------
@@ -941,7 +941,7 @@ def _linear_polar_mapping(output_coords, k_angle, k_radius, center):
 
 
 def _log_polar_mapping(output_coords, k_angle, k_radius, center):
-    """Inverse mapping function to convert from cartesion to polar coordinates
+    """Inverse mapping function to convert from cartesian to polar coordinates
 
     Parameters
     ----------
@@ -973,7 +973,7 @@ def _log_polar_mapping(output_coords, k_angle, k_radius, center):
 
 def warp_polar(image, center=None, *, radius=None, output_shape=None,
                scaling='linear', multichannel=False, **kwargs):
-    """Remap image to polor or log-polar coordinates space.
+    """Remap image to polar or log-polar coordinates space.
 
     Parameters
     ----------


### PR DESCRIPTION
## Description

This is a very small change to the documentation in `transform`. In addition to a few typos, it is fixing an error in the docstring for `transform.rescale`:

```
anti_aliasing_sigma{float, tuple of floats}, optional
Standard deviation for Gaussian filtering to avoid aliasing artifacts. By default, this value is chosen as (1 - s) / 2 where s is the down-scaling factor."
```
`(1 - s) / 2` is incorrect. This should read `(s - 1) / 2` as per the docs for `transform.resize` on which this function is based.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
