### PR TITLE
non-local means: support 3d+multichannel, 4d and 4d+multichannel

### DIFF
--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -410,7 +410,7 @@ cdef inline double _integral_to_distance_4d(double [:, :, :, ::] integral,
         integral[time + offset, pln + offset, row - offset, col + offset] -
         integral[time + offset, pln + offset, row + offset, col - offset] +
         integral[time + offset, pln + offset, row + offset, col + offset])
-    return  max(distance, 0.0) / (s4_h_square)
+    return  max(distance, 0.0) / s4_h_square
 
 
 cdef inline void _integral_image_2d(double [:, :, ::] padded,
@@ -542,8 +542,7 @@ cdef inline void _integral_image_4d(double [:, :, :, :, ::] padded,
                                     Py_ssize_t t_col, Py_ssize_t n_time, Py_ssize_t n_pln,
                                     Py_ssize_t n_row, Py_ssize_t n_col, Py_ssize_t n_channels,
                                     double var_diff) nogil:
-    """
-    Computes the integral of the squared difference between an image ``padded``
+    """Compute the integral of the squared difference between an image ``padded``
     and the same image shifted by ``(t_pln, t_row, t_col)``.
 
     Parameters
@@ -568,7 +567,7 @@ cdef inline void _integral_image_4d(double [:, :, :, :, ::] padded,
     var_diff : double
         The double of the expected noise variance. If non-zero, this
         is used to reduce the apparent patch distances by the expected
-         distance due to the noise.
+        distance due to the noise.
 
     Notes
     -----
@@ -914,7 +913,7 @@ def _fast_nl_means_denoising_4d(cnp.ndarray[np_floats, ndim=5] image,
     d : tuple of Py_ssize_t, optional
         Maximal distance in pixels along each axis to search for patches used for denoising.
     h : double, optional
-        cut-off distance (in gray levels). The higher h, the more permissive
+        Cut-off distance (in gray levels). The higher h, the more permissive
         one is in accepting patches.
     var : double
         Expected noise variance.  If non-zero, this is used to reduce the
@@ -933,7 +932,7 @@ def _fast_nl_means_denoising_4d(cnp.ndarray[np_floats, ndim=5] image,
     2008, pp. 1331-1334.
 
     Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
-    Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.
+    Denoising. Image Processing On Line, 2014, vol. 4, pp. 300-326.
     """
 
     cdef double DISTANCE_CUTOFF = 5.0

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -318,17 +318,36 @@ cdef inline double _integral_to_distance_2d(double [:, ::] integral,
                                             Py_ssize_t offset,
                                             double h2s2) nogil:
     """
+    Parameters
+    ----------
+    integral : ndarray
+        The integral image as computed by ``_integral_image_2d``.
+    row, col : Py_ssize_t
+        Index of the patch's center pixel.
+    offset : Py_ssize_t
+        The non-local means patch radius.
+    h2s2 : float
+        Normalization factor related to the image standard deviation and `h`
+        parameter.
+
+    Returns
+    -------
+    distance : float
+        The patch distance
+
+    Notes
+    -----
+    Used in `_fast_nl_means_denoising_2d` which is a fast non-local means
+    algorithm using integral images as described in [1]_, [2]_.
+
     References
     ----------
-    J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
-    nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
-    International Symposium on Biomedical Imaging: From Nano to Macro,
-    2008, pp. 1331-1334.
-
-    Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
-    Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.
-
-    Used in _fast_nl_means_denoising_2d
+    .. [1] J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen. Fast
+           nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
+           International Symposium on Biomedical Imaging: From Nano to Macro,
+           2008, pp. 1331-1334.
+    .. [2] Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
+           Denoising. Image Processing On Line, 2014, vol. 4, pp. 300-326.
     """
     cdef double distance = (integral[row + offset, col + offset] +
                             integral[row - offset, col - offset] -
@@ -342,19 +361,38 @@ cdef inline double _integral_to_distance_3d(double[:, :, ::] integral,
                                             Py_ssize_t col, Py_ssize_t offset,
                                             double s_cube_h_square) nogil:
     """
+    Parameters
+    ----------
+    integral : ndarray
+        The integral image as computed by ``_integral_image_3d``.
+    pln, row, col : Py_ssize_t
+        Index of the patch's center pixel.
+    offset : Py_ssize_t
+        The non-local means patch radius.
+    s_cube_h_square : float
+        Normalization factor related to the image standard deviation and `h`
+        parameter.
+
+    Returns
+    -------
+    distance : float
+        The patch distance
+
+    Notes
+    -----
+    Used in `_fast_nl_means_denoising_3d` which is a fast non-local means
+    algorithm using integral images as described in [1]_, [2]_.
+
     References
     ----------
-    J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
-    nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
-    International Symposium on Biomedical Imaging: From Nano to Macro,
-    2008, pp. 1331-1334.
-
-    Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
-    Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.
-
-    Used in _fast_nl_means_denoising_3d
+    .. [1] J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen. Fast
+           nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
+           International Symposium on Biomedical Imaging: From Nano to Macro,
+           2008, pp. 1331-1334.
+    .. [2] Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
+           Denoising. Image Processing On Line, 2014, vol. 4, pp. 300-326.
     """
-    cdef double distance= (
+    cdef double distance = (
         integral[pln + offset, row + offset, col + offset] -
         integral[pln - offset, row - offset, col - offset] +
         integral[pln - offset, row - offset, col + offset] +
@@ -372,25 +410,40 @@ cdef inline double _integral_to_distance_4d(double [:, :, :, ::] integral,
                                             Py_ssize_t offset,
                                             double s4_h_square) nogil:
     """
+    Parameters
+    ----------
+    integral : ndarray
+        The integral image as computed by ``_integral_image_4d``.
+    time, pln, row, col : Py_ssize_t
+        Index of the patch's center pixel.
+    offset : Py_ssize_t
+        The non-local means patch radius.
+    s4_h_square : float
+        Normalization factor related to the image standard deviation and `h`
+        parameter.
+
+    Returns
+    -------
+    distance : float
+        The patch distance
+
+    Notes
+    -----
+    Used in _fast_nl_means_denoising_4d which is a fast non-local means
+    algorithm using integral images as described in [1]_, [2]_. The
+    coefficients for the terms in the 4D case were determined using Eq. 54 of
+    [3]_ as implemented in the ``integral_image_coefficients`` function.
+
     References
     ----------
-    J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
-    nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
-    International Symposium on Biomedical Imaging: From Nano to Macro,
-    2008, pp. 1331-1334.
-
-    Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
-    Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.
-
-    Used in _fast_nl_means_denoising_4d
-
-    The coefficients for the terms were determined using Eq. 54 of [1]_ as
-    implemented in the integral_image_coefficients function.
-
-    E. Tapia.  A note on the computation of high-dimensional integral images.
-    Pattern Recognition Letters 2011. Vol. 32, pp.197-201.
-
-
+    .. [1] J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen. Fast
+           nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
+           International Symposium on Biomedical Imaging: From Nano to Macro,
+           2008, pp. 1331-1334.
+    .. [2] Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
+           Denoising. Image Processing On Line, 2014, vol. 4, pp. 300-326.
+    .. [3] Tapia, E. A note on the computation of high-dimensional integral
+           images. Pattern Recognition Letters, 2011, Vol. 32, pp.197-201.
     """
     cdef double distance
     distance = (
@@ -410,7 +463,7 @@ cdef inline double _integral_to_distance_4d(double [:, :, :, ::] integral,
         integral[time + offset, pln + offset, row - offset, col + offset] -
         integral[time + offset, pln + offset, row + offset, col - offset] +
         integral[time + offset, pln + offset, row + offset, col + offset])
-    return  max(distance, 0.0) / s4_h_square
+    return max(distance, 0.0) / s4_h_square
 
 
 cdef inline void _integral_image_2d(double [:, :, ::] padded,
@@ -419,9 +472,8 @@ cdef inline void _integral_image_2d(double [:, :, ::] padded,
                                     Py_ssize_t n_row, Py_ssize_t n_col,
                                     Py_ssize_t n_channels,
                                     double var_diff) nogil:
-    """
-    Computes the integral of the squared difference between an image ``padded``
-    and the same image shifted by ``(t_row, t_col)``.
+    """ Compute the integral of the squared difference between an image
+    ``padded`` and the same image shifted by ``(t_row, t_col)``.
 
     Parameters
     ----------
@@ -475,8 +527,7 @@ cdef inline void _integral_image_3d(double [:, :, :, ::] padded,
                                     Py_ssize_t n_row, Py_ssize_t n_col,
                                     Py_ssize_t n_channels,
                                     double var_diff) nogil:
-    """
-    Computes the integral of the squared difference between an image ``padded``
+    """Compute the integral of the squared difference between an image ``padded``
     and the same image shifted by ``(t_pln, t_row, t_col)``.
 
     Parameters
@@ -623,8 +674,7 @@ cdef inline void _integral_image_4d(double [:, :, :, :, ::] padded,
 def _fast_nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image,
                                 Py_ssize_t s, Py_ssize_t d,
                                 double h, double var):
-    """
-    Perform fast non-local means denoising on 2-D array, with the outer
+    """Perform fast non-local means denoising on 2-D array, with the outer
     loop on patch shifts in order to reduce the number of operations.
 
     Parameters
@@ -649,13 +699,13 @@ def _fast_nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image,
 
     References
     ----------
-    J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
-    nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
-    International Symposium on Biomedical Imaging: From Nano to Macro,
-    2008, pp. 1331-1334.
+    ..[1] J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
+          nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
+          International Symposium on Biomedical Imaging: From Nano to Macro,
+          2008, pp. 1331-1334.
 
-    Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
-    Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.
+    ..[2] Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
+          Denoising. Image Processing On Line, 2014, vol. 4, pp. 300-326.
     """
 
     cdef double DISTANCE_CUTOFF = 5.0
@@ -747,8 +797,7 @@ def _fast_nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image,
 def _fast_nl_means_denoising_3d(cnp.ndarray[np_floats, ndim=4] image,
                                 Py_ssize_t s=5, Py_ssize_t d=7, double h=0.1,
                                 double var=0.):
-    """
-    Perform fast non-local means denoising on 3-D array, with the outer
+    """Perform fast non-local means denoising on 3-D array, with the outer
     loop on patch shifts in order to reduce the number of operations.
 
     Parameters
@@ -773,13 +822,13 @@ def _fast_nl_means_denoising_3d(cnp.ndarray[np_floats, ndim=4] image,
 
     References
     ----------
-    J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
-    nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
-    International Symposium on Biomedical Imaging: From Nano to Macro,
-    2008, pp. 1331-1334.
+    ..[1] J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
+          nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
+          International Symposium on Biomedical Imaging: From Nano to Macro,
+          2008, pp. 1331-1334.
 
-    Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
-    Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.
+    ..[2] Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
+          Denoising. Image Processing On Line, 2014, vol. 4, pp. 300-326.
     """
 
     cdef double DISTANCE_CUTOFF = 5.0
@@ -926,13 +975,13 @@ def _fast_nl_means_denoising_4d(cnp.ndarray[np_floats, ndim=5] image,
 
     References
     ----------
-    J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
-    nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
-    International Symposium on Biomedical Imaging: From Nano to Macro,
-    2008, pp. 1331-1334.
+    ..[1] J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
+          nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
+          International Symposium on Biomedical Imaging: From Nano to Macro,
+          2008, pp. 1331-1334.
 
-    Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
-    Denoising. Image Processing On Line, 2014, vol. 4, pp. 300-326.
+    ..[2] Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
+          Denoising. Image Processing On Line, 2014, vol. 4, pp. 300-326.
     """
 
     cdef double DISTANCE_CUTOFF = 5.0

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -805,7 +805,7 @@ def _fast_nl_means_denoising_3d(cnp.ndarray[np_floats, ndim=4] image,
                mode='reflect'),
         dtype=np.float64)
     cdef double [:, :, ::1] weights = np.zeros_like(padded[..., 0])
-    cdef double [:, :, ::1] integral = np.empty_like(padded[..., 0])
+    cdef double [:, :, ::1] integral = np.zeros_like(padded[..., 0])
     cdef double [:, :, :, ::1] result = np.zeros_like(padded)
 
     cdef Py_ssize_t n_pln, n_row, n_col, t_pln, t_row, t_col, \

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -365,6 +365,52 @@ cdef inline double _integral_to_distance_3d(double[:, :, ::] integral,
     return max(distance, 0.0) / (s_cube_h_square)
 
 
+cdef inline double _integral_to_distance_4d(double [:, :, :, ::] integral,
+                                            Py_ssize_t time, Py_ssize_t pln, Py_ssize_t row,
+                                            Py_ssize_t col, Py_ssize_t offset,
+                                            double s4_h_square) nogil:
+    """
+    References
+    ----------
+    J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
+    nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
+    International Symposium on Biomedical Imaging: From Nano to Macro,
+    2008, pp. 1331-1334.
+
+    Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
+    Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.
+
+    Used in _fast_nl_means_denoising_4d
+
+    The coefficients for the terms were determined using Eq. 54 of [1]_ as
+    implemented in the integral_image_coefficients function.
+
+    E. Tapia.  A note on the computation of high-dimensional integral images.
+    Pattern Recognition Letters 2011. Vol. 32, pp.197-201.
+
+
+    """
+    cdef double distance
+    distance = (
+        integral[time - offset, pln - offset, row - offset, col - offset] -
+        integral[time - offset, pln - offset, row - offset, col + offset] -
+        integral[time - offset, pln - offset, row + offset, col - offset] +
+        integral[time - offset, pln - offset, row + offset, col + offset] -
+        integral[time - offset, pln + offset, row - offset, col - offset] +
+        integral[time - offset, pln + offset, row - offset, col + offset] +
+        integral[time - offset, pln + offset, row + offset, col - offset] -
+        integral[time - offset, pln + offset, row + offset, col + offset] -
+        integral[time + offset, pln - offset, row - offset, col - offset] +
+        integral[time + offset, pln - offset, row - offset, col + offset] +
+        integral[time + offset, pln - offset, row + offset, col - offset] -
+        integral[time + offset, pln - offset, row + offset, col + offset] +
+        integral[time + offset, pln + offset, row - offset, col - offset] -
+        integral[time + offset, pln + offset, row - offset, col + offset] -
+        integral[time + offset, pln + offset, row + offset, col - offset] +
+        integral[time + offset, pln + offset, row + offset, col + offset])
+    return  max(distance, 0.0) / (s4_h_square)
+
+
 cdef inline void _integral_image_2d(double [:, :, ::] padded,
                                     double [:, ::] integral,
                                     Py_ssize_t t_row, Py_ssize_t t_col,
@@ -420,11 +466,12 @@ cdef inline void _integral_image_2d(double [:, :, ::] padded,
                                   integral[row - 1, col - 1])
 
 
-cdef inline void _integral_image_3d(double [:, :, ::] padded,
+cdef inline void _integral_image_3d(double [:, :, :, ::] padded,
                                     double [:, :, ::] integral,
                                     Py_ssize_t t_pln, Py_ssize_t t_row,
                                     Py_ssize_t t_col, Py_ssize_t n_pln,
                                     Py_ssize_t n_row, Py_ssize_t n_col,
+                                    Py_ssize_t n_channels,
                                     double var_diff) nogil:
     """
     Computes the integral of the squared difference between an image ``padded``
@@ -446,6 +493,7 @@ cdef inline void _integral_image_3d(double [:, :, ::] padded,
     n_pln : Py_ssize_t
     n_row : Py_ssize_t
     n_col : Py_ssize_t
+    n_channels : Py_ssize_t
     var_diff : np_floats
         The double of the expected noise variance.  If non-zero, this
         is used to reduce the apparent patch distances by the expected
@@ -463,15 +511,18 @@ cdef inline void _integral_image_3d(double [:, :, ::] padded,
     cdef Py_ssize_t pln_end = min(n_pln, n_pln - t_pln)
     cdef Py_ssize_t row_start = max(1, -t_row)
     cdef Py_ssize_t row_end = min(n_row, n_row - t_row)
-    cdef double distance
+    cdef double t, distance
 
     for pln in range(pln_start, pln_end):
         for row in range(row_start, row_end):
             for col in range(1, n_col - t_col):
-                distance = (padded[pln, row, col] -
-                            padded[pln + t_pln, row + t_row, col + t_col])
-                distance *= distance
-                distance -= var_diff
+                distance = 0
+                for channel in range(n_channels):
+                    t = (padded[pln, row, col, channel] -
+                         padded[pln + t_pln, row + t_row, col + t_col,
+                                channel])
+                    distance += t * t
+                distance -= n_channels * var_diff
                 integral[pln, row, col] = (
                     distance +
                     integral[pln - 1, row, col] +
@@ -481,6 +532,97 @@ cdef inline void _integral_image_3d(double [:, :, ::] padded,
                     integral[pln - 1, row - 1, col] -
                     integral[pln, row - 1, col - 1] -
                     integral[pln - 1, row, col - 1])
+
+
+cdef inline void _integral_image_4d(double [:, :, :, :, ::] padded,
+                                    double [:, :, :, ::] integral,
+                                    Py_ssize_t t_time, Py_ssize_t t_pln, Py_ssize_t t_row,
+                                    Py_ssize_t t_col, Py_ssize_t n_time, Py_ssize_t n_pln,
+                                    Py_ssize_t n_row, Py_ssize_t n_col, Py_ssize_t n_channels,
+                                    double var_diff) nogil:
+    """
+    Computes the integral of the squared difference between an image ``padded``
+    and the same image shifted by ``(t_pln, t_row, t_col)``.
+
+    Parameters
+    ----------
+    padded : ndarray of shape (n_time, n_pln, n_row, n_col)
+        Image of interest.
+    integral : ndarray
+        Output of the function. The array is filled with integral values.
+        ``integral`` should have the same shape as ``padded``.
+    t_time : Py_ssize_t
+        Shift along the time axis.
+    t_pln : Py_ssize_t
+        Shift along the plane axis.
+    t_row : Py_ssize_t
+        Shift along the row axis.
+    t_col : Py_ssize_t
+        Shift along the column axis.
+    n_time : Py_ssize_t
+    n_pln : Py_ssize_t
+    n_row : Py_ssize_t
+    n_col : Py_ssize_t
+    var_diff : double
+        The double of the expected noise variance. If non-zero, this
+        is used to reduce the apparent patch distances by the expected
+         distance due to the noise.
+
+    Notes
+    -----
+
+    The integral computation could be performed using
+    ``transform.integral_image``, but this helper function saves memory
+    by avoiding copies of ``padded``.
+    """
+    cdef Py_ssize_t time, pln, row, col, channel
+    cdef Py_ssize_t time_start = max(1, -t_time)
+    cdef Py_ssize_t time_end = min(n_time, n_time - t_time)
+    cdef Py_ssize_t pln_start = max(1, -t_pln)
+    cdef Py_ssize_t pln_end = min(n_pln, n_pln - t_pln)
+    cdef Py_ssize_t row_start = max(1, -t_row)
+    cdef Py_ssize_t row_end = min(n_row, n_row - t_row)
+    cdef double t, distance
+
+    for time in range(time_start, time_end):
+        for pln in range(pln_start, pln_end):
+            for row in range(row_start, row_end):
+                for col in range(1, n_col - t_col):
+                    if n_channels == 1:
+                        t = (padded[time, pln, row, col, 0] -
+                             padded[time + t_time, pln + t_pln,
+                                    row + t_row, col + t_col, 0])
+                        distance = t * t
+                    else:
+                        distance = 0
+                        for channel in range(n_channels):
+                            t = (padded[time, pln, row, col, channel] -
+                                 padded[time + t_time, pln + t_pln,
+                                        row + t_row, col + t_col, channel])
+                            distance += t * t
+                    distance -= n_channels * var_diff
+
+                    integral[time, pln, row, col] = (
+                        distance +
+                        # add terms with shift along 1 axis
+                        integral[time - 1, pln, row, col] +
+                        integral[time, pln - 1, row, col] +
+                        integral[time, pln, row - 1, col] +
+                        integral[time, pln, row, col - 1] +
+                        # add terms with shift along 3 axes
+                        integral[time, pln - 1, row - 1, col - 1] +
+                        integral[time - 1, pln, row - 1, col - 1] +
+                        integral[time - 1, pln - 1, row, col - 1] +
+                        integral[time - 1, pln - 1, row - 1, col] -
+                        # subtract terms with shift along 2 axes
+                        integral[time, pln, row - 1, col - 1] -
+                        integral[time, pln - 1, row, col - 1] -
+                        integral[time, pln - 1, row - 1, col] -
+                        integral[time - 1, pln, row, col - 1] -
+                        integral[time - 1, pln, row - 1, col] -
+                        integral[time - 1, pln - 1, row, col] -
+                        # subtract term with shift along 4 axes
+                        integral[time - 1, pln - 1, row - 1, col - 1])
 
 
 def _fast_nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image,
@@ -658,18 +800,21 @@ def _fast_nl_means_denoising_3d(cnp.ndarray[np_floats, ndim=3] image,
     # Image padding: we need to account for patch size, possible shift,
     # + 1 for the boundary effects in finite differences
     cdef Py_ssize_t pad_size = offset + d + 1
-    cdef double [:, :, ::1] padded = np.ascontiguousarray(
+    cdef double [:, :, :, ::1] padded = np.ascontiguousarray(
         np.pad(image, pad_size, mode='reflect').astype(np.float64))
-    cdef double [:, :, ::1] weights = np.zeros_like(padded)
-    cdef double [:, :, ::1] integral = np.zeros_like(padded)
-    cdef double [:, :, ::1] result = np.zeros_like(padded)
+    cdef double [:, :, ::1] weights = np.zeros_like(padded[..., 0])
+    cdef double [:, :, ::1] integral = np.empty_like(padded[..., 0])
+    cdef double [:, :, :, ::1] result = np.zeros_like(padded)
+
     cdef Py_ssize_t n_pln, n_row, n_col, t_pln, t_row, t_col, \
-             pln, row, col
+             pln, row, col, channel, n_channels
     cdef Py_ssize_t pln_dist_min, pln_dist_max, row_dist_min, row_dist_max, \
              col_dist_min, col_dist_max
     cdef double weight, distance, alpha
-    cdef double s_cube_h_square = h * h * s * s * s
-    n_pln, n_row, n_col = padded.shape[0], padded.shape[1], padded.shape[2]
+    n_pln, n_row, n_col, n_channels = padded.shape[0], padded.shape[1], padded.shape[2], padded.shape[3]
+    cdef double s_cube_h_square = n_channels * h * h * s * s * s
+
+
     var *= 2
 
     with nogil:
@@ -702,7 +847,7 @@ def _fast_nl_means_denoising_3d(cnp.ndarray[np_floats, ndim=3] image,
                     # padded and the same image shifted by (t_pln, t_row, t_col)
                     _integral_image_3d(padded, integral, t_pln,
                                        t_row, t_col, n_pln, n_row,
-                                       n_col, var)
+                                       n_col, n_channels, var)
 
                     # Inner loops on pixel coordinates
                     # Iterate over planes, taking offset and shift into account
@@ -725,22 +870,196 @@ def _fast_nl_means_denoising_3d(cnp.ndarray[np_floats, ndim=3] image,
                                 weights[pln, row, col] += weight
                                 weights[pln + t_pln, row + t_row,
                                                      col + t_col] += weight
-                                result[pln, row, col] += weight * \
-                                    padded[pln + t_pln, row + t_row,
-                                           col + t_col]
-                                result[pln + t_pln, row + t_row,
-                                       col + t_col] += weight * \
-                                                       padded[pln, row, col]
+                                for channel in range(n_channels):
+                                    result[pln, row, col, channel] += weight * \
+                                            padded[pln + t_pln, row + t_row,
+                                                   col + t_col, channel]
+                                    result[pln + t_pln, row + t_row,
+                                           col + t_col, channel] += weight * \
+                                                                    padded[pln, row, col, channel]
                     alpha = 1.0
 
         # Normalize pixel values using sum of weights of contributing patches
-        for pln in range(pad_size, n_pln - pad_size):
-            for row in range(pad_size, n_row - pad_size):
-                for col in range(pad_size, n_col - pad_size):
-                    # No risk of division by zero, since the contribution
-                    # of a null shift is strictly positive
-                    result[pln, row, col] /= weights[pln, row, col]
+        for pln in range(offset, n_pln - offset):
+            for row in range(offset, n_row - offset):
+                for col in range(offset, n_col - offset):
+                    for channel in range(n_channels):
+                        # No risk of division by zero, since the contribution
+                        # of a null shift is strictly positive
+                        result[pln, row, col, channel] /= weights[pln, row, col]
 
     # Return cropped result, undoing padding
-    return np.asarray(result[pad_size:-pad_size, pad_size:-pad_size,
-                             pad_size:-pad_size]).astype(dtype)
+    return np.squeeze(
+        np.asarray(result[pad_size:-pad_size,
+                          pad_size:-pad_size,
+                          pad_size:-pad_size, :], dtype=dtype)
+    )
+
+
+def _fast_nl_means_denoising_4d(cnp.ndarray[np_floats, ndim=4] image,
+                                Py_ssize_t s=3, Py_ssize_t d=3, double h=0.1,
+                                double var=0.):
+    """
+    Perform fast non-local means denoising on 3-D array, with the outer
+    loop on patch shifts in order to reduce the number of operations.
+
+    Parameters
+    ----------
+    image : ndarray
+        4-D input data to be denoised.
+    s : Py_ssize_t, optional
+        Size of patches used for denoising.
+    d : tuple of Py_ssize_t, optional
+        Maximal distance in pixels along each axis to search for patches used for denoising.
+    h : double, optional
+        cut-off distance (in gray levels). The higher h, the more permissive
+        one is in accepting patches.
+    var : double
+        Expected noise variance.  If non-zero, this is used to reduce the
+        apparent patch distances by the expected distance due to the noise.
+
+    Returns
+    -------
+    result : ndarray
+        Denoised image, of same shape as input image.
+
+    References
+    ----------
+    J. Darbon, A. Cunha, T.F. Chan, S. Osher, and G.J. Jensen, Fast
+    nonlocal filtering applied to electron cryomicroscopy, in 5th IEEE
+    International Symposium on Biomedical Imaging: From Nano to Macro,
+    2008, pp. 1331-1334.
+
+    Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
+    Denoising. Image Processing On Line, 2014, vol. 4, p. 300-326.
+    """
+
+    cdef double DISTANCE_CUTOFF = 5.0
+    if s % 2 == 0:
+        s += 1  # odd value for symmetric patch
+
+    if np_floats is cnp.float32_t:
+        dtype = np.float32
+    else:
+        dtype = np.float64
+
+    cdef Py_ssize_t offset = s / 2
+    # Image padding: we need to account for patch size, possible shift,
+    # + 1 for the boundary effects in finite differences
+    cdef Py_ssize_t pad_size = offset + d + 1
+    cdef double [:, :, :, :, ::1] padded = np.ascontiguousarray(
+        np.pad(image,
+               ((pad_size, pad_size),
+                (pad_size, pad_size),
+                (pad_size, pad_size),
+                (pad_size, pad_size),
+                (0, 0)),
+               mode='reflect'),
+        dtype=np.float64)
+    cdef double [:, :, :, :, ::1] result = np.zeros_like(padded)
+    cdef double [:, :, :, ::1] weights = np.zeros_like(padded[..., 0])
+    cdef double [:, :, :, ::1] integral = np.zeros_like(padded[..., 0])
+    cdef Py_ssize_t n_pln, n_row, n_col, t_pln, t_row, t_col, \
+             pln, row, col, channel, n_channels, t_time, n_time, time
+    cdef Py_ssize_t time_dist_min, time_dist_max, pln_dist_min, pln_dist_max, \
+             row_dist_min, row_dist_max, col_dist_min, col_dist_max,
+    cdef Py_ssize_t d_row, d_col, d_pln, d_time
+    cdef double weight, distance, alpha
+    n_time, n_pln, n_row, n_col, n_channels = padded.shape[0], padded.shape[1], padded.shape[2], padded.shape[3], padded.shape[4]
+    cdef double s4_h_square = n_channels * h * h * s * s * s * s
+
+    # Outer loops on patch shifts
+    # With t2 >= 0, reference patch is always on the left of test patch
+    # Iterate over shifts along the plane axis
+    var *= 2
+    with nogil:
+        for t_time in range(-d, d + 1):
+            time_dist_min = max(offset, offset - t_time)
+            time_dist_max = min(n_time - offset, n_time - offset - t_time)
+            # alpha is to account for patches on the same column
+            # distance is computed twice in this case
+            if t_time == 0:
+                alpha = 1.0
+            else:
+                alpha = 0.5
+            for t_pln in range(-d, d + 1):
+                pln_dist_min = max(offset, offset - t_pln)
+                pln_dist_max = min(n_pln - offset, n_pln - offset - t_pln)
+                if t_pln == 0:
+                    alpha = 1.0
+                else:
+                    alpha = 0.5
+                # Iterate over shifts along the row axis
+                for t_row in range(-d, d + 1):
+                    row_dist_min = max(offset, offset - t_row)
+                    row_dist_max = min(n_row - offset, n_row - offset - t_row)
+                    if t_row == 0:
+                        alpha = 1.0
+                    else:
+                        alpha = 0.5
+                    # Iterate over shifts along the column axis
+                    for t_col in range(0, d + 1):
+                        col_dist_min = offset
+                        col_dist_max = n_col - offset - t_col
+
+                        # Compute integral image of the squared difference between
+                        # padded and the same image shifted by (t_pln, t_row, t_col)
+                        _integral_image_4d(padded, integral, t_time, t_pln, t_row,
+                                           t_col, n_time, n_pln, n_row, n_col,
+                                           n_channels, var)
+
+                        # Inner loops on pixel coordinates
+                        # Iterate over planes, taking offset and shift into account
+                        for time in range(time_dist_min, time_dist_max):
+                            for pln in range(pln_dist_min, pln_dist_max):
+                                # Iterate over rows, taking offset and shift
+                                # into account
+                                for row in range(row_dist_min, row_dist_max):
+                                    # Iterate over columns
+                                    for col in range(col_dist_min, col_dist_max):
+                                        # Compute squared distance between
+                                        # shifted patches
+                                        distance = _integral_to_distance_4d(
+                                            integral, time, pln, row, col, offset,
+                                            s4_h_square)
+                                        # exp of large negative numbers is close to zero
+                                        if distance > DISTANCE_CUTOFF:
+                                            continue
+
+                                        weight = alpha * _fast_exp(-distance)
+                                        # Accumulate weights for the different shifts
+                                        weights[time, pln, row, col] += weight
+                                        weights[time + t_time, pln + t_pln,
+                                                row + t_row, col + t_col] += weight
+                                        for channel in range(n_channels):
+                                            result[time, pln, row, col,
+                                                   channel] += weight * \
+                                                       padded[time + t_time,
+                                                              pln + t_pln,
+                                                              row + t_row,
+                                                              col + t_col, channel]
+                                            result[time + t_time, pln + t_pln,
+                                                   row + t_row, col + t_col,
+                                                   channel] += weight * \
+                                                       padded[time, pln, row,
+                                                              col, channel]
+                        alpha = 1.0
+
+        # Normalize pixel values using sum of weights of contributing patches
+        for time in range(offset, n_time - offset):
+            for pln in range(offset, n_pln - offset):
+                for row in range(offset, n_row - offset):
+                    for col in range(offset, n_col - offset):
+                        for channel in range(n_channels):
+                            # No risk of division by zero, since the contribution
+                            # of a null shift is strictly positive
+                            result[time, pln, row, col, channel] /= weights[
+                                time, pln, row, col]
+
+    # Return cropped result, undoing padding
+    return np.squeeze(
+        np.asarray(result[pad_size:-pad_size,
+                          pad_size:-pad_size,
+                          pad_size:-pad_size,
+                          pad_size:-pad_size, :], dtype=dtype)
+    )

--- a/skimage/restoration/non_local_means.py
+++ b/skimage/restoration/non_local_means.py
@@ -1,12 +1,14 @@
-import numpy as np
 from warnings import warn
+
+import numpy as np
+
 from .._shared import utils
 from .._shared.utils import convert_to_float
-from ._nl_means_denoising import (
-    _nl_means_denoising_2d,
-    _nl_means_denoising_3d,
-    _fast_nl_means_denoising_2d,
-    _fast_nl_means_denoising_3d)
+from ._nl_means_denoising import (_nl_means_denoising_2d,
+                                  _nl_means_denoising_3d,
+                                  _fast_nl_means_denoising_2d,
+                                  _fast_nl_means_denoising_3d,
+                                  _fast_nl_means_denoising_4d)
 
 
 @utils.channel_as_last_axis()
@@ -143,14 +145,18 @@ def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
     >>> rng = np.random.default_rng()
     >>> a += 0.3 * rng.standard_normal(a.shape)
     >>> denoised_a = denoise_nl_means(a, 7, 5, 0.1)
-
     """
-    if image.ndim == 2:
+    if channel_axis is None:
+        multichannel = False
         image = image[..., np.newaxis]
-        channel_axis = -1
-    if image.ndim != 3:
-        raise NotImplementedError("Non-local means denoising is only \
-        implemented for 2D grayscale and RGB images or 3-D grayscale images.")
+    else:
+        multichannel = True
+
+    ndim_no_channel = image.ndim - 1
+    if (ndim_no_channel < 2) or (ndim_no_channel > 4):
+        raise NotImplementedError(
+            "Non-local means denoising is only implemented for 2D, "
+            "3D or 4D grayscale or multichannel images.")
 
     if preserve_range is None and np.issubdtype(image.dtype, np.integer):
         warn('Image dtype is not float. By default denoise_nl_means will '
@@ -166,13 +172,23 @@ def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
         image = np.ascontiguousarray(image)
 
     kwargs = dict(s=patch_size, d=patch_distance, h=h, var=sigma * sigma)
-    if channel_axis is not None:  # 2-D images
+    if ndim_no_channel == 2:
+        nlm_func = (_fast_nl_means_denoising_2d if fast_mode else
+                    _nl_means_denoising_2d)
+    elif ndim_no_channel == 3:
+        if multichannel and not fast_mode:
+            raise NotImplementedError(
+                "Multichannel 3D requires fast_mode to be True.")
         if fast_mode:
-            return _fast_nl_means_denoising_2d(image, **kwargs)
+            nlm_func = _fast_nl_means_denoising_3d
         else:
-            return _nl_means_denoising_2d(image, **kwargs)
-    else:  # 3-D grayscale
+            # have to drop the size 1 channel axis for slow mode
+            image = image[..., 0]
+            nlm_func = _nl_means_denoising_3d
+    elif ndim_no_channel == 4:
         if fast_mode:
-            return _fast_nl_means_denoising_3d(image, **kwargs)
+            nlm_func = _fast_nl_means_denoising_4d
         else:
-            return _nl_means_denoising_3d(image, **kwargs)
+            raise NotImplementedError("4D requires fast_mode to be True.")
+    dn = np.asarray(nlm_func(image, **kwargs))
+    return dn

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -537,21 +537,21 @@ def test_denoise_nl_means_4d():
     for ch in range(img.shape[-1]):
         denoised_3d[..., ch] = restoration.denoise_nl_means(
             imgn[..., ch],
-            multichannel=False,
+            channel_axis=None,
             **nlmeans_kwargs)
     psnr_3d = peak_signal_noise_ratio(img, denoised_3d, data_range=1.)
     assert psnr_3d > psnr_noisy
 
     # denoise as 4D
     denoised_4d = restoration.denoise_nl_means(imgn,
-                                               multichannel=False,
+                                               channel_axis=None,
                                                **nlmeans_kwargs)
     psnr_4d = peak_signal_noise_ratio(img, denoised_4d, data_range=1.)
     assert psnr_4d > psnr_3d
 
     # denoise as 3D + channels instead
     denoised_3dmc = restoration.denoise_nl_means(imgn,
-                                                 multichannel=True,
+                                                 channel_axis=-1,
                                                  **nlmeans_kwargs)
     psnr_3dmc = peak_signal_noise_ratio(img, denoised_3dmc, data_range=1.)
     assert psnr_3dmc > psnr_3d
@@ -567,7 +567,7 @@ def test_denoise_nl_means_4d_multichannel():
 
     denoised_4dmc = restoration.denoise_nl_means(imgn, 3, 3, h=0.35 * sigma,
                                                  fast_mode=True,
-                                                 multichannel=True,
+                                                 channel_axis=None,
                                                  sigma=sigma)
     psnr_4dmc = peak_signal_noise_ratio(img, denoised_4dmc, data_range=1.)
     assert psnr_4dmc > psnr_noisy
@@ -577,31 +577,31 @@ def test_denoise_nl_means_wrong_dimension():
     # 1D not implemented
     img = np.zeros((5, ))
     with pytest.raises(NotImplementedError):
-        restoration.denoise_nl_means(img, multichannel=False)
+        restoration.denoise_nl_means(img, channel_axis=None)
 
     img = np.zeros((5, 3))
     with pytest.raises(NotImplementedError):
-        restoration.denoise_nl_means(img, multichannel=True)
+        restoration.denoise_nl_means(img, channel_axis=-1)
 
     # 3D + channels only for fast mode
     img = np.zeros((5, 5, 5, 5))
     with pytest.raises(NotImplementedError):
-        restoration.denoise_nl_means(img, multichannel=True, fast_mode=False)
+        restoration.denoise_nl_means(img, channel_axis=-1, fast_mode=False)
 
     # 4D only for fast mode
     img = np.zeros((5, 5, 5, 5))
     with pytest.raises(NotImplementedError):
-        restoration.denoise_nl_means(img, multichannel=False, fast_mode=False)
+        restoration.denoise_nl_means(img, channel_axis=None, fast_mode=False)
 
     # 4D + channels only for fast mode
     img = np.zeros((5, 5, 5, 5, 5))
     with pytest.raises(NotImplementedError):
-        restoration.denoise_nl_means(img, multichannel=True, fast_mode=False)
+        restoration.denoise_nl_means(img, channel_axis=-1, fast_mode=False)
 
     # 5D not implemented
     img = np.zeros((5, 5, 5, 5, 5))
     with pytest.raises(NotImplementedError):
-        restoration.denoise_nl_means(img, multichannel=False)
+        restoration.denoise_nl_means(img, channel_axis=None)
 
 
 @pytest.mark.parametrize('fast_mode', [False, True])

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -4,7 +4,7 @@ import itertools
 import numpy as np
 import pytest
 import pywt
-from numpy.testing import (assert_, assert_almost_equal, assert_equal,
+from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_warns)
 
 from skimage import color, data, img_as_float, restoration
@@ -73,7 +73,7 @@ def test_denoise_tv_chambolle_multichannel(channel_axis):
     denoised = restoration.denoise_tv_chambolle(img, weight=0.1,
                                                 channel_axis=channel_axis)
     _at = functools.partial(slice_at_axis, axis=channel_axis % img.ndim)
-    assert_equal(denoised[_at(0)], denoised0)
+    assert_array_equal(denoised[_at(0)], denoised0)
 
     # tile astronaut subset to generate 3D+channels data
     astro3 = np.tile(astro[:64, :64, np.newaxis, :], [1, 1, 2, 1])
@@ -86,7 +86,7 @@ def test_denoise_tv_chambolle_multichannel(channel_axis):
                                                 channel_axis=channel_axis)
     _at = functools.partial(slice_at_axis,
                             axis=channel_axis % astro3.ndim)
-    assert_equal(denoised[_at(0)], denoised0)
+    assert_array_equal(denoised[_at(0)], denoised0)
 
 
 def test_denoise_tv_chambolle_multichannel_deprecation():
@@ -101,20 +101,20 @@ def test_denoise_tv_chambolle_multichannel_deprecation():
         denoised = restoration.denoise_tv_chambolle(astro, 0.1, 2e-4, 200,
                                                     True)
 
-    assert_equal(denoised[..., 0], denoised0)
+    assert_array_equal(denoised[..., 0], denoised0)
 
 
 def test_denoise_tv_chambolle_float_result_range():
     # astronaut image
     img = astro_gray
     int_astro = np.multiply(img, 255).astype(np.uint8)
-    assert_(np.max(int_astro) > 1)
+    assert np.max(int_astro) > 1
     denoised_int_astro = restoration.denoise_tv_chambolle(int_astro,
                                                           weight=0.1)
     # test if the value range of output float data is within [0.0:1.0]
-    assert_(denoised_int_astro.dtype == float)
-    assert_(np.max(denoised_int_astro) <= 1.0)
-    assert_(np.min(denoised_int_astro) >= 0.0)
+    assert denoised_int_astro.dtype == float
+    assert np.max(denoised_int_astro) <= 1.0
+    assert np.min(denoised_int_astro) >= 0.0
 
 
 def test_denoise_tv_chambolle_3d():
@@ -127,8 +127,8 @@ def test_denoise_tv_chambolle_3d():
     mask[mask < 0] = 0
     mask[mask > 255] = 255
     res = restoration.denoise_tv_chambolle(mask.astype(np.uint8), weight=0.1)
-    assert_(res.dtype == float)
-    assert_(res.std() * 255 < mask.std())
+    assert res.dtype == float
+    assert res.std() * 255 < mask.std()
 
 
 def test_denoise_tv_chambolle_1d():
@@ -137,16 +137,16 @@ def test_denoise_tv_chambolle_1d():
     x += 20 * np.random.rand(x.size)
     x = np.clip(x, 0, 255)
     res = restoration.denoise_tv_chambolle(x.astype(np.uint8), weight=0.1)
-    assert_(res.dtype == float)
-    assert_(res.std() * 255 < x.std())
+    assert res.dtype == float
+    assert res.std() * 255 < x.std()
 
 
 def test_denoise_tv_chambolle_4d():
     """ TV denoising for a 4D input."""
     im = 255 * np.random.rand(8, 8, 8, 8)
     res = restoration.denoise_tv_chambolle(im.astype(np.uint8), weight=0.1)
-    assert_(res.dtype == float)
-    assert_(res.std() * 255 < im.std())
+    assert res.dtype == float
+    assert res.std() * 255 < im.std()
 
 
 def test_denoise_tv_chambolle_weighting():
@@ -163,8 +163,8 @@ def test_denoise_tv_chambolle_weighting():
     w = 0.2
     denoised_2d = restoration.denoise_tv_chambolle(img2d, weight=w)
     denoised_4d = restoration.denoise_tv_chambolle(img4d, weight=w)
-    assert_(structural_similarity(denoised_2d,
-                                  denoised_4d[:, :, 0, 0]) > 0.99)
+    assert structural_similarity(denoised_2d,
+                                 denoised_4d[:, :, 0, 0]) > 0.99
 
 
 def test_denoise_tv_bregman_2d():
@@ -177,20 +177,20 @@ def test_denoise_tv_bregman_2d():
     out2 = restoration.denoise_tv_bregman(img, weight=5)
 
     # make sure noise is reduced in the checkerboard cells
-    assert_(img[30:45, 5:15].std() > out1[30:45, 5:15].std())
-    assert_(out1[30:45, 5:15].std() > out2[30:45, 5:15].std())
+    assert img[30:45, 5:15].std() > out1[30:45, 5:15].std()
+    assert out1[30:45, 5:15].std() > out2[30:45, 5:15].std()
 
 
 def test_denoise_tv_bregman_float_result_range():
     # astronaut image
     img = astro_gray.copy()
     int_astro = np.multiply(img, 255).astype(np.uint8)
-    assert_(np.max(int_astro) > 1)
+    assert np.max(int_astro) > 1
     denoised_int_astro = restoration.denoise_tv_bregman(int_astro, weight=60.0)
     # test if the value range of output float data is within [0.0:1.0]
-    assert_(denoised_int_astro.dtype == float)
-    assert_(np.max(denoised_int_astro) <= 1.0)
-    assert_(np.min(denoised_int_astro) >= 0.0)
+    assert denoised_int_astro.dtype == float
+    assert np.max(denoised_int_astro) <= 1.0
+    assert np.min(denoised_int_astro) >= 0.0
 
 
 def test_denoise_tv_bregman_3d():
@@ -203,8 +203,8 @@ def test_denoise_tv_bregman_3d():
     out2 = restoration.denoise_tv_bregman(img, weight=5)
 
     # make sure noise is reduced in the checkerboard cells
-    assert_(img[30:45, 5:15].std() > out1[30:45, 5:15].std())
-    assert_(out1[30:45, 5:15].std() > out2[30:45, 5:15].std())
+    assert img[30:45, 5:15].std() > out1[30:45, 5:15].std()
+    assert out1[30:45, 5:15].std() > out2[30:45, 5:15].std()
 
 
 @pytest.mark.parametrize('channel_axis', [0, 1, 2, -1])
@@ -216,7 +216,7 @@ def test_denoise_tv_bregman_3d_multichannel(channel_axis):
                                               channel_axis=channel_axis)
     _at = functools.partial(slice_at_axis,
                             axis=channel_axis % img_astro.ndim)
-    assert_equal(denoised0, denoised[_at(0)])
+    assert_array_equal(denoised0, denoised[_at(0)])
 
 
 def test_denoise_tv_bregman_3d_multichannel_deprecation():
@@ -226,7 +226,7 @@ def test_denoise_tv_bregman_3d_multichannel_deprecation():
         denoised = restoration.denoise_tv_bregman(img_astro, weight=60.0,
                                                   multichannel=True)
 
-    assert_equal(denoised0, denoised[..., 0])
+    assert_array_equal(denoised0, denoised[..., 0])
 
 
 def test_denoise_tv_bregman_max_iter_deprecation():
@@ -243,7 +243,7 @@ def test_denoise_tv_bregman_multichannel():
     out1 = restoration.denoise_tv_bregman(img, weight=60.0)
     out2 = restoration.denoise_tv_bregman(img, weight=60.0, channel_axis=-1)
 
-    assert_equal(out1, out2)
+    assert_array_equal(out1, out2)
 
 
 def test_denoise_bilateral_2d():
@@ -258,8 +258,8 @@ def test_denoise_bilateral_2d():
                                          sigma_spatial=20, channel_axis=None)
 
     # make sure noise is reduced in the checkerboard cells
-    assert_(img[30:45, 5:15].std() > out1[30:45, 5:15].std())
-    assert_(out1[30:45, 5:15].std() > out2[30:45, 5:15].std())
+    assert img[30:45, 5:15].std() > out1[30:45, 5:15].std()
+    assert out1[30:45, 5:15].std() > out2[30:45, 5:15].std()
 
 
 def test_denoise_bilateral_pad():
@@ -272,7 +272,7 @@ def test_denoise_bilateral_pad():
     condition_padding = np.count_nonzero(np.isclose(img_bil,
                                                     0,
                                                     atol=0.001))
-    assert_equal(condition_padding, 0)
+    assert_array_equal(condition_padding, 0)
 
 
 @pytest.mark.parametrize('dtype', [np.float32, np.double])
@@ -300,12 +300,14 @@ def test_denoise_bregman_types(dtype):
 
 def test_denoise_bilateral_zeros():
     img = np.zeros((10, 10))
-    assert_equal(img, restoration.denoise_bilateral(img, channel_axis=None))
+    assert_array_equal(img,
+                       restoration.denoise_bilateral(img, channel_axis=None))
 
 
 def test_denoise_bilateral_constant():
     img = np.ones((10, 10)) * 5
-    assert_equal(img, restoration.denoise_bilateral(img, channel_axis=None))
+    assert_array_equal(img,
+                       restoration.denoise_bilateral(img, channel_axis=None))
 
 
 @pytest.mark.parametrize('channel_axis', [0, 1, -1])
@@ -327,8 +329,8 @@ def test_denoise_bilateral_color(channel_axis):
     out2 = np.moveaxis(out2, channel_axis, -1)
 
     # make sure noise is reduced in the checkerboard cells
-    assert_(img[30:45, 5:15].std() > out1[30:45, 5:15].std())
-    assert_(out1[30:45, 5:15].std() > out2[30:45, 5:15].std())
+    assert img[30:45, 5:15].std() > out1[30:45, 5:15].std()
+    assert out1[30:45, 5:15].std() > out2[30:45, 5:15].std()
 
 
 def test_denoise_bilateral_multichannel_deprecation():
@@ -347,8 +349,8 @@ def test_denoise_bilateral_multichannel_deprecation():
                                              multichannel=True)
 
     # make sure noise is reduced in the checkerboard cells
-    assert_(img[30:45, 5:15].std() > out1[30:45, 5:15].std())
-    assert_(out1[30:45, 5:15].std() > out2[30:45, 5:15].std())
+    assert img[30:45, 5:15].std() > out1[30:45, 5:15].std()
+    assert out1[30:45, 5:15].std() > out2[30:45, 5:15].std()
 
 
 def test_denoise_bilateral_3d_grayscale():
@@ -362,7 +364,7 @@ def test_denoise_bilateral_3d_multichannel():
     with expected_warnings(["grayscale"]):
         result = restoration.denoise_bilateral(img, channel_axis=-1)
 
-    assert_equal(result, img)
+    assert_array_equal(result, img)
 
 
 def test_denoise_bilateral_multidimensional():
@@ -379,7 +381,7 @@ def test_denoise_bilateral_nan():
     # Python 3.5 will not trigger a warning.
     with expected_warnings([r'invalid|\A\Z']):
         out = restoration.denoise_bilateral(img, channel_axis=None)
-    assert_equal(img, out)
+    assert_array_equal(img, out)
 
 
 @pytest.mark.parametrize('fast_mode', [False, True])
@@ -395,14 +397,14 @@ def test_denoise_nl_means_2d(fast_mode):
                                                 channel_axis=None,
                                                 sigma=s)
         # make sure noise is reduced
-        assert_(img.std() > denoised.std())
+        assert img.std() > denoised.std()
 
         denoised_f32 = restoration.denoise_nl_means(img_f32, 7, 5, 0.2,
                                                     fast_mode=fast_mode,
                                                     channel_axis=None,
                                                     sigma=s)
         # make sure noise is reduced
-        assert_(img.std() > denoised_f32.std())
+        assert img.std() > denoised_f32.std()
 
         # Sheck single precision result
         assert np.allclose(denoised_f32, denoised, atol=1e-2)
@@ -435,7 +437,7 @@ def test_denoise_nl_means_2d_multichannel(fast_mode, n_channels, dtype):
             denoised[..., :n_channels], img[..., :n_channels])
 
         # make sure noise is reduced
-        assert_(psnr_denoised > psnr_noisy)
+        assert psnr_denoised > psnr_noisy
 
 
 def test_denoise_nl_means_2d_multichannel_deprecated():
@@ -456,7 +458,7 @@ def test_denoise_nl_means_2d_multichannel_deprecated():
     psnr_denoised = peak_signal_noise_ratio(denoised, img)
 
     # make sure noise is reduced
-    assert_(psnr_denoised > psnr_noisy)
+    assert psnr_denoised > psnr_noisy
 
     # providing multichannel argument positionally also warns
     with expected_warnings(["Providing the `multichannel` argument"]):
@@ -478,7 +480,7 @@ def test_denoise_nl_means_3d(fast_mode, dtype):
                                                 fast_mode=fast_mode,
                                                 channel_axis=None, sigma=s)
         # make sure noise is reduced
-        assert_(peak_signal_noise_ratio(img, denoised) > psnr_noisy)
+        assert peak_signal_noise_ratio(img, denoised) > psnr_noisy
 
 
 @pytest.mark.parametrize('fast_mode', [False, True])
@@ -514,7 +516,7 @@ def test_denoise_nl_means_multichannel(fast_mode, dtype, channel_axis):
 
     psnr_wrong = peak_signal_noise_ratio(img, denoised_wrong_multichannel)
     psnr_ok = peak_signal_noise_ratio(img, denoised_ok_multichannel)
-    assert_(psnr_ok > psnr_wrong)
+    assert psnr_ok > psnr_wrong
 
 
 def test_denoise_nl_means_4d():
@@ -538,21 +540,21 @@ def test_denoise_nl_means_4d():
             multichannel=False,
             **nlmeans_kwargs)
     psnr_3d = peak_signal_noise_ratio(img, denoised_3d, data_range=1.)
