### PR TITLE
Added implementation of SSIM max/min algorithm from paper

### DIFF
--- a/skimage/transform/ssim_optimize.py
+++ b/skimage/transform/ssim_optimize.py
@@ -1,10 +1,8 @@
 import numpy as np
 from numpy.linalg import norm
 
-from skimage.metrics._structural_similarity import (
-    structural_similarity
-    as ssim
-)
+from ..metrics._structural_similarity import structural_similarity as ssim
+
 
 def E(X, Y):
     return (Y - X) / norm(Y - X)
@@ -42,7 +40,7 @@ def optimize_func(img, adv_x, op, _lambda, iters, sigma):
     Compute the image with the highest or lowest SSIM to a reference image
     on the L-2 ball of the reference image. Follows a two step iterative
     gradient descent procedure.
-    
+
     For actual use, the minimize_ssim or maximize_ssim wrapper functions
     should be used.
 

--- a/skimage/transform/ssim_optimize.py
+++ b/skimage/transform/ssim_optimize.py
@@ -1,0 +1,111 @@
+import numpy as np
+from numpy.linalg import norm
+
+from ..metrics._structural_similarity import 
+
+def E(X, Y):
+    return (Y - X) / norm(Y - X)
+
+def optimize_func(minimize=False, img, _lambda, iters, sigma):
+    if len(img.shape) != 3:
+        img = img[0]
+
+    """
+    Compute the image with the highest or lowest SSIM to a reference image
+    on the L-2 ball of the reference image. Follows a two step iterative 
+    gradient descent procedure. 
+
+    Parameters
+    ----------
+    minimize: bool
+        If True, image with lowest ssim is found. If False, highest ssim is found
+    img: ndarray
+        The reference image
+    _lambda: float
+        The L-2 distance from the reference image
+    iters: int
+        The number of iterations allowed to find image with highest/lowest ssim
+    sigma: int
+        A step size scalar
+
+    Returns
+    -------
+    adv_x: ndarray
+        Optimized image
+ 
+    Notes
+    ------
+    First step of algorithm is modified to increase memory efficiency. Behavior 
+    of the algorithm is unchanged.
+
+    References
+    ----------
+    .. [1] Wang, Z., Bovik, A. C., Sheikh, H. R., & Simoncelli, E. P.
+       (2004). Image quality assessment: From error visibility to
+       structural similarity. IEEE Transactions on Image Processing,
+       13, 600-612.
+       https://ece.uwaterloo.ca/~z70wang/publications/ssim.pdf,
+       :DOI:`10.1109/TIP.2003.819861`
+
+    """
+
+        
+    try:
+        assert len(img.shape) == 3:
+    except AssertionError:
+        print("Array should have dimensions (width, height, channel)\n")
+
+    try:
+        assert np.max(img) <= 1.0:
+    except AssertionError:
+        print("Array values should me in range [0, 1]")     
+        
+    noise = np.random.randint(0, 255, size = img.shape) / 255.
+    noise = noise * _lambda / norm(noise)
+    adv_x = np.clip(img + noise, 0, 1)
+    
+    prev_ssim = ssim(img, adv_x, multichannel=True)
+    prev_img = np.copy(adv_x)
+    
+    for i in range(iters):
+        # ----------------- step 1 -----------------
+        grad = ssim(img, adv_x, multichannel=True, gradient=True)[1].flatten()
+        grad = np.expand_dims(grad, axis=1) 
+
+        diff = E(img, adv_x).flatten()
+        diff = np.expand_dims(diff, axis=1) 
+
+        diff_t = diff.T
+
+        update = sigma * (grad - diff.dot( (diff_t.dot(grad)) ))
+        update = update.reshape(adv_x.shape)
+
+        if minimize:
+            adv_x = adv_x - update
+        else:
+            adv_x = adv_x + update
+            
+        # ----------------- step 2 -----------------
+        adv_x = np.clip(img + _lambda * E(img, adv_x), 0, 1)
+
+        # ----------- Conditional update -----------
+        ssim_score = ssim(img, adv_x, multichannel=True)
+
+        if ssim_score > prev_ssim:
+            adv_x = np.copy(prev_img)
+            sigma /= 2
+        else:
+            prev_img = np.copy(adv_x)
+            prev_ssim = ssim_score
+
+    return adv_x
+    
+
+def minimize_ssim(img, _lambda, iters=50, sigma=30):
+    adv_x = optimize_func(minimize=True, img, _lambda, iters, sigma)
+    return adv_x
+    
+def maximize_ssim(img, _lambda, iters=50, sigma=30):
+    adv_x = optimize_func(minimize=False, img, _lambda, iters, sigma)
+    return adv_x
+    

