### PR TITLE
Fix rescale using small scale factor

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -281,7 +281,7 @@ def rescale(image, scale, order=None, mode='reflect', cval=0, clip=True,
         if multichannel:
             scale = np.concatenate((scale, [1]))
     orig_shape = np.asarray(image.shape)
-    output_shape = np.round(scale * orig_shape)
+    output_shape = np.maximum(np.round(scale * orig_shape), 1)
     if multichannel:  # don't scale channel dimension
         output_shape[-1] = orig_shape[-1]
 

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -475,6 +475,13 @@ def test_downscale_anti_aliasing():
     assert_equal(scaled[:, 3:].sum(), 0)
 
 
+def test_downscale_to_the_limit():
+    img = np.random.rand(3, 4)
+    out = rescale(img, 1e-3)
+
+    assert out.size == 1
+
+
 def test_downscale_local_mean():
     image1 = np.arange(4 * 6).reshape(4, 6)
     out1 = downscale_local_mean(image1, (2, 3))


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

Fixes #5252.

The proposed fix is to return a 1 pixel image when a very small scale factor is used for rescaling an image:
```python
>>> img = zeros((2, 2))
>>> out = rescale(img, 0.1)  # current behavior is to raise an error as reported in #5252
>>> print(out)  # with this PR
[[0.]]
```

An other option would be to raise a proper error message instead of the actual `OverflowError`. What do you, reviewers, prefer?

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
