### PR TITLE
Fix usage of numpy.pad for old versions of numpy

### DIFF
--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -148,8 +148,9 @@ def test_structure_tensor_eigenvalues():
 
 
 def test_structure_tensor_eigenvalues_3d():
-    image = np.pad(cube(9), 5) * 1000
-    boundary = (np.pad(cube(9), 5) - np.pad(cube(7), 6)).astype(bool)
+    image = np.pad(cube(9), 5, mode='constant') * 1000
+    boundary = (np.pad(cube(9), 5, mode='constant') -
+                np.pad(cube(7), 6, mode='constant')).astype(bool)
     A_elems = structure_tensor(image, sigma=0.1)
     e0, e1, e2 = structure_tensor_eigenvalues(A_elems)
     # e0 should detect facets

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -149,8 +149,8 @@ def test_structure_tensor_eigenvalues():
 
 def test_structure_tensor_eigenvalues_3d():
     image = np.pad(cube(9), 5, mode='constant') * 1000
-    boundary = (np.pad(cube(9), 5, mode='constant') -
-                np.pad(cube(7), 6, mode='constant')).astype(bool)
+    boundary = (np.pad(cube(9), 5, mode='constant')
+                - np.pad(cube(7), 6, mode='constant')).astype(bool)
     A_elems = structure_tensor(image, sigma=0.1)
     e0, e1, e2 = structure_tensor_eigenvalues(A_elems)
     # e0 should detect facets


### PR DESCRIPTION
## Description
Pad default value is only set in numpy 1.17

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
