### PR TITLE
Do not mark image edges in 'subpixel' mode of find_boundaries

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -80,6 +80,9 @@ Bugfixes
   (#4756).
 - Input ``labels`` argument renumbering in ``skimage.feature.peak_local_max``
   is avoided (#5047).
+- Nonzero values at the image edge are no longer incorrectly marked as a
+  boundary when using ``find_bounaries`` with mode='subpixel' (#5447)
+
 
 Deprecations
 ------------

--- a/skimage/segmentation/boundaries.py
+++ b/skimage/segmentation/boundaries.py
@@ -34,8 +34,7 @@ def _find_boundaries_subpixel(label_img):
     edges = np.ones(label_img_expanded.shape, dtype=bool)
     edges[pixels] = False
     label_img_expanded[edges] = max_label
-    windows = view_as_windows(np.pad(label_img_expanded, 1,
-                                     mode='constant', constant_values=0),
+    windows = view_as_windows(np.pad(label_img_expanded, 1, mode='edge'),
                               (3,) * ndim)
 
     boundaries = np.zeros_like(edges)

--- a/skimage/segmentation/tests/test_boundaries.py
+++ b/skimage/segmentation/tests/test_boundaries.py
@@ -1,9 +1,9 @@
 import numpy as np
-from skimage.segmentation import find_boundaries, mark_boundaries
+import pytest
+from numpy.testing import assert_array_equal, assert_allclose
 
-from skimage._shared import testing
-from skimage._shared.testing import assert_array_equal, assert_allclose
 from skimage._shared.utils import _supported_float_type
+from skimage.segmentation import find_boundaries, mark_boundaries
 
 
 white = (1, 1, 1)
@@ -41,7 +41,9 @@ def test_find_boundaries_bool():
     assert_array_equal(result, ref)
 
 
-@testing.parametrize('dtype', [np.uint8, np.float16, np.float32, np.float64])
+@pytest.mark.parametrize(
+    'dtype', [np.uint8, np.float16, np.float32, np.float64]
+)
 def test_mark_boundaries(dtype):
     image = np.zeros((10, 10), dtype=dtype)
     label_image = np.zeros((10, 10), dtype=np.uint8)
@@ -100,7 +102,7 @@ def test_mark_boundaries_bool():
     assert_array_equal(result, ref)
 
 
-@testing.parametrize('dtype', [np.float16, np.float32, np.float64])
+@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_mark_boundaries_subpixel(dtype):
     labels = np.array([[0, 0, 0, 0],
                        [0, 0, 5, 0],
@@ -125,3 +127,11 @@ def test_mark_boundaries_subpixel(dtype):
          [ 0.2 ,  0.52,  0.92,  1.  ,  1.  ,  1.  ,  0.54],
          [ 0.02,  0.35,  0.83,  0.9 ,  0.78,  0.81,  0.87]])
     assert_allclose(marked_proj, ref_result, atol=0.01)
+
+
+@pytest.mark.parametrize('mode', ['thick', 'inner', 'outer', 'subpixel'])
+def test_boundaries_constant_image(mode):
+    """A constant-valued image has not boundaries."""
+    ones = np.ones((8, 8), dtype=int)
+    b = find_boundaries(ones, mode=mode)
+    assert np.all(b == 0)


### PR DESCRIPTION
## Description

This PR closes #5432, following the suggestion by @firerain42. If there is some reason we want to keep the option with the old behavior of treating the boundary of the image as an edge, let me know. At the moment I am considering this a bug fix and so have not set up a deprecation cycle. 

It seems none of the other `mode` options to `find_boundary` mark the edge as a boundary, it was only the subpixel mode. A test was added that demonstrates this for all modes.

@firerain42, if you are interested in being credited as a co-author on the commit message, please provide a name and email address and I will add a comment for that


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
