### PR TITLE
remove misleading comment in example code

### DIFF
--- a/doc/examples/segmentation/plot_thresholding.py
+++ b/doc/examples/segmentation/plot_thresholding.py
@@ -66,7 +66,5 @@ from skimage.filters import try_all_threshold
 
 img = data.page()
 
-# Here, we specify a radius for local thresholding algorithms.
-# If it is not specified, only global algorithms are called.
 fig, ax = try_all_threshold(img, figsize=(10, 8), verbose=False)
 plt.show()


### PR DESCRIPTION
## Description

This improves documentation by removing a misleading comment in example code. The comment mentioned a `radius` parameter which is not present and also not supported by the [`try_all_threshold` method](https://github.com/scikit-image/scikit-image/blob/main/skimage/filters/thresholding.py#L86). Removing the comment resolves my confusion. :-)

## Checklist

This is just a minor documentation update.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
