### PR TITLE
Add a draw_poly_on_array function to skimage.draw

### DIFF
--- a/skimage/draw/__init__.py
+++ b/skimage/draw/__init__.py
@@ -1,8 +1,7 @@
 from .draw import (circle, ellipse, set_color, polygon_perimeter,
-                   line, line_aa, polygon, ellipse_perimeter,
+                   line, line_aa, polygon, draw_poly_on_array, ellipse_perimeter,
                    circle_perimeter, circle_perimeter_aa,
-                   disk,
-                   bezier_curve, rectangle, rectangle_perimeter)
+                   disk, bezier_curve, rectangle, rectangle_perimeter)
 from .draw3d import ellipsoid, ellipsoid_stats
 from ._draw import _bezier_segment
 from ._random_shapes import random_shapes
@@ -15,6 +14,7 @@ __all__ = ['line',
            'line_nd',
            'bezier_curve',
            'polygon',
+           'draw_poly_on_array',
            'polygon_perimeter',
            'ellipse',
            'ellipse_perimeter',

--- a/skimage/draw/__init__.py
+++ b/skimage/draw/__init__.py
@@ -1,7 +1,8 @@
 from .draw import (circle, ellipse, set_color, polygon_perimeter,
-                   line, line_aa, polygon, draw_poly_on_array, ellipse_perimeter,
-                   circle_perimeter, circle_perimeter_aa,
-                   disk, bezier_curve, rectangle, rectangle_perimeter)
+                   line, line_aa, polygon, draw_poly_on_array,
+                   ellipse_perimeter, circle_perimeter,
+                   circle_perimeter_aa, disk, bezier_curve, rectangle,
+                   rectangle_perimeter)
 from .draw3d import ellipsoid, ellipsoid_stats
 from ._draw import _bezier_segment
 from ._random_shapes import random_shapes

--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -8,6 +8,7 @@ import numpy as np
 cimport numpy as cnp
 from libc.math cimport sqrt, sin, cos, floor, ceil, fabs
 from .._shared.geometry cimport point_in_polygon
+from .._shared.fused_numerics cimport np_anyint
 
 cnp.import_array()
 
@@ -245,7 +246,7 @@ def _polygon(r, c, shape):
     return np.array(rr, dtype=np.intp), np.array(cc, dtype=np.intp)
 
 
-def _draw_poly_on_array(r, c, image, fill_value):
+def _draw_poly_on_array(r, c, np_anyint[:, :] image, fill_value):
     """Fill the area of a polygon on an input image.
     
     Parameters
@@ -254,15 +255,17 @@ def _draw_poly_on_array(r, c, image, fill_value):
         Row coordinates of vertices of polygon.
     c : (N,) ndarray
         Column coordinates of vertices of polygon.
-    image : ndarray
+    image : ndarray:
         Input image that polygon will be drawn onto.
     fill_value : bool, int, tuple, optional
-        The value that will be assigned to coordinates within the polygon. Default is 1. 
+        The value that will be assigned to coordinates within the polygon. 
+        Default is 1. 
         
     Returns
     -------
     image: ndarray 
-        The updated image with the areas inside the polygon now assigned the fill_value.
+        The updated image with the areas inside the polygon now assigned the
+        fill_value.
     """
     r = np.atleast_1d(r)
     c = np.atleast_1d(c)
@@ -278,16 +281,15 @@ def _draw_poly_on_array(r, c, image, fill_value):
     maxr = min(shape[0] - 1, maxr)
     maxc = min(shape[1] - 1, maxc)
 
-    # make contiguous arrays for r, c coordinates and image - image dtype undefined to allow for any image type
+    # make contiguous arrays for r, c coordinates and image
     cdef cnp.float64_t[::1] rptr = np.ascontiguousarray(r, np.float64)
     cdef cnp.float64_t[::1] cptr = np.ascontiguousarray(c, np.float64)
-    image_ptr = np.ascontiguousarray(image)
     cdef Py_ssize_t r_i, c_i
 
     for r_i in range(minr, maxr+1):
         for c_i in range(minc, maxc+1):
             if point_in_polygon(cptr, rptr, <double>c_i, <double>r_i):
-                image_ptr[c_i, r_i] = fill_value
+                image[c_i, r_i] = fill_value
 
     return image
 

--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -245,6 +245,53 @@ def _polygon(r, c, shape):
     return np.array(rr, dtype=np.intp), np.array(cc, dtype=np.intp)
 
 
