### PR TITLE
minor refactoring in phase_cross_correlation

### DIFF
--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -250,11 +250,9 @@ def phase_cross_correlation(reference_image, moving_image, *,
         shifts = shifts + maxima / upsample_factor
 
         if return_error:
-            src_amp = _upsampled_dft(src_freq * src_freq.conj(),
-                                     1, upsample_factor)[0, 0]
+            src_amp = np.sum(np.real(src_freq * src_freq.conj()))
             src_amp /= normalization
-            target_amp = _upsampled_dft(target_freq * target_freq.conj(),
-                                        1, upsample_factor)[0, 0]
+            target_amp = np.sum(np.real(target_freq * target_freq.conj()))
             target_amp /= normalization
 
     # If its only one row or column the shift along that dimension has no

--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -234,14 +234,12 @@ def phase_cross_correlation(reference_image, moving_image, *,
         # Center of output array at dftshift + 1
         dftshift = np.fix(upsampled_region_size / 2.0)
         upsample_factor = np.array(upsample_factor, dtype=np.float64)
-        normalization = (src_freq.size * upsample_factor ** src_freq.ndim)
         # Matrix multiply DFT around the current shift estimate
         sample_region_offset = dftshift - shifts*upsample_factor
         cross_correlation = _upsampled_dft(image_product.conj(),
                                            upsampled_region_size,
                                            upsample_factor,
                                            sample_region_offset).conj()
-        cross_correlation /= normalization
         # Locate maximum and map back to original pixel grid
         maxima = np.unravel_index(np.argmax(np.abs(cross_correlation)),
                                   cross_correlation.shape)
@@ -253,9 +251,7 @@ def phase_cross_correlation(reference_image, moving_image, *,
 
         if return_error:
             src_amp = np.sum(np.real(src_freq * src_freq.conj()))
-            src_amp /= normalization
             target_amp = np.sum(np.real(target_freq * target_freq.conj()))
-            target_amp /= normalization
 
     # If its only one row or column the shift along that dimension has no
     # effect. We set to zero.

--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -221,8 +221,10 @@ def phase_cross_correlation(reference_image, moving_image, *,
 
     if upsample_factor == 1:
         if return_error:
-            src_amp = np.sum(np.abs(src_freq) ** 2) / src_freq.size
-            target_amp = np.sum(np.abs(target_freq) ** 2) / target_freq.size
+            src_amp = np.sum(np.real(src_freq * src_freq.conj()))
+            src_amp /= src_freq.size
+            target_amp = np.sum(np.real(target_freq * target_freq.conj()))
+            target_amp /= target_freq.size
             CCmax = cross_correlation[maxima]
     # If upsampling > 1, then refine estimate with matrix multiply DFT
     else:

--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -234,7 +234,7 @@ def phase_cross_correlation(reference_image, moving_image, *,
         # Center of output array at dftshift + 1
         dftshift = np.fix(upsampled_region_size / 2.0)
         upsample_factor = np.array(upsample_factor, dtype=np.float64)
-        normalization = (src_freq.size * upsample_factor ** 2)
+        normalization = (src_freq.size * upsample_factor ** src_freq.ndim)
         # Matrix multiply DFT around the current shift estimate
         sample_region_offset = dftshift - shifts*upsample_factor
         cross_correlation = _upsampled_dft(image_product.conj(),


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

This PR is just a minor cleanup of a few things in `phase_cross_correlation` and does not modify the behavior of the function. The commits can be reviewed sequentially with explanations given below.

When looking at #4886, I noticed calls to upsampled DFT that are only calculating a single element at the DC frequency. In that case, as far as I can tell, the `_upsampled_dft` call is equivalent to just calling `sum` (consistent with the code path for the upsample_factor=1 case). Here is an empirical verification that they are the same:

```Python
import numpy as np
from skimage.registration._phase_cross_correlation import _upsampled_dft
x = np.random.randn(64, 64) + 1j*np.random.randn(64, 64)

np.testing.assert_allclose(
    _upsampled_dft(x*x.conj(), 1, upsample_factor=10).ravel()[0],
    np.sum(x*x.conj())
)
```

The second commit just replaces code of the form `abs(x)**2` with the equivalent `np.real(x*x.conj())`. Currently the former convention was used in the upsample = 1 code path, but the latter was used in the upsampled code path. This commit makes the two paths consistent.

Elsewhere, the normalization factor for the upsample_factor != 1 case had a value that is equal to the number of pixels in the upsampled case, but the calculation was only correct for 2D images because it used `**2` instead of `**ndim` (see commit cafd737).

Fortunately this error in computing the number of pixels did not actually result in a bug, though, because as long as `CCmax`, `src_amp` and `target_amp` are all multiplied by the same scaling factor, the returned values will be the same. Given that, we can just remove the normalization.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
