### PR TITLE
multichannel to channel_axis (3 of 6): filters

### DIFF
--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -131,8 +131,8 @@ def test_deprecated_kwarg():
         assert foo(0, old_arg1=1) == (0, 1, None)
         assert bar(0, old_arg1=1) == (0, 1, None)
 
-    msg = ("'old_arg1' is a deprecated argument name "
-           "for `foo`. Please use 'new_arg1' instead.")
+    msg = ("`old_arg1` is a deprecated argument name "
+           "for `foo`. Please use `new_arg1` instead.")
     assert str(record[0].message) == msg
     assert str(record[1].message) == "Custom warning message"
 

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -134,12 +134,12 @@ class deprecate_kwarg:
     def __init__(self, kwarg_mapping, warning_msg=None, removed_version=None):
         self.kwarg_mapping = kwarg_mapping
         if warning_msg is None:
-            self.warning_msg = ("'{old_arg}' is a deprecated argument name "
+            self.warning_msg = ("`{old_arg}` is a deprecated argument name "
                                 "for `{func_name}`. ")
             if removed_version is not None:
                 self.warning_msg += ("It will be removed in version {}. "
                                      .format(removed_version))
-            self.warning_msg += "Please use '{new_arg}' instead."
+            self.warning_msg += "Please use `{new_arg}` instead."
         else:
             self.warning_msg = warning_msg
 
@@ -176,8 +176,6 @@ class deprecate_multichannel_kwarg(deprecate_kwarg):
             kwarg_mapping={'multichannel': 'channel_axis'},
             warning_msg=None,
             removed_version=removed_version)
-        self.warning_msg = ("`{old_arg}` is a deprecated argument name "
-                            "for `{func_name}`. ")
         self.position = multichannel_position
 
     def __call__(self, func):

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -171,15 +171,34 @@ class deprecate_multichannel_kwarg(deprecate_kwarg):
 
     """
 
-    def __init__(self, removed_version='1.0'):
+    def __init__(self, removed_version='1.0', multichannel_position=None):
         super().__init__(
             kwarg_mapping={'multichannel': 'channel_axis'},
             warning_msg=None,
             removed_version=removed_version)
+        self.position = multichannel_position
 
     def __call__(self, func):
         @functools.wraps(func)
         def fixed_func(*args, **kwargs):
+
+            if self.position is not None and len(args) > self.position:
+                warning_msg = (
+                    "Providing the 'multichannel' argument positionally to "
+                    "{func_name} is deprecated. Use the 'channel_axis' kwarg "
+                    "instead."
+                )
+                warnings.warn(warning_msg.format(func_name=func.__name__),
+                              FutureWarning,
+                              stacklevel=2)
+                if 'channel_axis' in kwargs:
+                    raise ValueError(
+                        "Cannot provide both a 'channel_axis' kwarg and a "
+                        "positional 'multichannel' value."
+                    )
+                else:
+                    channel_axis = -1 if args[self.position] else None
+                    kwargs['channel_axis'] = channel_axis
 
             if 'multichannel' in kwargs:
                 #  warn that the function interface has changed:
@@ -190,6 +209,7 @@ class deprecate_multichannel_kwarg(deprecate_kwarg):
                 # multichannel = True -> last axis corresponds to channels
                 convert = {True: -1, False: None}
                 kwargs['channel_axis'] = convert[kwargs.pop('multichannel')]
+
 
             # Call the function with the fixed arguments
             return func(*args, **kwargs)

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -184,8 +184,8 @@ class deprecate_multichannel_kwarg(deprecate_kwarg):
 
             if self.position is not None and len(args) > self.position:
                 warning_msg = (
-                    "Providing the 'multichannel' argument positionally to "
-                    "{func_name} is deprecated. Use the 'channel_axis' kwarg "
+                    "Providing the `multichannel` argument positionally to "
+                    "{func_name} is deprecated. Use the `channel_axis` kwarg "
                     "instead."
                 )
                 warnings.warn(warning_msg.format(func_name=func.__name__),
@@ -193,8 +193,8 @@ class deprecate_multichannel_kwarg(deprecate_kwarg):
                               stacklevel=2)
                 if 'channel_axis' in kwargs:
                     raise ValueError(
-                        "Cannot provide both a 'channel_axis' kwarg and a "
-                        "positional 'multichannel' value."
+                        "Cannot provide both a `channel_axis` kwarg and a "
+                        "positional `multichannel` value."
                     )
                 else:
                     channel_axis = -1 if args[self.position] else None

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -176,6 +176,8 @@ class deprecate_multichannel_kwarg(deprecate_kwarg):
             kwarg_mapping={'multichannel': 'channel_axis'},
             warning_msg=None,
             removed_version=removed_version)
+        self.warning_msg = ("`{old_arg}` is a deprecated argument name "
+                            "for `{func_name}`. ")
         self.position = multichannel_position
 
     def __call__(self, func):

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -188,7 +188,7 @@ class deprecate_multichannel_kwarg(deprecate_kwarg):
                     new_arg='channel_axis'), FutureWarning, stacklevel=2)
 
                 # multichannel = True -> last axis corresponds to channels
-                convert = {True: (-1,), False: None}
+                convert = {True: -1, False: None}
                 kwargs['channel_axis'] = convert[kwargs.pop('multichannel')]
 
             # Call the function with the fixed arguments
@@ -243,7 +243,7 @@ class channel_as_last_axis():
                 raise ValueError(
                     "only a single channel axis is currently suported")
 
-            if channel_axis == (-1,):
+            if channel_axis == (-1,) or channel_axis == -1:
                 return func(*args, **kwargs)
 
             if self.arg_positions:

--- a/skimage/draw/_random_shapes.py
+++ b/skimage/draw/_random_shapes.py
@@ -290,7 +290,7 @@ def _generate_random_colors(num_colors, num_channels, intensity_range, random):
     return np.transpose(colors)
 
 
-@deprecate_multichannel_kwarg()
+@deprecate_multichannel_kwarg(multichannel_position=5)
 def random_shapes(image_shape,
                   max_shapes,
                   min_shapes=1,

--- a/skimage/draw/tests/test_random_shapes.py
+++ b/skimage/draw/tests/test_random_shapes.py
@@ -19,13 +19,13 @@ def test_generates_gray_images_with_correct_shape():
 
 
 def test_generates_gray_images_with_correct_shape_deprecated_multichannel():
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         image, _ = random_shapes(
             (4567, 123), min_shapes=3, max_shapes=20, multichannel=False)
     assert image.shape == (4567, 123)
 
     # repeat prior test, but check for positional multichannel warning
-    with expected_warnings(["Providing the 'multichannel' argument"]):
+    with expected_warnings(["Providing the `multichannel` argument"]):
         image, _ = random_shapes((4567, 123), 20, 3, 2, None, False)
     assert image.shape == (4567, 123)
 
@@ -167,7 +167,7 @@ def test_can_generate_one_by_one_rectangle():
 
 def test_throws_when_intensity_range_out_of_range():
     with testing.raises(ValueError):
-        with expected_warnings(["'multichannel' is a deprecated argument"]):
+        with expected_warnings(["`multichannel` is a deprecated argument"]):
             random_shapes((1000, 1234), max_shapes=1, multichannel=False,
                           intensity_range=(0, 256))
     with testing.raises(ValueError):

--- a/skimage/draw/tests/test_random_shapes.py
+++ b/skimage/draw/tests/test_random_shapes.py
@@ -13,13 +13,20 @@ def test_generates_color_images_with_correct_shape():
 
 
 def test_generates_gray_images_with_correct_shape():
+    image, _ = random_shapes(
+        (4567, 123), min_shapes=3, max_shapes=20, channel_axis=None)
+    assert image.shape == (4567, 123)
+
+
+def test_generates_gray_images_with_correct_shape_deprecated_multichannel():
     with expected_warnings(["'multichannel' is a deprecated argument"]):
         image, _ = random_shapes(
             (4567, 123), min_shapes=3, max_shapes=20, multichannel=False)
     assert image.shape == (4567, 123)
 
-    image, _ = random_shapes(
-        (4567, 123), min_shapes=3, max_shapes=20, channel_axis=None)
+    # repeat prior test, but check for positional multichannel warning
+    with expected_warnings(["Providing the 'multichannel' argument"]):
+        image, _ = random_shapes((4567, 123), 20, 3, 2, None, False)
     assert image.shape == (4567, 123)
 
 

--- a/skimage/draw/tests/test_random_shapes.py
+++ b/skimage/draw/tests/test_random_shapes.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from skimage.draw import random_shapes
 
@@ -12,9 +13,31 @@ def test_generates_color_images_with_correct_shape():
 
 
 def test_generates_gray_images_with_correct_shape():
-    image, _ = random_shapes(
-        (4567, 123), min_shapes=3, max_shapes=20, multichannel=False)
+    with expected_warnings(["'multichannel' is a deprecated argument"]):
+        image, _ = random_shapes(
+            (4567, 123), min_shapes=3, max_shapes=20, multichannel=False)
     assert image.shape == (4567, 123)
+
+    image, _ = random_shapes(
+        (4567, 123), min_shapes=3, max_shapes=20, channel_axis=None)
+    assert image.shape == (4567, 123)
+
+
+@pytest.mark.parametrize('channel_axis', [None, 0, 1, 2])
+def test_generated_shape_for_channel_axis(channel_axis):
+    shape = (128, 64)
+    num_channels = 5
+
+    image, _ = random_shapes(
+        shape, num_channels=num_channels, min_shapes=3, max_shapes=10,
+        channel_axis=channel_axis)
+
+    if channel_axis is None:
+        expected_shape = shape
+    else:
+        expected_shape = tuple(np.insert(shape, channel_axis, num_channels))
+
+    assert image.shape == expected_shape
 
 
 def test_generates_correct_bounding_boxes_for_rectangles():
@@ -137,8 +160,9 @@ def test_can_generate_one_by_one_rectangle():
 
 def test_throws_when_intensity_range_out_of_range():
     with testing.raises(ValueError):
-        random_shapes((1000, 1234), max_shapes=1, multichannel=False,
-                      intensity_range=(0, 256))
+        with expected_warnings(["'multichannel' is a deprecated argument"]):
+            random_shapes((1000, 1234), max_shapes=1, multichannel=False,
+                          intensity_range=(0, 256))
     with testing.raises(ValueError):
         random_shapes((2, 2), max_shapes=1,
                       intensity_range=((-1, 255),))

--- a/skimage/exposure/tests/test_histogram_matching.py
+++ b/skimage/exposure/tests/test_histogram_matching.py
@@ -35,7 +35,7 @@ class TestMatchHistogram:
         """Assert that pdf of matched image is close to the reference's pdf for
         all channels and all values of matched"""
 
-        with expected_warnings(["'multichannel' is a deprecated argument"]):
+        with expected_warnings(["`multichannel` is a deprecated argument"]):
             matched = exposure.match_histograms(image, reference,
                                                 multichannel=multichannel)
 

--- a/skimage/feature/_basic_features.py
+++ b/skimage/feature/_basic_features.py
@@ -155,13 +155,13 @@ def multiscale_basic_features(
     Returns
     -------
     features : np.ndarray
-        Array of shape ``image.shape + (n_features,)``. When channel_axis is
+        Array of shape ``image.shape + (n_features,)``. When `channel_axis` is
         not None, all channels are concatenated along the features dimension.
         (i.e. ``n_features == n_features_singlechannel * n_channels``)
     """
     if not any([intensity, edges, texture]):
         raise ValueError(
-            "At least one of ``intensity``, ``edges`` or ``textures``"
+            "At least one of `intensity`, `edges` or `textures`"
             "must be True for features to be computed."
         )
     if channel_axis is None:

