### PR TITLE
Deprecate input kwarg in label

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -74,6 +74,8 @@ Version 1.0
 * In ``skimage/morphology/misc.py`` remove the deprecated parameter
   ``in_place`` in remove_small_holes(), remove_small_objects() and
   clear_border(), and update the tests.
+* Remove the deprecation warning for `input` kwarg of the `label`
+  function in `skimage/measure/_label.py`
 
 Other (2021)
 ------------

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -30,8 +30,8 @@ def _label_bool(image, background=None, return_num=False, connectivity=None):
         return result[0]
 
 
-@deprecate_kwarg({"input": "image"}, removed_version="1.0")
-def label(image, background=None, return_num=False, connectivity=None):
+@deprecate_kwarg({"input": "label_image"}, removed_version="1.0")
+def label(label_image, background=None, return_num=False, connectivity=None):
     r"""Label connected regions of an integer array.
 
     Two pixels are connected when they are neighbors and have the same value.
@@ -49,7 +49,7 @@ def label(image, background=None, return_num=False, connectivity=None):
 
     Parameters
     ----------
-    image : ndarray of dtype int
+    label_image : ndarray of dtype int
         Image to label.
     background : int, optional
         Consider all pixels with this value as background pixels, and label
@@ -115,8 +115,8 @@ def label(image, background=None, return_num=False, connectivity=None):
      [1 1 2]
      [0 0 0]]
     """
-    if image.dtype == bool:
-        return _label_bool(image, background=background,
+    if label_image.dtype == bool:
+        return _label_bool(label_image, background=background,
                            return_num=return_num, connectivity=connectivity)
     else:
-        return clabel(image, background, return_num, connectivity)
+        return clabel(label_image, background, return_num, connectivity)

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -30,7 +30,7 @@ def _label_bool(image, background=None, return_num=False, connectivity=None):
         return result[0]
 
 
-@deprecate_kwarg({"input": "image"}, removed_version="0.21")
+@deprecate_kwarg({"input": "image"}, removed_version="1.0")
 def label(image, background=None, return_num=False, connectivity=None):
     r"""Label connected regions of an integer array.
 

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -1,5 +1,6 @@
 from scipy import ndimage
 from ._ccomp import label_cython as clabel
+from .._shared.utils import deprecate_kwarg
 
 
 def _label_bool(image, background=None, return_num=False, connectivity=None):
@@ -29,7 +30,8 @@ def _label_bool(image, background=None, return_num=False, connectivity=None):
         return result[0]
 
 
-def label(input, background=None, return_num=False, connectivity=None):
+@deprecate_kwarg({"input": "image"}, removed_version="0.21")
+def label(image, background=None, return_num=False, connectivity=None):
     r"""Label connected regions of an integer array.
 
     Two pixels are connected when they are neighbors and have the same value.
@@ -47,7 +49,7 @@ def label(input, background=None, return_num=False, connectivity=None):
 
     Parameters
     ----------
-    input : ndarray of dtype int
+    image : ndarray of dtype int
         Image to label.
     background : int, optional
         Consider all pixels with this value as background pixels, and label
@@ -113,8 +115,8 @@ def label(input, background=None, return_num=False, connectivity=None):
      [1 1 2]
      [0 0 0]]
     """
-    if input.dtype == bool:
-        return _label_bool(input, background=background,
+    if image.dtype == bool:
+        return _label_bool(image, background=background,
                            return_num=return_num, connectivity=connectivity)
     else:
-        return clabel(input, background, return_num, connectivity)
+        return clabel(image, background, return_num, connectivity)


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->
Related to #4152.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
