### PR TITLE
DOC: Attempt at autoformatting docstrings in morphology/*

### DIFF
--- a/skimage/morphology/_deprecated.py
+++ b/skimage/morphology/_deprecated.py
@@ -37,9 +37,9 @@ def watershed(image, markers=None, connectivity=1, offset=None, mask=None,
     out: ndarray
         A labeled matrix of the same type and shape as markers
 
-    See also
+    See Also
     --------
-    skimage.segmentation.random_walker: random walker segmentation
+    skimage.segmentation.random_walker : random walker segmentation
         A segmentation algorithm based on anisotropic diffusion, usually
         slower than the watershed but with good results on noisy data and
         boundaries with holes.

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -34,7 +34,7 @@ def skeletonize(image, *, method=None):
     skeleton : ndarray
         The thinned image.
 
-    See also
+    See Also
     --------
     medial_axis
 
@@ -47,7 +47,6 @@ def skeletonize(image, *, method=None):
     .. [Zha84] A fast parallel algorithm for thinning digital patterns,
            T. Y. Zhang and C. Y. Suen, Communications of the ACM,
            March 1984, Volume 27, Number 3.
-
 
     Examples
     --------
@@ -108,7 +107,7 @@ def skeletonize_2d(image):
     skeleton : ndarray
         A matrix containing the thinned image.
 
-    See also
+    See Also
     --------
     medial_axis
 
@@ -132,7 +131,6 @@ def skeletonize_2d(image):
     .. [Zha84] A fast parallel algorithm for thinning digital patterns,
            T. Y. Zhang and C. Y. Suen, Communications of the ACM,
            March 1984, Volume 27, Number 3.
-
 
     Examples
     --------
@@ -264,7 +262,6 @@ def thin(image, max_iter=None):
     ----------
     image : binary (M, N) ndarray
         The image to be thinned.
-
     max_iter : int, number of iterations, optional
         Regardless of the value of this parameter, the thinned image
         is returned immediately if an iteration produces no change.
@@ -276,7 +273,7 @@ def thin(image, max_iter=None):
     out : ndarray of bool
         Thinned image.
 
-    See also
+    See Also
     --------
     skeletonize, medial_axis
 
@@ -383,7 +380,7 @@ def medial_axis(image, mask=None, return_distance=False):
         Distance transform of the image (only returned if `return_distance`
         is True)
 
-    See also
+    See Also
     --------
     skeletonize
 
@@ -532,8 +529,6 @@ def _table_lookup(image, table):
     table : ndarray
         A 512-element table giving the transform of each pixel given
         the values of that pixel and its 8-connected neighbors.
-    border_value : bool
-        The value of pixels beyond the border of the image.
 
     Returns
     -------
@@ -543,7 +538,6 @@ def _table_lookup(image, table):
     Notes
     -----
     The pixels are numbered like this::
-
 
       0 1 2
       3 4 5
@@ -593,7 +587,7 @@ def skeletonize_3d(image):
     skeleton : ndarray
         The thinned image.
 
-    See also
+    See Also
     --------
     skeletonize, medial_axis
 

--- a/skimage/morphology/_util.py
+++ b/skimage/morphology/_util.py
@@ -218,7 +218,7 @@ def _fast_pad(image, value, *, order="C"):
     image : ndarray
         Image to pad.
     value : scalar
-         The value to use. Should be compatible with `image`'s dtype.
+        The value to use. Should be compatible with `image`'s dtype.
     order : "C" or "F"
         Specify the memory layout of the padded image (C or Fortran style).
 

--- a/skimage/morphology/binary.py
+++ b/skimage/morphology/binary.py
@@ -56,7 +56,6 @@ def binary_dilation(image, selem=None, out=None):
 
     Parameters
     ----------
-
     image : ndarray
         Binary input image.
     selem : ndarray, optional

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -75,11 +75,11 @@ def h_maxima(image, h, selem=None):
     Returns
     -------
     h_max : ndarray
-       The local maxima of height >= h and the global maxima.
-       The resulting image is a binary image, where pixels belonging to
-       the determined maxima take value 1, the others take value 0.
+        The local maxima of height >= h and the global maxima.
+        The resulting image is a binary image, where pixels belonging to
+        the determined maxima take value 1, the others take value 0.
 
-    See also
+    See Also
     --------
     skimage.morphology.extrema.h_minima
     skimage.morphology.extrema.local_maxima
@@ -203,11 +203,11 @@ def h_minima(image, h, selem=None):
     Returns
     -------
     h_min : ndarray
-       The local minima of depth >= h and the global minima.
-       The resulting image is a binary image, where pixels belonging to
-       the determined minima take value 1, the others take value 0.
+        The local minima of depth >= h and the global minima.
+        The resulting image is a binary image, where pixels belonging to
+        the determined minima take value 1, the others take value 0.
 
-    See also
+    See Also
     --------
     skimage.morphology.extrema.h_maxima
     skimage.morphology.extrema.local_maxima

--- a/skimage/morphology/grey.py
+++ b/skimage/morphology/grey.py
@@ -196,7 +196,6 @@ def dilation(image, selem=None, out=None, shift_x=False, shift_y=False):
 
     Parameters
     ----------
-
     image : ndarray
         Image array.
     selem : ndarray, optional
@@ -376,7 +375,7 @@ def white_tophat(image, selem=None, out=None):
     out : array, same shape and type as `image`
         The result of the morphological white top hat.
 
-    See also
+    See Also
     --------
     black_tophat
 
@@ -451,7 +450,7 @@ def black_tophat(image, selem=None, out=None):
     out : array, same shape and type as `image`
         The result of the morphological black top hat.
 
-    See also
+    See Also
     --------
     white_tophat
 

--- a/skimage/morphology/greyreconstruct.py
+++ b/skimage/morphology/greyreconstruct.py
@@ -60,7 +60,7 @@ def reconstruction(seed, mask, method='dilation', selem=None, offset=None):
     Returns
     -------
     reconstructed : ndarray
-       The result of morphological reconstruction.
+        The result of morphological reconstruction.
 
     Examples
     --------

--- a/skimage/morphology/max_tree.py
+++ b/skimage/morphology/max_tree.py
@@ -78,7 +78,6 @@ def max_tree(image, connectivity=1):
     parent : ndarray, int64
         Array of same shape as image. The value of each pixel is the index of
         its parent in the ravelled array.
-
     tree_traverser : 1D array, int64
         The ordered pixel indices (referring to the ravelled array). The pixels
         are ordered such that every pixel is preceded by its parent (except for
@@ -189,7 +188,7 @@ def area_opening(image, area_threshold=64, connectivity=1,
     output : ndarray
         Output image of the same shape and type as the input image.
 
-    See also
+    See Also
     --------
     skimage.morphology.area_closing
     skimage.morphology.diameter_opening
@@ -197,7 +196,6 @@ def area_opening(image, area_threshold=64, connectivity=1,
     skimage.morphology.max_tree
     skimage.morphology.remove_small_objects
     skimage.morphology.remove_small_holes
-
 
     References
     ----------
@@ -224,7 +222,6 @@ def area_opening(image, area_threshold=64, connectivity=1,
 
     Examples
     --------
-
     We create an image (quadratic function with a maximum in the center and
     4 additional local maxima.
 
@@ -293,7 +290,7 @@ def diameter_opening(image, diameter_threshold=8, connectivity=1,
     output : ndarray
         Output image of the same shape and type as the input image.
 
-    See also
+    See Also
     --------
     skimage.morphology.area_opening
     skimage.morphology.area_closing
@@ -392,7 +389,7 @@ def area_closing(image, area_threshold=64, connectivity=1,
     output : ndarray
         Output image of the same shape and type as input image.
 
-    See also
+    See Also
     --------
     skimage.morphology.area_opening
     skimage.morphology.diameter_opening
@@ -424,7 +421,6 @@ def area_closing(image, area_threshold=64, connectivity=1,
            Processing, 23(9), 3885-3895.
            :DOI:`10.1109/TIP.2014.2336551`
 
-
     Examples
     --------
     We create an image (quadratic function with a minimum in the center and
@@ -443,7 +439,6 @@ def area_closing(image, area_threshold=64, connectivity=1,
 
     All small minima are removed, and the remaining minima have at least
     a size of 8.
-
 
     Notes
     -----
@@ -513,7 +508,7 @@ def diameter_closing(image, diameter_threshold=8, connectivity=1,
     output : ndarray
         Output image of the same shape and type as input image.
 
-    See also
+    See Also
     --------
     skimage.morphology.area_opening
     skimage.morphology.area_closing
@@ -551,7 +546,6 @@ def diameter_closing(image, diameter_threshold=8, connectivity=1,
 
     All small minima with a maximal extension of 2 or less are removed.
     The remaining minima have all a maximal extension of at least 3.
-
 
     Notes
     -----
@@ -596,14 +590,14 @@ def max_tree_local_maxima(image, connectivity=1,
     ----------
     image : ndarray
         The input image for which the maxima are to be calculated.
-    connectivity: unsigned int, optional
+    connectivity : unsigned int, optional
         The neighborhood connectivity. The integer represents the maximum
         number of orthogonal steps to reach a neighbor. In 2D, it is 1 for
         a 4-neighborhood and 2 for a 8-neighborhood. Default value is 1.
-    parent: ndarray, int64, optional
+    parent : ndarray, int64, optional
         The value of each pixel is the index of its parent in the ravelled
         array.
-    tree_traverser: 1D array, int64, optional
+    tree_traverser : 1D array, int64, optional
         The ordered pixel indices (referring to the ravelled array). The pixels
         are ordered such that every pixel is preceded by its parent (except for
         the root which has no parent).
@@ -613,7 +607,7 @@ def max_tree_local_maxima(image, connectivity=1,
     local_max : ndarray, uint64
         Labeled local maxima of the image.
 
-    See also
+    See Also
     --------
     skimage.morphology.local_maxima
     skimage.morphology.max_tree

--- a/skimage/morphology/selem.py
+++ b/skimage/morphology/selem.py
@@ -57,7 +57,6 @@ def rectangle(nrows, ncols, dtype=np.uint8):
         A structuring element consisting only of ones, i.e. every
         pixel belongs to the neighborhood.
 
-
     Notes
     -----
     - The use of ``width`` and ``height`` has been deprecated in
@@ -86,7 +85,6 @@ def diamond(radius, dtype=np.uint8):
 
     Returns
     -------
-
     selem : ndarray
         The structuring element where elements of the neighborhood
         are 1 and 0 otherwise.
@@ -214,7 +212,6 @@ def octahedron(radius, dtype=np.uint8):
 
     Returns
     -------
-
     selem : ndarray
         The structuring element where elements of the neighborhood
         are 1 and 0 otherwise.


### PR DESCRIPTION
Numpydoc is specific about the meaning of spaces arround : and a few
other things, while it may look almost identical in sphinx depending on
themes it is semantically different.

I'm attempting to write an docstring autoreformatter thetry to fix
common mistakes, and fix a couple of other things like typo in parameter
names, remove parameters that are still documented, and try to get a
uniform style.

You'll see in the diff
 - add / removal of spaces
 - add / removal of blank lines
 - indent 4 spaces always.
 - Capitalisation of section names
 - removal of `border_value` parameter which is indeed not a function
    argument.

In morphology/* this hasn't found any other issue it can fix, and the
only other non-automatically fixable issues are missing documentation
for `dtype` parameters.



## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
