### PR TITLE
Rename convert to _convert, as it is a private function

### DIFF
--- a/benchmarks/benchmark_transform_warp.py
+++ b/benchmarks/benchmark_transform_warp.py
@@ -1,6 +1,6 @@
 import numpy as np
 from skimage.transform import SimilarityTransform, warp
-from skimage.util.dtype import convert
+from skimage.util.dtype import _convert as convert
 import warnings
 import functools
 import inspect

--- a/skimage/color/adapt_rgb.py
+++ b/skimage/color/adapt_rgb.py
@@ -3,7 +3,7 @@ import functools
 import numpy as np
 
 from .. import color
-from ..util.dtype import convert
+from ..util.dtype import _convert
 
 
 __all__ = ['adapt_rgb', 'hsv_value', 'each_channel']
@@ -58,7 +58,7 @@ def hsv_value(image_filter, image, *args, **kwargs):
     hsv = color.rgb2hsv(image[:, :, :3])
     value = hsv[:, :, 2].copy()
     value = image_filter(value, *args, **kwargs)
-    hsv[:, :, 2] = convert(value, hsv.dtype)
+    hsv[:, :, 2] = _convert(value, hsv.dtype)
     return color.hsv2rgb(hsv)
 
 

--- a/skimage/io/_plugins/imread_plugin.py
+++ b/skimage/io/_plugins/imread_plugin.py
@@ -1,6 +1,6 @@
 __all__ = ['imread', 'imsave']
 
-from ...util.dtype import convert
+from ...util.dtype import _convert
 
 try:
     import imread as _imread
@@ -21,7 +21,7 @@ def imread(fname, dtype=None):
     """
     im = _imread.imread(fname)
     if dtype is not None:
-        im = convert(im, dtype)
+        im = _convert(im, dtype)
     return im
 
 

--- a/skimage/registration/_optical_flow_utils.py
+++ b/skimage/registration/_optical_flow_utils.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 from skimage.transform import pyramid_reduce
-from skimage.util.dtype import convert
+from skimage.util.dtype import _convert
 from scipy import ndimage as ndi
 
 
@@ -110,9 +110,9 @@ def coarse_to_fine(I0, I1, solver, downscale=2, nlevel=10, min_size=16,
         raise ValueError("Only floating point data type are valid"
                          " for optical flow")
 
-    pyramid = list(zip(get_pyramid(convert(I0, dtype),
+    pyramid = list(zip(get_pyramid(_convert(I0, dtype),
                                    downscale, nlevel, min_size),
-                       get_pyramid(convert(I1, dtype),
+                       get_pyramid(_convert(I1, dtype),
                                    downscale, nlevel, min_size)))
 
     # Initialization to 0 at coarsest level.

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -173,7 +173,7 @@ def _scale(a, n, m, copy=True):
             return a
 
 
-def convert(image, dtype, force_copy=False, uniform=False):
+def _convert(image, dtype, force_copy=False, uniform=False):
     """
     Convert an image to the requested data-type.
 
@@ -203,7 +203,7 @@ def convert(image, dtype, force_copy=False, uniform=False):
         conversion errors.
 
     .. versionchanged :: 0.15
-        ``convert`` no longer warns about possible precision or sign
+        ``_convert`` no longer warns about possible precision or sign
         information loss. See discussions on these warnings at:
         https://github.com/scikit-image/scikit-image/issues/2602
         https://github.com/scikit-image/scikit-image/issues/543#issuecomment-208202228
@@ -372,7 +372,7 @@ def img_as_float32(image, force_copy=False):
     and can be outside the ranges [0.0, 1.0] or [-1.0, 1.0].
 
     """
-    return convert(image, np.float32, force_copy)
+    return _convert(image, np.float32, force_copy)
 
 
 def img_as_float64(image, force_copy=False):
@@ -398,7 +398,7 @@ def img_as_float64(image, force_copy=False):
     and can be outside the ranges [0.0, 1.0] or [-1.0, 1.0].
 
     """
-    return convert(image, np.float64, force_copy)
+    return _convert(image, np.float64, force_copy)
 
 
 def img_as_float(image, force_copy=False):
@@ -427,7 +427,7 @@ def img_as_float(image, force_copy=False):
     and can be outside the ranges [0.0, 1.0] or [-1.0, 1.0].
 
     """
-    return convert(image, np.floating, force_copy)
+    return _convert(image, np.floating, force_copy)
 
 
 def img_as_uint(image, force_copy=False):
@@ -451,7 +451,7 @@ def img_as_uint(image, force_copy=False):
     Positive values are scaled between 0 and 65535.
 
     """
-    return convert(image, np.uint16, force_copy)
+    return _convert(image, np.uint16, force_copy)
 
 
 def img_as_int(image, force_copy=False):
@@ -476,7 +476,7 @@ def img_as_int(image, force_copy=False):
     the output image will still only have positive values.
 
     """
-    return convert(image, np.int16, force_copy)
+    return _convert(image, np.int16, force_copy)
 
 
 def img_as_ubyte(image, force_copy=False):
@@ -500,7 +500,7 @@ def img_as_ubyte(image, force_copy=False):
     Positive values are scaled between 0 and 255.
 
     """
-    return convert(image, np.uint8, force_copy)
+    return _convert(image, np.uint8, force_copy)
 
 
 def img_as_bool(image, force_copy=False):
@@ -524,4 +524,4 @@ def img_as_bool(image, force_copy=False):
     half is False. All negative values (if present) are False.
 
     """
-    return convert(image, np.bool_, force_copy)
+    return _convert(image, np.bool_, force_copy)

--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -4,7 +4,7 @@ import numpy as np
 import itertools
 from skimage import (img_as_float, img_as_float32, img_as_float64,
                      img_as_int, img_as_uint, img_as_ubyte)
-from skimage.util.dtype import convert
+from skimage.util.dtype import _convert
 
 from skimage._shared._warnings import expected_warnings
 from skimage._shared import testing
@@ -51,7 +51,7 @@ def test_range(dtype, f_and_dt):
                   y, omin, omax, np.dtype(dt))
 
 
-# Add non-standard data types that are allowed by the `convert` function.
+# Add non-standard data types that are allowed by the `_convert` function.
 dtype_range_extra = dtype_range.copy()
 dtype_range_extra.update({np.int32: (-2147483648, 2147483647),
                           np.uint32: (0, 4294967295)})
@@ -71,7 +71,7 @@ def test_range_extra_dtypes(dtype_in, dt):
     imin, imax = dtype_range_extra[dtype_in]
     x = np.linspace(imin, imax, 10).astype(dtype_in)
 
-    y = convert(x, dt)
+    y = _convert(x, dt)
 
     omin, omax = dtype_range_extra[dt]
     _verify_range("From %s to %s" % (np.dtype(dtype_in), np.dtype(dt)),
@@ -163,7 +163,7 @@ def test_float_conversion_dtype():
 
     for dtype_in, dtype_out in dtype_combin:
         x = x.astype(dtype_in)
-        y = convert(x, dtype_out)
+        y = _convert(x, dtype_out)
         assert y.dtype == np.dtype(dtype_out)
 
 
@@ -173,5 +173,5 @@ def test_subclass_conversion():
 
     for dtype in float_dtype_list:
         x = x.astype(dtype)
-        y = convert(x, np.floating)
+        y = _convert(x, np.floating)
         assert y.dtype == x.dtype


### PR DESCRIPTION
## Description
I do not understand why `convert`, which is not a private function, is not exposed in the API.

I'm opened to discussion with this PR.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
