### PR TITLE
Refactoring: threshold methods with histogram parameters

### DIFF
--- a/skimage/filters/__init__.py
+++ b/skimage/filters/__init__.py
@@ -9,7 +9,7 @@ from .edges import (sobel, sobel_h, sobel_v,
                     farid, farid_h, farid_v)
 from ._rank_order import rank_order
 from ._gabor import gabor_kernel, gabor
-from .thresholding import (threshold_local, threshold_otsu, threshold_yen,
+from .thresholding import (threshold_local, threshold_otsu, threshold_otsu_from_histogram, threshold_yen,
                            threshold_isodata, threshold_li, threshold_minimum,
                            threshold_mean, threshold_triangle,
                            threshold_niblack, threshold_sauvola,
@@ -52,6 +52,7 @@ __all__ = ['inverse',
            'frangi',
            'hessian',
            'threshold_otsu',
+           'threshold_otsu_from_histogram',
            'threshold_yen',
            'threshold_isodata',
            'threshold_li',

--- a/skimage/filters/__init__.py
+++ b/skimage/filters/__init__.py
@@ -9,7 +9,7 @@ from .edges import (sobel, sobel_h, sobel_v,
                     farid, farid_h, farid_v)
 from ._rank_order import rank_order
 from ._gabor import gabor_kernel, gabor
-from .thresholding import (threshold_local, threshold_otsu, threshold_otsu_from_histogram, threshold_yen,
+from .thresholding import (threshold_local, threshold_otsu, threshold_yen,
                            threshold_isodata, threshold_li, threshold_minimum,
                            threshold_mean, threshold_triangle,
                            threshold_niblack, threshold_sauvola,
@@ -52,7 +52,6 @@ __all__ = ['inverse',
            'frangi',
            'hessian',
            'threshold_otsu',
-           'threshold_otsu_from_histogram',
            'threshold_yen',
            'threshold_isodata',
            'threshold_li',

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -466,6 +466,17 @@ def test_threshold_minimum():
     threshold = threshold_minimum(astronaut)
     assert_equal(threshold, 114)
 
+def test_threshold_minimum_histogram():
+    camera = util.img_as_ubyte(data.camera())
+    hist = histogram(camera.ravel(), 256, source_range='image')
+    threshold = threshold_minimum(hist=hist)
+    assert_equal(threshold, 85)
+
+def test_threshold_minimum_counts():
+    camera = util.img_as_ubyte(data.camera())
+    counts, bin_centers = histogram(camera.ravel(), 256, source_range='image')
+    threshold = threshold_minimum(hist=counts)
+    assert_equal(threshold, 85)
 
 def test_threshold_minimum_synthetic():
     img = np.arange(25*25, dtype=np.uint8).reshape((25, 25))

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -352,6 +352,16 @@ def test_yen_camera_image():
     camera = util.img_as_ubyte(data.camera())
     assert 145 < threshold_yen(camera) < 147
 
+def test_yen_camera_image_histogram():
+    camera = util.img_as_ubyte(data.camera())
+    hist = histogram(camera.ravel(), 256, source_range='image')
+    assert 145 < threshold_yen(hist=hist) < 147
+
+def test_yen_camera_image_counts():
+    camera = util.img_as_ubyte(data.camera())
+    counts, bin_centers = histogram(camera.ravel(), 256, source_range='image')
+    assert 145 < threshold_yen(hist=counts) < 147
+
 
 def test_yen_coins_image():
     coins = util.img_as_ubyte(data.coins())

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -389,6 +389,18 @@ def test_isodata_camera_image():
 
     assert (threshold_isodata(camera, return_all=True) == [102, 103]).all()
 
+def test_isodata_camera_image_histogram():
+    camera = util.img_as_ubyte(data.camera())
+    hist = histogram(camera.ravel(), 256, source_range='image')
+    threshold = threshold_isodata(hist=hist)
+    assert threshold == 102
+
+def test_isodata_camera_image_counts():
+    camera = util.img_as_ubyte(data.camera())
+    counts, bin_centers = histogram(camera.ravel(), 256, source_range='image')
+    threshold = threshold_isodata(hist=counts)
+    assert threshold == 102
+
 
 def test_isodata_coins_image():
     coins = util.img_as_ubyte(data.coins())

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -230,7 +230,7 @@ def test_otsu_camera_image_histogram():
 
 def test_otsu_camera_image_counts():
     camera = util.img_as_ubyte(data.camera())
-    counts = histogram(camera.ravel(), 256, source_range='image')
+    counts, bin_centers = histogram(camera.ravel(), 256, source_range='image')
     assert 101 < threshold_otsu(hist=counts) < 103
 
 def test_otsu_coins_image():

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -223,6 +223,15 @@ def test_otsu_camera_image():
     camera = util.img_as_ubyte(data.camera())
     assert 101 < threshold_otsu(camera) < 103
 
+def test_otsu_camera_image_histogram():
+    camera = util.img_as_ubyte(data.camera())
+    hist = histogram(camera.ravel(), 256, source_range='image')
+    assert 101 < threshold_otsu(hist=hist) < 103
+
+def test_otsu_camera_image_counts():
+    camera = util.img_as_ubyte(data.camera())
+    counts = histogram(camera.ravel(), 256, source_range='image')
+    assert 101 < threshold_otsu(hist=counts) < 103
 
 def test_otsu_coins_image():
     coins = util.img_as_ubyte(data.coins())

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -293,9 +293,9 @@ def threshold_otsu(image=None, nbins=256, *, hist=None):
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
     hist : array, or 2-tuple of arrays, optional
-        Histogram from which to determine the threshold, and optionally a corresponding array
-        of bin center intensities. Alternatively, only the histogram can be
-        passed.
+        Histogram from which to determine the threshold, and optionally a
+        corresponding array of bin center intensities.
+        An alternative use of this function is to pass it only hist.
 
     Returns
     -------

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -237,6 +237,7 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
 
 def threshold_otsu(image=None, nbins=256, *, hist=None):
     """Return threshold value based on Otsu's method.
+
     Either image or hist must be provided. In case hist is given, the actual
     histogram of the image is ignored.
 

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -257,7 +257,7 @@ def _validate_image_histogram(image, hist, nbins=None):
     counts : 1D array of float
         Each element is the number of pixels falling in each intensity bin.
     bin_centers : 1D array
-        The value corresponding to the center of each intensity bin.
+        Each element is the value corresponding to the center of each intensity bin.
 
     Raises
     ------

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -293,7 +293,7 @@ def threshold_otsu(image=None, nbins=256, *, hist=None):
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
     hist : array, or 2-tuple of arrays, optional
-        Histogram to determine the threshold from and a corresponding array
+        Histogram from which to determine the threshold, and optionally a corresponding array
         of bin center intensities. Alternatively, only the histogram can be
         passed.
 

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -345,8 +345,7 @@ def threshold_otsu(image=None, nbins=256, *, hist=None):
     variance12 = weight1[:-1] * weight2[1:] * (mean1[:-1] - mean2[1:]) ** 2
 
     idx = np.argmax(variance12)
-
-    threshold = bin_centers[:-1][idx]
+    threshold = bin_centers[idx]
 
     return threshold
 

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -248,7 +248,7 @@ def threshold_otsu(image=None, nbins=256, *, hist=None):
     nbins : int, optional
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
-    hist : (array, array)  tuple, optional
+    hist : array, or 2-tuple of arrays, optional
         Histogram to determine the threshold from and a corresponding array
         of bin center intensities. Alternatively, only the histogram can be
         passed.

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -235,8 +235,7 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
 
     return thresh_image - offset
 
-
-def threshold_otsu(image=None, nbins=256, hist=None, bin_centers=None):
+def threshold_otsu(image=None, nbins=256, *, histogram=None):
     """Return threshold value based on Otsu's method.
     Either image or hist must be provided. In case hist is given, the actual
     histogram of the image is ignored.
@@ -248,11 +247,10 @@ def threshold_otsu(image=None, nbins=256, hist=None, bin_centers=None):
     nbins : int, optional
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
-    hist : optional
-        Histogram to determine the threshold from.
-    bin_centers : optional
-        Intensity values for each histogram bin, corresponding to the given
-        histogram
+    histogram : (array, array)  tuple, optional
+        Histogram to determine the threshold from and a corresponding array
+        of bin center intensities. Alternatively, only the histogram can be
+        passed.
 
     Returns
     -------
@@ -278,7 +276,13 @@ def threshold_otsu(image=None, nbins=256, hist=None, bin_centers=None):
     if image is None and hist is None:
         raise Exception("Either name or hist must be provided.")
 
-    if hist is None:
+    if histogram is not None:
+        if isinstance(histogram, (tuple, list)):
+            hist, bin_centers = histogram
+        else:
+            hist = histogram
+            bin_centers = np.arange(counts.size)
+    else:
         if image.ndim > 2 and image.shape[-1] in (3, 4):
             msg = "threshold_otsu is expected to work correctly only for " \
                   "grayscale images; image shape {0} looks like an RGB image"
@@ -307,10 +311,7 @@ def threshold_otsu(image=None, nbins=256, hist=None, bin_centers=None):
 
     idx = np.argmax(variance12)
 
-    if bin_centers is None:
-        threshold = idx
-    else :
-        threshold = bin_centers[:-1][idx]
+    threshold = bin_centers[:-1][idx]
 
     return threshold
 

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -279,6 +279,42 @@ def threshold_otsu(image, nbins=256):
         return first_pixel
 
     hist, bin_centers = histogram(image.ravel(), nbins, source_range='image')
+
+    return threshold_otsu_from_histogram(hist, bin_centers)
+
+def threshold_otsu_from_histogram(hist, bin_centers):
+    """Return threshold value based on Otsu's method dermined from a histogram.
+
+    Parameters
+    ----------
+    hist : optional
+        Histogram to determine the threshold from.
+    bin_centers : optional
+        Intensity values for each histogram bin, corresponding to the given
+        histogram
+
+    Returns
+    -------
+    threshold : float
+        Upper threshold value. All pixels with an intensity higher than
+        this value are assumed to be foreground.
+
+    References
+    ----------
+    .. [1] Wikipedia, https://en.wikipedia.org/wiki/Otsu's_Method
+
+    Examples
+    --------
+    >>> from skimage.data import camera
+    >>> from skimage.exposure import histogram
+    >>> from skimage.filters import threshold_otsu_from_histogram
+    >>> image = camera()
+    >>> nbins = 256
+    >>> hist, bin_centers = histogram(image.ravel(), nbins, source_range='image')
+    >>> thresh = threshold_otsu_from_histogram(hist, bin_centers)
+    >>> binary = image <= thresh
+    """
+
     hist = hist.astype(float)
 
     # class probabilities for all possible thresholds

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -363,9 +363,9 @@ def threshold_yen(image=None, nbins=256, *, hist=None):
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
     hist : array, or 2-tuple of arrays, optional
-        Histogram to determine the threshold from and a corresponding array
-        of bin center intensities. Alternatively, only the histogram can be
-        passed.
+        Histogram from which to determine the threshold, and optionally a
+        corresponding array of bin center intensities.
+        An alternative use of this function is to pass it only hist.
 
     Returns
     -------

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -274,7 +274,7 @@ def threshold_otsu(image=None, nbins=256, *, hist=None):
     The input image must be grayscale.
     """
     if image is None and hist is None:
-        raise Exception("Either name or hist must be provided.")
+        raise Exception("Either image or hist must be provided.")
 
     if hist is not None:
         if isinstance(hist, (tuple, list)):

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -235,7 +235,7 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
 
     return thresh_image - offset
 
-def threshold_otsu(image=None, nbins=256, *, histogram=None):
+def threshold_otsu(image=None, nbins=256, *, hist=None):
     """Return threshold value based on Otsu's method.
     Either image or hist must be provided. In case hist is given, the actual
     histogram of the image is ignored.
@@ -247,7 +247,7 @@ def threshold_otsu(image=None, nbins=256, *, histogram=None):
     nbins : int, optional
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
-    histogram : (array, array)  tuple, optional
+    hist : (array, array)  tuple, optional
         Histogram to determine the threshold from and a corresponding array
         of bin center intensities. Alternatively, only the histogram can be
         passed.
@@ -276,11 +276,11 @@ def threshold_otsu(image=None, nbins=256, *, histogram=None):
     if image is None and hist is None:
         raise Exception("Either name or hist must be provided.")
 
-    if histogram is not None:
-        if isinstance(histogram, (tuple, list)):
-            hist, bin_centers = histogram
+    if hist is not None:
+        if isinstance(hist, (tuple, list)):
+            counts, bin_centers = hist
         else:
-            hist = histogram
+            counts = hist
             bin_centers = np.arange(counts.size)
     else:
         if image.ndim > 2 and image.shape[-1] in (3, 4):
@@ -293,16 +293,16 @@ def threshold_otsu(image=None, nbins=256, *, histogram=None):
         if np.all(image == first_pixel):
             return first_pixel
 
-        hist, bin_centers = histogram(image.ravel(), nbins, source_range='image')
+        counts, bin_centers = histogram(image.ravel(), nbins, source_range='image')
 
-    hist = hist.astype(float)
+    counts = counts.astype(float)
 
     # class probabilities for all possible thresholds
-    weight1 = np.cumsum(hist)
-    weight2 = np.cumsum(hist[::-1])[::-1]
+    weight1 = np.cumsum(counts)
+    weight2 = np.cumsum(counts[::-1])[::-1]
     # class means for all possible thresholds
-    mean1 = np.cumsum(hist * bin_centers) / weight1
-    mean2 = (np.cumsum((hist * bin_centers)[::-1]) / weight2[::-1])[::-1]
+    mean1 = np.cumsum(counts * bin_centers) / weight1
+    mean2 = (np.cumsum((counts * bin_centers)[::-1]) / weight2[::-1])[::-1]
 
     # Clip ends to align class 1 and class 2 variables:
     # The last value of ``weight1``/``mean1`` should pair with zero values in

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -255,7 +255,7 @@ def _validate_image_histogram(image, hist, nbins=None):
     Returns
     -------
     counts : 1D array of float
-        The number of pixels falling in each intensity bin
+        Each element is the number of pixels falling in each intensity bin.
     bin_centers : 1D array
         The value corresponding to the center of each intensity bin.
 

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -282,7 +282,7 @@ def _validate_image_histogram(image, hist, nbins=None):
 def threshold_otsu(image=None, nbins=256, *, hist=None):
     """Return threshold value based on Otsu's method.
 
-    Either image or hist must be provided. In case hist is given, the actual
+    Either image or hist must be provided. If hist is provided, the actual
     histogram of the image is ignored.
 
     Parameters

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -369,16 +369,6 @@ def threshold_yen(image=None, nbins=256, *, hist=None):
             counts = hist
             bin_centers = np.arange(counts.size)
     else:
-        if image.ndim > 2 and image.shape[-1] in (3, 4):
-            msg = "threshold_otsu is expected to work correctly only for " \
-                  "grayscale images; image shape {0} looks like an RGB image"
-            warn(msg.format(image.shape))
-
-        # Check if the image is multi-colored or not
-        first_pixel = image.ravel()[0]
-        if np.all(image == first_pixel):
-            return first_pixel
-
         counts, bin_centers = histogram(image.ravel(), nbins, source_range='image')
 
     counts = counts.astype(float)
@@ -472,16 +462,6 @@ def threshold_isodata(image=None, nbins=256, return_all=False, *, hist=None):
             counts = hist
             bin_centers = np.arange(counts.size)
     else:
-        if image.ndim > 2 and image.shape[-1] in (3, 4):
-            msg = "threshold_otsu is expected to work correctly only for " \
-                  "grayscale images; image shape {0} looks like an RGB image"
-            warn(msg.format(image.shape))
-
-        # Check if the image is multi-colored or not
-        first_pixel = image.ravel()[0]
-        if np.all(image == first_pixel):
-            return first_pixel
-
         counts, bin_centers = histogram(image.ravel(), nbins, source_range='image')
 
     counts = counts.astype(float)


### PR DESCRIPTION
added method threshold_otsu_from_histogram as shortcut in case the histogram is known in advance

## Description
Hi all, hi @jni ,

this PR-draft refactors thresholding_otsu method so that one can call it also with a histogram instead of an image. I would like to use it in a [GPU-accelerated image processing library](https://github.com/clEsperanto/pyclesperanto_prototype) where we can determine the histogram on the GPU, but lack threshold-method implementations.

I would wonder what you think about this implementation. If it makes sense, I would offer to implement the same strategy for other threshold methods.

Best,
Robert

## Checklist

[x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
[ ] Gallery example in `./doc/examples` (new features only)
[ ] Benchmark in `./benchmarks`, if your changes aren't covered by an existing benchmark
[ ] Unit tests
[ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
