### PR TITLE
Misleading "ValueError: Input array has to be either 3- or 4-dimensional" in montage

### DIFF
--- a/skimage/util/_montage.py
+++ b/skimage/util/_montage.py
@@ -94,8 +94,9 @@ def montage(arr_in, fill='mean', rescale_intensity=False, grid_shape=None,
         arr_in = np.asarray(arr_in)[..., np.newaxis]
 
     if arr_in.ndim != 4:
-        raise ValueError('Input array has to be 3-dimensional '
-                         'or 4-dimensional, with `multichannel=True`')
+        raise ValueError('Input array has to be 3-dimensional for grayscale '
+                         'images, or 4-dimensional with `multichannel=True` '
+                         'for color images.')
 
     n_images, n_rows, n_cols, n_chan = arr_in.shape
 


### PR DESCRIPTION
## Description

fixes #4606

@jni @emmanuelle This has to be merged for 0.17. Fixes an incorrectly fixed wrong message...

I checked. Unitests are well implemented for this exception.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
