### PR TITLE
Implement lazy submodule importing

### DIFF
--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -68,10 +68,36 @@ dtype_limits
 
 """
 
-import sys
-
-
 __version__ = '0.18.0.dev0'
+
+__all__ = [
+    'color',
+    'data',
+    'draw',
+    'exposure',
+    'external',
+    'feature',
+    'filters',
+    'future',
+    'graph',
+    'io',
+    'measure',
+    'metrics',
+    'morphology',
+    'registration',
+    'restoration',
+    'segmentation',
+    '_shared',
+    'transform',
+    'util',
+    'viewer'
+]
+
+from .util.lazy import install_lazy
+__getattr__, __dir__ = install_lazy(__name__, __all__)
+
+
+import sys
 
 from ._shared.version_requirements import ensure_python_version
 ensure_python_version((3, 5))

--- a/skimage/util/lazy.py
+++ b/skimage/util/lazy.py
@@ -1,0 +1,39 @@
+# Adapted from https://stackoverflow.com/a/51126745/214686
+
+import sys
+import importlib
+import importlib.util
+
+
+def install_lazy(module_name, submodules):
+    def __getattr__(name):
+        if name in submodules:
+            lazy_mod = require(f'skimage.{name}')
+            return lazy_mod
+        else:
+            raise AttributeError(f'No skimage attribute {name}')
+
+
+    def __dir__():
+        return submodules
+
+    return __getattr__, __dir__
+
+
+def require(fullname):
+    if fullname in sys.modules:
+        return sys.modules[fullname]
+
+    spec = importlib.util.find_spec(fullname)
+    try:
+        module = importlib.util.module_from_spec(spec)
+    except:
+        raise ImportError(f'Could not lazy import module {fullname}') from None
+    loader = importlib.util.LazyLoader(spec.loader)
+
+    sys.modules[fullname] = module
+
+    # Make module with proper locking and get it inserted into sys.modules.
+    loader.exec_module(module)
+
+    return module


### PR DESCRIPTION
**Note:** This is an experimental PR, so that we can discuss the idea and get feedback on its implementation.

This allows scikit-image to be used as follows:

```
import skimage as ski
ski.filters.gaussian(...)
```

The lazy loading strategy could also be implemented inside submodules,
to speed up imports of that submodule.  E.g., we could do:

```
sla = lazy.require('scipy.linalg')
```

The linalg module is only loaded once used in the code, avoiding the
standard workaround of having to move the import inside of a function
call.

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
