### PR TITLE
Fix uint8 overflow in exposure.adjust_gamma

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -441,7 +441,7 @@ def _adjust_gamma_u8(image, gamma, gain):
 
     """
     lut = (255 * gain * (np.linspace(0, 1, 256) ** gamma))
-    np.minimum(lut, 255, out=lut).astype('uint8')
+    lut = np.minimum(lut, 255).astype('uint8')
     return lut[image]
 
 

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -441,7 +441,7 @@ def _adjust_gamma_u8(image, gamma, gain):
 
     """
     lut = (255 * gain * (np.linspace(0, 1, 256) ** gamma))
-    np.maximum(lut, 255, out=lut).astype('uint8')
+    np.minimum(lut, 255, out=lut).astype('uint8')
     return lut[image]
 
 

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -440,7 +440,8 @@ def _adjust_gamma_u8(image, gamma, gain):
     """LUT based implmentation of gamma adjustement.
 
     """
-    lut = (255 * gain * (np.linspace(0, 1, 256) ** gamma)).astype('uint8')
+    lut = (255 * gain * (np.linspace(0, 1, 256) ** gamma))
+    np.maximum(lut, 255, out=lut).astype('uint8')
     return lut[image]
 
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -598,6 +598,12 @@ def test_adjust_gamma_neggative():
         exposure.adjust_gamma(image, -1)
 
 
+def test_adjust_gamma_u8_overflow():
+    img = 255 * np.ones((2, 2), dtype=np.uint8)
+
+    assert np.all(exposure.adjust_gamma(img, gamma=1, gain=1.1) == 255)
+
+
 # Test Logarithmic Correction
 # ===========================
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -592,7 +592,7 @@ def test_adjust_gamma_greater_one():
     assert_array_equal(result, expected)
 
 
-def test_adjust_gamma_neggative():
+def test_adjust_gamma_negative():
     image = np.arange(0, 255, 4, np.uint8).reshape((8, 8))
     with testing.raises(ValueError):
         exposure.adjust_gamma(image, -1)
@@ -732,10 +732,10 @@ def test_adjust_inv_sigmoid_cutoff_half():
     assert_array_equal(result, expected)
 
 
-def test_negative():
+def test_adjust_sigmoid_negative():
     image = np.arange(-10, 245, 4).reshape((8, 8)).astype(np.double)
     with testing.raises(ValueError):
-        exposure.adjust_gamma(image)
+        exposure.adjust_sigmoid(image)
 
 
 def test_is_low_contrast():

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -732,12 +732,6 @@ def test_adjust_inv_sigmoid_cutoff_half():
     assert_array_equal(result, expected)
 
 
-def test_adjust_sigmoid_negative():
-    image = np.arange(-10, 245, 4).reshape((8, 8)).astype(np.double)
-    with testing.raises(ValueError):
-        exposure.adjust_sigmoid(image)
-
-
 def test_is_low_contrast():
     image = np.linspace(0, 0.04, 100)
     assert exposure.is_low_contrast(image)
@@ -760,6 +754,18 @@ def test_is_low_contrast_boolean():
 
     image[:5] = 1
     assert not exposure.is_low_contrast(image)
+
+
+# Test negative input
+#####################
+
+@pytest.mark.parametrize("exposure_func", [exposure.adjust_gamma,
+                                           exposure.adjust_log,
+                                           exposure.adjust_sigmoid])
+def test_negative_input(exposure_func):
+    image = np.arange(-10, 245, 4).reshape((8, 8)).astype(np.double)
+    with testing.raises(ValueError):
+        exposure_func(image)
 
 
 # Test Dask Compatibility


### PR DESCRIPTION
## Description

Closes #5413 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
