### PR TITLE
.format() converted to f-strings in io, morphology subpackage

### DIFF
--- a/skimage/io/sift.py
+++ b/skimage/io/sift.py
@@ -60,7 +60,7 @@ def _sift_read(filelike, mode='SIFT'):
 
     data = np.fromfile(f, sep=' ')
     if data.size != nr_features * datatype.itemsize / np.dtype(float).itemsize:
-        raise IOError("Invalid {} feature file.".format(mode))
+        raise IOError(f'Invalid {mode} feature file.')
 
     # If `filelike` is passed to the function as filename - close the file
     if filelike_is_str:

--- a/skimage/io/tests/test_io.py
+++ b/skimage/io/tests/test_io.py
@@ -41,7 +41,7 @@ def test_imread_file_url():
     # tweak data path so that file URI works on both unix and windows.
     data_path = str(testing.fetch('data/camera.png'))
     data_path = data_path.replace(os.path.sep, '/')
-    image_url = 'file:///{0}'.format(data_path)
+    image_url = f'file:///{data_path}'
     image = io.imread(image_url)
     assert image.shape == (512, 512)
 
@@ -95,7 +95,7 @@ def test_failed_temporary_file(monkeypatch, error_class):
     # tweak data path so that file URI works on both unix and windows.
     data_path = data_dir.lstrip(os.path.sep)
     data_path = data_path.replace(os.path.sep, '/')
-    image_url = 'file:///{0}/camera.png'.format(data_path)
+    image_url = f'file:///{data_path}/camera.png'
     with monkeypatch.context():
         monkeypatch.setattr(
             tempfile, 'NamedTemporaryFile', _named_tempfile_func(error_class)

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -84,8 +84,8 @@ def skeletonize(image, *, method=None):
     elif image.ndim == 3 or (image.ndim == 2 and method == 'lee'):
         skeleton = skeletonize_3d(image)
     else:
-        raise ValueError('skeletonize requires a 2D or 3D image as input, '
-                         'got {}D.'.format(image.ndim))
+        raise ValueError(f'skeletonize requires a 2D or 3D image as input, '
+                         'got {image.ndim}D.')
     return skeleton
 
 

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -85,7 +85,7 @@ def skeletonize(image, *, method=None):
         skeleton = skeletonize_3d(image)
     else:
         raise ValueError(f'skeletonize requires a 2D or 3D image as input, '
-                         'got {image.ndim}D.')
+                         f'got {image.ndim}D.')
     return skeleton
 
 

--- a/skimage/morphology/tests/test_gray.py
+++ b/skimage/morphology/tests/test_gray.py
@@ -33,8 +33,7 @@ class TestMorphology():
         for n in range(1, 4):
             for strel in footprints_2D:
                 for func in funcs:
-                    key = '{0}_{1}_{2}'.format(
-                        strel.__name__, n, func.__name__)
+                    key = f'{strel.__name__}_{n}_{func.__name__}'
                     output[key] = func(image, strel(n))
 
         return output


### PR DESCRIPTION
## Description
Partially addresses Issue #5474 
<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
