### PR TITLE
BUG: random_walker: fix import path for umfpack 

### DIFF
--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -20,7 +20,7 @@ from .._shared.utils import warn
 # https://groups.google.com/d/msg/scikit-image/FrM5IGP6wh4/1hp-FtVZmfcJ
 # https://stackoverflow.com/questions/13977970/ignore-exceptions-printed-to-stderr-in-del/13977992?noredirect=1#comment28386412_13977992
 try:
-    from scipy.sparse.linalg.dsolve import umfpack
+    from scipy.sparse.linalg.dsolve.linsolve import umfpack
     old_del = umfpack.UmfpackContext.__del__
 
     def new_del(self):

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -499,3 +499,15 @@ def test_prob_tol():
         res = random_walker(a, mask, return_full_prob=True, tol=1e-9)
     assert res[0, 1, 1] == 1
     assert res[1, 1, 1] == 0
+
+
+def test_umfpack_import():
+    from skimage.segmentation import random_walker_segmentation
+    UmfpackContext = random_walker_segmentation.UmfpackContext
+    try:
+        # when scikit-umfpack is installed UmfpackContext should not be None
+        import scikits.umfpack
+        assert UmfpackContext is not None
+    except ImportError:
+        assert UmfpackContext is None
+    return


### PR DESCRIPTION
## Description

`random_walker` seems to have a code path to allow use of UMFPACK, but it does not seem to get used even if `scikit-umfpack` is installed. The issue seems to be that the `umfpack` module is not visible via `scipy.sparse.linalg.dsolve`, but only within the `scipy.sparse.linalg.dsolve.linsolve` submodule. As far as I could tell, it has been this way in SciPy for many years. I verified locally that the tests still pass when `scikit-umfpack` is installed and added a new import test, although I don't think we ever run with `scikit-umfpack` on CI currently.

I thought about adding `scikit-umfpack` to `requirements/optional.txt`, but it does not have wheels on PyPI for recent Python or for Windows, so I have left it out for now. 


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
