### PR TITLE
enable pip and skimage.data caching on Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -183,7 +183,7 @@ jobs:
 
       # Run example applications
       for f in doc/examples/*/*.py; do
-        $PYTHON "${f}"
+        $PYTHON -W ignore:Matplotlib:UserWarning "${f}"
         if [ $? -ne 0 ]; then
           exit 1
         fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,9 @@
 # Azure Pipelines configuration file for Continuous Integration
 # for building the package and running the tests under Windows.
+variables:
+  PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+  # data cache dir determined via: print(pooch.os_cache('scikit-image'))
+  SKIMAGE_DATA_CACHE_FOLDER: C:\Users\VssAdministrator\AppData\Local\scikit-image\scikit-image\Cache
 
 jobs:
 - job: 'Default'
@@ -54,19 +58,40 @@ jobs:
       architecture: '$(ARCH)'
     name: python
 
-  - bash: |
-      set -ex
-      PYTHON="$(python.pythonLocation)\\python.exe"
+    # https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops
+    - task: Cache@2
+      inputs:
+        key: 'skimage_data'
+        path: $(SKIMAGE_DATA_CACHE_FOLDER)
+      displayName: Cache scikit-image data files
+
+    # https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops#pythonpip
+    - task: Cache@2
+      inputs:
+        key: '"Python$(PYTHON_VERSION)-$(ARCH)"" | "$(Agent.OS)" | requirements/build.txt | requirements/default.txt | requirements/test.txt | requirements/docs.txt'
+        restoreKeys: |
+          "Python$(PYTHON_VERSION)-$(ARCH)" | "$(Agent.OS)"
+          "Python$(PYTHON_VERSION)-$(ARCH)"
+        path: $(PIP_CACHE_DIR)
+      displayName: Cache pip packages
+
+    - bash: |
+        set -ex
+        PYTHON="$(python.pythonLocation)\\python.exe"
 
       # Update pip
       $PYTHON -m pip install -U pip setuptools wheel
 
-      # Check that we have the expected version and architecture for Python
-      $PYTHON --version
-      $PYTHON -m pip --version
-      $PYTHON -c "import struct; print('Void pointer width is', struct.calcsize('P') * 8)"
-      $PYTHON -m pip list
+        # print out the pip cache dir followed by the variable defined above
+	# to confirm that they match
+        $PYTHON -m pip cache dir
+        echo "PIP_CACHE_DIR: $PIP_CACHE_DIR"
 
+        # Check that we have the expected version and architecture for Python
+        $PYTHON --version
+        $PYTHON -m pip --version
+        $PYTHON -c "import struct; print('Void pointer width is', struct.calcsize('P') * 8)"
+        $PYTHON -m pip list
 
       # Install the build and runtime dependencies of the project
       $PYTHON -m pip install ${PIP_FLAGS} -r requirements/build.txt
@@ -113,6 +138,11 @@ jobs:
 
       # Show the info about the installed scikit-image
       $PYTHON -c "import skimage; print(skimage.__path__)"
+
+      # Show the path pooch is using for the data cache
+      # (this should match the SKIMAGE_DATA_CACHE_FOLDER variable above)
+      $PYTHON -c "import pooch; print(pooch.os_cache('scikit-image'))"
+      echo "SKIMAGE_DATA_CACHE_FOLDER: $SKIMAGE_DATA_CACHE_FOLDER"
 
       # Force matplotlib to use the prepared config
       export MATPLOTLIBRC=${AGENT_BUILDDIRECTORY}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,6 @@ jobs:
         PYTHON_VERSION: '3.8'
         ARCH: 'x64'
         PIP_FLAGS: ''
-        TEST_EXAMPLES: 'true'
         BUILD_DOCS: 'true'
       # build pre release packages on Python 3.8 since it has been out long
       # enough for wheels to be built for packages that need to be compiled.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,22 +75,22 @@ jobs:
       displayName: Cache pip packages
 
     - bash: |
-        set -ex
-        PYTHON="$(python.pythonLocation)\\python.exe"
+      set -ex
+      PYTHON="$(python.pythonLocation)\\python.exe"
 
       # Update pip
       $PYTHON -m pip install -U pip setuptools wheel
 
-        # print out the pip cache dir followed by the variable defined above
-	# to confirm that they match
-        $PYTHON -m pip cache dir
-        echo "PIP_CACHE_DIR: $PIP_CACHE_DIR"
+      # print out the pip cache dir followed by the variable defined above
+      # to confirm that they match
+      $PYTHON -m pip cache dir
+      echo "PIP_CACHE_DIR: $PIP_CACHE_DIR"
 
-        # Check that we have the expected version and architecture for Python
-        $PYTHON --version
-        $PYTHON -m pip --version
-        $PYTHON -c "import struct; print('Void pointer width is', struct.calcsize('P') * 8)"
-        $PYTHON -m pip list
+      # Check that we have the expected version and architecture for Python
+      $PYTHON --version
+      $PYTHON -m pip --version
+      $PYTHON -c "import struct; print('Void pointer width is', struct.calcsize('P') * 8)"
+      $PYTHON -m pip list
 
       # Install the build and runtime dependencies of the project
       $PYTHON -m pip install ${PIP_FLAGS} -r requirements/build.txt


### PR DESCRIPTION
## Description

This PR enables some caching of downloaded files on Azure as well as some other minor modifications. This was split of from #5338 where the caching behavior was originally verified. That PR will focus only on the change to the face classification example while this one will have the CI changes.

The goal here is to help avoid the somewhat common timeouts that have been seen recently in our Azure CI jobs involving either the documentation or gallery example builds.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
