### PR TITLE
WIP: Performance improvements for Canny feature detection

### DIFF
--- a/benchmarks/benchmark_feature.py
+++ b/benchmarks/benchmark_feature.py
@@ -2,20 +2,16 @@
 # https://asv.readthedocs.io/en/latest/writing_benchmarks.html
 import numpy as np
 from scipy import ndimage as ndi
-from skimage import feature, util
+from skimage import color, data, feature, util
 
 
 class FeatureSuite:
     """Benchmark for feature routines in scikit-image."""
     def setup(self):
-        self.image = np.zeros((640, 640))
-        self.image[320:-320, 320:-320] = 1
-
-        self.image = ndi.rotate(self.image, 15, mode='constant')
-        self.image = ndi.gaussian_filter(self.image, 4)
-        self.image += 0.2 * np.random.random(self.image.shape)
-
-        self.image_ubyte = util.img_as_ubyte(np.clip(self.image, 0, 1))
+        # Use a real-world image for more realistic features, but tile it to
+        # get a larger size for the benchmark.
+        self.image = np.tile(color.rgb2gray(data.astronaut()), (4, 4))
+        self.image_ubyte = util.img_as_ubyte(self.image)
 
     def time_canny(self):
         result = feature.canny(self.image)

--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -173,18 +173,18 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None, mask=None,
     else:
         high_threshold = high_threshold / dtype_max
 
-    def fsmooth(x):
-        return img_as_float(gaussian(x, sigma, mode='constant'))
+    def fsmooth(x, mode='constant'):
+        return img_as_float(gaussian(x, sigma, mode=mode))
 
     if mask is None:
-        mask = np.ones(image.shape, dtype=bool)
-        smoothed = smooth_with_function_and_mask(image, fsmooth, mask)
-        eroded_mask = mask
+        smoothed = fsmooth(image, mode='reflect')
+        eroded_mask = np.ones(image.shape, dtype=bool)
         eroded_mask[:1, :] = 0
         eroded_mask[-1:, :] = 0
         eroded_mask[:, :1] = 0
         eroded_mask[:, -1:] = 0
     else:
+
         smoothed = smooth_with_function_and_mask(image, fsmooth, mask)
         #
         # Make the eroded mask. Setting the border value to zero will wipe

--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -289,10 +289,9 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None, mask=None,
     if count == 0:
         return low_mask
 
-    sums = (np.array(ndi.sum(high_mask, labels,
-                             np.arange(count, dtype=np.int32) + 1),
-                     copy=False, ndmin=1))
+    nonzero_sums = np.unique(labels[high_mask])
     good_label = np.zeros((count + 1,), bool)
-    good_label[1:] = sums > 0
+    good_label[nonzero_sums] = True
+
     output_mask = good_label[labels]
     return output_mask


### PR DESCRIPTION
## UPDATE

I have marked this as WIP due to a similar preceding PR at #4342. It probably makes more sense to merge this PR into that one.

## Description

This PR makes multiple independent changes to the Canny feature detection code to improve performance. It will be easiest to review the commits in isolation as they each modify independent things. The table below shows the benchmark result for each commit here.

time_canny (ms) | commit
-----------|-------
1160   | 59889f5 (same as v0.18.1)
1090   | 769235e
1020   | 5757c11
988     | 5ab8429
791     | a69f6a8
22 | CuPy-based implementation equivalent to a69f6a8 (not in this PR)

Commits 5ab8429 and a69f6a8 only help for the case when `mask=None`. Overall, the reduction in runtime for the benchmark is 32% in the unmasked case and 12% in the masked case.

Commit 5757c11 gives only a minor improvement here, but makes an order of magnitude difference if using CuPy for the array module (`cupyx.scipy.ndimage.sum` is not very efficient for a large number of very small labeled regions). The poor performance of this function in a CuPy-based implementation was the reason I started looking at performance here in the first place. 

Commit a69f6a8 provides a substantial benefit, but this commit does result in small differences near the image edge as generated via results from the following script. Qualitatively, they look equivalent to me, but the results are not pixelwise identical to before near the edge.

```Python
import numpy as np
from scipy import ndimage as ndi
from skimage import color, data, feature, util

image = color.rgb2gray(data.astronaut())
result = feature.canny(image, sigma=1.5, use_quantiles=True)
```
![canny_compare](https://user-images.githubusercontent.com/6528957/103242285-b8520c80-4923-11eb-8530-b1989bef9d17.png)


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
