### PR TITLE
style: be explicit when stacking arrays

### DIFF
--- a/skimage/color/adapt_rgb.py
+++ b/skimage/color/adapt_rgb.py
@@ -76,4 +76,4 @@ def each_channel(image_filter, image, *args, **kwargs):
     """
     c_new = [image_filter(c, *args, **kwargs)
              for c in np.moveaxis(image, -1, 0)]
-    return np.moveaxis(np.array(c_new), 0, -1)
+    return np.stack(c_new, axis=-1)

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -338,12 +338,13 @@ def hsv2rgb(hsv):
     v = arr[..., 2]
 
     hi = np.stack([hi, hi, hi], axis=-1).astype(np.uint8) % 6
-    out = np.choose(hi, [np.stack((v, t, p), axis=-1),
-                         np.stack((q, v, p), axis=-1),
-                         np.stack((p, v, t), axis=-1),
-                         np.stack((p, q, v), axis=-1),
-                         np.stack((t, p, v), axis=-1),
-                         np.stack((v, p, q), axis=-1)])
+    out = np.choose(
+        hi, np.stack([np.stack((v, t, p), axis=-1),
+                      np.stack((q, v, p), axis=-1),
+                      np.stack((p, v, t), axis=-1),
+                      np.stack((p, q, v), axis=-1),
+                      np.stack((t, p, v), axis=-1),
+                      np.stack((v, p, q), axis=-1)]))
 
     return out
 

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -190,7 +190,7 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
 
     dense_labels = range(max(mapped_labels_flat) + 1)
 
-    label_to_color = np.array([c for i, c in zip(dense_labels, color_cycle)])
+    label_to_color = np.stack([c for i, c in zip(dense_labels, color_cycle)])
 
     mapped_labels = label
     mapped_labels.flat = mapped_labels_flat

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -182,7 +182,7 @@ def _prune_blobs(blobs_array, overlap, *, sigma_dim=1):
                 else:
                     blob1[-1] = 0
 
-    return np.array([b for b in blobs_array if b[-1] > 0])
+    return np.stack([b for b in blobs_array if b[-1] > 0])
 
 
 def _format_exclude_border(img_ndim, exclude_border):

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -315,7 +315,7 @@ def hessian_matrix_eigvals(H_elems):
            [ 0.,  0.,  2.,  0.,  0.]])
     """
     if len(H_elems) == 3:  # Use fast Cython code for 2D
-        eigvals = np.array(_image_orthogonal_matrix22_eigvals(*H_elems))
+        eigvals = np.stack(_image_orthogonal_matrix22_eigvals(*H_elems))
     else:
         matrices = _hessian_matrix_image(H_elems)
         # eigvalsh returns eigenvalues in increasing order. We want decreasing

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -13,7 +13,7 @@ def _get_high_intensity_peaks(image, mask, num_peaks):
     intensities = image[coord]
     # Highest peak first
     idx_maxsort = np.argsort(-intensities)
-    coord = np.transpose(coord)[idx_maxsort]
+    coord = np.stack(coord, axis=-1)[idx_maxsort]
     # select num_peaks peaks
     if len(coord) > num_peaks:
         coord = coord[:num_peaks]

--- a/skimage/feature/tests/test_peak.py
+++ b/skimage/feature/tests/test_peak.py
@@ -171,7 +171,7 @@ class TestPeakLocalMax():
             for jmin, jmax in ((0, 30), (30, 60)):
                 expected[imin:imax, jmin:jmax] = ndi.maximum_filter(
                     image[imin:imax, jmin:jmax], footprint=footprint)
-        expected = np.transpose(np.nonzero(expected == image))
+        expected = np.stack(np.nonzero(expected == image), axis=-1)
         expected = expected[np.argsort(image[tuple(expected.T)])[::-1]]
         result = peak.peak_local_max(image, labels=labels, min_distance=1,
                                      threshold_rel=0, footprint=footprint,

--- a/skimage/graph/mcp.py
+++ b/skimage/graph/mcp.py
@@ -67,7 +67,7 @@ def route_through_array(array, start, end, fully_connected=True,
            [30, 31, 32, 33, 34, 35]])
     >>> # Find the path with lowest cost
     >>> indices, weight = route_through_array(image, (0, 0), (5, 5))
