### PR TITLE
Fix blob dog docstring example and normalization

### DIFF
--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -334,6 +334,9 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=0.5,
     min_sigma = np.asarray(min_sigma, dtype=float_dtype)
     max_sigma = np.asarray(max_sigma, dtype=float_dtype)
 
+    if sigma_ratio <= 1.0:
+        raise ValueError('sigma_ratio must be > 1.0')
+
     # k such that min_sigma*(sigma_ratio**k) > max_sigma
     k = int(np.mean(np.log(max_sigma / min_sigma) / np.log(sigma_ratio) + 1))
 

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -346,7 +346,7 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=0.5,
 
     gaussian_images = [gaussian_filter(image, s) for s in sigma_list]
 
-    # normalization factor for consistency DoG magnitude
+    # normalization factor for consistency in DoG magnitude
     sf = 1 / (sigma_ratio - 1)
 
     # computing difference between two successive Gaussian blurred images

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -214,7 +214,7 @@ def _format_exclude_border(img_ndim, exclude_border):
         )
 
 
-def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
+def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=0.5,
              overlap=.5, *, exclude_border=False):
     r"""Finds blobs in the given grayscale image.
 
@@ -284,31 +284,32 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
     Examples
     --------
     >>> from skimage import data, feature
-    >>> feature.blob_dog(data.coins(), threshold=.5, max_sigma=40)
-    array([[120.      , 272.      ,  16.777216],
-           [193.      , 213.      ,  16.777216],
-           [263.      , 245.      ,  16.777216],
-           [185.      , 347.      ,  16.777216],
-           [128.      , 154.      ,  10.48576 ],
-           [198.      , 155.      ,  10.48576 ],
-           [124.      , 337.      ,  10.48576 ],
-           [ 45.      , 336.      ,  16.777216],
-           [195.      , 102.      ,  16.777216],
-           [125.      ,  45.      ,  16.777216],
-           [261.      , 173.      ,  16.777216],
-           [194.      , 277.      ,  16.777216],
-           [127.      , 102.      ,  10.48576 ],
-           [125.      , 208.      ,  10.48576 ],
-           [267.      , 115.      ,  10.48576 ],
-           [263.      , 302.      ,  16.777216],
-           [196.      ,  43.      ,  10.48576 ],
-           [260.      ,  46.      ,  16.777216],
-           [267.      , 359.      ,  16.777216],
-           [ 54.      , 276.      ,  10.48576 ],
-           [ 58.      , 100.      ,  10.48576 ],
-           [ 52.      , 155.      ,  16.777216],
-           [ 52.      , 216.      ,  16.777216],
-           [ 54.      ,  42.      ,  16.777216]])
+    >>> coins = data.coins()
+    >>> feature.blob_dog(coins, threshold=.05, min_sigma=10, max_sigma=40)
+    array([[128., 155.,  10.],
+           [198., 155.,  10.],
+           [124., 338.,  10.],
+           [127., 102.,  10.],
+           [193., 281.,  10.],
+           [126., 208.,  10.],
+           [267., 115.,  10.],
+           [197., 102.,  10.],
+           [198., 215.,  10.],
+           [123., 279.,  10.],
+           [126.,  46.,  10.],
+           [259., 247.,  10.],
+           [196.,  43.,  10.],
+           [ 54., 276.,  10.],
+           [267., 358.,  10.],
+           [ 58., 100.,  10.],
+           [259., 305.,  10.],
+           [185., 347.,  16.],
+           [261., 174.,  16.],
+           [ 46., 336.,  16.],
+           [ 54., 217.,  10.],
+           [ 55., 157.,  10.],
+           [ 57.,  41.,  10.],
+           [260.,  47.,  16.]])
 
     Notes
     -----
@@ -342,12 +343,16 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=2.0,
 
     gaussian_images = [gaussian_filter(image, s) for s in sigma_list]
 
+    # normalization factor for consistency DoG magnitude
+    sf = 1 / (sigma_ratio - 1)
+
     # computing difference between two successive Gaussian blurred images
     # to obtain an approximation of the scale invariant Laplacian of the
     # Gaussian operator
     dog_images = [
-        (gaussian_images[i] - gaussian_images[i + 1]) for i in range(k)
+        (gaussian_images[i] - gaussian_images[i + 1]) * sf for i in range(k)
     ]
+
 
     image_cube = np.stack(dog_images, axis=-1)
 

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -215,7 +215,7 @@ def _format_exclude_border(img_ndim, exclude_border):
 
 
 def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=0.5,
-             overlap=.5, *, exclude_border=False):
+             overlap=.5, *, threshold_rel=None, exclude_border=False):
     r"""Finds blobs in the given grayscale image.
 
     Blobs are found using the Difference of Gaussian (DoG) method [1]_, [2]_.
