### PR TITLE
Standardize colon usage in docstrings

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1379,7 +1379,7 @@ def separate_stains(rgb, conv_matrix):
     ----------
     rgb : array_like
         The image in RGB format, in a 3-D array of shape ``(.., .., 3)``.
-    conv_matrix: ndarray
+    conv_matrix : ndarray
         The stain separation matrix as described by G. Landini [1]_.
 
     Returns
@@ -1436,7 +1436,7 @@ def combine_stains(stains, conv_matrix):
     stains : array_like
         The image in stain color space, in a 3-D array of shape
         ``(.., .., 3)``.
-    conv_matrix: ndarray
+    conv_matrix : ndarray
         The stain separation matrix as described by G. Landini [1]_.
 
     Returns

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -136,7 +136,7 @@ def brick():
 
     Returns
     -------
-    brick: (512, 512) uint8 image
+    brick : (512, 512) uint8 image
         A small section of a brick wall.
 
     Notes
@@ -202,7 +202,7 @@ def grass():
 
     Returns
     -------
-    grass: (512, 512) uint8 image
+    grass : (512, 512) uint8 image
         Some grass.
 
     Notes
@@ -250,7 +250,7 @@ def rough_wall():
 
     Returns
     -------
-    rough_wall: (512, 512) uint8 image
+    rough_wall : (512, 512) uint8 image
         Some rough wall.
 
     """
@@ -266,7 +266,7 @@ def gravel():
 
     Returns
     -------
-    gravel: (512, 512) uint8 image
+    gravel : (512, 512) uint8 image
         Grayscale gravel sample.
 
     Notes
@@ -625,7 +625,7 @@ def shepp_logan_phantom():
 
     Returns
     -------
-    phantom: (400, 400) float64 image
+    phantom : (400, 400) float64 image
         Image of the Shepp-Logan phantom in grayscale.
     """
     return _load("phantom.png", as_gray=True)
@@ -636,7 +636,7 @@ def colorwheel():
 
     Returns
     -------
