### PR TITLE
Fixing order of elements in docstrings of skimage/color/colorconv

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -112,7 +112,6 @@ def convert_colorspace(arr, fromspace, tospace):
     >>> from skimage import data
     >>> img = data.astronaut()
     >>> img_hsv = convert_colorspace(img, 'RGB', 'HSV')
-
     """
     fromdict = {'rgb': lambda im: im, 'hsv': hsv2rgb, 'rgb cie': rgbcie2rgb,
                 'xyz': xyz2rgb, 'yuv': yuv2rgb, 'yiq': yiq2rgb,
@@ -136,7 +135,6 @@ def convert_colorspace(arr, fromspace, tospace):
 def _prepare_colorarray(arr):
     """Check the shape of the array and convert it to
     floating point representation.
-
     """
     arr = np.asanyarray(arr)
 
@@ -151,7 +149,6 @@ def _prepare_colorarray(arr):
 def _prepare_rgba_array(arr):
     """Check the shape of the array to be RGBA and convert it to
     floating point representation.
-
     """
     arr = np.asanyarray(arr)
 
@@ -475,7 +472,6 @@ def get_xyz_coords(illuminant, observer, dtype=float):
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Standard_illuminant
-
     """
     illuminant = illuminant.upper()
     try:
@@ -768,10 +764,6 @@ def rgb2gray(rgb):
         If `rgb2gray` is not a 3-D or 4-D arrays of shape
         ``(.., ..,[ ..,] 3)`` or ``(.., ..,[ ..,] 4)``.
 
-    References
-    ----------
-    .. [1] http://www.poynton.com/PDFs/ColorFAQ.pdf
-
     Notes
     -----
     The weights used in this conversion are calibrated for contemporary
@@ -780,6 +772,10 @@ def rgb2gray(rgb):
         Y = 0.2125 R + 0.7154 G + 0.0721 B
 
     If there is an alpha channel present, it is ignored.
+
+    References
+    ----------
+    .. [1] http://www.poynton.com/PDFs/ColorFAQ.pdf
 
     Examples
     --------
@@ -980,7 +976,6 @@ def lab2xyz(lab, illuminant="D65", observer="2"):
     UserWarning
         If any of the pixels are invalid (Z < 0).
 
-
     Notes
     -----
     By default Observer= 2A, Illuminant= D65. CIE XYZ tristimulus values x_ref
@@ -991,9 +986,7 @@ def lab2xyz(lab, illuminant="D65", observer="2"):
     ----------
     .. [1] http://www.easyrgb.com/index.php?X=MATH&H=07#text7
     .. [2] https://en.wikipedia.org/wiki/Lab_color_space
-
     """
-
     arr = _prepare_colorarray(lab).copy()
 
     L, a, b = arr[:, :, 0], arr[:, :, 1], arr[:, :, 2]
@@ -1043,16 +1036,16 @@ def rgb2lab(rgb, illuminant="D65", observer="2"):
     ValueError
         If `rgb` is not a 3- or 4-D array of shape ``(.., ..,[ ..,] 3)``.
 
-    References
-    ----------
-    .. [1] https://en.wikipedia.org/wiki/Standard_illuminant
-
     Notes
     -----
     This function uses rgb2xyz and xyz2lab.
     By default Observer= 2A, Illuminant= D65. CIE XYZ tristimulus values
     x_ref=95.047, y_ref=100., z_ref=108.883. See function `get_xyz_coords` for
     a list of supported illuminants.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Standard_illuminant
     """
     return xyz2lab(rgb2xyz(rgb), illuminant, observer)
 
@@ -1079,16 +1072,16 @@ def lab2rgb(lab, illuminant="D65", observer="2"):
     ValueError
         If `lab` is not a 3-D array of shape ``(.., .., 3)``.
 
-    References
-    ----------
-    .. [1] https://en.wikipedia.org/wiki/Standard_illuminant
-
     Notes
     -----
     This function uses lab2xyz and xyz2rgb.
     By default Observer= 2A, Illuminant= D65. CIE XYZ tristimulus values
     x_ref=95.047, y_ref=100., z_ref=108.883. See function `get_xyz_coords` for
     a list of supported illuminants.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Standard_illuminant
     """
     return xyz2rgb(lab2xyz(lab, illuminant, observer))
 
@@ -1206,9 +1199,7 @@ def luv2xyz(luv, illuminant="D65", observer="2"):
     ----------
     .. [1] http://www.easyrgb.com/index.php?X=MATH&H=16#text16
     .. [2] https://en.wikipedia.org/wiki/CIELUV
-
     """
