### PR TITLE
Fix use_quantiles behavior in canny

### DIFF
--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -169,7 +169,7 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None, mask=None,
         high_threshold = 0.2
     elif use_quantiles:
         if not(0.0 <= high_threshold <= 1.0):
-            raise ValueError("Quantile thresholds must not be > 1.0")
+            raise ValueError("Quantile thresholds must be between 0 and 1.")
     else:
         high_threshold = high_threshold / dtype_max
 

--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -161,7 +161,7 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None, mask=None,
         low_threshold = 0.1
     elif use_quantiles:
         if not(0.0 <= low_threshold <= 1.0):
-            raise ValueError("Quantile thresholds must not be > 1.0")
+            raise ValueError("Quantile thresholds must be between 0 and 1.")
     else:
         low_threshold = low_threshold / dtype_max
 

--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -159,11 +159,17 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None, mask=None,
 
     if low_threshold is None:
         low_threshold = 0.1
+    elif use_quantiles:
+        if not(0.0 <= low_threshold <= 1.0):
+            raise ValueError("Quantile thresholds must not be > 1.0")
     else:
         low_threshold = low_threshold / dtype_max
 
     if high_threshold is None:
         high_threshold = 0.2
+    elif use_quantiles:
+        if not(0.0 <= high_threshold <= 1.0):
+            raise ValueError("Quantile thresholds must not be > 1.0")
     else:
         high_threshold = high_threshold / dtype_max
 

--- a/skimage/feature/tests/test_canny.py
+++ b/skimage/feature/tests/test_canny.py
@@ -105,6 +105,11 @@ class TestCanny(unittest.TestCase):
         self.assertRaises(ValueError, F.canny, image, use_quantiles=True,
                           low_threshold=0.5, high_threshold=-100)
 
+        # Example from issue #4282
+        image = data.camera()
+        self.assertRaises(ValueError, F.canny, image, use_quantiles=True,
+                          low_threshold=50, high_threshold=150)
+
     def test_dtype(self):
         """Check that the same output is produced regardless of image dtype."""
         image_uint8 = data.camera()


### PR DESCRIPTION
## Description

Fixes #4282.

A test asserting the bug fix is added.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
