### PR TITLE
Fix deltaE cmc close colors bug

### DIFF
--- a/skimage/color/delta_e.py
+++ b/skimage/color/delta_e.py
@@ -20,7 +20,7 @@ https://en.wikipedia.org/wiki/Color_difference
 
 import numpy as np
 
-from ..color.colorconv import lab2lch, _cart2polar_2pi
+from .colorconv import lab2lch, _cart2polar_2pi
 
 
 def deltaE_cie76(lab1, lab2):
@@ -116,7 +116,7 @@ def deltaE_ciede94(lab1, lab2, kH=1, kC=1, kL=1, k1=0.045, k2=0.015):
     dE2 = (dL / (kL * SL)) ** 2
     dE2 += (dC / (kC * SC)) ** 2
     dE2 += dH2 / (kH * SH) ** 2
-    return np.sqrt(dE2)
+    return np.sqrt(np.max(dE2, 0))
 
 
 def deltaE_ciede2000(lab1, lab2, kL=1, kC=1, kH=1):
@@ -238,7 +238,7 @@ def deltaE_ciede2000(lab1, lab2, kL=1, kC=1, kH=1):
     dE2 += C_term ** 2
     dE2 += H_term ** 2
     dE2 += R_term
-    ans = np.sqrt(dE2)
+    ans = np.sqrt(max(0, dE2))
     if unroll:
         ans = ans[0]
     return ans
@@ -305,7 +305,7 @@ def deltaE_cmc(lab1, lab2, kL=1, kC=1):
     dE2 += (dC / (kC * SC)) ** 2
     dE2 += dH2 / (SH ** 2)
 
-    return np.sqrt(dE2)
+    return np.sqrt(np.max(0, dE2))
 
 
 def get_dH2(lab1, lab2):
@@ -328,9 +328,6 @@ def get_dH2(lab1, lab2):
     """
     lab1 = np.asarray(lab1)
     lab2 = np.asarray(lab2)
-
-    if np.allclose(lab1, lab2):
-        return np.zeros(lab1.shape[0])
 
     a1, b1 = np.rollaxis(lab1, -1)[1:3]
     a2, b2 = np.rollaxis(lab2, -1)[1:3]

--- a/skimage/color/delta_e.py
+++ b/skimage/color/delta_e.py
@@ -116,7 +116,7 @@ def deltaE_ciede94(lab1, lab2, kH=1, kC=1, kL=1, k1=0.045, k2=0.015):
     dE2 = (dL / (kL * SL)) ** 2
     dE2 += (dC / (kC * SC)) ** 2
     dE2 += dH2 / (kH * SH) ** 2
-    return np.sqrt(np.maximum(dE2, 0))
+    return np.sqrt(np.maximum(dE2, 0, out=dE2), out=dE2)
 
 
 def deltaE_ciede2000(lab1, lab2, kL=1, kC=1, kH=1):
@@ -238,7 +238,7 @@ def deltaE_ciede2000(lab1, lab2, kL=1, kC=1, kH=1):
     dE2 += C_term ** 2
     dE2 += H_term ** 2
     dE2 += R_term
-    ans = np.sqrt(np.maximum(0, dE2))
+    ans = np.sqrt(np.maximum(dE2, 0, out=dE2), out=dE2)
     if unroll:
         ans = ans[0]
     return ans
@@ -305,7 +305,7 @@ def deltaE_cmc(lab1, lab2, kL=1, kC=1):
     dE2 += (dC / (kC * SC)) ** 2
     dE2 += dH2 / (SH ** 2)
 
-    return np.sqrt(np.maximum(0, dE2))
+    return np.sqrt(np.maximum(dE2, 0, out=dE2), out=dE2)
 
 
 def get_dH2(lab1, lab2):

--- a/skimage/color/delta_e.py
+++ b/skimage/color/delta_e.py
@@ -304,6 +304,7 @@ def deltaE_cmc(lab1, lab2, kL=1, kC=1):
     dE2 = (dL / (kL * SL)) ** 2
     dE2 += (dC / (kC * SC)) ** 2
     dE2 += dH2 / (SH ** 2)
+
     return np.sqrt(dE2)
 
 
@@ -327,6 +328,10 @@ def get_dH2(lab1, lab2):
     """
     lab1 = np.asarray(lab1)
     lab2 = np.asarray(lab2)
