### PR TITLE
residual multichannel->channel_axis fixes

### DIFF
--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,9 @@
+import numpy as np
+import skimage
+
+
+def _channel_kwarg(is_multichannel=False):
+    if np.lib.NumpyVersion(skimage.__version__) < '0.19.0':
+        return dict(multichannel=is_multichannel)
+    else:
+        return dict(channel_axis=-1 if is_multichannel else None)

--- a/benchmarks/benchmark_restoration.py
+++ b/benchmarks/benchmark_restoration.py
@@ -1,4 +1,7 @@
 import numpy as np
+import scipy.ndimage as ndi
+
+import skimage
 from skimage.data import camera
 from skimage import restoration, data, color
 from skimage.morphology import binary_dilation
@@ -6,7 +9,7 @@ try:
     from skimage.morphology import disk
 except ImportError:
     from skimage.morphology import circle as disk
-import scipy.ndimage as ndi
+from . import _channel_kwarg
 
 
 class RestorationSuite:
@@ -26,19 +29,19 @@ class RestorationSuite:
         restoration.denoise_nl_means(self.volume_f64, patch_size=3,
                                      patch_distance=2, sigma=self.sigma,
                                      h=0.7 * self.sigma, fast_mode=False,
-                                     multichannel=False)
+                                     **_channel_kwarg(False))
 
     def time_denoise_nl_means_f32(self):
         restoration.denoise_nl_means(self.volume_f32, patch_size=3,
                                      patch_distance=2, sigma=self.sigma,
                                      h=0.7 * self.sigma, fast_mode=False,
-                                     multichannel=False)
+                                     **_channel_kwarg(False))
 
     def time_denoise_nl_means_fast_f64(self):
         restoration.denoise_nl_means(self.volume_f64, patch_size=3,
                                      patch_distance=2, sigma=self.sigma,
                                      h=0.7 * self.sigma, fast_mode=True,
-                                     multichannel=False)
+                                     **_channel_kwarg(False))
 
     def time_denoise_nl_means_fast_f32(self):
         restoration.denoise_nl_means(self.volume_f32, patch_size=3,
@@ -49,7 +52,7 @@ class RestorationSuite:
         restoration.denoise_nl_means(self.volume_f64, patch_size=3,
                                      patch_distance=2,  sigma=self.sigma,
                                      h=0.7 * self.sigma, fast_mode=False,
-                                     multichannel=False)
+                                     **_channel_kwarg(False))
 
     def peakmem_denoise_nl_means_f32(self):
         restoration.denoise_nl_means(self.volume_f32, patch_size=3,
@@ -60,13 +63,13 @@ class RestorationSuite:
         restoration.denoise_nl_means(self.volume_f64, patch_size=3,
                                      patch_distance=2, sigma=self.sigma,
                                      h=0.7 * self.sigma, fast_mode=True,
-                                     multichannel=False)
+                                     **_channel_kwarg(False))
 
     def peakmem_denoise_nl_means_fast_f32(self):
         restoration.denoise_nl_means(self.volume_f32, patch_size=3,
                                      patch_distance=2, sigma=self.sigma,
                                      h=0.7 * self.sigma, fast_mode=True,
-                                     multichannel=False)
+                                     **_channel_kwarg(False))
 
 
 class DeconvolutionSuite:
@@ -194,8 +197,8 @@ class Inpaint(object):
 
     def time_inpaint_rgb(self):
         restoration.inpaint_biharmonic(self.image_defect, self.mask,
-                                       multichannel=True)
+                                       **_channel_kwarg(True))
 
     def time_inpaint_grey(self):
         restoration.inpaint_biharmonic(self.image_defect_gray, self.mask,
-                                       multichannel=False)
+                                       **_channel_kwarg(False))

--- a/benchmarks/benchmark_segmentation.py
+++ b/benchmarks/benchmark_segmentation.py
@@ -3,6 +3,7 @@ import numpy as np
 from numpy.lib import NumpyVersion as Version
 import skimage
 from skimage import segmentation
