### PR TITLE
Ensure that README.txt has write permissions for subsequent imports.

### DIFF
--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -18,6 +18,7 @@ from .. import __version__
 
 import os.path as osp
 import os
+import stat
 
 __all__ = ['data_dir',
            'download_all',
@@ -254,8 +255,11 @@ def _fetch(data_filename):
 
 def _init_pooch():
     os.makedirs(data_dir, exist_ok=True)
+    dest_path = osp.join(data_dir, 'README.txt')
     shutil.copy2(osp.join(skimage_distribution_dir, 'data', 'README.txt'),
-                 osp.join(data_dir, 'README.txt'))
+                 dest_path)
+    current = stat.S_IMODE(os.lstat(dest_path).st_mode)
+    os.chmod(dest_path, current | stat.S_IWUSR)
 
     data_base_dir = osp.join(data_dir, '..')
     # Fetch all legacy data so that it is available by default

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -258,6 +258,9 @@ def _init_pooch():
     dest_path = osp.join(data_dir, 'README.txt')
     shutil.copy2(osp.join(skimage_distribution_dir, 'data', 'README.txt'),
                  dest_path)
+    # In case the user installing/running from a read-only filesystem,
+    # we need to ensure README.txt has user-write permission when it is
+    # put into their cache directory.
     current = stat.S_IMODE(os.lstat(dest_path).st_mode)
     os.chmod(dest_path, current | stat.S_IWUSR)
 

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -255,14 +255,17 @@ def _fetch(data_filename):
 
 def _init_pooch():
     os.makedirs(data_dir, exist_ok=True)
+
+    # Copy in the README.txt if it doesn't already exist.
+    # If the file was originally copied to the data cache directory read-only
+    # then we cannot overwrite it, nor do we need to copy on every init.
+    # In general, as the data cache directory contains the scikit-image version
+    # it should not be necessary to overwrite this file as it should not
+    # change.
     dest_path = osp.join(data_dir, 'README.txt')
-    shutil.copy2(osp.join(skimage_distribution_dir, 'data', 'README.txt'),
-                 dest_path)
-    # In case the user installing/running from a read-only filesystem,
-    # we need to ensure README.txt has user-write permission when it is
-    # put into their cache directory.
-    current = stat.S_IMODE(os.lstat(dest_path).st_mode)
-    os.chmod(dest_path, current | stat.S_IWUSR)
+    if not os.path.isfile(dest_path):
+        shutil.copy2(osp.join(skimage_distribution_dir, 'data', 'README.txt'),
+                     dest_path)
 
     data_base_dir = osp.join(data_dir, '..')
     # Fetch all legacy data so that it is available by default


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

This PR fixes a bug in which if `data/README.txt` has been made read-only in the source directory, then the first import of `skimage` works because the file is copied into the `.cache/scikit-image/` directory successfully.  But subsequent imports will fail because `copy2` will not be able to copy `README.txt` onto a read-only target.  This PR fixes the problem by ensuring that `README.txt` has user permissions as a writable file.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
