### PR TITLE
Add ORB full float32 support

### DIFF
--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -1135,4 +1135,5 @@ def corner_orientations(image, corners, mask):
     array([  45.,  135.,  -45., -135.])
 
     """
+    image = _prepare_grayscale_input_2D(image)
     return _corner_orientations(image, corners, mask)

--- a/skimage/feature/orb.py
+++ b/skimage/feature/orb.py
@@ -136,6 +136,7 @@ class ORB(FeatureDetector, DescriptorExtractor):
                                      self.downscale, multichannel=False))
 
     def _detect_octave(self, octave_image):
+        dtype = octave_image.dtype
         # Extract keypoints for current octave
         fast_response = corner_fast(octave_image, self.fast_n,
                                     self.fast_threshold)
@@ -143,9 +144,9 @@ class ORB(FeatureDetector, DescriptorExtractor):
                                  threshold_rel=0)
 
         if len(keypoints) == 0:
-            return (np.zeros((0, 2), dtype=np.double),
-                    np.zeros((0, ), dtype=np.double),
-                    np.zeros((0, ), dtype=np.double))
+            return (np.zeros((0, 2), dtype=dtype),
+                    np.zeros((0, ), dtype=dtype),
+                    np.zeros((0, ), dtype=dtype))
 
         mask = _mask_border_keypoints(octave_image.shape, keypoints,
                                       distance=16)
@@ -182,8 +183,8 @@ class ORB(FeatureDetector, DescriptorExtractor):
 
             octave_image = np.ascontiguousarray(pyramid[octave])
 
-            keypoints, orientations, responses = \
-                self._detect_octave(octave_image)
+            keypoints, orientations, responses = self._detect_octave(
+                octave_image)
 
             keypoints_list.append(keypoints * self.downscale ** octave)
             orientations_list.append(orientations)
@@ -215,7 +216,7 @@ class ORB(FeatureDetector, DescriptorExtractor):
                                       distance=20)
         keypoints = np.array(keypoints[mask], dtype=np.intp, order='C',
                              copy=False)
-        orientations = np.array(orientations[mask], dtype=np.double, order='C',
+        orientations = np.array(orientations[mask], order='C',
                                 copy=False)
 
         descriptors = _orb_loop(octave_image, keypoints, orientations)
@@ -263,7 +264,6 @@ class ORB(FeatureDetector, DescriptorExtractor):
 
                 octave_keypoints = keypoints[octave_mask]
                 octave_keypoints /= self.downscale ** octave
-
                 octave_orientations = orientations[octave_mask]
 
                 descriptors, mask = self._extract_octave(octave_image,
@@ -302,8 +302,8 @@ class ORB(FeatureDetector, DescriptorExtractor):
 
             octave_image = np.ascontiguousarray(pyramid[octave])
 
-            keypoints, orientations, responses = \
-                self._detect_octave(octave_image)
+            keypoints, orientations, responses = self._detect_octave(
+                octave_image)
 
             if len(keypoints) == 0:
                 keypoints_list.append(keypoints)

--- a/skimage/feature/orb_cy.pyx
+++ b/skimage/feature/orb_cy.pyx
@@ -8,17 +8,18 @@ import numpy as np
 from libc.math cimport sin, cos
 
 from .._shared.interpolation cimport round
+from .._shared.fused_numerics cimport np_floats
 
 from ._orb_descriptor_positions import POS, POS0, POS1
 
 
-def _orb_loop(double[:, ::1] image, Py_ssize_t[:, ::1] keypoints,
-              double[:] orientations):
+def _orb_loop(np_floats[:, ::1] image, Py_ssize_t[:, ::1] keypoints,
+              np_floats[:] orientations):
 
     cdef Py_ssize_t i, d, kr, kc, pr0, pr1, pc0, pc1, spr0, spc0, spr1, spc1
-    cdef double angle
-    cdef unsigned char[:, ::1] descriptors = \
-        np.zeros((keypoints.shape[0], POS.shape[0]), dtype=np.uint8)
+    cdef np_floats angle, sin_a, cos_a
+    cdef unsigned char[:, ::1] descriptors = np.zeros(
+        (keypoints.shape[0], POS.shape[0]), dtype=np.uint8)
     cdef signed char[:, ::1] cpos0 = POS0
     cdef signed char[:, ::1] cpos1 = POS1
 

--- a/skimage/feature/tests/test_orb.py
+++ b/skimage/feature/tests/test_orb.py
@@ -43,7 +43,8 @@ def test_keypoints_orb_desired_no_of_keypoints():
     assert_almost_equal(exp_cols, detector_extractor.keypoints[:, 1])
 
 
-def test_keypoints_orb_less_than_desired_no_of_keypoints():
+@pytest.mark.parametrize('dtype', ['float32', 'float64', 'uint8'])
+def test_keypoints_orb_less_than_desired_no_of_keypoints(dtype):
     detector_extractor = ORB(n_keypoints=15, fast_n=12,
                              fast_threshold=0.33, downscale=2, n_scales=2)
     detector_extractor.detect(img)
@@ -124,8 +125,11 @@ def test_no_descriptors_extracted_orb():
         detector_extractor.detect_and_extract(img)
 
 
-@pytest.mark.parametrize('dtype', ['float32', 'float64', 'uint8', 'int'])
+@pytest.mark.parametrize('dtype', ['float32', 'float64', 'uint8'])
 def test_dtype_support(dtype):
     img = data.checkerboard().astype(dtype)
-    orb = ORB()
-    orb.detect(img)
+    detector_extractor = ORB()
+    detector_extractor.detect(img)
+    detector_extractor.extract(img, detector_extractor.keypoints,
+                               detector_extractor.scales,
+                               detector_extractor.orientations)

--- a/skimage/feature/tests/test_orb.py
+++ b/skimage/feature/tests/test_orb.py
@@ -6,15 +6,19 @@ from skimage.feature import ORB
 from skimage._shared import testing
 from skimage import data
 from skimage._shared.testing import test_parallel, xfail, arch32
+from skimage.util.dtype import _convert
 
 
 img = data.coins()
 
 
 @test_parallel()
-def test_keypoints_orb_desired_no_of_keypoints():
+@pytest.mark.parametrize('dtype', ['float32', 'float64', 'uint8',
+                                   'uint16', 'int64'])
+def test_keypoints_orb_desired_no_of_keypoints(dtype):
+    _img = _convert(img, dtype)
     detector_extractor = ORB(n_keypoints=10, fast_n=12, fast_threshold=0.20)
-    detector_extractor.detect(img)
+    detector_extractor.detect(_img)
 
     exp_rows = np.array([141., 108., 214.56, 131., 214.272, 67.,
                          206., 177., 108., 141.])
@@ -34,20 +38,22 @@ def test_keypoints_orb_desired_no_of_keypoints():
     assert_almost_equal(exp_rows, detector_extractor.keypoints[:, 0])
     assert_almost_equal(exp_cols, detector_extractor.keypoints[:, 1])
     assert_almost_equal(exp_scales, detector_extractor.scales)
-    assert_almost_equal(exp_response, detector_extractor.responses)
+    assert_almost_equal(exp_response, detector_extractor.responses, 5)
     assert_almost_equal(exp_orientations,
-                        np.rad2deg(detector_extractor.orientations), 5)
+                        np.rad2deg(detector_extractor.orientations), 4)
 
     detector_extractor.detect_and_extract(img)
     assert_almost_equal(exp_rows, detector_extractor.keypoints[:, 0])
     assert_almost_equal(exp_cols, detector_extractor.keypoints[:, 1])
 
 
-@pytest.mark.parametrize('dtype', ['float32', 'float64', 'uint8'])
+@pytest.mark.parametrize('dtype', ['float32', 'float64', 'uint8',
+                                   'uint16', 'int64'])
 def test_keypoints_orb_less_than_desired_no_of_keypoints(dtype):
+    _img = _convert(img, dtype)
     detector_extractor = ORB(n_keypoints=15, fast_n=12,
                              fast_threshold=0.33, downscale=2, n_scales=2)
-    detector_extractor.detect(img)
+    detector_extractor.detect(_img)
 
     exp_rows = np.array([108., 203., 140.,  65.,  58.])
     exp_cols = np.array([293., 267., 202., 130., 291.])
@@ -65,7 +71,7 @@ def test_keypoints_orb_less_than_desired_no_of_keypoints(dtype):
     assert_almost_equal(exp_scales, detector_extractor.scales)
     assert_almost_equal(exp_response, detector_extractor.responses)
     assert_almost_equal(exp_orientations,
-                        np.rad2deg(detector_extractor.orientations), 5)
+                        np.rad2deg(detector_extractor.orientations), 3)
 
     detector_extractor.detect_and_extract(img)
     assert_almost_equal(exp_rows, detector_extractor.keypoints[:, 0])
@@ -123,13 +129,3 @@ def test_no_descriptors_extracted_orb():
     detector_extractor = ORB()
     with testing.raises(RuntimeError):
         detector_extractor.detect_and_extract(img)
-
-
-@pytest.mark.parametrize('dtype', ['float32', 'float64', 'uint8'])
-def test_dtype_support(dtype):
-    img = data.checkerboard().astype(dtype)
-    detector_extractor = ORB()
-    detector_extractor.detect(img)
-    detector_extractor.extract(img, detector_extractor.keypoints,
-                               detector_extractor.scales,
-                               detector_extractor.orientations)

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -7,7 +7,7 @@ from .._shared.utils import convert_to_float
 
 def _smooth(image, sigma, mode, cval, multichannel=None):
     """Return image with each channel smoothed by the Gaussian filter."""
-    smoothed = np.empty(image.shape, dtype=np.double)
+    smoothed = np.empty_like(image)
 
     # apply Gaussian filter to all channels independently
     if multichannel:


### PR DESCRIPTION
## Description

This PR completes #4684.
#4696 is a prerequisite for this PR.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