-    assert_(psnr_3d > psnr_noisy)
+    assert psnr_3d > psnr_noisy
 
     # denoise as 4D
     denoised_4d = restoration.denoise_nl_means(imgn,
                                                multichannel=False,
                                                **nlmeans_kwargs)
     psnr_4d = peak_signal_noise_ratio(img, denoised_4d, data_range=1.)
-    assert_(psnr_4d > psnr_3d)
+    assert psnr_4d > psnr_3d
 
     # denoise as 3D + channels instead
     denoised_3dmc = restoration.denoise_nl_means(imgn,
                                                  multichannel=True,
                                                  **nlmeans_kwargs)
     psnr_3dmc = peak_signal_noise_ratio(img, denoised_3dmc, data_range=1.)
-    assert_(psnr_3dmc > psnr_3d)
+    assert psnr_3dmc > psnr_3d
 
 
 def test_denoise_nl_means_4d_multichannel():
@@ -568,7 +570,7 @@ def test_denoise_nl_means_4d_multichannel():
                                                  multichannel=True,
                                                  sigma=sigma)
     psnr_4dmc = peak_signal_noise_ratio(img, denoised_4dmc, data_range=1.)
-    assert_(psnr_4dmc > psnr_noisy)
+    assert psnr_4dmc > psnr_noisy
 
 
 def test_denoise_nl_means_wrong_dimension():
