### PR TITLE
Cleanup disk circle warnings

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -89,4 +89,5 @@ Other
   ``skimage/exposure/tests/test_exposure.py::test_rescale_nan_warning``
   regarding ``Passing `np.nan` to mean no clipping in np.clip``.
 * Remove direct allocation of ``output`` from ``skimage/filters/_gaussian.py``,
-  when ``scipy`` upgrades to 1.1. 
+  when ``scipy`` upgrades to 1.1.
+* Think about how to deprecate ``circle`` from random_shapes.

--- a/TODO.txt
+++ b/TODO.txt
@@ -43,6 +43,8 @@ Version 0.19
 ------------
 
 * In ``skimage/draw/draw.py`` remove ``circle'' and related tests.
+* In ``skimage/segmentation/morphsnakes.py``, remove the if statement
+  ``_init_level_set`` that relates to using the set ``circle``.
 * In ``skimage/segmentation/morphsnakes.py`` remove ``circle_level_set'' and related tests.
 * In ``skimage/morphology/_flood_fill.py`` replace the deprecated parameter
   in flood_fill() ``inplace`` with ``in_place`` and update the tests.

--- a/skimage/draw/_random_shapes.py
+++ b/skimage/draw/_random_shapes.py
@@ -172,7 +172,7 @@ def _generate_triangle_mask(point, image, shape, random):
 # Allows lookup by key as well as random selection.
 SHAPE_GENERATORS = dict(
     rectangle=_generate_rectangle_mask,
-    circle=_generate_disk_mask,
+    disk=_generate_disk_mask,
     triangle=_generate_triangle_mask)
 SHAPE_CHOICES = list(SHAPE_GENERATORS.values())
 

--- a/skimage/draw/_random_shapes.py
+++ b/skimage/draw/_random_shapes.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from . import polygon as draw_polygon, circle as draw_circle
+from . import polygon as draw_polygon, disk as draw_disk
 from .._shared.utils import warn
 
 
@@ -60,10 +60,10 @@ def _generate_rectangle_mask(point, image, shape, random):
     return rectangle, label
 
 
-def _generate_circle_mask(point, image, shape, random):
-    """Generate a mask for a filled circle shape.
+def _generate_disk_mask(point, image, shape, random):
+    """Generate a mask for a filled disk shape.
 
-    The radius of the circle is generated randomly.
+    The radius of the disk is generated randomly.
 
     Parameters
     ----------
