### PR TITLE
updated regionprops_table test for iterable properties

### DIFF
--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -585,7 +585,9 @@ def test_regionprops_table_equal_to_original():
     for prop, dtype in COL_DTYPES.items():
         for i, reg in enumerate(regions):
             rp = reg[prop]
-            if np.isscalar(rp) or prop in OBJECT_COLUMNS or dtype is np.object_:
+            if np.isscalar(rp) or \
+                    prop in OBJECT_COLUMNS or \
+                    dtype is np.object_:
                 assert_array_equal(rp, out_table[prop][i])
             else:
                 shape = rp.shape if isinstance(rp, np.ndarray) else (len(rp),)

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -579,8 +579,7 @@ def test_regionprops_table():
 def test_regionprops_table_equal_to_original():
     regions = regionprops(SAMPLE, INTENSITY_FLOAT_SAMPLE)
     out_table = regionprops_table(SAMPLE, INTENSITY_FLOAT_SAMPLE,
-                                  properties=COL_DTYPES.keys(),
-                                  separator="-")
+                                  properties=COL_DTYPES.keys())
 
     for prop, dtype in COL_DTYPES.items():
         for i, reg in enumerate(regions):


### PR DESCRIPTION
## Description

Associated with pull request #5239 and issue #5222 . I updated test `test_regionprops_table_equal_to_original` so that they compare not only non-iterable properties but also iterable ones of `regionprops` and `regionprops_table`.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
→ not applicable
- Gallery example in `./doc/examples` (new features only)
→ not applicable
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
→ not applicable
- Unit tests
→ one modified here
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
→ checked with autopep8

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
