### PR TITLE
Update release notes with latest backported changes from master

### DIFF
--- a/doc/release/release_0.18.rst
+++ b/doc/release/release_0.18.rst
@@ -27,7 +27,7 @@ New Features
   preventing overlap (#4795)
 - It is now possible to pass extra measurement functions to
   ``measure.regionprops`` and ``regionprops_table`` (#4810)
-- Add rolling ball algorithm for background substraction (#4851)
+- Add rolling ball algorithm for background subtraction (#4851)
 - New sample images have been added in the ``data`` subpackage: ``data.eagle``
   (#4922), ``data.human_mitosis`` (#4939), ``data.cells3d`` (#4951), and
   ``data.vortex`` (#5041). Also note that the image for ``data.camera`` has
@@ -82,7 +82,7 @@ Improvements
 
 - float32 support for SLIC (#4683), ORB (#4684, #4697), BRIEF (#4685),
   ``pyramid_gaussian`` (#4696), Richardson-Lucy deconvolution (#4880)
-- In ``skimage.restoration.richardson_lucy``, computations are now be done in
+- In ``skimage.restoration.richardson_lucy``, computations are now done in
   single-precision when the input image is single-precision. This can give a
   substantial performance improvement when working with single precision data.
 - Richardson-Lucy deconvolution now has a ``filter_epsilon`` keyword argument
@@ -177,7 +177,7 @@ Deprecations
 - The ``skimage.viewer`` subpackage and the ``skivi`` script have been
   deprecated and will be removed in version 0.20. For interactive visualization
   we recommend using dedicated tools such as `napari <https://napari.org>`_ or
-  `plotly <https://plot.ly>`_. In a similar vein, the ``qt`` and ``skivi``
+  `plotly <https://plotly.com>`_. In a similar vein, the ``qt`` and ``skivi``
   plugins of ``skimage.io`` have been deprecated
   and will be removed in version 0.20. (#4941, #4954)
 - In ``skimage.morphology.selem.rectangle`` the arguments ``width`` and 
@@ -208,7 +208,7 @@ Development process
 - Artifacts for the documentation build are now found in each pull request
   (#4881).
 - Documentation source files can now be written in Markdown in addition to
-  ResT, thanks to ``myst`` (#4863).
+  ReST, thanks to ``myst`` (#4863).
 - update trove classifiers and tests for Python 3.9 + fix pytest config (#5052)
 - fix Azure Pipelines, pytest config, and trove classifiers for Python 3.8 (#5054)
 - Moved our testing from Travis to GitHub Actions (#5074)

--- a/doc/release/release_0.18.rst
+++ b/doc/release/release_0.18.rst
@@ -75,6 +75,7 @@ Documentation
   repository (#4892).
 - The `benchmarking section of the developer documentation <https://scikit-image.org/docs/dev/contribute.html#benchmarks>`_ 
   has been expanded (#4905).
+- Added links to the image.sc forum in example pages (#5094, #5096)
 
 Improvements
 ------------
@@ -103,6 +104,9 @@ Improvements
   inequalities in sequence (#5020)
 - Polygon rasterization is more precise and will no longer potentially exclude
   input vertices. (#5029)
+- Add data optional requirements to allow pip install scikit-image[data]
+  (#5105, #5111)
+- OpenMP support in MSVC (#4924, #5111)
 
 API Changes
 -----------
@@ -157,6 +161,8 @@ Bug fixes
   Before this fix, an incorrect value could be returned where the input images
   had NaNs (#4886).
 - Fix edge filters not respecting padding mode (#4907)
+- Use v{} for version tags with pooch (#5104, #5110)
+- Fix compilation error in XCode 12 (#5107, #5111)
 
 Deprecations
 ------------
@@ -209,6 +215,7 @@ Development process
 - We now build our wheels on GitHub Actions on the main repo using
   cibuildwheel. Many thanks to the matplotlib and scikit-learn developers for
   paving the way for us! (#5080)
+- Disable Travis-CI builds (#5099, #5111)
 
 Other Pull Requests
 -------------------
@@ -313,6 +320,7 @@ Other Pull Requests
 - Some minor tweaks to CI (#5079)
 - removed usage of numpy's private functions from util.arraycrop (#5081)
 - peak_local_max: remove deprecated `indices` argument from examples (#5082)
+- Replace np.bool, np.float, and np.int with bool, float, and int (#5103, #5108)
 
 
 52 authors added to this release [alphabetical by first name or login]

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -71,7 +71,7 @@ dtype_limits
 import sys
 
 
-__version__ = '0.18.0rc0'
+__version__ = '0.18.0rc1'
 
 from ._shared.version_requirements import ensure_python_version
 ensure_python_version((3, 5))


### PR DESCRIPTION
This also contains the typo fixes from #5106, with thanks to those reviewers. =)

@scikit-image/core if we merge this, I can tag v0.18.0rc1 which **hopefully** 🤞 will be v0.18.0!

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
