### PR TITLE
Fixup test for INSTALL_FROM_SDIST

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
             set -ex
             source tools/github/before_install.sh
             python setup.py sdist
-            if [[ $INSTALL_FROM_SDIST ]]; then
+            if [[ $INSTALL_FROM_SDIST != "0" ]]; then
                 pip uninstall cython -y;
                 pip install dist/scikit-image-*.tar.gz;
             else
@@ -144,7 +144,7 @@ jobs:
           # Problem with SimpleITK and py 3.9
           - python-version: 3.9
             OPTIONAL_DEPS: 1
-    
+
     env:
         BUILD_DOCS: 1
         TEST_EXAMPLES: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,6 +84,7 @@ jobs:
         run: |
             set -ex
             source tools/github/before_install.sh
+            set -ex
             python setup.py sdist
             if [[ $INSTALL_FROM_SDIST != "0" ]]; then
                 pip uninstall cython -y;


### PR DESCRIPTION
## Description
The previous test for `INSTALL_FROM_SDIST` always failed due to a bad boolean test.

I guess in bash, whatever non empty string is provided returns true. Therefore, you should explicitely test for truthyness.

```bash
(test) ✔ ~/git/sk/scikit-image [data-files-illuminants ↑·1|✚ 1…1] 
23:28 $ bash test.sh 
false
(test) 23:28 $ INSTALL_FROM_SDIST=0 bash test.sh 
true
(test) ✔ ~/git/sk/scikit-image [data-files-illuminants ↑·1|✚ 1…1] 
23:28 $ INSTALL_FROM_SDIST=1 bash test.sh 
true
(test) ✔ ~/git/sk/scikit-image [data-files-illuminants ↑·1|✚ 1…1] 
23:28 $ cat test.sh 
if [[ $INSTALL_FROM_SDIST ]]; then
    echo true
else
    echo false
fi

```

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
