### PR TITLE
add numpy version specification on aarch for cpython 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires = [
     # wheels require fixes contained in numpy 1.19.2
     "numpy==1.19.2; python_version=='3.6' and platform_machine=='aarch64'",
     "numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64'",
+    "numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64'",
 
     # default numpy requirements
     "numpy==1.17.3; python_version=='3.6' and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",


### PR DESCRIPTION
Correct fix cibuildwheel with cpython 3.8 on aarch64 as described in https://github.com/scikit-image/scikit-image/pull/5371

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.