### PR TITLE
Bump Pywavelets to 1.0.0

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -79,9 +79,6 @@ Version 0.19
 
 Other
 -----
-* Remove the conditional warning logic when ``numpy`` is set to >= 1.15.0
-  for ``scipy`` and ``pywl`` (``pywavelet``) in ``test_lpi_filter.py`` and
-  ``test_denoise.py`` regarding multidimensional indexing.
 * Remove the conditional import and function call when ``numpy`` is set
   to >= 1.16.0 in ``skimage/util/arraycrop.py``.
 * Remove custom fused type in ``skimage/filters/_max_tree.pyx`` once

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -5,5 +5,5 @@ networkx>=2.0
 pillow>=4.3.0,!=7.1.0,!=7.1.1
 imageio>=2.3.0
 tifffile>=2019.7.26
-PyWavelets>=0.5.2
+PyWavelets>=1.0.0
 pooch>=0.5.2

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -5,5 +5,5 @@ networkx>=2.0
 pillow>=4.3.0,!=7.1.0,!=7.1.1
 imageio>=2.3.0
 tifffile>=2019.7.26
-PyWavelets>=1.0.0
+PyWavelets>=1.1.1
 pooch>=0.5.2

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -857,13 +857,13 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
                 out[..., i] += _min
             out = color.ycbcr2rgb(out)
         else:
