### PR TITLE
Deprecate indices in peak_local_max

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -70,6 +70,9 @@ Version 0.19
 Version 0.20
 ------------
 
+* In ``skimage/feature/peak.py``, remove the `indices` argument and
+  the decorator `remove_arg`.
+
 
 Version 1.0
 -----------

--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -4,9 +4,70 @@ import numpy as np
 import numpy.testing as npt
 from skimage._shared.utils import (check_nD, deprecate_kwarg,
                                    _validate_interpolation_order,
-                                   change_default_value)
+                                   change_default_value, remove_arg)
 from skimage._shared import testing
 from skimage._shared._warnings import expected_warnings
+
+
+def test_remove_argument():
+
+    @remove_arg('arg1', changed_version='0.12')
+    def foo(arg0, arg1=0, arg2=1):
+        """Expected docstring"""
+        return arg0, arg1, arg2
+
+    @remove_arg('arg1', changed_version='0.12',
+                help_msg="Some indication on future behavior")
+    def bar(arg0, arg1=0, arg2=1):
+        """Expected docstring"""
+        return arg0, arg1, arg2
+
+    # Assert warning messages
+    expected_msg = ("arg1 argument is deprecated and will be removed "
+                    "in version 0.12. To avoid this warning, "
+                    "please do not use the arg1 argument. Please see "
+                    "foo documentation for more details.")
+
+    with pytest.warns(FutureWarning) as record:
+        assert foo(0, 1) == (0, 1, 1)
+
+    assert str(record[0].message) == expected_msg
+
+    with pytest.warns(FutureWarning) as record:
+        assert foo(0, arg1=1) == (0, 1, 1)
+
+    assert str(record[0].message) == expected_msg
+
+    expected_msg = ("arg1 argument is deprecated and will be removed "
+                    "in version 0.12. To avoid this warning, "
+                    "please do not use the arg1 argument. Please see "
+                    "bar documentation for more details."
+                    " Some indication on future behavior")
+
+    with pytest.warns(FutureWarning) as record:
+        assert bar(0, 1) == (0, 1, 1)
+
+    assert str(record[0].message) == expected_msg
+
+    with pytest.warns(FutureWarning) as record:
+        assert bar(0, arg1=1) == (0, 1, 1)
+
+    assert str(record[0].message) == expected_msg
+
+    # Assert that nothing happens if arg1 is set
+    with pytest.warns(None) as record:
+        # No kwargs
+        assert foo(0) == (0, 0, 1)
+        assert foo(0, arg2=0) == (0, 0, 0)
+
+        # Function name and doc is preserved
+        assert foo.__name__ == 'foo'
+        if sys.flags.optimize < 2:
+            # if PYTHONOPTIMIZE is set to 2, docstrings are stripped
+            assert foo.__doc__ == 'Expected docstring'
+
+    # Assert no warning was raised
+    assert not record.list
 
 
 def test_change_default_value():

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -2,6 +2,7 @@ import numpy as np
 import scipy.ndimage as ndi
 from .. import measure
 from ..filters import rank_order
+from .._shared.utils import remove_arg
 
 
 def _get_high_intensity_peaks(image, mask, num_peaks):
@@ -53,6 +54,7 @@ def _exclude_border(mask, exclude_border):
     return mask
 
 
