### PR TITLE
DOC: Clarify condition on unique vertices returned by marching cubes

### DIFF
--- a/skimage/measure/_marching_cubes_classic.py
+++ b/skimage/measure/_marching_cubes_classic.py
@@ -33,7 +33,9 @@ def marching_cubes_classic(volume, level=None, spacing=(1., 1., 1.),
     -------
     verts : (V, 3) array
         Spatial coordinates for V unique mesh vertices. Coordinate order
-        matches input `volume` (M, N, P).
+        matches input `volume` (M, N, P). If ``allow_degenerate`` is set to
+        True, then the presence of degenerate triangles in the mesh can make
+        this array appear to have duplicate vertices.
     faces : (F, 3) array
         Define triangular faces via referencing vertex indices from ``verts``.
         This algorithm specifically outputs triangles, so each face has

--- a/skimage/measure/_marching_cubes_classic.py
+++ b/skimage/measure/_marching_cubes_classic.py
@@ -35,7 +35,7 @@ def marching_cubes_classic(volume, level=None, spacing=(1., 1., 1.),
         Spatial coordinates for V unique mesh vertices. Coordinate order
         matches input `volume` (M, N, P). If ``allow_degenerate`` is set to
         True, then the presence of degenerate triangles in the mesh can make
-        this array appear to have duplicate vertices.
+        this array have duplicate vertices.
     faces : (F, 3) array
         Define triangular faces via referencing vertex indices from ``verts``.
         This algorithm specifically outputs triangles, so each face has

--- a/skimage/measure/_marching_cubes_lewiner.py
+++ b/skimage/measure/_marching_cubes_lewiner.py
@@ -60,7 +60,9 @@ def marching_cubes(volume, level=None, *, spacing=(1., 1., 1.),
     -------
     verts : (V, 3) array
         Spatial coordinates for V unique mesh vertices. Coordinate order
-        matches input `volume` (M, N, P).
+        matches input `volume` (M, N, P). If ``allow_degenerate`` is set to
+        True, then the presence of degenerate triangles in the mesh can make
+        this array appear to have duplicate vertices.
     faces : (F, 3) array
         Define triangular faces via referencing vertex indices from ``verts``.
         This algorithm specifically outputs triangles, so each face has
@@ -206,7 +208,9 @@ def marching_cubes_lewiner(volume, level=None, spacing=(1., 1., 1.),
     -------
     verts : (V, 3) array
         Spatial coordinates for V unique mesh vertices. Coordinate order
-        matches input `volume` (M, N, P).
+        matches input `volume` (M, N, P). If ``allow_degenerate`` is set to
+        True, then the presence of degenerate triangles in the mesh can make
+        this array appear to have duplicate vertices.
     faces : (F, 3) array
         Define triangular faces via referencing vertex indices from ``verts``.
         This algorithm specifically outputs triangles, so each face has

--- a/skimage/measure/_marching_cubes_lewiner.py
+++ b/skimage/measure/_marching_cubes_lewiner.py
@@ -62,7 +62,7 @@ def marching_cubes(volume, level=None, *, spacing=(1., 1., 1.),
         Spatial coordinates for V unique mesh vertices. Coordinate order
         matches input `volume` (M, N, P). If ``allow_degenerate`` is set to
         True, then the presence of degenerate triangles in the mesh can make
-        this array appear to have duplicate vertices.
+        this array have duplicate vertices.
     faces : (F, 3) array
         Define triangular faces via referencing vertex indices from ``verts``.
         This algorithm specifically outputs triangles, so each face has
@@ -210,7 +210,7 @@ def marching_cubes_lewiner(volume, level=None, spacing=(1., 1., 1.),
         Spatial coordinates for V unique mesh vertices. Coordinate order
         matches input `volume` (M, N, P). If ``allow_degenerate`` is set to
         True, then the presence of degenerate triangles in the mesh can make
-        this array appear to have duplicate vertices.
+        this array have duplicate vertices.
     faces : (F, 3) array
         Define triangular faces via referencing vertex indices from ``verts``.
         This algorithm specifically outputs triangles, so each face has


### PR DESCRIPTION
## Description

`marching_cubes` can actually return non unique vertices if the `allow_degenerate` argument is set to `True`. This is because if `allow_degenerate` is set to `True`, then degenerate triangles are not removed from the mesh, such as zero-area triangles. These triangles have an effect of adding duplicate vertices to the outputted `verts` array. I've added a clarification in the documentation so people won't be confused seeing non unique vertices in their output.

Addresses comments in #4537.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
