### PR TITLE
Highlight all source lines with HTML doc "source" links (sphinx.ext.linkcode)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -424,14 +424,12 @@ def linkcode_resolve(domain, info):
         return None
 
     try:
-        source, lineno = inspect.findsource(obj)
+        source, start_line = inspect.getsourcelines(obj)
     except:
-        lineno = None
-
-    if lineno:
-        linespec = "#L%d" % (lineno + 1)
-    else:
         linespec = ""
+    else:
+        stop_line = start_line + len(source) - 1
+        linespec = f"#L{start_line}-L{stop_line}"
 
     fn = relpath(fn, start=dirname(skimage.__file__))
 


### PR DESCRIPTION
## Description

Previously only the first line of an object's source was highlighted by the links enabled by sphinx.ext.linkcode.

In comparison to `inspect.findsource`, `getsourcelines` add's the "+ 1" internally and trims unwanted lines in front of the object's source.

## For reviewers

<!-- Don't remove the checklist below. -->
- [x] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [x] Check that new functions are imported in corresponding `__init__.py`.
- [x] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
