### PR TITLE
update boundary mode in profile_line

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -31,8 +31,6 @@ Version 0.19
   from `rgb2gray`.
 * In ``skimage/transform/radon_transform.py``, remove ``deprate_kwarg``
   decoration from ``iradon``.
-* In ``skimage/measure/profile.py``, set default mode to 'reflect' in
-  `profile_line` and remove the deprecation warning.
 * In ``skimage/_shared/utils.py``, raise a ValueError instead of the
   warning when order > 0 and input array is bool in _set_order.
 * In ``skimage/transform/_warps.py``, raise a ValueError instead of the

--- a/TODO.txt
+++ b/TODO.txt
@@ -109,7 +109,9 @@ Other (2022)
 Other (2023)
 ------------
 * When ``scipy`` is set to >= 1.16, remove legacy (i.e. non-zoom) code paths in
-``skimage.transform.resize``.
+  ``skimage.transform.resize``.
+* When ``scipy`` is set to >= 1.16, remove SciPy version checks from
+  ``skimage._shared.utils._fix_ndimage_mode``
 
 Other
 -----

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -6,10 +6,6 @@ import warnings
 
 import numpy as np
 from numpy.lib import NumpyVersion
-<<<<<<< HEAD
-import numbers
-=======
->>>>>>> 8a4f0bcff (Fix behavior of mode='constant' when SciPy 1.6 is available)
 import scipy
 
 from ..util import img_as_float

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -1,10 +1,15 @@
 import inspect
-import warnings
 import functools
+import numbers
 import sys
+import warnings
+
 import numpy as np
 from numpy.lib import NumpyVersion
+<<<<<<< HEAD
 import numbers
+=======
+>>>>>>> 8a4f0bcff (Fix behavior of mode='constant' when SciPy 1.6 is available)
 import scipy
 
 from ..util import img_as_float

--- a/skimage/measure/profile.py
+++ b/skimage/measure/profile.py
@@ -6,7 +6,7 @@ from .._shared.utils import _validate_interpolation_order, _fix_ndimage_mode
 
 
 def profile_line(image, src, dst, linewidth=1,
-                 order=None, mode=None, cval=0.0,
+                 order=None, mode='reflect', cval=0.0,
                  *, reduce_func=np.mean):
     """Return the intensity profile of an image measured along a scan line.
 
@@ -93,14 +93,6 @@ def profile_line(image, src, dst, linewidth=1,
     """
 
     order = _validate_interpolation_order(image.dtype, order)
-
-    if mode is None:
-        warn("Default out of bounds interpolation mode 'constant' is "
-             "deprecated. In version 0.19 it will be set to 'reflect'. "
-             "To avoid this warning, set `mode=` explicitly.",
-             FutureWarning, stacklevel=2)
-        mode = 'constant'
-
     mode = _fix_ndimage_mode(mode)
 
     perp_lines = _line_profile_coordinates(src, dst, linewidth=linewidth)

--- a/skimage/measure/profile.py
+++ b/skimage/measure/profile.py
@@ -2,7 +2,7 @@ from warnings import warn
 import numpy as np
 from scipy import ndimage as ndi
 
-from .._shared.utils import _validate_interpolation_order
+from .._shared.utils import _validate_interpolation_order, _fix_ndimage_mode
 
 
 def profile_line(image, src, dst, linewidth=1,
@@ -100,6 +100,8 @@ def profile_line(image, src, dst, linewidth=1,
              "To avoid this warning, set `mode=` explicitly.",
              FutureWarning, stacklevel=2)
         mode = 'constant'
+
+    mode = _fix_ndimage_mode(mode)
 
     perp_lines = _line_profile_coordinates(src, dst, linewidth=linewidth)
     if image.ndim == 3:

--- a/skimage/registration/tests/test_tvl1.py
+++ b/skimage/registration/tests/test_tvl1.py
@@ -28,7 +28,7 @@ def _sin_flow_gen(image0, max_motion=4.5, npics=5):
     grid = np.stack(grid)
     gt_flow = np.zeros_like(grid)
     gt_flow[0, ...] = max_motion * np.sin(grid[0]/grid[0].max()*npics*np.pi)
-    image1 = warp(image0, grid-gt_flow, mode='edge')
+    image1 = warp(image0, grid - gt_flow, mode='edge')
     return gt_flow, image1
 
 


### PR DESCRIPTION
## Description

This PR resolves a TODO item related to switching the default `profile_line` boundary mode to 'reflect' for release 0.19. I also added a small change to fix the behavior for modes 'constant' and 'wrap' using their new implementations from SciPy 1.6 when available. This fixes, for example, the unexpected behavior raised at the top of gh-4279.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
