### PR TITLE
Remove warnings/explicit settings on feature, restoration

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -11,22 +11,6 @@ Version 0.17
 Version 0.18
 ------------
 
-* In ``skimage.features.corner_peaks``, remove the warning.
-    * In the following docstrings, remove the explicit setting of ``threshold_rel=0``
-        * ``skimage/feature/brief.py::BRIEF``
-        * `` skimage/feature/corner.py::corner_harris``
-        * `` skimage/feature/corner.py::corner_shi_tomasi``
-        * `` skimage/feature/corner.py::corner_foerstner``
-        * `` skimage/feature/corner.py::corner_fast``
-        * `` skimage/feature/corner.py::corner_subpix``
-        * `` skimage/feature/corner.py::corner_peaks``
-        * `` skimage/feature/corner.py::corner_orientations``
-    * In ``skimage/feature/orb.py::_detect_octage`` remove explicitely setting
-      ``threshold_rel=0``.
-* In ``skimage/restoration/_denoise.py`` remove warning regarding
-  ``rescale_sigma``.
-    * In ``skimage/restoration/_cycle_spin.py::cycle_spin`` unskip the doctest
-      now that the denoise warning is gone.
 
 Version 0.19
 ------------

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -38,6 +38,17 @@ API Changes
 - ``skimage.restoration.richardson_lucy`` returns a single-precision output
   when the input is single-precision. Prior to this release, double-precision
   was always used.
+- The explicit setting ``threshold_rel=0` was removed from the Examples of the
+  following docstrings: ``skimage.feature.BRIEF``,
+  ``skimage.feature.corner_harris``, ``skimage.feature.corner_shi_tomasi``,
+  ``skimage.feature.corner_foerstner``, ``skimage.feature.corner_fast``,
+  ``skimage.feature.corner_subpix``, ``skimage.feature.corner_peaks``,
+  ``skimage.feature.corner_orientations``, and
+  ``skimage.feature._detect_octave``.
+- In ``skimage.restoration._denoise``, the warning regarding
+  ``rescale_sigma=None`` was removed.
+- In ``skimage.restoration._cycle_spin``, the ``# doctest: +SKIP`` was removed.
+
 
 Bugfixes
 --------
@@ -59,7 +70,6 @@ Deprecations
   instead.
 - In ``skimage.morphology.selem.rectangle`` the arguments ``width`` and 
   ``height`` have been deprecated. Use ``nrow`` and ``ncol`` instead.
-
 
 Contributors to this release
 ----------------------------

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -38,17 +38,10 @@ API Changes
 - ``skimage.restoration.richardson_lucy`` returns a single-precision output
   when the input is single-precision. Prior to this release, double-precision
   was always used.
-- The explicit setting ``threshold_rel=0` was removed from the Examples of the
-  following docstrings: ``skimage.feature.BRIEF``,
-  ``skimage.feature.corner_harris``, ``skimage.feature.corner_shi_tomasi``,
-  ``skimage.feature.corner_foerstner``, ``skimage.feature.corner_fast``,
-  ``skimage.feature.corner_subpix``, ``skimage.feature.corner_peaks``,
-  ``skimage.feature.corner_orientations``, and
-  ``skimage.feature._detect_octave``.
-- In ``skimage.restoration._denoise``, the warning regarding
-  ``rescale_sigma=None`` was removed.
-- In ``skimage.restoration._cycle_spin``, the ``# doctest: +SKIP`` was removed.
-
+- The default value of ``threshold_rel`` in ``skimage.feature.corner`` has
+  changed from 0.1 to None, which corresponds to letting 
+  ``skimage.feature.peak_local_max`` decide on the default. This is currently
+  equivalent to ``threshold_rel=0``.
 
 Bugfixes
 --------
@@ -70,6 +63,17 @@ Deprecations
   instead.
 - In ``skimage.morphology.selem.rectangle`` the arguments ``width`` and 
   ``height`` have been deprecated. Use ``nrow`` and ``ncol`` instead.