--- a/skimage/feature/_basic_features.py
+++ b/skimage/feature/_basic_features.py
@@ -3,6 +3,7 @@ import itertools
 import numpy as np
 from skimage import filters, feature
 from skimage import img_as_float32
+from skimage._shared import utils
 from concurrent.futures import ThreadPoolExecutor
 
 
@@ -96,6 +97,7 @@ def _mutiscale_basic_features_singlechannel(
     return features
 
 
+@utils.deprecate_multichannel_kwarg()
 def multiscale_basic_features(
     image,
     multichannel=False,
@@ -106,6 +108,8 @@ def multiscale_basic_features(
     sigma_max=16,
     num_sigma=None,
     num_workers=None,
+    *,
+    channel_axis=None,
 ):
     """Local features for a single- or multi-channel nd image.
 
@@ -118,6 +122,7 @@ def multiscale_basic_features(
         Input image, which can be grayscale or multichannel.
     multichannel : bool, default False
         True if the last dimension corresponds to color channels.
+        This argument is deprecated: specify `channel_axis` instead.
     intensity : bool, default True
         If True, pixel intensities averaged over the different scales
         are added to the feature set.
@@ -139,22 +144,32 @@ def multiscale_basic_features(
     num_workers : int or None, optional
         The number of parallel threads to use. If set to ``None``, the full
         set of available cores are used.
+    channel_axis : int or None, optional
+        If None, the image is assumed to be a grayscale (single channel) image.
+        Otherwise, this parameter indicates which axis of the array corresponds
+        to channels.
 
+        .. versionadded:: 0.19
+           ``channel_axis`` was added in 0.19.
 
     Returns
     -------
     features : np.ndarray
-        Array of shape ``image.shape + (n_features,)``
+        Array of shape ``image.shape + (n_features,)``. When channel_axis is
+        not None, all channels are concatenated along the features dimension.
+        (i.e. ``n_features == n_features_singlechannel * n_channels``)
     """
     if not any([intensity, edges, texture]):
         raise ValueError(
-                "At least one of ``intensity``, ``edges`` or ``textures``"
-                "must be True for features to be computed."
-                )
-    if image.ndim < 3:
-        multichannel = False
-    if not multichannel:
+            "At least one of ``intensity``, ``edges`` or ``textures``"
+            "must be True for features to be computed."
+        )
+    if channel_axis is None:
         image = image[..., np.newaxis]
+        channel_axis = -1
+    elif channel_axis != -1:
+        image = np.moveaxis(image, channel_axis, -1)
+
     all_results = (
         _mutiscale_basic_features_singlechannel(
             image[..., dim],
@@ -169,4 +184,5 @@ def multiscale_basic_features(
         for dim in range(image.shape[-1])
     )
     features = list(itertools.chain.from_iterable(all_results))
-    return np.stack(features, axis=-1)
+    out = np.stack(features, axis=-1)
+    return out

--- a/skimage/feature/_basic_features.py
+++ b/skimage/feature/_basic_features.py
@@ -97,7 +97,7 @@ def _mutiscale_basic_features_singlechannel(
     return features
 
 
-@utils.deprecate_multichannel_kwarg()
+@utils.deprecate_multichannel_kwarg(multichannel_position=1)
 def multiscale_basic_features(
     image,
     multichannel=False,

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -107,7 +107,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
         to channels.
 
         .. versionadded:: 0.19
-           ``channel_axis`` was added in 0.19.
+           `channel_axis` was added in 0.19.
 
     Returns
     -------

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -45,7 +45,7 @@ def _hog_channel_gradient(channel):
 
 
 @utils.channel_as_last_axis(multichannel_output=False)
-@utils.deprecate_multichannel_kwarg()
+@utils.deprecate_multichannel_kwarg(multichannel_position=8)
 def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
         block_norm='L2-Hys', visualize=False, transform_sqrt=False,
         feature_vector=True, multichannel=None, *, channel_axis=None):

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -1,5 +1,6 @@
 import numpy as np
 from . import _hoghistogram
+from .._shared import utils
 
 
 def _hog_normalize_block(block, method, eps=1e-5):
@@ -43,9 +44,11 @@ def _hog_channel_gradient(channel):
     return g_row, g_col
 
 
+@utils.channel_as_last_axis(multichannel_output=False)
+@utils.deprecate_multichannel_kwarg()
 def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
         block_norm='L2-Hys', visualize=False, transform_sqrt=False,
-        feature_vector=True, multichannel=None):
+        feature_vector=True, multichannel=None, *, channel_axis=None):
     """Extract Histogram of Oriented Gradients (HOG) for a given image.
 
     Compute a Histogram of Oriented Gradients (HOG) by
@@ -96,7 +99,15 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
         just before returning.
     multichannel : boolean, optional
         If True, the last `image` dimension is considered as a color channel,
-        otherwise as spatial.
+        otherwise as spatial. This argument is deprecated: specify
+        `channel_axis` instead.
+    channel_axis : int or None, optional
+        If None, the image is assumed to be a grayscale (single channel) image.
+        Otherwise, this parameter indicates which axis of the array corresponds
+        to channels.
+
+        .. versionadded:: 0.19
+           ``channel_axis`` was added in 0.19.
 
     Returns
     -------
@@ -141,9 +152,7 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
     """
     image = np.atleast_2d(image)
 
-    if multichannel is None:
-        multichannel = (image.ndim == 3)
-
+    multichannel = channel_axis is not None
     ndim_spatial = image.ndim - 1 if multichannel else image.ndim
     if ndim_spatial != 2:
         raise ValueError('Only images with 2 spatial dimensions are '

--- a/skimage/feature/tests/test_basic_features.py
+++ b/skimage/feature/tests/test_basic_features.py
@@ -12,7 +12,7 @@ def test_multiscale_basic_features(edges, texture):
     img = np.zeros((20, 20, 3))
     img[:10] = 1
     img += 0.05 * np.random.randn(*img.shape)
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         features = multiscale_basic_features(img, edges=edges, texture=texture,
                                              multichannel=True)
 
@@ -27,14 +27,14 @@ def test_multiscale_basic_features_deprecated_multichannel():
     img[:10] = 1
     img += 0.05 * np.random.randn(*img.shape)
     n_sigmas = 2
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         features = multiscale_basic_features(img, sigma_min=1, sigma_max=2,
                                              multichannel=True)
     assert features.shape[-1] == 5 * n_sigmas * 4
     assert features.shape[:-1] == img.shape[:-1]
 
     # repeat prior test, but check for positional multichannel warning
-    with expected_warnings(["Providing the 'multichannel' argument"]):
+    with expected_warnings(["Providing the `multichannel` argument"]):
         multiscale_basic_features(img, True, sigma_min=1, sigma_max=2)
     assert features.shape[-1] == 5 * n_sigmas * 4
     assert features.shape[:-1] == img.shape[:-1]

--- a/skimage/feature/tests/test_basic_features.py
+++ b/skimage/feature/tests/test_basic_features.py
@@ -33,7 +33,7 @@ def test_multiscale_basic_features_deprecated_multichannel():
     assert features.shape[-1] == 5 * n_sigmas * 4
     assert features.shape[:-1] == img.shape[:-1]
 
-    #repeat prior test, but checked for positional multichannel warning
+    # repeat prior test, but check for positional multichannel warning
     with expected_warnings(["Providing the 'multichannel' argument"]):
         multiscale_basic_features(img, True, sigma_min=1, sigma_max=2)
     assert features.shape[-1] == 5 * n_sigmas * 4

--- a/skimage/feature/tests/test_basic_features.py
+++ b/skimage/feature/tests/test_basic_features.py
@@ -1,6 +1,9 @@
 import pytest
 import numpy as np
+
+from skimage._shared.testing import expected_warnings
 from skimage.feature import multiscale_basic_features
+
 
 
 @pytest.mark.parametrize('edges', (False, True))
@@ -9,22 +12,52 @@ def test_multiscale_basic_features(edges, texture):
     img = np.zeros((20, 20, 3))
     img[:10] = 1
     img += 0.05 * np.random.randn(*img.shape)
-    features = multiscale_basic_features(img, edges=edges, texture=texture, multichannel=True)
+    with expected_warnings(["'multichannel' is a deprecated argument"]):
+        features = multiscale_basic_features(img, edges=edges, texture=texture,
+                                             multichannel=True)
+
     n_sigmas = 6
     intensity = True
     assert features.shape[-1] == 3 * n_sigmas * (int(intensity) + int(edges) + 2 * int(texture))
     assert features.shape[:-1] == img.shape[:-1]
 
 
-def test_multiscale_basic_features_channel():
+def test_multiscale_basic_features_multichannel():
     img = np.zeros((10, 10, 5))
     img[:10] = 1
     img += 0.05 * np.random.randn(*img.shape)
     n_sigmas = 2
-    features = multiscale_basic_features(img, sigma_min=1, sigma_max=2, multichannel=True)
+    with expected_warnings(["'multichannel' is a deprecated argument"]):
+        features = multiscale_basic_features(img, sigma_min=1, sigma_max=2,
+                                             multichannel=True)
     assert features.shape[-1] == 5 * n_sigmas * 4
     assert features.shape[:-1] == img.shape[:-1]
     # Consider last axis as spatial dimension
+    features = multiscale_basic_features(img, sigma_min=1, sigma_max=2)
+    assert features.shape[-1] == n_sigmas * 5
+    assert features.shape[:-1] == img.shape
+
+
+@pytest.mark.parametrize('channel_axis', [0, 1, 2, -1, -2])
+def test_multiscale_basic_features_channel_axis(channel_axis):
+    num_channels = 5
+    shape_spatial = (10, 10)
+    ndim = len(shape_spatial)
+    shape = tuple(
+        np.insert(shape_spatial, channel_axis % (ndim + 1), num_channels)
+    )
+    img = np.zeros(shape)
+    img[:10] = 1
+    img += 0.05 * np.random.randn(*img.shape)
+    n_sigmas = 2
+
+    # features for all channels are concatenated along the last axis
+    features = multiscale_basic_features(img, sigma_min=1, sigma_max=2,
+                                         channel_axis=channel_axis)
+    assert features.shape[-1] == 5 * n_sigmas * 4
+    assert features.shape[:-1] == np.moveaxis(img, channel_axis, -1).shape[:-1]
+
+    # Consider channel_axis as spatial dimension
     features = multiscale_basic_features(img, sigma_min=1, sigma_max=2)
     assert features.shape[-1] == n_sigmas * 5
     assert features.shape[:-1] == img.shape

--- a/skimage/feature/tests/test_basic_features.py
+++ b/skimage/feature/tests/test_basic_features.py
@@ -22,7 +22,7 @@ def test_multiscale_basic_features(edges, texture):
     assert features.shape[:-1] == img.shape[:-1]
 
 
-def test_multiscale_basic_features_multichannel():
+def test_multiscale_basic_features_deprecated_multichannel():
     img = np.zeros((10, 10, 5))
     img[:10] = 1
     img += 0.05 * np.random.randn(*img.shape)
@@ -32,6 +32,13 @@ def test_multiscale_basic_features_multichannel():
                                              multichannel=True)
     assert features.shape[-1] == 5 * n_sigmas * 4
     assert features.shape[:-1] == img.shape[:-1]
+
+    #repeat prior test, but checked for positional multichannel warning
+    with expected_warnings(["Providing the 'multichannel' argument"]):
+        multiscale_basic_features(img, True, sigma_min=1, sigma_max=2)
+    assert features.shape[-1] == 5 * n_sigmas * 4
+    assert features.shape[:-1] == img.shape[:-1]
+
     # Consider last axis as spatial dimension
     features = multiscale_basic_features(img, sigma_min=1, sigma_max=2)
     assert features.shape[-1] == n_sigmas * 5

--- a/skimage/feature/tests/test_censure.py
+++ b/skimage/feature/tests/test_censure.py
@@ -67,7 +67,6 @@ def test_keypoints_censure_moon_image_octagon():
     detector = CENSURE(mode='octagon')
     # quarter scale image for speed
     detector.detect(rescale(img, 0.25,
-                            multichannel=False,
                             anti_aliasing=False,
                             mode='constant'))
     expected_keypoints = np.array([[ 23,  27],
@@ -88,7 +87,6 @@ def test_keypoints_censure_moon_image_star():
     detector = CENSURE(mode='star')
     # quarter scale image for speed
     detector.detect(rescale(img, 0.25,
-                            multichannel=False,
                             anti_aliasing=False,
                             mode='constant'))
     expected_keypoints = np.array([[ 23,  27],

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -258,7 +258,7 @@ def test_hog_output_equivariance_deprecated_multichannel():
                                    block_norm='L1')
         assert_almost_equal(hog_ref, hog_fact)
 
-        #repeat prior test, but checked for positional multichannel warning
+        # repeat prior test, but check for positional multichannel warning
         with expected_warnings(["Providing the 'multichannel' argument"]):
             hog_fact = feature.hog(np.roll(img, n, axis=2), 9, (8, 8), (3, 3),
                                    'L1', False, False, True, True)

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -242,14 +242,14 @@ def test_hog_block_normalization_incorrect_error():
 def test_hog_incorrect_dimensions(shape, multichannel):
     img = np.zeros(shape)
     with testing.raises(ValueError):
-        with expected_warnings(["'multichannel' is a deprecated argument"]):
+        with expected_warnings(["`multichannel` is a deprecated argument"]):
             feature.hog(img, multichannel=multichannel, block_norm='L1')
 
 
 def test_hog_output_equivariance_deprecated_multichannel():
     img = data.astronaut()
     img[:, :, (1, 2)] = 0
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         hog_ref = feature.hog(img, multichannel=True, block_norm='L1')
 
     for n in (1, 2):

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -246,7 +246,7 @@ def test_hog_incorrect_dimensions(shape, multichannel):
             feature.hog(img, multichannel=multichannel, block_norm='L1')
 
 
-def test_hog_output_equivariance_multichannel():
+def test_hog_output_equivariance_deprecated_multichannel():
     img = data.astronaut()
     img[:, :, (1, 2)] = 0
     with expected_warnings(["'multichannel' is a deprecated argument"]):
@@ -256,6 +256,12 @@ def test_hog_output_equivariance_multichannel():
         with expected_warnings(["'multichannel' is a deprecated argument"]):
             hog_fact = feature.hog(np.roll(img, n, axis=2), multichannel=True,
                                    block_norm='L1')
+        assert_almost_equal(hog_ref, hog_fact)
+
+        #repeat prior test, but checked for positional multichannel warning
+        with expected_warnings(["Providing the 'multichannel' argument"]):
+            hog_fact = feature.hog(np.roll(img, n, axis=2), 9, (8, 8), (3, 3),
+                                   'L1', False, False, True, True)
         assert_almost_equal(hog_ref, hog_fact)
 
 

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -1,4 +1,3 @@
-import os
 import numpy as np
 from scipy import ndimage as ndi
 from skimage import color
@@ -8,6 +7,7 @@ from skimage import img_as_float
 from skimage import draw
 from skimage._shared.testing import assert_almost_equal, fetch
 from skimage._shared import testing
+from skimage._shared._warnings import expected_warnings
 
 
 def test_hog_output_size():
@@ -242,15 +242,31 @@ def test_hog_block_normalization_incorrect_error():
 def test_hog_incorrect_dimensions(shape, multichannel):
     img = np.zeros(shape)
     with testing.raises(ValueError):
-        feature.hog(img, multichannel=multichannel, block_norm='L1')
+        with expected_warnings(["'multichannel' is a deprecated argument"]):
+            feature.hog(img, multichannel=multichannel, block_norm='L1')
 
 
 def test_hog_output_equivariance_multichannel():
     img = data.astronaut()
     img[:, :, (1, 2)] = 0
-    hog_ref = feature.hog(img, multichannel=True, block_norm='L1')
+    with expected_warnings(["'multichannel' is a deprecated argument"]):
+        hog_ref = feature.hog(img, multichannel=True, block_norm='L1')
 
     for n in (1, 2):
-        hog_fact = feature.hog(np.roll(img, n, axis=2), multichannel=True,
-                               block_norm='L1')
+        with expected_warnings(["'multichannel' is a deprecated argument"]):
+            hog_fact = feature.hog(np.roll(img, n, axis=2), multichannel=True,
+                                   block_norm='L1')
+        assert_almost_equal(hog_ref, hog_fact)
+
+
+@testing.parametrize('channel_axis', [0, 1, -1, -2])
+def test_hog_output_equivariance_channel_axis(channel_axis):
+    img = data.astronaut()[:64, :32]
+    img[:, :, (1, 2)] = 0
+    img = np.moveaxis(img, -1, channel_axis)
+    hog_ref = feature.hog(img, channel_axis=channel_axis, block_norm='L1')
+
+    for n in (1, 2):
+        hog_fact = feature.hog(np.roll(img, n, axis=channel_axis),
+                               channel_axis=channel_axis, block_norm='L1')
         assert_almost_equal(hog_ref, hog_fact)

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -253,13 +253,13 @@ def test_hog_output_equivariance_deprecated_multichannel():
         hog_ref = feature.hog(img, multichannel=True, block_norm='L1')
 
     for n in (1, 2):
-        with expected_warnings(["'multichannel' is a deprecated argument"]):
+        with expected_warnings(["`multichannel` is a deprecated argument"]):
             hog_fact = feature.hog(np.roll(img, n, axis=2), multichannel=True,
                                    block_norm='L1')
         assert_almost_equal(hog_ref, hog_fact)
 
         # repeat prior test, but check for positional multichannel warning
-        with expected_warnings(["Providing the 'multichannel' argument"]):
+        with expected_warnings(["Providing the `multichannel` argument"]):
             hog_fact = feature.hog(np.roll(img, n, axis=2), 9, (8, 8), (3, 3),
                                    'L1', False, False, True, True)
         assert_almost_equal(hog_ref, hog_fact)

--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -3,14 +3,18 @@ import numpy as np
 from scipy import ndimage as ndi
 
 from ..util import img_as_float
+from .._shared import utils
 from .._shared.utils import warn, convert_to_float
 
 
 __all__ = ['gaussian', 'difference_of_gaussians']
 
 
+@utils.channel_as_last_axis()
+@utils.deprecate_multichannel_kwarg()
 def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
-             multichannel=None, preserve_range=False, truncate=4.0):
+             multichannel=None, preserve_range=False, truncate=4.0, *,
+             channel_axis=None):
     """Multi-dimensional Gaussian filter.
 
     Parameters
@@ -28,7 +32,8 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
     mode : {'reflect', 'constant', 'nearest', 'mirror', 'wrap'}, optional
         The ``mode`` parameter determines how the array borders are
         handled, where ``cval`` is the value when mode is equal to
-        'constant'. Default is 'nearest'.
+        'constant'. Default is 'nearest'. This argument is deprecated:
+        specify `channel_axis` instead.
     cval : scalar, optional
         Value to fill past edges of input if ``mode`` is 'constant'. Default
         is 0.0
@@ -38,6 +43,7 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
         not mixed together). Only 3 channels are supported. If ``None``,
         the function will attempt to guess this, and raise a warning if
         ambiguous, when the array has shape (M, N, 3).
+        This argument is deprecated: specify `channel_axis` instead.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of ``img_as_float``.
@@ -45,6 +51,13 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
         https://scikit-image.org/docs/dev/user_guide/data_types.html
     truncate : float, optional
         Truncate the filter at this many standard deviations.
+    channel_axis : int or None, optional
+        If None, the image is assumed to be a grayscale (single channel) image.
+        Otherwise, this parameter indicates which axis of the array corresponds
+        to channels.
+
+        .. versionadded:: 0.19
+           ``channel_axis`` was added in 0.19.
 
     Returns
     -------
@@ -96,21 +109,15 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
     >>> filtered_img = gaussian(image, sigma=1, multichannel=True)
 
     """
-
-    spatial_dims = None
-    try:
-        spatial_dims = _guess_spatial_dimensions(image)
-    except ValueError:
-        spatial_dims = image.ndim
-    if spatial_dims is None and multichannel is None:
+    if image.ndim == 3 and image.shape[-1] == 3 and channel_axis is None:
         msg = ("Images with dimensions (M, N, 3) are interpreted as 2D+RGB "
                "by default. Use `multichannel=False` to interpret as "
                "3D image with last dimension of length 3.")
         warn(RuntimeWarning(msg))
-        multichannel = True
+        channel_axis = -1
     if np.any(np.asarray(sigma) < 0.0):
         raise ValueError("Sigma values less than zero are not valid")
-    if multichannel:
+    if channel_axis is not None:
         # do not filter across channels
         if not isinstance(sigma, Iterable):
             sigma = [sigma] * (image.ndim - 1)
@@ -119,7 +126,7 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
     image = convert_to_float(image, preserve_range)
     if (output is not None) and (not np.issubdtype(output.dtype, np.floating)):
         raise ValueError("Provided output data type is not float")
-    return ndi.gaussian_filter(image, sigma, output=output, 
+    return ndi.gaussian_filter(image, sigma, output=output,
                                mode=mode, cval=cval, truncate=truncate)
 
 
@@ -156,9 +163,11 @@ def _guess_spatial_dimensions(image):
         raise ValueError("Expected 1D, 2D, 3D, or 4D array, got %iD." % image.ndim)
 
 
+@utils.channel_as_last_axis()
+@utils.deprecate_multichannel_kwarg()
 def difference_of_gaussians(image, low_sigma, high_sigma=None, *,
-                            mode='nearest', cval=0, multichannel=False,
-                            truncate=4.0):
+                            mode='nearest', cval=0, channel_axis=None,
+                            truncate=4.0, multichannel=False):
     """Find features between ``low_sigma`` and ``high_sigma`` in size.
 
     This function uses the Difference of Gaussians method for applying
@@ -192,12 +201,20 @@ def difference_of_gaussians(image, low_sigma, high_sigma=None, *,
     cval : scalar, optional
         Value to fill past edges of input if ``mode`` is 'constant'. Default
         is 0.0
+    channel_axis : int or None, optional
+        If None, the image is assumed to be a grayscale (single channel) image.
+        Otherwise, this parameter indicates which axis of the array corresponds
+        to channels.
+
+        .. versionadded:: 0.19
+           ``channel_axis`` was added in 0.19.
+    truncate : float, optional (default is 4.0)
+        Truncate the filter at this many standard deviations.
     multichannel : bool, optional (default: False)
         Whether the last axis of the image is to be interpreted as multiple
         channels. If True, each channel is filtered separately (channels are
-        not mixed together).
-    truncate : float, optional (default is 4.0)
-        Truncate the filter at this many standard deviations.
+        not mixed together). This argument is deprecated: specify
+        `channel_axis` instead.
 
     Returns
     -------
@@ -261,7 +278,7 @@ def difference_of_gaussians(image, low_sigma, high_sigma=None, *,
     else:
         high_sigma = np.array(high_sigma, dtype='float', ndmin=1)
 
-    if multichannel is True:
+    if channel_axis is not None:
         spatial_dims = image.ndim - 1
     else:
         spatial_dims = image.ndim
@@ -281,9 +298,9 @@ def difference_of_gaussians(image, low_sigma, high_sigma=None, *,
                          'low_sigma for all axes')
 
     im1 = gaussian(image, low_sigma, mode=mode, cval=cval,
-                   multichannel=multichannel, truncate=truncate)
+                   channel_axis=channel_axis, truncate=truncate)
 
     im2 = gaussian(image, high_sigma, mode=mode, cval=cval,
-                   multichannel=multichannel, truncate=truncate)
+                   channel_axis=channel_axis, truncate=truncate)
 
     return im1 - im2

--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -11,7 +11,7 @@ __all__ = ['gaussian', 'difference_of_gaussians']
 
 
 @utils.channel_as_last_axis()
-@utils.deprecate_multichannel_kwarg()
+@utils.deprecate_multichannel_kwarg(multichannel_position=5)
 def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
              multichannel=None, preserve_range=False, truncate=4.0, *,
              channel_axis=None):

--- a/skimage/filters/_unsharp_mask.py
+++ b/skimage/filters/_unsharp_mask.py
@@ -1,6 +1,7 @@
 import numpy as np
 from scipy.ndimage.filters import gaussian_filter
 from skimage import img_as_float
+from .._shared import utils
 
 
 def _unsharp_mask_single_channel(image, radius, amount, vrange):
@@ -16,8 +17,10 @@ def _unsharp_mask_single_channel(image, radius, amount, vrange):
     return result
 
 
+@utils.channel_as_last_axis()
+@utils.deprecate_multichannel_kwarg(multichannel_position=3)
 def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
-                 preserve_range=False):
+                 preserve_range=False, *, channel_axis=None):
     """Unsharp masking filter.
 
     The sharp details are identified as the difference between the original
@@ -40,10 +43,18 @@ def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
     multichannel : bool, optional
         If True, the last ``image`` dimension is considered as a color channel,
         otherwise as spatial. Color channels are processed individually.
+        This argument is deprecated: specify `channel_axis` instead.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of ``img_as_float``.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
+    channel_axis : int or None, optional
+        If None, the image is assumed to be a grayscale (single channel) image.
+        Otherwise, this parameter indicates which axis of the array corresponds
+        to channels.
+
+        .. versionadded:: 0.19
+           ``channel_axis`` was added in 0.19.
 
     Returns
     -------
@@ -125,7 +136,7 @@ def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
         else:
             vrange = [0., 1.]
 
-    if multichannel:
+    if channel_axis is not None:
         result = np.empty_like(fimg, dtype=float)
         for channel in range(image.shape[-1]):
             result[..., channel] = _unsharp_mask_single_channel(

--- a/skimage/filters/tests/test_gaussian.py
+++ b/skimage/filters/tests/test_gaussian.py
@@ -68,6 +68,7 @@ def test_multichannel(channel_axis):
     assert np.allclose(a.mean(axis=spatial_axes),
                        gaussian_rgb_a.mean(axis=spatial_axes))
 
+
 def test_deprecated_multichannel():
     a = np.zeros((5, 5, 3))
     a[1, 1] = np.arange(1, 4)
@@ -77,6 +78,11 @@ def test_deprecated_multichannel():
     # Check that the mean value is conserved in each channel
     # (color channels are not mixed together)
     assert np.allclose(a.mean(axis=(0, 1)), gaussian_rgb_a.mean(axis=(0, 1)))
+
+    # check positional multichannel argument warning
+    with expected_warnings(["Providing the 'multichannel' argument"]):
+        gaussian_rgb_a = gaussian(a, 1, None, 'reflect', 0, True)
+
 
 def test_preserve_range():
     img = np.array([[10.0, -10.0], [-4, 3]], dtype=np.float32)

--- a/skimage/filters/tests/test_gaussian.py
+++ b/skimage/filters/tests/test_gaussian.py
@@ -17,7 +17,7 @@ def test_negative_sigma():
     with testing.raises(ValueError):
         gaussian(a,
                  sigma=np.asarray([-1.0, 1.0]))
-        
+
 
 def test_null_sigma():
     a = np.zeros((3, 3))
@@ -38,28 +38,45 @@ def test_energy_decrease():
     assert gaussian_a.std() < a.std()
 
 
-def test_multichannel():
+@testing.parametrize('channel_axis', [0, 1, -1])
+def test_multichannel(channel_axis):
     a = np.zeros((5, 5, 3))
     a[1, 1] = np.arange(1, 4)
+    a = np.moveaxis(a, -1, channel_axis)
     gaussian_rgb_a = gaussian(a, sigma=1, mode='reflect',
-                              multichannel=True)
+                              channel_axis=channel_axis)
     # Check that the mean value is conserved in each channel
     # (color channels are not mixed together)
-    assert np.allclose([a[..., i].mean() for i in range(3)],
-                       [gaussian_rgb_a[..., i].mean() for i in range(3)])
-    # Test multichannel = None
-    with expected_warnings(['multichannel']):
-        gaussian_rgb_a = gaussian(a, sigma=1, mode='reflect')
-    # Check that the mean value is conserved in each channel
-    # (color channels are not mixed together)
-    assert np.allclose([a[..., i].mean() for i in range(3)],
-                       [gaussian_rgb_a[..., i].mean() for i in range(3)])
+    spatial_axes = tuple(
+        [ax for ax in range(a.ndim) if ax != channel_axis % a.ndim]
+    )
+    assert np.allclose(a.mean(axis=spatial_axes),
+                       gaussian_rgb_a.mean(axis=spatial_axes))
+
+    if channel_axis % a.ndim == 2:
+        # Test legacy behavior equivalent to old (multichannel = None)
+        with expected_warnings(['multichannel']):
+            gaussian_rgb_a = gaussian(a, sigma=1, mode='reflect')
+
+        # Check that the mean value is conserved in each channel
+        # (color channels are not mixed together)
+        assert np.allclose(a.mean(axis=spatial_axes),
+                           gaussian_rgb_a.mean(axis=spatial_axes))
     # Iterable sigma
     gaussian_rgb_a = gaussian(a, sigma=[1, 2], mode='reflect',
-                              multichannel=True)
-    assert np.allclose([a[..., i].mean() for i in range(3)],
-                       [gaussian_rgb_a[..., i].mean() for i in range(3)])
+                              channel_axis=channel_axis)
+    assert np.allclose(a.mean(axis=spatial_axes),
+                       gaussian_rgb_a.mean(axis=spatial_axes))
 
+def test_deprecated_multichannel():
+    a = np.zeros((5, 5, 3))
+    a[1, 1] = np.arange(1, 4)
+    with expected_warnings(["'multichannel' is a deprecated argument"]):
+        gaussian_rgb_a = gaussian(a, sigma=1, mode='reflect',
+                                  multichannel=True)
+    # Check that the mean value is conserved in each channel
+    # (color channels are not mixed together)
+    assert np.allclose(a.mean(axis=(0, 1)), gaussian_rgb_a.mean(axis=(0, 1)))
 
 def test_preserve_range():
     img = np.array([[10.0, -10.0], [-4, 3]], dtype=np.float32)
@@ -134,7 +151,10 @@ def test_dog_invalid_sigma_dims():
     with testing.raises(ValueError):
         difference_of_gaussians(image, 1, (3, 4))
     with testing.raises(ValueError):
-        difference_of_gaussians(image, (1, 2, 3), multichannel=True)
+        with expected_warnings(["'multichannel' is a deprecated argument"]):
+            difference_of_gaussians(image, (1, 2, 3), multichannel=True)
+    with testing.raises(ValueError):
+        difference_of_gaussians(image, (1, 2, 3), channel_axis=-1)
 
 
 def test_dog_invalid_sigma2():

--- a/skimage/filters/tests/test_gaussian.py
+++ b/skimage/filters/tests/test_gaussian.py
@@ -72,7 +72,7 @@ def test_multichannel(channel_axis):
 def test_deprecated_multichannel():
     a = np.zeros((5, 5, 3))
     a[1, 1] = np.arange(1, 4)
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         gaussian_rgb_a = gaussian(a, sigma=1, mode='reflect',
                                   multichannel=True)
     # Check that the mean value is conserved in each channel
@@ -80,7 +80,7 @@ def test_deprecated_multichannel():
     assert np.allclose(a.mean(axis=(0, 1)), gaussian_rgb_a.mean(axis=(0, 1)))
 
     # check positional multichannel argument warning
-    with expected_warnings(["Providing the 'multichannel' argument"]):
+    with expected_warnings(["Providing the `multichannel` argument"]):
         gaussian_rgb_a = gaussian(a, 1, None, 'reflect', 0, True)
 
 
@@ -157,7 +157,7 @@ def test_dog_invalid_sigma_dims():
     with testing.raises(ValueError):
         difference_of_gaussians(image, 1, (3, 4))
     with testing.raises(ValueError):
-        with expected_warnings(["'multichannel' is a deprecated argument"]):
+        with expected_warnings(["`multichannel` is a deprecated argument"]):
             difference_of_gaussians(image, (1, 2, 3), multichannel=True)
     with testing.raises(ValueError):
         difference_of_gaussians(image, (1, 2, 3), channel_axis=-1)

--- a/skimage/filters/tests/test_unsharp_mask.py
+++ b/skimage/filters/tests/test_unsharp_mask.py
@@ -1,6 +1,7 @@
 import numpy as np
 from skimage.filters import unsharp_mask
 from skimage._shared.testing import parametrize
+from skimage._shared._warnings import expected_warnings
 
 
 @parametrize("shape,multichannel",
@@ -24,7 +25,9 @@ def test_unsharp_masking_output_type_and_shape(
     array = ((array + offset) * 128).astype(dtype)
     if (preserve is False) and (dtype in [np.float32, np.float64]):
         array /= max(np.abs(array).max(), 1.0)
-    output = unsharp_mask(array, radius, amount, multichannel, preserve)
+    channel_axis = -1 if multichannel else None
+    output = unsharp_mask(array, radius, amount, preserve_range=preserve,
+                          channel_axis=channel_axis)
     assert output.dtype in [np.float32, np.float64]
     assert output.shape == shape
 
@@ -42,7 +45,36 @@ def test_unsharp_masking_with_different_radii(radius, shape,
     array = (np.random.random(shape) * 96).astype(dtype)
     if preserve is False:
         array /= max(np.abs(array).max(), 1.0)
-    output = unsharp_mask(array, radius, amount, multichannel, preserve)
+    channel_axis = -1 if multichannel else None
+    output = unsharp_mask(array, radius, amount, preserve_range=preserve,
+                          channel_axis=channel_axis)
+    assert output.dtype in [np.float32, np.float64]
+    assert output.shape == shape
+
+
+@parametrize("shape,channel_axis",
+             [((16, 16), None),
+              ((15, 15, 2), -1),
+              ((13, 17, 3), -1),
+              ((2, 15, 15), 0),
+              ((3, 13, 17), 0)])
+@parametrize("offset", [-5, 0, 5])
+@parametrize("preserve", [False, True])
+def test_unsharp_masking_with_different_ranges_deprecated(shape, offset,
+                                                          channel_axis,
+                                                          preserve):
+    radius = 2.0
+    amount = 1.0
+    dtype = np.int16
+    array = (np.random.random(shape) * 5 + offset).astype(dtype)
+    negative = np.any(array < 0)
+    output = unsharp_mask(array, radius, amount, preserve_range=preserve,
+                          channel_axis=channel_axis)
+    if preserve is False:
+        assert np.any(output <= 1)
+        assert np.any(output >= -1)
+        if negative is False:
+            assert np.any(output >= 0)
     assert output.dtype in [np.float32, np.float64]
     assert output.shape == shape
 
@@ -53,14 +85,17 @@ def test_unsharp_masking_with_different_radii(radius, shape,
               ((13, 17, 3), True)])
 @parametrize("offset", [-5, 0, 5])
 @parametrize("preserve", [False, True])
-def test_unsharp_masking_with_different_ranges(shape, offset,
-                                               multichannel, preserve):
+def test_unsharp_masking_with_different_ranges_deprecated(shape, offset,
+                                                          multichannel,
+                                                          preserve):
     radius = 2.0
     amount = 1.0
     dtype = np.int16
     array = (np.random.random(shape) * 5 + offset).astype(dtype)
     negative = np.any(array < 0)
-    output = unsharp_mask(array, radius, amount, multichannel, preserve)
+    with expected_warnings(["'multichannel' is a deprecated argument"]):
+        output = unsharp_mask(array, radius, amount, multichannel=multichannel,
+                              preserve_range=preserve)
     if preserve is False:
         assert np.any(output <= 1)
         assert np.any(output >= -1)
@@ -68,3 +103,7 @@ def test_unsharp_masking_with_different_ranges(shape, offset,
             assert np.any(output >= 0)
     assert output.dtype in [np.float32, np.float64]
     assert output.shape == shape
+
+    # providing multichannel positionally also raises a warning
+    with expected_warnings(["Providing the 'multichannel'"]):
+        output = unsharp_mask(array, radius, amount, multichannel, preserve)

--- a/skimage/filters/tests/test_unsharp_mask.py
+++ b/skimage/filters/tests/test_unsharp_mask.py
@@ -93,7 +93,7 @@ def test_unsharp_masking_with_different_ranges_deprecated(shape, offset,
     dtype = np.int16
     array = (np.random.random(shape) * 5 + offset).astype(dtype)
     negative = np.any(array < 0)
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         output = unsharp_mask(array, radius, amount, multichannel=multichannel,
                               preserve_range=preserve)
     if preserve is False:
@@ -105,5 +105,5 @@ def test_unsharp_masking_with_different_ranges_deprecated(shape, offset,
     assert output.shape == shape
 
     # providing multichannel positionally also raises a warning
-    with expected_warnings(["Providing the 'multichannel'"]):
+    with expected_warnings(["Providing the `multichannel`"]):
         output = unsharp_mask(array, radius, amount, multichannel, preserve)

--- a/skimage/registration/_optical_flow_utils.py
+++ b/skimage/registration/_optical_flow_utils.py
@@ -90,7 +90,7 @@ def get_pyramid(I, downscale=2.0, nlevel=10, min_size=16):
     count = 1
 
     while (count < nlevel) and (size > downscale * min_size):
-        J = pyramid_reduce(pyramid[-1], downscale, multichannel=False)
+        J = pyramid_reduce(pyramid[-1], downscale, channel_axis=None)
         pyramid.append(J)
         size = min(J.shape)
         count += 1

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -8,6 +8,7 @@ from ._geometric import (SimilarityTransform, AffineTransform,
 from ._warps_cy import _warp_fast
 from ..measure import block_reduce
 
+from .._shared import utils
 from .._shared.utils import (get_bound_method_class, safe_as_int, warn,
                              convert_to_float, _to_ndimage_mode,
                              _validate_interpolation_order)
@@ -148,7 +149,7 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
 
     # 2-dimensional interpolation
     elif len(output_shape) == 2 or (len(output_shape) == 3 and
-                                  output_shape[2] == input_shape[2]):
+                                    output_shape[2] == input_shape[2]):
         rows = output_shape[0]
         cols = output_shape[1]
         input_rows = input_shape[0]
@@ -196,9 +197,12 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
     return out
 
 
+@utils.channel_as_last_axis()
+@utils.deprecate_multichannel_kwarg()
 def rescale(image, scale, order=None, mode='reflect', cval=0, clip=True,
             preserve_range=False, multichannel=False,
-            anti_aliasing=None, anti_aliasing_sigma=None):
+            anti_aliasing=None, anti_aliasing_sigma=None, *,
+            channel_axis=None):
     """Scale image by a certain factor.
 
     Performs interpolation to up-scale or down-scale N-dimensional images.
@@ -242,7 +246,8 @@ def rescale(image, scale, order=None, mode='reflect', cval=0, clip=True,
         https://scikit-image.org/docs/dev/user_guide/data_types.html
     multichannel : bool, optional
         Whether the last axis of the image is to be interpreted as multiple
-        channels or another spatial dimension.
+        channels or another spatial dimension. This argument is deprecated:
+        specify `channel_axis` instead.
     anti_aliasing : bool, optional
         Whether to apply a Gaussian filter to smooth the image prior
         to down-scaling. It is crucial to filter when down-sampling
@@ -252,6 +257,13 @@ def rescale(image, scale, order=None, mode='reflect', cval=0, clip=True,
         Standard deviation for Gaussian filtering to avoid aliasing artifacts.
         By default, this value is chosen as (s - 1) / 2 where s is the
         down-scaling factor.
+    channel_axis : int or None, optional
+        If None, the image is assumed to be a grayscale (single channel) image.
+        Otherwise, this parameter indicates which axis of the array corresponds
+        to channels.
+
+        .. versionadded:: 0.19
+           ``channel_axis`` was added in 0.19.
 
     Notes
     -----
@@ -273,6 +285,7 @@ def rescale(image, scale, order=None, mode='reflect', cval=0, clip=True,
 
     """
     scale = np.atleast_1d(scale)
+    multichannel = channel_axis is not None
     if len(scale) > 1:
         if ((not multichannel and len(scale) != image.ndim) or
                 (multichannel and len(scale) != image.ndim - 1)):
@@ -992,8 +1005,11 @@ def _log_polar_mapping(output_coords, k_angle, k_radius, center):
     return coords
 
 
+@utils.channel_as_last_axis()
+@utils.deprecate_multichannel_kwarg()
 def warp_polar(image, center=None, *, radius=None, output_shape=None,
-               scaling='linear', multichannel=False, **kwargs):
+               scaling='linear', multichannel=False, channel_axis=None,
+               **kwargs):
     """Remap image to polar or log-polar coordinates space.
 
     Parameters
@@ -1016,7 +1032,15 @@ def warp_polar(image, center=None, *, radius=None, output_shape=None,
     multichannel : bool, optional
         Whether the image is a 3-D array in which the third axis is to be
         interpreted as multiple channels. If set to `False` (default), only 2-D
-        arrays are accepted.
+        arrays are accepted. This argument is deprecated: specify
+        `channel_axis` instead.
+    channel_axis : int or None, optional
+        If None, the image is assumed to be a grayscale (single channel) image.
+        Otherwise, this parameter indicates which axis of the array corresponds
+        to channels.
+
+        .. versionadded:: 0.19
+           ``channel_axis`` was added in 0.19.
     **kwargs : keyword arguments
         Passed to `transform.warp`.
 
@@ -1047,8 +1071,9 @@ def warp_polar(image, center=None, *, radius=None, output_shape=None,
     Perform a log-polar warp on a color image:
 
     >>> image = data.astronaut()
-    >>> warped = warp_polar(image, scaling='log', multichannel=True)
+    >>> warped = warp_polar(image, scaling='log', channel_axis=-1)
     """
+    multichannel = channel_axis is not None
     if image.ndim != 2 and not multichannel:
         raise ValueError("Input array must be 2 dimensions "
                          "when `multichannel=False`,"

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -198,7 +198,7 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
 
 
 @utils.channel_as_last_axis()
-@utils.deprecate_multichannel_kwarg()
+@utils.deprecate_multichannel_kwarg(multichannel_position=7)
 def rescale(image, scale, order=None, mode='reflect', cval=0, clip=True,
             preserve_range=False, multichannel=False,
             anti_aliasing=None, anti_aliasing_sigma=None, *,

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -24,7 +24,7 @@ def _check_factor(factor):
 
 
 @utils.channel_as_last_axis()
-@utils.deprecate_multichannel_kwarg()
+@utils.deprecate_multichannel_kwarg(multichannel_position=6)
 def pyramid_reduce(image, downscale=2, sigma=None, order=1,
                    mode='reflect', cval=0, multichannel=False,
                    preserve_range=False, *, channel_axis=-1):
@@ -95,7 +95,7 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
 
 
 @utils.channel_as_last_axis()
-@utils.deprecate_multichannel_kwarg()
+@utils.deprecate_multichannel_kwarg(multichannel_position=6)
 def pyramid_expand(image, upscale=2, sigma=None, order=1,
                    mode='reflect', cval=0, multichannel=False,
                    preserve_range=False, *, channel_axis=-1):
@@ -166,7 +166,7 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
 
 
 @utils.channel_as_last_axis()
-@utils.deprecate_multichannel_kwarg()
+@utils.deprecate_multichannel_kwarg(multichannel_position=7)
 def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
                      mode='reflect', cval=0, multichannel=False,
                      preserve_range=False, *, channel_axis=-1):
@@ -259,7 +259,7 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
 
 
 @utils.channel_as_last_axis()
-@utils.deprecate_multichannel_kwarg()
+@utils.deprecate_multichannel_kwarg(multichannel_position=7)
 def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
                       mode='reflect', cval=0, multichannel=False,
                       preserve_range=False, *, channel_axis=-1):

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -2,6 +2,7 @@ import math
 import numpy as np
 from scipy import ndimage as ndi
 from ..transform import resize
+from .._shared import utils
 from .._shared.utils import convert_to_float
 
 
@@ -22,9 +23,11 @@ def _check_factor(factor):
         raise ValueError('scale factor must be greater than 1')
 
 
+@utils.channel_as_last_axis()
+@utils.deprecate_multichannel_kwarg()
 def pyramid_reduce(image, downscale=2, sigma=None, order=1,
                    mode='reflect', cval=0, multichannel=False,
-                   preserve_range=False):
+                   preserve_range=False, *, channel_axis=-1):
     """Smooth and then downsample image.
 
     Parameters
@@ -47,11 +50,19 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
         Whether the last axis of the image is to be interpreted as multiple
-        channels or another spatial dimension.
+        channels or another spatial dimension. This argument is deprecated:
+        specify `channel_axis` instead.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
+    channel_axis : int or None, optional
+        If None, the image is assumed to be a grayscale (single channel) image.
+        Otherwise, this parameter indicates which axis of the array corresponds
+        to channels.
+
+        .. versionadded:: 0.19
+           ``channel_axis`` was added in 0.19.
 
     Returns
     -------
@@ -64,6 +75,7 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
 
     """
     _check_factor(downscale)
+    multichannel = channel_axis is not None
 
     image = convert_to_float(image, preserve_range)
 
@@ -82,9 +94,11 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
     return out
 
 
+@utils.channel_as_last_axis()
+@utils.deprecate_multichannel_kwarg()
 def pyramid_expand(image, upscale=2, sigma=None, order=1,
                    mode='reflect', cval=0, multichannel=False,
-                   preserve_range=False):
+                   preserve_range=False, *, channel_axis=-1):
     """Upsample and then smooth image.
 
     Parameters
@@ -107,11 +121,19 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
         Whether the last axis of the image is to be interpreted as multiple
-        channels or another spatial dimension.
+        channels or another spatial dimension. This argument is deprecated:
+        specify `channel_axis` instead.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
+    channel_axis : int or None, optional
+        If None, the image is assumed to be a grayscale (single channel) image.
+        Otherwise, this parameter indicates which axis of the array corresponds
+        to channels.
+
+        .. versionadded:: 0.19
+           ``channel_axis`` was added in 0.19.
 
     Returns
     -------
@@ -124,6 +146,7 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
 
     """
     _check_factor(upscale)
+    multichannel = channel_axis is not None
 
     image = convert_to_float(image, preserve_range)
 
@@ -142,9 +165,11 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
     return out
 
 
+@utils.channel_as_last_axis()
+@utils.deprecate_multichannel_kwarg()
 def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
                      mode='reflect', cval=0, multichannel=False,
-                     preserve_range=False):
+                     preserve_range=False, *, channel_axis=-1):
     """Yield images of the Gaussian pyramid formed by the input image.
 
     Recursively applies the `pyramid_reduce` function to the image, and yields
@@ -178,11 +203,19 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
         Whether the last axis of the image is to be interpreted as multiple
-        channels or another spatial dimension.
+        channels or another spatial dimension. This argument is deprecated:
+        specify `channel_axis` instead.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
+    channel_axis : int or None, optional
+        If None, the image is assumed to be a grayscale (single channel) image.
+        Otherwise, this parameter indicates which axis of the array corresponds
+        to channels.
+
+        .. versionadded:: 0.19
+           ``channel_axis`` was added in 0.19.
 
     Returns
     -------
@@ -195,6 +228,7 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
 
     """
     _check_factor(downscale)
+    multichannel = channel_axis is not None
 
     # cast to float for consistent data type in pyramid
     image = convert_to_float(image, preserve_range)
@@ -211,7 +245,7 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
         layer += 1
 
         layer_image = pyramid_reduce(prev_layer_image, downscale, sigma, order,
-                                     mode, cval, multichannel=multichannel)
+                                     mode, cval, channel_axis=channel_axis)
 
         prev_shape = np.asarray(current_shape)
         prev_layer_image = layer_image
