### PR TITLE
add relative threshold keyword argument to blob_doh and blob_log

### DIFF
--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -363,7 +363,6 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=0.5,
         (gaussian_images[i] - gaussian_images[i + 1]) * sf for i in range(k)
     ]
 
-
     image_cube = np.stack(dog_images, axis=-1)
 
     exclude_border = _format_exclude_border(image.ndim, exclude_border)
@@ -399,7 +398,8 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=0.5,
 
 
 def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
-             overlap=.5, log_scale=False, *, exclude_border=False):
+             overlap=.5, log_scale=False, *, threshold_rel=None,
+             exclude_border=False):
     r"""Finds blobs in the given grayscale image.
 
     Blobs are found using the Laplacian of Gaussian (LoG) method [1]_.
@@ -424,17 +424,24 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
     num_sigma : int, optional
         The number of intermediate values of standard deviations to consider
         between `min_sigma` and `max_sigma`.
-    threshold : float, optional.
+    threshold : float or None, optional.
         The absolute lower bound for scale space maxima. Local maxima smaller
-        than thresh are ignored. Reduce this to detect blobs with less
-        intensities.
-    overlap : float, optional
+        than `threshold` are ignored. Reduce this to detect blobs with lower
+        intensities. If `threshold_rel` is also specified, whichever threshold
+        is larger will be used. If None, `threshold_rel` is used instead.
+   overlap : float, optional
         A value between 0 and 1. If the area of two blobs overlaps by a
         fraction greater than `threshold`, the smaller blob is eliminated.
     log_scale : bool, optional
         If set intermediate values of standard deviations are interpolated
         using a logarithmic scale to the base `10`. If not, linear
         interpolation is used.
+    threshold_rel : float or None, optional
+        Minimum intensity of peaks, calculated as
+        ``max(dog_space) * threshold_rel``. Where ``dog_space`` refers to the
+        stack of Laplacian of Gaussian (LoG) images computed internally. This
+        should have a value between 0 and 1. If None, `threshold_abs` is used
+        instead.
     exclude_border : tuple of ints, int, or False, optional
         If tuple of ints, the length of the tuple must match the input array's
         dimensionality.  Each element of the tuple will exclude peaks from
@@ -528,9 +535,9 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
     local_maxima = peak_local_max(
         image_cube,
         threshold_abs=threshold,
-        footprint=np.ones((3,) * (image.ndim + 1)),
-        threshold_rel=0.0,
+        threshold_rel=threshold_rel,
         exclude_border=exclude_border,
+        footprint=np.ones((3,) * (image.ndim + 1)),
     )
 
     # Catch no peaks
@@ -557,7 +564,7 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
 
 
 def blob_doh(image, min_sigma=1, max_sigma=30, num_sigma=10, threshold=0.01,
-             overlap=.5, log_scale=False):
+             overlap=.5, log_scale=False, *, threshold_rel=None):
     """Finds blobs in the given grayscale image.
 
     Blobs are found using the Determinant of Hessian method [1]_. For each blob
