### PR TITLE
Reintroduced convert with a strong deprecation warning

### DIFF
--- a/skimage/util/__init__.py
+++ b/skimage/util/__init__.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 from .dtype import (img_as_float32, img_as_float64, img_as_float,
                     img_as_int, img_as_uint, img_as_ubyte,
-                    img_as_bool, dtype_limits)
+                    img_as_bool, convert, dtype_limits)
 from .shape import view_as_blocks, view_as_windows
 from .noise import random_noise
 from .apply_parallel import apply_parallel
@@ -32,6 +32,7 @@ __all__ = ['img_as_float32',
            'img_as_uint',
            'img_as_ubyte',
            'img_as_bool',
+           'convert',
            'dtype_limits',
            'view_as_blocks',
            'view_as_windows',

--- a/skimage/util/__init__.py
+++ b/skimage/util/__init__.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 from .dtype import (img_as_float32, img_as_float64, img_as_float,
                     img_as_int, img_as_uint, img_as_ubyte,
-                    img_as_bool, convert, dtype_limits)
+                    img_as_bool, dtype_limits)
 from .shape import view_as_blocks, view_as_windows
 from .noise import random_noise
 from .apply_parallel import apply_parallel
@@ -32,7 +32,6 @@ __all__ = ['img_as_float32',
            'img_as_uint',
            'img_as_ubyte',
            'img_as_bool',
-           'convert',
            'dtype_limits',
            'view_as_blocks',
            'view_as_windows',

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -4,7 +4,7 @@ from warnings import warn
 
 __all__ = ['img_as_float32', 'img_as_float64', 'img_as_float',
            'img_as_int', 'img_as_uint', 'img_as_ubyte',
-           'img_as_bool', 'dtype_limits', 'convert']
+           'img_as_bool', 'dtype_limits']
 
 # For integers Numpy uses `_integer_types` basis internally, and builds a leaky
 # `np.XintYY` abstraction on top of it. This leads to situations when, for

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -4,7 +4,7 @@ from warnings import warn
 
 __all__ = ['img_as_float32', 'img_as_float64', 'img_as_float',
            'img_as_int', 'img_as_uint', 'img_as_ubyte',
-           'img_as_bool', 'dtype_limits']
+           'img_as_bool', 'dtype_limits', 'convert']
 
 # For integers Numpy uses `_integer_types` basis internally, and builds a leaky
 # `np.XintYY` abstraction on top of it. This leads to situations when, for
@@ -347,6 +347,28 @@ def _convert(image, dtype, force_copy=False, uniform=False):
     image = _scale(image, 8 * itemsize_in, 8 * itemsize_out, copy=False)
     image += imin_out
     return image.astype(dtype_out)
+
+
+def convert(image, dtype, force_copy=False, uniform=False):
+    warn("The use of this function is discouraged as its behavior may change "
+         "dramatically in scikit-image 1.0. This function will be removed"
+         "in scikit-image 1.0.", FutureWarning, stacklevel=2)
+    return _convert(image=image, dtype=dtype,
+                    force_copy=force_copy, uniform=uniform)
+
+
+if _convert.__doc__ is not None:
+    convert.__doc__ = _convert.__doc__ + """
+
+    Warns
+    -----
+    FutureWarning:
+        .. versionadded:: 0.17
+
+        The use of this function is discouraged as its behavior may change
+        dramatically in scikit-image 1.0. This function will be removed
+        in scikit-image 1.0.
+    """
 
 
 def img_as_float32(image, force_copy=False):

--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -167,6 +167,22 @@ def test_float_conversion_dtype():
         assert y.dtype == np.dtype(dtype_out)
 
 
+def test_float_conversion_dtype_warns():
+    """Test that convert issues a warning when called"""
+    from skimage.util.dtype import convert
+    x = np.array([-1, 1])
+
+    # Test all combinations of dtypes convertions
+    dtype_combin = np.array(np.meshgrid(float_dtype_list,
+                                        float_dtype_list)).T.reshape(-1, 2)
+
+    for dtype_in, dtype_out in dtype_combin:
+        x = x.astype(dtype_in)
+        with expected_warnings(["The use of this function is discouraged"]):
+            y = convert(x, dtype_out)
+        assert y.dtype == np.dtype(dtype_out)
+
+
 def test_subclass_conversion():
     """Check subclass conversion behavior"""
     x = np.array([-1, 1])


### PR DESCRIPTION
## Description
This PR reintroduces `convert` with a strong warning to not use it.

I know we are working toward 1.0, but this broke my code.

I guess most people use the public API, but I was not keep on making my own if/elif statement:

Closes #4680

@sciunto @emmanuelle 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
