### PR TITLE
add docstring examples for moments_hu and centroid

### DIFF
--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -363,7 +363,7 @@ def centroid(image):
 
     Examples
     --------
-    image = np.zeros((20, 20), dtype=np.double)
+    >>> image = np.zeros((20, 20), dtype=np.double)
     >>> image[13:17, 13:17] = 0.5
     >>> image[10:12, 10:12] = 1
     >>> centroid(image)

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -292,7 +292,6 @@ def moments_normalized(mu, order=3):
            [       nan, 0.        , 0.        , 0.        ],
            [0.078125  , 0.        , 0.00610352, 0.        ],
            [0.        , 0.        , 0.        , 0.        ]])
-
     """
     if np.any(np.array(mu.shape) <= order):
         raise ValueError("Shape of image moments must be >= `order`")
@@ -315,7 +314,7 @@ def moments_hu(nu):
     Parameters
     ----------
     nu : (M, M) array
-        Normalized central image moments, where M must be > 4.
+        Normalized central image moments, where M must be >= 4.
 
     Returns
     -------
@@ -335,7 +334,16 @@ def moments_hu(nu):
            Berlin, 1993.
     .. [5] https://en.wikipedia.org/wiki/Image_moment
 
-
+    Examples
+    --------
+    >>> image = np.zeros((20, 20), dtype=np.double)
+    >>> image[13:17, 13:17] = 0.5
+    >>> image[10:12, 10:12] = 1
+    >>> mu = moments_central(image)
+    >>> nu = moments_normalized(mu)
+    >>> moments_hu(nu)
+    array([7.45370370e-01, 3.51165981e-01, 1.04049179e-01, 4.06442107e-02,
+           2.64312299e-03, 2.40854582e-02, 4.33680869e-19])
     """
     return _moments_cy.moments_hu(nu.astype(np.double))
 
@@ -352,6 +360,14 @@ def centroid(image):
     -------
     center : tuple of float, length ``image.ndim``
         The centroid of the (nonzero) pixels in ``image``.
+
+    Examples
+    --------
+    image = np.zeros((20, 20), dtype=np.double)
+    >>> image[13:17, 13:17] = 0.5
+    >>> image[10:12, 10:12] = 1
+    >>> centroid(image)
+    array([13.16666667, 13.16666667])
     """
     M = moments_central(image, center=(0,) * image.ndim, order=1)
     center = (M[tuple(np.eye(image.ndim, dtype=int))]  # array of weighted sums


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

This PR corrects a statement of ">4" to be ">=4" in the `moments_hu` docstring and adds a basic usage example.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)~

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
