### PR TITLE
threshold_local: n-dimensional support and anisotropic block_size

### DIFF
--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -123,7 +123,8 @@ class TestSimpleImage():
         assert all(0.49 < threshold_isodata(imfloat, nbins=1024,
                                             return_all=True))
 
-    def test_threshold_local_gaussian(self):
+    @pytest.mark.parametrize('ndim', [2, 3])
+    def test_threshold_local_gaussian(self, ndim):
         ref = np.array(
             [[False, False, False, False,  True],
              [False, False,  True, False,  True],
@@ -131,14 +132,20 @@ class TestSimpleImage():
              [False,  True,  True, False, False],
              [ True,  True, False, False, False]]
         )
-        out = threshold_local(self.image, 3, method='gaussian')
-        assert_equal(ref, self.image > out)
+        if ndim == 2:
+            image = self.image
+        else:
+            image = np.stack((self.image, ) * 5, axis=-1)
+            ref = np.stack((ref, ) * 5, axis=-1)
+        out = threshold_local(image, 3, method='gaussian', mode='reflect')
+        assert_equal(ref, image > out)
 
-        out = threshold_local(self.image, 3, method='gaussian',
-                              param=1./3.)
-        assert_equal(ref, self.image > out)
+        out = threshold_local(image, 3, method='gaussian', mode='reflect',
+                              param=1. / 3.)
+        assert_equal(ref, image > out)
 
-    def test_threshold_local_mean(self):
+    @pytest.mark.parametrize('ndim', [2, 3])
+    def test_threshold_local_mean(self, ndim):
         ref = np.array(
             [[False, False, False, False,  True],
              [False, False,  True, False,  True],
@@ -146,10 +153,16 @@ class TestSimpleImage():
              [False,  True,  True, False, False],
              [ True,  True, False, False, False]]
         )
-        out = threshold_local(self.image, 3, method='mean')
-        assert_equal(ref, self.image > out)
+        if ndim == 2:
+            image = self.image
+        else:
+            image = np.stack((self.image, ) * 5, axis=-1)
+            ref = np.stack((ref, ) * 5, axis=-1)
+        out = threshold_local(image, 3, method='mean', mode='reflect')
+        assert_equal(ref, image > out)
 
-    def test_threshold_local_median(self):
+    @pytest.mark.parametrize('ndim', [2, 3])
+    def test_threshold_local_median(self, ndim):
         ref = np.array(
             [[False, False, False, False,  True],
              [False, False,  True, False, False],
@@ -157,8 +170,13 @@ class TestSimpleImage():
              [False, False,  True,  True, False],
              [False,  True, False, False, False]]
         )
-        out = threshold_local(self.image, 3, method='median')
-        assert_equal(ref, self.image > out)
+        if ndim == 2:
+            image = self.image
+        else:
+            image = np.stack((self.image, ) * 5, axis=-1)
+            ref = np.stack((ref, ) * 5, axis=-1)
+        out = threshold_local(image, 3, method='median', mode='reflect')
+        assert_equal(ref, image > out)
 
     def test_threshold_local_median_constant_mode(self):
         out = threshold_local(self.image, 3, method='median',

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -134,14 +134,20 @@ class TestSimpleImage():
         )
         if ndim == 2:
             image = self.image
+            block_sizes = [3, (3,) * image.ndim]
         else:
             image = np.stack((self.image, ) * 5, axis=-1)
             ref = np.stack((ref, ) * 5, axis=-1)
-        out = threshold_local(image, 3, method='gaussian', mode='reflect')
-        assert_equal(ref, image > out)
+            block_sizes = [3, (3,) * image.ndim,
+                           (3,) * (image.ndim - 1) + (1,)]
+
+        for block_size in block_sizes:
+            out = threshold_local(image, block_size, method='gaussian',
+                                  mode='reflect')
+            assert_equal(ref, image > out)
 
         out = threshold_local(image, 3, method='gaussian', mode='reflect',
-                              param=1. / 3.)
+                              param=1 / 3)
         assert_equal(ref, image > out)
 
     @pytest.mark.parametrize('ndim', [2, 3])
@@ -155,11 +161,24 @@ class TestSimpleImage():
         )
         if ndim == 2:
             image = self.image
+            block_sizes = [3, (3,) * image.ndim]
         else:
             image = np.stack((self.image, ) * 5, axis=-1)
             ref = np.stack((ref, ) * 5, axis=-1)
-        out = threshold_local(image, 3, method='mean', mode='reflect')
-        assert_equal(ref, image > out)
+            # Given the same data at each z location, the following block sizes
+            # will all give an equivalent result.
+            block_sizes = [3, (3,) * image.ndim,
+                           (3,) * (image.ndim - 1) + (1,)]
+        for block_size in block_sizes:
+            out = threshold_local(image, block_size, method='mean',
+                                  mode='reflect')
+            assert_equal(ref, image > out)
+
+    @pytest.mark.parametrize('block_size', [(3, ), (3, 3, 3)])
+    def test_threshold_local_invalid_block_size(self, block_size):
+        # len(block_size) != image.ndim
+        with pytest.raises(ValueError):
+            threshold_local(self.image, block_size, method='mean')
 
     @pytest.mark.parametrize('ndim', [2, 3])
     def test_threshold_local_median(self, ndim):

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -224,16 +224,8 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
         ndi.gaussian_filter(image, sigma, output=thresh_image, mode=mode,
                             cval=cval)
     elif method == 'mean':
