### PR TITLE
Allow rank filters to output data as float32 instead of float64

### DIFF
--- a/skimage/filters/rank/core_cy.pxd
+++ b/skimage/filters/rank/core_cy.pxd
@@ -1,4 +1,4 @@
-from numpy cimport uint8_t, uint16_t, double_t
+from numpy cimport uint8_t, uint16_t, float32_t, double_t
 
 
 ctypedef fused dtype_t:
@@ -8,6 +8,7 @@ ctypedef fused dtype_t:
 ctypedef fused dtype_t_out:
     uint8_t
     uint16_t
+    float32_t
     double_t
 
 

--- a/skimage/filters/rank/core_cy_3d.pxd
+++ b/skimage/filters/rank/core_cy_3d.pxd
@@ -1,4 +1,4 @@
-from numpy cimport uint8_t, uint16_t, double_t
+from numpy cimport uint8_t, uint16_t, float32_t, double_t
 
 
 ctypedef fused dtype_t:
@@ -8,6 +8,7 @@ ctypedef fused dtype_t:
 ctypedef fused dtype_t_out:
     uint8_t
     uint16_t
+    float32_t
     double_t
 
 

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -144,7 +144,8 @@ class TestRank():
                 out = np.zeros_like(expected, dtype=outdt)
             else:
                 out = None
-            result = getattr(rank, filter)(self.volume, self.footprint_3d, out=out)
+            result = getattr(rank, filter)(self.volume, self.footprint_3d,
+                                           out=out)
             if outdt is not None:
                 # Avoid rounding issues comparing to expected result
                 if filter == 'sum':

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -114,12 +114,7 @@ class TestRank():
             else:
                 if outdt is not None:
                     # Avoid rounding issues comparing to expected result
-                    if filter == 'sum':
-                        # sum test data seems to be 8-bit disguised as 16-bit
-                        datadt = np.uint8
-                    else:
-                        datadt = expected.dtype
-                    result = result.astype(datadt)
+                    result = result.astype(expected.dtype)
                 assert_array_almost_equal(expected, result)
 
         check()


### PR DESCRIPTION
## Description

This simply adds float32_t to the fused types in rank filters, to allow operating on single-precision data. Otherwise, a conversion to float64 is needed which increases RAM usage 2x unnecessarily.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
