### PR TITLE
Change label2rgb default background value from -1 to 0

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -85,6 +85,8 @@ Version 0.19
   ``marching_cube_classic``.
 * In ``skimage/color/colorconv.py``, remove the `alpha`and `is_rgb`
   arguments and the associated deprecation warnings from `gray2rgb`.
+* In ``skimage/color/colorlabel.py``, remove the `change_default_value`
+  decorator from `label2rgb` and set `bg_label` default value to 0.
 
 Other
 -----

--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -11,19 +11,14 @@ from skimage._shared._warnings import expected_warnings
 
 def test_change_default_value():
 
-    @change_default_value('arg1', old_value=-1)
+    @change_default_value('arg1', new_value=-1, changed_version='0.12')
     def foo(arg0, arg1=0, arg2=1):
         """Expected docstring"""
         return arg0, arg1, arg2
 
-    @change_default_value('arg1', old_value=-1,
+    @change_default_value('arg1', new_value=-1, changed_version='0.12',
                           warning_msg="Custom warning message")
     def bar(arg0, arg1=0, arg2=1):
-        """Expected docstring"""
-        return arg0, arg1, arg2
-
-    @change_default_value('arg1', old_value=-1, changed_version='0.12')
-    def baz(arg0, arg1=0, arg2=1):
         """Expected docstring"""
         return arg0, arg1, arg2
 
@@ -31,14 +26,16 @@ def test_change_default_value():
     with pytest.warns(FutureWarning) as record:
         assert foo(0) == (0, 0, 1)
         assert bar(0) == (0, 0, 1)
-        assert baz(0) == (0, 0, 1)
 
-    expected_msg = (f"Default arg1 value changed from -1 to 0. To remove this "
-                    "warning, please explicitely set arg1 value.")
+    expected_msg = ("New recommanded value for arg1 is -1. "
+                    "Until version 0.12, default arg1 "
+                    "value is 0. Starting from version "
+                    "0.12, arg1 default value will be "
+                    "set to -1. To avoid this warning, please "
+                    "explicitely set arg1 value.")
+
     assert str(record[0].message) == expected_msg
     assert str(record[1].message) == "Custom warning message"
-    assert str(record[2].message) == ("Starting from version 0.12, "
-                                      + expected_msg)
 
     # Assert that nothing happens if arg1 is set
     with pytest.warns(None) as record:

--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -32,7 +32,7 @@ def test_change_default_value():
                     "value is 0. Starting from version "
                     "0.12, arg1 default value will be "
                     "set to -1. To avoid this warning, please "
-                    "explicitely set arg1 value.")
+                    "explicitly set arg1 value.")
 
     assert str(record[0].message) == expected_msg
     assert str(record[1].message) == "Custom warning message"

--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -27,12 +27,10 @@ def test_change_default_value():
         assert foo(0) == (0, 0, 1)
         assert bar(0) == (0, 0, 1)
 
-    expected_msg = ("New recommanded value for arg1 is -1. "
-                    "Until version 0.12, default arg1 "
-                    "value is 0. Starting from version "
-                    "0.12, arg1 default value will be "
-                    "set to -1. To avoid this warning, please "
-                    "explicitly set arg1 value.")
+    expected_msg = ("The new recommended value for arg1 is -1. Until "
+                    "version 0.12, the default arg1 value is 0. From "
+                    "version 0.12, the arg1 default value will be -1. "
+                    "To avoid this warning, please explicitly set arg1 value.")
 
     assert str(record[0].message) == expected_msg
     assert str(record[1].message) == "Custom warning message"

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -33,7 +33,7 @@ class change_default_value:
         Optional warning message. If None, a generic warning message
         is used.
     changed_version : str