@@ -613,11 +615,11 @@ def test_no_denoising_for_small_h(fast_mode, dtype):
     denoised = restoration.denoise_nl_means(img, 7, 5, 0.01,
                                             fast_mode=fast_mode,
                                             channel_axis=None)
-    assert_(np.allclose(denoised, img))
+    assert np.allclose(denoised, img)
     denoised = restoration.denoise_nl_means(img, 7, 5, 0.01,
                                             fast_mode=fast_mode,
                                             channel_axis=None)
-    assert_(np.allclose(denoised, img))
+    assert np.allclose(denoised, img)
 
 
 @pytest.mark.parametrize('fast_mode', [False, True])
@@ -676,7 +678,7 @@ def test_wavelet_denoising(img, multichannel, convert2ycbcr):
                                            rescale_sigma=True)
     psnr_noisy = peak_signal_noise_ratio(img, noisy)
     psnr_denoised = peak_signal_noise_ratio(img, denoised)
-    assert_(psnr_denoised > psnr_noisy)
+    assert psnr_denoised > psnr_noisy
 
     # Verify that SNR is improved with internally estimated sigma
     denoised = restoration.denoise_wavelet(noisy,
@@ -685,7 +687,7 @@ def test_wavelet_denoising(img, multichannel, convert2ycbcr):
                                            rescale_sigma=True)
     psnr_noisy = peak_signal_noise_ratio(img, noisy)
     psnr_denoised = peak_signal_noise_ratio(img, denoised)
