### PR TITLE
Draw node IDs in RAG example

### DIFF
--- a/doc/examples/segmentation/plot_rag.py
+++ b/doc/examples/segmentation/plot_rag.py
@@ -55,6 +55,7 @@ def display(g, title):
     plt.figure()
     plt.title(title)
     nx.draw(g, pos)
+    nx.draw_networkx_labels(g, pos)
     nx.draw_networkx_edge_labels(g, pos, font_size=20)
 
 


### PR DESCRIPTION
## Description

The node IDs are not currently drawn in the [plot_rag.py example](https://scikit-image.org/docs/0.18.x/auto_examples/segmentation/plot_rag.html#sphx-glr-auto-examples-segmentation-plot-rag-py). That makes the example confusing to follow, and appears to have masked a bug all this time, see [this post on image.sc](https://forum.image.sc/t/question-about-the-example-of-merging-rag-from-the-tutorial/51946)

After this change:

<img width="1405" alt="Screen Shot 2021-04-26 at 5 49 09 pm" src="https://user-images.githubusercontent.com/492549/116047697-b6247280-a6b7-11eb-86ce-fa1f31098b70.png">

Note that this PR doesn't fix the bug yet — will investigate soon.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
