### PR TITLE
Raise ValueError if NaN found in phase_cross_correlation result

### DIFF
--- a/skimage/registration/__init__.py
+++ b/skimage/registration/__init__.py
@@ -1,9 +1,7 @@
 from ._optical_flow import optical_flow_tvl1
 from ._phase_cross_correlation import phase_cross_correlation
-from ._masked_phase_cross_correlation import cross_correlate_masked
 
 __all__ = [
     'optical_flow_tvl1',
-    'phase_cross_correlation',
-    'cross_correlate_masked'
+    'phase_cross_correlation'
     ]

--- a/skimage/registration/__init__.py
+++ b/skimage/registration/__init__.py
@@ -1,8 +1,9 @@
 from ._optical_flow import optical_flow_tvl1
 from ._phase_cross_correlation import phase_cross_correlation
-
+from ._masked_phase_cross_correlation import cross_correlate_masked
 
 __all__ = [
     'optical_flow_tvl1',
-    'phase_cross_correlation'
+    'phase_cross_correlation',
+    'cross_correlate_masked'
     ]

--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -264,6 +264,11 @@ def phase_cross_correlation(reference_image, moving_image, *,
             shifts[dim] = 0
 
     if return_error:
+        # Redirect user to masked_phase_cross_correlation if NaNs are observed
+        if np.isnan(CCmax) or np.isnan(src_amp) or np.isnan(target_amp):
+            raise ValueError("NaN values found, please use the scikit-image "
+                "'cross_correlate_masked' function instead.")
+
         return shifts, _compute_error(CCmax, src_amp, target_amp),\
             _compute_phasediff(CCmax)
     else:

--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -266,7 +266,8 @@ def phase_cross_correlation(reference_image, moving_image, *,
     if return_error:
         # Redirect user to masked_phase_cross_correlation if NaNs are observed
         if np.isnan(CCmax) or np.isnan(src_amp) or np.isnan(target_amp):
-            raise ValueError("NaN values found, please remove NaNs from your "
+            raise ValueError(
+                "NaN values found, please remove NaNs from your "
                 "input data or use the `reference_mask`/`moving_mask` "
                 "keywords, eg: "
                 "phase_cross_correlation(reference_image, moving_image, "

--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -266,8 +266,12 @@ def phase_cross_correlation(reference_image, moving_image, *,
     if return_error:
         # Redirect user to masked_phase_cross_correlation if NaNs are observed
         if np.isnan(CCmax) or np.isnan(src_amp) or np.isnan(target_amp):
-            raise ValueError("NaN values found, please use the scikit-image "
-                "'cross_correlate_masked' function instead.")
+            raise ValueError("NaN values found, please remove NaNs from your "
+                "input data or use the `reference_mask`/`moving_mask` "
+                "keywords, eg: "
+                "phase_cross_correlation(reference_image, moving_image, "
+                "reference_mask=~np.isnan(reference_image), "
+                "moving_mask=~np.isnan(moving_image))")
 
         return shifts, _compute_error(CCmax, src_amp, target_amp),\
             _compute_phasediff(CCmax)

--- a/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_phase_cross_correlation.py
@@ -105,6 +105,13 @@ def test_wrong_input():
     with testing.raises(ValueError):
         phase_cross_correlation(template, image)
 
+    # NaN values in data
+    image = np.ones((5, 5))
+    image[0][0] = np.nan
+    template = np.ones((5, 5))
+    with testing.raises(ValueError):
+        phase_cross_correlation(template, image, return_error=True)
+
 
 def test_4d_input_pixel():
     phantom = img_as_float(binary_blobs(length=32, n_dim=4))


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

Closes https://github.com/scikit-image/scikit-image/issues/4763

As requested by @emmanuelle in https://github.com/scikit-image/scikit-image/pull/4767#issuecomment-668082059

This PR raises a `ValueError` if a NaN value is found in the error or phase_diff, indicating that there were unexpected NaN values in the input data. 

Note: this check *only* occurs if the keyword argument `return_error=True`, which is the default value for this kwarg in `phase_cross_correlation`. If `return_error=False` then there is no check, and it's possible to get a garbage shift result of zero back if the input data accidentally contained NaNs. This is because it's computationally expensive to check a large array for NaN values, which is what we'd have to do if `return_error=False`. Still, it seems helpful if we can catch at least some of these mistakes and redirect the user to the masked cross correlation functionality instead.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
