### PR TITLE
Backport PR #5243: Rename `master` to `main` throughout

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
 
 name: Build docs
 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -3,7 +3,7 @@ name: Build CI wheels
 on:
   push:
     branches:
-      - master
+      - main
       - v[0-9]+.[0-9]+.x
       - cibuildwheel
     tags:

--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -57,8 +57,8 @@ Here's the long and short of it:
 
    * Pull the latest changes from upstream::
 
-      git checkout master
-      git pull upstream master
+      git checkout main
+      git pull upstream main
 
    * Create a branch for the feature you want to work on. Since the
      branch name will appear in the merge message, use a sensible name
@@ -128,14 +128,14 @@ For a more detailed discussion, read these :doc:`detailed documents
    bug, also add "Closes #123" where 123 is the issue number.
 
 
-Divergence between ``upstream master`` and your feature branch
---------------------------------------------------------------
+Divergence between ``upstream main`` and your feature branch
+------------------------------------------------------------
 
 If GitHub indicates that the branch of your Pull Request can no longer
-be merged automatically, merge the master branch into yours::
+be merged automatically, merge the main branch into yours::
 
-   git fetch upstream master
-   git merge upstream/master
+   git fetch upstream main
+   git merge upstream/main
 
 If any conflicts occur, they need to be fixed before continuing.  See
 which files are in conflict using::
@@ -154,8 +154,8 @@ Inside the conflicted file, you'll find sections like these::
    <<<<<<< HEAD
    The way the text looks in your branch
    =======
-   The way the text looks in the master branch
-   >>>>>>> master
+   The way the text looks in the main branch
+   >>>>>>> main
 
 Choose one version of the text that should be kept, and delete the
 rest::
@@ -606,22 +606,22 @@ of time since building scikit-image can be a time consuming task::
 
   asv run -E existing -b TransformSuite
 
-Comparing results to master
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Comparing results to main
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Often, the goal of a PR is to compare the results of the modifications in terms
-speed to a snapshot of the code that is in the master branch of the
+speed to a snapshot of the code that is in the main branch of the
 ``scikit-image`` repository. The command ``asv continuous`` is of help here::
 
-  asv continuous master -b TransformSuite
+  asv continuous main -b TransformSuite
 
 This call will build out the environments specified in the ``asv.conf.json``
 file and compare the performance of the benchmark between your current commit
-and the code in the master branch.
+and the code in the main branch.
 
 The output may look something like::
 
-  $ asv continuous master -b TransformSuite
+  $ asv continuous main -b TransformSuite
   · Creating environments
   · Discovering benchmarks
   ·· Uninstalling from conda-py3.7-cython-numpy1.15-scipy
@@ -633,7 +633,7 @@ The output may look something like::
 
   BENCHMARKS NOT SIGNIFICANTLY CHANGED.
 
-In this case, the differences between HEAD and master are not significant
+In this case, the differences between HEAD and main are not significant
 enough for airspeed velocity to report.
 
 It is also possible to get a comparison of results for two specific revisions

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -241,7 +241,7 @@ We also make a few more assumptions about your system:
 - You have a C compiler set up.
 - You have a C++ compiler set up.
 - You are running a version of Python compatible with our system as listed
-  in our `setup.py file <https://github.com/scikit-image/scikit-image/blob/master/setup.py#L212>`_.
+  in our `setup.py file <https://github.com/scikit-image/scikit-image/blob/main/setup.py#L212>`_.
 - You've cloned the git repository into a directory called ``scikit-image``.
   You have set up the `upstream` remote to point to our repository and `origin`
   to point to your fork.
@@ -340,8 +340,8 @@ that have changed. Do so with the following commands:
 .. code-block:: sh
 
     # Grab the latest source
-    git checkout master
-    git pull upstream master
+    git checkout main
+    git pull upstream main
     # Update the installation
     pip install -e . -vv
 
@@ -429,7 +429,7 @@ either download and install Windows compilers from `here`_  or use
 A run-through of the compilation process for Windows is included in
 our `setup of Azure Pipelines`_ (a continuous integration service).
 
