### PR TITLE
Specify whether core dev should merge right after second approving review.

### DIFF
--- a/doc/source/core_developer.md
+++ b/doc/source/core_developer.md
@@ -125,6 +125,16 @@ While we collectively "own" any patches (and bugs!) that become part
 of the code base, you are vouching for changes you merge.  Please take
 that responsibility seriously.
 
+In practice, if you are the second core developer reviewing and approving a
+given pull request, you typically merge it (again, using GitHub's Squash and
+Merge feature) in the wake of your approval. What are the exceptions to this
+process? If the pull request has been particularly controversial or the
+subject of much debate (e.g., involving API changes), then you would want to
+wait a few days before merging. This waiting time gives others a chance to
+speak up in case they are not fine with the current state of the pull request.
+Another exceptional situation is one where the first approving review happened
+a long time ago and many changes have taken place in the meantime.
+
 Closing issues and pull requests
 --------------------------------
 


### PR DESCRIPTION
## Description

@grlee77 resubmitting #5039 over here.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
