### PR TITLE
Fix CI failures related to conversion of np.floating to dtype

### DIFF
--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -244,6 +244,8 @@ def _convert(image, dtype, force_copy=False, uniform=False):
         if force_copy:
             image = image.copy()
         return image
+    else:
+        dtype = np.float64
 
     if not (dtype_in in _supported_types and dtype_out in _supported_types):
         raise ValueError("Can not convert from {} to {}."

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -223,7 +223,10 @@ def _convert(image, dtype, force_copy=False, uniform=False):
     """
     image = np.asarray(image)
     dtypeobj_in = image.dtype
-    dtypeobj_out = np.dtype(dtype)
+    if dtype is np.floating:
+        dtypeobj_out = np.dtype('float64')
+    else:
+        dtypeobj_out = np.dtype(dtype)
     dtype_in = dtypeobj_in.type
     dtype_out = dtypeobj_out.type
     kind_in = dtypeobj_in.kind
@@ -244,8 +247,6 @@ def _convert(image, dtype, force_copy=False, uniform=False):
         if force_copy:
             image = image.copy()
         return image
-    else:
-        dtype = np.float64
 
     if not (dtype_in in _supported_types and dtype_out in _supported_types):
         raise ValueError("Can not convert from {} to {}."


### PR DESCRIPTION
## Description

This PR prevent the conversion using `np.floating` as it is [deprecated](https://numpy.org/devdocs/release/1.19.0-notes.html#converting-certain-types-to-dtypes-is-deprecated) in numpy 1.19.

It fixes CI failures in #4730

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
