### PR TITLE
update minimum supported Matplotlib, SciPy and Pillow

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -91,11 +91,6 @@ Other (2021)
 * Remove pillow version related warning for MPO file format in
   `io._plugins.pil_plugin.imread` when upgrading pillow min version to
   6.0.0
-* Specify atol value in `cg` calls and remove condition on scipy's version in
-  ``skimage/segmentation/random_walker_segmentation.py`` when ``scipy`` upgrades
-  to 1.1.
-* Remove direct allocation of ``output`` from ``skimage/filters/_gaussian.py``,
-  when ``scipy`` upgrades to 1.1.
 * Remove '--verify-repo=none' in tlmgr calls in ``tools/travis/osx_install.sh``,
   when texlive 2020 is available.
 

--- a/TODO.txt
+++ b/TODO.txt
@@ -103,9 +103,9 @@ Other (2022)
 
 Other (2023)
 ------------
-* When ``scipy`` is set to >= 1.16, remove legacy (i.e. non-zoom) code paths in
+* When ``scipy`` is set to >= 1.6.0, remove legacy (i.e. non-zoom) code paths in
   ``skimage.transform.resize``.
-* When ``scipy`` is set to >= 1.16, remove SciPy version checks from
+* When ``scipy`` is set to >= 1.6.0, remove SciPy version checks from
   ``skimage._shared.utils._fix_ndimage_mode``
 
 Other

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,8 +1,8 @@
 numpy>=1.16.5
 scipy>=1.2.3
 matplotlib>=3.0.3
-networkx>=2.0
+networkx>=2.2
 pillow>=5.4.0,!=7.1.0,!=7.1.1
-imageio>=2.3.0
+imageio>=2.4.1
 tifffile>=2019.7.26
 PyWavelets>=1.1.1

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,8 +1,8 @@
 numpy>=1.16.5
-scipy>=1.0.1
-matplotlib>=2.0.0,!=3.0.0
+scipy>=1.2.3
+matplotlib>=3.0.3
 networkx>=2.0
-pillow>=4.3.0,!=7.1.0,!=7.1.1
+pillow>=5.4.0,!=7.1.0,!=7.1.1
 imageio>=2.3.0
 tifffile>=2019.7.26
 PyWavelets>=1.1.1

--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -117,9 +117,7 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
         if len(sigma) != image.ndim:
             sigma = np.concatenate((np.asarray(sigma), [0]))
     image = convert_to_float(image, preserve_range)
-    if output is None:
-        output = np.empty_like(image)
-    elif not np.issubdtype(output.dtype, np.floating):
+    if (output is not None) and (not np.issubdtype(output.dtype, np.floating)):
         raise ValueError("Provided output data type is not float")
     ndi.gaussian_filter(image, sigma, output=output, mode=mode, cval=cval,
                         truncate=truncate)

--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -119,9 +119,8 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
     image = convert_to_float(image, preserve_range)
     if (output is not None) and (not np.issubdtype(output.dtype, np.floating)):
         raise ValueError("Provided output data type is not float")
-    ndi.gaussian_filter(image, sigma, output=output, mode=mode, cval=cval,
-                        truncate=truncate)
-    return output
+    return ndi.gaussian_filter(image, sigma, output=output, 
+                               mode=mode, cval=cval, truncate=truncate)
 
 
 def _guess_spatial_dimensions(image):

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -191,7 +191,8 @@ def _solve_linear_system(lap_sparse, B, tol, mode):
             M = ml.aspreconditioner(cycle='V')
             maxiter = 30
         cg_out = [
-            cg(lap_sparse, B[:, i].toarray(), tol=tol, atol=0, M=M, maxiter=maxiter)
+            cg(lap_sparse, B[:, i].toarray(), 
+               tol=tol, atol=0, M=M, maxiter=maxiter)
             for i in range(B.shape[1])]
         if np.any([info > 0 for _, info in cg_out]):
             warn("Conjugate gradient convergence to tolerance not achieved. "

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -42,12 +42,6 @@ except ImportError:
 from ..util import img_as_float
 
 from scipy.sparse.linalg import cg, spsolve
-import scipy
-from distutils.version import LooseVersion as Version
-import functools
-
-if Version(scipy.__version__) >= Version('1.1'):
-    cg = functools.partial(cg, atol=0)
 
 
 def _make_graph_edges_3d(n_x, n_y, n_z):
@@ -197,7 +191,7 @@ def _solve_linear_system(lap_sparse, B, tol, mode):
             M = ml.aspreconditioner(cycle='V')
             maxiter = 30
         cg_out = [
-            cg(lap_sparse, B[:, i].toarray(), tol=tol, M=M, maxiter=maxiter)
+            cg(lap_sparse, B[:, i].toarray(), tol=tol, atol=0, M=M, maxiter=maxiter)
             for i in range(B.shape[1])]
         if np.any([info > 0 for _, info in cg_out]):
             warn("Conjugate gradient convergence to tolerance not achieved. "

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -191,7 +191,7 @@ def _solve_linear_system(lap_sparse, B, tol, mode):
             M = ml.aspreconditioner(cycle='V')
             maxiter = 30
         cg_out = [
-            cg(lap_sparse, B[:, i].toarray(), 
+            cg(lap_sparse, B[:, i].toarray(),
                tol=tol, atol=0, M=M, maxiter=maxiter)
             for i in range(B.shape[1])]
         if np.any([info > 0 for _, info in cg_out]):

--- a/tools/github/before_install.sh
+++ b/tools/github/before_install.sh
@@ -33,15 +33,6 @@ fi
 
 python -m pip install --upgrade pip wheel setuptools
 
-
-# install specific wheels from wheelhouse
-for requirement in matplotlib scipy pillow; do
-    WHEELS="$WHEELS $(grep $requirement requirements/default.txt)"
-done
-# cython is not in the default.txt requirements
-WHEELS="$WHEELS $(grep -i cython requirements/build.txt)"
-python -m pip install $PIP_FLAGS $WHEELS
-
 # Install build time requirements
 python -m pip install $PIP_FLAGS -r requirements/build.txt
 # Default requirements are necessary to build because of lazy importing


### PR DESCRIPTION
## Description

This PR bumps our minimum Matplotlib, SciPy and Pillow to versions released ~48 months ago that all have Python 3.7 wheels. 

This prevents needing to build wheels for these on CI for our minimum supported version test matrix cases.

closes #5211

**Reference:** version histories for these projects:
https://pypi.org/project/scipy/#history
https://pypi.org/project/matplotlib/#history
https://pypi.org/project/pillow/#history

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
