### PR TITLE
standardize on num_iter and max_num_iter keyword names

### DIFF
--- a/doc/examples/edges/plot_skeleton.py
+++ b/doc/examples/edges/plot_skeleton.py
@@ -164,7 +164,7 @@ plt.show()
 # different rules of removal can speed up skeletonization and result in
 # different final skeletons.
 #
-# The `thin` function also takes an optional `max_iter` keyword argument to
+# The `thin` function also takes an optional `max_num_iter` keyword argument to
 # limit the number of thinning iterations, and thus produce a relatively
 # thicker skeleton.
 
@@ -172,7 +172,7 @@ from skimage.morphology import skeletonize, thin
 
 skeleton = skeletonize(image)
 thinned = thin(image)
-thinned_partial = thin(image, max_iter=25)
+thinned_partial = thin(image, max_num_iter=25)
 
 fig, axes = plt.subplots(2, 2, figsize=(8, 8), sharex=True, sharey=True)
 ax = axes.ravel()

--- a/doc/examples/filters/plot_deconvolution.py
+++ b/doc/examples/filters/plot_deconvolution.py
@@ -34,7 +34,7 @@ astro_noisy = astro.copy()
 astro_noisy += (rng.poisson(lam=25, size=astro.shape) - 10) / 255.
 
 # Restore Image using Richardson-Lucy algorithm
-deconvolved_RL = restoration.richardson_lucy(astro_noisy, psf, iterations=30)
+deconvolved_RL = restoration.richardson_lucy(astro_noisy, psf, num_iter=30)
 
 fig, ax = plt.subplots(nrows=1, ncols=3, figsize=(8, 5))
 plt.gray()

--- a/doc/examples/segmentation/plot_chan_vese.py
+++ b/doc/examples/segmentation/plot_chan_vese.py
@@ -49,8 +49,9 @@ from skimage.segmentation import chan_vese
 
 image = img_as_float(data.camera())
 # Feel free to play around with the parameters to see how they impact the result
-cv = chan_vese(image, mu=0.25, lambda1=1, lambda2=1, tol=1e-3, max_iter=200,
-               dt=0.5, init_level_set="checkerboard", extended_output=True)
+cv = chan_vese(image, mu=0.25, lambda1=1, lambda2=1, tol=1e-3,
+               max_num_iter=200, dt=0.5, init_level_set="checkerboard",
+               extended_output=True)
 
 fig, axes = plt.subplots(2, 2, figsize=(8, 8))
 ax = axes.flatten()

--- a/doc/examples/segmentation/plot_join_segmentations.py
+++ b/doc/examples/segmentation/plot_join_segmentations.py
@@ -35,7 +35,7 @@ ws = watershed(edges, markers)
 seg1 = label(ws == foreground)
 
 # Make segmentation using SLIC superpixels.