@@ -224,9 +258,11 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
         yield layer_image
 
 
+@utils.channel_as_last_axis()
+@utils.deprecate_multichannel_kwarg()
 def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
                       mode='reflect', cval=0, multichannel=False,
-                      preserve_range=False):
+                      preserve_range=False, *, channel_axis=-1):
     """Yield images of the laplacian pyramid formed by the input image.
 
     Each layer contains the difference between the downsampled and the
@@ -263,12 +299,19 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
         Value to fill past edges of input if mode is 'constant'.
     multichannel : bool, optional
         Whether the last axis of the image is to be interpreted as multiple
-        channels or another spatial dimension.
+        channels or another spatial dimension. This argument is deprecated:
+        specify `channel_axis` instead.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
         image is converted according to the conventions of `img_as_float`.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
+    channel_axis : int or None, optional
+        If None, the image is assumed to be a grayscale (single channel) image.
+        Otherwise, this parameter indicates which axis of the array corresponds
+        to channels.
 
+        .. versionadded:: 0.19
+           ``channel_axis`` was added in 0.19.
 
     Returns
     -------
@@ -282,6 +325,7 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
 
     """
     _check_factor(downscale)
+    multichannel = channel_axis is not None
 
     # cast to float for consistent data type in pyramid
     image = convert_to_float(image, preserve_range)

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -7,26 +7,37 @@ from skimage.transform import pyramids
 from skimage._shared import testing
 from skimage._shared.testing import (assert_array_equal, assert_, assert_equal,
                                      assert_almost_equal)
