### PR TITLE
typo fixes for register rotation gallery example

### DIFF
--- a/doc/examples/registration/plot_register_rotation.py
+++ b/doc/examples/registration/plot_register_rotation.py
@@ -71,7 +71,7 @@ print("Recovered value for counterclockwise rotation: "
 # =================================================================
 #
 # In this second example, the images differ by both rotation and scaling (note
-# the axis tick values). By remapping these images into log-polar space, we
+# the axis tick values). By remapping these images into log-polar space,
 # we can recover rotation as before, and now also scaling, by phase
 # correlation.
 
@@ -132,7 +132,7 @@ print(f"Recovered value for scaling difference: {shift_scale}")
 # rotation and scaling differences, but not translation differences, are
 # apparent in the frequency magnitude spectra of the images. These differences
 # can be recovered by treating the magnitude spectra as images themselves, and
-# appplying the same log-polar + phase correlation approach taken above.
+# applying the same log-polar + phase correlation approach taken above.
 
 from skimage.color import rgb2gray
 from skimage.filters import window, difference_of_gaussians


### PR DESCRIPTION
## Description
Fixing two small typos in the registration example that was just merged.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
