### PR TITLE
Remove unmaintained wiki page link in contributor guidelines

### DIFF
--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -8,9 +8,7 @@ list <https://mail.python.org/mailman3/lists/scikit-image.python.org/>`_ and tel
 which of the following challenges you'd like to solve.
 
 * Mentoring is available for those new to scientific programming in Python.
-* If you're looking for something to implement, you can find a list of
-  `requested features on GitHub <https://github.com/scikit-image/scikit-image/wiki/Requested-features>`__.
-  In addition, you can browse the
+* If you're looking for something to implement or to fix, you can browse the
   `open issues on GitHub <https://github.com/scikit-image/scikit-image/issues?q=is%3Aopen>`__.
 * The technical detail of the `development process`_ is summed up below.
   Refer to the :doc:`gitwash <gitwash/index>` for a step-by-step tutorial.


### PR DESCRIPTION
## Description

CC @emmanuelle 

looks like it is not the best idea to put this wiki page on the main entry point for new contributors.
