### PR TITLE
try to fix timeout problem with circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
               export
       - run:
           name: build doc
+          no_output_timeout: 50m
           command: |
               source skimage_venv/bin/activate
               cd doc


### PR DESCRIPTION
Circleci doc builds often fail with the error message "Too long with no output (exceeded 10m0s): context deadline exceeded". This PR implements the workaround suggested in https://support.circleci.com/hc/en-us/articles/360045268074-Build-Fails-with-Too-long-with-no-output-exceeded-10m0s-context-deadline-exceeded- 