### PR TITLE
Fixes to apply_parallel for functions working with multichannel data

### DIFF
--- a/skimage/util/apply_parallel.py
+++ b/skimage/util/apply_parallel.py
@@ -89,11 +89,11 @@ def apply_parallel(function, array, chunks=None, depth=0, mode=None,
     extra_keywords : dictionary, optional
         Dictionary of keyword arguments to be passed to the function.
     dtype : data-type or None, optional
-        The data-type of the output array. If None, Dask will attempt to infer
-        this by calling the function on data of shape ``(1,) * ndim``. For
-        functions expecting RGB or multichannel data this may be problematic.
-        In such cases, the user should manually specify this dtype argument
-        instead.
+        The data-type of the `function` output. If None, Dask will attempt to
+        infer this by calling the function on data of shape ``(1,) * ndim``.
+        For functions expecting RGB or multichannel data this may be
+        problematic. In such cases, the user should manually specify this dtype
+        argument instead.
 
         .. versionadded:: 0.18
            ``dtype`` was added in 0.18.

--- a/skimage/util/apply_parallel.py
+++ b/skimage/util/apply_parallel.py
@@ -53,7 +53,8 @@ def _ensure_dask_array(array, chunks=None):
 
 
 def apply_parallel(function, array, chunks=None, depth=0, mode=None,
-                   extra_arguments=(), extra_keywords={}, *, compute=None):
+                   extra_arguments=(), extra_keywords={}, *, dtype=None,
+                   compute=None):
     """Map a function in parallel across an array.
 
     Split an array into possibly overlapping chunks of a given depth and
@@ -84,6 +85,14 @@ def apply_parallel(function, array, chunks=None, depth=0, mode=None,
         Tuple of arguments to be passed to the function.
     extra_keywords : dictionary, optional
         Dictionary of keyword arguments to be passed to the function.
+    dtype : data-type or None, optional
+        The data-type of the output array. If None, Dask will attempt to infer
+        this by calling the function on data of shape ``(1,) * ndim``. For
+        functions expecting RGB or multichannel data this may be problematic.
+        In such cases, the user should manually specify this dtype argument
+        instead.
+        .. versionadded:: 0.18
+           ``dtype`` was added in 0.18.
     compute : bool, optional
         If ``True``, compute eagerly returning a NumPy Array.
         If ``False``, compute lazily returning a Dask Array.
@@ -140,7 +149,7 @@ def apply_parallel(function, array, chunks=None, depth=0, mode=None,
 
     darr = _ensure_dask_array(array, chunks=chunks)
 
-    res = darr.map_overlap(wrapped_func, depth, boundary=mode)
+    res = darr.map_overlap(wrapped_func, depth, boundary=mode, dtype=dtype)
     if compute:
         res = res.compute()
 

--- a/skimage/util/tests/test_apply_parallel.py
+++ b/skimage/util/tests/test_apply_parallel.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from skimage._shared.testing import assert_array_almost_equal
+from skimage import color, data
 from skimage.filters import threshold_local, gaussian
 from skimage.util.apply_parallel import apply_parallel
 
@@ -94,3 +95,16 @@ def test_apply_parallel_nearest():
                             mode='nearest')
 
     assert_array_almost_equal(result, expected)
+
+
+@pytest.mark.parametrize('chunks', (None, (128, 128, 3), 128))
+@pytest.mark.parametrize('depth', (0, 8, (8, 8, 0)))
+def test_apply_parallel_rgb(depth, chunks):
+    cat = data.chelsea() / 255.
+
+    func = color.rgb2ycbcr
+    cat_ycbcr_expected = func(cat)
+    cat_ycbcr = apply_parallel(func, cat, chunks=chunks, depth=depth,
+                               dtype=cat.dtype, multichannel=True)
+
+    assert_array_almost_equal(cat_ycbcr_expected, cat_ycbcr)

--- a/skimage/util/tests/test_apply_parallel.py
+++ b/skimage/util/tests/test_apply_parallel.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from skimage._shared.testing import assert_array_almost_equal
+from skimage._shared.testing import assert_array_almost_equal, assert_equal
 from skimage import color, data
 from skimage.filters import threshold_local, gaussian
 from skimage.util.apply_parallel import apply_parallel
@@ -97,14 +97,17 @@ def test_apply_parallel_nearest():
     assert_array_almost_equal(result, expected)
 
 
-@pytest.mark.parametrize('chunks', (None, (128, 128, 3), 128))
+@pytest.mark.parametrize('dtype', (np.float32, np.float64))
+@pytest.mark.parametrize('chunks', (None, (128, 128, 3)))
 @pytest.mark.parametrize('depth', (0, 8, (8, 8, 0)))
-def test_apply_parallel_rgb(depth, chunks):
-    cat = data.chelsea() / 255.
+def test_apply_parallel_rgb(depth, chunks, dtype):
+    cat = data.chelsea().astype(dtype) / 255.
 
     func = color.rgb2ycbcr
     cat_ycbcr_expected = func(cat)
     cat_ycbcr = apply_parallel(func, cat, chunks=chunks, depth=depth,
-                               dtype=cat.dtype, multichannel=True)
+                               dtype=dtype, multichannel=True)
+
+    assert_equal(cat_ycbcr.dtype, cat.dtype)
 
     assert_array_almost_equal(cat_ycbcr_expected, cat_ycbcr)


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->
closes #4900

The `multichannel` argument helps give sensible default chunks and expands scalar `depth` arguments appropriately for multichannel data.

A concrete example where the `dtype` argument is needed for this to pass was added as a test case. There is an explanation of the reason it is needed in https://github.com/scikit-image/scikit-image/issues/4900#issuecomment-675647296.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
