### PR TITLE
Fix warp output dtype when order=0

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -827,7 +827,8 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=None,
 
     order = _validate_interpolation_order(image.dtype, order)
 
-    image = convert_to_float(image, preserve_range)
+    if order > 0:
+        image = convert_to_float(image, preserve_range)
 
     input_shape = np.array(image.shape)
 
@@ -849,7 +850,7 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=None,
              "skimage's implementation is fixed, we recommend "
              "to use bi-linear or bi-cubic interpolation instead.")
 
-    if order in (0, 1, 3) and not map_args:
+    if order in (1, 3) and not map_args:
         # use fast Cython version for specific interpolation orders and input
 
         matrix = None

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -139,7 +139,8 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
         # The grid_mode kwarg was introduced in SciPy 1.6.0
         order = _validate_interpolation_order(image.dtype, order)
         zoom_factors = [1 / f for f in factors]
-        image = convert_to_float(image, preserve_range)
+        if order > 0:
+            image = convert_to_float(image, preserve_range)
         out = ndi.zoom(image, zoom_factors, order=order, mode=ndi_mode,
                        cval=cval, grid_mode=True)
         _clip_warp_output(image, out, order, mode, cval, clip)

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -688,7 +688,7 @@ def test_boll_array_warnings():
         warp(img, np.eye(3), order=1)
 
 
-@pytest.mark.parametrize("dtype", [np.uint8, bool, np.float32, np.float64])
+@pytest.mark.parametrize('dtype', [np.uint8, bool, np.float32, np.float64])
 def test_order_0_warp_dtype(dtype):
 
     img = _convert(astronaut()[:10, :10, 0], dtype)

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -1,8 +1,9 @@
+import pytest
 import numpy as np
 from scipy.ndimage import map_coordinates
 
 from skimage.data import checkerboard, astronaut
-from skimage.util.dtype import img_as_float
+from skimage.util.dtype import img_as_float, _convert
 from skimage.color.colorconv import rgb2gray
 from skimage.draw.draw import circle_perimeter_aa
 from skimage.feature.peak import peak_local_max
@@ -160,7 +161,8 @@ def test_rotate_resize_center():
     ref_x45[6, 0] = 1
     ref_x45[7, 0] = 1
 
-    x45 = rotate(x, 45, resize=True, center=(3, 3), order=0)
+    x45 = rotate(x, 45, resize=True, center=(3, 3), order=0,
+                 mode='reflect')
     # new dimension should be d = sqrt(2 * (10/2)^2)
     assert x45.shape == (14, 14)
     assert_equal(x45, ref_x45)
@@ -349,8 +351,8 @@ def test_resize_dtype():
     assert resize(x, (10, 10), preserve_range=True).dtype == x.dtype
     assert resize(x_u8, (10, 10), preserve_range=False).dtype == np.double
     assert resize(x_u8, (10, 10), preserve_range=True).dtype == np.double
-    assert resize(x_b, (10, 10), preserve_range=False).dtype == np.double
-    assert resize(x_b, (10, 10), preserve_range=True).dtype == np.double
+    assert resize(x_b, (10, 10), preserve_range=False).dtype == bool
+    assert resize(x_b, (10, 10), preserve_range=True).dtype == bool
     assert resize(x_f32, (10, 10), preserve_range=False).dtype == x_f32.dtype
     assert resize(x_f32, (10, 10), preserve_range=True).dtype == x_f32.dtype
 
@@ -535,7 +537,7 @@ def test_keep_range():
                   mode='constant', multichannel=False, anti_aliasing=False,
                   clip=True, order=0)
     assert out.min() == 0
-    assert out.max() == 2 / 255.0
+    assert out.max() == 2
 
 
 def test_zero_image_size():
@@ -684,3 +686,15 @@ def test_boll_array_warnings():
 
     with expected_warnings(['Input image dtype is bool']):
         warp(img, np.eye(3), order=1)
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, bool, np.float32, np.float64])
+def test_order_0_warp_dtype(dtype):
+
+    img = _convert(astronaut()[:10, :10, 0], dtype)
+
+    assert resize(img, (12, 12), order=0).dtype == dtype
+    assert rescale(img, 0.5, order=0).dtype == dtype
+    assert rotate(img, 45, order=0).dtype == dtype
+    assert warp_polar(img, order=0).dtype == dtype
+    assert swirl(img, order=0).dtype == dtype


### PR DESCRIPTION
## Description

Fixes #5268

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
