### PR TITLE
Fix h_maxima/minima strange behaviors on floating point image input

### DIFF
--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -111,6 +111,8 @@ def h_maxima(image, h, selem=None):
     The resulting image will contain 3 local maxima.
     """
     if np.issubdtype(image.dtype, np.floating):
+        if (h == 0.0):
+            raise ValueError("h = 0.0 is ambiguous, use local_maxima() instead?")
         resolution = 2 * np.finfo(image.dtype).resolution * np.abs(image)
         shifted_img = image - h - resolution
     else:
@@ -185,23 +187,21 @@ def h_minima(image, h, selem=None):
 
     >>> minima = extrema.h_minima(f, 40)
 
-    The resulting image will contain 4 local minima.
+    The resulting image will contain 3 local minima.
     """
     if np.issubdtype(image.dtype, np.floating):
-        resolution = 2 * np.finfo(image.dtype).resolution
-        if h < resolution:
-            h = resolution
-        h_corrected = h - resolution / 2.0
-        shifted_img = image + h
+        if (h == 0.0):
+            raise ValueError("h = 0.0 is ambiguous, use local_minima() instead?")
+        resolution = 2 * np.finfo(image.dtype).resolution * np.abs(image)
+        shifted_img = image + h + resolution
     else:
         shifted_img = _add_constant_clip(image, h)
-        h_corrected = h
 
     rec_img = greyreconstruct.reconstruction(shifted_img, image,
                                              method='erosion', selem=selem)
     residue_img = rec_img - image
     h_min = np.zeros(image.shape, dtype=np.uint8)
-    h_min[residue_img >= h_corrected] = 1
+    h_min[residue_img >= h] = 1    
     return h_min
 
 

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -151,7 +151,7 @@ def h_maxima(image, h, selem=None):
         # The purpose of the resolution variable is to allow for the
         # small rounding errors that inevitably occur when doing
         # floating point arithmetic. We want shifted_img to be
-        # gauranteed to be h less than image. If we only subtract h
+        # guaranteed to be h less than image. If we only subtract h
         # there may be pixels were shifted_img ends up being
         # slightly greater than image - h.
         #

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -108,23 +108,19 @@ def h_maxima(image, h, selem=None):
 
     >>> maxima = extrema.h_maxima(f, 40)
 
-    The resulting image will contain 4 local maxima.
+    The resulting image will contain 3 local maxima.
     """
     if np.issubdtype(image.dtype, np.floating):
-        resolution = 2 * np.finfo(image.dtype).resolution
-        if h < resolution:
-            h = resolution
-        h_corrected = h - resolution / 2.0
-        shifted_img = image - h
+        resolution = 2 * np.finfo(image.dtype).resolution * np.abs(image)
+        shifted_img = image - h - resolution
     else:
         shifted_img = _subtract_constant_clip(image, h)
-        h_corrected = h
 
     rec_img = greyreconstruct.reconstruction(shifted_img, image,
                                              method='dilation', selem=selem)
     residue_img = image - rec_img
     h_max = np.zeros(image.shape, dtype=np.uint8)
-    h_max[residue_img >= h_corrected] = 1
+    h_max[residue_img >= h] = 1
     return h_max
 
 

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -112,7 +112,8 @@ def h_maxima(image, h, selem=None):
     """
     if np.issubdtype(image.dtype, np.floating):
         if (h == 0.0):
-            raise ValueError("h = 0.0 is ambiguous, use local_maxima() instead?")
+            raise ValueError("h = 0.0 is ambiguous, use local_maxima() \
+instead?")
         resolution = 2 * np.finfo(image.dtype).resolution * np.abs(image)
         shifted_img = image - h - resolution
     else:
@@ -191,7 +192,8 @@ def h_minima(image, h, selem=None):
     """
     if np.issubdtype(image.dtype, np.floating):
         if (h == 0.0):
-            raise ValueError("h = 0.0 is ambiguous, use local_minima() instead?")
+            raise ValueError("h = 0.0 is ambiguous, use local_minima() \
+instead?")
         resolution = 2 * np.finfo(image.dtype).resolution * np.abs(image)
         shifted_img = image + h + resolution
     else:
@@ -201,7 +203,7 @@ def h_minima(image, h, selem=None):
                                              method='erosion', selem=selem)
     residue_img = rec_img - image
     h_min = np.zeros(image.shape, dtype=np.uint8)
-    h_min[residue_img >= h] = 1    
+    h_min[residue_img >= h] = 1
     return h_min
 
 

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -110,6 +110,33 @@ def h_maxima(image, h, selem=None):
 
     The resulting image will contain 3 local maxima.
     """
