### PR TITLE
Add note to remove option in doc config when numpydoc will be patched

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -109,3 +109,7 @@ Other
   when texlive 2020 is available.
 * Once NumPy is set to >= 1.17, consider removing
   ``skimage.morphology._util._fast_pad``.
+* Once numpydoc > 0.9.x (ie https://github.com/numpy/numpydoc/pull/256) is
+  released, remove `strip_signature_backslash = True` in
+  ``doc/source/conf.py``.
+

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -30,6 +30,7 @@ sys.path.append(os.path.join(curpath, '..', 'ext'))
 # -- General configuration -----------------------------------------------------
 
 # Strip backslahes in function's signature
+# To be removed when numpydoc > 0.9.x
 strip_signature_backslash = True
 
 # Add any Sphinx extension module names here, as strings. They can be extensions


### PR DESCRIPTION

## Description

This follows a former PR: https://github.com/scikit-image/scikit-image/pull/4569

One of the sphinx dev pushed [a patch to numpydoc](https://github.com/numpy/numpydoc/pull/256) to prevent natively the issue that I reported here: https://github.com/scikit-image/scikit-image/issues/4566
Then, the additional line will be useless.