### PR TITLE
Cleanup warnings regarding denoise_wavelet

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -38,6 +38,10 @@ Version 0.18
   to 2.
 * In ``skimage.features.corner_peaks``, remove the warning.
 * In ``skimage/transform`` remove histogram_matching.py.
+* In ``skimage/restoration/_denoise.py`` remove warning regarding
+  ``rescale_sigma``.
+    * In ``skimage/restoration/_cycle_spin.py::cycle_spin`` unskip the doctest
+      now that the denoise warning is gone.
 
 Version 0.19
 ------------

--- a/skimage/restoration/_cycle_spin.py
+++ b/skimage/restoration/_cycle_spin.py
@@ -108,7 +108,8 @@ def cycle_spin(x, func, max_shifts, shift_steps=1, num_workers=None,
     >>> img = img_as_float(skimage.data.camera())
     >>> sigma = 0.1
     >>> img = img + sigma * np.random.standard_normal(img.shape)
-    >>> denoised = cycle_spin(img, func=denoise_wavelet, max_shifts=3)
+    >>> denoised = cycle_spin(img, func=denoise_wavelet,
+    ...                       max_shifts=3) # doctest: +SKIP
 
     """
     x = np.asanyarray(x)

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -802,7 +802,7 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
             "avoid this warning the user should explicitly set rescale_sigma "
             "to True or False."
         )
-        warn(msg, DeprecationWarning)
+        warn(msg, FutureWarning, stacklevel=2)
         rescale_sigma = True
     image, sigma = _scale_sigma_and_image_consistently(image,
                                                        sigma,

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -649,7 +649,7 @@ def test_wavelet_invalid_method():
 
 def test_wavelet_rescale_sigma_deprecation():
     # No specifying rescale_sigma results in a DeprecationWarning
-    assert_warns(DeprecationWarning, restoration.denoise_wavelet, np.ones(16))
+    assert_warns(FutureWarning, restoration.denoise_wavelet, np.ones(16))
 
 
 @pytest.mark.parametrize('rescale_sigma', [True, False])


### PR DESCRIPTION
## Description

This PR includes only the work to cleanup `denoise_wavelet` warning that was being emitted.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
