### PR TITLE
Add saturation parameter to color.label2rgb

### DIFF
--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -74,7 +74,7 @@ def _match_label_with_color(label, colors, bg_label, bg_color):
 @change_default_value("bg_label", new_value=0, changed_version="0.19")
 def label2rgb(label, image=None, colors=None, alpha=0.3,
               bg_label=-1, bg_color=(0, 0, 0), image_alpha=1, kind='overlay',
-              saturation=0):
+              *, saturation=0):
     """Return an RGB image where color-coded labels are painted over the image.
 
     Parameters
@@ -161,6 +161,9 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
         The result of blending a cycling colormap (`colors`) for each distinct
         value in `label` with the image, at a certain alpha value.
     """
+    if not 0 <= saturation <= 1:
+        warn(f"saturation must be in range [0, 1], got {saturation}")
+
     if colors is None:
         colors = DEFAULT_COLORS
     colors = [_rgb_vector(c) for c in colors]

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -73,7 +73,8 @@ def _match_label_with_color(label, colors, bg_label, bg_color):
 
 @change_default_value("bg_label", new_value=0, changed_version="0.19")
 def label2rgb(label, image=None, colors=None, alpha=0.3,
-              bg_label=-1, bg_color=(0, 0, 0), image_alpha=1, kind='overlay'):
+              bg_label=-1, bg_color=(0, 0, 0), image_alpha=1, kind='overlay',
+              force_grayscale=True):
     """Return an RGB image where color-coded labels are painted over the image.
 
     Parameters
@@ -102,6 +103,9 @@ def label2rgb(label, image=None, colors=None, alpha=0.3,
         and overlays the colored labels over the original image. 'avg' replaces
         each labeled segment with its average color, for a stained-class or
         pastel painting appearance.
+    force_grayscale : bool, optional
+        Whether or not to convert the input image to grayscale. By default it 
+        converts the image to grayscale before making the overlay.
 
     Returns
     -------
@@ -111,7 +115,7 @@ def label2rgb(label, image=None, colors=None, alpha=0.3,
     """
     if kind == 'overlay':
         return _label2rgb_overlay(label, image, colors, alpha, bg_label,
-                                  bg_color, image_alpha)
+                                  bg_color, image_alpha, force_grayscale)
     elif kind == 'avg':
         return _label2rgb_avg(label, image, bg_label, bg_color)
     else:
@@ -119,7 +123,8 @@ def label2rgb(label, image=None, colors=None, alpha=0.3,
 
 
 def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
-                       bg_label=-1, bg_color=None, image_alpha=1):
+                       bg_label=-1, bg_color=None, image_alpha=1,
+                       force_grayscale=True):
     """Return an RGB image where color-coded labels are painted over the image.
 
     Parameters
@@ -142,6 +147,9 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
         between [0, 1].
     image_alpha : float [0, 1], optional
         Opacity of the image.
+    force_grayscale : bool, optional
+        Whether or not to convert the input image to grayscale. By default it 
+        converts the image to grayscale before making the overlay.
 
     Returns
     -------
@@ -164,11 +172,11 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
         if image.min() < 0:
             warn("Negative intensities in `image` are not supported")
 
-        if image.ndim > label.ndim:
-            image = img_as_float(rgb2gray(image))
+        if image.ndim > label.ndim and force_grayscale:
+            image = gray2rgb(img_as_float(rgb2gray(image)))
         else:
             image = img_as_float(image)
-        image = gray2rgb(image) * image_alpha + (1 - image_alpha)
+        image = image * image_alpha + (1 - image_alpha)
 
     # Ensure that all labels are non-negative so we can index into
     # `label_to_color` correctly.

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -100,9 +100,9 @@ def label2rgb(label, image=None, colors=None, alpha=0.3,
     kind : string, one of {'overlay', 'overlay-rgb', 'avg'}
         The kind of color image desired. 'overlay' cycles over defined colors
         and overlays the colored labels over the original image. 'overlay-rgb'
-        behaves same as 'overlay', but it preserves the rgb content of the 
-        input image. 'avg' replaces each labeled segment with its average color,
-        for a stained-class or pastel painting appearance.
+        behaves same as 'overlay', but it preserves the rgb content of the
+        input image. 'avg' replaces each labeled segment with its average
+        color, for a stained-class or pastel painting appearance.
 
     Returns
     -------
@@ -149,8 +149,8 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
     image_alpha : float [0, 1], optional
         Opacity of the image.
     preserve_rgb : bool, optional
-        Whether or not to preserve the rgb content of the input image. By default
-        it converts the image to grayscale before making the overlay.
+        Whether or not to preserve the rgb content of the input image.By
+        default it converts the image to grayscale before making the overlay.
 
     Returns
     -------

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -104,7 +104,7 @@ def label2rgb(label, image=None, colors=None, alpha=0.3,
         each labeled segment with its average color, for a stained-class or
         pastel painting appearance.
     force_grayscale : bool, optional
-        Whether or not to convert the input image to grayscale. By default it 
+        Whether or not to convert the input image to grayscale. By default it
         converts the image to grayscale before making the overlay.
 
     Returns
@@ -148,7 +148,7 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
     image_alpha : float [0, 1], optional
         Opacity of the image.
     force_grayscale : bool, optional
-        Whether or not to convert the input image to grayscale. By default it 
+        Whether or not to convert the input image to grayscale. By default it
         converts the image to grayscale before making the overlay.
 
     Returns

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -100,8 +100,8 @@ def label2rgb(label, image=None, colors=None, alpha=0.3,
     kind : string, one of {'overlay', 'overlay-rgb', 'avg'}
         The kind of color image desired. 'overlay' cycles over defined colors
         and overlays the colored labels over the original image. 'overlay-rgb'
-        behaves same as 'overlay', but it preserves the rgb content of the
-        input image. 'avg' replaces each labeled segment with its average
+        behaves just like 'overlay', but it preserves the RGB content of the
+        original image. 'avg' replaces each labeled segment with its average
         color, for a stained-glass or pastel painting appearance.
 
     Returns
@@ -112,7 +112,7 @@ def label2rgb(label, image=None, colors=None, alpha=0.3,
     """
     if kind == 'overlay':
         return _label2rgb_overlay(label, image, colors, alpha, bg_label,
-                                  bg_color, image_alpha, preserve_rgb=False)
+                                  bg_color, image_alpha)
     elif kind == 'overlay-rgb':
         return _label2rgb_overlay(label, image, colors, alpha, bg_label,
                                   bg_color, image_alpha, preserve_rgb=True)
@@ -120,7 +120,7 @@ def label2rgb(label, image=None, colors=None, alpha=0.3,
         return _label2rgb_avg(label, image, bg_label, bg_color)
     else:
         raise ValueError(
-            "`kind` must be either 'overlay', 'overlay-rgb' or 'avg'.")
+            "`kind` must be one of: 'overlay', 'overlay-rgb', or 'avg'.")
 
 
 def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
@@ -134,7 +134,7 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
         Integer array of labels with the same shape as `image`.
     image : array, shape (M, N, 3), optional
         Image used as underlay for labels. If the input is an RGB image, it's
-        converted to grayscale before coloring.
+        converted to grayscale before coloring unless `preserve_rgb=True`.
     colors : list, optional
         List of colors. If the number of labels exceeds the number of colors,
         then the colors are cycled.
@@ -149,8 +149,9 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
     image_alpha : float [0, 1], optional
         Opacity of the image.
     preserve_rgb : bool, optional