-    assert_(psnr_denoised > psnr_noisy)
+    assert psnr_denoised > psnr_noisy
 
     # SNR is improved less with 1 wavelet level than with the default.
     denoised_1 = restoration.denoise_wavelet(noisy,
@@ -694,8 +696,8 @@ def test_wavelet_denoising(img, multichannel, convert2ycbcr):
                                              convert2ycbcr=convert2ycbcr,
                                              rescale_sigma=True)
     psnr_denoised_1 = peak_signal_noise_ratio(img, denoised_1)
-    assert_(psnr_denoised > psnr_denoised_1)
-    assert_(psnr_denoised_1 > psnr_noisy)
+    assert psnr_denoised > psnr_denoised_1
+    assert psnr_denoised_1 > psnr_noisy
 
     # Test changing noise_std (higher threshold, so less energy in signal)
     res1 = restoration.denoise_wavelet(noisy, sigma=2 * sigma,
@@ -704,7 +706,7 @@ def test_wavelet_denoising(img, multichannel, convert2ycbcr):
     res2 = restoration.denoise_wavelet(noisy, sigma=sigma,
                                        channel_axis=channel_axis,
                                        rescale_sigma=True)
-    assert_(np.sum(res1**2) <= np.sum(res2**2))
+    assert np.sum(res1**2) <= np.sum(res2**2)
 
 
 @pytest.mark.parametrize('channel_axis', [0, 1, 2, -1])
@@ -726,7 +728,7 @@ def test_wavelet_denoising_channel_axis(channel_axis, convert2ycbcr):
                                            rescale_sigma=True)
     psnr_noisy = peak_signal_noise_ratio(img, noisy)
     psnr_denoised = peak_signal_noise_ratio(img, denoised)
