### PR TITLE
Deprecate in_place in clear_border

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -71,7 +71,8 @@ Version 1.0
 
 * consider removing the argument `coordinates` in
   `skimage.segmentation.active_contour`, which has not effect.
-
+* In ``skimage/morphology/_clear_border.py`` remove the deprecated parameter
+  in clear_border() ``in_place`` and update the tests.
 
 Other (2021)
 ------------

--- a/skimage/segmentation/_clear_border.py
+++ b/skimage/segmentation/_clear_border.py
@@ -1,8 +1,13 @@
 import numpy as np
+
 from ..measure import label
+from .._shared.utils import remove_arg
 
 
-def clear_border(labels, buffer_size=0, bgval=0, in_place=False, mask=None):
+@remove_arg("in_place", changed_version="1.0",
+            help_msg="Please use out argument instead.")
+def clear_border(labels, buffer_size=0, bgval=0, in_place=False, mask=None,
+                 *, out=None):
     """Clear objects connected to the label image border.
 
     Parameters
@@ -16,10 +21,14 @@ def clear_border(labels, buffer_size=0, bgval=0, in_place=False, mask=None):
         Cleared objects are set to this value.
     in_place : bool, optional
         Whether or not to manipulate the labels array in-place.
+        Deprecated since version 0.19. Please use `out` instead.
     mask : ndarray of bool, same shape as `image`, optional.
         Image data mask. Objects in labels image overlapping with
         False pixels of mask will be removed. If defined, the
         argument buffer_size will be ignored.
+    out : ndarray
+        Array of the same shape as `labels`, into which the
+        output is placed. By default, a new array is created.
 
     Returns
     -------
@@ -58,36 +67,44 @@ def clear_border(labels, buffer_size=0, bgval=0, in_place=False, mask=None):
            [0, 0, 0, 0, 0, 0, 0, 0, 0]])
 
     """
-    image = labels
-
-    if any((buffer_size >= s for s in image.shape)) and mask is None:
+    if any((buffer_size >= s for s in labels.shape)) and mask is None:
         # ignore buffer_size if mask
-        raise ValueError("buffer size may not be greater than image size")
+        raise ValueError("buffer size may not be greater than labels size")
+
+    if out is not None:
+        np.copyto(out, labels, casting='no')
+        in_place = True
+
+    if not in_place:
+        out = labels.copy()
+    elif out is None:
+        out = labels
 
     if mask is not None:
-        err_msg = "image and mask should have the same shape but are {} and {}"
-        assert image.shape == mask.shape, \
-               err_msg.format(image.shape, mask.shape)
+        err_msg = ("labels and mask should have the same shape but "
+                   "are {} and {}")
+        if out.shape != mask.shape:
+            raise(ValueError, err_msg.format(out.shape, mask.shape))
         if mask.dtype != bool:
             raise TypeError("mask should be of type bool.")
         borders = ~mask
     else:
         # create borders with buffer_size
-        borders = np.zeros_like(image, dtype=bool)
+        borders = np.zeros_like(out, dtype=bool)
         ext = buffer_size + 1
         slstart = slice(ext)
         slend = slice(-ext, None)
-        slices = [slice(s) for s in image.shape]
-        for d in range(image.ndim):
-            slicedim = list(slices)
-            slicedim[d] = slstart
-            borders[tuple(slicedim)] = True
-            slicedim[d] = slend
-            borders[tuple(slicedim)] = True
-    # Re-label, in case we are dealing with a binary image
+        slices = [slice(None) for _ in out.shape]
+        for d in range(out.ndim):
+            slices[d] = slstart
+            borders[tuple(slices)] = True
+            slices[d] = slend
+            borders[tuple(slices)] = True
+            slices[d] = slice(None)
+
+    # Re-label, in case we are dealing with a binary out
     # and to get consistent labeling
-    labels = label(image, background=0)
-    number = np.max(labels) + 1
+    labels, number = label(out, background=0, return_num=True)
 
     # determine all objects that are connected to borders
     borders_indices = np.unique(labels[borders])
@@ -95,12 +112,9 @@ def clear_border(labels, buffer_size=0, bgval=0, in_place=False, mask=None):
     # mask all label indices that are connected to borders
     label_mask = np.in1d(indices, borders_indices)
     # create mask for pixels to clear
