### PR TITLE
Multichannel support for denoise_tv_bregman (#4427)

### DIFF
--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -283,30 +283,23 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True,
     """
     image = np.atleast_3d(img_as_float(image))
 
-    shape_ext = np.asarray(image.shape)
-    shape_ext[0:2] += 2
+    rows = image.shape[0]
+    cols = image.shape[1]
+    dims = image.shape[2]
+
+    shape_ext = (rows + 2, cols + 2, dims)
 
     out = np.zeros(shape_ext, image.dtype)
 
     if multichannel:
         for c in range(image.shape[-1]):
-            if image.ndim == 3:
-                channel_in = np.ascontiguousarray(image[..., c, None])
-                channel_out = np.ascontiguousarray(out[..., c, None])
+                channel_in = np.ascontiguousarray(np.atleast_3d(image[..., c]))
+                channel_out = np.zeros(shape_ext[:2] + (1,), dtype=out.dtype)
 
                 _denoise_tv_bregman(channel_in, image.dtype.type(weight),
                                     max_iter, eps, isotropic, channel_out)
 
-                out[..., c] = channel_out[..., -1]
-
-            else:
-                channel_in = np.ascontiguousarray(image[..., c])
-                channel_out = np.ascontiguousarray(out[..., c])
-
-                _denoise_tv_bregman(channel_in, image.dtype.type(weight),
-                                    max_iter, eps, isotropic, channel_out)
-
-                out[..., c] = channel_out
+                out[..., c] = channel_out[..., 0]
 
     else:
         image = np.ascontiguousarray(image)

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -290,13 +290,13 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True,
     shape_ext = (rows + 2, cols + 2, dims)
 
     out = np.zeros(shape_ext, image.dtype)
+    channel_out = np.zeros(shape_ext[:2] + (1,), dtype=out.dtype)
 
     if multichannel:
         for c in range(image.shape[-1]):
             # the algorithm below expects 3 dimensions to always be present.
             # slicing the array in this fashion preserves the channel dimension for us
             channel_in = np.ascontiguousarray(image[..., c:c+1])
-            channel_out = np.zeros(shape_ext[:2] + (1,), dtype=out.dtype)
 
             _denoise_tv_bregman(channel_in, image.dtype.type(weight),
                                 max_iter, eps, isotropic, channel_out)

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -294,8 +294,8 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True,
                 channel_in = np.ascontiguousarray(image[..., c, None])
                 channel_out = np.ascontiguousarray(out[..., c, None])
 
-                _denoise_tv_bregman(channel_in, image.dtype.type(weight), max_iter, eps,
-                                    isotropic, channel_out)
+                _denoise_tv_bregman(channel_in, image.dtype.type(weight),
+                                    max_iter, eps, isotropic, channel_out)
 
                 out[..., c] = channel_out[..., -1]
 
@@ -303,8 +303,8 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True,
                 channel_in = np.ascontiguousarray(image[..., c])
                 channel_out = np.ascontiguousarray(out[..., c])
 
-                _denoise_tv_bregman(channel_in, image.dtype.type(weight), max_iter, eps,
-                                    isotropic, channel_out)
+                _denoise_tv_bregman(channel_in, image.dtype.type(weight),
+                                    max_iter, eps, isotropic, channel_out)
 
                 out[..., c] = channel_out
 

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -293,7 +293,7 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True,
 
     if multichannel:
         for c in range(image.shape[-1]):
-            # the algorithm below expects 3 channels to always be present.
+            # the algorithm below expects 3 dimensions to always be present.
             # slicing the array in this fashion preserves the channel dimension for us
             channel_in = np.ascontiguousarray(image[..., c:c+1])
             channel_out = np.zeros(shape_ext[:2] + (1,), dtype=out.dtype)

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -293,13 +293,13 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True,
 
     if multichannel:
         for c in range(image.shape[-1]):
-                channel_in = np.ascontiguousarray(np.atleast_3d(image[..., c]))
-                channel_out = np.zeros(shape_ext[:2] + (1,), dtype=out.dtype)
+            channel_in = np.ascontiguousarray(np.atleast_3d(image[..., c]))
+            channel_out = np.zeros(shape_ext[:2] + (1,), dtype=out.dtype)
 
-                _denoise_tv_bregman(channel_in, image.dtype.type(weight),
-                                    max_iter, eps, isotropic, channel_out)
+            _denoise_tv_bregman(channel_in, image.dtype.type(weight),
+                                max_iter, eps, isotropic, channel_out)
 
-                out[..., c] = channel_out[..., 0]
+            out[..., c] = channel_out[..., 0]
 
     else:
         image = np.ascontiguousarray(image)

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -293,7 +293,9 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True,
 
     if multichannel:
         for c in range(image.shape[-1]):
-            channel_in = np.ascontiguousarray(np.atleast_3d(image[..., c]))
+            # the algorithm below expects 3 channels to always be present.
+            # slicing the array in this fashion preserves the channel dimension for us
+            channel_in = np.ascontiguousarray(image[..., c:c+1])
             channel_out = np.zeros(shape_ext[:2] + (1,), dtype=out.dtype)
 
             _denoise_tv_bregman(channel_in, image.dtype.type(weight),

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -290,9 +290,9 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True,
     shape_ext = (rows + 2, cols + 2, dims)
 
     out = np.zeros(shape_ext, image.dtype)
-    channel_out = np.zeros(shape_ext[:2] + (1,), dtype=out.dtype)
 
     if multichannel:
+        channel_out = np.zeros(shape_ext[:2] + (1,), dtype=out.dtype)
         for c in range(image.shape[-1]):
             # the algorithm below expects 3 dimensions to always be present.
             # slicing the array in this fashion preserves the channel dimension for us

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -290,7 +290,7 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True,
 
     if multichannel:
         for c in range(image.shape[-1]):
-            if np.ndim(image) == 3:
+            if image.ndim == 3:
                 channel_in = np.ascontiguousarray(image[..., c, None])
                 channel_out = np.ascontiguousarray(out[..., c, None])
 

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -233,7 +233,7 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
 
 
 def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True,
-                       multichannel=False):
+                       *, multichannel=False):
     """Perform total-variation denoising using split-Bregman optimization.
 
     Total-variation denoising (also know as total-variation regularization)

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -178,6 +178,21 @@ def test_denoise_tv_bregman_3d():
     assert_(img[30:45, 5:15].std() > out1[30:45, 5:15].std())
     assert_(out1[30:45, 5:15].std() > out2[30:45, 5:15].std())
 
+def test_denoise_tv_bregman_multichannel():
+    img_astro = astro.copy()
+    denoised0 = restoration.denoise_tv_bregman(img_astro[..., 0], weight=60.0)
+    denoised = restoration.denoise_tv_bregman(img_astro, weight=60.0,
+                                                multichannel=True)
+    assert_equal(denoised[..., 0], denoised0)
+
+    # tile astronaut subset to generate 3D+channels data
+    astro3 = np.tile(img_astro[:64, :64, np.newaxis, :], [1, 1, 2, 1])
+    # modify along tiled dimension to give non-zero gradient on 3rd axis
+    astro3[:, :, 0, :] = 2*astro3[:, :, 0, :]
+    denoised0 = restoration.denoise_tv_bregman(astro3[..., 0], weight=60.0)
+    denoised = restoration.denoise_tv_bregman(astro3, weight=60.0,
+                                                multichannel=True)
+    assert_equal(denoised[..., 0], denoised0)
 
 def test_denoise_bilateral_2d():
     img = checkerboard_gray.copy()[:50, :50]

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -185,6 +185,8 @@ def test_denoise_tv_bregman_3d_multichannel():
     denoised = restoration.denoise_tv_bregman(img_astro, weight=60.0,
                                               multichannel=True)
 
+    assert_equal(denoised0, denoised[..., 0])
+
 
 def test_denoise_tv_bregman_multichannel():
     img = checkerboard_gray.copy()[:50, :50]

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -178,21 +178,23 @@ def test_denoise_tv_bregman_3d():
     assert_(img[30:45, 5:15].std() > out1[30:45, 5:15].std())
     assert_(out1[30:45, 5:15].std() > out2[30:45, 5:15].std())
 
+
 def test_denoise_tv_bregman_multichannel():
     img_astro = astro.copy()
     denoised0 = restoration.denoise_tv_bregman(img_astro[..., 0], weight=60.0)
     denoised = restoration.denoise_tv_bregman(img_astro, weight=60.0,
-                                                multichannel=True)
+                                              multichannel=True)
     assert_equal(denoised[..., 0], denoised0)
 
     # tile astronaut subset to generate 3D+channels data
     astro3 = np.tile(img_astro[:64, :64, np.newaxis, :], [1, 1, 2, 1])
     # modify along tiled dimension to give non-zero gradient on 3rd axis
