### PR TITLE
CI: Add verbose option to avoid travis timeout for OSX install script 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,7 @@ before_install:
         apt-key adv --list-public-keys --with-colons | grep '^pub' | cut -d':' -f 5 | egrep -o '.{8}$' | grep -wo 762E3157 > /dev/null 2>&1 || sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 762E3157;
       fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        travis_wait 20 source tools/travis/osx_install.sh;
+        source tools/travis/osx_install.sh;
       else
         virtualenv -p python ~/venv;
         source ~/venv/bin/activate;

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,7 @@ before_install:
         apt-key adv --list-public-keys --with-colons | grep '^pub' | cut -d':' -f 5 | egrep -o '.{8}$' | grep -wo 762E3157 > /dev/null 2>&1 || sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 762E3157;
       fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        source tools/travis/osx_install.sh;
+        travis_wait 20 source tools/travis/osx_install.sh;
       else
         virtualenv -p python ~/venv;
         source ~/venv/bin/activate;

--- a/tools/travis/osx_install.sh
+++ b/tools/travis/osx_install.sh
@@ -7,8 +7,8 @@ brew tap homebrew/homebrew-cask
 brew cask install basictex
 
 export PATH="$PATH:/Library/TeX/texbin"
-sudo travis_wait 20 tlmgr --verify-repo=none update --self
-sudo travis_wait 20 tlmgr --verify-repo=none install ucs dvipng anyfontsize
+travis_wait 20 sudo tlmgr --verify-repo=none update --self
+travis_wait 20 sudo tlmgr --verify-repo=none install ucs dvipng anyfontsize
 
 # Set up virtualenv on OSX
 git clone --depth 1 --branch devel https://github.com/matthew-brett/multibuild ~/multibuild

--- a/tools/travis/osx_install.sh
+++ b/tools/travis/osx_install.sh
@@ -7,8 +7,8 @@ brew tap homebrew/homebrew-cask
 brew cask install basictex
 
 export PATH="$PATH:/Library/TeX/texbin"
-sudo tlmgr --verify-repo=none update --self
-sudo tlmgr --verify-repo=none install ucs dvipng anyfontsize
+sudo travis_wait 20 tlmgr --verify-repo=none update --self
+sudo travis_wait 20 tlmgr --verify-repo=none install ucs dvipng anyfontsize
 
 # Set up virtualenv on OSX
 git clone --depth 1 --branch devel https://github.com/matthew-brett/multibuild ~/multibuild

--- a/tools/travis/osx_install.sh
+++ b/tools/travis/osx_install.sh
@@ -7,6 +7,7 @@ brew tap homebrew/homebrew-cask
 brew cask install basictex
 
 export PATH="$PATH:/Library/TeX/texbin"
+# Add verbosity (-v) to avoid a timeout on travis
 sudo tlmgr -v --verify-repo=none update --self
 sudo tlmgr -v --verify-repo=none install ucs dvipng anyfontsize
 

--- a/tools/travis/osx_install.sh
+++ b/tools/travis/osx_install.sh
@@ -7,8 +7,8 @@ brew tap homebrew/homebrew-cask
 brew cask install basictex
 
 export PATH="$PATH:/Library/TeX/texbin"
-travis_wait 20 sudo tlmgr --verify-repo=none update --self
-travis_wait 20 sudo tlmgr --verify-repo=none install ucs dvipng anyfontsize
+sudo tlmgr -v --verify-repo=none update --self
+sudo tlmgr -v --verify-repo=none install ucs dvipng anyfontsize
 
 # Set up virtualenv on OSX
 git clone --depth 1 --branch devel https://github.com/matthew-brett/multibuild ~/multibuild


### PR DESCRIPTION
## Description

Let's try this workaround for #4955


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
