### PR TITLE
change plausible script to track outbound links

### DIFF
--- a/doc/source/themes/scikit-image/layout.html
+++ b/doc/source/themes/scikit-image/layout.html
@@ -79,7 +79,7 @@
     <link rel="shortcut icon" href="{{ pathto('_static/', 1) }}favicon.ico">
     {%- block extrahead %}{% endblock %}
     <!-- Plausible analytics -->
-    <script async defer data-domain="scikit-image.org" src="https://plausible.io/js/plausible.js"></script>
+    <script async defer data-domain="scikit-image.org" src="https://plausible.io/js/plausible.outbound-links.js"></script>
 </head>
 <body class="container">
     <a href="https://scikit-image.org" class="logo"><img src="{{ pathto('_static/', 1) }}img/logo.png" alt=""></a>


### PR DESCRIPTION
A small change to the plausible.io javascript script; see https://docs.plausible.io/outbound-link-click-tracking for the explanation.

This would in particular allow to see whether people click on the user forum links.