### PR TITLE
Bump numpy versions to match scipy (kinda)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,11 @@ requires = [
     "wheel",
     "setuptools",
     "Cython>=0.29.18",
-    # AIX is IBM's variant of UNIX; Scipy uses special handling for it.
-    # Therefore we decided to handle it in the same way.
-    # https://github.com/scipy/scipy/pull/10431#issue-295816438
-    "numpy==1.15.1; python_version=='3.6' and platform_system!='AIX'",
-    "numpy==1.15.1; python_version=='3.7' and platform_system!='AIX'",
-    "numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'",
-    "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",
-    "numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'",
-    "numpy==1.17.3; python_version>='3.8' and platform_system=='AIX'",
+    # We follow scipy for much of these pinnings
+    # https://github.com/scipy/scipy/blob/master/pyproject.toml
+    "numpy==1.16.5; python_version=='3.6'",
+    "numpy==1.16.5; python_version=='3.7'",
+    "numpy==1.17.3; python_version=='3.8'",
+    # do not pin numpy on future versions of python to avoid incompatible numpy and python versions
+    "numpy; python_version>='3.9'",
 ]

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -2,4 +2,4 @@ Cython>=0.29.21,!=0.29.18
 wheel
 # numpy 1.18.0 breaks builds on MacOSX
 # https://github.com/numpy/numpy/pull/15194
-numpy>=1.15.1,!=1.18.0
+numpy>=1.16.5,!=1.18.0

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-numpy>=1.15.1
+numpy>=1.16.5
 scipy>=1.0.1
 matplotlib>=2.0.0,!=3.0.0
 networkx>=2.0


### PR DESCRIPTION
## Description
I'm waiting to hear back on the reasons why scipy held back bumping AIX numpy requirements.

https://github.com/scipy/scipy/issues/12940

Hopefully this should help with the failures on the minimum version requirement.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
