### PR TITLE
Benchmarks: fix ResizeLocalMeanSuite.time_resize_local_mean signature

### DIFF
--- a/benchmarks/benchmark_transform_warp.py
+++ b/benchmarks/benchmark_transform_warp.py
@@ -71,5 +71,5 @@ class ResizeLocalMeanSuite:
         self.shape_out = ndim_out * (shape_out, )
         self.grid_mode = grid_mode
 
-    def time_resize_local_mean(self):
+    def time_resize_local_mean(self, *args):
         resize_local_mean(self.image, self.shape_out, self.grid_mode)


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

Running `asv check` will fail on current `main` due to this incomplete function signature. `time_*` functions need (apparently) to accept all the parameters specified in the class (a total of six, in this case). They can also admit an arbitrary number of arguments with `*args`, which is the proposed fix.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
