### PR TITLE
Speedup warp for 3D images

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -3,7 +3,7 @@ from scipy import ndimage as ndi
 
 from ._geometric import (SimilarityTransform, AffineTransform,
                          ProjectiveTransform, _to_ndimage_mode)
-from ._warps_cy import _warp_fast
+from ._warps_cy import _warp_fast, _warp_fast_batch
 from ..measure import block_reduce
 
 from .._shared.utils import (get_bound_method_class, safe_as_int, warn,
@@ -855,13 +855,10 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=1,
                                            output_shape=output_shape,
                                            order=order, mode=mode, cval=cval)
             elif image.ndim == 3:
-                dims = []
-                for dim in range(image.shape[2]):
-                    dims.append(_warp_fast[ctype](image[..., dim], matrix,
-                                                  output_shape=output_shape,
-                                                  order=order, mode=mode,
-                                                  cval=cval))
-                warped = np.dstack(dims)
+                warped = _warp_fast_batch[ctype](image, matrix,
+                                                 output_shape=output_shape,
+                                                 order=order,
+                                                 mode=mode, cval=cval)
 
     if warped is None:
         # use ndi.map_coordinates

--- a/skimage/transform/_warps_cy.pyx
+++ b/skimage/transform/_warps_cy.pyx
@@ -143,6 +143,13 @@ def _warp_fast(
     would be [0, 1, 2, 1, 0, 1, 2].
 
     """
+    cdef np.intp_t[2] shape
+    if output_shape is None:
+        shape[0] = np.PyArray_DIM(image, 0)
+        shape[1] = np.PyArray_DIM(image, 1)
+    else:
+        shape[0] = output_shape[0]
+        shape[1] = output_shape[1]
 
     cdef np_floats[:, ::1] img = np.PyArray_GETCONTIGUOUS(image)
     cdef np_floats[:, ::1] M = np.PyArray_GETCONTIGUOUS(H)
@@ -180,14 +187,6 @@ def _warp_fast(
     else:
         raise ValueError("Unsupported interpolation order", order)
 
-    cdef np.intp_t[2] shape
-    if output_shape is None:
-        shape[0] = img.shape[0]
-        shape[1] = img.shape[1]
-    else:
-        shape[0] = output_shape[0]
-        shape[1] = output_shape[1]
-
     cdef np.ndarray out = np.PyArray_ZEROS(2, shape, dtype, 0)
     cdef np_floats[:, ::1] vout = out
 
@@ -211,5 +210,158 @@ def _warp_fast(
                 transform_func(tfc, tfr, pM, &c, &r)
                 interp_func(pimg, rows, cols, r, c, mode_c, cval, pout)
                 pout += 1
+
+    return out
+
+
+def _warp_fast_batch(
+    np.ndarray image not None,
+    np.ndarray H not None,
+    np.intp_t[:] output_shape=None,
+    int order=1,
+    str mode='constant',
+    np_floats cval=0,
+    int channel_axis=-1,  # (0, -1) API CHANGE
+    bint channel_innermost_loop=False  # For test only, replace with logic
+):
+    cdef np.intp_t[3] shape
+    if output_shape is None:
+        shape[0] = np.PyArray_DIM(image, 0)
+        shape[1] = np.PyArray_DIM(image, 1)
+        shape[2] = np.PyArray_DIM(image, 2)
+    else:
+        shape[0] = output_shape[0]
+        shape[1] = output_shape[1]
+        shape[2] = output_shape[2]
+
+    # Interpolation functions expect image to be contiguous in column axis
+    # Hence, transpose image that its channels are placed first
+    # Solving this would require changes in the interpolation functions
+    cdef np.intp_t[3] permute_ptr
+    if channel_axis == -1:
+        permute_ptr = [2, 0, 1]
+    elif channel_axis != 0:
+        raise ValueError("Unsupported channel axis", channel_axis)
+
+    cdef np.PyArray_Dims permute
+    if channel_axis != 0:
+        permute = [permute_ptr, 3]
+        image = np.PyArray_Transpose(image, &permute)
+
+    cdef np_floats[:, :, ::1] img = np.PyArray_GETCONTIGUOUS(image)
+    cdef np_floats[:, ::1] M = np.PyArray_GETCONTIGUOUS(H)
+
+    cdef int dtype
+    if np_floats is np.float32_t:
+        dtype = np.NPY_FLOAT32
+    else:
+        dtype = np.NPY_FLOAT64
+
+    if mode not in ('constant', 'wrap', 'symmetric', 'reflect', 'edge'):
+        raise ValueError("Invalid mode specified.  Please use `constant`, "
+                         "`edge`, `wrap`, `reflect` or `symmetric`.")
+    cdef char mode_c = ord(mode[0].upper())
+
+    cdef ftransform transform_func
+    if M[2, 0] == 0 and M[2, 1] == 0 and M[2, 2] == 1:
+        if M[0, 1] == 0 and M[1, 0] == 0:
+            transform_func = _transform_metric
+        else:
+            transform_func = _transform_affine
+    else:
+        transform_func = _transform_projective
+
+    cdef finterpolate interp_func
+    if order == 0:
+        interp_func = nearest_neighbour_interpolation[np_floats, np_floats,
+                                                      np_floats]
+    elif order == 1:
+        interp_func = bilinear_interpolation[np_floats, np_floats, np_floats]
+    elif order == 2:
+        interp_func = biquadratic_interpolation[np_floats, np_floats, np_floats]
+    elif order == 3:
+        interp_func = bicubic_interpolation[np_floats, np_floats, np_floats]
+    else:
+        raise ValueError("Unsupported interpolation order", order)
+
+    cdef np.ndarray out = np.PyArray_ZEROS(3, shape, dtype, 0)
+    cdef np_floats[:, :, ::1] vout = out
+
+    cdef Py_ssize_t out_n
+    cdef Py_ssize_t out_r
+    cdef Py_ssize_t out_c
+
+    if channel_axis == 0:
+        out_n = vout.shape[0]
+        out_r = vout.shape[1]
+        out_c = vout.shape[2]
+    else:
+        out_n = vout.shape[2]
+        out_r = vout.shape[0]
+        out_c = vout.shape[1]
+
+    cdef Py_ssize_t chns = img.shape[0] if img.shape[0] < out_n else out_n
+    cdef Py_ssize_t rows = img.shape[1]
+    cdef Py_ssize_t cols = img.shape[2]
+
+    cdef Py_ssize_t tfn
+    cdef Py_ssize_t tfr
+    cdef Py_ssize_t tfc
+    cdef np_floats r
+    cdef np_floats c
+
+    cdef np_floats *pM = &M[0, 0]
+
+    with nogil:
+        if channel_axis == 0:
+            if channel_innermost_loop:
+                for tfr in range(out_r):
+                    for tfc in range(out_c):
+                        transform_func(tfc, tfr, pM, &c, &r)
+                        for tfn in range(chns):
+                            interp_func(
+                                &img[tfn, 0, 0],
+                                rows, cols,
+                                r, c,
+                                mode_c, cval,
+                                &vout[tfn, tfr, tfc]
+                            )
+            else:
+                for tfn in range(chns):
+                    for tfr in range(out_r):
+                        for tfc in range(out_c):
+                            transform_func(tfc, tfr, pM, &c, &r)
+                            interp_func(
+                                &img[tfn, 0, 0],
+                                rows, cols,
+                                r, c,
+                                mode_c, cval,
+                                &vout[tfn, tfr, tfc]
+                            )
+        else:
+            if channel_innermost_loop:
+                for tfr in range(out_r):
+                    for tfc in range(out_c):
+                        transform_func(tfc, tfr, pM, &c, &r)
+                        for tfn in range(chns):
+                            interp_func(
+                                &img[tfn, 0, 0],
+                                rows, cols,
+                                r, c,
+                                mode_c, cval,
+                                &vout[tfr, tfc, tfn]
+                            )
+            else:
+                for tfn in range(chns):
+                    for tfr in range(out_r):
+                        for tfc in range(out_c):
+                            transform_func(tfc, tfr, pM, &c, &r)
+                            interp_func(
+                                &img[tfn, 0, 0],
+                                rows, cols,
+                                r, c,
+                                mode_c, cval,
+                                &vout[tfr, tfc, tfn]
+                            )
 
     return out

--- a/skimage/transform/_warps_cy.pyx
+++ b/skimage/transform/_warps_cy.pyx
@@ -2,8 +2,10 @@
 #cython: boundscheck=False
 #cython: nonecheck=False
 #cython: wraparound=False
-import numpy as np
-cimport numpy as cnp
+cimport numpy as np
+np.import_array()
+
+
 from .._shared.interpolation cimport (nearest_neighbour_interpolation,
                                       bilinear_interpolation,
                                       biquadratic_interpolation,
@@ -67,8 +69,30 @@ cdef inline void _transform_projective(np_floats x, np_floats y, np_floats* H,
     y_[0] = (H[3] * x + H[4] * y + H[5]) / z_
 
 
-def _warp_fast(np_floats[:, :] image, np_floats[:, :] H, output_shape=None,
-               int order=1, mode='constant', np_floats cval=0):
+ctypedef void (*ftransform)(
+    np_floats, np_floats,
+    np_floats*,
+    np_floats*, np_floats*
+) nogil
+
+
+ctypedef void (*finterpolate)(
+    np_floats*,
+    Py_ssize_t, Py_ssize_t,
+    np_floats, np_floats,
+    char, np_floats,
+    np_floats*
+) nogil
+
+
+def _warp_fast(
+    np.ndarray image not None,
+    np.ndarray H not None,
+    np.intp_t[:] output_shape=None,
+    int order=1,
+    str mode='constant',
+    np_floats cval=0
+):
     """Projective transformation (homography).
 
     Perform a projective transformation (homography) of a floating
@@ -120,36 +144,21 @@ def _warp_fast(np_floats[:, :] image, np_floats[:, :] H, output_shape=None,
 
     """
 
-    cdef np_floats[:, ::1] img = np.ascontiguousarray(image)
-    cdef np_floats[:, ::1] M = np.ascontiguousarray(H)
+    cdef np_floats[:, ::1] img = np.PyArray_GETCONTIGUOUS(image)
+    cdef np_floats[:, ::1] M = np.PyArray_GETCONTIGUOUS(H)
 
-    if np_floats is cnp.float32_t:
-        dtype = np.float32
+    cdef int dtype
+    if np_floats is np.float32_t:
+        dtype = np.NPY_FLOAT32
     else:
-        dtype = np.float64
+        dtype = np.NPY_FLOAT64
 
     if mode not in ('constant', 'wrap', 'symmetric', 'reflect', 'edge'):
         raise ValueError("Invalid mode specified.  Please use `constant`, "
                          "`edge`, `wrap`, `reflect` or `symmetric`.")
     cdef char mode_c = ord(mode[0].upper())
 
-    cdef Py_ssize_t out_r, out_c
-    if output_shape is None:
-        out_r = int(img.shape[0])
-        out_c = int(img.shape[1])
-    else:
-        out_r = int(output_shape[0])
-        out_c = int(output_shape[1])
-
-    cdef np_floats[:, ::1] out = np.zeros((out_r, out_c), dtype=dtype)
-
-    cdef Py_ssize_t tfr, tfc
-    cdef np_floats r, c
-    cdef Py_ssize_t rows = img.shape[0]
-    cdef Py_ssize_t cols = img.shape[1]
-
-    cdef void (*transform_func)(np_floats, np_floats, np_floats*,
-                                np_floats*, np_floats*) nogil
+    cdef ftransform transform_func
     if M[2, 0] == 0 and M[2, 1] == 0 and M[2, 2] == 1:
         if M[0, 1] == 0 and M[1, 0] == 0:
             transform_func = _transform_metric
@@ -158,9 +167,7 @@ def _warp_fast(np_floats[:, :] image, np_floats[:, :] H, output_shape=None,
     else:
         transform_func = _transform_projective
 
-    cdef void (*interp_func)(np_floats*, Py_ssize_t , Py_ssize_t ,
-                             np_floats, np_floats, char, np_floats,
-                             np_floats*) nogil
+    cdef finterpolate interp_func
     if order == 0:
         interp_func = nearest_neighbour_interpolation[np_floats, np_floats,
                                                       np_floats]
@@ -173,11 +180,36 @@ def _warp_fast(np_floats[:, :] image, np_floats[:, :] H, output_shape=None,
     else:
         raise ValueError("Unsupported interpolation order", order)
 
+    cdef np.intp_t[2] shape
+    if output_shape is None:
+        shape[0] = img.shape[0]
+        shape[1] = img.shape[1]
+    else:
+        shape[0] = output_shape[0]
+        shape[1] = output_shape[1]
+
+    cdef np.ndarray out = np.PyArray_ZEROS(2, shape, dtype, 0)
+    cdef np_floats[:, ::1] vout = out
+
+    cdef Py_ssize_t out_r = vout.shape[0]
+    cdef Py_ssize_t out_c = vout.shape[1]
+    cdef Py_ssize_t rows = img.shape[0]
+    cdef Py_ssize_t cols = img.shape[1]
+
+    cdef Py_ssize_t tfr
+    cdef Py_ssize_t tfc
+    cdef np_floats r
+    cdef np_floats c
+
+    cdef np_floats *pimg = &img[0, 0]
+    cdef np_floats *pM = &M[0, 0]
+    cdef np_floats *pout = &vout[0, 0]
+
     with nogil:
         for tfr in range(out_r):
             for tfc in range(out_c):
-                transform_func(tfc, tfr, &M[0, 0], &c, &r)
-                interp_func(&img[0, 0], rows, cols, r, c,
-                            mode_c, cval, &out[tfr, tfc])
+                transform_func(tfc, tfr, pM, &c, &r)
+                interp_func(pimg, rows, cols, r, c, mode_c, cval, pout)
+                pout += 1
 
-    return np.asarray(out)
+    return out


### PR DESCRIPTION
## Description

This PR speeds up warping for 3D images (3D or multichannel 2D) up-to 5x by writing `_warp_fast_batch` which handles a batch of 2D images directly.

The original approach had some performance problems like:
- Overhead slicing and repacking the image
- Force converting image slices to contiguous arrays which in some cases might not be needed
- Recomputing the transform at each iteration which only depends on the coordinates in the 2D plane

And also an API problem where the input had to have its channel axis placed last, overcoming that would require transposing the image before and after the computation

The proposed code works on images with format [plane, row, column] or [row, column, channel]
by specifying the `channel_axis` parameter and controls whether the iteration over the channel axis should be the innermost loop or the outermost loop which basically impacts the caching.

I've ran some benchmarks and here are the results
![CF32](https://user-images.githubusercontent.com/6504541/73088673-60be4c00-3edd-11ea-8f14-d0ca96089534.png)
![CF64](https://user-images.githubusercontent.com/6504541/73088680-63b93c80-3edd-11ea-9945-fe403f81292a.png)
![CL32](https://user-images.githubusercontent.com/6504541/73088681-64ea6980-3edd-11ea-8443-10d71afb1d11.png)
![CL64](https://user-images.githubusercontent.com/6504541/73088689-66b42d00-3edd-11ea-8f61-2eb4ca7f7863.png)
Each figure has 3 rows (for interpolation order) and 5 columns (for image size nxn) of subplots which compares the number of channels vs speedup

A bunch of TODOs:
- Settle on the logic for choosing channel loop placement
- Documentation
- Benchmark code

Reviews and change request are most welcome

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
