### PR TITLE
Fix cython warnings

### DIFF
--- a/skimage/_shared/fast_exp.h
+++ b/skimage/_shared/fast_exp.h
@@ -14,7 +14,7 @@
 /* For min. mean relative error */
 /* #define EXP_BC 1072625005 */        /* 1023*2^20 - 68243 */
 
-__inline double fast_exp (double y)
+__inline double _fast_exp (double y)
 {
     union
     {
@@ -41,7 +41,7 @@ __inline double fast_exp (double y)
     return _eco.d;
 }
 
-__inline float fast_expf (float y)
+__inline float _fast_expf (float y)
 {
-  return (float)fast_exp((double)y);
+  return (float)_fast_exp((double)y);
 }

--- a/skimage/_shared/fast_exp.pxd
+++ b/skimage/_shared/fast_exp.pxd
@@ -6,12 +6,12 @@ cimport numpy as cnp
 from .fused_numerics cimport np_floats
 
 cdef extern from "fast_exp.h":
-    double fast_exp(double y) nogil
-    float fast_expf(float y) nogil
+    double _fast_exp(double y) nogil
+    float _fast_expf(float y) nogil
 
 
-cdef inline np_floats _fast_exp(np_floats x) nogil:
+cdef inline np_floats _fast_exp_floats(np_floats x) nogil:
     if np_floats is cnp.float32_t:
-        return fast_expf(x)
+        return _fast_expf(x)
     else:
-        return fast_exp(x)
+        return _fast_exp(x)

--- a/skimage/_shared/fast_exp.pyx
+++ b/skimage/_shared/fast_exp.pyx
@@ -1,8 +1,8 @@
 import numpy as np
 cimport numpy as cnp
 from .fused_numerics cimport np_floats
-from .fast_exp cimport _fast_exp
+from .fast_exp cimport _fast_exp_floats
 cnp.import_array()
 
 def fast_exp(np_floats x):
-    return _fast_exp(x)
+    return _fast_exp_floats(x)

--- a/skimage/feature/_cascade.pyx
+++ b/skimage/feature/_cascade.pyx
@@ -734,7 +734,6 @@ cdef class Cascade:
 
                     if result:
 
-                        new_detection = Detection()
                         new_detection.r = current_row
                         new_detection.c = current_col
                         new_detection.width = current_width

--- a/skimage/feature/_cascade.pyx
+++ b/skimage/feature/_cascade.pyx
@@ -734,6 +734,7 @@ cdef class Cascade:
 
                     if result:
 
+                        new_detection = Detection()
                         new_detection.r = current_row
                         new_detection.c = current_col
                         new_detection.width = current_width

--- a/skimage/filters/rank/core_cy_3d.pyx
+++ b/skimage/filters/rank/core_cy_3d.pyx
@@ -28,6 +28,8 @@ cdef inline void _count_attack_border_elements(char[:, :, ::1] selem,
                                                Py_ssize_t centre_r,
                                                Py_ssize_t centre_c):
 
+    cdef Py_ssize_t r, c, p
+
     # build attack and release borders by using difference along axis
     t = np.dstack((selem, np.zeros((selem.shape[0], selem.shape[1], 1))))
     cdef unsigned char[:, :, :] t_e = (np.diff(t, axis=2) < 0).view(np.uint8)
@@ -81,6 +83,9 @@ cdef inline void _build_initial_histogram_from_neighborhood(dtype_t[:, :, ::1] i
                                                             Py_ssize_t centre_p,
                                                             Py_ssize_t centre_r,
                                                             Py_ssize_t centre_c):
+
+    cdef Py_ssize_t r, c, j
+
     for r in range(srows):
         for c in range(scols):
             for j in range(splanes):
@@ -105,6 +110,9 @@ cdef inline void _update_histogram(dtype_t[:, :, ::1] image,
                                    Py_ssize_t planes, Py_ssize_t rows,
                                    Py_ssize_t cols,
                                    Py_ssize_t axis_inc):
+
+    cdef Py_ssize_t pp, rr, cc, j
+
     # Increment histogram
     for j in range(num_se[axis_inc]):
         pp = p + se[axis_inc, 0, j]


### PR DESCRIPTION
## Description

Each of these three commits addresses a warning raised by Cython. Specifically:

```
warning: skimage\_shared\fast_exp.pyx:7:0: Overriding cdef method with def method.

warning: skimage\feature\_cascade.pyx:737:49: Not all members given for struct 'Detection'

warning: skimage\filters\rank\core_cy_3d.pyx:47:23: Index should be typed for more efficient access
```

The change in the 3D rank filter code likely improves performance by typing the loop variables/indices, but I have not tried to measure this.



## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
