### PR TITLE
allow either SyntaxError or OSError for truncated JPG

### DIFF
--- a/skimage/io/tests/test_imageio.py
+++ b/skimage/io/tests/test_imageio.py
@@ -35,7 +35,9 @@ def test_imageio_palette():
 def test_imageio_truncated_jpg():
     # imageio>2.0 uses Pillow / PIL to try and load the file.
     # Oddly, PIL explicitly raises a SyntaxError when the file read fails.
-    with testing.raises(SyntaxError):
+    # The exception type changed from SyntaxError to OSError in PIL 8.2.0, so
+    # allow for either to be raised.
+    with testing.raises((OSError, SyntaxError)):
         imread(fetch('data/truncated.jpg'))
 
 


### PR DESCRIPTION

## Description

Accounts for a change in the exception type returned by the Pillow backend used by imageio when Pillow >= 8.2.

closes #5314

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
