### PR TITLE
Upgrading Pillow version to 6.1.0

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -102,7 +102,7 @@ Other (2022)
 ------------
 * Remove conditional import of ``scipy.fft`` in ``skimage._shared.fft`` once
   the minimum supported version of ``scipy`` reaches 1.4.
-* Remove pillow version related warning for CVE when pillow > 7.1.0 in
+* Remove pillow version related warning for CVE when pillow > 8.1.2 in
   `skimage/io/_plugins/pil_plugin.py` and `skimage/io/collection.py`.
 
 Other (2023)

--- a/TODO.txt
+++ b/TODO.txt
@@ -92,9 +92,6 @@ Other (2021)
   vectorized version of ``np.linspace``.
 * Once NumPy is set to >= 1.17, consider removing
   ``skimage.morphology._util._fast_pad``.
-* Remove pillow version related warning for MPO file format in
-  `io._plugins.pil_plugin.imread` when upgrading pillow min version to
-  6.0.0
 * Remove '--verify-repo=none' in tlmgr calls in ``tools/travis/osx_install.sh``,
   when texlive 2020 is available.
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -2,7 +2,7 @@ numpy>=1.16.5
 scipy>=1.2.3
 matplotlib>=3.0.3
 networkx>=2.2
-pillow>=5.4.0,!=7.1.0,!=7.1.1
+pillow>=8.1.2
 imageio>=2.4.1
 tifffile>=2019.7.26
 PyWavelets>=1.1.1

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -2,7 +2,7 @@ numpy>=1.16.5
 scipy>=1.2.3
 matplotlib>=3.0.3
 networkx>=2.2
-pillow>=8.1.2
+pillow>=6.1.0,!=7.1.0,!=7.1.1
 imageio>=2.4.1
 tifffile>=2019.7.26
 PyWavelets>=1.1.1

--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -49,11 +49,6 @@ def imread(fname, dtype=None, img_num=None, **kwargs):
             return pil_to_ndarray(im, dtype=dtype, img_num=img_num)
     else:
         im = Image.open(fname)
-        if im.format == 'MPO' and LooseVersion(pil_version) < '6.0.0':
-            warnings.warn("You are trying to read a MPO image. "
-                          "To ensure a good support of this format, "
-                          "please upgrade pillow to 6.0.0 version or later.",
-                          stacklevel=2)
         return pil_to_ndarray(im, dtype=dtype, img_num=img_num)
 
 

--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -7,14 +7,14 @@ from PIL import Image, __version__ as pil_version
 
 from ...util import img_as_ubyte, img_as_uint
 
-# Check CVE-2020-10379
+# Check CVE-2021-27921 and others
 from distutils.version import LooseVersion
-if LooseVersion(pil_version) < LooseVersion('7.1.0'):
+if LooseVersion(pil_version) < LooseVersion('8.1.2'):
     from warnings import warn
-    warn('Your installed pillow version is < 7.1.0. '
-         'Several security issues (CVE-2020-11538, '
-         'CVE-2020-10379, CVE-2020-10994, CVE-2020-10177) '
-         'have been fixed in pillow 7.1.0 or higher. '
+    warn('Your installed pillow version is < 8.1.2. '
+         'Several security issues (CVE-2021-27921, '
+         'CVE-2021-25290, CVE-2021-25291, CVE-2021-25293, '
+         'and more) have been fixed in pillow 8.1.2 or higher. '
          'We recommend to upgrade this library.',
          stacklevel=2)
 

--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -10,14 +10,14 @@ from copy import copy
 import numpy as np
 from PIL import Image, __version__ as pil_version
 
-# Check CVE-2020-10379
+# Check CVE-2021-27921 and others
 from distutils.version import LooseVersion
-if LooseVersion(pil_version) < LooseVersion('7.1.0'):
+if LooseVersion(pil_version) < LooseVersion('8.1.2'):
     from warnings import warn
-    warn('Your installed pillow version is < 7.1.0. '
-         'Several security issues (CVE-2020-11538, '
-         'CVE-2020-10379, CVE-2020-10994, CVE-2020-10177) '
-         'have been fixed in pillow 7.1.0 or higher. '
+    warn('Your installed pillow version is < 8.1.2. '
+         'Several security issues (CVE-2021-27921, '
+         'CVE-2021-25290, CVE-2021-25291, CVE-2021-25293, '
+         'and more) have been fixed in pillow 8.1.2 or higher. '
          'We recommend to upgrade this library.',
          stacklevel=2)
 


### PR DESCRIPTION
## Description

Dependabot is showing some issues on Pillow < 8.1.1. Maybe upgrading won't hurt?

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