-        Whether or not to preserve the RGB content of the input image.By
-        default it converts the image to grayscale before making the overlay.
+        Whether or not to preserve the RGB content of the input image. By
+        default (`preserve_rgb=False`), the input image is converted to
+        grayscale before making the overlay.
 
     Returns
     -------

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -102,7 +102,7 @@ def label2rgb(label, image=None, colors=None, alpha=0.3,
         and overlays the colored labels over the original image. 'overlay-rgb'
         behaves same as 'overlay', but it preserves the rgb content of the
         input image. 'avg' replaces each labeled segment with its average
-        color, for a stained-class or pastel painting appearance.
+        color, for a stained-glass or pastel painting appearance.
 
     Returns
     -------
@@ -149,7 +149,7 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
     image_alpha : float [0, 1], optional
         Opacity of the image.
     preserve_rgb : bool, optional
-        Whether or not to preserve the rgb content of the input image.By
+        Whether or not to preserve the RGB content of the input image.By
         default it converts the image to grayscale before making the overlay.
 
     Returns
@@ -177,7 +177,7 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
         if image.ndim > label.ndim and not preserve_rgb:
             image = rgb2gray(image)
             image = gray2rgb(image)
-        else:
+        elif image.ndim == label.ndim:
             image = gray2rgb(image)
         image = image * image_alpha + (1 - image_alpha)
 

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -179,7 +179,7 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
         image = img_as_float(image)
         if image.ndim > label.ndim:
             hsv = rgb2hsv(image)
-            hsv[..., 1] = hsv[..., 1] * saturation
+            hsv[..., 1] *= saturation
             image = hsv2rgb(hsv)
         elif image.ndim == label.ndim:
             image = gray2rgb(image)

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -179,7 +179,7 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
         image = img_as_float(image)
         if image.ndim > label.ndim:
             hsv = rgb2hsv(image)
-            hsv[..., 1] = hsv[..., 1]*saturation
+            hsv[..., 1] = hsv[..., 1] * saturation
             image = hsv2rgb(hsv)
         elif image.ndim == label.ndim:
             image = gray2rgb(image)

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -170,12 +170,12 @@ def test_avg():
     # reference label-colored image
     rout = np.array([[0.5, 0.5, 0.5, 0.5],
                      [0.5, 0.5, 0.5, 0.5],
-                     [0. , 0. , 0. , 0. ]])
+                     [0., 0., 0., 0.]])
     gout = np.array([[0.25, 0.25, 0.25, 0.75],
                      [0.25, 0.75, 0.75, 0.75],
-                     [0.  , 0.  , 0.  , 0.  ]])
-    bout = np.array([[0. , 0. , 0. , 1. ],
-                     [0. , 1. , 1. , 1. ],
+                     [0., 0., 0., 0.]])
+    bout = np.array([[0., 0., 0., 1.],
+                     [0., 1., 1., 1.],
                      [0.0, 0.0, 1.0, 1.0]])
     expected_out = np.dstack((rout, gout, bout))
 
@@ -206,8 +206,9 @@ def test_bg_color_rgb_string():
     labels = np.zeros((10, 10), dtype=np.int64)
     labels[1:3, 1:3] = 1
     labels[6:9, 6:9] = 2
-    output = label2rgb(labels, image=img, alpha=0.9, bg_label=0, bg_color='red')
-    assert output[0, 0, 0] > 0.9 # red channel
+    output = label2rgb(labels, image=img, alpha=0.9,
+                       bg_label=0, bg_color='red')
+    assert output[0, 0, 0] > 0.9  # red channel
 
 
 def test_avg_with_2d_image():
@@ -216,3 +217,21 @@ def test_avg_with_2d_image():
     labels[1:3, 1:3] = 1
     labels[6:9, 6:9] = 2
     assert_no_warnings(label2rgb, labels, image=img, bg_label=0, kind='avg')
