### PR TITLE
Set minimum tifffile version to fix numpy incompatibility

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,6 +1,6 @@
 SimpleITK
 astropy>=1.2.0
-tifffile
+tifffile>=0.11.1
 qtpy
 pyamg
 dask[array]>=0.15.0


### PR DESCRIPTION
## Description

Fixes #4451 
This should fix the build failures due to incompatible minimum versions.

The version was chosen such that the release more or less matched the version that we vendor ourselves.
## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
