### PR TITLE
Deprecate in_place in remove_small_holes

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -71,6 +71,8 @@ Version 1.0
 
 * consider removing the argument `coordinates` in
   `skimage.segmentation.active_contour`, which has not effect.
+* In ``skimage/morphology/misc.py`` remove the deprecated parameter
+  in remove_small_holes() ``in_place`` and update the tests.
 
 
 Other (2021)

--- a/skimage/morphology/misc.py
+++ b/skimage/morphology/misc.py
@@ -2,7 +2,7 @@
 import numpy as np
 import functools
 from scipy import ndimage as ndi
-from .._shared.utils import warn
+from .._shared.utils import warn, remove_arg
 from .selem import _default_selem
 
 # Our function names don't exactly correspond to ndimages.
@@ -139,7 +139,10 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
     return out
 
 
-def remove_small_holes(ar, area_threshold=64, connectivity=1, in_place=False):
+@remove_arg("in_place", changed_version="0.21",
+            help_msg="Please use out argument instead.")
+def remove_small_holes(ar, area_threshold=64, connectivity=1, in_place=False,
+                       out=None):
     """Remove contiguous holes smaller than the specified size.
 
     Parameters
@@ -152,8 +155,12 @@ def remove_small_holes(ar, area_threshold=64, connectivity=1, in_place=False):
     connectivity : int, {1, 2, ..., ar.ndim}, optional (default: 1)
         The connectivity defining the neighborhood of a pixel.
     in_place : bool, optional (default: False)
-        If `True`, remove the connected components in the input array itself.
-        Otherwise, make a copy.
+        If `True`, remove the connected components in the input array
+        itself. Otherwise, make a copy. Deprecated since version 0.19
+        and will be removed in version 0.21. `out` can be used instead.
+    out : ndarray
+        Array of the same shape as `ar`, into which the output is
+        placed. By default, a new array is created.
 
     Raises
     ------
@@ -186,7 +193,7 @@ def remove_small_holes(ar, area_threshold=64, connectivity=1, in_place=False):
            [ True,  True,  True, False,  True, False],
            [ True, False, False,  True,  True, False],
            [ True,  True,  True,  True,  True, False]])
-    >>> d = morphology.remove_small_holes(a, 2, in_place=True)
+    >>> d = morphology.remove_small_holes(a, 2, out=a)
     >>> d is a
     True
 

--- a/skimage/morphology/misc.py
+++ b/skimage/morphology/misc.py
@@ -139,10 +139,10 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False):
     return out
 
 
-@remove_arg("in_place", changed_version="0.21",
+@remove_arg("in_place", changed_version="1.0",
             help_msg="Please use out argument instead.")
 def remove_small_holes(ar, area_threshold=64, connectivity=1, in_place=False,
-                       out=None):
+                       *, out=None):
     """Remove contiguous holes smaller than the specified size.
 
     Parameters
@@ -156,11 +156,11 @@ def remove_small_holes(ar, area_threshold=64, connectivity=1, in_place=False,
         The connectivity defining the neighborhood of a pixel.
     in_place : bool, optional (default: False)
         If `True`, remove the connected components in the input array
-        itself. Otherwise, make a copy. Deprecated since version 0.19
-        and will be removed in version 0.21. `out` can be used instead.
+        itself. Otherwise, make a copy. Deprecated since version 0.19.
+        Please use `out` instead.
     out : ndarray
-        Array of the same shape as `ar`, into which the output is
-        placed. By default, a new array is created.
+        Array of the same shape as `ar` and bool dtype, into which the
+        output is placed. By default, a new array is created.
 
     Raises
     ------
@@ -212,23 +212,23 @@ def remove_small_holes(ar, area_threshold=64, connectivity=1, in_place=False,
         warn("Any labeled images will be returned as a boolean array. "
              "Did you mean to use a boolean array?", UserWarning)
 
+    if out is not None:
+        if out.dtype != bool:
+            raise TypeError("out dtype must be bool")
+        in_place = False
+
     if in_place:
         out = ar
-    else:
-        out = ar.copy()
+    elif out is None:
+        out = ar.astype(bool, copy=True)
 
     # Creating the inverse of ar
-    if in_place:
-        np.logical_not(out, out=out)
-    else:
-        out = np.logical_not(out)
+    np.logical_not(ar, out=out)
 
     # removing small objects from the inverse of ar
-    out = remove_small_objects(out, area_threshold, connectivity, in_place)
+    out = remove_small_objects(out, area_threshold, connectivity,
+                               in_place=True)
 
-    if in_place:
-        np.logical_not(out, out=out)
-    else:
-        out = np.logical_not(out)
+    np.logical_not(out, out=out)
 
     return out

--- a/skimage/morphology/tests/test_misc.py
+++ b/skimage/morphology/tests/test_misc.py
@@ -119,9 +119,25 @@ def test_two_connectivity_holes():
 
 def test_in_place_holes():
     image = test_holes_image.copy()
-    observed = remove_small_holes(image, area_threshold=3, in_place=True)
+    with expected_warnings(["in_place argument is deprecated"]):
+        observed = remove_small_holes(image, area_threshold=3, in_place=True)
     assert_equal(observed is image, True,
                  "remove_small_holes in_place argument failed.")
+
+
+def test_out_remove_small_holes():
+    image = test_holes_image.copy()
+    expected_out = np.empty_like(image)
+    out = remove_small_holes(image, area_threshold=3, out=expected_out)
+
+    assert out is expected_out
+
+
+def test_non_bool_out():
+    image = test_holes_image.copy()
+    expected_out = np.empty_like(image, dtype=int)
+    with testing.raises(TypeError):
+        remove_small_holes(image, area_threshold=3, out=expected_out)
 
 
 def test_labeled_image_holes():


### PR DESCRIPTION
## Description

This PR deprecates `in_place` argument in `remove_small_objects`.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
