### PR TITLE
Add fluorescence microscopy images to data registry.

### DIFF
--- a/doc/examples/data/plot_scientific.py
+++ b/doc/examples/data/plot_scientific.py
@@ -15,6 +15,7 @@ matplotlib.rcParams['font.size'] = 18
 
 images = ('hubble_deep_field',
           'immunohistochemistry',
+          'lily',
           'microaneurysms',
           'moon',
           'retina',

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -38,6 +38,7 @@ __all__ = ['data_dir',
            'hubble_deep_field',
            'immunohistochemistry',
            'lbp_frontal_face_cascade_filename',
+           'lily',
            'lfw_subset',
            'logo',
            'microaneurysms',
@@ -646,6 +647,19 @@ def coins():
         Coins image.
     """
     return _load("data/coins.png")
+
+
+def lily():
+    """Microscopy image of a lily of the valley.
+    See `lily-of-the-valley-fluorescence.tif` entry at
+    https://gitlab.com/scikit-image/data/-/blob/master/README.md#data
+
+    Returns
+    -------
+    lily : (922, 922, 4) uint16 ndarray
+        Lily image.
+    """
+    return _load("data/lily.tif")
 
 
 def logo():

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -651,27 +651,50 @@ def coins():
 
 
 def kidney():
-    """Microscopy image of kidney tissue.
-    See `kidney-tissue-fluorescence.tif` entry at
-    https://gitlab.com/scikit-image/data/-/blob/master/README.md#data
+    """Mouse kidney tissue.
+
+    This biological tissue on a pre-prepared slide was imaged with confocal
+    fluorescence microscopy (Nikon C1 inverted microscope).
+    Image shape is (16, 512, 512, 3). That is 512x512 pixels in X-Y,
+    16 image slices in Z, and 3 color channels
+    (emission wavelengths 450nm, 515nm, and 605nm, respectively).
+    Real-space voxel size is 1.24 microns in X-Y, and 1.25 microns in Z.
+    Data type is unsigned 16-bit integers.
+
+    Notes
+    -----
+    This image was acquired by Genevieve Buckley at Monasoh Micro Imaging in
+    2018.
+    License: CC0
 
     Returns
     -------
     kidney : (16, 512, 512, 3) uint16 ndarray
-        Kidney image.
+        Kidney 3D multichannel image.
     """
     return _load("data/kidney.tif")
 
 
 def lily():
-    """Microscopy image of a lily of the valley.
-    See `lily-of-the-valley-fluorescence.tif` entry at
-    https://gitlab.com/scikit-image/data/-/blob/master/README.md#data
+    """Lily of the valley plant stem.
+
+    This plant stem on a pre-prepared slide was imaged with confocal
+    fluorescence microscopy (Nikon C1 inverted microscope).
+    Image shape is (922, 922, 4). That is 922x922 pixels in X-Y,
+    with 4 color channels.
+    Real-space voxel size is 1.24 microns in X-Y.
+    Data type is unsigned 16-bit integers.
+
+    Notes
+    -----
+    This image was acquired by Genevieve Buckley at Monasoh Micro Imaging in
+    2018.
+    License: CC0
 
     Returns
     -------
     lily : (922, 922, 4) uint16 ndarray
-        Lily image.
+        Lily 2D multichannel image.
     """
     return _load("data/lily.tif")
 

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -37,6 +37,7 @@ __all__ = ['data_dir',
            'horse',
            'hubble_deep_field',
            'immunohistochemistry',
+           'kidney',
            'lbp_frontal_face_cascade_filename',
            'lily',
            'lfw_subset',
@@ -647,6 +648,19 @@ def coins():
         Coins image.
     """
     return _load("data/coins.png")
+
+
+def kidney():
+    """Microscopy image of kidney tissue.
+    See `kidney-tissue-fluorescence.tif` entry at
+    https://gitlab.com/scikit-image/data/-/blob/master/README.md#data
+
+    Returns
+    -------
+    kidney : (16, 512, 512, 3) uint16 ndarray
+        Kidney image.
+    """
+    return _load("data/kidney.tif")
 
 
 def lily():

--- a/skimage/data/_registry.py
+++ b/skimage/data/_registry.py
@@ -130,12 +130,14 @@ registry = {
     "registration/tests/data/TransformedX130Y130.png": "bb10c6ae3f91a313b0ac543efdb7ca69c4b95e55674c65a88472a6c4f4692a25",
     "registration/tests/data/TransformedX75Y75.png": "a1e9ead5f8e4a0f604271e1f9c50e89baf53f068f1d19fab2876af4938e695ea",
     "data/cells.tif": "2120cfe08e0396324793a10a905c9bbcb64b117215eb63b2c24b643e1600c8c9",
+    "data/kidney-tissue-fluorescence.tif": "80c0799bc58b08cf6eaa53ecd202305eb42fd7bc73746cb6c5064dbeae7e8476",
     "data/mitosis.tif": "2751ba667c4067c5d30817cff004aa06f6f6287f1cdbb5b8c9c6a500308cb456",
 }
 
 registry_urls = {
     "data/cells.tif": "https://github.com/scikit-image/skimage-tutorials/raw/master/images/cells.tif",
     "data/eagle.png": "https://gitlab.com/scikit-image/data/-/raw/master/eagle.png",
+    "data/kidney-tissue-fluorescence.tif": "https://gitlab.com/scikit-image/data/-/raw/master/kidney-tissue-fluorescence.tif",
     "data/mitosis.tif": "https://gitlab.com/scikit-image/data/-/raw/master/AS_09125_050116030001_D03f00d0.tif",
     "restoration/tests/astronaut_rl.npy": "https://gitlab.com/scikit-image/data/-/raw/master/astronaut_rl.npy",
 }

--- a/skimage/data/_registry.py
+++ b/skimage/data/_registry.py
@@ -130,16 +130,16 @@ registry = {
     "registration/tests/data/TransformedX130Y130.png": "bb10c6ae3f91a313b0ac543efdb7ca69c4b95e55674c65a88472a6c4f4692a25",
     "registration/tests/data/TransformedX75Y75.png": "a1e9ead5f8e4a0f604271e1f9c50e89baf53f068f1d19fab2876af4938e695ea",
     "data/cells.tif": "2120cfe08e0396324793a10a905c9bbcb64b117215eb63b2c24b643e1600c8c9",
-    "data/kidney-tissue-fluorescence.tif": "80c0799bc58b08cf6eaa53ecd202305eb42fd7bc73746cb6c5064dbeae7e8476",
-    "data/lily-of-the-valley-fluorescence.tif": "395c2f0194c25b9824a8cd79266920362a0816bc9e906dd392adce2d8309af03",
+    "data/kidney.tif": "80c0799bc58b08cf6eaa53ecd202305eb42fd7bc73746cb6c5064dbeae7e8476",
+    "data/lily.tif": "395c2f0194c25b9824a8cd79266920362a0816bc9e906dd392adce2d8309af03",
     "data/mitosis.tif": "2751ba667c4067c5d30817cff004aa06f6f6287f1cdbb5b8c9c6a500308cb456",
 }
 
 registry_urls = {
     "data/cells.tif": "https://github.com/scikit-image/skimage-tutorials/raw/master/images/cells.tif",
     "data/eagle.png": "https://gitlab.com/scikit-image/data/-/raw/master/eagle.png",
-    "data/kidney-tissue-fluorescence.tif": "https://gitlab.com/scikit-image/data/-/raw/master/kidney-tissue-fluorescence.tif",
-    "data/lily-of-the-valley-fluorescence.tif": "https://gitlab.com/scikit-image/data/-/raw/master/lily-of-the-valley-fluorescence.tif",
+    "data/kidney.tif": "https://gitlab.com/scikit-image/data/-/raw/master/kidney-tissue-fluorescence.tif",
+    "data/lily.tif": "https://gitlab.com/scikit-image/data/-/raw/master/lily-of-the-valley-fluorescence.tif",
     "data/mitosis.tif": "https://gitlab.com/scikit-image/data/-/raw/master/AS_09125_050116030001_D03f00d0.tif",
     "restoration/tests/astronaut_rl.npy": "https://gitlab.com/scikit-image/data/-/raw/master/astronaut_rl.npy",
 }

--- a/skimage/data/_registry.py
+++ b/skimage/data/_registry.py
@@ -131,6 +131,7 @@ registry = {
     "registration/tests/data/TransformedX75Y75.png": "a1e9ead5f8e4a0f604271e1f9c50e89baf53f068f1d19fab2876af4938e695ea",
     "data/cells.tif": "2120cfe08e0396324793a10a905c9bbcb64b117215eb63b2c24b643e1600c8c9",
     "data/kidney-tissue-fluorescence.tif": "80c0799bc58b08cf6eaa53ecd202305eb42fd7bc73746cb6c5064dbeae7e8476",
+    "data/lily-of-the-valley-fluorescence.tif": "395c2f0194c25b9824a8cd79266920362a0816bc9e906dd392adce2d8309af03",
     "data/mitosis.tif": "2751ba667c4067c5d30817cff004aa06f6f6287f1cdbb5b8c9c6a500308cb456",
 }
 
@@ -138,6 +139,7 @@ registry_urls = {
     "data/cells.tif": "https://github.com/scikit-image/skimage-tutorials/raw/master/images/cells.tif",
     "data/eagle.png": "https://gitlab.com/scikit-image/data/-/raw/master/eagle.png",
     "data/kidney-tissue-fluorescence.tif": "https://gitlab.com/scikit-image/data/-/raw/master/kidney-tissue-fluorescence.tif",
+    "data/lily-of-the-valley-fluorescence.tif": "https://gitlab.com/scikit-image/data/-/raw/master/lily-of-the-valley-fluorescence.tif",
     "data/mitosis.tif": "https://gitlab.com/scikit-image/data/-/raw/master/AS_09125_050116030001_D03f00d0.tif",
     "restoration/tests/astronaut_rl.npy": "https://gitlab.com/scikit-image/data/-/raw/master/astronaut_rl.npy",
 }

--- a/skimage/data/tests/test_data.py
+++ b/skimage/data/tests/test_data.py
@@ -153,4 +153,11 @@ def test_cells_3d():
     assert image.shape == (60, 256, 256)
 
 
+def test_kidney_3d_multichannel():
+    """Test that 3D multichannel image of kidney tissue can be loaded.
 
+    Needs internet connection.
+    """
+    path = fetch('data/kidney-tissue-fluorescence.tif')
+    image = io.imread(path)
+    assert image.shape == (16, 512, 512, 3)

--- a/skimage/data/tests/test_data.py
+++ b/skimage/data/tests/test_data.py
@@ -161,3 +161,13 @@ def test_kidney_3d_multichannel():
     path = fetch('data/kidney.tif')
     image = io.imread(path)
     assert image.shape == (16, 512, 512, 3)
+
+
+def test_lily_multichannel():
+    """Test that microscopy image of lily of the valley can be loaded.
+
+    Needs internet connection.
+    """
+    fetch('data/lily.tif')
+    lily = data.lily()
+    assert lily.shape == (922, 922, 4)

--- a/skimage/data/tests/test_data.py
+++ b/skimage/data/tests/test_data.py
@@ -158,9 +158,9 @@ def test_kidney_3d_multichannel():
 
     Needs internet connection.
     """
-    path = fetch('data/kidney.tif')
-    image = io.imread(path)
-    assert image.shape == (16, 512, 512, 3)
+    fetch('data/kidney.tif')
+    kidney = data.kidney()
+    assert kidney.shape == (16, 512, 512, 3)
 
 
 def test_lily_multichannel():

--- a/skimage/data/tests/test_data.py
+++ b/skimage/data/tests/test_data.py
@@ -158,6 +158,6 @@ def test_kidney_3d_multichannel():
 
     Needs internet connection.
     """
-    path = fetch('data/kidney-tissue-fluorescence.tif')
+    path = fetch('data/kidney.tif')
     image = io.imread(path)
     assert image.shape == (16, 512, 512, 3)


### PR DESCRIPTION
## Description

This PR is a simple follow-up on this one https://gitlab.com/scikit-image/data/-/merge_requests/6 by @GenevieveBuckley. We will then be able to load these images, that she obtained in confocal fluorescence microscopy, within scikit-image (via pooch).

We will thus have a 2D multichannel image (`lily-of-the-valley-fluorescence.tif`) and a 3D multichannel image (`kidney-tissue-fluorescence.tif`) to play with! I'm excited for the upcoming gallery examples, notably more biomedical ones.

The only hesitation I had when submitting this was whether I should keep the descriptive (short enough) filenames or shorten them into `lily.tif` and `kidney.tif`, respectively.

Let me refer to #3384 and #4601, and thank @GenevieveBuckley again!

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
