### PR TITLE
Mention possible filters in radon_transform -> filtered-back-projection

### DIFF
--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -98,8 +98,7 @@ plt.show()
 # back projection is among the fastest methods of performing the inverse
 # Radon transform. The only tunable parameter for the FBP is the filter,
 # which is applied to the Fourier transformed projections. It may be used to
-# suppress high frequency noise in the reconstruction. ``skimage`` provides a
-# few different options for the filter.
+# suppress high frequency noise in the reconstruction. ``skimage`` provides 'ramp', 'shepp-logan', 'cosine', 'hamming', 'hann' as filters.
 
 from skimage.transform import iradon
 

--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -104,12 +104,15 @@ plt.show()
 import matplotlib.pyplot as plt
 from skimage.transform.radon_transform import _get_fourier_filter
 
-filters = ["ramp", "shepp-logan", "cosine", "hamming", "hann"]
-for f in filters:
+filters = ['ramp', 'shepp-logan', 'cosine', 'hamming', 'hann']
+
+for ix, f in enumerate(filters):
     response = _get_fourier_filter(2000, f)
-    plt.plot(response, label=f)
+    plt.plot(response, label= f)
+
+plt.xlim([0, 1000])
+plt.xlabel('frequency')
 plt.legend()
-plt.xlabel("position in pixel")
 plt.show()
 
 ######################################################################

--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -98,7 +98,8 @@ plt.show()
 # back projection is among the fastest methods of performing the inverse
 # Radon transform. The only tunable parameter for the FBP is the filter,
 # which is applied to the Fourier transformed projections. It may be used to
-# suppress high frequency noise in the reconstruction. ``skimage`` provides 'ramp', 'shepp-logan', 'cosine', 'hamming', 'hann' as filters.
+# suppress high frequency noise in the reconstruction. ``skimage`` provides 
+# 'ramp', 'shepp-logan', 'cosine', 'hamming', 'hann' as filters.
 
 from skimage.transform import iradon
 

--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -103,7 +103,7 @@ plt.show()
 
 from skimage.transform import iradon
 
-reconstruction_fbp = iradon(sinogram, theta=theta, circle=True)
+reconstruction_fbp = iradon(sinogram, theta=theta, filter_name='ramp', circle=True)
 error = reconstruction_fbp - image
 print(f"FBP rms reconstruction error: {np.sqrt(np.mean(error**2)):.3g}")
 

--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -108,7 +108,7 @@ filters = ['ramp', 'shepp-logan', 'cosine', 'hamming', 'hann']
 
 for ix, f in enumerate(filters):
     response = _get_fourier_filter(2000, f)
-    plt.plot(response, label= f)
+    plt.plot(response, label=f)
 
 plt.xlim([0, 1000])
 plt.xlabel('frequency')

--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -117,7 +117,8 @@ plt.show()
 
 from skimage.transform import iradon
 
-reconstruction_fbp = iradon(sinogram, theta=theta, filter_name='ramp', circle=True)
+reconstruction_fbp = iradon(sinogram, theta=theta, filter_name='ramp',
+                            circle=True)
 error = reconstruction_fbp - image
 print(f"FBP rms reconstruction error: {np.sqrt(np.mean(error**2)):.3g}")
 

--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -98,8 +98,8 @@ plt.show()
 # back projection is among the fastest methods of performing the inverse
 # Radon transform. The only tunable parameter for the FBP is the filter,
 # which is applied to the Fourier transformed projections. It may be used to
-# suppress high frequency noise in the reconstruction. ``skimage`` provides the filters
-# 'ramp', 'shepp-logan', 'cosine', 'hamming', and 'hann':
+# suppress high frequency noise in the reconstruction. ``skimage`` provides
+# the filters 'ramp', 'shepp-logan', 'cosine', 'hamming', and 'hann':
 
 import matplotlib.pyplot as plt
 from skimage.transform.radon_transform import _get_fourier_filter

--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -112,8 +112,8 @@ plt.legend()
 plt.xlabel("position in pixel")
 plt.show()
 
-# Applying the inverse radon transformation with the 'ramp' filter can be
-# seen here:
+######################################################################
+# Applying the inverse radon transformation with the 'ramp' filter, we get:
 
 from skimage.transform import iradon
 

--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -104,10 +104,10 @@ plt.show()
 import matplotlib.pyplot as plt
 from skimage.transform.radon_transform import _get_fourier_filter
 
