### PR TITLE
Fix morphology.flood for F-ordered images

### DIFF
--- a/skimage/morphology/_flood_fill.py
+++ b/skimage/morphology/_flood_fill.py
@@ -240,7 +240,7 @@ def flood(image, seed_point, *, selem=None, connectivity=None, tolerance=None):
     selem = _resolve_neighborhood(selem, connectivity, image.ndim)
 
     # Must annotate borders
-    working_image = _fast_pad(image, image.min(), order)
+    working_image = _fast_pad(image, image.min(), order=order)
 
     # Stride-aware neighbors - works for both C- and Fortran-contiguity
     ravelled_seed_idx = np.ravel_multi_index([i+1 for i in seed_point],

--- a/skimage/morphology/_flood_fill.py
+++ b/skimage/morphology/_flood_fill.py
@@ -240,16 +240,16 @@ def flood(image, seed_point, *, selem=None, connectivity=None, tolerance=None):
     selem = _resolve_neighborhood(selem, connectivity, image.ndim)
 
     # Must annotate borders
-    working_image = _fast_pad(image, image.min())
+    working_image = _fast_pad(image, image.min(), order)
 
     # Stride-aware neighbors - works for both C- and Fortran-contiguity
     ravelled_seed_idx = np.ravel_multi_index([i+1 for i in seed_point],
                                              working_image.shape, order=order)
     neighbor_offsets = _offsets_to_raveled_neighbors(
-        working_image.shape, selem, center=((1,) * image.ndim))
+        working_image.shape, selem, center=((1,) * image.ndim), order=order)
 
     # Use a set of flags; see _flood_fill_cy.pyx for meanings
-    flags = np.zeros(working_image.shape, dtype=np.uint8)
+    flags = np.zeros(working_image.shape, dtype=np.uint8, order=order)
     _set_edge_values_inplace(flags, value=2)
 
     try:
@@ -265,16 +265,16 @@ def flood(image, seed_point, *, selem=None, connectivity=None, tolerance=None):
             high_tol = min(max_value, seed_value + tolerance)
             low_tol = max(min_value, seed_value - tolerance)
 
-            _flood_fill_tolerance(working_image.ravel(),
-                                  flags.ravel(),
+            _flood_fill_tolerance(working_image.ravel(order),
+                                  flags.ravel(order),
                                   neighbor_offsets,
                                   ravelled_seed_idx,
                                   seed_value,
                                   low_tol,
                                   high_tol)
         else:
-            _flood_fill_equal(working_image.ravel(),
-                              flags.ravel(),
+            _flood_fill_equal(working_image.ravel(order),
+                              flags.ravel(order),
                               neighbor_offsets,
                               ravelled_seed_idx,
                               seed_value)

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -239,7 +239,7 @@ def _set_edge_values_inplace(image, value):
         image[tuple(sl)] = value
 
 
-def _fast_pad(image, value):
+def _fast_pad(image, value, order="C"):
     """Pad an array on all axes with one constant value.
 
     Parameters
@@ -248,6 +248,8 @@ def _fast_pad(image, value):
         Image to pad.
     value : scalar
          The value to use. Should be compatible with `image`'s dtype.
+    order : "C" or "F"
+        Specify the memory layout of the padded image.
 
     Returns
     -------
@@ -273,7 +275,7 @@ def _fast_pad(image, value):
     """
     # Allocate padded image
     new_shape = np.array(image.shape) + 2
-    new_image = np.empty(new_shape, dtype=image.dtype, order="C")
+    new_image = np.empty(new_shape, dtype=image.dtype, order=order)
 
     # Copy old image into new space
     original_slice = tuple(slice(1, -1) for _ in range(image.ndim))

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -239,7 +239,7 @@ def _set_edge_values_inplace(image, value):
         image[tuple(sl)] = value
 
 
-def _fast_pad(image, value, order="C"):
+def _fast_pad(image, value, *, order="C"):
     """Pad an array on all axes with one constant value.
 
     Parameters
@@ -249,7 +249,7 @@ def _fast_pad(image, value, order="C"):
     value : scalar
          The value to use. Should be compatible with `image`'s dtype.
     order : "C" or "F"
-        Specify the memory layout of the padded image.
+        Specify the memory layout of the padded image (C or Fortran style).
 
     Returns
     -------

--- a/skimage/morphology/tests/test_flood_fill.py
+++ b/skimage/morphology/tests/test_flood_fill.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from pytest import raises
 
 from skimage.morphology import flood, flood_fill
@@ -252,6 +253,26 @@ def test_basic_nd():
         # Test that the entire array is as expected
         np.testing.assert_equal(
             filled, np.pad(np.ones((3,)*dimension) * 2, 1, 'constant'))
+
+
+@pytest.mark.parametrize("tolerance", [None, 0])
+def test_f_order(tolerance):
+    image = np.array([
+        [0, 0, 0, 0],
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+    ], order="F")
+    expected = np.array([
+        [0, 0, 0, 0],
+        [1, 0, 0, 0],
+        [0, 1, 0, 0],
+    ], dtype=bool)
+
+    mask = flood(image, seed_point=(1, 0), tolerance=tolerance)
+    np.testing.assert_array_equal(expected, mask)
+
+    mask = flood(image, seed_point=(2, 1), tolerance=tolerance)
+    np.testing.assert_array_equal(expected, mask)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Fixes #4549. Previously flood wouldn't work with f-orderded images. This add's missing "order" parameters to `flood` and introduces the same parameter to `_fast_pad`. 

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`