### PR TITLE
modify development version string to allow use with NumpyVersion

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -65,8 +65,11 @@ access), specifically to:
 - On the master branch, update the version number in ``skimage/__init__.py``
   to the next ``.dev0`` version, commit, and push. This should follow PEP440
   meaning that the appropriate version number would look something like
-  ``0.20.dev0`` with the period between ``20`` and ``dev`` and a trailing
-  ``0`` immediately after ``dev``.
+  ``0.20.0.dev0`` with the period between ``0`` and ``dev`` and a trailing
+  ``0`` immediately after ``dev``. The final ``0`` is necessary to ensure
+  that 
+  `NumpyVersion <https://github.com/scikit-image/scikit-image/pull/4947>`_
+  correctly interprets the version number.
 
  - On the master branch, edit ``doc/source/_static/docversions.js``,
   add the release, e.g., `0.15.x`, and commit.  Cherry-pick this

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -71,7 +71,7 @@ dtype_limits
 import sys
 
 
-__version__ = '0.18.dev0'
+__version__ = '0.18.0.dev0'
 
 from ._shared.version_requirements import ensure_python_version
 ensure_python_version((3, 5))


### PR DESCRIPTION

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

We use NumpyVersion to compare version strings in some benchmarks. This currently fails on the master branch because '0.18.dev0' is not considered a valid version string by `NumpyVersion`. '0.18.0.dev0' works okay. 

If there is any reason not to change this version scheme we will instead have to change the version comparisons in the benchmark suite. Example usage in the benchmarks: https://github.com/scikit-image/scikit-image/blob/9e418094e9b7d80cf82b1090a93a16128f8f0a05/benchmarks/benchmark_segmentation.py#L3-L17


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
