### PR TITLE
.format() coverted to f-strings in segmentation subpackage

### DIFF
--- a/skimage/segmentation/_clear_border.py
+++ b/skimage/segmentation/_clear_border.py
@@ -81,7 +81,7 @@ def clear_border(labels, buffer_size=0, bgval=0, in_place=False, mask=None,
         out = labels
 
     if mask is not None:
-        err_msg = ("labels and mask should have the same shape but "
+        err_msg = (f"labels and mask should have the same shape but "
                    f"are {out.shape} and {mask.shape}")
         if out.shape != mask.shape:
             raise(ValueError, err_msg)

--- a/skimage/segmentation/_clear_border.py
+++ b/skimage/segmentation/_clear_border.py
@@ -82,9 +82,9 @@ def clear_border(labels, buffer_size=0, bgval=0, in_place=False, mask=None,
 
     if mask is not None:
         err_msg = ("labels and mask should have the same shape but "
-                   "are {} and {}")
+                   f"are {out.shape} and {mask.shape}")
         if out.shape != mask.shape:
-            raise(ValueError, err_msg.format(out.shape, mask.shape))
+            raise(ValueError, err_msg)
         if mask.dtype != bool:
             raise TypeError("mask should be of type bool.")
         borders = ~mask

--- a/skimage/segmentation/_clear_border.py
+++ b/skimage/segmentation/_clear_border.py
@@ -81,8 +81,8 @@ def clear_border(labels, buffer_size=0, bgval=0, in_place=False, mask=None,
         out = labels
 
     if mask is not None:
-        err_msg = (f"labels and mask should have the same shape but "
-                   f"are {out.shape} and {mask.shape}")
+        err_msg = (f'labels and mask should have the same shape but '
+                   f'are {out.shape} and {mask.shape}')
         if out.shape != mask.shape:
             raise(ValueError, err_msg)
         if mask.dtype != bool:

--- a/skimage/segmentation/_watershed.py
+++ b/skimage/segmentation/_watershed.py
@@ -84,8 +84,8 @@ def _validate_inputs(image, markers, mask, connectivity):
     else:
         markers = np.asanyarray(markers) * mask
         if markers.shape != image.shape:
-            message = (f"`markers` (shape {markers.shape}) must have same shape as "
-                       f"`image` (shape {image.shape})")
+            message = (f"`markers` (shape {markers.shape}) must have same "
+                       f"shape as `image` (shape {image.shape})")
             raise ValueError(message)
     return (image.astype(np.float64),
             markers.astype(np.int32),

--- a/skimage/segmentation/_watershed.py
+++ b/skimage/segmentation/_watershed.py
@@ -68,8 +68,8 @@ def _validate_inputs(image, markers, mask, connectivity):
         mask = np.asanyarray(mask, dtype=bool)
         n_pixels = np.sum(mask)
         if mask.shape != image.shape:
-            message = ("`mask` (shape {}) must have same shape as "
-                       "`image` (shape {})".format(mask.shape, image.shape))
+            message = (f"`mask` (shape {mask.shape}) must have same shape as "
+                       f"`image` (shape {image.shape})")
             raise ValueError(message)
     if markers is None:
         markers_bool = local_minima(image, connectivity=connectivity) * mask
@@ -84,8 +84,8 @@ def _validate_inputs(image, markers, mask, connectivity):
     else:
         markers = np.asanyarray(markers) * mask
         if markers.shape != image.shape:
-            message = ("`markers` (shape {}) must have same shape as "
-                       "`image` (shape {})".format(markers.shape, image.shape))
+            message = (f"`markers` (shape {markers.shape}) must have same shape as "
+                       f"`image` (shape {image.shape})")
             raise ValueError(message)
     return (image.astype(np.float64),
             markers.astype(np.int32),

--- a/skimage/segmentation/_watershed.py
+++ b/skimage/segmentation/_watershed.py
@@ -68,8 +68,8 @@ def _validate_inputs(image, markers, mask, connectivity):
         mask = np.asanyarray(mask, dtype=bool)
         n_pixels = np.sum(mask)
         if mask.shape != image.shape:
-            message = (f"`mask` (shape {mask.shape}) must have same shape as "
-                       f"`image` (shape {image.shape})")
+            message = (f'`mask` (shape {mask.shape}) must have same shape '
+                       f'as `image` (shape {image.shape})')
             raise ValueError(message)
     if markers is None:
         markers_bool = local_minima(image, connectivity=connectivity) * mask
@@ -84,8 +84,8 @@ def _validate_inputs(image, markers, mask, connectivity):
     else:
         markers = np.asanyarray(markers) * mask
         if markers.shape != image.shape:
-            message = (f"`markers` (shape {markers.shape}) must have same "
-                       f"shape as `image` (shape {image.shape})")
+            message = (f'`markers` (shape {markers.shape}) must have same '
+                       f'shape as `image` (shape {image.shape})')
             raise ValueError(message)
     return (image.astype(np.float64),
             markers.astype(np.int32),

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -428,8 +428,8 @@ def random_walker(data, labels, beta=130, mode='cg_j', tol=1.e-3, copy=True,
     # Parse input data
     if mode not in ('cg_mg', 'cg', 'bf', 'cg_j', None):
         raise ValueError(
-            "{mode} is not a valid mode. Valid modes are 'cg_mg',"
-            " 'cg', 'cg_j', 'bf' and None".format(mode=mode))
+            f"{mode} is not a valid mode. Valid modes are 'cg_mg',"
+            " 'cg', 'cg_j', 'bf' and None")
 
     # Spacing kwarg checks
     if spacing is None:

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -428,8 +428,8 @@ def random_walker(data, labels, beta=130, mode='cg_j', tol=1.e-3, copy=True,
     # Parse input data
     if mode not in ('cg_mg', 'cg', 'bf', 'cg_j', None):
         raise ValueError(
-            f'{mode} is not a valid mode. Valid modes are \'cg_mg\','
-            f' \'cg\', \'cg_j\', \'bf\', and None')
+            f"{mode} is not a valid mode. Valid modes are 'cg_mg',"
+            f" 'cg', 'cg_j', 'bf', and None")
 
     # Spacing kwarg checks
     if spacing is None:

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -428,8 +428,8 @@ def random_walker(data, labels, beta=130, mode='cg_j', tol=1.e-3, copy=True,
     # Parse input data
     if mode not in ('cg_mg', 'cg', 'bf', 'cg_j', None):
         raise ValueError(
-            f"{mode} is not a valid mode. Valid modes are 'cg_mg',"
-            f" 'cg', 'cg_j', 'bf', and None")
+            f'{mode} is not a valid mode. Valid modes are \'cg_mg\','
+            f' \'cg\', \'cg_j\', \'bf\', and None')
 
     # Spacing kwarg checks
     if spacing is None:

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -429,7 +429,7 @@ def random_walker(data, labels, beta=130, mode='cg_j', tol=1.e-3, copy=True,
     if mode not in ('cg_mg', 'cg', 'bf', 'cg_j', None):
         raise ValueError(
             f"{mode} is not a valid mode. Valid modes are 'cg_mg',"
-            " 'cg', 'cg_j', 'bf' and None")
+            f" 'cg', 'cg_j', 'bf', and None")
 
     # Spacing kwarg checks
     if spacing is None:


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->
This PR replaces `.format()` calls on strings within the `segmentation` package with f-strings to partially address issue #5474.

Thank you!

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
