### PR TITLE
Update reference link documentation in the adjust_sigmoid function in exposure.py

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -585,7 +585,7 @@ def adjust_sigmoid(image, cutoff=0.5, gain=10, inv=False):
     ----------
     .. [1] Gustav J. Braun, "Image Lightness Rescaling Using Sigmoidal Contrast
            Enhancement Functions",
-           http://www.cis.rit.edu/fairchild/PDFs/PAP07.pdf
+           http://markfairchild.org/PDFs/PAP07.pdf
 
     """
     _assert_non_negative(image)


### PR DESCRIPTION
update the broken link for the reference for exposure module

## Description

minor update on the broken link for the reference paper in adjust_sigmoid in exposure module

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
