### PR TITLE
reduce runtime of non-local means tests

### DIFF
--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -318,14 +318,14 @@ def test_denoise_nl_means_2d(fast_mode):
     for s in [sigma, 0]:
         denoised = restoration.denoise_nl_means(img, 7, 5, 0.2,
                                                 fast_mode=fast_mode,
-                                                multichannel=True,
+                                                multichannel=False,
                                                 sigma=s)
         # make sure noise is reduced
         assert_(img.std() > denoised.std())
 
         denoised_f32 = restoration.denoise_nl_means(img_f32, 7, 5, 0.2,
                                                     fast_mode=fast_mode,
-                                                    multichannel=True,
+                                                    multichannel=False,
                                                     sigma=s)
         # make sure noise is reduced
         assert_(img.std() > denoised_f32.std())
@@ -415,11 +415,11 @@ def test_no_denoising_for_small_h(fast_mode, dtype):
     # very small h should result in no averaging with other patches
     denoised = restoration.denoise_nl_means(img, 7, 5, 0.01,
                                             fast_mode=fast_mode,
-                                            multichannel=True)
+                                            multichannel=False)
     assert_(np.allclose(denoised, img))
     denoised = restoration.denoise_nl_means(img, 7, 5, 0.01,
                                             fast_mode=fast_mode,
-                                            multichannel=True)
+                                            multichannel=False)
     assert_(np.allclose(denoised, img))
 
 

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -448,13 +448,13 @@ def test_denoise_nl_means_3d_dtype(fast_mode):
 
     with expected_warnings(['Image dtype is not float']):
         assert restoration.denoise_nl_means(
-            img, fast_mode=fast_mode).dtype == 'float64'
+            img, patch_distance=2, fast_mode=fast_mode).dtype == 'float64'
 
     assert restoration.denoise_nl_means(
-        img_f32, fast_mode=fast_mode).dtype == img_f32.dtype
+        img_f32, patch_distance=2, fast_mode=fast_mode).dtype == img_f32.dtype
 
     assert restoration.denoise_nl_means(
-        img_f64, fast_mode=fast_mode).dtype == img_f64.dtype
+        img_f64, patch_distance=2, fast_mode=fast_mode).dtype == img_f64.dtype
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

This PR applies a couple of small fixes to the tests for `denoise_nl_means`:

1.) I set `patch_distance` to a reduced value in `test_denoise_nl_means_3d_dtype` and `test_denoise_nl_means_2d_dtype`. For the 3D case this reduces runtime from around 10 seconds to < 1 second. The patch distance is not important for this test as it is just verifying the dtype of the output.

2.) Two other tests involving 2D data seemed to have been setting `multichannel=True` when it seems the value for this case should be `multichannel=False`.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
