### PR TITLE
Fix default level computation for find_contours

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 # Workflow to build and test wheels
 name: Test
 
-on: push
+on: [push, pull_request]
 
 jobs:
 

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -25,7 +25,7 @@ def find_contours(image, level=None,
         Input image in which to find contours.
     level : float, optional
         Value along which to find contours in the array. By default, the level
-        is set to (max(image) - min(image)) / 2
+        is set to (max(image) + min(image)) / 2
 
         .. versionchanged:: 0.18
             This parameter is now optional.
@@ -144,7 +144,7 @@ def find_contours(image, level=None,
             raise TypeError('Parameter "mask" must be a binary array.')
         mask = mask.astype(np.uint8, copy=False)
     if level is None:
-        level = (np.nanmax(image) - np.nanmin(image)) / 2.0
+        level = (np.nanmin(image) + np.nanmax(image)) / 2.0
 
     segments = _get_contour_segments(image.astype(np.double), float(level),
                                      fully_connected == 'high', mask=mask)

--- a/skimage/measure/tests/test_find_contours.py
+++ b/skimage/measure/tests/test_find_contours.py
@@ -167,3 +167,11 @@ def test_memory_order_levelNone():
 
     contours = find_contours(np.asfortranarray(r), level=None)
     assert len(contours) == 1
+
+
+def test_level_default():
+    # image with range [0.9, 0.91]
+    image = np.random.random((100, 100)) * 0.01 + 0.9
+    contours = find_contours(image)  # use default level
+    # many contours should be found
+    assert len(contours) > 1


### PR DESCRIPTION
## Description

I noticed that the computation for the default find_contours level added in #4862 was actually incorrect. It should not be half the range, but the mean of the min and max. I've added a test to check for this. The test fails on master but passes here.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
