### PR TITLE
Improve error message when installing from source and cython isn't installed.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -196,13 +196,14 @@ if __name__ == "__main__":
             extra = {}
         else:
             print(textwrap.dedent("""
-                To install scikit-image from source, you will need NumPy.
-                Install NumPy with pip using:
+                To install scikit-image from source, you will need NumPy
+                and Cython.
+                Install NumPy and Cython with your python package manager.
+                If you are using pip, the commands are:
 
-                  pip install numpy
+                  pip install numpy cython
 
-                Or use your operating system package manager. For more
-                details, see:
+                For more details, see:
 
                    https://scikit-image.org/docs/stable/install.html
             """))


### PR DESCRIPTION
CC: mok0

Closes #5127

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
