### PR TITLE
Add nD support to several geometric transform classes

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1056,9 +1056,10 @@ def _euler_rotation(axis, angle):
         The rotation matrix along axis `axis`.
     """
     i = axis
-    s, c = np.sin(angle), np.cos(angle)
-    R2 = np.array([[          c, (-1)**(i+1) * s],
-                   [(-1)**i * s,               c]])
+    s = (-1)**i * np.sin(angle)
+    c = np.cos(angle)
+    R2 = np.array([[c, -s],
+                   [s,  c]])
     Ri = np.eye(3)
     # We need the axes other than the rotation axis, in the right order:
     # 0 -> (1, 2); 1 -> (0, 2); 2 -> (0, 1).

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -19,7 +19,7 @@ def _affine_matrix_from_vector(v):
         v, (dimensionality, dimensionality + 1)
     )
     matrix = np.concatenate(
-        (part_matrix, np.eye(dimensionality + 1)[-1:]), axis=0
+        (part_matrix, np.eye(1, dimensionality + 1, dimensionality)), axis=0
     )
     return matrix
 

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1067,7 +1067,7 @@ def _euler_rotation(axis, angle):
     return Ri
 
 
-def _euler_rotation_matrix(angles):
+def _euler_rotation_matrix(angles, axes=None):
     """Produce an Euler rotation matrix from the given angles.
 
     The matrix will have dimension equal to the number of angles given.
@@ -1076,15 +1076,19 @@ def _euler_rotation_matrix(angles):
     ----------
     angles : array of float, shape (3,)
         The transformation angles in radians.
+    axes : list of int
+        The axes about which to produce the rotation. Defaults to 0, 1, 2.
 
     Returns
     -------
     R : array of float, shape (3, 3)
         The Euler rotation matrix.
     """
+    if axes is None:
+        axes = list(range(3))
     dim = len(angles)
     R = np.eye(dim)
-    for i, angle in enumerate(angles):
+    for i, angle in zip(axes, angles):
         R = R @ _euler_rotation(i, angle)
     return R
 
@@ -1275,27 +1279,22 @@ class SimilarityTransform(EuclideanTransform):
                 self.params = matrix
                 dimensionality = matrix.shape[0] - 1
         if params:
-            if dimensionality == 2:
-                axes = ((0, 1),)
-            elif dimensionality == 3:
-                axes = ((1, 2), (0, 1), (1, 2))  # XZX Euler angles
-            else:
+            if dimensionality not in (2, 3):
                 raise ValueError('Parameters only supported for 2D and 3D.')
             matrix = np.eye(dimensionality + 1, dtype=float)
             if scale is None:
                 scale = 1
             if rotation is None:
-                rotation = (0,) if dimensionality == 2 else (0, 0, 0)
-            if np.isscalar(rotation):
-                rotation = [rotation]
+                rotation = 0 if dimensionality == 2 else (0, 0, 0)
             if translation is None:
                 translation = (0,) * dimensionality
-            for rot, ax in zip(rotation, axes):
-                R = np.eye(dimensionality + 1)
-                c, s = np.cos(rot), np.sin(rot)
-                R[ax, ax] = c
-                R[ax, ax[::-1]] = -s, s
-                matrix = R @ matrix
+            if dimensionality == 2:
+                ax = (0, 1)
+                c, s = np.cos(rotation), np.sin(rotation)
+                matrix[ax, ax] = c
+                matrix[ax, ax[::-1]] = -s, s
+            else:  # 3D rotation
+                matrix[:3, :3] = _euler_rotation_matrix(rotation)
 
             matrix[:dimensionality, :dimensionality] *= scale
             matrix[:dimensionality, dimensionality] = translation

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -9,9 +9,9 @@ from .._shared.utils import get_bound_method_class, safe_as_int
 def _affine_matrix_from_vector(v):
     """Affine matrix from linearized (d, d + 1) matrix entries."""
     nparam = v.size
-    # solve for d in: d * (d - 1) = nparam
+    # solve for d in: d * (d + 1) = nparam
     d = (1 + np.sqrt(1 + 4 * nparam)) / 2 - 1
-    dimensionality = int(d)
+    dimensionality = int(np.round(d))  # round to prevent approx errors
     if d != dimensionality:
         raise ValueError('Invalid number of elements for '
                          f'linearized matrix: {nparam}')

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -62,6 +62,10 @@ def _center_and_normalize_points(points):
 
     # if all the points are the same, the transformation matrix cannot be
     # created. We return an equivalent matrix with np.nans as sentinel values.
+    # This obviates the need for try/except blocks in functions calling this
+    # one, and those are only needed when actual 0 is reached, rather than some
+    # small value; ie, we don't need to worry about numerical stability here,
+    # only actual 0.
     if rms == 0:
         return np.full((d + 1, d + 1), np.nan), np.full_like(points, np.nan)
 

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -16,7 +16,7 @@ def _affine_matrix_from_vector(v):
         raise ValueError('Invalid number of elements for '
                          f'linearized matrix: {nparam}')
     matrix = np.eye(dimensionality + 1)
-    matrix[-1, :] = np.reshape(v, (dimensionality, dimensionality + 1))
+    matrix[:-1, :] = np.reshape(v, (dimensionality, dimensionality + 1))
     return matrix
 
 

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -804,8 +804,6 @@ class AffineTransform(ProjectiveTransform):
     matrix : (D+1, D+1) array, optional
         Homogeneous transformation matrix. If this matrix is provided, it is an
         error to provide any of scale, rotation, shear, or translation.
-    matrix : (3, 3) array, optional
-        Homogeneous transformation matrix.
     scale : {s as float or (sx, sy) as array, list or tuple}, optional
         Scale factor(s). If a single value, it will be assigned to both
         sx and sy. Only available for 2D.

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -837,12 +837,12 @@ class AffineTransform(ProjectiveTransform):
                 dimensionality = int(d)
                 if d != dimensionality:
                     raise ValueError('Invalid number of elements for '
-                                     'linearized matrix: {}'.format(nparam))
+                                     f'linearized matrix: {nparam}')
                 part_matrix = np.reshape(
-                        matrix, (dimensionality, dimensionality + 1)
+                    matrix, (dimensionality, dimensionality + 1)
                 )
                 matrix = np.concatenate(
-                        (part_matrix, [[0] * d + [1]]), axis=0
+                    (part_matrix, np.eye(dimensionality + 1)[-1:]), axis=0
                 )
             elif matrix.shape[0] != matrix.shape[1]:
                 raise ValueError("Invalid shape of transformation matrix.")

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1066,7 +1066,11 @@ def _euler_rotation(axis, angle):
     R2 = np.array([[          c, (-1)**(i+1) * s],
                    [(-1)**i * s,               c]])
     Ri = np.eye(3)
+    # We need the axes other than the rotation axis, in the right order:
+    # 0 -> (1, 2); 1 -> (0, 2); 2 -> (0, 1).
     axes = sorted({0, 1, 2} - {axis})
+    # We then embed the 2-axis rotation matrix into the full matrix.
+    # (1, 2) -> R[1:3:1, 1:3:1] = R2, (0, 2) -> R[0:3:2, 0:3:2] = R2, etc.
     sl = slice(axes[0], axes[1] + 1, axes[1] - axes[0])
     Ri[sl, sl] = R2
     return Ri

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -64,6 +64,8 @@ def _center_and_normalize_points(points):
     centered = points - centroid
     rms = np.sqrt(np.sum(centered ** 2) / n)
 
+    # if all the points are the same, the transformation matrix cannot be
+    # created. We return an equivalent matrix with np.nans as sentinel values.
     if rms == 0:
         return np.full((d + 1, d + 1), np.nan), np.full_like(points, np.nan)
 

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1255,7 +1255,7 @@ class SimilarityTransform(EuclideanTransform):
         Scale factor. Implemented only for 2D and 3D.
     rotation : float, optional
         Rotation angle in counter-clockwise direction as radians.
-        Implemented only for 2D and 3D. For 3D, this is given in XZX Euler
+        Implemented only for 2D and 3D. For 3D, this is given in ZYX Euler
         angles.
     translation : (dim,) array-like, optional
         x, y[, z] translation parameters. Implemented only for 2D and 3D.

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -17,18 +17,20 @@ def _center_and_normalize_points(points):
     origin at the centroid of the image points.
 
     Normalize the image points, such that the mean distance from the points
-    to the origin of the coordinate system is sqrt(2).
+    to the origin of the coordinate system is sqrt(D).
+
+    If the points are all identical, the returned values will contain nan.
 
     Parameters
     ----------
-    points : (N, 2) array
+    points : (N, D) array
         The coordinates of the image points.
 
     Returns
     -------
-    matrix : (3, 3) array
+    matrix : (D+1, D+1) array
         The transformation matrix to obtain the new points.
-    new_points : (N, 2) array
+    new_points : (N, D) array
         The transformed image points.
 
     References
@@ -38,24 +40,30 @@ def _center_and_normalize_points(points):
            (1997): 580-593.
 
     """