--- a/skimage/transform/ssim_optimize.py
+++ b/skimage/transform/ssim_optimize.py
@@ -59,8 +59,8 @@ def optimize_func(minimize, img, _lambda, iters, sigma):
         raise ValueError(
             "Array values should me in range [0, 1]")
 
-    noise = np.random.randint(0, 255, size = img.shape)/255.
-    noise = noise * _lambda/norm(noise)
+    noise = np.random.randint(0, 255, size=img.shape) / 255.
+    noise = noise * _lambda / norm(noise)
     adv_x = np.clip(img + noise, 0, 1)
 
     prev_ssim = ssim(img, adv_x, multichannel=True)

--- a/skimage/transform/ssim_optimize.py
+++ b/skimage/transform/ssim_optimize.py
@@ -3,8 +3,10 @@ from numpy.linalg import norm
 
 from ..metrics._structural_similarity import structural_similarity as ssim
 
+
 def E(X, Y):
     return (Y - X) / norm(Y - X)
+
 
 def optimize_func(minimize, img, _lambda, iters, sigma):
     if len(img.shape) != 3:
@@ -12,13 +14,13 @@ def optimize_func(minimize, img, _lambda, iters, sigma):
 
     """
     Compute the image with the highest or lowest SSIM to a reference image
-    on the L-2 ball of the reference image. Follows a two step iterative 
-    gradient descent procedure. 
+    on the L-2 ball of the reference image. Follows a two step iterative
+    gradient descent procedure.
 
     Parameters
     ----------
     minimize: bool
-        If True, image with lowest ssim is found. If False, highest ssim is found
+        If True, image with lowest ssim is found. Else, highest ssim is found
     img: ndarray
         The reference image
     _lambda: float
@@ -32,10 +34,10 @@ def optimize_func(minimize, img, _lambda, iters, sigma):
     -------
     adv_x: ndarray
         Optimized image
- 
+
     Notes
     ------
-    First step of algorithm is modified to increase memory efficiency. Behavior 
+    First step of algorithm is modified to increase memory efficiency. Behavior
     of the algorithm is unchanged.
 
     References
@@ -49,40 +51,39 @@ def optimize_func(minimize, img, _lambda, iters, sigma):
 
     """
 
-
     if len(img.shape) != 3:
         raise ValueError(
             "Array should have dimensions (width, height, channel)\n")
 
     if np.max(img) > 1.0:
         raise ValueError(
-            "Array values should me in range [0, 1]")     
-        
-    noise = np.random.randint(0, 255, size = img.shape) / 255.
-    noise = noise * _lambda / norm(noise)
+            "Array values should me in range [0, 1]")
+
+    noise = np.random.randint(0, 255, size = img.shape)/255.
+    noise = noise * _lambda/norm(noise)
     adv_x = np.clip(img + noise, 0, 1)
-    
+
     prev_ssim = ssim(img, adv_x, multichannel=True)
     prev_img = np.copy(adv_x)
-    
+
     for i in range(iters):
         # ----------------- step 1 -----------------
         grad = ssim(img, adv_x, multichannel=True, gradient=True)[1].flatten()
-        grad = np.expand_dims(grad, axis=1) 
+        grad = np.expand_dims(grad, axis=1)
 
         diff = E(img, adv_x).flatten()
