### PR TITLE
[CI fix] add import_array in cython files where numpy is cimport-ed

### DIFF
--- a/skimage/_shared/fast_exp.pyx
+++ b/skimage/_shared/fast_exp.pyx
@@ -2,7 +2,7 @@ import numpy as np
 cimport numpy as cnp
 from .fused_numerics cimport np_floats
 from .fast_exp cimport _fast_exp
-
+cnp.import_array()
 
 def fast_exp(np_floats x):
     return _fast_exp(x)

--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -9,6 +9,8 @@ cimport numpy as cnp
 from libc.math cimport sqrt, sin, cos, floor, ceil, fabs
 from .._shared.geometry cimport point_in_polygon
 
+cnp.import_array()
+
 
 def _coords_inside_image(rr, cc, shape, val=None):
     """

--- a/skimage/feature/_cascade.pyx
+++ b/skimage/feature/_cascade.pyx
@@ -22,6 +22,7 @@ import xml.etree.ElementTree as ET
 from ._texture cimport _multiblock_lbp
 import math
 
+cnp.import_array()
 
 # Struct for storing a single detection.
 cdef struct Detection:

--- a/skimage/feature/_hessian_det_appx.pyx
+++ b/skimage/feature/_hessian_det_appx.pyx
@@ -5,6 +5,8 @@
 import numpy as np
 cimport numpy as cnp
 
+cnp.import_array()
+
 
 cdef inline Py_ssize_t _clip(Py_ssize_t x, Py_ssize_t low,
                              Py_ssize_t high) nogil:

--- a/skimage/feature/_hoghistogram.pyx
+++ b/skimage/feature/_hoghistogram.pyx
@@ -4,7 +4,7 @@
 
 import numpy as np
 cimport numpy as cnp
-
+cnp.import_array()
 
 cdef float cell_hog(double[:, ::1] magnitude,
                     double[:, ::1] orientation,

--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -14,6 +14,7 @@ cdef extern from "numpy/npy_math.h":
 from .._shared.fused_numerics cimport np_anyint as any_int
 from .._shared.fused_numerics cimport np_real_numeric
 
+cnp.import_array()
 
 def _glcm_loop(any_int[:, ::1] image, double[:] distances,
                double[:] angles, Py_ssize_t levels,

--- a/skimage/feature/brief_cy.pyx
+++ b/skimage/feature/brief_cy.pyx
@@ -4,7 +4,7 @@
 #cython: wraparound=False
 
 cimport numpy as cnp
-
+cnp.import_array()
 
 def _brief_loop(double[:, ::1] image, unsigned char[:, ::1] descriptors,
                 Py_ssize_t[:, ::1] keypoints,

--- a/skimage/feature/corner_cy.pyx
+++ b/skimage/feature/corner_cy.pyx
@@ -11,6 +11,7 @@ from ..util import img_as_float64
 
 from .util import _prepare_grayscale_input_2D
 
+cnp.import_array()
 
 def _corner_moravec(image, Py_ssize_t window_size=1):
     """Compute Moravec corner measure response image.

--- a/skimage/filters/_multiotsu.pyx
+++ b/skimage/filters/_multiotsu.pyx
@@ -6,7 +6,7 @@ import numpy as np
 
 cimport numpy as cnp
 cimport cython
-
+cnp.import_array()
 
 def _get_multiotsu_thresh_indices_lut(float [::1] prob,
                                       Py_ssize_t thresh_count):

--- a/skimage/filters/rank/bilateral_cy.pyx
+++ b/skimage/filters/rank/bilateral_cy.pyx
@@ -8,6 +8,7 @@ from libc.math cimport log
 
 from .core_cy cimport dtype_t, dtype_t_out, _core
 
