### PR TITLE
Bounding Box crop module issue 5428

### DIFF
--- a/skimage/util/__init__.py
+++ b/skimage/util/__init__.py
@@ -16,7 +16,6 @@ from ._invert import invert
 from ._montage import montage
 from ._map_array import map_array
 from ._label import label_points
-from .crop_bounding_box import bounding_box_crop, download_path
 
 
 @functools.wraps(np.pad)
@@ -49,6 +48,4 @@ __all__ = ['img_as_float32',
            'invert',
            'unique_rows',
            'label_points',
-           'bounding_box_crop',
-           'download_path',
            ]

--- a/skimage/util/__init__.py
+++ b/skimage/util/__init__.py
@@ -16,6 +16,7 @@ from ._invert import invert
 from ._montage import montage
 from ._map_array import map_array
 from ._label import label_points
+from .crop_bounding_box import bounding_box_crop, download_path
 
 
 @functools.wraps(np.pad)
@@ -48,4 +49,6 @@ __all__ = ['img_as_float32',
            'invert',
            'unique_rows',
            'label_points',
+           'bounding_box_crop',
+           'download_path',
            ]

--- a/skimage/util/crop_bounding_box.py
+++ b/skimage/util/crop_bounding_box.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""Bounding boxes cropping module for any image."""
+
+import cv2
+from pathlib import Path
+import os
+
+
+def download_path():
+    """Download folder path along with folder creation if needed.
+
+    Returns
+    -------
+    downloads_path : str
+        Path to the folder in the Downloads
+
+    """
+    downloads_path = str(Path.home() / "Downloads"/"Cropped")
+    if not os.path.exists(downloads_path):
+        os.makedirs(downloads_path)
+    return downloads_path
+
+
+def bounding_box_crop(image_url):
+    """Bounding boxes are found and cropped.
+
+    Bounding boxes saved to "Cropped" folder retrieved from download_path()
+    function.
+
+    Parameters
+    ----------
+    image_url : str
+        URL of the image.
+
+    Returns
+    -------
+    None. "Cropped" Folder in Downloads to be looked for by user.
+
+    """
+    image_name = os.path.basename(image_url).split('.')[0]
+    orig = cv2.imread(image_url)
+    r = 1000.0/orig.shape[1]
+    dim = (1000, int(orig.shape[0] * r))
+    o_resized = cv2.resize(orig, dim, interpolation=cv2.INTER_LINEAR)
+
+    img_number = 0
+
+    img = cv2.imread(image_url, 0)
+    r = 1000.0/img.shape[1]
+    dim = (1000, int(img.shape[0] * r))
+    resized = cv2.resize(img, dim, interpolation=cv2.INTER_LINEAR)
+
+    ret, thresh = cv2.threshold(resized, 127, 255, 0)
+    contours, hierarchy = cv2.findContours(thresh, 1, 2)
+    for cnt in contours:
+        x, y, w, h = cv2.boundingRect(cnt)
+        if w*h < 5000:
+            continue
+        img = cv2.rectangle(resized, (x, y), (x+w, y+h), (0, 255, 0), 2)
+        crp = o_resized[y:y+h, x:x+w]
+        cv2.imwrite(download_path() + '//' + image_name + '{}.png'.format(
+            img_number), crp)
+        img_number += 1

--- a/skimage/util/crop_bounding_box.py
+++ b/skimage/util/crop_bounding_box.py
@@ -15,7 +15,7 @@ def download_path():
         Path to the folder in the Downloads
 
     """
-    downloads_path = str(Path.home() / "Downloads"/"Cropped")
+    downloads_path = str(Path.home() / "Downloads" / "Cropped")
     if not os.path.exists(downloads_path):
         os.makedirs(downloads_path)
     return downloads_path
@@ -39,14 +39,14 @@ def bounding_box_crop(image_url):
     """
     image_name = os.path.basename(image_url).split('.')[0]
     orig = cv2.imread(image_url)
-    r = 1000.0/orig.shape[1]
+    r = 1000.0 / orig.shape[1]
     dim = (1000, int(orig.shape[0] * r))
     o_resized = cv2.resize(orig, dim, interpolation=cv2.INTER_LINEAR)
 
     img_number = 0
 
     img = cv2.imread(image_url, 0)
-    r = 1000.0/img.shape[1]
+    r = 1000.0 / img.shape[1]
     dim = (1000, int(img.shape[0] * r))
     resized = cv2.resize(img, dim, interpolation=cv2.INTER_LINEAR)
 
@@ -54,10 +54,10 @@ def bounding_box_crop(image_url):
     contours, hierarchy = cv2.findContours(thresh, 1, 2)
     for cnt in contours:
         x, y, w, h = cv2.boundingRect(cnt)
-        if w*h < 5000:
+        if w * h < 5000:
             continue
-        img = cv2.rectangle(resized, (x, y), (x+w, y+h), (0, 255, 0), 2)
-        crp = o_resized[y:y+h, x:x+w]
+        img = cv2.rectangle(resized, (x, y), (x + w, y + h), (0, 255, 0), 2)
+        crp = o_resized[y:y + h, x:x + w]
         cv2.imwrite(download_path() + '//' + image_name + '{}.png'.format(
             img_number), crp)
         img_number += 1


### PR DESCRIPTION
Bounding Box crop module issue #5428
A newfile module - crop_bounding_box.py added. This file contains two
methods. One, to locate the users downloads folder and create the
Cropped folder if necessary. Two, a method to crop parts of the image
in the bounding box. All the cropped images are then saved in the folder
created in the download_path() method.

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
