### PR TITLE
Update Hough ellipse

### DIFF
--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -212,12 +212,12 @@ def _hough_ellipse(cnp.ndarray img, Py_ssize_t threshold=4, double accuracy=1,
                                 acc.append(b)
 
                 if len(acc) > 0:
-                    bins = np.arange(0, np.max(acc) + bin_size, bin_size)
+                    bins = np.arange(np.floor(np.min(acc)), np.max(acc) + bin_size, bin_size)
                     hist, bin_edges = np.histogram(acc, bins=bins)
                     hist_max = np.max(hist)
                     if hist_max > threshold:
                         orientation = atan2(p1x - p2x, p1y - p2y)
-                        b = bin_edges[hist.argmax()]
+                        b = bin_edges[hist.argmax()] + (bin_size / 2)
                         # to keep ellipse_perimeter() convention
                         if orientation != 0:
                             orientation = M_PI - orientation

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -186,7 +186,7 @@ def _hough_ellipse(cnp.ndarray img, Py_ssize_t threshold=4, double accuracy=1,
             dx = p1x - p2x
             dy = p1y - p2y
             a = 0.5 * sqrt(dx * dx + dy * dy)
-            if a > 0.5 * min_size:
+            if a >= min_size:
                 xc = 0.5 * (p1x + p2x)
                 yc = 0.5 * (p1y + p2y)
 
@@ -196,7 +196,7 @@ def _hough_ellipse(cnp.ndarray img, Py_ssize_t threshold=4, double accuracy=1,
                     dx = p3x - xc
                     dy = p3y - yc
                     d = sqrt(dx * dx + dy * dy)
-                    if d > min_size:
+                    if (d <= a) and (d > 0):
                         dx = p3x - p1x
                         dy = p3y - p1y
                         cos_tau_squared = ((a*a + d*d - dx*dx - dy*dy)

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -216,17 +216,13 @@ def _hough_ellipse(cnp.ndarray img, Py_ssize_t threshold=4, double accuracy=1,
                     hist, bin_edges = np.histogram(acc, bins=bins)
                     hist_max = np.max(hist)
                     if hist_max > threshold:
-                        orientation = atan2(p1x - p2x, p1y - p2y)
+                        orientation = atan2(p1y - p2y, p1x - p2x)
                         b = bin_edges[hist.argmax()] + (bin_size / 2)
                         # to keep ellipse_perimeter() convention
-                        if orientation != 0:
-                            orientation = M_PI - orientation
-                            # When orientation is not in [-pi:pi]
-                            # it would mean in ellipse_perimeter()
-                            # that a < b. But we keep a > b.
-                            if orientation > M_PI:
-                                orientation = orientation - M_PI / 2.
-                                a, b = b, a
+                        orientation += M_PI / 2
+                        # to keep orientation in [-pi/2 : pi/2]
+                        if orientation > M_PI/2:
+                            orientation -= M_PI
                         results.append((hist_max, # Accumulator
                                         yc, xc,
                                         a, b,


### PR DESCRIPTION
## Description
This PR addresses 4 issues. They follow the commits accordingly. 

1.  The accumulator currently uses b^2; however, this means that bin sizes are nonuniform. To correct, I suggest we us b instead of b^2. This will also result in a more consistent accuracy and ellipse fit uncertainty.
2.  We can reduce the number of bins used by setting the lower bin limit to the min accumulator value, instead of 0. Also it is simple enough to return the median bin value, instead of the lower bound.
3.  The logic for the major radius `a`, and radial distance to a third point `d`, are incorrect. `min_size` represents a radius, so it is directly comparable to `a`. Perhaps the docstring should also be updated to clearly state this is a radius. As for `d`, we should only consider third points which have a radial distance smaller than the presently considered major axis `a`.
4.  The current orientation logic is unnecessarily complicated, and occasionally swaps `a` and `b` when it shouldn't. With updated login in 3, it is simpler to always keep `a` the major axis, `b` the minor axis, and adjust the orientation after to maintain it within the [-pi/2 : pi/2] interval. 


## Checklist

These updates fail 3 tests.

- `test_hough_ellipse_zero_angle` I am unsure of the cause of this failure. When I run locally, the function returns the desired y0 position of 15. Error says it returns 17.
- `test_hough_ellipse_non_zero_posangle1` This fails because I actively choose to return orientations in the [-pi/2 : pi/2] range, instead of [-pi : pi]. I think this test should either be updated, or I can adjust the code accordingly.
- `test_hough_ellipse_non_zero_posangle2` This test should be updated. It actively seeks to compare the major axis field to the smaller axis value. The two generated radii are 6 and 12. The test looks for the major axis to be 6. My changes correctly return 12.

Examples of other tests I ran locally that exemplify the failure of the current implementation (and necessitate these changes) include ellipses drawn on a `np.zeros([100, 100])` canvas. I used detection parameters `min_size=10` and `max_size=45`
- `ellipse_perimeter(50, 50, 33, 30, -0.28)`
- `ellipse_perimeter(45, 51, 35, 30, 1.42)`
- `ellipse_perimeter(50, 50, 30, 20, 10/np.pi*180)`
- `ellipse_perimeter(50, 50, 30, 20, 45/np.pi*180)`


## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
