### PR TITLE
Add pre-commit configuration and instructions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,16 @@
+# See:
+#
+# https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes  (E, W)
+# https://flake8.pycqa.org/en/latest/user/error-codes.html (F)
+# https://github.com/PyCQA/flake8-bugbear
+#
+# for error codes.  And
+#
+# https://flake8.pycqa.org/en/latest/user/violations.html#selecting-violations-with-flake8
+#
+# for error classes selected below.
+
+[flake8]
+max-line-length = 80
+select = C,E,F,W,B,B950
+ignore = E501, W503

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-json
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+    -   id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v0.782'
+    hooks:
+    -   id: mypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,6 +136,8 @@ before_install:
     - python setup.py sdist
     - SDIST_NAME=dist/`python setup.py --fullname`.tar.gz
     - tools/check_sdist.py $SDIST_NAME
+    - pip install pre-commit
+    - pre-commit run -a
 
 install:
     - ccache --show-stats

--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -46,7 +46,12 @@ Here's the long and short of it:
      - ``upstream``, which refers to the ``scikit-image`` repository
      - ``origin``, which refers to your personal fork
 
-2. Develop your contribution:
+2. Install our pre-commit checker (this will verify that your commits
+   comply with PEP8)::
+
+     pip install pre-commit
+
+3. Develop your contribution:
 
    * Pull the latest changes from upstream::
 
@@ -61,7 +66,7 @@ Here's the long and short of it:
 
    * Commit locally as you progress (``git add`` and ``git commit``)
 
-3. To submit your contribution:
+4. To submit your contribution:
 
    * Push your changes back to your fork on GitHub::
 
@@ -81,7 +86,7 @@ Here's the long and short of it:
 For a more detailed discussion, read these :doc:`detailed documents
 <gitwash/index>` on how to use Git with ``scikit-image`` (:ref:`using-git`).
 
-4. Review process:
+5. Review process:
 
    * Reviewers (the other developers and interested community members) will
      write inline and/or general comments on your Pull Request (PR) to help
@@ -106,7 +111,7 @@ For a more detailed discussion, read these :doc:`detailed documents
 
    * A pull request must be approved by two core team members before merging.
 
-5. Document changes
+6. Document changes
 
    If your change introduces any API modifications, please update
    ``doc/source/api_changes.txt``.


### PR DESCRIPTION
I recommend we switch to pre-commit and disable pep8speaks.  Turns out, if you don't enforce it it gets ignored :)  I think this is actually a friendlier experience for contributors, since they get to sort out all the annoying PEP8 nitpicks before review.

Note, the test suite will now definitely fail, but I didn't want to pollute this PR with thousands of PEP8 tweaks.

We can also adjust the PEP8 rules we want to enforce, although I already disabled the ones I think we don't care about.