-    >>> indices = np.array(indices).T
+    >>> indices = np.stack(indices, axis=-1)
     >>> path = np.zeros_like(image)
     >>> path[indices[0], indices[1]] = 1
     >>> path

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -112,7 +112,7 @@ def moments_coords_central(coords, center=None, order=3):
         # This format corresponds to coordinate tuples as returned by
         # e.g. np.nonzero: (row_coords, column_coords).
         # We represent them as an npoints x ndim array.
-        coords = np.transpose(coords)
+        coords = np.stack(coords, axis=-1)
     check_nD(coords, 2)
     ndim = coords.shape[1]
     if center is None:

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -47,11 +47,11 @@ class LineModelND(BaseModel):
     >>> x = np.linspace(1, 2, 25)
     >>> y = 1.5 * x + 3
     >>> lm = LineModelND()
-    >>> lm.estimate(np.array([x, y]).T)
+    >>> lm.estimate(np.stack([x, y], axis=-1))
     True
     >>> tuple(np.round(lm.params, 5))
     (array([1.5 , 5.25]), array([0.5547 , 0.83205]))
-    >>> res = lm.residuals(np.array([x, y]).T)
+    >>> res = lm.residuals(np.stack([x, y], axis=-1))
     >>> np.abs(np.round(res, 9))
     array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
            0., 0., 0., 0., 0., 0., 0., 0.])
@@ -277,12 +277,12 @@ class CircleModel(BaseModel):
         sum_x = np.sum(x)
         sum_y = np.sum(y)
         sum_xy = np.sum(x * y)
