### PR TITLE
`equalize_adapthist`: More efficient processing scheme with symmetrical padding

### DIFF
--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -125,16 +125,20 @@ def _clahe(image, kernel_size, clip_limit, nbins):
     """
     ndim = image.ndim
     dtype = image.dtype
+    input_shape = image.shape
 
-    # pad the image such that the shape in each dimension
+    # pad the image symmetrically such that the shape in each dimension
     # - is a multiple of the kernel_size and
-    # - is preceded by half a kernel size
-    pad_start_per_dim = [k // 2 for k in kernel_size]
+    # - is preceded by half a kernel size (for histograms)
 
-    pad_end_per_dim = [(k - s % k) % k + int(np.ceil(k / 2.))
-                       for k, s in zip(kernel_size, image.shape)]
+    pad_to_fit_kernel = [(k - s % k) % k
+                         for k, s in zip(kernel_size, image.shape)]
+    pad_start_per_dim = [np.floor(k / 2) + np.ceil(pk / 2)
+                         for k, pk in zip(kernel_size, pad_to_fit_kernel)]
+    pad_end_per_dim = [np.ceil(k / 2) + np.floor(pk / 2)
+                       for k, pk in zip(kernel_size, pad_to_fit_kernel)]
 
-    image = np.pad(image, [[p_i, p_f] for p_i, p_f in
+    image = np.pad(image, [[int(p_i), int(p_f)] for p_i, p_f in
                            zip(pad_start_per_dim, pad_end_per_dim)],
                    mode='reflect')
 
@@ -147,13 +151,11 @@ def _clahe(image, kernel_size, clip_limit, nbins):
 
     # calculate graylevel mappings for each contextual region
     # rearrange image into flattened contextual regions
-    ns_hist = [int(s / k) - 1 for s, k in zip(image.shape, kernel_size)]
+    ns_hist = [int(s / k) for s, k in zip(image.shape, kernel_size)]
     hist_blocks_shape = np.array([ns_hist, kernel_size]).T.flatten()
     hist_blocks_axis_order = np.array([np.arange(0, ndim * 2, 2),
                                        np.arange(1, ndim * 2, 2)]).flatten()
-    hist_slices = [slice(k // 2, k // 2 + n * k)
-                   for k, n in zip(kernel_size, ns_hist)]
-    hist_blocks = image[tuple(hist_slices)].reshape(hist_blocks_shape)
+    hist_blocks = image.reshape(hist_blocks_shape)
     hist_blocks = np.transpose(hist_blocks, axes=hist_blocks_axis_order)
     hist_block_assembled_shape = hist_blocks.shape
     hist_blocks = hist_blocks.reshape((np.product(ns_hist), -1))
@@ -167,12 +169,7 @@ def _clahe(image, kernel_size, clip_limit, nbins):
     hist = np.apply_along_axis(np.bincount, -1, hist_blocks, minlength=nbins)
     hist = np.apply_along_axis(clip_histogram, -1, hist, clip_limit=clim)
     hist = map_histogram(hist, 0, NR_OF_GRAY - 1, np.product(kernel_size))
-    hist = hist.reshape(hist_block_assembled_shape[:ndim] + (-1,))
-
-    # duplicate leading mappings in each dim
-    map_array = np.pad(hist,
-                       [[1, 1] for _ in range(ndim)] + [[0, 0]],
-                       mode='edge')
+    map_array = hist.reshape(hist_block_assembled_shape[:ndim] + (-1,))
 
     # Perform multilinear interpolation of graylevel mappings
     # using the convention described here:
@@ -180,11 +177,14 @@ def _clahe(image, kernel_size, clip_limit, nbins):
     # equalization&oldid=936814673#Efficient_computation_by_interpolation
 
     # rearrange image into blocks for vectorized processing
-    ns_proc = [int(s / k) for s, k in zip(image.shape, kernel_size)]
+    ns_proc = [int(s / k) - 1 for s, k in zip(image.shape, kernel_size)]
     blocks_shape = np.array([ns_proc, kernel_size]).T.flatten()
     blocks_axis_order = np.array([np.arange(0, ndim * 2, 2),
                                   np.arange(1, ndim * 2, 2)]).flatten()
-    blocks = image.reshape(blocks_shape)
+    blocks_slices = [slice(int(np.floor(k / 2)),
+                           int(np.floor(k / 2) + n * k))
+                     for k, n in zip(kernel_size, ns_proc)]
+    blocks = image[tuple(blocks_slices)].reshape(blocks_shape)
     blocks = np.transpose(blocks, axes=blocks_axis_order)
     blocks_flattened_shape = blocks.shape
     blocks = np.reshape(blocks, (np.product(ns_proc),
@@ -222,12 +222,13 @@ def _clahe(image, kernel_size, clip_limit, nbins):
         np.array([np.arange(0, ndim),
                   np.arange(ndim, ndim * 2)]).T.flatten()
     result = np.transpose(result, axes=blocks_axis_rebuild_order)
-    result = result.reshape(image.shape)
+    result = result.reshape([k * n for k, n in zip(kernel_size, ns_proc)])
 
     # undo padding
-    unpad_slices = tuple([slice(p_i, s - p_f) for p_i, p_f, s in
-                          zip(pad_start_per_dim, pad_end_per_dim,
-                              image.shape)])
+    unpad_slices = tuple([slice(int(np.ceil(pk / 2)),
+                                int(np.ceil(pk / 2) + s))
+                          for pk, s in zip(pad_to_fit_kernel, input_shape)])
+
     result = result[unpad_slices]
 
     return result

--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -127,6 +127,13 @@ def _clahe(image, kernel_size, clip_limit, nbins):
     dtype = image.dtype
     input_shape = image.shape
 
+    # For block processing / padding use the convention illustrated
+    # in fig. 2 of this paper:
+    # V. Stimper, S. Bauer, R. Ernstorfer, B. Schölkopf and R. P. Xian,
+    # "Multidimensional Contrast Limited Adaptive Histogram
+    # Equalization," in IEEE Access, vol. 7, pp. 165437-165447, 2019,
+    # doi: 10.1109/ACCESS.2019.2952899.
+
     # pad the image symmetrically such that the shape in each dimension
     # - is a multiple of the kernel_size and
     # - is preceded by half a kernel size (for histograms)
@@ -172,9 +179,6 @@ def _clahe(image, kernel_size, clip_limit, nbins):
     map_array = hist.reshape(hist_block_assembled_shape[:ndim] + (-1,))
 
     # Perform multilinear interpolation of graylevel mappings
-    # using the convention described here:
-    # https://en.wikipedia.org/w/index.php?title=Adaptive_histogram_
-    # equalization&oldid=936814673#Efficient_computation_by_interpolation
 
     # rearrange image into blocks for vectorized processing
     ns_proc = [int(s / k) - 1 for s, k in zip(image.shape, kernel_size)]

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -370,8 +370,8 @@ def test_adapthist_grayscale():
     adapted = exposure.equalize_adapthist(img, kernel_size=(57, 51),
                                           clip_limit=0.01, nbins=128)
     assert img.shape == adapted.shape
-    assert_almost_equal(peak_snr(img, adapted), 100.140, 3)
-    assert_almost_equal(norm_brightness_err(img, adapted), 0.0529, 3)
+    assert_almost_equal(peak_snr(img, adapted), 99.238, 3)
+    assert_almost_equal(norm_brightness_err(img, adapted), 0.0549, 3)
 
 
 def test_adapthist_color():
@@ -388,7 +388,7 @@ def test_adapthist_color():
     assert adapted.max() == 1.0
     assert img.shape == adapted.shape
     full_scale = exposure.rescale_intensity(img)
-    assert_almost_equal(peak_snr(full_scale, adapted), 109.393, 1)
+    assert_almost_equal(peak_snr(full_scale, adapted), 108.794, 1)
     assert_almost_equal(norm_brightness_err(full_scale, adapted), 0.02, 2)
     return data, adapted
 
@@ -404,8 +404,8 @@ def test_adapthist_alpha():
     img = img[:, :, :3]
     full_scale = exposure.rescale_intensity(img)
     assert img.shape == adapted.shape
-    assert_almost_equal(peak_snr(full_scale, adapted), 109.393, 2)
-    assert_almost_equal(norm_brightness_err(full_scale, adapted), 0.0248, 3)
+    assert_almost_equal(peak_snr(full_scale, adapted), 108.794, 2)
+    assert_almost_equal(norm_brightness_err(full_scale, adapted), 0.0231, 3)
 
 
 def test_adapthist_grayscale_Nd():


### PR DESCRIPTION
## Description

Modified the processing scheme for obtaining CLAHE results. By performing symmetrical padding, the image blocks of size `kernel_size` to be processed can be overlapped more efficiently with the input image shape. This reduces overhead and increases processing speed while only slightly changing the results.

This has previously been discussed with @emmanuelle, @jni and @VincentStimper in the recent rewrite of `equalize_adapthist` https://github.com/scikit-image/scikit-image/pull/4598.

In addition to changing the processing scheme, this PR adapts the test values that changed slightly due to introduced implementation change.

Visual comparison between master and this PR (default arguments to `equalize_adapthist`):
![image](https://user-images.githubusercontent.com/12528388/81334458-5d268d80-90a6-11ea-9c3e-377ef891ac6b.png)



Performance comparison in 2D (improvement for large kernel sizes as number of blocks to process per dimension is reduced by one):
```python
img = util.img_as_float(data.astronaut())[:,:,0]
img = img.astype(np.float64) / img.max()

kernel_size = 10
%timeit exposure._adapthist.equalize_adapthist_master(img, kernel_size) # 0.194s
%timeit exposure._adapthist.equalize_adapthist_PR(img, kernel_size) # 0.191s

kernel_size = 100
%timeit exposure._adapthist.equalize_adapthist_master(img, kernel_size) # 0.0329s
%timeit exposure._adapthist.equalize_adapthist_PR(img, kernel_size) # 0.0257s
```
## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
