### PR TITLE
Handle NaNs in phase_cross_correlation

### DIFF
--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -190,6 +190,13 @@ def phase_cross_correlation(reference_image, moving_image, *,
         return _masked_phase_cross_correlation(reference_image, moving_image,
                                                reference_mask, moving_mask,
                                                overlap_ratio)
+    # If input images contain NaN pixels, must mask before correlation
+    if np.isnan(reference_image).any() or np.isnan(moving_image).any():
+        reference_mask = ~np.isnan(reference_image)
+        moving_mask = ~np.isnan(moving_image)
+        return _masked_phase_cross_correlation(reference_image, moving_image,
+                                               reference_mask, moving_mask,
+                                               overlap_ratio)
 
     # images must be the same shape
     if reference_image.shape != moving_image.shape:

--- a/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_phase_cross_correlation.py
@@ -84,6 +84,16 @@ def test_3d_input():
     assert_allclose(result, -np.array(subpixel_shift), atol=0.05)
 
 
+def test_input_with_nans():
+    reference_image = img_as_float(camera())
+    moving_image = np.roll(img_as_float(camera()), 20, axis=1)
+    expected = np.array([0, -20])  # so we expect to recover a -20 pixel shift
+    # Add NaN pixels
+    reference_image[0][0] = np.nan
+    result = phase_cross_correlation(reference_image, moving_image)
+    assert np.allclose(result, expected)
+
+
 def test_unknown_space_input():
     image = np.ones((5, 5))
     with testing.raises(ValueError):


### PR DESCRIPTION
## Description

Closes https://github.com/scikit-image/scikit-image/issues/4763

I recently found that if there is a NaN in an image passed to `phase_cross_correlation()`, you get an incorrect result back (rather than an error being raised, or the NaNs being handled by the function). 

Since it seems pretty easy to be genuinely unaware that there might be a NaN pixel somewhere in your data, it seems reasonable to add a check for this and dispatch to the masked phase correlation function if needed.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
