### PR TITLE
MNT: remove duplicate nogil specification

### DIFF
--- a/skimage/morphology/_flood_fill_cy.pyx
+++ b/skimage/morphology/_flood_fill_cy.pyx
@@ -41,7 +41,7 @@ cpdef inline void _flood_fill_equal(dtype_t[::1] image,
                                     unsigned char[::1] flags,
                                     Py_ssize_t[::1] neighbor_offsets,
                                     Py_ssize_t start_index,
-                                    dtype_t seed_value) nogil:
+                                    dtype_t seed_value):
     """Find connected areas to fill, requiring strict equality.
 
     Parameters
@@ -92,7 +92,7 @@ cpdef inline void _flood_fill_tolerance(dtype_t[::1] image,
                                         Py_ssize_t start_index,
                                         dtype_t seed_value,
                                         dtype_t low_tol,
-                                        dtype_t high_tol) nogil:
+                                        dtype_t high_tol):
     """Find connected areas to fill, within a tolerance.
 
     Parameters

--- a/skimage/morphology/_flood_fill_cy.pyx
+++ b/skimage/morphology/_flood_fill_cy.pyx
@@ -57,7 +57,7 @@ cpdef inline void _flood_fill_equal(dtype_t[::1] image,
     start_index : int
         Start position for the flood-fill.
     seed_value :
-        Value of `image[start_index]`.
+        Value of ``image[start_index]``.
     """
     cdef:
         QueueWithHistory queue
@@ -108,7 +108,7 @@ cpdef inline void _flood_fill_tolerance(dtype_t[::1] image,
     start_index : int
         Start position for the flood-fill.
     seed_value :
-        Value of `image[start_index]`.
+        Value of ``image[start_index]``.
     low_tol :
         Lower limit for tolerance comparison.
     high_tol :

--- a/skimage/morphology/_flood_fill_cy.pyx
+++ b/skimage/morphology/_flood_fill_cy.pyx
@@ -41,7 +41,7 @@ cpdef inline void _flood_fill_equal(dtype_t[::1] image,
                                     unsigned char[::1] flags,
                                     Py_ssize_t[::1] neighbor_offsets,
                                     Py_ssize_t start_index,
-                                    dtype_t seed_value) :
+                                    dtype_t seed_value):
     """Find connected areas to fill, requiring strict equality.
 
     Parameters

--- a/skimage/morphology/_flood_fill_cy.pyx
+++ b/skimage/morphology/_flood_fill_cy.pyx
@@ -41,7 +41,7 @@ cpdef inline void _flood_fill_equal(dtype_t[::1] image,
                                     unsigned char[::1] flags,
                                     Py_ssize_t[::1] neighbor_offsets,
                                     Py_ssize_t start_index,
-                                    dtype_t seed_value):
+                                    dtype_t seed_value) :
     """Find connected areas to fill, requiring strict equality.
 
     Parameters


### PR DESCRIPTION
## Description

The functions in _flood_fill_cy were marked as nogil both at the
function level and with a context manager inside.  Future versions of
cython will forbid this so remove the function marking.

closes #4545


I think this should be backported as far as backports are currently
being done as it fixes a future compilation problem.

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`