-
+from skimage._shared._warnings import expected_warnings
 
 image = data.astronaut()
 image_gray = image[..., 0]
 
 
-def test_pyramid_reduce_rgb():
+def test_pyramid_reduce_rgb_multichannel():
     rows, cols, dim = image.shape
-    out = pyramids.pyramid_reduce(image, downscale=2, multichannel=True)
+    with expected_warnings(["'multichannel' is a deprecated argument"]):
+        out = pyramids.pyramid_reduce(image, downscale=2, multichannel=True)
+    assert_array_equal(out.shape, (rows / 2, cols / 2, dim))
+
+
+@testing.parametrize('channel_axis', [0, 1, -1])
+def test_pyramid_reduce_rgb(channel_axis):
+    rows, cols, dim = image.shape
+    image_ = np.moveaxis(image, -1, channel_axis)
+    out_ = pyramids.pyramid_reduce(image_, downscale=2,
+                                   channel_axis=channel_axis)
+    out = np.moveaxis(out_, channel_axis, -1)
     assert_array_equal(out.shape, (rows / 2, cols / 2, dim))
 
 
 def test_pyramid_reduce_gray():
     rows, cols = image_gray.shape
     out1 = pyramids.pyramid_reduce(image_gray, downscale=2,
-                                   multichannel=False)
+                                   channel_axis=None)
     assert_array_equal(out1.shape, (rows / 2, cols / 2))
     assert_almost_equal(out1.ptp(), 1.0, decimal=2)
     out2 = pyramids.pyramid_reduce(image_gray, downscale=2,
-                                   multichannel=False, preserve_range=True)
+                                   channel_axis=None, preserve_range=True)
     assert_almost_equal(out2.ptp() / image_gray.ptp(), 1.0, decimal=2)
 
 
