### PR TITLE
Fix hanging documentation build in Azure

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -47,7 +47,11 @@ api:
 
 release_notes:
 	@echo "Copying release notes"
-	@tail -n +4 `ls release/*.rst | sort -k 2 -t . -n | tail -n 1` > release/_release_notes_for_docs.rst
+	@cat `$(PYTHON) -c \
+		"from pathlib import Path; from skimage import io; \
+		 l = list(str(e) for e in Path('release').glob('release_*.*.*')); \
+		 l.sort(key=io.collection.alphanumeric_key); print(l[-1])"` \
+		| tail -n +4 > release/_release_notes_for_docs.rst
 
 html: api release_notes
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(DEST)/html


### PR DESCRIPTION
## Description

This issue is related to the fact that Azure Pipelines environment has switched to Windows-like `sort` function. The latter does not support many of the used parameters, such as numerical sorting. Since I did not find a way to perform the very sorting with the new `sort`, I have changed the code to use an inline Python code to do the sorting.

Fixes https://github.com/scikit-image/scikit-image/issues/4408.

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
