### PR TITLE
Proofread gallery example for Radon transform.

### DIFF
--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -29,7 +29,7 @@ and reconstructing the original image are compared: The Filtered Back
 Projection (FBP) and the Simultaneous Algebraic Reconstruction
 Technique (SART).
 
-For further information on tomographic reconstruction, see
+For further information on tomographic reconstruction, see:
 
 .. [1] AC Kak, M Slaney, "Principles of Computerized Tomographic Imaging",
        IEEE Press 1988. http://www.slaney.org/pct/pct-toc.html
@@ -157,7 +157,7 @@ plt.show()
 #
 # ``skimage`` provides one of the more popular variations of the algebraic
 # reconstruction techniques: the Simultaneous Algebraic Reconstruction
-# Technique (SART) [1]_ [4]_. It uses Kaczmarz' method [3]_ as the iterative
+# Technique (SART) [4]_. It uses Kaczmarz' method as the iterative
 # solver. A good reconstruction is normally obtained in a single iteration,
 # making the method computationally effective. Running one or more extra
 # iterations will normally improve the reconstruction of sharp, high

--- a/doc/examples/transform/plot_radon_transform.py
+++ b/doc/examples/transform/plot_radon_transform.py
@@ -74,7 +74,7 @@ ax1.set_title("Original")
 ax1.imshow(image, cmap=plt.cm.Greys_r)
 
 theta = np.linspace(0., 180., max(image.shape), endpoint=False)
-sinogram = radon(image, theta=theta, circle=True)
+sinogram = radon(image, theta=theta)
 dx, dy = 0.5 * 180.0 / max(image.shape), 0.5 / sinogram.shape[0]
 ax2.set_title("Radon transform\n(Sinogram)")
 ax2.set_xlabel("Projection angle (deg)")
@@ -120,8 +120,7 @@ plt.show()
 
 from skimage.transform import iradon
 
-reconstruction_fbp = iradon(sinogram, theta=theta, filter_name='ramp',
-                            circle=True)
+reconstruction_fbp = iradon(sinogram, theta=theta, filter_name='ramp')
 error = reconstruction_fbp - image
 print(f"FBP rms reconstruction error: {np.sqrt(np.mean(error**2)):.3g}")
 


### PR DESCRIPTION
## Description

This minor PR follows from https://github.com/scikit-image/scikit-image/pull/5269/#discussion_r599725791.

The [citations](https://sphinx-rtd-theme.readthedocs.io/en/stable/demo/demo.html#citations) have rendering issues; it's not 100% satisfying to resolve them by removing the second instance of each citation, but I thought it was fine even in substance (no need to repeat "Kaczmarz' method [3]_" the exact same way if it's written a few sentences before; it's actually better not to).

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
