### PR TITLE
Added support for binary images in is_low_contrast to fix imshow of binary images

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -647,6 +647,10 @@ def is_low_contrast(image, fraction_threshold=0.05, lower_percentile=1,
         if image.shape[2] == 3:
             image = rgb2gray(image)
 
+    if image.dtype==np.bool:
+        return image.any() and (image==False).any()
+
+
     dlimits = dtype_limits(image, clip_negative=False)
     limits = np.percentile(image, [lower_percentile, upper_percentile])
     ratio = (limits[1] - limits[0]) / (dlimits[1] - dlimits[0])

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -647,7 +647,7 @@ def is_low_contrast(image, fraction_threshold=0.05, lower_percentile=1,
         if image.shape[2] == 3:
             image = rgb2gray(image)
 
-    if image.dtype == np.bool:
+    if image.dtype == bool:
         return image.any() and (image == False).any()
 
 

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -647,8 +647,8 @@ def is_low_contrast(image, fraction_threshold=0.05, lower_percentile=1,
         if image.shape[2] == 3:
             image = rgb2gray(image)
 
-    if image.dtype==np.bool:
-        return image.any() and (image==False).any()
+    if image.dtype == np.bool:
+        return image.any() and (image == False).any()
 
 
     dlimits = dtype_limits(image, clip_negative=False)


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

imshow stopped working when plotting boolean images, since np.percentile no longer support boolean arrays. This PR makes sure that is_low_contrast does not fail when the input is a boolean array.

This is a small test-script that would fail before this change:

```
import numpy as np
from skimage.io import imshow

im = np.ones((10,10), dtype=np.bool)

imshow(im)
```



## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