@@ -34,7 +45,7 @@ def test_pyramid_reduce_nd():
     for ndim in [1, 2, 3, 4]:
         img = np.random.randn(*((8, ) * ndim))
         out = pyramids.pyramid_reduce(img, downscale=2,
-                                      multichannel=False)
+                                      channel_axis=None)
         expected_shape = np.asarray(img.shape) / 2
         assert_array_equal(out.shape, expected_shape)
 
@@ -42,14 +53,14 @@ def test_pyramid_reduce_nd():
 def test_pyramid_expand_rgb():
     rows, cols, dim = image.shape
     out = pyramids.pyramid_expand(image, upscale=2,
-                                  multichannel=True)
+                                  channel_axis=-1)
     assert_array_equal(out.shape, (rows * 2, cols * 2, dim))
 
 
 def test_pyramid_expand_gray():
     rows, cols = image_gray.shape
     out = pyramids.pyramid_expand(image_gray, upscale=2,
-                                  multichannel=False)
+                                  channel_axis=None)
     assert_array_equal(out.shape, (rows * 2, cols * 2))
 
 
@@ -57,7 +68,7 @@ def test_pyramid_expand_nd():
     for ndim in [1, 2, 3, 4]:
         img = np.random.randn(*((4, ) * ndim))
         out = pyramids.pyramid_expand(img, upscale=2,
-                                      multichannel=False)
+                                      channel_axis=None)
         expected_shape = np.asarray(img.shape) * 2
         assert_array_equal(out.shape, expected_shape)
 
