### PR TITLE
Fix compilation error in XCode 12

### DIFF
--- a/skimage/restoration/_unwrap_2d.pyx
+++ b/skimage/restoration/_unwrap_2d.pyx
@@ -11,6 +11,18 @@ cdef extern from *:
                   int wrap_around_x, int wrap_around_y,
                   char use_seed, unsigned int seed) nogil
 
+
+cdef extern from "unwrap_2d_ljmu.h":
+    void unwrap2D(
+            double *wrapped_image,
+            double *UnwrappedImage,
+            unsigned char *input_mask,
+            int image_width, int image_height,
+            int wrap_around_x, int wrap_around_y,
+            char use_seed, unsigned int seed
+            )
+
+
 def unwrap_2d(double[:, ::1] image,
               unsigned char[:, ::1] mask,
               double[:, ::1] unwrapped_image,

--- a/skimage/restoration/_unwrap_2d.pyx
+++ b/skimage/restoration/_unwrap_2d.pyx
@@ -3,14 +3,6 @@
 # cython: nonecheck=False
 # cython: wraparound=False
 
-cdef extern from *:
-    void unwrap2D(double* wrapped_image,
-                  double* unwrapped_image,
-                  unsigned char* input_mask,
-                  int image_width, int image_height,
-                  int wrap_around_x, int wrap_around_y,
-                  char use_seed, unsigned int seed) nogil
-
 
 cdef extern from "unwrap_2d_ljmu.h":
     void unwrap2D(
@@ -20,7 +12,7 @@ cdef extern from "unwrap_2d_ljmu.h":
             int image_width, int image_height,
             int wrap_around_x, int wrap_around_y,
             char use_seed, unsigned int seed
-            )
+            ) nogil
 
 
 def unwrap_2d(double[:, ::1] image,

--- a/skimage/restoration/_unwrap_3d.pyx
+++ b/skimage/restoration/_unwrap_3d.pyx
@@ -3,14 +3,6 @@
 # cython: nonecheck=False
 # cython: wraparound=False
 
-cdef extern from *:
-  void unwrap3D(double* wrapped_volume,
-                double* unwrapped_volume,
-                unsigned char* input_mask,
-                int image_width, int image_height, int volume_depth,
-                int wrap_around_x, int wrap_around_y, int wrap_around_z,
-                char use_seed, unsigned int seed) nogil
-
 
 cdef extern from "unwrap_3d_ljmu.h":
     void unwrap3D(
@@ -20,7 +12,7 @@ cdef extern from "unwrap_3d_ljmu.h":
             int volume_width, int volume_height, int volume_depth,
             int wrap_around_x, int wrap_around_y, int wrap_around_z,
             char use_seed, unsigned int seed
-            )
+            ) nogil
 
 
 

--- a/skimage/restoration/_unwrap_3d.pyx
+++ b/skimage/restoration/_unwrap_3d.pyx
@@ -11,6 +11,19 @@ cdef extern from *:
                 int wrap_around_x, int wrap_around_y, int wrap_around_z,
                 char use_seed, unsigned int seed) nogil
 
+
+cdef extern from "unwrap_3d_ljmu.h":
+    void unwrap3D(
+            double *wrapped_volume,
+            double *unwrapped_volume,
+            unsigned char *input_mask,
+            int volume_width, int volume_height, int volume_depth,
+            int wrap_around_x, int wrap_around_y, int wrap_around_z,
+            char use_seed, unsigned int seed
+            )
+
+
+
 def unwrap_3d(double[:, :, ::1] image,
               unsigned char[:, :, ::1] mask,
               double[:, :, ::1] unwrapped_image,

--- a/skimage/restoration/unwrap_2d_ljmu.c
+++ b/skimage/restoration/unwrap_2d_ljmu.c
@@ -39,6 +39,18 @@
 #define NOMASK 0
 #define MASK 1
 
+
+cdef extern from "unwrap_2d_ljmu.h":
+    void unwrap2D(
+            double *wrapped_image,
+            double *UnwrappedImage,
+            unsigned char *input_mask,
+            int image_width, int image_height,
+            int wrap_around_x, int wrap_around_y,
+            char use_seed, unsigned int seed
+            );
+
+
 typedef struct {
   double mod;
   int x_connectivity;

--- a/skimage/restoration/unwrap_2d_ljmu.c
+++ b/skimage/restoration/unwrap_2d_ljmu.c
@@ -40,17 +40,6 @@
 #define MASK 1
 
 
-cdef extern from "unwrap_2d_ljmu.h":
-    void unwrap2D(
-            double *wrapped_image,
-            double *UnwrappedImage,
-            unsigned char *input_mask,
-            int image_width, int image_height,
-            int wrap_around_x, int wrap_around_y,
-            char use_seed, unsigned int seed
-            );
-
-
 typedef struct {
   double mod;
   int x_connectivity;

--- a/skimage/restoration/unwrap_2d_ljmu.h
+++ b/skimage/restoration/unwrap_2d_ljmu.h
@@ -1,0 +1,9 @@
+void unwrap2D(
+        double *wrapped_image,
+        double *UnwrappedImage,
+        unsigned char *input_mask,
+        int image_width, int image_height,
+        int wrap_around_x, int wrap_around_y,
+        char use_seed, unsigned int seed
+        );
+

--- a/skimage/restoration/unwrap_3d_ljmu.c
+++ b/skimage/restoration/unwrap_3d_ljmu.c
@@ -40,6 +40,18 @@
 #define NOMASK 0
 #define MASK 1
 
+
+cdef extern from unwrap_3d_ljmu.h:
+    void unwrap3D(
+            double *wrapped_volume,
+            double *unwrapped_volume,
+            unsigned char *input_mask,
+            int volume_width, int volume_height, int volume_depth,
+            int wrap_around_x, int wrap_around_y, int wrap_around_z,
+            char use_seed, unsigned int seed
+            );
+
+
 typedef struct {
   double mod;
   int x_connectivity;

--- a/skimage/restoration/unwrap_3d_ljmu.c
+++ b/skimage/restoration/unwrap_3d_ljmu.c
@@ -41,16 +41,6 @@
 #define MASK 1
 
 
-cdef extern from unwrap_3d_ljmu.h:
-    void unwrap3D(
-            double *wrapped_volume,
-            double *unwrapped_volume,
-            unsigned char *input_mask,
-            int volume_width, int volume_height, int volume_depth,
-            int wrap_around_x, int wrap_around_y, int wrap_around_z,
-            char use_seed, unsigned int seed
-            );
-
 
 typedef struct {
   double mod;

--- a/skimage/restoration/unwrap_3d_ljmu.h
+++ b/skimage/restoration/unwrap_3d_ljmu.h
@@ -1,0 +1,9 @@
+void unwrap3D(
+        double *wrapped_volume,
+        double *unwrapped_volume,
+        unsigned char *input_mask,
+        int volume_width, int volume_height, int volume_depth,
+        int wrap_around_x, int wrap_around_y, int wrap_around_z,
+        char use_seed, unsigned int seed
+        );
+


### PR DESCRIPTION
## Description

Closes #5051 

@david-a-joy thank you for the fix! Could you check that this branch compiles as-is?

Does anyone have suggestions for how we can test this? Is there a flag we can pass to our older compilers to make them error out on the missing declarations?

At any rate even without a test I think we should merge this, since we have seen many people hitting this issue.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
