### PR TITLE
Fix so docs properly render

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -1026,6 +1026,7 @@ def regionprops(label_image, intensity_image=None, cache=True,
     (22.72987986048314, 81.91228523446583)
 
     Add custom measurements by passing functions as ``extra_properties``
+    
     >>> from skimage import data, util
     >>> from skimage.measure import label, regionprops
     >>> import numpy as np

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -1026,7 +1026,7 @@ def regionprops(label_image, intensity_image=None, cache=True,
     (22.72987986048314, 81.91228523446583)
 
     Add custom measurements by passing functions as ``extra_properties``
-    
+
     >>> from skimage import data, util
     >>> from skimage.measure import label, regionprops
     >>> import numpy as np


### PR DESCRIPTION
This is a small fix so that the docs properly render in html (right now the code section is interpreted as text):
https://scikit-image.org/docs/dev/api/skimage.measure.html?highlight=region%20props#regionprops