### PR TITLE
Replacing filters .format() calls with f-strings

### DIFF
--- a/skimage/filters/_sparse.py
+++ b/skimage/filters/_sparse.py
@@ -16,9 +16,9 @@ def _validate_window_size(axis_sizes):
     """
     for axis_size in axis_sizes:
         if axis_size % 2 == 0:
-            msg = ('Window size for `threshold_sauvola` or '
-                   '`threshold_niblack` must not be even on any dimension. '
-                   'Got {}'.format(axis_sizes))
+            msg = (f'Window size for `threshold_sauvola` or '
+                   f'`threshold_niblack` must not be even on any dimension. '
+                   f'Got {axis_sizes}')
             raise ValueError(msg)
 
 

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -105,10 +105,10 @@ def _preprocess_input(image, footprint=None, out=None, mask=None,
     if (input_dtype in (bool, bool) or out_dtype in (bool, bool)):
         raise ValueError('dtype cannot be bool.')
     if input_dtype not in (np.uint8, np.uint16):
-        message = ('Possible precision loss converting image of type {} to '
-                   'uint8 as required by rank filters. Convert manually using '
-                   'skimage.util.img_as_ubyte to silence this warning.'
-                   .format(input_dtype))
+        message = (f'Possible precision loss converting image of type '
+                   f'{input_dtype} to uint8 as required by rank filters. '
+                   f'Convert manually using skimage.util.img_as_ubyte to '
+                   f'silence this warning.')
         warn(message, stacklevel=5)
         image = img_as_ubyte(image)
 
@@ -142,9 +142,9 @@ def _preprocess_input(image, footprint=None, out=None, mask=None,
         n_bins = int(max(3, image.max())) + 1
 
     if n_bins > 2 ** 10:
-        warn("Bad rank filter performance is expected due to a "
-             "large number of bins ({}), equivalent to an approximate "
-             "bitdepth of {:.1f}.".format(n_bins, np.log2(n_bins)),
+        warn(f"Bad rank filter performance is expected due to a "
+             f"large number of bins ({n_bins}), equivalent to an approximate "
+             f"bitdepth of {np.log2(n_bins):.1f}.",
              stacklevel=2)
 
     return image, footprint, out, mask, n_bins
@@ -188,10 +188,10 @@ def _handle_input_3D(image, footprint=None, out=None, mask=None,
     """
     check_nD(image, 3)
     if image.dtype not in (np.uint8, np.uint16):
-        message = ('Possible precision loss converting image of type {} to '
-                   'uint8 as required by rank filters. Convert manually using '
-                   'skimage.util.img_as_ubyte to silence this warning.'
-                   .format(image.dtype))
+        message = (f'Possible precision loss converting image of type '
+                   f'{image.dtype} to uint8 as required by rank filters. '
+                   f'Convert manually using skimage.util.img_as_ubyte to '
+                   f'silence this warning.')
         warn(message, stacklevel=2)
         image = img_as_ubyte(image)
 
