### PR TITLE
Deprecators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ doc/build
 source/api
 build
 dist
-skimage/version.py
 *.swp
 .coverage
 doc/source/auto_examples/**/*

--- a/doc/tools/build_modref_templates.py
+++ b/doc/tools/build_modref_templates.py
@@ -37,7 +37,7 @@ if __name__ == '__main__':
 
     installed_version = V(module.__version__)
 
-    source_lines = open('../skimage/__init__.py').readlines()
+    source_lines = open('../skimage/version.py').readlines()
     version = 'vUndefined'
     for l in source_lines:
         if l.startswith('__version__'):

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -5,3 +5,4 @@ networkx>=2.0
 pillow>=4.3.0
 imageio>=2.3.0
 PyWavelets>=0.5.2
+wabisabi>=0.2.8

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ def openmp_build_ext():
     return ConditionalOpenMP
 
 
-with open('skimage/__init__.py') as fid:
+with open('skimage/version.py') as fid:
     for line in fid:
         if line.startswith('__version__'):
             VERSION = line.strip().split()[-1][1:-1]

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -69,7 +69,7 @@ dtype_limits
 import sys
 
 
-__version__ = '0.17.dev0'
+from .version import __version__
 
 from ._shared.version_requirements import ensure_python_version
 ensure_python_version((3, 5))

--- a/skimage/_shared/_deprecators.py
+++ b/skimage/_shared/_deprecators.py
@@ -1,0 +1,12 @@
+from functools import partial
+from ..version import __version__
+from deprecation_factory import kwonly_change
+from deprecation_factory import default_parameter_change
+
+kwonly_change = partial(kwonly_change,
+                        library_name='scikit-image',
+                        current_library_version=__version__)
+
+default_parameter_change = partial(default_parameter_change,
+                                   library_name='scikit-image',
+                                   current_library_version=__version__)

--- a/skimage/_shared/_deprecators.py
+++ b/skimage/_shared/_deprecators.py
@@ -1,7 +1,6 @@
 from functools import partial
 from ..version import __version__
