### PR TITLE
Refactor ArrayMap.__setitem__ to prevent memory allocation

### DIFF
--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -347,7 +347,7 @@ class ArrayMap:
         if np.isscalar(values) or len(values) == 1:
             values = np.repeat(values, len(indices))
 
-        for ind, val in zip(np.atleast_1d(indices), np.atleast_1d(values)):
+        for ind, val in zip(indices, values):
             if ind in self.in_values:
                 self.out_values[self.in_values == ind] = val
             else:

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -332,9 +332,24 @@ class ArrayMap:
         return out
 
     def __setitem__(self, indices, values):
-        for ind, val in zip(indices, values):
+        if np.isscalar(indices):
+            indices = np.atleast_1d(indices)
+        elif isinstance(indices, slice):
+            start = indices.start or 0  # treat None or 0 the same way
+            stop = (indices.stop
+                    if indices.stop is not None
+                    else len(self))
+            step = indices.step
+            indices = np.arange(start, stop, step)
+        if indices.dtype == bool:
+            indices = np.flatnonzero(indices)
+
+        if np.isscalar(values) or len(values) == 1:
+            values = np.repeat(values, len(indices))
+
+        for ind, val in zip(np.atleast_1d(indices), np.atleast_1d(values)):
             if ind in self.in_values:
                 self.out_values[self.in_values == ind] = val
             else:
-                self.in_values = np.append(np.in_values, ind)
-                self.out_values = np.append(np.out_values, val)
+                self.in_values = np.append(self.in_values, ind)
+                self.out_values = np.append(self.out_values, val)

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -183,7 +183,7 @@ def map_array(input_arr, input_vals, output_vals, out=None):
     # We ravel the input array for simplicity of iteration in Cython:
     orig_shape = input_arr.shape
     # NumPy docs for `np.ravel()` says:
-    # "When a view is desired in as many cases as possible, 
+    # "When a view is desired in as many cases as possible,
     # arr.reshape(-1) may be preferable."
     input_arr = input_arr.reshape(-1)
     if out is None:
@@ -260,7 +260,6 @@ class ArrayMap:
         self.in_values = in_values
         self.out_values = out_values
         self._max_str_lines = 4
-        self._array = None
 
     def __len__(self):
         """Return one more than the maximum label value being remapped."""
@@ -268,7 +267,7 @@ class ArrayMap:
 
     def __array__(self, dtype=None):
         """Return an array that behaves like the arraymap when indexed.
-        
+
         This array can be very large: it is the size of the largest value
         in the ``in_vals`` array, plus one.
         """
@@ -333,8 +332,9 @@ class ArrayMap:
         return out
 
     def __setitem__(self, indices, values):
-        if self._array is None:
-            self._array = self.__array__()
-        self._array[indices] = values
-        self.in_values = np.flatnonzero(self._array)
-        self.out_values = self._array[self.in_values]
+        for ind, val in zip(indices, values):
+            if ind in self.in_values:
+                self.out_values[self.in_values == ind] = val
+            else:
+                self.in_values = np.append(np.in_values, ind)
+                self.out_values = np.append(np.out_values, val)

--- a/skimage/segmentation/tests/test_join.py
+++ b/skimage/segmentation/tests/test_join.py
@@ -258,4 +258,3 @@ def test_arraymap_bool_index():
     positive[0] = False
     m[positive] += 1
     assert np.all(m[image] >= 1)
-


### PR DESCRIPTION
## Description

I did not review this before the merge of #4612, sorry.
This PR removes the potential huge memory allocation when `MapArray.__array__` is called in `MapArray.__setitem__`.

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
