### PR TITLE
Handle pooch version 1.5.0

### DIFF
--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -82,6 +82,7 @@ Bugfixes
   is avoided (#5047).
 - Nonzero values at the image edge are no longer incorrectly marked as a
   boundary when using ``find_bounaries`` with mode='subpixel' (#5447)
+- Work with pooch 1.5.0 for fetching data (#5529).
 
 
 Deprecations

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -63,11 +63,11 @@ skimage_distribution_dir = osp.join(legacy_data_dir, '..')
 
 try:
     try:
-        # Pooch < 1.5.0
-        from pooch.utils import file_hash
-    except ImportError:
         # Pooch >= 1.5.0
         from pooch.hashes import file_hash
+    except ImportError:
+        # Pooch < 1.5.0
+        from pooch.utils import file_hash
 except ModuleNotFoundError:
     # Function taken from
     # https://github.com/fatiando/pooch/blob/master/pooch/utils.py
@@ -281,7 +281,8 @@ def _init_pooch():
 # downstream users, see
 # https://github.com/scikit-image/scikit-image/issues/4660
 # https://github.com/scikit-image/scikit-image/issues/4664
-if has_pooch:
+if has_
+:
     _init_pooch()
 
 

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -281,8 +281,7 @@ def _init_pooch():
 # downstream users, see
 # https://github.com/scikit-image/scikit-image/issues/4660
 # https://github.com/scikit-image/scikit-image/issues/4664
-if has_
-:
+if has_pooch:
     _init_pooch()
 
 

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -62,12 +62,7 @@ legacy_data_dir = osp.abspath(osp.dirname(__file__))
 skimage_distribution_dir = osp.join(legacy_data_dir, '..')
 
 try:
-    try:
-        # Pooch >= 1.5.0
-        from pooch.hashes import file_hash
-    except ImportError:
-        # Pooch < 1.5.0
-        from pooch.utils import file_hash
+    from pooch import file_hash
 except ModuleNotFoundError:
     # Function taken from
     # https://github.com/fatiando/pooch/blob/master/pooch/utils.py

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -62,7 +62,12 @@ legacy_data_dir = osp.abspath(osp.dirname(__file__))
 skimage_distribution_dir = osp.join(legacy_data_dir, '..')
 
 try:
-    from pooch.utils import file_hash
+    try:
+        # Pooch < 1.5.0
+        from pooch.utils import file_hash
+    except ImportError:
+        # Pooch >= 1.5.0
+        from pooch.hashes import file_hash
 except ModuleNotFoundError:
     # Function taken from
     # https://github.com/fatiando/pooch/blob/master/pooch/utils.py


### PR DESCRIPTION
This is compatible with pooch < 1.5.0, too.  If such older compatibility
is not desired, the dependency version could be changed and just the new
code could be kept.

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
Closes #5528.
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
