### PR TITLE
multichannel to channel_axis (1 of 6): features and draw

### DIFF
--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -131,8 +131,8 @@ def test_deprecated_kwarg():
         assert foo(0, old_arg1=1) == (0, 1, None)
         assert bar(0, old_arg1=1) == (0, 1, None)
 
-    msg = ("'old_arg1' is a deprecated argument name "
-           "for `foo`. Please use 'new_arg1' instead.")
+    msg = ("`old_arg1` is a deprecated argument name "
+           "for `foo`. Please use `new_arg1` instead.")
     assert str(record[0].message) == msg
     assert str(record[1].message) == "Custom warning message"
 

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -134,12 +134,12 @@ class deprecate_kwarg:
     def __init__(self, kwarg_mapping, warning_msg=None, removed_version=None):
         self.kwarg_mapping = kwarg_mapping
         if warning_msg is None:
-            self.warning_msg = ("'{old_arg}' is a deprecated argument name "
+            self.warning_msg = ("`{old_arg}` is a deprecated argument name "
                                 "for `{func_name}`. ")
             if removed_version is not None:
                 self.warning_msg += ("It will be removed in version {}. "
                                      .format(removed_version))
-            self.warning_msg += "Please use '{new_arg}' instead."
+            self.warning_msg += "Please use `{new_arg}` instead."
         else:
             self.warning_msg = warning_msg
 
@@ -176,8 +176,6 @@ class deprecate_multichannel_kwarg(deprecate_kwarg):
             kwarg_mapping={'multichannel': 'channel_axis'},
             warning_msg=None,
             removed_version=removed_version)
