### PR TITLE
0.18.X: Remove unecessary manual installation of packages from before_install

### DIFF
--- a/tools/github/before_install.sh
+++ b/tools/github/before_install.sh
@@ -33,15 +33,6 @@ fi
 
 python -m pip install --upgrade pip wheel setuptools
 
-
-# install specific wheels from wheelhouse
-for requirement in matplotlib scipy pillow; do
-    WHEELS="$WHEELS $(grep $requirement requirements/default.txt)"
-done
-# cython is not in the default.txt requirements
-WHEELS="$WHEELS $(grep -i cython requirements/build.txt)"
-python -m pip install $PIP_FLAGS $WHEELS
-
 # Install build time requirements
 python -m pip install $PIP_FLAGS -r requirements/build.txt
 # Default requirements are necessary to build because of lazy importing


### PR DESCRIPTION
Partially taken from
https://github.com/scikit-image/scikit-image/pull/5212

@jni sorry for creating this branch directly on scikit-image. I guess github doesn't automatically do the fork and create a branch there model.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
