### PR TITLE
Use rgba2rgb directly where rgb kind is inferred

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from ..color import rgb2gray, rgba2rgb
+from ..color.colorconv import rgb2gray, rgba2rgb
 from ..util.dtype import dtype_range, dtype_limits
 from .._shared.utils import warn
 

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from ..color import rgb2gray
+from ..color import rgb2gray, rgba2rgb
 from ..util.dtype import dtype_range, dtype_limits
 from .._shared.utils import warn
 
@@ -561,8 +561,11 @@ def is_low_contrast(image, fraction_threshold=0.05, lower_percentile=1,
     False
     """
     image = np.asanyarray(image)
-    if image.ndim == 3 and image.shape[2] in [3, 4]:
-        image = rgb2gray(image)
+    if image.ndim == 3:
+        if image.shape[2] == 4:
+            image = rgba2rgb(image)
+        if image.shape[2] == 3:
+            image = rgb2gray(image)
 
     dlimits = dtype_limits(image, clip_negative=False)
     limits = np.percentile(image, [lower_percentile, upper_percentile])

--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from ..io.manage_plugins import call_plugin
-from ..color import rgb2gray
+from ..color import rgb2gray, rgba2rgb
 from .util import file_or_url_context
 from ..exposure import is_low_contrast
 from .._shared.utils import warn
@@ -56,6 +56,8 @@ def imread(fname, as_gray=False, plugin=None, **plugin_args):
             img = np.swapaxes(img, -2, -3)
 
         if as_gray:
+            if img.shape[2] == 4:
+                img = rgba2rgb(img)
             img = rgb2gray(img)
 
     return img

--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from ..io.manage_plugins import call_plugin
-from ..color import rgb2gray, rgba2rgb
+from ..color.colorconv import rgb2gray, rgba2rgb
 from .util import file_or_url_context
 from ..exposure import is_low_contrast
 from .._shared.utils import warn


### PR DESCRIPTION
## Description
This kind of implicit behavior was deprecated, and was emitting warnings in our tests.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
