### PR TITLE
Make structure_tensor support 3d

### DIFF
--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -51,7 +51,8 @@ def structure_tensor(image, sigma=1, mode='constant', cval=0, order=None):
             [Arc Acc]
 
     which is approximated by the weighted sum of squared differences in a local
-    window around each pixel in the image.
+    window around each pixel in the image. This formula can be extended to a
+    larger number of dimensions (see [1]_).
 
     Parameters
     ----------
@@ -91,6 +92,13 @@ def structure_tensor(image, sigma=1, mode='constant', cval=0, order=None):
            [0., 1., 0., 1., 0.],
            [0., 0., 0., 0., 0.]])
 
+    See also
+    --------
+    structure_tensor_eigenvalues
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Structure_tensor
     """
     if order == 'xy' and image.ndim > 2:
         raise ValueError('Only "rc" order is supported for dim > 2.')
@@ -325,6 +333,9 @@ def structure_tensor_eigenvalues(A_elems):
            [0., 2., 4., 2., 0.],
            [0., 0., 0., 0., 0.]])
 
+    See also
+    --------
+    structure_tensor
     """
     return _symmetric_compute_eigenvalues(A_elems)
 
@@ -907,7 +918,7 @@ def corner_subpix(image, corners, window_size=11, alpha=0.99):
 
         winy, winx = _compute_derivatives(window, mode='constant', cval=0)
 
-        # compute gradient suares and remove border
+        # compute gradient squares and remove border
         winx_winx = (winx * winx)[1:-1, 1:-1]
         winx_winy = (winx * winy)[1:-1, 1:-1]
         winy_winy = (winy * winy)[1:-1, 1:-1]

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -7,7 +7,7 @@ from scipy import spatial
 
 from ..util import img_as_float
 from .peak import peak_local_max
-from .util import _prepare_grayscale_input_2D
+from .util import _prepare_grayscale_input_2D, _prepare_grayscale_input_nD
 from .corner_cy import _corner_fast
 from ._hessian_det_appx import _hessian_matrix_det
 from ..transform import integral_image
@@ -17,7 +17,7 @@ from warnings import warn
 
 
 def _compute_derivatives(image, mode='constant', cval=0):
-    """Compute derivatives in x and y direction using the Sobel operator.
+    """Compute derivatives in axis directions using the Sobel operator.
 
     Parameters
     ----------
@@ -31,23 +31,21 @@ def _compute_derivatives(image, mode='constant', cval=0):
 
     Returns
     -------
-    imx : ndarray
-        Derivative in x-direction.
-    imy : ndarray
-        Derivative in y-direction.
+    derivatives : list of ndarray
+        Derivatives in each axis direction.
 
     """
 
-    imy = ndi.sobel(image, axis=0, mode=mode, cval=cval)
-    imx = ndi.sobel(image, axis=1, mode=mode, cval=cval)
+    derivatives = [ndi.sobel(image, axis=i, mode=mode, cval=cval)
+                   for i in range(image.ndim)]
 
-    return imx, imy
+    return derivatives
 
 
 def structure_tensor(image, sigma=1, mode='constant', cval=0, order=None):
     """Compute structure tensor using sum of squared differences.
 
-    The structure tensor A is defined as::
+    The (2-dimensional) structure tensor A is defined as::
 
         A = [Arr Arc]
             [Arc Acc]
@@ -68,6 +66,7 @@ def structure_tensor(image, sigma=1, mode='constant', cval=0, order=None):
         Used in conjunction with mode 'constant', the value outside
         the image boundaries.
     order : {'rc', 'xy'}, optional
+        NOTE: Only applies in 2D. Higher dimensions must always use 'rc' order.
         This parameter allows for the use of reverse or forward order of
         the image axes in gradient computation. 'rc' indicates the use of
         the first axis initially (Arr, Arc, Acc), whilst 'xy' indicates the
@@ -75,12 +74,9 @@ def structure_tensor(image, sigma=1, mode='constant', cval=0, order=None):
 
     Returns
     -------
-    Arr : ndarray
-        Element of the structure tensor for each pixel in the input image.
-    Arc : ndarray
-        Element of the structure tensor for each pixel in the input image.
-    Acc : ndarray
-        Element of the structure tensor for each pixel in the input image.
+    A_elems : list of ndarray
+        Upper-diagonal elements of the structure tensor for each pixel in the
+        input image.
 
     Examples
     --------
@@ -96,6 +92,9 @@ def structure_tensor(image, sigma=1, mode='constant', cval=0, order=None):
            [0., 0., 0., 0., 0.]])
 
     """
+    if order == 'xy' and image.ndim > 2:
+        raise ValueError('Only "rc" order is supported for dim > 2.')
+
     if order is None:
         if image.ndim == 2:
             # The legacy 2D code followed (x, y) convention, so we swap the
@@ -109,11 +108,11 @@ def structure_tensor(image, sigma=1, mode='constant', cval=0, order=None):
         else:
             order = 'rc'
 
-    image = _prepare_grayscale_input_2D(image)
+    image = _prepare_grayscale_input_nD(image)
 
     derivatives = _compute_derivatives(image, mode=mode, cval=cval)
 
-    if order == 'rc':
+    if order == 'xy':
         derivatives = reversed(derivatives)
 
     # structure tensor
@@ -508,9 +507,9 @@ def corner_kitchen_rosenfeld(image, mode='constant', cval=0):
            :DOI:`10.1016/0167-8655(82)90020-4`
     """
 
-    imx, imy = _compute_derivatives(image, mode=mode, cval=cval)
-    imxx, imxy = _compute_derivatives(imx, mode=mode, cval=cval)
-    imyx, imyy = _compute_derivatives(imy, mode=mode, cval=cval)
+    imy, imx = _compute_derivatives(image, mode=mode, cval=cval)
+    imxy, imxx = _compute_derivatives(imx, mode=mode, cval=cval)
+    imyy, imyx = _compute_derivatives(imy, mode=mode, cval=cval)
 
     numerator = (imxx * imy ** 2 + imyy * imx ** 2 - 2 * imxy * imx * imy)
     denominator = (imx ** 2 + imy ** 2)
@@ -906,7 +905,7 @@ def corner_subpix(image, corners, window_size=11, alpha=0.99):
         maxx = x0 + wext + 2
         window = image[miny:maxy, minx:maxx]
 
-        winx, winy = _compute_derivatives(window, mode='constant', cval=0)
+        winy, winx = _compute_derivatives(window, mode='constant', cval=0)
 
         # compute gradient suares and remove border
         winx_winx = (winx * winx)[1:-1, 1:-1]

--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -143,6 +143,12 @@ def _prepare_grayscale_input_2D(image):
     return img_as_float(image)
 
 
+def _prepare_grayscale_input_nD(image):
+    image = np.squeeze(image)
+    check_nD(image, range(2, 6))
+    return img_as_float(image)
+
+
 def _mask_border_keypoints(image_shape, keypoints, distance):
     """Mask coordinates that are within certain distance from the image border.
 


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->
This PR adds multi-dimensional support to the structure_tensor function, as requested in #4831.

As it stands, the unit test for `structure_tensor_eigenvalues` needs to be beefed up.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