+
+    # Check for h value that is larger then range of the image. If this
+    # is True then there are no h-maxima in the image.
+    im_min = np.min(image)
+    im_max = np.max(image)
+    if (h > (im_max - im_min)):
+        return np.zeros(image.shape, dtype=np.uint8)
+
+    # Check for floating point h value. For this to work properly
+    # we need to explicitly convert image to float64.
+    #
+    # FIXME: This could give incorrect results if image is int64 and
+    #        has a very high dynamic range. The dtype of image is
+    #        changed to float64, and different integer values could
+    #        become the same float due to rounding.
+    #
+    #   >>> ii64 = np.iinfo(np.int64)
+    #   >>> a = np.array([ii64.max, ii64.max - 2])
+    #   >>> a[0] == a[1]
+    #   False
+    #   >>> b = a.astype(np.float64)
+    #   >>> b[0] == b[1]
+    #   True
+    #
+    if isinstance(h, float):
+        image = image.astype(np.float)
+
     if np.issubdtype(image.dtype, np.floating):
         if (h == 0.0):
             raise ValueError("h = 0.0 is ambiguous, use local_maxima() \
@@ -117,6 +144,9 @@ instead?")
         resolution = 2 * np.finfo(image.dtype).resolution * np.abs(image)
         shifted_img = image - h - resolution
     else:
