### PR TITLE
Accelerate gamma_adjust for uint8 images

### DIFF
--- a/benchmarks/benchmark_exposure.py
+++ b/benchmarks/benchmark_exposure.py
@@ -10,7 +10,8 @@ from skimage import exposure
 class ExposureSuite:
     """Benchmark for exposure routines in scikit-image."""
     def setup(self):
-        self.image = img_as_float(data.moon())
+        self.image_u8 = data.moon()
+        self.image = img_as_float(self.image_u8)
         self.image = rescale(self.image, 2.0, anti_aliasing=False)
         # for Contrast stretching
         self.p2, self.p98 = np.percentile(self.image, (2, 98))
@@ -32,3 +33,7 @@ class ExposureSuite:
         # Running it 10 times to achieve significant performance time.
         for i in range(10):
             result = exposure.histogram(self.image)
+
+    def time_gamma_adjust_u8(self):
+        for i in range(10):
+            _ = exposure.adjust_gamma(self.image_u8)

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -496,14 +496,16 @@ def adjust_gamma(image, gamma=1, gain=1):
     dtype = image.dtype.type
 
     if dtype is np.uint8:
-        return _adjust_gamma_u8(image, gamma, gain)
+        out = _adjust_gamma_u8(image, gamma, gain)
+    else:
+        _assert_non_negative(image)
 
-    _assert_non_negative(image)
+        scale = float(dtype_limits(image, True)[1]
+                      - dtype_limits(image, True)[0])
 
-    scale = float(dtype_limits(image, True)[1] - dtype_limits(image, True)[0])
+        out = (((image / scale) ** gamma) * scale * gain).astype(dtype)
 
-    out = ((image / scale) ** gamma) * scale * gain
-    return out.astype(dtype)
+    return out
 
 
 def adjust_log(image, gain=1, inv=False):

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -440,10 +440,8 @@ def _adjust_gamma_u8(image, gamma, gain):
     """LUT based implmentation of gamma adjustement.
 
     """
-    lut_size = image.max() + 1
-    # lut = (255 * gain * (np.linspace(0, 1, lut_size) ** gamma))
-    lut = (255 * gain * ((np.arange(0, lut_size) / 255) ** gamma))
-    return lut.astype('uint8')[image]
+    lut = (255 * gain * (np.linspace(0, 1, 256) ** gamma)).astype('uint8')
+    return lut[image]
 
 
 def adjust_gamma(image, gamma=1, gain=1):

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -436,6 +436,16 @@ def _assert_non_negative(image):
                          'skimage.exposure.rescale_intensity.')
 
 
+def _adjust_gamma_u8(image, gamma, gain):
+    """LUT based implmentation of gamma adjustement.
+
+    """
+    lut_size = image.max() + 1
+    # lut = (255 * gain * (np.linspace(0, 1, lut_size) ** gamma))
+    lut = (255 * gain * ((np.arange(0, lut_size) / 255) ** gamma))
+    return lut.astype('uint8')[image]
+
+
 def adjust_gamma(image, gamma=1, gain=1):
     """Performs Gamma Correction on the input image.
 
@@ -482,11 +492,15 @@ def adjust_gamma(image, gamma=1, gain=1):
     >>> image.mean() > gamma_corrected.mean()
     True
     """
-    _assert_non_negative(image)
-    dtype = image.dtype.type
-
     if gamma < 0:
         raise ValueError("Gamma should be a non-negative real number.")
+
+    dtype = image.dtype.type
+
+    if dtype is np.uint8:
+        return _adjust_gamma_u8(image, gamma, gain)
+
+    _assert_non_negative(image)
 
     scale = float(dtype_limits(image, True)[1] - dtype_limits(image, True)[0])
 


### PR DESCRIPTION
## Description

This PR proposes a LUT based approach for gamma correction of uint8 images. It allows for considerable speedup:

### Master branch

```python
In [1]: from skimage.exposure import adjust_gamma                                                       

In [2]: img = np.ones((1024, 1024, 3), dtype='uint8')                                                   

In [3]: %timeit adjust_gamma(img)                                                                       
10.7 ms ± 3.68 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

### Current branch

```python
In [1]: from skimage.exposure import adjust_gamma                                                       

In [2]: img = np.ones((1024, 1024, 3), dtype='uint8')                                                   

In [3]: %timeit adjust_gamma(img)                                   
6.87 ms ± 9.45 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