+
+
+def test_overlay_rgb():
+    rgb_img = np.random.uniform(size=(10, 10, 3))
+    labels = np.ones((10, 10), dtype=np.int64)
+    labels[5:, 5:] = 2
+    labels[:3, :3] = 0
+    alpha = 0.3
+    rgb = label2rgb(labels, image=rgb_img, alpha=alpha,
+                    bg_label=0, kind='overlay-rgb')
+    # check that rgb part of input image is preserved, where labels=0
+    assert_array_equal(rgb_img[:3, :3]*(1-alpha), rgb[:3, :3])
+
+    # now check only with kind=overlay that does not match
+    rgb = label2rgb(labels, image=rgb_img, alpha=alpha,
+                    bg_label=0, kind='overlay')
+    with testing.raises(AssertionError):
+        assert_array_equal(rgb_img[:3, :3]*(1-alpha), rgb[:3, :3])

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -219,19 +219,20 @@ def test_avg_with_2d_image():
     assert_no_warnings(label2rgb, labels, image=img, bg_label=0, kind='avg')
 
 
-def test_overlay_rgb():
+def test_overlay_saturation():
     rgb_img = np.random.uniform(size=(10, 10, 3))
     labels = np.ones((10, 10), dtype=np.int64)
     labels[5:, 5:] = 2
     labels[:3, :3] = 0
     alpha = 0.3
     rgb = label2rgb(labels, image=rgb_img, alpha=alpha,
-                    bg_label=0, kind='overlay-rgb')
+                    bg_label=0, saturation=1)
     # check that rgb part of input image is preserved, where labels=0
-    assert_array_equal(rgb_img[:3, :3] * (1 - alpha), rgb[:3, :3])
+    assert_array_almost_equal(rgb_img[:3, :3] * (1 - alpha), rgb[:3, :3])
 
-    # now check only with kind=overlay that does not match
+    # now check with saturation=0 that does not match with rgb values
     rgb = label2rgb(labels, image=rgb_img, alpha=alpha,
-                    bg_label=0, kind='overlay')
+                    bg_label=0, saturation=0)
+
     with testing.raises(AssertionError):
-        assert_array_equal(rgb_img[:3, :3] * (1 - alpha), rgb[:3, :3])
+        assert_array_almost_equal(rgb_img[:3, :3] * (1 - alpha), rgb[:3, :3])

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -228,10 +228,10 @@ def test_overlay_rgb():
     rgb = label2rgb(labels, image=rgb_img, alpha=alpha,
                     bg_label=0, kind='overlay-rgb')
     # check that rgb part of input image is preserved, where labels=0
-    assert_array_equal(rgb_img[:3, :3] * (1-alpha), rgb[:3, :3])
+    assert_array_equal(rgb_img[:3, :3] * (1 - alpha), rgb[:3, :3])
 
     # now check only with kind=overlay that does not match
     rgb = label2rgb(labels, image=rgb_img, alpha=alpha,
                     bg_label=0, kind='overlay')
     with testing.raises(AssertionError):
-        assert_array_equal(rgb_img[:3, :3] * (1-alpha), rgb[:3, :3])
+        assert_array_equal(rgb_img[:3, :3] * (1 - alpha), rgb[:3, :3])

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -228,10 +228,10 @@ def test_overlay_rgb():
     rgb = label2rgb(labels, image=rgb_img, alpha=alpha,
                     bg_label=0, kind='overlay-rgb')
     # check that rgb part of input image is preserved, where labels=0
-    assert_array_equal(rgb_img[:3, :3]*(1-alpha), rgb[:3, :3])
+    assert_array_equal(rgb_img[:3, :3] * (1-alpha), rgb[:3, :3])
 
     # now check only with kind=overlay that does not match
     rgb = label2rgb(labels, image=rgb_img, alpha=alpha,
                     bg_label=0, kind='overlay')
     with testing.raises(AssertionError):
-        assert_array_equal(rgb_img[:3, :3]*(1-alpha), rgb[:3, :3])
+        assert_array_equal(rgb_img[:3, :3] * (1-alpha), rgb[:3, :3])


### PR DESCRIPTION
## Description

The function `skimage.color.label2rgb` transforms always the input image to grayscale. There are cases where one wants to keep the image as it is (rgb). I added a flag `force_grayscale` to control this behavior. What do you think? I know the name could be improved :P 