### PR TITLE
[website] Standardize Documentation index page.

### DIFF
--- a/doc/source/_templates/navbar.html
+++ b/doc/source/_templates/navbar.html
@@ -1,7 +1,7 @@
-<li><a href="/docs/stable/install.html">Download</a></li>
+<li><a href="/docs/stable/install.html">Installation</a></li>
 <li><a href="{{ pathto('auto_examples/index') }}">Gallery</a></li>
 <li><a href="{{ pathto('index') }}">Documentation</a></li>
-<li><a href="/community_guidelines.html">Community Guidelines</a></li>
+<li><a href="/community_guidelines.html">Community</a></li>
 
 <li><a href="https://github.com/scikit-image/scikit-image">
     <img src="{{ pathto('_static', 1) }}/GitHub-Mark-32px.png"

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -40,15 +40,15 @@ Sections
 
        Documentation for the functions included in scikit-image.
 
-   * - `Mission statement <values.html>`_
+   * - `Mission Statement <values.html>`_
 
-       Our mission, vision and values.
+       Our mission, vision, and values.
 
      - `Governance <skips/1-governance.html>`_
 
        How decisions are made in scikit-image.
 
-   * - `Installation Steps <install.html>`_
+   * - `Installation <install.html>`_
 
        How to install scikit-image.
 
@@ -66,9 +66,9 @@ Sections
        <core_developer.html>`_.
 
 
-   * - `Examples <auto_examples/index.html>`_
+   * - `Gallery <auto_examples/index.html>`_
 
-       Introductory examples
+       Introductory generic and domain-specific examples.
 
      - `License Info <license.html>`_
 


### PR DESCRIPTION
## Description

Follows from https://github.com/scikit-image/scikit-image/issues/4988#issuecomment-700739458.

Should I revert 2d2c296522a34cc81b29fc14b94573e38898d2f2 because the template level is handled over at https://github.com/scikit-image/scikit-image-web? Maybe even a89d95e5dec3709c081e5c994e6ba0bbda1e8705?

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
