### PR TITLE
fix wheels for macOS 10.13

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -59,7 +59,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "10.13"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -75,7 +76,14 @@ jobs:
           python -m pip install cibuildwheel
       - name: Build wheels for CPython 3.9 and Mac OS
         run: |
-          brew install libomp
+          # Make sure to use a libomp version binary compatible with the oldest
+          # supported version of the macos SDK as libomp will be vendored into the
+          # scikit-learn wheels for macos. The list of bottles can be found at:
+          # https://formulae.brew.sh/api/formula/libomp.json. Currently, the oldest
+          # supported macos version is: High Sierra / 10.13. When upgrading this, be
+          # sure to update the MACOSX_DEPLOYMENT_TARGET environment variable
+          wget https://homebrew.bintray.com/bottles/libomp-11.0.0.high_sierra.bottle.tar.gz
+          brew install libomp-11.0.0.high_sierra.bottle.tar.gz
           python -m cibuildwheel --output-dir dist
         env:
           CIBW_BUILD: "cp39-*"


### PR DESCRIPTION
## Description

closes #5465 (fixes wheels for older OS X releases)

The first commit here is from Mark's comment: https://github.com/scikit-image/scikit-image/issues/5465#issuecomment-877629768

An open question that Mark raised is why we only include `libomp` for the Python 3.9 case on macOS? Was this intentional or an oversight?

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
