### PR TITLE
Fix slic float32 support regression

### DIFF
--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -272,14 +272,14 @@ def slic(image, n_segments=100, compactness=10., max_iter=10, sigma=0,
     n_centroids = centroids.shape[0]
     segments = np.ascontiguousarray(np.concatenate(
         [centroids, np.zeros((n_centroids, image.shape[3]))],
-        axis=-1))
+        axis=-1), dtype=dtype)
 
     # Scaling of ratio in the same way as in the SLIC paper so the
     # values have the same meaning
     step = max(steps)
     ratio = 1.0 / compactness
 
-    image = np.ascontiguousarray(image * ratio, dtype=np.double)
+    image = np.ascontiguousarray(image * ratio)
 
     if update_centroids:
         # Step 2 of the algorithm [3]_

--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -279,7 +279,7 @@ def slic(image, n_segments=100, compactness=10., max_iter=10, sigma=0,
     step = max(steps)
     ratio = 1.0 / compactness
 
-    image = np.ascontiguousarray(image * ratio)
+    image = np.ascontiguousarray(image * ratio, dtype=dtype)
 
     if update_centroids:
         # Step 2 of the algorithm [3]_

--- a/skimage/segmentation/tests/test_slic.py
+++ b/skimage/segmentation/tests/test_slic.py
@@ -470,4 +470,4 @@ def test_gray_3d_mask():
 def test_dtype_support(dtype):
     img = np.random.rand(28, 28).astype(dtype)
 
-    assert slic(img, start_label=1).dtype == np.dtype('int32')
+    assert slic(img, start_label=1).dtype == np.int_

--- a/skimage/segmentation/tests/test_slic.py
+++ b/skimage/segmentation/tests/test_slic.py
@@ -470,4 +470,5 @@ def test_gray_3d_mask():
 def test_dtype_support(dtype):
     img = np.random.rand(28, 28).astype(dtype)
 
-    assert slic(img, start_label=1).dtype == np.int_
+    # Simply run the function to assert that it runs without error
+    slic(img, start_label=1)

--- a/skimage/segmentation/tests/test_slic.py
+++ b/skimage/segmentation/tests/test_slic.py
@@ -1,5 +1,6 @@
 from itertools import product
 
+import pytest
 import numpy as np
 from skimage.segmentation import slic
 
@@ -463,3 +464,10 @@ def test_gray_3d_mask():
     assert_equal(len(np.unique(seg)), 9)
     for s, c in zip(slices, range(1, 9)):
         assert_equal(seg[s][2:-2, 2:-2, 2:-2], c)
+
+
+@pytest.mark.parametrize("dtype", ['float32', 'float64', 'uint8', 'int'])
+def test_dtype_support(dtype):
+    img = np.random.rand(28, 28).astype(dtype)
+
+    assert slic(img).dtype == int

--- a/skimage/segmentation/tests/test_slic.py
+++ b/skimage/segmentation/tests/test_slic.py
@@ -470,4 +470,4 @@ def test_gray_3d_mask():
 def test_dtype_support(dtype):
     img = np.random.rand(28, 28).astype(dtype)
 
-    assert slic(img).dtype == np.dtype(int)
+    assert slic(img, start_label=1).dtype == np.dtype(int)

--- a/skimage/segmentation/tests/test_slic.py
+++ b/skimage/segmentation/tests/test_slic.py
@@ -470,4 +470,4 @@ def test_gray_3d_mask():
 def test_dtype_support(dtype):
     img = np.random.rand(28, 28).astype(dtype)
 
-    assert slic(img).dtype == int
+    assert slic(img).dtype == np.dtype(int)

--- a/skimage/segmentation/tests/test_slic.py
+++ b/skimage/segmentation/tests/test_slic.py
@@ -470,4 +470,4 @@ def test_gray_3d_mask():
 def test_dtype_support(dtype):
     img = np.random.rand(28, 28).astype(dtype)
 
-    assert slic(img, start_label=1).dtype == np.dtype(int)
+    assert slic(img, start_label=1).dtype == np.dtype('int32')


### PR DESCRIPTION
## Description

Fixes #4682 

The use of `np_floats` fused type was already introduced in #4339, but the support for `float32` was not tested :confused: 

`foat32` support is added in this PR and a test for dtype support is added.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
