### PR TITLE
Fix rgb2gray docstring to show that 2-D arrays are allowed as inputs

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -753,7 +753,10 @@ def rgb2gray(rgb):
     rgb : array_like
         The image in RGB format, in a 3-D or 4-D array of shape
         ``(.., ..,[ ..,] 3)``, or in RGBA format with shape
-        ``(.., ..,[ ..,] 4)``.
+        ``(.., ..,[ ..,] 4)``
+        or
+        The image in grayscale format, in a 2-D array of shape
+        `(M, N)``
 
     Returns
     -------
@@ -764,7 +767,7 @@ def rgb2gray(rgb):
     Raises
     ------
     ValueError
-        If `rgb2gray` is not a 3-D or 4-D arrays of shape
+        If `rgb` is a 1-D array, or not a 3-D or 4-D array of shape
         ``(.., ..,[ ..,] 3)`` or ``(.., ..,[ ..,] 4)``.
 
     References
@@ -779,6 +782,9 @@ def rgb2gray(rgb):
         Y = 0.2125 R + 0.7154 G + 0.0721 B
 
     If there is an alpha channel present, it is ignored.
+
+    If the input array is 2-D, it is converted to a row-major (i.e. C-style)
+    array (f needed) and returned without any further changes.
 
     Examples
     --------

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -756,7 +756,7 @@ def rgb2gray(rgb):
         ``(.., ..,[ ..,] 4)``
         or
         The image in grayscale format, in a 2-D array of shape
-        `(M, N)``
+        ``(M, N)``
 
     Returns
     -------


### PR DESCRIPTION
## Description

This is a docstring fix, refers to discussion in #3200, specifically [this reply](https://github.com/scikit-image/scikit-image/issues/3200#issuecomment-578013692).

`rgb2gray()` allows 2-D arrays as inputs, but the docstring stated it would raise a `ValueError`. This PR does the following:
- Changes the docstring to show that 2-D inputs are allowed.
- Explains what happens to 2-D inputs (essentially, nothing changes except converting it to row-major order, if needed).

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
