### PR TITLE
suppressing warnings from gallery examples

### DIFF
--- a/doc/examples/applications/plot_coins_segmentation.py
+++ b/doc/examples/applications/plot_coins_segmentation.py
@@ -125,11 +125,12 @@ ax.axis('off')
 ######################################################################
 # Finally, we use the watershed transform to fill regions of the elevation
 # map starting from the markers determined above:
+from skimage import segmentation
 
-segmentation = morphology.watershed(elevation_map, markers)
+segmentation_coins = segmentation.watershed(elevation_map, markers)
 
 fig, ax = plt.subplots(figsize=(4, 3))
-ax.imshow(segmentation, cmap=plt.cm.gray)
+ax.imshow(segmentation_coins, cmap=plt.cm.gray)
 ax.set_title('segmentation')
 ax.axis('off')
 
@@ -139,13 +140,13 @@ ax.axis('off')
 
 from skimage.color import label2rgb
 
-segmentation = ndi.binary_fill_holes(segmentation - 1)
-labeled_coins, _ = ndi.label(segmentation)
-image_label_overlay = label2rgb(labeled_coins, image=coins)
+segmentation_coins = ndi.binary_fill_holes(segmentation_coins - 1)
+labeled_coins, _ = ndi.label(segmentation_coins)
+image_label_overlay = label2rgb(labeled_coins, image=coins, bg_label=0)
 
 fig, axes = plt.subplots(1, 2, figsize=(8, 3), sharey=True)
 axes[0].imshow(coins, cmap=plt.cm.gray)
-axes[0].contour(segmentation, [0.5], linewidths=1.2, colors='y')
+axes[0].contour(segmentation_coins, [0.5], linewidths=1.2, colors='y')
 axes[1].imshow(image_label_overlay)
 
 for a in axes:

--- a/doc/examples/features_detection/plot_brief.py
+++ b/doc/examples/features_detection/plot_brief.py
@@ -24,9 +24,12 @@ tform = transform.AffineTransform(scale=(1.2, 1.2), translation=(0, -100))
 img2 = transform.warp(img1, tform)
 img3 = transform.rotate(img1, 25)
 
-keypoints1 = corner_peaks(corner_harris(img1), min_distance=5)
-keypoints2 = corner_peaks(corner_harris(img2), min_distance=5)
-keypoints3 = corner_peaks(corner_harris(img3), min_distance=5)
+keypoints1 = corner_peaks(corner_harris(img1), min_distance=5,
+                          threshold_rel=0.1)
+keypoints2 = corner_peaks(corner_harris(img2), min_distance=5,
+                          threshold_rel=0.1)
+keypoints3 = corner_peaks(corner_harris(img3), min_distance=5,
+                          threshold_rel=0.1)
 
 extractor = BRIEF()
 

--- a/doc/examples/features_detection/plot_corner.py
+++ b/doc/examples/features_detection/plot_corner.py
@@ -29,7 +29,7 @@ image[rr, cc] = 1
 image[30:80, 200:250] = 1
 image[80:130, 250:300] = 1
 
-coords = corner_peaks(corner_harris(image), min_distance=5)
+coords = corner_peaks(corner_harris(image), min_distance=5, threshold_rel=0.02)
 coords_subpix = corner_subpix(image, coords, window_size=13)
 
 fig, ax = plt.subplots()

--- a/doc/examples/segmentation/plot_boundary_merge.py
+++ b/doc/examples/segmentation/plot_boundary_merge.py
@@ -68,7 +68,7 @@ def merge_boundary(graph, src, dst):
 
 img = data.coffee()
 edges = filters.sobel(color.rgb2gray(img))
-labels = segmentation.slic(img, compactness=30, n_segments=400)
+labels = segmentation.slic(img, compactness=30, n_segments=400, start_label=1)
 g = graph.rag_boundary(labels, edges)
 
 graph.show_rag(labels, g, img)
