### PR TITLE
Silence several warnings in the test suite

### DIFF
--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -728,7 +728,6 @@ def test_gray2rgba_alpha():
                                     (4, 5, 4, 5, 3)]))
 def test_nD_gray_conversion(func, shape):
     img = np.random.rand(*shape)
-    out = func(img)
 
     msg_list = []
     if img.ndim == 3 and func == gray2rgb:

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -995,7 +995,7 @@ def corner_peaks(image, min_distance=1, threshold_abs=None, threshold_rel=None,
                             threshold_abs=threshold_abs,
                             threshold_rel=threshold_rel,
                             exclude_border=exclude_border,
-                            indices=True, num_peaks=np.inf,
+                            num_peaks=np.inf,
                             footprint=footprint, labels=labels,
                             num_peaks_per_label=num_peaks_per_label)
 

--- a/skimage/future/graph/tests/test_rag.py
+++ b/skimage/future/graph/tests/test_rag.py
@@ -190,7 +190,8 @@ def test_reproducibility():
     when specifying random_state
     """
     img = data.coffee()
-    labels1 = segmentation.slic(img, compactness=30, n_segments=400)
+    labels1 = segmentation.slic(
+        img, compactness=30, n_segments=400, start_label=0)
     g = graph.rag_mean_color(img, labels1, mode='similarity')
     results = [None] * 4
     for i in range(len(results)):

--- a/skimage/measure/tests/test_profile.py
+++ b/skimage/measure/tests/test_profile.py
@@ -205,10 +205,10 @@ def test_bool_array_input():
     dx = 31 * np.sin(phi)
     dst = (center_y + dy, center_x + dx)
 
-    profile_u8 = profile_line(mask.astype(np.uint8), src, dst)
+    profile_u8 = profile_line(mask.astype(np.uint8), src, dst, mode='reflect')
     assert all(profile_u8[:radius] == 1)
 
-    profile_b = profile_line(mask, src, dst)
+    profile_b = profile_line(mask, src, dst, mode='reflect')
     assert all(profile_b[:radius] == 1)
 
     assert all(profile_b == profile_u8)

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -6,6 +6,8 @@ from numpy.testing import assert_equal
 from pytest import raises, warns
 
 from skimage.morphology import extrema
+from skimage._shared.testing import expected_warnings
+
 
 eps = 1e-12
 
@@ -200,8 +202,15 @@ class TestExtrema(unittest.TestCase):
 
         h_vals = np.linspace(1.0, 2.0, 100)
         failures = 0
-        for i in range(h_vals.size):
-            maxima = extrema.h_maxima(data, h_vals[i])
+
+        for h in h_vals:
+            if h % 1 != 0:
+                msgs = ['possible precision loss converting image']
+            else:
+                msgs = []
+
+            with expected_warnings(msgs):
+                maxima = extrema.h_maxima(data, h)
 
             if (maxima[2, 2] == 0):
                 failures += 1
@@ -257,8 +266,14 @@ class TestExtrema(unittest.TestCase):
 
         h_vals = np.linspace(1.0, 2.0, 100)
         failures = 0
-        for i in range(h_vals.size):
-            minima = extrema.h_minima(data, h_vals[i])
+        for h in h_vals:
+            if h % 1 != 0:
+                msgs = ['possible precision loss converting image']
+            else:
+                msgs = []
+
+            with expected_warnings(msgs):
+                minima = extrema.h_minima(data, h)
 
             if (minima[2, 2] == 0):
                 failures += 1

--- a/skimage/viewer/plugins/lineprofile.py
+++ b/skimage/viewer/plugins/lineprofile.py
@@ -64,7 +64,8 @@ class LineProfile(PlotPlugin):
         self.line_tool.end_points = np.transpose([x, y])
 
         scan_data = measure.profile_line(image,
-                                         *self.line_tool.end_points[:, ::-1])
+                                         *self.line_tool.end_points[:, ::-1],
+                                         mode='reflect')
         self.scan_data = scan_data
         if scan_data.ndim == 1:
             scan_data = scan_data[:, np.newaxis]
@@ -111,7 +112,8 @@ class LineProfile(PlotPlugin):
     def _update_data(self):
         scan = measure.profile_line(self.image_viewer.image,
                                     *self.line_tool.end_points[:, ::-1],
-                                    linewidth=self.line_tool.linewidth)
+                                    linewidth=self.line_tool.linewidth,
+                                    mode='reflect')
         self.scan_data = scan
         if scan.ndim == 1:
             scan = scan[:, np.newaxis]

--- a/skimage/viewer/widgets/core.py
+++ b/skimage/viewer/widgets/core.py
@@ -184,7 +184,7 @@ class Slider(BaseWidget):
     def val(self, value):
         if self.value_type == 'float':
             value = (value - self._low) / self._scale
-        self.slider.setValue(value)
+        self.slider.setValue(int(value))
 
 
 class ComboBox(BaseWidget):


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

These span multiple modules, but it is broken into small commits that should be easy to review individually.

The first 4 commits are very simple and just silence FutureWarnings in the existing tests.

Commit (519b8106) silences a `FutureWarning`, but is also a change in boundary behavior from the old default value of "constant" to the upcoming default of "reflect". Let me know if you want to set that to "constant" instead to keep the old behavior (not sure we are even updating/maintaining the `viewer` module anymore?)

After the fixes in this PR, I am now seeing only 3 `RuntimeWarnings` locally and can look into those in a separate PR.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
