### PR TITLE
avoid importing or calling functions from ndimage submodules

### DIFF
--- a/skimage/filters/_unsharp_mask.py
+++ b/skimage/filters/_unsharp_mask.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.ndimage.filters import gaussian_filter
+from scipy.ndimage import gaussian_filter
 from skimage import img_as_float
 
 

--- a/skimage/morphology/selem.py
+++ b/skimage/morphology/selem.py
@@ -366,4 +366,4 @@ def _default_selem(ndim):
         are 1 and 0 otherwise.
 
     """
-    return ndi.morphology.generate_binary_structure(ndim, 1)
+    return ndi.generate_binary_structure(ndim, 1)

--- a/skimage/registration/_optical_flow.py
+++ b/skimage/registration/_optical_flow.py
@@ -275,7 +275,7 @@ def _ilk(reference_image, moving_image, flow0, radius, num_warp, gaussian,
 
     for _ in range(num_warp):
         if prefilter:
-            flow = ndi.filters.median_filter(flow, (1, ) + ndim * (3, ))
+            flow = ndi.median_filter(flow, (1, ) + ndim * (3, ))
 
         moving_image_warp = warp(moving_image, get_warp_points(grid, flow),
                                  mode='edge')

--- a/skimage/restoration/inpaint.py
+++ b/skimage/restoration/inpaint.py
@@ -3,7 +3,7 @@ import numpy as np
 from scipy import sparse
 from scipy.sparse.linalg import spsolve
 import scipy.ndimage as ndi
-from scipy.ndimage.filters import laplace
+from scipy.ndimage import laplace
 import skimage
 from ..measure import label
 
@@ -127,8 +127,8 @@ def inpaint_biharmonic(image, mask, multichannel=False):
     mask = mask.astype(bool)
 
     # Split inpainting mask into independent regions
-    kernel = ndi.morphology.generate_binary_structure(mask.ndim, 1)
-    mask_dilated = ndi.morphology.binary_dilation(mask, structure=kernel)
+    kernel = ndi.generate_binary_structure(mask.ndim, 1)
+    mask_dilated = ndi.binary_dilation(mask, structure=kernel)
     mask_labeled, num_labels = label(mask_dilated, return_num=True)
     mask_labeled *= mask
 


### PR DESCRIPTION
## Description

This is a maintenance PR to avoid use of submodules of ndimage that are not technically part of the public API (for example, `scipy.ndimage.morphology` could be renamed `scipy.ndimage._morphology` upstream, although in practice I am not sure this will actually happen given how much downstream code it might break)

Only the top-level `scipy.ndimage` module is considered public API:
see: https://docs.scipy.org/doc/scipy/reference/api.html#api-definition
and recent discussion in https://github.com/cupy/cupy/pull/5047#issuecomment-814463488

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
