### PR TITLE
In release notes, better describe skimage's relationship to ecosystem

### DIFF
--- a/doc/release/release_template.rst
+++ b/doc/release/release_template.rst
@@ -3,9 +3,10 @@ Announcement: scikit-image 0.X.0
 
 We're happy to announce the release of scikit-image v0.X.0!
 
-scikit-image is an image processing toolbox for SciPy that includes algorithms
-for segmentation, geometric transformations, color space manipulation,
-analysis, filtering, morphology, feature detection, and more.
+scikit-image is an image processing library for the scientific Python
+ecosystem that includes algorithms for segmentation, geometric
+transformations, feature detection, registration, color space
+manipulation, analysis, filtering, morphology, and more.
 
 For more information, examples, and documentation, please visit our website:
 


### PR DESCRIPTION
I think scikit-image can no longer accurately be described as an image processing toolbox *for* SciPy.  Rather, it is a library that relies on SciPy to provide a wide array of image processing algorithms.