### PR TITLE
run Haar application gallery example in single-threaded mode

### DIFF
--- a/doc/examples/applications/plot_haar_extraction_selection_classification.py
+++ b/doc/examples/applications/plot_haar_extraction_selection_classification.py
@@ -73,7 +73,7 @@ feature_types = ['type-2-x', 'type-2-y']
 X = delayed(extract_feature_image(img, feature_types) for img in images)
 # Compute the result
 t_start = time()
-X = np.array(X.compute(scheduler='threads'))
+X = np.array(X.compute(scheduler='single-threaded'))
 time_full_feature_comp = time() - t_start
 
 # Label images (100 faces and 100 non-faces)
@@ -145,7 +145,7 @@ X = delayed(extract_feature_image(img, feature_type_sel, feature_coord_sel)
             for img in images)
 # Compute the result
 t_start = time()
-X = np.array(X.compute(scheduler='threads'))
+X = np.array(X.compute(scheduler='single-threaded'))
 time_subs_feature_comp = time() - t_start
 
 y = np.array([1] * 100 + [0] * 100)


### PR DESCRIPTION

## Description

I have noticed occasional timeouts on Azure when running the gallery examples on CI. When testing locally, `plot_haar_extraction_selection_classification.py` alone accounts for the majority of the time.

On my system with 10 cores, single-threaded operation is nearly an order of magnitude faster than running multi-threaded. This is probably due to relatively low computational complexity of the features leading to memory access times dominating the performance.

If the run time on Azure when checking the gallery examples is substantially reduced, we can consider merging this PR as is. If not, then another option to approximately halve the example time would be to reduce the number of images used for training from 200 to 100.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
