### PR TITLE
update sigma_color description in denoise_bilateral

### DIFF
--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -110,12 +110,13 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
     sigma_color : float
         Standard deviation for grayvalue/color distance (radiometric
         similarity). A larger value results in averaging of pixels with larger
-        radiometric differences. If the value is ``None`` the standard deviation 
-        of the ``image`` will be used. Note that, if the image is any `int` type, 
-        the image will be converted using the `img_as_float` function and thus the 
-        standard deviation is in respect to the range ``[0, 1]``. For more
-        information on scikit-image data type conversions and how images are 
-        rescaled in these conversions, see: https://scikit-image.org/docs/dev/user_guide/data_types.html.
+        radiometric differences. If the value is ``None`` the standard
+        deviation of the ``image`` will be used. Note that, if the image is
+        any `int` type, the image will be converted using the `img_as_float`
+        function and thus the standard deviation is in respect to the
+        range ``[0, 1]``. For more information on scikit-image data
+        type conversions and how images are rescaled in these conversions,
+        see: https://scikit-image.org/docs/dev/user_guide/data_types.html.
     sigma_spatial : float
         Standard deviation for range distance. A larger value results in
         averaging of pixels with larger spatial differences.

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -111,7 +111,7 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
         Standard deviation for grayvalue/color distance (radiometric
         similarity). A larger value results in averaging of pixels with larger
         radiometric differences. If ``None``, the standard deviation of
-        ``image`` will be used. Note that, if the image is
+        ``image`` will be used. Note that, if the image is of
         any `int` dtype, ``image`` will be converted using the `img_as_float`
         function and thus the standard deviation is in respect to the
         range ``[0, 1]``. For more information on scikit-image's data

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -110,13 +110,13 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
     sigma_color : float
         Standard deviation for grayvalue/color distance (radiometric
         similarity). A larger value results in averaging of pixels with larger
-        radiometric differences. If the value is ``None`` the standard
-        deviation of the ``image`` will be used. Note that, if the image is
-        any `int` type, the image will be converted using the `img_as_float`
+        radiometric differences. If ``None`` the standard deviation of 
+        ``image`` will be used. Note that, if the image is
+        any `int` dtype, ``image`` will be converted using the `img_as_float`
         function and thus the standard deviation is in respect to the
-        range ``[0, 1]``. For more information on scikit-image data
+        range ``[0, 1]``. For more information on scikit-image's data
         type conversions and how images are rescaled in these conversions,
-        see: https://scikit-image.org/docs/dev/user_guide/data_types.html.
+        see: https://scikit-image.org/docs/stable/user_guide/data_types.html.
     sigma_spatial : float
         Standard deviation for range distance. A larger value results in
         averaging of pixels with larger spatial differences.

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -110,10 +110,12 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
     sigma_color : float
         Standard deviation for grayvalue/color distance (radiometric
         similarity). A larger value results in averaging of pixels with larger
-        radiometric differences. Note, that the image will be converted using
-        the `img_as_float` function and thus the standard deviation is in
-        respect to the range ``[0, 1]``. If the value is ``None`` the standard
-        deviation of the ``image`` will be used.
+        radiometric differences. If the value is ``None`` the standard deviation 
+        of the ``image`` will be used. Note that, if the image is any `int` type, 
+        the image will be converted using the `img_as_float` function and thus the 
+        standard deviation is in respect to the range ``[0, 1]``. For more
+        information on scikit-image data type conversions and how images are 
+        rescaled in these conversions, see: https://scikit-image.org/docs/dev/user_guide/data_types.html.
     sigma_spatial : float
         Standard deviation for range distance. A larger value results in
         averaging of pixels with larger spatial differences.

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -110,7 +110,7 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
     sigma_color : float
         Standard deviation for grayvalue/color distance (radiometric
         similarity). A larger value results in averaging of pixels with larger
-        radiometric differences. If ``None`` the standard deviation of 
+        radiometric differences. If ``None`` the standard deviation of
         ``image`` will be used. Note that, if the image is
         any `int` dtype, ``image`` will be converted using the `img_as_float`
         function and thus the standard deviation is in respect to the

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -113,7 +113,7 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
         radiometric differences. If ``None``, the standard deviation of
         ``image`` will be used. Note that, if the image is of
         any `int` dtype, ``image`` will be converted using the `img_as_float`
-        function and thus the standard deviation is in respect to the
+        function and thus the standard deviation will be in
         range ``[0, 1]``. For more information on scikit-image's data
         type conversions and how images are rescaled in these conversions,
         see: https://scikit-image.org/docs/stable/user_guide/data_types.html.

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -110,7 +110,7 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
     sigma_color : float
         Standard deviation for grayvalue/color distance (radiometric
         similarity). A larger value results in averaging of pixels with larger
-        radiometric differences. If ``None`` the standard deviation of
+        radiometric differences. If ``None``, the standard deviation of
         ``image`` will be used. Note that, if the image is
         any `int` dtype, ``image`` will be converted using the `img_as_float`
         function and thus the standard deviation is in respect to the

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -111,12 +111,7 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
         Standard deviation for grayvalue/color distance (radiometric
         similarity). A larger value results in averaging of pixels with larger
         radiometric differences. If ``None``, the standard deviation of
-        ``image`` will be used. Note that, if the image is of
-        any `int` dtype, ``image`` will be converted using the `img_as_float`
-        function and thus the standard deviation will be in
-        range ``[0, 1]``. For more information on scikit-image's data
-        type conversions and how images are rescaled in these conversions,
-        see: https://scikit-image.org/docs/stable/user_guide/data_types.html.
+        ``image`` will be used.
     sigma_spatial : float
         Standard deviation for range distance. A larger value results in
         averaging of pixels with larger spatial differences.
@@ -158,6 +153,14 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
     Radiometric similarity is measured by the Gaussian function of the
     Euclidean distance between two color values and a certain standard
     deviation (`sigma_color`).
+
+    Note that, if the image is of any `int` dtype, ``image`` will be
+    converted using the `img_as_float` function and thus the standard
+    deviation (`sigma_color`) will be in range ``[0, 1]``.
+
+    For more information on scikit-image's data type conversions and how
+    images are rescaled in these conversions,
+    see: https://scikit-image.org/docs/stable/user_guide/data_types.html.
 
     References
     ----------


### PR DESCRIPTION
## Description

Update the description of `sigma_color` in `denoise_bilateral` to make it clear that `img_as_float` only rescales images with any `int` type, and that it does not rescale `float` images.

See discussion in: https://github.com/scikit-image/scikit-image/issues/5391

## Checklist

N/A

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