@@ -578,9 +585,11 @@ def blob_doh(image, min_sigma=1, max_sigma=30, num_sigma=10, threshold=0.01,
     num_sigma : int, optional
         The number of intermediate values of standard deviations to consider
         between `min_sigma` and `max_sigma`.
-    threshold : float, optional.
+    threshold : float or None, optional.
         The absolute lower bound for scale space maxima. Local maxima smaller
-        than thresh are ignored. Reduce this to detect less prominent blobs.
+        than `threshold` are ignored. Reduce this to detect blobs with lower
+        intensities. If `threshold_rel` is also specified, whichever threshold
+        is larger will be used. If None, `threshold_rel` is used instead.
     overlap : float, optional
         A value between 0 and 1. If the area of two blobs overlaps by a
         fraction greater than `threshold`, the smaller blob is eliminated.
@@ -588,6 +597,12 @@ def blob_doh(image, min_sigma=1, max_sigma=30, num_sigma=10, threshold=0.01,
         If set intermediate values of standard deviations are interpolated
         using a logarithmic scale to the base `10`. If not, linear
         interpolation is used.
+    threshold_rel : float or None, optional
+        Minimum intensity of peaks, calculated as
+        ``max(dog_space) * threshold_rel``. Where ``dog_space`` refers to the
+        stack of determinant-of-hessian (DoH) images computed internally. This
+        should have a value between 0 and 1. If None, `threshold_abs` is used
+        instead.
 
     Returns
     -------
@@ -655,10 +670,11 @@ def blob_doh(image, min_sigma=1, max_sigma=30, num_sigma=10, threshold=0.01,
     hessian_images = [_hessian_matrix_det(image, s) for s in sigma_list]
     image_cube = np.dstack(hessian_images)
 
-    local_maxima = peak_local_max(image_cube, threshold_abs=threshold,
-                                  footprint=np.ones((3,) * image_cube.ndim),
-                                  threshold_rel=0.0,
-                                  exclude_border=False)
+    local_maxima = peak_local_max(image_cube,
+                                  threshold_abs=threshold,
+                                  threshold_rel=threshold_rel,
+                                  exclude_border=False,
+                                  footprint=np.ones((3,) * image_cube.ndim))
 
     # Catch no peaks
     if local_maxima.size == 0:

--- a/skimage/feature/tests/test_blob.py
+++ b/skimage/feature/tests/test_blob.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_almost_equal
 
 from skimage.draw import disk
 from skimage.draw.draw3d import ellipsoid
-from skimage.feature import blob_dog, blob_log, blob_doh
+from skimage.feature import blob_dog, blob_doh, blob_log
 from skimage.feature.blob import _blob_overlap
 
 
@@ -62,7 +62,7 @@ def test_blob_dog(dtype, threshold_type):
     b = s[2]
     assert abs(b[0] - 200) <= thresh
     assert abs(b[1] - 350) <= thresh
-    assert abs(radius(b)- 45) <= ratio_thresh * 45
+    assert abs(radius(b) - 45) <= ratio_thresh * 45
 
     # Testing no peaks
     img_empty = np.zeros((100, 100), dtype=dtype)
@@ -172,7 +172,8 @@ def test_blob_dog_excl_border():
 @pytest.mark.parametrize(
     'dtype', [np.uint8, np.float16, np.float32, np.float64]
 )
-def test_blob_log(dtype):
+@pytest.mark.parametrize('threshold_type', ['absolute', 'relative'])
+def test_blob_log(dtype, threshold_type):
     r2 = math.sqrt(2)
     img = np.ones((256, 256), dtype=dtype)
 
@@ -188,12 +189,18 @@ def test_blob_log(dtype):
     xs, ys = disk((100, 175), 30)
     img[xs, ys] = 255
 
-    threshold = 1
-    if img.dtype.kind != 'f':
-        # account for internal scaling to [0, 1] by img_as_float
-        threshold /= img.ptp()
+    if threshold_type == 'absolute':
+        threshold = 1
+        if img.dtype.kind != 'f':
+            # account for internal scaling to [0, 1] by img_as_float
+            threshold /= img.ptp()
+        threshold_rel = None
+    elif threshold_type == 'relative':
+        threshold = None
+        threshold_rel = 0.5
 
-    blobs = blob_log(img, min_sigma=5, max_sigma=20, threshold=threshold)
+    blobs = blob_log(img, min_sigma=5, max_sigma=20, threshold=threshold,
+                     threshold_rel=threshold_rel)
 
     radius = lambda x: r2 * x[2]
     s = sorted(blobs, key=radius)
@@ -225,6 +232,7 @@ def test_blob_log(dtype):
         min_sigma=5,
         max_sigma=20,
         threshold=threshold,
+        threshold_rel=threshold_rel,
         log_scale=True)
 
     b = s[0]
@@ -332,7 +340,8 @@ def test_blob_log_exclude_border():
 
 
 @pytest.mark.parametrize("dtype", [np.uint8, np.float16, np.float32])
-def test_blob_doh(dtype):
+@pytest.mark.parametrize('threshold_type', ['absolute', 'relative'])
+def test_blob_doh(dtype, threshold_type):
     img = np.ones((512, 512), dtype=dtype)
 
     xs, ys = disk((400, 130), 20)
@@ -347,20 +356,26 @@ def test_blob_doh(dtype):
     xs, ys = disk((200, 350), 50)
     img[xs, ys] = 255
 
-    # Note: have to either scale up threshold or rescale the image to the range
-    #       [0, 1] internally.
-    threshold = 0.05
-    if img.dtype.kind == 'f':
-        # account for lack of internal scaling to [0, 1] by img_as_float
-        ptp = img.ptp()
-        threshold *= ptp ** 2
+    if threshold_type == 'absolute':
+        # Note: have to either scale up threshold or rescale the image to the
+        #       range [0, 1] internally.
+        threshold = 0.05
+        if img.dtype.kind == 'f':
+            # account for lack of internal scaling to [0, 1] by img_as_float
+            ptp = img.ptp()
+            threshold *= ptp ** 2
+        threshold_rel = None
+    elif threshold_type == 'relative':
+        threshold = None
+        threshold_rel = 0.5
 
     blobs = blob_doh(
         img,
         min_sigma=1,
         max_sigma=60,
         num_sigma=10,
-        threshold=threshold)
+        threshold=threshold,
+        threshold_rel=threshold_rel)
 
     radius = lambda x: x[2]
     s = sorted(blobs, key=radius)


### PR DESCRIPTION
## Description

In #5503 we added `threshold_rel` to `blob_dog`. This PR extends the same approach to the other two blob detectors.

In general, `threshold_rel` is easier to choose a default value for than using an absolute threshold. This is especially true now that we do not automatically rescale the input image to the range [0, 1].

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
