### PR TITLE
Adding info on venv activation on Windows

### DIFF
--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -1,7 +1,7 @@
 .. _howto_contribute:
 
-How to contribute to ``skimage``
-================================
+How to contribute to scikit-image
+=================================
 
 Developing Open Source is great fun!  Join us on the `scikit-image mailing
 list <https://mail.python.org/mailman/listinfo/scikit-image>`_ and tell us
@@ -186,7 +186,7 @@ When using ``venv``, you may find the following bash commands useful::
   # Create a virtualenv named ``skimage-dev`` that lives in the directory of
   # the same name
   python -m venv skimage-dev
-  # Activate it
+  # Activate it. On Linux and MacOS:
   source skimage-dev/bin/activate
   # Install all development and runtime dependencies of scikit-image
   pip install -r <(cat requirements/*.txt)
@@ -194,6 +194,8 @@ When using ``venv``, you may find the following bash commands useful::
   pip install -e .
   # Test your installation
   pytest skimage
+
+On Windows, please use ``skimage-dev\Scripts\activate`` on the activation step.
 
 conda
 =====


### PR DESCRIPTION
## Description

Fixes #4520 — adds info on how to activate a virtual env on Windows.
**Bonus!** Replaced `skimage` in favor of scikit-image, leading to a better formatting in the title.

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
