### PR TITLE
Watershed: consider connectivity when calculating markers.

### DIFF
--- a/skimage/segmentation/_watershed.py
+++ b/skimage/segmentation/_watershed.py
@@ -73,7 +73,8 @@ def _validate_inputs(image, markers, mask, connectivity):
             raise ValueError(message)
     if markers is None:
         markers_bool = local_minima(image, connectivity=connectivity) * mask
-        markers = ndi.label(markers_bool)[0]
+        footprint = ndi.generate_binary_structure(markers_bool.ndim, connectivity)
+        markers = ndi.label(markers_bool, structure=footprint)[0]
     elif not isinstance(markers, (np.ndarray, list, tuple)):
         # not array-like, assume int
         # given int, assume that number of markers *within mask*.

--- a/skimage/segmentation/tests/test_watershed.py
+++ b/skimage/segmentation/tests/test_watershed.py
@@ -496,7 +496,8 @@ def test_no_markers():
 
 def test_connectivity():
     """
-    watershed segmentation should output different result for different connectivity
+    Watershed segmentation should output different result for 
+    different connectivity
     when markers are calculated where None is supplied.
     Issue = 5084
     """
@@ -514,15 +515,15 @@ def test_connectivity():
 
     # calcuate distance in discrete increase
     DummyBT = ndi.distance_transform_edt(image)
-    DummyBT_dis = np.around(DummyBT/12, decimals=0)*12
+    DummyBT_dis = np.around(DummyBT / 12, decimals = 0)*12
     # calculate the mask
-    Img_mask = np.where(DummyBT_dis==0, 0, 1)
+    Img_mask = np.where(DummyBT_dis == 0, 0, 1)
 
     # segments for connectivity 1 and 2
     labels_c1 = watershed(200 - DummyBT_dis, mask=Img_mask, connectivity=1,
-                  compactness=0.01)
+                          compactness=0.01)
     labels_c2 = watershed(200 - DummyBT_dis, mask=Img_mask, connectivity=2,
-                   compactness=0.01)
+                          compactness=0.01)
 
     # assertions
     assert np.unique(labels_c1).shape[0] == 6

--- a/skimage/segmentation/tests/test_watershed.py
+++ b/skimage/segmentation/tests/test_watershed.py
@@ -497,13 +497,13 @@ def test_no_markers():
 def test_connectivity():
     """
     watershed segmentation should output different result for different connectivity
-    when markers are calculated where None is supplied. 
+    when markers are calculated where None is supplied.
     Issue = 5084
     """
     # Generate a dummy BrightnessTemperature image
     x, y = np.indices((406, 270))
     x1, y1, x2, y2, x3, y3, x4, y4 = 200, 208, 300, 120, 100, 100, 340, 208
-    r1, r2, r3, r4 = 100, 50 ,40, 80
+    r1, r2, r3, r4 = 100, 50, 40, 80
     mask_circle1 = (x - x1)**2 + (y - y1)**2 < r1**2
     mask_circle2 = (x - x2)**2 + (y - y2)**2 < r2**2
     mask_circle3 = (x - x3)**2 + (y - y3)**2 < r3**2
@@ -514,25 +514,26 @@ def test_connectivity():
 
     # calcuate distance in discrete increase
     DummyBT = ndi.distance_transform_edt(image)
-    DummyBT_dis=np.around(DummyBT/12, decimals=0)*12
-    # calculate the mask 
-    Img_mask=np.where(DummyBT_dis==0,0,1)
+    DummyBT_dis = np.around(DummyBT/12, decimals=0)*12
+    # calculate the mask
+    Img_mask = np.where(DummyBT_dis==0, 0, 1)
 
     # segments for connectivity 1 and 2
-    labels_c1  = watershed(200-DummyBT_dis, mask=Img_mask, connectivity=1, compactness=0.01)
-    labels_c2  = watershed(200-DummyBT_dis, mask=Img_mask, connectivity=2, compactness=0.01)
+    labels_c1 = watershed(200 - DummyBT_dis, mask=Img_mask, connectivity=1,
+                  compactness=0.01)
+    labels_c2 = watershed(200 - DummyBT_dis, mask=Img_mask, connectivity=2,
+                   compactness=0.01)
 
     # assertions
