### PR TITLE
Fixed off-by one error in pixel bins in hough line transform

### DIFF
--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -300,11 +300,11 @@ def _hough_line(cnp.ndarray img,
     cdef cnp.ndarray[ndim=1, dtype=cnp.double_t] bins
     cdef Py_ssize_t max_distance, offset
 
-    max_distance = 2 * <Py_ssize_t>ceil(sqrt(img.shape[0] * img.shape[0] +
-                                             img.shape[1] * img.shape[1]))
+    offset = <Py_ssize_t>ceil(sqrt(img.shape[0] * img.shape[0] +
+                                   img.shape[1] * img.shape[1]))
+    max_distance = 2 * offset + 1
     accum = np.zeros((max_distance, theta.shape[0]), dtype=np.uint64)
-    bins = np.linspace(-max_distance / 2.0, max_distance / 2.0, max_distance)
-    offset = max_distance / 2
+    bins = np.linspace(-offset, offset, max_distance)
 
     # compute the nonzero indexes
     cdef cnp.ndarray[ndim=1, dtype=cnp.npy_intp] x_idxs, y_idxs

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -23,7 +23,7 @@ def test_hough_line():
     dist = d[y[0]]
     theta = angles[x[0]]
 
-    assert_almost_equal(dist, 80.723, 1)
+    assert_almost_equal(dist, 80.0, 1)
     assert_almost_equal(theta, 1.41, 1)
 
 
@@ -101,7 +101,7 @@ def test_hough_line_peaks():
     out, theta, dist = transform.hough_line_peaks(out, angles, d)
 
     assert_equal(len(dist), 1)
-    assert_almost_equal(dist[0], 81.726, 1)
+    assert_almost_equal(dist[0], 81.0, 1)
     assert_almost_equal(theta[0], 1.41, 1)
 
 


### PR DESCRIPTION
## Description

Assuming that the goal is to have step in rho be 1px, the new formulation is correct. There is no issue open, but that can be done. This simplifies the computation by starting with the offset first, then doubling and adding one. The original code used double without the plus one.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.