### PR TITLE
MAINT: rename draw.circle() to draw.disk()

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -42,6 +42,7 @@ Version 0.18
 Version 0.19
 ------------
 
+* In ``skimage/draw/draw.py`` remove ``circle'' and related tests.
 * In ``skimage/segmentation/morphsnakes.py`` remove ``circle_level_set'' and related tests.
 * In ``skimage/morphology/_flood_fill.py`` replace the deprecated parameter
   in flood_fill() ``inplace`` with ``in_place`` and update the tests.

--- a/doc/examples/edges/plot_shapes.py
+++ b/doc/examples/edges/plot_shapes.py
@@ -48,7 +48,7 @@ rr, cc = polygon(poly[:, 0], poly[:, 1], img.shape)
 img[rr, cc, 1] = 1
 
 # fill circle
-rr, cc = disk(200, 200, 100, img.shape)
+rr, cc = disk(200, 200, 100, shape=img.shape)
 img[rr, cc, :] = (1, 1, 0)
 
 # fill ellipse

--- a/doc/examples/edges/plot_shapes.py
+++ b/doc/examples/edges/plot_shapes.py
@@ -48,7 +48,7 @@ rr, cc = polygon(poly[:, 0], poly[:, 1], img.shape)
 img[rr, cc, 1] = 1
 
 # fill circle
-rr, cc = disk(200, 200, 100, shape=img.shape)
+rr, cc = disk((200, 200), 100, shape=img.shape)
 img[rr, cc, :] = (1, 1, 0)
 
 # fill ellipse

--- a/doc/examples/edges/plot_shapes.py
+++ b/doc/examples/edges/plot_shapes.py
@@ -8,7 +8,7 @@ This example shows how to draw several different shapes:
 - line
 - Bezier curve
 - polygon
-- circle
+- disk
 - ellipse
 
 Anti-aliased drawing for:
@@ -21,7 +21,7 @@ import math
 import numpy as np
 import matplotlib.pyplot as plt
 