-    assert_(psnr_denoised > psnr_noisy)
+    assert psnr_denoised > psnr_noisy
 
 
 def test_wavelet_denoising_deprecated():
@@ -743,7 +745,7 @@ def test_wavelet_denoising_deprecated():
                                                rescale_sigma=True)
     psnr_noisy = peak_signal_noise_ratio(img, noisy)
     psnr_denoised = peak_signal_noise_ratio(img, denoised)
-    assert_(psnr_denoised > psnr_noisy)
+    assert psnr_denoised > psnr_noisy
 
     # providing multichannel argument positionally also warns
     with expected_warnings(["Providing the `multichannel` argument"]):
@@ -812,7 +814,7 @@ def test_wavelet_denoising_scaling(case, dtype, convert2ycbcr,
                                                 data_range=data_range)
 
         # output's max value is not substantially smaller than x's
-        assert_(denoised.max() > 0.9 * x.max())
+        assert denoised.max() > 0.9 * x.max()
     else:
         # have to compare to x_as_float in integer input cases
         x_as_float = img_as_float(x)
@@ -821,13 +823,13 @@ def test_wavelet_denoising_scaling(case, dtype, convert2ycbcr,
                                                 data_range=f_data_range)
 
         # output has been clipped to expected range
-        assert_(denoised.max() <= 1.0)
+        assert denoised.max() <= 1.0
         if np.dtype(dtype).kind == 'u':
