### PR TITLE
Rescale image consistently during SLIC superpixel segmentation

### DIFF
--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -245,6 +245,13 @@ def slic(image, n_segments=100, compactness=10., max_num_iter=10, sigma=0,
     float_dtype = utils._supported_float_type(image.dtype)
     image = image.astype(float_dtype, copy=False)
 
+    # Rescale image to [0, 1] to make choice of compactness insensitive to
+    # input image scale.
+    image -= image.min()
+    imax = image.max()
+    if imax != 0:
+        image /= imax
+
     use_mask = mask is not None
     dtype = image.dtype
 

--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -243,7 +243,8 @@ def slic(image, n_segments=100, compactness=10., max_num_iter=10, sigma=0,
 
     image = img_as_float(image)
     float_dtype = utils._supported_float_type(image.dtype)
-    image = image.astype(float_dtype, copy=False)
+    # copy=True so subsequent in-place operations do not modify the function input
+    image = image.astype(float_dtype, copy=True)
 
     # Rescale image to [0, 1] to make choice of compactness insensitive to
     # input image scale.


### PR DESCRIPTION
## Description

closes #5512

Currently the internal `img_as_float` call rescales the range of integer inputs, but leaves floating point inputs unnormalized. The `compactness` parameter thus needs to be tuned based on image scale. Here I propose rescaling to range [0, 1] internally so the default is a reasonable starting point regardless of the input image scale.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
