### PR TITLE
Fix wrong syntax for the string argument to ValueError 

### DIFF
--- a/skimage/metrics/_structural_similarity.py
+++ b/skimage/metrics/_structural_similarity.py
@@ -166,14 +166,14 @@ def structural_similarity(im1, im2,
 
     if np.any((np.asarray(im1.shape) - win_size) < 0):
         raise ValueError(
-            "win_size exceeds image extent. "
-            "Either ensure that your images are "
-            "at least 7x7; or pass win_size explicitly "
-            "in the function call, with an odd value "
-            "less than or equal to the smaller side of your "
-            "images. If your images are multichannel "
-            "(with color channels), set channel_axis to "
-            "the axis number corresponding to the channels.")
+            'win_size exceeds image extent. '
+            'Either ensure that your images are '
+            'at least 7x7; or pass win_size explicitly '
+            'in the function call, with an odd value '
+            'less than or equal to the smaller side of your '
+            'images. If your images are multichannel '
+            '(with color channels), set channel_axis to '
+            'the axis number corresponding to the channels.')
 
     if not (win_size % 2 == 1):
         raise ValueError('Window size must be odd.')

--- a/skimage/metrics/_structural_similarity.py
+++ b/skimage/metrics/_structural_similarity.py
@@ -166,13 +166,13 @@ def structural_similarity(im1, im2,
 
     if np.any((np.asarray(im1.shape) - win_size) < 0):
         raise ValueError(
-            "win_size exceeds image extent. ",
-            "Either ensure that your images are ",
-            "at least 7x7; or pass win_size explicitly ",
-            "in the function call, with an odd value ",
-            "less than or equal to the smaller side of your ",
-            "images. If your images are multichannel ",
-            "(with color channels), set channel_axis to ",
+            "win_size exceeds image extent. "
+            "Either ensure that your images are "
+            "at least 7x7; or pass win_size explicitly "
+            "in the function call, with an odd value "
+            "less than or equal to the smaller side of your "
+            "images. If your images are multichannel "
+            "(with color channels), set channel_axis to "
             "the axis number corresponding to the channels.")
 
     if not (win_size % 2 == 1):


### PR DESCRIPTION
## Description
https://github.com/scikit-image/scikit-image/issues/5366#issuecomment-881942867 
- In my PR in https://github.com/scikit-image/scikit-image/pull/5395, I used wrong syntax for the string argument to ValueError. 
Thanks @pomax for pointing out the issue. 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
