### PR TITLE
increase cibuildwheel verbosity

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -48,6 +48,7 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_TEST_REQUIRES: pytest pooch pytest-localserver pytest-faulthandler
           CIBW_TEST_COMMAND: pytest --pyargs skimage
+          CIBW_BUILD_VERBOSITY: 2
       - uses: actions/upload-artifact@v2
         with:
           name: wheels
@@ -92,6 +93,7 @@ jobs:
           LDFLAGS: "-Wl,-rpath,/usr/local/opt/libomp/lib -L/usr/local/opt/libomp/lib -lomp"
           CIBW_TEST_REQUIRES: pytest pooch pytest-localserver pytest-faulthandler
           CIBW_TEST_COMMAND: pytest --pyargs skimage
+          CIBW_BUILD_VERBOSITY: 2
 
       - name: Build wheels for CPython (MacOS)
         if: matrix.os == 'macos-latest'
@@ -112,6 +114,7 @@ jobs:
           LDFLAGS: "-Wl,-rpath,/usr/local/opt/libomp/lib -L/usr/local/opt/libomp/lib -lomp"
           CIBW_TEST_REQUIRES: pytest pooch pytest-localserver pytest-faulthandler
           CIBW_TEST_COMMAND: pytest --pyargs skimage
+          CIBW_BUILD_VERBOSITY: 2
 
       - name: Build wheels for CPython 3.6
         run: |
@@ -120,6 +123,7 @@ jobs:
           CIBW_BUILD: "cp36-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
+          CIBW_BUILD_VERBOSITY: 2
           # CIBW_BEFORE_BUILD: pip install certifi numpy==1.16
         if: >
           startsWith(github.ref, 'refs/heads/v0.17') ||
@@ -162,6 +166,7 @@ jobs:
           # CIBW_BEFORE_BUILD: pip install certifi numpy==1.19.3
           CIBW_TEST_REQUIRES: pytest pooch pytest-localserver pytest-faulthandler
           CIBW_TEST_COMMAND: pytest --pyargs skimage
+          CIBW_BUILD_VERBOSITY: 2
 
       - name: Build Windows wheels for CPython
         run: |
@@ -174,6 +179,7 @@ jobs:
           # CIBW_BEFORE_BUILD: pip install certifi numpy==1.16
           CIBW_TEST_REQUIRES: pytest pooch pytest-localserver pytest-faulthandler
           CIBW_TEST_COMMAND: pytest --pyargs skimage
+          CIBW_BUILD_VERBOSITY: 2
 
       - name: Build wheels for CPython 3.6
         run: |
@@ -182,6 +188,7 @@ jobs:
           CIBW_BUILD: "cp36-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
+          CIBW_BUILD_VERBOSITY: 2
           # CIBW_BEFORE_BUILD: pip install certifi numpy==1.16
         if: >
           startsWith(github.ref, 'refs/heads/v0.17') ||

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -9,6 +9,11 @@ on:
     tags:
       - v*
 
+env:
+  CIBW_BUILD_VERBOSITY: 2
+  CIBW_TEST_REQUIRES: pytest pooch pytest-localserver pytest-faulthandler
+  CIBW_TEST_COMMAND: pytest --pyargs skimage
+
 jobs:
   build_linux_37_and_above_wheels:
     name: Build python ${{ matrix.cibw_python }} wheels on ${{ matrix.os }}
@@ -46,9 +51,6 @@ jobs:
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
-          CIBW_TEST_REQUIRES: pytest pooch pytest-localserver pytest-faulthandler
-          CIBW_TEST_COMMAND: pytest --pyargs skimage
-          CIBW_BUILD_VERBOSITY: 2
       - uses: actions/upload-artifact@v2
         with:
           name: wheels
@@ -91,9 +93,6 @@ jobs:
           CFLAGS: "-Wno-implicit-function-declaration -I/usr/local/opt/libomp/include"
           CXXFLAGS: "-I/usr/local/opt/libomp/include"
           LDFLAGS: "-Wl,-rpath,/usr/local/opt/libomp/lib -L/usr/local/opt/libomp/lib -lomp"
-          CIBW_TEST_REQUIRES: pytest pooch pytest-localserver pytest-faulthandler
-          CIBW_TEST_COMMAND: pytest --pyargs skimage
-          CIBW_BUILD_VERBOSITY: 2
 
       - name: Build wheels for CPython (MacOS)
         if: matrix.os == 'macos-latest'
@@ -112,9 +111,6 @@ jobs:
           CFLAGS: "-Wno-implicit-function-declaration -I/usr/local/opt/libomp/include"
           CXXFLAGS: "-I/usr/local/opt/libomp/include"
           LDFLAGS: "-Wl,-rpath,/usr/local/opt/libomp/lib -L/usr/local/opt/libomp/lib -lomp"
-          CIBW_TEST_REQUIRES: pytest pooch pytest-localserver pytest-faulthandler
-          CIBW_TEST_COMMAND: pytest --pyargs skimage
-          CIBW_BUILD_VERBOSITY: 2
 
       - name: Build wheels for CPython 3.6
         run: |
@@ -164,9 +160,6 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
           # CIBW_BEFORE_BUILD: pip install certifi numpy==1.19.3
-          CIBW_TEST_REQUIRES: pytest pooch pytest-localserver pytest-faulthandler
-          CIBW_TEST_COMMAND: pytest --pyargs skimage
-          CIBW_BUILD_VERBOSITY: 2
 
       - name: Build Windows wheels for CPython
         run: |
@@ -177,9 +170,6 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
           # CIBW_BEFORE_BUILD: pip install certifi numpy==1.16
-          CIBW_TEST_REQUIRES: pytest pooch pytest-localserver pytest-faulthandler
-          CIBW_TEST_COMMAND: pytest --pyargs skimage
-          CIBW_BUILD_VERBOSITY: 2
 
       - name: Build wheels for CPython 3.6
         run: |


### PR DESCRIPTION
## Description

Currently cibuildwheel is failing for cpython 3.8. I believe this is due to a failure to resolve a numpy version, deduced by the fact that the build fails when trying to import numpy. The source of the failed import is hard to infer from the CI log though because of the default verbosity of cibuildwheel: increasing this will likely make debugging easier in the future.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.