### PR TITLE
Update pip during dev environment installation

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -298,6 +298,8 @@ When using ``venv``, you may find the following bash commands useful:
   python -m venv skimage-dev
   # Activate it. On Linux and MacOS:
   source skimage-dev/bin/activate
+  # Make sure that pip is up to date
+  pip install --upgrade pip
   # Install all development and runtime dependencies of scikit-image
   pip install -r <(cat requirements/*.txt)
   # Build and install scikit-image from source


### PR DESCRIPTION
## Description

Running `pip install -r <(cat requirements/*.txt)` with pip 20.2.3 will fail with an error "Double requirement given [...]" if any requirements have appear twice with conflicting version specs. E.g. numpy at the time of this commit. Updating pip to 21.1.1 solves this issue.

See #5377 for more details.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