-
     arr = _prepare_colorarray(luv).copy()
 
     L, u, v = arr[:, :, 0], arr[:, :, 1], arr[:, :, 2]
@@ -1268,7 +1259,6 @@ def rgb2luv(rgb):
     .. [1] http://www.easyrgb.com/index.php?X=MATH&H=16#text16
     .. [2] http://www.easyrgb.com/index.php?X=MATH&H=02#text2
     .. [3] https://en.wikipedia.org/wiki/CIELUV
-
     """
     return xyz2luv(rgb2xyz(rgb))
 
@@ -1316,7 +1306,6 @@ def rgb2hed(rgb):
     ------
     ValueError
         If `rgb` is not a 3-D array of shape ``(.., .., 3)``.
-
 
     References
     ----------
@@ -1471,7 +1460,6 @@ def combine_stains(stains, conv_matrix):
     ----------
     .. [1] https://mecourse.com/landinig/software/cdeconv/cdeconv.html
 
-
     Examples
     --------
     >>> from skimage import data
@@ -1614,13 +1602,12 @@ def rgb2yuv(rgb):
 
     Notes
     -----
-    Y is between 0 and 1.  Use YCbCr instead of YUV for the color space which
-    is commonly used by video codecs (where Y ranges from 16 to 235)
+    Y is between 0 and 1.  Use YCbCr instead of YUV for the color space
+    commonly used by video codecs, where Y ranges from 16 to 235.
 
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/YUV
-
     """
     return _convert(yuv_from_rgb, rgb)
 
@@ -1671,7 +1658,6 @@ def rgb2ypbpr(rgb):
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/YPbPr
-
     """
     return _convert(ypbpr_from_rgb, rgb)
 
@@ -1698,13 +1684,12 @@ def rgb2ycbcr(rgb):
 
     Notes
     -----
-    Y is between 16 and 235.  This is the color space which is commonly used
-    by video codecs, it is sometimes incorrectly called "YUV"
+    Y is between 16 and 235. This is the color space commonly used by video
+    codecs; it is sometimes incorrectly called "YUV".
 
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/YCbCr
-
     """
     arr = _convert(ycbcr_from_rgb, rgb)
     arr[..., 0] += 16
@@ -1735,13 +1720,12 @@ def rgb2ydbdr(rgb):
 
     Notes
     -----
-    This is the color space which is commonly used
-    by video codecs, it is also the reversible color transform in JPEG2000.
+    This is the color space commonly used by video codecs. It is also the
+    reversible color transform in JPEG2000.
 
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/YDbDr
-
     """
     arr = _convert(ydbdr_from_rgb, rgb)
     return arr
@@ -1770,7 +1754,6 @@ def yuv2rgb(yuv):
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/YUV
-
     """
     return _convert(rgb_from_yuv, yuv)
 
@@ -1821,7 +1804,6 @@ def ypbpr2rgb(ypbpr):
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/YPbPr
-
     """
     return _convert(rgb_from_ypbpr, ypbpr)
 
@@ -1848,13 +1830,12 @@ def ycbcr2rgb(ycbcr):
 
     Notes
     -----
-    Y is between 16 and 235.  This is the color space which is commonly used
-    by video codecs, it is sometimes incorrectly called "YUV"
+    Y is between 16 and 235. This is the color space commonly used by video
+    codecs; it is sometimes incorrectly called "YUV".
 
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/YCbCr
-
     """
     arr = ycbcr.copy()
     arr[..., 0] -= 16
@@ -1885,13 +1866,12 @@ def ydbdr2rgb(ydbdr):
 
     Notes
     -----
-    This is the color space which is commonly used
-    by video codecs, it is also the reversible color transform in JPEG2000.
+    This is the color space commonly used by video codecs, also called the
+    reversible color transform in JPEG2000.
 
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/YDbDr
-
     """
     arr = ydbdr.copy()
     return _convert(rgb_from_ydbdr, arr)


### PR DESCRIPTION
## Description
Some docstrings had elements with order different than given on numpydoc. Some small changes on text as well.

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
