### PR TITLE
DOC: autoformat docstrings of segmentation/*.py

### DIFF
--- a/skimage/segmentation/_clear_border.py
+++ b/skimage/segmentation/_clear_border.py
@@ -18,7 +18,7 @@ def clear_border(labels, buffer_size=0, bgval=0, in_place=False, mask=None):
         Whether or not to manipulate the labels array in-place.
     mask : ndarray of bool, same shape as `image`, optional.
         Image data mask. Objects in labels image overlapping with
-        False pixels of mask will be removed. If defined, the 
+        False pixels of mask will be removed. If defined, the
         argument buffer_size will be ignored.
 
     Returns

--- a/skimage/segmentation/_expand_labels.py
+++ b/skimage/segmentation/_expand_labels.py
@@ -16,15 +16,15 @@ from scipy.ndimage import distance_transform_edt
 def expand_labels(label_image, distance=1):
     """Expand labels in label image by ``distance`` pixels without overlapping.
 
-    Given a label image, ``expand_labels`` grows label regions (connected components) 
+    Given a label image, ``expand_labels`` grows label regions (connected components)
     outwards by up to ``distance`` pixels without overflowing into neighboring regions.
     More specifically, each background pixel that is within Euclidean distance
     of <= ``distance`` pixels of a connected component is assigned the label of that
     connected component.
-    Where multiple connected components are within ``distance`` pixels of a background 
-    pixel, the label value of the closest connected component will be assigned (see 
+    Where multiple connected components are within ``distance`` pixels of a background
+    pixel, the label value of the closest connected component will be assigned (see
     Notes for the case of multiple labels at equal distance).
-     
+
     Parameters
     ----------
     label_image : ndarray of dtype int

--- a/skimage/segmentation/_watershed.py
+++ b/skimage/segmentation/_watershed.py
@@ -126,9 +126,9 @@ def watershed(image, markers=None, connectivity=1, offset=None, mask=None,
     out : ndarray
         A labeled matrix of the same type and shape as markers
 
-    See also
+    See Also
     --------
-    skimage.segmentation.random_walker: random walker segmentation
+    skimage.segmentation.random_walker : random walker segmentation
         A segmentation algorithm based on anisotropic diffusion, usually
         slower than the watershed but with good results on noisy data and
         boundaries with holes.

--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -56,7 +56,7 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
         'free', respectively.
     coordinates : {'rc'}, optional
         This option remains for compatibility purpose only and has no effect.
-        It was introduced in 0.16 with the ``'xy'`` option, but since 0.18, 
+        It was introduced in 0.16 with the ``'xy'`` option, but since 0.18,
         only the ``'rc'`` option is valid.
         Coordinates must be set in a row-column format.
 

--- a/skimage/segmentation/morphsnakes.py
+++ b/skimage/segmentation/morphsnakes.py
@@ -141,7 +141,7 @@ def circle_level_set(image_shape, center=None, radius=None):
             This function is deprecated and will be removed in scikit-image 0.19.
             Please use the function named ``disk_level_set`` instead.
 
-    See also
+    See Also
     --------
     checkerboard_level_set
     """
@@ -172,7 +172,7 @@ def disk_level_set(image_shape, *, center=None, radius=None):
     out : array with shape `image_shape`
         Binary level set of the disk with the given `radius` and `center`.
 
-    See also
+    See Also
     --------
     checkerboard_level_set
     """
@@ -205,7 +205,7 @@ def checkerboard_level_set(image_shape, square_size=5):
     out : array with shape `image_shape`
         Binary level set of the checkerboard.
 
-    See also
+    See Also
     --------
     circle_level_set
     """
@@ -299,13 +299,12 @@ def morphological_chan_vese(image, iterations, init_level_set='checkerboard',
     out : (M, N) or (L, M, N) array
         Final segmentation (i.e., the final level set)
 
-    See also
+    See Also
     --------
     circle_level_set, checkerboard_level_set
 
     Notes
     -----
-
     This is a version of the Chan-Vese algorithm that uses morphological
     operators instead of solving a partial differential equation (PDE) for the
     evolution of the contour. The set of morphological operators used in this
@@ -413,13 +412,12 @@ def morphological_geodesic_active_contour(gimage, iterations,
     out : (M, N) or (L, M, N) array
         Final segmentation (i.e., the final level set)
 
-    See also
+    See Also
     --------
     inverse_gaussian_gradient, circle_level_set, checkerboard_level_set
 
     Notes
     -----
-
     This is a version of the Geodesic Active Contours (GAC) algorithm that uses
     morphological operators instead of solving partial differential equations
     (PDEs) for the evolution of the contour. The set of morphological operators

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -309,7 +309,6 @@ def random_walker(data, labels, beta=130, mode='cg_j', tol=1.e-3, copy=True,
           preconditioner is computed using a multigrid solver, then the
           solution is computed with the Conjugate Gradient method. This mode
           requires that the pyamg module is installed.
-
     tol : float, optional
         Tolerance to achieve when solving the linear system using
         the conjugate gradient based modes ('cg', 'cg_j' and 'cg_mg').
@@ -343,9 +342,9 @@ def random_walker(data, labels, beta=130, mode='cg_j', tol=1.e-3, copy=True,
           probability that label `label_nb` reaches the pixel `(i, j)`
           first.
 
-    See also
+    See Also
     --------
-    skimage.morphology.watershed: watershed segmentation
+    skimage.morphology.watershed : watershed segmentation
         A segmentation algorithm based on mathematical morphology
         and "flooding" of regions from markers.
 

--- a/skimage/segmentation/tests/test_expand_labels.py
+++ b/skimage/segmentation/tests/test_expand_labels.py
@@ -146,7 +146,7 @@ def test_expand_labels(input_array, expected_output, expand_distance):
 @testing.parametrize('distance', range(6))
 def test_binary_blobs(ndim, distance):
     """Check some invariants with label expansion.
-    
+
     - New labels array should exactly contain the original labels array.
     - Distance to old labels array within new labels should never exceed input
       distance.
@@ -172,9 +172,9 @@ def test_edge_case_behaviour():
     """ Check edge case behavior to detect upstream changes
 
     For edge cases where a pixel has the same distance to several regions,
-    lexicographical order seems to determine which region gets to expand 
-    into this pixel given the current upstream behaviour in 
-    scipy.ndimage.distance_map_edt. 
+    lexicographical order seems to determine which region gets to expand
+    into this pixel given the current upstream behaviour in
+    scipy.ndimage.distance_map_edt.
 
     As a result, we expect different results when transposing the array.
     If this test fails, something has changed upstream.


### PR DESCRIPTION
Mostly trailing whitespace, casing of `See Also`, whitespace after `:`,
whether there is a space after `:` in Parameters/Returns, and blank line
after titles.