### PR TITLE
Ensure assert messages from Cython rank filters are informative

### DIFF
--- a/skimage/filters/rank/core_cy.pyx
+++ b/skimage/filters/rank/core_cy.pyx
@@ -70,10 +70,10 @@ cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t*, double,
     cdef Py_ssize_t centre_c = <Py_ssize_t>(selem.shape[1] / 2) + shift_x
 
     # check that structuring element center is inside the element bounding box
-    assert centre_r >= 0
-    assert centre_c >= 0
-    assert centre_r < srows
-    assert centre_c < scols
+    assert centre_r >= 0, f'centre_r {centre_r} < 0'
+    assert centre_c >= 0, f'centre_c {centre_c} < 0'
+    assert centre_r < srows, f'centre_r {centre_r} >= srows {srows}'
+    assert centre_c < scols, f'centre_c {centre_c} >= scols {scols}'
 
     cdef Py_ssize_t mid_bin = n_bins / 2
 


### PR DESCRIPTION
## Description

I couldn't figure out why `shift_x` and `shift_y` weren't working when using an even-shaped structuring element with rank filters. This helped me troubleshoot in an instant.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
