### PR TITLE
handle color string mapping correctly

### DIFF
--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -33,6 +33,8 @@ def _rgb_vector(color):
     if isinstance(color, str):
         color = color_dict[color]
     # Slice to handle RGBA colors.
+    else:
+        color = color[:3]
     return np.array(color[:3])
 
 
@@ -45,7 +47,7 @@ def _match_label_with_color(label, colors, bg_label, bg_color):
     # Temporarily set background color; it will be removed later.
     if bg_color is None:
         bg_color = (0, 0, 0)
-    bg_color = _rgb_vector([bg_color])
+    bg_color = _rgb_vector(bg_color)
 
     # map labels to their ranks among all labels from small to large
     unique_labels, mapped_labels = np.unique(label, return_inverse=True)
@@ -66,7 +68,7 @@ def _match_label_with_color(label, colors, bg_label, bg_color):
 
     # Modify labels and color cycle so background color is used only once.
     color_cycle = itertools.cycle(colors)
-    color_cycle = itertools.chain(bg_color, color_cycle)
+    color_cycle = itertools.chain([bg_color], color_cycle)
 
     return mapped_labels, color_cycle
 

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -33,8 +33,6 @@ def _rgb_vector(color):
     if isinstance(color, str):
         color = color_dict[color]
     # Slice to handle RGBA colors.
-    else:
-        color = color[:3]
     return np.array(color[:3])
 
 

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -223,7 +223,7 @@ def _label2rgb_avg(label_field, image, bg_label=0, bg_color=(0, 0, 0)):
     out : array, same shape and type as `image`
         The output visualization.
     """
-    out = np.zeros_like(image)
+    out = np.zeros(label_field.shape + (3,))
     labels = np.unique(label_field)
     bg = (labels == bg_label)
     if bg.any():

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -6,7 +6,7 @@ from skimage.color.colorlabel import label2rgb
 
 from skimage._shared import testing
 from skimage._shared.testing import (assert_array_almost_equal,
-                                     assert_array_equal, assert_warns)
+                                     assert_array_equal, assert_warns, assert_no_warnings)
 
 
 def test_deprecation_warning():
@@ -198,3 +198,11 @@ def test_negative_intensity():
     labels = np.arange(100).reshape(10, 10)
     image = np.full((10, 10), -1, dtype='float64')
     assert_warns(UserWarning, label2rgb, labels, image, bg_label=-1)
+
+
+def test_bg_color_rgb_string():
+    img = np.random.randint(0, 255, (10, 10), dtype=np.uint8)
+    labels = np.zeros((10, 10), dtype=np.int64)
+    labels[1:3, 1:3] = 1
+    labels[6:9, 6:9] = 2
+    assert_no_warnings(label2rgb,labels, image=img, bg_label=0, bg_color='red')

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -6,7 +6,8 @@ from skimage.color.colorlabel import label2rgb
 
 from skimage._shared import testing
 from skimage._shared.testing import (assert_array_almost_equal,
-                                     assert_array_equal, assert_warns, assert_no_warnings)
+                                     assert_array_equal, assert_warns,
+                                     assert_no_warnings)
 
 
 def test_deprecation_warning():
@@ -205,4 +206,4 @@ def test_bg_color_rgb_string():
     labels = np.zeros((10, 10), dtype=np.int64)
     labels[1:3, 1:3] = 1
     labels[6:9, 6:9] = 2
-    assert_no_warnings(label2rgb,labels, image=img, bg_label=0, bg_color='red')
+    assert_no_warnings(label2rgb, labels, image=img, bg_label=0, bg_color='red')

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -207,3 +207,11 @@ def test_bg_color_rgb_string():
     labels[1:3, 1:3] = 1
     labels[6:9, 6:9] = 2
     assert_no_warnings(label2rgb, labels, image=img, bg_label=0, bg_color='red')
+
+
+def test_avg_with_2d_image():
+    img = np.random.randint(0, 255, (10, 10), dtype=np.uint8)
+    labels = np.zeros((10, 10), dtype=np.int64)
+    labels[1:3, 1:3] = 1
+    labels[6:9, 6:9] = 2
+    assert_no_warnings(label2rgb, labels, image=img, bg_label=0, kind='avg')

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -206,7 +206,8 @@ def test_bg_color_rgb_string():
     labels = np.zeros((10, 10), dtype=np.int64)
     labels[1:3, 1:3] = 1
     labels[6:9, 6:9] = 2
-    assert_no_warnings(label2rgb, labels, image=img, bg_label=0, bg_color='red')
+    output = label2rgb(labels, image=img, alpha=0.9, bg_label=0, bg_color='red')
+    assert output[0, 0, 0] > 0.9 # red channel
 
 
 def test_avg_with_2d_image():


### PR DESCRIPTION
## Description

Resolves #4534
I think previously the way the color isn't handled as intended in `_match_label_with_color` because if you pass `[color]` into `_rgb_vector` it's not dealing with color the way it's intended (you should only pass one color, not a list)

Also fixes (I think?) the vector size mismatch in  `label2rgb` with kind='avg' 
## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
