### PR TITLE
Fix gallery example mentioning deprecated argument

### DIFF
--- a/doc/examples/edges/plot_active_contours.py
+++ b/doc/examples/edges/plot_active_contours.py
@@ -16,9 +16,9 @@ points while obeying smoothness considerations. Typically it is a good idea to
 smooth images a bit before analyzing, as done in the following examples.
 
 We initialize a circle around the astronaut's face and use the default boundary
-condition ``bc='periodic'`` to fit a closed curve. The default parameters
-``w_line=0, w_edge=1`` will make the curve search towards edges, such as the
-boundaries of the face.
+condition ``boundary_condition='periodic'`` to fit a closed curve. The default
+parameters ``w_line=0, w_edge=1`` will make the curve search towards edges,
+such as the boundaries of the face.
 
 .. [1] *Snakes: Active contour models*. Kass, M.; Witkin, A.; Terzopoulos, D.
        International Journal of Computer Vision 1 (4): 321 (1988).
@@ -57,8 +57,8 @@ plt.show()
 ######################################################################
 # Here we initialize a straight line between two points, `(5, 136)` and
 # `(424, 50)`, and require that the spline has its end points there by giving
-# the boundary condition `bc='fixed'`. We furthermore make the algorithm
-# search for dark lines by giving a negative `w_line` value.
+# the boundary condition `boundary_condition='fixed'`. We furthermore
+# make the algorithm search for dark lines by giving a negative `w_line` value.
 
 img = data.text()
 


### PR DESCRIPTION
## Description
Cc @emmanuelle 

An example is mentioning deprecated (and removed) arguments.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