@@ -65,7 +76,7 @@ def test_pyramid_expand_nd():
 def test_build_gaussian_pyramid_rgb():
     rows, cols, dim = image.shape
     pyramid = pyramids.pyramid_gaussian(image, downscale=2,
-                                        multichannel=True)
+                                        channel_axis=-1)
     for layer, out in enumerate(pyramid):
         layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
         assert_array_equal(out.shape, layer_shape)
@@ -74,7 +85,7 @@ def test_build_gaussian_pyramid_rgb():
 def test_build_gaussian_pyramid_gray():
     rows, cols = image_gray.shape
     pyramid = pyramids.pyramid_gaussian(image_gray, downscale=2,
-                                        multichannel=False)
+                                        channel_axis=None)
     for layer, out in enumerate(pyramid):
         layer_shape = (rows / 2 ** layer, cols / 2 ** layer)
         assert_array_equal(out.shape, layer_shape)
@@ -85,7 +96,7 @@ def test_build_gaussian_pyramid_nd():
         img = np.random.randn(*((8, ) * ndim))
         original_shape = np.asarray(img.shape)
         pyramid = pyramids.pyramid_gaussian(img, downscale=2,
-                                            multichannel=False)
+                                            channel_axis=None)
         for layer, out in enumerate(pyramid):
             layer_shape = original_shape / 2 ** layer
             assert_array_equal(out.shape, layer_shape)
