### PR TITLE
Speed up find_local_max when given a finite num_peaks

### DIFF
--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -17,7 +17,13 @@ def _get_high_intensity_peaks(image, mask, num_peaks, min_distance, p_norm):
     idx_maxsort = np.argsort(-intensities)
     coord = np.transpose(coord)[idx_maxsort]
 
-    coord = ensure_spacing(coord, spacing=min_distance, p_norm=p_norm)
+    if np.isfinite(num_peaks):
+        max_out = int(num_peaks)
+    else:
+        max_out = None
+
+    coord = ensure_spacing(coord, spacing=min_distance, p_norm=p_norm,
+                           max_out=max_out)
 
     if len(coord) > num_peaks:
         coord = coord[:num_peaks]


### PR DESCRIPTION
## Description

Optimizes _shared.coord.ensure_spacing as used in
feature.peak.find_local_max when given num_peaks

There's no need to process all candidates, which could
far outnumber the requested maximum, since candidates
in find_local_max are sorted by intensity. So only return
the first few matches and ignore the rest.

The resulting speedup can be huge in a number of cases

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
