### PR TITLE
Revert "Skip extra deps on OSX (#3898)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ matrix:
     - os: osx
       osx_image: xcode9.4
       language: objective-c
-      env: MB_PYTHON_VERSION=3.7 OPTIONAL_DEPS=1 EXTRA_DEPS=0
+      env: MB_PYTHON_VERSION=3.7 OPTIONAL_DEPS=1
     - os: osx
       osx_image: xcode9.4
       language: objective-c
@@ -166,11 +166,7 @@ install:
     - |
       if [[ "${OPTIONAL_DEPS}" == "1" ]]; then
         pip install --retries 3 -r ./requirements/optional.txt $WHEELHOUSE
-        if [[ "${EXTRA_DEPS}" != "0" ]]; then
-          # Extra deps need compilation, and it may not always be possible to
-          # compile them easily on all platforms
-          pip install --retries 3 -r ./requirements/extras.txt $WHEELHOUSE
-        fi
+        pip install --retries 3 -r ./requirements/extras.txt $WHEELHOUSE
       fi
     - tools/travis/install_qt.sh
 


### PR DESCRIPTION
This reverts commit 5b8f675a26f407c4ef54b05e9b8b6b57eb91f566.

Fixes #4584

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
