### PR TITLE
update trove classifiers and tests for Python 3.9 + fix pytest config

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,13 @@ environment:
     - PYTHON: C:\Python37-x64
     - PYTHON: C:\Python38
     - PYTHON: C:\Python38-x64
-    - PYTHON: C:\Python37-x64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON: C:\Python39
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      PYTHON: C:\Python39-x64
+    # build pre release packages on Python 3.8 since it has been out long
+    # enough for wheels to be built for packages that need to be compiled.
+    - PYTHON: C:\Python38-x64
       PIP_FLAGS: --pre
 
 matrix:
@@ -29,7 +35,7 @@ install:
         throw "There are newer queued builds for this pull request, failing early." }
 
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - "python -m pip install --retries 3 -U pip"
+  - "python -m pip install -U pip"
 
   # Check that we have the expected version and architecture for Python
   - "python --version"
@@ -37,15 +43,15 @@ install:
   - "pip --version"
 
   # Install the build and runtime dependencies of the project.
-  - pip install %PIP_FLAGS% --retries 3 -r requirements/default.txt
-  - pip install %PIP_FLAGS% --retries 3 -r requirements/build.txt
+  - pip install %PIP_FLAGS% -r requirements/default.txt
+  - pip install %PIP_FLAGS% -r requirements/build.txt
   - python setup.py bdist_wheel bdist_wininst
   - ps: "ls dist"
 
   # Install the generated wheel package to test it.
   - pip install %PIP_FLAGS% --no-index --find-links dist/ scikit-image
   # Install the test dependencies
-  - pip install %PIP_FLAGS% --retries 3 -r requirements/test.txt
+  - pip install %PIP_FLAGS% -r requirements/test.txt
 
 # Not a .NET project, we build scikit-image in the install step instead
 build: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   doc:
     docker:
-      - image: circleci/python:3.8.2
+      - image: circleci/python:3.9.0
     steps:
       - checkout
       - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,10 +98,19 @@ matrix:
       services:
         - xvfb
     - os: linux
-      python: 3.7
+      python: 3.9
       stage: Comprehensive tests
-      env: QT=PyQt5 OPTIONAL_DEPS=1 PIP_FLAGS="--pre"
-      dist: xenial # Required for Python 3.7
+      env: QT=PyQt5 BUILD_DOCS=1
+      dist: xenial # Required for Python 3.7+
+      services:
+        - xvfb
+    # build pre release packages on Python 3.8 since it has been out long
+    # enough for wheels to be built for packages that need to be compiled.
+    - os: linux
+      python: 3.8
+      stage: Comprehensive tests
+      env: QT=PyQt5 PIP_FLAGS="--pre"
+      dist: xenial # Required for Python 3.7+
       services:
         - xvfb
     # For smooth deployment, the osx_image here should match
@@ -123,6 +132,11 @@ matrix:
       language: objective-c
       stage: Initial tests
       env: MB_PYTHON_VERSION=3.8 OPTIONAL_DEPS=1 EXTRA_DEPS=0
+    - os: osx
+      osx_image: xcode9.4
+      language: objective-c
+      stage: Comprehensive tests
+      env: MB_PYTHON_VERSION=3.9 TEST_EXAMPLES=0
 
 before_install:
     # Remove this line when the Ubuntu image is updated to Xenial
@@ -153,7 +167,10 @@ install:
     # pip will not create a virtual environment, just for building the package
     # This is problematic because the version of numpy of that virtual environment
     # may be higher than the version we want to test with.
-    - if [[ $INSTALL_FROM_SDIST ]]; then
+    - |
+      set -e
+
+      if [[ $INSTALL_FROM_SDIST ]]; then
         pip uninstall cython -y;
         pip install dist/scikit-image-*.tar.gz;
       else
@@ -173,6 +190,7 @@ install:
     - touch ${MPL_DIR}/matplotlibrc
     # Install most of the optional packages
     - |
+      set -e
       if [[ "${OPTIONAL_DEPS}" == "1" ]]; then
         pip install -r ./requirements/optional.txt $WHEELHOUSE
         if [[ "${EXTRA_DEPS}" != "0" ]]; then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,10 +35,23 @@ jobs:
         ARCH: 'x64'
         PIP_FLAGS: ''
         TEST_EXAMPLES: 'true'
-      Python37-x64-pre:
-        PYTHON_VERSION: '3.7'
+      # build pre release packages on Python 3.8 since it has been out long
+      # enough for wheels to be built for packages that need to be compiled.
+      Python38-x64-pre:
+        PYTHON_VERSION: '3.8'
         ARCH: 'x64'
         PIP_FLAGS: '--pre'
+      Python39:
+        PYTHON_VERSION: '3.9'
+        ARCH: 'x86'
+        PIP_FLAGS: ''
+      Python39-x64:
+        PYTHON_VERSION: '3.9'
+        ARCH: 'x64'
+        PIP_FLAGS: ''
+        # NOTE(honles): winpty is required by one of the doc dependencies,
+        #               but does not provide a wheel for Python 3.9
+        # TEST_EXAMPLES: 'true'
   continueOnError: false
   timeoutInMinutes: 60
 
@@ -62,9 +75,14 @@ jobs:
       $PYTHON -c "import struct; print('Void pointer width is', struct.calcsize('P') * 8)"
       $PYTHON -m pip list
 
+
       # Install the build and runtime dependencies of the project
-      $PYTHON -m pip install ${PIP_FLAGS} -r requirements/default.txt
       $PYTHON -m pip install ${PIP_FLAGS} -r requirements/build.txt
+
+      # Disable C99 complex if PyWavelets needs to be built from source.
+      # The compiler used will be MSVC, but C99 may be detected improperly
+      USE_C99_COMPLEX=0 $PYTHON -m pip install ${PIP_FLAGS} -r requirements/default.txt
+
       $PYTHON -m pip list
     displayName: 'Pre-installation'
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 PYTHON        ?= python
-SPHINXOPTS    ?= -j $(shell nproc || getconf _NPROCESSORS_ONLN || 1)
+SPHINXOPTS    ?= -j auto
 SPHINXBUILD   ?= $(PYTHON) -m sphinx
 SPHINXCACHE   ?= build/doctrees
 PAPER         ?=
@@ -38,7 +38,7 @@ clean:
 	-rm -rf $(DEST)
 	-rm -rf api
 	-rm -rf source/api
-	-find ./source/auto_examples/* -type f | grep -v blank | xargs rm -f
+	-find ./source/auto_examples/* -type f | grep -v blank | xargs -r rm -f
 
 api:
 	@mkdir -p source/api

--- a/setup.py
+++ b/setup.py
@@ -224,6 +224,7 @@ if __name__ == "__main__":
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
+            'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3 :: Only',
             'Topic :: Scientific/Engineering',
             'Operating System :: Microsoft :: Windows',


### PR DESCRIPTION
## Description

This change adds the trove classifiers for Python 3.8 & 3.9, updates the CI to test Python 3.9, and updates the pytest config to not try running the test setup as a test itself.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
