### PR TITLE
Fix random_walker regression

### DIFF
--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -26,6 +26,8 @@ def _get_peak_mask(image, min_distance, footprint, threshold_abs,
     Return the mask containing all peak candidates above thresholds.
     """
     if footprint is not None:
+        if footprint.size == 1 and min_distance == 1:
+            return np.ones_like(image, dtype=bool)
         image_max = ndi.maximum_filter(image, footprint=footprint,
                                        mode='constant')
     else:
@@ -37,6 +39,10 @@ def _get_peak_mask(image, min_distance, footprint, threshold_abs,
     else:
         threshold = threshold_abs
     mask &= image > threshold
+
+    # no peak for a trivial image
+    if np.count_nonzero(mask) == image.size:
+        mask[:] = False
     return mask
 
 
@@ -159,8 +165,6 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
     array([[10, 10, 10]])
 
     """
-    out = np.zeros_like(image, dtype=np.bool)
-
     threshold_abs = threshold_abs if threshold_abs is not None else image.min()
 
     if isinstance(exclude_border, bool):
@@ -188,13 +192,6 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
             "`exclude_border` must be bool, int, or tuple with the same "
             "length as the dimensionality of the image.")
 
-    # no peak for a trivial image
-    if np.all(image == image.flat[0]):
-        if indices is True:
-            return np.empty((0, image.ndim), np.int)
-        else:
-            return out
-
     # In the case of labels, call ndi on each label
     if labels is not None:
         label_values = np.unique(labels)
@@ -211,6 +208,8 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
         # For each label, extract a smaller image enclosing the object of
         # interest, identify num_peaks_per_label peaks and mark them in
         # variable out.
+        out = np.zeros_like(image, dtype=np.bool)
+
         for label_idx, obj in enumerate(ndi.find_objects(labels)):
             img_object = image[obj] * (labels[obj] == label_idx + 1)
             mask = _get_peak_mask(img_object, min_distance, footprint,
@@ -250,6 +249,7 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
         return coordinates
     else:
         nd_indices = tuple(coordinates.T)
+        out = np.zeros_like(image, dtype=np.bool)
         out[nd_indices] = True
         return out
 

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -499,9 +499,10 @@ def random_walker(data, labels, beta=130, mode='cg_j', tol=1.e-3, copy=True,
     labels[inds_isolated_seeds] = isolated_values
     labels = labels.reshape(labels_shape)
 
-    if return_full_prob:
-        mask = labels == 0
+    mask = labels == 0
+    mask[inds_isolated_seeds] = False
 
+    if return_full_prob:
         out = np.zeros((nlabels,) + labels_shape)
         for lab, (label_prob, prob) in enumerate(zip(out, X), start=1):
             label_prob[mask] = prob
@@ -509,6 +510,6 @@ def random_walker(data, labels, beta=130, mode='cg_j', tol=1.e-3, copy=True,
     else:
         X = np.argmax(X, axis=0) + 1
         out = labels.astype(labels_dtype)
-        out[labels == 0] = X
+        out[mask] = X
 
     return out

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -442,6 +442,30 @@ def test_isolated_seeds():
     assert res[1, 1, 1] == 0
 
 
+def test_isolated_area():
+    np.random.seed(0)
+    a = np.random.random((7, 7))
+    mask = - np.ones(a.shape)
+    # This pixel is an isolated seed
+    mask[1, 1] = 0
+    # Unlabeled pixels
+    mask[3:, 3:] = 0
+    # Seeds connected to unlabeled pixels
+    mask[4, 4] = 2
+    mask[6, 6] = 1
+
+    # Test that no error is raised, and that labels of isolated seeds are OK
+    with expected_warnings([NUMPY_MATRIX_WARNING,
+                            'The probability range is outside']):
+        res = random_walker(a, mask)
+    assert res[1, 1] == 0
+    with expected_warnings([NUMPY_MATRIX_WARNING,
+                            'The probability range is outside']):
+        res = random_walker(a, mask, return_full_prob=True)
+    assert res[0, 1, 1] == 0
+    assert res[1, 1, 1] == 0
+
+
 def test_prob_tol():
     np.random.seed(0)
     a = np.random.random((7, 7))


### PR DESCRIPTION
## Description

Fix #4770.

Regression was introduced in https://github.com/scikit-image/scikit-image/commit/8f76f0fb48908ba2ca92816d3611bba5cd09b998.

This PR
- fixes `random_walker` segmentation when labels contains isolated area
- adds `test_isolated_area`

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- [ ] Check that the PR title is short, concise, and will make sense 1 year
  later.
- [ ] Check that new functions are imported in corresponding `__init__.py`.
- [ ] Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