-    astro3[:, :, 0, :] = 2*astro3[:, :, 0, :]
+    astro3[:, :, 0, :] = 2 * astro3[:, :, 0, :]
     denoised0 = restoration.denoise_tv_bregman(astro3[..., 0], weight=60.0)
     denoised = restoration.denoise_tv_bregman(astro3, weight=60.0,
-                                                multichannel=True)
+                                              multichannel=True)
     assert_equal(denoised[..., 0], denoised0)
+
 
 def test_denoise_bilateral_2d():
     img = checkerboard_gray.copy()[:50, :50]

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -179,21 +179,23 @@ def test_denoise_tv_bregman_3d():
     assert_(out1[30:45, 5:15].std() > out2[30:45, 5:15].std())
 
 
-def test_denoise_tv_bregman_multichannel():
+def test_denoise_tv_bregman_3d_multichannel():
     img_astro = astro.copy()
     denoised0 = restoration.denoise_tv_bregman(img_astro[..., 0], weight=60.0)
     denoised = restoration.denoise_tv_bregman(img_astro, weight=60.0,
                                               multichannel=True)
-    assert_equal(denoised[..., 0], denoised0)
 
-    # tile astronaut subset to generate 3D+channels data
-    astro3 = np.tile(img_astro[:64, :64, np.newaxis, :], [1, 1, 2, 1])
-    # modify along tiled dimension to give non-zero gradient on 3rd axis
-    astro3[:, :, 0, :] = 2 * astro3[:, :, 0, :]
-    denoised0 = restoration.denoise_tv_bregman(astro3[..., 0], weight=60.0)
-    denoised = restoration.denoise_tv_bregman(astro3, weight=60.0,
-                                              multichannel=True)
-    assert_equal(denoised[..., 0], denoised0)
+
+def test_denoise_tv_bregman_multichannel():
+    img = checkerboard_gray.copy()[:50, :50]
+    # add some random noise
+    img += 0.5 * img.std() * np.random.rand(*img.shape)
+    img = np.clip(img, 0, 1)
+
+    out1 = restoration.denoise_tv_bregman(img, weight=60.0)
+    out2 = restoration.denoise_tv_bregman(img, weight=60.0, multichannel=True)
+
+    assert_equal(out1, out2)
 
 
 def test_denoise_bilateral_2d():


### PR DESCRIPTION
## Description

Proposal for closing issue #4427

Added `multichannel` parameter to `denoise_tv_bregman` function.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
-  [ ] ~~Gallery example in `./doc/examples`~~  (new features only)
- [ ] ~~Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark~~
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
