### PR TITLE
Deprecate non gray scale image conversion in gray2rgb

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -842,9 +842,12 @@ def gray2rgb(image, alpha=None):
             is_rgb = True
 
     if is_rgb:
-        warn('Non gray scale images conversion is now deprecated. In version '
-             '0.19, input image  will be considered as grey scale, whatever '
-             'is its shape.', FutureWarning, stacklevel=2)
+        warn('Pass-through of possibly RGB images in gray2rgb is deprecated. '
+             'In version 0.19, input arrays will always be considered '
+             'grayscale, even if the last dimension has length 3 or 4. '
+             'To prevent this warning and ensure compatibility with future '
+             'versions, detect RGB images outside of this function.',
+             FutureWarning, stacklevel=2)
         if alpha is False:
             image = image[..., :3]
 

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -842,6 +842,9 @@ def gray2rgb(image, alpha=None):
             is_rgb = True
 
     if is_rgb:
+        warn('Non gray scale images conversion is now deprecated. In version '
+             '0.19, input image  will be considered as grey scale, whatever '
+             'is its shape.', FutureWarning, stacklevel=2)
         if alpha is False:
             image = image[..., :3]
 

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -635,20 +635,27 @@ def test_gray2rgb():
 
 def test_gray2rgb_rgb():
     x = np.random.rand(5, 5, 4)
-    y = gray2rgb(x)
+    with expected_warnings(['Non gray scale images conversion']):
+        y = gray2rgb(x)
     assert_equal(x, y)
 
 
 def test_gray2rgb_alpha():
     x = np.random.random((5, 5, 4))
-    assert_equal(gray2rgb(x, alpha=None).shape, (5, 5, 4))
-    assert_equal(gray2rgb(x, alpha=False).shape, (5, 5, 3))
-    assert_equal(gray2rgb(x, alpha=True).shape, (5, 5, 4))
+    with expected_warnings(['Non gray scale images conversion']):
+        assert_equal(gray2rgb(x, alpha=None).shape, (5, 5, 4))
+    with expected_warnings(['Non gray scale images conversion']):
+        assert_equal(gray2rgb(x, alpha=False).shape, (5, 5, 3))
+    with expected_warnings(['Non gray scale images conversion']):
+        assert_equal(gray2rgb(x, alpha=True).shape, (5, 5, 4))
 
     x = np.random.random((5, 5, 3))
-    assert_equal(gray2rgb(x, alpha=None).shape, (5, 5, 3))
-    assert_equal(gray2rgb(x, alpha=False).shape, (5, 5, 3))
-    assert_equal(gray2rgb(x, alpha=True).shape, (5, 5, 4))
+    with expected_warnings(['Non gray scale images conversion']):
+        assert_equal(gray2rgb(x, alpha=None).shape, (5, 5, 3))
+    with expected_warnings(['Non gray scale images conversion']):
+        assert_equal(gray2rgb(x, alpha=False).shape, (5, 5, 3))
+    with expected_warnings(['Non gray scale images conversion']):
+        assert_equal(gray2rgb(x, alpha=True).shape, (5, 5, 4))
 
     assert_equal(gray2rgb(np.array([[1, 2], [3, 4.]]),
                           alpha=True)[0, 0, 3], 1)

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -635,26 +635,26 @@ def test_gray2rgb():
 
 def test_gray2rgb_rgb():
     x = np.random.rand(5, 5, 4)
-    with expected_warnings(['Non gray scale images conversion']):
+    with expected_warnings(['Pass-through of possibly RGB images']):
         y = gray2rgb(x)
     assert_equal(x, y)
 
 
 def test_gray2rgb_alpha():
     x = np.random.random((5, 5, 4))
-    with expected_warnings(['Non gray scale images conversion']):
+    with expected_warnings(['Pass-through of possibly RGB images']):
         assert_equal(gray2rgb(x, alpha=None).shape, (5, 5, 4))
-    with expected_warnings(['Non gray scale images conversion']):
+    with expected_warnings(['Pass-through of possibly RGB images']):
         assert_equal(gray2rgb(x, alpha=False).shape, (5, 5, 3))
-    with expected_warnings(['Non gray scale images conversion']):
+    with expected_warnings(['Pass-through of possibly RGB images']):
         assert_equal(gray2rgb(x, alpha=True).shape, (5, 5, 4))
 
     x = np.random.random((5, 5, 3))
-    with expected_warnings(['Non gray scale images conversion']):
+    with expected_warnings(['Pass-through of possibly RGB images']):
         assert_equal(gray2rgb(x, alpha=None).shape, (5, 5, 3))
-    with expected_warnings(['Non gray scale images conversion']):
+    with expected_warnings(['Pass-through of possibly RGB images']):
         assert_equal(gray2rgb(x, alpha=False).shape, (5, 5, 3))
-    with expected_warnings(['Non gray scale images conversion']):
+    with expected_warnings(['Pass-through of possibly RGB images']):
         assert_equal(gray2rgb(x, alpha=True).shape, (5, 5, 4))
 
     assert_equal(gray2rgb(np.array([[1, 2], [3, 4.]]),


### PR DESCRIPTION
## Description

Following @hmaarrfk recommandations, this PR is a prerequisite to #4418.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
