### PR TITLE
MAINT Build fix for pyodide

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,10 @@ def openmp_build_ext():
 
         def can_compile_link(self):
 
+            if "PYODIDE_PACKAGE_ABI" in os.environ:
+                # pyodide doesn't support OpenMP
+                return False
+
             cc = self.compiler
             fname = 'test.c'
             cwd = os.getcwd()


### PR DESCRIPTION
Adds a small fix to build scikit-image in pyodide, to avoid patching the `setup.py`, as done in https://github.com/iodide-project/pyodide/pull/733. ~~There the challenge is more with building pillow than scikit-image.~~

Contributes toward https://github.com/scikit-image/scikit-image/issues/4836

See [detecting Pyodide at build time](https://pyodide.readthedocs.io/en/latest/faq.html#how-to-detect-that-code-is-run-with-pyodide) for more information.
