### PR TITLE
Deprecate non RGB image conversion in rgb2gray

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -51,7 +51,8 @@ Version 0.19
 * Remove the warnings in ``skimage/filters/ridges.py`` from sato and hessian
   functions.
 * In ``skimage/color/colorconv.py``, remove  `rgb2grey` and `grey2rgb`.
-
+* In ``skimage/color/colorconv.py``, remove the deprecation warning
+  from `rgb2gray`.
 
 Other
 -----

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -794,7 +794,7 @@ def rgb2gray(rgb):
 
     if rgb.shape[-1] > 3:
         warn('Non RGB image conversion is now deprecated. For RGBA images, '
-             'Please use rgb2gray(rgba2rgb(rgb)) instead. In version 0.19, '
+             'please use rgb2gray(rgba2rgb(rgb)) instead. In version 0.19, '
              'a ValueError will be raised if input image last dimension '
              'length is not 3.', FutureWarning, stacklevel=2)
         rgb = rgb[..., :3]

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -792,7 +792,14 @@ def rgb2gray(rgb):
     if rgb.ndim == 2:
         return np.ascontiguousarray(rgb)
 
-    rgb = _prepare_colorarray(rgb[..., :3])
+    if rgb.shape[-1] > 3:
+        warn('Non RGB image conversion is now deprecated. For RGBA images, '
+             'Please use rgb2gray(rgba2rgb(rgb)) instead. In version 0.19, '
+             'a ValueError will be raised if input image last dimension '
+             'length is not 3.', FutureWarning, stacklevel=2)
+        rgb = rgb[..., :3]
+
+    rgb = _prepare_colorarray(rgb)
     coeffs = np.array([0.2125, 0.7154, 0.0721], dtype=rgb.dtype)
     return rgb @ coeffs
 

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -295,7 +295,8 @@ class TestColorconv(TestCase):
 
     def test_rgb2gray_alpha(self):
         x = np.random.rand(10, 10, 4)
-        assert rgb2gray(x).ndim == 2
+        with expected_warnings(['Non RGB image conversion']):
+            assert rgb2gray(x).ndim == 2
 
     def test_rgb2gray_on_gray(self):
         rgb2gray(np.random.rand(5, 5))


### PR DESCRIPTION
## Description

Following @hmaarrfk recommandations, this PR is a prerequisite to #4418.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
