### PR TITLE
[minor docs fix] Fix reference to multiscale_basic_features in TrainableSegmenter

### DIFF
--- a/skimage/future/trainable_segmentation.py
+++ b/skimage/future/trainable_segmentation.py
@@ -24,7 +24,7 @@ class TrainableSegmenter(object):
         function computing features on all pixels of the image, to be passed
         to the classifier. The output should be of shape
         ``(m_features, *labels.shape)``. If None,
-        :func:`skimage.segmentation.multiscale_basic_features` is used.
+        :func:`skimage.feature.multiscale_basic_features` is used.
 
     Methods
     -------


### PR DESCRIPTION
## Description

This fixes the refererence in the `TrainableSegmenter` documentation to `skimage.feature.multiscale_basic_features`.

## For reviewers
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