-        diff = np.expand_dims(diff, axis=1) 
+        diff = np.expand_dims(diff, axis=1)
 
         diff_t = diff.T
 
-        update = sigma * (grad - diff.dot( (diff_t.dot(grad)) ))
+        update = sigma * (grad - diff.dot((diff_t.dot(grad))))
         update = update.reshape(adv_x.shape)
 
         if minimize:
             adv_x = adv_x - update
         else:
             adv_x = adv_x + update
-            
+
         # ----------------- step 2 -----------------
         adv_x = np.clip(img + _lambda * E(img, adv_x), 0, 1)
 
@@ -103,15 +104,15 @@ def optimize_func(minimize, img, _lambda, iters, sigma):
             else:
                 prev_img = np.copy(adv_x)
                 prev_ssim = ssim_score
-            
+
     return adv_x
-    
+
 
 def minimize_ssim(img, _lambda, iters=50, sigma=30):
     adv_x = optimize_func(True, img, _lambda, iters, sigma)
     return adv_x
-    
+
+
 def maximize_ssim(img, _lambda, iters=50, sigma=30):
     adv_x = optimize_func(False, img, _lambda, iters, sigma)
     return adv_x
-    

--- a/skimage/transform/ssim_optimize.py
+++ b/skimage/transform/ssim_optimize.py
@@ -10,7 +10,7 @@ def E(X, Y):
 
 # Returns reference image with random noise at specified epsilon
 def add_noise(img, eps):
-    noise = np.random.random_sample(img.shape)
+    noise = np.random.randint(0, 255, img.shape) / 255.
     noise = noise * eps / norm(noise)
     with_noise = np.clip(img + noise, 0, 1)
     return with_noise

--- a/skimage/transform/ssim_optimize.py
+++ b/skimage/transform/ssim_optimize.py
@@ -1,14 +1,40 @@
 import numpy as np
 from numpy.linalg import norm
 
-from ..metrics._structural_similarity import structural_similarity as ssim
-
+from skimage.metrics._structural_similarity import (
+    structural_similarity
+    as ssim
+)
 
 def E(X, Y):
     return (Y - X) / norm(Y - X)
 
 
-def optimize_func(minimize, img, _lambda, iters, sigma):
+# Returns reference image with random noise at specified epsilon
+def add_noise(img, eps):
+    noise = np.random.random_sample(img.shape)
+    noise = noise * eps / norm(noise)
+    with_noise = np.clip(img + noise, 0, 1)
+    return with_noise
+
+
+# Returns next step of gradient descent/ascent
+def get_update(img, adv_x, sigma):
+    grad = ssim(img, adv_x, multichannel=True, gradient=True)[1].flatten()
+    grad = np.expand_dims(grad, axis=1)
+
+    diff = E(img, adv_x).flatten()
+    diff = np.expand_dims(diff, axis=1)
+
+    diff_t = diff.T
+
+    update = sigma * (grad - diff.dot((diff_t.dot(grad))))
+    update = update.reshape(adv_x.shape)
+
+    return update
+
+
+def optimize_func(img, adv_x, op, _lambda, iters, sigma):
     if len(img.shape) != 3:
         img = img[0]
 
@@ -16,13 +42,18 @@ def optimize_func(minimize, img, _lambda, iters, sigma):
     Compute the image with the highest or lowest SSIM to a reference image
     on the L-2 ball of the reference image. Follows a two step iterative
     gradient descent procedure.
+    
+    For actual use, the minimize_ssim or maximize_ssim wrapper functions
+    should be used.
 
     Parameters
     ----------
-    minimize: bool
-        If True, image with lowest ssim is found. Else, highest ssim is found
     img: ndarray
         The reference image
+    adv_x: The original corrupted version of img. If None, adv_x
+           is created using random noise
+    op: function
+        The operator used to specify gradient ascent/descent
     _lambda: float
         The L-2 distance from the reference image
     iters: int
@@ -33,7 +64,7 @@ def optimize_func(minimize, img, _lambda, iters, sigma):
     Returns
     -------
     adv_x: ndarray
