### PR TITLE
Fix duplicate test function names in test_unsharp_mask.py

### DIFF
--- a/skimage/filters/tests/test_unsharp_mask.py
+++ b/skimage/filters/tests/test_unsharp_mask.py
@@ -60,9 +60,8 @@ def test_unsharp_masking_with_different_radii(radius, shape,
               ((3, 13, 17), 0)])
 @parametrize("offset", [-5, 0, 5])
 @parametrize("preserve", [False, True])
-def test_unsharp_masking_with_different_ranges_deprecated(shape, offset,
-                                                          channel_axis,
-                                                          preserve):
+def test_unsharp_masking_with_different_ranges(shape, offset, channel_axis,
+                                               preserve):
     radius = 2.0
     amount = 1.0
     dtype = np.int16


### PR DESCRIPTION
## Description

This PR fixes a copy-paste error introduced in one of my `channel_axis` PRs. There were two test cases named `test_unsharp_masking_with_different_ranges_deprecated`, but the first was supposed to be named `test_unsharp_masking_with_different_ranges` because it is using the non-deprecated arguments.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
