### PR TITLE
label2rgb performance fix

### DIFF
--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -188,7 +188,7 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
     if len(mapped_labels_flat) == 0:
         return image
 
-    dense_labels = range(max(mapped_labels_flat) + 1)
+    dense_labels = range(np.max(mapped_labels_flat) + 1)
 
     label_to_color = np.stack([c for i, c in zip(dense_labels, color_cycle)])
 


### PR DESCRIPTION
## Description

I came across an inappropriate call to built-in `max` rather than `numpy.max` on arrays. This is slower on NumPy arrays, but where it would really cause problems is if using CuPy or device arrays because it will lead to separate host->device transfers for each element!

Here is an example illustrating ~ 200 fold performance difference for NumPy arrays on the CPU

```Python
import numpy as np

a = np.arange(10000000)

%timeit np.sum(a)
# gives: 6.62 ms ± 64.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

%timeit sum(a)
# gives: 1.25 s ± 42 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
