### PR TITLE
Fix bool array profile_line

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -60,6 +60,8 @@ Version 0.19
   from `rgb2gray`.
 * In ``skimage/transform/radon_transform.py``, remove ``deprate_kwarg``
   decoration from ``iradon``.
+* In ``skimage/measure/profile.py``, raise a ValueError instead of the
+  warning when order > 0 and input array is bool in profile_line.
 
 Other
 -----

--- a/skimage/measure/profile.py
+++ b/skimage/measure/profile.py
@@ -94,7 +94,9 @@ def profile_line(image, src, dst, linewidth=1,
     if image.dtype == bool and order != 0:
         warn("Input image dtype is bool. Interpolation is not defined "
              "with bool data type. Please set order to 0 or explicitely "
-             "cast input image to another data type.", stacklevel=2)
+             "cast input image to another data type. Starting from version "
+             "0.19 a ValueError will be raised instead of this warning.",
+             FutureWarning, stacklevel=2)
 
     perp_lines = _line_profile_coordinates(src, dst, linewidth=linewidth)
     if image.ndim == 3:

--- a/skimage/measure/profile.py
+++ b/skimage/measure/profile.py
@@ -1,9 +1,10 @@
+from warnings import warn
 import numpy as np
 from scipy import ndimage as ndi
 
 
 def profile_line(image, src, dst, linewidth=1,
-                 order=1, mode='constant', cval=0.0,
+                 order=None, mode='constant', cval=0.0,
                  *, reduce_func=np.mean):
     """Return the intensity profile of an image measured along a scan line.
 
@@ -21,8 +22,11 @@ def profile_line(image, src, dst, linewidth=1,
     linewidth : int, optional
         Width of the scan, perpendicular to the line
     order : int in {0, 1, 2, 3, 4, 5}, optional
-        The order of the spline interpolation to compute image values at
-        non-integer coordinates. 0 means nearest-neighbor interpolation.
+        The order of the spline interpolation, default is 1. The order has to
+        The order of the spline interpolation, default is 0 if
+        be in the range 0-5. See `skimage.transform.warp` for detail.
+        image.dtype is bool and 1 otherwise. The order has to be in
+        the range 0-5. See `skimage.transform.warp` for detail.
     mode : {'constant', 'nearest', 'reflect', 'mirror', 'wrap'}, optional
         How to compute any values falling outside of the image.
     cval : float, optional
@@ -86,14 +90,31 @@ def profile_line(image, src, dst, linewidth=1,
            [1.        , 1.        , 0.        ],
            [1.41421356, 1.41421356, 0.        ]])
     """
+    image_is_bool = image.dtype == bool
+
+    if order is None:
+        if image_is_bool:
+            order = 0
+        else:
+            order = 1
+
+    if image_is_bool and order != 0:
+        warn("Input image dtype is bool. Interpolation is not defined "
+             "with bool data type. Please set order to 0 or explicitely "
+             "cast input image to an other data type.")
+
+    prefilter = order > 1
+
     perp_lines = _line_profile_coordinates(src, dst, linewidth=linewidth)
     if image.ndim == 3:
         pixels = [ndi.map_coordinates(image[..., i], perp_lines,
-                                      order=order, mode=mode, cval=cval)
-                  for i in range(image.shape[2])]
+                                      prefilter=prefilter,
+                                      order=order, mode=mode,
+                                      cval=cval) for i in
+                  range(image.shape[2])]
         pixels = np.transpose(np.asarray(pixels), (1, 2, 0))
     else:
-        pixels = ndi.map_coordinates(image, perp_lines,
+        pixels = ndi.map_coordinates(image, perp_lines, prefilter=prefilter,
                                      order=order, mode=mode, cval=cval)
     # The outputted array with reduce_func=None gives an array where the
     # row values (axis=1) are flipped. Here, we make this consistent.

--- a/skimage/measure/tests/test_profile.py
+++ b/skimage/measure/tests/test_profile.py
@@ -1,7 +1,7 @@
 import numpy as np
-from skimage.measure import profile_line
 
-from skimage._shared.testing import assert_equal, assert_almost_equal
+from ..._shared.testing import assert_equal, assert_almost_equal
+from ..profile import profile_line
 
 
 image = np.arange(100).reshape((10, 10)).astype(np.float)

--- a/skimage/measure/tests/test_profile.py
+++ b/skimage/measure/tests/test_profile.py
@@ -178,3 +178,25 @@ def test_reduce_func_sumofsqrt_linewidth_3():
                         reduce_func=lambda x: np.sum(x**0.5))
     expected_prof = np.array([2.89083412, 3.45787824, 2.11623746, 0.77459667])
     assert_almost_equal(prof, expected_prof)
+
+
+def test_bool_array_input():
+
+    shape = (200, 200)
+    center_x, center_y = (140, 150)
+    radius = 20
+    x, y = np.meshgrid(range(shape[1]), range(shape[0]))
+    mask = (y - center_y)**2 + (x - center_x)**2 < radius**2
+    src = (center_y, center_x)
+    phi = 4*np.pi/9.
+    dy = 31 * np.cos(phi)
+    dx = 31 * np.sin(phi)
+    dst = (center_y + dy, center_x + dx)
+
+    profile_u8 = profile_line(mask.astype(np.uint8), src, dst)
+    assert all(profile_u8[:radius] == 1)
+
+    profile_b = profile_line(mask, src, dst)
+    assert all(profile_b[:radius] == 1)
+
+    assert all(profile_b == profile_u8)

--- a/skimage/measure/tests/test_profile.py
+++ b/skimage/measure/tests/test_profile.py
@@ -186,9 +186,9 @@ def test_bool_array_input():
     center_x, center_y = (140, 150)
     radius = 20
     x, y = np.meshgrid(range(shape[1]), range(shape[0]))
-    mask = (y - center_y)**2 + (x - center_x)**2 < radius**2
+    mask = (y - center_y) ** 2 + (x - center_x) ** 2 < radius ** 2
     src = (center_y, center_x)
-    phi = 4*np.pi/9.
+    phi = 4 * np.pi / 9.
     dy = 31 * np.cos(phi)
     dx = 31 * np.sin(phi)
     dst = (center_y + dy, center_x + dx)


### PR DESCRIPTION
## Description

Fixes #2258.

This PR proposes to set default spline interpolation's order to 0 if input array dtype is bool and 1 otherwise.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
