### PR TITLE
Fix IndexError when calling hough_line_peaks with too few angles

### DIFF
--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -58,6 +58,7 @@ def hough_line_peaks(hspace, angles, dists, min_distance=9, min_angle=10,
     """
     from ..feature.peak import _prominent_peaks
 
+    min_angle = min(min_angle, hspace.shape[1])
     h, a, d = _prominent_peaks(hspace, min_xdistance=min_angle,
                                min_ydistance=min_distance,
                                threshold=threshold,

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -180,6 +180,15 @@ def test_hough_line_peaks_zero_input():
     assert_equal(a, np.array([]))
 
 
+def test_hough_line_peaks_single_angle():
+    # Regression test for gh-4814
+    # This code snippet used to raise an IndexError
+    img = np.random.random((100, 100))
+    tested_angles = np.array([np.pi / 2])
+    h, theta, d = transform.hough_line(img, theta=tested_angles)
+    accum, angles, dists = transform.hough_line_peaks(h, theta, d, threshold=2)
+
+
 @test_parallel()
 def test_hough_circle():
     # Prepare picture


### PR DESCRIPTION
## Description

`hough_line_peaks` has a default parameter `min_angle=10` which does not make sense if the second dimension of the accumulator array is less than 10. In such cases, it would raise an IndexError.

Fixes gh-4814 with the single line fix suggested [in the issue's comments](https://github.com/scikit-image/scikit-image/issues/4814#issuecomment-654698200).

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