-            dwt_axes = tuple(range(image.ndim - 1))
-	    out = _wavelet_threshold(image,
-		                     wavelet=wavelet,
-		                     method=method,
-		                     sigma=sigma, mode=mode,
-		                     wavelet_levels=wavelet_levels,
-		                     dwt_axes=dwt_axes)
+            out = np.empty_like(image)
+            for c in range(image.shape[-1]):
+                out[..., c] = _wavelet_threshold(image[..., c],
+                                                 wavelet=wavelet,
+                                                 method=method,
+                                                 sigma=sigma[c], mode=mode,
+                                                 wavelet_levels=wavelet_levels)
     else:
         out = _wavelet_threshold(image, wavelet=wavelet, method=method,
                                  sigma=sigma, mode=mode,

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -591,8 +591,7 @@ def _wavelet_threshold(image, wavelet, method=None, threshold=None,
     if wavelet_levels is None:
         # Determine the maximum number of possible levels for image
         dlen = wavelet.dec_len
-        wavelet_levels = np.min(
-            [pywt.dwt_max_level(s, dlen) for s in image.shape])
+        wavelet_levels = pywt.dwtn_max_level(image.shape, wavelet)
 
         # Skip coarsest wavelet scales (see Notes in docstring).
         wavelet_levels = max(wavelet_levels - 3, 1)
@@ -858,13 +857,13 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
                 out[..., i] += _min
             out = color.ycbcr2rgb(out)
         else:
-            out = np.empty_like(image)
-            for c in range(image.shape[-1]):
-                out[..., c] = _wavelet_threshold(image[..., c],
-                                                 wavelet=wavelet,
-                                                 method=method,
-                                                 sigma=sigma[c], mode=mode,
-                                                 wavelet_levels=wavelet_levels)
+            dwt_axes = tuple(range(image.ndim - 1))
+	    out = _wavelet_threshold(image,
+		                     wavelet=wavelet,
+		                     method=method,
+		                     sigma=sigma, mode=mode,
+		                     wavelet_levels=wavelet_levels,
+		                     dwt_axes=dwt_axes)
     else:
         out = _wavelet_threshold(image, wavelet=wavelet, method=method,
                                  sigma=sigma, mode=mode,

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -15,11 +15,6 @@ from skimage._shared._warnings import expected_warnings
 from distutils.version import LooseVersion as Version
 
 
-if (Version(pywt.__version__) <= '0.5.2'):
-    PYWAVELET_ND_INDEXING_WARNING = 'Using a non-tuple sequence'
-else:
-    PYWAVELET_ND_INDEXING_WARNING = None
-
 try:
     import dask
 except ImportError:
@@ -471,21 +466,19 @@ def test_wavelet_denoising(img, multichannel, convert2ycbcr):
     noisy = np.clip(noisy, 0, 1)
 
     # Verify that SNR is improved when true sigma is used
-    with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
-        denoised = restoration.denoise_wavelet(noisy, sigma=sigma,
-                                               multichannel=multichannel,
-                                               convert2ycbcr=convert2ycbcr,
-                                               rescale_sigma=True)
+    denoised = restoration.denoise_wavelet(noisy, sigma=sigma,
+                                           multichannel=multichannel,
+                                           convert2ycbcr=convert2ycbcr,
+                                           rescale_sigma=True)
     psnr_noisy = peak_signal_noise_ratio(img, noisy)
     psnr_denoised = peak_signal_noise_ratio(img, denoised)
     assert_(psnr_denoised > psnr_noisy)
 
     # Verify that SNR is improved with internally estimated sigma
-    with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
-        denoised = restoration.denoise_wavelet(noisy,
-                                               multichannel=multichannel,
-                                               convert2ycbcr=convert2ycbcr,
-                                               rescale_sigma=True)
+    denoised = restoration.denoise_wavelet(noisy,
+                                           multichannel=multichannel,
+                                           convert2ycbcr=convert2ycbcr,
+                                           rescale_sigma=True)
     psnr_noisy = peak_signal_noise_ratio(img, noisy)
     psnr_denoised = peak_signal_noise_ratio(img, denoised)
     assert_(psnr_denoised > psnr_noisy)
@@ -501,14 +494,12 @@ def test_wavelet_denoising(img, multichannel, convert2ycbcr):
     assert_(psnr_denoised_1 > psnr_noisy)
 
     # Test changing noise_std (higher threshold, so less energy in signal)
-    with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
-        res1 = restoration.denoise_wavelet(noisy, sigma=2 * sigma,
-                                           multichannel=multichannel,
-                                           rescale_sigma=True)
-    with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
-        res2 = restoration.denoise_wavelet(noisy, sigma=sigma,
-                                           multichannel=multichannel,
-                                           rescale_sigma=True)
+    res1 = restoration.denoise_wavelet(noisy, sigma=2 * sigma,
+                                       multichannel=multichannel,
+                                       rescale_sigma=True)
+    res2 = restoration.denoise_wavelet(noisy, sigma=sigma,
+                                       multichannel=multichannel,
+                                       rescale_sigma=True)
     assert_(np.sum(res1**2) <= np.sum(res2**2))
 
 
@@ -599,9 +590,8 @@ def test_wavelet_threshold():
     noisy = np.clip(noisy, 0, 1)
 
     # employ a single, user-specified threshold instead of BayesShrink sigmas
-    with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
-        denoised = _wavelet_threshold(noisy, wavelet='db1', method=None,
-                                      threshold=sigma)
+    denoised = _wavelet_threshold(noisy, wavelet='db1', method=None,
+                                  threshold=sigma)
     psnr_noisy = peak_signal_noise_ratio(img, noisy)
     psnr_denoised = peak_signal_noise_ratio(img, denoised)
     assert_(psnr_denoised > psnr_noisy)
@@ -611,8 +601,7 @@ def test_wavelet_threshold():
         _wavelet_threshold(noisy, wavelet='db1', method=None, threshold=None)
 
     # warns if a threshold is provided in a case where it would be ignored
-    with expected_warnings(["Thresholding method ",
-                            PYWAVELET_ND_INDEXING_WARNING]):
+    with expected_warnings(["Thresholding method ",):
         _wavelet_threshold(noisy, wavelet='db1', method='BayesShrink',
                            threshold=sigma)
 
@@ -644,11 +633,8 @@ def test_wavelet_denoising_nd(rescale_sigma, method, ndim):
     #   Which includes a numpy 1.15 deprecation.
     #   for larger number of dimensions _match_coeff_dims isn't called
     #   for some reason.
-    anticipated_warnings = (PYWAVELET_ND_INDEXING_WARNING
-                            if ndim < 3 else None)
-    with expected_warnings([anticipated_warnings]):
-        # Verify that SNR is improved with internally estimated sigma
-        denoised = restoration.denoise_wavelet(
+    # Verify that SNR is improved with internally estimated sigma
+    denoised = restoration.denoise_wavelet(
             noisy, method=method,
             rescale_sigma=rescale_sigma)
     psnr_noisy = peak_signal_noise_ratio(img, noisy)
@@ -681,12 +667,11 @@ def test_wavelet_denoising_levels(rescale_sigma):
     noisy = img + sigma * rstate.randn(*(img.shape))
     noisy = np.clip(noisy, 0, 1)
 
-    with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
-        denoised = restoration.denoise_wavelet(noisy, wavelet=wavelet,
-                                               rescale_sigma=rescale_sigma)
-        denoised_1 = restoration.denoise_wavelet(noisy, wavelet=wavelet,
-                                                 wavelet_levels=1,
-                                                 rescale_sigma=rescale_sigma)
+    denoised = restoration.denoise_wavelet(noisy, wavelet=wavelet,
+                                           rescale_sigma=rescale_sigma)
+    denoised_1 = restoration.denoise_wavelet(noisy, wavelet=wavelet,
+                                             wavelet_levels=1,
+                                             rescale_sigma=rescale_sigma)
     psnr_noisy = peak_signal_noise_ratio(img, noisy)
     psnr_denoised = peak_signal_noise_ratio(img, denoised)
     psnr_denoised_1 = peak_signal_noise_ratio(img, denoised_1)
@@ -697,24 +682,15 @@ def test_wavelet_denoising_levels(rescale_sigma):
     # invalid number of wavelet levels results in a ValueError or UserWarning
     max_level = pywt.dwt_max_level(np.min(img.shape),
                                    pywt.Wavelet(wavelet).dec_len)
-    if Version(pywt.__version__) < '1.0.0':
-        # exceeding max_level raises a ValueError in PyWavelets 0.4-0.5.2
-        with testing.raises(ValueError):
-            with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
-                restoration.denoise_wavelet(
-                    noisy, wavelet=wavelet, wavelet_levels=max_level + 1,
-                    rescale_sigma=rescale_sigma)
-    else:
-        # exceeding max_level raises a UserWarning in PyWavelets >= 1.0.0
-        with expected_warnings([
-                'all coefficients will experience boundary effects']):
-            restoration.denoise_wavelet(
-                noisy, wavelet=wavelet, wavelet_levels=max_level + 1,
-                rescale_sigma=rescale_sigma)
+    # exceeding max_level raises a UserWarning in PyWavelets >= 1.0.0
+    with expected_warnings([
+            'all coefficients will experience boundary effects']):
+        restoration.denoise_wavelet(
+            noisy, wavelet=wavelet, wavelet_levels=max_level + 1,
+            rescale_sigma=rescale_sigma)
 
     with testing.raises(ValueError):
-        with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
-            restoration.denoise_wavelet(
+        restoration.denoise_wavelet(
                 noisy,
                 wavelet=wavelet, wavelet_levels=-1,
                 rescale_sigma=rescale_sigma)
@@ -789,17 +765,14 @@ def test_wavelet_denoising_args(rescale_sigma):
                                                 multichannel=multichannel,
                                                 rescale_sigma=rescale_sigma)
                 continue
-            anticipated_warnings = (PYWAVELET_ND_INDEXING_WARNING
-                                    if multichannel else None)
             for sigma in [0.1, [0.1, 0.1, 0.1], None]:
                 if (not multichannel and not convert2ycbcr) or \
                         (isinstance(sigma, list) and not multichannel):
                     continue
-                with expected_warnings([anticipated_warnings]):
-                    restoration.denoise_wavelet(noisy, sigma=sigma,
-                                                convert2ycbcr=convert2ycbcr,
-                                                multichannel=multichannel,
-                                                rescale_sigma=rescale_sigma)
+                restoration.denoise_wavelet(noisy, sigma=sigma,
+                                            convert2ycbcr=convert2ycbcr,
+                                            multichannel=multichannel,
+                                            rescale_sigma=rescale_sigma)
 
 
 @pytest.mark.parametrize('rescale_sigma', [True, False])
@@ -841,8 +814,7 @@ def test_cycle_spinning_multichannel(rescale_sigma):
                        rescale_sigma=rescale_sigma)
 
         # max_shifts=0 is equivalent to just calling denoise_func
-        with expected_warnings([PYWAVELET_ND_INDEXING_WARNING,
-                                DASK_NOT_INSTALLED_WARNING]):
+        with expected_warnings([DASK_NOT_INSTALLED_WARNING]):
             dn_cc = restoration.cycle_spin(noisy, denoise_func, max_shifts=0,
                                            func_kw=func_kw,
                                            multichannel=multichannel)
@@ -851,8 +823,7 @@ def test_cycle_spinning_multichannel(rescale_sigma):
 
         # denoising with cycle spinning will give better PSNR than without
         for max_shifts in valid_shifts:
-            with expected_warnings([PYWAVELET_ND_INDEXING_WARNING,
-                                    DASK_NOT_INSTALLED_WARNING]):
+            with expected_warnings([DASK_NOT_INSTALLED_WARNING]):
                 dn_cc = restoration.cycle_spin(noisy, denoise_func,
                                                max_shifts=max_shifts,
                                                func_kw=func_kw,
@@ -862,8 +833,7 @@ def test_cycle_spinning_multichannel(rescale_sigma):
             assert_(psnr_cc > psnr)
 
         for shift_steps in valid_steps:
-            with expected_warnings([PYWAVELET_ND_INDEXING_WARNING,
-                                    DASK_NOT_INSTALLED_WARNING]):
+            with expected_warnings([DASK_NOT_INSTALLED_WARNING]):
                 dn_cc = restoration.cycle_spin(noisy, denoise_func,
                                                max_shifts=2,
                                                shift_steps=shift_steps,
@@ -898,12 +868,10 @@ def test_cycle_spinning_num_workers():
     func_kw = dict(sigma=sigma, multichannel=True, rescale_sigma=True)
 
     # same results are expected whether using 1 worker or multiple workers
-    with expected_warnings([PYWAVELET_ND_INDEXING_WARNING]):
-        dn_cc1 = restoration.cycle_spin(noisy, denoise_func, max_shifts=1,
+    dn_cc1 = restoration.cycle_spin(noisy, denoise_func, max_shifts=1,
                                         func_kw=func_kw, multichannel=False,
                                         num_workers=1)
-    with expected_warnings([PYWAVELET_ND_INDEXING_WARNING,
-                            DASK_NOT_INSTALLED_WARNING]):
+    with expected_warnings([DASK_NOT_INSTALLED_WARNING,]):
         dn_cc2 = restoration.cycle_spin(noisy, denoise_func, max_shifts=1,
                                         func_kw=func_kw, multichannel=False,
                                         num_workers=4)

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -869,8 +869,8 @@ def test_cycle_spinning_num_workers():
 
     # same results are expected whether using 1 worker or multiple workers
     dn_cc1 = restoration.cycle_spin(noisy, denoise_func, max_shifts=1,
-                                        func_kw=func_kw, multichannel=False,
-                                        num_workers=1)
+                                    func_kw=func_kw, multichannel=False,
+                                    num_workers=1)
     with expected_warnings([DASK_NOT_INSTALLED_WARNING,]):
         dn_cc2 = restoration.cycle_spin(noisy, denoise_func, max_shifts=1,
                                         func_kw=func_kw, multichannel=False,

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -601,7 +601,7 @@ def test_wavelet_threshold():
         _wavelet_threshold(noisy, wavelet='db1', method=None, threshold=None)
 
     # warns if a threshold is provided in a case where it would be ignored
-    with expected_warnings(["Thresholding method ",):
+    with expected_warnings(["Thresholding method ",]):
         _wavelet_threshold(noisy, wavelet='db1', method='BayesShrink',
                            threshold=sigma)
 


### PR DESCRIPTION
## Description

We can discuss either we merge this PR now or after 0.17 is out. This PR corresponds to one of the tasks in the TODO list.
Pywavelets 1.0.0 was released in Aug 2018. https://github.com/PyWavelets/pywt/releases

It also applies the suggestion 2. in #3407 

