### PR TITLE
Change math formatting in the docstrings

### DIFF
--- a/skimage/metrics/_adapted_rand_error.py
+++ b/skimage/metrics/_adapted_rand_error.py
@@ -24,8 +24,8 @@ def adapted_rand_error(image_true=None, image_test=None, *, table=None,
     Returns
     -------
     are : float
-        The adapted Rand error; equal to $1 - \frac{2pr}{p + r}$,
-        where $p$ and $r$ are the precision and recall described below.
+        The adapted Rand error; equal to :math:`1 - \frac{2pr}{p + r}`,
+        where ``p`` and ``r`` are the precision and recall described below.
     prec : float
         The adapted Rand precision: this is the number of pairs of pixels that
         have the same label in the test label image *and* in the true image,

--- a/skimage/segmentation/boundaries.py
+++ b/skimage/segmentation/boundaries.py
@@ -12,8 +12,8 @@ def _find_boundaries_subpixel(label_img):
     Notes
     -----
     This function puts in an empty row and column between each *actual*
-    row and column of the image, for a corresponding shape of $2s - 1$
-    for every image dimension of size $s$. These "interstitial" rows
+    row and column of the image, for a corresponding shape of ``2s - 1``
+    for every image dimension of size ``s``. These "interstitial" rows
     and columns are filled as ``True`` if they separate two labels in
     `label_img`, ``False`` otherwise.
 


### PR DESCRIPTION
Some very minor enhancements as I was reading docstrings (I grepped to check that these are the only `$` in docstrings).