### PR TITLE
Blacklist cython version 0.29.18

### DIFF
--- a/requirements/README.md
+++ b/requirements/README.md
@@ -34,6 +34,7 @@ $ pip install -U -r requirements/test.txt
 
 * Cython 0.28.2 was empircally found to fail tests while other patch-releases 0.28.x do not
 * Cython 0.29.0 erroneously sets the `__path__` to `None`. See https://github.com/cython/cython/issues/2662
+* Cython 0.29.18 fails due to a bad definition of M_PI. See https://github.com/cython/cython/issues/3622
 * matplotlib 3.0.0 is not used because of a bug that collapses 3D axes (see https://github.com/scikit-image/scikit-image/pull/3474 and https://github.com/matplotlib/matplotlib/issues/12239).
 * pillow 7.1.0 fails on png files, See https://github.com/scikit-image/scikit-image/issues/4548
 * pillow 7.1.1 fails due to https://github.com/python-pillow/Pillow/issues/4518

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,4 +1,4 @@
-Cython>=0.29.13
+Cython>=0.29.13,!=0.29.18
 wheel
 # numpy 1.18.0 breaks builds on MacOSX
 # https://github.com/numpy/numpy/pull/15194


### PR DESCRIPTION
## Description

Closes #4727 

Seems that the cause comes from upstream. See https://github.com/cython/cython/issues/3622



