### PR TITLE
Update min required sphinx version for sphinx-copybutton

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,4 @@
-# Sphinx 1.7.8 has a bug when building on cached envs
-# https://github.com/sphinx-doc/sphinx/issues/5361
-sphinx>=1.3,!=1.7.8
+sphinx>=1.8
 numpydoc>=0.9
 sphinx-gallery>=0.3.1
 sphinx-copybutton


### PR DESCRIPTION
## Description

I discovered that our min sphinx version is not satisfying since the recent addition of sphinx copybutton. It leads to this sort of error:

```Running Sphinx v1.3
making output directory...
Adding copy buttons to code blocks...

Exception occurred:
  File "/home/fr/.local/share/virtualenvs/sk/lib/python3.8/site-packages/sphinx_copybutton/__init__.py", line 25, in setup
    app.add_js_file('clipboard.min.js')
AttributeError: 'Sphinx' object has no attribute 'add_js_file'
The full traceback has been saved in /tmp/sphinx-err-y2eoe9d4.log, if you want to report the issue to the developers.

```

The problem is solved for sphinx >= 1.8.

@scikit-image/core We may want to build the doc with the min requirements. If we want it, let's do it in another PR.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
