### PR TITLE
Cleanup corner peaks warnings

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -37,6 +37,17 @@ Version 0.18
   ``neighbors`` and update the tests. Set the default value of ``connectivity``
   to 2.
 * In ``skimage.features.corner_peaks``, remove the warning.
+    * In the following docstrings, remove the explicit setting of ``threshold_rel=0``
+        * ``skimage/feature/brief.py::BRIEF``
+        * `` skimage/feature/corner.py::corner_harris``
+        * `` skimage/feature/corner.py::corner_shi_tomasi``
+        * `` skimage/feature/corner.py::corner_foerstner``
+        * `` skimage/feature/corner.py::corner_fast``
+        * `` skimage/feature/corner.py::corner_subpix``
+        * `` skimage/feature/corner.py::corner_peaks``
+        * `` skimage/feature/corner.py::corner_orientations``
+    * In ``skimage/feature/orb.py::_detect_octage`` remove explicitely setting
+      ``threshold_rel=0``.
 * In ``skimage/transform`` remove histogram_matching.py.
 
 Version 0.19

--- a/skimage/feature/brief.py
+++ b/skimage/feature/brief.py
@@ -85,8 +85,10 @@ class BRIEF(DescriptorExtractor):
            [0, 0, 1, 1, 1, 1, 1, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=int32)
-    >>> keypoints1 = corner_peaks(corner_harris(square1), min_distance=1)
-    >>> keypoints2 = corner_peaks(corner_harris(square2), min_distance=1)
+    >>> keypoints1 = corner_peaks(corner_harris(square1), min_distance=1,
+    ...                           threshold_rel=0)
+    >>> keypoints2 = corner_peaks(corner_harris(square2), min_distance=1,
+    ...                           threshold_rel=0)
     >>> extractor = BRIEF(patch_size=5)
     >>> extractor.extract(square1, keypoints1)
     >>> descriptors1 = extractor.descriptors

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -501,7 +501,7 @@ def corner_harris(image, method='k', k=0.05, eps=1e-6, sigma=1):
            [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
-    >>> corner_peaks(corner_harris(square), min_distance=1)
+    >>> corner_peaks(corner_harris(square), min_distance=1, threshold_rel=0)
     array([[2, 2],
            [2, 7],
            [7, 2],
@@ -570,7 +570,8 @@ def corner_shi_tomasi(image, sigma=1):
            [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
-    >>> corner_peaks(corner_shi_tomasi(square), min_distance=1)
+    >>> corner_peaks(corner_shi_tomasi(square), min_distance=1,
+    ...              threshold_rel=0)
     array([[2, 2],
            [2, 7],
            [7, 2],
@@ -644,7 +645,7 @@ def corner_foerstner(image, sigma=1):
     >>> accuracy_thresh = 0.5
     >>> roundness_thresh = 0.3
     >>> foerstner = (q > roundness_thresh) * (w > accuracy_thresh) * w
-    >>> corner_peaks(foerstner, min_distance=1)
+    >>> corner_peaks(foerstner, min_distance=1, threshold_rel=0)
     array([[2, 2],
            [2, 7],
            [7, 2],
@@ -721,7 +722,7 @@ def corner_fast(image, n=12, threshold=0.15):
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
-    >>> corner_peaks(corner_fast(square, 9), min_distance=1)
+    >>> corner_peaks(corner_fast(square, 9), min_distance=1, threshold_rel=0)
     array([[3, 3],
            [3, 8],
            [8, 3],
@@ -787,7 +788,8 @@ def corner_subpix(image, corners, window_size=11, alpha=0.99):
            [0, 0, 0, 0, 0, 1, 1, 1, 1, 1],
            [0, 0, 0, 0, 0, 1, 1, 1, 1, 1],
            [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]])
-    >>> coords = corner_peaks(corner_harris(img), min_distance=2)
+    >>> coords = corner_peaks(corner_harris(img), min_distance=2,
+    ...                       threshold_rel=0)
     >>> coords_subpix = corner_subpix(img, coords, window_size=7)
     >>> coords_subpix
     array([[4.5, 4.5]])
@@ -953,7 +955,7 @@ def corner_peaks(image, min_distance=1, threshold_abs=None, threshold_rel=None,
            [3, 2],
            [2, 3],
            [2, 2]])
-    >>> corner_peaks(response)
+    >>> corner_peaks(response, threshold_rel=0)
     array([[2, 2]])
 
     """
@@ -1087,7 +1089,8 @@ def corner_orientations(image, corners, mask):
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
-    >>> corners = corner_peaks(corner_fast(square, 9), min_distance=1)
+    >>> corners = corner_peaks(corner_fast(square, 9), min_distance=1,
+    ...                        threshold_rel=0)
     >>> corners
     array([[3, 3],
            [3, 8],

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -959,10 +959,12 @@ def corner_peaks(image, min_distance=1, threshold_abs=None, threshold_rel=None,
     """
     if threshold_rel is None:
         threshold_rel = 0.1
-        warn("Until the version 0.16, threshold_rel was set to 0.1 by default."
-             "Starting from version 0.16, the default value is set to None."
-             "Until version 0.18, a None value corresponds to a threshold value of 0.1."
-             "The default behavior will match skimage.feature.peak_local_max.",
+        warn("Until version 0.16, threshold_rel was set to 0.1 by default. "
+             "Starting from version 0.16, the default value is set to None. "
+             "Until version 0.18, a None value corresponds to a threshold "
+             "value of 0.1. "
+             "The default behavior will match skimage.feature.peak_local_max. "
+             "To avoid this warning, set threshold_rel=0.",
              category=FutureWarning, stacklevel=2)
 
     peaks = peak_local_max(image, min_distance=min_distance,

--- a/skimage/feature/orb.py
+++ b/skimage/feature/orb.py
@@ -139,7 +139,8 @@ class ORB(FeatureDetector, DescriptorExtractor):
         # Extract keypoints for current octave
         fast_response = corner_fast(octave_image, self.fast_n,
                                     self.fast_threshold)
-        keypoints = corner_peaks(fast_response, min_distance=1)
+        keypoints = corner_peaks(fast_response, min_distance=1,
+                                 threshold_rel=0)
 
         if len(keypoints) == 0:
             return (np.zeros((0, 2), dtype=np.double),

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -1,6 +1,5 @@
 import numpy as np
-from skimage._shared.testing import assert_array_equal
-from skimage._shared.testing import assert_almost_equal, assert_warns
+from skimage._shared.testing import assert_array_equal, assert_almost_equal
 from skimage import data
 from skimage import img_as_float
 from skimage import draw
@@ -361,12 +360,14 @@ def test_corner_peaks():
                            threshold_rel=0)
     assert corners.shape == (2, 2)
 
-    corners = corner_peaks(response, exclude_border=False, min_distance=1)
-    assert corners.shape == (5, 2)
+    with pytest.warns(FutureWarning,
+                      match="Until version 0.16, threshold_rel.*"):
+        corners = corner_peaks(response, exclude_border=False, min_distance=1)
+        assert corners.shape == (5, 2)
 
-    corners = corner_peaks(response, exclude_border=False, min_distance=1,
-                           indices=False)
-    assert np.sum(corners) == 5
+        corners = corner_peaks(response, exclude_border=False, min_distance=1,
+                               indices=False)
+        assert np.sum(corners) == 5
 
 
 def test_blank_image_nans():


### PR DESCRIPTION
## Description

`coner_peaks` introduced many warnings in the doctests.

These would really help show users how to use the function call without adding warnings in their code.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
