### PR TITLE
Allow very large values in relabel_sequential

### DIFF
--- a/skimage/segmentation/__init__.py
+++ b/skimage/segmentation/__init__.py
@@ -5,7 +5,7 @@ from .slic_superpixels import slic
 from ._quickshift import quickshift
 from .boundaries import find_boundaries, mark_boundaries
 from ._clear_border import clear_border
-from ._join import join_segmentations, relabel_from_one, relabel_sequential
+from ._join import join_segmentations, relabel_sequential
 from ._watershed import watershed
 from ._chan_vese import chan_vese
 from .morphsnakes import (morphological_geodesic_active_contour,
@@ -24,7 +24,6 @@ __all__ = ['random_walker',
            'mark_boundaries',
            'clear_border',
            'join_segmentations',
-           'relabel_from_one',
            'relabel_sequential',
            'watershed',
            'chan_vese',

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -232,7 +232,11 @@ class ArrayMap:
         self._max_lines = 4
 
     def __array__(self, dtype=None):
-        """Return an array that behaves like the arraymap when indexed."""
+        """Return an array that behaves like the arraymap when indexed.
+        
+        This array can be very large: it is the size of the largest value
+        in the ``in_vals`` array, plus one.
+        """
         if dtype is None:
             dtype = self.out_values.dtype
         output = np.zeros(np.max(self.in_values) + 1, dtype=dtype)

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -134,8 +134,14 @@ def relabel_sequential(label_field, offset=1):
 
 
 def map_array(input_arr, input_vals, output_vals, out=None):
-    """
-    input_arr: input array (np.ndarray)
+    """Map values from input array from input_vals to output_vals.
+
+    Parameters
+    ----------
+    input_arr : array of int
+        The input label image.
+    input_vals : array of int
+        The values to map from.
     input_vals: 1d array of input values (integer)
     output_vals: 1d array of output values
     out: the output array. Created if not provided
@@ -166,7 +172,7 @@ class ArrayMap:
         return f'ArrayMap({repr(self.inval)}, {repr(self.outval)})'
 
     def __str__(self):
-        if len(self.inval) <= self._max_lines
+        if len(self.inval) <= self._max_lines:
             rows = range(len(self.inval))
             string = '\n'.join(
                 ['ArrayMap:'] +

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -168,6 +168,14 @@ class ArrayMap:
         self.outval = outval
         self._max_lines = 4
 
+    def __array__(self, dtype=None):
+        """Return an array that behaves like the arraymap when indexed."""
+        if dtype is None:
+            dtype = self.outval.dtype
+        output = np.zeros(np.max(self.inval) + 1, dtype=dtype)
+        output[self.inval] = self.outval
+        return output
+
     def __repr__(self):
         return f'ArrayMap({repr(self.inval)}, {repr(self.outval)})'
 

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -183,6 +183,9 @@ class ArrayMap:
             )
         return string
 
+    def __call__(self, arr):
+        return self.__getitem__(arr)
+
     def __getitem__(self, arr):
         return map_array(arr, self.inval, self.outval)
 

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -203,7 +203,7 @@ class ArrayMap:
     array if the values in the ``indices`` array are large.
 
     >>> values = np.array([0.25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1.0])
-    >>> indices = np.array([[0, 0, 10], [0, 10, 10]]
+    >>> indices = np.array([[0, 0, 10], [0, 10, 10]])
     >>> values[indices]
     array([[0.25, 0.25, 1.  ],
            [0.25, 1.  , 1.  ]])

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -186,15 +186,11 @@ def map_array(input_arr, input_vals, output_vals, out=None):
     input_arr = input_arr.reshape(-1)
     if out is None:
         out = np.empty_like(input_arr, dtype=output_vals.dtype)
-    else:
-        out_original = out
-        out = out_original.reshape(-1)
-        if out.strides[0] != min(out_original.strides):
-            # reshaping forced a copy
-            raise ValueError(
-                'If out array is provided, it should be either contiguous '
-                'or 1-dimensional.'
-            )
+    elif not (out.flags['FORC'] or out.ndim == 1):
+        raise ValueError(
+            'If out array is provided, it should be either contiguous '
+            'or 1-dimensional.'
+        )
 
     _map_array(input_arr, out, input_vals, output_vals)
     return out.reshape(orig_shape)
@@ -290,4 +286,3 @@ class ArrayMap:
         return map_array(
             arr, self.in_values.astype(arr.dtype, copy=False), self.out_values
         )
-

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -191,6 +191,13 @@ def map_array(input_arr, input_vals, output_vals, out=None):
             'If out array is provided, it should be either contiguous '
             'or 1-dimensional.'
         )
+    elif out.shape != orig_shape:
+        raise ValueError(
+            'If out array is provided, it should have the same shape as '
+            'the input array.'
+        )
+    else:
+        out = out.reshape(-1)
 
     _map_array(input_arr, out, input_vals, output_vals)
     return out.reshape(orig_shape)

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -101,6 +101,13 @@ def relabel_sequential(label_field, offset=1):
     >>> relab, fw, inv = relabel_sequential(label_field)
     >>> relab
     array([1, 1, 2, 2, 3, 5, 4])
+    >>> print(fw)
+    ArrayMap:
+      1 → 1
+      5 → 2
+      8 → 3
+      42 → 4
+      99 → 5
     >>> np.array(fw)
     array([0, 1, 0, 0, 0, 2, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0,
@@ -240,6 +247,12 @@ class ArrayMap:
     >>> in_indices = np.array([0, 10])
     >>> out_values = np.array([0.25, 1.0])
     >>> values = ArrayMap(in_indices, out_values)
+    >>> values
+    ArrayMap(array([ 0, 10]), array([0.25, 1.  ]))
+    >>> print(values)
+    ArrayMap:
+      0 → 0.25
+      10 → 1.0
     >>> indices = np.array([[0, 0, 10], [0, 10, 10]])
     >>> values[indices]
     array([[0.25, 0.25, 1.  ],
@@ -277,7 +290,7 @@ class ArrayMap:
         return f'ArrayMap({repr(self.in_values)}, {repr(self.out_values)})'
 
     def __str__(self):
-        if len(self.in_values) <= self._max_lines:
+        if len(self.in_values) <= self._max_lines + 1:
             rows = range(len(self.in_values))
             string = '\n'.join(
                 ['ArrayMap:'] +
@@ -285,7 +298,7 @@ class ArrayMap:
             )
         else:
             rows0 = list(range(0, self._max_lines // 2))
-            rows1 = list(range(-self.max_lines // 2, None))
+            rows1 = list(range(-self._max_lines // 2, 0))
             string = '\n'.join(
                 ['ArrayMap:'] +
                 [f'  {self.in_values[i]} → {self.out_values[i]}'

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -101,13 +101,13 @@ def relabel_sequential(label_field, offset=1):
     >>> relab, fw, inv = relabel_sequential(label_field)
     >>> relab
     array([1, 1, 2, 2, 3, 5, 4])
-    >>> fw
+    >>> np.array(fw)
     array([0, 1, 0, 0, 0, 2, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0,
            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5])
-    >>> inv
+    >>> np.array(inv)
     array([ 0,  1,  5,  8, 42, 99])
     >>> (fw[label_field] == relab).all()
     True

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -149,25 +149,19 @@ def map_array(input_arr, input_vals, output_vals, out=None):
     # arr.reshape(-1) may be preferable."
     input_arr = input_arr.reshape(-1)
     if out is None:
-        out_arr = np.empty_like(input_arr, dtype=output_vals.dtype)
-    out_arr = out_arr.reshape(-1)
+        out= np.empty_like(input_arr, dtype=output_vals.dtype)
+    out = out.reshape(-1)
 
-    _map_array(input_arr, out_arr, input_vals, output_vals)
-    return out_arr.reshape(orig_shape)
-
+    _map_array(input_arr, out, input_vals, output_vals)
+    return out.reshape(orig_shape)
 
 
 class ArrayMap:
-
     def __init__(self, inval, outval):
         self.inval = inval
         self.outval = outval
 
-    def inverse -> returns ArrayMap 
-        check bijunctive
-
     def __getitem__(self, arr):
-        output = np.empty(arr.shape, self.outval.dtype)
-        map_array(arr, output, self.inval, self.outval)
-        return output
+        return map_array(arr, self.inval, self.outval)
+
         

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -75,14 +75,14 @@ def relabel_sequential(label_field, offset=1):
         {offset, ..., number_of_labels + offset - 1}.
         The data type will be the same as `label_field`, except when
         offset + number_of_labels causes overflow of the current data type.
-    forward_map : numpy array of int, shape ``(label_field.max() + 1,)``
+    forward_map : ArrayMap
         The map from the original label space to the returned label
         space. Can be used to re-apply the same mapping. See examples
-        for usage. The data type will be the same as `relabeled`.
-    inverse_map : 1D numpy array of int, of length offset + number of labels
+        for usage. The output data type will be the same as `relabeled`.
+    inverse_map : ArrayMap
         The map from the new label space to the original space. This
         can be used to reconstruct the original label field from the
-        relabeled one. The data type will be the same as `relabeled`.
+        relabeled one. The output data type will be the same as `label_field`.
 
     Notes
     -----

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -117,6 +117,10 @@ def relabel_sequential(label_field, offset=1):
     >>> relab
     array([5, 5, 6, 6, 7, 9, 8])
     """
+    if offset <= 0:
+        raise ValueError("Offset must be strictly positive.")
+    if np.min(label_field) < 0:
+        raise ValueError("Cannot relabel array that contains negative values.")
     offset = int(offset)
     # current version can return signed (if it fits in input dtype and that one is signed)
     # but will return unsigned if a dtype change is necessary

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -44,15 +44,6 @@ def join_segmentations(s1, s2):
     return j
 
 
-@deprecated('relabel_sequential')
-def relabel_from_one(label_field):
-    """Convert labels in an arbitrary label field to {1, ... number_of_labels}.
-
-    This function is deprecated, see ``relabel_sequential`` for more.
-    """
-    return relabel_sequential(label_field, offset=1)
-
-
 def relabel_sequential(label_field, offset=1):
     """Relabel arbitrary labels to {`offset`, ... `offset` + number_of_labels}.
 

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -137,6 +137,7 @@ def relabel_sequential(label_field, offset=1):
     output_type = (input_type if input_type.itemsize > required_type.itemsize
                    else required_type)
     out_array = np.empty(label_field.shape, dtype=output_type)
+    out_vals = out_vals.astype(output_type)
     map_array(label_field, in_vals, out_vals, out=out_array)
     fw_map = ArrayMap(in_vals, out_vals)
     inv_map = ArrayMap(out_vals, in_vals)
@@ -185,6 +186,10 @@ class ArrayMap:
         output = np.zeros(np.max(self.inval) + 1, dtype=dtype)
         output[self.inval] = self.outval
         return output
+
+    @property
+    def dtype(self):
+        return self.outval.dtype
 
     def __repr__(self):
         return f'ArrayMap({repr(self.inval)}, {repr(self.outval)})'

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -189,7 +189,8 @@ def map_array(input_arr, input_vals, output_vals, out=None):
     elif out.shape != orig_shape:
         raise ValueError(
             'If out array is provided, it should have the same shape as '
-            'the input array.'
+            f'the input array. Input array has shape {orig_shape}, provided '
+            f'output array has shape {out.shape}.'
         )
     else:
         try:

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -202,7 +202,7 @@ class ArrayMap:
     The issue with this indexing is that you need a very large ``values``
     array if the values in the ``indices`` array are large.
 
-    >>> values = np.array([0.25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1.0])
+    >>> values = np.array([0.25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1.0])
     >>> indices = np.array([[0, 0, 10], [0, 10, 10]])
     >>> values[indices]
     array([[0.25, 0.25, 1.  ],

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -160,8 +160,29 @@ class ArrayMap:
     def __init__(self, inval, outval):
         self.inval = inval
         self.outval = outval
+        self._max_lines = 4
+
+    def __repr__(self):
+        return f'ArrayMap({repr(self.inval)}, {repr(self.outval)})'
+
+    def __str__(self):
+        if len(self.inval) <= self._max_lines
+            rows = range(len(self.inval))
+            string = '\n'.join(
+                ['ArrayMap:'] +
+                [f'  {self.inval[i]} → {self.outval[i]}' for i in rows]
+            )
+        else:
+            rows0 = list(range(0, self._max_lines // 2))
+            rows1 = list(range(-self.max_lines // 2, None))
+            string = '\n'.join(
+                ['ArrayMap:'] +
+                [f'  {self.inval[i]} → {self.outval[i]}' for i in rows0] +
+                ['  ...'] +
+                [f'  {self.inval[i]} → {self.outval[i]}' for i in rows1]
+            )
+        return string
 
     def __getitem__(self, arr):
         return map_array(arr, self.inval, self.outval)
 
-        

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -206,6 +206,9 @@ def map_array(input_arr, input_vals, output_vals, out=None):
                 f'strides {out.strides}.'
             )
 
+    # ensure all arrays have matching types before sending to Cython
+    input_vals = input_vals.astype(input_arr.dtype, copy=False)
+    output_vals = output_vals.astype(out.dtype, copy=False)
     _map_array(input_arr, out, input_vals, output_vals)
     return out.reshape(orig_shape)
 

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -227,40 +227,42 @@ class ArrayMap:
         The destination values from which to map.
     """
     def __init__(self, in_values, out_values):
-        self.inval = in_values
-        self.outval = out_values
+        self.in_values = in_values
+        self.out_values = out_values
         self._max_lines = 4
 
     def __array__(self, dtype=None):
         """Return an array that behaves like the arraymap when indexed."""
         if dtype is None:
-            dtype = self.outval.dtype
-        output = np.zeros(np.max(self.inval) + 1, dtype=dtype)
-        output[self.inval] = self.outval
+            dtype = self.out_values.dtype
+        output = np.zeros(np.max(self.in_values) + 1, dtype=dtype)
+        output[self.in_values] = self.out_values
         return output
 
     @property
     def dtype(self):
-        return self.outval.dtype
+        return self.out_values.dtype
 
     def __repr__(self):
-        return f'ArrayMap({repr(self.inval)}, {repr(self.outval)})'
+        return f'ArrayMap({repr(self.in_values)}, {repr(self.out_values)})'
 
     def __str__(self):
-        if len(self.inval) <= self._max_lines:
-            rows = range(len(self.inval))
+        if len(self.in_values) <= self._max_lines:
+            rows = range(len(self.in_values))
             string = '\n'.join(
                 ['ArrayMap:'] +
-                [f'  {self.inval[i]} → {self.outval[i]}' for i in rows]
+                [f'  {self.in_values[i]} → {self.out_values[i]}' for i in rows]
             )
         else:
             rows0 = list(range(0, self._max_lines // 2))
             rows1 = list(range(-self.max_lines // 2, None))
             string = '\n'.join(
                 ['ArrayMap:'] +
-                [f'  {self.inval[i]} → {self.outval[i]}' for i in rows0] +
+                [f'  {self.in_values[i]} → {self.out_values[i]}'
+                 for i in rows0] +
                 ['  ...'] +
-                [f'  {self.inval[i]} → {self.outval[i]}' for i in rows1]
+                [f'  {self.in_values[i]} → {self.out_values[i]}'
+                 for i in rows1]
             )
         return string
 
@@ -269,6 +271,6 @@ class ArrayMap:
 
     def __getitem__(self, arr):
         return map_array(
-            arr, self.inval.astype(arr.dtype, copy=False), self.outval
+            arr, self.in_values.astype(arr.dtype, copy=False), self.out_values
         )
 

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -188,9 +188,47 @@ def map_array(input_arr, input_vals, output_vals, out=None):
 
 
 class ArrayMap:
-    def __init__(self, inval, outval):
-        self.inval = inval
-        self.outval = outval
+    """Class designed to mimic mapping by NumPy array indexing.
+
+    This class is designed to replicate the use of NumPy arrays for mapping
+    values with indexing:
+
+    >>> values = np.array([0.25, 0.5, 1.0])
+    >>> indices = np.array([[0, 0, 1], [2, 2, 1]])
+    >>> values[indices]
+    array([[0.25, 0.25, 0.5 ],
+           [1.  , 1.  , 0.5 ]])
+
+    The issue with this indexing is that you need a very large ``values``
+    array if the values in the ``indices`` array are large.
+
+    >>> values = np.array([0.25, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1.0])
+    >>> indices = np.array([[0, 0, 10], [0, 10, 10]]
+    >>> values[indices]
+    array([[0.25, 0.25, 1.  ],
+           [0.25, 1.  , 1.  ]])
+
+    Using this class, the approach is similar, but there is no need to
+    create a large values array:
+
+    >>> in_indices = np.array([0, 10])
+    >>> out_values = np.array([0.25, 1.0])
+    >>> values = ArrayMap(in_indices, out_values)
+    >>> indices = np.array([[0, 0, 10], [0, 10, 10]])
+    >>> values[indices]
+    array([[0.25, 0.25, 1.  ],
+           [0.25, 1.  , 1.  ]])
+
+    Parameters
+    ----------
+    in_values : array of int, shape (N,)
+        The source values from which to map.
+    out_values : array, shape (N,)
+        The destination values from which to map.
+    """
+    def __init__(self, in_values, out_values):
+        self.inval = in_values
+        self.outval = out_values
         self._max_lines = 4
 
     def __array__(self, dtype=None):

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -319,6 +319,8 @@ class ArrayMap:
                     else len(self))
             step = index.step
             index = np.arange(start, stop, step)
+        if index.dtype == bool:
+            index = np.flatnonzero(index)
 
         out = map_array(
             index,

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -134,7 +134,7 @@ def relabel_sequential(label_field, offset=1):
     # current version can return signed (if it fits in input dtype and that one
     # is signed) but will return unsigned if a dtype change is necessary
     required_type = np.min_scalar_type(out_vals[-1])
-    output_type = (input_type if input_type.itemsize > required_type.itemsize
+    output_type = (input_type if input_type.itemsize >= required_type.itemsize
                    else required_type)
     out_array = np.empty(label_field.shape, dtype=output_type)
     out_vals = out_vals.astype(output_type)
@@ -216,5 +216,7 @@ class ArrayMap:
         return self.__getitem__(arr)
 
     def __getitem__(self, arr):
-        return map_array(arr, self.inval, self.outval)
+        return map_array(
+            arr, self.inval.astype(arr.dtype, copy=False), self.outval
+        )
 

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -308,13 +308,24 @@ class ArrayMap:
     def __call__(self, arr):
         return self.__getitem__(arr)
 
-    def __getitem__(self, arr):
-        scalar = np.isscalar(arr)
+    def __getitem__(self, index):
+        scalar = np.isscalar(index)
         if scalar:
-            arr = np.array([arr])
+            index = np.array([index])
+        elif isinstance(index, slice):
+            start = index.start or 0  # treat None or 0 the same way
+            stop = (index.stop
+                    if index.stop is not None
+                    else len(self))
+            step = index.step
+            index = np.arange(start, stop, step)
+
         out = map_array(
-            arr, self.in_values.astype(arr.dtype, copy=False), self.out_values
+            index,
+            self.in_values.astype(index.dtype, copy=False),
+            self.out_values,
         )
+
         if scalar:
             out = out[0]
         return out

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -268,7 +268,7 @@ class ArrayMap:
     def __init__(self, in_values, out_values):
         self.in_values = in_values
         self.out_values = out_values
-        self._max_lines = 4
+        self._max_str_lines = 4
 
     def __array__(self, dtype=None):
         """Return an array that behaves like the arraymap when indexed.
@@ -290,15 +290,15 @@ class ArrayMap:
         return f'ArrayMap({repr(self.in_values)}, {repr(self.out_values)})'
 
     def __str__(self):
-        if len(self.in_values) <= self._max_lines + 1:
+        if len(self.in_values) <= self._max_str_lines + 1:
             rows = range(len(self.in_values))
             string = '\n'.join(
                 ['ArrayMap:'] +
                 [f'  {self.in_values[i]} → {self.out_values[i]}' for i in rows]
             )
         else:
-            rows0 = list(range(0, self._max_lines // 2))
-            rows1 = list(range(-self._max_lines // 2, 0))
+            rows0 = list(range(0, self._max_str_lines // 2))
+            rows1 = list(range(-self._max_str_lines // 2, 0))
             string = '\n'.join(
                 ['ArrayMap:'] +
                 [f'  {self.in_values[i]} → {self.out_values[i]}'

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -186,18 +186,20 @@ def map_array(input_arr, input_vals, output_vals, out=None):
     input_arr = input_arr.reshape(-1)
     if out is None:
         out = np.empty_like(input_arr, dtype=output_vals.dtype)
-    elif not (out.flags['FORC'] or out.ndim == 1):
-        raise ValueError(
-            'If out array is provided, it should be either contiguous '
-            'or 1-dimensional.'
-        )
     elif out.shape != orig_shape:
         raise ValueError(
             'If out array is provided, it should have the same shape as '
             'the input array.'
         )
     else:
-        out = out.reshape(-1)
+        try:
+            out.shape = (-1,)  # no-copy reshape/ravel
+        except AttributeError:  # if out strides are not compatible with 0-copy
+            raise ValueError(
+                'If out array is provided, it should be either contiguous '
+                f'or 1-dimensional. Got array with shape {out.shape} and '
+                f'strides {out.strides}.'
+            )
 
     _map_array(input_arr, out, input_vals, output_vals)
     return out.reshape(orig_shape)

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -261,6 +261,10 @@ class ArrayMap:
         self.out_values = out_values
         self._max_str_lines = 4
 
+    def __len__(self):
+        """Return one more than the maximum label value being remapped."""
+        return np.max(self.in_values) + 1
+
     def __array__(self, dtype=None):
         """Return an array that behaves like the arraymap when indexed.
         

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -178,6 +178,10 @@ def map_array(input_arr, input_vals, output_vals, out=None):
         The array of mapped values.
     """
 
+    if not np.issubdtype(input_arr.dtype, np.integer):
+        raise TypeError(
+            'The dtype of an array to be remapped should be integer.'
+        )
     # We ravel the input array for simplicity of iteration in Cython:
     orig_shape = input_arr.shape
     # NumPy docs for `np.ravel()` says:

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -123,7 +123,13 @@ def relabel_sequential(label_field, offset=1):
         raise ValueError("Cannot relabel array that contains negative values.")
     offset = int(offset)
     in_vals = np.unique(label_field)
-    out_vals = np.arange(offset, offset+len(in_vals))
+    if in_vals[0] == 0:
+        # always map 0 to 0
+        out_vals = np.concatenate(
+            [[0], np.arange(offset, offset+len(in_vals)-1)]
+        )
+    else:
+        out_vals = np.arange(offset, offset+len(in_vals))
     input_type = label_field.dtype
     # current version can return signed (if it fits in input dtype and that one
     # is signed) but will return unsigned if a dtype change is necessary

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -260,6 +260,7 @@ class ArrayMap:
         self.in_values = in_values
         self.out_values = out_values
         self._max_str_lines = 4
+        self._array = None
 
     def __len__(self):
         """Return one more than the maximum label value being remapped."""
@@ -308,6 +309,19 @@ class ArrayMap:
         return self.__getitem__(arr)
 
     def __getitem__(self, arr):
-        return map_array(
+        scalar = np.isscalar(arr)
+        if scalar:
+            arr = np.array([arr])
+        out = map_array(
             arr, self.in_values.astype(arr.dtype, copy=False), self.out_values
         )
+        if scalar:
+            out = out[0]
+        return out
+
+    def __setitem__(self, indices, values):
+        if self._array is None:
+            self._array = self.__array__()
+        self._array[indices] = values
+        self.in_values = np.flatnonzero(self._array)
+        self.out_values = self._array[self.in_values]

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -122,12 +122,12 @@ def relabel_sequential(label_field, offset=1):
     if np.min(label_field) < 0:
         raise ValueError("Cannot relabel array that contains negative values.")
     offset = int(offset)
-    # current version can return signed (if it fits in input dtype and that one is signed)
-    # but will return unsigned if a dtype change is necessary
     in_vals = np.unique(label_field)
     out_vals = np.arange(offset, offset+len(in_vals))
     input_type = label_field.dtype
-    required_type = np.min_scalar_type(out_vals[-1]) # what happens to signed/unsigned ?
+    # current version can return signed (if it fits in input dtype and that one
+    # is signed) but will return unsigned if a dtype change is necessary
+    required_type = np.min_scalar_type(out_vals[-1])
     output_type = (input_type if input_type.itemsize > required_type.itemsize
                    else required_type)
     out_array = np.empty(label_field.shape, dtype=output_type)

--- a/skimage/segmentation/_remap.pyx
+++ b/skimage/segmentation/_remap.pyx
@@ -1,7 +1,6 @@
 # distutils: language = c++
 
 from libcpp.unordered_map cimport unordered_map
-import numpy as np
 cimport cython
 from .._shared.fused_numerics cimport np_numeric, np_anyint
 

--- a/skimage/segmentation/_remap.pyx
+++ b/skimage/segmentation/_remap.pyx
@@ -1,7 +1,6 @@
 # distutils: language = c++
 
 from libcpp.unordered_map cimport unordered_map
-from cython.parallel import prange
 import numpy as np
 cimport cython
 from .._shared.fused_numerics cimport np_numeric, np_anyint

--- a/skimage/segmentation/_remap.pyx
+++ b/skimage/segmentation/_remap.pyx
@@ -1,0 +1,26 @@
+# distutils: language = c++
+
+from libcpp.unordered_map cimport unordered_map
+from cython.parallel import prange
+import numpy as np
+cimport cython
+from .._shared.fused_numerics cimport np_numeric, np_anyint
+
+@cython.boundscheck(False)  # Deactivate bounds checking
+@cython.wraparound(False)   # Deactivate negative indexing
+def _map_array(np_anyint[:] inarr, np_numeric[:] outarr,
+               np_anyint[:] inval, np_numeric[:] outval):
+    # build the map from the input and output vectors
+    cdef size_t i, n_map, n_array
+    cdef unordered_map[np_anyint, np_numeric] lut
+    n_map = inval.shape[0]
+    for i in range(n_map):
+        lut[inval[i]] = outval[i]
+    # apply the map to the array
+    n_array = inarr.shape[0]
+    # The prange option gave some compilation warnings
+    #  "Unsigned index type not allowed before OpenMP 3.0"
+    # and didn't seem to be any faster
+    # for i in prange(n_array, nogil=True): #
+    for i in range(n_array):
+        outarr[i] = lut[inarr[i]]

--- a/skimage/segmentation/setup.py
+++ b/skimage/segmentation/setup.py
@@ -26,7 +26,7 @@ def configuration(parent_package='', top_path=None):
                          include_dirs=[get_numpy_include_dirs()])
     config.add_extension('_remap', sources='_remap.cpp',
                          include_dirs=[get_numpy_include_dirs()],
-                         language='c++')
+                         language='c++', extra_compile_args=['-std=c++0x'])
 
     return config
 

--- a/skimage/segmentation/setup.py
+++ b/skimage/segmentation/setup.py
@@ -24,6 +24,9 @@ def configuration(parent_package='', top_path=None):
                          include_dirs=[get_numpy_include_dirs()])
     config.add_extension('_slic', sources=['_slic.c'],
                          include_dirs=[get_numpy_include_dirs()])
+    # note: the extra compiler flag -std=c++0x is needed to access the
+    # std::unordered_map container on some earlier gcc compilers. See:
+    # https://stackoverflow.com/a/3973692/224254
     config.add_extension('_remap', sources='_remap.cpp',
                          include_dirs=[get_numpy_include_dirs()],
                          language='c++', extra_compile_args=['-std=c++0x'])

--- a/skimage/segmentation/setup.py
+++ b/skimage/segmentation/setup.py
@@ -14,7 +14,8 @@ def configuration(parent_package='', top_path=None):
     cython(['_watershed_cy.pyx',
             '_felzenszwalb_cy.pyx',
             '_quickshift_cy.pyx',
-            '_slic.pyx'], working_path=base_path)
+            '_slic.pyx',
+            '_remap.pyx'], working_path=base_path)
     config.add_extension('_watershed_cy', sources=['_watershed_cy.c'],
                          include_dirs=[get_numpy_include_dirs()])
     config.add_extension('_felzenszwalb_cy', sources=['_felzenszwalb_cy.c'],
@@ -23,6 +24,9 @@ def configuration(parent_package='', top_path=None):
                          include_dirs=[get_numpy_include_dirs()])
     config.add_extension('_slic', sources=['_slic.c'],
                          include_dirs=[get_numpy_include_dirs()])
+    config.add_extension('_remap', sources='_remap.cpp',
+                         include_dirs=[get_numpy_include_dirs()],
+                         language='c++')
 
     return config
 

--- a/skimage/segmentation/tests/test_join.py
+++ b/skimage/segmentation/tests/test_join.py
@@ -213,3 +213,10 @@ def test_arraymap_long_str():
     out_values = np.random.random(in_values.shape)
     m = ArrayMap(in_values, out_values)
     assert len(str(m).split('\n')) == m._max_str_lines + 2
+
+
+def test_arraymap_call():
+    ar = np.array([1, 1, 5, 5, 8, 99, 42, 0], dtype=np.intp)
+    relabeled, fw, inv = relabel_sequential(ar)
+    testing.assert_array_equal(relabeled, fw(ar))
+    testing.assert_array_equal(ar, inv(relabeled))

--- a/skimage/segmentation/tests/test_join.py
+++ b/skimage/segmentation/tests/test_join.py
@@ -220,3 +220,12 @@ def test_arraymap_call():
     relabeled, fw, inv = relabel_sequential(ar)
     testing.assert_array_equal(relabeled, fw(ar))
     testing.assert_array_equal(ar, inv(relabeled))
+
+
+def test_arraymap_len():
+    ar = np.array([1, 1, 5, 5, 8, 99, 42, 0], dtype=np.intp)
+    relabeled, fw, inv = relabel_sequential(ar)
+    assert len(fw) == 100
+    assert len(fw) == len(np.array(fw))
+    assert len(inv) == 6
+    assert len(inv) == len(np.array(inv))

--- a/skimage/segmentation/tests/test_join.py
+++ b/skimage/segmentation/tests/test_join.py
@@ -246,3 +246,16 @@ def test_arraymap_update():
     assert np.all(m[image] < 1)  # missing values map to 0.
     m[1:] += 1
     assert np.all(m[image] >= 1)
+
+
+def test_arraymap_bool_index():
+    in_values = np.unique(np.random.randint(0, 200, size=5))
+    out_values = np.random.random(len(in_values))
+    m = ArrayMap(in_values, out_values)
+    image = np.random.randint(1, len(in_values), size=(512, 512))
+    assert np.all(m[image] < 1)  # missing values map to 0.
+    positive = np.ones(len(m), dtype=bool)
+    positive[0] = False
+    m[positive] += 1
+    assert np.all(m[image] >= 1)
+

--- a/skimage/segmentation/tests/test_join.py
+++ b/skimage/segmentation/tests/test_join.py
@@ -1,5 +1,6 @@
 import numpy as np
 from skimage.segmentation import join_segmentations, relabel_sequential
+from skimage.segmentation._join import map_array, ArrayMap
 
 from skimage._shared import testing
 from skimage._shared.testing import assert_array_equal
@@ -186,3 +187,12 @@ def test_incorrect_input_dtype():
     labels = np.array([0, 2, 2, 1, 1, 8], dtype=float)
     with testing.raises(TypeError):
         _ = relabel_sequential(labels)
+
+
+def test_incorrect_map_array_output_shape():
+    labels = np.random.randint(0, 5, size=(24, 25))
+    out = np.empty((24, 24))
+    in_values = np.unique(labels)
+    out_values = np.random.random(in_values.shape).astype(out.dtype)
+    with testing.raises(ValueError):
+        map_array(labels, in_values, out_values, out=out)

--- a/skimage/segmentation/tests/test_join.py
+++ b/skimage/segmentation/tests/test_join.py
@@ -103,6 +103,16 @@ def test_relabel_sequential_dtype():
     assert_array_equal(inv, inv_ref)
 
 
+def test_relabel_sequential_signed_overflow():
+    imax = np.iinfo(np.int32).max
+    labels = np.array([0, 1, 99, 42, 42], dtype=np.int32)
+    output, fw, inv = relabel_sequential(labels, offset=imax)
+    reference = np.array([0, imax, imax + 2, imax + 1, imax + 1],
+                         dtype=np.uint32)
+    assert_array_equal(output, reference)
+    assert output.dtype == reference.dtype
+
+
 @pytest.mark.parametrize('dtype', (np.byte, np.short, np.intc, np.int_,
                                    np.longlong, np.ubyte, np.ushort,
                                    np.uintc, np.uint, np.ulonglong))

--- a/skimage/segmentation/tests/test_join.py
+++ b/skimage/segmentation/tests/test_join.py
@@ -236,3 +236,13 @@ def test_arraymap_set():
     relabeled, fw, inv = relabel_sequential(ar)
     fw[72] = 6
     assert fw[72] == 6
+
+
+def test_arraymap_update():
+    in_values = np.unique(np.random.randint(0, 200, size=5))
+    out_values = np.random.random(len(in_values))
+    m = ArrayMap(in_values, out_values)
+    image = np.random.randint(1, len(in_values), size=(512, 512))
+    assert np.all(m[image] < 1)  # missing values map to 0.
+    m[1:] += 1
+    assert np.all(m[image] >= 1)

--- a/skimage/segmentation/tests/test_join.py
+++ b/skimage/segmentation/tests/test_join.py
@@ -113,6 +113,13 @@ def test_relabel_sequential_signed_overflow():
     assert output.dtype == reference.dtype
 
 
+def test_very_large_labels():
+    imax = np.iinfo(np.int64).max
+    labels = np.array([0, 1, imax, 42, 42], dtype=np.int64)
+    output, fw, inv = relabel_sequential(labels, offset=imax)
+    assert np.max(output) == imax + 2
+
+
 @pytest.mark.parametrize('dtype', (np.byte, np.short, np.intc, np.int_,
                                    np.longlong, np.ubyte, np.ushort,
                                    np.uintc, np.uint, np.ulonglong))

--- a/skimage/segmentation/tests/test_join.py
+++ b/skimage/segmentation/tests/test_join.py
@@ -205,3 +205,11 @@ def test_map_array_non_contiguous_output_array():
     out_values = np.random.random(in_values.shape).astype(out.dtype)
     with testing.raises(ValueError):
         map_array(labels, in_values, out_values, out=out)
+
+
+def test_arraymap_long_str():
+    labels = np.random.randint(0, 40, size=(24, 25))
+    in_values = np.unique(labels)
+    out_values = np.random.random(in_values.shape)
+    m = ArrayMap(in_values, out_values)
+    assert len(str(m).split('\n')) == m._max_str_lines + 2

--- a/skimage/segmentation/tests/test_join.py
+++ b/skimage/segmentation/tests/test_join.py
@@ -87,7 +87,7 @@ def test_relabel_sequential_offset5_with0():
 
 
 def test_relabel_sequential_dtype():
-    ar = np.array([1, 1, 5, 5, 8, 99, 42, 0], dtype=float)
+    ar = np.array([1, 1, 5, 5, 8, 99, 42, 0], dtype=np.uint8)
     ar_relab, fw, inv = relabel_sequential(ar, offset=5)
     _check_maps(ar.astype(int), ar_relab, fw, inv)
     ar_relab_ref = np.array([5, 5, 6, 6, 7, 9, 8, 0])

--- a/skimage/segmentation/tests/test_join.py
+++ b/skimage/segmentation/tests/test_join.py
@@ -121,7 +121,8 @@ def test_relabel_sequential_int_dtype_overflow():
     offset = 254
     ar_relab, fw, inv = relabel_sequential(ar, offset=offset)
     _check_maps(ar, ar_relab, fw, inv)
-    assert all(a.dtype == np.uint16 for a in (ar_relab, fw, inv))
+    assert all(a.dtype == np.uint16 for a in (ar_relab, fw))
+    assert inv.dtype == ar.dtype
     ar_relab_ref = np.where(ar > 0, ar.astype(np.int) + offset - 1, 0)
     assert_array_equal(ar_relab, ar_relab_ref)
 

--- a/skimage/segmentation/tests/test_join.py
+++ b/skimage/segmentation/tests/test_join.py
@@ -189,9 +189,18 @@ def test_incorrect_input_dtype():
         _ = relabel_sequential(labels)
 
 
-def test_incorrect_map_array_output_shape():
+def test_map_array_incorrect_output_shape():
     labels = np.random.randint(0, 5, size=(24, 25))
     out = np.empty((24, 24))
+    in_values = np.unique(labels)
+    out_values = np.random.random(in_values.shape).astype(out.dtype)
+    with testing.raises(ValueError):
+        map_array(labels, in_values, out_values, out=out)
+
+
+def test_map_array_non_contiguous_output_array():
+    labels = np.random.randint(0, 5, size=(24, 25))
+    out = np.empty((24 * 3, 25 * 2))[::3, ::2]
     in_values = np.unique(labels)
     out_values = np.random.random(in_values.shape).astype(out.dtype)
     with testing.raises(ValueError):

--- a/skimage/segmentation/tests/test_join.py
+++ b/skimage/segmentation/tests/test_join.py
@@ -229,3 +229,10 @@ def test_arraymap_len():
     assert len(fw) == len(np.array(fw))
     assert len(inv) == 6
     assert len(inv) == len(np.array(inv))
+
+
+def test_arraymap_set():
+    ar = np.array([1, 1, 5, 5, 8, 99, 42, 0], dtype=np.intp)
+    relabeled, fw, inv = relabel_sequential(ar)
+    fw[72] = 6
+    assert fw[72] == 6

--- a/skimage/segmentation/tests/test_join.py
+++ b/skimage/segmentation/tests/test_join.py
@@ -180,3 +180,9 @@ def test_relabel_sequential_already_sequential(offset, with0,
     else:
         ar_relab_ref = np.where(ar > 0, ar + offset - 1, 0)
     assert_array_equal(ar_relab, ar_relab_ref)
+
+
+def test_incorrect_input_dtype():
+    labels = np.array([0, 2, 2, 1, 1, 8], dtype=float)
+    with testing.raises(TypeError):
+        _ = relabel_sequential(labels)


### PR DESCRIPTION
## Description

This PR introduces:
 
* an ehancement (I might even go as far as calling it a bug-fix) to `relabel_sequential`,  and 
* a generic vay to remap integer arrays (that can also remap from integer to other types)

Background:

**Storage requirements in `relabel_sequential` currently scale with maxim value in array not with the size of the array:**

The current implementation of  `relabel_sequential` uses numpy's fancy indexing in a very clever way. As it leverages numpy's array operators it is very fast. However, the current implementation requires building a LUT as a numpy array that scales (in memory requirement) with the value of the largest label. This is a long-standing problem mentioned in https://github.com/scikit-image/scikit-image/issues/1349#issuecomment-296676180. Depending on the exact value in the array this can lead  to `MemoryError` or `ValueError` exceptions. I have documented these failure modes in  [this notebook  under the heading Storage Requirements](https://github.com/VolkerH/PythonSnippets/blob/master/relabel_label_images/skimage_relabel_sequential_issues.ipynb).

**Cython implementation implements a sparse LUT using a hashmap**

To address the undesired memory scaling behaviour, a new function `map_array` is introduced that maps one array to another in which the LUT is implemented as a hashmap. Numpy does not provide a hash-table data structure and using a Python dict would be too slow. Instead, an `unordered_map`  from the C++ STL is used with Cython. Initial benchmarking on my machine suggests that this is not dramatically slower than the fany indexing (see [this notebook for my initial experiments, including alternative implementations using numba](https://github.com/VolkerH/PythonSnippets/blob/master/NumbaReassignPixels/numba_reassign_experiments.ipynb) for additional background.

`relabel_sequential` is reimplemented using the new `map_array`.

**Other uses: e.g. creating value-maps**
I have recently played around with some visualizations for measurements returned by `regionprops_table` to create value maps, [see here for an example](https://github.com/napari/napari/issues/998). This has been suggested for skimage in #1396 and can be trivially implemented using `map_array`.


There is still plenty of work to do in terms of code tidying, documentation and testing. 

Thanks to @jni for some help and encouragement with this.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
