### PR TITLE
Fix edge filters do not respect padding mode

### DIFF
--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -175,7 +175,7 @@ def _generic_edge_filter(image, *, smooth_weights, edge_weights=[1, 0, -1],
         smooth_axes = list(set(range(ndim)) - {edge_dim})
         for smooth_dim in smooth_axes:
             kernel = kernel * _reshape_nd(smooth_weights, ndim, smooth_dim)
-        ax_output = ndi.convolve(image, kernel, mode='reflect')
+        ax_output = ndi.convolve(image, kernel, mode=mode)
         if return_magnitude:
             ax_output *= ax_output
         output += ax_output


### PR DESCRIPTION
## Description

Bug-fix for edge filters not respecting the padding mode.
skimage.filters.edges._generic_edge_filter does not make use of mode parameter.

<!-- ## Checklist -->

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
<!-- - [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py) -->
<!-- - Gallery example in `./doc/examples` (new features only) -->
<!-- - Benchmark in `./benchmarks`, if your changes aren't covered by an -->
<!--   existing benchmark -->
<!-- - Unit tests -->
<!-- - Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/) -->

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
