### PR TITLE
bugfix: prevent integer overflow in EllipseModel

### DIFF
--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -270,6 +270,9 @@ class CircleModel(BaseModel):
 
         _check_data_dim(data, dim=2)
 
+        float_type = np.promote_types(data.dtype, np.float32)
+        data = data.astype(float_type, copy=False)
+
         x = data[:, 0]
         y = data[:, 1]
 
@@ -280,7 +283,7 @@ class CircleModel(BaseModel):
         sum_xy = np.sum(x * y)
         m1 = np.stack([[np.sum(x ** 2), sum_xy, sum_x],
                        [sum_xy, np.sum(y ** 2), sum_y],
-                       [sum_x, sum_y, float(len(x))]])
+                       [sum_x, sum_y, len(x)]])
         m2 = np.stack([[np.sum(x * x2y2),
                         np.sum(y * x2y2),
                         np.sum(x2y2)]], axis=-1)
@@ -414,13 +417,16 @@ class EllipseModel(BaseModel):
         # another REFERENCE: [2] http://mathworld.wolfram.com/Ellipse.html
         _check_data_dim(data, dim=2)
 
+        float_type = np.promote_types(data.dtype, np.float32)
+        data = data.astype(float_type, copy=False)
+
         x = data[:, 0]
         y = data[:, 1]
 
         # Quadratic part of design matrix [eqn. 15] from [1]
         D1 = np.vstack([x ** 2, x * y, y ** 2]).T
         # Linear part of design matrix [eqn. 16] from [1]
-        D2 = np.vstack([x, y, np.ones(len(x))]).T
+        D2 = np.vstack([x, y, np.ones(len(x), dtype=float_type)]).T
 
         # forming scatter matrix [eqn. 17] from [1]
         S1 = D1.T @ D1

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -270,6 +270,7 @@ class CircleModel(BaseModel):
 
         _check_data_dim(data, dim=2)
 
+        # to prevent integer overflow, cast data to float, if it isn't already
         float_type = np.promote_types(data.dtype, np.float32)
         data = data.astype(float_type, copy=False)
 
@@ -417,6 +418,7 @@ class EllipseModel(BaseModel):
         # another REFERENCE: [2] http://mathworld.wolfram.com/Ellipse.html
         _check_data_dim(data, dim=2)
 
+        # to prevent integer overflow, cast data to float, if it isn't already
         float_type = np.promote_types(data.dtype, np.float32)
         data = data.astype(float_type, copy=False)
 
@@ -426,7 +428,7 @@ class EllipseModel(BaseModel):
         # Quadratic part of design matrix [eqn. 15] from [1]
         D1 = np.vstack([x ** 2, x * y, y ** 2]).T
         # Linear part of design matrix [eqn. 16] from [1]
-        D2 = np.vstack([x, y, np.ones(len(x), dtype=float_type)]).T
+        D2 = np.vstack([x, y, np.ones_like(x)]).T
 
         # forming scatter matrix [eqn. 17] from [1]
         S1 = D1.T @ D1

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -212,14 +212,14 @@ def test_ellipse_model_estimate_from_data():
         [643, 926], [644, 975], [643, 655], [646, 705], [651, 664], [651, 984],
         [647, 665], [651, 715], [651, 725], [651, 734], [647, 809], [651, 825],
         [651, 873], [647, 900], [652, 917], [651, 944], [652, 742], [648, 811],
-        [651, 994], [652, 783], [650, 911], [654, 879]], dtype="int32")
+        [651, 994], [652, 783], [650, 911], [654, 879]], dtype=np.int32)
 
     # estimate parameters of real data
     model = EllipseModel()
     model.estimate(data)
 
     # test whether estimated parameters are smaller then 1000, so means stable
-    assert_array_less(model.params[:4], np.array([1e3] * 4))
+    assert_array_less(model.params[:4], np.full(4, 1000))
 
     # test whether all parameters are more than 0. Negative values were the
     # result of an integer overflow

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -142,17 +142,6 @@ def test_circle_model_estimate():
     assert_almost_equal(model0.params, model_est.params, 0)
 
 
-@pytest.mark.skip(reason="This must be a bug.")
-def test_circle_model_int_overflow():
-    xy = np.array([[1, 0], [0, 1], [-1, 0], [0, -1]], dtype="int16")
-    xy += 500
-
-    model = CircleModel()
-    model.estimate(xy)
-
-    assert_almost_equal(model.params, [500, 500, 1])
-
-
 def test_circle_model_residuals():
     model = CircleModel()
     model.params = (0, 0, 5)
@@ -232,8 +221,8 @@ def test_ellipse_model_estimate_from_data():
     # test whether estimated parameters are smaller then 1000, so means stable
     assert_array_less(model.params[:4], np.array([1e3] * 4))
 
-    # test whether all parameters are more than 0. Negative values were the result
-    # of an integer overflow
+    # test whether all parameters are more than 0. Negative values were the
+    # result of an integer overflow
     assert_array_less(np.zeros(4), np.abs(model.params[:4]))
 
 

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from skimage.measure import LineModelND, CircleModel, EllipseModel, ransac
 from skimage.transform import AffineTransform
 from skimage.measure.fit import _dynamic_max_trials


### PR DESCRIPTION
## Description

This is a bugfix to issue #5042. It makes sure that the `EllipseModel` and `CircleModel` do not cause integer overflows

## Checklist

I have a question, while trying to implement a unit test I ran into another bug. The test is still implemented, but is marked with a `pytest.mark.skip`. How would you like to handle this?

Also, does the code need to pass any kind of static analysis? Like black or flake8?

## For reviewers

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
