### PR TITLE
Update rescale_intensity to prevent under/overflow and produce proper output dtype

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -37,6 +37,9 @@ API Changes
   ``'reflect'``, which allows meaningful values at the borders for these
   filters. To retain the old behavior, pass
   ``mask=np.ones(image.shape, dtype=bool)`` (#4347)
+- When ``out_range`` is a range of numbers and not a dtype in
+  :func:`skimage.exposure.rescale_intensity`, the output data type will always
+  be float.
 
 
 Bugfixes

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -39,7 +39,10 @@ API Changes
   ``mask=np.ones(image.shape, dtype=bool)`` (#4347)
 - When ``out_range`` is a range of numbers and not a dtype in
   :func:`skimage.exposure.rescale_intensity`, the output data type will always
-  be float.
+  be float (#4585)
+- The values returned by :func:`skimage.exposure.equalize_adapthist` will be
+  slightly different from previous versions due to different rounding behavior
+  (#4585)
 
 
 Bugfixes

--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -75,7 +75,9 @@ def equalize_adapthist(image, kernel_size=None,
         return img_as_float(image)  # convert to float for consistency
 
     image = img_as_uint(image)
-    image = rescale_intensity(image, out_range=(0, NR_OF_GRAY - 1))
+    image = np.round(
+        rescale_intensity(image, out_range=(0, NR_OF_GRAY - 1))
+    ).astype(np.uint16)
 
     if kernel_size is None:
         kernel_size = (image.shape[0] // 8, image.shape[1] // 8)

--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -65,6 +65,10 @@ def equalize_adapthist(image, kernel_size=None,
        - The image is converted back to RGB space and returned
     * For RGBA images, the original alpha channel is removed.
 
+    .. versionchanged:: 0.17
+        The values returned by this function are slightly shifted upwards
+        because of an internal change in rounding behavior.
+
     References
     ----------
     .. [1] http://tog.acm.org/resources/GraphicsGems/

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -271,8 +271,8 @@ def _output_dtype(dtype_or_range):
 
     The dtype is determined according to the following rules:
     - if ``dtype_or_range`` is a dtype, that is the output dtype.
-    - if ``dtype_or_range`` is a dtype string, that is the dtype used, unless it
-      is not a NumPy data type (e.g. 'uint12' for 12-bit unsigned integers),
+    - if ``dtype_or_range`` is a dtype string, that is the dtype used, unless
+      it is not a NumPy data type (e.g. 'uint12' for 12-bit unsigned integers),
       in which case the data type that can contain it will be used
       (e.g. uint16 in this case).
     - if ``dtype_or_range`` is a pair of values, the output data type will be

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -270,12 +270,12 @@ def _output_dtype(dtype_or_range):
     """Determine the output dtype for rescale_intensity.
 
     The dtype is determined according to the following rules:
-    - if ``out_range`` is a dtype, that is the output dtype.
-    - if ``out_range`` is a dtype string, that is the dtype used, unless it
+    - if ``dtype_or_range`` is a dtype, that is the output dtype.
+    - if ``dtype_or_range`` is a dtype string, that is the dtype used, unless it
       is not a NumPy data type (e.g. 'uint12' for 12-bit unsigned integers),
       in which case the data type that can contain it will be used
       (e.g. uint16 in this case).
-    - if ``out_range`` is a pair of values, the output data type will be
+    - if ``dtype_or_range`` is a pair of values, the output data type will be
       float.
 
     Parameters

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -303,6 +303,11 @@ def _output_dtype(dtype_or_range):
         except TypeError:  # uint10, uint12, uint14
             # otherwise, return uint16
             return np.uint16
+    else:
+        raise ValueError(
+            'Incorrect value for out_range, should be a valid image data '
+            f'type or a pair of values, got {dtype_or_range}.'
+        )
 
 
 def rescale_intensity(image, in_range='image', out_range='dtype'):

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -385,9 +385,8 @@ def rescale_intensity(image, in_range='image', out_range='dtype'):
     array([  0,  63, 127], dtype=int8)
 
     """
-    input_dtype = image.dtype.type
     if out_range in ['dtype', 'image']:
-        out_dtype = _output_dtype(input_dtype)
+        out_dtype = _output_dtype(image.dtype.type)
     else:
         out_dtype = _output_dtype(out_range)
 

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -341,6 +341,12 @@ def rescale_intensity(image, in_range='image', out_range='dtype'):
         Image array after rescaling its intensity. This image is the same dtype
         as the input image.
 
+    Notes
+    -----
+    .. versionchanged:: 0.17
+        The dtype of the output array has changed to match the output dtype, or
+        float if the output range is specified by a pair of floats.
+
     See Also
     --------
     equalize_hist

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -374,10 +374,15 @@ def rescale_intensity(image, in_range='image', out_range='dtype'):
     array([  0,  63, 127], dtype=int8)
 
     """
-    dtype = image.dtype.type
+    input_dtype = image.dtype.type
+    if out_range in ['dtype', 'image']:
+        out_dtype = _output_dtype(input_dtype)
+    else:
+        out_dtype = _output_dtype(out_range)
 
-    imin, imax = intensity_range(image, in_range)
-    omin, omax = intensity_range(image, out_range, clip_negative=(imin >= 0))
+    imin, imax = map(float, intensity_range(image, in_range))
+    omin, omax = map(float, intensity_range(image, out_range,
+                                            clip_negative=(imin >= 0)))
 
     # Fast test for multiple values, operations with at least 1 NaN return NaN
     if np.isnan(imin + imax + omin + omax):
@@ -391,8 +396,8 @@ def rescale_intensity(image, in_range='image', out_range='dtype'):
     image = np.clip(image, imin, imax)
 
     if imin != imax:
-        image = (image - imin) / float(imax - imin)
-    return np.asarray(image * (omax - omin) + omin, dtype=dtype)
+        image = (image - imin) / (imax - imin)
+    return np.asarray(image * (omax - omin) + omin, dtype=out_dtype)
 
 
 def _assert_non_negative(image):

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -266,6 +266,39 @@ def intensity_range(image, range_values='image', clip_negative=False):
     return i_min, i_max
 
 
+def _output_dtype(out_range):
+    """Determine the output dtype for rescale_intensity.
+
+    The dtype is determined according to the following rules:
+    - if ``out_range`` is a dtype, that is the output dtype.
+    - if ``out_range`` is a dtype string, that is the dtype used, unless it
+      is not a NumPy data type (e.g. 'uint12' for 12-bit unsigned integers),
+      in which case the data type that can contain it will be used
+      (e.g. uint16 in this case).
+    - if ``out_range`` is a pair of values, the output data type will be
+      float.
+
+    Parameters
+    ----------
+    out_dtype : type
+        The data type appropriate for the desired output.
+    """
+    if type(out_range) in [list, tuple, np.ndarray]:
+        # pair of values: always return float.
+        return np.float_
+    if type(out_range) == type:
+        # already a type: return it
+        return out_range
+    if out_range in DTYPE_RANGE:
+        # string key in DTYPE_RANGE dictionary
+        try:
+            # if it's a canonical numpy dtype, convert
+            return np.dtype(out_range).type
+        except TypeError:  # uint10, uint12, uint14
+            # otherwise, return uint16
+            return np.uint16
+
+
 def rescale_intensity(image, in_range='image', out_range='dtype'):
     """Return image after stretching or shrinking its intensity levels.
 

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -378,12 +378,17 @@ def rescale_intensity(image, in_range='image', out_range='dtype'):
     array([0.5, 1. , 1. ])
 
     If you have an image with signed integers but want to rescale the image to
-    just the positive range, use the `out_range` parameter:
+    just the positive range, use the `out_range` parameter. In that case, the
+    output dtype will be float:
 
     >>> image = np.array([-10, 0, 10], dtype=np.int8)
     >>> rescale_intensity(image, out_range=(0, 127))
-    array([  0,  63, 127], dtype=int8)
+    array([  0. ,  63.5, 127. ])
 
+    To get the desired range with a specific dtype, use ``.astype()``:
+
+    >>> rescale_intensity(image, out_range=(0, 127)).astype(np.int8)
+    array([  0,  63, 127], dtype=int8)
     """
     if out_range in ['dtype', 'image']:
         out_dtype = _output_dtype(image.dtype.type)

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -266,7 +266,7 @@ def intensity_range(image, range_values='image', clip_negative=False):
     return i_min, i_max
 
 
-def _output_dtype(out_range):
+def _output_dtype(dtype_or_range):
     """Determine the output dtype for rescale_intensity.
 
     The dtype is determined according to the following rules:
@@ -280,20 +280,26 @@ def _output_dtype(out_range):
 
     Parameters
     ----------
+    dtype_or_range : type, string, or 2-tuple of int/float
+        The desired range for the output, expressed as either a NumPy dtype or
+        as a (min, max) pair of numbers.
+
+    Returns
+    -------
     out_dtype : type
         The data type appropriate for the desired output.
     """
-    if type(out_range) in [list, tuple, np.ndarray]:
+    if type(dtype_or_range) in [list, tuple, np.ndarray]:
         # pair of values: always return float.
         return np.float_
-    if type(out_range) == type:
+    if type(dtype_or_range) == type:
         # already a type: return it
-        return out_range
-    if out_range in DTYPE_RANGE:
+        return dtype_or_range
+    if dtype_or_range in DTYPE_RANGE:
         # string key in DTYPE_RANGE dictionary
         try:
             # if it's a canonical numpy dtype, convert
-            return np.dtype(out_range).type
+            return np.dtype(dtype_or_range).type
         except TypeError:  # uint10, uint12, uint14
             # otherwise, return uint16
             return np.uint16

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -346,6 +346,12 @@ def test_rescale_float_output():
     testing.assert_array_equal(output_image, [0, 128, 255])
     assert output_image.dtype == np.float_
 
+
+def test_rescale_raises_on_incorrect_out_range():
+    image = np.array([-128, 0, 127], dtype=np.int8)
+    with testing.raises(ValueError):
+        _ = exposure.rescale_intensity(image, out_range='flat')
+
 # Test adaptive histogram equalization
 # ====================================
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -318,6 +318,34 @@ def test_rescale_nan_warning(in_range, out_range):
         exposure.rescale_intensity(image, in_range, out_range)
 
 
+@pytest.mark.parametrize(
+    "out_range, out_dtype", [
+        ('uint8', np.uint8),
+        ('uint10', np.uint16),
+        ('uint12', np.uint16),
+        ('uint16', np.uint16),
+        ('float', np.float_),
+    ]
+)
+def test_rescale_output_dtype(out_range, out_dtype):
+    image = np.array([-128, 0, 127], dtype=np.int8)
+    output_image = exposure.rescale_intensity(image, out_range=out_range)
+    assert output_image.dtype == out_dtype
+
+
+def test_rescale_no_overflow():
+    image = np.array([-128, 0, 127], dtype=np.int8)
+    output_image = exposure.rescale_intensity(image, out_range=np.uint8)
+    testing.assert_array_equal(output_image, [0, 128, 255])
+    assert output_image.dtype == np.uint8
+
+
+def test_rescale_float_output():
+    image = np.array([-128, 0, 127], dtype=np.int8)
+    output_image = exposure.rescale_intensity(image, out_range=(0, 255))
+    testing.assert_array_equal(output_image, [0, 128, 255])
+    assert output_image.dtype == np.float_
+
 # Test adaptive histogram equalization
 # ====================================
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -358,7 +358,7 @@ def test_adapthist_grayscale():
     adapted = exposure.equalize_adapthist(img, kernel_size=(57, 51),
                                           clip_limit=0.01, nbins=128)
     assert img.shape == adapted.shape
-    assert_almost_equal(peak_snr(img, adapted), 102.078, 3)
+    assert_almost_equal(peak_snr(img, adapted), 102.019, 3)
     assert_almost_equal(norm_brightness_err(img, adapted), 0.0529, 3)
 
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -237,10 +237,16 @@ def test_rescale_in_range_clip():
 
 
 def test_rescale_out_range():
+    """Check that output range is correct.
+
+    .. versionchanged:: 0.17
+        This function used to return dtype matching the input dtype. It now
+        matches the output.
+    """
     image = np.array([-10, 0, 10], dtype=np.int8)
     out = exposure.rescale_intensity(image, out_range=(0, 127))
-    assert out.dtype == np.int8
-    assert_array_almost_equal(out, [0, 63, 127])
+    assert out.dtype == np.float_
+    assert_array_almost_equal(out, [0, 63.5, 127])
 
 
 def test_rescale_named_in_range():


### PR DESCRIPTION
## Description

Fixes #4583 

- All computations are now in float, preventing under/overflow
- If `out_range` is a dtype, then the output will be in that dtype (currently it is the input dtype, which is insane).
- If `out_range` is a range of numbers, the output will be of type float and the caller will be responsible for converting to the correct dtype. **This is a breaking change in some circumstances.** See our use of `rescale_intensity` within `equalize_adapthist` which I had to fix.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] ~~Gallery example in `./doc/examples` (new features only)~~
- [ ] ~~Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark~~
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
