### PR TITLE
MAINT: use internal function for noise + clarify code in canny example

### DIFF
--- a/doc/examples/edges/plot_canny.py
+++ b/doc/examples/edges/plot_canny.py
@@ -18,38 +18,36 @@ the hysteresis thresholding.
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy import ndimage as ndi
-
+from skimage.util import random_noise
 from skimage import feature
 
 
 # Generate noisy image of a square
-im = np.zeros((128, 128))
-im[32:-32, 32:-32] = 1
+image = np.zeros((128, 128), dtype=float)
+image[32:-32, 32:-32] = 1
 
-im = ndi.rotate(im, 15, mode='constant')
-im = ndi.gaussian_filter(im, 4)
-im += 0.2 * np.random.random(im.shape)
+image = ndi.rotate(image, 15, mode='constant')
+image = ndi.gaussian_filter(image, 4)
+image = random_noise(image, mode='speckle', mean=0.1)
 
 # Compute the Canny filter for two values of sigma
-edges1 = feature.canny(im)
-edges2 = feature.canny(im, sigma=3)
+edges1 = feature.canny(image)
+edges2 = feature.canny(image, sigma=3)
 
 # display results
-fig, (ax1, ax2, ax3) = plt.subplots(nrows=1, ncols=3, figsize=(8, 3),
-                                    sharex=True, sharey=True)
+fig, ax = plt.subplots(nrows=1, ncols=3, figsize=(8, 3))
 
-ax1.imshow(im, cmap=plt.cm.gray)
-ax1.axis('off')
-ax1.set_title('noisy image', fontsize=20)
+ax[0].imshow(image, cmap='gray')
+ax[0].set_title('noisy image', fontsize=20)
 
-ax2.imshow(edges1, cmap=plt.cm.gray)
-ax2.axis('off')
-ax2.set_title(r'Canny filter, $\sigma=1$', fontsize=20)
+ax[1].imshow(edges1, cmap='gray')
+ax[1].set_title(r'Canny filter, $\sigma=1$', fontsize=20)
 
-ax3.imshow(edges2, cmap=plt.cm.gray)
-ax3.axis('off')
-ax3.set_title(r'Canny filter, $\sigma=3$', fontsize=20)
+ax[2].imshow(edges2, cmap='gray')
+ax[2].set_title(r'Canny filter, $\sigma=3$', fontsize=20)
+
+for a in ax:
+    a.axis('off')
 
 fig.tight_layout()
-
 plt.show()


### PR DESCRIPTION
## Description

I propose to update the canny example to make it more "modern": variable name, noise function...

Here is the new image
![index](https://user-images.githubusercontent.com/335370/112296820-753ed580-8c95-11eb-9f35-4ac2300b30fe.png)



## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