-
+    n, d = points.shape
     centroid = np.mean(points, axis=0)
 
-    rms = math.sqrt(np.sum((points - centroid) ** 2) / points.shape[0])
+    centered = points - centroid
+    rms = np.sqrt(np.sum(centered ** 2) / n)
 
-    norm_factor = math.sqrt(2) / rms
+    if rms == 0:
+        return np.full((d + 1, d + 1), np.nan), np.full_like(points, np.nan)
 
-    matrix = np.array([[norm_factor, 0, -norm_factor * centroid[0]],
-                       [0, norm_factor, -norm_factor * centroid[1]],
-                       [0, 0, 1]])
+    norm_factor = np.sqrt(d) / rms
 
-    pointsh = np.row_stack([points.T, np.ones((points.shape[0]),)])
+    part_matrix = norm_factor * np.concatenate(
+            (np.eye(d), -centroid[:, np.newaxis]), axis=1
+            )
+    matrix = np.concatenate(
+            (part_matrix, [[0,] * d + [1]]), axis=0
+            )
 
-    new_pointsh = (matrix @ pointsh).T
+    points_h = np.row_stack([points.T, np.ones(n)])
 
-    new_points = new_pointsh[:, :2]
-    new_points[:, 0] /= new_pointsh[:, 2]
-    new_points[:, 1] /= new_pointsh[:, 2]
+    new_points_h = (matrix @ points_h).T
+
+    new_points = new_points_h[:, :d]
+    new_points /= new_points_h[:, d:]
 
     return matrix, new_points
 
@@ -229,13 +237,20 @@ class FundamentalMatrixTransform(GeometricTransform):
 
     """
 
-    def __init__(self, matrix=None):
+    def __init__(self, matrix=None, *, dimensionality=2):
         if matrix is None:
             # default to an identity transform
-            matrix = np.eye(3)
-        if matrix.shape != (3, 3):
+            matrix = np.eye(dimensionality + 1)
+        else:
+            dimensionality = matrix.shape[0] - 1
+        if matrix.shape != (dimensionality + 1, dimensionality + 1):
             raise ValueError("Invalid shape of transformation matrix")
         self.params = matrix
+        if dimensionality != 2:
+            raise NotImplementedError(
+                f'{self.__class__} is only implemented for 2D coordinates '
+                '(i.e. 3D transformation matrices).'
+            )
 
     def __call__(self, coords):
         """Apply forward transformation.
