### PR TITLE
Fix computation of the correlation in register.phase_cross_correlation

### DIFF
--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -118,14 +118,15 @@ def _compute_error(cross_correlation_max, src_amp, target_amp):
 def phase_cross_correlation(reference_image, moving_image, *,
                             upsample_factor=1, space="real",
                             return_error=True, reference_mask=None,
-                            moving_mask=None, overlap_ratio=0.3):
+                            moving_mask=None, overlap_ratio=0.3,
+                            normalization="phase"):
     """Efficient subpixel image translation registration by cross-correlation.
 
     This code gives the same precision as the FFT upsampled cross-correlation
     in a fraction of the computation time and with reduced memory requirements.
     It obtains an initial estimate of the cross-correlation peak by an FFT and
     then refines the shift estimation by upsampling the DFT only in a small
-    neighborhood of that estimate by means of a matrix-multiply DFT.
+    neighborhood of that estimate by means of a matrix-multiply DFT [1]_.
 
     Parameters
     ----------
@@ -166,6 +167,10 @@ def phase_cross_correlation(reference_image, moving_image, *,
         robustness against spurious matches due to small overlap between
         masked images. Used only if one of ``reference_mask`` or
         ``moving_mask`` is None.
+    normalization : {"phase", None}
+        The type of normalization to apply to the cross-correlation. This
+        parameter is unused when masks (`reference_mask` and `moving_mask`) are
+        supplied.
 
     Returns
     -------
@@ -180,20 +185,41 @@ def phase_cross_correlation(reference_image, moving_image, *,
         Global phase difference between the two images (should be
         zero if images are non-negative).
 
+    Notes
+    -----
+    The use of cross-correlation to estimate image translation has a long
+    history dating back to at least [2]_. The "phase correlation"
+    method (selected by ``normalization="phase"``) was first proposed in [3]_.
+    Publications [1]_ and [2]_ use an unnormalized cross-correlation
+    (``normalization=None``). Which form of normalization is better is
+    application-dependent. For example, the phase correlation method works
+    well in registering images under different illumination, but is not very
+    robust to noise. In a high noise scenario, the unnormalized method may be
+    preferable.
+
+    When masks are provided, a masked normalized cross-correlation algorithm is
+    used [5]_, [6]_.
+
     References
     ----------
     .. [1] Manuel Guizar-Sicairos, Samuel T. Thurman, and James R. Fienup,
            "Efficient subpixel image registration algorithms,"
            Optics Letters 33, 156-158 (2008). :DOI:`10.1364/OL.33.000156`
-    .. [2] James R. Fienup, "Invariant error metrics for image reconstruction"
+    .. [2] P. Anuta, Spatial registration of multispectral and multitemporal
+           digital imagery using fast Fourier transform techniques, IEEE Trans.
+           Geosci. Electron., vol. 8, no. 4, pp. 353–368, Oct. 1970.
+           :DOI:`10.1109/TGE.1970.271435`.
+    .. [3] C. D. Kuglin D. C. Hines. The phase correlation image alignment
+           method, Proceeding of IEEE International Conference on Cybernetics
+           and Society, pp. 163-165, New York, NY, USA, 1975, pp. 163–165.
+    .. [4] James R. Fienup, "Invariant error metrics for image reconstruction"
            Optics Letters 36, 8352-8357 (1997). :DOI:`10.1364/AO.36.008352`
-    .. [3] Dirk Padfield. Masked Object Registration in the Fourier Domain.
+    .. [5] Dirk Padfield. Masked Object Registration in the Fourier Domain.
            IEEE Transactions on Image Processing, vol. 21(5),
            pp. 2706-2718 (2012). :DOI:`10.1109/TIP.2011.2181402`
-    .. [4] D. Padfield. "Masked FFT registration". In Proc. Computer Vision and
+    .. [6] D. Padfield. "Masked FFT registration". In Proc. Computer Vision and
            Pattern Recognition, pp. 2918-2925 (2010).
            :DOI:`10.1109/CVPR.2010.5540032`
-
     """
     if (reference_mask is not None) or (moving_mask is not None):
         return _masked_phase_cross_correlation(reference_image, moving_image,
@@ -218,8 +244,11 @@ def phase_cross_correlation(reference_image, moving_image, *,
     # Whole-pixel shift - Compute cross-correlation by an IFFT
     shape = src_freq.shape
     image_product = src_freq * target_freq.conj()
-    eps = np.finfo(image_product.real.dtype).eps
-    image_product /= np.maximum(np.abs(image_product), 100 * eps)
+    if normalization == "phase":
+        eps = np.finfo(image_product.real.dtype).eps
+        image_product /= np.maximum(np.abs(image_product), 100 * eps)
+    elif normalization is not None:
+        raise ValueError("normalization must be either phase or None")
     cross_correlation = ifftn(image_product)
 
     # Locate maximum

--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -218,6 +218,8 @@ def phase_cross_correlation(reference_image, moving_image, *,
     # Whole-pixel shift - Compute cross-correlation by an IFFT
     shape = src_freq.shape
     image_product = src_freq * target_freq.conj()
+    eps = np.finfo(image_product.real.dtype).eps
+    image_product /= (np.abs(image_product) + eps)
     cross_correlation = ifftn(image_product)
 
     # Locate maximum

--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -219,7 +219,7 @@ def phase_cross_correlation(reference_image, moving_image, *,
     shape = src_freq.shape
     image_product = src_freq * target_freq.conj()
     eps = np.finfo(image_product.real.dtype).eps
-    image_product /= (np.abs(image_product) + eps)
+    image_product /= np.maximum(np.abs(image_product), 100 * eps)
     cross_correlation = ifftn(image_product)
 
     # Locate maximum

--- a/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_phase_cross_correlation.py
@@ -12,28 +12,46 @@ from skimage.registration._phase_cross_correlation import (
 )
 
 
-def test_correlation():
+@pytest.mark.parametrize('normalization', [None, 'phase'])
+def test_correlation(normalization):
     reference_image = fft.fftn(camera())
     shift = (-7, 12)
     shifted_image = fourier_shift(reference_image, shift)
 
     # pixel precision
-    result, error, diffphase = phase_cross_correlation(reference_image,
-                                                       shifted_image,
-                                                       space="fourier")
+    result, _, _ = phase_cross_correlation(reference_image,
+                                           shifted_image,
+                                           space="fourier",
+                                           normalization=normalization)
     assert_allclose(result[:2], -np.array(shift))
 
 
-def test_subpixel_precision():
+@pytest.mark.parametrize('normalization', ['nonexisting'])
+def test_correlation_invalid_normalization(normalization):
+    reference_image = fft.fftn(camera())
+    shift = (-7, 12)
+    shifted_image = fourier_shift(reference_image, shift)
+
+    # pixel precision
+    with pytest.raises(ValueError):
+        phase_cross_correlation(reference_image,
+                                shifted_image,
+                                space="fourier",
+                                normalization=normalization)
+
+
+@pytest.mark.parametrize('normalization', [None, 'phase'])
+def test_subpixel_precision(normalization):
     reference_image = fft.fftn(camera())
     subpixel_shift = (-2.4, 1.32)
     shifted_image = fourier_shift(reference_image, subpixel_shift)
 
     # subpixel precision
-    result, error, diffphase = phase_cross_correlation(reference_image,
-                                                       shifted_image,
-                                                       upsample_factor=100,
-                                                       space="fourier")
+    result, _, _ = phase_cross_correlation(reference_image,
+                                           shifted_image,
+                                           upsample_factor=100,
+                                           space="fourier",
+                                           normalization=normalization)
     assert_allclose(result[:2], -np.array(subpixel_shift), atol=0.05)
 
 


### PR DESCRIPTION
## Description
closes #5459, closes #5460

#5459 pointed out the need to divide by the magnitude before taking the ifftn of `image_product`. See the two images in my first comment in that issue for a visualization of the difference doing this makes in practice.

I also added epsilon to avoid any potential NaN values due to divide by zero.

@JulesScholler, I added you as a co-author in the first commit. Let me know if you do not want to be listed and I will remove it.

### TODO
- [ ] add test case (perhaps adapt the failing example from #5460 which seems to work after this change, but not before)

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
