### PR TITLE
Update sphinx mapping for sklearn and numpy

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -379,11 +379,11 @@ _python_version_str = '{0.major}.{0.minor}'.format(sys.version_info)
 _python_doc_base = 'https://docs.python.org/' + _python_version_str
 intersphinx_mapping = {
     'python': (_python_doc_base, None),
-    'numpy': ('https://docs.scipy.org/doc/numpy',
+    'numpy': ('https://numpy.org/doc/stable',
               (None, './_intersphinx/numpy-objects.inv')),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference',
               (None, './_intersphinx/scipy-objects.inv')),
-    'sklearn': ('http://scikit-learn.org/stable',
+    'sklearn': ('https://scikit-learn.org/stable',
                 (None, './_intersphinx/sklearn-objects.inv')),
     'matplotlib': ('https://matplotlib.org/',
                    (None, 'https://matplotlib.org/objects.inv'))


### PR DESCRIPTION
## Description
I got this message:


```
chargement de l'inventaire intersphinx de https://docs.python.org/3.8/objects.inv...
chargement de l'inventaire intersphinx de https://docs.scipy.org/doc/numpy/objects.inv...
chargement de l'inventaire intersphinx de https://docs.scipy.org/doc/scipy/reference/objects.inv...
chargement de l'inventaire intersphinx de http://scikit-learn.org/stable/objects.inv...
chargement de l'inventaire intersphinx de https://matplotlib.org/objects.inv...
l’inventaire intersphinx a bougé : http://scikit-learn.org/stable/objects.inv -> https://scikit-learn.org/stable/objects.inv
l’inventaire intersphinx a bougé : https://docs.scipy.org/doc/numpy/objects.inv -> https://numpy.org/doc/stable/objects.inv
```