### PR TITLE
Deprecate gray scale image support for rgb2gray

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -51,7 +51,8 @@ Version 0.19
 * Remove the warnings in ``skimage/filters/ridges.py`` from sato and hessian
   functions.
 * In ``skimage/color/colorconv.py``, remove  `rgb2grey` and `grey2rgb`.
-
+* In ``skimage/color/colorconv.py``, remove gray scale image support
+  deprecation from rgb2gray.
 
 Other
 -----

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -793,7 +793,7 @@ def rgb2gray(rgb):
         warn('The behavior of rgb2gray will change in scikit-image 0.19. '
              'Currently, rgb2gray allows 2D grayscale image to be passed '
              'as inputs and leaves them unmodified as outputs. '
-             'In version 0.19, this will no longer be these images will '
+             'Starting from version 0.19, 2D arrays will '
              'be treated as 1D images with 3 channels.',
              FutureWarning, stacklevel=2)
         return np.ascontiguousarray(rgb)

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -790,7 +790,11 @@ def rgb2gray(rgb):
     """
 
     if rgb.ndim == 2:
-        warn('Gray scale image conversion is now deprecated.',
+        warn('The behavior of rgb2gray will change in scikit-image 0.19. '
+             'Currently, rgb2gray allows 2D grayscale image to be passed '
+             'as inputs and leaves them unmodified as outputs. '
+             'In version 0.19, this will no longer be these images will '
+             'be treated as 1D images with 3 channels.',
              FutureWarning, stacklevel=2)
         return np.ascontiguousarray(rgb)
 

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -790,6 +790,8 @@ def rgb2gray(rgb):
     """
 
     if rgb.ndim == 2:
+        warn('Gray scale image conversion is now deprecated.',
+             FutureWarning, stacklevel=2)
         return np.ascontiguousarray(rgb)
 
     rgb = _prepare_colorarray(rgb[..., :3])

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -298,7 +298,8 @@ class TestColorconv(TestCase):
         assert rgb2gray(x).ndim == 2
 
     def test_rgb2gray_on_gray(self):
-        rgb2gray(np.random.rand(5, 5))
+        with expected_warnings(['Gray scale image conversion']):
+            rgb2gray(np.random.rand(5, 5))
 
     def test_rgb2gray_dtype(self):
         img = np.random.rand(10, 10, 3).astype('float64')

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -298,7 +298,7 @@ class TestColorconv(TestCase):
         assert rgb2gray(x).ndim == 2
 
     def test_rgb2gray_on_gray(self):
-        with expected_warnings(['Gray scale image conversion']):
+        with expected_warnings(['The behavior of rgb2gray will change']):
             rgb2gray(np.random.rand(5, 5))
 
     def test_rgb2gray_dtype(self):


### PR DESCRIPTION
## Description

Fixes #3200 

Following @hmaarrfk [comment](https://github.com/scikit-image/scikit-image/pull/4418/files#r376811009), this PR is a prerequisite to #4418.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