+from . import _channel_kwarg
 
 
 class SlicSegmentation:
@@ -21,11 +22,11 @@ class SlicSegmentation:
 
     def time_slic_basic(self):
         segmentation.slic(self.image, enforce_connectivity=False,
-                          multichannel=False, **self.slic_kwargs)
+                          **_channel_kwarg(False), **self.slic_kwargs)
 
     def time_slic_basic_multichannel(self):
         segmentation.slic(self.image, enforce_connectivity=False,
-                          multichannel=True, **self.slic_kwargs)
+                          **_channel_kwarg(True), **self.slic_kwargs)
 
     def peakmem_setup(self):
         """peakmem includes the memory used by setup.
@@ -46,11 +47,11 @@ class SlicSegmentation:
 
     def peakmem_slic_basic(self):
         segmentation.slic(self.image, enforce_connectivity=False,
-                          multichannel=False, **self.slic_kwargs)
+                          **_channel_kwarg(False), **self.slic_kwargs)
 
     def peakmem_slic_basic_multichannel(self):
         segmentation.slic(self.image, enforce_connectivity=False,
-                          multichannel=True, **self.slic_kwargs)
+                          **_channel_kwarg(True), **self.slic_kwargs)
 
 
 class MaskSlicSegmentation(SlicSegmentation):
@@ -76,8 +77,8 @@ class MaskSlicSegmentation(SlicSegmentation):
 
     def time_mask_slic(self):
         segmentation.slic(self.image, enforce_connectivity=False,
-                          mask=self.msk, multichannel=False)
+                          mask=self.msk, **_channel_kwarg(False))
 
     def time_mask_slic_multichannel(self):
         segmentation.slic(self.image, enforce_connectivity=False,
-                          mask=self.msk_slice, multichannel=True)
+                          mask=self.msk_slice, **_channel_kwarg(True))

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -158,9 +158,9 @@ def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
     multichannel = channel_axis is not None
     ndim_spatial = image.ndim - 1 if multichannel else image.ndim
     if ndim_spatial != 2:
-        raise ValueError('Only images with 2 spatial dimensions are '
+        raise ValueError('Only images with two spatial dimensions are '
                          'supported. If using with color/multichannel '
-                         'images, specify `multichannel=True`.')
+                         'images, specify `channel_axis`.')
 
     """
     The first stage applies an optional global image normalization

--- a/skimage/feature/orb.py
+++ b/skimage/feature/orb.py
@@ -133,7 +133,7 @@ class ORB(FeatureDetector, DescriptorExtractor):
     def _build_pyramid(self, image):
         image = _prepare_grayscale_input_2D(image)
         return list(pyramid_gaussian(image, self.n_scales - 1,
-                                     self.downscale, multichannel=False))
+                                     self.downscale, channel_axis=None))
 
     def _detect_octave(self, octave_image):
         dtype = octave_image.dtype

--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -106,7 +106,7 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
     >>> # For RGB images, each is filtered separately
     >>> from skimage.data import astronaut
     >>> image = astronaut()