+cnp.import_array()
 
 cdef inline void _kernel_mean(dtype_t_out* out, Py_ssize_t odepth,
                               Py_ssize_t* histo,

--- a/skimage/filters/rank/core_cy.pyx
+++ b/skimage/filters/rank/core_cy.pyx
@@ -8,6 +8,7 @@ import numpy as np
 cimport numpy as cnp
 from libc.stdlib cimport malloc, free
 
+cnp.import_array()
 
 cdef inline dtype_t _max(dtype_t a, dtype_t b) nogil:
     return a if a >= b else b

--- a/skimage/filters/rank/generic_cy.pyx
+++ b/skimage/filters/rank/generic_cy.pyx
@@ -10,6 +10,8 @@ from .core_cy cimport dtype_t, dtype_t_out, _core
 
 from ..._shared.interpolation cimport round
 
+cnp.import_array()
+
 cdef inline void _kernel_autolevel(dtype_t_out* out, Py_ssize_t odepth,
                                    Py_ssize_t* histo,
                                    double pop, dtype_t g,

--- a/skimage/filters/rank/percentile_cy.pyx
+++ b/skimage/filters/rank/percentile_cy.pyx
@@ -5,7 +5,7 @@
 
 cimport numpy as cnp
 from .core_cy cimport dtype_t, dtype_t_out, _core, _min, _max
-
+cnp.import_array()
 
 cdef inline void _kernel_autolevel(dtype_t_out* out, Py_ssize_t odepth,
                                    Py_ssize_t* histo,

--- a/skimage/future/graph/_ncut_cy.pyx
+++ b/skimage/future/graph/_ncut_cy.pyx
@@ -4,7 +4,7 @@
 # cython: wraparound=False
 cimport numpy as cnp
 import numpy as np
-
+cnp.import_array()
 
 def argmin2(cnp.double_t[:] array):
     """Return the index of the 2nd smallest value in an array.

--- a/skimage/graph/_mcp.pyx
+++ b/skimage/graph/_mcp.pyx
@@ -41,6 +41,8 @@ from .._shared.utils import warn
 cimport numpy as cnp
 from . cimport heap
 
+cnp.import_array()
+
 OFFSET_D = np.int8
 OFFSETS_INDEX_D = np.int16
 EDGE_D = np.int8

--- a/skimage/io/_plugins/_colormixer.pyx
+++ b/skimage/io/_plugins/_colormixer.pyx
@@ -14,6 +14,7 @@ one.
 
 cimport numpy as cnp
 from libc.math cimport exp, pow
+cnp.import_array()
 
 
 def add(cnp.ndarray[cnp.uint8_t, ndim=3] img,

--- a/skimage/io/_plugins/_colormixer.pyx
+++ b/skimage/io/_plugins/_colormixer.pyx
@@ -14,7 +14,6 @@ one.
 
 cimport numpy as cnp
 from libc.math cimport exp, pow
-cnp.import_array()
 
 
 def add(cnp.ndarray[cnp.uint8_t, ndim=3] img,

--- a/skimage/io/_plugins/_histograms.pyx
+++ b/skimage/io/_plugins/_histograms.pyx
@@ -5,6 +5,7 @@
 import numpy as np
 
 cimport numpy as cnp
+cnp.import_array()
 
 
 cdef inline float tri_max(float a, float b, float c):

--- a/skimage/io/tests/test_colormixer.py
+++ b/skimage/io/tests/test_colormixer.py
@@ -32,7 +32,7 @@ class ColorMixerTest(object):
 
 
 class TestColorMixerAdd(ColorMixerTest):
-    op = cm.add
+    op = staticmethod(cm.add)
     py_op = np.add
     positive = 50
     positive_clip = 56
@@ -41,7 +41,7 @@ class TestColorMixerAdd(ColorMixerTest):
 
 
 class TestColorMixerMul(ColorMixerTest):
-    op = cm.multiply
+    op = staticmethod(cm.multiply)
     py_op = np.multiply
     positive = 1.2
     positive_clip = 2

--- a/skimage/measure/_ccomp.pyx
+++ b/skimage/measure/_ccomp.pyx
@@ -7,7 +7,7 @@ import numpy as np
 from warnings import warn
 
 cimport numpy as cnp
-
+cnp.import_array()
 
 DTYPE = np.intp
 cdef DTYPE_t BG_NODE_NULL = -999

--- a/skimage/measure/_find_contours_cy.pyx
+++ b/skimage/measure/_find_contours_cy.pyx
@@ -4,6 +4,7 @@
 #cython: wraparound=False
 import numpy as np
 cimport numpy as cnp
+cnp.import_array()
 
 cdef extern from "numpy/npy_math.h":
     bint npy_isnan(double x)

--- a/skimage/measure/_marching_cubes_classic_cy.pyx
+++ b/skimage/measure/_marching_cubes_classic_cy.pyx
@@ -4,6 +4,7 @@
 #cython: wraparound=False
 import numpy as np
 cimport numpy as cnp
+cnp.import_array()
 
 
 cdef inline double _get_fraction(double from_value, double to_value,

--- a/skimage/measure/_marching_cubes_lewiner_cy.pyx
+++ b/skimage/measure/_marching_cubes_lewiner_cy.pyx
@@ -23,7 +23,7 @@ by Almar Klein in 2012. Adapted for scikit-image in 2016.
 import numpy as np
 cimport numpy as np
 import cython
-cnp.import_array()
+np.import_array()
 
 # Enable low level memory management
 from libc.stdlib cimport malloc, free

--- a/skimage/measure/_marching_cubes_lewiner_cy.pyx
+++ b/skimage/measure/_marching_cubes_lewiner_cy.pyx
@@ -23,6 +23,7 @@ by Almar Klein in 2012. Adapted for scikit-image in 2016.
 import numpy as np
 cimport numpy as np
 import cython
+cnp.import_array()
 
 # Enable low level memory management
 from libc.stdlib cimport malloc, free

--- a/skimage/measure/_pnpoly.pyx
+++ b/skimage/measure/_pnpoly.pyx
@@ -7,6 +7,8 @@ import numpy as np
 cimport numpy as cnp
 from .._shared.geometry cimport point_in_polygon, points_in_polygon
 
+cnp.import_array()
+
 
 def _grid_points_in_poly(shape, verts):
     """Test whether points on a specified grid are inside a polygon.

--- a/skimage/morphology/_convex_hull.pyx
+++ b/skimage/morphology/_convex_hull.pyx
@@ -5,6 +5,7 @@
 import numpy as np
 
 cimport numpy as cnp
+cnp.import_array()
 
 
 def possible_hull(cnp.uint8_t[:, ::1] img):

--- a/skimage/morphology/_extrema_cy.pyx
+++ b/skimage/morphology/_extrema_cy.pyx
@@ -6,6 +6,7 @@
 """Cython code used in extrema.py."""
 
 cimport numpy as cnp
+cnp.import_array()
 
 
 # Must be defined to use QueueWithHistory

--- a/skimage/morphology/_flood_fill_cy.pyx
+++ b/skimage/morphology/_flood_fill_cy.pyx
@@ -6,7 +6,7 @@
 """Cython code used in _flood_fill.py."""
 
 cimport numpy as cnp
-
+cnp.import_array()
 
 # Must be defined to use QueueWithHistory
 ctypedef Py_ssize_t QueueItem

--- a/skimage/morphology/_greyreconstruct.pyx
+++ b/skimage/morphology/_greyreconstruct.pyx
@@ -10,6 +10,7 @@ Original author: Lee Kamentsky
 """
 cimport numpy as cnp
 cimport cython
+cnp.import_array()
 
 
 @cython.boundscheck(False)

--- a/skimage/morphology/_max_tree.pyx
+++ b/skimage/morphology/_max_tree.pyx
@@ -17,7 +17,7 @@ import numpy as np
 cimport numpy as np
 cimport cython
 
-cnp.import_array()
+np.import_array()
 
 ctypedef np.float64_t DTYPE_FLOAT64_t
 ctypedef np.int32_t DTYPE_INT32_t

--- a/skimage/morphology/_max_tree.pyx
+++ b/skimage/morphology/_max_tree.pyx
@@ -17,7 +17,7 @@ import numpy as np
 cimport numpy as np
 cimport cython
 
-np.import_array()
+cnp.import_array()
 
 ctypedef np.float64_t DTYPE_FLOAT64_t
 ctypedef np.int32_t DTYPE_INT32_t

--- a/skimage/morphology/_max_tree.pyx
+++ b/skimage/morphology/_max_tree.pyx
@@ -17,6 +17,8 @@ import numpy as np
 cimport numpy as np
 cimport cython
 
+cnp.import_array()
+
 ctypedef np.float64_t DTYPE_FLOAT64_t
 ctypedef np.int32_t DTYPE_INT32_t
 ctypedef np.uint32_t DTYPE_UINT32_t

--- a/skimage/morphology/_skeletonize_cy.pyx
+++ b/skimage/morphology/_skeletonize_cy.pyx
@@ -5,6 +5,8 @@
 
 import numpy as np
 cimport numpy as cnp
+cnp.import_array()
+
 
 def _fast_skeletonize(image):
     """Optimized parts of the Zhang-Suen [1]_ skeletonization.

--- a/skimage/morphology/cmorph.pyx
+++ b/skimage/morphology/cmorph.pyx
@@ -7,7 +7,7 @@ import numpy as np
 cimport numpy as np
 from libc.stdlib cimport malloc, free
 
-cnp.import_array()
+np.import_array()
 
 def _dilate(np.uint8_t[:, :] image,
             np.uint8_t[:, :] selem,

--- a/skimage/morphology/cmorph.pyx
+++ b/skimage/morphology/cmorph.pyx
@@ -7,7 +7,7 @@ import numpy as np
 cimport numpy as np
 from libc.stdlib cimport malloc, free
 
-np.import_array()
+cnp.import_array()
 
 def _dilate(np.uint8_t[:, :] image,
             np.uint8_t[:, :] selem,

--- a/skimage/morphology/cmorph.pyx
+++ b/skimage/morphology/cmorph.pyx
@@ -7,6 +7,7 @@ import numpy as np
 cimport numpy as np
 from libc.stdlib cimport malloc, free
 
+cnp.import_array()
 
 def _dilate(np.uint8_t[:, :] image,
             np.uint8_t[:, :] selem,

--- a/skimage/restoration/_denoise_cy.pyx
+++ b/skimage/restoration/_denoise_cy.pyx
@@ -10,6 +10,7 @@ from libc.float cimport DBL_MAX
 from .._shared.interpolation cimport get_pixel3d
 from .._shared.fused_numerics cimport np_floats
 
+cnp.import_array()
 
 cdef inline Py_ssize_t Py_ssize_t_min(Py_ssize_t value1, Py_ssize_t value2):
     if value1 < value2:

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -9,6 +9,7 @@ cimport numpy as cnp
 from .._shared.fused_numerics cimport np_floats
 from .._shared.fast_exp cimport _fast_exp
 
+cnp.import_array()
 
 cdef inline np_floats patch_distance_2d(np_floats [:, :, :] p1,
                                         np_floats [:, :, :] p2,

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -9,7 +9,6 @@ cimport numpy as cnp
 from .._shared.fused_numerics cimport np_floats
 from .._shared.fast_exp cimport _fast_exp
 
-cnp.import_array()
 
 cdef inline np_floats patch_distance_2d(np_floats [:, :, :] p1,
                                         np_floats [:, :, :] p2,

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -484,8 +484,8 @@ cdef inline void _integral_image_3d(double [:, :, ::] padded,
 
 
 def _fast_nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image,
-                                Py_ssize_t s=7, Py_ssize_t d=13,
-                                double h=0.1, double var=0.):
+                                Py_ssize_t s, Py_ssize_t d,
+                                double h, double var):
     """
     Perform fast non-local means denoising on 2-D array, with the outer
     loop on patch shifts in order to reduce the number of operations.
@@ -608,8 +608,8 @@ def _fast_nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image,
 
 
 def _fast_nl_means_denoising_3d(cnp.ndarray[np_floats, ndim=3] image,
-                                Py_ssize_t s=5, Py_ssize_t d=7, double h=0.1,
-                                double var=0.):
+                                Py_ssize_t s, Py_ssize_t d, double h,
+                                double var):
     """
     Perform fast non-local means denoising on 3-D array, with the outer
     loop on patch shifts in order to reduce the number of operations.

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -109,8 +109,8 @@ cdef inline np_floats patch_distance_3d(np_floats [:, :, :] p1,
     return _fast_exp(-max(0.0, distance))
 
 
-def _nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image, Py_ssize_t s=7,
-                           Py_ssize_t d=13, double h=0.1, double var=0.):
+def _nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image, Py_ssize_t s,
+                           Py_ssize_t d, double h, double var):
     """
     Perform non-local means denoising on 2-D RGB image
 
@@ -213,8 +213,8 @@ def _nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image, Py_ssize_t s=7,
 
 
 def _nl_means_denoising_3d(cnp.ndarray[np_floats, ndim=3] image,
-                           Py_ssize_t s=7, Py_ssize_t d=13,
-                           double h=0.1, double var=0.0):
+                           Py_ssize_t s, Py_ssize_t d,
+                           double h, double var):
     """
     Perform non-local means denoising on 3-D array
 

--- a/skimage/segmentation/_felzenszwalb_cy.pyx
+++ b/skimage/segmentation/_felzenszwalb_cy.pyx
@@ -13,6 +13,7 @@ from .._shared.utils import warn
 
 cnp.import_array()
 
+
 def _felzenszwalb_cython(image, double scale=1, sigma=0.8,
                          Py_ssize_t min_size=20):
     """Felzenszwalb's efficient graph based segmentation for

--- a/skimage/segmentation/_felzenszwalb_cy.pyx
+++ b/skimage/segmentation/_felzenszwalb_cy.pyx
@@ -11,6 +11,7 @@ from ..measure._ccomp cimport find_root, join_trees
 from ..util import img_as_float64
 from .._shared.utils import warn
 
+cnp.import_array()
 
 def _felzenszwalb_cython(image, double scale=1, sigma=0.8,
                          Py_ssize_t min_size=20):

--- a/skimage/segmentation/_quickshift_cy.pyx
+++ b/skimage/segmentation/_quickshift_cy.pyx
@@ -9,6 +9,8 @@ cimport numpy as cnp
 from libc.math cimport exp, sqrt, ceil
 from libc.float cimport DBL_MAX
 
+cnp.import_array()
+
 
 def _quickshift_cython(double[:, :, ::1] image, double kernel_size,
                        double max_dist, bint return_tree, int random_seed):

--- a/skimage/segmentation/_slic.pyx
+++ b/skimage/segmentation/_slic.pyx
@@ -10,6 +10,8 @@ cimport numpy as cnp
 from ..util import regular_grid
 from .._shared.fused_numerics cimport np_floats
 
+cnp.import_array()
+
 
 def _slic_cython(np_floats[:, :, :, ::1] image_zyx,
                  np_floats[:, ::1] segments,

--- a/skimage/segmentation/_watershed_cy.pyx
+++ b/skimage/segmentation/_watershed_cy.pyx
@@ -14,7 +14,7 @@ from libc.math cimport sqrt
 
 cimport numpy as cnp
 cimport cython
-
+cnp.import_array()
 
 ctypedef cnp.int32_t DTYPE_INT32_t
 ctypedef cnp.int8_t DTYPE_BOOL_t

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -14,6 +14,7 @@ from ..draw import circle_perimeter
 
 from .._shared.interpolation cimport round
 
+cnp.import_array()
 
 def _hough_circle(cnp.ndarray img,
                   cnp.ndarray[ndim=1, dtype=cnp.intp_t] radius,

--- a/skimage/transform/_radon_transform.pyx
+++ b/skimage/transform/_radon_transform.pyx
@@ -9,6 +9,7 @@ cimport cython
 from libc.math cimport cos, sin, floor, ceil, sqrt, abs, M_PI
 from .._shared.fused_numerics cimport np_floats
 
+cnp.import_array()
 
 cdef bilinear_ray_sum(np_floats[:, :] image, np_floats theta,
                       np_floats ray_position):

--- a/skimage/transform/_warps_cy.pyx
+++ b/skimage/transform/_warps_cy.pyx
@@ -10,6 +10,7 @@ from .._shared.interpolation cimport (nearest_neighbour_interpolation,
                                       bicubic_interpolation)
 from .._shared.fused_numerics cimport np_floats
 
+cnp.import_array()
 
 cdef inline void _transform_metric(np_floats x, np_floats y, np_floats* H,
                                    np_floats *x_, np_floats *y_) nogil:


### PR DESCRIPTION
Closes #4577 (hopefully). 

Lots of places where `import_array` should be added, but let's check first whether the CI is green.
