### PR TITLE
[WIP] MNT: Use an image fetcher class instead of global variables.

### DIFF
--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -213,7 +213,7 @@ def teardown_test():
 def fetch(data_filename):
     """Attempt to fetch data, but if unavailable, skip the tests."""
     try:
-        return data._fetch(data_filename)
+        return data.image_fetcher.fetch(data_filename)
     except (ConnectionError, ModuleNotFoundError):
         pytest.skip(f'Unable to download {data_filename}')
 


### PR DESCRIPTION
## Description

@rfezzani this is the idea of using a class I had to avoid the generous use of globals out of order.

Honestly, at this stage, it doesn't fix any of the issues that are brought up, but I feel like it is a better starting point.

Feel free to take it over.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