@@ -423,7 +438,9 @@ class EssentialMatrixTransform(FundamentalMatrixTransform):
 
     """
 
-    def __init__(self, rotation=None, translation=None, matrix=None):
+    def __init__(self, rotation=None, translation=None, matrix=None,
+                 *, dimensionality=2):
+        super().__init__(matrix=matrix, dimensionality=dimensionality)
         if rotation is not None:
             if translation is None:
                 raise ValueError("Both rotation and translation required")
@@ -512,57 +529,67 @@ class ProjectiveTransform(GeometricTransform):
 
     Parameters
     ----------
-    matrix : (3, 3) array, optional
+    matrix : (D+1, D+1) array, optional
         Homogeneous transformation matrix.
+    dimensionality : int, optional
+        The number of dimensions of the transform. This is ignored if
+        ``matrix`` is not None.
 
     Attributes
     ----------
-    params : (3, 3) array
+    params : (D+1, D+1) array
         Homogeneous transformation matrix.
 
     """
 
-    _coeffs = range(8)
-
-    def __init__(self, matrix=None):
+    def __init__(self, matrix=None, *, dimensionality=2):
+        if matrix is not None:
+            dimensionality = matrix.shape[0] - 1
         if matrix is None:
             # default to an identity transform
-            matrix = np.eye(3)
-        if matrix.shape != (3, 3):
+            matrix = np.eye(dimensionality + 1)
+        if matrix.shape != (dimensionality + 1, dimensionality + 1):
             raise ValueError("invalid shape of transformation matrix")
         self.params = matrix
+        self._coeffs = range(matrix.size - 1)
 
     @property
     def _inv_matrix(self):
         return np.linalg.inv(self.params)
 
     def _apply_mat(self, coords, matrix):
+        ndim = matrix.shape[0] - 1
         coords = np.array(coords, copy=False, ndmin=2)
 
-        x, y = np.transpose(coords)
-        src = np.vstack((x, y, np.ones_like(x)))
-        dst = src.T @ matrix.T
+        src = np.concatenate([coords, np.ones((coords.shape[0], 1))], axis=1)
+        dst = src @ matrix.T
 
         # below, we will divide by the last dimension of the homogeneous
         # coordinate matrix. In order to avoid division by zero,
         # we replace exact zeros in this column with a very small number.
-        dst[dst[:, 2] == 0, 2] = np.finfo(float).eps
+        dst[dst[:, ndim] == 0, ndim] = np.finfo(float).eps
         # rescale to homogeneous coordinates
-        dst[:, :2] /= dst[:, 2:3]
+        dst[:, :ndim] /= dst[:, ndim:ndim+1]
 
-        return dst[:, :2]
+        return dst[:, :ndim]
+
+    def __array__(self, dtype=None):
+        if dtype is None:
+            return self.params
+        else:
+            return self.params.astype(dtype)
 
     def __call__(self, coords):
         """Apply forward transformation.
 
         Parameters
         ----------
-        coords : (N, 2) array
+        coords : (N, D) array
             Source coordinates.
 
         Returns
         -------
-        coords : (N, 2) array
+        coords_out : (N, D) array
             Destination coordinates.
 
         """
@@ -573,12 +600,12 @@ class ProjectiveTransform(GeometricTransform):
 
         Parameters
         ----------
-        coords : (N, 2) array
+        coords : (N, D) array
             Destination coordinates.
 
         Returns
         -------
-        coords : (N, 2) array
+        coords_out : (N, D) array
             Source coordinates.
 
         """
@@ -640,37 +667,25 @@ class ProjectiveTransform(GeometricTransform):
             True, if model estimation succeeds.
 
         """
+        n, d = src.shape
 
-        try:
-            src_matrix, src = _center_and_normalize_points(src)
-            dst_matrix, dst = _center_and_normalize_points(dst)
-        except ZeroDivisionError:
-            self.params = np.nan * np.empty((3, 3))
+        src_matrix, src = _center_and_normalize_points(src)
+        dst_matrix, dst = _center_and_normalize_points(dst)
+        if not np.all(np.isfinite(src_matrix + dst_matrix)):
+            self.params = np.full((d, d), np.nan)
             return False
 
-        xs = src[:, 0]
-        ys = src[:, 1]
-        xd = dst[:, 0]
-        yd = dst[:, 1]
-        rows = src.shape[0]
-
         # params: a0, a1, a2, b0, b1, b2, c0, c1
-        A = np.zeros((rows * 2, 9))
-        A[:rows, 0] = xs
-        A[:rows, 1] = ys
-        A[:rows, 2] = 1
-        A[:rows, 6] = - xd * xs
-        A[:rows, 7] = - xd * ys
-        A[rows:, 3] = xs
-        A[rows:, 4] = ys
-        A[rows:, 5] = 1
-        A[rows:, 6] = - yd * xs
-        A[rows:, 7] = - yd * ys
-        A[:rows, 8] = xd
-        A[rows:, 8] = yd
+        A = np.zeros((n * d, (d+1) ** 2))
+        for ddim in range(d):
+            A[ddim*n : (ddim+1)*n, ddim*(d+1) : ddim*(d+1) + d] = src
+            A[ddim*n : (ddim+1)*n, ddim*(d+1) + d] = 1
+            A[ddim*n : (ddim+1)*n, -d-1:-1] = src
+            A[ddim*n : (ddim+1)*n, -1] = -1
+            A[ddim*n : (ddim+1)*n, -d-1:] *= -dst[:, ddim:(ddim+1)]
 
         # Select relevant columns, depending on params
-        A = A[:, list(self._coeffs) + [8]]
+        A = A[:, list(self._coeffs) + [-1]]
 
         _, _, V = np.linalg.svd(A)
         # if the last element of the vector corresponding to the smallest
@@ -680,11 +695,11 @@ class ProjectiveTransform(GeometricTransform):
         if np.isclose(V[-1, -1], 0):
             return False
 
-        H = np.zeros((3, 3))
+        H = np.zeros((d+1, d+1))
         # solution is right singular vector that corresponds to smallest
         # singular value
