### PR TITLE
Changed .format() to f-string in data, draw, and feature folders

### DIFF
--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -92,8 +92,7 @@ except ModuleNotFoundError:
         """
         import hashlib
         if alg not in hashlib.algorithms_available:
-            raise ValueError(
-                "Algorithm '{}' not available in hashlib".format(alg))
+            raise ValueError(f"Algorithm '{alg}' not available in hashlib")
         # Calculate the hash in chunks to avoid overloading the memory
         chunksize = 65536
         hasher = hashlib.new(alg)

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -331,9 +331,8 @@ def set_color(image, coords, color, alpha=1):
     color = np.array(color, ndmin=1, copy=False)
 
     if image.shape[-1] != color.shape[-1]:
-        raise ValueError('Color shape ({}) must match last '
-                         'image dimension ({}).'.format(color.shape[0],
-                                                        image.shape[-1]))
+        raise ValueError(f'Color shape ({color.shape[0]}) must watch last '
+                          'image dimension ({image.shape[-1]}).')
 
     if np.isscalar(alpha):
         # Can be replaced by ``full_like`` when numpy 1.8 becomes

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -331,7 +331,7 @@ def set_color(image, coords, color, alpha=1):
     color = np.array(color, ndmin=1, copy=False)
 
     if image.shape[-1] != color.shape[-1]:
-        raise ValueError(f'Color shape ({color.shape[0]}) must watch last '
+        raise ValueError(f'Color shape ({color.shape[0]}) must match last '
                           'image dimension ({image.shape[-1]}).')
 
     if np.isscalar(alpha):

--- a/skimage/feature/haar.py
+++ b/skimage/feature/haar.py
@@ -28,7 +28,7 @@ def _validate_feature_type(feature_type):
             if feat_t not in FEATURE_TYPE:
                 raise ValueError(
                                 f'The given feature type is unknown. Got {feat_t} instead of one'
-                                'of {FEATURE_TYPE}.')
+                                f'of {FEATURE_TYPE}.')
     return feature_type_
 
 

--- a/skimage/feature/haar.py
+++ b/skimage/feature/haar.py
@@ -27,8 +27,8 @@ def _validate_feature_type(feature_type):
         for feat_t in feature_type_:
             if feat_t not in FEATURE_TYPE:
                 raise ValueError(
-                    'The given feature type is unknown. Got {} instead of one'
-                    ' of {}.'.format(feat_t, FEATURE_TYPE))
+                                f'The given feature type is unknown. Got {feat_t} instead of one'
+                                'of {FEATURE_TYPE}.')
     return feature_type_
 
 

--- a/skimage/feature/haar.py
+++ b/skimage/feature/haar.py
@@ -27,7 +27,7 @@ def _validate_feature_type(feature_type):
         for feat_t in feature_type_:
             if feat_t not in FEATURE_TYPE:
                 raise ValueError(
-                                f'The given feature type is unknown. Got {feat_t} instead of one'
+                                f'The given feature type is unknown. Got {feat_t} instead of one '
                                 f'of {FEATURE_TYPE}.')
     return feature_type_
 

--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -108,7 +108,7 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
         offset[1] = 0
     else:
         mesg = (f"plot_matches accepts either 'horizontal' or 'vertical' for "
-                "alignment, but '{alignment}' was given. See "
+                f"alignment, but '{alignment}' was given. See "
                 "https://scikit-image.org/docs/dev/api/skimage.feature.html#skimage.feature.plot_matches "  # noqa
                 "for details.")
         raise ValueError(mesg)

--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -107,10 +107,10 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
         image = np.concatenate([image1, image2], axis=0)
         offset[1] = 0
     else:
-        mesg = ("plot_matches accepts either 'horizontal' or 'vertical' for "
-                "alignment, but '{}' was given. See "
+        mesg = (f"plot_matches accepts either 'horizontal' or 'vertical' for "
+                "alignment, but '{alignment}' was given. See "
                 "https://scikit-image.org/docs/dev/api/skimage.feature.html#skimage.feature.plot_matches "  # noqa
-                "for details.").format(alignment)
+                "for details.")
         raise ValueError(mesg)
 
     if not only_matches:

--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -110,7 +110,7 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
         mesg = (f"plot_matches accepts either 'horizontal' or 'vertical' for "
                 f"alignment, but '{alignment}' was given. See "
                 f"https://scikit-image.org/docs/dev/api/skimage.feature.html#skimage.feature.plot_matches "  # noqa
-                "for details.")
+                f"for details.")
         raise ValueError(mesg)
 
     if not only_matches:

--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -109,7 +109,7 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
     else:
         mesg = (f"plot_matches accepts either 'horizontal' or 'vertical' for "
                 f"alignment, but '{alignment}' was given. See "
-                "https://scikit-image.org/docs/dev/api/skimage.feature.html#skimage.feature.plot_matches "  # noqa
+                f"https://scikit-image.org/docs/dev/api/skimage.feature.html#skimage.feature.plot_matches "  # noqa
                 "for details.")
         raise ValueError(mesg)
 


### PR DESCRIPTION
## Description

Contributes to issue #5474 by changing places where .format() is used to f-string


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