@@ -94,7 +105,7 @@ def test_build_gaussian_pyramid_nd():
 def test_build_laplacian_pyramid_rgb():
     rows, cols, dim = image.shape
     pyramid = pyramids.pyramid_laplacian(image, downscale=2,
-                                         multichannel=True)
+                                         channel_axis=-1)
     for layer, out in enumerate(pyramid):
         layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
         assert_array_equal(out.shape, layer_shape)
@@ -105,7 +116,7 @@ def test_build_laplacian_pyramid_nd():
         img = np.random.randn(*(16, )*ndim)
         original_shape = np.asarray(img.shape)
         pyramid = pyramids.pyramid_laplacian(img, downscale=2,
-                                             multichannel=False)
+                                             channel_axis=None)
         for layer, out in enumerate(pyramid):
             print(out.shape)
             layer_shape = original_shape / 2 ** layer
@@ -116,7 +127,7 @@ def test_laplacian_pyramid_max_layers():
     for downscale in [2, 3, 5, 7]:
         img = np.random.randn(32, 8)
         pyramid = pyramids.pyramid_laplacian(img, downscale=downscale,
-                                             multichannel=False)
+                                             channel_axis=None)
         max_layer = int(np.ceil(math.log(np.max(img.shape), downscale)))
         for layer, out in enumerate(pyramid):
             if layer < max_layer:

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -15,12 +15,12 @@ image_gray = image[..., 0]
 
 def test_pyramid_reduce_rgb_deprecated_multichannel():
     rows, cols, dim = image.shape
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         out = pyramids.pyramid_reduce(image, downscale=2, multichannel=True)
     assert_array_equal(out.shape, (rows / 2, cols / 2, dim))
 
     # repeat prior test, but check for positional multichannel warning
-    with expected_warnings(["Providing the 'multichannel' argument"]):
+    with expected_warnings(["Providing the `multichannel` argument"]):
         out = pyramids.pyramid_reduce(image, 2, None, 1, 'reflect', 0, True)
     assert_array_equal(out.shape, (rows / 2, cols / 2, dim))
 
@@ -64,12 +64,12 @@ def test_pyramid_expand_rgb():
 
 def test_pyramid_expand_rgb_deprecated_multichannel():
     rows, cols, dim = image.shape
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         out = pyramids.pyramid_expand(image, upscale=2, multichannel=True)
     assert_array_equal(out.shape, (rows * 2, cols * 2, dim))
 
     # repeat prior test, but check for positional multichannel warning
-    with expected_warnings(["Providing the 'multichannel' argument"]):
+    with expected_warnings(["Providing the `multichannel` argument"]):
         out = pyramids.pyramid_expand(image, 2, None, 1, 'reflect', 0, True)
     assert_array_equal(out.shape, (rows * 2, cols * 2, dim))
 
@@ -101,7 +101,7 @@ def test_build_gaussian_pyramid_rgb():
 
 def test_build_gaussian_pyramid_rgb_deprecated_multichannel():
     rows, cols, dim = image.shape
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         pyramid = pyramids.pyramid_gaussian(image, downscale=2,
                                             multichannel=True)
     for layer, out in enumerate(pyramid):
@@ -109,7 +109,7 @@ def test_build_gaussian_pyramid_rgb_deprecated_multichannel():
         assert_array_equal(out.shape, layer_shape)
 
     # repeat prior test, but check for positional multichannel warning
-    with expected_warnings(["Providing the 'multichannel' argument"]):
+    with expected_warnings(["Providing the `multichannel` argument"]):
         pyramid = pyramids.pyramid_gaussian(image, -1, 2, None, 1, 'reflect',
                                             0, True)
     for layer, out in enumerate(pyramid):
@@ -148,7 +148,7 @@ def test_build_laplacian_pyramid_rgb():
 
 def test_build_laplacian_pyramid_rgb_deprecated_multichannel():
     rows, cols, dim = image.shape
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         pyramid = pyramids.pyramid_laplacian(image, downscale=2,
                                              multichannel=True)
     for layer, out in enumerate(pyramid):
@@ -156,7 +156,7 @@ def test_build_laplacian_pyramid_rgb_deprecated_multichannel():
         assert_array_equal(out.shape, layer_shape)
 
     # repeat prior test, but check for positional multichannel warning
-    with expected_warnings(["Providing the 'multichannel' argument"]):
+    with expected_warnings(["Providing the `multichannel` argument"]):
         pyramid = pyramids.pyramid_laplacian(image, -1, 2, None, 1, 'reflect',
                                              0, True)
     for layer, out in enumerate(pyramid):

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -62,7 +62,6 @@ def test_pyramid_expand_rgb():
     assert_array_equal(out.shape, (rows * 2, cols * 2, dim))
 
 
-
 def test_pyramid_expand_rgb_deprecated_multichannel():
     rows, cols, dim = image.shape
     with expected_warnings(["'multichannel' is a deprecated argument"]):

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -13,10 +13,15 @@ image = data.astronaut()
 image_gray = image[..., 0]
 
 
-def test_pyramid_reduce_rgb_multichannel():
+def test_pyramid_reduce_rgb_deprecated_multichannel():
     rows, cols, dim = image.shape
     with expected_warnings(["'multichannel' is a deprecated argument"]):
         out = pyramids.pyramid_reduce(image, downscale=2, multichannel=True)
+    assert_array_equal(out.shape, (rows / 2, cols / 2, dim))
+
+    # repeat prior test, but check for positional multichannel warning
+    with expected_warnings(["Providing the 'multichannel' argument"]):
+        out = pyramids.pyramid_reduce(image, 2, None, 1, 'reflect', 0, True)
     assert_array_equal(out.shape, (rows / 2, cols / 2, dim))
 
 
@@ -57,6 +62,19 @@ def test_pyramid_expand_rgb():
     assert_array_equal(out.shape, (rows * 2, cols * 2, dim))
 
 
+
+def test_pyramid_expand_rgb_deprecated_multichannel():
+    rows, cols, dim = image.shape
+    with expected_warnings(["'multichannel' is a deprecated argument"]):
+        out = pyramids.pyramid_expand(image, upscale=2, multichannel=True)
+    assert_array_equal(out.shape, (rows * 2, cols * 2, dim))
+
+    # repeat prior test, but check for positional multichannel warning
+    with expected_warnings(["Providing the 'multichannel' argument"]):
+        out = pyramids.pyramid_expand(image, 2, None, 1, 'reflect', 0, True)
+    assert_array_equal(out.shape, (rows * 2, cols * 2, dim))
+
+
 def test_pyramid_expand_gray():
     rows, cols = image_gray.shape
     out = pyramids.pyramid_expand(image_gray, upscale=2,
@@ -77,6 +95,24 @@ def test_build_gaussian_pyramid_rgb():
     rows, cols, dim = image.shape
     pyramid = pyramids.pyramid_gaussian(image, downscale=2,
                                         channel_axis=-1)
+    for layer, out in enumerate(pyramid):
+        layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
+        assert_array_equal(out.shape, layer_shape)
+
+
+def test_build_gaussian_pyramid_rgb_deprecated_multichannel():
+    rows, cols, dim = image.shape
+    with expected_warnings(["'multichannel' is a deprecated argument"]):
+        pyramid = pyramids.pyramid_gaussian(image, downscale=2,
+                                            multichannel=True)
+    for layer, out in enumerate(pyramid):
+        layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
+        assert_array_equal(out.shape, layer_shape)
+
+    # repeat prior test, but check for positional multichannel warning
+    with expected_warnings(["Providing the 'multichannel' argument"]):
+        pyramid = pyramids.pyramid_gaussian(image, -1, 2, None, 1, 'reflect',
+                                            0, True)
     for layer, out in enumerate(pyramid):
         layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
         assert_array_equal(out.shape, layer_shape)
@@ -106,6 +142,24 @@ def test_build_laplacian_pyramid_rgb():
     rows, cols, dim = image.shape
     pyramid = pyramids.pyramid_laplacian(image, downscale=2,
                                          channel_axis=-1)
+    for layer, out in enumerate(pyramid):
+        layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
+        assert_array_equal(out.shape, layer_shape)
+
+
+def test_build_laplacian_pyramid_rgb_deprecated_multichannel():
+    rows, cols, dim = image.shape
+    with expected_warnings(["'multichannel' is a deprecated argument"]):
+        pyramid = pyramids.pyramid_laplacian(image, downscale=2,
+                                             multichannel=True)
+    for layer, out in enumerate(pyramid):
+        layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
+        assert_array_equal(out.shape, layer_shape)
+
+    # repeat prior test, but check for positional multichannel warning
+    with expected_warnings(["Providing the 'multichannel' argument"]):
+        pyramid = pyramids.pyramid_laplacian(image, -1, 2, None, 1, 'reflect',
+                                             0, True)
     for layer, out in enumerate(pyramid):
         layer_shape = (rows / 2 ** layer, cols / 2 ** layer, dim)
         assert_array_equal(out.shape, layer_shape)

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -99,12 +99,12 @@ def test_warp_clip():
     x = np.zeros((5, 5), dtype=np.double)
     x[2, 2] = 1
 
-    outx = rescale(x, 3, order=3, clip=False,
-                   multichannel=False, anti_aliasing=False, mode='constant')
+    outx = rescale(x, 3, order=3, clip=False, anti_aliasing=False,
+                   mode='constant')
     assert outx.min() < 0
 
-    outx = rescale(x, 3, order=3, clip=True,
-                   multichannel=False, anti_aliasing=False, mode='constant')
+    outx = rescale(x, 3, order=3, clip=True, anti_aliasing=False,
+                   mode='constant')
     assert_almost_equal(outx.min(), 0)
     assert_almost_equal(outx.max(), 1)
 
@@ -176,7 +176,7 @@ def test_rescale():
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
     scaled = rescale(x, 2, order=0,
-                     multichannel=False, anti_aliasing=False, mode='constant')
+                     channel_axis=None, anti_aliasing=False, mode='constant')
     ref = np.zeros((10, 10))
     ref[2:4, 2:4] = 1
     assert_almost_equal(scaled, ref)