-            assert_(denoised.min() >= 0)
+            assert denoised.min() >= 0
         else:
-            assert_(denoised.min() >= -1)
+            assert denoised.min() >= -1
 
-    assert_(psnr_denoised > psnr_noisy)
+    assert psnr_denoised > psnr_noisy
 
 
 def test_wavelet_threshold():
@@ -843,7 +845,7 @@ def test_wavelet_threshold():
                                   threshold=sigma)
     psnr_noisy = peak_signal_noise_ratio(img, noisy)
     psnr_denoised = peak_signal_noise_ratio(img, denoised)
-    assert_(psnr_denoised > psnr_noisy)
+    assert psnr_denoised > psnr_noisy
 
     # either method or threshold must be defined
     with pytest.raises(ValueError):
@@ -888,7 +890,7 @@ def test_wavelet_denoising_nd(rescale_sigma, method, ndim):
         rescale_sigma=rescale_sigma)
     psnr_noisy = peak_signal_noise_ratio(img, noisy)
     psnr_denoised = peak_signal_noise_ratio(img, denoised)
-    assert_(psnr_denoised > psnr_noisy)
+    assert psnr_denoised > psnr_noisy
 
 
 def test_wavelet_invalid_method():
@@ -921,7 +923,7 @@ def test_wavelet_denoising_levels(rescale_sigma):
     psnr_denoised_1 = peak_signal_noise_ratio(img, denoised_1)
 
     # multi-level case should outperform single level case
