### PR TITLE
.format to f-string in metrics, measure subpackage

### DIFF
--- a/skimage/measure/mc_meta/visual_test.py
+++ b/skimage/measure/mc_meta/visual_test.py
@@ -97,7 +97,7 @@ def timer(message):
     print(message, end=' ')
     start = time.time()
     yield
-    print('took {:1.0f} ms'.format(1000 * (time.time() - start)))
+    print(f"took {1000 * (time.time() - start):1.0f} ms")
 
 
 if __name__ == '__main__':

--- a/skimage/metrics/simple_metrics.py
+++ b/skimage/metrics/simple_metrics.py
@@ -239,7 +239,8 @@ def normalized_mutual_information(image0, image1, *, bins=100):
     """
     if image0.ndim != image1.ndim:
         raise ValueError(f"NMI requires images of same number of dimensions. "
-                         f"Got {image0.ndim}D for `image0` and {image1.ndim}D for `image1`.")
+                         f"Got {image0.ndim}D for `image0` and "
+                         f"{image1.ndim}D for `image1`.")
     if image0.shape != image1.shape:
         max_shape = np.maximum(image0.shape, image1.shape)
         padded0 = _pad_to(image0, max_shape)

--- a/skimage/metrics/simple_metrics.py
+++ b/skimage/metrics/simple_metrics.py
@@ -238,9 +238,8 @@ def normalized_mutual_information(image0, image1, *, bins=100):
            :DOI:`10.1016/S0031-3203(98)00091-0`
     """
     if image0.ndim != image1.ndim:
-        raise ValueError('NMI requires images of same number of dimensions. '
-                         'Got {}D for `image0` and {}D for `image1`.'
-                         .format(image0.ndim, image1.ndim))
+        raise ValueError(f"NMI requires images of same number of dimensions. "
+                         f"Got {image0.ndim}D for `image0` and {image1.ndim}D for `image1`.")
     if image0.shape != image1.shape:
         max_shape = np.maximum(image0.shape, image1.shape)
         padded0 = _pad_to(image0, max_shape)


### PR DESCRIPTION
## Description
Partially addresses Issue #5474
<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
