### PR TITLE
Documentation: add binder to gallery examples

### DIFF
--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -26,7 +26,7 @@ cp -r doc/examples .binder $TMP_CONTENT_DIR
 find . -delete
 
 # Generate notebooks and remove other files from examples folder
-GENERATED_NOTEBOOKS_DIR=notebooks
+GENERATED_NOTEBOOKS_DIR=auto_examples
 cp -r $TMP_CONTENT_DIR/examples $GENERATED_NOTEBOOKS_DIR
 
 find $GENERATED_NOTEBOOKS_DIR -name '*.py' -exec sphx_glr_python_to_jupyter.py '{}' +
@@ -35,8 +35,8 @@ rm -f $NON_NOTEBOOKS
 
 # Modify path to be consistent by the path given by sphinx-gallery
 pwd
-mkdir $GENERATED_NOTEBOOKS_DIR/auto_examples
-mv $GENERATED_NOTEBOOKS_DIR/* $GENERATED_NOTEBOOKS_DIR/auto_examples
+mkdir notebooks
+mv $GENERATED_NOTEBOOKS_DIR notebooks/
 
 
 # Put the .binder folder back (may be useful for debugging purposes)

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -33,6 +33,10 @@ find $GENERATED_NOTEBOOKS_DIR -name '*.py' -exec sphx_glr_python_to_jupyter.py '
 NON_NOTEBOOKS=$(find $GENERATED_NOTEBOOKS_DIR -type f | grep -v '\.ipynb')
 rm -f $NON_NOTEBOOKS
 
+# Modify path to be consistent by the path given by sphinx-gallery
+mv $GENERATED_NOTEBOOKS_DIR/notebooks $GENERATED_NOTEBOOKS_DIR/auto_examples
+
+
 # Put the .binder folder back (may be useful for debugging purposes)
 mv $TMP_CONTENT_DIR/.binder .
 # Final clean up

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -34,7 +34,9 @@ NON_NOTEBOOKS=$(find $GENERATED_NOTEBOOKS_DIR -type f | grep -v '\.ipynb')
 rm -f $NON_NOTEBOOKS
 
 # Modify path to be consistent by the path given by sphinx-gallery
-mv $GENERATED_NOTEBOOKS_DIR/notebooks $GENERATED_NOTEBOOKS_DIR/auto_examples
+pwd
+mkdir $GENERATED_NOTEBOOKS_DIR/auto_examples
+mv $GENERATED_NOTEBOOKS_DIR/* $GENERATED_NOTEBOOKS_DIR/auto_examples
 
 
 # Put the .binder folder back (may be useful for debugging purposes)

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -34,7 +34,6 @@ NON_NOTEBOOKS=$(find $GENERATED_NOTEBOOKS_DIR -type f | grep -v '\.ipynb')
 rm -f $NON_NOTEBOOKS
 
 # Modify path to be consistent by the path given by sphinx-gallery
-pwd
 mkdir notebooks
 mv $GENERATED_NOTEBOOKS_DIR notebooks/
 

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+# Taken from https://github.com/scikit-learn/scikit-learn/blob/72b3041ed57e42817e4c5c9853b3a2597cab3654/.binder/postBuild
+# under BSD3 license, copyright the scikit-learn contributors
+
+python -m pip install .
+
+# This script is called in a binder context. When this script is called, we are
+# inside a git checkout of the scikit-image/scikit-image repo. This script
+# generates notebooks from the scikit-image python examples.
+
+if [[ ! -f /.dockerenv ]]; then
+    echo "This script was written for repo2docker and is supposed to run inside a docker container."
+    echo "Exiting because this script can delete data if run outside of a docker container."
+    exit 1
+fi
+
+# Copy content we need from the scikit-image repo
+TMP_CONTENT_DIR=/tmp/scikit-image
+mkdir -p $TMP_CONTENT_DIR
+cp -r doc/examples .binder $TMP_CONTENT_DIR
+# delete everything in current directory including dot files and dot folders
+# to create a "clean" experience for readers
+find . -delete
+
+# Generate notebooks and remove other files from examples folder
+GENERATED_NOTEBOOKS_DIR=notebooks
+cp -r $TMP_CONTENT_DIR/examples $GENERATED_NOTEBOOKS_DIR
+
+find $GENERATED_NOTEBOOKS_DIR -name '*.py' -exec sphx_glr_python_to_jupyter.py '{}' +
+NON_NOTEBOOKS=$(find $GENERATED_NOTEBOOKS_DIR -type f | grep -v '\.ipynb')
+rm -f $NON_NOTEBOOKS
+
+# Put the .binder folder back (may be useful for debugging purposes)
+mv $TMP_CONTENT_DIR/.binder .
+# Final clean up
+rm -rf $TMP_CONTENT_DIR

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,0 +1,25 @@
+Cython>=0.29.13
+wheel
+# numpy 1.18.0 breaks builds on MacOSX
+# https://github.com/numpy/numpy/pull/15194
+numpy>=1.15.1,!=1.18.0
+scikit-learn
+matplotlib>=3.0.1
+dask[array]>=0.15.0
+# cloudpickle is necessary to provide the 'processes' scheduler for dask
+cloudpickle>=0.2.1
+pandas>=0.23.0
+seaborn>=0.7.1
+scipy>=1.0.1
+networkx>=2.0
+pillow>=4.3.0
+imageio>=2.3.0
+tifffile>=2019.7.26
+PyWavelets>=0.5.2
+pooch>=0.5.2
+SimpleITK
+astropy>=1.2.0
+qtpy
+pyamg
+
+

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -21,5 +21,4 @@ SimpleITK
 astropy>=1.2.0
 qtpy
 pyamg
-
-
+sphinx-gallery

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,24 +1,8 @@
-Cython>=0.29.13
-wheel
-# numpy 1.18.0 breaks builds on MacOSX
-# https://github.com/numpy/numpy/pull/15194
-numpy>=1.15.1,!=1.18.0
+-r ../requirements/default.txt
+-r ../requirements/build.txt
 scikit-learn
-matplotlib>=3.0.1
 dask[array]>=0.15.0
-# cloudpickle is necessary to provide the 'processes' scheduler for dask
 cloudpickle>=0.2.1
 pandas>=0.23.0
 seaborn>=0.7.1
-scipy>=1.0.1
-networkx>=2.0
-pillow>=4.3.0
-imageio>=2.3.0
-tifffile>=2019.7.26
-PyWavelets>=0.5.2
-pooch>=0.5.2
-SimpleITK
-astropy>=1.2.0
-qtpy
-pyamg
 sphinx-gallery

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -80,10 +80,10 @@ access), specifically to:
   - On the release branch, build a clean version of the docs. In the
     root directory, run ``pip install .``.
   - In the ``doc/`` directory:
-    - Modify `source/conf.py` so that `sphinx_gallery_conf['binder']['branch']`
-      points to the name of the release branch, e.g. `0.16.x`.
     - Build using
       ``make clean; make html; make gh-pages``.
+    - Check (since this a new feature) that binder links in gallery examples
+      point to the release branch, e.g. `0.16.x`.
     - In the ``gh-pages/`` directory:
       - Update the symlink to ``stable`` and commit.
       - Upload the docs: ``git push origin gh-pages``.

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -80,6 +80,8 @@ access), specifically to:
   - On the release branch, build a clean version of the docs. In the
     root directory, run ``pip install .``.
   - In the ``doc/`` directory:
+    - Modify `source/conf.py` so that `sphinx_gallery_conf['binder']['branch']`
+      points to the name of the release branch, e.g. `0.16.x`.
     - Build using
       ``make clean; make html; make gh-pages``.
     - In the ``gh-pages/`` directory:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -68,6 +68,17 @@ sphinx_gallery_conf = {
         '../examples/applications',
         '../examples/developers',
     ]),
+    'binder': {
+        # Required keys
+        'org': 'emmanuelle',
+        'repo': 'scikit-image',
+        'branch': 'binder-from-tim',  # Can be any branch, tag, or commit hash
+        'binderhub_url': 'https://mybinder.org',  # Any URL of a binderhub.
+        'dependencies': '../../.binder/requirements.txt',
+        # Optional keys
+        #'filepath_prefix': 'dev/', # A prefix to prepend to filepaths in links.
+        'use_jupyter_lab': False
+     }
 }
 
 # Determine if the matplotlib has a recent enough version of the

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -44,42 +44,6 @@ extensions = ['sphinx_copybutton',
 
 autosummary_generate = True
 
-#------------------------------------------------------------------------
-# Sphinx-gallery configuration
-#------------------------------------------------------------------------
-
-sphinx_gallery_conf = {
-    'doc_module': ('skimage',),
-    # path to your examples scripts
-    'examples_dirs': '../examples',
-    # path where to save gallery generated examples
-    'gallery_dirs': 'auto_examples',
-    'backreferences_dir': 'api',
-    'reference_url': {'skimage': None},
-    'subsection_order': ExplicitOrder([
-        '../examples/data',
-        '../examples/numpy_operations',
-        '../examples/color_exposure',
-        '../examples/edges',
-        '../examples/transform',
-        '../examples/filters',
-        '../examples/features_detection',
-        '../examples/segmentation',
-        '../examples/applications',
-        '../examples/developers',
-    ]),
-    'binder': {
-        # Required keys
-        'org': 'scikit-image',
-        'repo': 'scikit-image',
-        'branch': 'master',  # Can be any branch, tag, or commit hash
-        'binderhub_url': 'https://mybinder.org',  # Any URL of a binderhub.
-        'dependencies': '../../.binder/requirements.txt',
-        # Optional keys
-        'use_jupyter_lab': False
-     }
-}
-
 # Determine if the matplotlib has a recent enough version of the
 # plot_directive, otherwise use the local fork.
 try:
@@ -166,6 +130,57 @@ pygments_style = 'sphinx'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []
+
+#------------------------------------------------------------------------
+# Sphinx-gallery configuration
+#------------------------------------------------------------------------
+
+from packaging.version import parse
+v = parse(release)
+if v.release is None:
+    raise ValueError(
+        'Ill-formed version: {!r}. Version should follow '
+        'PEP440'.format(version))
+
+if v.is_devrelease:
+    binder_branch = 'master'
+else:
+    major, minor = v.release[:2]
+    binder_branch = 'v{}.{}.x'.format(major, minor)
+
+
+sphinx_gallery_conf = {
+    'doc_module': ('skimage',),
+    # path to your examples scripts
+    'examples_dirs': '../examples',
+    # path where to save gallery generated examples
+    'gallery_dirs': 'auto_examples',
+    'backreferences_dir': 'api',
+    'reference_url': {'skimage': None},
+    'subsection_order': ExplicitOrder([
+        '../examples/data',
+        '../examples/numpy_operations',
+        '../examples/color_exposure',
+        '../examples/edges',
+        '../examples/transform',
+        '../examples/filters',
+        '../examples/features_detection',
+        '../examples/segmentation',
+        '../examples/applications',
+        '../examples/developers',
+    ]),
+    'binder': {
+        # Required keys
+        'org': 'scikit-image',
+        'repo': 'scikit-image',
+        'branch': binder_branch,  # Can be any branch, tag, or commit hash
+        'binderhub_url': 'https://mybinder.org',  # Any URL of a binderhub.
+        'dependencies': '../../.binder/requirements.txt',
+        # Optional keys
+        'use_jupyter_lab': False
+     }
+}
+
 
 
 # -- Options for HTML output ---------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -70,13 +70,12 @@ sphinx_gallery_conf = {
     ]),
     'binder': {
         # Required keys
-        'org': 'emmanuelle',
+        'org': 'scikit-image',
         'repo': 'scikit-image',
-        'branch': 'binder-from-tim',  # Can be any branch, tag, or commit hash
+        'branch': 'master',  # Can be any branch, tag, or commit hash
         'binderhub_url': 'https://mybinder.org',  # Any URL of a binderhub.
         'dependencies': '../../.binder/requirements.txt',
         # Optional keys
-        #'filepath_prefix': 'dev/', # A prefix to prepend to filepaths in links.
         'use_jupyter_lab': False
      }
 }


### PR DESCRIPTION
Supersedes #4485 and #4340, in order to add binder links to gallery examples. The strategy is the one proposed by @betatim in #4485: add a `postBuild` script for binder that will build the notebooks using the scikit-image version from the branch from which binder was launched. This solves elegantly version problems. I checked from another branch on my fork that it works correctly (if you want to check, pull https://github.com/emmanuelle/scikit-image/tree/binder-from-tim, build the doc locally and follow a binder link).

If this PR is merged binder links will work for the dev examples.

At release time, one should update the `doc/source/conf.py` as explained in the updated release notes to generate suitable links for the stable examples.

Apologies to @betatim, I should have started from your commits to give you better credit. Whoever merges this PR, please mention Tim in the commit message. 