### PR TITLE
Simplify equivalent_diameter function

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -217,10 +217,7 @@ class RegionProperties:
 
     @property
     def equivalent_diameter(self):
-        if self._ndim == 2:
-            return sqrt(4 * self.area / PI)
-        elif self._ndim == 3:
-            return (6 * self.area / PI) ** (1. / 3)
+        return (2 * self._ndim * self.area / PI) ** (1 / self._ndim)
 
     @property
     def euler_number(self):


### PR DESCRIPTION
The equivalent_diameter function in regionprops is a little messy, and only works with 2/3 dimensions (although I think this is a moot point as the regionprops function only applies to 2/3D images).

Regardless, it's a little messy, and the proposed PR neatens this up and removes needless if statements