### PR TITLE
Support variable number of channels in rag_mean_color

### DIFF
--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -359,8 +359,7 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
     for n in graph:
         graph.nodes[n].update({'labels': [n],
                                'pixel count': 0,
-                               'total color': np.zeros(img_channels,
-                                                      dtype=np.double)})
+                               'total color': np.zeros(img_channels)})
 
     for index in np.ndindex(labels.shape):
         current = labels[index]

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -359,7 +359,8 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
     for n in graph:
         graph.nodes[n].update({'labels': [n],
                                'pixel count': 0,
-                               'total color': np.zeros(img_channels)})
+                               'total color': np.zeros(img_channels,
+                                                      dtype=np.double)})
 
     for index in np.ndindex(labels.shape):
         current = labels[index]

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -304,11 +304,11 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
 
     Parameters
     ----------
-    image : ndarray, shape(M, N, [..., P,] 3)
+    image : ndarray, shape(M, N, [..., P,] C)
         Input image.
     labels : ndarray, shape(M, N, [..., P])
         The labelled image. This should have one dimension less than
-        `image`. If `image` has dimensions `(M, N, 3)` `labels` should have
+        `image`. If `image` has dimensions `(M, N, C)` `labels` should have
         dimensions `(M, N)`.
     connectivity : int, optional
         Pixels with a squared distance less than `connectivity` from each other
