### PR TITLE
Richardson-Lucy deconvolution: allow single-precision computation

### DIFF
--- a/benchmarks/benchmark_restoration.py
+++ b/benchmarks/benchmark_restoration.py
@@ -1,6 +1,7 @@
 import numpy as np
 from skimage.data import camera
 from skimage import restoration
+import scipy.ndimage as ndi
 
 
 class RestorationSuite:
@@ -61,3 +62,37 @@ class RestorationSuite:
                                      patch_distance=2, sigma=self.sigma,
                                      h=0.7 * self.sigma, fast_mode=True,
                                      multichannel=False)
+
+
+class DeconvolutionSuite:
+    """Benchmark for restoration routines in scikit image."""
+    def setup(self):
+        nz = 32
+        self.volume_f64 = np.stack([camera()[::2, ::2], ] * nz,
+                                   axis=-1).astype(float) / 255
+        self.sigma = .02
+        self.psf_f64 = np.ones((5, 5, 5)) / 125
+        self.psf_f32 = self.psf_f64.astype(np.float32)
+        self.volume_f64 = ndi.convolve(self.volume_f64, self.psf_f64)
+        self.volume_f64 += self.sigma * np.random.randn(*self.volume_f64.shape)
+        self.volume_f32 = self.volume_f64.astype(np.float32)
+
+    def peakmem_setup(self):
+        pass
+
+    def time_richardson_lucy_f64(self):
+        restoration.richardson_lucy(self.volume_f64, self.psf_f64,
+                                    iterations=10)
+
+    def time_richardson_lucy_f32(self):
+        restoration.richardson_lucy(self.volume_f32, self.psf_f32,
+                                    iterations=10)
+
+    # use iterations=1 for peak-memory cases to save time
+    def peakmem_richardson_lucy_f64(self):
+        restoration.richardson_lucy(self.volume_f64, self.psf_f64,
+                                    iterations=1)
+
+    def peakmem_richardson_lucy_f32(self):
+        restoration.richardson_lucy(self.volume_f32, self.psf_f32,
+                                    iterations=1)

--- a/benchmarks/benchmark_restoration.py
+++ b/benchmarks/benchmark_restoration.py
@@ -8,8 +8,7 @@ class RestorationSuite:
     def setup(self):
         nz = 32
         self.volume_f64 = np.stack([camera()[::2, ::2], ] * nz,
-                                  axis=-1).astype(float) / 255
-
+                                   axis=-1).astype(float) / 255
         self.sigma = .05
         self.volume_f64 += self.sigma * np.random.randn(*self.volume_f64.shape)
         self.volume_f32 = self.volume_f64.astype(np.float32)

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -15,7 +15,6 @@ https://scikit-image.org
 New Features
 ------------
 
-
 - A new doc tutorial presenting a cell biology example has been added to the
   gallery (#4648). The scientific content benefited from a much appreciated
   review by Pierre Poulain and Fred Bernard, both assistant professors at
@@ -24,12 +23,16 @@ New Features
 Improvements
 ------------
 
-
+- In ``skimage.restoration.richardson_lucy``, computations are now be done in
+  single-precision when the input image is single-precision. This can give a
+  substantial performance improvement when working with single precision data.
 
 API Changes
 -----------
 
-
+- ``skimage.restoration.richardson_lucy`` returns a single-precision output
+  when the input is single-precision. Prior to this release, double-precision
+  was always used.
 
 Bugfixes
 --------

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -364,9 +364,10 @@ def richardson_lucy(image, psf, iterations=50, clip=True, filter_epsilon=None):
     ----------
     .. [1] https://en.wikipedia.org/wiki/Richardson%E2%80%93Lucy_deconvolution
     """
-    image = image.astype(np.float)
-    psf = psf.astype(np.float)
-    im_deconv = np.full(image.shape, 0.5)
+    float_type = np.promote_types(image.dtype, np.float32)
+    image = image.astype(float_type, copy=False)
+    psf = psf.astype(float_type, copy=False)
+    im_deconv = np.full(image.shape, 0.5, dtype=float_type)
     psf_mirror = np.flip(psf)
 
     for _ in range(iterations):

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -352,8 +352,8 @@ def richardson_lucy(image, psf, iterations=50, clip=True, filter_epsilon=None):
 
     Examples
     --------
-    >>> from skimage import color, data, restoration
-    >>> camera = color.rgb2gray(data.camera())
+    >>> from skimage import img_as_float, data, restoration
+    >>> camera = img_as_float(data.camera())
     >>> from scipy.signal import convolve2d
     >>> psf = np.ones((5, 5)) / 25
     >>> camera = convolve2d(camera, psf, 'same')

--- a/skimage/restoration/tests/test_restoration.py
+++ b/skimage/restoration/tests/test_restoration.py
@@ -1,5 +1,3 @@
-import itertools
-
 import numpy as np
 import pytest
 from scipy.signal import convolve2d
@@ -91,13 +89,8 @@ def test_richardson_lucy():
     np.testing.assert_allclose(deconvolved, np.load(path), rtol=1e-3)
 
 
-@pytest.mark.parametrize(
-    'dtype_image, dtype_psf',
-    itertools.product(
-        [np.float32, np.float64],
-        [np.float32, np.float64],
-    )
-)
+@pytest.mark.parametrize('dtype_image', [np.float32, np.float64])
+@pytest.mark.parametrize('dtype_psf', [np.float32, np.float64])
 def test_richardson_lucy_filtered(dtype_image, dtype_psf):
     if dtype_image == np.float64:
         atol = 1e-8


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->
This PR improves the performance of deconvolution by keeping the computations in single-precision when the input image is single-precision.

It also avoids unnecessary copies of the input arrays by adding `copy=False` to existing `.astype()` calls.

This can give up to a factor 2 performance improvement when calling Richardson Lucy either single-threaded or in various multi-threaded scenarios.  See the timings for double-precision in https://github.com/scikit-image/scikit-image/issues/4083#issuecomment-667611962 vs. single-precision in https://github.com/scikit-image/scikit-image/issues/4083#issuecomment-667612287.

If this seems reasonable to others, I can also adapt the example from the comments into an ASV benchmark.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
