### PR TITLE
Minor fixups to Hough line transform code and examples

### DIFF
--- a/doc/examples/edges/plot_line_hough_transform.py
+++ b/doc/examples/edges/plot_line_hough_transform.py
@@ -65,6 +65,7 @@ import numpy as np
 
 from skimage.transform import hough_line, hough_line_peaks
 from skimage.feature import canny
+from skimage.draw import line
 from skimage import data
 
 import matplotlib.pyplot as plt
@@ -74,8 +75,9 @@ from matplotlib import cm
 # Constructing test image
 image = np.zeros((200, 200))
 idx = np.arange(25, 175)
-image[idx[::-1], idx] = 255
 image[idx, idx] = 255
+image[line(45, 25, 25, 175)] = 255
+image[line(25, 135, 175, 155)] = 255
 
 # Classic straight-line Hough transform
 # Set a precision of 0.5 degree.

--- a/doc/examples/edges/plot_line_hough_transform.py
+++ b/doc/examples/edges/plot_line_hough_transform.py
@@ -30,7 +30,7 @@ appropriately.
 
 We can think of each non-zero pixel "voting" for potential line candidates. The
 local maxima in the resulting histogram indicates the parameters of the most
-probably lines. In our example, the maxima occur at 45 and 135 degrees,
+probable lines. In our example, the maxima occur at 45 and 135 degrees,
 corresponding to the normal vector angles of each line.
 
 Another approach is the Progressive Probabilistic Hough Transform [2]_. It is

--- a/doc/examples/edges/plot_line_hough_transform.py
+++ b/doc/examples/edges/plot_line_hough_transform.py
@@ -91,7 +91,7 @@ ax[0].set_title('Input image')
 ax[0].set_axis_off()
 
 ax[1].imshow(np.log(1 + h),
-             extent=[np.rad2deg(theta[-1]), np.rad2deg(theta[0]), d[-1], d[0]],
+             extent=[np.rad2deg(theta[0]), np.rad2deg(theta[-1]), d[-1], d[0]],
              cmap=cm.gray, aspect=1/1.5)
 ax[1].set_title('Hough transform')
 ax[1].set_xlabel('Angles (degrees)')

--- a/doc/source/plots/hough_tf.py
+++ b/doc/source/plots/hough_tf.py
@@ -21,7 +21,7 @@ axes[0].set_title('Input image')
 
 axes[1].imshow(
     out, cmap=plt.cm.bone,
-    extent=(np.rad2deg(angles[-1]), np.rad2deg(angles[0]), d[-1], d[0]))
+    extent=(np.rad2deg(angles[0]), np.rad2deg(angles[-1]), d[-1], d[0]))
 axes[1].set_title('Hough transform')
 axes[1].set_xlabel('Angle (degree)')
 axes[1].set_ylabel('Distance (pixel)')

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -174,7 +174,7 @@ def hough_line(image, theta=None):
         Input image with nonzero values representing edges.
     theta : 1D ndarray of double, optional
         Angles at which to compute the transform, in radians.
-        Defaults to a vector of 180 angles evenly spaced from -pi/2 to pi/2.
+        Defaults to a vector of 180 angles evenly spaced in the range [-pi/2, pi/2).
 
     Returns
     -------