+- The explicit setting ``threshold_rel=0` was removed from the Examples of the
+  following docstrings: ``skimage.feature.BRIEF``,
+  ``skimage.feature.corner_harris``, ``skimage.feature.corner_shi_tomasi``,
+  ``skimage.feature.corner_foerstner``, ``skimage.feature.corner_fast``,
+  ``skimage.feature.corner_subpix``, ``skimage.feature.corner_peaks``,
+  ``skimage.feature.corner_orientations``, and
+  ``skimage.feature._detect_octave``.
+- In ``skimage.restoration._denoise``, the warning regarding
+  ``rescale_sigma=None`` was removed.
+- In ``skimage.restoration._cycle_spin``, the ``# doctest: +SKIP`` was removed.
+
 
 Contributors to this release
 ----------------------------

--- a/skimage/feature/brief.py
+++ b/skimage/feature/brief.py
@@ -85,10 +85,8 @@ class BRIEF(DescriptorExtractor):
            [0, 0, 1, 1, 1, 1, 1, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=int32)
-    >>> keypoints1 = corner_peaks(corner_harris(square1), min_distance=1,
-    ...                           threshold_rel=0)
-    >>> keypoints2 = corner_peaks(corner_harris(square2), min_distance=1,
-    ...                           threshold_rel=0)
+    >>> keypoints1 = corner_peaks(corner_harris(square1), min_distance=1)
+    >>> keypoints2 = corner_peaks(corner_harris(square2), min_distance=1)
     >>> extractor = BRIEF(patch_size=5)
     >>> extractor.extract(square1, keypoints1)
     >>> descriptors1 = extractor.descriptors

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -1054,9 +1054,6 @@ def corner_peaks(image, min_distance=1, threshold_abs=None, threshold_rel=None,
     array([[2, 2]])
 
     """
-    if threshold_rel is None:
-        threshold_rel = 0.1
-
     if np.isinf(num_peaks):
         num_peaks = None
 

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -1029,9 +1029,13 @@ def corner_peaks(image, min_distance=1, threshold_abs=None, threshold_rel=None,
 
     Notes
     -----
-    The `num_peaks` limit is applied before suppression of
-    connected peaks. If you want to limit the number of peaks
-    after suppression, you should set `num_peaks=np.inf` and
+    .. versionchanged:: 0.18
+        The default value of `threshold_rel` has changed to None, which
+        corresponds to letting `skimage.feature.peak_local_max` decide on the
+        default. This is equivalent to `threshold_rel=0`.
+
+    The `num_peaks` limit is applied before suppression of connected peaks.
+    To limit the number of peaks after suppression, set `num_peaks=np.inf` and
     post-process the output of this function.
 
     Examples

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -580,7 +580,7 @@ def corner_harris(image, method='k', k=0.05, eps=1e-6, sigma=1):
            [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
-    >>> corner_peaks(corner_harris(square), min_distance=1, threshold_rel=0)
+    >>> corner_peaks(corner_harris(square), min_distance=1)
     array([[2, 2],
            [2, 7],
            [7, 2],
@@ -649,8 +649,7 @@ def corner_shi_tomasi(image, sigma=1):
            [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
-    >>> corner_peaks(corner_shi_tomasi(square), min_distance=1,
-    ...              threshold_rel=0)
+    >>> corner_peaks(corner_shi_tomasi(square), min_distance=1)
     array([[2, 2],
            [2, 7],
            [7, 2],
@@ -724,7 +723,7 @@ def corner_foerstner(image, sigma=1):
     >>> accuracy_thresh = 0.5
     >>> roundness_thresh = 0.3
     >>> foerstner = (q > roundness_thresh) * (w > accuracy_thresh) * w
-    >>> corner_peaks(foerstner, min_distance=1, threshold_rel=0)
+    >>> corner_peaks(foerstner, min_distance=1)
     array([[2, 2],
            [2, 7],
            [7, 2],
@@ -801,7 +800,7 @@ def corner_fast(image, n=12, threshold=0.15):
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
-    >>> corner_peaks(corner_fast(square, 9), min_distance=1, threshold_rel=0)
+    >>> corner_peaks(corner_fast(square, 9), min_distance=1)
     array([[3, 3],
            [3, 8],
            [8, 3],
@@ -867,8 +866,7 @@ def corner_subpix(image, corners, window_size=11, alpha=0.99):
            [0, 0, 0, 0, 0, 1, 1, 1, 1, 1],
            [0, 0, 0, 0, 0, 1, 1, 1, 1, 1],
            [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]])
-    >>> coords = corner_peaks(corner_harris(img), min_distance=2,
-    ...                       threshold_rel=0)
+    >>> coords = corner_peaks(corner_harris(img), min_distance=2)
     >>> coords_subpix = corner_subpix(img, coords, window_size=7)
     >>> coords_subpix
     array([[4.5, 4.5]])
@@ -1052,7 +1050,7 @@ def corner_peaks(image, min_distance=1, threshold_abs=None, threshold_rel=None,
            [2, 3],
            [3, 2],
            [3, 3]])
-    >>> corner_peaks(response, threshold_rel=0)
+    >>> corner_peaks(response)
     array([[2, 2]])
 
     """
@@ -1195,8 +1193,7 @@ def corner_orientations(image, corners, mask):
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
-    >>> corners = corner_peaks(corner_fast(square, 9), min_distance=1,
-    ...                        threshold_rel=0)
+    >>> corners = corner_peaks(corner_fast(square, 9), min_distance=1)
     >>> corners
     array([[3, 3],
            [3, 8],

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -1058,12 +1058,6 @@ def corner_peaks(image, min_distance=1, threshold_abs=None, threshold_rel=None,
     """
     if threshold_rel is None:
         threshold_rel = 0.1
-        warn("Until version 0.16, threshold_rel was set to 0.1 by default. "
-             "Starting from version 0.16, the default value is set to None. "
-             "Until version 0.18, a None value corresponds to a threshold "
-             "value of 0.1. The default behavior will match "
-             "skimage.feature.peak_local_max. To avoid this warning, set "
-             "threshold_rel=0.", category=FutureWarning, stacklevel=2)
 
     if np.isinf(num_peaks):
         num_peaks = None

--- a/skimage/feature/orb.py
+++ b/skimage/feature/orb.py
@@ -140,8 +140,7 @@ class ORB(FeatureDetector, DescriptorExtractor):
         # Extract keypoints for current octave
         fast_response = corner_fast(octave_image, self.fast_n,
                                     self.fast_threshold)
-        keypoints = corner_peaks(fast_response, min_distance=1,
-                                 threshold_rel=0)
+        keypoints = corner_peaks(fast_response, min_distance=1)
 
         if len(keypoints) == 0:
             return (np.zeros((0, 2), dtype=dtype),

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -383,14 +383,12 @@ def test_corner_peaks():
                            threshold_rel=0)
     assert corners.shape == (2, 2)
 
-    with pytest.warns(FutureWarning,
-                      match="Until version 0.16, threshold_rel.*"):
-        corners = corner_peaks(response, exclude_border=False, min_distance=1)
-        assert corners.shape == (5, 2)
+    corners = corner_peaks(response, exclude_border=False, min_distance=1)
+    assert corners.shape == (5, 2)
 
-        corners = corner_peaks(response, exclude_border=False, min_distance=1,
-                               indices=False)
-        assert np.sum(corners) == 5
+    corners = corner_peaks(response, exclude_border=False, min_distance=1,
+                           indices=False)
+    assert np.sum(corners) == 5
 
 
 def test_blank_image_nans():

--- a/skimage/restoration/_cycle_spin.py
+++ b/skimage/restoration/_cycle_spin.py
@@ -109,7 +109,7 @@ def cycle_spin(x, func, max_shifts, shift_steps=1, num_workers=None,
     >>> sigma = 0.1
     >>> img = img + sigma * np.random.standard_normal(img.shape)
     >>> denoised = cycle_spin(img, func=denoise_wavelet,
-    ...                       max_shifts=3) # doctest: +SKIP
+    ...                       max_shifts=3)
 
     """
     x = np.asanyarray(x)

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -815,14 +815,6 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
         raise ValueError("convert2ycbcr requires multichannel == True")
 
     if rescale_sigma is None:
-        msg = (
-            "As of scikit-image 0.16, automated rescaling of sigma to match "
-            "any internal rescaling of the image is performed. Setting "
-            "rescale_sigma to False, will disable this new behaviour. To "
-            "avoid this warning the user should explicitly set rescale_sigma "
-            "to True or False."
-        )
-        warn(msg, FutureWarning, stacklevel=2)
         rescale_sigma = True
     image, sigma = _scale_sigma_and_image_consistently(image,
                                                        sigma,

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -694,7 +694,7 @@ def _rescale_sigma_rgb2ycbcr(sigmas):
 def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
                     wavelet_levels=None, multichannel=False,
                     convert2ycbcr=False, method='BayesShrink',
-                    rescale_sigma=None):
+                    rescale_sigma=True):
     """Perform wavelet denoising on an image.
 
     Parameters
@@ -728,12 +728,10 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
     method : {'BayesShrink', 'VisuShrink'}, optional
         Thresholding method to be used. The currently supported methods are
         "BayesShrink" [1]_ and "VisuShrink" [2]_. Defaults to "BayesShrink".
-    rescale_sigma : bool or None, optional
+    rescale_sigma : bool, optional
         If False, no rescaling of the user-provided ``sigma`` will be
-        performed. The default of ``None`` rescales sigma appropriately if the
-        image is rescaled internally. A ``DeprecationWarning`` is raised to
-        warn the user about this new behaviour. This warning can be avoided
-        by setting ``rescale_sigma=True``.
+        performed. The default of ``True`` rescales sigma appropriately if the
+        image is rescaled internally.
 
         .. versionadded:: 0.16
            ``rescale_sigma`` was introduced in 0.16
@@ -814,8 +812,6 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
     if convert2ycbcr and not multichannel:
         raise ValueError("convert2ycbcr requires multichannel == True")
 
-    if rescale_sigma is None:
-        rescale_sigma = True
     image, sigma = _scale_sigma_and_image_consistently(image,
                                                        sigma,
                                                        multichannel,

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -648,11 +648,6 @@ def test_wavelet_invalid_method():
                                     rescale_sigma=True)
 
 
-def test_wavelet_rescale_sigma_deprecation():
-    # Not specifying rescale_sigma results in a DeprecationWarning
-    assert_warns(FutureWarning, restoration.denoise_wavelet, np.arange(16))
-
-
 @pytest.mark.parametrize('rescale_sigma', [True, False])
 def test_wavelet_denoising_levels(rescale_sigma):
     rstate = np.random.RandomState(1234)


### PR DESCRIPTION
## Description

Solves #4969.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