-    assert np.unique(labels_c1).shape[0]==6
-    assert np.unique(labels_c2).shape[0]==5
+    assert np.unique(labels_c1).shape[0] == 6
+    assert np.unique(labels_c2).shape[0] == 5
 
-    # checking via area of each individual segment. 
-    
-    for lab, area in zip(range(6),[61824,3653,20467,11097,1301,11278]):
-        assert np.sum(labels_c1==lab)==area
+    # checking via area of each individual segment.
+    for lab, area in zip(range(6), [61824, 3653, 20467, 11097, 1301, 11278]):
+        assert np.sum(labels_c1 == lab) == area
 
-    for lab, area in zip(range(5),[61824, 3653, 20466, 12386, 11291]):
-        assert np.sum(labels_c2==lab)==area
+    for lab, area in zip(range(5), [61824, 3653, 20466, 12386, 11291]):
+        assert np.sum(labels_c2 == lab) == area
 
 
 if __name__ == "__main__":

--- a/skimage/segmentation/tests/test_watershed.py
+++ b/skimage/segmentation/tests/test_watershed.py
@@ -494,5 +494,9 @@ def test_no_markers():
     assert np.max(out) == 2
 
 
+def test_connectivity():
+    1==1
+
+
 if __name__ == "__main__":
     np.testing.run_module_suite()

--- a/skimage/segmentation/tests/test_watershed.py
+++ b/skimage/segmentation/tests/test_watershed.py
@@ -495,7 +495,44 @@ def test_no_markers():
 
 
 def test_connectivity():
-    1==1
+    """
+    watershed segmentation should output different result for different connectivity
+    when markers are calculated where None is supplied. 
+    Issue = 5084
+    """
+    # Generate a dummy BrightnessTemperature image
+    x, y = np.indices((406, 270))
+    x1, y1, x2, y2, x3, y3, x4, y4 = 200, 208, 300, 120, 100, 100, 340, 208
+    r1, r2, r3, r4 = 100, 50 ,40, 80
+    mask_circle1 = (x - x1)**2 + (y - y1)**2 < r1**2
+    mask_circle2 = (x - x2)**2 + (y - y2)**2 < r2**2
+    mask_circle3 = (x - x3)**2 + (y - y3)**2 < r3**2
+    mask_circle4 = (x - x4)**2 + (y - y4)**2 < r4**2
+    image = np.logical_or(mask_circle1, mask_circle2)
+    image = np.logical_or(image, mask_circle3)
+    image = np.logical_or(image, mask_circle4)
+
+    # calcuate distance in discrete increase
+    DummyBT = ndi.distance_transform_edt(image)
+    DummyBT_dis=np.around(DummyBT/12, decimals=0)*12
+    # calculate the mask 
+    Img_mask=np.where(DummyBT_dis==0,0,1)
+
+    # segments for connectivity 1 and 2
+    labels_c1  = watershed(200-DummyBT_dis, mask=Img_mask, connectivity=1, compactness=0.01)
+    labels_c2  = watershed(200-DummyBT_dis, mask=Img_mask, connectivity=2, compactness=0.01)
+
+    # assertions
+    assert np.unique(labels_c1).shape[0]==6
+    assert np.unique(labels_c2).shape[0]==5
+
+    # checking via area of each individual segment. 
+    
+    for lab, area in zip(range(6),[61824,3653,20467,11097,1301,11278]):
+        assert np.sum(labels_c1==lab)==area
+
+    for lab, area in zip(range(5),[61824, 3653, 20466, 12386, 11291]):
+        assert np.sum(labels_c2==lab)==area
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

here, we pass the user supplied parameter connectivity to ndi.label function instead of using default parameter value. 
Changes also include the test case to cover the difference that may arise due to the change in code. 

closes #5084 

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->




## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
