### PR TITLE
Recommend cnp.import_array in contribution guide

### DIFF
--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -245,7 +245,9 @@ Stylistic Guidelines
    import matplotlib.pyplot as plt
    from scipy import ndimage as ndi
 
-   cimport numpy as cnp  # in Cython code
+   # only in Cython code
+   cimport numpy as cnp
+   cnp.import_arrays()
 
 * When documenting array parameters, use ``image : (M, N) ndarray``
   and then refer to ``M`` and ``N`` in the docstring, if necessary.


### PR DESCRIPTION
Sorry, I missed #4592 and thus failed to mention it there in time. Nevertheless I think we can help contributors (and ourselves) by recommending a call to `cnp.import_array()` in the contribution guide.

See also #4577.

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