-        The package version in which the change have been introduced.
+        The package version in which the change will be introduced.
 
     """
 

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -27,13 +27,13 @@ class change_default_value:
     ----------
     arg_name: str
         The name of the argument to be updated.
-    old_value: any
-        The argument old value.
+    new_value: any
+        The argument new value.
+    changed_version : str
+        The package version in which the change will be introduced.
     warning_msg: str
         Optional warning message. If None, a generic warning message
         is used.
-    changed_version : str
-        The package version in which the change will be introduced.
 
     """
 

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -37,35 +37,34 @@ class change_default_value:
 
     """
 
-    def __init__(self, arg_name, *, old_value, warning_msg=None,
-                 changed_version=None):
+    def __init__(self, arg_name, *, new_value, changed_version,
+                 warning_msg=None):
         self.arg_name = arg_name
-        self.old_value = old_value
+        self.new_value = new_value
         self.warning_msg = warning_msg
         self.changed_version = changed_version
 
     def __call__(self, func):
         parameters = inspect.signature(func).parameters
         arg_idx = list(parameters.keys()).index(self.arg_name)
-        new_value = parameters[self.arg_name].default
+        old_value = parameters[self.arg_name].default
 
         if self.warning_msg is None:
-            self.warning_msg = ""
-            if self.changed_version is not None:
-                self.warning_msg = ("Starting from version "
-                                    f"{self.changed_version}, ")
-            self.warning_msg += (f"Default {self.arg_name} value changed from "
-                                 f"{self.old_value} to {new_value}. To remove "
-                                 "this warning, please explicitely set "
-                                 f"{self.arg_name} value.")
+            self.warning_msg = (
+                f"New recommanded value for {self.arg_name} is "
+                f"{self.new_value}. Until version {self.changed_version}, "
+                f"default {self.arg_name} value is {old_value}. Starting "
+                f"from version {self.changed_version}, {self.arg_name} "
+                f"default value will be set to {self.new_value}. To avoid "
+                f"this warning, please explicitely set {self.arg_name} value.")
 
         @functools.wraps(func)
         def fixed_func(*args, **kwargs):
             if len(args) < arg_idx + 1 and self.arg_name not in kwargs.keys():
                 # warn that arg_name default value changed:
                 warnings.warn(self.warning_msg, FutureWarning, stacklevel=2)
-
             return func(*args, **kwargs)
+
         return fixed_func
 
 

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -51,11 +51,11 @@ class change_default_value:
 
         if self.warning_msg is None:
             self.warning_msg = (
-                f"New recommanded value for {self.arg_name} is "
+                f"The new recommended value for {self.arg_name} is "
                 f"{self.new_value}. Until version {self.changed_version}, "
-                f"default {self.arg_name} value is {old_value}. Starting "
-                f"from version {self.changed_version}, {self.arg_name} "
-                f"default value will be set to {self.new_value}. To avoid "
+                f"the default {self.arg_name} value is {old_value}. "
+                f"From version {self.changed_version}, the {self.arg_name} "
+                f"default value will be {self.new_value}. To avoid "
                 f"this warning, please explicitly set {self.arg_name} value.")
 
         @functools.wraps(func)

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -56,7 +56,7 @@ class change_default_value:
                 f"default {self.arg_name} value is {old_value}. Starting "
                 f"from version {self.changed_version}, {self.arg_name} "
                 f"default value will be set to {self.new_value}. To avoid "
-                f"this warning, please explicitely set {self.arg_name} value.")
+                f"this warning, please explicitly set {self.arg_name} value.")
 
         @functools.wraps(func)
         def fixed_func(*args, **kwargs):

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -71,9 +71,9 @@ def _match_label_with_color(label, colors, bg_label, bg_color):
     return mapped_labels, color_cycle
 
 
-@change_default_value("bg_label", old_value=-1, changed_version="0.17")
+@change_default_value("bg_label", new_value=0, changed_version="0.19")
 def label2rgb(label, image=None, colors=None, alpha=0.3,
-              bg_label=0, bg_color=(0, 0, 0), image_alpha=1, kind='overlay'):
+              bg_label=-1, bg_color=(0, 0, 0), image_alpha=1, kind='overlay'):
     """Return an RGB image where color-coded labels are painted over the image.
 
     Parameters

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -2,7 +2,7 @@ import itertools
 
 import numpy as np
 
-from .._shared.utils import warn
+from .._shared.utils import warn, change_default_value
 from ..util import img_as_float
 from . import rgb_colors
 from .colorconv import rgb2gray, gray2rgb
