### PR TITLE
Deprecate qt and skivi plugins in skimage.io

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -78,6 +78,8 @@ Version 0.20
   `structure_tensor`.
 * In ``skimage/feature/corner.py``, remove the `structure_tensor_eigvals`
   function.
+* Remove deprecated qt plugins, i.e. `qt_plugin.py`, `qt_plugin.ini` and
+  `skivi.py` in `skimage.io._plugins`.
 
 Version 1.0
 -----------

--- a/TODO.txt
+++ b/TODO.txt
@@ -79,7 +79,7 @@ Version 0.20
 * In ``skimage/feature/corner.py``, remove the `structure_tensor_eigvals`
   function.
 * Remove deprecated qt plugins, i.e. `qt_plugin.py`, `qt_plugin.ini` and
-  `skivi.py` in `skimage.io._plugins`.
+  `skivi.py` in `skimage/io/_plugins`.
 
 Version 1.0
 -----------

--- a/skimage/io/_plugins/qt_plugin.ini
+++ b/skimage/io/_plugins/qt_plugin.ini
@@ -1,4 +1,4 @@
 [qt]
-description = Fast image display using the Qt library
+description = Fast image display using the Qt library. Deprecated since 0.18. Will be removed in 0.20.
 provides = imshow, _app_show, imsave, imread
 

--- a/skimage/io/_plugins/qt_plugin.py
+++ b/skimage/io/_plugins/qt_plugin.py
@@ -68,6 +68,10 @@ def imread(filename):
     """
     Read an image using QT's QImage.load
     """
+    warn('`qt` plugin is deprecated and will be removed in 0.20. '
+         'For alternatives, refer to '
+         'https://scikit-image.org/docs/stable/user_guide/visualization.html',
+         FutureWarning, stacklevel=2)
     qtimg = QImage()
     if not qtimg.load(filename):
         # QImage.load() returns false on failure, so raise an exception
@@ -100,6 +104,10 @@ def imread(filename):
     return img
 
 def imshow(arr, fancy=False):
+    warn('`qt` plugin is deprecated and will be removed in 0.20. '
+         'For alternatives, refer to '
+         'https://scikit-image.org/docs/stable/user_guide/visualization.html',
+         FutureWarning, stacklevel=2)
     global app
     if not app:
         app = QApplication([])
@@ -124,6 +132,10 @@ def _app_show():
 
 
 def imsave(filename, img, format_str=None):
+    warn('`qt` plugin is deprecated and will be removed in 0.20. '
+         'For alternatives, refer to '
+         'https://scikit-image.org/docs/stable/user_guide/visualization.html',
+         FutureWarning, stacklevel=2)
     # we can add support for other than 3D uint8 here...
     img = prepare_for_display(img)
     qimg = QImage(img.data, img.shape[1], img.shape[0],


### PR DESCRIPTION
## Description

Ready for reviews.

Solves part of the overall deprecation of skivi. The viewer module is the other part, but I prefer to split in different PR.




## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
