### PR TITLE
fix Azure Pipelines, pytest config, and trove classifiers for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ addons:
     # https://github.com/matplotlib/matplotlib/pull/13412
     - qtbase5-dev
 
-stage: Comprehensive tests
-
 stages:
     # Do the style check and a single test job, don't proceed if it fails
     - name: Initial tests
@@ -52,24 +50,30 @@ matrix:
   include:
     - os: linux
       python: 3.6
+      stage: Comprehensive tests
       env: OPTIONAL_DEPS=1 WITH_PYSIDE=1 BUILD_DOCS=1 INSTALL_FROM_SDIST=1
     - os: linux
       python: 3.6
+      stage: Comprehensive tests
       env: QT=PyQt5 MINIMUM_REQUIREMENTS=1
     - os: linux
       python: 3.6
+      stage: Comprehensive tests
       env: PYTHONOPTIMIZE=2 BUILD_DOCS=0 TEST_EXAMPLES=0
     - os: linux
       python: 3.6
+      stage: Comprehensive tests
       env: QT=PyQt5 OPTIONAL_DEPS=1 MINIMUM_REQUIREMENTS=1
     - os: linux
       python: 3.7
+      stage: Comprehensive tests
       dist: xenial # Required for Python 3.7+
       env: QT=PyQt5 OPTIONAL_DEPS=1 BUILD_DOCS=1 DEPLOY_DOCS=1
       services:
         - xvfb
     - os: linux
       python: 3.7
+      stage: Comprehensive tests
       # Testing and installing from sdist will ensure that tests do not
       # depend on pooch to pass
       # pooch is used as an optional dependency to download datasets on the fly
@@ -81,19 +85,21 @@ matrix:
         - xvfb
     - os: linux
       python: 3.7
-      stage: Initial tests
+      stage: Comprehensive tests
       dist: xenial # Required for Python 3.7
       env: QT=PyQt5 OPTIONAL_DEPS=1 BUILD_DOCS=1
       services:
         - xvfb
     - os: linux
       python: 3.8
+      stage: Initial tests
       env: QT=PyQt5 OPTIONAL_DEPS=1 BUILD_DOCS=1
       dist: xenial # Required for Python 3.7+
       services:
         - xvfb
     - os: linux
       python: 3.7
+      stage: Comprehensive tests
       env: QT=PyQt5 OPTIONAL_DEPS=1 PIP_FLAGS="--pre"
       dist: xenial # Required for Python 3.7
       services:
@@ -105,16 +111,18 @@ matrix:
     - os: osx
       osx_image: xcode9.4
       language: objective-c
-      env: MB_PYTHON_VERSION=3.6
+      stage: Comprehensive tests
+      env: MB_PYTHON_VERSION=3.6 TEST_EXAMPLES=0
     - os: osx
       osx_image: xcode9.4
       language: objective-c
+      stage: Comprehensive tests
       env: MB_PYTHON_VERSION=3.7 OPTIONAL_DEPS=1 EXTRA_DEPS=0
     - os: osx
       osx_image: xcode9.4
       language: objective-c
-      # Require pre for scikit-learn 0.22 that has builds for 3.8
-      env: MB_PYTHON_VERSION=3.8
+      stage: Initial tests
+      env: MB_PYTHON_VERSION=3.8 OPTIONAL_DEPS=1 EXTRA_DEPS=0
 
 before_install:
     # Remove this line when the Ubuntu image is updated to Xenial
@@ -123,7 +131,6 @@ before_install:
         apt-key adv --list-public-keys --with-colons | grep '^pub' | cut -d':' -f 5 | egrep -o '.{8}$' | grep -wo 762E3157 > /dev/null 2>&1 || sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 762E3157;
       fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        pip3 install travis-wait-improved;
         source tools/travis/osx_install.sh;
       else
         virtualenv -p python ~/venv;
@@ -159,7 +166,7 @@ install:
     # installing from SDIST will force the use of pooch as a downloading
     # backend to test the pooch functionality
     # Install testing requirements
-    - pip install --retries 3 $PIP_FLAGS -r requirements/test.txt
+    - pip install $PIP_FLAGS -r requirements/test.txt
     # Matplotlib settings - do not show figures during doc examples
     - export MPL_DIR=`python -c 'import matplotlib; print(matplotlib.get_configdir())'`
     - mkdir -p ${MPL_DIR}
@@ -167,11 +174,11 @@ install:
     # Install most of the optional packages
     - |
       if [[ "${OPTIONAL_DEPS}" == "1" ]]; then
