### PR TITLE
Fixes broken link to CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,1 @@
-[scikit-image Code of Conduct](doc/source/conduct/code_of_conduct.rst)
+[scikit-image Code of Conduct](doc/source/conduct/code_of_conduct.md)


### PR DESCRIPTION
Fixes broken link.

It links to a markdown (`.md`) file, not a restructured text (`.rst`) one.
