### PR TITLE
Optimize peak_local_max trivial image test

### DIFF
--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -26,6 +26,8 @@ def _get_peak_mask(image, min_distance, footprint, threshold_abs,
     Return the mask containing all peak candidates above thresholds.
     """
     if footprint is not None:
+        if footprint.size == 1 and min_distance == 1:
+            return np.ones_like(image, dtype=bool)
         image_max = ndi.maximum_filter(image, footprint=footprint,
                                        mode='constant')
     else:
@@ -37,6 +39,10 @@ def _get_peak_mask(image, min_distance, footprint, threshold_abs,
     else:
         threshold = threshold_abs
     mask &= image > threshold
+
+    # no peak for a trivial image
+    if np.count_nonzero(mask) == image.size:
+        mask[:] = False
     return mask
 
 
@@ -159,8 +165,6 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
     array([[10, 10, 10]])
 
     """
-    out = np.zeros_like(image, dtype=np.bool)
-
     threshold_abs = threshold_abs if threshold_abs is not None else image.min()
 
     if isinstance(exclude_border, bool):
@@ -188,13 +192,6 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
             "`exclude_border` must be bool, int, or tuple with the same "
             "length as the dimensionality of the image.")
 
-    # no peak for a trivial image
-    if np.all(image == image.flat[0]):
-        if indices is True:
-            return np.empty((0, image.ndim), np.int)
-        else:
-            return out
-
     # In the case of labels, call ndi on each label
     if labels is not None:
         label_values = np.unique(labels)
@@ -211,6 +208,8 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
         # For each label, extract a smaller image enclosing the object of
         # interest, identify num_peaks_per_label peaks and mark them in
         # variable out.
+        out = np.zeros_like(image, dtype=np.bool)
+
         for label_idx, obj in enumerate(ndi.find_objects(labels)):
             img_object = image[obj] * (labels[obj] == label_idx + 1)
             mask = _get_peak_mask(img_object, min_distance, footprint,
@@ -250,6 +249,7 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
         return coordinates
     else:
         nd_indices = tuple(coordinates.T)
+        out = np.zeros_like(image, dtype=np.bool)
         out[nd_indices] = True
         return out
 

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -189,7 +189,7 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
             "length as the dimensionality of the image.")
 
     # no peak for a trivial image
-    if np.all(image == image.flat[0]):
+    if all((val == image.flat[0] for val in np.nditer(image))):
         if indices is True:
             return np.empty((0, image.ndim), np.int)
         else:


### PR DESCRIPTION
## Description

Closes #3990 

Using a generator to perform the [trivial image check](https://github.com/scikit-image/scikit-image/blob/master/skimage/feature/peak.py#L192) in `peak_local_max` makes the operation O(1) instead of O(n).

Some timings to show the difference:

```python
In [1]: x = np.random.rand(1000, 1000)                                                                                 

In [2]: %timeit np.all(x == x.flat[0])                                                                                 
718 µs ± 1.03 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [3]: %timeit all((v == x.flat[0] for v in np.nditer(x)))                                                            
6.29 µs ± 35.1 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [4]: x = np.ones((1000, 1000))                                                                                      

In [5]: %timeit np.all(x == x.flat[0])                                                                                 
760 µs ± 2.39 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [6]: %timeit all((v == x.flat[0] for v in np.nditer(x)))                                                            
2.3 s ± 11.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

The speedup is more then 100× for a random image!

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [ ] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
