### PR TITLE
Skip doctests for deprecated functions rank.tophat rank.bottomhat since they emit warnings

### DIFF
--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -325,7 +325,7 @@ def bottomhat(image, selem, out=None, mask=None, shift_x=False,
     >>> from skimage.morphology import disk
     >>> from skimage.filters.rank import bottomhat
     >>> img = data.camera()
-    >>> out = bottomhat(img, disk(5))
+    >>> out = bottomhat(img, disk(5))  # doctest: +SKIP
 
     """
     warnings.warn("rank.bottomhat is deprecated. This filter is named"
@@ -974,7 +974,7 @@ def tophat(image, selem, out=None, mask=None, shift_x=False,
     >>> from skimage.morphology import disk
     >>> from skimage.filters.rank import tophat
     >>> img = data.camera()
-    >>> out = tophat(img, disk(5))
+    >>> out = tophat(img, disk(5))  # doctest: +SKIP
 
     """
     warnings.warn("rank.tophat is deprecated. This filter is named"


### PR DESCRIPTION
Getting us one step closer to 0 warnings on tests

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
