### PR TITLE
Check for Integral ABC instead of `int` in `crop`

### DIFF
--- a/skimage/util/arraycrop.py
+++ b/skimage/util/arraycrop.py
@@ -4,6 +4,7 @@ n-dimensional array.
 """
 
 import numpy as np
+from numbers import Integral
 
 __all__ = ['crop']
 
@@ -39,9 +40,9 @@ def crop(ar, crop_width, copy=False, order='K'):
     """
     ar = np.array(ar, copy=False)
 
-    if isinstance(crop_width, int):
+    if isinstance(crop_width, Integral):
         crops = [[crop_width, crop_width]] * ar.ndim
-    elif isinstance(crop_width[0], int):
+    elif isinstance(crop_width[0], Integral):
         if len(crop_width) == 1:
             crops = [[crop_width[0], crop_width[0]]] * ar.ndim
         elif len(crop_width) == 2:

--- a/skimage/util/tests/test_arraycrop.py
+++ b/skimage/util/tests/test_arraycrop.py
@@ -62,3 +62,11 @@ def test_zero_crop():
     arr = np.arange(45).reshape(9, 5)
     out = crop(arr, 0)
     assert out.shape == (9, 5)
+
+
+def test_np_int_crop():
+    arr = np.arange(45).reshape(9, 5)
+    out1 = crop(arr, np.int64(1))
+    out2 = crop(arr, np.int32(1))
+    assert_array_equal(out1, out2)
+    assert out1.shape == (7, 3)


### PR DESCRIPTION
This also catches the numpy integer types which
do not inherit from python int

## Description
Fixes: https://github.com/scikit-image/scikit-image/issues/5418


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [NA] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [NA] Gallery example in `./doc/examples` (new features only)
- [NA?] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