@@ -92,7 +92,7 @@ def _generate_circle_mask(point, image, shape, random):
         A mask of indices that the shape fills.
     """
     if shape[0] == 1 or shape[1] == 1:
-        raise ValueError('size must be > 1 for circles')
+        raise ValueError('size must be > 1 for disks')
     min_radius = shape[0] / 2.0
     max_radius = shape[1] / 2.0
     left = point[1]
@@ -103,11 +103,17 @@ def _generate_circle_mask(point, image, shape, random):
     if available_radius < min_radius:
         raise ArithmeticError('cannot fit shape to image')
     radius = random.randint(min_radius, available_radius + 1)
-    circle = draw_circle(point[0], point[1], radius)
+    # TODO: think about how to deprecate this
+    # Unfortunately, renaming `circle` to `disk` directly would break
+    # downstream code that switches between `circle` and disk.
+    # See discussion on naming convention here
+    # https://github.com/scikit-image/scikit-image/pull/4428
+    disk = draw_disk((point[0], point[1]), radius)
+    # Until a deprecation path is decided, always return `'circle'`
     label = ('circle', ((point[0] - radius + 1, point[0] + radius),
                         (point[1] - radius + 1, point[1] + radius)))
 
-    return circle, label
+    return disk, label
 
 
 def _generate_triangle_mask(point, image, shape, random):
@@ -166,7 +172,7 @@ def _generate_triangle_mask(point, image, shape, random):
 # Allows lookup by key as well as random selection.
 SHAPE_GENERATORS = dict(
     rectangle=_generate_rectangle_mask,
-    circle=_generate_circle_mask,
+    circle=_generate_disk_mask,
     triangle=_generate_triangle_mask)
 SHAPE_CHOICES = list(SHAPE_GENERATORS.values())
 

--- a/skimage/draw/_random_shapes.py
+++ b/skimage/draw/_random_shapes.py
@@ -104,8 +104,9 @@ def _generate_disk_mask(point, image, shape, random):
         raise ArithmeticError('cannot fit shape to image')
     radius = random.randint(min_radius, available_radius + 1)
     # TODO: think about how to deprecate this
-    # Unfortunately, renaming `circle` to `disk` directly would break
-    # downstream code that switches between `circle` and disk.
+    # while the 'circle' argument has been deprecated in favor of the
+    # 'disk' argument, switching the return value to 'disk' here
+    # would be a breaking change for downstream libraries
     # See discussion on naming convention here
     # https://github.com/scikit-image/scikit-image/pull/4428
     disk = draw_disk((point[0], point[1]), radius)

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -5,7 +5,7 @@ from scipy import ndimage as ndi
 from skimage import util
 from skimage import data
 from skimage.color import rgb2gray
-from skimage.draw import circle
+from skimage.draw import disk
 from skimage._shared._warnings import expected_warnings
 from skimage.exposure import histogram
 from skimage.filters.thresholding import (threshold_local,
@@ -565,7 +565,7 @@ def test_multiotsu_output():
     coords = [(25, 25), (50, 50), (75, 75)]
     values = [64, 128, 192]
     for coor, val in zip(coords, values):
-        rr, cc = circle(coor[1], coor[0], 20)
+        rr, cc = disk(coor, 20)
         image[rr, cc] = val
     thresholds = [0, 64, 128]
     assert np.array_equal(thresholds, threshold_multiotsu(image, classes=4))

--- a/skimage/segmentation/morphsnakes.py
+++ b/skimage/segmentation/morphsnakes.py
@@ -101,11 +101,14 @@ def _init_level_set(init_level_set, image_shape):
     if isinstance(init_level_set, str):
         if init_level_set == 'checkerboard':
             res = checkerboard_level_set(image_shape)
+        # TODO: remove me in 0.19.0
         elif init_level_set == 'circle':
             res = circle_level_set(image_shape)
+        elif init_level_set == 'disk':
+            res = disk_level_set(image_shape)
         else:
             raise ValueError("`init_level_set` not in "
-                             "['checkerboard', 'circle']")
+                             "['checkerboard', 'circle', 'disk']")
     else:
         res = init_level_set
     return res

--- a/skimage/segmentation/tests/test_morphsnakes.py
+++ b/skimage/segmentation/tests/test_morphsnakes.py
@@ -115,16 +115,16 @@ def test_init_level_sets():
                                  [0, 0, 0, 0, 0, 1],
                                  [1, 1, 1, 1, 1, 0]], dtype=np.int8)
 
-    circle_ls = morphological_geodesic_active_contour(image, 0, 'circle')
-    circle_ref = np.array([[0, 0, 0, 0, 0, 0],
-                           [0, 0, 1, 1, 1, 0],
-                           [0, 1, 1, 1, 1, 1],
-                           [0, 1, 1, 1, 1, 1],
-                           [0, 1, 1, 1, 1, 1],
-                           [0, 0, 1, 1, 1, 0]], dtype=np.int8)
+    disk_ls = morphological_geodesic_active_contour(image, 0, 'disk')
+    disk_ref = np.array([[0, 0, 0, 0, 0, 0],
+                         [0, 0, 1, 1, 1, 0],
+                         [0, 1, 1, 1, 1, 1],
+                         [0, 1, 1, 1, 1, 1],
+                         [0, 1, 1, 1, 1, 1],
+                         [0, 0, 1, 1, 1, 0]], dtype=np.int8)
 
     assert_array_equal(checkerboard_ls, checkerboard_ref)
-    assert_array_equal(circle_ls, circle_ref)
+    assert_array_equal(disk_ls, disk_ref)
 
 
 def test_morphsnakes_3d():
@@ -135,10 +135,10 @@ def test_morphsnakes_3d():
     def callback(x):
         evolution.append(x.sum())
 
-    ls = morphological_chan_vese(image, 5, 'circle',
+    ls = morphological_chan_vese(image, 5, 'disk',
                                  iter_callback=callback)
 
-    # Check that the initial circle level set is correct
+    # Check that the initial disk level set is correct
     assert evolution[0] == 81
 
     # Check that the final level set is correct


### PR DESCRIPTION
## Description
This introduced many deprecation warnings to appear all over:
https://github.com/scikit-image/scikit-image/pull/4428


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
