### PR TITLE
[WIP] change numpy version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires = [
     # default numpy requirements
     "numpy==1.16.5; python_version=='3.6' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.16.5; python_version=='3.7' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
-    "numpy==1.17.3; python_version=='3.8' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
+    "numpy>='1.17.0,!=1.18.0'; python_version=='3.8' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
     "numpy==1.19.3; python_version=='3.9' and platform_python_implementation != 'PyPy'",
 
     # First PyPy versions for which there are numpy wheels


### PR DESCRIPTION
## Description

Will likely be made redundant by #5340 but some fix for cibuildwheel is
required prior to release for CI to pass for cibuildwheel with cpython 3.8   

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.