### PR TITLE
Add multichannel to regionprops

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -215,7 +215,7 @@ class RegionProperties:
                     and intensity_image.ndim in [ndim, ndim + 1]
                     ):
                 raise ValueError('Label and intensity image shapes must match,'
-                                 ' except for channels (last) axis.')
+                                 ' except for channel (last) axis.')
             multichannel = label_image.shape < intensity_image.shape
         else:
             multichannel = False

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -212,7 +212,7 @@ class RegionProperties:
             ndim = label_image.ndim
             if not (
                     intensity_image.shape[:ndim] == label_image.shape
-                    and intensity_image.ndim == label_image.ndim + 1
+                    and intensity_image.ndim in [ndim, ndim + 1]
                     ):
                 raise ValueError('Label and intensity image shapes must match,'
                                  ' except for channels (last) axis.')

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -210,7 +210,10 @@ class RegionProperties:
 
         if intensity_image is not None:
             ndim = label_image.ndim
-            if not intensity_image.shape[:ndim] == label_image.shape:
+            if not (
+                    intensity_image.shape[:ndim] == label_image.shape
+                    and intensity_image.ndim == label_image.ndim + 1
+                    ):
                 raise ValueError('Label and intensity image shapes must match,'
                                  ' except for channels (last) axis.')
             multichannel = label_image.shape < intensity_image.shape

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -486,7 +486,7 @@ class RegionProperties:
         if self._multichannel:
             moments = np.stack(
                     [_moments.moments(image[..., i], order=3)
-                    for i in range(image.shape[-1])],
+                        for i in range(image.shape[-1])],
                     axis=-1,
                     )
         else:

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -482,16 +482,16 @@ class RegionProperties:
     @property
     @_cached
     def weighted_moments(self):
-        image = (
-            self._intensity_image_double()
-            if self._multichannel
-            else np.expand_dims(self._intensity_image_double(), self._ndim)
-        )
-        moments = [
-            _moments.moments(image[..., i], order=3)
-            for i in range(image.shape[-1])
-        ]
-        return np.squeeze(np.stack(moments, axis=-1))
+        image = self._intensity_image_double()
+        if self._multichannel:
+            moments = np.stack(
+                    [_moments.moments(image[..., i], order=3)
+                    for i in range(image.shape[-1])],
+                    axis=-1,
+                    )
+        else:
+            moments = _moments.moments(image, order=3)
+        return moments
 
     @property
     @_cached

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -841,11 +841,14 @@ def regionprops_table(label_image, intensity_image=None,
             list(properties) + [prop.__name__ for prop in extra_properties]
         )
     if len(regions) == 0:
-        label_image = np.zeros((3,) * label_image.ndim, dtype=int)
-        label_image[(1,) * label_image.ndim] = 1
+        ndim = label_image.ndim
+        label_image = np.zeros((3,) * ndim, dtype=int)
+        label_image[(1,) * ndim] = 1
         if intensity_image is not None:
-            intensity_image = np.zeros(label_image.shape,
-                                       dtype=intensity_image.dtype)
+            intensity_image = np.zeros(
+                    label_image.shape + intensity_image.shape[ndim:],
+                    dtype=intensity_image.dtype
+                )
         regions = regionprops(label_image, intensity_image=intensity_image,
                               cache=cache, extra_properties=extra_properties)
 

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -491,18 +491,18 @@ class RegionProperties:
     @_cached
     def weighted_moments_central(self):
         ctr = self.weighted_local_centroid
-        image = (
-            self._intensity_image_double()
-            if self._multichannel
-            else np.expand_dims(self._intensity_image_double(), self._ndim)
-        )
-        moments = [
-            _moments.moments_central(
-                image[..., i], center=ctr[..., i], order=3
-            )
-            for i in range(image.shape[-1])
-        ]
-        return np.squeeze(np.stack(moments, axis=-1))
+        image = self._intensity_image_double()
+        if self._multichannel:
+            moments_list = [
+                _moments.moments_central(
+                    image[..., i], center=ctr[..., i], order=3
+                )
+                for i in range(image.shape[-1])
+            ]
+            moments = np.stack(moments_list, axis=-1)
+        else:
+            moments = _moments.moments_central(image, ctr, order=3)
+        return moments
 
     @property
     @only2d

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -851,7 +851,7 @@ def regionprops_table(label_image, intensity_image=None,
             intensity_image = np.zeros(
                     label_image.shape + intensity_image.shape[ndim:],
                     dtype=intensity_image.dtype
-                )
+                    )
         regions = regionprops(label_image, intensity_image=intensity_image,
                               cache=cache, extra_properties=extra_properties)
 

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -699,7 +699,7 @@ def test_extra_properties_table():
 
 def test_multichannel():
     """Test that computing multichannel properties works."""
-    astro = data.astronaut()
+    astro = data.astronaut()[::4, ::4]
     astro_green = astro[..., 1]
     labels = slic(astro.astype(float), start_label=1)
 

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -705,7 +705,7 @@ def test_multichannel():
 
     segment_idx = np.max(labels) // 2
     region = regionprops(labels, astro_green)[segment_idx]
-    region_multi = regionprops(labels, astro, multichannel=True)[segment_idx]
+    region_multi = regionprops(labels, astro)[segment_idx]
     for prop in PROPS:
         p = region[prop]
         p_multi = region_multi[prop]


### PR DESCRIPTION
## Description

This PR adds multichannel capabilities to regionprops. Demo:

```python
In [1]: from skimage import measure, segmentation                                      
In [2]: from skimage import data                                           
In [3]: coffee = data.coffee()                                             
In [4]: labels = segmentation.slic(coffee, start_label=1)                  
In [5]: props = measure.regionprops(labels, coffee, multichannel=True)     
In [6]: len(props)                                                         
Out[6]: 67

In [7]: p = props[50]                                                      
In [8]: p.centroid                                                         
Out[8]: (308.07710764532663, 102.91591231322936)

In [9]: p.mean_intensity                                                   
Out[9]: array([159.86705202,  75.2480096 ,  44.72875995])
```

One Q I have is whether we want the multichannel keyword or whether we can just enable multichannel just by detecting the difference in shape between the label image and the intensity image. I'm kinda leaning against the multichannel keyword argument ­— I was a bit annoyed that I had to type `multichannel=True` above where it's perfectly unambiguous without it.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
