### PR TITLE
Use v{} for version tags with pooch

### DIFF
--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -125,7 +125,8 @@ def create_image_fetcher():
     # This helps pooch understand that it should look in master
     # to find the required files
     pooch_version = __version__.replace('.dev', '+')
-    url = "https://github.com/scikit-image/scikit-image/raw/{version}/skimage/"
+    url = ("https://github.com/scikit-image/scikit-image/raw/"
+           "v{version}/skimage/")
 
     # Create a new friend to manage your sample data storage
     image_fetcher = pooch.create(

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -125,8 +125,12 @@ def create_image_fetcher():
     # This helps pooch understand that it should look in master
     # to find the required files
     pooch_version = __version__.replace('.dev', '+')
-    url = ("https://github.com/scikit-image/scikit-image/raw/"
-           "v{version}/skimage/")
+    if '+' in pooch_version:
+        url = ("https://github.com/scikit-image/scikit-image/raw/"
+               "{version}/skimage/")
+    else:
+        url = ("https://github.com/scikit-image/scikit-image/raw/"
+               "v{version}/skimage/")
 
     # Create a new friend to manage your sample data storage
     image_fetcher = pooch.create(


### PR DESCRIPTION
## Description

The pooch URL was incorrect for released version tags given our convention to use v0.18.0 rather than just 0.18.0 for releases.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
