### PR TITLE
DOC: Add a link to Mayavi example for mesh decimation

### DIFF
--- a/skimage/measure/_marching_cubes_lewiner.py
+++ b/skimage/measure/_marching_cubes_lewiner.py
@@ -109,6 +109,11 @@ def marching_cubes(volume, level=None, *, spacing=(1., 1., 1.),
       >> vv.mesh(np.fliplr(verts), faces, normals, values)
       >> vv.use().Run()
 
+    To reduce the number of triangles in the mesh for better performance,
+    see this `example
+    <https://docs.enthought.com/mayavi/mayavi/auto/example_julia_set_decimation.html#example-julia-set-decimation>`_
+    using the ``mayavi`` package.
+
     References
     ----------
     .. [1] Thomas Lewiner, Helio Lopes, Antonio Wilson Vieira and Geovan


### PR DESCRIPTION
## Description
This commit adds a link to Mayavi example for mesh decimation in the `marching_cubes` docstring.

Temporarily addresses https://github.com/scikit-image/scikit-image/issues/4537.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
