### PR TITLE
channel_as_last_axis decorator fix

### DIFF
--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -5,7 +5,8 @@ import numpy.testing as npt
 from skimage._shared.utils import (check_nD, deprecate_kwarg,
                                    _validate_interpolation_order,
                                    change_default_value, remove_arg,
-                                   _supported_float_type)
+                                   _supported_float_type,
+                                   channel_as_last_axis)
 from skimage._shared import testing
 from skimage._shared._warnings import expected_warnings
 
@@ -236,6 +237,28 @@ def test_supported_float_dtype_input_kinds(dtype):
 def test_supported_float_dtype_sequence(dtypes, expected):
     float_dtype = _supported_float_type(dtypes)
     assert float_dtype == expected
+
+
+@channel_as_last_axis(multichannel_output=False)
+def _decorated_channel_axis_size(x, *, channel_axis=None):
+    if channel_axis is None:
+        return None
+    assert channel_axis == -1
+    return x.shape[-1]
+
+
+@testing.parametrize('channel_axis', [None, 0, 1, 2, -1, -2, -3])
+def test_decorated_channel_axis_shape(channel_axis):
+    # Verify that channel_as_last_axis modifies the channel_axis as expected
+
+    # need unique size per axis here
+    x = np.zeros((2, 3, 4))
+
+    size = _decorated_channel_axis_size(x, channel_axis=channel_axis)
+    if channel_axis is None:
+        assert size is None
+    else:
+        assert size == x.shape[channel_axis]
 
 
 if __name__ == "__main__":

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -281,6 +281,10 @@ class channel_as_last_axis():
             for name in self.kwarg_names:
                 kwargs[name] = np.moveaxis(kwargs[name], channel_axis[0], -1)
 
+            # now that we have moved the channels axis to the last position,
+            # change the channel_axis argument to -1
+            kwargs["channel_axis"] = -1
+
             # Call the function with the fixed arguments
             out = func(*new_args, **kwargs)
             if self.multichannel_output:


### PR DESCRIPTION
## Description

After moving the channel axis to the last position, `channel_as_last_axis` also needs to update the `channel_axis` kwarg to -1.

This bug was not revealed by the existing test cases for functions where it was used because these functions seem to only check that `channel_axis is not None`. See for example:

https://github.com/scikit-image/scikit-image/blob/044ac80ebd3de9c075f4a15237a1c8122f26c4dd/skimage/exposure/histogram_matching.py#L66

The new test here verifies both that the data has been reshaped and the argument set to -1 as expected.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