-from deprecation_factory import kwonly_change
-from deprecation_factory import default_parameter_change
+from wabisabi import kwonly_change, default_parameter_change
 
 kwonly_change = partial(kwonly_change,
                         library_name='scikit-image',

--- a/skimage/feature/orb.py
+++ b/skimage/feature/orb.py
@@ -132,8 +132,9 @@ class ORB(FeatureDetector, DescriptorExtractor):
 
     def _build_pyramid(self, image):
         image = _prepare_grayscale_input_2D(image)
-        return list(pyramid_gaussian(image, self.n_scales - 1,
-                                     self.downscale, multichannel=False))
+        return list(pyramid_gaussian(image, max_layer=self.n_scales - 1,
+                                     downscale=self.downscale,
+                                     multichannel=False))
 
     def _detect_octave(self, octave_image):
         # Extract keypoints for current octave

--- a/skimage/registration/_optical_flow_utils.py
+++ b/skimage/registration/_optical_flow_utils.py
@@ -67,7 +67,8 @@ def get_pyramid(I, downscale=2.0, nlevel=10, min_size=16):
     count = 1
 
     while (count < nlevel) and (size > downscale * min_size):
-        J = pyramid_reduce(pyramid[-1], downscale, multichannel=False)
+        J = pyramid_reduce(pyramid[-1],
+                           downscale=downscale, multichannel=False)
         pyramid.append(J)
         size = min(J.shape)
         count += 1

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -4,9 +4,10 @@ from ._hough_transform import (_hough_circle,
                                _hough_ellipse,
                                _hough_line,
                                _probabilistic_hough_line as _prob_hough_line)
+from .._shared._deprecators import kwonly_change
 
-
-def hough_line_peaks(hspace, angles, dists, min_distance=9, min_angle=10,
+@kwonly_change('1.0')
+def hough_line_peaks(hspace, angles, dists, *, min_distance=9, min_angle=10,
                      threshold=None, num_peaks=np.inf):
     """Return peaks in a straight line Hough transform.
 
@@ -68,7 +69,8 @@ def hough_line_peaks(hspace, angles, dists, min_distance=9, min_angle=10,
         return (h, np.array([]), np.array([]))
 
 
-def hough_circle(image, radius, normalize=True, full_output=False):
+@kwonly_change('1.0')
+def hough_circle(image, radius, *, normalize=True, full_output=False):
     """Perform a circular Hough transform.
 
     Parameters
@@ -112,7 +114,8 @@ def hough_circle(image, radius, normalize=True, full_output=False):
                          normalize=normalize, full_output=full_output)
 
 
-def hough_ellipse(image, threshold=4, accuracy=1, min_size=4, max_size=None):
+@kwonly_change('1.0')
+def hough_ellipse(image, *, threshold=4, accuracy=1, min_size=4, max_size=None):
     """Perform an elliptical Hough transform.
 
     Parameters
@@ -164,7 +167,8 @@ def hough_ellipse(image, threshold=4, accuracy=1, min_size=4, max_size=None):
                           min_size=min_size, max_size=max_size)
 
 
-def hough_line(image, theta=None):
+@kwonly_change('1.0')
+def hough_line(image, *, theta=None):
     """Perform a straight line Hough transform.
 
     Parameters
@@ -222,7 +226,8 @@ def hough_line(image, theta=None):
     return _hough_line(image, theta=theta)
 
 
-def probabilistic_hough_line(image, threshold=10, line_length=50, line_gap=10,
+@kwonly_change('1.0')
+def probabilistic_hough_line(image, *, threshold=10, line_length=50, line_gap=10,
                              theta=None, seed=None):
     """Return lines from a progressive probabilistic line Hough transform.
 
@@ -267,7 +272,8 @@ def probabilistic_hough_line(image, threshold=10, line_length=50, line_gap=10,
                             line_gap=line_gap, theta=theta, seed=seed)
 
 
-def hough_circle_peaks(hspaces, radii, min_xdistance=1, min_ydistance=1,
+@kwonly_change('1.0')
+def hough_circle_peaks(hspaces, radii, *, min_xdistance=1, min_ydistance=1,
                        threshold=None, num_peaks=np.inf,
                        total_num_peaks=np.inf, normalize=False):
     """Return peaks in a circle Hough transform.

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -3,6 +3,7 @@ import numpy as np
 from scipy import ndimage as ndi
 from ..transform import resize
 from .._shared.utils import convert_to_float
+from .._shared._deprecators import kwonly_change
 
 
 def _smooth(image, sigma, mode, cval, multichannel=None):
@@ -22,7 +23,8 @@ def _check_factor(factor):
         raise ValueError('scale factor must be greater than 1')
 
 
-def pyramid_reduce(image, downscale=2, sigma=None, order=1,
+@kwonly_change('1.0')
+def pyramid_reduce(image, *, downscale=2, sigma=None, order=1,
                    mode='reflect', cval=0, multichannel=False,
                    preserve_range=False):
     """Smooth and then downsample image.
@@ -82,6 +84,7 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
     return out
 
 
+@kwonly_change('1.0')
 def pyramid_expand(image, upscale=2, sigma=None, order=1,
                    mode='reflect', cval=0, multichannel=False,
                    preserve_range=False):
@@ -142,9 +145,12 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
     return out
 
 
-def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
-                     mode='reflect', cval=0, multichannel=False,
-                     preserve_range=False):
+@kwonly_change('1.0', previous_arg_order=['image', 'max_layer', 'downscale',
+                                          'sigma', 'order',
+                                          'mode', 'cval', 'multichannel'])
+def pyramid_gaussian(image, *, downscale=2, sigma=None, order=1,
+                     mode='reflect', cval=0, max_layer=-1,
+                     multichannel=None, preserve_range=False):
     """Yield images of the Gaussian pyramid formed by the input image.
 
     Recursively applies the `pyramid_reduce` function to the image, and yields

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -233,6 +233,7 @@ def pyramid_gaussian(image, *, downscale=2, sigma=None, order=1,
         yield layer_image
 
 
+@kwonly_change('1.0')
 def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
                       mode='reflect', cval=0, multichannel=False,
                       preserve_range=False):

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -234,7 +234,7 @@ def pyramid_gaussian(image, *, downscale=2, sigma=None, order=1,
 
 
 @kwonly_change('1.0')
-def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
+def pyramid_laplacian(image, *, max_layer=-1, downscale=2, sigma=None, order=1,
                       mode='reflect', cval=0, multichannel=False,
                       preserve_range=False):
     """Yield images of the laplacian pyramid formed by the input image.

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -85,7 +85,7 @@ def pyramid_reduce(image, *, downscale=2, sigma=None, order=1,
 
 
 @kwonly_change('1.0')
-def pyramid_expand(image, upscale=2, sigma=None, order=1,
+def pyramid_expand(image, *, upscale=2, sigma=None, order=1,
                    mode='reflect', cval=0, multichannel=False,
                    preserve_range=False):
     """Upsample and then smooth image.

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -216,8 +216,11 @@ def pyramid_gaussian(image, *, downscale=2, sigma=None, order=1,
     while layer != max_layer:
         layer += 1
 
-        layer_image = pyramid_reduce(prev_layer_image, downscale, sigma, order,
-                                     mode, cval, multichannel=multichannel)
+        layer_image = pyramid_reduce(prev_layer_image,
+                                     downscale=downscale,
+                                     sigma=sigma, order=order,
+                                     mode=mode, cval=cval,
+                                     multichannel=multichannel)
 
         prev_shape = np.asarray(current_shape)
         prev_layer_image = layer_image

--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -196,7 +196,7 @@ def _get_fourier_filter(size, filter_name):
 @kwonly_change('1.0', previous_arg_order=['radon_image', 'theta',
                                           'output_size', 'filter_name',
                                           'interpolation', 'circle'])
-def iradon(radon_image, theta=None, output_size=None,
+def iradon(radon_image, *, theta=None, output_size=None,
            filter_name="ramp", interpolation="linear", circle=True):
     """Inverse radon transform.
 
@@ -241,8 +241,8 @@ def iradon(radon_image, theta=None, output_size=None,
 
     References
     ----------
-    .. [1] AC Kak, M Slaney, "Principles of Computerized Tomographic
-           Imaging", IEEE Press 1988.
+    .. [1] AC Kak, M Slaney, "Principles of Computerized Tomographic Imaging",
+           IEEE Press 1988.
     .. [2] B.R. Ramesh, N. Srinivasa, K. Rajgopal, "An Algorithm for Computing
            the Discrete Radon Transform With Some Applications", Proceedings of
            the Fourth IEEE Region 10 International Conference, TENCON '89, 1989

--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -8,6 +8,7 @@ from .._shared.fft import fftmodule
 from .._shared.utils import deprecate_kwarg, convert_to_float
 from warnings import warn
 from functools import partial
+from .._shared._deprecators import kwonly_change
 
 if fftmodule is np.fft:
     # fallback from scipy.fft to scipy.fftpack instead of numpy.fft
@@ -21,7 +22,8 @@ else:
 __all__ = ['radon', 'order_angles_golden_ratio', 'iradon', 'iradon_sart']
 
 
-def radon(image, theta=None, circle=True, *, preserve_range=None):
+@kwonly_change('1.0', previous_arg_order=['image', 'theta', 'circle'])
+def radon(image, *, theta=None, circle=True, preserve_range=None):
     """
     Calculates the radon transform of an image given specified
     projection angles.
@@ -191,6 +193,9 @@ def _get_fourier_filter(size, filter_name):
 
 @deprecate_kwarg(kwarg_mapping={'filter': 'filter_name'},
                  removed_version="0.19")
+@kwonly_change('1.0', previous_arg_order=['radon_image', 'theta',
+                                          'output_size', 'filter_name',
+                                          'interpolation', 'circle'])
 def iradon(radon_image, theta=None, output_size=None,
            filter_name="ramp", interpolation="linear", circle=True):
     """Inverse radon transform.
@@ -372,7 +377,10 @@ def order_angles_golden_ratio(theta):
             yield remaining_indices.pop(index_above)
 
 
-def iradon_sart(radon_image, theta=None, image=None, projection_shifts=None,
+@kwonly_change('1.0', previous_arg_order=['radon_image', 'theta', 'image',
+                                          'projection_shifts', 'clip', 'relaxation',
+                                          'dtype'])
+def iradon_sart(radon_image, *, theta=None, image=None, projection_shifts=None,
                 clip=None, relaxation=0.15, dtype=None):
     """Inverse radon transform.
 

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -31,7 +31,7 @@ def test_hough_line_angles():
     img = np.zeros((10, 10))
     img[0, 0] = 1
 
-    out, angles, d = transform.hough_line(img, np.linspace(0, 360, 10))
+    out, angles, d = transform.hough_line(img, theta=np.linspace(0, 360, 10))
 
     assert_equal(len(angles), 10)
 
@@ -42,7 +42,7 @@ def test_hough_line_bad_input():
 
     # Expected error, img must be 2D
     with testing.raises(ValueError):
-        transform.hough_line(img, np.linspace(0, 360, 10))
+        transform.hough_line(img, theta=np.linspace(0, 360, 10))
 
 
 def test_probabilistic_hough():
@@ -147,14 +147,14 @@ def check_hough_line_peaks_angle():
                                           min_angle=90)[0]) == 1
 
     theta = np.linspace(0, np.pi, 100)
-    hspace, angles, dists = transform.hough_line(img, theta)
+    hspace, angles, dists = transform.hough_line(img, theta=theta)
     assert len(transform.hough_line_peaks(hspace, angles, dists,
                                           min_angle=45)[0]) == 2
     assert len(transform.hough_line_peaks(hspace, angles, dists,
                                           min_angle=90)[0]) == 1
 
     theta = np.linspace(np.pi / 3, 4. / 3 * np.pi, 100)
-    hspace, angles, dists = transform.hough_line(img, theta)
+    hspace, angles, dists = transform.hough_line(img, theta=theta)
     assert len(transform.hough_line_peaks(hspace, angles, dists,
                                           min_angle=45)[0]) == 2
     assert len(transform.hough_line_peaks(hspace, angles, dists,
@@ -175,7 +175,7 @@ def test_hough_line_peaks_zero_input():
     # Test to make sure empty input doesn't cause a failure
     img = np.zeros((100, 100), dtype='uint8')
     theta = np.linspace(0, np.pi, 100)
-    hspace, angles, dists = transform.hough_line(img, theta)
+    hspace, angles, dists = transform.hough_line(img, theta=theta)
     h, a, d = transform.hough_line_peaks(hspace, angles, dists)
     assert_equal(a, np.array([]))
 

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -64,8 +64,7 @@ def test_pyramid_expand_nd():
 
 def test_build_gaussian_pyramid_rgb():
     rows, cols, dim = image.shape
-    with expected_warnings(['The default multichannel',
-                            'will become keyword-only argument']):
+    with expected_warnings(['will become keyword-only argument']):
         pyramid = pyramids.pyramid_gaussian(image, downscale=2,
                                             multichannel=True)
         for layer, out in enumerate(pyramid):
@@ -75,10 +74,8 @@ def test_build_gaussian_pyramid_rgb():
 
 def test_build_gaussian_pyramid_gray():
     rows, cols = image_gray.shape
-    with expected_warnings(['The default multichannel',
-                            'will become keyword-only argument']):
-        pyramid = pyramids.pyramid_gaussian(image_gray, downscale=2,
-                                            multichannel=False)
+    with expected_warnings(['will become keyword-only argument']):
+        pyramid = pyramids.pyramid_gaussian(image_gray, downscale=2)
         for layer, out in enumerate(pyramid):
             layer_shape = (rows / 2 ** layer, cols / 2 ** layer)
             assert_array_equal(out.shape, layer_shape)

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -64,21 +64,19 @@ def test_pyramid_expand_nd():
 
 def test_build_gaussian_pyramid_rgb():
     rows, cols, dim = image.shape
-    with expected_warnings(['will become keyword-only argument']):
-        pyramid = pyramids.pyramid_gaussian(image, downscale=2,
-                                            multichannel=True)
-        for layer, out in enumerate(pyramid):
-            layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
-            assert_array_equal(out.shape, layer_shape)
+    pyramid = pyramids.pyramid_gaussian(image, downscale=2,
+                                        multichannel=True)
+    for layer, out in enumerate(pyramid):
+        layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
+        assert_array_equal(out.shape, layer_shape)
 
 
 def test_build_gaussian_pyramid_gray():
     rows, cols = image_gray.shape
-    with expected_warnings(['will become keyword-only argument']):
-        pyramid = pyramids.pyramid_gaussian(image_gray, downscale=2)
-        for layer, out in enumerate(pyramid):
-            layer_shape = (rows / 2 ** layer, cols / 2 ** layer)
-            assert_array_equal(out.shape, layer_shape)
+    pyramid = pyramids.pyramid_gaussian(image_gray, downscale=2)
+    for layer, out in enumerate(pyramid):
+        layer_shape = (rows / 2 ** layer, cols / 2 ** layer)
+        assert_array_equal(out.shape, layer_shape)
 
 
 def test_build_gaussian_pyramid_nd():

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -64,20 +64,24 @@ def test_pyramid_expand_nd():
 
 def test_build_gaussian_pyramid_rgb():
     rows, cols, dim = image.shape
-    pyramid = pyramids.pyramid_gaussian(image, downscale=2,
-                                        multichannel=True)
-    for layer, out in enumerate(pyramid):
-        layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
-        assert_array_equal(out.shape, layer_shape)
+    with expected_warnings(['The default multichannel',
+                            'will become keyword-only argument']):
+        pyramid = pyramids.pyramid_gaussian(image, downscale=2,
+                                            multichannel=True)
+        for layer, out in enumerate(pyramid):
+            layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
+            assert_array_equal(out.shape, layer_shape)
 
 
 def test_build_gaussian_pyramid_gray():
     rows, cols = image_gray.shape
-    pyramid = pyramids.pyramid_gaussian(image_gray, downscale=2,
-                                        multichannel=False)
-    for layer, out in enumerate(pyramid):
-        layer_shape = (rows / 2 ** layer, cols / 2 ** layer)
-        assert_array_equal(out.shape, layer_shape)
+    with expected_warnings(['The default multichannel',
+                            'will become keyword-only argument']):
+        pyramid = pyramids.pyramid_gaussian(image_gray, downscale=2,
+                                            multichannel=False)
+        for layer, out in enumerate(pyramid):
+            layer_shape = (rows / 2 ** layer, cols / 2 ** layer)
+            assert_array_equal(out.shape, layer_shape)
 
 
 def test_build_gaussian_pyramid_nd():

--- a/skimage/version.py
+++ b/skimage/version.py
@@ -1,0 +1,2 @@
+# Avoid circular imports
+__version__ = '0.15.dev0'

--- a/skimage/version.py
+++ b/skimage/version.py
@@ -1,2 +1,2 @@
 # Avoid circular imports
-__version__ = '0.15.dev0'
+__version__ = '0.17.dev0'


### PR DESCRIPTION
## Description

@jni, @alexdesiqueira this is the demo that I was talking about regarding how the decorator can be used to basically make the change "once".

In version 1.0, you are left with "zombie" decorators that would basically do nothing.

https://github.com/hmaarrfk/wabisabi/blob/master/wabisabi/kwonly_change.py#L89
I forced push to my old PR, now i can't reopen it.
https://github.com/scikit-image/scikit-image/pull/3346

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
