### PR TITLE
Fix type in cython import_array

### DIFF
--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -247,7 +247,7 @@ Stylistic Guidelines
 
    # only in Cython code
    cimport numpy as cnp
-   cnp.import_arrays()
+   cnp.import_array()
 
 * When documenting array parameters, use ``image : (M, N) ndarray``
   and then refer to ``M`` and ``N`` in the docstring, if necessary.


### PR DESCRIPTION
## Description

Fixes https://github.com/scikit-image/scikit-image/pull/4593#discussion_r411572924 .


## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
