### PR TITLE
Remove importing skimage.transform as tf

### DIFF
--- a/doc/examples/features_detection/plot_brief.py
+++ b/doc/examples/features_detection/plot_brief.py
@@ -12,7 +12,7 @@ extracting features at different scales.
 
 """
 from skimage import data
-from skimage import transform as tf
+from skimage import transform
 from skimage.feature import (match_descriptors, corner_peaks, corner_harris,
                              plot_matches, BRIEF)
 from skimage.color import rgb2gray
@@ -20,9 +20,9 @@ import matplotlib.pyplot as plt
 
 
 img1 = rgb2gray(data.astronaut())
-tform = tf.AffineTransform(scale=(1.2, 1.2), translation=(0, -100))
-img2 = tf.warp(img1, tform)
-img3 = tf.rotate(img1, 25)
+tform = transform.AffineTransform(scale=(1.2, 1.2), translation=(0, -100))
+img2 = transform.warp(img1, tform)
+img3 = transform.rotate(img1, 25)
 
 keypoints1 = corner_peaks(corner_harris(img1), min_distance=5)
 keypoints2 = corner_peaks(corner_harris(img2), min_distance=5)

--- a/doc/examples/features_detection/plot_censure.py
+++ b/doc/examples/features_detection/plot_censure.py
@@ -9,7 +9,7 @@ implementation.
 """
 
 from skimage import data
-from skimage import transform as tf
+from skimage import transform
 from skimage.feature import CENSURE
 from skimage.color import rgb2gray
 
@@ -17,9 +17,9 @@ import matplotlib.pyplot as plt
 
 
 img_orig = rgb2gray(data.astronaut())
-tform = tf.AffineTransform(scale=(1.5, 1.5), rotation=0.5,
-                           translation=(150, -200))
-img_warp = tf.warp(img_orig, tform)
+tform = transform.AffineTransform(scale=(1.5, 1.5), rotation=0.5,
+                                  translation=(150, -200))
+img_warp = transform.warp(img_orig, tform)
 
 detector = CENSURE()
 

