### PR TITLE
Unwrap decorators before resolving link to source (sphinx.ext.linkcode)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -413,6 +413,9 @@ def linkcode_resolve(domain, info):
         except:
             return None
 
+    # Strip decorators which would resolve to the source of the decorator
+    obj = inspect.unwrap(obj)
+
     try:
         fn = inspect.getsourcefile(obj)
     except:


### PR DESCRIPTION
## Description

Ensures that the source links in the HTML documentation, generated by [sphinx.ext.linkcode](https://www.sphinx-doc.org/en/master/usage/extensions/linkcode.html), point to the source of wrapped objects rather then the source of their decorator(s).

In case of decorated functions this will still not pint to the line with the `def` statement because the inspect module seems to consider the decorator as part of the objects source.

See https://github.com/scikit-image/scikit-image/issues/2221#issuecomment-631986646.

Closes #2221 

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
