### PR TITLE
Replace numpy dtype by builtin dtype

### DIFF
--- a/skimage/filters/_gabor.py
+++ b/skimage/filters/_gabor.py
@@ -87,7 +87,7 @@ def gabor_kernel(frequency, theta=0, bandwidth=1, sigma_x=None, sigma_y=None,
     rotx = x * np.cos(theta) + y * np.sin(theta)
     roty = -x * np.sin(theta) + y * np.cos(theta)
 
-    g = np.zeros(y.shape, dtype=np.complex)
+    g = np.zeros(y.shape, dtype=complex)
     g[:] = np.exp(-0.5 * (rotx ** 2 / sigma_x ** 2 + roty ** 2 / sigma_y ** 2))
     g /= 2 * np.pi * sigma_x * sigma_y
     g *= np.exp(1j * (2 * np.pi * frequency * rotx + offset))

--- a/skimage/registration/tests/test_masked_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_masked_phase_cross_correlation.py
@@ -222,7 +222,7 @@ def test_cross_correlate_masked_over_axes():
     m2 = np.random.choice([True, False], arr2.shape)
 
     # Loop over last axis
-    with_loop = np.empty_like(arr1, dtype=np.complex)
+    with_loop = np.empty_like(arr1, dtype=complex)
     for index in range(arr1.shape[-1]):
         with_loop[:, :, index] = cross_correlate_masked(arr1[:, :, index],
                                                         arr2[:, :, index],

--- a/skimage/segmentation/tests/test_clear_border.py
+++ b/skimage/segmentation/tests/test_clear_border.py
@@ -35,7 +35,7 @@ def test_clear_border():
                      [1, 1, 1, 1, 1, 1, 1, 1, 1],
                      [1, 1, 1, 1, 1, 1, 1, 1, 1],
                      [1, 1, 1, 1, 1, 1, 1, 1, 1],
-                     [1, 1, 1, 1, 1, 1, 1, 1, 1]]).astype(np.bool)
+                     [1, 1, 1, 1, 1, 1, 1, 1, 1]]).astype(bool)
     result = clear_border(image.copy(), mask=mask)
     ref = image.copy()
     ref[1:3, 0:2] = 0

--- a/skimage/util/_label.py
+++ b/skimage/util/_label.py
@@ -46,8 +46,7 @@ def label_points(coords, output_shape):
     if np.any(coords < 0):
         raise ValueError("Coordinates should be positive and start from 0")
 
-    np_indices = tuple(np.transpose(np.round(coords).astype(np.int,
-                                                            copy=False)))
+    np_indices = tuple(np.transpose(np.round(coords).astype(int, copy=False)))
     labels = np.zeros(output_shape, dtype=np.uint64)
     labels[np_indices] = np.arange(1, coords.shape[0] + 1)
     return labels


### PR DESCRIPTION
## Description

Follows #5103 



## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