+        if (h == 0):
+            raise ValueError("h = 0 is ambiguous, use local_maxima() \
+instead?")
         shifted_img = _subtract_constant_clip(image, h)
 
     rec_img = greyreconstruct.reconstruction(shifted_img, image,

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -96,7 +96,7 @@ def h_maxima(image, h, selem=None):
 
     We create an image (quadratic function with a maximum in the center and
     4 additional constant maxima.
-    The heights of the maxima are: 1, 21, 41, 61, 81, 101
+    The heights of the maxima are: 1, 21, 41, 61, 81
 
     >>> w = 10
     >>> x, y = np.mgrid[0:w,0:w]
@@ -176,7 +176,7 @@ def h_minima(image, h, selem=None):
 
     We create an image (quadratic function with a minimum in the center and
     4 additional constant maxima.
-    The depth of the minima are: 1, 21, 41, 61, 81, 101
+    The depth of the minima are: 1, 21, 41, 61, 81
 
     >>> w = 10
     >>> x, y = np.mgrid[0:w,0:w]

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -171,8 +171,8 @@ class TestExtrema(unittest.TestCase):
         error = diff(expected_result, out)
         assert error < eps
 
-    def test_h_maxima_float(self):
-        """specific tests for h-maxima float type"""
+    def test_h_maxima_float_image(self):
+        """specific tests for h-maxima float image type"""
         w = 10
         x, y = np.mgrid[0:w,0:w]
         data = 20 - 0.2*((x - w/2)**2 + (y-w/2)**2)
@@ -189,9 +189,47 @@ class TestExtrema(unittest.TestCase):
             out = extrema.h_maxima(data, h)
             error = diff(expected_result, out)
             assert error < eps
+            
+    def test_h_maxima_float_h(self):
+        """specific tests for h-maxima float h parameter"""
+        data = np.array([[0,0,0,0,0],
+                         [0,3,3,3,0],
+                         [0,3,4,3,0],
+                         [0,3,3,3,0],
+                         [0,0,0,0,0]], dtype = np.uint8)
 
-    def test_h_minima_float(self):
-        """specific tests for h-minima float type"""
+        h_vals = np.linspace(1.0, 2.0, 100)
+        failures = 0
+        for i in range(h_vals.size):
+            maxima = extrema.h_maxima(data, h_vals[i])
+
+            if (maxima[2,2] == 0):
+                failures += 1
+                
+        assert (failures == 0)
+
+    def test_h_maxima_large_h(self):
+        """test that h-maxima works correctly for large h"""
+        data = np.array([[0,0,0,0,0],
+                         [0,3,3,3,0],
+                         [0,3,4,3,0],
+                         [0,3,3,3,0],
+                         [0,0,0,0,0]], dtype = np.uint8)
+
+        maxima = extrema.h_maxima(data, 5)
+        assert (np.sum(maxima) == 0)
+
+        data = np.array([[0,0,0,0,0],
+                         [0,3,3,3,0],
+                         [0,3,4,3,0],
+                         [0,3,3,3,0],
+                         [0,0,0,0,0]], dtype = np.float32)
+
+        maxima = extrema.h_maxima(data, 5.0)
+        assert (np.sum(maxima) == 0)
+    
+    def test_h_minima_float_image(self):
+        """specific tests for h-minima float image type"""
         w = 10
         x, y = np.mgrid[0:w,0:w]
         data = 180 + 0.2*((x - w/2)**2 + (y-w/2)**2)

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -171,6 +171,25 @@ class TestExtrema(unittest.TestCase):
         error = diff(expected_result, out)
         assert error < eps
 
+    def test_h_maxima_float(self):
+        """specific tests for h-maxima float type"""
+        w = 10
+        x, y = np.mgrid[0:w,0:w]
+        data = 20 - 0.2*((x - w/2)**2 + (y-w/2)**2)
+        data[2:4,2:4] = 40
+        data[2:4,7:9] = 60
+        data[7:9,2:4] = 80
+        data[7:9,7:9] = 100
+        data = data.astype(np.float32)
+
+        expected_result = np.zeros_like(data)
+        expected_result[(data>19.9)] = 1.0
+
+        for h in [1.0e-12, 1.0e-6, 1.0e-3, 1.0e-2, 1.0e-1, 0.1]:
+            out = extrema.h_maxima(data, h)
+            error = diff(expected_result, out)
+            assert error < eps
+
 
 class TestLocalMaxima(unittest.TestCase):
     """Some tests for local_minima are included as well."""

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -174,79 +174,79 @@ class TestExtrema(unittest.TestCase):
     def test_h_maxima_float_image(self):
         """specific tests for h-maxima float image type"""
         w = 10
-        x, y = np.mgrid[0:w,0:w]
+        x, y = np.mgrid[0:w, 0:w]
         data = 20 - 0.2*((x - w/2)**2 + (y-w/2)**2)
-        data[2:4,2:4] = 40
-        data[2:4,7:9] = 60
-        data[7:9,2:4] = 80
-        data[7:9,7:9] = 100
+        data[2:4, 2:4] = 40
+        data[2:4, 7:9] = 60
+        data[7:9, 2:4] = 80
+        data[7:9, 7:9] = 100
         data = data.astype(np.float32)
 
         expected_result = np.zeros_like(data)
-        expected_result[(data>19.9)] = 1.0
+        expected_result[(data > 19.9)] = 1.0
 
         for h in [1.0e-12, 1.0e-6, 1.0e-3, 1.0e-2, 1.0e-1, 0.1]:
             out = extrema.h_maxima(data, h)
             error = diff(expected_result, out)
             assert error < eps
-            
+
     def test_h_maxima_float_h(self):
         """specific tests for h-maxima float h parameter"""
-        data = np.array([[0,0,0,0,0],
-                         [0,3,3,3,0],
-                         [0,3,4,3,0],
-                         [0,3,3,3,0],
-                         [0,0,0,0,0]], dtype = np.uint8)
+        data = np.array([[0, 0, 0, 0, 0],
+                         [0, 3, 3, 3, 0],
+                         [0, 3, 4, 3, 0],
+                         [0, 3, 3, 3, 0],
+                         [0, 0, 0, 0, 0]], dtype=np.uint8)
 
         h_vals = np.linspace(1.0, 2.0, 100)
         failures = 0
         for i in range(h_vals.size):
             maxima = extrema.h_maxima(data, h_vals[i])
 
-            if (maxima[2,2] == 0):
+            if (maxima[2, 2] == 0):
                 failures += 1
-                
+
         assert (failures == 0)
 
     def test_h_maxima_large_h(self):
         """test that h-maxima works correctly for large h"""
-        data = np.array([[0,0,0,0,0],
-                         [0,3,3,3,0],
-                         [0,3,4,3,0],
-                         [0,3,3,3,0],
-                         [0,0,0,0,0]], dtype = np.uint8)
+        data = np.array([[0, 0, 0, 0, 0],
+                         [0, 3, 3, 3, 0],
+                         [0, 3, 4, 3, 0],
+                         [0, 3, 3, 3, 0],
+                         [0, 0, 0, 0, 0]], dtype=np.uint8)
 
         maxima = extrema.h_maxima(data, 5)
         assert (np.sum(maxima) == 0)
 
-        data = np.array([[0,0,0,0,0],
-                         [0,3,3,3,0],
-                         [0,3,4,3,0],
-                         [0,3,3,3,0],
-                         [0,0,0,0,0]], dtype = np.float32)
+        data = np.array([[0, 0, 0, 0, 0],
+                         [0, 3, 3, 3, 0],
+                         [0, 3, 4, 3, 0],
+                         [0, 3, 3, 3, 0],
+                         [0, 0, 0, 0, 0]], dtype=np.float32)
 
         maxima = extrema.h_maxima(data, 5.0)
         assert (np.sum(maxima) == 0)
-    
+
     def test_h_minima_float_image(self):
         """specific tests for h-minima float image type"""
         w = 10
-        x, y = np.mgrid[0:w,0:w]
+        x, y = np.mgrid[0:w, 0:w]
         data = 180 + 0.2*((x - w/2)**2 + (y-w/2)**2)
-        data[2:4,2:4] = 160
-        data[2:4,7:9] = 140
-        data[7:9,2:4] = 120
-        data[7:9,7:9] = 100
+        data[2:4, 2:4] = 160
+        data[2:4, 7:9] = 140
+        data[7:9, 2:4] = 120
+        data[7:9, 7:9] = 100
         data = data.astype(np.float32)
 
         expected_result = np.zeros_like(data)
-        expected_result[(data<180.1)] = 1.0
+        expected_result[(data < 180.1)] = 1.0
 
         for h in [1.0e-12, 1.0e-6, 1.0e-3, 1.0e-2, 1.0e-1, 0.1]:
             out = extrema.h_minima(data, h)
             error = diff(expected_result, out)
             assert error < eps
-            
+
 
 class TestLocalMaxima(unittest.TestCase):
     """Some tests for local_minima are included as well."""

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -175,7 +175,7 @@ class TestExtrema(unittest.TestCase):
         """specific tests for h-maxima float image type"""
         w = 10
         x, y = np.mgrid[0:w, 0:w]
-        data = 20 - 0.2*((x - w/2)**2 + (y-w/2)**2)
+        data = 20 - 0.2 * ((x - w / 2) ** 2 + (y - w / 2) ** 2)
         data[2:4, 2:4] = 40
         data[2:4, 7:9] = 60
         data[7:9, 2:4] = 80
@@ -232,7 +232,7 @@ class TestExtrema(unittest.TestCase):
         """specific tests for h-minima float image type"""
         w = 10
         x, y = np.mgrid[0:w, 0:w]
-        data = 180 + 0.2*((x - w/2)**2 + (y-w/2)**2)
+        data = 180 + 0.2 * ((x - w / 2) ** 2 + (y - w / 2) ** 2)
         data[2:4, 2:4] = 160
         data[2:4, 7:9] = 140
         data[7:9, 2:4] = 120

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -247,6 +247,44 @@ class TestExtrema(unittest.TestCase):
             error = diff(expected_result, out)
             assert error < eps
 
+    def test_h_minima_float_h(self):
+        """specific tests for h-minima float h parameter"""
+        data = np.array([[4, 4, 4, 4, 4],
+                         [4, 1, 1, 1, 4],
+                         [4, 1, 0, 1, 4],
+                         [4, 1, 1, 1, 4],
+                         [4, 4, 4, 4, 4]], dtype=np.uint8)
+
+        h_vals = np.linspace(1.0, 2.0, 100)
+        failures = 0
+        for i in range(h_vals.size):
+            minima = extrema.h_minima(data, h_vals[i])
+
+            if (minima[2, 2] == 0):
+                failures += 1
+
+        assert (failures == 0)
+
+    def test_h_minima_large_h(self):
+        """test that h-minima works correctly for large h"""
+        data = np.array([[14, 14, 14, 14, 14],
+                         [14, 11, 11, 11, 14],
+                         [14, 11, 10, 11, 14],
+                         [14, 11, 11, 11, 14],
+                         [14, 14, 14, 14, 14]], dtype=np.uint8)
+
+        maxima = extrema.h_minima(data, 5)
+        assert (np.sum(maxima) == 0)
+
+        data = np.array([[14, 14, 14, 14, 14],
+                         [14, 11, 11, 11, 14],
+                         [14, 11, 10, 11, 14],
+                         [14, 11, 11, 11, 14],
+                         [14, 14, 14, 14, 14]], dtype=np.float32)
+
+        maxima = extrema.h_minima(data, 5.0)
+        assert (np.sum(maxima) == 0)
+
 
 class TestLocalMaxima(unittest.TestCase):
     """Some tests for local_minima are included as well."""

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -190,6 +190,25 @@ class TestExtrema(unittest.TestCase):
             error = diff(expected_result, out)
             assert error < eps
 
+    def test_h_minima_float(self):
+        """specific tests for h-minima float type"""
+        w = 10
+        x, y = np.mgrid[0:w,0:w]
+        data = 180 + 0.2*((x - w/2)**2 + (y-w/2)**2)
+        data[2:4,2:4] = 160
+        data[2:4,7:9] = 140
+        data[7:9,2:4] = 120
+        data[7:9,7:9] = 100
+        data = data.astype(np.float32)
+
+        expected_result = np.zeros_like(data)
+        expected_result[(data<180.1)] = 1.0
+
+        for h in [1.0e-12, 1.0e-6, 1.0e-3, 1.0e-2, 1.0e-1, 0.1]:
+            out = extrema.h_minima(data, h)
+            error = diff(expected_result, out)
+            assert error < eps
+            
 
 class TestLocalMaxima(unittest.TestCase):
     """Some tests for local_minima are included as well."""

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -210,20 +210,20 @@ class TestExtrema(unittest.TestCase):
 
     def test_h_maxima_large_h(self):
         """test that h-maxima works correctly for large h"""
-        data = np.array([[0, 0, 0, 0, 0],
-                         [0, 3, 3, 3, 0],
-                         [0, 3, 4, 3, 0],
-                         [0, 3, 3, 3, 0],
-                         [0, 0, 0, 0, 0]], dtype=np.uint8)
+        data = np.array([[10, 10, 10, 10, 10],
+                         [10, 13, 13, 13, 10],
+                         [10, 13, 14, 13, 10],
+                         [10, 13, 13, 13, 10],
+                         [10, 10, 10, 10, 10]], dtype=np.uint8)
 
         maxima = extrema.h_maxima(data, 5)
         assert (np.sum(maxima) == 0)
 
-        data = np.array([[0, 0, 0, 0, 0],
-                         [0, 3, 3, 3, 0],
-                         [0, 3, 4, 3, 0],
-                         [0, 3, 3, 3, 0],
-                         [0, 0, 0, 0, 0]], dtype=np.float32)
+        data = np.array([[10, 10, 10, 10, 10],
+                         [10, 13, 13, 13, 10],
+                         [10, 13, 14, 13, 10],
+                         [10, 13, 13, 13, 10],
+                         [10, 10, 10, 10, 10]], dtype=np.float32)
 
         maxima = extrema.h_maxima(data, 5.0)
         assert (np.sum(maxima) == 0)


### PR DESCRIPTION
## Description

Closes #4194

* bug-fix for issue #4194, add test.
* Fix the same bug in the `extrema.h_minima()` function, add test.
* Raise `ValueError` if the `h` parameter equals 0.0.
* Update `extrema.h_maxima()` and `extrema.h_minima()` documentation.
* Add additional tests that currently fail because of bugs in the `extrema.h_maxima()` function.

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
