### PR TITLE
DOC: Fixup to linspace in example

### DIFF
--- a/doc/examples/edges/plot_line_hough_transform.py
+++ b/doc/examples/edges/plot_line_hough_transform.py
@@ -79,7 +79,7 @@ image[idx, idx] = 255
 
 # Classic straight-line Hough transform
 # Set a precision of 0.5 degree.
-tested_angles = np.linspace(-np.pi / 2, np.pi / 2, 360)
+tested_angles = np.linspace(-np.pi / 2, np.pi / 2, 360, endpoint=False)
 h, theta, d = hough_line(image, theta=tested_angles)
 
 # Generating figure 1


### PR DESCRIPTION
Right now the data is not sampled every half degree. Also, angles -pi/2 to pi/2 are equivalent for the purposes of the transform.

## Description

Extremely minor fixup, for technical correctness. No API changes, just doc example.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
