### PR TITLE
avoid warnings about use of deprecated `scipy.linalg.pinv2`

### DIFF
--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -188,7 +188,7 @@ def _solve_linear_system(lap_sparse, B, tol, mode):
         else:
             # mode == 'cg_mg'
             lap_sparse = lap_sparse.tocsr()
-            ml = ruge_stuben_solver(lap_sparse)
+            ml = ruge_stuben_solver(lap_sparse, coarse_solver='pinv')
             M = ml.aspreconditioner(cycle='V')
             maxiter = 30
         cg_out = [


### PR DESCRIPTION
## Description

SciPy 1.7.0 is causing a new failure in the CI tests due to a deprecation warning regarding `scipy.linalg.pinv2`. We never call this function directly in scikit-image, but the `cg_mg` option to `random_walker_segmentation` calls a `pyamg` functdion that uses it by default.

Here, I change the pyamg call to prefer `pinv` rather than `pinv2` to avoid the warning.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
