### PR TITLE
MAINT: update minimal NumPy version

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -84,8 +84,6 @@ Other (2021)
   and update osx_install to point to the correct branch
 * When ``numpy`` is set to > 1.16, one may simplify the implementation of
   of `feature.blob_log` using the vectorized version of ``np.logspace``.
-* When ``numpy`` is set to >= 1.16, simplify ``draw.line_nd`` by using the
-  vectorized version of ``np.linspace``.
 * Once NumPy is set to >= 1.17, consider removing
   ``skimage.morphology._util._fast_pad``.
 * Remove pillow version related warning for MPO file format in

--- a/TODO.txt
+++ b/TODO.txt
@@ -82,10 +82,6 @@ Other (2021)
 * Monitor when multibuild devel gets merged into master for python 3.8
   compatibility https://github.com/matthew-brett/multibuild/issues/284
   and update osx_install to point to the correct branch
-* When ``numpy`` is set to >= 1.16, remove the warning assertion in
-  ``skimage/exposure/tests/test_exposure.py::test_rescale_nan_warning``
-  regarding ``invalid value encountered in reduce``.
-  regarding ``Passing `np.nan` to mean no clipping in np.clip``.
 * When ``numpy`` is set to > 1.16, one may simplify the implementation of
   of `feature.blob_log` using the vectorized version of ``np.logspace``.
 * When ``numpy`` is set to >= 1.16, simplify ``draw.line_nd`` by using the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ requires = [
     "numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64'",
 
     # default numpy requirements
-    "numpy==1.16.5; python_version=='3.6' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
-    "numpy==1.16.5; python_version=='3.7' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
+    "numpy==1.17.3; python_version=='3.6' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
+    "numpy==1.17.3; python_version=='3.7' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.17.3; python_version=='3.8' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.19.3; python_version=='3.9' and platform_python_implementation != 'PyPy'",
 

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -2,4 +2,4 @@ Cython>=0.29.21,!=0.29.18
 wheel
 # numpy 1.18.0 breaks builds on MacOSX
 # https://github.com/numpy/numpy/pull/15194
-numpy>=1.16.5,!=1.18.0
+numpy>=1.17.0,!=1.18.0

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,5 @@
 numpy>=1.16.5
-scipy>=1.2.3
+scipy>=1.5.4
 matplotlib>=3.0.3
 networkx>=2.2
 pillow>=5.4.0,!=7.1.0,!=7.1.1

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,5 @@
-numpy>=1.16.5
-scipy>=1.5.4
+numpy>=1.17.0
+scipy>=1.2.3
 matplotlib>=3.0.3
 networkx>=2.2
 pillow>=5.4.0,!=7.1.0,!=7.1.1

--- a/skimage/draw/draw_nd.py
+++ b/skimage/draw/draw_nd.py
@@ -99,10 +99,12 @@ def line_nd(start, stop, *, endpoint=False, integer=True):
     npoints = int(np.ceil(np.max(np.abs(stop - start))))
     if endpoint:
         npoints += 1
-    coords = []
-    for dim in range(len(start)):
-        dimcoords = np.linspace(start[dim], stop[dim], npoints, endpoint)
-        if integer:
-            dimcoords = _round_safe(dimcoords).astype(int)
-        coords.append(dimcoords)
+
+    coords = np.linspace(start, stop, num=npoints, endpoint=endpoint).T
+    if integer:
+        for dim in range(len(start)):
+            coords[dim, :] = _round_safe(coords[dim, :])
+
+        coords = coords.astype(int)
+
     return tuple(coords)

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -305,7 +305,8 @@ def test_rescale_nan_warning(in_range, out_range):
         r"One or more intensity levels are NaN\."
         r" Rescaling will broadcast NaN to the full image\."
     )
-     # 2019/11/10 Passing NaN to np.clip raises a DeprecationWarning for
+
+    # 2019/11/10 Passing NaN to np.clip raises a DeprecationWarning for
     # versions above 1.17
     # TODO: Remove once NumPy removes this DeprecationWarning
     numpy_warning_1_17_plus = (

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -305,9 +305,16 @@ def test_rescale_nan_warning(in_range, out_range):
         r"One or more intensity levels are NaN\."
         r" Rescaling will broadcast NaN to the full image\."
     )
+     # 2019/11/10 Passing NaN to np.clip raises a DeprecationWarning for
+    # versions above 1.17
+    # TODO: Remove once NumPy removes this DeprecationWarning
+    numpy_warning_1_17_plus = (
+        r"Passing `np.nan` to mean no clipping in np.clip "
+        r"has always been unreliable"
+    )
 
     with expected_warnings(
-            [msg]
+            [msg, numpy_warning_1_17_plus]
     ):
         exposure.rescale_intensity(image, in_range, out_range)
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -306,16 +306,8 @@ def test_rescale_nan_warning(in_range, out_range):
         r" Rescaling will broadcast NaN to the full image\."
     )
 
-    # 2019/11/10 Passing NaN to np.clip raises a DeprecationWarning for
-    # versions above 1.17
-    # TODO: Remove once NumPy removes this DeprecationWarning
-    numpy_warning_1_17_plus = (
-        r"Passing `np.nan` to mean no clipping in np.clip "
-        r"has always been unreliable|\A\Z"
-    )
-
     with expected_warnings(
-            [msg, numpy_warning_1_17_plus]
+            [msg]
     ):
         exposure.rescale_intensity(image, in_range, out_range)
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -310,13 +310,15 @@ def test_rescale_nan_warning(in_range, out_range):
     # versions above 1.17
     # TODO: Remove once NumPy removes this DeprecationWarning
     numpy_warning_1_17_plus = (
-        r"Passing `np.nan` to mean no clipping in np.clip "
-        r"has always been unreliable"
+        "Passing `np.nan` to mean no clipping in np.clip"
     )
 
-    with expected_warnings(
-            [msg, numpy_warning_1_17_plus]
-    ):
+    if in_range == "image":
+        exp_warn = [msg, numpy_warning_1_17_plus]
+    else:
+        exp_warn = [msg]
+
+    with expected_warnings(exp_warn):
         exposure.rescale_intensity(image, in_range, out_range)
 
 


### PR DESCRIPTION
## Description

Since the minimal version of Python is 3.6 and NumPy is 1.16.5, you could update minimal SciPy to 1.5.4. SciPy 1.2.3 is quite old now and was the last to be fully compatible with Python 2.

https://scipy.github.io/devdocs/dev/toolchain.html#numpy