### PR TITLE
Document the multichannel->channel_axis transition in the release notes

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -15,6 +15,10 @@ https://scikit-image.org
 New Features
 ------------
 
+- Added support for processing images with channels located along any array
+  axis. This is in contrast to previous releases where channels were required
+  to be the last axis of an image. See more info on the new ``channel_axis``
+  argument under the API section of the release notes.
 - Added a new keyword only parameter ``random_state`` to
   ``morphology.medial_axis`` and ``restoration.unsupervised_wiener``.
 - Seeding random number generators will not give the same results as the
@@ -48,6 +52,12 @@ Improvements
 API Changes
 -----------
 
+- The ``multichannel`` boolean argument has been deprecated. All functions with
+  multichannel support now use an integer ``channel_axis`` to specify which
+  axis corresponds to channels. Setting ``channel_axis`` to None is used to
+  indicate that the image is grayscale. Specifically, existing code with
+  ``multichannel=True`` should be updated to use ``channel_axis=-1`` and code
+  with ``multichannel=False`` should now specify ``channel_axis=None``.
 - A default value has been added to ``measure.find_contours``, corresponding to
   the half distance between the min and max values of the image 
   #4862
@@ -76,6 +86,9 @@ Deprecations
 
 - In ``measure.label``, the deprecated ``neighbors`` parameter has been
   removed.
+- The ``multichannel`` argument has been deprecated throughout the library and
+  will be removed in 1.0. The new ``channel_axis`` argument should be used
+  instead.
 
 
 Development process


### PR DESCRIPTION
## Description

I put the most detail under the API section, but there were also deprecation and new feature components.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
