### PR TITLE
Deprecate rgb2grey and grey2rgb

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -48,6 +48,7 @@ Version 0.19
   skimage/util/tests/test_arraypad.py.
 * Remove the warnings in ``skimage/filters/ridges.py`` from sato and hessian
   functions.
+* In ``skimage/color/colorconv.py``, remove  `rgb2grey` and `grey2rgb`.
 
 
 Other

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -50,9 +50,9 @@ References
 """
 
 
-from functools import update_wrapper
-from warnings import warn
+import functools
 import numpy as np
+from warnings import warn
 from scipy import linalg
 from ..util import dtype, dtype_limits
 
@@ -797,13 +797,11 @@ def rgb2gray(rgb):
     return rgb @ coeffs
 
 
+@functools.wraps(rgb2gray)
 def rgb2grey(rgb):
     warn('rgb2grey is deprecated. It will be removed in version 0.19.'
          'Please use rgb2gray instead.', FutureWarning, stacklevel=2)
     return rgb2gray(rgb)
-
-
-update_wrapper(rgb2grey, rgb2gray)
 
 
 def gray2rgb(image, alpha=None):
@@ -867,13 +865,11 @@ def gray2rgb(image, alpha=None):
         raise ValueError("Input image expected to be RGB, RGBA or gray.")
 
 
+@functools.wraps(gray2rgb)
 def grey2rgb(image):
     warn('grey2rgb is deprecated. It will be removed in version 0.19.'
          'Please use gray2rgb instead.', FutureWarning, stacklevel=2)
     return gray2rgb(image)
-
-
-update_wrapper(grey2rgb, gray2rgb)
 
 
 def xyz2lab(xyz, illuminant="D65", observer="2"):

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -50,6 +50,7 @@ References
 """
 
 
+from functools import update_wrapper
 from warnings import warn
 import numpy as np
 from scipy import linalg
@@ -796,7 +797,13 @@ def rgb2gray(rgb):
     return rgb @ coeffs
 
 
-rgb2grey = rgb2gray
+def rgb2grey(rgb):
+    warn('rgb2grey is deprecated. It will be removed in version 0.19.'
+         'Please use rgb2gray instead.', FutureWarning, stacklevel=2)
+    return rgb2gray(rgb)
+
+
+update_wrapper(rgb2grey, rgb2gray)
 
 
 def gray2rgb(image, alpha=None):
@@ -859,7 +866,14 @@ def gray2rgb(image, alpha=None):
     else:
         raise ValueError("Input image expected to be RGB, RGBA or gray.")
 
-grey2rgb = gray2rgb
+
+def grey2rgb(image):
+    warn('grey2rgb is deprecated. It will be removed in version 0.19.'
+         'Please use gray2rgb instead.', FutureWarning, stacklevel=2)
+    return gray2rgb(image)
+
+
+update_wrapper(grey2rgb, gray2rgb)
 
 
 def xyz2lab(xyz, illuminant="D65", observer="2"):

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -24,7 +24,7 @@ from skimage.color import (rgb2hsv, hsv2rgb,
                            combine_stains,
                            rgb2rgbcie, rgbcie2rgb,
                            convert_colorspace,
-                           rgb2grey, gray2rgb,
+                           rgb2gray, gray2rgb,
                            xyz2lab, lab2xyz,
                            lab2rgb, rgb2lab,
                            xyz2luv, luv2xyz,
@@ -281,31 +281,31 @@ class TestColorconv(TestCase):
         self.assertRaises(ValueError, convert_colorspace,
                           self.colbars_array, 'RGB', 'nokey')
 
-    def test_rgb2grey(self):
+    def test_rgb2gray(self):
         x = np.array([1, 1, 1]).reshape((1, 1, 3)).astype(np.float)
-        g = rgb2grey(x)
+        g = rgb2gray(x)
         assert_array_almost_equal(g, 1)
 
         assert_equal(g.shape, (1, 1))
 
-    def test_rgb2grey_contiguous(self):
+    def test_rgb2gray_contiguous(self):
         x = np.random.rand(10, 10, 3)
-        assert rgb2grey(x).flags["C_CONTIGUOUS"]
-        assert rgb2grey(x[:5, :5]).flags["C_CONTIGUOUS"]
+        assert rgb2gray(x).flags["C_CONTIGUOUS"]
+        assert rgb2gray(x[:5, :5]).flags["C_CONTIGUOUS"]
 
-    def test_rgb2grey_alpha(self):
+    def test_rgb2gray_alpha(self):
         x = np.random.rand(10, 10, 4)
-        assert rgb2grey(x).ndim == 2
+        assert rgb2gray(x).ndim == 2
 
-    def test_rgb2grey_on_grey(self):
-        rgb2grey(np.random.rand(5, 5))
+    def test_rgb2gray_on_gray(self):
+        rgb2gray(np.random.rand(5, 5))
 
-    def test_rgb2grey_dtype(self):
+    def test_rgb2gray_dtype(self):
         img = np.random.rand(10, 10, 3).astype('float64')
         img32 = img.astype('float32')
 
-        assert rgb2grey(img).dtype == img.dtype
-        assert rgb2grey(img32).dtype == img32.dtype
+        assert rgb2gray(img).dtype == img.dtype
+        assert rgb2gray(img32).dtype == img32.dtype
 
     # test matrices for xyz2lab and lab2xyz generated using
     # http://www.easyrgb.com/index.php?X=CALC

--- a/skimage/feature/corner_cy.pyx
+++ b/skimage/feature/corner_cy.pyx
@@ -8,7 +8,6 @@ from libc.float cimport DBL_MAX
 from libc.math cimport atan2, fabs
 
 from ..util import img_as_float64
-from ..color import rgb2grey
 
 from .util import _prepare_grayscale_input_2D
 


### PR DESCRIPTION
## Description

In this PR, `rgb2grey` and `grey2rgb` are deprecated.
It is related to #2604.

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
