### PR TITLE
removed usage of numpy's private functions from util.arraycrop

### DIFF
--- a/skimage/util/arraycrop.py
+++ b/skimage/util/arraycrop.py
@@ -20,7 +20,7 @@ def crop(ar, crop_width, copy=False, order='K'):
         Number of values to remove from the edges of each axis.
         ``((before_1, after_1),`` ... ``(before_N, after_N))`` specifies
         unique crop widths at the start and end of each axis.
-        ``((before, after),)`` specifies a fixed start and end crop
+        ``((before, after),) or (before, after)`` specifies a fixed start and end crop
         for every axis.
         ``(n,)`` or ``n`` for integer ``n`` is a shortcut for
         before = after = ``n`` for all axes.
@@ -39,7 +39,22 @@ def crop(ar, crop_width, copy=False, order='K'):
         view of the input array.
     """
     ar = np.array(ar, copy=False)
-    crops = _as_pairs(crop_width, ar.ndim, as_index=True)
+
+    if isinstance(crop_width, int):
+        crops = [[crop_width, crop_width]] * ar.ndim
+    elif isinstance(crop_width[0], int):
+        if len(crop_width) == 1:
+            crops = [[crop_width[0], crop_width[0]]] * ar.ndim
+        elif len(crop_width) == 2:
+            crops = [crop_width] * ar.ndim
+        else:
+            raise ValueError('invalid length for sequence crop_width')
+    elif len(crop_width) == 1:
+        crops = [crop_width[0]] * ar.ndim
+    elif len(crop_width)==ar.ndim:
+        crops = crop_width
+    else:
+        raise ValueError('invalid length for sequence crop_width')
 
     slices = tuple(slice(a, ar.shape[i] - b)
                    for i, (a, b) in enumerate(crops))

--- a/skimage/util/arraycrop.py
+++ b/skimage/util/arraycrop.py
@@ -48,7 +48,7 @@ def crop(ar, crop_width, copy=False, order='K'):
             crops = [crop_width] * ar.ndim
         else:
             raise ValueError(
-                f"crop_width sequence of length {len(crop_width)} is invalid\n"
+                f"crop_width has an invalid length: {len(crop_width)}\n"
                 "crop_width should be a sequence of N pairs, "
                 "a single pair, or a single integer"
             )
@@ -58,7 +58,7 @@ def crop(ar, crop_width, copy=False, order='K'):
         crops = crop_width
     else:
         raise ValueError(
-            f"crop_width sequence of length {len(crop_width)} is invalid\n"
+            f"crop_width has an invalid length: {len(crop_width)}\n"
             "crop_width should be a sequence of N pairs, "
             "a single pair, or a single integer"
         )

--- a/skimage/util/arraycrop.py
+++ b/skimage/util/arraycrop.py
@@ -8,12 +8,12 @@ import numpy as np
 __all__ = ['crop']
 
 
-def crop(array, crop_width, copy=False, order='K'):
-    """Crop array `array` by `crop_width` along each dimension.
+def crop(ar, crop_width, copy=False, order='K'):
+    """Crop array `ar` by `crop_width` along each dimension.
 
     Parameters
     ----------
-    array : array-like of rank N
+    ar : array-like of rank N
         Input array.
     crop_width : {sequence, int}
         Number of values to remove from the edges of each axis.
@@ -37,28 +37,36 @@ def crop(array, crop_width, copy=False, order='K'):
         The cropped array. If ``copy=False`` (default), this is a sliced
         view of the input array.
     """
-    array = np.array(array, copy=False)
+    ar = np.array(ar, copy=False)
 
     if isinstance(crop_width, int):
-        crops = [[crop_width, crop_width]] * array.ndim
+        crops = [[crop_width, crop_width]] * ar.ndim
     elif isinstance(crop_width[0], int):
         if len(crop_width) == 1:
-            crops = [[crop_width[0], crop_width[0]]] * array.ndim
+            crops = [[crop_width[0], crop_width[0]]] * ar.ndim
         elif len(crop_width) == 2:
-            crops = [crop_width] * array.ndim
+            crops = [crop_width] * ar.ndim
         else:
-            raise ValueError('invalid length for sequence crop_width')
+            raise ValueError(
+                f"crop_width sequence of length {len(crop_width)} is invalid\n"
+                "crop_width should be a sequence of N pairs, "
+                "a single pair, or a single integer"
+            )
     elif len(crop_width) == 1:
-        crops = [crop_width[0]] * array.ndim
-    elif len(crop_width) == array.ndim:
+        crops = [crop_width[0]] * ar.ndim
+    elif len(crop_width) == ar.ndim:
         crops = crop_width
     else:
-        raise ValueError('invalid length for sequence crop_width')
+        raise ValueError(
+            f"crop_width sequence of length {len(crop_width)} is invalid\n"
+            "crop_width should be a sequence of N pairs, "
+            "a single pair, or a single integer"
+        )
 
