### PR TITLE
DEV: fix CircleCI caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,8 @@ jobs:
       - restore_cache:
           keys:
               - data-v1-{{ checksum "skimage/data/_registry.py" }}
+      - restore_cache:
+          keys:
               - packages-v1-{{ checksum "requirements/all_requirements" }}
       - run:
           name: install dependencies and package


### PR DESCRIPTION
Caching is not properly working as can be seen in the logs. For instance in the [following](https://app.circleci.com/pipelines/github/scikit-image/scikit-image/1638/workflows/c72c0029-071a-4b03-8247-f9d737d34b13/jobs/1740), only the data part is restored.
This is because the list is not a list of paths, but a list of [cascading fallbacks](https://circleci.com/docs/2.0/caching/#example-caching-configuration).