@@ -241,7 +241,7 @@ def probabilistic_hough_line(image, threshold=10, line_length=50, line_gap=10,
         Increase the parameter to merge broken lines more aggressively.
     theta : 1D ndarray, dtype=double, optional
         Angles at which to compute the transform, in radians.
-        If None, use a range from -pi/2 to pi/2.
+        Defaults to a vector of 180 angles evenly spaced in the range [-pi/2, pi/2).
     seed : int, optional
         Seed to initialize the random number generator.
 
@@ -262,7 +262,7 @@ def probabilistic_hough_line(image, threshold=10, line_length=50, line_gap=10,
         raise ValueError('The input image `image` must be 2D.')
 
     if theta is None:
-        theta = np.pi / 2 - np.arange(180) / 180.0 * np.pi
+        theta = np.linspace(-np.pi / 2, np.pi / 2, 180, endpoint=False)
 
     return _prob_hough_line(image, threshold=threshold, line_length=line_length,
                             line_gap=line_gap, theta=theta, seed=seed)

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -218,7 +218,7 @@ def hough_line(image, theta=None):
 
     if theta is None:
         # These values are approximations of pi/2
-        theta = np.linspace(-np.pi / 2, np.pi / 2, 180)
+        theta = np.linspace(-np.pi / 2, np.pi / 2, 180, endpoint=False)
 
     return _hough_line(image, theta=theta)
 

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -174,7 +174,8 @@ def hough_line(image, theta=None):
         Input image with nonzero values representing edges.
     theta : 1D ndarray of double, optional
         Angles at which to compute the transform, in radians.
-        Defaults to a vector of 180 angles evenly spaced in the range [-pi/2, pi/2).
+        Defaults to a vector of 180 angles evenly spaced in the
+        range [-pi/2, pi/2).
 
     Returns
     -------
@@ -241,7 +242,8 @@ def probabilistic_hough_line(image, threshold=10, line_length=50, line_gap=10,
         Increase the parameter to merge broken lines more aggressively.
     theta : 1D ndarray, dtype=double, optional
         Angles at which to compute the transform, in radians.
-        Defaults to a vector of 180 angles evenly spaced in the range [-pi/2, pi/2).
+        Defaults to a vector of 180 angles evenly spaced in the
+        range [-pi/2, pi/2).
     seed : int, optional
         Seed to initialize the random number generator.
 

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -23,7 +23,7 @@ def test_hough_line():
     dist = d[y[0]]
     theta = angles[x[0]]
 
-    assert_almost_equal(dist, 80.723, 1)
+    assert_almost_equal(dist, 81.726, 1)
     assert_almost_equal(theta, 1.41, 1)
 
 
@@ -79,7 +79,7 @@ def test_probabilistic_hough_seed():
     lines = transform.probabilistic_hough_line(image, threshold=50,
                                                line_length=50, line_gap=1,
                                                seed=1234)
-    assert len(lines) == 65
+    assert len(lines) == 64
 
 
 def test_probabilistic_hough_bad_input():
@@ -101,7 +101,7 @@ def test_hough_line_peaks():
     out, theta, dist = transform.hough_line_peaks(out, angles, d)
 
     assert_equal(len(dist), 1)
-    assert_almost_equal(dist[0], 80.723, 1)
+    assert_almost_equal(dist[0], 81.726, 1)
     assert_almost_equal(theta[0], 1.41, 1)
 
 
@@ -110,7 +110,7 @@ def test_hough_line_peaks_ordered():
     testim = np.zeros((256, 64), dtype=bool)
 
     testim[50:100, 20] = True
-    testim[85:200, 25] = True
+    testim[20:225, 25] = True
     testim[15:35, 50] = True
     testim[1:-1, 58] = True
 

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -23,7 +23,7 @@ def test_hough_line():
     dist = d[y[0]]
     theta = angles[x[0]]
 
-    assert_almost_equal(dist, 81.726, 1)
+    assert_almost_equal(dist, 80.723, 1)
     assert_almost_equal(theta, 1.41, 1)
 
 


### PR DESCRIPTION
## Description

- Without `endpoint=False`, the default ranges include both -pi/2 and +pi/2, which is redundant. The spacing is also not one degree (see #5181)
- `theta = np.pi / 2 - np.arange(180) / 180.0 * np.pi` is equivalent to `linspace(np.pi / 2, -np.pi / 2, 180, endpoint=False)`. This is backwards from what is advertised. Also, a call to `linspace` is likely easier to read than the `arange` expression.
- Why swap the x-extents on the plots? Let's take a look:

    ```
    img = np.zeros((100, 100), bool)
    img[50] = True
    img[np.arange(75), np.arange(25, 100)] = True

    tested_angles = np.linspace(-np.pi / 2, np.pi / 2, 3600, endpoint=False)
    h, theta, d = hough_line(img, theta=tested_angles)
    fig, ax = plt.subplots(1, 2)
    ax[0].imshow(np.log(1 + h),
               extent=[np.rad2deg(theta[-1]), np.rad2deg(theta[0]), d[-1], d[0]],
               cmap='gray')
    ax[1].imshow(np.log(1 + h),
             extent=[np.rad2deg(theta[0]), np.rad2deg(theta[-1]), d[-1], d[0]],
             cmap='gray')
    for _, angle, dist in zip(*hough_line_peaks(h, theta, d)):
        ax[0].plot(np.rad2deg(angle), dist, 'ro')
        ax[1].plot(np.rad2deg(angle), dist, 'ro')
    ax[0].set_title('Current (wrong)')
    ax[1].set_title('Proposed (correct)')
    plt.show()
    ```
    ![image](https://user-images.githubusercontent.com/4617010/104203479-cc047500-53f1-11eb-98cf-f1e35962363e.png)

    It's safe to say that the version of image extent that lets you plot (angle, dist) correctly is the right one.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
