### PR TITLE
Do not enforce pil plugin in skimage.data

### DIFF
--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -268,7 +268,7 @@ def _load(f, as_gray=False):
     # importing io is quite slow since it scans all the backends
     # we lazy import it here
     from ..io import imread
-    return imread(_fetch(f), plugin='pil', as_gray=as_gray)
+    return imread(_fetch(f), as_gray=as_gray)
 
 
 def camera():


### PR DESCRIPTION
## Description

I noticed that the imread call in our data module currently enforces the pil plugin, this was the case even before the integration of pooch by @hmaarrfk 

I propose to leave it to None to let the best plugin to be chosen, imageio in most cases.
 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
- [ ] Consider backporting the PR with `@meeseeksdev backport to v0.14.x`
