### PR TITLE
DOC: remove entries that are duplicate with release_0.18.rst

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -16,8 +16,6 @@ New Features
 ------------
 
 
-
-
 Documentation
 -------------
 

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -15,16 +15,7 @@ https://scikit-image.org
 New Features
 ------------
 
-- A new function ``segmentation.expand_labels`` has been added in order to dilate
-  labels while preventing overlap (#4795)
-- It is now possible to pass extra measurement functions to
-  ``measure.regionprops`` and ``regionprops_table`` (#4810)
-- Added a new perimeter function - ``measure.perimeter_crofton``.
-- Added 3D support for many filters in skimage.filters.rank.
-- New images have been added in the ``data`` subpackage: ``data.eagle``
-  (#4922), TODO for other images 
-  Also note that the image for ``data.camera`` has been changed due to
-  copyright issues (#4913).
+
 
 
 Documentation
@@ -40,10 +31,6 @@ Documentation
 Improvements
 ------------
 
-- In ``skimage.restoration.richardson_lucy``, computations are now be done in
-  single-precision when the input image is single-precision. This can give a
-  substantial performance improvement when working with single precision data.
-- ``pyproject.toml`` has been added to the sdist.
 - The performance of the SLIC superpixels algorithm
   (``skimage.segmentation.slice``) was improved for the case where a mask
   is supplied by the user (#4903). The specific superpixels produced by
@@ -62,13 +49,6 @@ API Changes
 - A default value has been added to ``measure.find_contours``, corresponding to
   the half distance between the min and max values of the image 
   #4862
-- ``skimage.restoration.richardson_lucy`` returns a single-precision output
-  when the input is single-precision. Prior to this release, double-precision
-  was always used.
-- The default value of ``threshold_rel`` in ``skimage.feature.corner`` has
-  changed from 0.1 to None, which corresponds to letting 
-  ``skimage.feature.peak_local_max`` decide on the default. This is currently
-  equivalent to ``threshold_rel=0``.
 - ``data.cat`` has been introduced as an alias of ``data.chelsea`` for a more
   descriptive name.
 - The ``level`` parameter of ``measure.find_contours`` is now a keyword
@@ -80,30 +60,8 @@ API Changes
 Bugfixes
 --------
 
-- For the RANSAC algorithm, improved the case where all data points are 
-  outliers, which was previously raising an error 
-  (#4844)
-- An error-causing bug has been corrected for the ``bg_color`` parameter in
-  ``label2rgb`` when its value is a string (#4840)
-- A normalization bug was fixed in ``metrics.variation_of_information`` 
-  (#4875)
 - Fixed the behaviour of Richardson-Lucy deconvolution for images with 3
   dimensions or more (#4823)
-- Euler characteristic property of ``skimage.measure.regionprops`` was erroneous
-  for 3D objects, since it did not take tunnels into account. A new implementation
-  based on integral geometry fixes this bug.
-- In ``skimage.morphology.selem.rectangle`` the ``height`` argument
-  controlled the width and the ``width`` argument controlled the height.
-  They have been replaced with ``nrow`` and ``ncol``.
-- ``skimage.segmentation.flood_fill`` and ``skimage.segmentation.flood``
-  now consistently handle negative values for ``seed_point``.
-- Segmentation faults in ``segmentation.flood`` have been fixed in #4948 and #4972
-- A segfault in ``draw.polygon`` for the case of 0-d input has been fixed
-  (#4943).
-- In ``registration.phase_cross_correlation``, a ``ValueError`` is raised when
-  NaNs are found in the computation (as a result of NaNs in input images).
-  Before this fix, an incorrect value could be returned where the input images
-  had NaNs (#4886).
 - ``min_distance`` is now enforced for ``skimage.feature.peak_local_max``
   (#2592).
 - Peak detection in labels is fixed in ``skimage.feature.peak_local_max``
@@ -111,32 +69,9 @@ Bugfixes
 - Input ``labels`` argument renumbering in ``skimage.feature.peak_local_max``
   is avoided (#5047).
 
-
 Deprecations
 ------------
 
-- In ``skimage.feature.structure_tensor``, an ``order`` argument has been
-  introduced which will default to 'rc' starting in version 0.20.
-- ``skimage.feature.structure_tensor_eigvals`` has been deprecated and will be
-  removed in version 0.20. Use ``skimage.feature.structure_tensor_eigenvalues``
-  instead.
-- The ``skimage.viewer`` subpackage and the ``skivi`` script have been
-  deprecated and will be removed in version 0.20. For interactive visualization
-  we recommend using dedicated tools such as napari or plotly. In a similar
-  vein, the ``qt`` and ``skivi`` plugins of ``skimage.io`` have been deprecated
-  and will be removed in version 0.20.
-- In ``skimage.morphology.selem.rectangle`` the arguments ``width`` and 
-  ``height`` have been deprecated. Use ``nrow`` and ``ncol`` instead.
-- The explicit setting ``threshold_rel=0` was removed from the Examples of the
-  following docstrings: ``skimage.feature.BRIEF``,
-  ``skimage.feature.corner_harris``, ``skimage.feature.corner_shi_tomasi``,
-  ``skimage.feature.corner_foerstner``, ``skimage.feature.corner_fast``,
-  ``skimage.feature.corner_subpix``, ``skimage.feature.corner_peaks``,
-  ``skimage.feature.corner_orientations``, and
-  ``skimage.feature._detect_octave``.
-- In ``skimage.restoration._denoise``, the warning regarding
-  ``rescale_sigma=None`` was removed.
-- In ``skimage.restoration._cycle_spin``, the ``# doctest: +SKIP`` was removed.
 - In ``measure.label``, the deprecated ``neighbors`` parameter has been
   removed.
 
@@ -144,13 +79,6 @@ Deprecations
 Development process
 -------------------
 
-- Benchmarks can now run on older scikit-image commits (#4891)
-- Website analytics are tracked using plausible.io and can be visualized on
-  https://plausible.io/scikit-image.org (#4893)
-- Artifacts for the documentation build are now found in each pull request
-  (#4881).
-- Documentation source files can now be written in Markdown in addition to
-  ResT, thanks to ``myst`` (#4863).
 
 Contributors to this release
 ----------------------------


### PR DESCRIPTION
## Description

closes #5341

Removes all items that previously appeared in the 0.18 release notes.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
