### PR TITLE
[WIP] Add binder specific requirements config

### DIFF
--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+# Taken from https://github.com/scikit-learn/scikit-learn/blob/72b3041ed57e42817e4c5c9853b3a2597cab3654/.binder/postBuild
+# under BSD3 license, copyright the scikit-learn contributors
+
+python -m pip install .
+
+# This script is called in a binder context. When this script is called, we are
+# inside a git checkout of the scikit-image/scikit-image repo. This script
+# generates notebooks from the scikit-image python examples.
+
+if [[ ! -f /.dockerenv ]]; then
+    echo "This script was written for repo2docker and is supposed to run inside a docker container."
+    echo "Exiting because this script can delete data if run outside of a docker container."
+    exit 1
+fi
+
+# Copy content we need from the scikit-image repo
+TMP_CONTENT_DIR=/tmp/scikit-image
+mkdir -p $TMP_CONTENT_DIR
+cp -r doc/examples .binder $TMP_CONTENT_DIR
+# delete everything in current directory including dot files and dot folders
+# to create a "clean" experience for readers
+find . -delete
+
+# Generate notebooks and remove other files from examples folder
+GENERATED_NOTEBOOKS_DIR=notebooks
+cp -r $TMP_CONTENT_DIR/examples $GENERATED_NOTEBOOKS_DIR
+
+find $GENERATED_NOTEBOOKS_DIR -name '*.py' -exec sphx_glr_python_to_jupyter.py '{}' +
+NON_NOTEBOOKS=$(find $GENERATED_NOTEBOOKS_DIR -type f | grep -v '\.ipynb')
+rm -f $NON_NOTEBOOKS
+
+# Put the .binder folder back (may be useful for debugging purposes)
+mv $TMP_CONTENT_DIR/.binder .
+# Final clean up
+rm -rf $TMP_CONTENT_DIR

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,0 +1,11 @@
+-r ../requirements/default.txt
+# Explicitly adding Cython instead of using `requirements/build.txt`
+# because we'd get a double numpy dependency otherwise
+Cython>=0.29.13
+sphinx-gallery
+scikit-learn
+dask[array]>=0.15.0
+# cloudpickle is necessary to provide the 'processes' scheduler for dask
+cloudpickle>=0.2.1
+pandas>=0.23.0
+seaborn>=0.7.1


### PR DESCRIPTION
This PR is a proposal for how to setup things to convert all the examples from the documentation gallery to notebooks that users can try on mybinder.org

The idea is to have a specific `.binder/requirements.txt` which installs the packages needed to run the examples. I tried to reuse the files in `requirements/` but ran into an issue with duplicate dependency specification. Maybe someone who knows a bit more about how things are organised.

You can launch it via https://mybinder.org/v2/gh/betatim/scikit-image/binder-examples

This came out of https://github.com/jupyter/repo2docker/issues/853

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
