### PR TITLE
Deprecate in_place in remove_small_objects

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -71,6 +71,8 @@ Version 1.0
 
 * consider removing the argument `coordinates` in
   `skimage.segmentation.active_contour`, which has not effect.
+* In ``skimage/morphology/misc.py`` remove the deprecated parameter
+  in remove_small_objects() ``in_place`` with ``out`` and update the tests.
 
 
 Other (2021)

--- a/skimage/morphology/misc.py
+++ b/skimage/morphology/misc.py
@@ -48,7 +48,7 @@ def _check_dtype_supported(ar):
                         "Got %s." % ar.dtype)
 
 
-@remove_arg("in_place", changed_version="0.21",
+@remove_arg("in_place", changed_version="1.0",
             help_msg="Please use out argument instead.")
 def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False,
                          *, out=None):

--- a/skimage/morphology/misc.py
+++ b/skimage/morphology/misc.py
@@ -2,7 +2,7 @@
 import numpy as np
 import functools
 from scipy import ndimage as ndi
-from .._shared.utils import warn
+from .._shared.utils import warn, remove_arg
 from .selem import _default_selem
 
 # Our function names don't exactly correspond to ndimages.
@@ -48,7 +48,10 @@ def _check_dtype_supported(ar):
                         "Got %s." % ar.dtype)
 
 
-def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
+@remove_arg("in_place", changed_version="0.21",
+            help_msg="Please use out argument instead.")
+def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False,
+                         *, out=None):
     """Remove objects smaller than the specified size.
 
     Expects ar to be an array with labeled objects, and removes objects
@@ -68,7 +71,11 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
         labelling if `ar` is bool.
     in_place : bool, optional (default: False)
         If ``True``, remove the objects in the input array itself.
-        Otherwise, make a copy.
+        Otherwise, make a copy. Deprecated since version 0.19. Please
+        use `out` instead.
+    out : ndarray
+        Array of the same shape as `ar`, into which the output is
+        placed. By default, a new array is created.
 
     Raises
     ------
@@ -98,7 +105,7 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
     array([[False, False, False,  True, False],
            [ True,  True,  True, False, False],
            [ True,  True,  True, False, False]])
-    >>> d = morphology.remove_small_objects(a, 6, in_place=True)
+    >>> d = morphology.remove_small_objects(a, 6, out=a)
     >>> d is a
     True
 
@@ -106,9 +113,12 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
     # Raising type error if not int or bool
     _check_dtype_supported(ar)
 
+    if out is not None:
+        in_place = False
+
     if in_place:
         out = ar
-    else:
+    elif out is None:
         out = ar.copy()
 
     if min_size == 0:  # shortcut for efficiency
@@ -217,7 +227,7 @@ def remove_small_holes(ar, area_threshold=64, connectivity=1, in_place=False):
         out = np.logical_not(out)
 
     # removing small objects from the inverse of ar
-    out = remove_small_objects(out, area_threshold, connectivity, in_place)
+    out = remove_small_objects(out, area_threshold, connectivity, out=out)
 
     if in_place:
         np.logical_not(out, out=out)

--- a/skimage/morphology/tests/test_misc.py
+++ b/skimage/morphology/tests/test_misc.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from skimage.morphology import remove_small_objects, remove_small_holes
 
 from skimage._shared import testing
@@ -33,6 +34,16 @@ def test_in_place():
         observed = remove_small_objects(image, min_size=6, in_place=True)
     assert_equal(observed is image, True,
                  "remove_small_objects in_place argument failed.")
+
+
+@pytest.mark.parametrize("in_dtype", [bool, int, np.int32])
+@pytest.mark.parametrize("out_dtype", [bool, int, np.int32])
+def test_out(in_dtype, out_dtype):
+    image = test_image.astype(in_dtype, copy=True)
+    expected_out = np.empty_like(test_image, dtype=out_dtype)
+    out = remove_small_objects(image, min_size=6, out=expected_out)
+
+    assert out is expected_out
 
 
 def test_labeled_image():

--- a/skimage/morphology/tests/test_misc.py
+++ b/skimage/morphology/tests/test_misc.py
@@ -29,7 +29,8 @@ def test_two_connectivity():
 
 def test_in_place():
     image = test_image.copy()
-    observed = remove_small_objects(image, min_size=6, in_place=True)
+    with expected_warnings(["in_place argument is deprecated"]):
+        observed = remove_small_objects(image, min_size=6, in_place=True)
     assert_equal(observed is image, True,
                  "remove_small_objects in_place argument failed.")
 


### PR DESCRIPTION
## Description

As proposed in @emmanuelle https://github.com/scikit-image/scikit-image/issues/4563#issuecomment-772013518, this PR deprecates `in_place` argument in `remove_small_objects`.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