@@ -240,13 +240,20 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=0.5,
     sigma_ratio : float, optional
         The ratio between the standard deviation of Gaussian Kernels used for
         computing the Difference of Gaussians
-    threshold : float, optional.
+    threshold : float or None, optional.
         The absolute lower bound for scale space maxima. Local maxima smaller
-        than thresh are ignored. Reduce this to detect blobs with less
-        intensities.
+        than `threshold` are ignored. Reduce this to detect blobs with lower
+        intensities. If `threshold_rel` is also specified, whichever threshold
+        is larger will be used. If None, `threshold_rel` is used instead.
     overlap : float, optional
         A value between 0 and 1. If the area of two blobs overlaps by a
         fraction greater than `threshold`, the smaller blob is eliminated.
+    threshold_rel : float or None, optional
+        Minimum intensity of peaks, calculated as
+        ``max(dog_space) * threshold_rel``. Where ``dog_space`` refers to the
+        stack of difference-of-Gaussian (DoG) images computed internally. This
+        should have a value between 0 and 1. If None, `threshold_abs` is used
+        instead.
     exclude_border : tuple of ints, int, or False, optional
         If tuple of ints, the length of the tuple must match the input array's
         dimensionality.  Each element of the tuple will exclude peaks from
@@ -363,9 +370,9 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=0.5,
     local_maxima = peak_local_max(
         image_cube,
         threshold_abs=threshold,
-        footprint=np.ones((3,) * (image.ndim + 1)),
-        threshold_rel=0.0,
+        threshold_rel=threshold_rel,
         exclude_border=exclude_border,
+        footprint=np.ones((3,) * (image.ndim + 1)),
     )
 
     # Catch no peaks

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -142,11 +142,12 @@ def peak_local_max(image, min_distance=1, threshold_abs=None,
     min_distance : int, optional
         The minimal allowed distance separating peaks. To find the
         maximum number of peaks, use `min_distance=1`.
-    threshold_abs : float, optional
+    threshold_abs : float or None, optional
         Minimum intensity of peaks. By default, the absolute threshold is
         the minimum intensity of the image.
-    threshold_rel : float, optional
-        Minimum intensity of peaks, calculated as `max(image) * threshold_rel`.
+    threshold_rel : float or None, optional
+        Minimum intensity of peaks, calculated as
+        ``max(image) * threshold_rel``.
     exclude_border : int, tuple of ints, or bool, optional
         If positive integer, `exclude_border` excludes peaks from within
         `exclude_border`-pixels of the border of the image.

--- a/skimage/feature/tests/test_blob.py
+++ b/skimage/feature/tests/test_blob.py
@@ -56,16 +56,18 @@ def test_blob_dog(dtype):
     img_empty = np.zeros((100, 100), dtype=dtype)
     assert blob_dog(img_empty).size == 0
 
+
+@pytest.mark.parametrize(
+    'dtype', [np.uint8, np.float16, np.float32, np.float64]
+)
+def test_blob_dog_3d(dtype):
     # Testing 3D
     r = 10
     pad = 10
     im3 = ellipsoid(r, r, r)
     im3 = np.pad(im3, pad, mode='constant')
 
-    threshold = 0.1
-    if img.dtype.kind != 'f':
-        # account for internal scaling to [0, 1] by img_as_float
-        threshold /= img.ptp()
+    threshold = 0.001
 
     blobs = blob_dog(
         im3, min_sigma=3, max_sigma=10, sigma_ratio=1.2, threshold=threshold
@@ -78,18 +80,25 @@ def test_blob_dog(dtype):
     assert b[2] == r + pad + 1
     assert abs(math.sqrt(3) * b[3] - r) < 1.1
 
+
+@pytest.mark.parametrize(
+    'dtype', [np.uint8, np.float16, np.float32, np.float64]
+)
+def test_blob_dog_3d_anisotropic(dtype):
     # Testing 3D anisotropic
     r = 10
     pad = 10
     im3 = ellipsoid(r / 2, r, r)
     im3 = np.pad(im3, pad, mode='constant')
 
+    threshold=0.001
+
     blobs = blob_dog(
         im3.astype(dtype, copy=False),
         min_sigma=[1.5, 3, 3],
         max_sigma=[5, 10, 10],
         sigma_ratio=1.2,
-        threshold=threshold
+        threshold=threshold,
     )
     b = blobs[0]
 
@@ -128,13 +137,6 @@ def test_blob_dog_excl_border():
     )
     msg = "zero blobs should be detected, as only blob is 5 px from border"
     assert blobs.shape[0] == 0, msg
-
-
-@pytest.mark.parametrize('sigma_ratio', [0.5, 1.0])
-def test_blob_dog_invalid_sigma_ratio(sigma_ratio):
-
-    with pytest.raises(ValueError):
-        blob_dog(np.zeros((8, 8)), sigma_ratio=sigma_ratio)
 
 
 @pytest.mark.parametrize(

--- a/skimage/feature/tests/test_blob.py
+++ b/skimage/feature/tests/test_blob.py
@@ -130,6 +130,13 @@ def test_blob_dog_excl_border():
     assert blobs.shape[0] == 0, msg
 
 
+@pytest.mark.parametrize('sigma_ratio', [0.5, 1.0])
+def test_blob_dog_invalid_sigma_ratio(sigma_ratio):
+
+    with pytest.raises(ValueError):
+        blob_dog(np.zeros((8, 8)), sigma_ratio=sigma_ratio)
+
+
 @pytest.mark.parametrize(
     'dtype', [np.uint8, np.float16, np.float32, np.float64]
 )


### PR DESCRIPTION
## Description

This PR fixes a few small issues in the previously merged #4482.

1.) To make the choice of `threshold` less dependent on the choice of `sigma_scale`, we should normalize all of the difference-of-Gaussian (DoG) images by `(sigma_scale - 1)`. This was originally suggested in #4482 but I mistakenly omitted it in the version that got merged.

2.) The docstring example was broken by #4482, but this was not caught since our docstring checks were accidentally removed from CI last year (see #5502). Now that the DoG is no longer biased toward larger sigma, it was necessary to adjust the `min_sigma` to avoid detecting additional peaks associated with the edges of the coins. The adjusted parameters give one peak per coin again.

3.) The default threshold was reduced a bit and perhaps should be reduced even further now that we don't multiply each DoG image by sigma. 

### Additional info

As another verification, the gallery example still looks fine with the existing threshold of 0.1:

Current gallery example output: (see **blob_dog** in the center)
![plot_blob_main](https://user-images.githubusercontent.com/6528957/128546144-5195af4e-07f6-461a-8505-fc89c124d7fa.png)

Note that before #4482 was merged, there was more bias toward larger blobs. See for example the result in the release 0.18.2 docs:
![plot_blob_v018](https://user-images.githubusercontent.com/6528957/128546246-3badc68c-76a6-4bf0-804e-1e7f38d4b2e2.png)






## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
