### PR TITLE
fix histogram and regionprops_table doctests

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -233,9 +233,9 @@ def histogram(image, nbins=256, source_range='image', normalize=False, *,
     >>> from skimage import data, exposure, img_as_float
     >>> image = img_as_float(data.camera())
     >>> np.histogram(image, bins=2)
-    (array([107432, 154712]), array([ 0. ,  0.5,  1. ]))
+    (array([ 93585, 168559]), array([0. , 0.5, 1. ]))
     >>> exposure.histogram(image, nbins=2)
-    (array([107432, 154712]), array([ 0.25,  0.75]))
+    (array([ 93585, 168559]), array([0.25, 0.75]))
     """
     sh = image.shape
     if len(sh) == 3 and sh[-1] < 4 and channel_axis is None:

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -861,7 +861,7 @@ def regionprops_table(label_image, intensity_image=None,
     >>>
     >>> image = data.coins()
     >>> label_image = measure.label(image > 110, connectivity=image.ndim)
-    >>> props = measure.regionprops_table(label_image, image_intensity=image,
+    >>> props = measure.regionprops_table(label_image, intensity_image=image,
     ...                                   properties=('label',),
     ...                                   extra_properties=(quartiles,))
     >>> import pandas as pd # doctest: +SKIP


### PR DESCRIPTION
## Description

These two doctest errors were missed since their corresponding PRs were merged before #5505. For `histogram` the values are restored to the ones updated previously for 0.18 to reflect the new `skimage.data.camera` image. Those had gotten unintentionally set back to the old values in #3772 rebasing.

Also fixes a misspelled parameter in the `regionprops_table` doctest.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