-        masks = {}
-        for b in set(block_size):
-            masks[b] = 1. / b * np.ones((b,))
-        # # separation of filters to speedup convolution
-        b = block_size[0]
-        ndi.convolve1d(
-            image, masks[b], axis=0, output=thresh_image, mode=mode, cval=cval)
-        for ax, b in zip(range(1, image.ndim), block_size[1:]):
-            ndi.convolve1d(thresh_image, masks[b], axis=ax,
-                           output=thresh_image, mode=mode, cval=cval)
+        ndi.uniform_filter(image, block_size, output=thresh_image, mode=mode,
+                           cval=cval)
     elif method == 'median':
         ndi.median_filter(image, block_size, output=thresh_image, mode=mode,
                           cval=cval)

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -229,7 +229,7 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
             masks[b] = 1. / b * np.ones((b,))
         # # separation of filters to speedup convolution
         b = block_size[0]
-        thresh_image = ndi.convolve1d(
+        ndi.convolve1d(
             image, masks[b], axis=0, output=thresh_image, mode=mode, cval=cval)
         for ax, b in zip(range(1, image.ndim), block_size[1:]):
             ndi.convolve1d(thresh_image, masks[b], axis=ax,

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -295,7 +295,7 @@ def threshold_otsu(image=None, nbins=256, *, hist=None):
 
     Parameters
     ----------
-    image : (N, M) ndarray, optional
+    image : (N, M[, ..., P]) ndarray
         Grayscale input image.
     nbins : int, optional
         Number of bins used to calculate histogram. This value is ignored for
@@ -365,8 +365,8 @@ def threshold_yen(image=None, nbins=256, *, hist=None):
 
     Parameters
     ----------
-    image : (N, M) ndarray, optional
-        Input image.
+    image : (N, M[, ..., P]) ndarray
+        Grayscale input image.
     nbins : int, optional
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
@@ -440,8 +440,8 @@ def threshold_isodata(image=None, nbins=256, return_all=False, *, hist=None):
 
     Parameters
     ----------
-    image : (N, M) ndarray, optional
-        Input image.
+    image : (N, M[, ..., P]) ndarray
+        Grayscale input image.
     nbins : int, optional
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
@@ -597,8 +597,8 @@ def threshold_li(image, *, tolerance=None, initial_guess=None,
 
     Parameters
     ----------
-    image : ndarray
-        Input image.
+    image : (N, M[, ..., P]) ndarray
+        Grayscale input image.
 
     tolerance : float, optional
         Finish the computation when the change in the threshold in an iteration
@@ -727,8 +727,8 @@ def threshold_minimum(image=None, nbins=256, max_iter=10000, *, hist=None):
 
     Parameters
     ----------
-    image : (M, N) ndarray, optional
-        Input image.
+    image : (N, M[, ..., P]) ndarray, optional
+        Grayscale input image.
     nbins : int, optional
         Number of bins used to calculate histogram. This value is ignored for
         integer arrays.
@@ -923,8 +923,8 @@ def _mean_std(image, w):
 
     Parameters
     ----------
-    image : ndarray
-        Input image.
+    image : (N, M[, ..., P]) ndarray
+        Grayscale input image.
     w : int, or iterable of int
         Window size specified as a single odd integer (3, 5, 7, …),
         or an iterable of length ``image.ndim`` containing only odd
@@ -987,8 +987,8 @@ def threshold_niblack(image, window_size=15, k=0.2):
 
     Parameters
     ----------
-    image : ndarray
-        Input image.
+    image : (N, M[, ..., P]) ndarray
+        Grayscale input image.
     window_size : int, or iterable of int, optional
         Window size specified as a single odd integer (3, 5, 7, …),
         or an iterable of length ``image.ndim`` containing only odd
@@ -1052,8 +1052,8 @@ def threshold_sauvola(image, window_size=15, k=0.2, r=None):
 
     Parameters
     ----------
-    image : ndarray
-        Input image.
+    image : (N, M[, ..., P]) ndarray
+        Grayscale input image.
     window_size : int, or iterable of int, optional
         Window size specified as a single odd integer (3, 5, 7, …),
         or an iterable of length ``image.ndim`` containing only odd
@@ -1151,7 +1151,7 @@ def threshold_multiotsu(image, classes=3, nbins=256):
 
     Parameters
     ----------
-    image : (N, M) ndarray
+    image : (N, M[, ..., P]) ndarray
         Grayscale input image.
     classes : int, optional
         Number of classes to be thresholded, i.e. the number of resulting


### PR DESCRIPTION
## Description

`threshold_local` appears to be the only function in `skimage.filters.thresholding` that does not support n-dimensional inputs. I have added n-d support in this PR. This was fairly easy because the underlying `scipy.ndimage` functions used were already n-dimensional.

I was not sure about good 3d test cases, but decided to just replicate the existing 2d test cases via tiling so that the same expected results could be reused.

Allowing anisotropic `block_size` can be useful to enable `block_size = 1` for any non-spatial dimensions as an easy way to batch threshold across multiple channels or timepoints.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
