### PR TITLE
Stain unmixing fix

### DIFF
--- a/doc/examples/color_exposure/plot_ihc_color_separation.py
+++ b/doc/examples/color_exposure/plot_ihc_color_separation.py
@@ -71,7 +71,7 @@ d = rescale_intensity(ihc_hed[:, :, 2], out_range=(0, 1),
                       in_range=(0, np.percentile(ihc_hed[:, :, 2], 99)))
 
 # Put the two channels into an RGB image as green and blue channels
-zdh = np.dstack((np.zeros_like(h), d, h))
+zdh = np.dstack((null, d, h))
 
 fig = plt.figure()
 axis = plt.subplot(1, 1, 1, sharex=ax[0], sharey=ax[0])

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1451,6 +1451,8 @@ def separate_stains(rgb, conv_matrix):
 
     stains = (np.log(rgb) / log_adjust) @ conv_matrix
 
+    np.maximum(stains, 0, out=stains)
+
     return stains
 
 

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -47,6 +47,7 @@ class TestColorconv(TestCase):
     img_rgba = np.array([[[0, 0.5, 1, 0],
                           [0, 0.5, 1, 1],
                           [0, 0.5, 1, 0.5]]]).astype(float)
+    img_stains = img_as_float(img_rgb) * 0.3
 
     colbars = np.array([[1, 1, 0, 0, 1, 1, 0, 0],
                         [1, 1, 1, 1, 0, 0, 0, 0],
@@ -183,32 +184,33 @@ class TestColorconv(TestCase):
         img_rgb = img_as_float(self.img_rgb)
         assert_array_almost_equal(xyz2rgb(rgb2xyz(img_rgb)), img_rgb)
 
-    # RGB<->HED roundtrip with ubyte image
+    # HED<->RGB roundtrip with ubyte image
     def test_hed_rgb_roundtrip(self):
-        img_rgb = img_as_ubyte(self.img_rgb)
-        new = img_as_ubyte(hed2rgb(rgb2hed(img_rgb)))
-        assert_equal(new, img_rgb)
+        img_in = img_as_ubyte(self.img_stains)
+        img_out = rgb2hed(hed2rgb(img_in))
+        assert_equal(img_as_ubyte(img_out), img_in)
 
-    # RGB<->HED roundtrip with float image
+    # HED<->RGB roundtrip with float image
     def test_hed_rgb_float_roundtrip(self):
-        img_rgb = img_as_float(self.img_rgb)
-        assert_array_almost_equal(hed2rgb(rgb2hed(img_rgb)), img_rgb)
+        img_in = self.img_stains
+        img_out = rgb2hed(hed2rgb(img_in))
+        assert_array_almost_equal(img_out, img_in)
 
-    # RGB<->HDX roundtrip with ubyte image
-    def test_hdx_rgb_roundtrip(self):
-        from skimage.color.colorconv import hdx_from_rgb, rgb_from_hdx
-        img_rgb = self.img_rgb
-        conv = combine_stains(separate_stains(img_rgb, hdx_from_rgb),
-                              rgb_from_hdx)
-        assert_equal(img_as_ubyte(conv), img_rgb)
+    # BRO<->RGB roundtrip with ubyte image
+    def test_bro_rgb_roundtrip(self):
+        from skimage.color.colorconv import bro_from_rgb, rgb_from_bro
+        img_in = img_as_ubyte(self.img_stains)
+        img_out = combine_stains(img_in, rgb_from_bro)
+        img_out = separate_stains(img_out, bro_from_rgb)
+        assert_equal(img_as_ubyte(img_out), img_in)
 
-    # RGB<->HDX roundtrip with float image
-    def test_hdx_rgb_roundtrip_float(self):
-        from skimage.color.colorconv import hdx_from_rgb, rgb_from_hdx
-        img_rgb = img_as_float(self.img_rgb)
-        conv = combine_stains(separate_stains(img_rgb, hdx_from_rgb),
-                              rgb_from_hdx)
-        assert_array_almost_equal(conv, img_rgb)
+    # BRO<->RGB roundtrip with float image
+    def test_bro_rgb_roundtrip_float(self):
+        from skimage.color.colorconv import bro_from_rgb, rgb_from_bro
+        img_in = self.img_stains
+        img_out = combine_stains(img_in, rgb_from_bro)
+        img_out = separate_stains(img_out, bro_from_rgb)
+        assert_array_almost_equal(img_out, img_in)
 
     # RGB to RGB CIE
     def test_rgb2rgbcie_conversion(self):


### PR DESCRIPTION
## Description

Closes #5164

- Clip negative values in output of RGB to HED conversion (actually in `skimage.color. separate_stains`).
- Fixed stain separation tests accordingly:
   - Round trips start with stains, such that the roundtrip does not require negative values. Unmixing an RGB image can lead to negative values, which we clip in this fix. The round-trip is now impossible. But if we start with a stains image, convert it to RGB, and then unmix that RGB image, we can have a round-trip without errors. The stains image must be dim enough such that adding stains together doesn't saturate a channel in the RGB image.
   - Using a blue+red+orange stain combination, the test previously used a 2-stain combination that made it impossible to do a correct roundtrip: one of the stain channels was multiplied by 0, and could therefore never be recovered. I picked the first 3-stain combination I found in the existing set that wasn't HED.
- Improves IHC stain separation example:
    - Proper display of unmixed stains requires applying the non-linear mapping in `combine_stains`.
    - The contrast stretch ignores 1% of pixel values, to ensure a clear image.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->



## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
