### PR TITLE
Added handling of case K1 = 0 and/or K2 = 0

### DIFF
--- a/skimage/metrics/_structural_similarity.py
+++ b/skimage/metrics/_structural_similarity.py
@@ -227,7 +227,15 @@ def structural_similarity(im1, im2,
                        ux ** 2 + uy ** 2 + C1,
                        vx + vy + C2))
     D = B1 * B2
-    S = (A1 * A2) / D
+    
+    S1 = A1 / B1
+    S2 = A2 / B2
+
+    # When K1 = 0 and/or K2 = 0, set NaN elements of S1 and S2 to 1
+    S1[B1==0.0] = 1.0
+    S2[B2==0.0] = 1.0
+
+    S = S1 * S2
 
     # to avoid edge effects will ignore filter radius strip around edges
     pad = (win_size - 1) // 2


### PR DESCRIPTION
The cases K1 = 0 and/or K2 = 0 gave NaNs in S if D had zeros.
Fixed by introducing appropriate factors S1 and S2, which
we set to 1 when zeros appear in the denominator.
This fixes the case when gradient is False.

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