@@ -83,7 +83,7 @@ graph.show_rag(labels, g, img)
 plt.title('RAG after hierarchical merging')
 
 plt.figure()
-out = color.label2rgb(labels2, img, kind='avg')
+out = color.label2rgb(labels2, img, kind='avg', bg_label=0)
 plt.imshow(out)
 plt.title('Final segmentation')
 

--- a/doc/examples/segmentation/plot_compact_watershed.py
+++ b/doc/examples/segmentation/plot_compact_watershed.py
@@ -34,10 +34,10 @@ w1 = watershed(edges, seeds, compactness=0.01)
 
 fig, (ax0, ax1) = plt.subplots(1, 2)
 
-ax0.imshow(color.label2rgb(w0, coins))
+ax0.imshow(color.label2rgb(w0, coins, bg_label=-1))
 ax0.set_title('Classical watershed')
 
-ax1.imshow(color.label2rgb(w1, coins))
+ax1.imshow(color.label2rgb(w1, coins, bg_label=-1))
 ax1.set_title('Compact watershed')
 
 plt.show()

--- a/doc/examples/segmentation/plot_join_segmentations.py
+++ b/doc/examples/segmentation/plot_join_segmentations.py
@@ -36,7 +36,7 @@ seg1 = label(ws == foreground)
 
 # Make segmentation using SLIC superpixels.
 seg2 = slic(coins, n_segments=117, max_iter=160, sigma=1, compactness=0.75,
-            multichannel=False)
+            multichannel=False, start_label=0)
 
 # Combine the two.
 segj = join_segmentations(seg1, seg2)
@@ -52,11 +52,11 @@ color1 = label2rgb(seg1, image=coins, bg_label=0)
 ax[1].imshow(color1)
 ax[1].set_title('Sobel+Watershed')
 
-color2 = label2rgb(seg2, image=coins, image_alpha=0.5)
+color2 = label2rgb(seg2, image=coins, image_alpha=0.5, bg_label=-1)
 ax[2].imshow(color2)
 ax[2].set_title('SLIC superpixels')
 
-color3 = label2rgb(segj, image=coins, image_alpha=0.5)
+color3 = label2rgb(segj, image=coins, image_alpha=0.5, bg_label=-1)
 ax[3].imshow(color3)
 ax[3].set_title('Join')
 

--- a/doc/examples/segmentation/plot_mask_slic.py
+++ b/doc/examples/segmentation/plot_mask_slic.py
@@ -45,7 +45,7 @@ mask = morphology.opening(mask, morphology.disk(3))
 slic = segmentation.slic(img, n_segments=200, start_label=1)
 
 # maskSLIC result
-m_slic = segmentation.slic(img, n_segments=100, mask=mask)
+m_slic = segmentation.slic(img, n_segments=100, mask=mask, start_label=1)
 
 # Display result
 fig, ax_arr = plt.subplots(2, 2, sharex=True, sharey=True, figsize=(10, 10))

--- a/doc/examples/segmentation/plot_rag_boundary.py
+++ b/doc/examples/segmentation/plot_rag_boundary.py
@@ -19,7 +19,7 @@ from matplotlib import pyplot as plt
 img = data.coffee()
 gimg = color.rgb2gray(img)
 
-labels = segmentation.slic(img, compactness=30, n_segments=400)
+labels = segmentation.slic(img, compactness=30, n_segments=400, start_label=1)
 edges = filters.sobel(gimg)
 edges_rgb = color.gray2rgb(edges)
 

--- a/doc/examples/segmentation/plot_rag_draw.py
+++ b/doc/examples/segmentation/plot_rag_draw.py
@@ -13,7 +13,7 @@ from matplotlib import pyplot as plt
 
 
 img = data.coffee()
-labels = segmentation.slic(img, compactness=30, n_segments=400)
+labels = segmentation.slic(img, compactness=30, n_segments=400, start_label=1)
 g = graph.rag_mean_color(img, labels)
 
 fig, ax = plt.subplots(nrows=2, sharex=True, sharey=True, figsize=(6, 8))