-        pip install --retries 3 -r ./requirements/optional.txt $WHEELHOUSE
+        pip install -r ./requirements/optional.txt $WHEELHOUSE
         if [[ "${EXTRA_DEPS}" != "0" ]]; then
           # Extra deps need compilation, and it may not always be possible to
           # compile them easily on all platforms
-          pip install --retries 3 -r ./requirements/extras.txt $WHEELHOUSE
+          pip install -r ./requirements/extras.txt $WHEELHOUSE
         fi
       fi
     - tools/travis/install_qt.sh
@@ -180,5 +187,3 @@ script: tools/travis/script.sh
 
 after_success:
     - codecov
-    # Prepare.release
-    - doc/release/contribs.py HEAD~10

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all clean test
-PYTHON=python
-PYTESTS=pytest
+PYTHON ?= python
+PYTEST ?= $(PYTHON) -m pytest
 
 all:
 	$(PYTHON) setup.py build_ext --inplace
@@ -14,20 +14,19 @@ cleandoc:
 	rm -rf doc/build
 
 test:
-	$(PYTESTS) skimage --doctest-modules
+	$(PYTEST) skimage --doctest-modules
 
 doctest:
 	$(PYTHON) -c "import skimage, sys, io; sys.exit(skimage.doctest_verbose())"
 
 benchmark_coverage:
-	$(PYTESTS) benchmarks --cov=skimage --cov-config=setup.cfg
+	$(PYTEST) benchmarks --cov=skimage --cov-config=setup.cfg
 
 coverage: test_coverage
 
 test_coverage:
-	$(PYTESTS) -o python_functions=test_* skimage --cov=skimage
+	$(PYTEST) -o python_functions=test_* skimage --cov=skimage
 
 html:
 	pip install -q -r requirements/docs.txt
 	export SPHINXOPTS=-W; make -C doc html
-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,46 +47,46 @@ jobs:
     inputs:
       versionSpec: '$(PYTHON_VERSION)'
       architecture: '$(ARCH)'
-
-  - powershell: |
-      Write-Host "##vso[task.setvariable variable=PATH;]${env:PYTHON};${env:PYTHON}\Scripts;${env:PATH}";
-    displayName: 'Add Python paths to PATH'
+    name: python
 
   - bash: |
-      set -x
+      set -ex
+      PYTHON="$(python.pythonLocation)\\python.exe"
 
       # Update pip
-      python -m pip install --retries 3 -U pip setuptools
+      $PYTHON -m pip install -U pip setuptools wheel
 
       # Check that we have the expected version and architecture for Python
-      python --version
-      pip --version
-      python -c "import struct; print('Void pointer width is', struct.calcsize('P') * 8)"
-      pip list
+      $PYTHON --version
+      $PYTHON -m pip --version
+      $PYTHON -c "import struct; print('Void pointer width is', struct.calcsize('P') * 8)"
+      $PYTHON -m pip list
 
       # Install the build and runtime dependencies of the project
-      pip install ${PIP_FLAGS} --retries 3 -r requirements/default.txt
-      pip install ${PIP_FLAGS} --retries 3 -r requirements/build.txt
-      pip list
+      $PYTHON -m pip install ${PIP_FLAGS} -r requirements/default.txt
+      $PYTHON -m pip install ${PIP_FLAGS} -r requirements/build.txt
+      $PYTHON -m pip list
     displayName: 'Pre-installation'
 
   - bash: |
-      set -x
+      set -ex
+      PYTHON="$(python.pythonLocation)\\python.exe"
 
       # Compile the package and build the wheel
-      python setup.py bdist_wheel 
+      $PYTHON setup.py bdist_wheel
 
       # Install the generated wheel package
       ls dist
-      pip install ${PIP_FLAGS} --no-index --find-links dist/ scikit-image
+      $PYTHON -m pip install ${PIP_FLAGS} --no-index --find-links dist/ scikit-image
     displayName: 'Installation'
 
   - bash: |
-      set -x
+      set -ex
+      PYTHON="$(python.pythonLocation)\\python.exe"
 
       # Install the test dependencies
-      pip install ${PIP_FLAGS} --retries 3 -r requirements/test.txt
-      pip list
+      $PYTHON -m pip install ${PIP_FLAGS} -r requirements/test.txt
+      $PYTHON -m pip list
 
       # Set non-UI Matplotlib backend
       cd ${AGENT_BUILDDIRECTORY}  # D:\a\1
@@ -94,14 +94,15 @@ jobs:
     displayName: 'Pre-testing'
 
   - bash: |