-        H.flat[list(self._coeffs) + [8]] = - V[-1, :-1] / V[-1, -1]
-        H[2, 2] = 1
+        H.flat[list(self._coeffs) + [-1]] = - V[-1, :-1] / V[-1, -1]
+        H[d, d] = 1
 
         # De-center and de-normalize
         H = np.linalg.inv(dst_matrix) @ H @ src_matrix
@@ -694,9 +709,7 @@ class ProjectiveTransform(GeometricTransform):
         return True
 
     def __add__(self, other):
-        """Combine this transformation with another.
-
-        """
+        """Combine this transformation with another."""
         if isinstance(other, ProjectiveTransform):
             # combination of the same types result in a transformation of this
             # type again, otherwise use general projective transformation
@@ -733,9 +746,14 @@ class ProjectiveTransform(GeometricTransform):
         classstr = classname
         return '<{}({})>'.format(classstr, paramstr)
 
+    @property
+    def dimensionality(self):
+        """The dimensionality of the transformation."""
+        return self.params.shape[0] - 1
+
 
 class AffineTransform(ProjectiveTransform):
-    """2D affine transformation.
+    """Affine transformation.
 
     Has the following form::
 
@@ -752,45 +770,88 @@ class AffineTransform(ProjectiveTransform):
          [b0  b1  b2]
          [0   0    1]]
 
+    In 2D, the transformation parameters can be given as the homogeneous
+    transformation matrix, above, or as the implicit parameters, scale,
+    rotation, shear, and translation in x (a2) and y (b2). For 3D and higher,
+    only the matrix form is allowed.
+
+    In narrower transforms, such as the Euclidean (only rotation and
+    translation) or Similarity (rotation, translation, and a global scale
+    factor) transforms, it is possible to specify 3D transforms using implicit
+    parameters also.
+
     Parameters
     ----------
+    matrix : (D+1, D+1) array, optional
+        Homogeneous transformation matrix. If this matrix is provided, it is an
+        error to provide any of scale, rotation, shear, or translation.
     matrix : (3, 3) array, optional
         Homogeneous transformation matrix.
     scale : {s as float or (sx, sy) as array, list or tuple}, optional
         Scale factor(s). If a single value, it will be assigned to both
-        sx and sy.
+        sx and sy. Only available for 2D.
 
         .. versionadded:: 0.17
            Added support for supplying a single scalar value.
     rotation : float, optional
-        Rotation angle in counter-clockwise direction as radians.
+        Rotation angle in counter-clockwise direction as radians. Only
+        available for 2D.
     shear : float, optional
-        Shear angle in counter-clockwise direction as radians.
+        Shear angle in counter-clockwise direction as radians. Only available
+        for 2D.
     translation : (tx, ty) as array, list or tuple, optional
-        Translation parameters.
+        Translation parameters. Only available for 2D.
+    dimensionality : int, optional
+        The dimensionality of the transform. This is not used if any other
+        parameters are provided.
 
     Attributes
     ----------
-    params : (3, 3) array
+    params : (D+1, D+1) array
         Homogeneous transformation matrix.
 
+    Raises
+    ------
+    ValueError
+        If both ``matrix`` and any of the other parameters are provided.
     """
 
-    _coeffs = range(6)
-
     def __init__(self, matrix=None, scale=None, rotation=None, shear=None,
-                 translation=None):
+                 translation=None, *, dimensionality=2):
         params = any(param is not None
                      for param in (scale, rotation, shear, translation))
+
+        # these parameters get overwritten if a higher-D matrix is given
+        self._coeffs = range(dimensionality * (dimensionality + 1))
 
         if params and matrix is not None:
             raise ValueError("You cannot specify the transformation matrix and"
                              " the implicit parameters at the same time.")
+        if params and dimensionality > 2:
+            raise ValueError('Parameter input is only supported in 2D.')
         elif matrix is not None:
-            if matrix.shape != (3, 3):
+            if matrix.ndim == 1:  # linearized (d, d + 1) homogeneous matrix
+                nparam = matrix.size
+                # solve for d in: d * (d - 1) = nparam
+                d = (1 + np.sqrt(1 + 4 * nparam)) / 2 - 1
+                dimensionality = int(d)
+                if d != dimensionality:
+                    raise ValueError('Invalid number of elements for '
+                                     'linearized matrix: {}'.format(nparam))
+                part_matrix = np.reshape(
+                        matrix, (dimensionality, dimensionality + 1)
+                )
+                matrix = np.concatenate(
+                        (part_matrix, [[0] * d + [1]]), axis=0
+                )
+            elif matrix.shape[0] != matrix.shape[1]:
                 raise ValueError("Invalid shape of transformation matrix.")
+            else:
+                dimensionality = matrix.shape[0] - 1
+                nparam = dimensionality * (dimensionality + 1)
+            self._coeffs = range(nparam)
             self.params = matrix
-        elif params:
+        elif params:  # note: 2D only
             if scale is None:
                 scale = (1, 1)
             if rotation is None:
@@ -813,30 +874,36 @@ class AffineTransform(ProjectiveTransform):
             self.params[0:2, 2] = translation
         else:
             # default to an identity transform
-            self.params = np.eye(3)
+            self.params = np.eye(dimensionality + 1)
 
     @property
     def scale(self):
-        sx = math.sqrt(self.params[0, 0] ** 2 + self.params[1, 0] ** 2)
-        sy = math.sqrt(self.params[0, 1] ** 2 + self.params[1, 1] ** 2)
-        return sx, sy
+        return np.sqrt(np.sum(self.params ** 2, axis=0))[:self.dimensionality]
 
     @property
     def rotation(self):
+        if self.dimensionality != 2:
+            raise NotImplementedError(
+                'The rotation property is only implemented for 2D transforms.'
+            )
         return math.atan2(self.params[1, 0], self.params[0, 0])
 
     @property
     def shear(self):
+        if self.dimensionality != 2:
+            raise NotImplementedError(
+                'The shear property is only implemented for 2D transforms.'
+            )
         beta = math.atan2(- self.params[0, 1], self.params[1, 1])
         return beta - self.rotation
 
     @property
     def translation(self):
-        return self.params[0:2, 2]
+        return self.params[0:self.dimensionality, self.dimensionality]
 
 
 class PiecewiseAffineTransform(GeometricTransform):
-    """2D piecewise affine transformation.
+    """Piecewise affine transformation.
 
     Control points are used to define the mapping. The transform is based on
     a Delaunay triangulation of the points to form a mesh. Each triangle is
@@ -864,9 +931,9 @@ class PiecewiseAffineTransform(GeometricTransform):
 
         Parameters
         ----------
-        src : (N, 2) array
+        src : (N, D) array
             Source coordinates.
-        dst : (N, 2) array
+        dst : (N, D) array
             Destination coordinates.
 
         Returns
@@ -876,13 +943,14 @@ class PiecewiseAffineTransform(GeometricTransform):
 
         """
 
