### PR TITLE
Backports for 0.18.3 (pooch 1.5 fix, deprecated `scipy.linalg.pinv2` fix)

### DIFF
--- a/doc/release/release_0.18.rst
+++ b/doc/release/release_0.18.rst
@@ -1,3 +1,34 @@
+scikit-image 0.18.3
+===================
+
+We're happy to announce the release of scikit-image v0.18.3!
+
+scikit-image is an image processing toolbox for SciPy that includes algorithms
+for segmentation, geometric transformations, color space manipulation,
+analysis, filtering, morphology, feature detection, and more.
+
+This is a small bugfix release for compatibility with Pooch 1.5 and SciPy 1.7.
+
+Bug fixes
+---------
+- Only import from Pooch's public API. This resolves an import failure with
+  Pooch 1.5.0. (#5531, backport of #5437)
+- Do not use deprecated ``scipy.linalg.pinv2`` in ``random_walker`` when
+  using the multigrid solver. (#5531, backport of #5437)
+
+3 authors added to this release [alphabetical by first name or login]
+---------------------------------------------------------------------
+David Manthey
+Gregory Lee
+Mark Harfouche
+
+3 reviewers added to this release [alphabetical by first name or login]
+-----------------------------------------------------------------------
+Gregory Lee
+Juan Nunez-Iglesias
+Mark Harfouche
+
+
 scikit-image 0.18.2
 ===================
 

--- a/doc/release/release_0.18.rst
+++ b/doc/release/release_0.18.rst
@@ -12,7 +12,7 @@ This is a small bugfix release for compatibility with Pooch 1.5 and SciPy 1.7.
 Bug fixes
 ---------
 - Only import from Pooch's public API. This resolves an import failure with
-  Pooch 1.5.0. (#5531, backport of #5437)
+  Pooch 1.5.0. (#5531, backport of #5529)
 - Do not use deprecated ``scipy.linalg.pinv2`` in ``random_walker`` when
   using the multigrid solver. (#5531, backport of #5437)
 

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -22,7 +22,7 @@ New Features
 - Added a new perimeter function - ``measure.perimeter_crofton``.
 - Added 3D support for many filters in skimage.filters.rank.
 - New images have been added in the ``data`` subpackage: ``data.eagle``
-  (#4922), TODO for other images 
+  (#4922), TODO for other images
   Also note that the image for ``data.camera`` has been changed due to
   copyright issues (#4913).
 
@@ -53,7 +53,7 @@ Documentation
   which are not installed with scikit-image (#4984). Similarly, the contributor
   guide has been updated to mention how to host new datasets in a gitlab
   repository (#4892).
-- The `benchmarking section of the developer documentation <https://scikit-image.org/docs/dev/contribute.html#benchmarks>`_ 
+- The `benchmarking section of the developer documentation <https://scikit-image.org/docs/dev/contribute.html#benchmarks>`_
   has been expanded (#4905).
 
 
@@ -86,7 +86,7 @@ API Changes
   when the input is single-precision. Prior to this release, double-precision
   was always used.
 - The default value of ``threshold_rel`` in ``skimage.feature.corner`` has
-  changed from 0.1 to None, which corresponds to letting 
+  changed from 0.1 to None, which corresponds to letting
   ``skimage.feature.peak_local_max`` decide on the default. This is currently
   equivalent to ``threshold_rel=0``.
 - ``data.cat`` has been introduced as an alias of ``data.chelsea`` for a more
@@ -100,12 +100,12 @@ API Changes
 Bugfixes
 --------
 
-- For the RANSAC algorithm, improved the case where all data points are 
-  outliers, which was previously raising an error 
+- For the RANSAC algorithm, improved the case where all data points are
+  outliers, which was previously raising an error
   (#4844)
 - An error-causing bug has been corrected for the ``bg_color`` parameter in
   ``label2rgb`` when its value is a string (#4840)
-- A normalization bug was fixed in ``metrics.variation_of_information`` 
+- A normalization bug was fixed in ``metrics.variation_of_information``
   (#4875)
 - Fixed the behaviour of Richardson-Lucy deconvolution for images with 3
   dimensions or more (#4823)
@@ -130,6 +130,7 @@ Bugfixes
   (#4756).
 - Input ``labels`` argument renumbering in ``skimage.feature.peak_local_max``
   is avoided (#5047).
+- Work with pooch 1.5.0 for fetching data (#5529).
 
 
 Deprecations
@@ -145,7 +146,7 @@ Deprecations
   we recommend using dedicated tools such as napari or plotly. In a similar
   vein, the ``qt`` and ``skivi`` plugins of ``skimage.io`` have been deprecated
   and will be removed in version 0.20.
-- In ``skimage.morphology.selem.rectangle`` the arguments ``width`` and 
+- In ``skimage.morphology.selem.rectangle`` the arguments ``width`` and
   ``height`` have been deprecated. Use ``nrow`` and ``ncol`` instead.
 - The explicit setting ``threshold_rel=0` was removed from the Examples of the
   following docstrings: ``skimage.feature.BRIEF``,

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -71,7 +71,7 @@ dtype_limits
 import sys
 
 
-__version__ = '0.18.2.dev0'
+__version__ = '0.18.3.dev0'
 
 from ._shared.version_requirements import ensure_python_version
 ensure_python_version((3, 5))

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -71,7 +71,7 @@ dtype_limits
 import sys
 
 
-__version__ = '0.18.2rc2.dev0'
+__version__ = '0.18.2.dev0'
 
 from ._shared.version_requirements import ensure_python_version
 ensure_python_version((3, 5))

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -138,7 +138,6 @@ def create_image_fetcher():
     else:
         url = ("https://github.com/scikit-image/scikit-image/raw/"
                "v{version}/skimage/")
-
     # Create a new friend to manage your sample data storage
     image_fetcher = pooch.create(
         # Pooch uses appdirs to select an appropriate directory for the cache

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -61,7 +61,7 @@ legacy_data_dir = osp.abspath(osp.dirname(__file__))
 skimage_distribution_dir = osp.join(legacy_data_dir, '..')
 
 try:
-    from pooch.utils import file_hash
+    from pooch import file_hash
 except ModuleNotFoundError:
     # Function taken from
     # https://github.com/fatiando/pooch/blob/master/pooch/utils.py

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -193,7 +193,7 @@ def _solve_linear_system(lap_sparse, B, tol, mode):
         else:
             # mode == 'cg_mg'
             lap_sparse = lap_sparse.tocsr()
-            ml = ruge_stuben_solver(lap_sparse)
+            ml = ruge_stuben_solver(lap_sparse, coarse_solver='pinv')
             M = ml.aspreconditioner(cycle='V')
             maxiter = 30
         cg_out = [


### PR DESCRIPTION
## Description

- backports #5529 (Pooch v1.5.0 compatibility)

import `file_hash` from Pooch public API

- backports #5437 (SciPy v1.7.x compatibility)

use `pinv` instead of deprected `scipy.linalg.pinv2` in `random_walker`

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