-.. _setup of Azure Pipelines: https://github.com/scikit-image/scikit-image/blob/master/azure-pipelines.yml
+.. _setup of Azure Pipelines: https://github.com/scikit-image/scikit-image/blob/main/azure-pipelines.yml
 .. _here: https://wiki.python.org/moin/WindowsCompilers#Microsoft_Visual_C.2B-.2B-_14.0_standalone:_Visual_C.2B-.2B-_Build_Tools_2015_.28x86.2C_x64.2C_ARM.29
 .. _MinGW compilers: http://www.mingw.org/wiki/howto_install_the_mingw_gcc_compiler_suite
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Image.sc forum](https://img.shields.io/badge/dynamic/json.svg?label=forum&url=https%3A%2F%2Fforum.image.sc%2Ftags%2Fscikit-image.json&query=%24.topic_list.tags.0.topic_count&colorB=brightgreen&suffix=%20topics&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAABPklEQVR42m3SyyqFURTA8Y2BER0TDyExZ+aSPIKUlPIITFzKeQWXwhBlQrmFgUzMMFLKZeguBu5y+//17dP3nc5vuPdee6299gohUYYaDGOyyACq4JmQVoFujOMR77hNfOAGM+hBOQqB9TjHD36xhAa04RCuuXeKOvwHVWIKL9jCK2bRiV284QgL8MwEjAneeo9VNOEaBhzALGtoRy02cIcWhE34jj5YxgW+E5Z4iTPkMYpPLCNY3hdOYEfNbKYdmNngZ1jyEzw7h7AIb3fRTQ95OAZ6yQpGYHMMtOTgouktYwxuXsHgWLLl+4x++Kx1FJrjLTagA77bTPvYgw1rRqY56e+w7GNYsqX6JfPwi7aR+Y5SA+BXtKIRfkfJAYgj14tpOF6+I46c4/cAM3UhM3JxyKsxiOIhH0IO6SH/A1Kb1WBeUjbkAAAAAElFTkSuQmCC)](https://forum.image.sc/tags/scikit-image)
 [![Stackoverflow](https://img.shields.io/badge/stackoverflow-Ask%20questions-blue.svg)](https://stackoverflow.com/questions/tagged/scikit-image)
 [![project chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://skimage.zulipchat.com)
-[![codecov.io](https://codecov.io/github/scikit-image/scikit-image/coverage.svg?branch=master)](https://codecov.io/github/scikit-image/scikit-image?branch=master)
+[![codecov.io](https://codecov.io/github/scikit-image/scikit-image/coverage.svg?branch=main)](https://codecov.io/github/scikit-image/scikit-image?branch=main)
 
 - **Website (including documentation):** [https://scikit-image.org/](https://scikit-image.org)
 - **Mailing list:** [https://mail.python.org/mailman3/lists/scikit-image.python.org/](https://mail.python.org/mailman3/lists/scikit-image.python.org/)

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -23,9 +23,9 @@ access), specifically to:
 
 - Check ``TODO.txt`` for any outstanding tasks.
 
-- Branch v<major>.<minor>.x from master. This is the "release branch", where
+- Branch v<major>.<minor>.x from `main`. This is the "release branch", where
   you will make your changes gearing up for release, and cherry-pick them as
-  appropriate to master.
+  appropriate to `main`.
 
 - On the release branch, update the release notes:
 
@@ -55,14 +55,14 @@ access), specifically to:
 
 - Submit the release notes for review by other project maintainers:
 
-  - Create a PR from v<major>.<minor>.x branch to master (at this point,
+  - Create a PR from v<major>.<minor>.x branch to `main` (at this point,
     the difference should show the full contents of the release notes).
   - Discuss with others, and make the changes directly to v<major>.<minor>.x branch.
   - Once the consensus is found, ask the project maintainers to merge
     the PR.
   - Cherry pick the change onto the release branch.
 
-- On the master branch, update the version number in ``skimage/__init__.py``
+- On the main branch, update the version number in ``skimage/__init__.py``
   to the next ``.dev0`` version, commit, and push. This should follow PEP440
   meaning that the appropriate version number would look something like
   ``0.20.0.dev0`` with the period between ``0`` and ``dev`` and a trailing
@@ -71,7 +71,7 @@ access), specifically to:
   `NumpyVersion <https://github.com/scikit-image/scikit-image/pull/4947>`_
   correctly interprets the version number.
 
- - On the master branch, edit ``doc/source/_static/docversions.js``,
+ - On the main branch, edit ``doc/source/_static/docversions.js``,
   add the release, e.g., `0.15.x`, and commit.  Cherry-pick this
   change back to the release branch.
 
@@ -211,7 +211,7 @@ access), specifically to:
 - Make a PR to scikit-image with any updates you might have to these notes
 
 - If making a patch release (v<major>.<minor>.<patch>), forward-port the
-  release notes to the master branch and make a PR.
+  release notes to the main branch and make a PR.
 
 Conda-forge
 -----------

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -9,7 +9,7 @@
     "project_url": "https://scikit-image.org/",
     "repo": ".",
 
-    "branches": ["master"],
+    "branches": ["main"],
     "dvcs": "git",
     "environment_type": "conda",
     "install_timeout": 1200,

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -72,6 +72,7 @@ source_suffix = '.rst'
 #source_encoding = 'utf-8-sig'
 
 # The master toctree document.
+# Changes to `root_doc` in newest versions of Sphinx (we're still on v2)
 master_doc = 'index'
 
 # General information about the project.
@@ -144,7 +145,7 @@ if v.release is None:
         'PEP440'.format(version))
 
 if v.is_devrelease:
-    binder_branch = 'master'
+    binder_branch = 'main'
 else:
     major, minor = v.release[:2]
     binder_branch = 'v{}.{}.x'.format(major, minor)
@@ -444,7 +445,7 @@ def linkcode_resolve(domain, info):
 
     if 'dev' in skimage.__version__:
         return ("https://github.com/scikit-image/scikit-image/blob/"
-                "master/skimage/%s%s" % (fn, linespec))
+                "main/skimage/%s%s" % (fn, linespec))
     else:
         return ("https://github.com/scikit-image/scikit-image/blob/"
                 "v%s/skimage/%s%s" % (skimage.__version__, fn, linespec))

--- a/doc/source/core_developer.md
+++ b/doc/source/core_developer.md
@@ -20,7 +20,7 @@ guidelines.
 All Contributors Are Treated The Same
 -------------------------------------
 
-You now have the ability to push changes directly to the master
+You now have the ability to push changes directly to the main
 branch, but should never do so; instead, continue making pull requests
 as before and in accordance with the 
 {doc}`general contributor guide <contribute>`.
@@ -95,7 +95,7 @@ whether to accept the changes.)
 [gh_feedback]: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request
 
 Our default merge policy is to squash all PR commits into a single
-commit. Users who wish to bring the latest changes from ``master``
+commit. Users who wish to bring the latest changes from ``main``
 into their branch should be advised to merge, not to rebase.  Even
 when merge conflicts arise, don’t ask for a rebase unless you know
 that a contributor is experienced with git. Instead, rebase the branch

--- a/doc/source/gitwash/development_workflow.rst
+++ b/doc/source/gitwash/development_workflow.rst
@@ -11,10 +11,10 @@ git by following :ref:`configure-git`.  Now you are ready for some real work.
 Workflow summary
 ================
 
-In what follows we'll refer to the upstream scikit-image ``master`` branch, as
+In what follows we'll refer to the upstream scikit-image ``main`` branch, as
 "trunk".
 
-* Don't use your ``master`` branch for anything.  Consider deleting it.
+* Don't use your ``main`` branch for anything.  Consider deleting it.
 * When you are starting a new set of changes, fetch any changes from trunk,
   and start a new *feature branch* from that.
 * Make a new branch for each separable set of changes |emdash| "one task, one
@@ -33,12 +33,12 @@ what you've done, and why you did it.
 
 See `linux git workflow`_ and `ipython git workflow`_ for some explanation.
 
-Consider deleting your master branch
+Consider deleting your main branch
 ====================================
 
-It may sound strange, but deleting your own ``master`` branch can help reduce
+It may sound strange, but deleting your own ``main`` branch can help reduce
 confusion about which branch you are on.  See `deleting master on github`_ for
-details.
+details (replacing `master` with `main`).
 
 .. _update-mirror-trunk:
 
@@ -53,8 +53,8 @@ From time to time you should fetch the upstream (trunk) changes from github::
 
 This will pull down any commits you don't have, and set the remote branches to
 point to the right commit.  For example, 'trunk' is the branch referred to by
-(remote/branchname) ``upstream/master`` - and if there have been commits since
-you last checked, ``upstream/master`` will change after you do the fetch.
+(remote/branchname) ``upstream/main`` - and if there have been commits since
+you last checked, ``upstream/main`` will change after you do the fetch.
 
 .. _make-feature-branch:
 
@@ -77,7 +77,7 @@ what the changes in the branch are for.  For example ``add-ability-to-fly``, or
     # Update the mirror of trunk
     git fetch upstream
     # Make new feature branch starting at current trunk
-    git branch my-new-feature upstream/master
+    git branch my-new-feature upstream/main
     git checkout my-new-feature
 
 Generally, you will want to keep your feature branches on your public github_
@@ -176,7 +176,7 @@ Delete a branch on github
 
 ::
 
-   git checkout master
+   git checkout main
    # delete branch locally
    git branch -D my-unwanted-branch
    # delete branch on github
@@ -213,7 +213,7 @@ Your collaborators can then commit directly into that repo with the
 usual::
 
      git commit -am 'ENH - much better code'
-     git push origin master # pushes directly into your repo
+     git push origin main # pushes directly into your repo
 
 Explore your repository
 -----------------------
@@ -276,12 +276,12 @@ To do a rebase on trunk::
     # make a backup in case you mess up
     git branch tmp cool-feature
     # rebase cool-feature onto trunk
-    git rebase --onto upstream/master upstream/master cool-feature
+    git rebase --onto upstream/main upstream/main cool-feature
 
 In this situation, where you are already on branch ``cool-feature``, the last
 command can be written more succinctly as::
 
-    git rebase upstream/master
+    git rebase upstream/main
 
 When all looks good you can delete your backup branch::
 

--- a/doc/source/gitwash/maintainer_workflow.rst
+++ b/doc/source/gitwash/maintainer_workflow.rst
@@ -24,7 +24,7 @@ Integrating changes
 *******************
 
 Let's say you have some changes that need to go into trunk
-(``upstream-rw/master``).
+(``upstream-rw/main``).
 
 The changes are in some branch that you are currently on.  For example, you are
 looking at someone's changes like this::
@@ -45,7 +45,7 @@ If there are only a few commits, consider rebasing to upstream::
     # Fetch upstream changes
     git fetch upstream-rw
     # rebase
-    git rebase upstream-rw/master
+    git rebase upstream-rw/main
 
 Remember that, if you do a rebase, and push that, you'll have to close any
 github pull requests manually, because github will not be able to detect the
@@ -57,7 +57,7 @@ A long series of commits
 If there are a longer series of related commits, consider a merge instead::
 
     git fetch upstream-rw
-    git merge --no-ff upstream-rw/master
+    git merge --no-ff upstream-rw/main
 
 The merge will be detected by github, and should close any related pull requests
 automatically.
@@ -74,11 +74,11 @@ Now, in either case, you should check that the history is sensible and you have
 the right commits::
 
     git log --oneline --graph
-    git log -p upstream-rw/master..
+    git log -p upstream-rw/main..
 
 The first line above just shows the history in a compact way, with a text
 representation of the history graph. The second line shows the log of commits
-excluding those that can be reached from trunk (``upstream-rw/master``), and
+excluding those that can be reached from trunk (``upstream-rw/main``), and
 including those that can be reached from current HEAD (implied with the ``..``
 at the end). So, it shows the commits unique to this branch compared to trunk.
 The ``-p`` option shows the diff for these commits in patch form.
@@ -88,9 +88,9 @@ Push to trunk
 
 ::
 
-    git push upstream-rw my-new-feature:master
+    git push upstream-rw my-new-feature:main
 
-This pushes the ``my-new-feature`` branch in this repository to the ``master``
+This pushes the ``my-new-feature`` branch in this repository to the ``main``
 branch in the ``upstream-rw`` repository.
 
 .. include:: links.inc

--- a/doc/source/gitwash/patching.rst
+++ b/doc/source/gitwash/patching.rst
@@ -42,7 +42,7 @@ Overview
    # hack hack, hack
    git commit -am 'BF - added fix for Funny bug'
    # make the patch files
-   git format-patch -M -C master
+   git format-patch -M -C main
 
 Then, send the generated patch files to the `scikit-image
 mailing list`_ |emdash| where we will thank you warmly.
@@ -91,9 +91,9 @@ In detail
       git status
 
 #. Finally, make your commits into patches.  You want all the
-   commits since you branched from the ``master`` branch::
+   commits since you branched from the ``main`` branch::
 
-      git format-patch -M -C master
+      git format-patch -M -C main
 
    You will now have several files named for the commits::
 
@@ -103,9 +103,9 @@ In detail
    Send these files to the `scikit-image mailing list`_.
 
 When you are done, to switch back to the main copy of the
-code, just return to the ``master`` branch::
+code, just return to the ``main`` branch::
 
-   git checkout master
+   git checkout main
 
 Moving from patching to development
 ===================================
@@ -118,9 +118,9 @@ have.
 Fork the `scikit-image`_ repository on github |emdash| :ref:`forking`.
 Then::
 
-   # checkout and refresh master branch from main repo
-   git checkout master
-   git pull origin master
+   # checkout and refresh main branch from main repo
+   git checkout main
+   git pull origin main
    # rename pointer to main repository to 'upstream'
    git remote rename origin upstream
    # point your repo to default read / write to your fork on github

--- a/doc/source/gitwash/set_up_fork.rst
+++ b/doc/source/gitwash/set_up_fork.rst
@@ -27,11 +27,11 @@ Clone your fork
    ``git branch -a`` to show you all branches.  You'll get something
    like::
 
-      * master
-      remotes/origin/master
+      * main
+      remotes/origin/main
 
-   This tells you that you are currently on the ``master`` branch, and
-   that you also have a ``remote`` connection to ``origin/master``.
+   This tells you that you are currently on the ``main`` branch, and
+   that you also have a ``remote`` connection to ``origin/main``.
    What remote repository is ``remote/origin``? Try ``git remote -v`` to
    see the URLs for the remote.  They will point to your github fork.
 

--- a/doc/source/skips/0-skip-process.rst
+++ b/doc/source/skips/0-skip-process.rst
@@ -272,7 +272,7 @@ References and Footnotes
 
 .. [1] This historical record is available by the normal git commands
    for retrieving older revisions, and can also be browsed on
-   `GitHub <https://github.com/scikit-image/scikit-image/tree/master/doc/source/skips>`_.
+   `GitHub <https://github.com/scikit-image/scikit-image/tree/main/doc/source/skips>`_.
 
 .. [2] The URL for viewing SKIPs on the web is
    https://scikit-image.org/docs/stable/skips/

--- a/doc/source/themes/scikit-image/static/css/custom.css
+++ b/doc/source/themes/scikit-image/static/css/custom.css
@@ -139,7 +139,7 @@ table.docutils td, table.docutils th {
     margin-right: -15px;
 }
 
-/* master content table */
+/* main content table */
 .contentstable.docutils, .contentstable.docutils td {
     border-color: transparent;
 }

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -150,6 +150,7 @@ def create_image_fetcher():
         path=pooch.os_cache("scikit-image"),
         base_url=url,
         version=skimage_version_for_pooch,
+        version_dev="main",
         env="SKIMAGE_DATADIR",
         registry=registry,
         urls=registry_urls,

--- a/tools/generate_release_notes.py
+++ b/tools/generate_release_notes.py
@@ -7,7 +7,7 @@ export GH_TOKEN=<your-gh-api-token>
 
 Then, for a major release:
 ```
-python /path/to/generate_release_notes.py v0.14.0 master --version 0.15.0
+python /path/to/generate_release_notes.py v0.14.0 main --version 0.15.0
 ```
 
 For a minor release:


### PR DESCRIPTION
## Description

Hopefully with this we can build aarch64 wheels.

Backport of #5243

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
