### PR TITLE
Add expand_labels function to dilate segments while avoiding overlaps

### DIFF
--- a/doc/examples/segmentation/plot_expand_labels.py
+++ b/doc/examples/segmentation/plot_expand_labels.py
@@ -3,12 +3,12 @@
 Expand segmentation labels without overlap
 ==========================================
 
-When you have a set of regions
-segmentations. The :py:func:`skimage.segmentation.join_segmentations`
-function computes the join of two segmentations, in which a pixel is
-placed in the same segment if and only if it is in the same segment in
-*both* segmentations.
-
+Given several connected components represented by a label image, these
+connected components can be expanded into background regions using
+ :py:func:`skimage.segmentation.expand_labels`.
+In contrast to :py:func:`skimage.morphology.dilation` this method will
+not let connected components expand into neighboring connected components
+with lower label number.
 """
 import numpy as np
 import matplotlib.pyplot as plt

--- a/doc/examples/segmentation/plot_expand_labels.py
+++ b/doc/examples/segmentation/plot_expand_labels.py
@@ -14,8 +14,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from skimage.filters import sobel
-from skimage.measure import label, expand_labels
-from skimage.segmentation import watershed
+from skimage.measure import label
+from skimage.segmentation import watershed, expand_labels
 from skimage.color import label2rgb
 from skimage import data
 

--- a/doc/examples/segmentation/plot_expand_labels.py
+++ b/doc/examples/segmentation/plot_expand_labels.py
@@ -5,7 +5,7 @@ Expand segmentation labels without overlap
 
 Given several connected components represented by a label image, these
 connected components can be expanded into background regions using
- :py:func:`skimage.segmentation.expand_labels`.
+:py:func:`skimage.segmentation.expand_labels`.
 In contrast to :py:func:`skimage.morphology.dilation` this method will
 not let connected components expand into neighboring connected components
 with lower label number.

--- a/doc/examples/segmentation/plot_expand_labels.py
+++ b/doc/examples/segmentation/plot_expand_labels.py
@@ -1,0 +1,54 @@
+"""
+==========================================
+Expand segmentation labels without overlap
+==========================================
+
+When you have a set of regions
+segmentations. The :py:func:`skimage.segmentation.join_segmentations`
+function computes the join of two segmentations, in which a pixel is
+placed in the same segment if and only if it is in the same segment in
+*both* segmentations.
+
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+
+from skimage.filters import sobel
+from skimage.measure import label, expand_labels
+from skimage.segmentation import watershed
+from skimage.color import label2rgb
+from skimage import data
+
+coins = data.coins()
+
+# Make segmentation using edge-detection and watershed.
+edges = sobel(coins)
+
+# Identify some background and foreground pixels from the intensity values.
+# These pixels are used as seeds for watershed.
+markers = np.zeros_like(coins)
+foreground, background = 1, 2
+markers[coins < 30.0] = background
+markers[coins > 150.0] = foreground
+
+ws = watershed(edges, markers)
+seg1 = label(ws == foreground)
+
+expanded = expand_labels(seg1, distance=10)
+
+# Show the segmentations.
+fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(9, 5),
+                         sharex=True, sharey=True)
+
+color1 = label2rgb(seg1, image=coins, bg_label=0)
+axes[0].imshow(color1)
+axes[0].set_title('Sobel+Watershed')
+
+color2 = label2rgb(expanded, image=coins, image_alpha=0.5, bg_label=0)
+axes[1].imshow(color2)
+axes[1].set_title('Expanded labels')
+
+for a in axes:
+    a.axis('off')
+fig.tight_layout()
+plt.show()

--- a/doc/examples/segmentation/plot_expand_labels.py
+++ b/doc/examples/segmentation/plot_expand_labels.py
@@ -44,7 +44,7 @@ color1 = label2rgb(seg1, image=coins, bg_label=0)
 axes[0].imshow(color1)
 axes[0].set_title('Sobel+Watershed')
 
-color2 = label2rgb(expanded, image=coins, image_alpha=0.5, bg_label=0)
+color2 = label2rgb(expanded, image=coins, bg_label=0)
 axes[1].imshow(color2)
 axes[1].set_title('Expanded labels')
 

