### PR TITLE
AffineTransform: Allow a single value for 'scale' to apply to both sx & sy

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -806,8 +806,7 @@ class AffineTransform(ProjectiveTransform):
             if translation is None:
                 translation = (0, 0)
 
-            scale = np.atleast_1d(scale)
-            if len(scale) == 1:
+            if np.isscalar(scale):
                 sx = sy = scale
             else:
                 sx, sy = scale

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -765,8 +765,8 @@ class AffineTransform(ProjectiveTransform):
     ----------
     matrix : (3, 3) array, optional
         Homogeneous transformation matrix.
-    scale : (sx, sy) as array, list or tuple, optional
-        Scale factors.
+    scale : {s as float or (sx, sy) as array, list or tuple}, optional
+        Scale factor(s). If a single value, it will be assigned to both sx and sy.
     rotation : float, optional
         Rotation angle in counter-clockwise direction as radians.
     shear : float, optional
@@ -805,7 +805,12 @@ class AffineTransform(ProjectiveTransform):
             if translation is None:
                 translation = (0, 0)
 
-            sx, sy = scale
+            scale = np.atleast_1d(scale)
+            if len(scale) == 1:
+                sx = sy = scale
+            else:
+                sx, sy = scale
+
             self.params = np.array([
                 [sx * math.cos(rotation), -sy * math.sin(rotation + shear), 0],
                 [sx * math.sin(rotation),  sy * math.cos(rotation + shear), 0],

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -766,7 +766,8 @@ class AffineTransform(ProjectiveTransform):
     matrix : (3, 3) array, optional
         Homogeneous transformation matrix.
     scale : {s as float or (sx, sy) as array, list or tuple}, optional
-        Scale factor(s). If a single value, it will be assigned to both sx and sy.
+        Scale factor(s). If a single value, it will be assigned to both
+        sx and sy.
     rotation : float, optional
         Rotation angle in counter-clockwise direction as radians.
     shear : float, optional

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -199,6 +199,9 @@ def test_affine_init():
     assert_almost_equal(tform2.shear, shear)
     assert_almost_equal(tform2.translation, translation)
 
+    # scalar vs. tuple scale arguments
+    assert_almost_equal(AffineTransform(scale=0.5).scale, AffineTransform(scale=(0.5, 0.5)).scale)
+
 
 def test_piecewise_affine():
     tform = PiecewiseAffineTransform()


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

This is a small change to the AffineTransform constructor to accept a single scaling factor as an alternative to an explicit sx & sy. This is similar to transform.rescale which works with either a single scalar or one per dimension.

(This is probably not the right style to detect a single value, but sufficient for getting feedback if it should be fixed. Thanks!)

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