-    assert_(psnr_denoised > psnr_denoised_1 > psnr_noisy)
+    assert psnr_denoised > psnr_denoised_1 > psnr_noisy
 
     # invalid number of wavelet levels results in a ValueError or UserWarning
     max_level = pywt.dwt_max_level(np.min(img.shape),
@@ -949,7 +951,7 @@ def test_estimate_sigma_gray():
     img += sigma * rstate.standard_normal(img.shape)
 
     sigma_est = restoration.estimate_sigma(img, channel_axis=None)
-    assert_almost_equal(sigma, sigma_est, decimal=2)
+    assert_array_almost_equal(sigma, sigma_est, decimal=2)
 
 
 def test_estimate_sigma_masked_image():
@@ -966,7 +968,7 @@ def test_estimate_sigma_masked_image():
     img[center_roi] = sigma * rstate.standard_normal(img[center_roi].shape)
 
     sigma_est = restoration.estimate_sigma(img, channel_axis=None)
-    assert_almost_equal(sigma, sigma_est, decimal=1)
+    assert_array_almost_equal(sigma, sigma_est, decimal=1)
 
 
 @pytest.mark.parametrize('channel_axis', [0, 1, 2, -1])
@@ -981,12 +983,12 @@ def test_estimate_sigma_color(channel_axis):
 
     sigma_est = restoration.estimate_sigma(img, channel_axis=channel_axis,
                                            average_sigmas=True)
-    assert_almost_equal(sigma, sigma_est, decimal=2)
+    assert_array_almost_equal(sigma, sigma_est, decimal=2)
 
     sigma_list = restoration.estimate_sigma(img, channel_axis=channel_axis,
                                             average_sigmas=False)
-    assert_equal(len(sigma_list), img.shape[channel_axis])
-    assert_almost_equal(sigma_list[0], sigma_est, decimal=2)
+    assert_array_equal(len(sigma_list), img.shape[channel_axis])
+    assert_array_almost_equal(sigma_list[0], sigma_est, decimal=2)
 
     if channel_axis % img.ndim == 2:
         # default channel_axis=None should raise a warning about last axis size
@@ -1004,12 +1006,12 @@ def test_estimate_sigma_color_deprecated_multichannel():
     with expected_warnings(["`multichannel` is a deprecated argument"]):
         sigma_est = restoration.estimate_sigma(img, multichannel=True,
                                                average_sigmas=True)
-    assert_almost_equal(sigma, sigma_est, decimal=2)
+    assert_array_almost_equal(sigma, sigma_est, decimal=2)
 
     # providing multichannel argument positionally also warns
     with expected_warnings(["Providing the `multichannel` argument"]):
         sigma_est = restoration.estimate_sigma(img, True, True)
-    assert_almost_equal(sigma, sigma_est, decimal=2)
+    assert_array_almost_equal(sigma, sigma_est, decimal=2)
 
 
 @pytest.mark.parametrize('rescale_sigma', [True, False])
@@ -1086,7 +1088,7 @@ def test_cycle_spinning_multichannel(rescale_sigma):
                                            func_kw=func_kw,
                                            channel_axis=channel_axis)
             dn = denoise_func(noisy, **func_kw)
