### PR TITLE
Add "roundness" property to regionprops

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -53,6 +53,7 @@ PROPS = {
     'CroftonPerimeter': 'perimeter_crofton',
     # 'PixelIdxList',
     # 'PixelList',
+    'Roundness': 'roundness',
     'Slice': 'slice',
     'Solidity': 'solidity',
     # 'SubarrayIdx'

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -468,11 +468,9 @@ class RegionProperties:
     
     @property
     def roundness(self)
-        """
-        returns: int
-            parameter used for assessment of deviation from roundness, where 1 is a perfect circle.
-        """
-        return self.area/(self.major_axis_length/2*self.minor_axis_length/2*math.pi)
+        return self.area / (self.major_axis_length / 
+                            2*self.minor_axis_length / 
+                            2*math.pi)
 
     @property
     def solidity(self):

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -469,9 +469,9 @@ class RegionProperties:
 
     @property
     def roundness(self):
-        return self.area / (self.major_axis_length /
-                            2 * self.minor_axis_length /
-                            2 * math.pi)
+        return self.area / (self.major_axis_length
+                            / 2 * self.minor_axis_length
+                            / 2 * math.pi)
 
     @property
     def solidity(self):

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -102,6 +102,7 @@ COL_DTYPES = {
     'orientation': float,
     'perimeter': float,
     'perimeter_crofton': float,
+    'roundness': float,
     'slice': object,
     'solidity': float,
     'weighted_moments_central': float,
@@ -464,6 +465,14 @@ class RegionProperties:
     @only2d
     def perimeter_crofton(self):
         return perimeter_crofton(self.image, 4)
+    
+    @property
+    def roundness(self)
+        """
+        returns: int
+            parameter used for assessment of deviation from roundness, where 1 is a perfect circle.
+        """
+        return self.area/(self.major_axis_length/2*self.minor_axis_length/2*math.pi)
 
     @property
     def solidity(self):

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -465,12 +465,12 @@ class RegionProperties:
     @only2d
     def perimeter_crofton(self):
         return perimeter_crofton(self.image, 4)
-    
+
     @property
-    def roundness(self)
-        return self.area / (self.major_axis_length / 
-                            2*self.minor_axis_length / 
-                            2*math.pi)
+    def roundness(self):
+        return self.area / (self.major_axis_length /
+                            2 * self.minor_axis_length /
+                            2 * math.pi)
 
     @property
     def solidity(self):


### PR DESCRIPTION
## Description

This is adds a property to regionprops which calculates the roundness of a particle, similart to what is done in the following paper: 1. Abu-Qasmieh I (2018) Novel and Efficient Approach for Automated Separation, Segmentation, and Detection of Overlapped Elliptical Red Blood Cells. Pattern Recognit Image Anal 28:792–804. doi: 10.1134/S1054661818040156

For cell based imaging of nuclei and red blood cells this is a usefull parameter for stratification of objects into single objects/multiple objects.


## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
