### PR TITLE
Add notes on deprecation warnings in marching_cube_* and gray2rgb

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -79,6 +79,12 @@ Version 0.19
 * In ``skimage/transform/_warps.py``, raise a ValueError instead of the
   warning when anti_aliasing is True and input array is bool in resize.
 * In ``skimage/feature/__init__.py``, remove `register_translation`.
+* In ``skimage.measure._marching_cube_lewiner.py``, remove
+  ``marching_cube_lewiner``.
+* In ``skimage.measure._marching_cube_classic.py``, remove
+  ``marching_cube_classic``.
+* In ``skimage/color/colorconv.py``, remove the `alpha`and `is_rgb`
+  arguments and the associated deprecation warnings from `gray2rgb`.
 
 Other
 -----


### PR DESCRIPTION
## Description

Add notes in TODO.txt to manage the end of the deprecation cycle for `gray2rgb`, `marchin_cube_lewiner` and `marching_cube_classic`.

Thank you @jni for noticing this https://github.com/scikit-image/scikit-image/issues/3014#issuecomment-617039733 ;-)