-        Optimized image
+        Noisy image with highest/lowest SSIM to reference image
 
     Notes
     ------
@@ -52,45 +83,38 @@ def optimize_func(minimize, img, _lambda, iters, sigma):
     """
 
     if len(img.shape) != 3:
-        raise ValueError(
-            "Array should have dimensions (width, height, channel)\n")
+        raise ValueError("Array should have dims (width, height, channel)\n")
 
     if np.max(img) > 1.0:
-        raise ValueError(
-            "Array values should me in range [0, 1]")
+        raise ValueError("Array values should me in range [0, 1]")
 
-    noise = np.random.randint(0, 255, size=img.shape) / 255.
-    noise = noise * _lambda / norm(noise)
-    adv_x = np.clip(img + noise, 0, 1)
+    if adv_x is None:
+        # create initial noisy image
+        adv_x = add_noise(img, _lambda)
 
+    # save starting ssim
     prev_ssim = ssim(img, adv_x, multichannel=True)
     prev_img = np.copy(adv_x)
 
     for i in range(iters):
+
         # ----------------- step 1 -----------------
-        grad = ssim(img, adv_x, multichannel=True, gradient=True)[1].flatten()
-        grad = np.expand_dims(grad, axis=1)
 
-        diff = E(img, adv_x).flatten()
-        diff = np.expand_dims(diff, axis=1)
+        # get gradient update
+        update = get_update(img, adv_x, sigma)
 
-        diff_t = diff.T
-
-        update = sigma * (grad - diff.dot((diff_t.dot(grad))))
-        update = update.reshape(adv_x.shape)
-
-        if minimize:
-            adv_x = adv_x - update
-        else:
-            adv_x = adv_x + update
+        # add or subtract gradient for ascent or descent respectively
+        adv_x = op(adv_x, update)
 
         # ----------------- step 2 -----------------
+
+        # update noisy image
         adv_x = np.clip(img + _lambda * E(img, adv_x), 0, 1)
 
         # ----------- Conditional update -----------
         ssim_score = ssim(img, adv_x, multichannel=True)
 
-        if minimize:
+        if op == sub:
             if ssim_score > prev_ssim:
                 adv_x = np.copy(prev_img)
                 sigma *= 0.9
@@ -108,11 +132,20 @@ def optimize_func(minimize, img, _lambda, iters, sigma):
     return adv_x
 
 
-def minimize_ssim(img, _lambda, iters=50, sigma=30):
-    adv_x = optimize_func(True, img, _lambda, iters, sigma)
+# helper functions to pass ops as parameters
+def add(x, y):
+    return x + y
+
+
+def sub(x, y):
+    return x - y
+
+
+def minimize_ssim(img, noisy=None, _lambda=8, iters=50, sigma=30):
+    adv_x = optimize_func(img, noisy, sub, _lambda, iters, sigma)
     return adv_x
 
 
-def maximize_ssim(img, _lambda, iters=50, sigma=30):
-    adv_x = optimize_func(False, img, _lambda, iters, sigma)
+def maximize_ssim(img, noisy=None, _lambda=8, iters=50, sigma=30):
+    adv_x = optimize_func(img, noisy, add, _lambda, iters, sigma)
     return adv_x


### PR DESCRIPTION
## Description

Enhancement

Added ssim_optimize.py to transform. This file contains two functions, maximize_ssim and minimize_ssim, which respectively search for the image with the highest and lowest ssim to a reference image on a specified L-2 ball from the original image.

This is an implementation of the algorithm described in "Image quality assessment: From error visibility to structural similarity" (Wang, Z., Bovik, A. C., Sheikh, H. R. et al.) 

https://ece.uwaterloo.ca/~z70wang/publications/ssim.pdf

An example of the need for this algorithm is shown in "On the Suitability of Lp-norms for
Creating and Preventing Adversarial Examples" (Sharif, M., Bauer, L., Reiter, M. K.)

https://arxiv.org/pdf/1802.09653.pdf

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
