### PR TITLE
Add versionadded for new scalar type support for "scale" param in transform.AffineTransform

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -768,6 +768,9 @@ class AffineTransform(ProjectiveTransform):
     scale : {s as float or (sx, sy) as array, list or tuple}, optional
         Scale factor(s). If a single value, it will be assigned to both
         sx and sy.
+
+        .. versionadded:: 0.17
+           Added support for supplying a single scalar value.
     rotation : float, optional
         Rotation angle in counter-clockwise direction as radians.
     shear : float, optional


### PR DESCRIPTION
## Description

Scalar type support was added for the `scale` parameter in #4642. This adds a `versionadded` tag for clarity. Prompted by #4711. 

cc @jni 

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
