### PR TITLE
Clarify disk documentation inconsistency regarding 'shape'

### DIFF
--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -205,7 +205,26 @@ def disk(center, radius, *, shape=None):
 
     Examples
     --------
+    >>> import numpy as np
     >>> from skimage.draw import disk
+    >>> shape = (4, 4)
+    >>> img = np.zeros(shape, dtype=np.uint8)
+    >>> rr, cc = disk((0, 0), 2, shape=shape)
+    >>> img[rr, cc] = 1
+    >>> img
+    array([[1, 1, 0, 0],
+           [1, 1, 0, 0],
+           [0, 0, 0, 0],
+           [0, 0, 0, 0]], dtype=uint8)
+    >>> img = np.zeros(shape, dtype=np.uint8)
+    >>> # Negative coordinates in rr and cc perform a wraparound
+    >>> rr, cc = disk((0, 0), 2, shape=None)
+    >>> img[rr, cc] = 1
+    >>> img
+    array([[1, 1, 0, 1],
+           [1, 1, 0, 1],
+           [0, 0, 0, 0],
+           [1, 1, 0, 1]], dtype=uint8)
     >>> img = np.zeros((10, 10), dtype=np.uint8)
     >>> rr, cc = disk((4, 4), 5)
     >>> img[rr, cc] = 1

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -190,11 +190,11 @@ def disk(center, radius, *, shape=None):
     radius : double
         Radius of disk.
     shape : tuple, optional
-        Image shape which is used to determine the maximum extent of output
-        pixel coordinates. This is useful for disks that exceed the image
-        size. If None, the full extent of the disk is used.  Must be at least
-        length 2. Only the first two values are used to determine the extent of
-        the input image.
+        Image shape as a tuple of size 2 which is used to determine the maximum
+        extent of output pixel coordinates. This is useful for disks that
+        exceed the image size. If None, the full extent of the disk is used.
+        and the shape might result in negative coordinates and wraparound
+        behaviour.
 
     Returns
     -------

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -190,10 +190,10 @@ def disk(center, radius, *, shape=None):
     radius : double
         Radius of disk.
     shape : tuple, optional
-        Image shape as a tuple of size 2 which is used to determine the maximum
+        Image shape as a tuple of size 2, used to determine the maximum
         extent of output pixel coordinates. This is useful for disks that
         exceed the image size. If None, the full extent of the disk is used.
-        and the shape might result in negative coordinates and wraparound
+        The  shape might result in negative coordinates and wraparound
         behaviour.
 
     Returns

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -190,7 +190,7 @@ def disk(center, radius, *, shape=None):
     radius : double
         Radius of disk.
     shape : tuple, optional
-        Image shape as a tuple of size 2, used to determine the maximum
+        Image shape as a tuple of size 2. Determines the maximum
         extent of output pixel coordinates. This is useful for disks that
         exceed the image size. If None, the full extent of the disk is used.
         The  shape might result in negative coordinates and wraparound


### PR DESCRIPTION
## Description

Fixes #5038.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
