### PR TITLE
Add hausdorff points

### DIFF
--- a/benchmarks/benchmark_metrics.py
+++ b/benchmarks/benchmark_metrics.py
@@ -14,13 +14,16 @@ class SetMetricsSuite(object):
 
     def setup(self):
         try:
-            from skimage.metrics import hausdorff_distance
+            from skimage.metrics import hausdorff_distance, hausdorff_points
         except ImportError:
-            raise NotImplementedError("hausdorff_distance unavailable")
+            raise NotImplementedError("hausdorff metrics unavailable")
         points_a = (1, 0)
         points_b = (5, 2)
         self.coords_a[points_a] = True
         self.coords_b[points_b] = True
 
-    def time_hausdorff(self):
+    def time_hausdorff_distance(self):
         metrics.hausdorff_distance(self.coords_a, self.coords_b)
+
+    def time_hausdorff_points(self):
+        metrics.hausdorff_points(self.coords_a, self.coords_b)

--- a/benchmarks/benchmark_metrics.py
+++ b/benchmarks/benchmark_metrics.py
@@ -16,7 +16,7 @@ class SetMetricsSuite(object):
         try:
             from skimage.metrics import hausdorff_distance, hausdorff_pair
         except ImportError:
-            raise NotImplementedError("hausdorff metrics unavailable")
+            raise NotImplementedError("Hausdorff metrics unavailable")
         points_a = (1, 0)
         points_b = (5, 2)
         self.coords_a[points_a] = True

--- a/benchmarks/benchmark_metrics.py
+++ b/benchmarks/benchmark_metrics.py
@@ -14,7 +14,7 @@ class SetMetricsSuite(object):
 
     def setup(self):
         try:
-            from skimage.metrics import hausdorff_distance, hausdorff_points
+            from skimage.metrics import hausdorff_distance, hausdorff_pair
         except ImportError:
             raise NotImplementedError("hausdorff metrics unavailable")
         points_a = (1, 0)
@@ -25,5 +25,5 @@ class SetMetricsSuite(object):
     def time_hausdorff_distance(self):
         metrics.hausdorff_distance(self.coords_a, self.coords_b)
 
-    def time_hausdorff_points(self):
-        metrics.hausdorff_points(self.coords_a, self.coords_b)
+    def time_hausdorff_pair(self):
+        metrics.hausdorff_pair(self.coords_a, self.coords_b)

--- a/doc/examples/segmentation/plot_hausdorff_distance.py
+++ b/doc/examples/segmentation/plot_hausdorff_distance.py
@@ -41,7 +41,7 @@ set_bx = [(x_kite + x_r * x) for x in plt_x]
 set_by = [(y_kite + y_r * y) for y in plt_y]
 plt.plot(set_bx, set_by, 'og')
 
-# Set up the data to compute the hausdorff distance
+# Set up the data to compute the Hausdorff distance
 coords_a = np.zeros(shape, dtype=bool)
 coords_b = np.zeros(shape, dtype=bool)
 for x, y in zip(set_ax, set_ay):
@@ -50,12 +50,12 @@ for x, y in zip(set_ax, set_ay):
 for x, y in zip(set_bx, set_by):
     coords_b[(x, y)] = True
 
-# Call the hausdorff function on the coordinates
+# Call the Hausdorff function on the coordinates
 metrics.hausdorff_distance(coords_a, coords_b)
 hausdorff_point_a, hausdorff_point_b = metrics.hausdorff_pair(coords_a,
                                                               coords_b)
 
-# Plot the lines that shows the length of the hausdorff distance
+# Plot the lines that shows the length of the Hausdorff distance
 x_line = [30, 30]
 y_line = [20, 10]
 plt.plot(x_line, y_line, 'y')
@@ -64,14 +64,14 @@ x_line = [30, 30]
 y_line = [40, 50]
 plt.plot(x_line, y_line, 'y')
 
-# Plot circles to show that at this distance, the hausdorff distance can
+# Plot circles to show that at this distance, the Hausdorff distance can
 # travel to its nearest neighbor (in this case, from the kite to diamond)
 ax.add_artist(plt.Circle((30, 10), 10, color='y', fill=None))
 ax.add_artist(plt.Circle((30, 50), 10, color='y', fill=None))
 ax.add_artist(plt.Circle((15, 30), 10, color='y', fill=None))
 ax.add_artist(plt.Circle((45, 30), 10, color='y', fill=None))
 