-    mask = label_mask[labels.ravel()].reshape(labels.shape)
-
-    if not in_place:
-        image = image.copy()
+    mask = label_mask[labels.reshape(-1)].reshape(labels.shape)
 
     # clear border pixels
-    image[mask] = bgval
+    out[mask] = bgval
 
-    return image
+    return out

--- a/skimage/segmentation/tests/test_clear_border.py
+++ b/skimage/segmentation/tests/test_clear_border.py
@@ -2,6 +2,7 @@ import numpy as np
 from skimage.segmentation import clear_border
 
 from skimage._shared.testing import assert_array_equal, assert_
+from skimage._shared._warnings import expected_warnings
 
 
 def test_clear_border():
@@ -39,6 +40,7 @@ def test_clear_border():
     ref = image.copy()
     ref[1:3, 0:2] = 0
     assert_array_equal(result, ref)
+
 
 def test_clear_border_3d():
     image = np.array([
@@ -128,7 +130,8 @@ def test_clear_border_non_binary_inplace():
                       [3, 4, 5, 4, 2],
                       [3, 3, 2, 1, 2]])
 
-    result = clear_border(image, in_place=True)
+    with expected_warnings(["in_place argument is deprecated"]):
+        result = clear_border(image, in_place=True)
     expected = np.array([[0, 0, 0, 0, 0],
                          [0, 0, 5, 4, 0],
                          [0, 4, 5, 4, 0],
@@ -154,7 +157,8 @@ def test_clear_border_non_binary_inplace_3d():
           [3, 3, 2, 1, 2]],
          ])
 
-    result = clear_border(image3d, in_place=True)
+    with expected_warnings(["in_place argument is deprecated"]):
+        result = clear_border(image3d, in_place=True)
     expected = np.array(
         [[[0, 0, 0, 0, 0],
           [0, 0, 0, 0, 0],
@@ -173,3 +177,55 @@ def test_clear_border_non_binary_inplace_3d():
     assert_array_equal(result, expected)
     assert_array_equal(image3d, result)
 
+
+def test_clear_border_non_binary_out():
+    image = np.array([[1, 2, 3, 1, 2],
+                      [3, 3, 5, 4, 2],
+                      [3, 4, 5, 4, 2],
+                      [3, 3, 2, 1, 2]])
+    out = np.empty_like(image)
+    result = clear_border(image, out=out)
+    expected = np.array([[0, 0, 0, 0, 0],
+                         [0, 0, 5, 4, 0],
+                         [0, 4, 5, 4, 0],
+                         [0, 0, 0, 0, 0]])
+
+    assert_array_equal(result, expected)
+    assert_array_equal(out, result)
+
+
+def test_clear_border_non_binary_out_3d():
+    image3d = np.array(
+        [[[1, 2, 3, 1, 2],
+          [3, 3, 3, 4, 2],
+          [3, 4, 3, 4, 2],
+          [3, 3, 2, 1, 2]],
+         [[1, 2, 3, 1, 2],
+          [3, 3, 5, 4, 2],
+          [3, 4, 5, 4, 2],
+          [3, 3, 2, 1, 2]],
+         [[1, 2, 3, 1, 2],
+          [3, 3, 3, 4, 2],
+          [3, 4, 3, 4, 2],
+          [3, 3, 2, 1, 2]],
+         ])
+    out = np.empty_like(image3d)
+
+    result = clear_border(image3d, out=out)
+    expected = np.array(
+        [[[0, 0, 0, 0, 0],
+          [0, 0, 0, 0, 0],
+          [0, 0, 0, 0, 0],
+          [0, 0, 0, 0, 0]],
+         [[0, 0, 0, 0, 0],
+          [0, 0, 5, 0, 0],
+          [0, 0, 5, 0, 0],
+          [0, 0, 0, 0, 0]],
+         [[0, 0, 0, 0, 0],
+          [0, 0, 0, 0, 0],
+          [0, 0, 0, 0, 0],
+          [0, 0, 0, 0, 0]],
+         ])
+
+    assert_array_equal(result, expected)
+    assert_array_equal(out, result)


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

This PR deprecates `in_place` argument in `clear_border`

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
