### PR TITLE
Fix KeyError in find_contours

### DIFF
--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -175,8 +175,8 @@ def _assemble_contours(points_iterator):
                 # Add the end point, and remove the contour from the
                 # 'starts' and 'ends' dicts.
                 head.append(to_point)
-                del starts[to_point]
-                del ends[from_point]
+                starts.pop(to_point, None)
+                ends.pop(from_point, None)
             else:  # tail is not head
                 # We need to join two distinct contours.
                 # We want to keep the first contour segment created, so that
@@ -185,24 +185,21 @@ def _assemble_contours(points_iterator):
                     # tail was created second. Append tail to head.
                     head.extend(tail)
                     # remove all traces of tail:
-                    del starts[to_point]
-                    try:
-                        del ends[tail[-1]]
-                    except KeyError:
-                        pass
-                    del contours[tail_num]
+                    starts.pop(to_point, None)
+                    ends.pop(tail[-1], None)
+                    contours.pop(tail_num, None)
                     # remove the old end of head and add the new end.
-                    del ends[from_point]
+                    ends.pop(from_point, None)
                     ends[head[-1]] = (head, head_num)
                 else:  # tail_num <= head_num
                     # head was created second. Prepend head to tail.
                     tail.extendleft(reversed(head))
                     # remove all traces of head:
-                    del starts[head[0]]
-                    del ends[from_point]
-                    del contours[head_num]
+                    starts.pop(head[0], None)
+                    ends.pop(from_point, None)
+                    contours.pop(head_num, None)
                     # remove the old start of tail and add the new start.
-                    del starts[to_point]
+                    starts.pop(to_point, None)
                     starts[tail[0]] = (tail, tail_num)
         elif tail_data is None and head_data is None:
             # we need to add a new contour
@@ -217,14 +214,14 @@ def _assemble_contours(points_iterator):
             # We've found a single contour to which the new segment should be
             # prepended.
             tail.appendleft(from_point)
-            del starts[to_point]
+            starts.pop(to_point, None)
             starts[from_point] = (tail, tail_num)
         elif tail_data is None and head_data is not None:
             head, head_num = head_data
             # We've found a single contour to which the new segment should be
             # appended
             head.append(to_point)
-            del ends[from_point]
+            ends.pop(from_point, None)
             ends[to_point] = (head, head_num)
     # end iteration over from_ and to_ points
 

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -173,7 +173,7 @@ def _assemble_contours(point_list):
                     # remove all traces of tail:
                     ends.pop(tail[-1])
                     contours.pop(tail_num, None)
-                    # add the new end.
+                    # Update contour starts end ends
                     starts[head[0]] = (head, head_num)
                     ends[head[-1]] = (head, head_num)
                 else:  # tail_num <= head_num
@@ -182,7 +182,7 @@ def _assemble_contours(point_list):
                     # remove all traces of head:
                     starts.pop(head[0])
                     contours.pop(head_num, None)
