### PR TITLE
Remove Python 3.6 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,8 +2,6 @@
 # Windows
 environment:
   matrix:
-    - PYTHON: C:\Python36
-    - PYTHON: C:\Python36-x64
     - PYTHON: C:\Python37
     - PYTHON: C:\Python37-x64
     - PYTHON: C:\Python38

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         PIP_FLAGS: [""]
         MINIMUM_REQUIREMENTS: [0]
         QT: ["PyQt5"]
@@ -127,19 +127,19 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         QT: ["PyQt5"]
         BUILD_DOCS: [1]
         TEST_EXAMPLES: [0]
         OPTIONAL_DEPS: [1]
         OPTIONS_NAME: ["default"]
         include:
-          - python-version: 3.6
-            OPTIONAL_DEPS: 0 
+          - python-version: 3.7
+            OPTIONAL_DEPS: 0
           - python-version: 3.9
-            OPTIONAL_DEPS: 0 
+            OPTIONAL_DEPS: 0
         exclude:
-          - python-version: 3.6
+          - python-version: 3.7
             OPTIONAL_DEPS: 1
           # Problem with SimpleITK and py 3.9
           - python-version: 3.9

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,15 +8,6 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      Python36:
-        PYTHON_VERSION: '3.6'
-        ARCH: 'x86'
-        PIP_FLAGS: ''
-      Python36-x64:
-        PYTHON_VERSION: '3.6'
-        ARCH: 'x64'
-        PIP_FLAGS: ''
-        BUILD_DOCS: 'true'
       Python37:
         PYTHON_VERSION: '3.7'
         ARCH: 'x86'
@@ -35,6 +26,7 @@ jobs:
         ARCH: 'x64'
         PIP_FLAGS: ''
         TEST_EXAMPLES: 'true'
+        BUILD_DOCS: 'true'
       # build pre release packages on Python 3.8 since it has been out long
       # enough for wheels to be built for packages that need to be compiled.
       Python38-x64-pre:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ requires = [
     "Cython>=0.29.18",
     # We follow scipy for much of these pinnings
     # https://github.com/scipy/scipy/blob/master/pyproject.toml
-    "numpy==1.16.5; python_version=='3.6'",
     "numpy==1.16.5; python_version=='3.7'",
     "numpy==1.17.3; python_version=='3.8'",
     # do not pin numpy on future versions of python to avoid incompatible numpy and python versions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires = [
     # https://github.com/scipy/scipy/blob/master/pyproject.toml
     "numpy==1.16.5; python_version=='3.7'",
     "numpy==1.17.3; python_version=='3.8'",
+    "numpy==1.19.3; python_version=='3.9'",
     # do not pin numpy on future versions of python to avoid incompatible numpy and python versions
-    "numpy; python_version>='3.9'",
+    "numpy; python_version>='3.10'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools",
+    "setuptools<=51.0.0",
     "Cython>=0.29.18",
     # We follow scipy for much of these pinnings
     # https://github.com/scipy/scipy/blob/master/pyproject.toml

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if sys.version_info < (3, 6):
 
     error = """Python {py} detected.
 
-scikit-image 0.16+ supports only Python 3.6 and above.
+scikit-image 0.18+ supports only Python 3.7 and above.
 
 For Python 2.7, please install the 0.14.x Long Term Support release using:
 
@@ -229,7 +229,6 @@ if __name__ == "__main__":
             'Programming Language :: C',
             'Programming Language :: Python',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
@@ -243,7 +242,7 @@ if __name__ == "__main__":
         install_requires=INSTALL_REQUIRES,
         requires=REQUIRES,
         extras_require=extras_require,
-        python_requires='>=3.6',
+        python_requires='>=3.7',
         packages=setuptools.find_packages(exclude=['doc', 'benchmarks']),
         include_package_data=True,
         zip_safe=False,  # the package can run out of an .egg file


### PR DESCRIPTION
## Description

Closes #5053, see discussion there.

Currently, if we release 0.18 without this PR, users on py3.6 will need to compile from source, since we are not building 3.6 wheels. Given the discussion in #5053 and elsewhere in the community, I think we should pull the bandaid and remove 3.6 support altogether from this release.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
