### PR TITLE
Fix sphinx

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,4 @@
-sphinx>=1.8
+sphinx>=1.8,<=2.4.4
 numpydoc>=0.9
 sphinx-gallery>=0.3.1
 sphinx-copybutton

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -313,9 +313,9 @@ def _hough_line(cnp.ndarray img,
     # finally, run the transform
     cdef Py_ssize_t nidxs, nthetas, i, j, x, y, accum_idx
 
+    nidxs = y_idxs.shape[0]  # x and y are the same shape
+    nthetas = theta.shape[0]
     with nogil:
-        nidxs = y_idxs.shape[0]  # x and y are the same shape
-        nthetas = theta.shape[0]
         for i in range(nidxs):
             x = x_idxs[i]
             y = y_idxs[i]


### PR DESCRIPTION
Closes #4616. At the moment the search is broken in the dev documentation (including on the deployed website). We should try to fix this with the most recent sphinx but since the release is coming, this is a quick and dirty solution, pinning the sphinx version before the offending version.