### PR TITLE
random walker: Display a warning when the probability is outsite [0,1] for a given tol

### DIFF
--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -264,7 +264,8 @@ def _preprocess(labels):
 
 
 def random_walker(data, labels, beta=130, mode='cg_j', tol=1.e-3, copy=True,
-                  multichannel=False, return_full_prob=False, spacing=None):
+                  multichannel=False, return_full_prob=False, spacing=None,
+                  *, prob_tol=1e-3):
     """Random walker algorithm for segmentation from markers.
 
     Random walker algorithm is implemented for gray-level or multichannel
@@ -310,7 +311,7 @@ def random_walker(data, labels, beta=130, mode='cg_j', tol=1.e-3, copy=True,
           requires that the pyamg module is installed.
 
     tol : float, optional
-        tolerance to achieve when solving the linear system using
+        Tolerance to achieve when solving the linear system using
         the conjugate gradient based modes ('cg', 'cg_j' and 'cg_mg').
     copy : bool, optional
         If copy is False, the `labels` array will be overwritten with
@@ -326,6 +327,9 @@ def random_walker(data, labels, beta=130, mode='cg_j', tol=1.e-3, copy=True,
     spacing : iterable of floats, optional
         Spacing between voxels in each spatial dimension. If `None`, then
         the spacing between pixels/voxels in each dimension is assumed 1.
+    prob_tol : float, optional
+        Tolerance on the resulting probability to be in the interval [0, 1].
+        If the tolerance is not satisfied, a warning is displayed.
 
     Returns
     -------
@@ -484,6 +488,11 @@ def random_walker(data, labels, beta=130, mode='cg_j', tol=1.e-3, copy=True,
     # where X[i, j] is the probability that a marker of label i arrives
     # first at pixel j by anisotropic diffusion.
     X = _solve_linear_system(lap_sparse, B, tol, mode)
+
+    if -X.min() < prob_tol or X.max() - 1 < prob_tol:
+        warn('The probability range is outside [0, 1] given the tolerance '
+             '`prob_tol`. Consider decreasing `beta` and/or decreasing '
+             '`tol`'.)
 
     # Build the output according to return_full_prob value
     # Put back labels of isolated seeds

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -492,7 +492,7 @@ def random_walker(data, labels, beta=130, mode='cg_j', tol=1.e-3, copy=True,
     if X.min() < -prob_tol or X.max() > 1 + prob_tol:
         warn('The probability range is outside [0, 1] given the tolerance '
              '`prob_tol`. Consider decreasing `beta` and/or decreasing '
-             '`tol`'.)
+             '`tol`.')
 
     # Build the output according to return_full_prob value
     # Put back labels of isolated seeds

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -489,7 +489,7 @@ def random_walker(data, labels, beta=130, mode='cg_j', tol=1.e-3, copy=True,
     # first at pixel j by anisotropic diffusion.
     X = _solve_linear_system(lap_sparse, B, tol, mode)
 
-    if -X.min() < prob_tol or X.max() - 1 < prob_tol:
+    if X.min() < -prob_tol or X.max() > 1 + prob_tol:
         warn('The probability range is outside [0, 1] given the tolerance '
              '`prob_tol`. Consider decreasing `beta` and/or decreasing '
              '`tol`'.)

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -444,9 +444,6 @@ def test_isolated_seeds():
 
 
 def test_prob_tol():
-    # Turn warnings into errors
-    warnings.simplefilter('error')
-
     np.random.seed(0)
     a = np.random.random((7, 7))
     mask = - np.ones(a.shape)

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -463,16 +463,19 @@ def test_prob_tol():
         res = random_walker(a, mask, return_full_prob=True)
 
     # Lower beta, no warning is expected.
-    res = random_walker(a, mask, return_full_prob=True, beta=10)
+    with expected_warnings([NUMPY_MATRIX_WARNING]):
+        res = random_walker(a, mask, return_full_prob=True, beta=10)
     assert res[0, 1, 1] == 1
     assert res[1, 1, 1] == 0
 
     # Being more prob_tol tolerant, no warning is expected.
-    res = random_walker(a, mask, return_full_prob=True, prob_tol=1e-1)
+    with expected_warnings([NUMPY_MATRIX_WARNING]):
+        res = random_walker(a, mask, return_full_prob=True, prob_tol=1e-1)
     assert res[0, 1, 1] == 1
     assert res[1, 1, 1] == 0
 
     # Reduced tol, no warning is expected.
-    res = random_walker(a, mask, return_full_prob=True, tol=1e-9)
+    with expected_warnings([NUMPY_MATRIX_WARNING]):
+        res = random_walker(a, mask, return_full_prob=True, tol=1e-9)
     assert res[0, 1, 1] == 1
     assert res[1, 1, 1] == 0

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -215,7 +215,8 @@ def test_multispectral_2d():
     data, labels = make_2d_syntheticdata(lx, ly)
     data = data[..., np.newaxis].repeat(2, axis=-1)  # Expect identical output
     with expected_warnings(['"cg" mode' + '|' + SCIPY_RANK_WARNING,
-                            NUMPY_MATRIX_WARNING]):
+                            NUMPY_MATRIX_WARNING,
+                            'The probability range is outside [0, 1]']):
         multi_labels = random_walker(data, labels, mode='cg',
                                      multichannel=True)
     assert data[..., 0].shape == labels.shape
@@ -430,7 +431,8 @@ def test_isolated_seeds():
     mask[6, 6] = 1
 
     # Test that no error is raised, and that labels of isolated seeds are OK
-    with expected_warnings([NUMPY_MATRIX_WARNING]):
+    with expected_warnings([NUMPY_MATRIX_WARNING,
+                            'The probability range is outside [0, 1]']):
         res = random_walker(a, mask)
     assert res[1, 1] == 1
     with expected_warnings([NUMPY_MATRIX_WARNING]):

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -467,8 +467,12 @@ def test_prob_tol():
     assert res[0, 1, 1] == 1
     assert res[1, 1, 1] == 0
 
-    # Reduced prob_tol tolerance, no warning is expected.
+    # Being more prob_tol tolerant, no warning is expected.
     res = random_walker(a, mask, return_full_prob=True, prob_tol=1e-1)
     assert res[0, 1, 1] == 1
     assert res[1, 1, 1] == 0
 
+    # Reduced tol, no warning is expected.
+    res = random_walker(a, mask, return_full_prob=True, tol=1e-9)
+    assert res[0, 1, 1] == 1
+    assert res[1, 1, 1] == 0

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -216,7 +216,7 @@ def test_multispectral_2d():
     data = data[..., np.newaxis].repeat(2, axis=-1)  # Expect identical output
     with expected_warnings(['"cg" mode' + '|' + SCIPY_RANK_WARNING,
                             NUMPY_MATRIX_WARNING,
-                            'The probability range is outside [0, 1]']):
+                            'The probability range is outside']):
         multi_labels = random_walker(data, labels, mode='cg',
                                      multichannel=True)
     assert data[..., 0].shape == labels.shape
@@ -432,10 +432,11 @@ def test_isolated_seeds():
 
     # Test that no error is raised, and that labels of isolated seeds are OK
     with expected_warnings([NUMPY_MATRIX_WARNING,
-                            'The probability range is outside [0, 1]']):
+                            'The probability range is outside']):
         res = random_walker(a, mask)
     assert res[1, 1] == 1
-    with expected_warnings([NUMPY_MATRIX_WARNING]):
+    with expected_warnings([NUMPY_MATRIX_WARNING,
+                            'The probability range is outside']):
         res = random_walker(a, mask, return_full_prob=True)
     assert res[0, 1, 1] == 1
     assert res[1, 1, 1] == 0

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -1,5 +1,4 @@
 import numpy as np
-import warnings
 from skimage.segmentation import random_walker
 from skimage.transform import resize
 from skimage._shared._warnings import expected_warnings


### PR DESCRIPTION

## Description

I fully agree with the diagnosis explained in this https://github.com/scikit-image/scikit-image/issues/2360#issuecomment-326753181

In this PR, I add a new parameter to display a warning when the probability is off.

Closes #2360

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