@@ -354,11 +354,12 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
     """
     graph = RAG(labels, connectivity=connectivity)
 
+    img_channels = image.shape[-1]
+
     for n in graph:
         graph.nodes[n].update({'labels': [n],
                                'pixel count': 0,
-                               'total color': np.array([0, 0, 0],
-                                                      dtype=np.double)})
+                               'total color': np.zeros(img_channels)})
 
     for index in np.ndindex(labels.shape):
         current = labels[index]

--- a/skimage/future/graph/tests/test_rag.py
+++ b/skimage/future/graph/tests/test_rag.py
@@ -49,7 +49,7 @@ def test_rag_merge():
 
 
 @pytest.mark.parametrize(
-    "img_channels", [channels for channels in range(1, 4)]
+    "img_channels", [channels for channels in range(1, 5)]
 )
 def test_threshold_cut(img_channels):
 
@@ -76,7 +76,7 @@ def test_threshold_cut(img_channels):
 
 
 @pytest.mark.parametrize(
-    "img_channels", [channels for channels in range(1, 4)]
+    "img_channels", [channels for channels in range(1, 5)]
 )
 def test_cut_normalized(img_channels):
 
@@ -133,20 +133,18 @@ def merge_hierarchical_mean_color(labels, rag, thresh, rag_copy=True,
                                     in_place_merge, _pre_merge_mean_color,
                                     _weight_mean_color)
 
-@pytest.mark.parametrize(
-    "img_channels", [channels for channels in range(1, 4)]
-)
-def test_rag_hierarchical(img_channels):
-    img = np.zeros((8, 8, img_channels), dtype='uint8')
+
+def test_rag_hierarchical():
+    img = np.zeros((8, 8, 3), dtype='uint8')
     labels = np.zeros((8, 8), dtype='uint8')
 
     img[:, :, :] = 31
     labels[:, :] = 1
 
-    img[0:4, 0:4, :] = 10
+    img[0:4, 0:4, :] = 10, 10, 10
     labels[0:4, 0:4] = 2
 
-    img[4:, 0:4, :] = 20
+    img[4:, 0:4, :] = 20, 20, 20
     labels[4:, 0:4] = 3
 
     g = graph.rag_mean_color(img, labels)
@@ -165,13 +163,11 @@ def test_rag_hierarchical(img_channels):
     result = graph.cut_threshold(labels, g, thresh)
     assert np.all(result == result[0, 0])
 
-@pytest.mark.parametrize(
-    "img_channels", [channels for channels in range(1, 4)]
-)
-def test_ncut_stable_subgraph(img_channels):
+
+def test_ncut_stable_subgraph():
     """ Test to catch an error thrown when subgraph has all equal edges. """
 
-    img = np.zeros((100, 100, img_channels), dtype='uint8')
+    img = np.zeros((100, 100, 3), dtype='uint8')
 
     labels = np.zeros((100, 100), dtype='uint8')
     labels[:50, :50] = 1

--- a/skimage/future/graph/tests/test_rag.py
+++ b/skimage/future/graph/tests/test_rag.py
@@ -1,3 +1,4 @@
+import pytest
 from numpy.testing import assert_array_equal
 import numpy as np
 from skimage.future import graph
@@ -46,14 +47,14 @@ def test_rag_merge():
     assert sorted(g.nodes[n]['labels']) == list(range(5))
     assert list(g.edges()) == []
 
+@pytest.mark.parametrize("img_channels", [channels for channels in range(1,5)])
+def test_threshold_cut(img_channels):
 
-def test_threshold_cut():
-
-    img = np.zeros((100, 100, 3), dtype='uint8')
-    img[:50, :50] = 255, 255, 255
-    img[:50, 50:] = 254, 254, 254
-    img[50:, :50] = 2, 2, 2
-    img[50:, 50:] = 1, 1, 1
+    img = np.zeros((100, 100, img_channels), dtype='uint8')
+    img[:50, :50] = 255
+    img[:50, 50:] = 254
+    img[50:, :50] = 2
+    img[50:, 50:] = 1
 
     labels = np.zeros((100, 100), dtype='uint8')
     labels[:50, :50] = 0
@@ -70,14 +71,14 @@ def test_threshold_cut():
     # Two labels
     assert new_labels.max() == 1
 
+@pytest.mark.parametrize("img_channels", [channels for channels in range(1,5)])
+def test_cut_normalized(img_channels):
 
-def test_cut_normalized():
-
-    img = np.zeros((100, 100, 3), dtype='uint8')
-    img[:50, :50] = 255, 255, 255
-    img[:50, 50:] = 254, 254, 254
-    img[50:, :50] = 2, 2, 2
-    img[50:, 50:] = 1, 1, 1
+    img = np.zeros((100, 100, img_channels), dtype='uint8')
+    img[:50, :50] = 255
+    img[:50, 50:] = 254
+    img[50:, :50] = 2
+    img[50:, 50:] = 1
 
     labels = np.zeros((100, 100), dtype='uint8')
     labels[:50, :50] = 0

--- a/skimage/future/graph/tests/test_rag.py
+++ b/skimage/future/graph/tests/test_rag.py
@@ -47,7 +47,9 @@ def test_rag_merge():
     assert sorted(g.nodes[n]['labels']) == list(range(5))
     assert list(g.edges()) == []
 
-@pytest.mark.parametrize("img_channels", [channels for channels in range(1,5)])
+@pytest.mark.parametrize(
+    "img_channels", [channels for channels in range(1,5)]
+)
 def test_threshold_cut(img_channels):
 
     img = np.zeros((100, 100, img_channels), dtype='uint8')
@@ -71,7 +73,9 @@ def test_threshold_cut(img_channels):
     # Two labels
     assert new_labels.max() == 1
 
-@pytest.mark.parametrize("img_channels", [channels for channels in range(1,5)])
+@pytest.mark.parametrize(
+    "img_channels", [channels for channels in range(1,5)]
+)
 def test_cut_normalized(img_channels):
 
     img = np.zeros((100, 100, img_channels), dtype='uint8')

--- a/skimage/future/graph/tests/test_rag.py
+++ b/skimage/future/graph/tests/test_rag.py
@@ -47,8 +47,9 @@ def test_rag_merge():
     assert sorted(g.nodes[n]['labels']) == list(range(5))
     assert list(g.edges()) == []
 
+
 @pytest.mark.parametrize(
-    "img_channels", [channels for channels in range(1,5)]
+    "img_channels", [channels for channels in range(1, 5)]
 )
 def test_threshold_cut(img_channels):
 
@@ -73,8 +74,9 @@ def test_threshold_cut(img_channels):
     # Two labels
     assert new_labels.max() == 1
 
+
 @pytest.mark.parametrize(
-    "img_channels", [channels for channels in range(1,5)]
+    "img_channels", [channels for channels in range(1, 5)]
 )
 def test_cut_normalized(img_channels):
 

--- a/skimage/future/graph/tests/test_rag.py
+++ b/skimage/future/graph/tests/test_rag.py
@@ -49,7 +49,7 @@ def test_rag_merge():
 
 
 @pytest.mark.parametrize(
-    "img_channels", [channels for channels in range(1, 5)]
+    "img_channels", [channels for channels in range(1, 4)]
 )
 def test_threshold_cut(img_channels):
 
@@ -76,7 +76,7 @@ def test_threshold_cut(img_channels):
 
 
 @pytest.mark.parametrize(
-    "img_channels", [channels for channels in range(1, 5)]
+    "img_channels", [channels for channels in range(1, 4)]
 )
 def test_cut_normalized(img_channels):
 
@@ -133,18 +133,20 @@ def merge_hierarchical_mean_color(labels, rag, thresh, rag_copy=True,
                                     in_place_merge, _pre_merge_mean_color,
                                     _weight_mean_color)
 
-
-def test_rag_hierarchical():
-    img = np.zeros((8, 8, 3), dtype='uint8')
+@pytest.mark.parametrize(
+    "img_channels", [channels for channels in range(1, 4)]
+)
+def test_rag_hierarchical(img_channels):
+    img = np.zeros((8, 8, img_channels), dtype='uint8')
     labels = np.zeros((8, 8), dtype='uint8')
 
     img[:, :, :] = 31
     labels[:, :] = 1
 
-    img[0:4, 0:4, :] = 10, 10, 10
+    img[0:4, 0:4, :] = 10
     labels[0:4, 0:4] = 2
 
-    img[4:, 0:4, :] = 20, 20, 20
+    img[4:, 0:4, :] = 20
     labels[4:, 0:4] = 3
 
     g = graph.rag_mean_color(img, labels)
@@ -163,11 +165,13 @@ def test_rag_hierarchical():
     result = graph.cut_threshold(labels, g, thresh)
     assert np.all(result == result[0, 0])
 
-
-def test_ncut_stable_subgraph():
+@pytest.mark.parametrize(
+    "img_channels", [channels for channels in range(1, 4)]
+)
+def test_ncut_stable_subgraph(img_channels):
     """ Test to catch an error thrown when subgraph has all equal edges. """
 
-    img = np.zeros((100, 100, 3), dtype='uint8')
+    img = np.zeros((100, 100, img_channels), dtype='uint8')
 
     labels = np.zeros((100, 100), dtype='uint8')
     labels[:50, :50] = 1

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1,7 +1,6 @@
 import math
 import numpy as np
 from scipy import spatial
-from scipy.sparse.linalg import svds
 import textwrap
 
 from .._shared.utils import get_bound_method_class, safe_as_int
@@ -1448,8 +1447,8 @@ class PolynomialTransform(GeometricTransform):
         A[:rows, -1] = xd
         A[rows:, -1] = yd
 
-        U, s, V = np.linalg.svd(A)
-      
+        _, _, V = np.linalg.svd(A)
+
         # solution is right singular vector that corresponds to smallest
         # singular value
         params = - V[-1, :-1] / V[-1, -1]

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1,6 +1,7 @@
 import math
 import numpy as np
 from scipy import spatial
+from scipy.sparse.linalg import svds
 import textwrap
 
 from .._shared.utils import get_bound_method_class, safe_as_int
@@ -1447,8 +1448,8 @@ class PolynomialTransform(GeometricTransform):
         A[:rows, -1] = xd
         A[rows:, -1] = yd
 
-        _, _, V = np.linalg.svd(A)
-
+        U, s, V = np.linalg.svd(A)
+      
         # solution is right singular vector that corresponds to smallest
         # singular value
         params = - V[-1, :-1] / V[-1, -1]

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1,7 +1,6 @@
 import math
 import numpy as np
 from scipy import spatial
-from scipy.sparse.linalg import svds
 import textwrap
 
 from .._shared.utils import get_bound_method_class, safe_as_int
@@ -1448,7 +1447,7 @@ class PolynomialTransform(GeometricTransform):
         A[:rows, -1] = xd
         A[rows:, -1] = yd
 
-        U, s, V = np.linalg.svd(A)
+        _, _, V = np.linalg.svd(A)
       
         # solution is right singular vector that corresponds to smallest
         # singular value


### PR DESCRIPTION
## Description

Fixes scikit-image/scikit-image#4293
Enhancement to rag_mean_color, allowing varying number of channels in the input image.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