+
+    if np.allclose(lab1, lab2):
+        return np.zeros(lab1.shape[0])
+
     a1, b1 = np.rollaxis(lab1, -1)[1:3]
     a2, b2 = np.rollaxis(lab2, -1)[1:3]
 

--- a/skimage/color/delta_e.py
+++ b/skimage/color/delta_e.py
@@ -116,7 +116,7 @@ def deltaE_ciede94(lab1, lab2, kH=1, kC=1, kL=1, k1=0.045, k2=0.015):
     dE2 = (dL / (kL * SL)) ** 2
     dE2 += (dC / (kC * SC)) ** 2
     dE2 += dH2 / (kH * SH) ** 2
-    return np.sqrt(np.max(dE2, 0))
+    return np.sqrt(np.maximum(dE2, 0))
 
 
 def deltaE_ciede2000(lab1, lab2, kL=1, kC=1, kH=1):
@@ -238,7 +238,7 @@ def deltaE_ciede2000(lab1, lab2, kL=1, kC=1, kH=1):
     dE2 += C_term ** 2
     dE2 += H_term ** 2
     dE2 += R_term
-    ans = np.sqrt(max(0, dE2))
+    ans = np.sqrt(np.maximum(0, dE2))
     if unroll:
         ans = ans[0]
     return ans
@@ -305,7 +305,7 @@ def deltaE_cmc(lab1, lab2, kL=1, kC=1):
     dE2 += (dC / (kC * SC)) ** 2
     dE2 += dH2 / (SH ** 2)
 
-    return np.sqrt(np.max(0, dE2))
+    return np.sqrt(np.maximum(0, dE2))
 
 
 def get_dH2(lab1, lab2):

--- a/skimage/color/delta_e.py
+++ b/skimage/color/delta_e.py
@@ -116,7 +116,7 @@ def deltaE_ciede94(lab1, lab2, kH=1, kC=1, kL=1, k1=0.045, k2=0.015):
     dE2 = (dL / (kL * SL)) ** 2
     dE2 += (dC / (kC * SC)) ** 2
     dE2 += dH2 / (kH * SH) ** 2
-    return np.sqrt(np.maximum(dE2, 0, out=dE2), out=dE2)
+    return np.sqrt(np.maximum(dE2, 0))
 
 
 def deltaE_ciede2000(lab1, lab2, kL=1, kC=1, kH=1):
@@ -238,7 +238,7 @@ def deltaE_ciede2000(lab1, lab2, kL=1, kC=1, kH=1):
     dE2 += C_term ** 2
     dE2 += H_term ** 2
     dE2 += R_term
-    ans = np.sqrt(np.maximum(dE2, 0, out=dE2), out=dE2)
+    ans = np.sqrt(np.maximum(dE2, 0))
     if unroll:
         ans = ans[0]
     return ans
@@ -305,7 +305,7 @@ def deltaE_cmc(lab1, lab2, kL=1, kC=1):
     dE2 += (dC / (kC * SC)) ** 2
     dE2 += dH2 / (SH ** 2)
 
-    return np.sqrt(np.maximum(dE2, 0, out=dE2), out=dE2)
+    return np.sqrt(np.maximum(dE2, 0))
 
 
 def get_dH2(lab1, lab2):

--- a/skimage/color/tests/test_delta_e.py
+++ b/skimage/color/tests/test_delta_e.py
@@ -2,13 +2,11 @@
 from os.path import abspath, dirname, join as pjoin
 
 import numpy as np
-from skimage._shared.testing import (assert_allclose, assert_equal,
-                                     assert_almost_equal)
+from ..._shared.testing import (assert_allclose, assert_equal,
+                                assert_almost_equal)
 
