### PR TITLE
Re-enable skipped Qt tests

### DIFF
--- a/skimage/viewer/tests/test_utils.py
+++ b/skimage/viewer/tests/test_utils.py
@@ -20,7 +20,6 @@ def test_format_filename():
     assert fname is None
 
 
-@testing.skipif(True, reason="Can't automatically close window. See #3081.")
 @testing.skipif(not has_qt, reason="Qt not installed")
 def test_open_file_dialog():
     QApp = utils.init_qtapp()
@@ -30,7 +29,6 @@ def test_open_file_dialog():
     assert filename is None
 
 
-@testing.skipif(True, reason="Can't automatically close window. See #3081.")
 @testing.skipif(not has_qt, reason="Qt not installed")
 def test_save_file_dialog():
     QApp = utils.init_qtapp()

--- a/skimage/viewer/tests/test_widgets.py
+++ b/skimage/viewer/tests/test_widgets.py
@@ -87,7 +87,6 @@ def test_slider_float():
     assert_almost_equal(sld.val, 2.5, 2)
 
 
-@testing.skipif(True, reason="Can't automatically close window. See #3081.")
 @testing.skipif(not has_qt, reason="Qt not installed")
 def test_save_buttons():
     viewer = get_image_viewer()


### PR DESCRIPTION
This PR just re-enables some tests that were previously skipped due to #3081. Given that we are no longer using Travis, I wanted to see if the issue is still relevant.

(I think the plan is to move the viewer to a separate repo in any case)

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