-    colorwheel: (370, 371, 3) uint8 image
+    colorwheel : (370, 371, 3) uint8 image
         A colorwheel.
     """
     return _load("color.png")

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -507,7 +507,7 @@ def circle_perimeter(r, c, radius, method='bresenham', shape=None):
     ----------
     r, c : int
         Centre coordinate of circle.
-    radius: int
+    radius : int
         Radius of circle.
     method : {'bresenham', 'andres'}, optional
         bresenham : Bresenham method (default)
@@ -570,7 +570,7 @@ def circle_perimeter_aa(r, c, radius, shape=None):
     ----------
     r, c : int
         Centre coordinate of circle.
-    radius: int
+    radius : int
         Radius of circle.
     shape : tuple, optional
         Image shape which is used to determine the maximum extent of output

--- a/skimage/filters/_unsharp_mask.py
+++ b/skimage/filters/_unsharp_mask.py
@@ -40,7 +40,7 @@ def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
     multichannel : bool, optional
         If True, the last ``image`` dimension is considered as a color channel,
         otherwise as spatial. Color channels are processed individually.
-    preserve_range: bool, optional
+    preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of ``img_as_float``.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -379,7 +379,7 @@ def threshold_isodata(image, nbins=256, return_all=False):
     nbins : int, optional
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
-    return_all: bool, optional
+    return_all : bool, optional
         If False (default), return only the lowest threshold that satisfies
         the above equality. If True, return all valid thresholds.
 
@@ -659,7 +659,7 @@ def threshold_minimum(image, nbins=256, max_iter=10000):
     nbins : int, optional
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
-    max_iter: int, optional
+    max_iter : int, optional
         Maximum number of iterations to smooth the histogram.
 
     Returns
@@ -930,7 +930,7 @@ def threshold_niblack(image, window_size=15, k=0.2):
 
     Parameters
     ----------
-    image: ndarray
+    image : ndarray
         Input image.
     window_size : int, or iterable of int, optional
         Window size specified as a single odd integer (3, 5, 7, …),
@@ -995,7 +995,7 @@ def threshold_sauvola(image, window_size=15, k=0.2, r=None):
 
     Parameters
     ----------
-    image: ndarray
+    image : ndarray
         Input image.
     window_size : int, or iterable of int, optional
         Window size specified as a single odd integer (3, 5, 7, …),

--- a/skimage/graph/spath.py
+++ b/skimage/graph/spath.py
@@ -16,7 +16,7 @@ def shortest_path(arr, reach=1, axis=-1, output_indexlist=False):
         dimension at each step.
     axis : int, optional
         The axis along which the path must always move forward (default -1)
-    output_indexlist: bool, optional
+    output_indexlist : bool, optional
         See return value `p` for explanation.
 
     Returns

--- a/skimage/morphology/_deprecated.py
+++ b/skimage/morphology/_deprecated.py
@@ -8,21 +8,21 @@ def watershed(image, markers=None, connectivity=1, offset=None, mask=None,
 
     Parameters
     ----------
-    image: ndarray (2-D, 3-D, ...) of integers
+    image : ndarray (2-D, 3-D, ...) of integers
         Data array where the lowest value points are labeled first.
-    markers: int, or ndarray of int, same shape as `image`, optional
+    markers : int, or ndarray of int, same shape as `image`, optional
         The desired number of markers, or an array marking the basins with the
         values to be assigned in the label matrix. Zero means not a marker. If
         ``None`` (no markers given), the local minima of the image are used as
         markers.
-    connectivity: ndarray, optional
+    connectivity : ndarray, optional
         An array with the same number of dimensions as `image` whose
         non-zero elements indicate neighbors for connection.
         Following the scipy convention, default is a one-connected array of
         the dimension of the image.
-    offset: array_like of shape image.ndim, optional
+    offset : array_like of shape image.ndim, optional
         offset of the connectivity (one offset per dimension)
-    mask: ndarray of bools or 0s and 1s, optional
+    mask : ndarray of bools or 0s and 1s, optional
         Array of same shape as `image`. Only points at which mask == True
         will be labeled.
     compactness : float, optional

--- a/skimage/morphology/max_tree.py
+++ b/skimage/morphology/max_tree.py
@@ -65,21 +65,21 @@ def max_tree(image, connectivity=1):
 
     Parameters
     ----------
-    image: ndarray
+    image : ndarray
         The input image for which the max-tree is to be calculated.
         This image can be of any type.
-    connectivity: unsigned int, optional
+    connectivity : unsigned int, optional
         The neighborhood connectivity. The integer represents the maximum
         number of orthogonal steps to reach a neighbor. In 2D, it is 1 for
         a 4-neighborhood and 2 for a 8-neighborhood. Default value is 1.
 
     Returns
     -------
-    parent: ndarray, int64
+    parent : ndarray, int64
         Array of same shape as image. The value of each pixel is the index of
         its parent in the ravelled array.
 
-    tree_traverser: 1D array, int64
+    tree_traverser : 1D array, int64
         The ordered pixel indices (referring to the ravelled array). The pixels
         are ordered such that every pixel is preceded by its parent (except for
         the root which has no parent).
@@ -166,27 +166,27 @@ def area_opening(image, area_threshold=64, connectivity=1,
 
     Parameters
     ----------
-    image: ndarray
+    image : ndarray
         The input image for which the area_opening is to be calculated.
         This image can be of any type.
-    area_threshold: unsigned int
+    area_threshold : unsigned int
         The size parameter (number of pixels). The default value is arbitrarily
         chosen to be 64.
-    connectivity: unsigned int, optional
+    connectivity : unsigned int, optional
         The neighborhood connectivity. The integer represents the maximum
         number of orthogonal steps to reach a neighbor. In 2D, it is 1 for
         a 4-neighborhood and 2 for a 8-neighborhood. Default value is 1.
-    parent: ndarray, int64, optional
+    parent : ndarray, int64, optional
         Parent image representing the max tree of the image. The
         value of each pixel is the index of its parent in the ravelled array.
-    tree_traverser: 1D array, int64, optional
+    tree_traverser : 1D array, int64, optional
         The ordered pixel indices (referring to the ravelled array). The pixels
         are ordered such that every pixel is preceded by its parent (except for
         the root which has no parent).
 
     Returns
     -------
-    output: ndarray
+    output : ndarray
         Output image of the same shape and type as the input image.
 
     See also
@@ -270,27 +270,27 @@ def diameter_opening(image, diameter_threshold=8, connectivity=1,
 
     Parameters
     ----------
-    image: ndarray
+    image : ndarray
         The input image for which the area_opening is to be calculated.
         This image can be of any type.
-    diameter_threshold: unsigned int
+    diameter_threshold : unsigned int
         The maximal extension parameter (number of pixels). The default value
         is 8.
-    connectivity: unsigned int, optional
+    connectivity : unsigned int, optional
         The neighborhood connectivity. The integer represents the maximum
         number of orthogonal steps to reach a neighbor. In 2D, it is 1 for
         a 4-neighborhood and 2 for a 8-neighborhood. Default value is 1.
-    parent: ndarray, int64, optional
+    parent : ndarray, int64, optional
         Parent image representing the max tree of the image. The
         value of each pixel is the index of its parent in the ravelled array.
-    tree_traverser: 1D array, int64, optional
+    tree_traverser : 1D array, int64, optional
         The ordered pixel indices (referring to the ravelled array). The pixels
         are ordered such that every pixel is preceded by its parent (except for
         the root which has no parent).
 
     Returns
     -------
-    output: ndarray
+    output : ndarray
         Output image of the same shape and type as the input image.
 
     See also
@@ -368,28 +368,28 @@ def area_closing(image, area_threshold=64, connectivity=1,
 
     Parameters
     ----------
-    image: ndarray
+    image : ndarray
         The input image for which the area_closing is to be calculated.
         This image can be of any type.
-    area_threshold: unsigned int
+    area_threshold : unsigned int
         The size parameter (number of pixels). The default value is arbitrarily
         chosen to be 64.
-    connectivity: unsigned int, optional
+    connectivity : unsigned int, optional
         The neighborhood connectivity. The integer represents the maximum
         number of orthogonal steps to reach a neighbor. In 2D, it is 1 for
         a 4-neighborhood and 2 for a 8-neighborhood. Default value is 1.
-    parent: ndarray, int64, optional
+    parent : ndarray, int64, optional
         Parent image representing the max tree of the inverted image. The
         value of each pixel is the index of its parent in the ravelled array.
         See Note for further details.
-    tree_traverser: 1D array, int64, optional
+    tree_traverser : 1D array, int64, optional
         The ordered pixel indices (referring to the ravelled array). The pixels
         are ordered such that every pixel is preceded by its parent (except for
         the root which has no parent).
 
     Returns
     -------
-    output: ndarray
+    output : ndarray
         Output image of the same shape and type as input image.
 
     See also
@@ -488,21 +488,21 @@ def diameter_closing(image, diameter_threshold=8, connectivity=1,
 
     Parameters
     ----------
-    image: ndarray
+    image : ndarray
         The input image for which the diameter_closing is to be calculated.
         This image can be of any type.
-    diameter_threshold: unsigned int
+    diameter_threshold : unsigned int
         The maximal extension parameter (number of pixels). The default value
         is 8.
-    connectivity: unsigned int, optional
+    connectivity : unsigned int, optional
         The neighborhood connectivity. The integer represents the maximum
         number of orthogonal steps to reach a neighbor. In 2D, it is 1 for
         a 4-neighborhood and 2 for a 8-neighborhood. Default value is 1.
-    parent: ndarray, int64, optional
+    parent : ndarray, int64, optional
         Precomputed parent image representing the max tree of the inverted
         image. This function is fast, if precomputed parent and tree_traverser
         are provided. See Note for further details.
-    tree_traverser: 1D array, int64, optional
+    tree_traverser : 1D array, int64, optional
         Precomputed traverser, where the pixels are ordered such that every
         pixel is preceded by its parent (except for the root which has no
         parent). This function is fast, if precomputed parent and
@@ -510,7 +510,7 @@ def diameter_closing(image, diameter_threshold=8, connectivity=1,
 
     Returns
     -------
-    output: ndarray
+    output : ndarray
         Output image of the same shape and type as input image.
 
     See also

--- a/skimage/segmentation/_clear_border.py
+++ b/skimage/segmentation/_clear_border.py
@@ -20,6 +20,7 @@ def clear_border(labels, buffer_size=0, bgval=0, in_place=False, mask=None):
         Image data mask. Objects in labels image overlapping with
         False pixels of mask will be removed. If defined, the 
         argument buffer_size will be ignored.
+
     Returns
     -------
     out : (M[, N[, ..., P]]) array

--- a/skimage/segmentation/_watershed.py
+++ b/skimage/segmentation/_watershed.py
@@ -97,21 +97,21 @@ def watershed(image, markers=None, connectivity=1, offset=None, mask=None,
 
     Parameters
     ----------
-    image: ndarray (2-D, 3-D, ...) of integers
+    image : ndarray (2-D, 3-D, ...) of integers
         Data array where the lowest value points are labeled first.
-    markers: int, or ndarray of int, same shape as `image`, optional
+    markers : int, or ndarray of int, same shape as `image`, optional
         The desired number of markers, or an array marking the basins with the
         values to be assigned in the label matrix. Zero means not a marker. If
         ``None`` (no markers given), the local minima of the image are used as
         markers.
-    connectivity: ndarray, optional
+    connectivity : ndarray, optional
         An array with the same number of dimensions as `image` whose
         non-zero elements indicate neighbors for connection.
         Following the scipy convention, default is a one-connected array of
         the dimension of the image.
-    offset: array_like of shape image.ndim, optional
+    offset : array_like of shape image.ndim, optional
         offset of the connectivity (one offset per dimension)
-    mask: ndarray of bools or 0s and 1s, optional
+    mask : ndarray of bools or 0s and 1s, optional
         Array of same shape as `image`. Only points at which mask == True
         will be labeled.
     compactness : float, optional
@@ -123,7 +123,7 @@ def watershed(image, markers=None, connectivity=1, offset=None, mask=None,
 
     Returns
     -------
-    out: ndarray
+    out : ndarray
         A labeled matrix of the same type and shape as markers
 
     See also

--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -47,7 +47,7 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
         Maximum pixel distance to move per iteration.
     max_iterations : int, optional
         Maximum iterations to optimize snake shape.
-    convergence: float, optional
+    convergence : float, optional
         Convergence criteria.
     boundary_condition : string, optional
         Boundary conditions for the contour. Can be one of 'periodic',

--- a/skimage/segmentation/boundaries.py
+++ b/skimage/segmentation/boundaries.py
@@ -53,14 +53,14 @@ def find_boundaries(label_img, connectivity=1, mode='thick', background=0):
     label_img : array of int or bool
         An array in which different regions are labeled with either different
         integers or boolean values.
-    connectivity: int in {1, ..., `label_img.ndim`}, optional
+    connectivity : int in {1, ..., `label_img.ndim`}, optional
         A pixel is considered a boundary pixel if any of its neighbors
         has a different label. `connectivity` controls which pixels are
         considered neighbors. A connectivity of 1 (default) means
         pixels sharing an edge (in 2D) or a face (in 3D) will be
         considered neighbors. A connectivity of `label_img.ndim` means
         pixels sharing a corner will be considered neighbors.
-    mode: string in {'thick', 'inner', 'outer', 'subpixel'}
+    mode : string in {'thick', 'inner', 'outer', 'subpixel'}
         How to mark the boundaries:
 
         - thick: any pixel not completely surrounded by pixels of the
@@ -73,7 +73,7 @@ def find_boundaries(label_img, connectivity=1, mode='thick', background=0):
           marked.
         - subpixel: return a doubled image, with pixels *between* the
           original pixels marked as boundary where appropriate.
-    background: int, optional
+    background : int, optional
         For modes 'inner' and 'outer', a definition of a background
         label is required. See `mode` for descriptions of these two.
 

--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -50,15 +50,15 @@ def slic(image, n_segments=100, compactness=10., max_iter=10, sigma=0,
         segmentation. The input image *must* be RGB. Highly recommended.
         This option defaults to ``True`` when ``multichannel=True`` *and*
         ``image.shape[-1] == 3``.
-    enforce_connectivity: bool, optional
+    enforce_connectivity : bool, optional
         Whether the generated segments are connected or not
-    min_size_factor: float, optional
+    min_size_factor : float, optional
         Proportion of the minimum segment size to be removed with respect
         to the supposed segment size ```depth*width*height/n_segments```
-    max_size_factor: float, optional
+    max_size_factor : float, optional
         Proportion of the maximum connected segment size. A value of 3 works
         in most of the cases.
-    slic_zero: bool, optional
+    slic_zero : bool, optional
         Run SLIC-zero, the zero-parameter mode of SLIC. [2]_
 
     Returns

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -119,7 +119,7 @@ def hough_ellipse(image, threshold=4, accuracy=1, min_size=4, max_size=None):
     ----------
     image : (M, N) ndarray
         Input image with nonzero values representing edges.
-    threshold: int, optional
+    threshold : int, optional
         Accumulator threshold value.
     accuracy : double, optional
         Bin size on the minor axis used in the accumulator.


### PR DESCRIPTION
## Description
I have been recently working on a project that parses docstrings across many `skimage` modules, and I found a few places where non-standard colon usage (no space between the parameter name and the colon) breaks numpydoc scraping.  This also affects the sphinx docs: see, for example the `max_iter` parameter of the [`threshold_minimum` docstring](https://scikit-image.org/docs/dev/api/skimage.filters.html#threshold-minimum).

These were all the formatting errors I could find.

## Checklist
This PR does not touch any code... only fixes a couple spaces in docstrings.

- [x] Docstrings for all functions

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