-    slices = tuple(slice(a, array.shape[i] - b)
+    slices = tuple(slice(a, ar.shape[i] - b)
                    for i, (a, b) in enumerate(crops))
     if copy:
-        cropped = np.array(array[slices], order=order, copy=True)
+        cropped = np.array(ar[slices], order=order, copy=True)
     else:
-        cropped = array[slices]
+        cropped = ar[slices]
     return cropped

--- a/skimage/util/arraycrop.py
+++ b/skimage/util/arraycrop.py
@@ -4,24 +4,23 @@ n-dimensional array.
 """
 
 import numpy as np
-from numpy.lib.arraypad import _as_pairs
 
 __all__ = ['crop']
 
 
-def crop(ar, crop_width, copy=False, order='K'):
-    """Crop array `ar` by `crop_width` along each dimension.
+def crop(array, crop_width, copy=False, order='K'):
+    """Crop array `array` by `crop_width` along each dimension.
 
     Parameters
     ----------
-    ar : array-like of rank N
+    array : array-like of rank N
         Input array.
     crop_width : {sequence, int}
         Number of values to remove from the edges of each axis.
         ``((before_1, after_1),`` ... ``(before_N, after_N))`` specifies
         unique crop widths at the start and end of each axis.
-        ``((before, after),) or (before, after)`` specifies a fixed start and end crop
-        for every axis.
+        ``((before, after),) or (before, after)`` specifies
+        a fixed start and end crop for every axis.
         ``(n,)`` or ``n`` for integer ``n`` is a shortcut for
         before = after = ``n`` for all axes.
     copy : bool, optional
@@ -38,28 +37,28 @@ def crop(ar, crop_width, copy=False, order='K'):
         The cropped array. If ``copy=False`` (default), this is a sliced
         view of the input array.
     """
-    ar = np.array(ar, copy=False)
+    array = np.array(array, copy=False)
 
     if isinstance(crop_width, int):
-        crops = [[crop_width, crop_width]] * ar.ndim
+        crops = [[crop_width, crop_width]] * array.ndim
     elif isinstance(crop_width[0], int):
         if len(crop_width) == 1:
-            crops = [[crop_width[0], crop_width[0]]] * ar.ndim
+            crops = [[crop_width[0], crop_width[0]]] * array.ndim
         elif len(crop_width) == 2:
-            crops = [crop_width] * ar.ndim
+            crops = [crop_width] * array.ndim
         else:
             raise ValueError('invalid length for sequence crop_width')
     elif len(crop_width) == 1:
-        crops = [crop_width[0]] * ar.ndim
-    elif len(crop_width)==ar.ndim:
+        crops = [crop_width[0]] * array.ndim
+    elif len(crop_width) == array.ndim:
         crops = crop_width
     else:
         raise ValueError('invalid length for sequence crop_width')
 
-    slices = tuple(slice(a, ar.shape[i] - b)
+    slices = tuple(slice(a, array.shape[i] - b)
                    for i, (a, b) in enumerate(crops))
     if copy:
-        cropped = np.array(ar[slices], order=order, copy=True)
+        cropped = np.array(array[slices], order=order, copy=True)
     else:
-        cropped = ar[slices]
+        cropped = array[slices]
     return cropped

--- a/skimage/util/tests/test_arraycrop.py
+++ b/skimage/util/tests/test_arraycrop.py
@@ -19,12 +19,14 @@ def test_pair_crop():
     assert_array_equal(out[-1], [31, 32])
     assert_equal(out.shape, (6, 2))
 
+
 def test_pair_tuple_crop():
     arr = np.arange(45).reshape(9, 5)
     out = crop(arr, ((1, 2),))
     assert_array_equal(out[0], [6, 7])
     assert_array_equal(out[-1], [31, 32])
     assert_equal(out.shape, (6, 2))
+
 
 def test_int_crop():
     arr = np.arange(45).reshape(9, 5)
@@ -33,12 +35,14 @@ def test_int_crop():
     assert_array_equal(out[-1], [36, 37, 38])
     assert_equal(out.shape, (7, 3))
 
+
 def test_int_tuple_crop():
     arr = np.arange(45).reshape(9, 5)
     out = crop(arr, (1,))
     assert_array_equal(out[0], [6, 7, 8])
     assert_array_equal(out[-1], [36, 37, 38])
     assert_equal(out.shape, (7, 3))
+
 
 def test_copy_crop():
     arr = np.arange(45).reshape(9, 5)

--- a/skimage/util/tests/test_arraycrop.py
+++ b/skimage/util/tests/test_arraycrop.py
@@ -19,6 +19,12 @@ def test_pair_crop():
     assert_array_equal(out[-1], [31, 32])
     assert_equal(out.shape, (6, 2))
 
+def test_pair_tuple_crop():
+    arr = np.arange(45).reshape(9, 5)
+    out = crop(arr, ((1, 2),))
+    assert_array_equal(out[0], [6, 7])
+    assert_array_equal(out[-1], [31, 32])
+    assert_equal(out.shape, (6, 2))
 
 def test_int_crop():
     arr = np.arange(45).reshape(9, 5)
@@ -27,6 +33,12 @@ def test_int_crop():
     assert_array_equal(out[-1], [36, 37, 38])
     assert_equal(out.shape, (7, 3))
 
+def test_int_tuple_crop():
+    arr = np.arange(45).reshape(9, 5)
+    out = crop(arr, (1,))
+    assert_array_equal(out[0], [6, 7, 8])
+    assert_array_equal(out[-1], [36, 37, 38])
+    assert_equal(out.shape, (7, 3))
 
 def test_copy_crop():
     arr = np.arange(45).reshape(9, 5)


### PR DESCRIPTION
## Description

Modified skimage.util.arraycrop to remove references to numpy's private method _as_pair.
Also added tests to more closely match the documentation of the method.
Fixed documentation to match parameter format already implemented in method and in tests.

Closes issue #5028 
I did not find any other places where numpy's private methods were being used.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
