### PR TITLE
Some minor tweaks to CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ install:
         throw "There are newer queued builds for this pull request, failing early." }
 
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - "python -m pip install --retries 3 -U pip"
+  - "python -m pip install -U pip"
 
   # Check that we have the expected version and architecture for Python
   - "python --version"
@@ -43,15 +43,15 @@ install:
   - "pip --version"
 
   # Install the build and runtime dependencies of the project.
-  - pip install %PIP_FLAGS% --retries 3 -r requirements/default.txt
-  - pip install %PIP_FLAGS% --retries 3 -r requirements/build.txt
+  - pip install %PIP_FLAGS% -r requirements/default.txt
+  - pip install %PIP_FLAGS% -r requirements/build.txt
   - python setup.py bdist_wheel bdist_wininst
   - ps: "ls dist"
 
   # Install the generated wheel package to test it.
   - pip install %PIP_FLAGS% --no-index --find-links dist/ scikit-image
   # Install the test dependencies
-  - pip install %PIP_FLAGS% --retries 3 -r requirements/test.txt
+  - pip install %PIP_FLAGS% -r requirements/test.txt
 
 # Not a .NET project, we build scikit-image in the install step instead
 build: false

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ install:
         throw "There are newer queued builds for this pull request, failing early." }
 
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - "python -m pip install -U pip"
+  - "python -m pip install --retries 3 -U pip"
 
   # Check that we have the expected version and architecture for Python
   - "python --version"
@@ -43,15 +43,15 @@ install:
   - "pip --version"
 
   # Install the build and runtime dependencies of the project.
-  - pip install %PIP_FLAGS% -r requirements/default.txt
-  - pip install %PIP_FLAGS% -r requirements/build.txt
+  - pip install %PIP_FLAGS% --retries 3 -r requirements/default.txt
+  - pip install %PIP_FLAGS% --retries 3 -r requirements/build.txt
   - python setup.py bdist_wheel bdist_wininst
   - ps: "ls dist"
 
   # Install the generated wheel package to test it.
   - pip install %PIP_FLAGS% --no-index --find-links dist/ scikit-image
   # Install the test dependencies
-  - pip install %PIP_FLAGS% -r requirements/test.txt
+  - pip install %PIP_FLAGS% --retries 3 -r requirements/test.txt
 
 # Not a .NET project, we build scikit-image in the install step instead
 build: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   doc:
     docker:
-      - image: circleci/python:3.9.0
+      - image: circleci/python:3.8.2
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Description

These are just minor follow-up tweaks on top of #5052:
- Circle-CI is just for doc builds. I think we should keep it on 3.8 until wheels for 3.9 are available for all our dependencies.
- ~~I think it's better to keep the `--retries` on pip installs on Azure, though happy to be overruled there! (?)~~ **Update:** undid this, see discussion below.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