-      set -x
+      set -ex
+      PYTHON="$(python.pythonLocation)\\python.exe"
 
       # Change the working directory in order to run the tests
       # on the installed version of skimage
       cd ${AGENT_BUILDDIRECTORY}  # D:\a\1
 
       # Show the info about the installed scikit-image
-      python -c "import skimage; print(skimage.__path__)"
+      $PYTHON -c "import skimage; print(skimage.__path__)"
 
       # Force matplotlib to use the prepared config
       export MATPLOTLIBRC=${AGENT_BUILDDIRECTORY}
@@ -111,36 +112,39 @@ jobs:
       # Windows due to inconsistent ndarray formatting in `numpy`.
       # For more details, see https://github.com/numpy/numpy/issues/13468
       export TEST_ARGS="-v --cov=skimage"
-      pytest ${TEST_ARGS} --pyargs skimage
+      $PYTHON -m pytest ${TEST_ARGS} --pyargs skimage
     displayName: 'Package testing'
 
   - bash: |
-      set -x
+      set -ex
+      export PYTHON="$(python.pythonLocation)\\python.exe"
 
       # Install the doc dependencies
-      pip install ${PIP_FLAGS} --retries 3 -q -r requirements/docs.txt
-      pip list
+      $PYTHON -m pip install ${PIP_FLAGS} -r requirements/docs.txt
+      $PYTHON -m pip list
 
       # Build the documentation
-      sudo apt install optipng
+      choco install optipng
       export SPHINXCACHE=${AGENT_BUILDDIRECTORY}/.cache/sphinx
-      make html
+      export SPHINXOPTS=-W
+      make -C doc html
     condition: eq(variables['BUILD_DOCS'], 'true')
     displayName: 'Documentation testing'
 
   - bash: |
-      set -x
+      set -ex
+      PYTHON="$(python.pythonLocation)\\python.exe"
 
       # Install the doc dependencies
