### PR TITLE
avoid duplicate API documentation for ImageViewer, CollectionViewer

### DIFF
--- a/doc/tools/build_modref_templates.py
+++ b/doc/tools/build_modref_templates.py
@@ -49,10 +49,12 @@ if __name__ == '__main__':
 
     outdir = 'source/api'
     docwriter = ApiDocWriter(package)
-    docwriter.package_skip_patterns += [r'\.fixes$',
-                                        r'\.externals$',
-                                        r'filter$',
-                                        ]
+    docwriter.package_skip_patterns += [
+        r'\.fixes$',
+        r'\.externals$',
+        r'filter$',
+        r'viewer.viewers$',  # all functions already imported to viewer
+    ]
     docwriter.write_api_docs(outdir)
     docwriter.write_index(outdir, 'api', relative_to='source/api')
     print('%d files written' % len(docwriter.written_modules))


### PR DESCRIPTION
Recent PRs have been failing on some of the CI jobs due to warnings from Sphinx about duplicate entries in the API docs for `CollectionViewer`.

It seems that both `ImageViewer` and `CollectionViewer` are imported under both `skimage.viewer` and `skimage.viewer.viewers`. `apigen.py` generates API docs for these two classes for both locations and sphinx 4.x raises a warning about this.

As a workaround, this PR removes the `skimage.viewer.viewers` submodule from the autogenerated API documentation so that there are no longer duplicate occurrences. I'm not sure if there is any better workaround. The warning message generated by sphinx mentions adding `:noindex:` to one of the instances in the `.rst` files, but that didn't seem applicable here since the `.rst` files are autogenerated by the `tools/build_modref_templates.py` script.


## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
