### PR TITLE
Remove reference to opencv in threshold_local documentation

### DIFF
--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -192,7 +192,9 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
 
     References
     ----------
-    .. [1] https://docs.opencv.org/modules/imgproc/doc/miscellaneous_transformations.html?highlight=threshold#adaptivethreshold
+    .. [1] Gonzalez, R. C. and Wood, R. E. "Digital Image Processing
+           (2nd Edition)." Prentice-Hall Inc, 2002: 600-612.
+           ISBN: 0-201-18075-8
 
     Examples
     --------
@@ -202,6 +204,7 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
     >>> func = lambda arr: arr.mean()
     >>> binary_image2 = image > threshold_local(image, 15, 'generic',
     ...                                         param=func)
+
     """
     if block_size % 2 == 0:
         raise ValueError("The kwarg ``block_size`` must be odd! Given "

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -193,7 +193,7 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
     References
     ----------
     .. [1] Gonzalez, R. C. and Wood, R. E. "Digital Image Processing
-           (2nd Edition)." Prentice-Hall Inc, 2002: 600-612.
+           (2nd Edition)." Prentice-Hall Inc., 2002: 600--612.
            ISBN: 0-201-18075-8
 
     Examples


### PR DESCRIPTION
## Description

Removes the reference to openCV documentation for the `threshold_local` function.
I propose
*Gonzalez, R. C. and Wood, R. E. "Digital Image Processing (2nd Edition)." Prentice-Hall Inc, 2002: 600-612.*
but any other ref other then openCV is OK IMHO.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
