### PR TITLE
Rename `label` variable to circumvent link issue in docs.

### DIFF
--- a/doc/examples/segmentation/plot_regionprops.py
+++ b/doc/examples/segmentation/plot_regionprops.py
@@ -104,14 +104,14 @@ properties = ['area', 'eccentricity', 'perimeter', 'mean_intensity']
 # For each label, add a filled scatter trace for its contour,
 # and display the properties of the label in the hover of this trace.
 for index in range(1, labels.max()):
-    label = props[index].label
-    contour = measure.find_contours(labels == label, 0.5)[0]
+    label_i = props[index].label
+    contour = measure.find_contours(labels == label_i, 0.5)[0]
     y, x = contour.T
     hoverinfo = ''
     for prop_name in properties:
         hoverinfo += f'<b>{prop_name}: {getattr(props[index], prop_name):.2f}</b><br>'
     fig.add_trace(go.Scatter(
-        x=x, y=y, name=label,
+        x=x, y=y, name=label_i,
         mode='lines', fill='toself', showlegend=False,
         hovertemplate=hoverinfo, hoveron='points+fills'))
 

--- a/doc/examples/segmentation/plot_regionprops.py
+++ b/doc/examples/segmentation/plot_regionprops.py
@@ -59,7 +59,7 @@ ax.axis((0, 600, 600, 0))
 plt.show()
 
 #####################################################################
-# We use the :py:func:`skimage.measure.regionprops_table` to compute
+# We use the :py:func:`skimage.measure.regionprops_table` function to compute
 # (selected) properties for each region. Note that
 # ``skimage.measure.regionprops_table`` actually computes the properties,
 # whereas ``skimage.measure.regionprops`` computes them when they come in use
@@ -83,6 +83,7 @@ pd.DataFrame(props)
 # This example uses plotly in order to display properties when
 # hovering over the objects.
 
+import plotly
 import plotly.express as px
 import plotly.graph_objects as go
 from skimage import data, filters, measure, morphology
@@ -115,4 +116,4 @@ for index in range(1, labels.max()):
         mode='lines', fill='toself', showlegend=False,
         hovertemplate=hoverinfo, hoveron='points+fills'))
 
-fig
+plotly.io.show(fig)


### PR DESCRIPTION
## Description

Fixes #5414 -- thanks for catching this, @jni 

Another way of avoiding this issue is to import submodules rather than functions; the link is correct when calling `measure.label`. Personally, I prefer writing
```py
from skimage import draw, measure, transform
```
in gallery examples, so functions are prefixed with their submodule and the reader becomes familiar with the code structure...

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
