### PR TITLE
Add stacklevel=2 to deprecation warnings in skimage.measure.marching_cubes

### DIFF
--- a/skimage/measure/_marching_cubes_classic.py
+++ b/skimage/measure/_marching_cubes_classic.py
@@ -104,7 +104,7 @@ def marching_cubes_classic(volume, level=None, spacing=(1., 1., 1.),
                   "marching_cubes with `method='_lorensen'` "
                   "to apply Lorensen et al. algorithm. "
                   "marching_cubes_classic will be removed in version 0.19",
-                  FutureWarning)
+                  FutureWarning, stacklevel=2)
 
     return _marching_cubes_classic(volume, level, spacing, gradient_direction)
 

--- a/skimage/measure/_marching_cubes_lewiner.py
+++ b/skimage/measure/_marching_cubes_lewiner.py
@@ -242,7 +242,7 @@ def marching_cubes_lewiner(volume, level=None, spacing=(1., 1., 1.),
     warnings.warn("marching_cubes_lewiner is deprecated in favor of "
                   "marching_cubes. marching_cubes_lewiner will "
                   "be removed in version 0.19",
-                  FutureWarning)
+                  FutureWarning, stacklevel=2)
 
     return _marching_cubes_lewiner(volume, level, spacing, gradient_direction,
                                    step_size, allow_degenerate, use_classic)


### PR DESCRIPTION
## Description

@rfezzani If I did it wrong, it's because I cheated :)


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
