### PR TITLE
revert bool back to np.bool_ for np.issubdtype calls

### DIFF
--- a/skimage/morphology/grey.py
+++ b/skimage/morphology/grey.py
@@ -482,7 +482,7 @@ def black_tophat(image, selem=None, out=None):
     else:
         original = image
     out = closing(image, selem, out=out)
-    if np.issubdtype(out.dtype, bool):
+    if np.issubdtype(out.dtype, np.bool_):
         np.logical_xor(out, original, out=out)
     else:
         out -= original


### PR DESCRIPTION
Follow-up of #5103 in order to fox the test failures with minimal requirements (numpy 1.16.5)