-# Annotate the returned pair of points that are hausdorff distance apart
+# Annotate the returned pair of points that are Hausdorff distance apart
 ax.annotate('a', xy=hausdorff_point_a, xytext=(35, 15),
             arrowprops=dict(facecolor='red', shrink=0.005))
 ax.annotate('b', xy=hausdorff_point_b, xytext=(35, 5),

--- a/doc/examples/segmentation/plot_hausdorff_distance.py
+++ b/doc/examples/segmentation/plot_hausdorff_distance.py
@@ -52,8 +52,8 @@ for x, y in zip(set_bx, set_by):
 
 # Call the hausdorff function on the coordinates
 metrics.hausdorff_distance(coords_a, coords_b)
-hausdorff_point_a, hausdorff_point_b = metrics.hausdorff_points(coords_a,
-                                                                coords_b)
+hausdorff_point_a, hausdorff_point_b = metrics.hausdorff_pair(coords_a,
+                                                              coords_b)
 
 # Plot the lines that shows the length of the hausdorff distance
 x_line = [30, 30]

--- a/doc/examples/segmentation/plot_hausdorff_distance.py
+++ b/doc/examples/segmentation/plot_hausdorff_distance.py
@@ -52,6 +52,7 @@ for x, y in zip(set_bx, set_by):
 
 # Call the hausdorff function on the coordinates
 metrics.hausdorff_distance(coords_a, coords_b)
+hausdorff_point_a, hausdorff_point_b = metrics.hausdorff_points(coords_a, coords_b)
 
 # Plot the lines that shows the length of the hausdorff distance
 x_line = [30, 30]
@@ -68,6 +69,10 @@ ax.add_artist(plt.Circle((30, 10), 10, color='y', fill=None))
 ax.add_artist(plt.Circle((30, 50), 10, color='y', fill=None))
 ax.add_artist(plt.Circle((15, 30), 10, color='y', fill=None))
 ax.add_artist(plt.Circle((45, 30), 10, color='y', fill=None))
+
+# Annotate the returned pair of points that are hausdorff distance apart
+ax.annotate('a', xy=hausdorff_point_a, xytext=(35, 15), arrowprops=dict(facecolor='red', shrink=0.005))
+ax.annotate('b', xy=hausdorff_point_b, xytext=(35, 5), arrowprops=dict(facecolor='green', shrink=0.005))
 
 ax.imshow(image, cmap=plt.cm.gray)
 ax.axis((0, 60, 60, 0))

--- a/doc/examples/segmentation/plot_hausdorff_distance.py
+++ b/doc/examples/segmentation/plot_hausdorff_distance.py
@@ -52,7 +52,8 @@ for x, y in zip(set_bx, set_by):
 
 # Call the hausdorff function on the coordinates
 metrics.hausdorff_distance(coords_a, coords_b)
-hausdorff_point_a, hausdorff_point_b = metrics.hausdorff_points(coords_a, coords_b)
+hausdorff_point_a, hausdorff_point_b = metrics.hausdorff_points(coords_a,
+                                                                coords_b)
 
 # Plot the lines that shows the length of the hausdorff distance
 x_line = [30, 30]
@@ -71,8 +72,10 @@ ax.add_artist(plt.Circle((15, 30), 10, color='y', fill=None))
 ax.add_artist(plt.Circle((45, 30), 10, color='y', fill=None))
 
 # Annotate the returned pair of points that are hausdorff distance apart
-ax.annotate('a', xy=hausdorff_point_a, xytext=(35, 15), arrowprops=dict(facecolor='red', shrink=0.005))
-ax.annotate('b', xy=hausdorff_point_b, xytext=(35, 5), arrowprops=dict(facecolor='green', shrink=0.005))
+ax.annotate('a', xy=hausdorff_point_a, xytext=(35, 15),
+            arrowprops=dict(facecolor='red', shrink=0.005))
+ax.annotate('b', xy=hausdorff_point_b, xytext=(35, 5),
+            arrowprops=dict(facecolor='green', shrink=0.005))
 
 ax.imshow(image, cmap=plt.cm.gray)
 ax.axis((0, 60, 60, 0))

--- a/skimage/metrics/__init__.py
+++ b/skimage/metrics/__init__.py
@@ -7,7 +7,7 @@ from .simple_metrics import (mean_squared_error,
                              peak_signal_noise_ratio)
 from ._structural_similarity import structural_similarity
 from .set_metrics import (hausdorff_distance,
-                          hausdorff_points)
+                          hausdorff_pair)
 
 __all__ = ['adapted_rand_error',
            'variation_of_information',
@@ -18,5 +18,5 @@ __all__ = ['adapted_rand_error',
            'peak_signal_noise_ratio',
            'structural_similarity',
            'hausdorff_distance',
-           'hausdorff_points'
+           'hausdorff_pair'
            ]

--- a/skimage/metrics/__init__.py
+++ b/skimage/metrics/__init__.py
@@ -6,7 +6,8 @@ from .simple_metrics import (mean_squared_error,
                              normalized_root_mse,
                              peak_signal_noise_ratio)
 from ._structural_similarity import structural_similarity
-from .set_metrics import hausdorff_distance
+from .set_metrics import (hausdorff_distance,
+                          hausdorff_points)
 
 __all__ = ['adapted_rand_error',
            'variation_of_information',
@@ -16,5 +17,6 @@ __all__ = ['adapted_rand_error',
            'normalized_root_mse',
            'peak_signal_noise_ratio',
            'structural_similarity',
-           'hausdorff_distance'
+           'hausdorff_distance',
+           'hausdorff_points'
            ]

--- a/skimage/metrics/set_metrics.py
+++ b/skimage/metrics/set_metrics.py
@@ -1,6 +1,7 @@
 import numpy as np
 from scipy.spatial import cKDTree
 
+
 def hausdorff_distance(image0, image1):
     """Calculate the Hausdorff distance between nonzero elements of given images.
 
@@ -49,3 +50,64 @@ def hausdorff_distance(image0, image1):
 
     return max(max(cKDTree(a_points).query(b_points, k=1)[0]),
                max(cKDTree(b_points).query(a_points, k=1)[0]))
+
+
+def hausdorff_points(image0, image1):
+    """Returns pair of points that are Hausdorff distance apart between nonzero
+    elements of given images.
+
+    The Hausdorff distance [1]_ is the maximum distance between any point on
+    ``image0`` and its nearest point on ``image1``, and vice-versa.
+
+    Parameters
+    ----------
+    image0, image1 : ndarray
+        Arrays where ``True`` represents a point that is included in a
+        set of points. Both arrays must have the same shape.
+
+    Returns
+    -------
+    point_a, point_b : array
+        A pair of points that have Hausdorff distance between them.
+
+    References
+    ----------
+    .. [1] http://en.wikipedia.org/wiki/Hausdorff_distance
+
+    Examples
+    --------
+    >>> points_a = (3, 0)
+    >>> points_b = (6, 0)
+    >>> shape = (7, 1)
+    >>> image_a = np.zeros(shape, dtype=bool)
+    >>> image_b = np.zeros(shape, dtype=bool)
+    >>> image_a[points_a] = True
+    >>> image_b[points_b] = True
+    >>> hausdorff_points(image_a, image_b)
+    (array([3, 0]), array([6, 0]))
+
+    """
+    a_points = np.transpose(np.nonzero(image0))
+    b_points = np.transpose(np.nonzero(image1))
+
+    # If either of the sets are empty, there is no corresponding pair of points
+    if len(a_points) == 0 or len(b_points) == 0:
+        return ()
+
+    nearest_dists_from_b, nearest_a_point_indices_from_b = cKDTree(a_points)\
+        .query(b_points)
+    nearest_dists_from_a, nearest_b_point_indices_from_a = cKDTree(b_points)\
+        .query(a_points)
+
+    max_dist_from_a = nearest_dists_from_b.max()
+    max_dist_from_b = nearest_dists_from_a.max()
+
+    max_index_from_a = nearest_dists_from_b.argmax()
+    max_index_from_b = nearest_dists_from_a.argmax()
+
+    if max_dist_from_b > max_dist_from_a:
+        return a_points[max_index_from_b],\
+               b_points[nearest_b_point_indices_from_a[max_index_from_b]]
+    else:
+        return a_points[nearest_a_point_indices_from_b[max_index_from_a]],\
+               b_points[max_index_from_a]

--- a/skimage/metrics/set_metrics.py
+++ b/skimage/metrics/set_metrics.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 from scipy.spatial import cKDTree
 
@@ -52,7 +54,7 @@ def hausdorff_distance(image0, image1):
                max(cKDTree(b_points).query(a_points, k=1)[0]))
 
 
-def hausdorff_points(image0, image1):
+def hausdorff_pair(image0, image1):
     """Returns pair of points that are Hausdorff distance apart between nonzero
     elements of given images.
 
@@ -83,7 +85,7 @@ def hausdorff_points(image0, image1):
     >>> image_b = np.zeros(shape, dtype=bool)
     >>> image_a[points_a] = True
     >>> image_b[points_b] = True
-    >>> hausdorff_points(image_a, image_b)
+    >>> hausdorff_pair(image_a, image_b)
     (array([3, 0]), array([6, 0]))
 
     """
@@ -92,18 +94,19 @@ def hausdorff_points(image0, image1):
 
     # If either of the sets are empty, there is no corresponding pair of points
     if len(a_points) == 0 or len(b_points) == 0:
-        return ()
+        warnings.warn("One or both of the images is empty.", stacklevel=2)
+        return (), ()
 
     nearest_dists_from_b, nearest_a_point_indices_from_b = cKDTree(a_points)\
         .query(b_points)
     nearest_dists_from_a, nearest_b_point_indices_from_a = cKDTree(b_points)\
         .query(a_points)
 
-    max_dist_from_a = nearest_dists_from_b.max()
-    max_dist_from_b = nearest_dists_from_a.max()
-
     max_index_from_a = nearest_dists_from_b.argmax()
     max_index_from_b = nearest_dists_from_a.argmax()
+
+    max_dist_from_a = nearest_dists_from_b[max_index_from_a]
+    max_dist_from_b = nearest_dists_from_a[max_index_from_b]
 
     if max_dist_from_b > max_dist_from_a:
         return a_points[max_index_from_b],\

--- a/skimage/metrics/set_metrics.py
+++ b/skimage/metrics/set_metrics.py
@@ -107,7 +107,7 @@ def hausdorff_points(image0, image1):
 
     if max_dist_from_b > max_dist_from_a:
         return a_points[max_index_from_b],\
-               b_points[nearest_b_point_indices_from_a[max_index_from_b]]
+            b_points[nearest_b_point_indices_from_a[max_index_from_b]]
     else:
         return a_points[nearest_a_point_indices_from_b[max_index_from_a]],\
-               b_points[max_index_from_a]
+            b_points[max_index_from_a]

--- a/skimage/metrics/set_metrics.py
+++ b/skimage/metrics/set_metrics.py
@@ -97,9 +97,9 @@ def hausdorff_pair(image0, image1):
         warnings.warn("One or both of the images is empty.", stacklevel=2)
         return (), ()
 
-    nearest_dists_from_b, nearest_a_point_indices_from_b = cKDTree(a_points)\
+    nearest_dists_from_b, nearest_a_point_indices_from_b = cKDTree(a_points) \
         .query(b_points)
-    nearest_dists_from_a, nearest_b_point_indices_from_a = cKDTree(b_points)\
+    nearest_dists_from_a, nearest_b_point_indices_from_a = cKDTree(b_points) \
         .query(a_points)
 
     max_index_from_a = nearest_dists_from_b.argmax()
@@ -109,8 +109,8 @@ def hausdorff_pair(image0, image1):
     max_dist_from_b = nearest_dists_from_a[max_index_from_b]
 
     if max_dist_from_b > max_dist_from_a:
-        return a_points[max_index_from_b],\
+        return a_points[max_index_from_b], \
             b_points[nearest_b_point_indices_from_a[max_index_from_b]]
     else:
-        return a_points[nearest_a_point_indices_from_b[max_index_from_a]],\
+        return a_points[nearest_a_point_indices_from_b[max_index_from_a]], \
             b_points[max_index_from_a]

--- a/skimage/metrics/tests/test_set_metrics.py
+++ b/skimage/metrics/tests/test_set_metrics.py
@@ -32,7 +32,8 @@ def test_hausdorff_simple():
     distance = np.sqrt(sum((ca - cb) ** 2
                            for ca, cb in zip(points_a, points_b)))
     assert_almost_equal(hausdorff_distance(coords_a, coords_b), distance)
-    assert_array_equal(hausdorff_pair(coords_a, coords_b), (points_a, points_b))
+    assert_array_equal(hausdorff_pair(coords_a, coords_b), (points_a,
+                                                            points_b))
 
 
 @parametrize("points_a, points_b",
@@ -47,7 +48,8 @@ def test_hausdorff_region_single(points_a, points_b):
     distance = np.sqrt(sum((ca - cb) ** 2
                            for ca, cb in zip(points_a, points_b)))
     assert_almost_equal(hausdorff_distance(coords_a, coords_b), distance)
-    assert_array_equal(hausdorff_pair(coords_a, coords_b), (points_a, points_b))
+    assert_array_equal(hausdorff_pair(coords_a, coords_b), (points_a,
+                                                            points_b))
 
 
 @parametrize("points_a, points_b",
@@ -63,7 +65,8 @@ def test_hausdorff_region_different_points(points_a, points_b):
     distance = np.sqrt(sum((ca - cb) ** 2
                            for ca, cb in zip(points_a, points_b)))
     assert_almost_equal(hausdorff_distance(coords_a, coords_b), distance)
-    assert_array_equal(hausdorff_pair(coords_a, coords_b), (points_a, points_b))
+    assert_array_equal(hausdorff_pair(coords_a, coords_b), (points_a,
+                                                            points_b))
 
 
 def test_gallery():
@@ -114,7 +117,6 @@ def test_gallery():
            np.equal(hd_points, ((30, 40), (30, 50))).all()
 
 
-
 @parametrize("points_a, points_b",
              itertools.product([(0, 0, 1), (0, 1, 0), (1, 0, 0)],
                                [(0, 0, 2), (0, 2, 0), (2, 0, 0)]))
@@ -128,4 +130,5 @@ def test_3d_hausdorff_region(points_a, points_b):
     distance = np.sqrt(sum((ca - cb) ** 2
                            for ca, cb in zip(points_a, points_b)))
     assert_almost_equal(hausdorff_distance(coords_a, coords_b), distance)
-    assert_array_equal(hausdorff_pair(coords_a, coords_b), (points_a, points_b))
+    assert_array_equal(hausdorff_pair(coords_a, coords_b), (points_a,
+                                                            points_b))

--- a/skimage/metrics/tests/test_set_metrics.py
+++ b/skimage/metrics/tests/test_set_metrics.py
@@ -3,11 +3,13 @@ from __future__ import print_function, division
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
 import itertools
+import pytest
 
 from skimage._shared.testing import parametrize
 from skimage.metrics import hausdorff_distance, hausdorff_pair
 
 
+@pytest.mark.filterwarnings("ignore:One or both")
 def test_hausdorff_empty():
     empty = np.zeros((0, 2), dtype=bool)
     non_empty = np.zeros((3, 2), dtype=bool)

--- a/skimage/metrics/tests/test_set_metrics.py
+++ b/skimage/metrics/tests/test_set_metrics.py
@@ -5,18 +5,18 @@ from numpy.testing import assert_almost_equal, assert_array_equal
 import itertools
 
 from skimage._shared.testing import parametrize
-from skimage.metrics import hausdorff_distance, hausdorff_points
+from skimage.metrics import hausdorff_distance, hausdorff_pair
 
 
 def test_hausdorff_empty():
     empty = np.zeros((0, 2), dtype=bool)
     non_empty = np.zeros((3, 2), dtype=bool)
     assert hausdorff_distance(empty, non_empty) == 0.
-    assert_array_equal(hausdorff_points(empty, non_empty), ())
+    assert_array_equal(hausdorff_pair(empty, non_empty), [(), ()])
     assert hausdorff_distance(non_empty, empty) == 0.
-    assert_array_equal(hausdorff_points(non_empty, empty), ())
+    assert_array_equal(hausdorff_pair(non_empty, empty), [(), ()])
     assert hausdorff_distance(empty, non_empty) == 0.
-    assert_array_equal(hausdorff_points(empty, non_empty), ())
+    assert_array_equal(hausdorff_pair(empty, non_empty), [(), ()])
 
 
 def test_hausdorff_simple():
@@ -30,8 +30,7 @@ def test_hausdorff_simple():
     distance = np.sqrt(sum((ca - cb) ** 2
                            for ca, cb in zip(points_a, points_b)))
     assert_almost_equal(hausdorff_distance(coords_a, coords_b), distance)
-    assert_array_equal(hausdorff_points(coords_a, coords_b), (points_a,
-                                                              points_b))
+    assert_array_equal(hausdorff_pair(coords_a, coords_b), (points_a, points_b))
 
 
 @parametrize("points_a, points_b",
@@ -46,8 +45,7 @@ def test_hausdorff_region_single(points_a, points_b):
     distance = np.sqrt(sum((ca - cb) ** 2
                            for ca, cb in zip(points_a, points_b)))
     assert_almost_equal(hausdorff_distance(coords_a, coords_b), distance)
-    assert_array_equal(hausdorff_points(coords_a, coords_b), (points_a,
-                                                              points_b))
+    assert_array_equal(hausdorff_pair(coords_a, coords_b), (points_a, points_b))
 
 
 @parametrize("points_a, points_b",
@@ -63,8 +61,7 @@ def test_hausdorff_region_different_points(points_a, points_b):
     distance = np.sqrt(sum((ca - cb) ** 2
                            for ca, cb in zip(points_a, points_b)))
     assert_almost_equal(hausdorff_distance(coords_a, coords_b), distance)
-    assert_array_equal(hausdorff_points(coords_a, coords_b), (points_a,
-                                                              points_b))
+    assert_array_equal(hausdorff_pair(coords_a, coords_b), (points_a, points_b))
 
 
 def test_gallery():
@@ -110,7 +107,7 @@ def test_gallery():
 
     # There are two pairs of points ((30, 20), (30, 10) or (30, 40), (30, 50)),
     # that are hausdorff distance apart. This tests for either of them.
-    hd_points = hausdorff_points(coords_a, coords_b)
+    hd_points = hausdorff_pair(coords_a, coords_b)
     assert np.equal(hd_points, ((30, 20), (30, 10))).all() or \
            np.equal(hd_points, ((30, 40), (30, 50))).all()
 
@@ -129,5 +126,4 @@ def test_3d_hausdorff_region(points_a, points_b):
     distance = np.sqrt(sum((ca - cb) ** 2
                            for ca, cb in zip(points_a, points_b)))
     assert_almost_equal(hausdorff_distance(coords_a, coords_b), distance)
-    assert_array_equal(hausdorff_points(coords_a, coords_b), (points_a,
-                                                              points_b))
+    assert_array_equal(hausdorff_pair(coords_a, coords_b), (points_a, points_b))

--- a/skimage/metrics/tests/test_set_metrics.py
+++ b/skimage/metrics/tests/test_set_metrics.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
+from scipy.spatial import distance
 import itertools
 import pytest
 
@@ -29,9 +30,9 @@ def test_hausdorff_simple():
     coords_b = np.zeros(shape, dtype=bool)
     coords_a[points_a] = True
     coords_b[points_b] = True
-    distance = np.sqrt(sum((ca - cb) ** 2
-                           for ca, cb in zip(points_a, points_b)))
-    assert_almost_equal(hausdorff_distance(coords_a, coords_b), distance)
+    dist = np.sqrt(sum((ca - cb) ** 2
+                       for ca, cb in zip(points_a, points_b)))
+    assert_almost_equal(hausdorff_distance(coords_a, coords_b), dist)
     assert_array_equal(hausdorff_pair(coords_a, coords_b), (points_a,
                                                             points_b))
 
@@ -45,9 +46,9 @@ def test_hausdorff_region_single(points_a, points_b):
     coords_a[points_a] = True
     coords_b[points_b] = True
 
-    distance = np.sqrt(sum((ca - cb) ** 2
-                           for ca, cb in zip(points_a, points_b)))
-    assert_almost_equal(hausdorff_distance(coords_a, coords_b), distance)
+    dist = np.sqrt(sum((ca - cb) ** 2
+                       for ca, cb in zip(points_a, points_b)))
+    assert_almost_equal(hausdorff_distance(coords_a, coords_b), dist)
     assert_array_equal(hausdorff_pair(coords_a, coords_b), (points_a,
                                                             points_b))
 
@@ -62,9 +63,9 @@ def test_hausdorff_region_different_points(points_a, points_b):
     coords_a[points_a] = True
     coords_b[points_b] = True
 
-    distance = np.sqrt(sum((ca - cb) ** 2
-                           for ca, cb in zip(points_a, points_b)))
-    assert_almost_equal(hausdorff_distance(coords_a, coords_b), distance)
+    dist = np.sqrt(sum((ca - cb) ** 2
+                       for ca, cb in zip(points_a, points_b)))
+    assert_almost_equal(hausdorff_distance(coords_a, coords_b), dist)
     assert_array_equal(hausdorff_pair(coords_a, coords_b), (points_a,
                                                             points_b))
 
@@ -94,7 +95,7 @@ def test_gallery():
     set_bx = [(x_kite + x_r * x) for x in plt_x]
     set_by = [(y_kite + y_r * y) for y in plt_y]
 
-    # Set up the data to compute the hausdorff distance
+    # Set up the data to compute the Hausdorff distance
     coords_a = np.zeros(shape, dtype=bool)
     coords_b = np.zeros(shape, dtype=bool)
 
@@ -104,14 +105,14 @@ def test_gallery():
     for x, y in zip(set_bx, set_by):
         coords_b[(x, y)] = True
 
-    # Test the hausdorff function on the coordinates
+    # Test the Hausdorff function on the coordinates
     # Should return 10, the distance between the furthest tip of the kite and
     # its closest point on the diamond, which is the furthest someone can make
     # you travel to encounter your nearest neighboring point on the other set.
     assert_almost_equal(hausdorff_distance(coords_a, coords_b), 10.)
 
     # There are two pairs of points ((30, 20), (30, 10) or (30, 40), (30, 50)),
-    # that are hausdorff distance apart. This tests for either of them.
+    # that are Hausdorff distance apart. This tests for either of them.
     hd_points = hausdorff_pair(coords_a, coords_b)
     assert np.equal(hd_points, ((30, 20), (30, 10))).all() or \
            np.equal(hd_points, ((30, 40), (30, 50))).all()
@@ -127,8 +128,25 @@ def test_3d_hausdorff_region(points_a, points_b):
     coords_a[points_a] = True
     coords_b[points_b] = True
 
-    distance = np.sqrt(sum((ca - cb) ** 2
-                           for ca, cb in zip(points_a, points_b)))
-    assert_almost_equal(hausdorff_distance(coords_a, coords_b), distance)
+    dist = np.sqrt(sum((ca - cb) ** 2
+                       for ca, cb in zip(points_a, points_b)))
+    assert_almost_equal(hausdorff_distance(coords_a, coords_b), dist)
     assert_array_equal(hausdorff_pair(coords_a, coords_b), (points_a,
                                                             points_b))
+
+
+def test_hausdorff_metrics_match():
+    # Test that Hausdorff distance is the Euclidean distance between Hausdorff
+    # pair
+    points_a = (3, 0)
+    points_b = (6, 0)
+    shape = (7, 1)
+    coords_a = np.zeros(shape, dtype=bool)
+    coords_b = np.zeros(shape, dtype=bool)
+    coords_a[points_a] = True
+    coords_b[points_b] = True
+    assert_array_equal(hausdorff_pair(coords_a, coords_b), (points_a,
+                                                            points_b))
+    euclidean_distance = distance.euclidean(points_a, points_b)
+    assert_almost_equal(euclidean_distance, hausdorff_distance(coords_a,
+                                                               coords_b))


### PR DESCRIPTION
## Description
This PR returns a pair of points that is Hausdorff distance apart, building on top of the existing Hausdorff distance feature.

Discussion can be found on #5178.

Linking the the [original Hausdorff distance PR](https://github.com/scikit-image/scikit-image/pull/4382) for the paper this implements.

## Gallery Example Output
![HDPoints](https://user-images.githubusercontent.com/24197092/106252191-d765e780-61ca-11eb-9368-a7d6dbdcae14.PNG)


<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
