### PR TITLE
Integral_image: promote floating point inputs to double by default

### DIFF
--- a/skimage/transform/integral.py
+++ b/skimage/transform/integral.py
@@ -37,7 +37,7 @@ def integral_image(image, *, dtype=None):
     """
     if dtype is None and image.real.dtype.kind == 'f':
         # default to at least double precision cumsum for accuracy
-        dtype = np.promote_types(image.dtype, float)
+        dtype = np.promote_types(image.dtype, np.float64)
         image = image.astype(dtype, copy=False)
 
     S = image

--- a/skimage/transform/integral.py
+++ b/skimage/transform/integral.py
@@ -23,8 +23,8 @@ def integral_image(image, *, dtype=None):
 
     Notes
     -----
-    For better accuracy and to avoid potential overflow, the datatype of the
-    output may differ from the input when the default dtype of None is used.
+    For better accuracy and to avoid potential overflow, the data type of the
+    output may differ from the input's when the default dtype of None is used.
     For inputs with integer dtype, the behavior matches that for
     :func:`numpy.cumsum`. Floating point inputs will be promoted to at least
     double precision. The user can set `dtype` to override this behavior.

--- a/skimage/transform/integral.py
+++ b/skimage/transform/integral.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def integral_image(image):
+def integral_image(image, *, dtype=None):
     r"""Integral image / summed area table.
 
     The integral image contains the sum of all elements above and to the
@@ -21,15 +21,28 @@ def integral_image(image):
     S : ndarray
         Integral image/summed area table of same shape as input image.
 
+    Notes
+    -----
+    For better accuracy and to avoid potential overflow, the datatype of the
+    output may differ from the input when the default dtype of None is used.
+    For inputs with integer dtype, the behavior matches that for
+    :func:`numpy.cumsum`. Floating point inputs will be promoted to at least
+    double precision. The user can set `dtype` to override this behavior.
+
     References
     ----------
     .. [1] F.C. Crow, "Summed-area tables for texture mapping,"
            ACM SIGGRAPH Computer Graphics, vol. 18, 1984, pp. 207-212.
 
     """
+    if dtype is None and image.real.dtype.kind == 'f':
+        # default to at least double precision cumsum for accuracy
+        dtype = np.promote_types(image.dtype, float)
+        image = image.astype(dtype, copy=False)
+
     S = image
     for i in range(image.ndim):
-        S = S.cumsum(axis=i)
+        S = S.cumsum(axis=i, dtype=dtype)
     return S
 
 

--- a/skimage/transform/tests/test_integral.py
+++ b/skimage/transform/tests/test_integral.py
@@ -1,7 +1,8 @@
 import numpy as np
-from skimage.transform import integral_image, integrate
+import pytest
 
-from skimage._shared.testing import assert_equal
+from skimage._shared.testing import assert_allclose, assert_equal
+from skimage.transform import integral_image, integrate
 
 
 np.random.seed(0)
@@ -9,12 +10,28 @@ x = (np.random.rand(50, 50) * 255).astype(np.uint8)
 s = integral_image(x)
 
 
-def test_validity():
-    y = np.arange(12).reshape((4, 3))
-
-    y = (np.random.rand(50, 50) * 255).astype(np.uint8)
-    assert_equal(integral_image(y)[-1, -1],
-                 y.sum())
+@pytest.mark.parametrize(
+    'dtype', [np.float16, np.float32, np.float64, np.uint8, np.int32]
+)
+@pytest.mark.parametrize('dtype_as_kwarg', [False, True])
+def test_integral_image_validity(dtype, dtype_as_kwarg):
+    rstate = np.random.RandomState(1234)
+    dtype_kwarg = dtype if dtype_as_kwarg else None
+    y = (rstate.rand(20, 20) * 255).astype(dtype)
+    out = integral_image(y, dtype=dtype_kwarg)
+    if y.dtype.kind == 'f':
+        if dtype_as_kwarg:
+            assert out.dtype == dtype
+            rtol = 1e-3 if dtype == np.float16 else 1e-7
+            assert_allclose(out[-1, -1], y.sum(dtype=np.float64), rtol=rtol)
+        else:
+            assert out.dtype == np.float64
+            assert_allclose(out[-1, -1], y.sum(dtype=np.float64))
+    else:
+        assert out.dtype.kind == y.dtype.kind
+        if not (dtype_as_kwarg and dtype == np.uint8):
+            # omit check for dtype=uint8 case as it will overflow
+            assert_equal(out[-1, -1], y.sum())
 
 
 def test_basic():


### PR DESCRIPTION
## Description

This PR was split off from #5372 as it is a change in existing behavior. To avoid surprises due to poor accuracy of floating point cumulative sums, I propose we default to double precision when computing integral images. See additional details in prior comment: https://github.com/scikit-image/scikit-image/pull/5372#discussion_r625460770.

The user can override the default by manually specifying the `dtype` argument.

One question is whether we can consider this a bug fix or if we should introduce a deprecation cycle before making the switch. The new output should be strictly an improvement from an accuracy standpoint, but output dtype will be larger for `float16`, `float32` or `complex64` inputs.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
