### PR TITLE
DOC: fix broken DOI links

### DIFF
--- a/doc/examples/edges/plot_active_contours.py
+++ b/doc/examples/edges/plot_active_contours.py
@@ -22,7 +22,7 @@ boundaries of the face.
 
 .. [1] *Snakes: Active contour models*. Kass, M.; Witkin, A.; Terzopoulos, D.
        International Journal of Computer Vision 1 (4): 321 (1988).
-       DOI:`10.1007/BF00133570`
+       :DOI:`10.1007/BF00133570`
 """
 
 import numpy as np

--- a/skimage/morphology/max_tree.py
+++ b/skimage/morphology/max_tree.py
@@ -208,19 +208,19 @@ def area_opening(image, area_threshold=64, connectivity=1,
            May 1993.
     .. [2] Soille, P., "Morphological Image Analysis: Principles and
            Applications" (Chapter 6), 2nd edition (2003), ISBN 3540429883.
-           DOI:10.1007/978-3-662-05088-0
+           :DOI:10.1007/978-3-662-05088-0
     .. [3] Salembier, P., Oliveras, A., & Garrido, L. (1998). Antiextensive
            Connected Operators for Image and Sequence Processing.
            IEEE Transactions on Image Processing, 7(4), 555-570.
-           DOI:10.1109/83.663500
+           :DOI:10.1109/83.663500
     .. [4] Najman, L., & Couprie, M. (2006). Building the component tree in
            quasi-linear time. IEEE Transactions on Image Processing, 15(11),
            3531-3539.
-           DOI:10.1109/TIP.2006.877518
+           :DOI:10.1109/TIP.2006.877518
     .. [5] Carlinet, E., & Geraud, T. (2014). A Comparative Review of
            Component Tree Computation Algorithms. IEEE Transactions on Image
            Processing, 23(9), 3885-3895.
-           DOI:10.1109/TIP.2014.2336551
+           :DOI:10.1109/TIP.2014.2336551
 
     Examples
     --------


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->
I grepped the code base for locations where the sphinx `:DOI:` roie was missing the first colon, causing the links to not be generated. I also checked for, but did not find any broken `:arXiv:` links.

Missing links can be seen in the references to `area_opening` here: https://scikit-image.org/docs/dev/api/skimage.morphology.html#area-opening


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->


<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