--- a/doc/examples/segmentation/plot_rag_mean_color.py
+++ b/doc/examples/segmentation/plot_rag_mean_color.py
@@ -15,12 +15,12 @@ from matplotlib import pyplot as plt
 
 img = data.coffee()
 
-labels1 = segmentation.slic(img, compactness=30, n_segments=400)
-out1 = color.label2rgb(labels1, img, kind='avg')
+labels1 = segmentation.slic(img, compactness=30, n_segments=400, start_label=1)
+out1 = color.label2rgb(labels1, img, kind='avg', bg_label=0)
 
 g = graph.rag_mean_color(img, labels1)
 labels2 = graph.cut_threshold(labels1, g, 29)
-out2 = color.label2rgb(labels2, img, kind='avg')
+out2 = color.label2rgb(labels2, img, kind='avg', bg_label=0)
 
 fig, ax = plt.subplots(nrows=2, sharex=True, sharey=True,
                        figsize=(6, 8))

--- a/doc/examples/segmentation/plot_rag_merge.py
+++ b/doc/examples/segmentation/plot_rag_merge.py
@@ -60,7 +60,7 @@ def merge_mean_color(graph, src, dst):
 
 
 img = data.coffee()
-labels = segmentation.slic(img, compactness=30, n_segments=400)
+labels = segmentation.slic(img, compactness=30, n_segments=400, start_label=1)
 g = graph.rag_mean_color(img, labels)
 
 labels2 = graph.merge_hierarchical(labels, g, thresh=35, rag_copy=False,
@@ -68,7 +68,7 @@ labels2 = graph.merge_hierarchical(labels, g, thresh=35, rag_copy=False,
                                    merge_func=merge_mean_color,
                                    weight_func=_weight_mean_color)
 
-out = color.label2rgb(labels2, img, kind='avg')
+out = color.label2rgb(labels2, img, kind='avg', bg_label=0)
 out = segmentation.mark_boundaries(out, labels2, (0, 0, 0))
 io.imshow(out)
 io.show()

--- a/doc/examples/segmentation/plot_segmentations.py
+++ b/doc/examples/segmentation/plot_segmentations.py
@@ -96,7 +96,8 @@ from skimage.util import img_as_float
 img = img_as_float(astronaut()[::2, ::2])
 
 segments_fz = felzenszwalb(img, scale=100, sigma=0.5, min_size=50)
-segments_slic = slic(img, n_segments=250, compactness=10, sigma=1)
+segments_slic = slic(img, n_segments=250, compactness=10, sigma=1,
+                     start_label=1)
 segments_quick = quickshift(img, kernel_size=3, max_dist=6, ratio=0.5)
 gradient = sobel(rgb2gray(img))
 segments_watershed = watershed(gradient, markers=250, compactness=0.001)

--- a/doc/examples/transform/plot_edge_modes.py
+++ b/doc/examples/transform/plot_edge_modes.py
@@ -10,8 +10,6 @@ and :py:func:`skimage.transform.resize`.
 import numpy as np
 import matplotlib.pyplot as plt
 
-from skimage.util import pad
-
 
 img = np.zeros((16, 16))
 img[:8, :8] += 1
@@ -25,7 +23,7 @@ fig, axes = plt.subplots(2, 3)
 ax = axes.flatten()
 
 for n, mode in enumerate(modes):
-    img_padded = pad(img, pad_width=img.shape[0], mode=mode)
+    img_padded = np.pad(img, pad_width=img.shape[0], mode=mode)
     ax[n].imshow(img_padded, cmap=plt.cm.gray)
     ax[n].plot([15.5, 15.5, 31.5, 31.5, 15.5],
                [15.5, 31.5, 31.5, 15.5, 15.5], 'y--', linewidth=0.5)


### PR DESCRIPTION
I created this PR to remove some warnings from the gallery examples (they appear in the html as output, all the more with the local path on my computer :-)). To be backported to 0.17.x.