### PR TITLE
Fix Laplacian matrix size bug in random_walker

### DIFF
--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -119,7 +119,7 @@ def _build_laplacian(data, spacing, mask, beta, multichannel):
         edges = inv_idx.reshape(edges.shape)
 
     # Build the sparse linear system
-    pixel_nb = edges.shape[1]
+    pixel_nb = l_x * l_y * l_z
     i_indices = edges.ravel()
     j_indices = edges[::-1].ravel()
     data = np.hstack((weights, weights))

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -183,6 +183,24 @@ def test_2d_inactive():
     return data, labels
 
 
+def test_2d_laplacian_size():
+    # test case from: https://github.com/scikit-image/scikit-image/issues/5034
+    # The markers here were modified from the ones in the original issue to
+    # avoid a singular matrix, but still reproduce the issue.
+    data = np.asarray([[12823, 12787, 12710],
+                       [12883, 13425, 12067],
+                       [11934, 11929, 12309]])
+    markers = np.asarray([[0, -1, 2],
+                          [0, -1, 0],
+                          [1, 0, -1]])
+    expected_labels = np.asarray([[1, -1, 2],
+                                  [1, -1, 2],
+                                  [1, 1, -1]])
+    labels = random_walker(data, markers, beta=10)
+    np.testing.assert_array_equal(labels, expected_labels)
+    return data, labels
+
+
 def test_3d():
     n = 30
     lx, ly, lz = n, n, n


### PR DESCRIPTION
## Description

closes #5034 using the suggestion from @morgan-bc in that issue (thanks!). The max size as used here looks like the maximum possible value for the `unlabeled_indices` array that is used later in indexing the rows and columns.


<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
