### PR TITLE
Silence a few RuntimeWarnings in the test suite

### DIFF
--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -329,7 +329,9 @@ def test_li_pathological_arrays():
     e = np.array([1, 1])
     f = np.array([1, 2])
     arrays = [a, b, c, d, e, f]
-    thresholds = [threshold_li(arr) for arr in arrays]
+    with np.errstate(divide='ignore'):
+        # ignoring "divide by zero encountered in log" error from np.log(0)
+        thresholds = [threshold_li(arr) for arr in arrays]
     assert np.all(np.isfinite(thresholds))
 
 

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -649,8 +649,8 @@ def test_wavelet_invalid_method():
 
 
 def test_wavelet_rescale_sigma_deprecation():
-    # No specifying rescale_sigma results in a DeprecationWarning
-    assert_warns(FutureWarning, restoration.denoise_wavelet, np.ones(16))
+    # Not specifying rescale_sigma results in a DeprecationWarning
+    assert_warns(FutureWarning, restoration.denoise_wavelet, np.arange(16))
 
 
 @pytest.mark.parametrize('rescale_sigma', [True, False])


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

The first commit avoids a RuntimeWarning from NumPy related to taking `log(0)` in pathological test cases of `threshold_li`.

The second fix is in a `denoise_wavelet` test case. Here, I modified the array used in the test to be **non-constant** to avoid the detail coefficient array being all zeros (internally to denoise_wavelet, values where the details are exactly 0 are assumed to be masked out, which was leading to an empty slice). The actual values in the array are irrelevant to that test case, so any non-constant array would work, I just chose `arange` arbitrarily.



## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
