### PR TITLE
Let biomed example load image data with Pooch.

### DIFF
--- a/doc/examples/applications/plot_human_mitosis.py
+++ b/doc/examples/applications/plot_human_mitosis.py
@@ -24,9 +24,11 @@ from scipy import ndimage as ndi
 from skimage import (
     color, feature, filters, io, measure, morphology, segmentation, util
 )
+from skimage.data import image_fetcher
 
 
-image = io.imread('https://github.com/CellProfiler/examples/blob/master/ExampleHuman/images/AS_09125_050116030001_D03f00d0.tif?raw=true')
+path = image_fetcher.fetch('data/mitosis.tif')
+image = io.imread(path)
 
 fig, ax = plt.subplots()
 ax.imshow(image, cmap='gray')

--- a/skimage/data/_registry.py
+++ b/skimage/data/_registry.py
@@ -127,10 +127,12 @@ registry = {
     "registration/tests/data/TransformedX130Y130.png": "bb10c6ae3f91a313b0ac543efdb7ca69c4b95e55674c65a88472a6c4f4692a25",
     "registration/tests/data/TransformedX75Y75.png": "a1e9ead5f8e4a0f604271e1f9c50e89baf53f068f1d19fab2876af4938e695ea",
     "data/cells.tif": "2120cfe08e0396324793a10a905c9bbcb64b117215eb63b2c24b643e1600c8c9",
+    "data/mitosis.tif": "2751ba667c4067c5d30817cff004aa06f6f6287f1cdbb5b8c9c6a500308cb456",
 }
 
 registry_urls = {
     "data/cells.tif": "https://github.com/scikit-image/skimage-tutorials/raw/master/images/cells.tif",
+    "data/mitosis.tif": "https://gitlab.com/scikit-image/data/-/raw/master/AS_09125_050116030001_D03f00d0.tif",
 }
 
 legacy_registry = {


### PR DESCRIPTION
## Description

In this PR, we are making use of a recent (v0.17.1) feature, namely on-the-fly download of data with `pooch`.
It follows from the fact that we are [now](https://gitlab.com/scikit-image/data/-/merge_requests/2) hosting a copy of the CC0-licensed image at: https://gitlab.com/scikit-image/data

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
