### PR TITLE
ENH: Reduce memory use for convex_hull_image by checking hull inequalities in sequence

### DIFF
--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -19,12 +19,12 @@ def _offsets_diamond(ndim):
 
 
 def _check_coords_in_hull(gridcoords, hull_equations, tolerance):
-    r"""Checks all the co-ordinates for inclusiveness in the convex hull.
+    r"""Checks all the coordinates for inclusiveness in the convex hull.
 
     Parameters
     ----------
     gridcoords : (M, N) ndarray
-        Co-ordinates of ``N`` points in ``M`` dimensions.
+        Coordinates of ``N`` points in ``M`` dimensions.
     hull_equations : (M, N) ndarray
         Hyperplane equations of the facets of the convex hull.
     tolerance : float
@@ -40,10 +40,10 @@ def _check_coords_in_hull(gridcoords, hull_equations, tolerance):
 
     Notes
     -----
-    Check inclusiveness of co-ordinates in convex hull requires intermediate
-    calculations of dot products which are memory-intensive. Thus, the convex
-    hull equations are checked individually with all co-ordinates to keep
-    within the memory limit.
+    Checking the inclusiveness of coordinates in a convex hull requires
+    intermediate calculations of dot products which are memory-intensive.
+    Thus, the convex hull equations are checked individually with all
+    coordinates to keep within the memory limit.
 
     References
     ----------
@@ -55,13 +55,13 @@ def _check_coords_in_hull(gridcoords, hull_equations, tolerance):
     coords_in_hull = np.ones(n_coords, dtype=np.bool_)
 
     # Pre-allocate arrays to cache intermediate results for reducing overheads
-    dot_array = np.zeros(n_coords, dtype=np.float64)
-    test_ineq_temp = np.zeros(n_coords, dtype=np.float64)
-    coords_single_ineq = np.zeros(n_coords, dtype=np.bool_)
+    dot_array = np.empty(n_coords, dtype=np.float64)
+    test_ineq_temp = np.empty(n_coords, dtype=np.float64)
+    coords_single_ineq = np.empty(n_coords, dtype=np.bool_)
 
     # A point is in the hull if it satisfies all of the hull's inequalities
     for idx in range(n_hull_equations):
-        # Tests a hyperplane equation on all co-ordinates of volume
+        # Tests a hyperplane equation on all coordinates of volume
         np.dot(hull_equations[idx, :ndim], gridcoords, out=dot_array)
         np.add(dot_array, hull_equations[idx, ndim:], out=test_ineq_temp)
         np.less(test_ineq_temp, tolerance, out=coords_single_ineq)

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -57,13 +57,15 @@ def _check_coords_in_hull(gridcoords, hull_equations, tolerance):
     # Pre-allocate arrays to cache intermediate results for reducing overheads
     dot_array = np.zeros(n_coords, dtype=np.float64)
     test_ineq_temp = np.zeros(n_coords, dtype=np.float64)
+    coords_single_ineq = np.zeros(n_coords, dtype=np.bool_)
 
     # A point is in the hull if it satisfies all of the hull's inequalities
     for idx in range(n_hull_equations):
-        # Tests a hull equation on all co-ordinates of volume
+        # Tests a hyperplane equation on all co-ordinates of volume
         np.dot(hull_equations[idx, :ndim], gridcoords, out=dot_array)
         np.add(dot_array, hull_equations[idx, ndim:], out=test_ineq_temp)
-        coords_in_hull *= test_ineq_temp < tolerance
+        np.less(test_ineq_temp, tolerance, out=coords_single_ineq)
+        coords_in_hull *= coords_single_ineq
 
     return coords_in_hull
 


### PR DESCRIPTION
## Description

Fixes issue #5019 


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
