### PR TITLE
API: Add cross_correlation regularization to register_translation

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -37,6 +37,9 @@ API Changes
   ``'reflect'``, which allows meaningful values at the borders for these
   filters. To retain the old behavior, pass
   ``mask=np.ones(image.shape, dtype=bool)`` (#4347)
+- A regularization term was added to ``register_translation`` so that when
+  multiple translations have the same cross-correlation value, the smallest
+  translation is chosen.
 
 
 Bugfixes

--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -128,7 +128,7 @@ def _area_overlap(A):
         if dim == 0:
             w = _triangle(shape)
         else:
-            w = w[..., None] @ _triangle(shape)[None, ]
+            w = w[..., np.newaxis] @ _triangle(shape)[np.newaxis, ...]
     return w
 
 

--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -163,7 +163,7 @@ def register_translation(src_image, target_image, upsample_factor=1,
         will be FFT'd to compute the correlation, while "fourier" data will
         bypass FFT of input data.  Case insensitive.
     return_error : bool, optional
-        Returns error and phase difference if when True, otherwise only shifts
+        Returns error and phase difference if True, otherwise only shifts
         are returned.
     reg_weight : float, optional
         Determines the strength of shift regularization.

--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -167,9 +167,11 @@ def register_translation(src_image, target_image, upsample_factor=1,
         are returned.
     reg_weight : float, optional
         Determines the strength of shift regularization.
+
         .. versionadded:: 0.17
-           ``reg_weight`` was introduced to break ties between
-           cross-correlation peaks.
+
+          ``reg_weight`` was introduced to break ties between
+          cross-correlation peaks.
 
     Returns
     -------

--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -148,6 +148,24 @@ def register_translation(src_image, target_image, upsample_factor=1,
     regularizer which favors smaller shifts. This regularization may be
     disabled by setting ``reg_weight`` to zero.
 
+    Define two arrays to be registered which have two possible alignments
+    with the same error.
+    >>> A = np.zeros((8, 8))
+    >>> A[4, 4] = 1
+    >>> B = np.zeros((8, 8))
+    >>> B[3, 3], B[5, 7] = 1, 1
+    >>> register_translation(src_image=A, target_image=B)[:2]
+    (array([1., 1.]), 0.7071067811865476)
+
+    Switch the order of the input arrays. Without regularization, the larger
+    shift is returned.
+    >>> register_translation(src_image=B, target_image=A, reg_weight=0)[:2]
+    (array([1., 3.]), 0.7071067811865476)
+
+    With regularization, the shorter shift is returned.
+    >>> register_translation(src_image=B, target_image=A, reg_weight=1e-12)[:2]
+    (array([-1., -1.]), 0.7071067811865476)
+
     Parameters
     ----------
     src_image : array

--- a/skimage/feature/register_translation.py
+++ b/skimage/feature/register_translation.py
@@ -110,6 +110,7 @@ def _triangle(N):
     x = np.linspace(0, 1, N, endpoint=False) + 0.5 / N
     return 1 - abs(x - 0.5)
 
+
 def _area_overlap(A):
     """
     Return overlapping area of A with itself.


### PR DESCRIPTION
## Description
`register_translation(A, B) != -register_translation(B, A)`, but it should be!

Shifts are chosen by using the "the first" maximum of the cross_correlation function, but this means that the shifts are always biased towards one of the corners of the image. Instead when multiple
shifts have the same cross_correlation, we should choose the smallest shift.

We can favor smaller shifts by adding a regularizer to the cross_correlation which favors higher overlap between the two images.

Closes scikit-image/scikit-image#4500

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