+@remove_arg("indices", changed_version="0.20")
 def peak_local_max(image, min_distance=1, threshold_abs=None,
                    threshold_rel=None, exclude_border=True, indices=True,
                    num_peaks=np.inf, footprint=None, labels=None,
@@ -98,7 +100,10 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
         coordinates. The coordinates are sorted according to peaks
         values (Larger first). If False, the output will be a boolean
         array shaped as `image.shape` with peaks present at True
-        elements.
+        elements. ``indices`` is deprecated and will be removed in
+        version 0.20. Default behavior will be to always return peak
+        coordinates. You can obtain a mask as shown in the example
+        below.
     num_peaks : int, optional
         Maximum number of peaks. When the number of peaks exceeds `num_peaks`,
         return `num_peaks` peaks based on highest peak intensity.
@@ -155,8 +160,12 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
 
     >>> img2 = np.zeros((20, 20, 20))
     >>> img2[10, 10, 10] = 1
-    >>> peak_local_max(img2, exclude_border=0)
+    >>> peak_idx = peak_local_max(img2, exclude_border=0)
+    >>> peak_idx
     array([[10, 10, 10]])
+
+    >>> peak_mask = np.zeros_like(img2, dtype=bool)
+    >>> peak_mask[peak_idx] = True
 
     """
     out = np.zeros_like(image, dtype=np.bool)

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -26,6 +26,8 @@ def _get_peak_mask(image, min_distance, footprint, threshold_abs,
     Return the mask containing all peak candidates above thresholds.
     """
     if footprint is not None:
+        if footprint.size == 1 and min_distance == 1:
+            return np.ones_like(image, dtype=bool)
         image_max = ndi.maximum_filter(image, footprint=footprint,
                                        mode='constant')
     else:
@@ -37,6 +39,10 @@ def _get_peak_mask(image, min_distance, footprint, threshold_abs,
     else:
         threshold = threshold_abs
     mask &= image > threshold
+
+    # no peak for a trivial image
+    if np.count_nonzero(mask) == image.size:
+        mask[:] = False
     return mask
 
 
@@ -159,8 +165,6 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
     array([[10, 10, 10]])
 
     """
-    out = np.zeros_like(image, dtype=np.bool)
-
     threshold_abs = threshold_abs if threshold_abs is not None else image.min()
 
     if isinstance(exclude_border, bool):
@@ -188,13 +192,6 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
             "`exclude_border` must be bool, int, or tuple with the same "
             "length as the dimensionality of the image.")
 
-    # no peak for a trivial image
-    if np.all(image == image.flat[0]):
-        if indices is True:
-            return np.empty((0, image.ndim), np.int)
-        else:
-            return out
-
     # In the case of labels, call ndi on each label
     if labels is not None:
         label_values = np.unique(labels)
@@ -211,6 +208,8 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
         # For each label, extract a smaller image enclosing the object of
         # interest, identify num_peaks_per_label peaks and mark them in
         # variable out.
+        out = np.zeros_like(image, dtype=np.bool)
+
         for label_idx, obj in enumerate(ndi.find_objects(labels)):
             img_object = image[obj] * (labels[obj] == label_idx + 1)
             mask = _get_peak_mask(img_object, min_distance, footprint,
@@ -250,6 +249,7 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
         return coordinates
     else:
         nd_indices = tuple(coordinates.T)
+        out = np.zeros_like(image, dtype=np.bool)
         out[nd_indices] = True
         return out
 

--- a/skimage/feature/tests/test_peak.py
+++ b/skimage/feature/tests/test_peak.py
@@ -2,6 +2,7 @@ import itertools
 import numpy as np
 import pytest
 import unittest
+from skimage._shared._warnings import expected_warnings
 from skimage._shared.testing import assert_array_almost_equal
 from skimage._shared.testing import assert_equal
 from scipy import ndimage as ndi
@@ -13,10 +14,12 @@ np.random.seed(21)
 class TestPeakLocalMax():
     def test_trivial_case(self):
         trivial = np.zeros((25, 25))
-        peak_indices = peak.peak_local_max(trivial, min_distance=1, indices=True)
+        peak_indices = peak.peak_local_max(trivial, min_distance=1)
         assert type(peak_indices) is np.ndarray
         assert peak_indices.size == 0
-        peaks = peak.peak_local_max(trivial, min_distance=1, indices=False)
+        with expected_warnings(["indices argument is deprecated"]):
+            peaks = peak.peak_local_max(trivial, min_distance=1,
+                                        indices=False)
         assert (peaks.astype(np.bool) == trivial).all()
 
     def test_noisy_peaks(self):
@@ -116,19 +119,16 @@ class TestPeakLocalMax():
         labels = 1 + (i >= 10) + (j >= 15) * 2
         result = peak.peak_local_max(image, labels=labels,
                                      min_distance=1, threshold_rel=0,
-                                     indices=True,
                                      num_peaks=np.inf,
                                      num_peaks_per_label=2)
         assert len(result) == 8
         result = peak.peak_local_max(image, labels=labels,
                                      min_distance=1, threshold_rel=0,
-                                     indices=True,
                                      num_peaks=np.inf,
                                      num_peaks_per_label=1)
         assert len(result) == 4
         result = peak.peak_local_max(image, labels=labels,
                                      min_distance=1, threshold_rel=0,
-                                     indices=True,
                                      num_peaks=2,
                                      num_peaks_per_label=2)
         assert len(result) == 2
@@ -155,9 +155,10 @@ class TestPeakLocalMax():
                 expected[imin:imax, jmin:jmax] = ndi.maximum_filter(
                                 image[imin:imax, jmin:jmax], footprint=footprint)
         expected = (expected == image)
-        result = peak.peak_local_max(image, labels=labels, min_distance=1,
-                                     threshold_rel=0, footprint=footprint,
-                                     indices=False, exclude_border=False)
+        with expected_warnings(["indices argument is deprecated"]):
+            result = peak.peak_local_max(image, labels=labels, min_distance=1,
+                                         threshold_rel=0, footprint=footprint,
+                                         indices=False, exclude_border=False)
         assert (result == expected).all()
 
     def test_indices_with_labels(self):
@@ -175,14 +176,15 @@ class TestPeakLocalMax():
         expected = expected[np.argsort(image[tuple(expected.T)])[::-1]]
         result = peak.peak_local_max(image, labels=labels, min_distance=1,
                                      threshold_rel=0, footprint=footprint,
-                                     indices=True, exclude_border=False)
+                                     exclude_border=False)
         result = result[np.argsort(image[tuple(result.T)])[::-1]]
         assert (result == expected).all()
 
     def test_ndarray_indices_false(self):
         nd_image = np.zeros((5, 5, 5))
         nd_image[2, 2, 2] = 1
-        peaks = peak.peak_local_max(nd_image, min_distance=1, indices=False)
+        with expected_warnings(["indices argument is deprecated"]):
+            peaks = peak.peak_local_max(nd_image, min_distance=1, indices=False)
         assert (peaks == nd_image.astype(np.bool)).all()
 
     def test_ndarray_exclude_border(self):
@@ -193,41 +195,43 @@ class TestPeakLocalMax():
         expected = np.zeros_like(nd_image, dtype=np.bool)
         expected[2, 2, 2] = True
         expectedNoBorder = nd_image > 0
-        result = peak.peak_local_max(nd_image, min_distance=2,
-            exclude_border=2, indices=False)
-        assert_equal(result, expected)
-        # Check that bools work as expected
-        assert_equal(
-            peak.peak_local_max(nd_image, min_distance=2,
-                exclude_border=2, indices=False),
-            peak.peak_local_max(nd_image, min_distance=2,
-                exclude_border=True, indices=False)
+        with expected_warnings(["indices argument is deprecated"]):
+            result = peak.peak_local_max(nd_image, min_distance=2,
+                                         exclude_border=2, indices=False)
+            assert_equal(result, expected)
+            # Check that bools work as expected
+            assert_equal(
+                peak.peak_local_max(nd_image, min_distance=2,
+                                    exclude_border=2, indices=False),
+                peak.peak_local_max(nd_image, min_distance=2,
+                                    exclude_border=True, indices=False)
             )
-        assert_equal(
-            peak.peak_local_max(nd_image, min_distance=2,
-                exclude_border=0, indices=False),
-            peak.peak_local_max(nd_image, min_distance=2,
-                exclude_border=False, indices=False)
+            assert_equal(
+                peak.peak_local_max(nd_image, min_distance=2,
+                                    exclude_border=0, indices=False),
+                peak.peak_local_max(nd_image, min_distance=2,
+                                    exclude_border=False, indices=False)
             )
-        # Check both versions with  no border
-        assert_equal(
-            peak.peak_local_max(nd_image, min_distance=2,
-                exclude_border=0, indices=False),
-            expectedNoBorder,
+            # Check both versions with  no border
+            assert_equal(
+                peak.peak_local_max(nd_image, min_distance=2,
+                                    exclude_border=0, indices=False),
+                expectedNoBorder,
             )
-        assert_equal(
-            peak.peak_local_max(nd_image,
-                exclude_border=False, indices=False),
-            expectedNoBorder,
+            assert_equal(
+                peak.peak_local_max(nd_image,
+                                    exclude_border=False, indices=False),
+                expectedNoBorder,
             )
 
     def test_empty(self):
         image = np.zeros((10, 20))
         labels = np.zeros((10, 20), int)
-        result = peak.peak_local_max(image, labels=labels,
-                                     footprint=np.ones((3, 3), bool),
-                                     min_distance=1, threshold_rel=0,
-                                     indices=False, exclude_border=False)
+        with expected_warnings(["indices argument is deprecated"]):
+            result = peak.peak_local_max(image, labels=labels,
+                                         footprint=np.ones((3, 3), bool),
+                                         min_distance=1, threshold_rel=0,
+                                         indices=False, exclude_border=False)
         assert np.all(~ result)
 
     def test_empty_non2d_indices(self):
@@ -235,7 +239,7 @@ class TestPeakLocalMax():
         result = peak.peak_local_max(image,
                                      footprint=np.ones((3, 3), bool),
                                      min_distance=1, threshold_rel=0,
-                                     indices=True, exclude_border=False)
+                                     exclude_border=False)
         assert result.shape == (0, image.ndim)
 
     def test_one_point(self):
@@ -243,10 +247,11 @@ class TestPeakLocalMax():
         labels = np.zeros((10, 20), int)
         image[5, 5] = 1
         labels[5, 5] = 1
-        result = peak.peak_local_max(image, labels=labels,
-                                     footprint=np.ones((3, 3), bool),
-                                     min_distance=1, threshold_rel=0,
-                                     indices=False, exclude_border=False)
+        with expected_warnings(["indices argument is deprecated"]):
+            result = peak.peak_local_max(image, labels=labels,
+                                         footprint=np.ones((3, 3), bool),
+                                         min_distance=1, threshold_rel=0,
+                                         indices=False, exclude_border=False)
         assert np.all(result == (labels == 1))
 
     def test_adjacent_and_same(self):
@@ -254,10 +259,11 @@ class TestPeakLocalMax():
         labels = np.zeros((10, 20), int)
         image[5, 5:6] = 1
         labels[5, 5:6] = 1
-        result = peak.peak_local_max(image, labels=labels,
-                                     footprint=np.ones((3, 3), bool),
-                                     min_distance=1, threshold_rel=0,
-                                     indices=False, exclude_border=False)
+        with expected_warnings(["indices argument is deprecated"]):
+            result = peak.peak_local_max(image, labels=labels,
+                                         footprint=np.ones((3, 3), bool),
+                                         min_distance=1, threshold_rel=0,
+                                         indices=False, exclude_border=False)
         assert np.all(result == (labels == 1))
 
     def test_adjacent_and_different(self):
@@ -267,14 +273,16 @@ class TestPeakLocalMax():
         image[5, 6] = .5
         labels[5, 5:6] = 1
         expected = (image == 1)
-        result = peak.peak_local_max(image, labels=labels,
-                                     footprint=np.ones((3, 3), bool),
-                                     min_distance=1, threshold_rel=0,
-                                     indices=False, exclude_border=False)
+        with expected_warnings(["indices argument is deprecated"]):
+            result = peak.peak_local_max(image, labels=labels,
+                                         footprint=np.ones((3, 3), bool),
+                                         min_distance=1, threshold_rel=0,
+                                         indices=False, exclude_border=False)
         assert np.all(result == expected)
-        result = peak.peak_local_max(image, labels=labels,
-                                     min_distance=1, threshold_rel=0,
-                                     indices=False, exclude_border=False)
+        with expected_warnings(["indices argument is deprecated"]):
+            result = peak.peak_local_max(image, labels=labels,
+                                         min_distance=1, threshold_rel=0,
+                                         indices=False, exclude_border=False)
         assert np.all(result == expected)
 
     def test_not_adjacent_and_different(self):
@@ -284,10 +292,11 @@ class TestPeakLocalMax():
         image[5, 8] = .5
         labels[image > 0] = 1
         expected = (labels == 1)
-        result = peak.peak_local_max(image, labels=labels,
-                                     footprint=np.ones((3, 3), bool),
-                                     min_distance=1, threshold_rel=0,
-                                     indices=False, exclude_border=False)
+        with expected_warnings(["indices argument is deprecated"]):
+            result = peak.peak_local_max(image, labels=labels,
+                                         footprint=np.ones((3, 3), bool),
+                                         min_distance=1, threshold_rel=0,
+                                         indices=False, exclude_border=False)
         assert np.all(result == expected)
 
     def test_two_objects(self):
@@ -298,10 +307,11 @@ class TestPeakLocalMax():
         labels[5, 5] = 1
         labels[5, 15] = 2
         expected = (labels > 0)
-        result = peak.peak_local_max(image, labels=labels,
-                                     footprint=np.ones((3, 3), bool),
-                                     min_distance=1, threshold_rel=0,
-                                     indices=False, exclude_border=False)
+        with expected_warnings(["indices argument is deprecated"]):
+            result = peak.peak_local_max(image, labels=labels,
+                                         footprint=np.ones((3, 3), bool),
+                                         min_distance=1, threshold_rel=0,
+                                         indices=False, exclude_border=False)
         assert np.all(result == expected)
 
     def test_adjacent_different_objects(self):
@@ -312,10 +322,11 @@ class TestPeakLocalMax():
         labels[5, 5] = 1
         labels[5, 6] = 2
         expected = (labels > 0)
-        result = peak.peak_local_max(image, labels=labels,
-                                     footprint=np.ones((3, 3), bool),
-                                     min_distance=1, threshold_rel=0,
-                                     indices=False, exclude_border=False)
+        with expected_warnings(["indices argument is deprecated"]):
+            result = peak.peak_local_max(image, labels=labels,
+                                         footprint=np.ones((3, 3), bool),
+                                         min_distance=1, threshold_rel=0,
+                                         indices=False, exclude_border=False)
         assert np.all(result == expected)
 
     def test_four_quadrants(self):
@@ -330,9 +341,13 @@ class TestPeakLocalMax():
                 expected[imin:imax, jmin:jmax] = ndi.maximum_filter(
                     image[imin:imax, jmin:jmax], footprint=footprint)
         expected = (expected == image)
-        result = peak.peak_local_max(image, labels=labels, footprint=footprint,
-                                     min_distance=1, threshold_rel=0,
-                                     indices=False, exclude_border=False)
+        with expected_warnings(["indices argument is deprecated"]):
+            result = peak.peak_local_max(image, labels=labels,
+                                         footprint=footprint,
+                                         min_distance=1,
+                                         threshold_rel=0,
+                                         indices=False,
+                                         exclude_border=False)
         assert np.all(result == expected)
 
     def test_disk(self):
@@ -341,14 +356,18 @@ class TestPeakLocalMax():
         '''
         image = np.random.uniform(size=(10, 20))
         footprint = np.array([[1]])
-        result = peak.peak_local_max(image, labels=np.ones((10, 20)),
-                                     footprint=footprint,
-                                     min_distance=1, threshold_rel=0,
-                                     threshold_abs=-1, indices=False,
-                                     exclude_border=False)
+        with expected_warnings(["indices argument is deprecated"]):
+            result = peak.peak_local_max(image, labels=np.ones((10, 20)),
+                                         footprint=footprint,
+                                         min_distance=1, threshold_rel=0,
+                                         threshold_abs=-1, indices=False,
+                                         exclude_border=False)
         assert np.all(result)
-        result = peak.peak_local_max(image, footprint=footprint, threshold_abs=-1,
-                                     indices=False, exclude_border=False)
+        with expected_warnings(["indices argument is deprecated"]):
+            result = peak.peak_local_max(image, footprint=footprint,
+                                         threshold_abs=-1,
+                                         indices=False,
+                                         exclude_border=False)
         assert np.all(result)
 
     def test_3D(self):
@@ -518,10 +537,11 @@ class TestProminentPeaks(unittest.TestCase):
         image[5, 5] = 1
         labels[5, 5] = 1
         labelsin = labels.copy()
-        result = peak.peak_local_max(image, labels=labels,
-                                     footprint=np.ones((3, 3), bool),
-                                     min_distance=1, threshold_rel=0,
-                                     indices=False, exclude_border=False)
+        with expected_warnings(["indices argument is deprecated"]):
+            result = peak.peak_local_max(image, labels=labels,
+                                         footprint=np.ones((3, 3), bool),
+                                         min_distance=1, threshold_rel=0,
+                                         indices=False, exclude_border=False)
         assert np.all(labels == labelsin)
 
     def test_many_objects(self):
@@ -532,6 +552,6 @@ class TestProminentPeaks(unittest.TestCase):
         mask[(x - x_c) ** 2 + (y - y_c) ** 2 < 8 ** 2] = True
         labels, num_objs = ndi.label(mask)
         dist = ndi.distance_transform_edt(mask)
-        local_max = peak.peak_local_max(dist, min_distance=20, indices=True,
+        local_max = peak.peak_local_max(dist, min_distance=20,
                                         exclude_border=False, labels=labels)
         assert len(local_max) == 625

--- a/skimage/feature/tests/test_peak.py
+++ b/skimage/feature/tests/test_peak.py
@@ -184,7 +184,8 @@ class TestPeakLocalMax():
         nd_image = np.zeros((5, 5, 5))
         nd_image[2, 2, 2] = 1
         with expected_warnings(["indices argument is deprecated"]):
-            peaks = peak.peak_local_max(nd_image, min_distance=1, indices=False)
+            peaks = peak.peak_local_max(nd_image, min_distance=1,
+                                        indices=False)
         assert (peaks == nd_image.astype(np.bool)).all()
 
     def test_ndarray_exclude_border(self):


### PR DESCRIPTION
## Description

This PR proposes to deprecate the `indices` argument from `peak_local_max`. The `remove_arg` decorator is added for this purpose.

To motivate this change I would like to cite @stefanv's https://github.com/scikit-image/scikit-image/issues/3892#issuecomment-591819705, that BTW should be integrated in the contributions guide lines ;)


<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