--- a/doc/examples/features_detection/plot_orb.py
+++ b/doc/examples/features_detection/plot_orb.py
@@ -13,7 +13,7 @@ is preferred for real-time applications.
 
 """
 from skimage import data
-from skimage import transform as tf
+from skimage import transform
 from skimage.feature import (match_descriptors, corner_harris,
                              corner_peaks, ORB, plot_matches)
 from skimage.color import rgb2gray
@@ -21,10 +21,10 @@ import matplotlib.pyplot as plt
 
 
 img1 = rgb2gray(data.astronaut())
-img2 = tf.rotate(img1, 180)
-tform = tf.AffineTransform(scale=(1.3, 1.1), rotation=0.5,
-                           translation=(0, -200))
-img3 = tf.warp(img1, tform)
+img2 = transform.rotate(img1, 180)
+tform = transform.AffineTransform(scale=(1.3, 1.1), rotation=0.5,
+                                  translation=(0, -200))
+img3 = transform.warp(img1, tform)
 
 descriptor_extractor = ORB(n_keypoints=200)
 

--- a/doc/examples/transform/plot_geometric.py
+++ b/doc/examples/transform/plot_geometric.py
@@ -13,7 +13,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from skimage import data
-from skimage import transform as tf
+from skimage import transform
 
 ######################################################################
 # Basics
@@ -29,8 +29,8 @@ from skimage import transform as tf
 #
 # First we create a transformation using explicit parameters:
 
-tform = tf.SimilarityTransform(scale=1, rotation=math.pi/2,
-                               translation=(0, 1))
+tform = transform.SimilarityTransform(scale=1, rotation=math.pi/2,
+                                      translation=(0, 1))
 print(tform.params)
 
 ######################################################################
@@ -39,7 +39,7 @@ print(tform.params)
 
 matrix = tform.params.copy()
 matrix[1, 2] = 2
-tform2 = tf.SimilarityTransform(matrix)
+tform2 = transform.SimilarityTransform(matrix)
 
 ######################################################################
 # These transformation objects can then be used to apply forward and inverse
@@ -58,11 +58,11 @@ print(tform2.inverse(tform(coord)))
 
 text = data.text()
 
-tform = tf.SimilarityTransform(scale=1, rotation=math.pi/4,
-                               translation=(text.shape[0]/2, -100))
+tform = transform.SimilarityTransform(scale=1, rotation=math.pi/4,
+                                      translation=(text.shape[0]/2, -100))
 
-rotated = tf.warp(text, tform)
-back_rotated = tf.warp(rotated, tform.inverse)
+rotated = transform.warp(text, tform)
+back_rotated = transform.warp(rotated, tform.inverse)
 
 fig, ax = plt.subplots(nrows=3)
 
@@ -99,9 +99,9 @@ text = data.text()
 src = np.array([[0, 0], [0, 50], [300, 50], [300, 0]])
 dst = np.array([[155, 15], [65, 40], [260, 130], [360, 95]])
 
-tform3 = tf.ProjectiveTransform()
+tform3 = transform.ProjectiveTransform()
 tform3.estimate(src, dst)
-warped = tf.warp(text, tform3, output_shape=(50, 300))
+warped = transform.warp(text, tform3, output_shape=(50, 300))
 
 fig, ax = plt.subplots(nrows=2, figsize=(8, 3))
 

--- a/doc/source/user_guide/geometrical_transform.rst
+++ b/doc/source/user_guide/geometrical_transform.rst
@@ -47,10 +47,10 @@ Projective transformations can either be created using the explicit
 parameters (e.g. scale, shear, rotation and translation)::
 
    from skimage import data
-   from skimage import transform as tf
+   from skimage import transform
    from skimage import img_as_float
    
-   tform = tf.EuclideanTransform(
+   tform = transform.EuclideanTransform(
       rotation=np.pi / 12.,
       translation = (100, -20)
       )
@@ -58,13 +58,13 @@ parameters (e.g. scale, shear, rotation and translation)::
 or the full transformation matrix::
 
    from skimage import data
-   from skimage import transform as tf
+   from skimage import transform
    from skimage import img_as_float
    
    matrix = np.array([[np.cos(np.pi/12), -np.sin(np.pi/12), 100],
                       [np.sin(np.pi/12), np.cos(np.pi/12), -20],
                       [0, 0, 1]])
-   tform = tf.EuclideanTransform(matrix)
+   tform = transform.EuclideanTransform(matrix)
 
 The transformation matrix of a transform is available as its ``tform.params``
 attribute. Transformations can be composed by multiplying matrices with the
@@ -79,7 +79,7 @@ represented with finite coordinates.
 Transformations can be applied to images using :func:`skimage.transform.warp`::
 
    img = img_as_float(data.chelsea())
-   tf_img = tf.warp(img, tform.inverse)
+   tf_img = transform.warp(img, tform.inverse)
 
 .. image:: ../auto_examples/transform/images/sphx_glr_plot_transform_types_001.png
    :target: ../auto_examples/transform/plot_transform_types.html
@@ -96,9 +96,9 @@ of points (the source and the destination), as explained in the
    src = np.array([[0, 0], [0, 50], [300, 50], [300, 0]])
    dst = np.array([[155, 15], [65, 40], [260, 130], [360, 95]])
 
-   tform3 = tf.ProjectiveTransform()
+   tform3 = transform.ProjectiveTransform()
    tform3.estimate(src, dst)
-   warped = tf.warp(text, tform3, output_shape=(50, 300))
+   warped = transform.warp(text, tform3, output_shape=(50, 300))
 
 
 .. image:: ../auto_examples/transform/images/sphx_glr_plot_geometric_002.png

--- a/skimage/feature/tests/test_match.py
+++ b/skimage/feature/tests/test_match.py
@@ -80,8 +80,8 @@ def test_binary_descriptors_rotation_crosscheck_true():
     cross_check enabled."""
     img = data.astronaut()
     img = rgb2gray(img)
-    tform = tf.SimilarityTransform(scale=1, rotation=0.15, translation=(0, 0))
-    rotated_img = tf.warp(img, tform, clip=False)
+    tform = transform.SimilarityTransform(scale=1, rotation=0.15, translation=(0, 0))
+    rotated_img = transform.warp(img, tform, clip=False)
 
     extractor = BRIEF(descriptor_size=512)
 

