### PR TITLE
Revert change to preserve_range default for Gaussian filter

### DIFF
--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -10,7 +10,6 @@ from .._shared import utils
 __all__ = ['gaussian', 'difference_of_gaussians']
 
 
-@change_default_value('preserve_range', new_value=True, changed_version='1.0')
 @utils.channel_as_last_axis()
 @utils.deprecate_multichannel_kwarg(multichannel_position=5)
 def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
@@ -46,9 +45,8 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
         ambiguous, when the array has shape (M, N, 3).
         This argument is deprecated: specify `channel_axis` instead.
     preserve_range : bool, optional
-        If True (by default) - keep the original range of values.
-        Otherwise, the input 'image' is converted according to the conventions
-        of ``img_as_float``
+        If True, keep the original range of values. Otherwise, the input
+        ``image`` is converted according to the conventions of ``img_as_float``
         (Normalized first to values [-1.0 ; 1.0] or [0 ; 1.0] depending on
         dtype of input)
 

--- a/skimage/filters/tests/test_gaussian.py
+++ b/skimage/filters/tests/test_gaussian.py
@@ -8,18 +8,16 @@ from skimage._shared._warnings import expected_warnings
 from skimage.filters._gaussian import (gaussian, _guess_spatial_dimensions,
                                        difference_of_gaussians)
 
-_preserve_range_msg = "The new recommended value for preserve_range"
-
 
 def test_negative_sigma():
     a = np.zeros((3, 3))
     a[1, 1] = 1.
     with pytest.raises(ValueError):
-        gaussian(a, sigma=-1.0, preserve_range=True)
+        gaussian(a, sigma=-1.0)
     with pytest.raises(ValueError):
-        gaussian(a, sigma=[-1.0, 1.0], preserve_range=True)
+        gaussian(a, sigma=[-1.0, 1.0])
     with pytest.raises(ValueError):
-        gaussian(a, sigma=np.asarray([-1.0, 1.0]), preserve_range=True)
+        gaussian(a, sigma=np.asarray([-1.0, 1.0]))
 
 
 def test_null_sigma():
@@ -61,8 +59,9 @@ def test_multichannel(channel_axis):
 
     if channel_axis % a.ndim == 2:
         # Test legacy behavior equivalent to old (multichannel = None)
-        with expected_warnings(['multichannel', _preserve_range_msg]):
-            gaussian_rgb_a = gaussian(a, sigma=1, mode='reflect')
+        with expected_warnings(['multichannel']):
+            gaussian_rgb_a = gaussian(a, sigma=1, mode='reflect',
+                                      preserve_range=True)
 
         # Check that the mean value is conserved in each channel
         # (color channels are not mixed together)
@@ -79,8 +78,7 @@ def test_multichannel(channel_axis):
 def test_deprecated_multichannel():
     a = np.zeros((5, 5, 3))
     a[1, 1] = np.arange(1, 4)
-    with expected_warnings(["`multichannel` is a deprecated argument",
-                            _preserve_range_msg]):
+    with expected_warnings(["`multichannel` is a deprecated argument"]):
         gaussian_rgb_a = gaussian(a, sigma=1, mode='reflect',
                                   multichannel=True)
     # Check that the mean value is conserved in each channel
@@ -88,8 +86,7 @@ def test_deprecated_multichannel():
     assert np.allclose(a.mean(axis=(0, 1)), gaussian_rgb_a.mean(axis=(0, 1)))
 
     # check positional multichannel argument warning
-    with expected_warnings(["Providing the `multichannel` argument",
-                            _preserve_range_msg]):
+    with expected_warnings(["Providing the `multichannel` argument"]):
         gaussian_rgb_a = gaussian(a, 1, None, 'reflect', 0, True)
 
 
@@ -104,8 +101,7 @@ def test_preserve_range():
     assert np.all(filtered_preserved == 1.)
 
     img = np.array([[10.0, -10.0], [-4, 3]], dtype=np.float32)
-    with expected_warnings([_preserve_range_msg]):
-        gaussian(img, 1)
+    gaussian(img, 1)
 
 
 def test_1d_ok():


### PR DESCRIPTION
## Description

This is an alternative to #5435, that only partially reverts #5281 (modified so that `preserve_range` stays False as before)

This seems a bit easier to me than fully reverting and then opening a new PR with only the non-preserve_range changes.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
