### PR TITLE
debug travis build

### DIFF
--- a/tools/travis/osx_install.sh
+++ b/tools/travis/osx_install.sh
@@ -7,8 +7,8 @@ brew tap homebrew/homebrew-cask
 brew cask install basictex
 
 export PATH="$PATH:/Library/TeX/texbin"
-travis-wait-improved --timeout 30m sudo tlmgr --verify-repo=none update --self
-travis-wait-improved --timeout 30m sudo tlmgr --verify-repo=none install ucs dvipng anyfontsize
+sudo tlmgr --verify-repo=none update --self
+sudo tlmgr --verify-repo=none install ucs dvipng anyfontsize
 
 # Set up virtualenv on OSX
 git clone --depth 1 --branch devel https://github.com/matthew-brett/multibuild ~/multibuild


### PR DESCRIPTION
Travis OSX builds are failing with mysterious error messages such as "/usr/local/opt/python/bin/python3.7: bad interpreter: No such file or directory", I'm trying to debug this here but would welcome also ideas if it rings a bell for some folks.