### PR TITLE
Block sphinx versions for which links from search engine are broken

### DIFF
--- a/requirements/README.md
+++ b/requirements/README.md
@@ -39,3 +39,5 @@ $ pip install -U -r requirements/test.txt
 * pillow 7.1.0 fails on png files, See https://github.com/scikit-image/scikit-image/issues/4548
 * pillow 7.1.1 fails due to https://github.com/python-pillow/Pillow/issues/4518
 * imread 0.7.2 fails due to bluid failure https://github.com/luispedro/imread/issues/36
+* sphinx 3.0.x are blocked due to broken search links https://github.com/scikit-image/scikit-image/issues/4616
+* sphinx 3.1.0 is blocked due to https://github.com/sphinx-doc/sphinx/issues/7802

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,6 @@
-sphinx>=1.8,<=2.4.4
-sphinx-gallery>=0.7.0
-numpydoc>=1.0
+sphinx>=1.8,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3,!=3.0.4
+numpydoc>=0.9
+sphinx-gallery>=0.3.1
 sphinx-copybutton
 pytest-runner
 scikit-learn

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,6 @@
 sphinx>=1.8,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3,!=3.0.4
-numpydoc>=0.9
-sphinx-gallery>=0.3.1
+sphinx-gallery>=0.7.0
+numpydoc>=1.0
 sphinx-copybutton
 pytest-runner
 scikit-learn


### PR DESCRIPTION
## Description

Attempt to close #4647 

-> need to check that the search engine is working for sphinx>=3.1.0


## 3.0.x

links are broken

## 3.1.0

Failure due to https://github.com/sphinx-doc/sphinx/issues/7802

## >=3.1.1

not checked yet

## 3.2.0

On my computer, with sphinx==3.2.0 (4 days ago), I have

```
Sphinx parallel build error:
KeyError: 'Shiboken'
```

But build is successful on circle-ci... however, the links are still broken.
