### PR TITLE
Slight `shape_index` docstring modification to specify 2D array

### DIFF
--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -455,7 +455,7 @@ def shape_index(image, sigma=1, mode='constant', cval=0):
 
     Parameters
     ----------
-    image : ndarray
+    image : (M, N) ndarray
         Input image.
     sigma : float, optional
         Standard deviation used for the Gaussian kernel, which is used for


### PR DESCRIPTION
## Description

I was recently exploring the `shape_index` function and found some discussion here: https://mail.python.org/archives/list/scikit-image@python.org/thread/Q5FNUVXJBCB7YDAGHKTO7EUQORR7WMGF/ where, I think, @emmanuelle had suggested changing the docstring to explicitly state that 2D arrays are expected. From what I see, this change seems to not have been added yet, so I have tried to do it here.

Thanks!


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