-                    # add the new start.
+                    # Update contour starts end ends
                     starts[tail[0]] = (tail, tail_num)
                     ends[tail[-1]] = (tail, tail_num)
         elif tail is None and head is None:

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -120,6 +120,8 @@ def find_contours(array, level,
     if positive_orientation not in _param_options:
         raise ValueError('Parameters "positive_orientation" must be either '
                          '"high" or "low".')
+    if array.shape[0] < 2 or array.shape[1] < 2:
+        raise ValueError("Input array must be at least 2x2.")
     if array.ndim != 2:
         raise ValueError('Only 2D arrays are supported.')
     if mask is not None:

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -114,47 +114,38 @@ def find_contours(array, level,
     [array([[0. , 0.5],
            [0.5, 0. ]])]
     """
-    array = np.asarray(array, dtype=np.double)
+    if fully_connected not in _param_options:
+        raise ValueError('Parameters "fully_connected" must be either '
+                         '"high" or "low".')
+    if positive_orientation not in _param_options:
+        raise ValueError('Parameters "positive_orientation" must be either '
+                         '"high" or "low".')
     if array.ndim != 2:
         raise ValueError('Only 2D arrays are supported.')
-    level = float(level)
     if mask is not None:
-        if not np.can_cast(mask.dtype, bool, casting='safe'):
-            raise TypeError('Parameter "mask" must be a binary array.')
-        mask = mask.view(np.uint8)
         if mask.shape != array.shape:
             raise ValueError('Parameters "array" and "mask"'
                              ' must have same shape.')
-    if (fully_connected not in _param_options or
-       positive_orientation not in _param_options):
-        raise ValueError('Parameters "fully_connected" and'
-        ' "positive_orientation" must be either "high" or "low".')
-    point_list = _find_contours_cy.iterate_and_store(array, level,
+        if not np.can_cast(mask.dtype, bool, casting='safe'):
+            raise TypeError('Parameter "mask" must be a binary array.')
+        mask = mask.astype(np.uint8)
+
+    point_list = _find_contours_cy.iterate_and_store(array.astype(np.double),
+                                                     float(level),
                                                      fully_connected == 'high',
                                                      mask=mask)
-    contours = _assemble_contours(_take_2(point_list))
+    contours = _assemble_contours(point_list)
     if positive_orientation == 'high':
         contours = [c[::-1] for c in contours]
     return contours
 
 
-def _take_2(seq):
-    iterator = iter(seq)
-    while True:
-        try:
-            n1 = next(iterator)
-            n2 = next(iterator)
-            yield (n1, n2)
-        except StopIteration:
-            return
-
-
-def _assemble_contours(points_iterator):
+def _assemble_contours(point_list):
     current_index = 0
     contours = {}
     starts = {}
     ends = {}
-    for from_point, to_point in points_iterator:
+    for from_point, to_point in zip(point_list[::2], point_list[1::2]):
         # Ignore degenerate segments.
         # This happens when (and only when) one vertex of the square is
         # exactly the contour level, and the rest are above or below.
@@ -163,20 +154,16 @@ def _assemble_contours(points_iterator):
         if from_point == to_point:
             continue
 
-        tail_data = starts.get(to_point)
-        head_data = ends.get(from_point)
+        tail, tail_num = starts.pop(to_point, (None, None))
+        head, head_num = ends.pop(from_point, (None, None))
 
-        if tail_data is not None and head_data is not None:
-            tail, tail_num = tail_data
-            head, head_num = head_data
+        if tail is not None and head is not None:
             # We need to connect these two contours.
             if tail is head:
                 # We need to closed a contour.
                 # Add the end point, and remove the contour from the
                 # 'starts' and 'ends' dicts.
                 head.append(to_point)
-                starts.pop(to_point, None)
-                ends.pop(from_point, None)
             else:  # tail is not head
                 # We need to join two distinct contours.
                 # We want to keep the first contour segment created, so that
@@ -185,44 +172,34 @@ def _assemble_contours(points_iterator):
                     # tail was created second. Append tail to head.
                     head.extend(tail)
                     # remove all traces of tail:
-                    starts.pop(to_point, None)
                     ends.pop(tail[-1], None)
                     contours.pop(tail_num, None)
-                    # remove the old end of head and add the new end.
-                    ends.pop(from_point, None)
+                    # add the new end.
                     ends[head[-1]] = (head, head_num)
                 else:  # tail_num <= head_num
                     # head was created second. Prepend head to tail.
                     tail.extendleft(reversed(head))
                     # remove all traces of head:
                     starts.pop(head[0], None)
-                    ends.pop(from_point, None)
                     contours.pop(head_num, None)
-                    # remove the old start of tail and add the new start.
-                    starts.pop(to_point, None)
+                    # add the new start.
                     starts[tail[0]] = (tail, tail_num)
-        elif tail_data is None and head_data is None:
+        elif tail is None and head is None:
             # we need to add a new contour
-            current_index += 1
-            new_num = current_index
             new_contour = deque((from_point, to_point))
-            contours[new_num] = new_contour
-            starts[from_point] = (new_contour, new_num)
-            ends[to_point] = (new_contour, new_num)
-        elif tail_data is not None and head_data is None:
-            tail, tail_num = tail_data
+            contours[current_index] = new_contour
+            starts[from_point] = (new_contour, current_index)
+            ends[to_point] = (new_contour, current_index)
+            current_index += 1
+        elif head is None:  # tail is not None
             # We've found a single contour to which the new segment should be
             # prepended.
             tail.appendleft(from_point)
-            starts.pop(to_point, None)
             starts[from_point] = (tail, tail_num)
-        elif tail_data is None and head_data is not None:
-            head, head_num = head_data
+        else:  # tail is None and head is not None:
             # We've found a single contour to which the new segment should be
             # appended
             head.append(to_point)
-            ends.pop(from_point, None)
             ends[to_point] = (head, head_num)
-    # end iteration over from_ and to_ points
 
-    return [np.array(contour) for (num, contour) in sorted(contours.items())]
+    return [np.array(contour) for _, contour in sorted(contours.items())]

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -161,8 +161,7 @@ def _assemble_contours(point_list):
             # We need to connect these two contours.
             if tail is head:
                 # We need to closed a contour.
-                # Add the end point, and remove the contour from the
-                # 'starts' and 'ends' dicts.
+                # Add the end point
                 head.append(to_point)
             else:  # tail is not head
                 # We need to join two distinct contours.
@@ -172,18 +171,20 @@ def _assemble_contours(point_list):
                     # tail was created second. Append tail to head.
                     head.extend(tail)
                     # remove all traces of tail:
-                    ends.pop(tail[-1], None)
+                    ends.pop(tail[-1])
                     contours.pop(tail_num, None)
                     # add the new end.
+                    starts[head[0]] = (head, head_num)
                     ends[head[-1]] = (head, head_num)
                 else:  # tail_num <= head_num
                     # head was created second. Prepend head to tail.
                     tail.extendleft(reversed(head))
                     # remove all traces of head:
-                    starts.pop(head[0], None)
+                    starts.pop(head[0])
                     contours.pop(head_num, None)
                     # add the new start.
                     starts[tail[0]] = (tail, tail_num)
+                    ends[tail[-1]] = (tail, tail_num)
         elif tail is None and head is None:
             # we need to add a new contour
             new_contour = deque((from_point, to_point))

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -130,7 +130,7 @@ def find_contours(array, level,
                              ' must have same shape.')
         if not np.can_cast(mask.dtype, bool, casting='safe'):
             raise TypeError('Parameter "mask" must be a binary array.')
-        mask = mask.astype(np.uint8)
+        mask = mask.astype(np.uint8, copy=False)
 
     segments = _get_contour_segments(array.astype(np.double), float(level),
                                      fully_connected == 'high', mask=mask)

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -1,5 +1,5 @@
 import numpy as np
-from . import _find_contours_cy
+from ._find_contours_cy import _get_contour_segments
 
 from collections import deque
 
@@ -130,22 +130,20 @@ def find_contours(array, level,
             raise TypeError('Parameter "mask" must be a binary array.')
         mask = mask.astype(np.uint8)
 
-    point_list = _find_contours_cy.iterate_and_store(array.astype(np.double),
-                                                     float(level),
-                                                     fully_connected == 'high',
-                                                     mask=mask)
-    contours = _assemble_contours(point_list)
+    segments = _get_contour_segments(array.astype(np.double), float(level),
+                                     fully_connected == 'high', mask=mask)
+    contours = _assemble_contours(segments)
     if positive_orientation == 'high':
         contours = [c[::-1] for c in contours]
     return contours
 
 
-def _assemble_contours(point_list):
+def _assemble_contours(segments):
     current_index = 0
     contours = {}
     starts = {}
     ends = {}
-    for from_point, to_point in zip(point_list[::2], point_list[1::2]):
+    for from_point, to_point in segments:
         # Ignore degenerate segments.
         # This happens when (and only when) one vertex of the square is
         # exactly the contour level, and the rest are above or below.

--- a/skimage/measure/_find_contours_cy.pyx
+++ b/skimage/measure/_find_contours_cy.pyx
@@ -28,8 +28,6 @@ def _get_contour_segments(double[:, :] array,
     Positions where the boolean array ``mask`` is ``False`` are considered
     as not containing data.
     """
-    if array.shape[0] < 2 or array.shape[1] < 2:
-        raise ValueError("Input array must be at least 2x2.")
 
     # The plan is to iterate a 2x2 square across the input array. This means
     # that the upper-left corner of the square needs to iterate across a

--- a/skimage/measure/_find_contours_cy.pyx
+++ b/skimage/measure/_find_contours_cy.pyx
@@ -16,7 +16,7 @@ cdef inline double _get_fraction(double from_value, double to_value,
 
 
 def iterate_and_store(double[:, :] array,
-                      double level, Py_ssize_t vertex_connect_high,
+                      double level, bint vertex_connect_high,
                       cnp.uint8_t[:, :] mask):
     """Iterate across the given array in a marching-squares fashion,
     looking for segments that cross 'level'. If such a segment is
@@ -31,9 +31,6 @@ def iterate_and_store(double[:, :] array,
     if array.shape[0] < 2 or array.shape[1] < 2:
         raise ValueError("Input array must be at least 2x2.")
 
-    cdef list arc_list = []
-    cdef Py_ssize_t n
-
     # The plan is to iterate a 2x2 square across the input array. This means
     # that the upper-left corner of the square needs to iterate across a
     # sub-array that's one-less-large in each direction (so that the square
@@ -42,159 +39,147 @@ def iterate_and_store(double[:, :] array,
     # 2D coordinates for the position of the upper-left pointer. Note that we
     # ensured that the array is of type 'double' and is C-contiguous (last
     # index varies the fastest).
+    #
+    # There are sixteen different possible square types, diagramed below.
+    # A + indicates that the vertex is above the contour value, and a -
+    # indicates that the vertex is below or equal to the contour value.
+    # The vertices of each square are:
+    # ul ur
+    # ll lr
+    # and can be treated as a binary value with the bits in that order. Thus
+    # each square case can be numbered:
+    #  0--   1+-   2-+   3++   4--   5+-   6-+   7++
+    #   --    --    --    --    +-    +-    +-    +-
+    #
+    #  8--   9+-  10-+  11++  12--  13+-  14-+  15++
+    #   -+    -+    -+    -+    ++    ++    ++    ++
+    #
+    # The position of the line segment that cuts through (or
+    # doesn't, in case 0 and 15) each square is clear, except in
+    # cases 6 and 9. In this case, where the segments are placed
+    # is determined by vertex_connect_high.  If
+    # vertex_connect_high is false, then lines like \\ are drawn
+    # through square 6, and lines like // are drawn through square
+    # 9.  Otherwise, the situation is reversed.
+    # Finally, recall that we draw the lines so that (moving from tail to
+    # head) the lower-valued pixels are on the left of the line. So, for
+    # example, case 1 entails a line slanting from the middle of the top of
+    # the square to the middle of the left side of the square.
 
-    # Current coords start at 0,0.
-    cdef Py_ssize_t[2] coords
-    coords[0] = 0
-    coords[1] = 0
+    cdef list arc_list = []
 
-    # Calculate the number of iterations we'll need
-    cdef Py_ssize_t num_square_steps = (array.shape[0] - 1) \
-                                        * (array.shape[1] - 1)
-
+    cdef bint use_mask = mask is not None
     cdef unsigned char square_case = 0
     cdef tuple top, bottom, left, right
     cdef double ul, ur, ll, lr
     cdef Py_ssize_t r0, r1, c0, c1
 
-    for n in range(num_square_steps):
-        # There are sixteen different possible square types, diagramed below.
-        # A + indicates that the vertex is above the contour value, and a -
-        # indicates that the vertex is below or equal to the contour value.
-        # The vertices of each square are:
-        # ul ur
-        # ll lr
-        # and can be treated as a binary value with the bits in that order. Thus
-        # each square case can be numbered:
-        #  0--   1+-   2-+   3++   4--   5+-   6-+   7++
-        #   --    --    --    --    +-    +-    +-    +-
-        #
-        #  8--   9+-  10-+  11++  12--  13+-  14-+  15++
-        #   -+    -+    -+    -+    ++    ++    ++    ++
-        #
-        # The position of the line segment that cuts through (or
-        # doesn't, in case 0 and 15) each square is clear, except in
-        # cases 6 and 9. In this case, where the segments are placed
-        # is determined by vertex_connect_high.  If
-        # vertex_connect_high is false, then lines like \\ are drawn
-        # through square 6, and lines like // are drawn through square
-        # 9.  Otherwise, the situation is reversed.
-        # Finally, recall that we draw the lines so that (moving from tail to
-        # head) the lower-valued pixels are on the left of the line. So, for
-        # example, case 1 entails a line slanting from the middle of the top of
-        # the square to the middle of the left side of the square.
+    for r0 in range(array.shape[0] - 1):
+        for c0 in range(array.shape[1] - 1):
+            r1, c1 = r0 + 1, c0 + 1
 
-        r0, c0 = coords[0], coords[1]
-        r1, c1 = r0 + 1, c0 + 1
+            # Skip this square if any of the four input values are masked out.
+            if use_mask and not (mask[r0, c0] and mask[r0, c1] and
+                                 mask[r1, c0] and mask[r1, c1]):
+                continue
 
-        ul = array[r0, c0]
-        ur = array[r0, c1]
-        ll = array[r1, c0]
-        lr = array[r1, c1]
+            ul = array[r0, c0]
+            ur = array[r0, c1]
+            ll = array[r1, c0]
+            lr = array[r1, c1]
 
-        # now in advance the coords indices
-        if coords[1] < array.shape[1] - 2:
-            coords[1] += 1
-        else:
-            coords[0] += 1
-            coords[1] = 0
+            # Skip this square if any of the four input values are NaN.
+            if npy_isnan(ul) or npy_isnan(ur) or npy_isnan(ll) or npy_isnan(lr):
+                continue
 
-        # Skip this square if any of the four input values are masked out.
-        if mask is not None and not (mask[r0, c0] and mask[r0, c1] and
-                                     mask[r1, c0] and mask[r1, c1]):
-            continue
+            square_case = 0
+            if (ul > level): square_case += 1
+            if (ur > level): square_case += 2
+            if (ll > level): square_case += 4
+            if (lr > level): square_case += 8
 
-        # Skip this square if any of the four input values are NaN.
-        if npy_isnan(ul) or npy_isnan(ur) or npy_isnan(ll) or npy_isnan(lr):
-            continue
+            if (square_case > 0 and square_case < 15):
+                # only do anything if there's a line passing through the
+                # square. Cases 0 and 15 are entirely below/above the contour.
 
-        square_case = 0
-        if (ul > level): square_case += 1
-        if (ur > level): square_case += 2
-        if (ll > level): square_case += 4
-        if (lr > level): square_case += 8
+                top = r0, c0 + _get_fraction(ul, ur, level)
+                bottom = r1, c0 + _get_fraction(ll, lr, level)
+                left = r0 + _get_fraction(ul, ll, level), c0
+                right = r0 + _get_fraction(ur, lr, level), c1
 
-        if (square_case != 0 and square_case != 15):
-            # only do anything if there's a line passing through the
-            # square. Cases 0 and 15 are entirely below/above the contour.
-
-            top = r0, c0 + _get_fraction(ul, ur, level)
-            bottom = r1, c0 + _get_fraction(ll, lr, level)
-            left = r0 + _get_fraction(ul, ll, level), c0
-            right = r0 + _get_fraction(ur, lr, level), c1
-
-            if (square_case == 1):
-                # top to left
-                arc_list.append(top)
-                arc_list.append(left)
-            elif (square_case == 2):
-                # right to top
-                arc_list.append(right)
-                arc_list.append(top)
-            elif (square_case == 3):
-                # right to left
-                arc_list.append(right)
-                arc_list.append(left)
-            elif (square_case == 4):
-                # left to bottom
-                arc_list.append(left)
-                arc_list.append(bottom)
-            elif (square_case == 5):
-                # top to bottom
-                arc_list.append(top)
-                arc_list.append(bottom)
-            elif (square_case == 6):
-                if vertex_connect_high:
-                    arc_list.append(left)
-                    arc_list.append(top)
-
-                    arc_list.append(right)
-                    arc_list.append(bottom)
-                else:
-                    arc_list.append(right)
+                if (square_case == 1):
+                    # top to left
                     arc_list.append(top)
                     arc_list.append(left)
-                    arc_list.append(bottom)
-            elif (square_case == 7):
-                # right to bottom
-                arc_list.append(right)
-                arc_list.append(bottom)
-            elif (square_case == 8):
-                # bottom to right
-                arc_list.append(bottom)
-                arc_list.append(right)
-            elif (square_case == 9):
-                if vertex_connect_high:
-                    arc_list.append(top)
+                elif (square_case == 2):
+                    # right to top
                     arc_list.append(right)
+                    arc_list.append(top)
+                elif (square_case == 3):
+                    # right to left
+                    arc_list.append(right)
+                    arc_list.append(left)
+                elif (square_case == 4):
+                    # left to bottom
+                    arc_list.append(left)
+                    arc_list.append(bottom)
+                elif (square_case == 5):
+                    # top to bottom
+                    arc_list.append(top)
+                    arc_list.append(bottom)
+                elif (square_case == 6):
+                    if vertex_connect_high:
+                        arc_list.append(left)
+                        arc_list.append(top)
 
+                        arc_list.append(right)
+                        arc_list.append(bottom)
+                    else:
+                        arc_list.append(right)
+                        arc_list.append(top)
+
+                        arc_list.append(left)
+                        arc_list.append(bottom)
+                elif (square_case == 7):
+                    # right to bottom
+                    arc_list.append(right)
+                    arc_list.append(bottom)
+                elif (square_case == 8):
+                    # bottom to right
+                    arc_list.append(bottom)
+                    arc_list.append(right)
+                elif (square_case == 9):
+                    if vertex_connect_high:
+                        arc_list.append(top)
+                        arc_list.append(right)
+
+                        arc_list.append(bottom)
+                        arc_list.append(left)
+                    else:
+                        arc_list.append(top)
+                        arc_list.append(left)
+
+                        arc_list.append(bottom)
+                        arc_list.append(right)
+                elif (square_case == 10):
+                    # bottom to top
+                    arc_list.append(bottom)
+                    arc_list.append(top)
+                elif (square_case == 11):
+                    # bottom to left
                     arc_list.append(bottom)
                     arc_list.append(left)
-                else:
-                    arc_list.append(top)
+                elif (square_case == 12):
+                    # lef to right
                     arc_list.append(left)
-
-                    arc_list.append(bottom)
                     arc_list.append(right)
-            elif (square_case == 10):
-                # bottom to top
-                arc_list.append(bottom)
-                arc_list.append(top)
-            elif (square_case == 11):
-                # bottom to left
-                arc_list.append(bottom)
-                arc_list.append(left)
-            elif (square_case == 12):
-                # lef to right
-                arc_list.append(left)
-                arc_list.append(right)
-            elif (square_case == 13):
-                # top to right
-                arc_list.append(top)
-                arc_list.append(right)
-            elif (square_case == 14):
-                # left to top
-                arc_list.append(left)
-                arc_list.append(top)
+                elif (square_case == 13):
+                    # top to right
+                    arc_list.append(top)
+                    arc_list.append(right)
+                elif (square_case == 14):
+                    # left to top
+                    arc_list.append(left)
+                    arc_list.append(top)
 
     return arc_list


### PR DESCRIPTION
## Description

Fixes #4497, Fixes #817.

In this PR, the dictionary entries deletion using `del` in `find_contours` are replaced by `dict.pop` to avoid `KeyError` raising when the key doesn't exist.