-seg2 = slic(coins, n_segments=117, max_iter=160, sigma=1, compactness=0.75,
+seg2 = slic(coins, n_segments=117, max_num_iter=160, sigma=1, compactness=0.75,
             channel_axis=None, start_label=0)
 
 # Combine the two.

--- a/doc/examples/segmentation/plot_metrics.py
+++ b/doc/examples/segmentation/plot_metrics.py
@@ -77,7 +77,7 @@ image = img_as_float(image)
 gradient = inverse_gaussian_gradient(image)
 init_ls = np.zeros(image.shape, dtype=np.int8)
 init_ls[10:-10, 10:-10] = 1
-im_test3 = morphological_geodesic_active_contour(gradient, iterations=100,
+im_test3 = morphological_geodesic_active_contour(gradient, num_iter=100,
                                                  init_level_set=init_ls,
                                                  smoothing=1, balloon=-1,
                                                  threshold=0.69)

--- a/doc/examples/segmentation/plot_morphsnakes.py
+++ b/doc/examples/segmentation/plot_morphsnakes.py
@@ -75,8 +75,8 @@ init_ls = checkerboard_level_set(image.shape, 6)
 # List with intermediate results for plotting the evolution
 evolution = []
 callback = store_evolution_in(evolution)
-ls = morphological_chan_vese(image, 35, init_level_set=init_ls, smoothing=3,
-                             iter_callback=callback)
+ls = morphological_chan_vese(image, num_iter=35, init_level_set=init_ls,
+                             smoothing=3, iter_callback=callback)
 
 fig, axes = plt.subplots(2, 2, figsize=(8, 8))
 ax = axes.flatten()
@@ -109,7 +109,8 @@ init_ls[10:-10, 10:-10] = 1
 # List with intermediate results for plotting the evolution
 evolution = []
 callback = store_evolution_in(evolution)
-ls = morphological_geodesic_active_contour(gimage, 230, init_ls,
+ls = morphological_geodesic_active_contour(gimage, num_iter=230,
+                                           init_level_set=init_ls,
                                            smoothing=1, balloon=-1,
                                            threshold=0.69,
                                            iter_callback=callback)

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -257,15 +257,18 @@ def test_otsu_camera_image():
     camera = util.img_as_ubyte(data.camera())
     assert 101 < threshold_otsu(camera) < 103
 
+
 def test_otsu_camera_image_histogram():
     camera = util.img_as_ubyte(data.camera())
     hist = histogram(camera.ravel(), 256, source_range='image')
     assert 101 < threshold_otsu(hist=hist) < 103
 
+
 def test_otsu_camera_image_counts():
     camera = util.img_as_ubyte(data.camera())
     counts, bin_centers = histogram(camera.ravel(), 256, source_range='image')
     assert 101 < threshold_otsu(hist=counts) < 103
+
 
 def test_otsu_coins_image():
     coins = util.img_as_ubyte(data.coins())
@@ -364,7 +367,7 @@ def test_li_arbitrary_start_point():
 def test_li_negative_inital_guess():
     coins = data.coins()
     with pytest.raises(ValueError):
-        result = threshold_li(coins, initial_guess=-5)
+        threshold_li(coins, initial_guess=-5)
 
 
 def test_li_pathological_arrays():
@@ -386,10 +389,12 @@ def test_yen_camera_image():
     camera = util.img_as_ubyte(data.camera())
     assert 145 < threshold_yen(camera) < 147
 
+
 def test_yen_camera_image_histogram():
     camera = util.img_as_ubyte(data.camera())
     hist = histogram(camera.ravel(), 256, source_range='image')
     assert 145 < threshold_yen(hist=hist) < 147
+
 
 def test_yen_camera_image_counts():
     camera = util.img_as_ubyte(data.camera())
@@ -423,11 +428,13 @@ def test_isodata_camera_image():
 
     assert (threshold_isodata(camera, return_all=True) == [102, 103]).all()
 
+
 def test_isodata_camera_image_histogram():
     camera = util.img_as_ubyte(data.camera())
     hist = histogram(camera.ravel(), 256, source_range='image')
     threshold = threshold_isodata(hist=hist)
     assert threshold == 102
+
 
 def test_isodata_camera_image_counts():
     camera = util.img_as_ubyte(data.camera())
@@ -500,11 +507,13 @@ def test_threshold_minimum():
     threshold = threshold_minimum(astronaut)
     assert_equal(threshold, 114)
 
+
 def test_threshold_minimum_histogram():
     camera = util.img_as_ubyte(data.camera())
     hist = histogram(camera.ravel(), 256, source_range='image')
     threshold = threshold_minimum(hist=hist)
     assert_equal(threshold, 85)
+
 
 def test_threshold_minimum_deprecated_max_iter_kwarg():
     camera = util.img_as_ubyte(data.camera())
@@ -512,11 +521,13 @@ def test_threshold_minimum_deprecated_max_iter_kwarg():
     with expected_warnings(["`max_iter` is a deprecated argument"]):
         threshold_minimum(hist=hist, max_iter=5000)
 
+
 def test_threshold_minimum_counts():
     camera = util.img_as_ubyte(data.camera())
     counts, bin_centers = histogram(camera.ravel(), 256, source_range='image')
     threshold = threshold_minimum(hist=counts)
     assert_equal(threshold, 85)
+
 
 def test_threshold_minimum_synthetic():
     img = np.arange(25*25, dtype=np.uint8).reshape((25, 25))

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -7,7 +7,7 @@ import numpy as np
 from ..util import img_as_ubyte, crop
 from scipy import ndimage as ndi
 
-from .._shared.utils import check_nD, warn
+from .._shared.utils import check_nD, deprecate_kwarg, warn
 from ._skeletonize_cy import (_fast_skeletonize, _skeletonize_loop,
                               _table_lookup_index)
 from ._skeletonize_3d_cy import _compute_thin_image
@@ -254,7 +254,8 @@ G123P_LUT = np.array([0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0,
                       0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=bool)
 
 
-def thin(image, max_iter=None):
+@deprecate_kwarg({'max_iter': 'max_num_iter'}, removed_version="1.0")
+def thin(image, max_num_iter=None):
     """
     Perform morphological thinning of a binary image.
 
@@ -262,7 +263,7 @@ def thin(image, max_iter=None):
     ----------
     image : binary (M, N) ndarray
         The image to be thinned.
-    max_iter : int, number of iterations, optional
+    max_num_iter : int, number of iterations, optional
         Regardless of the value of this parameter, the thinned image
         is returned immediately if an iteration produces no change.
         If this parameter is specified it thus sets an upper bound on
@@ -332,10 +333,10 @@ def thin(image, max_iter=None):
                      [32, 64, 128]], dtype=np.uint8)
 
     # iterate until convergence, up to the iteration limit
-    max_iter = max_iter or np.inf
-    n_iter = 0
+    max_num_iter = max_num_iter or np.inf
+    num_iter = 0
     n_pts_old, n_pts_new = np.inf, np.sum(skel)
-    while n_pts_old != n_pts_new and n_iter < max_iter:
+    while n_pts_old != n_pts_new and num_iter < max_num_iter:
         n_pts_old = n_pts_new
 
         # perform the two "subiterations" described in the paper
@@ -348,7 +349,7 @@ def thin(image, max_iter=None):
             skel[D] = 0
 
         n_pts_new = np.sum(skel)  # count points after thinning
-        n_iter += 1
+        num_iter += 1
 
     return skel.astype(bool)
 

--- a/skimage/morphology/tests/test_skeletonize.py
+++ b/skimage/morphology/tests/test_skeletonize.py
@@ -1,14 +1,15 @@
 import numpy as np
-from skimage.morphology import skeletonize, medial_axis, thin
+import pytest
+from numpy.testing import assert_array_equal
+from scipy.ndimage import correlate
+
+from skimage import data, draw
+from skimage._shared._warnings import expected_warnings
+from skimage._shared.testing import fetch
+from skimage.io import imread
+from skimage.morphology import medial_axis, skeletonize, thin
 from skimage.morphology._skeletonize import (_generate_thin_luts,
                                              G123_LUT, G123P_LUT)
-from skimage import draw
-from scipy.ndimage import correlate
-from skimage.io import imread
-from skimage import data
-
-from skimage._shared import testing
-from skimage._shared.testing import assert_array_equal, fetch
 
 
 class TestSkeletonize():
@@ -19,25 +20,25 @@ class TestSkeletonize():
 
     def test_skeletonize_wrong_dim1(self):
         im = np.zeros((5))
-        with testing.raises(ValueError):
+        with pytest.raises(ValueError):
             skeletonize(im)
 
     def test_skeletonize_wrong_dim2(self):
         im = np.zeros((5, 5, 5))
-        with testing.raises(ValueError):
+        with pytest.raises(ValueError):
             skeletonize(im, method='zhang')
 
     def test_skeletonize_not_binary(self):
         im = np.zeros((5, 5))
         im[0, 0] = 1
         im[0, 1] = 2
-        with testing.raises(ValueError):
+        with pytest.raises(ValueError):
             skeletonize(im)
 
     def test_skeletonize_unexpected_value(self):
         im = np.zeros((5, 5))
         im[0, 0] = 2
-        with testing.raises(ValueError):
+        with pytest.raises(ValueError):
             skeletonize(im)
 
     def test_skeletonize_all_foreground(self):
@@ -145,6 +146,12 @@ class TestThin():
                              [0, 0, 0, 0, 0, 0, 0]], dtype=np.uint8)
         assert_array_equal(result, expected)
 
+    def test_max_iter_kwarg_deprecation(self):
+        result1 = thin(self.input_image, max_num_iter=1).astype(np.uint8)
+        with expected_warnings(["`max_iter` is a deprecated argument name"]):
+            result2 = thin(self.input_image, max_iter=1).astype(np.uint8)
+        assert_array_equal(result1, result2)
+
     def test_noiter(self):
         result = thin(self.input_image).astype(np.uint8)
         expected = np.array([[0, 0, 0, 0, 0, 0, 0],
@@ -158,7 +165,7 @@ class TestThin():
 
     def test_baddim(self):
         for ii in [np.zeros((3)), np.zeros((3, 3, 3))]:
-            with testing.raises(ValueError):
+            with pytest.raises(ValueError):
                 thin(ii)
 
     def test_lut_generation(self):

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -32,7 +32,7 @@ def _gaussian_weight(array, sigma_squared, *, dtype=float):
     gaussian : ndarray
         The input array filtered by the Gaussian.
     """
-    return np.exp(-0.5 * (array ** 2  / sigma_squared), dtype=dtype)
+    return np.exp(-0.5 * (array ** 2 / sigma_squared), dtype=dtype)
 
 
 def _compute_color_lut(bins, sigma, max_value, *, dtype=float):
@@ -237,7 +237,8 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
     color_lut = _compute_color_lut(bins, sigma_color, max_value,
                                    dtype=image.dtype)
 
-    range_lut = _compute_spatial_lut(win_size, sigma_spatial, dtype=image.dtype)
+    range_lut = _compute_spatial_lut(win_size, sigma_spatial,
+                                     dtype=image.dtype)
 
     out = np.empty(image.shape, dtype=image.dtype)
 
@@ -257,8 +258,9 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
 @utils.channel_as_last_axis()
 @utils.deprecate_multichannel_kwarg()
 @utils.deprecate_kwarg({'max_iter': 'max_num_iter'}, removed_version="1.0")
-def denoise_tv_bregman(image, weight, max_num_iter=100, eps=1e-3, isotropic=True,
-                       *, channel_axis=None, multichannel=False):
+def denoise_tv_bregman(image, weight, max_num_iter=100, eps=1e-3,
+                       isotropic=True, *, channel_axis=None,
+                       multichannel=False):
     """Perform total-variation denoising using split-Bregman optimization.
 
     Total-variation denoising (also know as total-variation regularization)
@@ -328,7 +330,8 @@ def denoise_tv_bregman(image, weight, max_num_iter=100, eps=1e-3, isotropic=True
         channel_out = np.zeros(shape_ext[:2] + (1,), dtype=out.dtype)
         for c in range(image.shape[-1]):
             # the algorithm below expects 3 dimensions to always be present.
-            # slicing the array in this fashion preserves the channel dimension for us
+            # slicing the array in this fashion preserves the channel dimension
+            # for us
             channel_in = np.ascontiguousarray(image[..., c:c+1])
 
             _denoise_tv_bregman(channel_in, image.dtype.type(weight),
@@ -640,7 +643,6 @@ def _wavelet_threshold(image, wavelet, method=None, threshold=None,
     # Determine the number of wavelet decomposition levels
     if wavelet_levels is None:
         # Determine the maximum number of possible levels for image
-        dlen = wavelet.dec_len
         wavelet_levels = pywt.dwtn_max_level(image.shape, wavelet)
 
         # Skip coarsest wavelet scales (see Notes in docstring).

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -256,7 +256,8 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
 
 @utils.channel_as_last_axis()
 @utils.deprecate_multichannel_kwarg()
-def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True,
+@utils.deprecate_kwarg({'max_iter': 'max_num_iter'}, removed_version="1.0")
+def denoise_tv_bregman(image, weight, max_num_iter=100, eps=1e-3, isotropic=True,
                        *, channel_axis=None, multichannel=False):
     """Perform total-variation denoising using split-Bregman optimization.
 
@@ -279,7 +280,7 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True,
 
             SUM((u(n) - u(n-1))**2) < eps
 
-    max_iter : int, optional
+    max_num_iter : int, optional
         Maximal number of iterations used for the optimization.
     isotropic : boolean, optional
         Switch between isotropic and anisotropic TV denoising.
@@ -331,14 +332,14 @@ def denoise_tv_bregman(image, weight, max_iter=100, eps=1e-3, isotropic=True,
             channel_in = np.ascontiguousarray(image[..., c:c+1])
 
             _denoise_tv_bregman(channel_in, image.dtype.type(weight),
-                                max_iter, eps, isotropic, channel_out)
+                                max_num_iter, eps, isotropic, channel_out)
 
             out[..., c] = channel_out[..., 0]
 
     else:
         image = np.ascontiguousarray(image)
 
-        _denoise_tv_bregman(image, image.dtype.type(weight), max_iter, eps,
+        _denoise_tv_bregman(image, image.dtype.type(weight), max_num_iter, eps,
                             isotropic, out)
 
     return np.squeeze(out[1:-1, 1:-1])

--- a/skimage/restoration/_denoise_cy.pyx
+++ b/skimage/restoration/_denoise_cy.pyx
@@ -97,7 +97,7 @@ def _denoise_bilateral(np_floats[:, :, ::1] image, double max_value,
 
 
 def _denoise_tv_bregman(np_floats[:, :, ::1] image, np_floats weight,
-                        int max_iter, double eps,
+                        int max_num_iter, double eps,
                         char isotropic, np_floats[:, :, ::1] out):
     cdef:
         Py_ssize_t rows = image.shape[0]
@@ -135,7 +135,7 @@ def _denoise_tv_bregman(np_floats[:, :, ::1] image, np_floats weight,
         out[out_rows-1, 1:out_cols-1] = image[rows-1, :]
         out[1:out_rows-1, out_cols-1] = image[:, cols-1]
 
-        while i < max_iter and rmse > eps:
+        while i < max_num_iter and rmse > eps:
 
             rmse = 0
 

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -353,7 +353,10 @@ def unsupervised_wiener(image, psf, reg=None, user_params=None, is_real=True,
         prev_x_postmean = x_postmean
 
         # stop of the algorithm
-        if (iteration > params['min_num_iter']) and (delta < params['threshold']):
+        if (
+            (iteration > params['min_num_iter']) and
+            (delta < params['threshold'])
+        ):
             break
 
     # Empirical average \approx POSTMEAN Eq. 44

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -4,7 +4,7 @@ import warnings
 import numpy as np
 from scipy.signal import convolve
 
-from .._shared.utils import _supported_float_type
+from .._shared.utils import _supported_float_type, deprecate_kwarg
 from . import uft
 
 
@@ -377,7 +377,8 @@ def unsupervised_wiener(image, psf, reg=None, user_params=None, is_real=True,
     return (x_postmean, {'noise': gn_chain, 'prior': gx_chain})
 
 
-def richardson_lucy(image, psf, iterations=50, clip=True, filter_epsilon=None):
+@deprecate_kwarg({'iterations': 'num_iter'}, removed_version="1.0")
+def richardson_lucy(image, psf, num_iter=50, clip=True, filter_epsilon=None):
     """Richardson-Lucy deconvolution.
 
     Parameters
@@ -386,7 +387,7 @@ def richardson_lucy(image, psf, iterations=50, clip=True, filter_epsilon=None):
        Input degraded image (can be N dimensional).
     psf : ndarray
        The point spread function.
-    iterations : int, optional
+    num_iter : int, optional
        Number of iterations. This parameter plays the role of
        regularisation.
     clip : boolean, optional
@@ -422,7 +423,7 @@ def richardson_lucy(image, psf, iterations=50, clip=True, filter_epsilon=None):
     im_deconv = np.full(image.shape, 0.5, dtype=float_type)
     psf_mirror = np.flip(psf)
 
-    for _ in range(iterations):
+    for _ in range(num_iter):
         conv = convolve(im_deconv, psf, mode='same')
         if filter_epsilon:
             with np.errstate(invalid='ignore'):

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -354,8 +354,8 @@ def unsupervised_wiener(image, psf, reg=None, user_params=None, is_real=True,
 
         # stop of the algorithm
         if (
-            (iteration > params['min_num_iter']) and
-            (delta < params['threshold'])
+            (iteration > params['min_num_iter'])
+            and (delta < params['threshold'])
         ):
             break
 

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -41,7 +41,7 @@ except AttributeError:
     pass
 
 
-@pytest.mark.parametrize('dtype',float_dtypes)
+@pytest.mark.parametrize('dtype', float_dtypes)
 def test_denoise_tv_chambolle_2d(dtype):
     # astronaut image
     img = astro_gray.astype(dtype, copy=True)
@@ -284,8 +284,8 @@ def test_denoise_bilateral_types(dtype):
     img = np.clip(img, 0, 1).astype(dtype)
 
     # check that we can process multiple float types
-    out = restoration.denoise_bilateral(img, sigma_color=0.1,
-                                        sigma_spatial=10, channel_axis=None)
+    restoration.denoise_bilateral(img, sigma_color=0.1,
+                                  sigma_spatial=10, channel_axis=None)
 
 
 @pytest.mark.parametrize('dtype', [np.float32, np.double])
@@ -296,7 +296,7 @@ def test_denoise_bregman_types(dtype):
     img = np.clip(img, 0, 1).astype(dtype)
 
     # check that we can process multiple float types
-    out = restoration.denoise_tv_bregman(img, weight=5)
+    restoration.denoise_tv_bregman(img, weight=5)
 
 
 def test_denoise_bilateral_zeros():
@@ -772,7 +772,7 @@ def test_wavelet_threshold():
         _wavelet_threshold(noisy, wavelet='db1', method=None, threshold=None)
 
     # warns if a threshold is provided in a case where it would be ignored
-    with expected_warnings(["Thresholding method ",]):
+    with expected_warnings(["Thresholding method "]):
         _wavelet_threshold(noisy, wavelet='db1', method='BayesShrink',
                            threshold=sigma)
 
@@ -1060,7 +1060,7 @@ def test_cycle_spinning_num_workers():
     dn_cc1 = restoration.cycle_spin(noisy, denoise_func, max_shifts=1,
                                     func_kw=func_kw, channel_axis=None,
                                     num_workers=1)
-    with expected_warnings([DASK_NOT_INSTALLED_WARNING,]):
+    with expected_warnings([DASK_NOT_INSTALLED_WARNING]):
         dn_cc2 = restoration.cycle_spin(noisy, denoise_func, max_shifts=1,
                                         func_kw=func_kw, channel_axis=None,
                                         num_workers=4)
@@ -1111,4 +1111,4 @@ def test_cycle_spinning_num_workers_deprecated_multichannel():
 
 
 if __name__ == "__main__":
-    testing.run_module_suite()
+    np.testing.run_module_suite()

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -1,19 +1,17 @@
 import functools
 import itertools
+
 import numpy as np
 import pytest
-
-from skimage import restoration, data, color, img_as_float
-from skimage.metrics import structural_similarity
-from skimage.metrics import peak_signal_noise_ratio
-from skimage.restoration._denoise import _wavelet_threshold
 import pywt
+from numpy.testing import (assert_, assert_almost_equal, assert_equal,
+                           assert_warns)
 
-from skimage._shared import testing, utils
-from skimage._shared.testing import (assert_equal, assert_almost_equal,
-                                     assert_warns, assert_)
-from skimage._shared.utils import _supported_float_type
+from skimage import color, data, img_as_float, restoration
 from skimage._shared._warnings import expected_warnings
+from skimage._shared.utils import _supported_float_type, slice_at_axis
+from skimage.metrics import peak_signal_noise_ratio, structural_similarity
+from skimage.restoration._denoise import _wavelet_threshold
 
 
 try:
@@ -43,7 +41,7 @@ except AttributeError:
     pass
 
 
-@testing.parametrize('dtype',float_dtypes)
+@pytest.mark.parametrize('dtype',float_dtypes)
 def test_denoise_tv_chambolle_2d(dtype):
     # astronaut image
     img = astro_gray.astype(dtype, copy=True)
@@ -68,14 +66,14 @@ def test_denoise_tv_chambolle_2d(dtype):
     assert np.sqrt((grad_denoised**2).sum()) < np.sqrt((grad**2).sum())
 
 
-@testing.parametrize('channel_axis', [0, 1, 2, -1])
+@pytest.mark.parametrize('channel_axis', [0, 1, 2, -1])
 def test_denoise_tv_chambolle_multichannel(channel_axis):
     denoised0 = restoration.denoise_tv_chambolle(astro[..., 0], weight=0.1)
 
     img = np.moveaxis(astro, -1, channel_axis)
     denoised = restoration.denoise_tv_chambolle(img, weight=0.1,
                                                 channel_axis=channel_axis)
-    _at = functools.partial(utils.slice_at_axis, axis=channel_axis % img.ndim)
+    _at = functools.partial(slice_at_axis, axis=channel_axis % img.ndim)
     assert_equal(denoised[_at(0)], denoised0)
 
     # tile astronaut subset to generate 3D+channels data
@@ -87,7 +85,7 @@ def test_denoise_tv_chambolle_multichannel(channel_axis):
     astro3 = np.moveaxis(astro3, -1, channel_axis)
     denoised = restoration.denoise_tv_chambolle(astro3, weight=0.1,
                                                 channel_axis=channel_axis)
-    _at = functools.partial(utils.slice_at_axis,
+    _at = functools.partial(slice_at_axis,
                             axis=channel_axis % astro3.ndim)
     assert_equal(denoised[_at(0)], denoised0)
 
@@ -217,7 +215,7 @@ def test_denoise_tv_bregman_3d_multichannel(channel_axis):
     img_astro = np.moveaxis(img_astro, -1, channel_axis)
     denoised = restoration.denoise_tv_bregman(img_astro, weight=60.0,
                                               channel_axis=channel_axis)
-    _at = functools.partial(utils.slice_at_axis,
+    _at = functools.partial(slice_at_axis,
                             axis=channel_axis % img_astro.ndim)
     assert_equal(denoised0, denoised[_at(0)])
 
@@ -230,6 +228,11 @@ def test_denoise_tv_bregman_3d_multichannel_deprecation():
                                                   multichannel=True)
 
     assert_equal(denoised0, denoised[..., 0])
+
+
+def test_denoise_tv_bregman_max_iter_deprecation():
+    with expected_warnings(["`max_iter` is a deprecated argument"]):
+        restoration.denoise_tv_bregman(astro_gray, weight=60.0, max_iter=5)
 
 
 def test_denoise_tv_bregman_multichannel():
@@ -351,7 +354,7 @@ def test_denoise_bilateral_multichannel_deprecation():
 
 def test_denoise_bilateral_3d_grayscale():
     img = np.ones((50, 50, 3))
-    with testing.raises(ValueError):
+    with pytest.raises(ValueError):
         restoration.denoise_bilateral(img, channel_axis=None)
 
 
@@ -365,9 +368,9 @@ def test_denoise_bilateral_3d_multichannel():
 
 def test_denoise_bilateral_multidimensional():
     img = np.ones((10, 10, 10, 10))
-    with testing.raises(ValueError):
+    with pytest.raises(ValueError):
         restoration.denoise_bilateral(img, channel_axis=None)
-    with testing.raises(ValueError):
+    with pytest.raises(ValueError):
         restoration.denoise_bilateral(img, channel_axis=-1)
 
 
@@ -517,7 +520,7 @@ def test_denoise_nl_means_multichannel(fast_mode, dtype, channel_axis):
 
 def test_denoise_nl_means_wrong_dimension():
     img = np.zeros((5, 5, 5, 5))
-    with testing.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError):
         restoration.denoise_nl_means(img, channel_axis=-1)
 
 
@@ -707,7 +710,7 @@ def test_wavelet_denoising_scaling(case, dtype, convert2ycbcr,
 
     if convert2ycbcr and channel_axis is None:
         # YCbCr requires multichannel == True
-        with testing.raises(ValueError):
+        with pytest.raises(ValueError):
             denoised = restoration.denoise_wavelet(noisy,
                                                    sigma=sigma_est,
                                                    wavelet='sym4',
@@ -765,7 +768,7 @@ def test_wavelet_threshold():
     assert_(psnr_denoised > psnr_noisy)
 
     # either method or threshold must be defined
-    with testing.raises(ValueError):
+    with pytest.raises(ValueError):
         _wavelet_threshold(noisy, wavelet='db1', method=None, threshold=None)
 
     # warns if a threshold is provided in a case where it would be ignored
@@ -811,7 +814,7 @@ def test_wavelet_denoising_nd(rescale_sigma, method, ndim):
 
 
 def test_wavelet_invalid_method():
-    with testing.raises(ValueError):
+    with pytest.raises(ValueError):
         restoration.denoise_wavelet(np.ones(16), method='Unimplemented',
                                     rescale_sigma=True)
 
@@ -852,7 +855,7 @@ def test_wavelet_denoising_levels(rescale_sigma):
             noisy, wavelet=wavelet, wavelet_levels=max_level + 1,
             rescale_sigma=rescale_sigma)
 
-    with testing.raises(ValueError):
+    with pytest.raises(ValueError):
         restoration.denoise_wavelet(
             noisy,
             wavelet=wavelet, wavelet_levels=-1,
@@ -945,7 +948,7 @@ def test_wavelet_denoising_args(rescale_sigma):
         for multichannel in [True, False]:
             channel_axis = -1 if multichannel else None
             if convert2ycbcr and not multichannel:
-                with testing.raises(ValueError):
+                with pytest.raises(ValueError):
                     restoration.denoise_wavelet(noisy,
                                                 convert2ycbcr=convert2ycbcr,
                                                 channel_axis=channel_axis,
@@ -1030,13 +1033,13 @@ def test_cycle_spinning_multichannel(rescale_sigma):
             assert_(psnr_cc > psnr)
 
         for max_shifts in invalid_shifts:
-            with testing.raises(ValueError):
+            with pytest.raises(ValueError):
                 dn_cc = restoration.cycle_spin(noisy, denoise_func,
                                                max_shifts=max_shifts,
                                                func_kw=func_kw,
                                                channel_axis=channel_axis)
         for shift_steps in invalid_steps:
-            with testing.raises(ValueError):
+            with pytest.raises(ValueError):
                 dn_cc = restoration.cycle_spin(noisy, denoise_func,
                                                max_shifts=2,
                                                shift_steps=shift_steps,

--- a/skimage/restoration/tests/test_restoration.py
+++ b/skimage/restoration/tests/test_restoration.py
@@ -110,7 +110,7 @@ def test_image_shape():
     point[2, 2] = 1.
     psf = ndi.gaussian_filter(point, sigma=1.)
     # image shape: (45, 45), as reported in #1172
-    image = util.img_as_float(camera()[65:165, 215:315]) # just the face
+    image = util.img_as_float(camera()[65:165, 215:315])  # just the face
     image_conv = ndi.convolve(image, psf)
     deconv_sup = restoration.wiener(image_conv, psf, 1)
     deconv_un = restoration.unsupervised_wiener(image_conv, psf)[0]
@@ -134,6 +134,7 @@ def test_richardson_lucy():
     path = fetch('restoration/tests/camera_rl.npy')
     np.testing.assert_allclose(deconvolved, np.load(path), rtol=1e-3)
 
+
 def test_richardson_lucy_deprecated_iterations_kwarg():
     psf = np.ones((5, 5)) / 25
     data = convolve2d(test_img, psf, 'same')
@@ -141,6 +142,7 @@ def test_richardson_lucy_deprecated_iterations_kwarg():
     data += 0.1 * data.std() * np.random.standard_normal(data.shape)
     with expected_warnings(["`iterations` is a deprecated argument"]):
         restoration.richardson_lucy(data, psf, iterations=5)
+
 
 @pytest.mark.parametrize('dtype_image', [np.float16, np.float32, np.float64])
 @pytest.mark.parametrize('dtype_psf', [np.float32, np.float64])

--- a/skimage/restoration/tests/test_restoration.py
+++ b/skimage/restoration/tests/test_restoration.py
@@ -129,11 +129,18 @@ def test_richardson_lucy():
     data = convolve2d(test_img, psf, 'same')
     np.random.seed(0)
     data += 0.1 * data.std() * np.random.standard_normal(data.shape)
-    deconvolved = restoration.richardson_lucy(data, psf, 5)
+    deconvolved = restoration.richardson_lucy(data, psf, num_iter=5)
 
     path = fetch('restoration/tests/camera_rl.npy')
     np.testing.assert_allclose(deconvolved, np.load(path), rtol=1e-3)
 
+def test_richardson_lucy_deprecated_iterations_kwarg():
+    psf = np.ones((5, 5)) / 25
+    data = convolve2d(test_img, psf, 'same')
+    np.random.seed(0)
+    data += 0.1 * data.std() * np.random.standard_normal(data.shape)
+    with expected_warnings(["`iterations` is a deprecated argument"]):
+        restoration.richardson_lucy(data, psf, iterations=5)
 
 @pytest.mark.parametrize('dtype_image', [np.float16, np.float32, np.float64])
 @pytest.mark.parametrize('dtype_psf', [np.float32, np.float64])

--- a/skimage/segmentation/_chan_vese.py
+++ b/skimage/segmentation/_chan_vese.py
@@ -1,7 +1,7 @@
 import numpy as np
 from scipy.ndimage import distance_transform_edt as distance
 
-from .._shared.utils import _supported_float_type
+from .._shared.utils import _supported_float_type, deprecate_kwarg
 
 
 def _cv_curvature(phi):
@@ -172,8 +172,9 @@ def _cv_init_level_set(init_level_set, image_shape, dtype=np.float64):
     return res.astype(dtype, copy=False)
 
 
-def chan_vese(image, mu=0.25, lambda1=1.0, lambda2=1.0, tol=1e-3, max_iter=500,
-              dt=0.5, init_level_set='checkerboard',
+@deprecate_kwarg({'max_iter': 'max_num_iter'}, removed_version="1.0")
+def chan_vese(image, mu=0.25, lambda1=1.0, lambda2=1.0, tol=1e-3,
+              max_num_iter=500, dt=0.5, init_level_set='checkerboard',
               extended_output=False):
     """Chan-Vese segmentation algorithm.
 
@@ -202,7 +203,7 @@ def chan_vese(image, mu=0.25, lambda1=1.0, lambda2=1.0, tol=1e-3, max_iter=500,
         iterations normalized by the area of the image is below this
         value, the algorithm will assume that the solution was
         reached.
-    max_iter : uint, optional
+    max_num_iter : uint, optional
         Maximum number of iterations allowed before the algorithm
         interrupts itself.
     dt : float, optional
@@ -320,7 +321,7 @@ def chan_vese(image, mu=0.25, lambda1=1.0, lambda2=1.0, tol=1e-3, max_iter=500,
     phivar = tol + 1
     segmentation = phi > 0
 
-    while(phivar > tol and i < max_iter):
+    while(phivar > tol and i < max_num_iter):
         # Save old level set values
         oldphi = phi
 

--- a/skimage/segmentation/_slic.pyx
+++ b/skimage/segmentation/_slic.pyx
@@ -17,7 +17,7 @@ def _slic_cython(np_floats[:, :, :, ::1] image_zyx,
                  cnp.uint8_t[:, :, ::1] mask,
                  np_floats[:, ::1] segments,
                  float step,
-                 Py_ssize_t max_iter,
+                 Py_ssize_t max_num_iter,
                  np_floats[::1] spacing,
                  bint slic_zero,
                  Py_ssize_t start_label=1,
@@ -34,7 +34,7 @@ def _slic_cython(np_floats[:, :, :, ::1] image_zyx,
         The initial centroids obtained by SLIC as [Z, Y, X, C...].
     step : np_floats
         The size of the step between two seeds in voxels.
-    max_iter : int
+    max_num_iter : int
         The maximum number of k-means iterations.
     spacing : 1D array of np_floats, shape (3,)
         The voxel spacing along each image dimension. This parameter
@@ -125,7 +125,7 @@ def _slic_cython(np_floats[:, :, :, ::1] image_zyx,
     cdef np_floats spatial_weight = 1.0 / (step * step)
 
     with nogil:
-        for i in range(max_iter):
+        for i in range(max_num_iter):
             change = False
             distance[:, :, :] = DBL_MAX
 

--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -1,15 +1,16 @@
 import numpy as np
 from scipy.interpolate import RectBivariateSpline
 
-from .._shared.utils import _supported_float_type
+from .._shared.utils import _supported_float_type, deprecate_kwarg
 from ..util import img_as_float
 from ..filters import sobel
 
 
+@deprecate_kwarg({'max_iterations': 'max_num_iter'}, removed_version="1.0")
 def active_contour(image, snake, alpha=0.01, beta=0.1,
                    w_line=0, w_edge=1, gamma=0.01,
                    max_px_move=1.0,
-                   max_iterations=2500, convergence=0.1,
+                   max_num_iter=2500, convergence=0.1,
                    *,
                    boundary_condition='periodic',
                    coordinates='rc'):
@@ -44,7 +45,7 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
         Explicit time stepping parameter.
     max_px_move : float, optional
         Maximum pixel distance to move per iteration.
-    max_iterations : int, optional
+    max_num_iter : int, optional
         Maximum iterations to optimize snake shape.
     convergence : float, optional
         Convergence criteria.
@@ -101,9 +102,9 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
     if coordinates != 'rc':
         raise ValueError('Coordinate values must be set in a row column '
                          'format. `coordinates` must be set to "rc".')
-    max_iterations = int(max_iterations)
-    if max_iterations <= 0:
-        raise ValueError("max_iterations should be >0.")
+    max_num_iter = int(max_num_iter)
+    if max_num_iter <= 0:
+        raise ValueError("max_num_iter should be >0.")
     convergence_order = 10
     valid_bcs = ['periodic', 'free', 'fixed', 'free-fixed',
                  'fixed-free', 'fixed-fixed', 'free-free']
@@ -192,7 +193,7 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
     inv = inv.astype(float_dtype, copy=False)
 
     # Explicit time stepping for image energy minimization:
-    for i in range(max_iterations):
+    for i in range(max_num_iter):
         # RectBivariateSpline always returns float64, so call astype here
         fx = intp(x, y, dx=1, grid=False).astype(float_dtype, copy=False)
         fy = intp(x, y, dy=1, grid=False).astype(float_dtype, copy=False)

--- a/skimage/segmentation/morphsnakes.py
+++ b/skimage/segmentation/morphsnakes.py
@@ -4,7 +4,7 @@ from itertools import cycle
 import numpy as np
 from scipy import ndimage as ndi
 
-from .._shared.utils import check_nD
+from .._shared.utils import check_nD, deprecate_kwarg
 
 __all__ = ['morphological_chan_vese',
            'morphological_geodesic_active_contour',
@@ -253,7 +253,8 @@ def inverse_gaussian_gradient(image, alpha=100.0, sigma=5.0):
     return 1.0 / np.sqrt(1.0 + alpha * gradnorm)
 
 
-def morphological_chan_vese(image, iterations, init_level_set='checkerboard',
+@deprecate_kwarg({'iterations': 'num_iter'}, removed_version="1.0")
+def morphological_chan_vese(image, num_iter, init_level_set='checkerboard',
                             smoothing=1, lambda1=1, lambda2=1,
                             iter_callback=lambda x: None):
     """Morphological Active Contours without Edges (MorphACWE)
@@ -268,8 +269,8 @@ def morphological_chan_vese(image, iterations, init_level_set='checkerboard',
     ----------
     image : (M, N) or (L, M, N) array
         Grayscale image or volume to be segmented.
-    iterations : uint
-        Number of iterations to run
+    num_iter : uint
+        Number of num_iter to run
     init_level_set : str, (M, N) array, or (L, M, N) array
         Initial level set. If an array is given, it will be binarized and used
         as the initial level set. If a string is given, it defines the method
@@ -332,7 +333,7 @@ def morphological_chan_vese(image, iterations, init_level_set='checkerboard',
 
     iter_callback(u)
 
-    for _ in range(iterations):
+    for _ in range(num_iter):
 
         # inside = u > 0
         # outside = u <= 0
@@ -356,7 +357,8 @@ def morphological_chan_vese(image, iterations, init_level_set='checkerboard',
     return u
 
 
-def morphological_geodesic_active_contour(gimage, iterations,
+@deprecate_kwarg({'iterations': 'num_iter'}, removed_version="1.0")
+def morphological_geodesic_active_contour(gimage, num_iter,
                                           init_level_set='circle', smoothing=1,
                                           threshold='auto', balloon=0,
                                           iter_callback=lambda x: None):
@@ -379,8 +381,8 @@ def morphological_geodesic_active_contour(gimage, iterations,
         perform this preprocessing. Note that the quality of
         `morphological_geodesic_active_contour` might greatly depend on this
         preprocessing.
-    iterations : uint
-        Number of iterations to run.
+    num_iter : uint
+        Number of num_iter to run.
     init_level_set : str, (M, N) array, or (L, M, N) array
         Initial level set. If an array is given, it will be binarized and used
         as the initial level set. If a string is given, it defines the method
@@ -455,7 +457,7 @@ def morphological_geodesic_active_contour(gimage, iterations,
 
     iter_callback(u)
 
-    for _ in range(iterations):
+    for _ in range(num_iter):
 
         # Balloon
         if balloon > 0:

--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -108,7 +108,8 @@ def _get_grid_centroids(image, n_centroids):
 
 @utils.channel_as_last_axis(multichannel_output=False)
 @utils.deprecate_multichannel_kwarg(multichannel_position=6)
-def slic(image, n_segments=100, compactness=10., max_iter=10, sigma=0,
+@utils.deprecate_kwarg({'max_iter': 'max_num_iter'}, removed_version="1.0")
+def slic(image, n_segments=100, compactness=10., max_num_iter=10, sigma=0,
          spacing=None, multichannel=True, convert2lab=None,
          enforce_connectivity=True, min_size_factor=0.5, max_size_factor=3,
          slic_zero=False, start_label=None, mask=None, *,
@@ -131,7 +132,7 @@ def slic(image, n_segments=100, compactness=10., max_iter=10, sigma=0,
         shapes of objects in the image. We recommend exploring possible
         values on a log scale, e.g., 0.01, 0.1, 1, 10, 100, before
         refining around a chosen value.
-    max_iter : int, optional
+    max_num_iter : int, optional
         Maximum number of iterations of k-means.
     sigma : float or (3,) array-like of floats, optional
         Width of Gaussian smoothing kernel for pre-processing for each
@@ -326,11 +327,11 @@ def slic(image, n_segments=100, compactness=10., max_iter=10, sigma=0,
 
     if update_centroids:
         # Step 2 of the algorithm [3]_
-        _slic_cython(image, mask, segments, step, max_iter, spacing,
+        _slic_cython(image, mask, segments, step, max_num_iter, spacing,
                      slic_zero, ignore_color=True,
                      start_label=start_label)
 
-    labels = _slic_cython(image, mask, segments, step, max_iter,
+    labels = _slic_cython(image, mask, segments, step, max_num_iter,
                           spacing, slic_zero, ignore_color=False,
                           start_label=start_label)
 

--- a/skimage/segmentation/tests/test_chan_vese.py
+++ b/skimage/segmentation/tests/test_chan_vese.py
@@ -1,12 +1,13 @@
 import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from skimage._shared._warnings import expected_warnings
+from skimage._shared.utils import _supported_float_type
 from skimage.segmentation import chan_vese
 
-from skimage._shared import testing
-from skimage._shared.testing import assert_array_equal
-from skimage._shared.utils import _supported_float_type
 
-
-@testing.parametrize('dtype', [np.float32, np.float64])
+@pytest.mark.parametrize('dtype', [np.float32, np.float64])
 def test_chan_vese_flat_level_set(dtype):
     # because the algorithm evolves the level set around the
     # zero-level, it the level-set has no zero level, the algorithm
@@ -37,7 +38,9 @@ def test_chan_vese_simple_shape():
     assert_array_equal(result, img)
 
 
-@testing.parametrize('dtype', [np.uint8, np.float16, np.float32, np.float64])
+@pytest.mark.parametrize(
+    'dtype', [np.uint8, np.float16, np.float32, np.float64]
+)
 def test_chan_vese_extended_output(dtype):
     img = np.zeros((10, 10), dtype=dtype)
     img[3:6, 3:6] = 1
@@ -57,7 +60,7 @@ def test_chan_vese_remove_noise():
                               [0, 1, 1, 1, 0]])
     img = ref.copy()
     img[8, 3] = 1
-    result = chan_vese(img, mu=0.3, tol=1e-3, max_iter=100, dt=10,
+    result = chan_vese(img, mu=0.3, tol=1e-3, max_num_iter=100, dt=10,
                        init_level_set="disk").astype(float)
     assert_array_equal(result, ref)
 
@@ -65,7 +68,7 @@ def test_chan_vese_remove_noise():
 def test_chan_vese_incorrect_image_type():
     img = np.zeros((10, 10, 3))
     ls = np.zeros((10, 9))
-    with testing.raises(ValueError):
+    with pytest.raises(ValueError):
         chan_vese(img, mu=0.0, init_level_set=ls)
 
 
@@ -74,17 +77,23 @@ def test_chan_vese_gap_closing():
     ref[8:15, :] = np.ones((7, 20))
     img = ref.copy()
     img[:, 6] = np.zeros((20))
-    result = chan_vese(img, mu=0.7, tol=1e-3, max_iter=1000, dt=1000,
+    result = chan_vese(img, mu=0.7, tol=1e-3, max_num_iter=1000, dt=1000,
                        init_level_set="disk").astype(float)
     assert_array_equal(result, ref)
+
+
+def test_chan_vese_max_iter_deprecation():
+    img = np.zeros((20, 20))
+    with expected_warnings(["`max_iter` is a deprecated argument"]):
+        chan_vese(img, max_iter=10)
 
 
 def test_chan_vese_incorrect_level_set():
     img = np.zeros((10, 10))
     ls = np.zeros((10, 9))
-    with testing.raises(ValueError):
+    with pytest.raises(ValueError):
         chan_vese(img, mu=0.0, init_level_set=ls)
-    with testing.raises(ValueError):
+    with pytest.raises(ValueError):
         chan_vese(img, mu=0.0, init_level_set="a")
 
 

--- a/skimage/segmentation/tests/test_morphsnakes.py
+++ b/skimage/segmentation/tests/test_morphsnakes.py
@@ -1,13 +1,13 @@
 import numpy as np
-from skimage.segmentation import (morphological_chan_vese,
-                                  morphological_geodesic_active_contour,
-                                  inverse_gaussian_gradient,
-                                  circle_level_set,
-                                  disk_level_set)
+import pytest
+from numpy.testing import assert_array_equal
 
-from skimage._shared import testing
-from skimage._shared.testing import assert_array_equal
 from skimage._shared._warnings import expected_warnings
+from skimage.segmentation import (circle_level_set,
+                                  disk_level_set,
+                                  inverse_gaussian_gradient,
+                                  morphological_chan_vese,
+                                  morphological_geodesic_active_contour)
 
 
 def gaussian_blob():
@@ -20,10 +20,10 @@ def test_morphsnakes_incorrect_image_shape():
     img = np.zeros((10, 10, 3))
     ls = np.zeros((10, 9))
 
-    with testing.raises(ValueError):
-        morphological_chan_vese(img, iterations=1, init_level_set=ls)
-    with testing.raises(ValueError):
-        morphological_geodesic_active_contour(img, iterations=1,
+    with pytest.raises(ValueError):
+        morphological_chan_vese(img, num_iter=1, init_level_set=ls)
+    with pytest.raises(ValueError):
+        morphological_geodesic_active_contour(img, num_iter=1,
                                               init_level_set=ls)
 
 
@@ -31,10 +31,10 @@ def test_morphsnakes_incorrect_ndim():
     img = np.zeros((4, 4, 4, 4))
     ls = np.zeros((4, 4, 4, 4))
 
-    with testing.raises(ValueError):
-        morphological_chan_vese(img, iterations=1, init_level_set=ls)
-    with testing.raises(ValueError):
-        morphological_geodesic_active_contour(img, iterations=1,
+    with pytest.raises(ValueError):
+        morphological_chan_vese(img, num_iter=1, init_level_set=ls)
+    with pytest.raises(ValueError):
+        morphological_geodesic_active_contour(img, num_iter=1,
                                               init_level_set=ls)
 
 
@@ -45,14 +45,14 @@ def test_morphsnakes_black():
     ref_zeros = np.zeros(img.shape, dtype=np.int8)
     ref_ones = np.ones(img.shape, dtype=np.int8)
 
-    acwe_ls = morphological_chan_vese(img, iterations=6, init_level_set=ls)
+    acwe_ls = morphological_chan_vese(img, num_iter=6, init_level_set=ls)
     assert_array_equal(acwe_ls, ref_zeros)
 
-    gac_ls = morphological_geodesic_active_contour(img, iterations=6,
+    gac_ls = morphological_geodesic_active_contour(img, num_iter=6,
                                                    init_level_set=ls)
     assert_array_equal(gac_ls, ref_zeros)
 
-    gac_ls2 = morphological_geodesic_active_contour(img, iterations=6,
+    gac_ls2 = morphological_geodesic_active_contour(img, num_iter=6,
                                                     init_level_set=ls,
                                                     balloon=1, threshold=-1,
                                                     smoothing=0)
@@ -61,13 +61,30 @@ def test_morphsnakes_black():
     assert acwe_ls.dtype == gac_ls.dtype == gac_ls2.dtype == np.int8
 
 
+def test_morphsnakes_iterations_kwarg_deprecation():
+    img = np.zeros((11, 11))
+    ls = disk_level_set(img.shape, center=(5, 5), radius=3)
+
+    ref_zeros = np.zeros(img.shape, dtype=np.int8)
+    ref_ones = np.ones(img.shape, dtype=np.int8)
+
+    with expected_warnings(["`iterations` is a deprecated argument"]):
+        acwe_ls = morphological_chan_vese(img, iterations=6, init_level_set=ls)
+    assert_array_equal(acwe_ls, ref_zeros)
+
+    with expected_warnings(["`iterations` is a deprecated argument"]):
+        gac_ls = morphological_geodesic_active_contour(img, iterations=6,
+                                                       init_level_set=ls)
+    assert_array_equal(gac_ls, ref_zeros)
+
+
 def test_morphsnakes_simple_shape_chan_vese():
     img = gaussian_blob()
     ls1 = disk_level_set(img.shape, center=(5, 5), radius=3)
     ls2 = disk_level_set(img.shape, center=(5, 5), radius=6)
 
-    acwe_ls1 = morphological_chan_vese(img, iterations=10, init_level_set=ls1)
-    acwe_ls2 = morphological_chan_vese(img, iterations=10, init_level_set=ls2)
+    acwe_ls1 = morphological_chan_vese(img, num_iter=10, init_level_set=ls1)
+    acwe_ls2 = morphological_chan_vese(img, num_iter=10, init_level_set=ls2)
 
     assert_array_equal(acwe_ls1, acwe_ls2)
 
@@ -92,7 +109,7 @@ def test_morphsnakes_simple_shape_geodesic_active_contour():
                     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
                    dtype=np.int8)
 
-    gac_ls = morphological_geodesic_active_contour(gimg, iterations=10,
+    gac_ls = morphological_geodesic_active_contour(gimg, num_iter=10,
                                                    init_level_set=ls,
                                                    balloon=-1)
     assert_array_equal(gac_ls, ref)

--- a/skimage/segmentation/tests/test_slic.py
+++ b/skimage/segmentation/tests/test_slic.py
@@ -1,12 +1,11 @@
 from itertools import product
 
-import pytest
 import numpy as np
-from skimage.segmentation import slic
+import pytest
+from numpy.testing import assert_equal
 
-from skimage._shared import testing
-from skimage._shared.testing import (test_parallel, assert_equal,
-                                     expected_warnings)
+from skimage._shared.testing import test_parallel, expected_warnings
+from skimage.segmentation import slic
 
 
 @test_parallel()
@@ -29,6 +28,12 @@ def test_color_2d():
     assert_equal(seg[10:, :10], 2)
     assert_equal(seg[:10, 10:], 1)
     assert_equal(seg[10:, 10:], 3)
+
+
+def test_max_iter_kwarg_deprecation():
+    img = np.zeros((20, 21, 3))
+    with expected_warnings(["`max_iter` is a deprecated argument"]):
+        slic(img, max_iter=10, start_label=0)
 
 
 def test_multichannel_2d():
@@ -171,7 +176,7 @@ def test_spacing():
 def test_invalid_lab_conversion():
     img = np.array([[1, 1, 1, 0, 0],
                     [1, 1, 0, 0, 0]], float) + 1
-    with testing.raises(ValueError):
+    with pytest.raises(ValueError):
         slic(img, channel_axis=-1, convert2lab=True, start_label=0)
 
 


### PR DESCRIPTION
## Description

This PR addresses one of the cases discussed in #4154.

There is no change in behavior aside from the deprecation warnings when an old parameter name is provided. These warnings are explicitly tested via `expected_warnings`

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
