### PR TITLE
MAINT: Remove conditional import on networkx

### DIFF
--- a/skimage/future/graph/_ncut.py
+++ b/skimage/future/graph/_ncut.py
@@ -1,8 +1,4 @@
-try:
-    import networkx as nx
-except ImportError:
-    from ..._shared.utils import warn
-    warn('RAGs require networkx')
+import networkx as nx
 import numpy as np
 from scipy import sparse
 from . import _ncut_cy

--- a/skimage/future/graph/graph_cut.py
+++ b/skimage/future/graph/graph_cut.py
@@ -1,8 +1,4 @@
-try:
-    import networkx as nx
-except ImportError:
-    from ..._shared.utils import warn
-    warn('RAGs require networkx')
+import networkx as nx
 import numpy as np
 from . import _ncut
 from . import _ncut_cy

--- a/skimage/future/graph/tests/test_rag.py
+++ b/skimage/future/graph/tests/test_rag.py
@@ -13,8 +13,6 @@ def max_edge(g, src, dst, n):
     return {'weight': max(w1, w2)}
 
 
-@testing.skipif(not is_installed('networkx'),
-                reason="networkx not installed")
 def test_rag_merge():
     g = graph.rag.RAG()
 
@@ -49,8 +47,6 @@ def test_rag_merge():
     assert list(g.edges()) == []
 
 
-@testing.skipif(not is_installed('networkx'),
-                reason="networkx not installed")
 def test_threshold_cut():
 
     img = np.zeros((100, 100, 3), dtype='uint8')
@@ -75,8 +71,6 @@ def test_threshold_cut():
     assert new_labels.max() == 1
 
 
-@testing.skipif(not is_installed('networkx'),
-                reason="networkx not installed")
 def test_cut_normalized():
 
     img = np.zeros((100, 100, 3), dtype='uint8')
@@ -103,8 +97,6 @@ def test_cut_normalized():
     assert new_labels.max() == 1
 
 
-@testing.skipif(not is_installed('networkx'),
-                reason="networkx not installed")
 def test_rag_error():
     img = np.zeros((10, 10, 3), dtype='uint8')
     labels = np.zeros((10, 10), dtype='uint8')
@@ -135,8 +127,6 @@ def merge_hierarchical_mean_color(labels, rag, thresh, rag_copy=True,
                                     _weight_mean_color)
 
 
-@testing.skipif(not is_installed('networkx'),
-                reason="networkx not installed")
 def test_rag_hierarchical():
     img = np.zeros((8, 8, 3), dtype='uint8')
     labels = np.zeros((8, 8), dtype='uint8')
@@ -167,8 +157,6 @@ def test_rag_hierarchical():
     assert np.all(result == result[0, 0])
 
 
-@testing.skipif(not is_installed('networkx'),
-                reason="networkx not installed")
 def test_ncut_stable_subgraph():
     """ Test to catch an error thrown when subgraph has all equal edges. """
 


### PR DESCRIPTION
## Description

It is part of the task to finalize graph's API (see https://github.com/scikit-image/scikit-image/blob/999a6b0894990a79e22611edda16b2222b6341df/TODO.txt#L8) + networkx is in the default requirements.

Therefore, no need to keep conditional imports of networkx. 


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
