### PR TITLE
Fix typo in _shared/utils.py docs

### DIFF
--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -119,7 +119,7 @@ class deprecate_kwarg:
 
     Parameters
     ----------
-    arg_mapping: dict
+    kwarg_mapping: dict
         Mapping between the function's old argument names and the new
         ones.
     warning_msg: str


### PR DESCRIPTION
Fixes #5203 
* Change the documentation of class `deprecate_kwarg` to show `kwarg_mapping` as the argument name

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
