### PR TITLE
Use manylinux2010 for python 3.9+

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -17,7 +17,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04]
-        cibw_python: [ "cp37-*", "cp38-*", "cp39-*" ]
+        cibw_python: [ "cp37-*", "cp38-*" ]
+        cibw_manylinux: [ manylinux1 ]
+        include:
+          - os: ubuntu-18.04
+            cibw_python: "cp39-*"
+            cibw_manylinux: manylinux2010
     steps:
       - uses: actions/checkout@v2
         with:
@@ -39,8 +44,8 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ARCHS_LINUX: auto aarch64
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
-          CIBW_MANYLINUX_I686_IMAGE: manylinux1
+          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
+          CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_TEST_REQUIRES: pytest pooch pytest-localserver pytest-faulthandler
           CIBW_TEST_COMMAND: pytest --pyargs skimage
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Description

Closes https://github.com/scikit-image/scikit-image/issues/5302

Numpy released the CPython 3.9 wheels as manylinux2010. Without specifying the buildwheel options as manylinux2010, it seems that our CI is building from source which is causing it to have strange failures with BLAS and other optimized code.

This should be backported to v0.18.x

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