--- a/skimage/measure/__init__.py
+++ b/skimage/measure/__init__.py
@@ -11,12 +11,11 @@ from ._moments import (moments, moments_central, moments_coords,
 from .profile import profile_line
 from .fit import LineModelND, CircleModel, EllipseModel, ransac
 from .block import block_reduce
-from ._label import label, expand_labels
+from ._label import label
 from .entropy import shannon_entropy
 
 
-__all__ = ['expand_labels',
-           'find_contours',
+__all__ = ['find_contours',
            'regionprops',
            'regionprops_table',
            'perimeter',
@@ -44,4 +43,4 @@ __all__ = ['expand_labels',
            'points_in_poly',
            'grid_points_in_poly',
            'shannon_entropy',
-]
+           ]

--- a/skimage/measure/__init__.py
+++ b/skimage/measure/__init__.py
@@ -11,7 +11,7 @@ from ._moments import (moments, moments_central, moments_coords,
 from .profile import profile_line
 from .fit import LineModelND, CircleModel, EllipseModel, ransac
 from .block import block_reduce
-from ._label import label
+from ._label import label, expand_labels
 from .entropy import shannon_entropy
 
 

--- a/skimage/measure/__init__.py
+++ b/skimage/measure/__init__.py
@@ -15,7 +15,8 @@ from ._label import label, expand_labels
 from .entropy import shannon_entropy
 
 
-__all__ = ['find_contours',
+__all__ = ['expand_labels',
+           'find_contours',
            'regionprops',
            'regionprops_table',
            'perimeter',

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -113,7 +113,7 @@ def expand_labels(label_image, distance):
     stop at less than distance pixels (this is where it differs from a 
     morphological dilation, where a connected component with a high label 
     number can potentially override connected components with lower label
-    numbers)::
+    numbers):
 
     This is equivalent to CellProfiler [1] IdentifySecondaryObjects method
     using the option "Distance-N"
@@ -126,9 +126,9 @@ def expand_labels(label_image, distance):
     points and you don't want to merge those. Distance N will grow up to N pixels without
     merging objects that are closer together than 2N. 
 
-    There is an important edge case when regions are separated by one background pixels,
-    see the discussion in [2].
-    We give no guarantee which region will get to expand into the 1-pixel gap. 
+    There is an important edge case when a pixel has the same distance to multiple regions,
+    as it is not defined which region expands into that space, see the discussion in [2].
+    Here, the exact bahaviour depends on the upstream implementation
 
     Parameters
     ----------
@@ -144,7 +144,7 @@ def expand_labels(label_image, distance):
 
     See Also
     --------
-    label
+    :func:`label`, :func:`skimage.segmentation.watershed`
 
     References
     ----------
@@ -153,7 +153,30 @@ def expand_labels(label_image, distance):
 
     Examples
     --------
-    >>> TODO
+    >>> labels = np.array([0, 1, 0, 0, 0, 0, 2])
+    >>> expand_labels(labels, distance=1)
+    array([1, 1, 1, 0, 0, 2, 2])
+
+    Labels will not overwrite each other:
+
+    >>> expand_labels(labels, distance=3)
+    array([1, 1, 1, 1, 2, 2, 2])
+
+    In case of ties, behavior is undefined, but currently resolves to the
+    label closest to ``(0,) * ndim`` in lexicographical order.
+
+    >>> labels_tied = np.array([0, 1, 0, 2, 0])
+    >>> expand_labels(labels_tied, 1)
+    array([1, 1, 1, 2, 2])
+    >>> labels2d = np.array(
+    ...     [[0, 1, 0, 0],
+    ...      [2, 0, 0, 0],
+    ...      [0, 3, 0, 0]]
+    ... )
+    >>> expand_labels(labels2d, 1)
+    array([[2, 1, 1, 0],
+           [2, 2, 0, 0],
+           [2, 3, 3, 0]])
     """
     
     distances, nearest_label_coords = distance_transform_edt(

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -10,7 +10,6 @@ Original author/s: Cellprofiler team
 """
 
 from ._ccomp import label_cython as clabel
-import numpy as np
 
 def label(input, neighbors=None, background=None, return_num=False,
           connectivity=None):
@@ -102,5 +101,4 @@ def label(input, neighbors=None, background=None, return_num=False,
      [0 0 0]]
     """
     return clabel(input, neighbors, background, return_num, connectivity)
-
 

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -1,3 +1,14 @@
+""" 
+expand_labels is based on code in  CellProfiler, 
+code licensed under BSD-3 licenses.
+Website: http://www.cellprofiler.org
+
+Copyright (c) 2020 Broad Institute
+All rights reserved.
+
+Original author/s: Cellprofiler team 
+"""
+
 from ._ccomp import label_cython as clabel
 from scipy.ndimage import distance_transform_edt
 import numpy as np
@@ -94,7 +105,7 @@ def label(input, neighbors=None, background=None, return_num=False,
     return clabel(input, neighbors, background, return_num, connectivity)
 
 
-def expand_labels(input, distance):
+def expand_labels(label_image, distance):
     r"""Expand labels in label image by ``distance`` pixels without overlapping.
 
     Given a label image, each label is grown by up to distance pixels. 
@@ -121,7 +132,7 @@ def expand_labels(input, distance):
 
     Parameters
     ----------
-    input : ndarray of dtype int
+    label_image : ndarray of dtype int
         label image
     distance : int
         number of pixels to grow the labels
@@ -144,14 +155,12 @@ def expand_labels(input, distance):
     >>> TODO
     """
     
-    distances, indexmap = distance_transform_edt(input == 0, return_indices = True)
-    labels_out = np.zeros(input.shape, input.dtype)
+    distances, indexmap = distance_transform_edt(label_image == 0, return_indices = True)
+    labels_out = np.zeros(label_image.shape, label_image.dtype)
     dilate_mask = distances <= distance
     # build the array slice, this change to [1] enables support for arbitrary dimensions
     indexmap_slices = []
     for el in indexmap:
         indexmap_slices.append(np.s_[el[dilate_mask]])
-    labels_out[dilate_mask] = input[tuple(indexmap_slices)]
+    labels_out[dilate_mask] = label_image[tuple(indexmap_slices)]
     return labels_out
-
- 

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -90,4 +90,3 @@ def label(input, neighbors=None, background=None, return_num=False,
      [0 0 0]]
     """
     return clabel(input, neighbors, background, return_num, connectivity)
-

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -1,14 +1,3 @@
-""" 
-expand_labels is  inspired by code in CellProfiler, 
-code licensed under BSD-3 licenses.
-Website: http://www.cellprofiler.org
-
-Copyright (c) 2020 Broad Institute
-All rights reserved.
-
-Original author/s: Cellprofiler team 
-"""
-
 from ._ccomp import label_cython as clabel
 
 def label(input, neighbors=None, background=None, return_num=False,

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -10,7 +10,6 @@ Original author/s: Cellprofiler team
 """
 
 from ._ccomp import label_cython as clabel
-from scipy.ndimage import distance_transform_edt
 import numpy as np
 
 def label(input, neighbors=None, background=None, return_num=False,
@@ -105,95 +104,3 @@ def label(input, neighbors=None, background=None, return_num=False,
     return clabel(input, neighbors, background, return_num, connectivity)
 
 
-def expand_labels(label_image, distance):
-    """Expand labels in label image by ``distance`` pixels without overlapping.
-
-    Given a label image, each label is grown by up to distance pixels. 
-    However, where labels would start to overlap, the label growth may
-    stop at less than distance pixels (this is where it differs from a 
-    morphological dilation, where a connected component with a high label 
-    number can potentially override connected components with lower label
-    numbers).
-
-    This is equivalent to CellProfiler [1] [2] IdentifySecondaryObjects method
-    using the option "Distance-N".
-
-    The basic idea is that you have some seed labels that you want 
-    to grow by n pixels to give a mask for a larger object.
-    
-    If you were only dealing with a single seed object, you could simply
-    dilate with a suitably sized structuring element. However, in general you
-    have multiple seed points and you don't want to merge those. Distance N
-    will grow up to N pixels without merging objects that are closer together
-    than 2N.
-    
-    There is an important edge case when a pixel has the same distance to
-    multiple regions, as it is not defined which region expands into that
-    space, see the discussion in [1]. Here, the exact bahaviour depends on
-    the upstream implementation.
-
-    Parameters
-    ----------
-    label_image : ndarray of dtype int
-        label image
-    distance : float
-        Number of pixels by which to grow the labels.
-
-    Returns
-    -------
-    enlarged_labels : ndarray of dtype int
-        Labeled array, where all connected regions have been enlarged
-
-    See Also
-    --------
-    :py:func:`label`, :py:func:`skimage.segmentation.watershed`
-
-    References
-    ----------
-    .. [1] https://cellprofiler.org
-    .. [2] https://github.com/CellProfiler/CellProfiler/blob/082930ea95add7b72243a4fa3d39ae5145995e9c/cellprofiler/modules/identifysecondaryobjects.py#L559
-    .. [3] https://forum.image.sc/t/equivalent-to-cellprofilers-identifysecondaryobjects-distance-n-in-fiji/39146/16
-
-    Examples
-    --------
-    >>> labels = np.array([0, 1, 0, 0, 0, 0, 2])
-    >>> expand_labels(labels, distance=1)
-    array([1, 1, 1, 0, 0, 2, 2])
-
-    Labels will not overwrite each other:
-
-    >>> expand_labels(labels, distance=3)
-    array([1, 1, 1, 1, 2, 2, 2])
-
-    In case of ties, behavior is undefined, but currently resolves to the
-    label closest to ``(0,) * ndim`` in lexicographical order.
-
-    >>> labels_tied = np.array([0, 1, 0, 2, 0])
-    >>> expand_labels(labels_tied, 1)
-    array([1, 1, 1, 2, 2])
-    >>> labels2d = np.array(
-    ...     [[0, 1, 0, 0],
-    ...      [2, 0, 0, 0],
-    ...      [0, 3, 0, 0]]
-    ... )
-    >>> expand_labels(labels2d, 1)
-    array([[2, 1, 1, 0],
-           [2, 2, 0, 0],
-           [2, 3, 3, 0]])
-    """
-    
-    distances, nearest_label_coords = distance_transform_edt(
-        label_image == 0, return_indices=True
-    )
-    labels_out = np.zeros(label_image.shape, label_image.dtype)
-    dilate_mask = distances <= distance
-    # build the coordinates to find nearest labels,
-    # in contrast to [1] this implementation supports label arrays
-    # of any dimension
-    masked_nearest_label_coords = [
-        dimension_indices[dilate_mask]
-        for dimension_indices in nearest_label_coords
-    ]
-    nearest_labels = label_image[tuple(masked_nearest_label_coords)]
-    labels_out[dilate_mask] = nearest_labels
-    return labels_out

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -1,5 +1,5 @@
 """ 
-expand_labels is based on code in  CellProfiler, 
+expand_labels is  inspired by code in CellProfiler, 
 code licensed under BSD-3 licenses.
 Website: http://www.cellprofiler.org
 
@@ -134,8 +134,9 @@ def expand_labels(label_image, distance):
     ----------
     label_image : ndarray of dtype int
         label image
-    distance : int
-        number of pixels to grow the labels
+    distance : float
+        Number of pixels by which to grow the labels.
+
     Returns
     -------
     enlarged_labels : ndarray of dtype int
@@ -155,12 +156,18 @@ def expand_labels(label_image, distance):
     >>> TODO
     """
     
-    distances, indexmap = distance_transform_edt(label_image == 0, return_indices = True)
+    distances, nearest_label_coords = distance_transform_edt(
+        label_image == 0, return_indices=True
+    )
     labels_out = np.zeros(label_image.shape, label_image.dtype)
     dilate_mask = distances <= distance
-    # build the array slice, this change to [1] enables support for arbitrary dimensions
-    indexmap_slices = []
-    for el in indexmap:
-        indexmap_slices.append(el[dilate_mask])
-    labels_out[dilate_mask] = label_image[tuple(indexmap_slices)]
+    # build the coordinates to find nearest labels,
+    # in contrast to [1] this implementation supports label arrays
+    # of any dimension
+    masked_nearest_label_coords = [
+        dimension_indices[dilate_mask]
+        for dimension_indices in nearest_label_coords
+    ]
+    nearest_labels = label_image[tuple(masked_nearest_label_coords)]
+    labels_out[dilate_mask] = nearest_labels
     return labels_out

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -106,29 +106,31 @@ def label(input, neighbors=None, background=None, return_num=False,
 
 
 def expand_labels(label_image, distance):
-    r"""Expand labels in label image by ``distance`` pixels without overlapping.
+    """Expand labels in label image by ``distance`` pixels without overlapping.
 
     Given a label image, each label is grown by up to distance pixels. 
     However, where labels would start to overlap, the label growth may
     stop at less than distance pixels (this is where it differs from a 
     morphological dilation, where a connected component with a high label 
     number can potentially override connected components with lower label
-    numbers):
+    numbers).
 
-    This is equivalent to CellProfiler [1] IdentifySecondaryObjects method
-    using the option "Distance-N"
+    This is equivalent to CellProfiler [1] [2] IdentifySecondaryObjects method
+    using the option "Distance-N".
 
     The basic idea is that you have some seed labels that you want 
     to grow by n pixels to give a mask for a larger object.
     
-    If you were only dealing with a single seed object, you could simply dilate with 
-    a suitably sized structuring element. However, in general you have multiple seed 
-    points and you don't want to merge those. Distance N will grow up to N pixels without
-    merging objects that are closer together than 2N. 
-
-    There is an important edge case when a pixel has the same distance to multiple regions,
-    as it is not defined which region expands into that space, see the discussion in [2].
-    Here, the exact bahaviour depends on the upstream implementation
+    If you were only dealing with a single seed object, you could simply
+    dilate with a suitably sized structuring element. However, in general you
+    have multiple seed points and you don't want to merge those. Distance N
+    will grow up to N pixels without merging objects that are closer together
+    than 2N.
+    
+    There is an important edge case when a pixel has the same distance to
+    multiple regions, as it is not defined which region expands into that
+    space, see the discussion in [1]. Here, the exact bahaviour depends on
+    the upstream implementation.
 
     Parameters
     ----------
@@ -144,12 +146,13 @@ def expand_labels(label_image, distance):
 
     See Also
     --------
-    :func:`label`, :func:`skimage.segmentation.watershed`
+    :py:func:`label`, :py:func:`skimage.segmentation.watershed`
 
     References
     ----------
-    .. [1] https://github.com/CellProfiler/CellProfiler/blob/082930ea95add7b72243a4fa3d39ae5145995e9c/cellprofiler/modules/identifysecondaryobjects.py#L559
-    .. [2] https://forum.image.sc/t/equivalent-to-cellprofilers-identifysecondaryobjects-distance-n-in-fiji/39146/16
+    .. [1] https://cellprofiler.org
+    .. [2] https://github.com/CellProfiler/CellProfiler/blob/082930ea95add7b72243a4fa3d39ae5145995e9c/cellprofiler/modules/identifysecondaryobjects.py#L559
+    .. [3] https://forum.image.sc/t/equivalent-to-cellprofilers-identifysecondaryobjects-distance-n-in-fiji/39146/16
 
     Examples
     --------

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -147,7 +147,7 @@ def expand_labels(label_image, distance):
 
     References
     ----------
-    .. [1] https://github.com/CellProfiler/CellProfiler/blob/master/cellprofiler/modules/identifysecondaryobjects.py
+    .. [1] https://github.com/CellProfiler/CellProfiler/blob/082930ea95add7b72243a4fa3d39ae5145995e9c/cellprofiler/modules/identifysecondaryobjects.py#L559
     .. [2] https://forum.image.sc/t/equivalent-to-cellprofilers-identifysecondaryobjects-distance-n-in-fiji/39146/16
 
     Examples
@@ -161,6 +161,6 @@ def expand_labels(label_image, distance):
     # build the array slice, this change to [1] enables support for arbitrary dimensions
     indexmap_slices = []
     for el in indexmap:
-        indexmap_slices.append(np.s_[el[dilate_mask]])
+        indexmap_slices.append(el[dilate_mask])
     labels_out[dilate_mask] = label_image[tuple(indexmap_slices)]
     return labels_out

--- a/skimage/measure/tests/test_expand_labels.py
+++ b/skimage/measure/tests/test_expand_labels.py
@@ -58,6 +58,20 @@ SAMPLE2D_EXPANDED_3 = np.array(
        [0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0]]
        )
 
+# non-integer expansion
+SAMPLE2D_EXPANDED_1_5 = np.array(
+      [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+       [0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
+       [1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
+       [1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
+       [1, 1, 1, 1, 1, 0, 0, 0, 2, 2, 2],
+       [1, 1, 1, 1, 0, 0, 0, 0, 2, 2, 2],
+       [0, 1, 1, 1, 0, 0, 0, 0, 2, 2, 2],
+       [0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2],
+       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+       [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
+
+
 EDGECASE2D =  np.array(
     [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
      [0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0],
@@ -120,6 +134,7 @@ SAMPLE3D_EXPANDED_2 =np.array(
     [
     (SAMPLE1D, SAMPLE1D_EXPANDED_3, 3),
     (SAMPLE2D, SAMPLE2D_EXPANDED_3, 3),
+    (SAMPLE2D, SAMPLE2D_EXPANDED_1_5, 1.5),
     (EDGECASE1D, EDGECASE1D_EXPANDED_3, 3),
     (EDGECASE2D, EDGECASE2D_EXPANDED_4, 4),
     (SAMPLE3D, SAMPLE3D_EXPANDED_2, 2)

--- a/skimage/measure/tests/test_expand_labels.py
+++ b/skimage/measure/tests/test_expand_labels.py
@@ -129,6 +129,8 @@ SAMPLE3D_EXPANDED_2 =np.array(
         [3, 3, 5, 5],
         [5, 5, 5, 5]]])
 
+SAMPLE_EDGECASE_BEHAVIOUR = np.array([[0, 1, 0, 0], [2, 0, 0, 0], [0, 3, 0, 0]])
+
 @testing.parametrize(
     "input_array, expected_output, expand_distance", 
     [
@@ -171,3 +173,20 @@ def test_binary_blobs(ndim, distance):
     beyond_expanded_distances = distance_map[~expanded.astype(bool)]
     if beyond_expanded_distances.size > 0:
         assert np.all(beyond_expanded_distances > distance)
+
+def test_edge_case_behaviour():
+    """ Check edge case behavior to detect upstream changes
+
+    For edge cases where a pixel has the same distance to several regions,
+    lexicographical order seems to determine which region gets to expand 
+    into this pixel given the current upstream behaviour in 
+    scipy.ndimage.distance_map_edt. 
+
+    As a result, we expect different results when transposing the array.
+    If this test fails, something has changed upstream.
+    """
+    expanded = expand_labels(SAMPLE_EDGECASE_BEHAVIOUR, 1)
+    expanded_transpose = expand_labels(SAMPLE_EDGECASE_BEHAVIOUR.T, 1)
+    assert not np.all(expanded == expanded_transpose.T)
+
+     

--- a/skimage/measure/tests/test_expand_labels.py
+++ b/skimage/measure/tests/test_expand_labels.py
@@ -1,0 +1,158 @@
+from itertools import product
+import math
+from scipy import ndimage as ndi
+from skimage import data
+
+import numpy as np
+from numpy import array
+
+from skimage import measure
+from skimage._shared._warnings import expected_warnings
+from skimage.measure import expand_labels
+
+from skimage._shared import testing
+from skimage._shared.testing import (assert_array_equal, assert_almost_equal,
+                                     assert_array_almost_equal, assert_equal)
+
+SAMPLE1D = np.array([0, 0, 4, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0])
+SAMPLE1D_EXPANDED_3 = array([4, 4, 4, 4, 4, 4, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0])
+
+# Some pixels are important edge cases with undefined behaviour:
+# these are the pixels that are at the same distance from
+# multiple labels. Ideally the label would be chosen at random
+# to avoid bias, but as we are relying on the index map returned
+# by the scipy.ndimage distance transform, what actually happens
+# is determined by the upstream implementation of the distance
+# tansform, thus we don't give any guarantees for the edge case pixels.
+#  
+# Regardless, it seems prudent to have a test including an edge case
+# so we can detect whether future upstream changes in scipy.ndimage 
+# modify the behaviour.
+
+EDGECASE1D = np.array([0, 0, 4, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0])
+EDGECASE1D_EXPANDED_3 = np.array([4, 4, 4, 4, 4, 4, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0])
+
+SAMPLE2D = np.array(
+    [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+     [0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+     [0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+     [0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+     [0, 0, 1, 0, 0, 0, 0, 0, 0, 2, 0],
+     [0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0],
+     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]
+)
+
+SAMPLE2D_EXPANDED_3 = np.array(
+      [[1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+       [1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+       [1, 1, 1, 1, 1, 1, 1, 0, 0, 2, 0],
+       [1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2],
+       [1, 1, 1, 1, 1, 1, 0, 2, 2, 2, 2],
+       [1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2],
+       [1, 1, 1, 1, 1, 0, 2, 2, 2, 2, 2],
+       [1, 1, 1, 1, 1, 0, 0, 2, 2, 2, 2],
+       [0, 0, 1, 0, 0, 0, 0, 2, 2, 2, 2],
+       [0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0]]
+       )
+
+EDGECASE2D =  np.array(
+    [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+     [0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0],
+     [0, 0, 1, 1, 0, 2, 2, 0, 0, 0, 0],
+     [0, 1, 1, 1, 0, 2, 0, 0, 0, 0, 0],
+     [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]]
+)
+
+EDGECASE2D_EXPANDED_4 = array(
+      [[1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 0],
+       [1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2],
+       [1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2],
+       [1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 0],
+       [1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 0]])
+
+SAMPLE3D = np.array(
+      [[[0, 0, 0, 0],
+        [0, 3, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0]],
+
+       [[0, 0, 0, 0],
+        [0, 3, 3, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0]],
+
+       [[0, 0, 0, 0],
+        [0, 3, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 5, 0]],
+
+       [[0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 5, 0]]])
+
+SAMPLE3D_EXPANDED_2 =np.array(
+      [[[3, 3, 3, 3],
+        [3, 3, 3, 3],
+        [3, 3, 3, 3],
+        [0, 3, 5, 0]],
+
+       [[3, 3, 3, 3],
+        [3, 3, 3, 3],
+        [3, 3, 3, 3],
+        [0, 5, 5, 5]],
+
+       [[3, 3, 3, 3],
+        [3, 3, 3, 3],
+        [3, 3, 5, 5],
+        [5, 5, 5, 5]],
+
+       [[3, 3, 3, 0],
+        [3, 3, 3, 0],
+        [3, 3, 5, 5],
+        [5, 5, 5, 5]]])
+
+@testing.parametrize(
+    "input_array, expected_output, expand_distance", 
+    [
+    (SAMPLE1D, SAMPLE1D_EXPANDED_3, 3),
+    (SAMPLE2D, SAMPLE2D_EXPANDED_3, 3),
+    (EDGECASE1D, EDGECASE1D_EXPANDED_3, 3),
+    (EDGECASE2D, EDGECASE2D_EXPANDED_4, 4),
+    (SAMPLE3D, SAMPLE3D_EXPANDED_2, 2)
+    ]
+
+)
+def test_expand_labels(input_array, expected_output, expand_distance):
+    expanded = expand_labels(input_array, expand_distance)
+    assert_array_equal(expanded, expected_output)
+
+
+@testing.parametrize(
+    'ndim, distance', list(product([2, 3], range(6))),
+)
+def test_binary_blobs(ndim, distance):
+    """Check some invariants with label expansion.
+    
+    - New labels array should exactly contain the original labels array.
+    - Distance to old labels array within new labels should never exceed input
+      distance.
+    - Distance beyond the expanded labels should always exceed the input
+      distance.
+    """
+    array = data.binary_blobs(length=64, blob_size_fraction=0.05, n_dim=ndim)
+    labels = measure.label(array)
+    expanded = expand_labels(labels, distance=distance)
+    original_mask = labels != 0
+    assert_array_equal(labels[original_mask], expanded[original_mask])
+    expanded_only_mask = (expanded - labels).astype(bool)
+    distance_map = ndi.distance_transform_edt(~original_mask)
+    expanded_distances = distance_map[expanded_only_mask]
+    if expanded_distances.size > 0:
+        assert np.all(expanded_distances <= distance)
+    beyond_expanded_distances = distance_map[~expanded.astype(bool)]
+    if beyond_expanded_distances.size > 0:
+        assert np.all(beyond_expanded_distances > distance)

--- a/skimage/segmentation/__init__.py
+++ b/skimage/segmentation/__init__.py
@@ -1,3 +1,4 @@
+from ._expand_labels import expand_labels
 from .random_walker_segmentation import random_walker
 from .active_contour_model import active_contour
 from ._felzenszwalb import felzenszwalb
@@ -15,24 +16,26 @@ from .morphsnakes import (morphological_geodesic_active_contour,
 from ..morphology import flood, flood_fill
 
 
-__all__ = ['random_walker',
-           'active_contour',
-           'felzenszwalb',
-           'slic',
-           'quickshift',
-           'find_boundaries',
-           'mark_boundaries',
-           'clear_border',
-           'join_segmentations',
-           'relabel_sequential',
-           'watershed',
-           'chan_vese',
-           'morphological_geodesic_active_contour',
-           'morphological_chan_vese',
-           'inverse_gaussian_gradient',
-           'circle_level_set',
-           'disk_level_set',
-           'checkerboard_level_set',
-           'flood',
-           'flood_fill',
-           ]
+__all__ = [
+    'expand_labels',
+    'random_walker',
+    'active_contour',
+    'felzenszwalb',
+    'slic',
+    'quickshift',
+    'find_boundaries',
+    'mark_boundaries',
+    'clear_border',
+    'join_segmentations',
+    'relabel_sequential',
+    'watershed',
+    'chan_vese',
+    'morphological_geodesic_active_contour',
+    'morphological_chan_vese',
+    'inverse_gaussian_gradient',
+    'circle_level_set',
+    'disk_level_set',
+    'checkerboard_level_set',
+    'flood',
+    'flood_fill',
+]

--- a/skimage/segmentation/_expand_labels.py
+++ b/skimage/segmentation/_expand_labels.py
@@ -1,0 +1,96 @@
+import numpy as np
+from scipy.ndimage import distance_transform_edt
+
+
+def expand_labels(label_image, distance):
+    """Expand labels in label image by ``distance`` pixels without overlapping.
+
+    Given a label image, each label is grown by up to distance pixels.
+    However, where labels would start to overlap, the label growth may
+    stop at less than distance pixels (this is where it differs from a
+    morphological dilation, where a connected component with a high label
+    number can potentially override connected components with lower label
+    numbers).
+
+    This is equivalent to CellProfiler [1] [2] IdentifySecondaryObjects method
+    using the option "Distance-N".
+
+    The basic idea is that you have some seed labels that you want
+    to grow by n pixels to give a mask for a larger object.
+
+    If you were only dealing with a single seed object, you could simply
+    dilate with a suitably sized structuring element. However, in general you
+    have multiple seed points and you don't want to merge those. Distance N
+    will grow up to N pixels without merging objects that are closer together
+    than 2N.
+
+    There is an important edge case when a pixel has the same distance to
+    multiple regions, as it is not defined which region expands into that
+    space, see the discussion in [1]. Here, the exact bahaviour depends on
+    the upstream implementation.
+
+    Parameters
+    ----------
+    label_image : ndarray of dtype int
+        label image
+    distance : float
+        Number of pixels by which to grow the labels.
+
+    Returns
+    -------
+    enlarged_labels : ndarray of dtype int
+        Labeled array, where all connected regions have been enlarged
+
+    See Also
+    --------
+    :py:func:`label`, :py:func:`skimage.segmentation.watershed`
+
+    References
+    ----------
+    .. [1] https://cellprofiler.org
+    .. [2] https://github.com/CellProfiler/CellProfiler/blob/082930ea95add7b72243a4fa3d39ae5145995e9c/cellprofiler/modules/identifysecondaryobjects.py#L559
+    .. [3] https://forum.image.sc/t/equivalent-to-cellprofilers-identifysecondaryobjects-distance-n-in-fiji/39146/16
+
+    Examples
+    --------
+    >>> labels = np.array([0, 1, 0, 0, 0, 0, 2])
+    >>> expand_labels(labels, distance=1)
+    array([1, 1, 1, 0, 0, 2, 2])
+
+    Labels will not overwrite each other:
+
+    >>> expand_labels(labels, distance=3)
+    array([1, 1, 1, 1, 2, 2, 2])
+
+    In case of ties, behavior is undefined, but currently resolves to the
+    label closest to ``(0,) * ndim`` in lexicographical order.
+
+    >>> labels_tied = np.array([0, 1, 0, 2, 0])
+    >>> expand_labels(labels_tied, 1)
+    array([1, 1, 1, 2, 2])
+    >>> labels2d = np.array(
+    ...     [[0, 1, 0, 0],
+    ...      [2, 0, 0, 0],
+    ...      [0, 3, 0, 0]]
+    ... )
+    >>> expand_labels(labels2d, 1)
+    array([[2, 1, 1, 0],
+           [2, 2, 0, 0],
+           [2, 3, 3, 0]])
+    """
+
+    distances, nearest_label_coords = distance_transform_edt(
+        label_image == 0, return_indices=True
+    )
+    labels_out = np.zeros(label_image.shape, label_image.dtype)
+    dilate_mask = distances <= distance
+    # build the coordinates to find nearest labels,
+    # in contrast to [1] this implementation supports label arrays
+    # of any dimension
+    masked_nearest_label_coords = [
+        dimension_indices[dilate_mask]
+        for dimension_indices in nearest_label_coords
+    ]
+    nearest_labels = label_image[tuple(masked_nearest_label_coords)]
+    labels_out[dilate_mask] = nearest_labels
+    return labels_out

--- a/skimage/segmentation/_expand_labels.py
+++ b/skimage/segmentation/_expand_labels.py
@@ -43,7 +43,7 @@ def expand_labels(label_image, distance):
 
     See Also
     --------
-    :py:func:`label`, :py:func:`skimage.segmentation.watershed`
+    :func:`skimage.measure.label`, :func:`skimage.segmentation.watershed`
 
     References
     ----------

--- a/skimage/segmentation/_expand_labels.py
+++ b/skimage/segmentation/_expand_labels.py
@@ -1,14 +1,3 @@
-""" 
-expand_labels is  inspired by code in CellProfiler, 
-code licensed under BSD-3 licenses.
-Website: http://www.cellprofiler.org
-
-Copyright (c) 2020 Broad Institute
-All rights reserved.
-
-Original author/s: Cellprofiler team 
-"""
-
 import numpy as np
 from scipy.ndimage import distance_transform_edt
 
@@ -16,12 +5,14 @@ from scipy.ndimage import distance_transform_edt
 def expand_labels(label_image, distance):
     """Expand labels in label image by ``distance`` pixels without overlapping.
 
-    Given a label image, each label is grown by up to distance pixels.
-    However, where labels would start to overlap, the label growth may
-    stop at less than distance pixels (this is where it differs from a
-    morphological dilation, where a connected component with a high label
-    number can potentially override connected components with lower label
-    numbers).
+    Given a label image, `expand_labels` expands each connected component by up
+    to ``distance`` pixels by assigning the integer label of a connected component 
+    to background pixels that are within a Euclidean distance of <= ``distance`` 
+    pixels of that component. Where multiple connected components are within 
+    ``distance`` pixels of a background pixel, the label value of the closest
+    connected component will be assigned (see Notes for multiple labels at equal 
+    distance).
+     
 
     Parameters
     ----------
@@ -37,17 +28,13 @@ def expand_labels(label_image, distance):
 
     Notes
     -----
-    This is equivalent to CellProfiler [1] [2] IdentifySecondaryObjects method
-    using the option "Distance-N".
+    Where labels are spaced more than ``distance`` pixels are apart, this is
+    equivalent to a morpholgical dilation with a disc or hyperball of radius ``distance``.
+    However, in contrast to a morphological dilation, ``expand_labels`` will
+    not expand a region into a neighbouring region.  
 
-    The basic idea is that you have some seed labels that you want
-    to grow by n pixels to give a mask for a larger object.
-
-    If you were only dealing with a single seed object, you could simply
-    dilate with a suitably sized structuring element. However, in general you
-    have multiple seed points and you don't want to merge those. Distance N
-    will grow up to N pixels without merging objects that are closer together
-    than 2N.
+    This implementation of ``expand_labels`` is derived from CellProfiler [1], where
+    it is known as module "IdentifySecondaryObjects (Distance-N)" [2].
 
     There is an important edge case when a pixel has the same distance to
     multiple regions, as it is not defined which region expands into that
@@ -55,7 +42,7 @@ def expand_labels(label_image, distance):
 
     See Also
     --------
-    :func:`skimage.measure.label`, :func:`skimage.segmentation.watershed`
+    :func:`skimage.measure.label`, :func:`skimage.segmentation.watershed`, :func:`skimage.morphology.dilation`
 
     References
     ----------

--- a/skimage/segmentation/_expand_labels.py
+++ b/skimage/segmentation/_expand_labels.py
@@ -23,6 +23,20 @@ def expand_labels(label_image, distance):
     number can potentially override connected components with lower label
     numbers).
 
+    Parameters
+    ----------
+    label_image : ndarray of dtype int
+        label image
+    distance : float
+        Number of pixels by which to grow the labels.
+
+    Returns
+    -------
+    enlarged_labels : ndarray of dtype int
+        Labeled array, where all connected regions have been enlarged
+
+    Notes
+    -----
     This is equivalent to CellProfiler [1] [2] IdentifySecondaryObjects method
     using the option "Distance-N".
 
@@ -38,18 +52,6 @@ def expand_labels(label_image, distance):
     There is an important edge case when a pixel has the same distance to
     multiple regions, as it is not defined which region expands into that
     space. Here, the exact bahaviour depends on the upstream implementation.
-
-    Parameters
-    ----------
-    label_image : ndarray of dtype int
-        label image
-    distance : float
-        Number of pixels by which to grow the labels.
-
-    Returns
-    -------
-    enlarged_labels : ndarray of dtype int
-        Labeled array, where all connected regions have been enlarged
 
     See Also
     --------

--- a/skimage/segmentation/_expand_labels.py
+++ b/skimage/segmentation/_expand_labels.py
@@ -13,7 +13,7 @@ import numpy as np
 from scipy.ndimage import distance_transform_edt
 
 
-def expand_labels(label_image, distance):
+def expand_labels(label_image, distance=1):
     """Expand labels in label image by ``distance`` pixels without overlapping.
 
     Given a label image, ``expand_labels`` grows label regions (connected components) 
@@ -30,7 +30,7 @@ def expand_labels(label_image, distance):
     label_image : ndarray of dtype int
         label image
     distance : float
-        Number of pixels by which to grow the labels.
+        Euclidean distance in pixels by which to grow the labels. Default is one.
 
     Returns
     -------

--- a/skimage/segmentation/_expand_labels.py
+++ b/skimage/segmentation/_expand_labels.py
@@ -1,3 +1,14 @@
+"""
+expand_labels is derived from code that was
+originally part of CellProfiler, code licensed under BSD license.
+Website: http://www.cellprofiler.org
+
+Copyright (c) 2020 Broad Institute
+All rights reserved.
+
+Original authors: CellProfiler team
+
+"""
 import numpy as np
 from scipy.ndimage import distance_transform_edt
 
@@ -5,13 +16,14 @@ from scipy.ndimage import distance_transform_edt
 def expand_labels(label_image, distance):
     """Expand labels in label image by ``distance`` pixels without overlapping.
 
-    Given a label image, `expand_labels` expands each connected component by up
-    to ``distance`` pixels by assigning the integer label of a connected component 
-    to background pixels that are within a Euclidean distance of <= ``distance`` 
-    pixels of that component. Where multiple connected components are within 
-    ``distance`` pixels of a background pixel, the label value of the closest
-    connected component will be assigned (see Notes for multiple labels at equal 
-    distance).
+    Given a label image, `expand_labels` grows label regions (connected components) 
+    outwards by up to ``distance`` pixels without overflowing into neighboring regions.
+    More specifically, each background pixel that is within Euclidean distance
+    of <= ``distance`` pixels of a connected component is assigned the label of that
+    connected component.
+    Where multiple connected components are within ``distance`` pixels of a background 
+    pixel, the label value of the closest connected component will be assigned (see 
+    Notes for the case of multiple labels at equal distance).
      
 
     Parameters
@@ -31,14 +43,15 @@ def expand_labels(label_image, distance):
     Where labels are spaced more than ``distance`` pixels are apart, this is
     equivalent to a morpholgical dilation with a disc or hyperball of radius ``distance``.
     However, in contrast to a morphological dilation, ``expand_labels`` will
-    not expand a region into a neighboring region.  
+    not expand a label region into a neighboring region.  
 
     This implementation of ``expand_labels`` is derived from CellProfiler [1], where
     it is known as module "IdentifySecondaryObjects (Distance-N)" [2].
 
     There is an important edge case when a pixel has the same distance to
     multiple regions, as it is not defined which region expands into that
-    space. Here, the exact bahaviour depends on the upstream implementation.
+    space. Here, the exact bahaviour depends on the upstream implementation
+    of ``scipy.ndimage.distance_transform_edt``.
 
     See Also
     --------

--- a/skimage/segmentation/_expand_labels.py
+++ b/skimage/segmentation/_expand_labels.py
@@ -82,7 +82,7 @@ def expand_labels(label_image, distance):
     distances, nearest_label_coords = distance_transform_edt(
         label_image == 0, return_indices=True
     )
-    labels_out = np.zeros(label_image.shape, label_image.dtype)
+    labels_out = np.zeros_like(label_image)
     dilate_mask = distances <= distance
     # build the coordinates to find nearest labels,
     # in contrast to [1] this implementation supports label arrays

--- a/skimage/segmentation/_expand_labels.py
+++ b/skimage/segmentation/_expand_labels.py
@@ -31,7 +31,7 @@ def expand_labels(label_image, distance):
     Where labels are spaced more than ``distance`` pixels are apart, this is
     equivalent to a morpholgical dilation with a disc or hyperball of radius ``distance``.
     However, in contrast to a morphological dilation, ``expand_labels`` will
-    not expand a region into a neighbouring region.  
+    not expand a region into a neighboring region.  
 
     This implementation of ``expand_labels`` is derived from CellProfiler [1], where
     it is known as module "IdentifySecondaryObjects (Distance-N)" [2].

--- a/skimage/segmentation/_expand_labels.py
+++ b/skimage/segmentation/_expand_labels.py
@@ -49,7 +49,6 @@ def expand_labels(label_image, distance):
     ----------
     .. [1] https://cellprofiler.org
     .. [2] https://github.com/CellProfiler/CellProfiler/blob/082930ea95add7b72243a4fa3d39ae5145995e9c/cellprofiler/modules/identifysecondaryobjects.py#L559
-    .. [3] https://forum.image.sc/t/equivalent-to-cellprofilers-identifysecondaryobjects-distance-n-in-fiji/39146/16
 
     Examples
     --------

--- a/skimage/segmentation/_expand_labels.py
+++ b/skimage/segmentation/_expand_labels.py
@@ -1,3 +1,14 @@
+""" 
+expand_labels is  inspired by code in CellProfiler, 
+code licensed under BSD-3 licenses.
+Website: http://www.cellprofiler.org
+
+Copyright (c) 2020 Broad Institute
+All rights reserved.
+
+Original author/s: Cellprofiler team 
+"""
+
 import numpy as np
 from scipy.ndimage import distance_transform_edt
 
@@ -26,8 +37,7 @@ def expand_labels(label_image, distance):
 
     There is an important edge case when a pixel has the same distance to
     multiple regions, as it is not defined which region expands into that
-    space, see the discussion in [1]. Here, the exact bahaviour depends on
-    the upstream implementation.
+    space. Here, the exact bahaviour depends on the upstream implementation.
 
     Parameters
     ----------

--- a/skimage/segmentation/tests/test_expand_labels.py
+++ b/skimage/segmentation/tests/test_expand_labels.py
@@ -157,8 +157,8 @@ def test_binary_blobs(ndim, distance):
     - Distance beyond the expanded labels should always exceed the input
       distance.
     """
-    array = data.binary_blobs(length=64, blob_size_fraction=0.05, n_dim=ndim)
-    labels = measure.label(array)
+    img = data.binary_blobs(length=64, blob_size_fraction=0.05, n_dim=ndim)
+    labels = measure.label(img)
     expanded = expand_labels(labels, distance=distance)
     original_mask = labels != 0
     assert_array_equal(labels[original_mask], expanded[original_mask])

--- a/skimage/segmentation/tests/test_expand_labels.py
+++ b/skimage/segmentation/tests/test_expand_labels.py
@@ -1,5 +1,4 @@
 from itertools import product
-import math
 from scipy import ndimage as ndi
 from skimage import data
 
@@ -7,12 +6,10 @@ import numpy as np
 from numpy import array
 
 from skimage import measure
-from skimage._shared._warnings import expected_warnings
-from skimage.measure import expand_labels
+from skimage.segmentation._expand_labels import expand_labels
 
 from skimage._shared import testing
-from skimage._shared.testing import (assert_array_equal, assert_almost_equal,
-                                     assert_array_almost_equal, assert_equal)
+from skimage._shared.testing import assert_array_equal
 
 SAMPLE1D = np.array([0, 0, 4, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0])
 SAMPLE1D_EXPANDED_3 = array([4, 4, 4, 4, 4, 4, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0])

--- a/skimage/segmentation/tests/test_expand_labels.py
+++ b/skimage/segmentation/tests/test_expand_labels.py
@@ -77,7 +77,7 @@ EDGECASE2D =  np.array(
      [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]]
 )
 
-EDGECASE2D_EXPANDED_4 = array(
+EDGECASE2D_EXPANDED_4 = np.array(
       [[1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 0],
        [1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2],
        [1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2],

--- a/skimage/segmentation/tests/test_expand_labels.py
+++ b/skimage/segmentation/tests/test_expand_labels.py
@@ -3,7 +3,6 @@ from scipy import ndimage as ndi
 from skimage import data
 
 import numpy as np
-from numpy import array
 
 from skimage import measure
 from skimage.segmentation._expand_labels import expand_labels

--- a/skimage/segmentation/tests/test_expand_labels.py
+++ b/skimage/segmentation/tests/test_expand_labels.py
@@ -137,7 +137,6 @@ SAMPLE_EDGECASE_BEHAVIOUR = np.array([[0, 1, 0, 0], [2, 0, 0, 0], [0, 3, 0, 0]])
     (EDGECASE2D, EDGECASE2D_EXPANDED_4, 4),
     (SAMPLE3D, SAMPLE3D_EXPANDED_2, 2)
     ]
-
 )
 def test_expand_labels(input_array, expected_output, expand_distance):
     expanded = expand_labels(input_array, expand_distance)

--- a/skimage/segmentation/tests/test_expand_labels.py
+++ b/skimage/segmentation/tests/test_expand_labels.py
@@ -69,7 +69,7 @@ SAMPLE2D_EXPANDED_1_5 = np.array(
        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
 
 
-EDGECASE2D =np.array(
+EDGECASE2D = np.array(
     [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
      [0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0],
      [0, 0, 1, 1, 0, 2, 2, 0, 0, 0, 0],
@@ -186,3 +186,4 @@ def test_edge_case_behaviour():
     expanded = expand_labels(SAMPLE_EDGECASE_BEHAVIOUR, 1)
     expanded_transpose = expand_labels(SAMPLE_EDGECASE_BEHAVIOUR.T, 1)
     assert not np.all(expanded == expanded_transpose.T)
+    

--- a/skimage/segmentation/tests/test_expand_labels.py
+++ b/skimage/segmentation/tests/test_expand_labels.py
@@ -1,4 +1,3 @@
-from itertools import product
 from scipy import ndimage as ndi
 from skimage import data
 

--- a/skimage/segmentation/tests/test_expand_labels.py
+++ b/skimage/segmentation/tests/test_expand_labels.py
@@ -143,9 +143,8 @@ def test_expand_labels(input_array, expected_output, expand_distance):
     assert_array_equal(expanded, expected_output)
 
 
-@testing.parametrize(
-    'ndim, distance', list(product([2, 3], range(6))),
-)
+@testing.parametrize('ndim', [2, 3])
+@testing.parametrize('distance', range(6))
 def test_binary_blobs(ndim, distance):
     """Check some invariants with label expansion.
     

--- a/skimage/segmentation/tests/test_expand_labels.py
+++ b/skimage/segmentation/tests/test_expand_labels.py
@@ -12,7 +12,7 @@ from skimage._shared import testing
 from skimage._shared.testing import assert_array_equal
 
 SAMPLE1D = np.array([0, 0, 4, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0])
-SAMPLE1D_EXPANDED_3 = array([4, 4, 4, 4, 4, 4, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0])
+SAMPLE1D_EXPANDED_3 = np.array([4, 4, 4, 4, 4, 4, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0])
 
 # Some pixels are important edge cases with undefined behaviour:
 # these are the pixels that are at the same distance from

--- a/skimage/segmentation/tests/test_expand_labels.py
+++ b/skimage/segmentation/tests/test_expand_labels.py
@@ -171,6 +171,7 @@ def test_binary_blobs(ndim, distance):
     if beyond_expanded_distances.size > 0:
         assert np.all(beyond_expanded_distances > distance)
 
+
 def test_edge_case_behaviour():
     """ Check edge case behavior to detect upstream changes
 

--- a/skimage/segmentation/tests/test_expand_labels.py
+++ b/skimage/segmentation/tests/test_expand_labels.py
@@ -69,7 +69,7 @@ SAMPLE2D_EXPANDED_1_5 = np.array(
        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
 
 
-EDGECASE2D =  np.array(
+EDGECASE2D =np.array(
     [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
      [0, 0, 0, 0, 0, 2, 2, 0, 0, 0, 0],
      [0, 0, 1, 1, 0, 2, 2, 0, 0, 0, 0],
@@ -186,5 +186,3 @@ def test_edge_case_behaviour():
     expanded = expand_labels(SAMPLE_EDGECASE_BEHAVIOUR, 1)
     expanded_transpose = expand_labels(SAMPLE_EDGECASE_BEHAVIOUR.T, 1)
     assert not np.all(expanded == expanded_transpose.T)
-
-     


### PR DESCRIPTION
## Description

This implements growing of connected component regions in a label array up to a specified number of pixels/voxels, but not starting to merge/overlap separate regions.

This functionality is similar to the `Distance N` method in Cellprofiler's IdentifySecondaryObjects module, in fact I adapted the code from [there](
https://github.com/CellProfiler/CellProfiler/blob/022c55f3c3644eccbd285ae1bf8ed242d3416b2b/cellprofiler/modules/identifysecondaryobjects.py#L569) but modified it to support arbitrary dimensions (that should tick a box with @jni).  Also see the discussion on [image.sc](https://forum.image.sc/t/equivalent-to-cellprofilers-identifysecondaryobjects-distance-n-in-fiji/39146).
I am not aware of an original paper I can cite for this, but there probably is one.

I created a demo notebook that shows what this is doing. You can see the demo notebook [here](https://github.com/VolkerH/PythonSnippets/blob/master/ExpandLabels/expand_labels_demo.ipynb).

This is still a WIP.
Tests, examples, and formatting still to do.

## Checklist

- (started) [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- (TODO) Gallery example in `./doc/examples` (new features only)
- (TODO) Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- (TODO) Unit tests
- (TODO) Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)


## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
