### PR TITLE
Fix 'blog_dog' typo in gaussian docs

### DIFF
--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -228,7 +228,7 @@ def difference_of_gaussians(image, low_sigma, high_sigma=None, *,
 
     See also
     --------
-    skimage.feature.blog_dog
+    skimage.feature.blob_dog
 
     Notes
     -----


### PR DESCRIPTION
## Description
Fix 'blog_dog' typo in gaussian docs.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