@@ -227,11 +227,10 @@ def _handle_input_3D(image, footprint=None, out=None, mask=None,
         n_bins = int(max(3, image.max())) + 1
 
     if n_bins > 2**10:
-        warn("Bad rank filter performance is expected due to a "
-             "large number of bins ({}), equivalent to an approximate "
-             "bitdepth of {:.1f}.".format(n_bins, np.log2(n_bins)),
+        warn(f"Bad rank filter performance is expected due to a "
+             f"large number of bins ({n_bins}), equivalent to an approximate "
+             f"bitdepth of {np.log2(n_bins):.1f}.",
              stacklevel=2)
-
     return image, footprint, out, mask, n_bins
 
 

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -231,6 +231,7 @@ def _handle_input_3D(image, footprint=None, out=None, mask=None,
              f'large number of bins ({n_bins}), equivalent to an approximate '
              f'bitdepth of {np.log2(n_bins):.1f}.',
              stacklevel=2)
+
     return image, footprint, out, mask, n_bins
 
 

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -142,9 +142,9 @@ def _preprocess_input(image, footprint=None, out=None, mask=None,
         n_bins = int(max(3, image.max())) + 1
 
     if n_bins > 2 ** 10:
-        warn(f"Bad rank filter performance is expected due to a "
-             f"large number of bins ({n_bins}), equivalent to an approximate "
-             f"bitdepth of {np.log2(n_bins):.1f}.",
+        warn(f'Bad rank filter performance is expected due to a '
+             f'large number of bins ({n_bins}), equivalent to an approximate '
+             f'bitdepth of {np.log2(n_bins):.1f}.',
              stacklevel=2)
 
     return image, footprint, out, mask, n_bins
@@ -227,9 +227,9 @@ def _handle_input_3D(image, footprint=None, out=None, mask=None,
         n_bins = int(max(3, image.max())) + 1
 
     if n_bins > 2**10:
-        warn(f"Bad rank filter performance is expected due to a "
-             f"large number of bins ({n_bins}), equivalent to an approximate "
-             f"bitdepth of {np.log2(n_bins):.1f}.",
+        warn(f'Bad rank filter performance is expected due to a '
+             f'large number of bins ({n_bins}), equivalent to an approximate '
+             f'bitdepth of {np.log2(n_bins):.1f}.',
              stacklevel=2)
     return image, footprint, out, mask, n_bins
 

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -212,8 +212,8 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
         raise ValueError("len(block_size) must equal image.ndim.")
     block_size = tuple(block_size)
     if any(b % 2 == 0 for b in block_size):
-        raise ValueError("block_size must be odd! Given block_size"
-                         "{0} contains even values.".format(block_size))
+        raise ValueError(f"block_size must be odd! Given block_size "
+                         f"{block_size} contains even values.")
     thresh_image = np.zeros(image.shape, 'double')
     if method == 'generic':
         ndi.generic_filter(image, param, block_size,
@@ -322,9 +322,10 @@ def threshold_otsu(image=None, nbins=256, *, hist=None):
     The input image must be grayscale.
     """
     if image is not None and image.ndim > 2 and image.shape[-1] in (3, 4):
-        msg = "threshold_otsu is expected to work correctly only for " \
-              "grayscale images; image shape {0} looks like an RGB image"
-        warn(msg.format(image.shape))
+        msg = (f"threshold_otsu is expected to work correctly only for "
+               f"grayscale images; image shape {image.shape} looks like "
+               f"an RGB image")
+        warn(msg)
 
     # Check if the image has more than one intensity value; if not, return that
     # value
@@ -674,9 +675,9 @@ def threshold_li(image, *, tolerance=None, initial_guess=None,
         t_next = initial_guess - image_min
         image_max = np.max(image) + image_min
         if not 0 < t_next < np.max(image):
-            msg = ('The initial guess for threshold_li must be within the '
-                   'range of the image. Got {} for image min {} and max {} '
-                   .format(initial_guess, image_min, image_max))
+            msg = (f'The initial guess for threshold_li must be within the '
+                   f'range of the image. Got {initial_guess} for image min '
+                   f'{image_min} and max {image_max}.')
             raise ValueError(msg)
     else:
         raise TypeError('Incorrect type for `initial_guess`; should be '
@@ -1203,9 +1204,10 @@ def threshold_multiotsu(image, classes=3, nbins=256):
     """
 
     if len(image.shape) > 2 and image.shape[-1] in (3, 4):
-        msg = ("threshold_multiotsu is expected to work correctly only for "
-               "grayscale images; image shape {0} looks like an RGB image")
-        warn(msg.format(image.shape))
+        msg = (f"threshold_multiotsu is expected to work correctly only for "
+               f"grayscale images; image shape {image.shape} looks like an "
+               f"RGB image")
+        warn(msg)
 
     # calculating the histogram and the probability of each gray level.
     prob, bin_centers = histogram(image.ravel(),
@@ -1216,9 +1218,9 @@ def threshold_multiotsu(image, classes=3, nbins=256):
 
     nvalues = np.count_nonzero(prob)
     if nvalues < classes:
-        msg = ("The input image has only {} different values. "
-               "It can not be thresholded in {} classes")
-        raise ValueError(msg.format(nvalues, classes))
+        msg = (f"The input image has only {nvalues} different values. "
+               f"It can not be thresholded in {classes} classes")
+        raise ValueError(msg)
     elif nvalues == classes:
         thresh_idx = np.where(prob > 0)[0][:-1]
     else:

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -322,10 +322,9 @@ def threshold_otsu(image=None, nbins=256, *, hist=None):
     The input image must be grayscale.
     """
     if image is not None and image.ndim > 2 and image.shape[-1] in (3, 4):
-        msg = (f'threshold_otsu is expected to work correctly only for '
-               f'grayscale images; image shape {image.shape} looks like '
-               f'that of an RGB image.')
-        warn(msg)
+        warn(f'threshold_otsu is expected to work correctly only for '
+             f'grayscale images; image shape {image.shape} looks like '
+             f'that of an RGB image.')
 
     # Check if the image has more than one intensity value; if not, return that
     # value
@@ -1204,10 +1203,9 @@ def threshold_multiotsu(image, classes=3, nbins=256):
     """
 
     if len(image.shape) > 2 and image.shape[-1] in (3, 4):
-        msg = (f'threshold_multiotsu is expected to work correctly only for '
-               f'grayscale images; image shape {image.shape} looks like an '
-               f'RGB image')
-        warn(msg)
+        warn(f'threshold_multiotsu is expected to work correctly only for '
+             f'grayscale images; image shape {image.shape} looks like an '
+             f'RGB image')
 
     # calculating the histogram and the probability of each gray level.
     prob, bin_centers = histogram(image.ravel(),

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -1204,8 +1204,8 @@ def threshold_multiotsu(image, classes=3, nbins=256):
 
     if len(image.shape) > 2 and image.shape[-1] in (3, 4):
         warn(f'threshold_multiotsu is expected to work correctly only for '
-             f'grayscale images; image shape {image.shape} looks like an '
-             f'RGB image')
+             f'grayscale images; image shape {image.shape} looks like '
+             f'that of an RGB image.')
 
     # calculating the histogram and the probability of each gray level.
     prob, bin_centers = histogram(image.ravel(),

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -212,8 +212,8 @@ def threshold_local(image, block_size, method='gaussian', offset=0,
         raise ValueError("len(block_size) must equal image.ndim.")
     block_size = tuple(block_size)
     if any(b % 2 == 0 for b in block_size):
-        raise ValueError(f"block_size must be odd! Given block_size "
-                         f"{block_size} contains even values.")
+        raise ValueError(f'block_size must be odd! Given block_size '
+                         f'{block_size} contains even values.')
     thresh_image = np.zeros(image.shape, 'double')
     if method == 'generic':
         ndi.generic_filter(image, param, block_size,
@@ -322,9 +322,9 @@ def threshold_otsu(image=None, nbins=256, *, hist=None):
     The input image must be grayscale.
     """
     if image is not None and image.ndim > 2 and image.shape[-1] in (3, 4):
-        msg = (f"threshold_otsu is expected to work correctly only for "
-               f"grayscale images; image shape {image.shape} looks like "
-               f"an RGB image")
+        msg = (f'threshold_otsu is expected to work correctly only for '
+               f'grayscale images; image shape {image.shape} looks like '
+               f'that of an RGB image.')
         warn(msg)
 
     # Check if the image has more than one intensity value; if not, return that
@@ -1204,9 +1204,9 @@ def threshold_multiotsu(image, classes=3, nbins=256):
     """
 
     if len(image.shape) > 2 and image.shape[-1] in (3, 4):
-        msg = (f"threshold_multiotsu is expected to work correctly only for "
-               f"grayscale images; image shape {image.shape} looks like an "
-               f"RGB image")
+        msg = (f'threshold_multiotsu is expected to work correctly only for '
+               f'grayscale images; image shape {image.shape} looks like an '
+               f'RGB image')
         warn(msg)
 
     # calculating the histogram and the probability of each gray level.
@@ -1218,8 +1218,8 @@ def threshold_multiotsu(image, classes=3, nbins=256):
 
     nvalues = np.count_nonzero(prob)
     if nvalues < classes:
-        msg = (f"The input image has only {nvalues} different values. "
-               f"It can not be thresholded in {classes} classes")
+        msg = (f'The input image has only {nvalues} different values. '
+               f'It cannot be thresholded in {classes} classes.')
         raise ValueError(msg)
     elif nvalues == classes:
         thresh_idx = np.where(prob > 0)[0][:-1]


### PR DESCRIPTION
## Description

This PR replaces `.format()` calls on strings within the `filters` package with f-strings to partially address issue #5474.

Thank you!