-        m1 = np.array([[np.sum(x ** 2), sum_xy, sum_x],
+        m1 = np.stack([[np.sum(x ** 2), sum_xy, sum_x],
                        [sum_xy, np.sum(y ** 2), sum_y],
                        [sum_x, sum_y, float(len(x))]])
-        m2 = np.array([[np.sum(x * x2y2),
+        m2 = np.stack([[np.sum(x * x2y2),
                         np.sum(y * x2y2),
-                        np.sum(x2y2)]]).T
+                        np.sum(x2y2)]], axis=-1)
         a, b, c = pinv(m1) @ m2
         a, b, c = a[0], b[0], c[0]
         xc = a / 2

--- a/skimage/measure/profile.py
+++ b/skimage/measure/profile.py
@@ -167,8 +167,8 @@ def _line_profile_coordinates(src, dst, linewidth=1):
     # distance between pixel centers)
     col_width = (linewidth - 1) * np.sin(-theta) / 2
     row_width = (linewidth - 1) * np.cos(theta) / 2
-    perp_rows = np.array([np.linspace(row_i - row_width, row_i + row_width,
+    perp_rows = np.stack([np.linspace(row_i - row_width, row_i + row_width,
                                       linewidth) for row_i in line_row])
-    perp_cols = np.array([np.linspace(col_i - col_width, col_i + col_width,
+    perp_cols = np.stack([np.linspace(col_i - col_width, col_i + col_width,
                                       linewidth) for col_i in line_col])
-    return np.array([perp_rows, perp_cols])
+    return np.stack([perp_rows, perp_cols])

--- a/skimage/morphology/_util.py
+++ b/skimage/morphology/_util.py
@@ -95,7 +95,7 @@ def _offsets_to_raveled_neighbors(image_shape, selem, center, order='C'):
             "center index does not match"
         )
 
-    selem_indices = np.array(np.nonzero(selem)).T
+    selem_indices = np.stack(np.nonzero(selem), axis=-1)
     offsets = selem_indices - center
 
     if order == 'F':

--- a/skimage/registration/_masked_phase_cross_correlation.py
+++ b/skimage/registration/_masked_phase_cross_correlation.py
@@ -80,7 +80,7 @@ def _masked_phase_cross_correlation(reference_image, moving_image,
                                    overlap_ratio=overlap_ratio)
 
     # Generalize to the average of multiple equal maxima
-    maxima = np.transpose(np.nonzero(xcorr == xcorr.max()))
+    maxima = np.stack(np.nonzero(xcorr == xcorr.max()), axis=1)
     center = np.mean(maxima, axis=0)
     shifts = center - np.array(reference_image.shape) + 1
 

--- a/skimage/registration/_optical_flow.py
+++ b/skimage/registration/_optical_flow.py
@@ -52,6 +52,7 @@ def _tvl1(reference_image, moving_image, flow0, attachment, tightness,
     grid = np.meshgrid(*[np.arange(n, dtype=dtype)
                          for n in reference_image.shape],
                        indexing='ij')
+    grid = np.stack(grid)
 
     dt = 0.5 / reference_image.ndim
     reg_num_iter = 2
@@ -75,7 +76,7 @@ def _tvl1(reference_image, moving_image, flow0, attachment, tightness,
                                              [1] + reference_image.ndim * [3])
 
         image1_warp = warp(moving_image, grid + flow_current, mode='nearest')
-        grad = np.array(np.gradient(image1_warp))
+        grad = np.stack(np.gradient(image1_warp))
         NI = (grad*grad).sum(0)
         NI[NI == 0] = 1
 

--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -216,7 +216,7 @@ def phase_cross_correlation(reference_image, moving_image, *,
                               cross_correlation.shape)
     midpoints = np.array([np.fix(axis_size / 2) for axis_size in shape])
 
-    shifts = np.array(maxima, dtype=np.float64)
+    shifts = np.stack(maxima).astype(np.float64)
     shifts[shifts > midpoints] -= np.array(shape)[shifts > midpoints]
 
     if upsample_factor == 1:
@@ -245,7 +245,7 @@ def phase_cross_correlation(reference_image, moving_image, *,
                                   cross_correlation.shape)
         CCmax = cross_correlation[maxima]
 
-        maxima = np.array(maxima, dtype=np.float64) - dftshift
+        maxima = np.stack(maxima).astype(np.float64) - dftshift
 
         shifts = shifts + maxima / upsample_factor
 

--- a/skimage/registration/tests/test_tvl1.py
+++ b/skimage/registration/tests/test_tvl1.py
@@ -25,6 +25,7 @@ def _sin_flow_gen(image0, max_motion=4.5, npics=5):
 
     """
     grid = np.meshgrid(*[np.arange(n) for n in image0.shape], indexing='ij')
+    grid = np.stack(grid)
     gt_flow = np.zeros_like(grid)
     gt_flow[0, ...] = max_motion * np.sin(grid[0]/grid[0].max()*npics*np.pi)
     image1 = warp(image0, grid-gt_flow, mode='nearest')

--- a/skimage/restoration/inpaint.py
+++ b/skimage/restoration/inpaint.py
@@ -23,7 +23,7 @@ def _inpaint_biharmonic_single_channel(mask, out, limits):
     mask_i = np.ravel_multi_index(np.where(mask), mask.shape)
 
     # Find masked points and prepare them to be easily enumerate over
-    mask_pts = np.array(np.where(mask)).T
+    mask_pts = np.stack(np.where(mask), axis=-1)
 
     # Iterate over masked points
     for mask_pt_n, mask_pt_idx in enumerate(mask_pts):

--- a/skimage/segmentation/morphsnakes.py
+++ b/skimage/segmentation/morphsnakes.py
@@ -57,9 +57,9 @@ def sup_inf(u):
 
     erosions = []
     for P_i in P:
-        erosions.append(ndi.binary_erosion(u, P_i))
+        erosions.append(ndi.binary_erosion(u, P_i).astype(np.int8))
 
-    return np.array(erosions, dtype=np.int8).max(0)
+    return np.stack(erosions, axis=0).max(0)
 
 
 def inf_sup(u):
@@ -75,9 +75,9 @@ def inf_sup(u):
 
     dilations = []
     for P_i in P:
-        dilations.append(ndi.binary_dilation(u, P_i))
+        dilations.append(ndi.binary_dilation(u, P_i).astype(np.int8))
 
-    return np.array(dilations, dtype=np.int8).min(0)
+    return np.stack(dilations, axis=0).min(0)
 
 
 _curvop = _fcycle([lambda u: sup_inf(inf_sup(u)),   # SIoIS


### PR DESCRIPTION

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

This PR relies on calling `np.stack` explicitly rather than relying on implicit stacking of lists of arrays via `np.array`. I think this "explicit is better than implicit" approach is preferable from a readability standpoint. 

There should be no change in existing behavior, it is purely a style/maintenance PR. That said, there will be a change in the contiguity of the returned type in at least one place. In `adapt_rgb.py` the current code

```Python
    return np.moveaxis(np.array(c_new), 0, -1)
```
returns an F-ordered array while the updated code

```Python
    return np.stack(c_new, axis=-1)
```
returns a C-ordered array. I don't think we typically guarantee a specific contiguity for the returned arrays, but it is something to consider.

This issue was inspired by discovering that passing lists of arrays to `array()`, or `tranpose()` does not work in CuPy. So, in addition to style/readability benefits, it may also ease potentially supporting other array module backends in the future.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
