### PR TITLE
MAINT: remove numpydoc option, issue fixed in numpydoc 1.0

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -120,8 +120,5 @@ Other
   when texlive 2020 is available.
 * Once NumPy is set to >= 1.17, consider removing
   ``skimage.morphology._util._fast_pad``.
-* Once numpydoc > 0.9.x (ie https://github.com/numpy/numpydoc/pull/256) is
-  released, remove `strip_signature_backslash = True` in
-  ``doc/source/conf.py``.
 * When sphinx-gallery>=0.9.0, remove the thumbnail_size in
   doc/source/conf.py as the default value will be comparable (#4801).

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,10 +29,6 @@ sys.path.append(os.path.join(curpath, '..', 'ext'))
 
 # -- General configuration -----------------------------------------------------
 
-# Strip backslahes in function's signature
-# To be removed when numpydoc > 0.9.x
-strip_signature_backslash = True
-
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx_copybutton',

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,5 +1,5 @@
 sphinx>=1.8,<=2.4.4
-numpydoc>=0.9
+numpydoc>=1.0
 sphinx-gallery>=0.3.1
 sphinx-copybutton
 pytest-runner


### PR DESCRIPTION
## Description



## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
