### PR TITLE
Bring release_dev.txt up to date

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -19,10 +19,33 @@ New Features
   axis. This is in contrast to previous releases where channels were required
   to be the last axis of an image. See more info on the new ``channel_axis``
   argument under the API section of the release notes.
+- A no-reference measure of perceptual blur was added
+  (``skimage.measure.blur_effect``).
+- Non-local means (``skimage.restoration.denoise_nl_means``) now supports
+  3D multichannel, 4D and 4D multichannel data when ``fast_mode=True``.
+- An n-dimensional Fourier-domain Butterworth filter
+  (``skimage.filters.butterworth``) was added.
+- Color conversion functions now have a new ``channel_axis`` keyword argument
+  that allows specification of which axis of an array corresponds to channels.
+  For backwards compatibility, this parameter defaults to ``channel_axis=-1``,
+  indicating that channels are along the last axis.
 - Added a new keyword only parameter ``random_state`` to
   ``morphology.medial_axis`` and ``restoration.unsupervised_wiener``.
 - Seeding random number generators will not give the same results as the
   underlying generator was updated to use ``numpy.random.Generator``.
+- Added ``saturation`` parameter to ``skimage.color.label2rgb``
+- Added normalized mutual information metric
+  ``skimage.metrics.normalized_mutual_information``
+- threshold_local now supports n-dimensional inputs and anisotropic block_size
+- New ``skimage.util.label_points`` function for assigning labels to points.
+- Added nD support to several geometric transform classes
+- Added ``skimage.metrics.hausdorff_pair`` to find points separated by the
+  Hausdorff distance.
+- Additional colorspace ``illuminants`` and ``observers`` parameter options
+  were added to ``skimage.color.lab2rgb``, ``skimage.color.rgb2lab``,
+  ``skimage.color.xyz2lab``, ``skimage.color.lab2xyz``,
+  ``skimage.color.xyz2luv`` and ``skimage.color.luv2xyz``.
+
 
 Documentation
 -------------
@@ -37,6 +60,12 @@ Documentation
 Improvements
 ------------
 