+def _draw_poly_on_array(r, c, image, fill_value):
+    """Fill the area of a polygon on an input image.
+    
+    Parameters
+    ----------
+    r : (N,) ndarray
+        Row coordinates of vertices of polygon.
+    c : (N,) ndarray
+        Column coordinates of vertices of polygon.
+    image : ndarray
+        Input image that polygon will be drawn onto.
+    fill_value : bool, int, tuple, optional
+        The value that will be assigned to coordinates within the polygon. Default is 1. 
+        
+    Returns
+    -------
+    image: ndarray 
+        The updated image with the areas inside the polygon now assigned the fill_value.
+    """
+    r = np.atleast_1d(r)
+    c = np.atleast_1d(c)
+
+    cdef Py_ssize_t nr_verts = c.shape[0]
+    cdef Py_ssize_t minr = int(max(0, r.min()))
+    cdef Py_ssize_t maxr = int(ceil(r.max()))
+    cdef Py_ssize_t minc = int(max(0, c.min()))
+    cdef Py_ssize_t maxc = int(ceil(c.max()))
+
+    # make sure output coordinates do not exceed image size
+    shape = image.shape
+    maxr = min(shape[0] - 1, maxr)
+    maxc = min(shape[1] - 1, maxc)
+
+    # make contiguous arrays for r, c coordinates and image - image dtype undefined to allow for any image type
+    cdef cnp.float64_t[::1] rptr = np.ascontiguousarray(r, np.float64)
+    cdef cnp.float64_t[::1] cptr = np.ascontiguousarray(c, np.float64)
+    image_ptr = np.ascontiguousarray(image)
+    cdef Py_ssize_t r_i, c_i
+
+    for r_i in range(minr, maxr+1):
+        for c_i in range(minc, maxc+1):
+            if point_in_polygon(cptr, rptr, <double>c_i, <double>r_i):
+                image_ptr[c_i, r_i] = fill_value
+
+    return image
+
+
 def _circle_perimeter(Py_ssize_t r_o, Py_ssize_t c_o, Py_ssize_t radius,
                       method, shape):
     """Generate circle perimeter coordinates.

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from .._shared._geometry import polygon_clip
 from ._draw import (_coords_inside_image, _line, _line_aa,
-                    _polygon, _ellipse_perimeter,
+                    _polygon, _draw_poly_on_array,_ellipse_perimeter,
                     _circle_perimeter, _circle_perimeter_aa,
                     _bezier_curve)
 
@@ -516,6 +516,47 @@ def polygon(r, c, shape=None):
 
     """
     return _polygon(r, c, shape)
+
+
+def draw_poly_on_array(r, c, image, fill_value=1):
+    """Fill the area of a polygon on an input image.
+
+    Parameters
+    ----------
+    r : (N,) ndarray
+        Row coordinates of vertices of polygon.
+    c : (N,) ndarray
+        Column coordinates of vertices of polygon.
+    image : ndarray
+        Input image that polygon will be drawn onto.
+    fill_value : bool, int, tuple, optional
+        The value that will be assigned to coordinates within the polygon. Default is 1.
+
+    Returns
+    -------
+    image: ndarray 
+        The updated image with the areas inside the polygon now assigned the fill_value.
+
+    Examples
+    --------
+    >>> from skimage.draw import draw_poly_on_array
+    >>> img = np.zeros((10, 10), dtype=np.uint8)
+    >>> r = np.array([1, 2, 8])
+    >>> c = np.array([1, 7, 4])
+    >>> img = draw_poly_on_array(r, c, image, fill_value=1)
+    >>> img
+    array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+           [0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+           [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+           [0, 0, 1, 1, 1, 1, 1, 0, 0, 0],
+           [0, 0, 0, 1, 1, 1, 1, 0, 0, 0],
+           [0, 0, 0, 1, 1, 1, 0, 0, 0, 0],
+           [0, 0, 0, 0, 1, 1, 0, 0, 0, 0],
+           [0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=uint8)
+    """
+    return _draw_poly_on_array(r, c, image, fill_value)
 
 
 def circle_perimeter(r, c, radius, method='bresenham', shape=None):

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -545,7 +545,7 @@ def draw_poly_on_array(r, c, image, fill_value=1):
     >>> img = np.zeros((10, 10), dtype=np.uint8)
     >>> r = np.array([1, 2, 8])
     >>> c = np.array([1, 7, 4])
-    >>> img = draw_poly_on_array(r, c, image, fill_value=1)
+    >>> img = draw_poly_on_array(r, c, img, fill_value=1)
     >>> img
     array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
            [0, 1, 0, 0, 0, 0, 0, 0, 0, 0],

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from .._shared._geometry import polygon_clip
 from ._draw import (_coords_inside_image, _line, _line_aa,
-                    _polygon, _draw_poly_on_array,_ellipse_perimeter,
+                    _polygon, _draw_poly_on_array, _ellipse_perimeter,
                     _circle_perimeter, _circle_perimeter_aa,
                     _bezier_curve)
 
@@ -530,12 +530,14 @@ def draw_poly_on_array(r, c, image, fill_value=1):
     image : ndarray
         Input image that polygon will be drawn onto.
     fill_value : bool, int, tuple, optional
-        The value that will be assigned to coordinates within the polygon. Default is 1.
+        The value that will be assigned to coordinates within the polygon.
+        Default is 1.
 
     Returns
     -------
-    image: ndarray 
-        The updated image with the areas inside the polygon now assigned the fill_value.
+    image: ndarray
+        The updated image with the areas inside the polygon now assigned the
+        fill_value.
 
     Examples
     --------


### PR DESCRIPTION
## Description

Adds a function called `draw_poly_on_array` that directly draws a polygon onto an image array. This is an alternative and possibly faster/more memory efficient method than using the `polygon` function to generate coordinate lists and then indexing the array to assign a value. You can pass most any image shape and assign a value for each channel by setting the `fill_value=(0, 0, 255, 80)`, for example.

Any suggestions on how to improve the functionality and help on the unit tests would be really appreciated. 

Closes #5451 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
    - [x] There don't seem to be any other examples for draw in `./doc/examples`, so please let me know if this is needed.
- [x] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
    - [x] Likewise, there are no benchmarks for `skimage.draw`, please let me know if this is needed.
- [ ] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
