### PR TITLE
Fix binder requirements

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,5 +1,7 @@
 -r ../requirements/default.txt
-# numpy is present both in default.txt and build.txt, with pinning instructions which are slightly different, therefore pip gives up and errors
+# numpy is present both in default.txt and build.txt
+# with pinning instructions which are slightly different, 
+# therefore pip gives up and errors
 Cython>=0.29.13
 wheel
 scikit-learn

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,4 +1,5 @@
 -r ../requirements/default.txt
+# numpy is present both in default.txt and build.txt, with pinning instructions which are slightly different, therefore pip gives up and errors
 Cython>=0.29.13
 wheel
 scikit-learn

--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,5 +1,6 @@
 -r ../requirements/default.txt
--r ../requirements/build.txt
+Cython>=0.29.13
+wheel
 scikit-learn
 dask[array]>=0.15.0
 cloudpickle>=0.2.1


### PR DESCRIPTION
The binder deployment currently fails because of duplicated requirements for numpy.

(Sorry about that, I had first tested the deployment using a local branch, and then I addressed a review comments but did not check again...)