### PR TITLE
DOC: add empty line before section for proper parsing.

### DIFF
--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -589,6 +589,7 @@ class EllipseModel(BaseModel):
 def _dynamic_max_trials(n_inliers, n_samples, min_samples, probability):
     """Determine number trials such that at least one outlier-free subset is
     sampled for the given inlier/outlier ratio.
+
     Parameters
     ----------
     n_inliers : int
@@ -599,6 +600,7 @@ def _dynamic_max_trials(n_inliers, n_samples, min_samples, probability):
         Minimum number of samples chosen randomly from original data.
     probability : float
         Probability (confidence) that one outlier-free sample is generated.
+
     Returns
     -------
     trials : int


### PR DESCRIPTION
Numpydoc needs an empty line to properly detect sections.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
