### PR TITLE
added script for plausible analytics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,12 +24,6 @@ jobs:
       - store_artifacts:
           path: doc/build/html
           destination: doc/build/html
-      # Persists generated documentation so that it can be attached and deployed
-      # in the 'deploy' step.
-      # - persist_to_workspace:
-      #    root: doc/build/html
-      #    paths: .
-
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,9 @@ jobs:
           destination: doc/build/html
       # Persists generated documentation so that it can be attached and deployed
       # in the 'deploy' step.
-      - persist_to_workspace:
-          root: doc/build/html
-          paths: .
+      # - persist_to_workspace:
+      #    root: doc/build/html
+      #    paths: .
 
 
 workflows:

--- a/doc/source/themes/scikit-image/layout.html
+++ b/doc/source/themes/scikit-image/layout.html
@@ -78,6 +78,8 @@
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
     <link rel="shortcut icon" href="{{ pathto('_static/', 1) }}favicon.ico">
     {%- block extrahead %}{% endblock %}
+    <!-- Plausible analytics -->
+    <script async defer data-domain="scikit-image.org" src="https://plausible.io/js/plausible.js"></script>
 </head>
 <body class="container">
     <a href="https://scikit-image.org" class="logo"><img src="{{ pathto('_static/', 1) }}img/logo.png" alt=""></a>


### PR DESCRIPTION
At the moment we have a script corresponding to Matomo Analytics, where we have a 21-day trial plan. However, Juan recently discovered Plausible Analytics, which is an open source alternative to Matomo. Both solutions are open-source and don't sell your data. Plausible seems to be cheaper.

This PR adds the script for plausible. The idea is to compare both solutions and to take a paid plan before the end of the trial plan.