-        assert_equal(dn, dn_cc)
+        assert_array_equal(dn, dn_cc)
 
         # denoising with cycle spinning will give better PSNR than without
         for max_shifts in valid_shifts:
@@ -1097,7 +1099,7 @@ def test_cycle_spinning_multichannel(rescale_sigma):
                                                channel_axis=channel_axis)
             psnr = peak_signal_noise_ratio(img, dn)
             psnr_cc = peak_signal_noise_ratio(img, dn_cc)
-            assert_(psnr_cc > psnr)
+            assert psnr_cc > psnr
 
         for shift_steps in valid_steps:
             with expected_warnings([DASK_NOT_INSTALLED_WARNING]):
@@ -1108,7 +1110,7 @@ def test_cycle_spinning_multichannel(rescale_sigma):
                                                channel_axis=channel_axis)
             psnr = peak_signal_noise_ratio(img, dn)
             psnr_cc = peak_signal_noise_ratio(img, dn_cc)
-            assert_(psnr_cc > psnr)
+            assert psnr_cc > psnr
 
         for max_shifts in invalid_shifts:
             with pytest.raises(ValueError):
@@ -1145,8 +1147,8 @@ def test_cycle_spinning_num_workers():
         dn_cc3 = restoration.cycle_spin(noisy, denoise_func, max_shifts=1,
                                         func_kw=func_kw, channel_axis=None,
                                         num_workers=None)
-    assert_almost_equal(dn_cc1, dn_cc2)
-    assert_almost_equal(dn_cc1, dn_cc3)
+    assert_array_almost_equal(dn_cc1, dn_cc2)
+    assert_array_almost_equal(dn_cc1, dn_cc3)
 
 
 def test_cycle_spinning_num_workers_deprecated_multichannel():
@@ -1175,7 +1177,7 @@ def test_cycle_spinning_num_workers_deprecated_multichannel():
         dn_cc2 = restoration.cycle_spin(noisy, denoise_func, max_shifts=1,
                                         func_kw=func_kw, multichannel=False,
                                         num_workers=2)
-    assert_almost_equal(dn_cc1, dn_cc2)
+    assert_array_almost_equal(dn_cc1, dn_cc2)
 
     # providing multichannel argument positionally also warns
     mc_warn_str = "Providing the `multichannel` argument"

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -516,7 +516,6 @@ def test_denoise_nl_means_multichannel(fast_mode, dtype, channel_axis):
 
     psnr_wrong = peak_signal_noise_ratio(img, denoised_wrong_multichannel)
     psnr_ok = peak_signal_noise_ratio(img, denoised_ok_multichannel)
-    print(f"psnr_wrong={psnr_wrong}, psnr_ok={psnr_ok}")
     assert psnr_ok > psnr_wrong
 
 

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -520,12 +520,12 @@ def test_denoise_nl_means_multichannel(fast_mode, dtype, channel_axis):
 
 
 def test_denoise_nl_means_4d():
-    rstate = np.random.RandomState(5)
+    rng = np.random.default_rng(5)
     img = np.zeros((10, 10, 8, 5))
     img[2:-2, 2:-2, 2:-2, :2] = 0.5
     img[2:-2, 2:-2, 2:-2, 2:] = 1.
     sigma = 0.3
-    imgn = img + sigma * rstate.randn(*img.shape)
+    imgn = img + sigma * rng.standard_normal(img.shape)
 
     nlmeans_kwargs = dict(patch_size=3, patch_distance=2, h=0.3 * sigma,
                           sigma=sigma, fast_mode=True)


### PR DESCRIPTION
## Description

closes #5483 (3D complex-valued data can be processed as 2-channel 3D data)

This PR adds support for additional dimensions to non-local means. I had originally implemented this a couple of years ago for a research project and had never made a PR for it.  The recent request in #5483 lead to reviving this work.

The new dimensions are supported only for `fast_mode=True` as the slower mode becomes increasingly impractical in higher dimensions.

Although there are quite a few lines of code, the changes are straightforward extensions of the existing approach:
- The existing `_fast_nl_means_denoising_3d` has a new "channels" loop added.
- The new `_fast_nl_means_denoising_4d` is basically just a copy of `_fast_nl_means_denoising_3d`, but with one additional loop. 
- The new `_integral_to_distance_4d` follows an n-dimensional formula for this given in the reference by E. Tapia in that function's docstring

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