+        ndim = src.shape[1]
         # forward piecewise affine
         # triangulate input positions into mesh
         self._tesselation = spatial.Delaunay(src)
         # find affine mapping from source positions to destination
         self.affines = []
         for tri in self._tesselation.vertices:
-            affine = AffineTransform()
+            affine = AffineTransform(dimensionality=ndim)
             affine.estimate(src[tri, :], dst[tri, :])
             self.affines.append(affine)
 
@@ -892,7 +960,7 @@ class PiecewiseAffineTransform(GeometricTransform):
         # find affine mapping from source positions to destination
         self.inverse_affines = []
         for tri in self._inverse_tesselation.vertices:
-            affine = AffineTransform()
+            affine = AffineTransform(dimensionality=ndim)
             affine.estimate(dst[tri, :], src[tri, :])
             self.inverse_affines.append(affine)
 
@@ -905,7 +973,7 @@ class PiecewiseAffineTransform(GeometricTransform):
 
         Parameters
         ----------
-        coords : (N, 2) array
+        coords : (N, D) array
             Source coordinates.
 
         Returns
@@ -940,12 +1008,12 @@ class PiecewiseAffineTransform(GeometricTransform):
 
         Parameters
         ----------
-        coords : (N, 2) array
+        coords : (N, D) array
             Source coordinates.
 
         Returns
         -------
-        coords : (N, 2) array
+        coords : (N, D) array
             Transformed coordinates.
 
         """
@@ -969,8 +1037,55 @@ class PiecewiseAffineTransform(GeometricTransform):
         return out
 
 
+def _euler_rotation(axis, angle):
+    """Produce a single-axis Euler rotation matrix.
+
+    Parameters
+    ----------
+    axis : int in {0, 1, 2}
+        The axis of rotation.
+    angle : float
+        The angle of rotation in radians.
+
+    Returns
+    -------
+    Ri : array of float, shape (3, 3)
+        The rotation matrix along axis `axis`.
+    """
+    i = axis
+    s, c = np.sin(angle), np.cos(angle)
+    R2 = np.array([[          c, (-1)**(i+1) * s],
+                   [(-1)**i * s,               c]])
+    Ri = np.eye(3)
+    axes = sorted({0, 1, 2} - {axis})
+    Ri[axes][:, axes] = R2
+    return Ri
+
+
+def _euler_rotation_matrix(angles):
+    """Produce an Euler rotation matrix from the given angles.
+
+    The matrix will have dimension equal to the number of angles given.
+
+    Parameters
+    ----------
+    angles : array of float, shape (3,)
+        The transformation angles in radians.
+
+    Returns
+    -------
+    R : array of float, shape (3, 3)
+        The Euler rotation matrix.
+    """
+    dim = len(angles)
+    R = np.eye(dim)
+    for i, angle in enumerate(angles):
+        R @= _euler_rotation(i, angle)
+    return R
+
+
 class EuclideanTransform(ProjectiveTransform):
-    """2D Euclidean transformation.
+    """Euclidean transformation, also known as a rigid transform.
 
     Has the following form::
 
@@ -992,46 +1107,76 @@ class EuclideanTransform(ProjectiveTransform):
 
     Parameters
     ----------
-    matrix : (3, 3) array, optional
+    matrix : (D+1, D+1) array, optional
         Homogeneous transformation matrix.
-    rotation : float, optional
-        Rotation angle in counter-clockwise direction as radians.
-    translation : (tx, ty) as array, list or tuple, optional
-        x, y translation parameters.
+    rotation : float or sequence of float, optional
+        Rotation angle in counter-clockwise direction as radians. If given as
+        a vector, it is interpreted as Euler rotation angles [1]_. Only 2D
+        (single rotation) and 3D (Euler rotations) values are supported. For
+        higher dimensions, you must provide or estimate the transformation
+        matrix.
+    translation : sequence of float, length D, optional
+        Translation parameters for each axis.
+    dimensionality : int, optional
+        The dimensionality of the transform.
 
     Attributes
     ----------
-    params : (3, 3) array
+    params : (D+1, D+1) array
         Homogeneous transformation matrix.
 
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions
     """
 
-    def __init__(self, matrix=None, rotation=None, translation=None):
-        params = any(param is not None
-                     for param in (rotation, translation))
+    def __init__(self, matrix=None, rotation=None, translation=None,
+                 *, dimensionality=2):
+        params_given = rotation is not None or translation is not None
 
-        if params and matrix is not None:
+        if params_given and matrix is not None:
             raise ValueError("You cannot specify the transformation matrix and"
                              " the implicit parameters at the same time.")
         elif matrix is not None:
-            if matrix.shape != (3, 3):
+            if matrix.shape[0] != matrix.shape[1]:
                 raise ValueError("Invalid shape of transformation matrix.")
             self.params = matrix
-        elif params:
+        elif params_given:
             if rotation is None:
-                rotation = 0
+                dimensionality = len(translation)
+                if dimensionality == 2:
+                    rotation = 0
+                elif dimensionality == 3:
+                    rotation = np.zeros(3)
+                else:
+                    raise ValueError(
+                        'Parameters cannot be specified for dimension '
+                        f'{dimensionality} transforms'
+                    )
+            else:
+                if not np.isscalar(rotation) and len(rotation) != 3:
+                    raise ValueError(
+                        'Parameters cannot be specified for dimension '
+                        f'{dimensionality} transforms'
+                    )
             if translation is None:
-                translation = (0, 0)
+                translation = (0,) * dimensionality
 
-            self.params = np.array([
-                [math.cos(rotation), - math.sin(rotation), 0],
-                [math.sin(rotation),   math.cos(rotation), 0],
-                [                 0,                    0, 1]
-            ])
-            self.params[0:2, 2] = translation
+            if dimensionality == 2:
+                self.params = np.array([
+                    [math.cos(rotation), - math.sin(rotation), 0],
+                    [math.sin(rotation),   math.cos(rotation), 0],
+                    [                 0,                    0, 1]
+                ])
+            elif dimensionality == 3:
+                self.params = np.eye(dimensionality + 1)
+                self.params[:dimensionality, :dimensionality] = (
+                    _euler_rotation_matrix(rotation)
+                )
+            self.params[0:dimensionality, dimensionality] = translation
         else:
             # default to an identity transform
-            self.params = np.eye(3)
+            self.params = np.eye(dimensionality + 1)
 
     def estimate(self, src, dst):
         """Estimate the transformation from a set of corresponding points.
@@ -1091,24 +1236,27 @@ class SimilarityTransform(EuclideanTransform):
 
     Parameters
     ----------
-    matrix : (3, 3) array, optional
+    matrix : (dim+1, dim+1) array, optional
         Homogeneous transformation matrix.
     scale : float, optional
-        Scale factor.
+        Scale factor. Implemented only for 2D and 3D.
     rotation : float, optional
         Rotation angle in counter-clockwise direction as radians.
-    translation : (tx, ty) as array, list or tuple, optional
-        x, y translation parameters.
+        Implemented only for 2D and 3D. For 3D, this is given in XZX Euler
+        angles.
+    translation : (dim,) array-like, optional
+        x, y[, z] translation parameters. Implemented only for 2D and 3D.
 
     Attributes
     ----------
-    params : (3, 3) array
+    params : (dim+1, dim+1) array
         Homogeneous transformation matrix.
 
     """
 
     def __init__(self, matrix=None, scale=None, rotation=None,
-                 translation=None):
+                 translation=None, *, dimensionality=2):
+        self.params = None
         params = any(param is not None
                      for param in (scale, rotation, translation))
 
@@ -1116,27 +1264,49 @@ class SimilarityTransform(EuclideanTransform):
             raise ValueError("You cannot specify the transformation matrix and"
                              " the implicit parameters at the same time.")
         elif matrix is not None:
-            if matrix.shape != (3, 3):
+            if matrix.ndim == 1:  # parameter vector: scale, rot, translation
+                if dimensionality > 3:
+                    raise ValueError(
+                        'Parameter vectors are only supported for 2D and 3D.'
+                    )
+                scale = matrix[0]
+                rotation = matrix[1:-dimensionality]
+                translation = matrix[-dimensionality:]
+                params = True
+            elif matrix.shape[0] != matrix.shape[1] or matrix.ndim > 2:
                 raise ValueError("Invalid shape of transformation matrix.")
-            self.params = matrix
-        elif params:
+            else:
+                self.params = matrix
+                dimensionality = matrix.shape[0] - 1
+        if params:
+            if dimensionality == 2:
+                axes = ((0, 1),)
+            elif dimensionality == 3:
+                axes = ((1, 2), (0, 1), (1, 2))  # XZX Euler angles
+            else:
+                raise ValueError('Parameters only supported for 2D and 3D.')
+            matrix = np.eye(dimensionality + 1, dtype=float)
             if scale is None:
                 scale = 1
             if rotation is None:
-                rotation = 0
+                rotation = (0,) if dimensionality == 2 else (0, 0, 0)
+            if np.isscalar(rotation):
+                rotation = [rotation]
             if translation is None:
-                translation = (0, 0)
+                translation = (0,) * dimensionality
+            for rot, ax in zip(rotation, axes):
+                R = np.eye(dimensionality + 1)
+                c, s = np.cos(rot), np.sin(rot)
+                R[ax, ax] = c
+                R[ax, ax[::-1]] = -s, s
+                matrix = R @ matrix
 
-            self.params = np.array([
-                [math.cos(rotation), - math.sin(rotation), 0],
-                [math.sin(rotation),   math.cos(rotation), 0],
-                [                 0,                    0, 1]
-            ])
-            self.params[0:2, 0:2] *= scale
-            self.params[0:2, 2] = translation
-        else:
+            matrix[:dimensionality, :dimensionality] *= scale
+            matrix[:dimensionality, dimensionality] = translation
+            self.params = matrix
+        elif self.params is None:
             # default to an identity transform
-            self.params = np.eye(3)
+            self.params = np.eye(dimensionality + 1)
 
     def estimate(self, src, dst):
         """Estimate the transformation from a set of corresponding points.
@@ -1160,7 +1330,7 @@ class SimilarityTransform(EuclideanTransform):
 
         """
 
-        self.params = _umeyama(src, dst, True)
+        self.params = _umeyama(src, dst, estimate_scale=True)
 
         return True
 