-      pip install ${PIP_FLAGS} --retries 3 -q -r requirements/docs.txt
-      pip list
+      $PYTHON -m pip install ${PIP_FLAGS} -r requirements/docs.txt
+      $PYTHON -m pip list
 
       # Force matplotlib to use the prepared config
       export MATPLOTLIBRC=${AGENT_BUILDDIRECTORY}
 
       # Run example applications
       for f in doc/examples/*/*.py; do
-        python "${f}"
+        $PYTHON "${f}"
         if [ $? -ne 0 ]; then
           exit 1
         fi

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -47,11 +47,12 @@ api:
 
 release_notes:
 	@echo "Copying release notes"
-	@cat `$(PYTHON) -c \
-		"from pathlib import Path; from skimage import io; \
-		 l = list(str(e) for e in Path('release').glob('release_*.*.*')); \
-		 l.sort(key=io.collection.alphanumeric_key); print(l[-1])"` \
-		| tail -n +4 > release/_release_notes_for_docs.rst
+	@tail -n +4 release/release_$$(\
+		ls release/release_*.*.* \
+			| sed s:release/release_:: \
+			| sort -nrt. -k1,1 -k2,2 \
+			| head -n 1) \
+		> release/_release_notes_for_docs.rst
 
 html: api release_notes
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(DEST)/html

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [tool:pytest]
 python_files=benchmark_*.py test_*.py
 python_classes=Test* *Suite
-python_functions=time_* test_* setup peakmem*
+python_functions=time_* test_* peakmem_*
 [run]
 omit= */tests/*
 [metadata]

--- a/setup.py
+++ b/setup.py
@@ -219,6 +219,7 @@ if __name__ == "__main__":
             'Programming Language :: Python :: 3',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3 :: Only',
             'Topic :: Scientific/Engineering',
             'Operating System :: Microsoft :: Windows',

--- a/tools/travis/before_install.sh
+++ b/tools/travis/before_install.sh
@@ -63,8 +63,7 @@ if [[ $MINIMUM_REQUIREMENTS == 1 ]]; then
     done
 fi
 
-python -m pip install --upgrade pip
-pip install --retries 3 -q wheel
+python -m pip install --upgrade pip wheel
 
 # install specific wheels from wheelhouse
 for requirement in matplotlib scipy pillow; do
@@ -72,16 +71,16 @@ for requirement in matplotlib scipy pillow; do
 done
 # cython is not in the default.txt requirements
 WHEELS="$WHEELS $(grep -i cython requirements/build.txt)"
-pip install --retries 3 -q $PIP_FLAGS $WHEELHOUSE $WHEELS
+python -m pip install $PIP_FLAGS $WHEELHOUSE $WHEELS
 
 # Install build time requirements
-pip install --retries 3 -q $PIP_FLAGS -r requirements/build.txt
+python -m pip install $PIP_FLAGS -r requirements/build.txt
 # Default requirements are necessary to build because of lazy importing
 # They can be moved after the build step if #3158 is accepted
-pip install --retries 3 -q $PIP_FLAGS -r requirements/default.txt
+python -m pip install $PIP_FLAGS -r requirements/default.txt
 
 # Show what's installed
-pip list
+python -m pip list
 
 section () {
     echo -en "travis_fold:start:$1\r"

--- a/tools/travis/install_qt.sh
+++ b/tools/travis/install_qt.sh
@@ -10,18 +10,18 @@ if [[ "${QT}" == "PyQt5" ]]; then
         # PyQt 5.11 changed how they ship SIP
         # Which conflicts with how matplotlib detects the
         # presence of PyQt before MPL 2.2.3
-        pip install --retries 3 -q $PIP_FLAGS "pyqt5<5.11"
+        python -m pip install $PIP_FLAGS "pyqt5<5.11"
     elif [[ `lsb_release  -r -s` == "14.04" ]]; then
         # Apparently Qt 5.12 is only supported by ubuntu 16.04
         # https://github.com/scikit-image/scikit-image/pull/3744#issuecomment-463450663
-        pip install --retries 3 -q $PIP_FLAGS "pyqt5<5.12"
+        python -m pip install $PIP_FLAGS "pyqt5<5.12"
     else
-        pip install --retries 3 -q $PIP_FLAGS "pyqt5!=5.15.0,!=5.15.1"
+        python -m pip install $PIP_FLAGS "pyqt5!=5.15.0,!=5.15.1"
     fi
     MPL_QT_API=PyQt5
     export QT_API=pyqt5
 elif [[ "${QT}" == "PySide2" ]]; then
-    pip install--retries 3 -q $PIP_FLAGS pyside2
+    python -m pip install $PIP_FLAGS pyside2
     MPL_QT_API=PySide2
     export QT_API=pyside2
 else

--- a/tools/travis/osx_install.sh
+++ b/tools/travis/osx_install.sh
@@ -1,19 +1,20 @@
 #!/bin/bash
 set -ex
 
-travis-wait-improved --timeout 30m brew update
+brew update
 brew install ccache
 brew tap homebrew/homebrew-cask
 brew cask install basictex
-
-export PATH="$PATH:/Library/TeX/texbin"
-travis-wait-improved --timeout 30m sudo tlmgr --verify-repo=none update --self
-travis-wait-improved --timeout 30m sudo tlmgr --verify-repo=none install ucs dvipng anyfontsize
 
 # Set up virtualenv on OSX
 git clone --depth 1 --branch devel https://github.com/matthew-brett/multibuild ~/multibuild
 source ~/multibuild/osx_utils.sh
 get_macpython_environment $MB_PYTHON_VERSION ~/venv
+
+export PATH="$PATH:/Library/TeX/texbin"
+python -m pip install travis-wait-improved;
+travis-wait-improved --timeout 30m sudo tlmgr --verify-repo=none update --self
+travis-wait-improved --timeout 30m sudo tlmgr --verify-repo=none install ucs dvipng anyfontsize
 
 # libpng 1.6.32 has a bug in reading PNG
 # that seems to be the default library that is installed

--- a/tools/travis/script.sh
+++ b/tools/travis/script.sh
@@ -10,7 +10,7 @@ if [[ $TRAVIS_OS_NAME == "osx" ]]; then
 fi
 
 section "List.installed.dependencies"
-pip list
+python -m pip list
 tools/build_versions.py
 section_end "List.installed.dependencies"
 
@@ -29,8 +29,8 @@ section "Tests.examples"
 # Run example applications
 if [[ "${BUILD_DOCS}" == "1" ]] || [[ "${TEST_EXAMPLES}" != "0" ]]; then
   echo Build or run examples
-  pip install $PIP_FLAGS --retries 3 -q -r ./requirements/docs.txt
-  pip list
+  python -m pip install $PIP_FLAGS -r ./requirements/docs.txt
+  python -m pip list
   tools/build_versions.py
   echo 'backend : Template' > $MPL_DIR/matplotlibrc
 fi


### PR DESCRIPTION
## Description

Azure Pipelines did not appear to be running the correct Python versions because they were running on a Windows image and the UsePythonVersion task did not set the path correctly for running bash scripts. This change uses the variable produced by UsePythonVersion to specify the full path to Python.

This change also updates the trove classifiers to specify Python 3.8 which is already supported and tested, and updates the pytest config to not try running the test setup as a test itself.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
