### PR TITLE
Added 1/2 pixel bounds to extent of displayed images

### DIFF
--- a/doc/examples/color_exposure/plot_tinting_grayscale_images.py
+++ b/doc/examples/color_exposure/plot_tinting_grayscale_images.py
@@ -60,7 +60,8 @@ all_hues = color.hsv2rgb(hsv)
 
 fig, ax = plt.subplots(figsize=(5, 2))
 # Set image extent so hues go from 0 to 1 and the image is a nice aspect ratio.
-ax.imshow(all_hues, extent=(0, 1, 0, 0.2))
+ax.imshow(all_hues, extent=(0 - 0.5 / len(hue_gradient),
+                            1 + 0.5 / len(hue_gradient), 0, 0.2))
 ax.set_axis_off()
 
 ######################################################################

--- a/doc/examples/edges/plot_line_hough_transform.py
+++ b/doc/examples/edges/plot_line_hough_transform.py
@@ -92,9 +92,12 @@ ax[0].imshow(image, cmap=cm.gray)
 ax[0].set_title('Input image')
 ax[0].set_axis_off()
 
-ax[1].imshow(np.log(1 + h),
-             extent=[np.rad2deg(theta[0]), np.rad2deg(theta[-1]), d[-1], d[0]],
-             cmap=cm.gray, aspect=1/1.5)
+angle_step = 0.5 * np.diff(theta).mean()
+d_step = 0.5 * np.diff(d).mean()
+bounds = [np.rad2deg(theta[0] - angle_step),
+          np.rad2deg(theta[-1] + angle_step),
+          d[-1] + d_step, d[0] - d_step]
+ax[1].imshow(np.log(1 + h), extent=bounds, cmap=cm.gray, aspect=1 / 1.5)
 ax[1].set_title('Hough transform')
 ax[1].set_xlabel('Angles (degrees)')
 ax[1].set_ylabel('Distance (pixels)')

--- a/doc/examples/numpy_operations/plot_view_as_blocks.py
+++ b/doc/examples/numpy_operations/plot_view_as_blocks.py
@@ -48,7 +48,7 @@ ax = axes.ravel()
 
 l_resized = ndi.zoom(l, 2, order=3)
 ax[0].set_title("Original rescaled with\n spline interpolation (order=3)")
-ax[0].imshow(l_resized, extent=(0, 128, 128, 0),
+ax[0].imshow(l_resized, extent=(-0.5, 128.5, 128.5, -0.5),
              cmap=cm.Greys_r)
 
 ax[1].set_title("Block view with\n local mean pooling")

--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -75,11 +75,13 @@ ax1.imshow(image, cmap=plt.cm.Greys_r)
 
 theta = np.linspace(0., 180., max(image.shape), endpoint=False)
 sinogram = radon(image, theta=theta, circle=True)
+dx, dy = 0.5 * 180.0 / max(image.shape), 0.5 / sinogram.shape[0]
 ax2.set_title("Radon transform\n(Sinogram)")
 ax2.set_xlabel("Projection angle (deg)")
 ax2.set_ylabel("Projection position (pixels)")
 ax2.imshow(sinogram, cmap=plt.cm.Greys_r,
-           extent=(0, 180, 0, sinogram.shape[0]), aspect='auto')
+           extent=(-dx, 180.0 + dx, -dy, sinogram.shape[0] + dy),
+           aspect='auto')
 
 fig.tight_layout()
 plt.show()

--- a/doc/source/plots/hough_tf.py
+++ b/doc/source/plots/hough_tf.py
@@ -19,9 +19,13 @@ fix, axes = plt.subplots(1, 2, figsize=(7, 4))
 axes[0].imshow(img, cmap=plt.cm.gray)
 axes[0].set_title('Input image')
 
-axes[1].imshow(
-    out, cmap=plt.cm.bone,
-    extent=(np.rad2deg(angles[0]), np.rad2deg(angles[-1]), d[-1], d[0]))
+angle_step = 0.5 * np.rad2deg(np.diff(angles).mean())
+d_step = 0.5 * np.diff(d).mean()
+bounds = (np.rad2deg(angles[0]) - angle_step,
+          np.rad2deg(angles[-1]) + angle_step,
+          d[-1] + d_step, d[0] - d_step)
+
+axes[1].imshow(out, cmap=plt.cm.bone, extent=bounds)
 axes[1].set_title('Hough transform')
 axes[1].set_xlabel('Angle (degree)')
 axes[1].set_ylabel('Distance (pixel)')

--- a/skimage/viewer/plugins/color_histogram.py
+++ b/skimage/viewer/plugins/color_histogram.py
@@ -27,7 +27,7 @@ class ColorHistogram(PlotPlugin):
         # Calculate color histogram in the Lab colorspace:
         L, a, b = self.lab_image.T
         left, right = -100, 100
-        ab_extents = [left, right, right, left]
+        ab_extents = [left - 0.5, right + 0.5, right + 0.5, left - 0.5]
         self.mask = np.ones(L.shape, bool)
         bins = np.arange(left, right)
         hist, x_edges, y_edges = np.histogram2d(a.flatten(), b.flatten(),


### PR DESCRIPTION
## Description

Why set extents to be off by half a pixel? Here's an example:

```
x = np.arange(9).reshape(3, 3)
fig, ax = plt.subplots(1, 2)
ax[0].imshow(x, extent=[0, 2, 0, 2])
ax[0].set_title('Slightly Off')
ax[1].imshow(x, extent=[-0.5, 2.5, -0.5, 2.5])
ax[1].set_title('Corrected')
```

![image](https://user-images.githubusercontent.com/4617010/104462004-08fd7280-557e-11eb-930c-87830c571b53.png)

Notice that in the left image, the nominal locations of the pixels are all a bit off.

This PR does not affect production code, just examples in the documentation.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
