### PR TITLE
Resolve stochastic rank filter test failures on CI

### DIFF
--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -70,14 +70,10 @@ def test_subtract_mean_underflow_correction(dtype):
     assert np.all(result == expected_val)
 
 
-@pytest.fixture(scope='module')
-def refs():
-    yield np.load(fetch("data/rank_filter_tests.npz"))
-
-
-@pytest.fixture(scope='module')
-def refs():
-    yield np.load(fetch("data/rank_filter_tests.npz"))
+# Note: Explicitly read all values into a dict. Otherwise, stochastic test
+#       failures related to I/O can occur during parallel test cases.
+ref_data = dict(np.load(fetch("data/rank_filter_tests.npz")))
+ref_data_3d = dict(np.load(fetch('data/rank_filters_tests_3d.npz')))
 
 
 class TestRank():
@@ -92,8 +88,8 @@ class TestRank():
         np.random.seed(0)
         self.selem = morphology.disk(1)
         self.selem_3d = morphology.ball(1)
-        self.refs = np.load(fetch('data/rank_filter_tests.npz'))
-        self.refs_3d = np.load(fetch('data/rank_filters_tests_3d.npz'))
+        self.refs = ref_data
+        self.refs_3d = ref_data_3d
 
     @parametrize('filter', all_rank_filters)
     def test_rank_filter(self, filter):


### PR DESCRIPTION
## Description

This should avoid stochastic test failures that have been occuring on GitHub Actions. For example: https://github.com/scikit-image/scikit-image/pull/5170/checks?check_run_id=1653149444, This PR modifies `test_rank.py` to fetch the reference data once into a dictionary rather than making repeated calls to fetch from each thread. Apparently, there are issues running fetch in parallel.

The following error that occurred locally when I had increased the threads to make occurance more common, pointed to this way of fetching the data possibly leading to the issue:
```
skimage/filters/rank/tests/test_rank.py::TestRank::test_rank_filter[entropy]
  /home/lee8rx/miniconda3/envs/py38pre/lib/python3.8/site-packages/_pytest/threadexception.py:75: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-248
  
  Traceback (most recent call last):
    File "/home/lee8rx/miniconda3/envs/py38pre/lib/python3.8/threading.py", line 932, in _bootstrap_inner
      self.run()
    File "/home/lee8rx/miniconda3/envs/py38pre/lib/python3.8/threading.py", line 870, in run
      self._target(*self._args, **self._kwargs)
    File "/home/lee8rx/my_git/pyir/scikit-image/skimage/filters/rank/tests/test_rank.py", line 102, in check
      expected = self.refs[filter]
    File "/home/lee8rx/miniconda3/envs/py38pre/lib/python3.8/site-packages/numpy/lib/npyio.py", line 249, in __getitem__
      bytes = self.zip.open(key)
    File "/home/lee8rx/miniconda3/envs/py38pre/lib/python3.8/zipfile.py", line 1556, in open
      raise BadZipFile(
  zipfile.BadZipFile: File name in directory 'entropy.npy' and header b'\x93\x02@r\xa3y\tO\x93\x02@' differ.
  
    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))
```

I have seen other messages as well as the one above, but always in this test function. I also never see the errors if I disable the parallel tests. With the changes here, I ran the parallel tests repeatedly and never encounter any failures, so hopefully this resolves the matter on the CI as well.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
