### PR TITLE
Add example for 3D adaptive histogram equalization (AHE)

### DIFF
--- a/doc/examples/color_exposure/plot_adapt_hist_eq.py
+++ b/doc/examples/color_exposure/plot_adapt_hist_eq.py
@@ -83,8 +83,8 @@ def plt_render_volume(vol, fig_ax, ref_vol=None, vmin=0, vmax=1, bin_width=10):
     # group pixels by intensity and plot separately, as 3D scatter
     # does not accept arrays of alpha values
     for il in range(1, len(levels)):
-        sel = (ref_vol_scaled >= levels[il - 1])\
-                * (ref_vol_scaled < levels[il])
+        sel = (ref_vol_scaled >= levels[il - 1])
+        sel *= (ref_vol_scaled < levels[il])
         c = get_rgba(vol_scaled[sel], 'viridis',
                      vmin=0, vmax=1, alpha=alphas[il - 1])
         fig_ax.scatter(xs.flatten()[sel],

--- a/doc/examples/color_exposure/plot_adapt_hist_eq.py
+++ b/doc/examples/color_exposure/plot_adapt_hist_eq.py
@@ -3,10 +3,10 @@
 3D adaptive histogram equalization
 ==================================
 
-Adaptive histogram equalization (AHE) can be used to improve the local contrast of an
-image [1]_. Specifically, AHE can be useful for normalizing intensities across images.
-This example compares the results of applying AHE to a 3D image and a degraded version
-of it.
+Adaptive histogram equalization (AHE) can be used to improve the local
+contrast of an image [1]_. Specifically, AHE can be useful for normalizing
+intensities across images. This example compares the results of applying AHE
+to a 3D image and a degraded version of it.
 
 .. [1] https://en.wikipedia.org/wiki/Histogram_equalization
 """
@@ -84,7 +84,7 @@ def plt_render_volume(vol, fig_ax, ref_vol=None, vmin=0, vmax=1, bin_width=10):
     # does not accept arrays of alpha values
     for il in range(1, len(levels)):
         sel = (ref_vol_scaled >= levels[il - 1])\
-              * (ref_vol_scaled < levels[il])
+                * (ref_vol_scaled < levels[il])
         c = get_rgba(vol_scaled[sel], 'viridis',
                      vmin=0, vmax=1, alpha=alphas[il - 1])
         fig_ax.scatter(xs.flatten()[sel],

--- a/doc/examples/color_exposure/plot_adapt_hist_eq.py
+++ b/doc/examples/color_exposure/plot_adapt_hist_eq.py
@@ -1,0 +1,130 @@
+"""
+==================================
+3D adaptive histogram equalization
+==================================
+
+Adaptive histogram equalization (AHE) can be used to improve the local contrast of an
+image [1]_. Specifically, AHE can be useful for normalizing intensities across images.
+This example compares the results of applying AHE to a 3D image and a degraded version
+of it.
+
+.. [1] https://en.wikipedia.org/wiki/Histogram_equalization
+"""
+
+import matplotlib.pyplot as plt
+from matplotlib import cm, colors
+
+import numpy as np
+from skimage import exposure
+from scipy import ndimage
+
+
+#############
+# Prepare data and apply AHE
+#############
+
+# create random 3d data by zooming into random array
+a = 5
+np.random.seed(100)
+im_orig = np.random.randint(0, 1000,
+                            (a, a, a)).astype(np.float64) / 1000.
+im_orig = ndimage.zoom(im_orig, 50, order=1)
+
+
+# degrade image by applying uneven intensity gradient along x
+sigmoid = (1 / (1 + np.exp(5 * (np.linspace(0, 1, im_orig.shape[0]) - 0.5))))
+im_degraded = (im_orig.T * sigmoid).T
+
+# recover local contrast with AHE
+kernel_size, clip_limit = 55, 0.5
+im_orig_ahe = exposure.equalize_adapthist(im_orig,
+                                          kernel_size=kernel_size,
+                                          clip_limit=clip_limit)
+im_degraded_ahe = exposure.equalize_adapthist(im_degraded,
+                                              kernel_size=kernel_size,
+                                              clip_limit=clip_limit)
+
+
+#############
+# define functions to help plot the data
+#############
+
+def get_rgba(scalars, cmap, vmin, vmax, alpha=0.2):
+    """
+    Convert array of scalars into array of corresponding RGBA values.
+    """
+    norm = colors.Normalize(vmin=vmin, vmax=vmax)
+    scalar_map = cm.ScalarMappable(norm=norm, cmap=cmap)
+    rgbas = scalar_map.to_rgba(scalars)
+    rgbas[:, 3] = alpha
+    return rgbas
+
+
+def plt_render_volume(vol, fig_ax, ref_vol=None, vmin=0, vmax=1, bin_width=10):
+    """
+    Render a volume in a 3D matplotlib scatter plot.
+    Better would be to use napari.
+    """
+
+    xs, ys, zs = np.mgrid[0:vol.shape[0]:bin_width,
+                          0:vol.shape[1]:bin_width,
+                          0:vol.shape[2]:bin_width]
+    vol_scaled = vol[::bin_width, ::bin_width, ::bin_width].flatten()
+    ref_vol_scaled = ref_vol[::bin_width, ::bin_width, ::bin_width].flatten()
+
+    # define alpha transfer function
+    levels = np.linspace(vmin, vmax, 50)
+    alphas = np.mean([levels[1:], levels[:-1]], 0)
+    alphas = alphas ** 3
+    alphas = (alphas - alphas.min()) / (alphas.max() - alphas.min())
+    alphas *= 0.8
+    alphas = np.clip(alphas, 0.2, 1)
+
+    # group pixels by intensity and plot separately, as 3D scatter
+    # does not accept arrays of alpha values
+    for il in range(1, len(levels)):
+        sel = (ref_vol_scaled >= levels[il - 1])\
+              * (ref_vol_scaled < levels[il])
+        c = get_rgba(vol_scaled[sel], 'viridis',
+                     vmin=0, vmax=1, alpha=alphas[il - 1])
+        fig_ax.scatter(xs.flatten()[sel],
+                       ys.flatten()[sel],
+                       zs.flatten()[sel],
+                       marker='o', c=c, s=2 * bin_width, linewidth=0)
+
+
+#############
+# create nice plot
+#############
+
+fig = plt.figure(figsize=(8, 7))
+axs = [fig.add_subplot(2, 2, i + 1, projection='3d') for i in range(4)]
+
+ims = [im_orig, im_degraded, im_orig_ahe, im_degraded_ahe]
+titles = ['Original image\n(randomly generated)',
+          'Degraded image\n(sigmoid in x)',
+          '3D AHE\n(original image)',
+          '3D AHE\n(degraded image)']
+
+for iax, ax in enumerate(axs):
+    plt_render_volume(ims[iax], ax, ref_vol=ims[0], bin_width=10)
+    ax.grid(False)
+    ax.set_title(titles[iax])
+
+    lpad = -15
+    ax.set_xlabel('x', labelpad=lpad)
+    ax.set_ylabel('y', labelpad=lpad)
+    ax.set_zlabel('z', labelpad=lpad)
+
+    # Get rid of the panes
+    ax.w_xaxis.set_pane_color((1.0, 1.0, 1.0, 0.0))
+    ax.w_yaxis.set_pane_color((1.0, 1.0, 1.0, 0.0))
+    ax.w_zaxis.set_pane_color((1.0, 1.0, 1.0, 0.0))
+
+    # Get rid of the ticks
+    ax.set_xticks([])
+    ax.set_yticks([])
+    ax.set_zticks([])
+
+plt.tight_layout()
+plt.show()

--- a/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
+++ b/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
@@ -61,7 +61,8 @@ def get_rgba(scalars, cmap, vmin, vmax, alpha=0.2):
     return rgbas
 
 
-def plt_render_volume(vol, fig_ax, ref_vol=None, vmin=0, vmax=1, bin_width=10):
+def plt_render_volume(vol, fig_ax, ref_vol=None,
+                      vmin=0, vmax=1, bin_width=10, n_levels=50):
     """
     Render a volume in a 3D matplotlib scatter plot.
     Better would be to use napari.
@@ -74,7 +75,7 @@ def plt_render_volume(vol, fig_ax, ref_vol=None, vmin=0, vmax=1, bin_width=10):
     ref_vol_scaled = ref_vol[::bin_width, ::bin_width, ::bin_width].flatten()
 
     # define alpha transfer function
-    levels = np.linspace(vmin, vmax, 50)
+    levels = np.linspace(vmin, vmax, n_levels)
     alphas = np.mean([levels[1:], levels[:-1]], 0)
     alphas = alphas ** 3
     alphas = (alphas - alphas.min()) / (alphas.max() - alphas.min())
@@ -86,6 +87,8 @@ def plt_render_volume(vol, fig_ax, ref_vol=None, vmin=0, vmax=1, bin_width=10):
     for il in range(1, len(levels)):
         sel = (ref_vol_scaled >= levels[il - 1])
         sel *= (ref_vol_scaled < levels[il])
+        if not len(sel):
+            continue
         c = get_rgba(vol_scaled[sel], 'viridis',
                      vmin=0, vmax=1, alpha=alphas[il - 1])
         fig_ax.scatter(xs.flatten()[sel],

--- a/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
+++ b/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
@@ -5,52 +5,68 @@
 
 Adaptive histogram equalization (AHE) can be used to improve the local
 contrast of an image [1]_. Specifically, AHE can be useful for normalizing
-intensities across images. This example compares the results of applying AHE
-to a 3D image and a degraded version of it.
+intensities across images. This example compares the results of applying
+global histogram equalization and AHE to a 3D image and a synthetically
+degraded version of it.
 
 .. [1] https://en.wikipedia.org/wiki/Histogram_equalization
 """
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
+import matplotlib.patches as patches
 from matplotlib import cm, colors
 from mpl_toolkits.mplot3d import Axes3D
 
 import numpy as np
 from skimage import exposure
-from scipy import ndimage
+from skimage import io
 
 
 #############
-# Prepare data and apply AHE
+# Prepare data and apply hist. eq.
 #############
 
-# create random 3d data by zooming into random array
-a = 5
-np.random.seed(100)
-im_orig = np.random.randint(0, 1000,
-                            (a, a, a)).astype(np.float64) / 1000.
-im_orig = ndimage.zoom(im_orig, 50, order=1)
+im_orig = io.imread('https://github.com/scikit-image/'
+                    'skimage-tutorials/blob/master/images/cells.tif?raw=True',
+                    plugin='tifffile')
+im_orig = im_orig.transpose()
 
+# apply some rescaling
+im_orig = np.clip(im_orig,
+                  np.percentile(im_orig, 5),
+                  np.percentile(im_orig, 95))
+im_orig = (im_orig - im_orig.min()) / (im_orig.max() - im_orig.min())
 
-# degrade image by applying uneven intensity gradient along x
-sigmoid = (1 / (1 + np.exp(5 * (np.linspace(0, 1, im_orig.shape[0]) - 0.5))))
+# degrade image by applying exponential intensity decay along x
+sigmoid = np.exp(-3 * np.linspace(0, 1, im_orig.shape[0]))
 im_degraded = (im_orig.T * sigmoid).T
 
-# recover local contrast with AHE
-kernel_size, clip_limit = 55, 0.5
-im_orig_ahe = exposure.equalize_adapthist(im_orig,
-                                          kernel_size=kernel_size,
-                                          clip_limit=clip_limit)
-im_degraded_ahe = exposure.equalize_adapthist(im_degraded,
-                                              kernel_size=kernel_size,
-                                              clip_limit=clip_limit)
+# set parameters for AHE
+# determine kernel sizes in each dim relative to image shape
+kernel_size = (im_orig.shape[0] // 5,
+               im_orig.shape[1] // 5,
+               im_orig.shape[2] // 2)
+kernel_size = np.array(kernel_size)
+clip_limit = 0.9
+
+# perform hist. eq.
+im_orig_he, im_degraded_he = \
+    [exposure.equalize_hist(im)
+     for im in [im_orig, im_degraded]]
+
+im_orig_ahe, im_degraded_ahe = \
+    [exposure.equalize_adapthist(im,
+                                 kernel_size=kernel_size,
+                                 clip_limit=clip_limit)
+     for im in [im_orig, im_degraded]]
 
 
 #############
 # define functions to help plot the data
 #############
 
-def get_rgba(scalars, cmap, vmin, vmax, alpha=0.2):
+def get_rgba(scalars, cmap, vmin=0., vmax=1., alpha=0.2):
     """
     Convert array of scalars into array of corresponding RGBA values.
     """
@@ -61,75 +77,170 @@ def get_rgba(scalars, cmap, vmin, vmax, alpha=0.2):
     return rgbas
 
 
-def plt_render_volume(vol, fig_ax, ref_vol=None,
-                      vmin=0, vmax=1, bin_width=10, n_levels=50):
+def plt_render_volume(vol, fig_ax, cmap,
+                      vmin=0, vmax=1,
+                      bin_widths=None, n_levels=20):
     """
     Render a volume in a 3D matplotlib scatter plot.
     Better would be to use napari.
     """
+    vol = np.clip(vol, vmin, vmax)
 
-    xs, ys, zs = np.mgrid[0:vol.shape[0]:bin_width,
-                          0:vol.shape[1]:bin_width,
-                          0:vol.shape[2]:bin_width]
-    vol_scaled = vol[::bin_width, ::bin_width, ::bin_width].flatten()
-    ref_vol_scaled = ref_vol[::bin_width, ::bin_width, ::bin_width].flatten()
+    xs, ys, zs = np.mgrid[0:vol.shape[0]:bin_widths[0],
+                          0:vol.shape[1]:bin_widths[1],
+                          0:vol.shape[2]:bin_widths[2]]
+    vol_scaled = vol[::bin_widths[0],
+                     ::bin_widths[1],
+                     ::bin_widths[2]].flatten()
 
     # define alpha transfer function
     levels = np.linspace(vmin, vmax, n_levels)
-    alphas = np.mean([levels[1:], levels[:-1]], 0)
-    alphas = alphas ** 3
+    alphas = np.linspace(0, .7, n_levels)
+    alphas = alphas ** 11
     alphas = (alphas - alphas.min()) / (alphas.max() - alphas.min())
     alphas *= 0.8
-    alphas = np.clip(alphas, 0.2, 1)
 
-    # group pixels by intensity and plot separately, as 3D scatter
-    # does not accept arrays of alpha values
+    # group pixels by intensity and plot separately,
+    # as 3D scatter does not accept arrays of alpha values
     for il in range(1, len(levels)):
-        sel = (ref_vol_scaled >= levels[il - 1])
-        sel *= (ref_vol_scaled < levels[il])
+        sel = (vol_scaled >= levels[il - 1])
+        sel *= (vol_scaled <= levels[il])
         if not np.max(sel):
             continue
-        c = get_rgba(vol_scaled[sel], 'viridis',
-                     vmin=0, vmax=1, alpha=alphas[il - 1])
+        c = get_rgba(vol_scaled[sel], cmap,
+                     vmin=vmin, vmax=vmax, alpha=alphas[il - 1])
         fig_ax.scatter(xs.flatten()[sel],
                        ys.flatten()[sel],
                        zs.flatten()[sel],
-                       marker='o', c=c, s=2 * bin_width, linewidth=0)
+                       c=c, s=0.5 * np.mean(bin_widths),
+                       marker='o', linewidth=0)
 
 
 #############
-# create nice plot
+# create figure with subplots
 #############
 
-fig = plt.figure(figsize=(8, 7))
-axs = [fig.add_subplot(2, 2, i + 1, projection=Axes3D.name)
-       for i in range(4)]
+cmap = 'Blues'
 
-ims = [im_orig, im_degraded, im_orig_ahe, im_degraded_ahe]
-titles = ['Original image\n(randomly generated)',
-          'Degraded image\n(sigmoid in x)',
-          '3D AHE\n(original image)',
-          '3D AHE\n(degraded image)']
+fig = plt.figure(figsize=(10, 6))
+axs = [fig.add_subplot(2, 3, i + 1,
+                       projection=Axes3D.name, facecolor="none")
+       for i in range(6)]
+ims = [im_orig, im_orig_he, im_orig_ahe,
+       im_degraded, im_degraded_he, im_degraded_ahe]
 
-for iax, ax in enumerate(axs):
-    plt_render_volume(ims[iax], ax, ref_vol=ims[0], bin_width=10)
-    ax.grid(False)
-    ax.set_title(titles[iax])
+# prepare lines for the various boxes to be plotted
+verts = np.array([[i, j, k] for i in [0, 1]
+                  for j in [0, 1] for k in [0, 1]]).astype(np.float32)
+lines = [np.array([i, j]) for i in verts
+         for j in verts if np.allclose(np.linalg.norm(i - j), 1)]
 
-    lpad = -15
-    ax.set_xlabel('x', labelpad=lpad)
-    ax.set_ylabel('y', labelpad=lpad)
-    ax.set_zlabel('z', labelpad=lpad)
+# "render" volumetric data
+for iax, ax in enumerate(axs[:]):
+    plt_render_volume(ims[iax], ax, cmap, 0, 1, [2, 2, 2], 20)
 
-    # Get rid of the panes
-    ax.w_xaxis.set_pane_color((1.0, 1.0, 1.0, 0.0))
-    ax.w_yaxis.set_pane_color((1.0, 1.0, 1.0, 0.0))
-    ax.w_zaxis.set_pane_color((1.0, 1.0, 1.0, 0.0))
+    # plot 3D box
+    rect_shape = np.array(im_orig.shape) + 2
+    for line in lines:
+        ax.plot((line * rect_shape)[:, 0] - 1,
+                (line * rect_shape)[:, 1] - 1,
+                (line * rect_shape)[:, 2] - 1,
+                linewidth=1, color='grey')
 
-    # Get rid of the ticks
+# add boxes illustrating the kernels
+ns = np.array(im_orig.shape) // kernel_size - 1
+for iax, ind, rect_shape in zip([1] + [2] * 4,
+                                [[0, 0, 0],
+                                 [ns[0] - 1, ns[1], ns[2] - 1],
+                                 [ns[0], ns[1] - 1, ns[2] - 1],
+                                 [ns[0], ns[1], ns[2] - 1],
+                                 [ns[0], ns[1], ns[2]]],
+                                [np.array(im_orig.shape)]
+                                + [kernel_size] * 4):
+
+    for line in lines:
+        axs[iax].plot(((line + ind) * rect_shape)[:, 0],
+                      ((line + ind) * rect_shape)[:, 1],
+                      ((line + ind) * rect_shape)[:, 2],
+                      linewidth=1.2, color='crimson')
+
+# plot degradation function
+axs[3].scatter(xs=np.arange(len(sigmoid)),
+               ys=np.zeros(len(sigmoid)) + im_orig.shape[1],
+               zs=sigmoid * im_orig.shape[2],
+               s=5,
+               c=get_rgba(sigmoid,
+                          cmap=cmap, vmin=0, vmax=1, alpha=1.)[:, :3])
+
+# subplot aesthetics
+for iax, ax in enumerate(axs[:]):
+
+    # Get rid of panes and axis lines
+    for dim_ax in [ax.w_xaxis, ax.w_yaxis, ax.w_zaxis]:
+        dim_ax.set_pane_color((1., 1., 1., 0.))
+        dim_ax.line.set_color((1., 1., 1., 0.))
+
+    # Make axes limits, see https://github.com/
+    # matplotlib/matplotlib/issues/17172#issuecomment-617546105
+    xyzlim = np.array([ax.get_xlim3d(),
+                       ax.get_ylim3d(),
+                       ax.get_zlim3d()]).T
+    XYZlim = np.asarray([min(xyzlim[0]), max(xyzlim[1])])
+    ax.set_xlim3d(XYZlim)
+    ax.set_ylim3d(XYZlim)
+    ax.set_zlim3d(XYZlim * 3 / 4)
+
+    ax.set_xlabel('x', labelpad=-25)
+    ax.set_ylabel('y', labelpad=-25)
     ax.set_xticks([])
     ax.set_yticks([])
-    ax.set_zticks([])
+    ax.set_zticks([im_orig.shape[2] * 2/3.])
+    ax.set_zticklabels('z')
+    ax.tick_params(axis='z', which='major', pad=-12)
+    ax.w_zaxis._axinfo['tick']['linewidth'] = 0
+    ax.grid(False)
+    ax.elev = 30
 
-plt.tight_layout()
+
+plt.subplots_adjust(left=0.,
+                    bottom=-.05,
+                    right=1.03,
+                    top=1.19,
+                    wspace=-0.2,
+                    hspace=-0.45)
+
+# highlight AHE
+rect_ax = fig.add_axes([0, 0, 1, 1], facecolor='none')
+rect_ax.axis(False)
+rect = patches.Rectangle((0.69, 0.01), 0.305, 0.98,
+                         edgecolor='grey', facecolor='none',
+                         linewidth=2, linestyle='--')
+rect_ax.add_patch(rect)
+
+# add text
+rect_ax.text(0.17, 0.35, '$I_{degr}(x,y,z) = e^{-x}I_{orig}(x,y,z)$',
+             fontsize=9, rotation=-19,
+             color=get_rgba([0.8], cmap='Blues', alpha=1.)[0])
+
+fc = {'size': 14}
+rect_ax.text(0.02, 0.61, '3D cell image', rotation=90, fontdict=fc)
+rect_ax.text(0.02, 0.15, '$\it{Degraded}$ image',
+             rotation=90, fontdict=fc)
+rect_ax.text(0.13, 0.92, 'Input volume', fontdict=fc)
+rect_ax.text(0.51, 0.91, '$\it{Global}$\nhistogram equalization',
+             fontdict=fc, horizontalalignment='center')
+rect_ax.text(0.84, 0.91,
+             '$\it{Adaptive}$\nhistogram equalization (AHE)',
+             fontdict=fc, horizontalalignment='center')
+rect_ax.text(0.58, 0.83, 'non-local', fontsize=12, color='crimson')
+rect_ax.text(0.89, 0.83, 'local kernel', fontsize=12, color='crimson')
+
+# add colorbar
+cbar_ax = fig.add_axes([0.08, 0.47, 0.008, 0.08])
+norm = mpl.colors.Normalize(vmin=0, vmax=1)
+cbar = fig.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap=cmap),
+                    cax=cbar_ax)
+cbar.set_ticks([0, 1])
+
+
 plt.show()

--- a/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
+++ b/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
@@ -236,10 +236,12 @@ rect_ax.text(0.89, 0.83, 'local kernel', fontsize=12, color='crimson')
 
 # add colorbar
 cbar_ax = fig.add_axes([0.08, 0.47, 0.008, 0.08])
-norm = colors.Normalize(vmin=0, vmax=1)
-cbar = fig.colorbar(cm.ScalarMappable(norm=norm, cmap=cmap),
-                    cax=cbar_ax)
-cbar.set_ticks([0, 1])
+cbar_ax.imshow(np.arange(256).reshape(256, 1)[::-1],
+               cmap=cmap, aspect="auto")
+cbar_ax.set_xticks([])
+cbar_ax.set_yticks([0, 255])
+cbar_ax.set_xticklabels([])
+cbar_ax.set_yticklabels([1., 0.])
 
 
 plt.show()

--- a/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
+++ b/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
@@ -19,7 +19,7 @@ from mpl_toolkits.mplot3d import Axes3D
 
 import numpy as np
 from skimage import exposure
-import imageio
+import imageio as io
 
 
 #############
@@ -28,7 +28,7 @@ import imageio
 
 from skimage.data import image_fetcher
 path = image_fetcher.fetch('data/cells.tif')
-img_orig = io.imread(path) 
+im_orig = io.volread(path)
 im_orig = im_orig.transpose()
 
 # apply some rescaling

--- a/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
+++ b/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
@@ -26,9 +26,9 @@ import imageio
 # Prepare data and apply hist. eq.
 #############
 
-im_orig = imageio.volread('https://github.com/scikit-image/'
-                          'skimage-tutorials/blob/master/'
-                          'images/cells.tif?raw=True')
+from skimage.data import image_fetcher
+path = image_fetcher.fetch('data/cells.tif')
+img_orig = io.imread(path) 
 im_orig = im_orig.transpose()
 
 # apply some rescaling

--- a/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
+++ b/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
@@ -194,7 +194,7 @@ for iax, ax in enumerate(axs[:]):
     ax.set_ylabel('y', labelpad=-25)
     ax.set_xticks([])
     ax.set_yticks([])
-    ax.set_zticks([im_orig.shape[2] * 2/3.])
+    ax.set_zticks([im_orig.shape[2] * 2 / 3.])
     ax.set_zticklabels('z')
     ax.tick_params(axis='z', which='major', pad=-12)
     ax.w_zaxis._axinfo['tick']['linewidth'] = 0
@@ -224,13 +224,13 @@ rect_ax.text(0.17, 0.35, '$I_{degr}(x,y,z) = e^{-x}I_{orig}(x,y,z)$',
 
 fc = {'size': 14}
 rect_ax.text(0.02, 0.61, '3D cell image', rotation=90, fontdict=fc)
-rect_ax.text(0.02, 0.15, '$\it{Degraded}$ image',
+rect_ax.text(0.02, 0.15, r'$\it{Degraded}$ image',
              rotation=90, fontdict=fc)
 rect_ax.text(0.13, 0.92, 'Input volume', fontdict=fc)
-rect_ax.text(0.51, 0.91, '$\it{Global}$\nhistogram equalization',
+rect_ax.text(0.51, 0.91, r'$\it{Global}$' + '\nhistogram equalization',
              fontdict=fc, horizontalalignment='center')
 rect_ax.text(0.84, 0.91,
-             '$\it{Adaptive}$\nhistogram equalization (AHE)',
+             r'$\it{Adaptive}$' + '\nhistogram equalization (AHE)',
              fontdict=fc, horizontalalignment='center')
 rect_ax.text(0.58, 0.83, 'non-local', fontsize=12, color='crimson')
 rect_ax.text(0.89, 0.83, 'local kernel', fontsize=12, color='crimson')

--- a/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
+++ b/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
@@ -22,34 +22,41 @@ from skimage import exposure
 import imageio as io
 
 
-#############
-# Prepare data and apply hist. eq.
-#############
+# Prepare data and apply histogram equalization
 
+# Try using skimage.data.image_fetcher for cached data loading,
+# otherwise fall back to reading the data from url
 from skimage.data import image_fetcher
-path = image_fetcher.fetch('data/cells.tif')
-im_orig = io.volread(path)
+try:
+    path = image_fetcher.fetch('data/cells.tif')
+    im_orig = io.volread(path)
+except:
+    im_orig = io.volread('https://github.com/scikit-image/'
+                         'skimage-tutorials/blob/master/'
+                         'images/cells.tif?raw=True')
+
+# Reorder axis order from (z, y, x) to (x, y, z)
 im_orig = im_orig.transpose()
 
-# apply some rescaling
+# Rescale image data to range [0, 1]
 im_orig = np.clip(im_orig,
                   np.percentile(im_orig, 5),
                   np.percentile(im_orig, 95))
 im_orig = (im_orig - im_orig.min()) / (im_orig.max() - im_orig.min())
 
-# degrade image by applying exponential intensity decay along x
+# Degrade image by applying exponential intensity decay along x
 sigmoid = np.exp(-3 * np.linspace(0, 1, im_orig.shape[0]))
 im_degraded = (im_orig.T * sigmoid).T
 
-# set parameters for AHE
-# determine kernel sizes in each dim relative to image shape
+# Set parameters for AHE
+# Determine kernel sizes in each dim relative to image shape
 kernel_size = (im_orig.shape[0] // 5,
                im_orig.shape[1] // 5,
                im_orig.shape[2] // 2)
 kernel_size = np.array(kernel_size)
 clip_limit = 0.9
 
-# perform hist. eq.
+# Perform histogram equalization
 im_orig_he, im_degraded_he = \
     [exposure.equalize_hist(im)
      for im in [im_orig, im_degraded]]
@@ -61,11 +68,9 @@ im_orig_ahe, im_degraded_ahe = \
      for im in [im_orig, im_degraded]]
 
 
-#############
-# define functions to help plot the data
-#############
+# Define functions to help plot the data
 
-def get_rgba(scalars, cmap, vmin=0., vmax=1., alpha=0.2):
+def scalars_to_rgba(scalars, cmap, vmin=0., vmax=1., alpha=0.2):
     """
     Convert array of scalars into array of corresponding RGBA values.
     """
@@ -92,22 +97,22 @@ def plt_render_volume(vol, fig_ax, cmap,
                      ::bin_widths[1],
                      ::bin_widths[2]].flatten()
 
-    # define alpha transfer function
+    # Define alpha transfer function
     levels = np.linspace(vmin, vmax, n_levels)
     alphas = np.linspace(0, .7, n_levels)
     alphas = alphas ** 11
     alphas = (alphas - alphas.min()) / (alphas.max() - alphas.min())
     alphas *= 0.8
 
-    # group pixels by intensity and plot separately,
+    # Group pixels by intensity and plot separately,
     # as 3D scatter does not accept arrays of alpha values
     for il in range(1, len(levels)):
         sel = (vol_scaled >= levels[il - 1])
         sel *= (vol_scaled <= levels[il])
         if not np.max(sel):
             continue
-        c = get_rgba(vol_scaled[sel], cmap,
-                     vmin=vmin, vmax=vmax, alpha=alphas[il - 1])
+        c = scalars_to_rgba(vol_scaled[sel], cmap,
+                            vmin=vmin, vmax=vmax, alpha=alphas[il - 1])
         fig_ax.scatter(xs.flatten()[sel],
                        ys.flatten()[sel],
                        zs.flatten()[sel],
@@ -115,9 +120,7 @@ def plt_render_volume(vol, fig_ax, cmap,
                        marker='o', linewidth=0)
 
 
-#############
-# create figure with subplots
-#############
+# Create figure with subplots
 
 cmap = 'Blues'
 
@@ -128,7 +131,7 @@ axs = [fig.add_subplot(2, 3, i + 1,
 ims = [im_orig, im_orig_he, im_orig_ahe,
        im_degraded, im_degraded_he, im_degraded_ahe]
 
-# prepare lines for the various boxes to be plotted
+# Prepare lines for the various boxes to be plotted
 verts = np.array([[i, j, k] for i in [0, 1]
                   for j in [0, 1] for k in [0, 1]]).astype(np.float32)
 lines = [np.array([i, j]) for i in verts
@@ -146,9 +149,9 @@ for iax, ax in enumerate(axs[:]):
                 (line * rect_shape)[:, 2] - 1,
                 linewidth=1, color='grey')
 
-# add boxes illustrating the kernels
+# Add boxes illustrating the kernels
 ns = np.array(im_orig.shape) // kernel_size - 1
-for iax, ind, rect_shape in zip([1] + [2] * 4,
+for axis_ind, vertex_ind, box_shape in zip([1] + [2] * 4,
                                 [[0, 0, 0],
                                  [ns[0] - 1, ns[1], ns[2] - 1],
                                  [ns[0], ns[1] - 1, ns[2] - 1],
@@ -158,28 +161,28 @@ for iax, ind, rect_shape in zip([1] + [2] * 4,
                                 + [kernel_size] * 4):
 
     for line in lines:
-        axs[iax].plot(((line + ind) * rect_shape)[:, 0],
-                      ((line + ind) * rect_shape)[:, 1],
-                      ((line + ind) * rect_shape)[:, 2],
-                      linewidth=1.2, color='crimson')
+        axs[axis_ind].plot(((line + vertex_ind) * box_shape)[:, 0],
+                           ((line + vertex_ind) * box_shape)[:, 1],
+                           ((line + vertex_ind) * box_shape)[:, 2],
+                           linewidth=1.2, color='crimson')
 
-# plot degradation function
+# Plot degradation function
 axs[3].scatter(xs=np.arange(len(sigmoid)),
                ys=np.zeros(len(sigmoid)) + im_orig.shape[1],
                zs=sigmoid * im_orig.shape[2],
                s=5,
-               c=get_rgba(sigmoid,
-                          cmap=cmap, vmin=0, vmax=1, alpha=1.)[:, :3])
+               c=scalars_to_rgba(sigmoid,
+                                 cmap=cmap, vmin=0, vmax=1, alpha=1.)[:, :3])
 
-# subplot aesthetics
+# Subplot aesthetics (optimized for matplotlib 3.3)
 for iax, ax in enumerate(axs[:]):
 
     # Get rid of panes and axis lines
-    for dim_ax in [ax.w_xaxis, ax.w_yaxis, ax.w_zaxis]:
+    for dim_ax in [ax.xaxis, ax.yaxis, ax.zaxis]:
         dim_ax.set_pane_color((1., 1., 1., 0.))
         dim_ax.line.set_color((1., 1., 1., 0.))
 
-    # Make axes limits, see https://github.com/
+    # Define 3D axes limits, see https://github.com/
     # matplotlib/matplotlib/issues/17172#issuecomment-617546105
     xyzlim = np.array([ax.get_xlim3d(),
                        ax.get_ylim3d(),
@@ -187,15 +190,15 @@ for iax, ax in enumerate(axs[:]):
     XYZlim = np.asarray([min(xyzlim[0]), max(xyzlim[1])])
     ax.set_xlim3d(XYZlim)
     ax.set_ylim3d(XYZlim)
-    ax.set_zlim3d(XYZlim * 0.55)
+    ax.set_zlim3d(XYZlim * 0.5)
 
     try:
         ax.set_aspect('equal')
     except NotImplementedError:
         pass
 
-    ax.set_xlabel('x', labelpad=-25)
-    ax.set_ylabel('y', labelpad=-25)
+    ax.set_xlabel('x', labelpad=-20)
+    ax.set_ylabel('y', labelpad=-20)
     ax.text2D(0.63, 0.2, "z", transform=ax.transAxes)
     ax.set_xticks([])
     ax.set_yticks([])
@@ -203,15 +206,14 @@ for iax, ax in enumerate(axs[:]):
     ax.grid(False)
     ax.elev = 30
 
-
-plt.subplots_adjust(left=0.01,
-                    bottom=-.05,
-                    right=1.03,
+plt.subplots_adjust(left=0.05,
+                    bottom=-0.1,
+                    right=1.01,
                     top=1.1,
-                    wspace=-0.2,
+                    wspace=-0.1,
                     hspace=-0.45)
 
-# highlight AHE
+# Highlight AHE
 rect_ax = fig.add_axes([0, 0, 1, 1], facecolor='none')
 rect_ax.set_axis_off()
 rect = patches.Rectangle((0.68, 0.01), 0.315, 0.98,
@@ -219,32 +221,32 @@ rect = patches.Rectangle((0.68, 0.01), 0.315, 0.98,
                          linewidth=2, linestyle='--')
 rect_ax.add_patch(rect)
 
-# add text
-rect_ax.text(0.18, 0.37, '$I_{degr}(x,y,z) = e^{-x}I_{orig}(x,y,z)$',
+# Add text
+rect_ax.text(0.19, 0.34, '$I_{degr}(x,y,z) = e^{-x}I_{orig}(x,y,z)$',
              fontsize=9, rotation=-15,
-             color=get_rgba([0.8], cmap='Blues', alpha=1.)[0])
+             color=scalars_to_rgba([0.8], cmap='Blues', alpha=1.)[0])
 
 fc = {'size': 14}
-rect_ax.text(0.02, 0.61, '3D cell image', rotation=90, fontdict=fc)
-rect_ax.text(0.02, 0.15, r'$\it{Degraded}$ image',
-             rotation=90, fontdict=fc)
-rect_ax.text(0.13, 0.92, 'Input volume', fontdict=fc)
+rect_ax.text(0.03, 0.58, r'$\it{Original}$' + '\ninput image',
+             rotation=90, fontdict=fc, horizontalalignment='center')
+rect_ax.text(0.03, 0.16, r'$\it{Degraded}$' + '\ninput image',
+             rotation=90, fontdict=fc, horizontalalignment='center')
+rect_ax.text(0.13, 0.91, 'Input volume:\n3D cell image', fontdict=fc)
 rect_ax.text(0.51, 0.91, r'$\it{Global}$' + '\nhistogram equalization',
              fontdict=fc, horizontalalignment='center')
 rect_ax.text(0.84, 0.91,
              r'$\it{Adaptive}$' + '\nhistogram equalization (AHE)',
              fontdict=fc, horizontalalignment='center')
-rect_ax.text(0.58, 0.83, 'non-local', fontsize=12, color='crimson')
-rect_ax.text(0.89, 0.83, 'local kernel', fontsize=12, color='crimson')
+rect_ax.text(0.58, 0.82, 'non-local', fontsize=12, color='crimson')
+rect_ax.text(0.87, 0.82, 'local kernel', fontsize=12, color='crimson')
 
-# add colorbar
-cbar_ax = fig.add_axes([0.1, 0.42, 0.008, 0.08])
+# Add colorbar
+cbar_ax = fig.add_axes([0.12, 0.43, 0.008, 0.08])
 cbar_ax.imshow(np.arange(256).reshape(256, 1)[::-1],
                cmap=cmap, aspect="auto")
 cbar_ax.set_xticks([])
 cbar_ax.set_yticks([0, 255])
 cbar_ax.set_xticklabels([])
 cbar_ax.set_yticklabels([1., 0.])
-
 
 plt.show()

--- a/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
+++ b/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
@@ -13,6 +13,7 @@ to a 3D image and a degraded version of it.
 
 import matplotlib.pyplot as plt
 from matplotlib import cm, colors
+from mpl_toolkits.mplot3d import Axes3D
 
 import numpy as np
 from skimage import exposure
@@ -98,7 +99,8 @@ def plt_render_volume(vol, fig_ax, ref_vol=None, vmin=0, vmax=1, bin_width=10):
 #############
 
 fig = plt.figure(figsize=(8, 7))
-axs = [fig.add_subplot(2, 2, i + 1, projection='3d') for i in range(4)]
+axs = [fig.add_subplot(2, 2, i + 1, projection=Axes3D.name)
+       for i in range(4)]
 
 ims = [im_orig, im_degraded, im_orig_ahe, im_degraded_ahe]
 titles = ['Original image\n(randomly generated)',

--- a/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
+++ b/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
@@ -12,7 +12,6 @@ degraded version of it.
 .. [1] https://en.wikipedia.org/wiki/Histogram_equalization
 """
 
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.patches as patches
 from matplotlib import cm, colors
@@ -20,16 +19,16 @@ from mpl_toolkits.mplot3d import Axes3D
 
 import numpy as np
 from skimage import exposure
-from skimage import io
+import imageio
 
 
 #############
 # Prepare data and apply hist. eq.
 #############
 
-im_orig = io.imread('https://github.com/scikit-image/'
-                    'skimage-tutorials/blob/master/images/cells.tif?raw=True',
-                    plugin='tifffile')
+im_orig = imageio.volread('https://github.com/scikit-image/'
+                          'skimage-tutorials/blob/master/'
+                          'images/cells.tif?raw=True')
 im_orig = im_orig.transpose()
 
 # apply some rescaling
@@ -211,7 +210,7 @@ plt.subplots_adjust(left=0.,
 
 # highlight AHE
 rect_ax = fig.add_axes([0, 0, 1, 1], facecolor='none')
-rect_ax.axis(False)
+rect_ax.set_axis_off()
 rect = patches.Rectangle((0.69, 0.01), 0.305, 0.98,
                          edgecolor='grey', facecolor='none',
                          linewidth=2, linestyle='--')
@@ -237,8 +236,8 @@ rect_ax.text(0.89, 0.83, 'local kernel', fontsize=12, color='crimson')
 
 # add colorbar
 cbar_ax = fig.add_axes([0.08, 0.47, 0.008, 0.08])
-norm = mpl.colors.Normalize(vmin=0, vmax=1)
-cbar = fig.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap=cmap),
+norm = colors.Normalize(vmin=0, vmax=1)
+cbar = fig.colorbar(cm.ScalarMappable(norm=norm, cmap=cmap),
                     cax=cbar_ax)
 cbar.set_ticks([0, 1])
 

--- a/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
+++ b/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
@@ -187,38 +187,41 @@ for iax, ax in enumerate(axs[:]):
     XYZlim = np.asarray([min(xyzlim[0]), max(xyzlim[1])])
     ax.set_xlim3d(XYZlim)
     ax.set_ylim3d(XYZlim)
-    ax.set_zlim3d(XYZlim * 3 / 4)
+    ax.set_zlim3d(XYZlim * 0.55)
+
+    try:
+        ax.set_aspect('equal')
+    except NotImplementedError:
+        pass
 
     ax.set_xlabel('x', labelpad=-25)
     ax.set_ylabel('y', labelpad=-25)
+    ax.text2D(0.63, 0.2, "z", transform=ax.transAxes)
     ax.set_xticks([])
     ax.set_yticks([])
-    ax.set_zticks([im_orig.shape[2] * 2 / 3.])
-    ax.set_zticklabels('z')
-    ax.tick_params(axis='z', which='major', pad=-12)
-    ax.w_zaxis._axinfo['tick']['linewidth'] = 0
+    ax.set_zticks([])
     ax.grid(False)
     ax.elev = 30
 
 
-plt.subplots_adjust(left=0.,
+plt.subplots_adjust(left=0.01,
                     bottom=-.05,
                     right=1.03,
-                    top=1.19,
+                    top=1.1,
                     wspace=-0.2,
                     hspace=-0.45)
 
 # highlight AHE
 rect_ax = fig.add_axes([0, 0, 1, 1], facecolor='none')
 rect_ax.set_axis_off()
-rect = patches.Rectangle((0.69, 0.01), 0.305, 0.98,
+rect = patches.Rectangle((0.68, 0.01), 0.315, 0.98,
                          edgecolor='grey', facecolor='none',
                          linewidth=2, linestyle='--')
 rect_ax.add_patch(rect)
 
 # add text
-rect_ax.text(0.17, 0.35, '$I_{degr}(x,y,z) = e^{-x}I_{orig}(x,y,z)$',
-             fontsize=9, rotation=-19,
+rect_ax.text(0.18, 0.37, '$I_{degr}(x,y,z) = e^{-x}I_{orig}(x,y,z)$',
+             fontsize=9, rotation=-15,
              color=get_rgba([0.8], cmap='Blues', alpha=1.)[0])
 
 fc = {'size': 14}
@@ -235,7 +238,7 @@ rect_ax.text(0.58, 0.83, 'non-local', fontsize=12, color='crimson')
 rect_ax.text(0.89, 0.83, 'local kernel', fontsize=12, color='crimson')
 
 # add colorbar
-cbar_ax = fig.add_axes([0.08, 0.47, 0.008, 0.08])
+cbar_ax = fig.add_axes([0.1, 0.42, 0.008, 0.08])
 cbar_ax.imshow(np.arange(256).reshape(256, 1)[::-1],
                cmap=cmap, aspect="auto")
 cbar_ax.set_xticks([])

--- a/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
+++ b/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
@@ -87,7 +87,7 @@ def plt_render_volume(vol, fig_ax, ref_vol=None,
     for il in range(1, len(levels)):
         sel = (ref_vol_scaled >= levels[il - 1])
         sel *= (ref_vol_scaled < levels[il])
-        if not len(sel):
+        if not np.max(sel):
             continue
         c = get_rgba(vol_scaled[sel], 'viridis',
                      vmin=0, vmax=1, alpha=alphas[il - 1])


### PR DESCRIPTION
## Description

New gallery example illustrating functionality added in this PR https://github.com/scikit-image/scikit-image/pull/4598.

The example compares the results of applying AHE to a 3D image and a degraded version of it to illustrate how AHE can be used to recover contrast and normalize images.


![image](https://user-images.githubusercontent.com/12528388/81348033-9b7b7700-90bd-11ea-9be5-73ffa5be3e90.png)

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
