### PR TITLE
Add stitching gallery example

### DIFF
--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -136,7 +136,7 @@ glob_trfm[:2, 2] = -margin, -margin
 ############################################################################
 # Now, the relative position of the other images in the global domain
 # are obtained by composing the global transformation with the
-# relative transformations
+# relative transformations:
 global_img_list = [warp(img, trfm.dot(glob_trfm), output_shape=out_shape,
                         mode="constant", cval=np.nan)
                    for img, trfm in zip(img_list, trfm_list)]

--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -64,7 +64,7 @@ def match_locations(img0, img1, coords0, coords1, radius=5, sigma=3):
 
 
 ############################################################################
-# For this example, a set of slightly tilted noisy images are generated
+# For this example, we generate a set of slightly tilted noisy images.
 
 img = moon()
 

--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -57,6 +57,9 @@ def match_locations(img0, img1, coords0, coords1, radius=5, sigma=3):
 
 
 ############################################################################
+# Data generation
+# ---------------
+#
 # For this example, we generate a list of slightly tilted noisy images.
 
 img = data.moon()
@@ -74,6 +77,9 @@ img_list = [util.random_noise(filters.gaussian(im, 1.1), var=5e-4, seed=seed)
 psnr_ref = metrics.peak_signal_noise_ratio(ref_img, img_list[0])
 
 ############################################################################
+# Image registration
+# ------------------
+#
 # Reference points are detected over all images in the list.
 
 min_dist = 5
@@ -117,10 +123,13 @@ for idx, (im, trfm, (ax0, ax1)) in enumerate(zip(img_list, trfm_list,
 fig.tight_layout()
 
 ############################################################################
+# Image assembling
+# ----------------
+#
 # A composite image can be obtained using the positions of the
-# registered images relative to the reference one. To do so, we can
-# define a global domain around the reference image and position the
-# other images in this domain.
+# registered images relative to the reference one. To do so, we define
+# a global domain around the reference image and position the other
+# images in this domain.
 #
 # A global transformation is defined to move the reference image in the
 # global domain image via a simple translation:
@@ -131,8 +140,8 @@ glob_trfm = np.eye(3)
 glob_trfm[:2, 2] = -margin, -margin
 
 ############################################################################
-# Now, the relative position of the other images in the global domain
-# are obtained by composing the global transformation with the
+# Finally, the relative position of the other images in the global
+# domain are obtained by composing the global transformation with the
 # relative transformations:
 global_img_list = [transform.warp(img, trfm.dot(glob_trfm),
                                   output_shape=out_shape,

--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -20,7 +20,7 @@ from skimage.metrics import peak_signal_noise_ratio
 
 
 def match_locations(img0, img1, coords0, coords1, radius=5, sigma=3):
-    """Image locations matching using SSD minimization.
+    """Match image locations using SSD minimization.
 
     Areas from `img0` are matched with areas from `img1`. These areas
     are defined as patches located around pixels with Gaussian

--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -99,7 +99,7 @@ matching_corners = [match_locations(img0, img1, coords0, coords1, min_dist)
 
 ############################################################################
 # Once all the points are registred to the reference points, robust
-# relative affine transformations can be estimated using RANSAC method
+# relative affine transformations can be estimated using the RANSAC method.
 src = np.array(coords0)
 trfm_list = [ransac((dst, src), EuclideanTransform, min_samples=3,
                     residual_threshold=2, max_trials=100)[0].params

--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -81,7 +81,7 @@ img_list = [random_noise(gaussian(im, 1.1), var=5e-4, seed=seed)
 psnr_ref = peak_signal_noise_ratio(ref_img, img_list[0])
 
 ############################################################################
-# Reference points are detected over all the set images
+# Reference points are detected over all images in the set.
 min_dist = 5
 corner_list = [corner_peaks(corner_harris(img), threshold_rel=0.001,
                             min_distance=min_dist)

--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -36,10 +36,9 @@ def match_locations(img0, img1, coords0, coords1, radius=5, sigma=3):
     Returns:
     --------
     match_coords: (2, m) array
-        The points in `coords1` that are the closest corresponding match to
+        The points in `coords1` that are the closest corresponding matches to
         those in `coords0` as determined by the (Gaussian weighted) sum of
         squared differences between patches surrounding each point.
-
     """
     y, x = np.mgrid[-radius:radius + 1, -radius:radius + 1]
     weights = np.exp(-0.5 * (x ** 2 + y ** 2) / sigma ** 2)
@@ -58,7 +57,7 @@ def match_locations(img0, img1, coords0, coords1, radius=5, sigma=3):
 
 
 ############################################################################
-# For this example, we generate a set of slightly tilted noisy images.
+# For this example, we generate a list of slightly tilted noisy images.
 
 img = data.moon()
 
@@ -75,14 +74,14 @@ img_list = [util.random_noise(filters.gaussian(im, 1.1), var=5e-4, seed=seed)
 psnr_ref = metrics.peak_signal_noise_ratio(ref_img, img_list[0])
 
 ############################################################################
-# Reference points are detected over all images in the set.
+# Reference points are detected over all images in the list.
 min_dist = 5
 corner_list = [feature.corner_peaks(
     feature.corner_harris(img), threshold_rel=0.001, min_distance=min_dist)
                for img in img_list]
 
 ############################################################################
-# The Harris corner detected in the first image are choosen as
+# The Harris corners detected in the first image are chosen as
 # references. Then the detected points on the other images are
 # matched to the reference points.
 
@@ -92,7 +91,7 @@ matching_corners = [match_locations(img0, img1, coords0, coords1, min_dist)
                     for img1, coords1 in zip(img_list, corner_list)]
 
 ############################################################################
-# Once all the points are registred to the reference points, robust
+# Once all the points are registered to the reference points, robust
 # relative affine transformations can be estimated using the RANSAC method.
 src = np.array(coords0)
 trfm_list = [measure.ransac((dst, src),

--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -80,11 +80,11 @@ psnr_ref = metrics.peak_signal_noise_ratio(ref_img, img_list[0])
 # Image registration
 # ------------------
 #
-# .. hint::
-#   This step is performed using the approach described in the
-#   **Robust matching using Ransac** gallery example, but any other
-#   method from the **Image registration** section can be applied,
-#   depending on your problem.
+# .. note::
+#    This step is performed using the approach described in the
+#    **Robust matching using Ransac** gallery example, but any other
+#    method from the **Image registration** section can be applied,
+#    depending on your problem.
 #
 # Reference points are detected over all images in the list.
 

--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -82,8 +82,9 @@ psnr_ref = metrics.peak_signal_noise_ratio(ref_img, img_list[0])
 #
 # .. hint::
 #   This step is performed using the approach described in the
-#   **Robust matching using Ransac** gallery example, but any method
-#   from the **Image registration** section can be applied.
+#   **Robust matching using Ransac** gallery example, but any other
+#   method from the **Image registration** section can be applied,
+#   depending on your problem.
 #
 # Reference points are detected over all images in the list.
 

--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -80,6 +80,11 @@ psnr_ref = metrics.peak_signal_noise_ratio(ref_img, img_list[0])
 # Image registration
 # ------------------
 #
+# .. hint::
+#   This step is performed using the approach described in the
+#   **Robust matching using Ransac** gallery example, but any method
+#   from the **Image registration** section can be applied.
+#
 # Reference points are detected over all images in the list.
 
 min_dist = 5

--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -126,7 +126,7 @@ fig.tight_layout()
 # images in this domain:
 #
 # A global transformation is defined to move the reference image in the
-# global domain image via a simple translation
+# global domain image via a simple translation:
 margin = 50
 height, width = img_list[0].shape
 out_shape = height + 2 * margin, width + 2 * margin

--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -107,19 +107,20 @@ for idx, (im, trfm, (ax0, ax1)) in enumerate(zip(img_list, trfm_list,
     ax1.imshow(transform.warp(im, trfm), cmap="gray", vmin=0, vmax=1)
 
     if idx == 0:
-        ax0.set_title(f"Tilted images (PSNR={psnr_ref:.2f})")
+        ax0.set_title(f"Tilted images")
+        ax0.set_ylabel(f"Reference Image\n(PSNR={psnr_ref:.2f})")
         ax1.set_title(f"Registered images")
 
-    ax0.set_axis_off()
+    ax0.set(xticklabels=[], yticklabels=[], xticks=[], yticks=[])
     ax1.set_axis_off()
 
 fig.tight_layout()
 
 ############################################################################
-# A composite image can be obtained using the relative positions of
-# the registered images to the reference one. To do so, we can define a
-# global domain around the reference image and position the other
-# images in this domain.
+# A composite image can be obtained using the positions of the
+# registered images relative to the reference one. To do so, we can
+# define a global domain around the reference image and position the
+# other images in this domain.
 #
 # A global transformation is defined to move the reference image in the
 # global domain image via a simple translation:

--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -123,7 +123,7 @@ fig.tight_layout()
 # A composite image can be obtained using the relative positions of
 # the registered images to the reference one. To do so, we can define a
 # global domain around the reference image and position the other
-# images in this domain:
+# images in this domain.
 #
 # A global transformation is defined to move the reference image in the
 # global domain image via a simple translation:

--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -1,7 +1,7 @@
 """
-======================
-Simple image stitching
-======================
+===========================================
+Assemble images with simple image stitching
+===========================================
 
 This example demonstrates how a set of images can be assembled under
 the hypothesis of rigid body motions.
@@ -75,6 +75,7 @@ psnr_ref = metrics.peak_signal_noise_ratio(ref_img, img_list[0])
 
 ############################################################################
 # Reference points are detected over all images in the list.
+
 min_dist = 5
 corner_list = [feature.corner_peaks(
     feature.corner_harris(img), threshold_rel=0.001, min_distance=min_dist)
@@ -99,14 +100,15 @@ trfm_list = [measure.ransac((dst, src),
                             residual_threshold=2, max_trials=100)[0].params
              for dst in matching_corners]
 
-fig, ax_list = plt.subplots(6, 2, figsize=(4, 6), sharex=True, sharey=True)
-for idx, (im, trfm, (ax0, ax1)) in enumerate(zip(img_list, trfm_list, ax_list)):
+fig, ax_list = plt.subplots(6, 2, figsize=(6, 9), sharex=True, sharey=True)
+for idx, (im, trfm, (ax0, ax1)) in enumerate(zip(img_list, trfm_list,
+                                                 ax_list)):
     ax0.imshow(im, cmap="gray", vmin=0, vmax=1)
     ax1.imshow(transform.warp(im, trfm), cmap="gray", vmin=0, vmax=1)
 
     if idx == 0:
-        ax0.set_title(f"Input (PSNR={psnr_ref:.2f})")
-        ax1.set_title(f"Registered")
+        ax0.set_title(f"Tilted images (PSNR={psnr_ref:.2f})")
+        ax1.set_title(f"Registered images")
 
     ax0.set_axis_off()
     ax1.set_axis_off()

--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -1,0 +1,148 @@
+"""Simulate a set of noisy images slightly shifted and rotated.
+
+"""
+
+from matplotlib import pyplot as plt
+import numpy as np
+from skimage.data import moon
+from skimage.util import random_noise, img_as_float
+from skimage.transform import warp, AffineTransform, rotate
+from skimage.feature import corner_harris, corner_peaks
+from skimage.measure import ransac
+from skimage.filters import gaussian
+from skimage.metrics import peak_signal_noise_ratio
+
+
+def match_locations(img0, img1, coords0, coords1, radius=7, sigma=3):
+    """Image locations matching using SSD minimization.
+
+    Areas from `img0` are matched with areas from `img1`. These areas
+    are defined as patches located around pixels with gaussian
+    weights.
+
+    Parameters:
+    -----------
+    img0, img1: 2D array
+        input images.
+    coords0: (2, m) array_like
+        centers of the reference patches in img0.
+    coords1: (2, n) array_like
+        centers of the candidate patches in img1.
+    radius: int
+        radius of the considered patches
+    sigma: float
+        std of the gaussian kernel centred over the patches.
+
+    Returns:
+    --------
+    match_coords: (2, m) array
+        The matching points from coords1 the closer to coords0.
+
+    """
+    y, x = np.mgrid[-radius:radius+1, -radius:radius+1]
+    weights = np.exp(-0.5 * (x**2 / sigma**2 + y**2 / sigma**2))
+    weights /= 2 * np.pi * sigma * sigma
+
+    match_list = []
+    for r0, c0 in coords0:
+        roi0 = img0[r0-radius:r0+radius+1, c0-radius:c0+radius+1]
+        roi1_list = [img1[r1-radius:r1+radius+1, c1-radius:c1+radius+1]
+                     for r1, c1 in coords1]
+        # sum of squared differences
+        ssd_list = [np.sum(weights*(roi0 - roi1)**2) for roi1 in roi1_list]
+        match_list.append(coords1[np.argmin(ssd_list)])
+
+    return np.array(match_list)
+
+################################################################################
+# For this example, a set of noisy images slightly tilted is generated
+
+img = moon()
+
+angle_list = [5, 6, -2, 3, -4]
+center_list = [(10, 10), (5, 12), (11, 21), (21, 17), (43, 15)]
+
+ref_img = img_as_float(img[40:240, 50:350])
+img_list = [ref_img.copy()] + [
+    rotate(img, angle=a, center =c)[40:240, 50:350]
+    for a, c in zip(angle_list, center_list)]
+
+sigma = 0.015
+img_list = [random_noise(gaussian(im, 1.2), var=sigma ** 2, seed=12)
+            for im in img_list]
+
+psnr_ref = peak_signal_noise_ratio(ref_img, img_list[0])
+
+# Reference points are detected over all the set images
+corner_list = [corner_peaks(corner_harris(img), threshold_rel=0.001,
+                            min_distance=5)
+               for img in img_list]
+
+# The Harris corner detected in the first image are choosen as
+# references. Then the detected points on the other images are
+# matched to the reference points.
+
+img0 = img_list[0]
+coords0 = corner_list[0]
+matching_corners = [match_locations(img0, img1, coords0, coords1)
+                    for img1, coords1 in zip(img_list[1:], corner_list[1:])]
+
+# Once all the points are registred to the reference points, robust
+# relative affine transformations can be estimated using RANSAC method
+src = np.array(coords0)
+trfm_list = [ransac((dst, src), AffineTransform, min_samples=3,
+                    residual_threshold=2, max_trials=100)[0].params
+             for dst in matching_corners]
+
+matching_corners = [coords0] + matching_corners
+trfm_list = [np.eye(3)] + trfm_list
+
+fig, ax_list = plt.subplots(6, 2, figsize=(4, 6), sharex=True, sharey=True)
+for idx, (im, trfm, (ax0, ax1)) in enumerate(zip(img_list, trfm_list, ax_list)):
+    ax0.imshow(im, cmap="gray", vmin=0, vmax=1)
+    ax1.imshow(warp(im, trfm), cmap="gray", vmin=0, vmax=1)
+
+    if idx == 0:
+        ax1.set_title(f"Registered")
+        ax0.set_title(f"Input (PSNR={psnr_ref:.2f})")
+        ax0.set_ylabel(f"")
+
+    ax0.set_axis_off()
+    ax1.set_axis_off()
+
+fig.tight_layout()
+
+# A composite image can be optained using the relative positions of
+# the registred images to the reference one. To do so, we can define a
+# global domain around the reference image and position the other
+# images in this domain:
+margin = 50
+height, width = img_list[0].shape
+out_shape = height + 2 * margin, width + 2 * margin
+
+# A global transormation is defined to move the reference image in the
+# global domain image as a simple translation
+glob_trfm = np.eye(3)
+glob_trfm[:2, 2] = -margin, -margin
+
+# Now, the relative position of the other images in the global domain
+# are obtained by composing the global transformation with the
+# relative transformations
+global_img_list = [warp(img, trfm.dot(glob_trfm), output_shape=out_shape,
+                        mode="constant", cval=np.nan)
+                   for img, trfm in zip(img_list, trfm_list)]
+
+composit_img = np.nanmean(global_img_list, 0)
+psnr_composit = peak_signal_noise_ratio(ref_img,
+                                        composit_img[margin:margin + height,
+                                                     margin:margin + width])
+
+fig, ax = plt.subplots(1, 1)
+
+ax.imshow(composit_img, cmap="gray", vmin=0, vmax=1)
+ax.set_axis_off()
+ax.set_title(f"Reconstructed image (PSNR={psnr_composit:.2f})")
+
+fig.tight_layout()
+
+plt.show()

--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -1,4 +1,10 @@
-"""Simulate a set of noisy images slightly shifted and rotated.
+"""
+======================
+Simple image stitching
+======================
+
+This example demonstrate how a set of images can be assembled under
+the hypothesis of rigid body motions.
 
 """
 

--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -39,22 +39,23 @@ def match_locations(img0, img1, coords0, coords1, radius=7, sigma=3):
         The matching points from coords1 the closer to coords0.
 
     """
-    y, x = np.mgrid[-radius:radius+1, -radius:radius+1]
-    weights = np.exp(-0.5 * (x**2 / sigma**2 + y**2 / sigma**2))
+    y, x = np.mgrid[-radius:radius + 1, -radius:radius + 1]
+    weights = np.exp(-0.5 * (x ** 2 + y ** 2) / sigma ** 2)
     weights /= 2 * np.pi * sigma * sigma
 
     match_list = []
     for r0, c0 in coords0:
-        roi0 = img0[r0-radius:r0+radius+1, c0-radius:c0+radius+1]
-        roi1_list = [img1[r1-radius:r1+radius+1, c1-radius:c1+radius+1]
-                     for r1, c1 in coords1]
+        roi0 = img0[r0 - radius:r0 + radius + 1, c0 - radius:c0 + radius + 1]
+        roi1_list = [img1[r1 - radius:r1 + radius + 1,
+                          c1 - radius:c1 + radius + 1] for r1, c1 in coords1]
         # sum of squared differences
-        ssd_list = [np.sum(weights*(roi0 - roi1)**2) for roi1 in roi1_list]
+        ssd_list = [np.sum(weights * (roi0 - roi1) ** 2) for roi1 in roi1_list]
         match_list.append(coords1[np.argmin(ssd_list)])
 
     return np.array(match_list)
 
-################################################################################
+
+############################################################################
 # For this example, a set of noisy images slightly tilted is generated
 
 img = moon()
@@ -62,10 +63,10 @@ img = moon()
 angle_list = [5, 6, -2, 3, -4]
 center_list = [(10, 10), (5, 12), (11, 21), (21, 17), (43, 15)]
 
-ref_img = img_as_float(img[40:240, 50:350])
-img_list = [ref_img.copy()] + [
-    rotate(img, angle=a, center =c)[40:240, 50:350]
-    for a, c in zip(angle_list, center_list)]
+i0, j0, i1, j1 = 40, 50, 240, 350
+ref_img = img_as_float(img[i0:i1, j0:j1])
+img_list = [ref_img.copy()] + [rotate(img, angle=a, center=c)[i0:i1, j0:j1]
+                               for a, c in zip(angle_list, center_list)]
 
 sigma = 0.015
 img_list = [random_noise(gaussian(im, 1.2), var=sigma ** 2, seed=12)
@@ -103,9 +104,8 @@ for idx, (im, trfm, (ax0, ax1)) in enumerate(zip(img_list, trfm_list, ax_list)):
     ax1.imshow(warp(im, trfm), cmap="gray", vmin=0, vmax=1)
 
     if idx == 0:
-        ax1.set_title(f"Registered")
         ax0.set_title(f"Input (PSNR={psnr_ref:.2f})")
-        ax0.set_ylabel(f"")
+        ax1.set_title(f"Registered")
 
     ax0.set_axis_off()
     ax1.set_axis_off()


### PR DESCRIPTION
## Description

This gallery example is a show case for the stitching problem using `skimage`. It is based on my answer to a [question](https://forum.image.sc/t/skimage-warp-determine-output-shape-so-output-does-not-crop/51433/5) in image.sc forum and its related issue #5330.

I used the `moon` image to simulate a set of noisy and tilted images:
![input](https://user-images.githubusercontent.com/3438227/116696812-ac09b900-a9c2-11eb-95cb-c6553425ba0c.png)

And here is the obtained composite image:
![compoist](https://user-images.githubusercontent.com/3438227/116696893-c479d380-a9c2-11eb-9dee-6d753c967336.png)

I will appreciate any help for rephrasing and clarifying the comments :wink:.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
