### PR TITLE
Use matplotlib's infinite axline to demonstrate hough transform

### DIFF
--- a/doc/examples/edges/plot_line_hough_transform.py
+++ b/doc/examples/edges/plot_line_hough_transform.py
@@ -104,14 +104,13 @@ ax[1].set_ylabel('Distance (pixels)')
 ax[1].axis('image')
 
 ax[2].imshow(image, cmap=cm.gray)
-origin = np.array((0, image.shape[1]))
-for _, angle, dist in zip(*hough_line_peaks(h, theta, d)):
-    y0, y1 = (dist - origin * np.cos(angle)) / np.sin(angle)
-    ax[2].plot(origin, (y0, y1), '-r')
-ax[2].set_xlim(origin)
 ax[2].set_ylim((image.shape[0], 0))
 ax[2].set_axis_off()
 ax[2].set_title('Detected lines')
+
+for _, angle, dist in zip(*hough_line_peaks(h, theta, d)):
+    (x0, y0) = dist * np.array([np.cos(angle), np.sin(angle)])
+    ax[2].axline((x0, y0), slope=np.tan(angle + np.pi/2))
 
 plt.tight_layout()
 plt.show()

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,6 @@
 numpy>=1.16.5
 scipy>=1.2.3
-matplotlib>=3.0.3
+matplotlib>=3.3
 networkx>=2.2
 pillow>=5.4.0,!=7.1.0,!=7.1.1
 imageio>=2.4.1

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,6 @@
 numpy>=1.16.5
 scipy>=1.2.3
-matplotlib>=3.3
+matplotlib>=3.0.3
 networkx>=2.2
 pillow>=5.4.0,!=7.1.0,!=7.1.1
 imageio>=2.4.1

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,7 +4,7 @@ numpydoc>=1.0
 sphinx-copybutton
 pytest-runner
 scikit-learn
-matplotlib>=3.0.1
+matplotlib>=3.3
 dask[array]>=0.15.0,!=2.17.0
 # cloudpickle is necessary to provide the 'processes' scheduler for dask
 cloudpickle>=0.2.1


### PR DESCRIPTION
This requires matplotlib 3.3.

It does prevent problems when `np.sin(angle)` is zero.