### PR TITLE
Improve loading speed of our gallery by reducing the thumbnail size

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -161,6 +161,7 @@ sphinx_gallery_conf = {
     'gallery_dirs': 'auto_examples',
     'backreferences_dir': 'api',
     'reference_url': {'skimage': None},
+    'thumbnail_size': (280, 196),  # Default CSS does 0.4 scaling (160, 112)
     'subsection_order': ExplicitOrder([
         '../examples/data',
         '../examples/numpy_operations',

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -161,7 +161,10 @@ sphinx_gallery_conf = {
     'gallery_dirs': 'auto_examples',
     'backreferences_dir': 'api',
     'reference_url': {'skimage': None},
-    'thumbnail_size': (280, 196),  # Default CSS does 0.4 scaling (160, 112)
+    # Default thumbnail size (400, 280)
+    # Default CSS rescales (160, 112)
+    # Size is decreased to reduce webpage loading time
+    'thumbnail_size': (280, 196),
     'subsection_order': ExplicitOrder([
         '../examples/data',
         '../examples/numpy_operations',


### PR DESCRIPTION
## Description

The gallery webpage is fairly slow to load. To be convinced, please check:
* this chart: https://www.webpagetest.org/video/compare.php?tests=200424_JS_aae4151a4160a4603aa53ba512685906-r:1-c:0
* this video: https://www.webpagetest.org/video/view.php?id=200424_JS_aae4151a4160a4603aa53ba512685906.1.0

The loading time goes up to 12 seconds, costs 7MB, which is not the best user experience and not particularly green.


Thumbnails are in png format (better for edges, fonts etc). I reduced by a factor 0.7 the default resolution and it seems that the rendering is fairly good, close to the original one.

Original
![1_init](https://user-images.githubusercontent.com/335370/80203294-3d638400-8627-11ea-8775-3ff05f2cf214.png)
Compressed
![2_reduced](https://user-images.githubusercontent.com/335370/80203306-40f70b00-8627-11ea-82f6-e3df816aae18.png)



Now, let's compare the sizes

Original 
```  64K 24 avril 12:15 sphx_glr_plot_active_contours_thumb.png
  78K 24 avril 12:15 sphx_glr_plot_adapt_rgb_thumb.png
  44K 24 avril 12:16 sphx_glr_plot_attribute_operators_thumb.png
  98K 24 avril 12:16 sphx_glr_plot_blob_thumb.png
 161K 24 avril 12:17 sphx_glr_plot_boundary_merge_thumb.png
  79K 24 avril 12:16 sphx_glr_plot_brief_thumb.png
  44K 24 avril 12:15 sphx_glr_plot_camera_numpy_thumb.png
  35K 24 avril 12:15 sphx_glr_plot_canny_thumb.png
  80K 24 avril 12:16 sphx_glr_plot_censure_thumb.png
  52K 24 avril 12:17 sphx_glr_plot_chan_vese_thumb.png
  46K 24 avril 12:15 sphx_glr_plot_circular_elliptical_hough_transform_thumb.png
  37K 24 avril 12:17 sphx_glr_plot_coins_segmentation_thumb.png
  76K 24 avril 12:17 sphx_glr_plot_compact_watershed_thumb.png
  43K 24 avril 12:15 sphx_glr_plot_contours_thumb.png
  15K 24 avril 12:15 sphx_glr_plot_convex_hull_thumb.png
  21K 24 avril 12:16 sphx_glr_plot_corner_thumb.png
  67K 24 avril 12:16 sphx_glr_plot_cycle_spinning_thumb.png
 104K 24 avril 12:16 sphx_glr_plot_daisy_thumb.png
  73K 24 avril 12:16 sphx_glr_plot_deconvolution_thumb.png
  89K 24 avril 12:16 sphx_glr_plot_denoise_thumb.png
  18K 24 avril 12:16 sphx_glr_plot_denoise_wavelet_thumb.png
  99K 24 avril 12:16 sphx_glr_plot_dog_thumb.png
  71K 24 avril 12:15 sphx_glr_plot_edge_filter_thumb.png
  17K 24 avril 12:15 sphx_glr_plot_edge_modes_thumb.png
  73K 24 avril 12:16 sphx_glr_plot_entropy_thumb.png
  54K 24 avril 12:15 sphx_glr_plot_equalize_thumb.png
  46K 24 avril 12:17 sphx_glr_plot_extrema_thumb.png
  96K 24 avril 12:17 sphx_glr_plot_face_detection_thumb.png
 9,1K 24 avril 12:17 sphx_glr_plot_floodfill_thumb.png
  57K 24 avril 12:15 sphx_glr_plot_fundamental_matrix_thumb.png
  73K 24 avril 12:16 sphx_glr_plot_gabors_from_astronaut_thumb.png
  56K 24 avril 12:16 sphx_glr_plot_gabor_thumb.png
 101K 24 avril 12:15 sphx_glr_plot_general_thumb.png
  56K 24 avril 12:15 sphx_glr_plot_geometric_thumb.png
  39K 24 avril 12:16 sphx_glr_plot_glcm_thumb.png
  31K 24 avril 12:20 sphx_glr_plot_haar_extraction_selection_classification_thumb.png
  13K 24 avril 12:16 sphx_glr_plot_haar_thumb.png
  75K 24 avril 12:15 sphx_glr_plot_histogram_matching_thumb.png
  86K 24 avril 12:16 sphx_glr_plot_hog_thumb.png
  43K 24 avril 12:16 sphx_glr_plot_holes_and_peaks_thumb.png
 113K 24 avril 12:16 sphx_glr_plot_hysteresis_thumb.png
 130K 24 avril 12:15 sphx_glr_plot_ihc_color_separation_thumb.png
  82K 24 avril 12:17 sphx_glr_plot_image_comparison_thumb.png
  78K 24 avril 12:16 sphx_glr_plot_inpaint_thumb.png
  81K 24 avril 12:17 sphx_glr_plot_join_segmentations_thumb.png
  88K 24 avril 12:17 sphx_glr_plot_label_thumb.png
  14K 24 avril 12:15 sphx_glr_plot_line_hough_transform_thumb.png
  13K 24 avril 12:16 sphx_glr_plot_local_binary_pattern_thumb.png
  64K 24 avril 12:15 sphx_glr_plot_local_equalize_thumb.png
  44K 24 avril 12:15 sphx_glr_plot_log_gamma_thumb.png
  78K 24 avril 12:15 sphx_glr_plot_marching_cubes_thumb.png
  86K 24 avril 12:17 sphx_glr_plot_marked_watershed_thumb.png
  46K 24 avril 12:15 sphx_glr_plot_masked_register_translation_thumb.png
  65K 24 avril 12:16 sphx_glr_plot_matching_thumb.png
  19K 24 avril 12:21 sphx_glr_plot_max_tree_thumb.png
 101K 24 avril 12:17 sphx_glr_plot_metrics_thumb.png
  20K 24 avril 12:17 sphx_glr_plot_morphology_thumb.png
  88K 24 avril 12:17 sphx_glr_plot_morphsnakes_thumb.png
  79K 24 avril 12:16 sphx_glr_plot_multiblock_local_binary_pattern_thumb.png
  33K 24 avril 12:17 sphx_glr_plot_multiotsu_thumb.png
  46K 24 avril 12:17 sphx_glr_plot_ncut_thumb.png
  42K 24 avril 12:17 sphx_glr_plot_niblack_sauvola_thumb.png
 122K 24 avril 12:16 sphx_glr_plot_nonlocal_means_thumb.png
  70K 24 avril 12:16 sphx_glr_plot_opticalflow_thumb.png
  93K 24 avril 12:16 sphx_glr_plot_orb_thumb.png
  54K 24 avril 12:17 sphx_glr_plot_peak_local_max_thumb.png
  60K 24 avril 12:16 sphx_glr_plot_phase_unwrap_thumb.png
 102K 24 avril 12:15 sphx_glr_plot_piecewise_affine_thumb.png
  24K 24 avril 12:15 sphx_glr_plot_polygon_thumb.png
 110K 24 avril 12:15 sphx_glr_plot_pyramid_thumb.png
  43K 24 avril 12:16 sphx_glr_plot_radon_transform_thumb.png
 125K 24 avril 12:16 sphx_glr_plot_rag_boundary_thumb.png
 124K 24 avril 12:17 sphx_glr_plot_rag_draw_thumb.png
  48K 24 avril 12:17 sphx_glr_plot_rag_mean_color_thumb.png
  61K 24 avril 12:17 sphx_glr_plot_rag_merge_thumb.png
  23K 24 avril 12:17 sphx_glr_plot_rag_thumb.png
  25K 24 avril 12:15 sphx_glr_plot_random_shapes_thumb.png
 100K 24 avril 12:17 sphx_glr_plot_random_walker_segmentation_thumb.png
  48K 24 avril 12:21 sphx_glr_plot_rank_filters_thumb.png
  57K 24 avril 12:16 sphx_glr_plot_rank_mean_thumb.png
  26K 24 avril 12:16 sphx_glr_plot_ransac_thumb.png
  42K 24 avril 12:15 sphx_glr_plot_regional_maxima_thumb.png
  27K 24 avril 12:17 sphx_glr_plot_regionprops_table_thumb.png
  13K 24 avril 12:17 sphx_glr_plot_regionprops_thumb.png
  63K 24 avril 12:16 sphx_glr_plot_register_rotation_thumb.png
  39K 24 avril 12:15 sphx_glr_plot_register_translation_thumb.png
  87K 24 avril 12:15 sphx_glr_plot_rescale_thumb.png
  86K 24 avril 12:16 sphx_glr_plot_restoration_thumb.png
 105K 24 avril 12:15 sphx_glr_plot_rgb_to_gray_thumb.png
  65K 24 avril 12:15 sphx_glr_plot_rgb_to_hsv_thumb.png
 123K 24 avril 12:15 sphx_glr_plot_ridge_filter_thumb.png
 120K 24 avril 12:15 sphx_glr_plot_scientific_thumb.png
 170K 24 avril 12:17 sphx_glr_plot_segmentations_thumb.png
  80K 24 avril 12:16 sphx_glr_plot_shape_index_thumb.png
  14K 24 avril 12:15 sphx_glr_plot_shapes_thumb.png
  16K 24 avril 12:15 sphx_glr_plot_skeleton_thumb.png
  81K 24 avril 12:15 sphx_glr_plot_specific_thumb.png
  69K 24 avril 12:15 sphx_glr_plot_ssim_thumb.png
  80K 24 avril 12:15 sphx_glr_plot_structuring_elements_thumb.png
  19K 24 avril 12:15 sphx_glr_plot_swirl_thumb.png
  38K 24 avril 12:16 sphx_glr_plot_template_thumb.png
  63K 24 avril 12:17 sphx_glr_plot_thresholding_thumb1.png
  28K 24 avril 12:17 sphx_glr_plot_thresholding_thumb.png
  33K 24 avril 12:21 sphx_glr_plot_threshold_li_thumb.png
  46K 24 avril 12:15 sphx_glr_plot_tinting_grayscale_images_thumb.png
  34K 24 avril 12:16 sphx_glr_plot_tophat_thumb.png
  40K 24 avril 12:15 sphx_glr_plot_transform_types_thumb.png
  69K 24 avril 12:16 sphx_glr_plot_unsharp_mask_thumb.png
  88K 24 avril 12:15 sphx_glr_plot_view_as_blocks_thumb.png
  13K 24 avril 12:17 sphx_glr_plot_watershed_thumb.png
  81K 24 avril 12:16 sphx_glr_plot_windowed_histogram_thumb.png
  69K 24 avril 12:16 sphx_glr_plot_window_thumb.png
```


compressed
```  36K 24 avril 12:04 sphx_glr_plot_active_contours_thumb.png
  40K 24 avril 12:04 sphx_glr_plot_adapt_rgb_thumb.png
  26K 24 avril 12:05 sphx_glr_plot_attribute_operators_thumb.png
  51K 24 avril 12:05 sphx_glr_plot_blob_thumb.png
  83K 24 avril 12:05 sphx_glr_plot_boundary_merge_thumb.png
  44K 24 avril 12:05 sphx_glr_plot_brief_thumb.png
  25K 24 avril 12:03 sphx_glr_plot_camera_numpy_thumb.png
  21K 24 avril 12:04 sphx_glr_plot_canny_thumb.png
  46K 24 avril 12:05 sphx_glr_plot_censure_thumb.png
  30K 24 avril 12:05 sphx_glr_plot_chan_vese_thumb.png
  27K 24 avril 12:04 sphx_glr_plot_circular_elliptical_hough_transform_thumb.png
  21K 24 avril 12:06 sphx_glr_plot_coins_segmentation_thumb.png
  42K 24 avril 12:05 sphx_glr_plot_compact_watershed_thumb.png
  26K 24 avril 12:04 sphx_glr_plot_contours_thumb.png
 9,6K 24 avril 12:04 sphx_glr_plot_convex_hull_thumb.png
  14K 24 avril 12:05 sphx_glr_plot_corner_thumb.png
  37K 24 avril 12:05 sphx_glr_plot_cycle_spinning_thumb.png
  56K 24 avril 12:05 sphx_glr_plot_daisy_thumb.png
  41K 24 avril 12:04 sphx_glr_plot_deconvolution_thumb.png
  48K 24 avril 12:05 sphx_glr_plot_denoise_thumb.png
  11K 24 avril 12:05 sphx_glr_plot_denoise_wavelet_thumb.png
  50K 24 avril 12:04 sphx_glr_plot_dog_thumb.png
  37K 24 avril 12:04 sphx_glr_plot_edge_filter_thumb.png
  12K 24 avril 12:04 sphx_glr_plot_edge_modes_thumb.png
  37K 24 avril 12:04 sphx_glr_plot_entropy_thumb.png
  34K 24 avril 12:04 sphx_glr_plot_equalize_thumb.png
  25K 24 avril 12:05 sphx_glr_plot_extrema_thumb.png
  51K 24 avril 12:06 sphx_glr_plot_face_detection_thumb.png
 6,6K 24 avril 12:05 sphx_glr_plot_floodfill_thumb.png
  33K 24 avril 12:04 sphx_glr_plot_fundamental_matrix_thumb.png
  42K 24 avril 12:05 sphx_glr_plot_gabors_from_astronaut_thumb.png
  30K 24 avril 12:05 sphx_glr_plot_gabor_thumb.png
  55K 24 avril 12:03 sphx_glr_plot_general_thumb.png
  31K 24 avril 12:04 sphx_glr_plot_geometric_thumb.png
  24K 24 avril 12:05 sphx_glr_plot_glcm_thumb.png
  22K 24 avril 12:08 sphx_glr_plot_haar_extraction_selection_classification_thumb.png
 7,8K 24 avril 12:05 sphx_glr_plot_haar_thumb.png
  40K 24 avril 12:03 sphx_glr_plot_histogram_matching_thumb.png
  46K 24 avril 12:05 sphx_glr_plot_hog_thumb.png
  24K 24 avril 12:05 sphx_glr_plot_holes_and_peaks_thumb.png
  62K 24 avril 12:04 sphx_glr_plot_hysteresis_thumb.png
  67K 24 avril 12:04 sphx_glr_plot_ihc_color_separation_thumb.png
  44K 24 avril 12:06 sphx_glr_plot_image_comparison_thumb.png
  43K 24 avril 12:04 sphx_glr_plot_inpaint_thumb.png
  46K 24 avril 12:05 sphx_glr_plot_join_segmentations_thumb.png
  50K 24 avril 12:05 sphx_glr_plot_label_thumb.png
 7,5K 24 avril 12:04 sphx_glr_plot_line_hough_transform_thumb.png
 8,6K 24 avril 12:05 sphx_glr_plot_local_binary_pattern_thumb.png
  38K 24 avril 12:04 sphx_glr_plot_local_equalize_thumb.png
  26K 24 avril 12:04 sphx_glr_plot_log_gamma_thumb.png
  40K 24 avril 12:04 sphx_glr_plot_marching_cubes_thumb.png
  46K 24 avril 12:05 sphx_glr_plot_marked_watershed_thumb.png
  23K 24 avril 12:04 sphx_glr_plot_masked_register_translation_thumb.png
  38K 24 avril 12:04 sphx_glr_plot_matching_thumb.png
  13K 24 avril 12:09 sphx_glr_plot_max_tree_thumb.png
  55K 24 avril 12:06 sphx_glr_plot_metrics_thumb.png
  13K 24 avril 12:06 sphx_glr_plot_morphology_thumb.png
  50K 24 avril 12:06 sphx_glr_plot_morphsnakes_thumb.png
  43K 24 avril 12:05 sphx_glr_plot_multiblock_local_binary_pattern_thumb.png
  19K 24 avril 12:05 sphx_glr_plot_multiotsu_thumb.png
  30K 24 avril 12:05 sphx_glr_plot_ncut_thumb.png
  23K 24 avril 12:05 sphx_glr_plot_niblack_sauvola_thumb.png
  65K 24 avril 12:05 sphx_glr_plot_nonlocal_means_thumb.png
  37K 24 avril 12:04 sphx_glr_plot_opticalflow_thumb.png
  50K 24 avril 12:05 sphx_glr_plot_orb_thumb.png
  31K 24 avril 12:05 sphx_glr_plot_peak_local_max_thumb.png
  35K 24 avril 12:05 sphx_glr_plot_phase_unwrap_thumb.png
  55K 24 avril 12:04 sphx_glr_plot_piecewise_affine_thumb.png
  15K 24 avril 12:04 sphx_glr_plot_polygon_thumb.png
  59K 24 avril 12:04 sphx_glr_plot_pyramid_thumb.png
  26K 24 avril 12:04 sphx_glr_plot_radon_transform_thumb.png
  66K 24 avril 12:05 sphx_glr_plot_rag_boundary_thumb.png
  62K 24 avril 12:05 sphx_glr_plot_rag_draw_thumb.png
  31K 24 avril 12:05 sphx_glr_plot_rag_mean_color_thumb.png
  39K 24 avril 12:05 sphx_glr_plot_rag_merge_thumb.png
  15K 24 avril 12:05 sphx_glr_plot_rag_thumb.png
  17K 24 avril 12:04 sphx_glr_plot_random_shapes_thumb.png
  54K 24 avril 12:05 sphx_glr_plot_random_walker_segmentation_thumb.png
  27K 24 avril 12:09 sphx_glr_plot_rank_filters_thumb.png
  33K 24 avril 12:04 sphx_glr_plot_rank_mean_thumb.png
  16K 24 avril 12:04 sphx_glr_plot_ransac_thumb.png
  25K 24 avril 12:04 sphx_glr_plot_regional_maxima_thumb.png
  16K 24 avril 12:05 sphx_glr_plot_regionprops_table_thumb.png
 8,3K 24 avril 12:05 sphx_glr_plot_regionprops_thumb.png
  34K 24 avril 12:04 sphx_glr_plot_register_rotation_thumb.png
  22K 24 avril 12:04 sphx_glr_plot_register_translation_thumb.png
  50K 24 avril 12:04 sphx_glr_plot_rescale_thumb.png
  47K 24 avril 12:04 sphx_glr_plot_restoration_thumb.png
  59K 24 avril 12:03 sphx_glr_plot_rgb_to_gray_thumb.png
  35K 24 avril 12:03 sphx_glr_plot_rgb_to_hsv_thumb.png
  62K 24 avril 12:04 sphx_glr_plot_ridge_filter_thumb.png
  62K 24 avril 12:03 sphx_glr_plot_scientific_thumb.png
  90K 24 avril 12:05 sphx_glr_plot_segmentations_thumb.png
  45K 24 avril 12:05 sphx_glr_plot_shape_index_thumb.png
 8,7K 24 avril 12:04 sphx_glr_plot_shapes_thumb.png
  11K 24 avril 12:04 sphx_glr_plot_skeleton_thumb.png
  45K 24 avril 12:03 sphx_glr_plot_specific_thumb.png
  36K 24 avril 12:04 sphx_glr_plot_ssim_thumb.png
  51K 24 avril 12:03 sphx_glr_plot_structuring_elements_thumb.png
  13K 24 avril 12:04 sphx_glr_plot_swirl_thumb.png
  22K 24 avril 12:05 sphx_glr_plot_template_thumb.png
  34K 24 avril 12:06 sphx_glr_plot_thresholding_thumb1.png
  16K 24 avril 12:05 sphx_glr_plot_thresholding_thumb.png
  19K 24 avril 12:09 sphx_glr_plot_threshold_li_thumb.png
  26K 24 avril 12:04 sphx_glr_plot_tinting_grayscale_images_thumb.png
  18K 24 avril 12:04 sphx_glr_plot_tophat_thumb.png
  22K 24 avril 12:04 sphx_glr_plot_transform_types_thumb.png
  35K 24 avril 12:04 sphx_glr_plot_unsharp_mask_thumb.png
  50K 24 avril 12:03 sphx_glr_plot_view_as_blocks_thumb.png
 8,5K 24 avril 12:05 sphx_glr_plot_watershed_thumb.png
  46K 24 avril 12:05 sphx_glr_plot_windowed_histogram_thumb.png
  37K 24 avril 12:04 sphx_glr_plot_window_thumb.png
```
We nearly gain a factor 2.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