@@ -1192,7 +1362,11 @@ class PolynomialTransform(GeometricTransform):
 
     """
 
-    def __init__(self, params=None):
+    def __init__(self, params=None, *, dimensionality=2):
+        if dimensionality != 2:
+            raise NotImplementedError(
+                'Polynomial transforms are only implemented for 2D.'
+            )
         if params is None:
             # default to transformation which preserves original coordinates
             params = np.array([[0, 1, 0], [0, 0, 1]])
@@ -1398,7 +1572,7 @@ def estimate_transform(ttype, src, dst, **kwargs):
         raise ValueError('the transformation type \'%s\' is not'
                          'implemented' % ttype)
 
-    tform = TRANSFORMS[ttype]()
+    tform = TRANSFORMS[ttype](dimensionality=src.shape[1])
     tform.estimate(src, dst, **kwargs)
 
     return tform

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -71,8 +71,12 @@ def _center_and_normalize_points(points):
 
     norm_factor = np.sqrt(d) / rms
 
-    matrix = np.eye(d + 1)
-    matrix[:-1, -1] = -centroid
+    part_matrix = norm_factor * np.concatenate(
+            (np.eye(d), -centroid[:, np.newaxis]), axis=1
+            )
+    matrix = np.concatenate(
+            (part_matrix, [[0,] * d + [1]]), axis=0
+            )
 
     points_h = np.row_stack([points.T, np.ones(n)])
 

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -15,12 +15,8 @@ def _affine_matrix_from_vector(v):
     if d != dimensionality:
         raise ValueError('Invalid number of elements for '
                          f'linearized matrix: {nparam}')
-    part_matrix = np.reshape(
-        v, (dimensionality, dimensionality + 1)
-    )
-    matrix = np.concatenate(
-        (part_matrix, np.eye(1, dimensionality + 1, dimensionality)), axis=0
-    )
+    matrix = np.eye(dimensionality + 1)
+    matrix[-1, :] = np.reshape(v, (dimensionality, dimensionality + 1))
     return matrix
 
 

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1089,7 +1089,7 @@ def _euler_rotation_matrix(angles, axes=None):
         The Euler rotation matrix.
     """
     if axes is None:
-        axes = list(range(3))
+        axes = range(3)
     dim = len(angles)
     R = np.eye(dim)
     for i, angle in zip(axes, angles):

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -559,13 +559,13 @@ class ProjectiveTransform(GeometricTransform):
     """
 
     def __init__(self, matrix=None, *, dimensionality=2):
-        if matrix is not None:
-            dimensionality = matrix.shape[0] - 1
         if matrix is None:
             # default to an identity transform
             matrix = np.eye(dimensionality + 1)
-        if matrix.shape != (dimensionality + 1, dimensionality + 1):
-            raise ValueError("invalid shape of transformation matrix")
+        else:
+            dimensionality = matrix.shape[0] - 1
+            if matrix.shape != (dimensionality + 1, dimensionality + 1):
+                raise ValueError("invalid shape of transformation matrix")
         self.params = matrix
         self._coeffs = range(matrix.size - 1)
 

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -259,8 +259,8 @@ class FundamentalMatrixTransform(GeometricTransform):
             matrix = np.eye(dimensionality + 1)
         else:
             dimensionality = matrix.shape[0] - 1
-        if matrix.shape != (dimensionality + 1, dimensionality + 1):
-            raise ValueError("Invalid shape of transformation matrix")
+            if matrix.shape != (dimensionality + 1, dimensionality + 1):
+                raise ValueError("Invalid shape of transformation matrix")
         self.params = matrix
         if dimensionality != 2:
             raise NotImplementedError(

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -71,12 +71,8 @@ def _center_and_normalize_points(points):
 
     norm_factor = np.sqrt(d) / rms
 
-    part_matrix = norm_factor * np.concatenate(
-            (np.eye(d), -centroid[:, np.newaxis]), axis=1
-            )
-    matrix = np.concatenate(
-            (part_matrix, [[0,] * d + [1]]), axis=0
-            )
+    matrix = np.eye(d + 1)
+    matrix[:-1, -1] = -centroid
 
     points_h = np.row_stack([points.T, np.ones(n)])
 

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1058,7 +1058,8 @@ def _euler_rotation(axis, angle):
                    [(-1)**i * s,               c]])
     Ri = np.eye(3)
     axes = sorted({0, 1, 2} - {axis})
-    Ri[axes][:, axes] = R2
+    sl = slice(axes[0], axes[1] + 1, axes[1] - axes[0])
+    Ri[sl, sl] = R2
     return Ri
 
 
@@ -1080,7 +1081,7 @@ def _euler_rotation_matrix(angles):
     dim = len(angles)
     R = np.eye(dim)
     for i, angle in enumerate(angles):
-        R @= _euler_rotation(i, angle)
+        R = R @ _euler_rotation(i, angle)
     return R
 
 

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -697,6 +697,9 @@ class ProjectiveTransform(GeometricTransform):
 
         # params: a0, a1, a2, b0, b1, b2, c0, c1
         A = np.zeros((n * d, (d+1) ** 2))
+        # fill the A matrix with the appropriate block matrices; see docstring
+        # for 2D example — this can be generalised to more blocks in the 3D and
+        # higher-dimensional cases.
         for ddim in range(d):
             A[ddim*n : (ddim+1)*n, ddim*(d+1) : ddim*(d+1) + d] = src
             A[ddim*n : (ddim+1)*n, ddim*(d+1) + d] = 1

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -587,3 +587,6 @@ def test_affine_transform_from_linearized_parameters():
     )
     tf = AffineTransform(matrix=mat[:-1].ravel())
     assert_equal(np.array(tf), mat)
+    # incorrect number of parameters
+    with testing.raises(ValueError):
+        tf = AffineTransform(matrix=mat[:-1].ravel()[:-1])

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -565,3 +565,10 @@ def test_estimate_affine_3d():
     assert_almost_equal(tf2.params[:, :-1], matrix[:, :-1], decimal=2)
     assert_almost_equal(tf2.params[:, -1], matrix[:, -1], decimal=0)
     _assert_least_squares(tf2, src, dst_noisy)
+
+
+def test_fundamental_3d_not_implemented():
+    with testing.raises(NotImplementedError):
+        _ = FundamentalMatrixTransform(dimensionality=3)
+    with testing.raises(NotImplementedError):
+        _ = FundamentalMatrixTransform(np.eye(4))

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -1,7 +1,9 @@
 import numpy as np
 import re
 from skimage.transform._geometric import GeometricTransform
-from skimage.transform._geometric import _center_and_normalize_points
+from skimage.transform._geometric import (
+    _center_and_normalize_points, _euler_rotation_matrix
+)
 from skimage.transform import (estimate_transform, matrix_transform,
                                EuclideanTransform, SimilarityTransform,
                                AffineTransform, FundamentalMatrixTransform,
@@ -590,3 +592,11 @@ def test_affine_transform_from_linearized_parameters():
     # incorrect number of parameters
     with testing.raises(ValueError):
         tf = AffineTransform(matrix=mat[:-1].ravel()[:-1])
+
+
+def test_euler_rotation():
+    v = [0, 10, 0]
+    angles = np.radians([90, 45, 45])
+    expected = [-5, -5, 7.1]
+    R = _euler_rotation_matrix(angles)
+    assert_almost_equal(R @ v, expected, decimal=1)

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -2,7 +2,8 @@ import numpy as np
 import re
 from skimage.transform._geometric import GeometricTransform
 from skimage.transform._geometric import (
-    _center_and_normalize_points, _euler_rotation_matrix
+    _center_and_normalize_points, _euler_rotation_matrix,
+    _affine_matrix_from_vector,
 )
 from skimage.transform import (estimate_transform, matrix_transform,
                                EuclideanTransform, SimilarityTransform,
@@ -587,11 +588,15 @@ def test_affine_transform_from_linearized_parameters():
     mat = np.concatenate(
         (np.random.random((3, 4)), np.eye(4)[-1:]), axis=0
     )
-    tf = AffineTransform(matrix=mat[:-1].ravel())
+    v = mat[:-1].ravel()
+    mat_from_v = _affine_matrix_from_vector(v)
+    tf = AffineTransform(matrix=mat_from_v)
     assert_equal(np.array(tf), mat)
     # incorrect number of parameters
     with testing.raises(ValueError):
-        tf = AffineTransform(matrix=mat[:-1].ravel()[:-1])
+        _ = _affine_matrix_from_vector(v[:-1])
+    with testing.raises(ValueError):
+        _ = AffineTransform(matrix=v[:-1])
 
 
 def test_euler_rotation():

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -605,3 +605,11 @@ def test_euler_rotation():
     expected = [-5, -5, 7.1]
     R = _euler_rotation_matrix(angles)
     assert_almost_equal(R @ v, expected, decimal=1)
+
+
+
+def test_euler_angle_consistency():
+    angles = np.random.random((3,)) * 2 * np.pi - np.pi
+    euclid = EuclideanTransform(rotation=angles, dimensionality=3)
+    similar = SimilarityTransform(rotation=angles, dimensionality=3)
+    testing.assert_array_almost_equal(euclid, similar)

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -579,3 +579,11 @@ def test_array_protocol():
     tf = ProjectiveTransform(mat)
     assert_equal(np.array(tf), mat)
     assert_equal(np.array(tf, dtype=int), mat.astype(int))
+
+
+def test_affine_transform_from_linearized_parameters():
+    mat = np.concatenate(
+        (np.random.random((3, 4)), np.eye(4)[-1:]), axis=0
+    )
+    tf = AffineTransform(matrix=mat[:-1].ravel())
+    assert_equal(np.array(tf), mat)

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -1,6 +1,7 @@
 import numpy as np
 import re
 from skimage.transform._geometric import GeometricTransform
+from skimage.transform._geometric import _center_and_normalize_points
 from skimage.transform import (estimate_transform, matrix_transform,
                                EuclideanTransform, SimilarityTransform,
                                AffineTransform, FundamentalMatrixTransform,
@@ -488,6 +489,17 @@ def test_degenerate():
         # Prior to gh-3926, under the above circumstances,
         # a transform could be returned with nan values.
         assert(not tform.estimate(src, dst) or np.isfinite(tform.params).all())
+
+
+def test_normalize_degenerate_points():
+    """Return nan matrix *of appropriate size* when point is repeated."""
+    pts = np.array([[73.42834308, 94.2977623 ],] * 3)
+    mat, pts_tf = _center_and_normalize_points(pts)
+    assert np.all(np.isnan(mat))
+    assert np.all(np.isnan(pts_tf))
+    assert mat.shape == (3, 3)
+    assert pts_tf.shape == pts.shape
+
 
 
 def test_projective_repr():

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -572,3 +572,10 @@ def test_fundamental_3d_not_implemented():
         _ = FundamentalMatrixTransform(dimensionality=3)
     with testing.raises(NotImplementedError):
         _ = FundamentalMatrixTransform(np.eye(4))
+
+
+def test_array_protocol():
+    mat = np.eye(4)
+    tf = ProjectiveTransform(mat)
+    assert_equal(np.array(tf), mat)
+    assert_equal(np.array(tf, dtype=int), mat.astype(int))


### PR DESCRIPTION
This is the second PR with more gradual changes from #3544. I've pulled out the
automatic conversion of 1D parameter vectors to transforms. Viewed in
isolation, that was definitely way too magical given our values. I've left the
implementation in as a private function for future reference. Eventually, I'd
like to add a class method, `from_parameter_vector`, that would be
well-documented for each class, but I think that should come in a future PR.

I've done my best with the Euler rotation matrix code, but that would benefit
the most from review. Since we don't have a strict xyz/zyx axis order, it's
basically ambiguous whether XYZ or ZYX Euler angles are implemented (if it's
either of those :joy:). CC @stefanv @grlee77 @matthew-brett


## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