+- Many more functions throughout the library now have single precision
+  (float32) support.
+- Biharmonic  inpainting (``skimage.restoration.inpaint_biharmonic``) was
+  refactored and is orders of magnitude faster than before.
+- Salt-and-pepper noise generation with ``skimage.util.random_noise`` is now
+  faster.
 - The performance of the SLIC superpixels algorithm
   (``skimage.segmentation.slice``) was improved for the case where a mask
   is supplied by the user (#4903). The specific superpixels produced by
@@ -47,9 +76,15 @@ Improvements
   ``scipy.ndimage``'s implementation for this case (#4945).
 - ``util.apply_parallel`` now works with multichannel data (#4927).
 - ``skimage.feature.peak_local_max`` supports now any Minkowski distance.
-- Many more functions throughout the library now have single precision
-  (float32) support.
-
+- Fast, non-Cython implementation for ``skimage.filters.correlate_sparse``
+- For efficiency, the histogram is now precomputed within
+  ``skimage.filters.try_all_threshold``.
+- Faster ``skimage.filters.find_local_max`` when given a finite ``num_peaks``.
+- All filters in the ``skimage.filters.rank`` module now release the GIL,
+  enabling multithreaded use.
+- ``skimage.restoration.denoise_tv_bregman`` and
+  ``skimage.restoration.denoise_bilateral`` now release the GIL, enabling
+  multithreaded use.
 
 API Changes
 -----------
@@ -73,6 +108,8 @@ API Changes
 - ``skimage.transforms.integral_image`` now promotes floating point inputs to
   double precision by default (for accuracy). A new ``dtype`` keyword argument
   can be used to override this behavior when desired.
+- Color conversion functions now have a new ``channel_axis`` keyword argument
+  (see **New Features** section).
 
 Bugfixes
 --------
@@ -217,6 +254,43 @@ Newly introduced deprecations:
 
 Development process
 -------------------
+
+- Test setup and teardown functions added to allow raising an error on any
+  uncaught warnings via ``SKIMAGE_TEST_STRICT_WARNINGS_GLOBAL`` environment
+  variable.
+- Increase automation in release process.
+- Build aarch64 wheels
+- Release wheels before source
+- Update pyproject.toml to ensure pypy compatibility and aarch compatibility
+- Add numpy version specification on aarch for cpython 3.8
+- update minimum supported Matplotlib, NumPy, SciPy and Pillow
+- Pin pillow to !=8.3.0
+- Use manylinux2010 for python 3.9+
+- Rename `master` to `main` throughout
+- Ensure that README.txt has write permissions for subsequent imports.
+- Fixup test for INSTALL_FROM_SDIST
+- Run face classification gallery example with a single thread
+- Enable pip and skimage.data caching on Azure
+- Fix CircleCI caching
+- Fix Azure CI caching
+- Fix Cython warnings
+- disable calls to plotly.io.show when running on Azure
+- Remove legacy Travis-CI scripts and update contributor documentation
+  accordingly
+- Increase cibuildwheel verbosity
+- Update pip during dev environment installation
+- Add benchmark checks to CI
+- Resolve stochastic rank filter test failures on CI
+- Use latest Ubuntu image to fix QEMU CPU detection issue
+- Ensure that README.txt has write permissions for subsequent imports.
+- Decorators for helping with the multichannel->channel_axis transition
+
+Other Updates
+-------------
+- refactor np.random.x to use np.random.Generator
+- avoid warnings about use of deprecated `scipy.linalg.pinv2`
+- Simplify resize implementation using new SciPy 1.6 zoom option
+
 
 
 Contributors to this release

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -56,6 +56,8 @@ Documentation
 - New gallery example for 3D structure tensor
 - New gallery example displaying a 3D dataset
 - Extended rolling ball example with ECG data (1D)
+- The stain unmixing gallery example was fixed and now displays proper
+  separation of the stains.
 - Documentation has been added to the contributing notes about how to submit a
   gallery example 
 - Autoformat docstrings in morphology/*
@@ -123,6 +125,8 @@ Improvements
 - ``skimage.restoration.denoise_tv_bregman`` and
   ``skimage.restoration.denoise_bilateral`` now release the GIL, enabling
   multithreaded use.
+- A ``skimage.color.label2rgb`` performance regression was addressed
+
 
 API Changes
 -----------
@@ -135,7 +139,7 @@ API Changes
   with ``multichannel=False`` should now specify ``channel_axis=None``.
 - Most functions now return float32 images when the input has float32 dtype.
 - A default value has been added to ``measure.find_contours``, corresponding to
-  the half distance between the min and max values of the image 
+  the half distance between the min and max values of the image
   #4862
 - ``data.cat`` has been introduced as an alias of ``data.chelsea`` for a more
   descriptive name.
@@ -149,19 +153,39 @@ API Changes
 - Color conversion functions now have a new ``channel_axis`` keyword argument
   (see **New Features** section).
 
+
 Bugfixes
 --------
 
-- Fixed the behaviour of Richardson-Lucy deconvolution for images with 3
-  dimensions or more (#4823)
-- ``min_distance`` is now enforced for ``skimage.feature.peak_local_max``
-  (#2592).
-- Peak detection in labels is fixed in ``skimage.feature.peak_local_max``
-  (#4756).
 - Input ``labels`` argument renumbering in ``skimage.feature.peak_local_max``
   is avoided (#5047).
 - Nonzero values at the image edge are no longer incorrectly marked as a
-  boundary when using ``find_bounaries`` with mode='subpixel' (#5447)
+  boundary when using ``find_bounaries`` with mode='subpixel' (#5447).
+- Fix large array labelling in ``skimage.measure.label``.
+- Only use retry_if_failed with recent pooch.
+- Fix return dtype of ``_label2rgb_avg`` function.
+- Ensure ``skimage.color.separate_stains`` does not return negative values.
+- Prevent integer overflow in ``EllipseModel``.
+- Fixed off-by one error in pixel bins in Hough line transform.
+- Handle 1D arrays properly in ``skimage.filters.gaussian``.
+- Fix Laplacian matrix size bug in ``skimage.segmentation.random_walker``.
+- Regionprops table (``skimage.measure.reginoprops_table``) dtype bugfix.
+- Fix ``skimage.transform.rescale`` when using a small scale factor.
+- Fix ``skimage.measure.label`` segfault.
+- Watershed (``skimage.segmentation.watershed``): consider connectivity when
+  calculating markers.
+- Fix ``skimage.transform.warp`` output dtype when order=0.
+- Fix multichannel ``intensity_image`` extra_properties in regionprops.
+- Fix error message for ``skimage.metric.structural_similarity`` when image is
+  too small.
+- Do not mark image edges in 'subpixel' mode of
+  ``skimage.segmentation.find_boundaries``.
+- Fix behavior of ``skimage.exposure.is_low_contrast`` for boolean inputs.
+- Fix wrong syntax for the string argument of ValueError in
+  ``skimage.metric.structural_similarity`` .
+- Fixed NaN issue in ``skimage.filters.threshold_otsu``.
+- Fix ``skimage.feature.blob_dog`` docstring example and normalization.
+- Fix uint8 overflow in ``skimage.exposure.adjust_gamma``.
 
 
 Deprecations
@@ -323,12 +347,14 @@ Development process
 - Ensure that README.txt has write permissions for subsequent imports.
 - Decorators for helping with the multichannel->channel_axis transition
 
+
 Other Updates
 -------------
 - refactor np.random.x to use np.random.Generator
 - avoid warnings about use of deprecated `scipy.linalg.pinv2`
 - Simplify resize implementation using new SciPy 1.6 zoom option
-
+- Fix duplicate test function names in ``test_unsharp_mask.py``
+- Benchmarks: ``fix ResizeLocalMeanSuite.time_resize_local_mean`` signature
 
 
 Contributors to this release

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -163,10 +163,11 @@ Bugfixes
 - Fix return dtype of ``_label2rgb_avg`` function.
 - Ensure ``skimage.color.separate_stains`` does not return negative values.
 - Prevent integer overflow in ``EllipseModel``.
-- Fixed off-by one error in pixel bins in Hough line transform.
+- Fixed off-by one error in pixel bins in Hough line transform,
+  ``skimage.transform.hough_line``.
 - Handle 1D arrays properly in ``skimage.filters.gaussian``.
 - Fix Laplacian matrix size bug in ``skimage.segmentation.random_walker``.
-- Regionprops table (``skimage.measure.reginoprops_table``) dtype bugfix.
+- Regionprops table (``skimage.measure.regionprops_table``) dtype bugfix.
 - Fix ``skimage.transform.rescale`` when using a small scale factor.
 - Fix ``skimage.measure.label`` segfault.
 - Watershed (``skimage.segmentation.watershed``): consider connectivity when

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -82,7 +82,6 @@ Documentation
 - Make more comprehensive 'see also' sections in filters
 - Specify the release note version instead of the misleading `latest`
 - Remove misleading comment in ``plot_thresholding.py`` example.
-- Fix sphinx: role already being registered
 - Fix sphinx layout to make the search engine work with recent sphinx versions
 - Draw node IDs in RAG example
 - Update sigma_color description in denoise_bilateral
@@ -161,8 +160,6 @@ Bugfixes
   is avoided (#5047).
 - Nonzero values at the image edge are no longer incorrectly marked as a
   boundary when using ``find_bounaries`` with mode='subpixel' (#5447).
-- Fix large array labelling in ``skimage.measure.label``.
-- Only use retry_if_failed with recent pooch.
 - Fix return dtype of ``_label2rgb_avg`` function.
 - Ensure ``skimage.color.separate_stains`` does not return negative values.
 - Prevent integer overflow in ``EllipseModel``.
@@ -321,16 +318,11 @@ Development process
   uncaught warnings via ``SKIMAGE_TEST_STRICT_WARNINGS_GLOBAL`` environment
   variable.
 - Increase automation in release process.
-- Build aarch64 wheels
 - Release wheels before source
-- Update pyproject.toml to ensure pypy compatibility and aarch compatibility
-- Add numpy version specification on aarch for cpython 3.8
 - update minimum supported Matplotlib, NumPy, SciPy and Pillow
 - Pin pillow to !=8.3.0
-- Use manylinux2010 for python 3.9+
 - Rename `master` to `main` throughout
 - Ensure that README.txt has write permissions for subsequent imports.
-- Fixup test for INSTALL_FROM_SDIST
 - Run face classification gallery example with a single thread
 - Enable pip and skimage.data caching on Azure
 - Fix CircleCI caching
@@ -343,7 +335,6 @@ Development process
 - Update pip during dev environment installation
 - Add benchmark checks to CI
 - Resolve stochastic rank filter test failures on CI
-- Use latest Ubuntu image to fix QEMU CPU detection issue
 - Ensure that README.txt has write permissions for subsequent imports.
 - Decorators for helping with the multichannel->channel_axis transition
 

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -53,8 +53,46 @@ Documentation
 - A new doc tutorial presenting a 3D biomedical imaging example has been added
   to the gallery (#4946). The technical content benefited from conversations
   with Genevieve Buckley, Kevin Mader, and Volker Hilsenstein.
+- New gallery example for 3D structure tensor
+- New gallery example displaying a 3D dataset
+- Extended rolling ball example with ECG data (1D)
 - Documentation has been added to the contributing notes about how to submit a
   gallery example 
+- Autoformat docstrings in morphology/*
+- Display plotly figures from gallery example even when running script at CLI.
+- Single out docs-only PRs in review process.
+- Use matplotlib's infinite axline to demonstrate hough transform.
+- Clarify disk documentation inconsistency regarding 'shape'.
+- docs: fix simple typo, convertions -> conversions.
+- Fixes to linspace in example.
+- Minor fixes to Hough line transform code and examples.
+- Added 1/2 pixel bounds to extent of displayed images in several examples.
+- Add release step on github to RELEASE.txt.
+- Remove reference to opencv in threshold_local documentation.
+- Update structure_tensor docstring to include per-axis sigma.
+- Fix typo in _shared/utils.py docs.
+- Proofread and crosslink examples with immunohistochemistry image.
+- Spelling correction: witch -> which.
+- Mention possible filters in radon_transform -> filtered-back-projection
+- Fix dtype info in documentation for watershed.
+- Proofread gallery example for Radon transform.
+- Use internal function for noise + clarify code in Canny example.
+- Make more comprehensive 'see also' sections in filters
+- Specify the release note version instead of the misleading `latest`
+- Remove misleading comment in ``plot_thresholding.py`` example.
+- Fix sphinx: role already being registered
+- Fix sphinx layout to make the search engine work with recent sphinx versions
+- Draw node IDs in RAG example
+- Update sigma_color description in denoise_bilateral
+- Update intersphinx fallback inventories + add matplotlib fallback inventory
+- Fix numpy deprecation in ``plot_local_equalize.py``
+- Rename ``label`` variable in ``plot_regionprops.py`` to circumvent link issue
+  in docs.
+- Avoid duplicate API documentation for ImageViewer, CollectionViewer
+- Fix 'blog_dog' typo in ``gaussian`` docs
+- Update reference link documentation in the ``adjust_sigmoid`` function.
+- Fix reference to multiscale_basic_features in TrainableSegmenter
+- Slight ``shape_index`` docstring modification to specify 2D array
 
 
 Improvements


### PR DESCRIPTION
## Description

We have not done a good job of regularly updating `release_dev.txt` before merging PRs in recent months. This is a bulk update to that file, reflecting many PRs merged since the last release. Hopefully in the future, consistent use of `towncrier` (#5477) will allow updates without the merge conflict pains seen with `release_dev.txt` in the past.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
