### PR TITLE
Add default level parameter in measure.find_contours

### DIFF
--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -25,7 +25,7 @@ def find_contours(image, level=None,
         Input image in which to find contours.
     level : float
         Value along which to find contours in the array. By default, the level
-        is set to the median value of the array.
+        is set to (max(image) - min(image)) / 2
     fully_connected : str, {'low', 'high'}
          Indicates whether array elements below the given level value are to be
          considered fully-connected (and hence elements above the value will

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -9,7 +9,7 @@ _param_options = ('high', 'low')
 
 
 @deprecate_kwarg({'array': 'image'}, removed_version="0.20")
-def find_contours(image, level='median',
+def find_contours(image, level=None,
                   fully_connected='low', positive_orientation='low',
                   *,
                   mask=None):
@@ -140,7 +140,7 @@ def find_contours(image, level='median',
         if not np.can_cast(mask.dtype, bool, casting='safe'):
             raise TypeError('Parameter "mask" must be a binary array.')
         mask = mask.astype(np.uint8, copy=False)
-    if level == 'median':
+    if level is None:
         level = np.median(image)
     segments = _get_contour_segments(image.astype(np.double), float(level),
                                      fully_connected == 'high', mask=mask)

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -23,7 +23,7 @@ def find_contours(image, level=None,
     ----------
     image : 2D ndarray of double
         Input image in which to find contours.
-    level : float
+    level : float, optional
         Value along which to find contours in the array. By default, the level
         is set to (max(image) - min(image)) / 2
     fully_connected : str, {'low', 'high'}

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -25,7 +25,7 @@ def find_contours(image, level='median',
         Input image in which to find contours.
     level : float
         Value along which to find contours in the array. By default, the level
-        is set to the median value of the array. 
+        is set to the median value of the array.
     fully_connected : str, {'low', 'high'}
          Indicates whether array elements below the given level value are to be
          considered fully-connected (and hence elements above the value will

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -9,7 +9,7 @@ _param_options = ('high', 'low')
 
 
 @deprecate_kwarg({'array': 'image'}, removed_version="0.20")
-def find_contours(image, level='average',
+def find_contours(image, level='median',
                   fully_connected='low', positive_orientation='low',
                   *,
                   mask=None):
@@ -24,7 +24,8 @@ def find_contours(image, level='average',
     image : 2D ndarray of double
         Input image in which to find contours.
     level : float
-        Value along which to find contours in the array.
+        Value along which to find contours in the array. By default, the level
+        is set to the median value of the array. 
     fully_connected : str, {'low', 'high'}
          Indicates whether array elements below the given level value are to be
          considered fully-connected (and hence elements above the value will
@@ -139,8 +140,8 @@ def find_contours(image, level='average',
         if not np.can_cast(mask.dtype, bool, casting='safe'):
             raise TypeError('Parameter "mask" must be a binary array.')
         mask = mask.astype(np.uint8, copy=False)
-    if level == 'average':
-        level = np.average(image)
+    if level == 'median':
+        level = (image.max() - image.min())/2
     segments = _get_contour_segments(image.astype(np.double), float(level),
                                      fully_connected == 'high', mask=mask)
     contours = _assemble_contours(segments)

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -141,7 +141,8 @@ def find_contours(image, level=None,
             raise TypeError('Parameter "mask" must be a binary array.')
         mask = mask.astype(np.uint8, copy=False)
     if level is None:
-        level = np.median(image)
+        level = (np.nanmax(image) - np.nanmin(image)) / 2.0
+
     segments = _get_contour_segments(image.astype(np.double), float(level),
                                      fully_connected == 'high', mask=mask)
     contours = _assemble_contours(segments)

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -141,7 +141,7 @@ def find_contours(image, level='median',
             raise TypeError('Parameter "mask" must be a binary array.')
         mask = mask.astype(np.uint8, copy=False)
     if level == 'median':
-        level = (image.max() - image.min()) / 2
+        level = np.median(image)
     segments = _get_contour_segments(image.astype(np.double), float(level),
                                      fully_connected == 'high', mask=mask)
     contours = _assemble_contours(segments)

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -141,7 +141,7 @@ def find_contours(image, level='median',
             raise TypeError('Parameter "mask" must be a binary array.')
         mask = mask.astype(np.uint8, copy=False)
     if level == 'median':
-        level = (image.max() - image.min())/2
+        level = (image.max() - image.min()) / 2
     segments = _get_contour_segments(image.astype(np.double), float(level),
                                      fully_connected == 'high', mask=mask)
     contours = _assemble_contours(segments)

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -9,7 +9,7 @@ _param_options = ('high', 'low')
 
 
 @deprecate_kwarg({'array': 'image'}, removed_version="0.20")
-def find_contours(image, level,
+def find_contours(image, level='average',
                   fully_connected='low', positive_orientation='low',
                   *,
                   mask=None):
@@ -139,7 +139,8 @@ def find_contours(image, level,
         if not np.can_cast(mask.dtype, bool, casting='safe'):
             raise TypeError('Parameter "mask" must be a binary array.')
         mask = mask.astype(np.uint8, copy=False)
-
+    if level == 'average':
+        level = np.average(image)
     segments = _get_contour_segments(image.astype(np.double), float(level),
                                      fully_connected == 'high', mask=mask)
     contours = _assemble_contours(segments)

--- a/skimage/measure/tests/test_find_contours.py
+++ b/skimage/measure/tests/test_find_contours.py
@@ -101,7 +101,7 @@ def test_mask_shape():
 
 
 def test_mask_dtype():
-    bad_mask = np.ones((8,8), dtype=np.uint8)
+    bad_mask = np.ones((8, 8), dtype=np.uint8)
     with raises(TypeError, match='binary'):
         find_contours(a, 0, mask=bad_mask)
 
@@ -130,3 +130,40 @@ def test_invalid_input():
         find_contours(r, 0.5, 'foo', 'bar')
     with testing.raises(ValueError):
         find_contours(r[..., None], 0.5)
+
+
+def test_nodata_levelNone():
+    # Test missing data via NaNs in input array
+    b = np.copy(a)
+    b[~mask] = np.nan
+    contours = find_contours(b, level=None, positive_orientation='high')
+    assert len(contours) == 1
+    assert_array_equal(contours[0], mask_contour)
+
+
+def test_mask_levelNone():
+    # Test missing data via explicit masking
+    contours = find_contours(a, level=None, positive_orientation='high',
+                             mask=mask)
+    assert len(contours) == 1
+    assert_array_equal(contours[0], mask_contour)
+
+
+def test_mask_shape_levelNone():
+    bad_mask = np.ones((8, 7), dtype=bool)
+    with raises(ValueError, match='shape'):
+        find_contours(a, level=None, mask=bad_mask)
+
+
+def test_mask_dtype_levelNone():
+    bad_mask = np.ones((8, 8), dtype=np.uint8)
+    with raises(TypeError, match='binary'):
+        find_contours(a, level=None, mask=bad_mask)
+
+
+def test_memory_order_levelNone():
+    contours = find_contours(np.ascontiguousarray(r), level=None)
+    assert len(contours) == 1
+
+    contours = find_contours(np.asfortranarray(r), level=None)
+    assert len(contours) == 1

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -128,8 +128,8 @@ def convex_hull_object(image, *, connectivity=2):
     objects may overlap in the result. If this is suspected, consider using
     convex_hull_image separately on each object or adjust ``connectivity``.
     """
-    if image.ndim > 3:
-        raise ValueError("Input must be a 2D or 3D image")
+    if image.ndim > 2:
+        raise ValueError("Input must be a 2D image")
 
     if connectivity not in (1, 2):
         raise ValueError('`connectivity` must be either 1 or 2.')

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -128,8 +128,8 @@ def convex_hull_object(image, *, connectivity=2):
     objects may overlap in the result. If this is suspected, consider using
     convex_hull_image separately on each object or adjust ``connectivity``.
     """
-    if image.ndim > 2:
-        raise ValueError("Input must be a 2D image")
+    if image.ndim > 3:
+        raise ValueError("Input must be a 2D or 3D image")
 
     if connectivity not in (1, 2):
         raise ValueError('`connectivity` must be either 1 or 2.')


### PR DESCRIPTION
## Description
Fixes #4813
This PR adds the median as the default level parameter in `find_contours`. After reading the discussion in #4813 and looking at different image arrays [see [notebook](https://github.com/rubywerman/notebooks/blob/master/plot_contours.ipynb)], I thought the median could be a good default value. 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