-filters = ['ramp', 'shepp-logan', 'cosine', 'hamming', 'hann']
+filters = ["ramp", "shepp-logan", "cosine", "hamming", "hann"]
 for f in filters:
-    response = _get_fourier_filter(2000,f)
-    plt.plot(response, label= f)
+    response = _get_fourier_filter(2000, f)
+    plt.plot(response, label=f)
 plt.legend()
 plt.xlabel("position in pixel")
 plt.show()

--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -112,7 +112,8 @@ plt.legend()
 plt.xlabel("position in pixel")
 plt.show()
 
-## Applying the inverse radon transformation with the 'ramp' filter can be seen here:
+# Applying the inverse radon transformation with the 'ramp' filter can be
+# seen here:
 
 from skimage.transform import iradon
 

--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -98,8 +98,21 @@ plt.show()
 # back projection is among the fastest methods of performing the inverse
 # Radon transform. The only tunable parameter for the FBP is the filter,
 # which is applied to the Fourier transformed projections. It may be used to
-# suppress high frequency noise in the reconstruction. ``skimage`` provides 
-# 'ramp', 'shepp-logan', 'cosine', 'hamming', 'hann' as filters.
+# suppress high frequency noise in the reconstruction. ``skimage`` provides the filters
+# 'ramp', 'shepp-logan', 'cosine', 'hamming', and 'hann':
+
+import matplotlib.pyplot as plt
+from skimage.transform.radon_transform import _get_fourier_filter
+
+filters = ['ramp', 'shepp-logan', 'cosine', 'hamming', 'hann']
+for f in filters:
+    response = _get_fourier_filter(2000,f)
+    plt.plot(response, label= f)
+plt.legend()
+plt.xlabel("position in pixel")
+plt.show()
+
+## Applying the inverse radon transformation with the 'ramp' filter can be seen here:
 
 from skimage.transform import iradon
 


### PR DESCRIPTION
## Description
As this section https://scikit-image.org/docs/dev/auto_examples/transform/plot_radon_transform.html#reconstruction-with-the-filtered-back-projection-fbp explains that one can use filters, I think it would be nice to explicitly mention these filters.
Further, it might be nice to show an image of the filters, e.g. like this:
![image](https://user-images.githubusercontent.com/44469195/111005867-ede78d00-838b-11eb-8902-1883497e91ad.png)
which was produced by this code:
```py
import numpy as np
import matplotlib.pylab as plt
from scipy.fftpack import fft

def frequency_response(size,filter_name):
    
    n = np.concatenate((np.arange(1, size / 2 + 1, 2, dtype=int),
                        np.arange(size / 2 - 1, 0, -2, dtype=int)))
    f = np.zeros(size)
    f[0] = 0.25
    f[1::2] = -1 / (np.pi * n) ** 2

    # Computing the ramp filter from the fourier transform of its
    # frequency domain representation lessens artifacts and removes a
    # small bias as explained in [1], Chap 3. Equation 61
    fourier_filter = 2 * np.real(fft(f))         # ramp filter
    if filter_name == "ramp":
        pass
    elif filter_name == "shepp-logan":
        # Start from first element to avoid divide by zero
        omega = np.pi * np.fft.fftfreq(size)[1:]
        fourier_filter[1:] *= np.sin(omega) / omega
    elif filter_name == "cosine":
        freq = np.linspace(0, np.pi, size, endpoint=False)
        cosine_filter = np.fft.fftshift(np.sin(freq))
        fourier_filter *= cosine_filter
    elif filter_name == "hamming":
        fourier_filter *= np.fft.fftshift(np.hamming(size))
    elif filter_name == "hann":
        fourier_filter *= np.fft.fftshift(np.hanning(size))
    elif filter_name is None:
        fourier_filter[:] = 1

    return fourier_filter[:, np.newaxis]



filters = ['ramp', 'shepp-logan', 'cosine', 'hamming', 'hann']

for ix, f in enumerate(filters):
    response = frequency_response(2000,f)
    plt.plot(response, label= f)
plt.legend()
plt.show()
```
the code is basically this function:
https://github.com/scikit-image/scikit-image/blob/944760c6f925fa8e8dbb968c2aa100e1797b2c48/skimage/transform/radon_transform.py#L128-L181 
<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
