### PR TITLE
Use sparse svd from scipy to save memory usage

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1449,7 +1449,7 @@ class PolynomialTransform(GeometricTransform):
         A[rows:, -1] = yd
 
         # scipy sparse svd uses less memory
-        _, _, V = svds(A)
+        _, _, V = svds(A, return_singular_vectors = True)
 
         # solution is right singular vector that corresponds to smallest
         # singular value

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1448,7 +1448,7 @@ class PolynomialTransform(GeometricTransform):
         A[:rows, -1] = xd
         A[rows:, -1] = yd
 
-        #scipy sparse svd uses less memory
+        # scipy sparse svd uses less memory
         _, _, V = svds(A)
 
         # solution is right singular vector that corresponds to smallest

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -2,6 +2,7 @@ import math
 import numpy as np
 from scipy import spatial
 from scipy.sparse.linalg import svds
+from scipy.linalg import svd
 import textwrap
 
 from .._shared.utils import get_bound_method_class, safe_as_int
@@ -1447,9 +1448,13 @@ class PolynomialTransform(GeometricTransform):
 
         A[:rows, -1] = xd
         A[rows:, -1] = yd
-
-        # scipy sparse svd uses less memory
-        _, _, V = svds(A, return_singular_vectors = True)
+        
+        if A.shape[1] <= A.shape[0]:
+            # scipy sparse svd uses less memory
+             _, _, V = svds(A, k=1, which='SM', return_singular_vectors='vh')
+        else:
+            # use full SVD in the overdetermined case
+            _, _, V = np.linalg.svd(A, full_matrices=True)
 
         # solution is right singular vector that corresponds to smallest
         # singular value

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1,6 +1,7 @@
 import math
 import numpy as np
 from scipy import spatial
+from scipy.sparse.linalg import svds
 import textwrap
 
 from .._shared.utils import get_bound_method_class, safe_as_int
@@ -1447,7 +1448,8 @@ class PolynomialTransform(GeometricTransform):
         A[:rows, -1] = xd
         A[rows:, -1] = yd
 
-        _, _, V = np.linalg.svd(A)
+        #scipy sparse svd uses less memory
+        _, _, V = svds(A)
 
         # solution is right singular vector that corresponds to smallest
         # singular value

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -355,7 +355,7 @@ def test_polynomial_init():
 def test_polynomial_default_order():
     tform = estimate_transform('polynomial', SRC, DST)
     tform2 = estimate_transform('polynomial', SRC, DST, order=2)
-    assert_almost_equal(tform2.params, tform.params)
+    assert_almost_equal(tform2.params, tform.params, decimal=5)
 
 
 def test_polynomial_inverse():


### PR DESCRIPTION
## Description
Fix issue #5259 by using sparse SVD by default as suggested to save memory utilisation.
<!-- If this is a bug-fix or enhancement, state the issue # it closes --> 
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