-    >>> filtered_img = gaussian(image, sigma=1, multichannel=True)
+    >>> filtered_img = gaussian(image, sigma=1, channel_axis=-1)
 
     """
     if image.ndim == 3 and image.shape[-1] == 3 and channel_axis is None:
@@ -250,13 +250,13 @@ def difference_of_gaussians(image, low_sigma, high_sigma=None, *,
     >>> from skimage.data import astronaut
     >>> from skimage.filters import difference_of_gaussians
     >>> filtered_image = difference_of_gaussians(astronaut(), 2, 10,
-    ...                                          multichannel=True)
+    ...                                          channel_axis=-1)
 
     Apply a Laplacian of Gaussian filter as approximated by the Difference
     of Gaussians filter:
 
     >>> filtered_image = difference_of_gaussians(astronaut(), 2,
-    ...                                          multichannel=True)
+    ...                                          channel_axis=-1)
 
     Apply a Difference of Gaussians filter to a grayscale image using different
     sigma values for each axis:

--- a/skimage/future/tests/test_trainable_segmentation.py
+++ b/skimage/future/tests/test_trainable_segmentation.py
@@ -53,7 +53,7 @@ def test_trainable_segmentation_multichannel():
         texture=False,
         sigma_min=0.5,
         sigma_max=2,
-        multichannel=True
+        channel_axis=-1,
     )
     features = features_func(img)
     clf = fit_segmenter(labels, features, clf)

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -177,7 +177,7 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
     >>> noisy = astro + 0.6 * astro.std() * rng.random(astro.shape)
     >>> noisy = np.clip(noisy, 0, 1)
     >>> denoised = denoise_bilateral(noisy, sigma_color=0.05, sigma_spatial=15,
-    ...                              multichannel=True)
+    ...                              channel_axis=-1)
     """
     if channel_axis is not None:
         if image.ndim != 3:
@@ -208,7 +208,7 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
             raise ValueError("Bilateral filter is not implemented for "
                              "grayscale images of 3 or more dimensions, "
                              "but input image has {0} dimension. Use "
-                             "``multichannel=True`` for 2-D RGB "
+                             "``channel_axis=-1`` for 2-D RGB "
                              "images.".format(image.shape))
 
     if win_size is None:
@@ -979,7 +979,7 @@ def estimate_sigma(image, average_sigmas=False, multichannel=False, *,
     >>> sigma = 0.1
     >>> rng = np.random.default_rng()
     >>> img = img + sigma * rng.standard_normal(img.shape)
-    >>> sigma_hat = estimate_sigma(img, multichannel=False)
+    >>> sigma_hat = estimate_sigma(img, channel_axis=None)
     """
     if channel_axis is not None:
         channel_axis = channel_axis % image.ndim

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -274,7 +274,7 @@ def random_walker(data, labels, beta=130, mode='cg_j', tol=1.e-3, copy=True,
     data : array_like
         Image to be segmented in phases. Gray-level `data` can be two- or
         three-dimensional; multichannel data can be three- or four-
-        dimensional (multichannel=True) with the highest dimension denoting
+        dimensional with `channel_axis` specifying the dimension containing
         channels. Data spacing is assumed isotropic unless the `spacing`
         keyword argument is used.
     labels : array of ints, of same shape as `data` without channels dimension

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -1123,11 +1123,11 @@ def warp_polar(image, center=None, *, radius=None, output_shape=None,
     """
     multichannel = channel_axis is not None
     if image.ndim != 2 and not multichannel:
-        raise ValueError("Input array must be 2 dimensional when "
+        raise ValueError("Input array must be 2-dimensional when "
                          f"`channel_axis=None`, got {image.ndim}")
 
     if image.ndim != 3 and multichannel:
-        raise ValueError("Input array must be 3 dimensional when "
+        raise ValueError("Input array must be 3-dimensional when "
                          f"`channel_axis` is specified, got {image.ndim}")
 
     if center is None:

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -8,11 +8,11 @@ from ._geometric import (SimilarityTransform, AffineTransform,
 from ._warps_cy import _warp_fast
 from ..measure import block_reduce
 
-from .._shared import utils
 from .._shared.utils import (get_bound_method_class, safe_as_int, warn,
                              convert_to_float, _to_ndimage_mode,
                              _validate_interpolation_order,
-                             channel_as_last_axis)
+                             channel_as_last_axis,
+                             deprecate_multichannel_kwarg)
 
 HOMOGRAPHY_TRANSFORMS = (
     SimilarityTransform,
@@ -239,8 +239,8 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
     return out
 
 
-@utils.channel_as_last_axis()
-@utils.deprecate_multichannel_kwarg(multichannel_position=7)
+@channel_as_last_axis()
+@deprecate_multichannel_kwarg(multichannel_position=7)
 def rescale(image, scale, order=None, mode='reflect', cval=0, clip=True,
             preserve_range=False, multichannel=False,
             anti_aliasing=None, anti_aliasing_sigma=None, *,
@@ -1054,8 +1054,8 @@ def _log_polar_mapping(output_coords, k_angle, k_radius, center):
     return coords
 
 
-@utils.channel_as_last_axis()
-@utils.deprecate_multichannel_kwarg()
+@channel_as_last_axis()
+@deprecate_multichannel_kwarg()
 def warp_polar(image, center=None, *, radius=None, output_shape=None,
                scaling='linear', multichannel=False, channel_axis=None,
                **kwargs):
@@ -1064,9 +1064,8 @@ def warp_polar(image, center=None, *, radius=None, output_shape=None,
     Parameters
     ----------
     image : ndarray
-        Input image. Only 2-D arrays are accepted by default. If
-        `multichannel=True`, 3-D arrays are accepted and the last axis is
-        interpreted as multiple channels.
+        Input image. Only 2-D arrays are accepted by default. 3-D arrays are
+        accepted if a `channel_axis` is specified.
     center : tuple (row, col), optional
         Point in image that represents the center of the transformation (i.e.,
         the origin in cartesian space). Values can be of type `float`.
@@ -1124,14 +1123,12 @@ def warp_polar(image, center=None, *, radius=None, output_shape=None,
     """
     multichannel = channel_axis is not None
     if image.ndim != 2 and not multichannel:
-        raise ValueError("Input array must be 2 dimensions "
-                         "when `multichannel=False`,"
-                         " got {}".format(image.ndim))
+        raise ValueError("Input array must be 2 dimensional when "
+                         f"`channel_axis=None`, got {image.ndim}")
 
     if image.ndim != 3 and multichannel:
-        raise ValueError("Input array must be 3 dimensions "
-                         "when `multichannel=True`,"
-                         " got {}".format(image.ndim))
+        raise ValueError("Input array must be 3 dimensional when "
+                         f"`channel_axis` is specified, got {image.ndim}")
 
     if center is None:
         center = (np.array(image.shape)[:2] / 2) - 0.5

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -12,7 +12,7 @@ from skimage.transform import radon, iradon, iradon_sart, rescale
 
 PHANTOM = shepp_logan_phantom()[::2, ::2]
 PHANTOM = rescale(PHANTOM, 0.5, order=1,
-                  mode='constant', anti_aliasing=False, multichannel=False)
+                  mode='constant', anti_aliasing=False, channel_axis=None)
 
 
 def _debug_plot(original, result, sinogram=None):
@@ -394,7 +394,7 @@ def test_iradon_sart():
     debug = False
 
     image = rescale(PHANTOM, 0.8, mode='reflect',
-                    multichannel=False, anti_aliasing=False)
+                    channel_axis=None, anti_aliasing=False)
     theta_ordered = np.linspace(0., 180., image.shape[0], endpoint=False)
     theta_missing_wedge = np.linspace(0., 150., image.shape[0], endpoint=True)
     for theta, error_factor in ((theta_ordered, 1.),

--- a/skimage/viewer/tests/test_viewer.py
+++ b/skimage/viewer/tests/test_viewer.py
@@ -42,7 +42,7 @@ def make_key_event(key):
 def test_collection_viewer():
 
     img = data.astronaut()
-    img_collection = tuple(pyramid_gaussian(img, multichannel=True))
+    img_collection = tuple(pyramid_gaussian(img, channel_axis=-1))
 
     view = CollectionViewer(img_collection)
     make_key_event(48)


### PR DESCRIPTION
## Description

The first commit here cleans up a few residual uses of `multichannel` in docstring examples, parameter descriptions and warning texts.

The second commit is to update the benchmark scripts with a `_channel_kwarg` helper that will specify `multichannel` when benchmarking against `skimage<0.19`, but `channel_axis` on newer versions.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
