### PR TITLE
Add fixture enforcing SimpleITK I/O in test_simpleitk.py

### DIFF
--- a/skimage/io/tests/test_simpleitk.py
+++ b/skimage/io/tests/test_simpleitk.py
@@ -8,22 +8,24 @@ from skimage import data
 from skimage.io import imread, imsave, use_plugin, reset_plugins
 from skimage._shared import testing
 
-from pytest import importorskip, raises
+from pytest import importorskip, raises, fixture
 
 importorskip('SimpleITK')
 
 np.random.seed(0)
 
+
 def teardown():
     reset_plugins()
 
 
-def setup_module(self):
-    """The effect of the `plugin.use` call may be overridden by later imports.
-    Call `use_plugin` directly before the tests to ensure that SimpleITK is
-    used.
+@fixture(autouse=True)
+def setup_plugin():
+    """This ensures that `use_plugin` is directly called before all tests to
+    ensure that SimpleITK is used.
     """
     use_plugin('simpleitk')
+    yield
 
 
 def test_imread_as_gray():
@@ -44,7 +46,7 @@ def test_bilevel():
 
 
 def test_imread_truncated_jpg():
-    with raises(OSError):
+    with raises(RuntimeError):
         imread(testing.fetch('data/truncated.jpg'))
 
 

--- a/skimage/io/tests/test_simpleitk.py
+++ b/skimage/io/tests/test_simpleitk.py
@@ -8,7 +8,7 @@ from skimage import data
 from skimage.io import imread, imsave, use_plugin, reset_plugins
 from skimage._shared import testing
 
-from pytest import importorskip
+from pytest import importorskip, raises
 
 importorskip('SimpleITK')
 
@@ -42,13 +42,10 @@ def test_bilevel():
     img = imread(testing.fetch('data/checker_bilevel.png'))
     np.testing.assert_array_equal(img, expected)
 
-"""
-#TODO: This test causes a Segmentation fault
+
 def test_imread_truncated_jpg():
-    assert_raises((RuntimeError, ValueError),
-                  imread,
-                  testing.fetch('data/truncated.jpg'))
-"""
+    with raises(OSError):
+        imread(testing.fetch('data/truncated.jpg'))
 
 
 def test_imread_uint16():


### PR DESCRIPTION
## Description

TODO Reference: 
https://github.com/scikit-image/scikit-image/blob/178e05f17855859d6661ebb6e04d8ddcb50c1cc5/skimage/io/tests/test_simpleitk.py#L46

The test initially checked for `RuntimeError` or `ValueError` but given that the image being tested is truncated, means that it would result in an error when trying to read the image because the image does not have an end.
Refactored to check for an `OSError`.


## Checklist

- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