@@ -71,8 +71,9 @@ def _match_label_with_color(label, colors, bg_label, bg_color):
     return mapped_labels, color_cycle
 
 
+@change_default_value("bg_label", old_value=-1, changed_version="0.17")
 def label2rgb(label, image=None, colors=None, alpha=0.3,
-              bg_label=-1, bg_color=(0, 0, 0), image_alpha=1, kind='overlay'):
+              bg_label=0, bg_color=(0, 0, 0), image_alpha=1, kind='overlay'):
     """Return an RGB image where color-coded labels are painted over the image.
 
     Parameters

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -17,12 +17,7 @@ def test_deprecation_warning():
     with pytest.warns(FutureWarning) as record:
         label2rgb(image, label)
 
-    expected_msg = ("New recommanded value for bg_label is 0. "
-                    "Until version 0.19, default bg_label "
-                    "value is -1. Starting from version "
-                    "0.19, bg_label default value will be "
-                    "set to 0. To avoid this warning, please "
-                    "explicitly set bg_label value.")
+    expected_msg = "The new recommended value"
 
     assert str(record[0].message) == expected_msg
 

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -22,7 +22,7 @@ def test_deprecation_warning():
                     "value is -1. Starting from version "
                     "0.19, bg_label default value will be "
                     "set to 0. To avoid this warning, please "
-                    "explicitely set bg_label value.")
+                    "explicitly set bg_label value.")
 
     assert str(record[0].message) == expected_msg
 

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -1,4 +1,5 @@
 import itertools
+import pytest
 
 import numpy as np
 from skimage.color.colorlabel import label2rgb
@@ -6,6 +7,24 @@ from skimage.color.colorlabel import label2rgb
 from skimage._shared import testing
 from skimage._shared.testing import (assert_array_almost_equal,
                                      assert_array_equal, assert_warns)
+
+
+def test_deprecation_warning():
+
+    image = np.ones((3, 3))
+    label = np.ones((3, 3))
+
+    with pytest.warns(FutureWarning) as record:
+        label2rgb(image, label)
+
+    expected_msg = ("New recommanded value for bg_label is 0. "
+                    "Until version 0.19, default bg_label "
+                    "value is -1. Starting from version "
+                    "0.19, bg_label default value will be "
+                    "set to 0. To avoid this warning, please "
+                    "explicitely set bg_label value.")
+
+    assert str(record[0].message) == expected_msg
 
 
 def test_shape_mismatch():

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -19,7 +19,7 @@ def test_deprecation_warning():
 
     expected_msg = "The new recommended value"
 
-    assert str(record[0].message) == expected_msg
+    assert str(record[0].message).startswith(expected_msg)
 
 
 def test_shape_mismatch():

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -12,17 +12,17 @@ def test_shape_mismatch():
     image = np.ones((3, 3))
     label = np.ones((2, 2))
     with testing.raises(ValueError):
-        label2rgb(image, label)
+        label2rgb(image, label, bg_label=-1)
 
 
 def test_wrong_kind():
     image = np.ones((3, 3))
     label = image
     # Must not raise an error.
-    label2rgb(image, label)
+    label2rgb(image, label, bg_label=-1)
     # kind='foo' is wrong.
     with testing.raises(ValueError):
-        label2rgb(image, label, kind='foo')
+        label2rgb(image, label, kind='foo', bg_label=-1)
 
 
 def test_rgb():
@@ -30,7 +30,8 @@ def test_rgb():
     label = np.arange(3).reshape(1, -1)
     colors = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
     # Set alphas just in case the defaults change
-    rgb = label2rgb(label, image=image, colors=colors, alpha=1, image_alpha=1)
+    rgb = label2rgb(label, image=image, colors=colors, alpha=1,
+                    image_alpha=1, bg_label=-1)
     assert_array_almost_equal(rgb, [colors])
 
 
@@ -38,7 +39,8 @@ def test_alpha():
     image = np.random.uniform(size=(3, 3))
     label = np.random.randint(0, 9, size=(3, 3))
     # If we set `alpha = 0`, then rgb should match image exactly.
-    rgb = label2rgb(label, image=image, alpha=0, image_alpha=1)
+    rgb = label2rgb(label, image=image, alpha=0, image_alpha=1,
+                    bg_label=-1)
     assert_array_almost_equal(rgb[..., 0], image)
     assert_array_almost_equal(rgb[..., 1], image)
     assert_array_almost_equal(rgb[..., 2], image)
@@ -47,7 +49,7 @@ def test_alpha():
 def test_no_input_image():
     label = np.arange(3).reshape(1, -1)
     colors = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
-    rgb = label2rgb(label, colors=colors)
+    rgb = label2rgb(label, colors=colors, bg_label=-1)
     assert_array_almost_equal(rgb, [colors])
 
 
@@ -56,7 +58,8 @@ def test_image_alpha():
     label = np.arange(3).reshape(1, -1)
     colors = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
     # If we set `image_alpha = 0`, then rgb should match label colors exactly.
-    rgb = label2rgb(label, image=image, colors=colors, alpha=1, image_alpha=0)
+    rgb = label2rgb(label, image=image, colors=colors, alpha=1,
+                    image_alpha=0, bg_label=-1)
     assert_array_almost_equal(rgb, [colors])
 
 
@@ -66,7 +69,8 @@ def test_color_names():
     cnames = ['red', 'lime', 'blue']
     colors = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]
     # Set alphas just in case the defaults change
-    rgb = label2rgb(label, image=image, colors=cnames, alpha=1, image_alpha=1)
+    rgb = label2rgb(label, image=image, colors=cnames, alpha=1,
+                    image_alpha=1, bg_label=-1)
     assert_array_almost_equal(rgb, [colors])
 
 
@@ -94,7 +98,8 @@ def test_nonconsecutive():
     colors = [(1, 0, 0), (0, 0, 1)]
     rout = np.array([(1., 0., 0.), (0., 0., 1.), (1., 0., 0.), (1., 0., 0.)])
     assert_array_almost_equal(
-        rout, label2rgb(labels, colors=colors, alpha=1, image_alpha=1))
+        rout, label2rgb(labels, colors=colors, alpha=1,
+                        image_alpha=1, bg_label=-1))
 
 
 def test_label_consistency():
@@ -103,8 +108,8 @@ def test_label_consistency():
     label_2 = np.array([0, 1])
     colors = [(1, 0, 0), (0, 1, 0), (0, 0, 1), (1, 1, 0), (1, 0, 1)]
     # Set alphas just in case the defaults change
-    rgb_1 = label2rgb(label_1, colors=colors)
-    rgb_2 = label2rgb(label_2, colors=colors)
+    rgb_1 = label2rgb(label_1, colors=colors, bg_label=-1)
+    rgb_2 = label2rgb(label_2, colors=colors, bg_label=-1)
     for label_id in label_2.flat:
         assert_array_almost_equal(rgb_1[label_1 == label_id],
                                   rgb_2[label_2 == label_id])
@@ -114,7 +119,7 @@ def test_leave_labels_alone():
     labels = np.array([-1, 0, 1])
     labels_saved = labels.copy()
 
-    label2rgb(labels)
+    label2rgb(labels, bg_label=-1)
     label2rgb(labels, bg_label=1)
     assert_array_equal(labels, labels_saved)
 
@@ -150,7 +155,7 @@ def test_avg():
     expected_out = np.dstack((rout, gout, bout))
 
     # test standard averaging
-    out = label2rgb(label_field, image, kind='avg')
+    out = label2rgb(label_field, image, kind='avg', bg_label=-1)
     assert_array_equal(out, expected_out)
 
     # test averaging with custom background value
@@ -168,4 +173,4 @@ def test_avg():
 def test_negative_intensity():
     labels = np.arange(100).reshape(10, 10)
     image = np.full((10, 10), -1, dtype='float64')
-    assert_warns(UserWarning, label2rgb, labels, image)
+    assert_warns(UserWarning, label2rgb, labels, image, bg_label=-1)


### PR DESCRIPTION
## Description

As proposed in #3015, this PR changes `bg_label` argument default value from -1 to 0.
To do so, the `skimage._shared.utils.change_default_value` decorator is implemented in the same spirit as `skimage._shared.utils.deprecate_kwarg`.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