-        self.warning_msg = ("`{old_arg}` is a deprecated argument name "
-                            "for `{func_name}`. ")
         self.position = multichannel_position
 
     def __call__(self, func):

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -171,15 +171,34 @@ class deprecate_multichannel_kwarg(deprecate_kwarg):
 
     """
 
-    def __init__(self, removed_version='1.0'):
+    def __init__(self, removed_version='1.0', multichannel_position=None):
         super().__init__(
             kwarg_mapping={'multichannel': 'channel_axis'},
             warning_msg=None,
             removed_version=removed_version)
+        self.position = multichannel_position
 
     def __call__(self, func):
         @functools.wraps(func)
         def fixed_func(*args, **kwargs):
+
+            if self.position is not None and len(args) > self.position:
+                warning_msg = (
+                    "Providing the 'multichannel' argument positionally to "
+                    "{func_name} is deprecated. Use the 'channel_axis' kwarg "
+                    "instead."
+                )
+                warnings.warn(warning_msg.format(func_name=func.__name__),
+                              FutureWarning,
+                              stacklevel=2)
+                if 'channel_axis' in kwargs:
+                    raise ValueError(
+                        "Cannot provide both a 'channel_axis' kwarg and a "
+                        "positional 'multichannel' value."
+                    )
+                else:
+                    channel_axis = -1 if args[self.position] else None
+                    kwargs['channel_axis'] = channel_axis
 
             if 'multichannel' in kwargs:
                 #  warn that the function interface has changed:
@@ -190,6 +209,7 @@ class deprecate_multichannel_kwarg(deprecate_kwarg):
                 # multichannel = True -> last axis corresponds to channels
                 convert = {True: -1, False: None}
                 kwargs['channel_axis'] = convert[kwargs.pop('multichannel')]
+
 
             # Call the function with the fixed arguments
             return func(*args, **kwargs)

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -184,8 +184,8 @@ class deprecate_multichannel_kwarg(deprecate_kwarg):
 
             if self.position is not None and len(args) > self.position:
                 warning_msg = (
-                    "Providing the 'multichannel' argument positionally to "
-                    "{func_name} is deprecated. Use the 'channel_axis' kwarg "
+                    "Providing the `multichannel` argument positionally to "
+                    "{func_name} is deprecated. Use the `channel_axis` kwarg "
                     "instead."
                 )
                 warnings.warn(warning_msg.format(func_name=func.__name__),
@@ -193,8 +193,8 @@ class deprecate_multichannel_kwarg(deprecate_kwarg):
                               stacklevel=2)
                 if 'channel_axis' in kwargs:
                     raise ValueError(
-                        "Cannot provide both a 'channel_axis' kwarg and a "
-                        "positional 'multichannel' value."
+                        "Cannot provide both a `channel_axis` kwarg and a "
+                        "positional `multichannel` value."
                     )
                 else:
                     channel_axis = -1 if args[self.position] else None

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -176,6 +176,8 @@ class deprecate_multichannel_kwarg(deprecate_kwarg):
             kwarg_mapping={'multichannel': 'channel_axis'},
             warning_msg=None,
             removed_version=removed_version)
+        self.warning_msg = ("`{old_arg}` is a deprecated argument name "
+                            "for `{func_name}`. ")
         self.position = multichannel_position
 
     def __call__(self, func):

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -188,7 +188,7 @@ class deprecate_multichannel_kwarg(deprecate_kwarg):
                     new_arg='channel_axis'), FutureWarning, stacklevel=2)
 
                 # multichannel = True -> last axis corresponds to channels
-                convert = {True: (-1,), False: None}
+                convert = {True: -1, False: None}
                 kwargs['channel_axis'] = convert[kwargs.pop('multichannel')]
 
             # Call the function with the fixed arguments
@@ -243,7 +243,7 @@ class channel_as_last_axis():
                 raise ValueError(
                     "only a single channel axis is currently suported")
 
-            if channel_axis == (-1,):
+            if channel_axis == (-1,) or channel_axis == -1:
                 return func(*args, **kwargs)
 
             if self.arg_positions:

--- a/skimage/draw/_random_shapes.py
+++ b/skimage/draw/_random_shapes.py
@@ -290,7 +290,7 @@ def _generate_random_colors(num_colors, num_channels, intensity_range, random):
     return np.transpose(colors)
 
 
-@deprecate_multichannel_kwarg()
+@deprecate_multichannel_kwarg(multichannel_position=5)
 def random_shapes(image_shape,
                   max_shapes,
                   min_shapes=1,

--- a/skimage/draw/tests/test_random_shapes.py
+++ b/skimage/draw/tests/test_random_shapes.py
@@ -19,13 +19,13 @@ def test_generates_gray_images_with_correct_shape():
 
 
 def test_generates_gray_images_with_correct_shape_deprecated_multichannel():
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         image, _ = random_shapes(
             (4567, 123), min_shapes=3, max_shapes=20, multichannel=False)
     assert image.shape == (4567, 123)
 
     # repeat prior test, but check for positional multichannel warning
-    with expected_warnings(["Providing the 'multichannel' argument"]):
+    with expected_warnings(["Providing the `multichannel` argument"]):
         image, _ = random_shapes((4567, 123), 20, 3, 2, None, False)
     assert image.shape == (4567, 123)
 
@@ -167,7 +167,7 @@ def test_can_generate_one_by_one_rectangle():
 
 def test_throws_when_intensity_range_out_of_range():
     with testing.raises(ValueError):
-        with expected_warnings(["'multichannel' is a deprecated argument"]):
+        with expected_warnings(["`multichannel` is a deprecated argument"]):
             random_shapes((1000, 1234), max_shapes=1, multichannel=False,
                           intensity_range=(0, 256))
     with testing.raises(ValueError):

--- a/skimage/draw/tests/test_random_shapes.py
+++ b/skimage/draw/tests/test_random_shapes.py
@@ -13,13 +13,20 @@ def test_generates_color_images_with_correct_shape():
 
 
 def test_generates_gray_images_with_correct_shape():
+    image, _ = random_shapes(
+        (4567, 123), min_shapes=3, max_shapes=20, channel_axis=None)
+    assert image.shape == (4567, 123)
+
+
+def test_generates_gray_images_with_correct_shape_deprecated_multichannel():
     with expected_warnings(["'multichannel' is a deprecated argument"]):
         image, _ = random_shapes(
             (4567, 123), min_shapes=3, max_shapes=20, multichannel=False)
     assert image.shape == (4567, 123)
 
-    image, _ = random_shapes(
-        (4567, 123), min_shapes=3, max_shapes=20, channel_axis=None)
+    # repeat prior test, but check for positional multichannel warning
+    with expected_warnings(["Providing the 'multichannel' argument"]):
+        image, _ = random_shapes((4567, 123), 20, 3, 2, None, False)
     assert image.shape == (4567, 123)
 
 

--- a/skimage/draw/tests/test_random_shapes.py
+++ b/skimage/draw/tests/test_random_shapes.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from skimage.draw import random_shapes
 
@@ -12,9 +13,31 @@ def test_generates_color_images_with_correct_shape():
 
 
 def test_generates_gray_images_with_correct_shape():
-    image, _ = random_shapes(
-        (4567, 123), min_shapes=3, max_shapes=20, multichannel=False)
+    with expected_warnings(["'multichannel' is a deprecated argument"]):
+        image, _ = random_shapes(
+            (4567, 123), min_shapes=3, max_shapes=20, multichannel=False)
     assert image.shape == (4567, 123)
+
+    image, _ = random_shapes(
+        (4567, 123), min_shapes=3, max_shapes=20, channel_axis=None)
+    assert image.shape == (4567, 123)
+
+
+@pytest.mark.parametrize('channel_axis', [None, 0, 1, 2])
+def test_generated_shape_for_channel_axis(channel_axis):
+    shape = (128, 64)
+    num_channels = 5
+
+    image, _ = random_shapes(
+        shape, num_channels=num_channels, min_shapes=3, max_shapes=10,
+        channel_axis=channel_axis)
+
+    if channel_axis is None:
+        expected_shape = shape
+    else:
+        expected_shape = tuple(np.insert(shape, channel_axis, num_channels))
+
+    assert image.shape == expected_shape
 
 
 def test_generates_correct_bounding_boxes_for_rectangles():
@@ -137,8 +160,9 @@ def test_can_generate_one_by_one_rectangle():
 
 def test_throws_when_intensity_range_out_of_range():
     with testing.raises(ValueError):
-        random_shapes((1000, 1234), max_shapes=1, multichannel=False,
-                      intensity_range=(0, 256))
+        with expected_warnings(["'multichannel' is a deprecated argument"]):
+            random_shapes((1000, 1234), max_shapes=1, multichannel=False,
+                          intensity_range=(0, 256))
     with testing.raises(ValueError):
         random_shapes((2, 2), max_shapes=1,
                       intensity_range=((-1, 255),))

--- a/skimage/exposure/tests/test_histogram_matching.py
+++ b/skimage/exposure/tests/test_histogram_matching.py
@@ -35,7 +35,7 @@ class TestMatchHistogram:
         """Assert that pdf of matched image is close to the reference's pdf for
         all channels and all values of matched"""
 
-        with expected_warnings(["'multichannel' is a deprecated argument"]):
+        with expected_warnings(["`multichannel` is a deprecated argument"]):
             matched = exposure.match_histograms(image, reference,
                                                 multichannel=multichannel)
 

--- a/skimage/feature/_basic_features.py
+++ b/skimage/feature/_basic_features.py
@@ -155,13 +155,13 @@ def multiscale_basic_features(
     Returns
     -------
     features : np.ndarray
-        Array of shape ``image.shape + (n_features,)``. When channel_axis is
+        Array of shape ``image.shape + (n_features,)``. When `channel_axis` is
         not None, all channels are concatenated along the features dimension.
         (i.e. ``n_features == n_features_singlechannel * n_channels``)
     """
     if not any([intensity, edges, texture]):
         raise ValueError(
-            "At least one of ``intensity``, ``edges`` or ``textures``"
+            "At least one of `intensity`, `edges` or `textures`"
             "must be True for features to be computed."
         )
     if channel_axis is None:

--- a/skimage/feature/_basic_features.py
+++ b/skimage/feature/_basic_features.py
@@ -3,6 +3,7 @@ import itertools
 import numpy as np
 from skimage import filters, feature
 from skimage import img_as_float32
+from skimage._shared import utils
 from concurrent.futures import ThreadPoolExecutor
 
 
@@ -96,6 +97,7 @@ def _mutiscale_basic_features_singlechannel(
     return features
 
 
+@utils.deprecate_multichannel_kwarg()
 def multiscale_basic_features(
     image,
     multichannel=False,
@@ -106,6 +108,8 @@ def multiscale_basic_features(
     sigma_max=16,
     num_sigma=None,
     num_workers=None,
+    *,
+    channel_axis=None,
 ):
     """Local features for a single- or multi-channel nd image.
 
@@ -118,6 +122,7 @@ def multiscale_basic_features(
         Input image, which can be grayscale or multichannel.
     multichannel : bool, default False
         True if the last dimension corresponds to color channels.
+        This argument is deprecated: specify `channel_axis` instead.
     intensity : bool, default True
         If True, pixel intensities averaged over the different scales
         are added to the feature set.
@@ -139,22 +144,32 @@ def multiscale_basic_features(
     num_workers : int or None, optional
         The number of parallel threads to use. If set to ``None``, the full
         set of available cores are used.
+    channel_axis : int or None, optional
+        If None, the image is assumed to be a grayscale (single channel) image.
+        Otherwise, this parameter indicates which axis of the array corresponds
+        to channels.
 
+        .. versionadded:: 0.19
+           ``channel_axis`` was added in 0.19.
 
     Returns
     -------
     features : np.ndarray
-        Array of shape ``image.shape + (n_features,)``
+        Array of shape ``image.shape + (n_features,)``. When channel_axis is
+        not None, all channels are concatenated along the features dimension.
+        (i.e. ``n_features == n_features_singlechannel * n_channels``)
     """
     if not any([intensity, edges, texture]):
         raise ValueError(
-                "At least one of ``intensity``, ``edges`` or ``textures``"
-                "must be True for features to be computed."
-                )
-    if image.ndim < 3:
-        multichannel = False
-    if not multichannel:
+            "At least one of ``intensity``, ``edges`` or ``textures``"
+            "must be True for features to be computed."
+        )
+    if channel_axis is None:
         image = image[..., np.newaxis]
+        channel_axis = -1
+    elif channel_axis != -1:
+        image = np.moveaxis(image, channel_axis, -1)
+
     all_results = (
         _mutiscale_basic_features_singlechannel(
             image[..., dim],
@@ -169,4 +184,5 @@ def multiscale_basic_features(
         for dim in range(image.shape[-1])
     )
     features = list(itertools.chain.from_iterable(all_results))
-    return np.stack(features, axis=-1)
+    out = np.stack(features, axis=-1)
+    return out

--- a/skimage/feature/_basic_features.py
+++ b/skimage/feature/_basic_features.py
@@ -97,7 +97,7 @@ def _mutiscale_basic_features_singlechannel(
     return features
 
 
-@utils.deprecate_multichannel_kwarg()
+@utils.deprecate_multichannel_kwarg(multichannel_position=1)
 def multiscale_basic_features(
     image,
     multichannel=False,

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -107,7 +107,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
         to channels.
 
         .. versionadded:: 0.19
-           ``channel_axis`` was added in 0.19.
+           `channel_axis` was added in 0.19.
 
     Returns
     -------

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -45,7 +45,7 @@ def _hog_channel_gradient(channel):
 
 
 @utils.channel_as_last_axis(multichannel_output=False)
-@utils.deprecate_multichannel_kwarg()
+@utils.deprecate_multichannel_kwarg(multichannel_position=8)
 def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
         block_norm='L2-Hys', visualize=False, transform_sqrt=False,
         feature_vector=True, multichannel=None, *, channel_axis=None):

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -1,5 +1,6 @@
 import numpy as np
 from . import _hoghistogram
+from .._shared import utils
 
 
 def _hog_normalize_block(block, method, eps=1e-5):
@@ -43,9 +44,11 @@ def _hog_channel_gradient(channel):
     return g_row, g_col
 
 
+@utils.channel_as_last_axis(multichannel_output=False)
+@utils.deprecate_multichannel_kwarg()
 def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
         block_norm='L2-Hys', visualize=False, transform_sqrt=False,
-        feature_vector=True, multichannel=None):
+        feature_vector=True, multichannel=None, *, channel_axis=None):
     """Extract Histogram of Oriented Gradients (HOG) for a given image.
 
     Compute a Histogram of Oriented Gradients (HOG) by
@@ -96,7 +99,15 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
         just before returning.
     multichannel : boolean, optional
         If True, the last `image` dimension is considered as a color channel,
-        otherwise as spatial.
+        otherwise as spatial. This argument is deprecated: specify
+        `channel_axis` instead.
+    channel_axis : int or None, optional
+        If None, the image is assumed to be a grayscale (single channel) image.
+        Otherwise, this parameter indicates which axis of the array corresponds
+        to channels.
+
+        .. versionadded:: 0.19
+           ``channel_axis`` was added in 0.19.
 
     Returns
     -------
@@ -141,9 +152,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
     """
     image = np.atleast_2d(image)
 
-    if multichannel is None:
-        multichannel = (image.ndim == 3)
-
+    multichannel = channel_axis is not None
     ndim_spatial = image.ndim - 1 if multichannel else image.ndim
     if ndim_spatial != 2:
         raise ValueError('Only images with 2 spatial dimensions are '

--- a/skimage/feature/tests/test_basic_features.py
+++ b/skimage/feature/tests/test_basic_features.py
@@ -12,7 +12,7 @@ def test_multiscale_basic_features(edges, texture):
     img = np.zeros((20, 20, 3))
     img[:10] = 1
     img += 0.05 * np.random.randn(*img.shape)
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         features = multiscale_basic_features(img, edges=edges, texture=texture,
                                              multichannel=True)
 
@@ -27,14 +27,14 @@ def test_multiscale_basic_features_deprecated_multichannel():
     img[:10] = 1
     img += 0.05 * np.random.randn(*img.shape)
     n_sigmas = 2
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         features = multiscale_basic_features(img, sigma_min=1, sigma_max=2,
                                              multichannel=True)
     assert features.shape[-1] == 5 * n_sigmas * 4
     assert features.shape[:-1] == img.shape[:-1]
 
     # repeat prior test, but check for positional multichannel warning
-    with expected_warnings(["Providing the 'multichannel' argument"]):
+    with expected_warnings(["Providing the `multichannel` argument"]):
         multiscale_basic_features(img, True, sigma_min=1, sigma_max=2)
     assert features.shape[-1] == 5 * n_sigmas * 4
     assert features.shape[:-1] == img.shape[:-1]

--- a/skimage/feature/tests/test_basic_features.py
+++ b/skimage/feature/tests/test_basic_features.py
@@ -33,7 +33,7 @@ def test_multiscale_basic_features_deprecated_multichannel():
     assert features.shape[-1] == 5 * n_sigmas * 4
     assert features.shape[:-1] == img.shape[:-1]
 
-    #repeat prior test, but checked for positional multichannel warning
+    # repeat prior test, but check for positional multichannel warning
     with expected_warnings(["Providing the 'multichannel' argument"]):
         multiscale_basic_features(img, True, sigma_min=1, sigma_max=2)
     assert features.shape[-1] == 5 * n_sigmas * 4

--- a/skimage/feature/tests/test_basic_features.py
+++ b/skimage/feature/tests/test_basic_features.py
@@ -1,6 +1,9 @@
 import pytest
 import numpy as np
+
+from skimage._shared.testing import expected_warnings
 from skimage.feature import multiscale_basic_features
+
 
 
 @pytest.mark.parametrize('edges', (False, True))
@@ -9,22 +12,52 @@ def test_multiscale_basic_features(edges, texture):
     img = np.zeros((20, 20, 3))
     img[:10] = 1
     img += 0.05 * np.random.randn(*img.shape)
-    features = multiscale_basic_features(img, edges=edges, texture=texture, multichannel=True)
+    with expected_warnings(["'multichannel' is a deprecated argument"]):
+        features = multiscale_basic_features(img, edges=edges, texture=texture,
+                                             multichannel=True)
+
     n_sigmas = 6
     intensity = True
     assert features.shape[-1] == 3 * n_sigmas * (int(intensity) + int(edges) + 2 * int(texture))
     assert features.shape[:-1] == img.shape[:-1]
 
 
-def test_multiscale_basic_features_channel():
+def test_multiscale_basic_features_multichannel():
     img = np.zeros((10, 10, 5))
     img[:10] = 1
     img += 0.05 * np.random.randn(*img.shape)
     n_sigmas = 2
-    features = multiscale_basic_features(img, sigma_min=1, sigma_max=2, multichannel=True)
+    with expected_warnings(["'multichannel' is a deprecated argument"]):
+        features = multiscale_basic_features(img, sigma_min=1, sigma_max=2,
+                                             multichannel=True)
     assert features.shape[-1] == 5 * n_sigmas * 4
     assert features.shape[:-1] == img.shape[:-1]
     # Consider last axis as spatial dimension
+    features = multiscale_basic_features(img, sigma_min=1, sigma_max=2)
+    assert features.shape[-1] == n_sigmas * 5
+    assert features.shape[:-1] == img.shape
+
+
+@pytest.mark.parametrize('channel_axis', [0, 1, 2, -1, -2])
+def test_multiscale_basic_features_channel_axis(channel_axis):
+    num_channels = 5
+    shape_spatial = (10, 10)
+    ndim = len(shape_spatial)
+    shape = tuple(
+        np.insert(shape_spatial, channel_axis % (ndim + 1), num_channels)
+    )
+    img = np.zeros(shape)
+    img[:10] = 1
+    img += 0.05 * np.random.randn(*img.shape)
+    n_sigmas = 2
+
+    # features for all channels are concatenated along the last axis
+    features = multiscale_basic_features(img, sigma_min=1, sigma_max=2,
+                                         channel_axis=channel_axis)
+    assert features.shape[-1] == 5 * n_sigmas * 4
+    assert features.shape[:-1] == np.moveaxis(img, channel_axis, -1).shape[:-1]
+
+    # Consider channel_axis as spatial dimension
     features = multiscale_basic_features(img, sigma_min=1, sigma_max=2)
     assert features.shape[-1] == n_sigmas * 5
     assert features.shape[:-1] == img.shape

--- a/skimage/feature/tests/test_basic_features.py
+++ b/skimage/feature/tests/test_basic_features.py
@@ -22,7 +22,7 @@ def test_multiscale_basic_features(edges, texture):
     assert features.shape[:-1] == img.shape[:-1]
 
 
-def test_multiscale_basic_features_multichannel():
+def test_multiscale_basic_features_deprecated_multichannel():
     img = np.zeros((10, 10, 5))
     img[:10] = 1
     img += 0.05 * np.random.randn(*img.shape)
@@ -32,6 +32,13 @@ def test_multiscale_basic_features_multichannel():
                                              multichannel=True)
     assert features.shape[-1] == 5 * n_sigmas * 4
     assert features.shape[:-1] == img.shape[:-1]
+
+    #repeat prior test, but checked for positional multichannel warning
+    with expected_warnings(["Providing the 'multichannel' argument"]):
+        multiscale_basic_features(img, True, sigma_min=1, sigma_max=2)
+    assert features.shape[-1] == 5 * n_sigmas * 4
+    assert features.shape[:-1] == img.shape[:-1]
+
     # Consider last axis as spatial dimension
     features = multiscale_basic_features(img, sigma_min=1, sigma_max=2)
     assert features.shape[-1] == n_sigmas * 5

--- a/skimage/feature/tests/test_censure.py
+++ b/skimage/feature/tests/test_censure.py
@@ -67,7 +67,6 @@ def test_keypoints_censure_moon_image_octagon():
     detector = CENSURE(mode='octagon')
     # quarter scale image for speed
     detector.detect(rescale(img, 0.25,
-                            multichannel=False,
                             anti_aliasing=False,
                             mode='constant'))
     expected_keypoints = np.array([[ 23,  27],
@@ -88,7 +87,6 @@ def test_keypoints_censure_moon_image_star():
     detector = CENSURE(mode='star')
     # quarter scale image for speed
     detector.detect(rescale(img, 0.25,
-                            multichannel=False,
                             anti_aliasing=False,
                             mode='constant'))
     expected_keypoints = np.array([[ 23,  27],

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -258,7 +258,7 @@ def test_hog_output_equivariance_deprecated_multichannel():
                                    block_norm='L1')
         assert_almost_equal(hog_ref, hog_fact)
 
-        #repeat prior test, but checked for positional multichannel warning
+        # repeat prior test, but check for positional multichannel warning
         with expected_warnings(["Providing the 'multichannel' argument"]):
             hog_fact = feature.hog(np.roll(img, n, axis=2), 9, (8, 8), (3, 3),
                                    'L1', False, False, True, True)

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -242,14 +242,14 @@ def test_hog_block_normalization_incorrect_error():
 def test_hog_incorrect_dimensions(shape, multichannel):
     img = np.zeros(shape)
     with testing.raises(ValueError):
-        with expected_warnings(["'multichannel' is a deprecated argument"]):
+        with expected_warnings(["`multichannel` is a deprecated argument"]):
             feature.hog(img, multichannel=multichannel, block_norm='L1')
 
 
 def test_hog_output_equivariance_deprecated_multichannel():
     img = data.astronaut()
     img[:, :, (1, 2)] = 0
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         hog_ref = feature.hog(img, multichannel=True, block_norm='L1')
 
     for n in (1, 2):

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -246,7 +246,7 @@ def test_hog_incorrect_dimensions(shape, multichannel):
             feature.hog(img, multichannel=multichannel, block_norm='L1')
 
 
-def test_hog_output_equivariance_multichannel():
+def test_hog_output_equivariance_deprecated_multichannel():
     img = data.astronaut()
     img[:, :, (1, 2)] = 0
     with expected_warnings(["'multichannel' is a deprecated argument"]):
@@ -256,6 +256,12 @@ def test_hog_output_equivariance_multichannel():
         with expected_warnings(["'multichannel' is a deprecated argument"]):
             hog_fact = feature.hog(np.roll(img, n, axis=2), multichannel=True,
                                    block_norm='L1')
+        assert_almost_equal(hog_ref, hog_fact)
+
+        #repeat prior test, but checked for positional multichannel warning
+        with expected_warnings(["Providing the 'multichannel' argument"]):
+            hog_fact = feature.hog(np.roll(img, n, axis=2), 9, (8, 8), (3, 3),
+                                   'L1', False, False, True, True)
         assert_almost_equal(hog_ref, hog_fact)
 
 

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -1,4 +1,3 @@
-import os
 import numpy as np
 from scipy import ndimage as ndi
 from skimage import color
@@ -8,6 +7,7 @@ from skimage import img_as_float
 from skimage import draw
 from skimage._shared.testing import assert_almost_equal, fetch
 from skimage._shared import testing
+from skimage._shared._warnings import expected_warnings
 
 
 def test_hog_output_size():
@@ -242,15 +242,31 @@ def test_hog_block_normalization_incorrect_error():
 def test_hog_incorrect_dimensions(shape, multichannel):
     img = np.zeros(shape)
     with testing.raises(ValueError):
-        feature.hog(img, multichannel=multichannel, block_norm='L1')
+        with expected_warnings(["'multichannel' is a deprecated argument"]):
+            feature.hog(img, multichannel=multichannel, block_norm='L1')
 
 
 def test_hog_output_equivariance_multichannel():
     img = data.astronaut()
     img[:, :, (1, 2)] = 0
-    hog_ref = feature.hog(img, multichannel=True, block_norm='L1')
+    with expected_warnings(["'multichannel' is a deprecated argument"]):
+        hog_ref = feature.hog(img, multichannel=True, block_norm='L1')
 
     for n in (1, 2):
-        hog_fact = feature.hog(np.roll(img, n, axis=2), multichannel=True,
-                               block_norm='L1')
+        with expected_warnings(["'multichannel' is a deprecated argument"]):
+            hog_fact = feature.hog(np.roll(img, n, axis=2), multichannel=True,
+                                   block_norm='L1')
+        assert_almost_equal(hog_ref, hog_fact)
+
+
+@testing.parametrize('channel_axis', [0, 1, -1, -2])
+def test_hog_output_equivariance_channel_axis(channel_axis):
+    img = data.astronaut()[:64, :32]
+    img[:, :, (1, 2)] = 0
+    img = np.moveaxis(img, -1, channel_axis)
+    hog_ref = feature.hog(img, channel_axis=channel_axis, block_norm='L1')
+
+    for n in (1, 2):
+        hog_fact = feature.hog(np.roll(img, n, axis=channel_axis),
+                               channel_axis=channel_axis, block_norm='L1')
         assert_almost_equal(hog_ref, hog_fact)

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -253,13 +253,13 @@ def test_hog_output_equivariance_deprecated_multichannel():
         hog_ref = feature.hog(img, multichannel=True, block_norm='L1')
 
     for n in (1, 2):
-        with expected_warnings(["'multichannel' is a deprecated argument"]):
+        with expected_warnings(["`multichannel` is a deprecated argument"]):
             hog_fact = feature.hog(np.roll(img, n, axis=2), multichannel=True,
                                    block_norm='L1')
         assert_almost_equal(hog_ref, hog_fact)
 
         # repeat prior test, but check for positional multichannel warning
-        with expected_warnings(["Providing the 'multichannel' argument"]):
+        with expected_warnings(["Providing the `multichannel` argument"]):
             hog_fact = feature.hog(np.roll(img, n, axis=2), 9, (8, 8), (3, 3),
                                    'L1', False, False, True, True)
         assert_almost_equal(hog_ref, hog_fact)

--- a/skimage/util/tests/test_apply_parallel.py
+++ b/skimage/util/tests/test_apply_parallel.py
@@ -106,7 +106,7 @@ def test_apply_parallel_rgb(depth, chunks, dtype):
 
     func = color.rgb2ycbcr
     cat_ycbcr_expected = func(cat)
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         cat_ycbcr = apply_parallel(func, cat, chunks=chunks, depth=depth,
                                    dtype=dtype, multichannel=True)
 

--- a/skimage/util/tests/test_montage.py
+++ b/skimage/util/tests/test_montage.py
@@ -29,7 +29,7 @@ def test_montage_simple_rgb():
             )
     arr_in = arr_in.reshape(n_images, n_rows, n_cols, n_channels)
 
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         arr_out = montage(arr_in, multichannel=True)
     arr_ref = np.array(
         [[[ 0,  1],


### PR DESCRIPTION
## Description

This is the first of a series of 6 PRs completing the `multichannel` to `channel_axis` migration. I am breaking these up into separate modules to keep the size more manageable to review, but the PRs should be reviewed in order since each is based on the previous one.

The decorators used here were introduced in #5228, but an additional check for positional use of the `multichannel` argument has been added to `deprecate_multichannel_kwarg`.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