-from skimage.color import (deltaE_cie76,
-                           deltaE_ciede94,
-                           deltaE_ciede2000,
-                           deltaE_cmc)
+from ..delta_e import (deltaE_cie76, deltaE_ciede94, deltaE_ciede2000,
+                       deltaE_cmc)
 
 
 def test_ciede2000_dE():

--- a/skimage/color/tests/test_delta_e.py
+++ b/skimage/color/tests/test_delta_e.py
@@ -143,7 +143,7 @@ def test_cmc():
 
     # Small difference case
     lab2[0, 0] += np.finfo(float).eps
-    assert_almost_equal(deltaE_cmc(lab1, lab2), expected)
+    assert_almost_equal(deltaE_cmc(lab1, lab2), expected, decimal=6)
 
     # Single item case:
     lab1 = lab2 = np.array([0., 1.59607713, 0.87755709])

--- a/skimage/color/tests/test_delta_e.py
+++ b/skimage/color/tests/test_delta_e.py
@@ -139,7 +139,7 @@ def test_cmc():
     # Equal colors have a distance of 0:
     lab1 = lab2
     expected = np.zeros_like(oracle)
-    assert_equal(deltaE_cmc(lab1, lab2), expected)
+    assert_almost_equal(deltaE_cmc(lab1, lab2), expected)
 
     # Small difference case
     lab2[0, 0] += np.finfo(float).eps

--- a/skimage/color/tests/test_delta_e.py
+++ b/skimage/color/tests/test_delta_e.py
@@ -139,7 +139,7 @@ def test_cmc():
     # Equal colors have a distance of 0:
     lab1 = lab2
     expected = np.zeros_like(oracle)
-    assert_almost_equal(deltaE_cmc(lab1, lab2), expected)
+    assert_almost_equal(deltaE_cmc(lab1, lab2), expected, decimal=6)
 
     # Small difference case
     lab2[0, 0] += np.finfo(float).eps

--- a/skimage/color/tests/test_delta_e.py
+++ b/skimage/color/tests/test_delta_e.py
@@ -2,7 +2,8 @@
 from os.path import abspath, dirname, join as pjoin
 
 import numpy as np
-from skimage._shared.testing import assert_allclose
+from skimage._shared.testing import (assert_allclose, assert_equal,
+                                     assert_almost_equal)
 
 from skimage.color import (deltaE_cie76,
                            deltaE_ciede94,
@@ -136,6 +137,22 @@ def test_cmc():
     ])
 
     assert_allclose(dE2, oracle, rtol=1.e-8)
+
+    # Equal colors have a distance of 0:
+    lab1 = lab2
+    expected = np.zeros_like(oracle)
+    assert_equal(deltaE_cmc(lab1, lab2), expected)
+
+    # Small difference case
+    lab2[0, 0] += np.finfo(float).eps
+    assert_almost_equal(deltaE_cmc(lab1, lab2), expected)
+
+    # Single item case:
+    lab1 = lab2 = np.array([0., 1.59607713, 0.87755709])
+    assert_equal(deltaE_cmc(lab1, lab2), 0)
+
+    lab2[0] += np.finfo(float).eps
+    assert_equal(deltaE_cmc(lab1, lab2), 0)
 
 
 def test_single_color_cie76():

--- a/skimage/color/tests/test_delta_e.py
+++ b/skimage/color/tests/test_delta_e.py
@@ -136,12 +136,13 @@ def test_cmc():
 
     assert_allclose(dE2, oracle, rtol=1.e-8)
 
-    # Equal colors have a distance of 0:
+    # Equal or close colors make `delta_e.get_dH2` function to return
+    # negative values resulting in NaNs when passed to sqrt (see #1908
+    # issue on Github):
     lab1 = lab2
     expected = np.zeros_like(oracle)
     assert_almost_equal(deltaE_cmc(lab1, lab2), expected, decimal=6)
 
-    # Small difference case
     lab2[0, 0] += np.finfo(float).eps
     assert_almost_equal(deltaE_cmc(lab1, lab2), expected, decimal=6)
 


### PR DESCRIPTION
## Description

Fixes #1908 and closes #1909.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