@@ -186,7 +186,7 @@ def test_rescale():
     x[1, 1] = 1
 
     scaled = rescale(x, (2, 1), order=0,
-                     multichannel=False, anti_aliasing=False, mode='constant')
+                     channel_axis=None, anti_aliasing=False, mode='constant')
     ref = np.zeros((10, 5))
     ref[2:4, 1] = 1
     assert_almost_equal(scaled, ref)
@@ -196,48 +196,59 @@ def test_rescale_invalid_scale():
     x = np.zeros((10, 10, 3))
     with testing.raises(ValueError):
         rescale(x, (2, 2),
-                multichannel=False, anti_aliasing=False, mode='constant')
+                channel_axis=None, anti_aliasing=False, mode='constant')
     with testing.raises(ValueError):
         rescale(x, (2, 2, 2),
-                multichannel=True, anti_aliasing=False, mode='constant')
+                channel_axis=-1, anti_aliasing=False, mode='constant')
 
 
 def test_rescale_multichannel():
     # 1D + channels
     x = np.zeros((8, 3), dtype=np.double)
-    scaled = rescale(x, 2, order=0, multichannel=True, anti_aliasing=False,
+    scaled = rescale(x, 2, order=0, channel_axis=-1, anti_aliasing=False,
                      mode='constant')
     assert_equal(scaled.shape, (16, 3))
     # 2D
-    scaled = rescale(x, 2, order=0, multichannel=False, anti_aliasing=False,
+    scaled = rescale(x, 2, order=0, channel_axis=None, anti_aliasing=False,
                      mode='constant')
     assert_equal(scaled.shape, (16, 6))
 
     # 2D + channels
     x = np.zeros((8, 8, 3), dtype=np.double)
-    scaled = rescale(x, 2, order=0, multichannel=True, anti_aliasing=False,
+    scaled = rescale(x, 2, order=0, channel_axis=-1, anti_aliasing=False,
                      mode='constant')
     assert_equal(scaled.shape, (16, 16, 3))
     # 3D
-    scaled = rescale(x, 2, order=0, multichannel=False, anti_aliasing=False,
+    scaled = rescale(x, 2, order=0, channel_axis=None, anti_aliasing=False,
                      mode='constant')
     assert_equal(scaled.shape, (16, 16, 6))
 
     # 3D + channels
     x = np.zeros((8, 8, 8, 3), dtype=np.double)
-    scaled = rescale(x, 2, order=0, multichannel=True, anti_aliasing=False,
+    scaled = rescale(x, 2, order=0, channel_axis=-1, anti_aliasing=False,
                      mode='constant')
     assert_equal(scaled.shape, (16, 16, 16, 3))
     # 4D
-    scaled = rescale(x, 2, order=0, multichannel=False, anti_aliasing=False,
+    scaled = rescale(x, 2, order=0, channel_axis=None, anti_aliasing=False,
                      mode='constant')
     assert_equal(scaled.shape, (16, 16, 16, 6))
 
 
 def test_rescale_multichannel_multiscale():
     x = np.zeros((5, 5, 3), dtype=np.double)
-    scaled = rescale(x, (2, 1), order=0, multichannel=True,
+    with expected_warnings(["'multichannel' is a deprecated argument"]):
+        scaled = rescale(x, (2, 1), order=0, multichannel=True,
+                         anti_aliasing=False, mode='constant')
+    assert_equal(scaled.shape, (10, 5, 3))
+
+
+@testing.parametrize('channel_axis', [0, 1, 2, -1])
+def test_rescale_channel_axis_multiscale(channel_axis):
+    x = np.zeros((5, 5, 3), dtype=np.double)
+    x = np.moveaxis(x, -1, channel_axis)
+    scaled = rescale(x, scale=(2, 1), order=0, channel_axis=channel_axis,
                      anti_aliasing=False, mode='constant')
+    scaled = np.moveaxis(scaled, channel_axis, -1)
     assert_equal(scaled.shape, (10, 5, 3))
 
 
@@ -457,7 +468,7 @@ def test_downscale():
     x = np.zeros((10, 10), dtype=np.double)
     x[2:4, 2:4] = 1
     scaled = rescale(x, 0.5, order=0, anti_aliasing=False,
-                     multichannel=False, mode='constant')
+                     channel_axis=None, mode='constant')
     assert_equal(scaled.shape, (5, 5))
     assert_equal(scaled[1, 1], 1)
     assert_equal(scaled[2:, :].sum(), 0)
@@ -468,7 +479,7 @@ def test_downscale_anti_aliasing():
     x = np.zeros((10, 10), dtype=np.double)
     x[2, 2] = 1
     scaled = rescale(x, 0.5, order=1, anti_aliasing=True,
-                     multichannel=False, mode='constant')
+                     channel_axis=None, mode='constant')
     assert_equal(scaled.shape, (5, 5))
     assert np.all(scaled[:3, :3] > 0)
     assert_equal(scaled[3:, :].sum(), 0)
@@ -522,17 +533,17 @@ def test_slow_warp_nonint_oshape():
 def test_keep_range():
     image = np.linspace(0, 2, 25).reshape(5, 5)
     out = rescale(image, 2, preserve_range=False, clip=True, order=0,
-                  mode='constant', multichannel=False, anti_aliasing=False)
+                  mode='constant', channel_axis=None, anti_aliasing=False)
     assert out.min() == 0
     assert out.max() == 2
 
     out = rescale(image, 2, preserve_range=True, clip=True, order=0,
-                  mode='constant', multichannel=False, anti_aliasing=False)
+                  mode='constant', channel_axis=None, anti_aliasing=False)
     assert out.min() == 0
     assert out.max() == 2
 
     out = rescale(image.astype(np.uint8), 2, preserve_range=False,
-                  mode='constant', multichannel=False, anti_aliasing=False,
+                  mode='constant', channel_axis=None, anti_aliasing=False,
                   clip=True, order=0)
     assert out.min() == 0
     assert out.max() == 2 / 255.0
@@ -640,9 +651,9 @@ def test_invalid_dimensions_polar():
     with testing.raises(ValueError):
         warp_polar(np.zeros((10, 10, 3)), (5, 5))
     with testing.raises(ValueError):
-        warp_polar(np.zeros((10, 10)), (5, 5), multichannel=True)
+        warp_polar(np.zeros((10, 10)), (5, 5), channel_axis=-1)
     with testing.raises(ValueError):
-        warp_polar(np.zeros((10, 10, 10, 3)), (5, 5), multichannel=True)
+        warp_polar(np.zeros((10, 10, 10, 3)), (5, 5), channel_axis=-1)
 
 
 def test_bool_img_rescale():

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -236,13 +236,13 @@ def test_rescale_multichannel():
 
 def test_rescale_multichannel_deprecated_multiscale():
     x = np.zeros((5, 5, 3), dtype=np.double)
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         scaled = rescale(x, (2, 1), order=0, multichannel=True,
                          anti_aliasing=False, mode='constant')
     assert_equal(scaled.shape, (10, 5, 3))
 
     # repeat prior test, but check for positional multichannel _warnings
-    with expected_warnings(["Providing the 'multichannel' argument"]):
+    with expected_warnings(["Providing the `multichannel` argument"]):
         scaled = rescale(x, (2, 1), 0, 'constant', 0, True, False, True,
                          anti_aliasing=False)
     assert_equal(scaled.shape, (10, 5, 3))

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -234,11 +234,17 @@ def test_rescale_multichannel():
     assert_equal(scaled.shape, (16, 16, 16, 6))
 
 
-def test_rescale_multichannel_multiscale():
+def test_rescale_multichannel_deprecated_multiscale():
     x = np.zeros((5, 5, 3), dtype=np.double)
     with expected_warnings(["'multichannel' is a deprecated argument"]):
         scaled = rescale(x, (2, 1), order=0, multichannel=True,
                          anti_aliasing=False, mode='constant')
+    assert_equal(scaled.shape, (10, 5, 3))
+
+    # repeat prior test, but check for positional multichannel _warnings
+    with expected_warnings(["Providing the 'multichannel' argument"]):
+        scaled = rescale(x, (2, 1), 0, 'constant', 0, True, False, True,
+                         anti_aliasing=False)
     assert_equal(scaled.shape, (10, 5, 3))
 
 

--- a/skimage/util/tests/test_apply_parallel.py
+++ b/skimage/util/tests/test_apply_parallel.py
@@ -106,7 +106,7 @@ def test_apply_parallel_rgb(depth, chunks, dtype):
 
     func = color.rgb2ycbcr
     cat_ycbcr_expected = func(cat)
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         cat_ycbcr = apply_parallel(func, cat, chunks=chunks, depth=depth,
                                    dtype=dtype, multichannel=True)
 

--- a/skimage/util/tests/test_montage.py
+++ b/skimage/util/tests/test_montage.py
@@ -29,7 +29,7 @@ def test_montage_simple_rgb():
             )
     arr_in = arr_in.reshape(n_images, n_rows, n_cols, n_channels)
 
-    with expected_warnings(["'multichannel' is a deprecated argument"]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         arr_out = montage(arr_in, multichannel=True)
     arr_ref = np.array(
         [[[ 0,  1],


### PR DESCRIPTION
follows #5285. Implements `channel_axis` for the filters module

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
