### PR TITLE
accelerate the masked slic superpixels algorithm

### DIFF
--- a/benchmarks/benchmark_segmentation.py
+++ b/benchmarks/benchmark_segmentation.py
@@ -20,7 +20,6 @@ class SlicSegmentation:
             self.slic_kwargs = {}
 
     def time_slic_basic(self):
-
         segmentation.slic(self.image, enforce_connectivity=False,
                           multichannel=False, **self.slic_kwargs)
 

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -27,6 +27,11 @@ Improvements
   single-precision when the input image is single-precision. This can give a
   substantial performance improvement when working with single precision data.
 
+- The performance of the SLIC superpixels algorithm
+  (``skimage.segmentation.slice``) was improved for the case where a mask
+  is supplied by the user (#4903). The specific superpixels produced by
+  masked SLIC will not be identical to those produced by prior releases.
+
 API Changes
 -----------
 

--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -12,7 +12,7 @@ from ..util import img_as_float, regular_grid
 from ..color import rgb2lab
 
 
-def _get_mask_centroids(mask, n_centroids):
+def _get_mask_centroids(mask, n_centroids, multichannel):
     """Find regularly spaced centroids on a mask.
 
     Parameters
@@ -48,7 +48,8 @@ def _get_mask_centroids(mask, n_centroids):
     # somewhat arbitrarily choose dense_factor=10 to make the samples
     # 10 times closer together along each axis than the n_centroids samples.
     dense_factor = 10
-    n_dense = (dense_factor ** mask.ndim) * n_centroids
+    ndim_spatial = mask.ndim - 1 if multichannel else mask.ndim
+    n_dense = int((dense_factor ** ndim_spatial) * n_centroids)
     if len(coord) > n_dense:
         # subset of points to use for the k-means calculation
         # (much denser than idx, but less than the full set)
@@ -274,7 +275,7 @@ def slic(image, n_segments=100, compactness=10., max_iter=10, sigma=0,
             mask = np.ascontiguousarray(mask[np.newaxis, ...])
         if mask.shape != image.shape[:3]:
             raise ValueError("image and mask should have the same shape.")
-        centroids, steps = _get_mask_centroids(mask, n_segments)
+        centroids, steps = _get_mask_centroids(mask, n_segments, multichannel)
         update_centroids = True
     else:
         centroids, steps = _get_grid_centroids(image, n_segments)


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

This PR is related to #4902. For the image of shape (400, 400, 100) used in the benchmarks (`with multichannel=False`), I get a time of 59 seconds prior to this change where >60% of the time is taken up by the call to `kmeans2` in `_get_mask_centroids`. 

Two ways to make the kmeans2 call run faster are:
1.) use a subset of the full set of points for the first argument.
2.) lower the number of k-means iterations from SciPy's default value of 10.

This gives a reduction from 59.4 s to 19.9 s to run the `time_mask_slic` benchmark. Before this change ~60% of the execution time is in `_get_mask_slic` while afterwards it is around 5%.

After this change the `slic` output is still deterministic, but the starting centroids would not be identical to prior releases. If that is a problem, we could add a flag to only enable this acceleration on request.

One unresolved question is how many iterations and what density of samples is most appropriate. I set `dense_factor=10` empirically. It may be possible to use a somewhat lower value, but there is very little further performance gain, at least for the benchmark case. Also, with `dense_factor` of 1 or 2 I sometimes see warnings like:

```
scipy/cluster/vq.py:574:
UserWarning: One of the clusters is empty. Re-run kmeans with a different initialization.
  warnings.warn("One of the clusters is empty. "
```

For the `mask_time_slic` benchmark case there are 25,992,000 nonzero voxels in the mask, but after the change in this PR we will only use a much smaller subset of these in `kmeans2`. After this change, for the benchmark example, ``n_dense = (dense_factor**ndim) * n_centroids`` is only 100,000 out of 25,992,000 points. 



## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
