### PR TITLE
More uniform docs in texture.py and _hog.py

### DIFF
--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -296,21 +296,21 @@ def local_binary_pattern(image, P, R, method='default'):
         Method to determine the pattern:
 
         ``default``
-           Original local binary pattern which is gray scale but not 
-           rotation invariant.
+           Original local binary pattern which is gray scale but not
+            rotation invariant.
         ``ror``
-           Extension of default implementation which is gray scale and 
-           rotation invariant.
+           Extension of default implementation which is gray scale and
+            rotation invariant.
         ``uniform``
-           Improved rotation invariance with uniform patterns and finer 
-           quantization of the angular space which is gray scale and 
-           rotation invariant.
+           Improved rotation invariance with uniform patterns and finer
+            quantization of the angular space which is gray scale and
+            rotation invariant.
         ``nri_uniform``
-           Non rotation-invariant uniform patterns variant which is 
-           only gray scale invariant [2]_.
+           Non rotation-invariant uniform patterns variant which is
+            only gray scale invariant [2]_.
         ``var``
-           Rotation invariant variance measures of the contrast of local 
-           image texture which is rotation but not gray scale invariant.
+           Rotation invariant variance measures of the contrast of local
+            image texture which is rotation but not gray scale invariant.
 
     Returns
     -------

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -293,19 +293,24 @@ def local_binary_pattern(image, P, R, method='default'):
     R : float
         Radius of circle (spatial resolution of the operator).
     method : {'default', 'ror', 'uniform', 'var'}
-        Method to determine the pattern.
+        Method to determine the pattern:
 
-        * 'default': original local binary pattern which is gray scale but not
-            rotation invariant.
-        * 'ror': extension of default implementation which is gray scale and
-            rotation invariant.
-        * 'uniform': improved rotation invariance with uniform patterns and
-            finer quantization of the angular space which is gray scale and
-            rotation invariant.
-        * 'nri_uniform': non rotation-invariant uniform patterns variant
-            which is only gray scale invariant [2]_.
-        * 'var': rotation invariant variance measures of the contrast of local
-            image texture which is rotation but not gray scale invariant.
+        ``default``
+           Original local binary pattern which is gray scale but not 
+           rotation invariant.
+        ``ror``
+           Extension of default implementation which is gray scale and 
+           rotation invariant.
+        ``uniform``
+           Improved rotation invariance with uniform patterns and finer 
+           quantization of the angular space which is gray scale and 
+           rotation invariant.
+        ``nri_uniform``
+           Non rotation-invariant uniform patterns variant which is 
+           only gray scale invariant [2]_.
+        ``var``
+           Rotation invariant variance measures of the contrast of local 
+           image texture which is rotation but not gray scale invariant.
 
     Returns
     -------


### PR DESCRIPTION
## Description

The description of `local_binary_pattern` [(docs)](https://scikit-image.org/docs/dev/api/skimage.feature.html#local-binary-pattern) `method` argument was non uniform, partially with bold and partially regular text. I've changed it to be exactly like `block_norm` argument of the `hog` function [(docs)](https://scikit-image.org/docs/dev/api/skimage.feature.html#hog). The choice of style was made based on the fact that both functions are from the same `feature` module.

## Checklist

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

All done, change is minor and unifies the existing docs style.

## For reviewers

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
