### PR TITLE
Sort naturally peaks coordinates of same amplitude in peak_local_max

### DIFF
--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -951,10 +951,10 @@ def corner_peaks(image, min_distance=1, threshold_abs=None, threshold_rel=None,
            [0., 0., 1., 1., 0.],
            [0., 0., 0., 0., 0.]])
     >>> peak_local_max(response)
-    array([[3, 3],
-           [3, 2],
+    array([[2, 2],
            [2, 3],
-           [2, 2]])
+           [3, 2],
+           [3, 3]])
     >>> corner_peaks(response, threshold_rel=0)
     array([[2, 2]])
 

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -12,7 +12,7 @@ def _get_high_intensity_peaks(image, mask, num_peaks):
     coord = np.nonzero(mask)
     intensities = image[coord]
     # Highest peak first
-    idx_maxsort = np.argsort(intensities)[::-1]
+    idx_maxsort = np.argsort(-intensities)
     coord = np.transpose(coord)[idx_maxsort]
     # select num_peaks peaks
     if len(coord) > num_peaks:


### PR DESCRIPTION
## Description

Fixes #4580. This PR is the one line fix proposed [here](https://github.com/scikit-image/scikit-image/pull/4218#issuecomment-612641502).

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
