### PR TITLE
Fixed wrong behaviour of `exposure.rescale_intensity` for constant input.

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -411,7 +411,6 @@ def rescale_intensity(image, in_range='image', out_range='dtype'):
     omin, omax = map(float, intensity_range(image, out_range,
                                             clip_negative=(imin >= 0)))
 
-    # Fast test for multiple values, operations with at least 1 NaN return NaN
     if np.any(np.isnan([imin, imax, omin, omax])):
         warn(
             "One or more intensity levels are NaN. Rescaling will broadcast "

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -391,17 +391,16 @@ def rescale_intensity(image, in_range='image', out_range='dtype'):
     >>> rescale_intensity(image, out_range=(0, 127))
     array([  0. ,  63.5, 127. ])
 
-    If the input image is constant, the output will be clipped directly to the
-    output range:
-    >>> image = np.array([130, 130, 130], dtype=np.int8)
-    >>> rescale_intensity(image, out_range=(0, 127))
-    array([ 127, 127, 127], dtype=int8)
-
     To get the desired range with a specific dtype, use ``.astype()``:
 
     >>> rescale_intensity(image, out_range=(0, 127)).astype(np.int8)
     array([  0,  63, 127], dtype=int8)
 
+    If the input image is constant, the output will be clipped directly to the
+    output range:
+    >>> image = np.array([130, 130, 130], dtype=np.int32)
+    >>> rescale_intensity(image, out_range=(0, 127)).astype(np.int32)
+    array([127, 127, 127], dtype=int32)
     """
     if out_range in ['dtype', 'image']:
         out_dtype = _output_dtype(image.dtype.type)

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -280,6 +280,12 @@ def test_rescale_all_zeros():
     assert_array_almost_equal(out, image)
 
 
+def test_rescale_constant():
+    image = np.array([130, 130], dtype=np.uint16)
+    out = exposure.rescale_intensity(image, out_range=(0, 127))
+    assert_array_almost_equal(out, [127, 127])
+
+
 def test_rescale_same_values():
     image = np.ones((2, 2))
     out = exposure.rescale_intensity(image)
@@ -400,6 +406,22 @@ def test_adapthist_alpha():
     assert img.shape == adapted.shape
     assert_almost_equal(peak_snr(full_scale, adapted), 109.393, 2)
     assert_almost_equal(norm_brightness_err(full_scale, adapted), 0.0248, 3)
+
+
+def test_adapthist_constant():
+    """Test constant image, float and uint
+    """
+    img = np.zeros((8, 8))
+    img += 2
+    img = img.astype(np.uint16)
+    adapted = exposure.equalize_adapthist(img, 3)
+    assert np.min(adapted) == np.max(adapted)
+
+    img = np.zeros((8, 8))
+    img += 0.1
+    img = img.astype(np.float64)
+    adapted = exposure.equalize_adapthist(img, 3)
+    assert np.min(adapted) == np.max(adapted)
 
 
 def test_adapthist_borders():


### PR DESCRIPTION
## Description

This closes https://github.com/scikit-image/scikit-image/issues/4596.

For a constant image, the output of `exposure.rescale_intensity` could lie outside of what is defined using out_range. The proposed fix in this case directly clips the input image to the output range (and converts to the output dtype). This is consistent with intended behaviour judging from already existing tests (test_rescale_same_values).

Importantly, this bug was leading to an exception in `equalize_adapthist` for constant input images in many cases.

Tests:
- add test to check that `rescale_intensity` behavior is fixed
- add test to check fixed `equalize_adapthist` behavior when providing constant input

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
