### PR TITLE
Port 3D image processing tutorial into gallery.

### DIFF
--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -250,9 +250,9 @@ gamma_high = exposure.adjust_gamma(data, gamma=gamma_high_val)
 
 _, ((a, b, c), (d, e, f)) = plt.subplots(nrows=2, ncols=3, figsize=(12, 8))
 
-show_plane(a, data[32], title="Original")
-show_plane(b, gamma_low[32], title="Gamma = {}".format(gamma_low_val))
-show_plane(c, gamma_high[32], title="Gamma = {}".format(gamma_high_val))
+show_plane(a, data[32], title='Original')
+show_plane(b, gamma_low[32], title=f'Gamma = {gamma_low_val}')
+show_plane(c, gamma_high[32], title=f'Gamma = {gamma_high_val}')
 
 plot_hist(d, data)
 plot_hist(e, gamma_low)

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -100,9 +100,9 @@ def show_plane(ax, plane, cmap="gray", title=None):
 (n_plane, n_row, n_col) = data.shape
 _, (a, b, c) = plt.subplots(ncols=3, figsize=(15, 5))
 
-show_plane(a, data[n_plane // 2], title="Plane = {}".format(n_plane // 2))
-show_plane(b, data[:, n_row // 2, :], title="Row = {}".format(n_row // 2))
-show_plane(c, data[:, :, n_col // 2], title="Column = {}".format(n_col // 2))
+show_plane(a, data[n_plane // 2], title=f'Plane = {n_plane // 2}')
+show_plane(b, data[:, n_row // 2, :], title=f'Row = {n_row // 2}')
+show_plane(c, data[:, :, n_col // 2], title=f'Column = {n_col // 2}')
 
 #####################################################################
 # As hinted before, a three-dimensional image can be viewed as a series of

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -267,7 +267,8 @@ plot_hist(f, gamma_high)
 # equalization <https://en.wikipedia.org/wiki/Histogram_equalization>`_
 # improves contrast in an image by redistributing pixel intensities. The most
 # common pixel intensities get spread out, increasing contrast in low-contrast
-# areas. One downside of this approach is that it may enhance background noise.
+# areas. One downside of this approach is that it may enhance background
+# noise.
 
 equalized_data = exposure.equalize_hist(data)
 

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -266,10 +266,16 @@ plot_hist(f, gamma_high)
 
 equalized_data = exposure.equalize_hist(data)
 
+display(equalized_data)
+
+#####################################################################
+# As before, if we have a Jupyter kernel running, we can explore the above
+# slices interactively.
+
 explore_slices(equalized_data);
 
 #####################################################################
-# Let us plot the image histogram before and after histogram equalization.
+# Let us now plot the image histogram before and after histogram equalization.
 # Below, we plot the respective cumulative distribution functions (CDF).
 
 _, ((a, b), (c, d)) = plt.subplots(nrows=2, ncols=2, figsize=(16, 8))
@@ -300,4 +306,4 @@ clipped_data = exposure.rescale_intensity(
     out_range=np.float32
 )
 
-explore_slices(clipped_data);
+display(clipped_data)

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -126,6 +126,11 @@ display(data)
 # Alternatively, we can explore these planes (slices) interactively using
 # Jupyter widgets. Let the user select which slice to display and show the
 # position of this slice in the 3D dataset.
+# Note that you cannot see the Jupyter widget at work in a static HTML page,
+# as is the case in the scikit-image gallery. For the following piece of
+# code to work, you need a Jupyter kernel running either locally or in the
+# cloud: see the bottom of this page to either download the Jupyter notebook
+# and run it on your computer, or open it directly in Binder.
 
 
 def slice_in_3D(ax, i):

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -248,6 +248,7 @@ show_plane(c, gamma_high[32], title="Gamma = {}".format(gamma_high_val))
 plot_hist(d, data)
 plot_hist(e, gamma_low)
 plot_hist(f, gamma_high)
+# sphinx_gallery_thumbnail_number = 4
 
 #####################################################################
 # `Histogram

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -84,7 +84,7 @@ except TypeError as e:
     print(str(e))
 
 #####################################################################
-# Function `io.imshow` can only display grayscale and RGB(A) 2D images.
+# The `io.imshow` function can only display grayscale and RGB(A) 2D images.
 # We can thus use it to visualize 2D planes. By fixing one axis, we can
 # observe three different views of the image.
 

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -224,7 +224,10 @@ explore_slices(data);
 # ===============
 # Scikit-image's `exposure` module contains a number of functions for
 # adjusting image contrast. These functions operate on pixel values.
-# Generally, image dimensionality or pixel spacing needn't be considered.
+# Generally, image dimensionality or pixel spacing doesn't need to be
+# considered. In local exposure correction, though, one might want to
+# adjust the window size to ensure equal size in *real* coordinates along
+# each axis.
 
 #####################################################################
 # `Gamma correction <https://en.wikipedia.org/wiki/Gamma_correction>`_

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -5,21 +5,23 @@ Explore 3D images (of cells)
 
 This tutorial is an introduction to three-dimensional image processing. Images
 are represented as `numpy` arrays. A single-channel, or grayscale, image is a
-2D matrix of pixel intensities of shape `(row, column)`. We can construct a 3D
-volume as a series of 2D planes, giving 3D images the shape
-`(plane, row, column)`. A multichannel, or RGB(A), image has an additional
+2D matrix of pixel intensities of shape ``(n_row, n_col)``, where ``n_row``
+(resp. ``n_col``) denotes the number of `rows` (resp. `columns`). We can
+construct a 3D volume as a series of 2D `planes`, giving 3D images the shape
+``(n_plane, n_row, n_col)``, where ``n_plane`` is the number of planes.
+A multichannel, or RGB(A), image has an additional
 `channel` dimension in the final position containing color information.
 
 These conventions are summarized in the table below:
 
-=============== ===============================
+=============== =================================
 Image type      Coordinates
-=============== ===============================
-2D grayscale    `(row, column)`
-2D multichannel `(row, column, channel)`
-3D grayscale    `(plane, row, column)`
-3D multichannel `(plane, row, column, channel)`
-=============== ===============================
+=============== =================================
+2D grayscale    ``[row, column]``
+2D multichannel ``[row, column, channel]``
+3D grayscale    ``[plane, row, column]``
+3D multichannel ``[plane, row, column, channel]``
+=============== =================================
 
 Some 3D images are constructed with equal resolution in each dimension (e.g.,
 synchrotron tomography or computer-generated rendering of a sphere).

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -182,6 +182,7 @@ def slice_in_3D(ax, i):
     ax.set_xlabel("plane")
     ax.set_ylabel("row")
     ax.set_zlabel("col")
+ax.set_xlim(0, 100)
 
     # Autoscale plot axes
     scaling = np.array([getattr(ax,

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -180,9 +180,9 @@ def slice_in_3D(ax, i):
     )
 
     ax.set_xlabel("plane")
+    ax.set_xlim(0, 100)
     ax.set_ylabel("row")
     ax.set_zlabel("col")
-ax.set_xlim(0, 100)
 
     # Autoscale plot axes
     scaling = np.array([getattr(ax,

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -195,7 +195,7 @@ def slice_in_3D(ax, i):
 
     # Autoscale plot axes
     scaling = np.array([getattr(ax,
-                                "get_{}lim".format(dim))() for dim in "xyz"])
+                                f'get_{dim}lim')() for dim in "xyz"])
     ax.auto_scale_xyz(* [[np.min(scaling), np.max(scaling)]] * 3)
 
 

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -7,8 +7,8 @@ This tutorial is an introduction to three-dimensional image processing. Images
 are represented as `numpy` arrays. A single-channel, or grayscale, image is a
 2D matrix of pixel intensities of shape `(row, column)`. We can construct a 3D
 volume as a series of 2D planes, giving 3D images the shape
-`(plane, row, column)`. Multichannel images have an additional channel
-dimension in the final position containing color information.
+`(plane, row, column)`. A multichannel, or RGB(A), image has an additional
+channel dimension in the final position containing color information.
 
 Some 3D images are constructed with equal resolution in each dimension (e.g.,
 computer-generated rendering of a sphere). Most experimental data are captured
@@ -20,7 +20,8 @@ used to adjust contributions to filters.
 
 The data used in this tutorial were provided by the Allen Institute for Cell
 Science. They were downsampled by a factor of 4 in the `row` and `column`
-dimensions to reduce computational time.
+dimensions to reduce their size and, hence, computational time. The spacing
+information was reported by the microscope used to image the cells.
 
 """
 
@@ -46,6 +47,41 @@ print("shape: {}".format(data.shape))
 print("dtype: {}".format(data.dtype))
 print("range: ({}, {})".format(data.min(), data.max()))
 
+# Report spacing from microscope
+original_spacing = np.array([0.2900000, 0.0650000, 0.0650000])
+
+# Account for downsampling of slices by 4
+rescaled_spacing = original_spacing * [1, 4, 4]
+
+# Normalize spacing so that pixels are a distance of 1 apart
+spacing = rescaled_spacing / rescaled_spacing[2]
+
+print("microscope spacing: {}\n".format(original_spacing))
+print("rescaled spacing: {} (after downsampling)\n".format(rescaled_spacing))
+print("normalized spacing: {}\n".format(spacing))
+
 #####################################################################
-# The distance between pixels was reported by the microscope used to image the
-# cells.
+# Let us try and visualize the (3D) image with `io.imshow`.
+
+try:
+    io.imshow(data, cmap="gray")
+except TypeError as e:
+    print(str(e))
+
+#####################################################################
+# Function `io.imshow` can only display grayscale and RGB(A) 2D images.
+# We can thus use it to visualize 2D planes. By fixing one axis, we can
+# observe three different views of the image.
+
+def show_plane(ax, plane, cmap="gray", title=None):
+    ax.imshow(plane, cmap=cmap)
+    ax.axis("off")
+
+    if title:
+        ax.set_title(title)
+
+_, (a, b, c) = plt.subplots(ncols=3, figsize=(15, 5))
+
+show_plane(a, data[32], title="Plane = 32")
+show_plane(b, data[:, 128, :], title="Row = 128")
+show_plane(c, data[:, :, 128], title="Column = 128")

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -1,6 +1,6 @@
 """
 ============================
-Analyze 3D images (of cells)
+Explore 3D images (of cells)
 ============================
 
 This tutorial is an introduction to three-dimensional image processing. Images
@@ -8,7 +8,18 @@ are represented as `numpy` arrays. A single-channel, or grayscale, image is a
 2D matrix of pixel intensities of shape `(row, column)`. We can construct a 3D
 volume as a series of 2D planes, giving 3D images the shape
 `(plane, row, column)`. A multichannel, or RGB(A), image has an additional
-channel dimension in the final position containing color information.
+`channel` dimension in the final position containing color information.
+
+These conventions are summarized in the table below:
+
+=============== ===============================
+Image type      Coordinates
+=============== ===============================
+2D grayscale    `(row, column)`
+2D multichannel `(row, column, channel)`
+3D grayscale    `(plane, row, column)`
+3D multichannel `(plane, row, column, channel)`
+=============== ===============================
 
 Some 3D images are constructed with equal resolution in each dimension (e.g.,
 computer-generated rendering of a sphere). Most experimental data are captured

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -1,0 +1,51 @@
+"""
+============================
+Analyze 3D images (of cells)
+============================
+
+This tutorial is an introduction to three-dimensional image processing. Images
+are represented as `numpy` arrays. A single-channel, or grayscale, image is a
+2D matrix of pixel intensities of shape `(row, column)`. We can construct a 3D
+volume as a series of 2D planes, giving 3D images the shape
+`(plane, row, column)`. Multichannel images have an additional channel
+dimension in the final position containing color information.
+
+Some 3D images are constructed with equal resolution in each dimension (e.g.,
+computer-generated rendering of a sphere). Most experimental data are captured
+with a lower resolution in one of the three dimensions, e.g., photographing
+thin slices to approximate a 3D structure as a stack of 2D images.
+The distance between pixels in each dimension, called spacing, is encoded as a
+tuple and is accepted as a parameter by some `skimage` functions and can be
+used to adjust contributions to filters.
+
+The data used in this tutorial were provided by the Allen Institute for Cell
+Science. They were downsampled by a factor of 4 in the `row` and `column`
+dimensions to reduce computational time.
+
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy import ndimage as ndi
+
+from skimage import (
+    feature, filters, io, measure, morphology, segmentation, util
+)
+from skimage.data import image_fetcher
+
+
+#####################################################################
+# Load and display 3D images
+# ==========================
+# Three-dimensional data can be loaded with `io.imread`.
+
+path = image_fetcher.fetch('data/cells.tif')
+data = io.imread(path)
+
+print("shape: {}".format(data.shape))
+print("dtype: {}".format(data.dtype))
+print("range: ({}, {})".format(data.min(), data.max()))
+
+#####################################################################
+# The distance between pixels was reported by the microscope used to image the
+# cells.

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -37,6 +37,7 @@ information was reported by the microscope used to image the cells.
 """
 
 import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 import numpy as np
 from scipy import ndimage as ndi
 
@@ -96,3 +97,108 @@ _, (a, b, c) = plt.subplots(ncols=3, figsize=(15, 5))
 show_plane(a, data[32], title="Plane = 32")
 show_plane(b, data[:, 128, :], title="Row = 128")
 show_plane(c, data[:, :, 128], title="Column = 128")
+
+#####################################################################
+# As hinted before, a three-dimensional image can be viewed as a series of
+# two-dimensional planes. Let us write a helper function, `display`, to
+# display 30 planes of our data. By default, every other plane is displayed.
+
+def display(im3d, cmap="gray", step=2):
+    _, axes = plt.subplots(nrows=5, ncols=6, figsize=(16, 14))
+
+    vmin = im3d.min()
+    vmax = im3d.max()
+
+    for ax, image in zip(axes.flatten(), im3d[::step]):
+        ax.imshow(image, cmap=cmap, vmin=vmin, vmax=vmax)
+        ax.set_xticks([])
+        ax.set_yticks([])
+
+display(data)
+
+#####################################################################
+# Alternatively, we can explore these planes (slices) interactively using
+# Jupyter widgets. Let the user select which slice to display and show the
+# position of this slice in the 3D dataset.
+
+def slice_in_3D(ax, i):
+    # From https://stackoverflow.com/questions/44881885/python-draw-3d-cube
+    Z = np.array([[0, 0, 0],
+                  [1, 0, 0],
+                  [1, 1, 0],
+                  [0, 1, 0],
+                  [0, 0, 1],
+                  [1, 0, 1],
+                  [1, 1, 1],
+                  [0, 1, 1]])
+
+    Z = Z * data.shape
+
+    r = [-1, 1]
+
+    X, Y = np.meshgrid(r, r)
+    # Plot vertices
+    ax.scatter3D(Z[:, 0], Z[:, 1], Z[:, 2])
+
+    # List sides' polygons of figure
+    verts = [[Z[0], Z[1], Z[2], Z[3]],
+             [Z[4], Z[5], Z[6], Z[7]],
+             [Z[0], Z[1], Z[5], Z[4]],
+             [Z[2], Z[3], Z[7], Z[6]],
+             [Z[1], Z[2], Z[6], Z[5]],
+             [Z[4], Z[7], Z[3], Z[0]],
+             [Z[2], Z[3], Z[7], Z[6]]]
+
+    # Plot sides
+    ax.add_collection3d(
+        Poly3DCollection(
+            verts,
+            facecolors=(0, 1, 1, 0.25),
+            linewidths=1,
+            edgecolors="darkblue"
+        )
+    )
+
+    verts = np.array([[[0, 0, 0],
+                       [0, 0, 1],
+                       [0, 1, 1],
+                       [0, 1, 0]]])
+    verts = verts * (60, 256, 256)
+    verts += [i, 0, 0]
+
+    ax.add_collection3d(
+        Poly3DCollection(
+            verts,
+            facecolors="magenta",
+            linewidths=1,
+            edgecolors="black"
+        )
+    )
+
+    ax.set_xlabel("plane")
+    ax.set_ylabel("row")
+    ax.set_zlabel("col")
+
+    # Autoscale plot axes
+    scaling = np.array([getattr(ax,
+        "get_{}lim".format(dim))() for dim in "xyz"])
+    ax.auto_scale_xyz(* [[np.min(scaling), np.max(scaling)]] * 3)
+
+def explore_slices(data, cmap="gray"):
+    from ipywidgets import interact
+    N = len(data)
+
+    @interact(plane=(0, N - 1))
+    def display_slice(plane=34):
+        fig, ax = plt.subplots(figsize=(20, 5))
+
+        ax_3D = fig.add_subplot(133, projection="3d")
+
+        show_plane(ax, data[plane], title="Plane {}".format(plane), cmap=cmap)
+        slice_in_3D(ax_3D, plane)
+
+        plt.show()
+
+    return display_slice
+
+explore_slices(data);

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -22,7 +22,8 @@ Image type      Coordinates
 =============== ===============================
 
 Some 3D images are constructed with equal resolution in each dimension (e.g.,
-synchrotron tomography or computer-generated rendering of a sphere). Most experimental data are captured
+synchrotron tomography or computer-generated rendering of a sphere).
+But most experimental data are captured
 with a lower resolution in one of the three dimensions, e.g., photographing
 thin slices to approximate a 3D structure as a stack of 2D images.
 The distance between pixels in each dimension, called spacing, is encoded as a
@@ -94,11 +95,12 @@ def show_plane(ax, plane, cmap="gray", title=None):
         ax.set_title(title)
 
 
+(n_plane, n_row, n_col) = data.shape
 _, (a, b, c) = plt.subplots(ncols=3, figsize=(15, 5))
 
-show_plane(a, data[32], title="Plane = 32")
-show_plane(b, data[:, 128, :], title="Row = 128")
-show_plane(c, data[:, :, 128], title="Column = 128")
+show_plane(a, data[n_plane // 2], title="Plane = {}".format(n_plane // 2))
+show_plane(b, data[:, n_row // 2, :], title="Row = {}".format(n_row // 2))
+show_plane(c, data[:, :, n_col // 2], title="Column = {}".format(n_col // 2))
 
 #####################################################################
 # As hinted before, a three-dimensional image can be viewed as a series of

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -266,8 +266,8 @@ plot_hist(f, gamma_high)
 # `Histogram
 # equalization <https://en.wikipedia.org/wiki/Histogram_equalization>`_
 # improves contrast in an image by redistributing pixel intensities. The most
-# common pixel intensities get spread out, letting areas of lower local
-# contrast gain a higher contrast. This may enhance background noise though.
+# common pixel intensities get spread out, increasing contrast in low-contrast
+# areas. One downside of this approach is that it may enhance background noise.
 
 equalized_data = exposure.equalize_hist(data)
 

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -93,6 +93,7 @@ def show_plane(ax, plane, cmap="gray", title=None):
     if title:
         ax.set_title(title)
 
+
 _, (a, b, c) = plt.subplots(ncols=3, figsize=(15, 5))
 
 show_plane(a, data[32], title="Plane = 32")
@@ -115,6 +116,7 @@ def display(im3d, cmap="gray", step=2):
         ax.imshow(image, cmap=cmap, vmin=vmin, vmax=vmax)
         ax.set_xticks([])
         ax.set_yticks([])
+
 
 display(data)
 
@@ -204,6 +206,7 @@ def explore_slices(data, cmap="gray"):
 
     return display_slice
 
+
 explore_slices(data);
 
 #####################################################################
@@ -227,6 +230,7 @@ def plot_hist(ax, data, title=None):
 
     if title:
         ax.set_title(title)
+
 
 gamma_low_val = 0.5
 gamma_low = exposure.adjust_gamma(data, gamma=gamma_low_val)

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -85,6 +85,7 @@ except TypeError as e:
 # We can thus use it to visualize 2D planes. By fixing one axis, we can
 # observe three different views of the image.
 
+
 def show_plane(ax, plane, cmap="gray", title=None):
     ax.imshow(plane, cmap=cmap)
     ax.axis("off")
@@ -103,6 +104,7 @@ show_plane(c, data[:, :, 128], title="Column = 128")
 # two-dimensional planes. Let us write a helper function, `display`, to
 # display 30 planes of our data. By default, every other plane is displayed.
 
+
 def display(im3d, cmap="gray", step=2):
     _, axes = plt.subplots(nrows=5, ncols=6, figsize=(16, 14))
 
@@ -120,6 +122,7 @@ display(data)
 # Alternatively, we can explore these planes (slices) interactively using
 # Jupyter widgets. Let the user select which slice to display and show the
 # position of this slice in the 3D dataset.
+
 
 def slice_in_3D(ax, i):
     # From https://stackoverflow.com/questions/44881885/python-draw-3d-cube
@@ -180,8 +183,9 @@ def slice_in_3D(ax, i):
 
     # Autoscale plot axes
     scaling = np.array([getattr(ax,
-        "get_{}lim".format(dim))() for dim in "xyz"])
+                                "get_{}lim".format(dim))() for dim in "xyz"])
     ax.auto_scale_xyz(* [[np.min(scaling), np.max(scaling)]] * 3)
+
 
 def explore_slices(data, cmap="gray"):
     from ipywidgets import interact
@@ -214,6 +218,7 @@ explore_slices(data);
 # brightens or darkens an image. A power-law transform, where `gamma` denotes
 # the power-law exponent, is applied to each pixel in the image: `gamma < 1`
 # will brighten an image, while `gamma > 1` will darken an image.
+
 
 def plot_hist(ax, data, title=None):
     # Helper function for plotting histograms

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -22,7 +22,7 @@ Image type      Coordinates
 =============== ===============================
 
 Some 3D images are constructed with equal resolution in each dimension (e.g.,
-computer-generated rendering of a sphere). Most experimental data are captured
+synchrotron tomography or computer-generated rendering of a sphere). Most experimental data are captured
 with a lower resolution in one of the three dimensions, e.g., photographing
 thin slices to approximate a 3D structure as a stack of 2D images.
 The distance between pixels in each dimension, called spacing, is encoded as a

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,3 +12,4 @@ pandas>=0.23.0
 seaborn>=0.7.1
 pooch>=0.5.2
 tifffile>=2020.5.30
+ipywidgets


### PR DESCRIPTION
## Description

In this PR, we are porting an existing tutorial, i.e., https://github.com/scikit-image/skimage-tutorials/blob/master/lectures/three_dimensional_image_processing.ipynb, into the gallery of examples. This addition falls under #4601 and makes use of the 3D dataset available with Pooch (namely, `cells.tif`).

I have only included the first two sections of the original tutorial:

* Load and display 3D images
* Adjust exposure (in experimental images)

I think that the segmentation of cells and nuclei could be its own tutorial, and so could feature extraction. Each example should be self-contained, but could nevertheless refer to another example (e.g., this introduction to 3D image processing where we only explore slices and adjust exposure).

If core devs prefer keeping everything in one place, I'm happy to keep going and append sections to the same file.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
