### PR TITLE
peak_local_max: remove deprecated `indices` argument from examples

### DIFF
--- a/doc/examples/applications/plot_human_mitosis.py
+++ b/doc/examples/applications/plot_human_mitosis.py
@@ -172,10 +172,10 @@ print(cleaned_dividing.max())
 
 distance = ndi.distance_transform_edt(cells)
 
-local_maxi = feature.peak_local_max(distance, indices=False,
-                                    min_distance=7)
-
-markers = measure.label(local_maxi)
+local_max_coords = feature.peak_local_max(distance, min_distance=7)
+local_max_mask = np.zeros(distance.shape, dtype=bool)
+local_max_mask[tuple(local_max_coords.T)] = True
+markers = measure.label(local_max_mask)
 
 segmented_cells = segmentation.watershed(-distance, markers, mask=cells)
 

--- a/doc/examples/segmentation/plot_peak_local_max.py
+++ b/doc/examples/segmentation/plot_peak_local_max.py
@@ -4,9 +4,9 @@ Finding local maxima
 ====================
 
 The ``peak_local_max`` function returns the coordinates of local peaks (maxima)
-in an image. A maximum filter is used for finding local maxima. This operation
-dilates the original image and merges neighboring local maxima closer than the
-size of the dilation. Locations where the original image is equal to the
+in an image. Internally, a maximum filter is used for finding local maxima. This
+operation dilates the original image and merges neighboring local maxima closer
+than the size of the dilation. Locations where the original image is equal to the
 dilated image are returned as local maxima.
 
 """

--- a/doc/examples/segmentation/plot_watershed.py
+++ b/doc/examples/segmentation/plot_watershed.py
@@ -43,9 +43,10 @@ image = np.logical_or(mask_circle1, mask_circle2)
 # Now we want to separate the two objects in image
 # Generate the markers as local maxima of the distance to the background
 distance = ndi.distance_transform_edt(image)
-local_maxi = peak_local_max(distance, indices=False, footprint=np.ones((3, 3)),
-                            labels=image)
-markers = ndi.label(local_maxi)[0]
+coords = peak_local_max(distance, footprint=np.ones((3, 3)), labels=image)
+mask = np.zeros(distance.shape, dtype=bool)
+mask[tuple(coords.T)] = True
+markers, _ = ndi.label(mask)
 labels = watershed(-distance, markers, mask=image)
 
 fig, axes = plt.subplots(ncols=3, figsize=(9, 3), sharex=True, sharey=True)

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -188,10 +188,10 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
     Notes
     -----
     The peak local maximum function returns the coordinates of local peaks
-    (maxima) in an image. A maximum filter is used for finding local maxima.
-    This operation dilates the original image. After comparison of the dilated
-    and original image, this function returns the coordinates or a mask of the
-    peaks where the dilated image equals the original image.
+    (maxima) in an image. Internally, a maximum filter is used for finding local
+    maxima. This operation dilates the original image. After comparison of the
+    dilated and original image, this function returns the coordinates or a mask
+    of the peaks where the dilated image equals the original image.
 
     See also
     --------
@@ -220,12 +220,17 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
 
     >>> img2 = np.zeros((20, 20, 20))
     >>> img2[10, 10, 10] = 1
+    >>> img2[15, 15, 15] = 1
     >>> peak_idx = peak_local_max(img2, exclude_border=0)
     >>> peak_idx
-    array([[10, 10, 10]])
+    array([[10, 10, 10],
+           [15, 15, 15]])
 
     >>> peak_mask = np.zeros_like(img2, dtype=bool)
-    >>> peak_mask[peak_idx] = True
+    >>> peak_mask[tuple(peak_idx.T)] = True
+    >>> np.argwhere(peak_mask)
+    array([[10, 10, 10],
+           [15, 15, 15]])
 
     """
     if (footprint is None or footprint.size == 1) and min_distance < 1:


### PR DESCRIPTION
@mkcor  This PR updates examples to demonstrate the creation of a mask using the same method currently employed inside the `peak_local_mask` function, namely: `peak_mask[tuple(peak_idx.T)] = True`

As it turns out, the description in `plot_peak_local_max.py` was not as misleading as I initially thought.  The text is copied verbatim from the "Note" in the function docstring, where is is more clear that it's talking about the internal algorithm.   I think adding the word "Internally" to this note and to the example makes this a little more clear.

I think the main improvement here is updating the example in `skimage/feature/peak.py`, such that it demonstrates how to elegantly create a mask (when the indices contain more than one element!) and without using the deprecated `indices=False` method.

I built the docs on my laptop and my changes look good to me in the resultant HTML.

By the way, the plot_watershed.py example has an empty plot for "distances" -- this [exists on the live docs](https://scikit-image.org/docs/dev/auto_examples/segmentation/plot_watershed.html#sphx-glr-auto-examples-segmentation-plot-watershed-py) as well as this PR.  Just noticed this but I could look into it and fix it if you'd like me to roll that into this PR.

## Description

Closes #5078 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
