### PR TITLE
Fix plotting error in j-invariant denoising tutorial

### DIFF
--- a/doc/examples/filters/plot_j_invariant_tutorial.py
+++ b/doc/examples/filters/plot_j_invariant_tutorial.py
@@ -37,7 +37,7 @@ from functools import partial
 _denoise_wavelet = partial(denoise_wavelet, rescale_sigma=True)
 
 image = img_as_float(chelsea())
-sigma = 0.3
+sigma = 0.2
 noisy = random_noise(image, var=sigma ** 2)
 
 # Parameters to test when calibrating the denoising algorithm
@@ -99,7 +99,7 @@ for ax, img, title in zip(axes,
 
 from skimage.restoration.j_invariant import _invariant_denoise
 
-sigma_range = np.arange(0.12, 0.26, 0.03)
+sigma_range = np.arange(sigma/2, 1.5*sigma, 0.025)
 
 parameters_tested = [{'sigma': sigma, 'convert2ycbcr': True, 'wavelet': 'db2',
                       'multichannel': True}
@@ -113,7 +113,7 @@ self_supervised_loss = [mse(img, noisy) for img in denoised_invariant]
 ground_truth_loss = [mse(img, image) for img in denoised_invariant]
 
 opt_idx = np.argmin(self_supervised_loss)
-plot_idx = [0, 2, 4]
+plot_idx = [0, opt_idx, len(sigma_range) - 1]
 
 get_inset = lambda x: x[25:225, 100:300]
 


### PR DESCRIPTION
## Description

In the J-invariant denoising example, the wrong image is highlighted in red at the bottom of the second figure.
This PR fixes that and adjusts the range of `sigmas` so the plot extends on either side of the minimum.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

This is the image currently in the dev-docs (sigma=0.18 is highlighted, but the minimum is at 0.24):
![jinv_online](https://user-images.githubusercontent.com/6528957/82662518-010e4e00-9bfc-11ea-9ee0-b94c311c8963.png)

And this is the one after the adjustments in this PR:

![jinv_pr](https://user-images.githubusercontent.com/6528957/82662551-11bec400-9bfc-11ea-935a-50ba98f17cba.png)

I changed sigma from 0.3 to 0.2 so the visibility in denoising effects was more visually apparent across the range. This does result in some change to figures 1 and 3 as well, but they remain consistent in terms of interpretation as the currently existing ones.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
N/A

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
