### PR TITLE
Add float32 support to moments_hu

### DIFF
--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -345,7 +345,8 @@ def moments_hu(nu):
     array([7.45370370e-01, 3.51165981e-01, 1.04049179e-01, 4.06442107e-02,
            2.64312299e-03, 2.40854582e-02, 4.33680869e-19])
     """
-    return _moments_cy.moments_hu(nu.astype(np.double))
+    dtype = np.float32 if nu.dtype == 'float32' else np.float64
+    return _moments_cy.moments_hu(nu.astype(dtype, copy=False))
 
 
 def centroid(image):

--- a/skimage/measure/_moments_cy.pyx
+++ b/skimage/measure/_moments_cy.pyx
@@ -2,17 +2,26 @@
 #cython: nonecheck=False
 #cython: wraparound=False
 import numpy as np
+cimport numpy as cnp
+
+from .._shared.fused_numerics cimport np_floats
+cnp.import_array()
 
 
-def moments_hu(double[:, :] nu):
-    cdef double[::1] hu = np.zeros((7, ), dtype=np.double)
-    cdef double t0 = nu[3, 0] + nu[1, 2]
-    cdef double t1 = nu[2, 1] + nu[0, 3]
-    cdef double q0 = t0 * t0
-    cdef double q1 = t1 * t1
-    cdef double n4 = 4 * nu[1, 1]
-    cdef double s = nu[2, 0] + nu[0, 2]
-    cdef double d = nu[2, 0] - nu[0, 2]
+def moments_hu(np_floats[:, :] nu):
+    if np_floats is cnp.float32_t:
+        dtype = np.float32
+    else:
+        dtype = np.float64
+
+    cdef np_floats[::1] hu = np.zeros((7, ), dtype=dtype)
+    cdef np_floats t0 = nu[3, 0] + nu[1, 2]
+    cdef np_floats t1 = nu[2, 1] + nu[0, 3]
+    cdef np_floats q0 = t0 * t0
+    cdef np_floats q1 = t1 * t1
+    cdef np_floats n4 = 4 * nu[1, 1]
+    cdef np_floats s = nu[2, 0] + nu[0, 2]
+    cdef np_floats d = nu[2, 0] - nu[0, 2]
     hu[0] = s
     hu[1] = d * d + n4 * nu[1, 1]
     hu[3] = q0 + q1

--- a/skimage/measure/tests/test_moments.py
+++ b/skimage/measure/tests/test_moments.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 from scipy import ndimage as ndi
 from skimage import draw
@@ -9,7 +10,6 @@ from skimage.measure import (moments, moments_central, moments_coords,
 from skimage._shared import testing
 from skimage._shared.testing import (assert_equal, assert_almost_equal,
                                      assert_allclose)
-from skimage._shared._warnings import expected_warnings
 
 
 def test_moments():
@@ -131,6 +131,17 @@ def test_moments_hu():
     hu2 = moments_hu(nu2)
     # central moments must be translation and scale invariant
     assert_almost_equal(hu, hu2, decimal=1)
+
+
+@pytest.mark.parametrize('dtype', ['float32', 'float64'])
+def test_moments_hu_dtype(dtype):
+    image = np.zeros((20, 20), dtype=np.double)
+    image[13:15, 13:17] = 1
+    mu = moments_central(image, (13.5, 14.5))
+    nu = moments_normalized(mu)
+    hu = moments_hu(nu.astype(dtype))
+
+    assert hu.dtype == dtype
 
 
 def test_centroid():


### PR DESCRIPTION
## Description

Related to #5199.
Fused types are used to allow processing single precision values.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