--- a/skimage/feature/tests/test_match.py
+++ b/skimage/feature/tests/test_match.py
@@ -1,7 +1,7 @@
 import numpy as np
 from skimage._shared.testing import assert_equal
 from skimage import data
-from skimage import transform as tf
+from skimage import transform
 from skimage.color import rgb2gray
 from skimage.feature import (BRIEF, match_descriptors,
                              corner_peaks, corner_harris)
@@ -33,8 +33,8 @@ def test_binary_descriptors_rotation_crosscheck_false():
     cross_check disabled."""
     img = data.astronaut()
     img = rgb2gray(img)
-    tform = tf.SimilarityTransform(scale=1, rotation=0.15, translation=(0, 0))
-    rotated_img = tf.warp(img, tform, clip=False)
+    tform = transform.SimilarityTransform(scale=1, rotation=0.15, translation=(0, 0))
+    rotated_img = transform.warp(img, tform, clip=False)
 
     extractor = BRIEF(descriptor_size=512)
 

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1367,13 +1367,13 @@ def estimate_transform(ttype, src, dst, **kwargs):
     Examples
     --------
     >>> import numpy as np
-    >>> from skimage import transform as tf
+    >>> from skimage import transform
 
     >>> # estimate transformation parameters
     >>> src = np.array([0, 0, 10, 10]).reshape((2, 2))
     >>> dst = np.array([12, 14, 1, -20]).reshape((2, 2))
 
-    >>> tform = tf.estimate_transform('similarity', src, dst)
+    >>> tform = transform.estimate_transform('similarity', src, dst)
 
     >>> np.allclose(tform.inverse(tform(src)), src)
     True
@@ -1385,7 +1385,7 @@ def estimate_transform(ttype, src, dst, **kwargs):
     >>> warp(image, inverse_map=tform.inverse) # doctest: +SKIP
 
     >>> # create transformation with explicit parameters
-    >>> tform2 = tf.SimilarityTransform(scale=1.1, rotation=1,
+    >>> tform2 = transform.SimilarityTransform(scale=1.1, rotation=1,
     ...     translation=(10, 20))
 
     >>> # unite transformations, applied in order from left to right

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -9,7 +9,7 @@ from skimage.transform import (warp, warp_coords, rotate, resize, rescale,
                                SimilarityTransform,
                                downscale_local_mean,
                                warp_polar)
-from skimage import transform as tf, data, img_as_float
+from skimage import transform, data, img_as_float
 from skimage.color import rgb2gray
 from skimage.draw import circle_perimeter_aa
 from skimage.feature import peak_local_max
@@ -358,16 +358,16 @@ def test_swirl():
     swirl_params = {'radius': 80, 'rotation': 0, 'order': 2, 'mode': 'reflect'}
 
     with expected_warnings(['Bi-quadratic.*bug']):
-        swirled = tf.swirl(image, strength=10, **swirl_params)
-        unswirled = tf.swirl(swirled, strength=-10, **swirl_params)
+        swirled = transform.swirl(image, strength=10, **swirl_params)
+        unswirled = transform.swirl(swirled, strength=-10, **swirl_params)
 
     assert np.mean(np.abs(image - unswirled)) < 0.01
 
     swirl_params.pop('mode')
 
     with expected_warnings(['Bi-quadratic.*bug']):
-        swirled = tf.swirl(image, strength=10, **swirl_params)
-        unswirled = tf.swirl(swirled, strength=-10, **swirl_params)
+        swirled = transform.swirl(image, strength=10, **swirl_params)
+        unswirled = transform.swirl(swirled, strength=-10, **swirl_params)
 
     assert np.mean(np.abs(image[1:-1, 1:-1] - unswirled[1:-1, 1:-1])) < 0.01
 


### PR DESCRIPTION
## Description

Fixes [issue #4572](https://github.com/scikit-image/scikit-image/issues/4572).

Remove importing `skimage.transform as tf` in favor of just importing it as `transform`.

The motiviation is that `tf` is a commonly-used abbreviation for TensorFlow, and we want to avoid people mistaking `skimage.transform` for TensorFlow in this library's source code. 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
