### PR TITLE
Add pyramid_gaussian support for float32

### DIFF
--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -7,7 +7,7 @@ from .._shared.utils import convert_to_float
 
 def _smooth(image, sigma, mode, cval, multichannel=None):
     """Return image with each channel smoothed by the Gaussian filter."""
-    smoothed = np.empty(image.shape, dtype=np.double)
+    smoothed = np.empty_like(image)
 
     # apply Gaussian filter to all channels independently
     if multichannel:

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -1,4 +1,5 @@
 import math
+import pytest
 import numpy as np
 from skimage import data
 from skimage.transform import pyramids
@@ -6,7 +7,6 @@ from skimage.transform import pyramids
 from skimage._shared import testing
 from skimage._shared.testing import (assert_array_equal, assert_, assert_equal,
                                      assert_almost_equal)
-from skimage._shared._warnings import expected_warnings
 
 
 image = data.astronaut()
@@ -135,3 +135,13 @@ def test_check_factor():
         pyramids._check_factor(0.99)
     with testing.raises(ValueError):
         pyramids._check_factor(- 2)
+
+
+@pytest.mark.parametrize('dtype, expected',
+                         zip(['float32', 'float64', 'uint8', 'int64'],
+                             ['float32', 'float64', 'float64', 'float64']))
+def test_pyramid_gaussian_dtype_support(dtype, expected):
+    img = np.random.randn(32, 8).astype(dtype)
+    pyramid = pyramids.pyramid_gaussian(img)
+
+    assert np.all([im.dtype == expected for im in pyramid])


### PR DESCRIPTION
## Description

Fixes #4695. This PR is prerequisite to add full `float32` support to `ORB` in #4697.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
