### PR TITLE
Add cast to minimum dtype before imsave

### DIFF
--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -141,7 +141,7 @@ def color_check(plugin, fmt='png'):
         testing.assert_allclose(r4, img4)
     else:
         r4 = roundtrip(img4, plugin, fmt)
-        testing.assert_allclose(r4, img_as_ubyte(img4))
+        testing.assert_allclose(r4, img_as_ubyte(img4.astype(np.uint16)))
 
     img5 = img_as_uint(img)
     r5 = roundtrip(img5, plugin, fmt)
@@ -176,7 +176,7 @@ def mono_check(plugin, fmt='png'):
         testing.assert_allclose(r4, img4)
     else:
         r4 = roundtrip(img4, plugin, fmt)
-        testing.assert_allclose(r4, img_as_uint(img4))
+        testing.assert_allclose(r4, img4)
 
     img5 = img_as_uint(img)
     r5 = roundtrip(img5, plugin, fmt)

--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -130,10 +130,14 @@ def imsave(fname, arr, plugin=None, check_contrast=True, **plugin_args):
         warn('%s is a low contrast image' % fname)
     if arr.dtype == bool:
         warn('%s is a boolean image: setting True to 1 and False to 0' % fname)
-    min_dtype = np.result_type(np.min_scalar_type(arr.max()),
-                               np.min_scalar_type(arr.min()))
-    return call_plugin('imsave', fname, arr.astype(min_dtype),
-                       plugin=plugin, **plugin_args)
+    arr = np.asarray(arr)
+    min_dtype = arr.dtype
+    if np.issubdtype(min_dtype, np.integer):
+        min_dtype = np.result_type(np.min_scalar_type(arr.max()),
+                                   np.min_scalar_type(arr.min()))
+    print("------------", arr.dtype, min_dtype, arr.min(), arr.max())
+    return call_plugin('imsave', fname, arr.astype(min_dtype), plugin=plugin,
+                       **plugin_args)
 
 
 def imshow(arr, plugin=None, **plugin_args):

--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -130,7 +130,10 @@ def imsave(fname, arr, plugin=None, check_contrast=True, **plugin_args):
         warn('%s is a low contrast image' % fname)
     if arr.dtype == bool:
         warn('%s is a boolean image: setting True to 1 and False to 0' % fname)
-    return call_plugin('imsave', fname, arr, plugin=plugin, **plugin_args)
+    min_dtype = np.result_type(np.min_scalar_type(arr.max()),
+                               np.min_scalar_type(arr.min()))
+    return call_plugin('imsave', fname, arr.astype(min_dtype),
+                       plugin=plugin, **plugin_args)
 
 
 def imshow(arr, plugin=None, **plugin_args):

--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -135,7 +135,6 @@ def imsave(fname, arr, plugin=None, check_contrast=True, **plugin_args):
     if np.issubdtype(min_dtype, np.integer):
         min_dtype = np.result_type(np.min_scalar_type(arr.max()),
                                    np.min_scalar_type(arr.min()))
-    print("------------", arr.dtype, min_dtype, arr.min(), arr.max())
     return call_plugin('imsave', fname, arr.astype(min_dtype), plugin=plugin,
                        **plugin_args)
 

--- a/skimage/io/tests/test_imageio.py
+++ b/skimage/io/tests/test_imageio.py
@@ -60,6 +60,12 @@ class TestSave(TestCase):
                 x = (x * 255).astype(dtype)
                 yield self.roundtrip, x
 
+    def test_low_contrast_roundtrip(self):
+        img = np.zeros((32, 32), dtype=np.uint64)
+        img[8:24, 8:24] = 1
+
+        yield self.roundtrip, img
+
 
 def test_return_class():
     testing.assert_equal(


### PR DESCRIPTION
## Description

Fixes #4509.

This PR proposes to cast the image  to the dtype with the smallest size and smallest scalar kind which can hold its value before saving. This may prevent the `#Lossy conversion from uint64 to uint8. Losing 56 bits of resolution`  `imageio` warning to be raised (See #4509).

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
