### PR TITLE
Fix runtime warning in blob.py

### DIFF
--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -115,7 +115,9 @@ def _blob_overlap(blob1, blob2, *, sigma_dim=1):
 
     # we divide coordinates by sigma * sqrt(ndim) to rescale space to isotropy,
     # giving spheres of radius = 1 or < 1.
-    if blob1[-1] > blob2[-1]:
+    if blob1[-1] == 0 and blob2[-1] == 0:
+        return 0.0
+    elif blob1[-1] > blob2[-1]:
         max_sigma = blob1[-sigma_dim:]
         r1 = 1
         r2 = blob2[-1] / blob1[-1]

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -115,7 +115,7 @@ def _blob_overlap(blob1, blob2, *, sigma_dim=1):
 
     # we divide coordinates by sigma * sqrt(ndim) to rescale space to isotropy,
     # giving spheres of radius = 1 or < 1.
-    if blob1[-1] == 0 and blob2[-1] == 0:
+    if blob1[-1] == blob2[-1] == 0:
         return 0.0
     elif blob1[-1] > blob2[-1]:
         max_sigma = blob1[-sigma_dim:]

--- a/skimage/feature/tests/test_blob.py
+++ b/skimage/feature/tests/test_blob.py
@@ -1,3 +1,5 @@
+import pytest
+
 import numpy as np
 from skimage.draw import disk
 from skimage.draw.draw3d import ellipsoid
@@ -189,6 +191,20 @@ def test_blob_log():
     # Testing no peaks
     img_empty = np.zeros((100,100))
     assert blob_log(img_empty).size == 0
+
+
+def test_blob_log_no_warnings():
+    img = np.ones((11, 11))
+
+    xs, ys = disk((5, 5), 2)
+    img[xs, ys] = 255
+
+    xs, ys = disk((7, 6), 2)
+    img[xs, ys] = 255
+
+    with pytest.warns(None) as records:
+        blob_log(img, max_sigma=20, num_sigma=10, threshold=.1)
+    assert len(records) == 0
 
 
 def test_blob_log_3d():


### PR DESCRIPTION
Runtime warning (division by zero) is observed during blob_overlap when the sigma of both the blobs is zero (i.e., radius of the blobs is 0. This means that the both the blobs are part of a bigger one). Therefore, the overlap can return 0 in this case.

Fixes #4729 