-from skimage.draw import (line, polygon, circle,
+from skimage.draw import (line, polygon, disk,
                           circle_perimeter,
                           ellipse, ellipse_perimeter,
                           bezier_curve)
@@ -48,7 +48,7 @@ rr, cc = polygon(poly[:, 0], poly[:, 1], img.shape)
 img[rr, cc, 1] = 1
 
 # fill circle
-rr, cc = circle(200, 200, 100, img.shape)
+rr, cc = disk(200, 200, 100, img.shape)
 img[rr, cc, :] = (1, 1, 0)
 
 # fill ellipse

--- a/doc/examples/features_detection/plot_shape_index.py
+++ b/doc/examples/features_detection/plot_shape_index.py
@@ -44,7 +44,7 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
 from scipy import ndimage as ndi
 from skimage.feature import shape_index
-from skimage.draw import circle
+from skimage.draw import disk
 
 
 def create_test_image(
@@ -62,7 +62,7 @@ def create_test_image(
     )
 
     for _ in range(spot_count):
-        rr, cc = circle(
+        rr, cc = disk(
             np.random.randint(image.shape[0]),
             np.random.randint(image.shape[1]),
             spot_radius,

--- a/doc/examples/features_detection/plot_shape_index.py
+++ b/doc/examples/features_detection/plot_shape_index.py
@@ -63,8 +63,8 @@ def create_test_image(
 
     for _ in range(spot_count):
         rr, cc = disk(
-            np.random.randint(image.shape[0]),
-            np.random.randint(image.shape[1]),
+            (np.random.randint(image.shape[0]),
+             np.random.randint(image.shape[1])),
             spot_radius,
             shape=image.shape
         )

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -53,6 +53,8 @@ Deprecations
   in favor of ``in_place`` and will be removed in version scikit-image 0.19.0.
 - ``skimage.segmentation.circle_level_set`` has been deprecated and will be
   removed in 0.19. Use ``skimage.segmentation.disk_level_set`` instead.
+- ``skimage.draw.circle`` has been deprecated and will be removed in 0.19.
+  Use ``skimage.draw.disk`` instead.
 
 
 Contributors to this release

--- a/skimage/draw/__init__.py
+++ b/skimage/draw/__init__.py
@@ -1,6 +1,7 @@
 from .draw import (circle, ellipse, set_color, polygon_perimeter,
                    line, line_aa, polygon, ellipse_perimeter,
                    circle_perimeter, circle_perimeter_aa,
+                   disk,
                    bezier_curve, rectangle, rectangle_perimeter)
 from .draw3d import ellipsoid, ellipsoid_stats
 from ._draw import _bezier_segment
@@ -22,6 +23,7 @@ __all__ = ['line',
            'circle',
            'circle_perimeter',
            'circle_perimeter_aa',
+           'disk',
            'set_color',
            'random_shapes',
            'rectangle',

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 
 from .._shared._geometry import polygon_clip
@@ -148,28 +149,66 @@ def circle(r, c, radius, shape=None):
     Parameters
     ----------
     r, c : double
-        Centre coordinate of circle.
+        Center coordinate of disk.
     radius : double
-        Radius of circle.
+        Radius of disk.
     shape : tuple, optional
         Image shape which is used to determine the maximum extent of output
-        pixel coordinates. This is useful for circles that exceed the image
-        size. If None, the full extent of the circle is used.  Must be at least
+        pixel coordinates. This is useful for disks that exceed the image
+        size. If None, the full extent of the disk is used.  Must be at least
         length 2. Only the first two values are used to determine the extent of
         the input image.
 
     Returns
     -------
     rr, cc : ndarray of int
-        Pixel coordinates of circle.
+        Pixel coordinates of disk.
+        May be used to directly index into an array, e.g.
+        ``img[rr, cc] = 1``.
+
+    Warns
+    -----
+    Deprecated:
+        .. versionadded:: 0.17
+
+            This function is deprecated and will be removed in scikit-image 0.19.
+            Please use the function named ``disk`` instead.
+    """
+    warnings.warn("circle is deprecated in favor of "
+                  "disk."
+                  "circle will be removed in version 0.19",
+                  FutureWarning, stacklevel=2)
+    return disk(r, c, radius, shape=shape)
+
+
+def disk(r, c, radius, *, shape=None):
+    """Generate coordinates of pixels within circle.
+
+    Parameters
+    ----------
+    r, c : double
+        Center coordinate of disk.
+    radius : double
+        Radius of disk.
+    shape : tuple, optional
+        Image shape which is used to determine the maximum extent of output
+        pixel coordinates. This is useful for disks that exceed the image
+        size. If None, the full extent of the disk is used.  Must be at least
+        length 2. Only the first two values are used to determine the extent of
+        the input image.
+
+    Returns
+    -------
+    rr, cc : ndarray of int
+        Pixel coordinates of disk.
         May be used to directly index into an array, e.g.
         ``img[rr, cc] = 1``.
 
     Examples
     --------
-    >>> from skimage.draw import circle
+    >>> from skimage.draw import disk
     >>> img = np.zeros((10, 10), dtype=np.uint8)
-    >>> rr, cc = circle(4, 4, 5)
+    >>> rr, cc = disk(4, 4, 5)
     >>> img[rr, cc] = 1
     >>> img
     array([[0, 0, 1, 1, 1, 1, 1, 0, 0, 0],

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -178,15 +178,15 @@ def circle(r, c, radius, shape=None):
                   "disk."
                   "circle will be removed in version 0.19",
                   FutureWarning, stacklevel=2)
-    return disk(r, c, radius, shape=shape)
+    return disk((r, c), radius, shape=shape)
 
 
-def disk(r, c, radius, *, shape=None):
+def disk(center, radius, *, shape=None):
     """Generate coordinates of pixels within circle.
 
     Parameters
     ----------
-    r, c : double
+    center : tuple
         Center coordinate of disk.
     radius : double
         Radius of disk.
@@ -208,7 +208,7 @@ def disk(r, c, radius, *, shape=None):
     --------
     >>> from skimage.draw import disk
     >>> img = np.zeros((10, 10), dtype=np.uint8)
-    >>> rr, cc = disk(4, 4, 5)
+    >>> rr, cc = disk((4, 4), 5)
     >>> img[rr, cc] = 1
     >>> img
     array([[0, 0, 1, 1, 1, 1, 1, 0, 0, 0],
@@ -222,6 +222,7 @@ def disk(r, c, radius, *, shape=None):
            [0, 0, 1, 1, 1, 1, 1, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=uint8)
     """
+    r, c = center
     return ellipse(r, c, radius, radius, shape)
 
 

--- a/skimage/draw/tests/test_draw.py
+++ b/skimage/draw/tests/test_draw.py
@@ -1,10 +1,12 @@
 import numpy as np
+from skimage._shared._warnings import expected_warnings
 from skimage._shared.testing import test_parallel
 from skimage._shared import testing
 from skimage._shared.testing import assert_array_equal, assert_equal
 from skimage._shared.testing import assert_almost_equal
 
 from skimage.draw import (set_color, line, line_aa, polygon, polygon_perimeter,
+                          disk,
                           circle, circle_perimeter, circle_perimeter_aa,
                           ellipse, ellipse_perimeter,
                           _bezier_segment, bezier_curve, rectangle,
@@ -212,10 +214,15 @@ def test_polygon_exceed():
     assert_array_equal(img, img_)
 
 
-def test_circle():
+def test_circle_deprecated():
+    with expected_warnings(['circle is deprecated']):
+        _ = circle(7, 7, 6)
+
+
+def test_disk():
     img = np.zeros((15, 15), 'uint8')
 
-    rr, cc = circle(7, 7, 6)
+    rr, cc = disk(7, 7, 6)
     img[rr, cc] = 1
 
     img_ = np.array(

--- a/skimage/draw/tests/test_draw.py
+++ b/skimage/draw/tests/test_draw.py
@@ -222,7 +222,7 @@ def test_circle_deprecated():
 def test_disk():
     img = np.zeros((15, 15), 'uint8')
 
-    rr, cc = disk(7, 7, 6)
+    rr, cc = disk((7, 7), 6)
     img[rr, cc] = 1
 
     img_ = np.array(

--- a/skimage/feature/tests/test_blob.py
+++ b/skimage/feature/tests/test_blob.py
@@ -1,5 +1,5 @@
 import numpy as np
-from skimage.draw import circle
+from skimage.draw import disk
 from skimage.draw.draw3d import ellipsoid
 from skimage.feature import blob_dog, blob_log, blob_doh
 from skimage.feature.blob import _blob_overlap
@@ -11,13 +11,13 @@ def test_blob_dog():
     r2 = math.sqrt(2)
     img = np.ones((512, 512))
 
-    xs, ys = circle(400, 130, 5)
+    xs, ys = disk(400, 130, 5)
     img[xs, ys] = 255
 
-    xs, ys = circle(100, 300, 25)
+    xs, ys = disk(100, 300, 25)
     img[xs, ys] = 255
 
-    xs, ys = circle(200, 350, 45)
+    xs, ys = disk(200, 350, 45)
     img[xs, ys] = 255
 
     blobs = blob_dog(img, min_sigma=5, max_sigma=50)
@@ -87,13 +87,13 @@ def test_blob_dog():
 
     # image where blob is 5 px from borders, radius 5
     img = np.ones((512, 512))
-    xs, ys = circle(5, 5, 5)
+    xs, ys = disk(5, 5, 5)
     img[xs, ys] = 255
 
 
 def test_blob_dog_excl_border():
     img = np.ones((512, 512))
-    xs, ys = circle(5, 5, 5)
+    xs, ys = disk(5, 5, 5)
     img[xs, ys] = 255
     blobs = blob_dog(
         img,
@@ -120,16 +120,16 @@ def test_blob_log():
     r2 = math.sqrt(2)
     img = np.ones((256, 256))
 
-    xs, ys = circle(200, 65, 5)
+    xs, ys = disk(200, 65, 5)
     img[xs, ys] = 255
 
-    xs, ys = circle(80, 25, 15)
+    xs, ys = disk(80, 25, 15)
     img[xs, ys] = 255
 
-    xs, ys = circle(50, 150, 25)
+    xs, ys = disk(50, 150, 25)
     img[xs, ys] = 255
 
-    xs, ys = circle(100, 175, 30)
+    xs, ys = disk(100, 175, 30)
     img[xs, ys] = 255
 
     blobs = blob_log(img, min_sigma=5, max_sigma=20, threshold=1)
@@ -234,7 +234,7 @@ def test_blob_log_3d_anisotropic():
 def test_blob_log_exclude_border():
     # image where blob is 5 px from borders, radius 5
     img = np.ones((512, 512))
-    xs, ys = circle(5, 5, 5)
+    xs, ys = disk(5, 5, 5)
     img[xs, ys] = 255
 
     blobs = blob_log(
@@ -259,16 +259,16 @@ def test_blob_log_exclude_border():
 def test_blob_doh():
     img = np.ones((512, 512), dtype=np.uint8)
 
-    xs, ys = circle(400, 130, 20)
+    xs, ys = disk(400, 130, 20)
     img[xs, ys] = 255
 
-    xs, ys = circle(460, 50, 30)
+    xs, ys = disk(460, 50, 30)
     img[xs, ys] = 255
 
-    xs, ys = circle(100, 300, 40)
+    xs, ys = disk(100, 300, 40)
     img[xs, ys] = 255
 
-    xs, ys = circle(200, 350, 50)
+    xs, ys = disk(200, 350, 50)
     img[xs, ys] = 255
 
     blobs = blob_doh(
@@ -306,16 +306,16 @@ def test_blob_doh():
 def test_blob_doh_log_scale():
     img = np.ones((512, 512), dtype=np.uint8)
 
-    xs, ys = circle(400, 130, 20)
+    xs, ys = disk(400, 130, 20)
     img[xs, ys] = 255
 
-    xs, ys = circle(460, 50, 30)
+    xs, ys = disk(460, 50, 30)
     img[xs, ys] = 255
 
-    xs, ys = circle(100, 300, 40)
+    xs, ys = disk(100, 300, 40)
     img[xs, ys] = 255
 
-    xs, ys = circle(200, 350, 50)
+    xs, ys = disk(200, 350, 50)
     img[xs, ys] = 255
 
     blobs = blob_doh(
@@ -360,10 +360,10 @@ def test_blob_doh_no_peaks():
 def test_blob_doh_overlap():
     img = np.ones((256, 256), dtype=np.uint8)
 
-    xs, ys = circle(100, 100, 20)
+    xs, ys = disk(100, 100, 20)
     img[xs, ys] = 255
 
-    xs, ys = circle(120, 100, 30)
+    xs, ys = disk(120, 100, 30)
     img[xs, ys] = 255
 
     blobs = blob_doh(

--- a/skimage/feature/tests/test_blob.py
+++ b/skimage/feature/tests/test_blob.py
@@ -11,13 +11,13 @@ def test_blob_dog():
     r2 = math.sqrt(2)
     img = np.ones((512, 512))
 
-    xs, ys = disk(400, 130, 5)
+    xs, ys = disk((400, 130), 5)
     img[xs, ys] = 255
 
-    xs, ys = disk(100, 300, 25)
+    xs, ys = disk((100, 300), 25)
     img[xs, ys] = 255
 
-    xs, ys = disk(200, 350, 45)
+    xs, ys = disk((200, 350), 45)
     img[xs, ys] = 255
 
     blobs = blob_dog(img, min_sigma=5, max_sigma=50)
@@ -87,13 +87,13 @@ def test_blob_dog():
 
     # image where blob is 5 px from borders, radius 5
     img = np.ones((512, 512))
-    xs, ys = disk(5, 5, 5)
+    xs, ys = disk((5, 5), 5)
     img[xs, ys] = 255
 
 
 def test_blob_dog_excl_border():
     img = np.ones((512, 512))
-    xs, ys = disk(5, 5, 5)
+    xs, ys = disk((5, 5), 5)
     img[xs, ys] = 255
     blobs = blob_dog(
         img,
@@ -120,16 +120,16 @@ def test_blob_log():
     r2 = math.sqrt(2)
     img = np.ones((256, 256))
 
-    xs, ys = disk(200, 65, 5)
+    xs, ys = disk((200, 65), 5)
     img[xs, ys] = 255
 
-    xs, ys = disk(80, 25, 15)
+    xs, ys = disk((80, 25), 15)
     img[xs, ys] = 255
 
-    xs, ys = disk(50, 150, 25)
+    xs, ys = disk((50, 150), 25)
     img[xs, ys] = 255
 
-    xs, ys = disk(100, 175, 30)
+    xs, ys = disk((100, 175), 30)
     img[xs, ys] = 255
 
     blobs = blob_log(img, min_sigma=5, max_sigma=20, threshold=1)
@@ -234,7 +234,7 @@ def test_blob_log_3d_anisotropic():
 def test_blob_log_exclude_border():
     # image where blob is 5 px from borders, radius 5
     img = np.ones((512, 512))
-    xs, ys = disk(5, 5, 5)
+    xs, ys = disk((5, 5), 5)
     img[xs, ys] = 255
 
     blobs = blob_log(
@@ -259,16 +259,16 @@ def test_blob_log_exclude_border():
 def test_blob_doh():
     img = np.ones((512, 512), dtype=np.uint8)
 
-    xs, ys = disk(400, 130, 20)
+    xs, ys = disk((400, 130), 20)
     img[xs, ys] = 255
 
-    xs, ys = disk(460, 50, 30)
+    xs, ys = disk((460, 50), 30)
     img[xs, ys] = 255
 
-    xs, ys = disk(100, 300, 40)
+    xs, ys = disk((100, 300), 40)
     img[xs, ys] = 255
 
-    xs, ys = disk(200, 350, 50)
+    xs, ys = disk((200, 350), 50)
     img[xs, ys] = 255
 
     blobs = blob_doh(
@@ -306,16 +306,16 @@ def test_blob_doh():
 def test_blob_doh_log_scale():
     img = np.ones((512, 512), dtype=np.uint8)
 
-    xs, ys = disk(400, 130, 20)
+    xs, ys = disk((400, 130), 20)
     img[xs, ys] = 255
 
-    xs, ys = disk(460, 50, 30)
+    xs, ys = disk((460, 50), 30)
     img[xs, ys] = 255
 
-    xs, ys = disk(100, 300, 40)
+    xs, ys = disk((100, 300), 40)
     img[xs, ys] = 255
 
-    xs, ys = disk(200, 350, 50)
+    xs, ys = disk((200, 350), 50)
     img[xs, ys] = 255
 
     blobs = blob_doh(
@@ -360,10 +360,10 @@ def test_blob_doh_no_peaks():
 def test_blob_doh_overlap():
     img = np.ones((256, 256), dtype=np.uint8)
 
-    xs, ys = disk(100, 100, 20)
+    xs, ys = disk((100, 100), 20)
     img[xs, ys] = 255
 
-    xs, ys = disk(120, 100, 30)
+    xs, ys = disk((120, 100), 30)
     img[xs, ys] = 255
 
     blobs = blob_doh(

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -160,7 +160,7 @@ def test_hog_orientations_circle():
     width = height = 100
 
     image = np.zeros((height, width))
-    rr, cc = draw.circle(int(height / 2), int(width / 2), int(width / 3))
+    rr, cc = draw.disk(int(height / 2), int(width / 2), int(width / 3))
     image[rr, cc] = 100
     image = ndi.gaussian_filter(image, 2)
 

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -160,7 +160,7 @@ def test_hog_orientations_circle():
     width = height = 100
 
     image = np.zeros((height, width))
-    rr, cc = draw.disk(int(height / 2), int(width / 2), int(width / 3))
+    rr, cc = draw.disk((int(height / 2), int(width / 2)), int(width / 3))
     image[rr, cc] = 100
     image = ndi.gaussian_filter(image, 2)
 


### PR DESCRIPTION
## Description

`draw.circle` draws a filled circle aka a disk. By renaming the function, we make the nomenclature mathematically correct, as well as more consistent with the rest of the library.

See #4406 for details.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
