### PR TITLE
Support user-supplied histogram in threshold_multiotsu

### DIFF
--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -733,7 +733,7 @@ def test_multiotsu_lut():
 
 
 def test_multiotsu_missing_img_and_hist():
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         threshold_multiotsu()
 
 
@@ -742,10 +742,7 @@ def test_multiotsu_hist_parameter():
         for name in ['camera', 'moon', 'coins', 'text', 'clock', 'page']:
             img = getattr(data, name)()
             sk_hist = histogram(img, nbins=256)
-            np_hist = np.histogram(img, bins=256)
             #
             thresh_img = threshold_multiotsu(img, classes)
             thresh_sk_hist = threshold_multiotsu(classes=classes, hist=sk_hist)
-            thresh_np_hist = threshold_multiotsu(classes=classes, hist=np_hist)
             assert np.allclose(thresh_img, thresh_sk_hist)
-            assert not np.allclose(thresh_img, thresh_np_hist)

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -268,11 +268,11 @@ def test_otsu_camera_image_counts():
     camera = util.img_as_ubyte(data.camera())
     counts, bin_centers = histogram(camera.ravel(), 256, source_range='image')
     assert 101 < threshold_otsu(hist=counts) < 103
-    
-    
+
+
 def test_otsu_zero_count_histogram():
     """Issue #5497.
-    
+
     As the histogram returned by np.bincount starts with zero,
     it resulted in NaN-related issues.
     """

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -730,3 +730,22 @@ def test_multiotsu_lut():
             result = _get_multiotsu_thresh_indices(prob, classes - 1)
 
             assert np.array_equal(result_lut, result)
+
+
+def test_multiotsu_missing_img_and_hist():
+    with pytest.raises(ValueError):
+        threshold_multiotsu()
+
+
+def test_multiotsu_hist_parameter():
+    for classes in [2, 3, 4]:
+        for name in ['camera', 'moon', 'coins', 'text', 'clock', 'page']:
+            img = getattr(data, name)()
+            sk_hist = histogram(img, nbins=256)
+            np_hist = np.histogram(img, bins=256)
+            #
+            thresh_img = threshold_multiotsu(img, classes)
+            thresh_sk_hist = threshold_multiotsu(classes=classes, hist=sk_hist)
+            thresh_np_hist = threshold_multiotsu(classes=classes, hist=np_hist)
+            assert np.allclose(thresh_img, thresh_sk_hist)
+            assert not np.allclose(thresh_img, thresh_np_hist)

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -1237,9 +1237,9 @@ def threshold_multiotsu(image=None, classes=3, nbins=256, *, hist=None):
     >>> regions_colorized = label2rgb(regions)
     """
     if image is not None and image.ndim > 2 and image.shape[-1] in (3, 4):
-             f'threshold_multiotsu is expected to work correctly only for '
-             f'grayscale images; image shape {image.shape} looks like '
-             f'that of an RGB image.')
+        warn(f'threshold_multiotsu is expected to work correctly only for '
+             f'grayscale images; image shape {image.shape} looks like that'
+             f'of an RGB image.')
 
     # calculating the histogram and the probability of each gray level.
     prob, bin_centers = _validate_image_histogram(image, hist, nbins,

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -1245,7 +1245,7 @@ def threshold_multiotsu(image=None, classes=3, nbins=256, *, hist=None):
     prob, bin_centers = _validate_image_histogram(image, hist, nbins,
                                                   normalize=True)
     prob = prob.astype('float32')
-    
+
     nvalues = np.count_nonzero(prob)
     if nvalues < classes:
         msg = ('The input image has only {} different values. '

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -1248,9 +1248,9 @@ def threshold_multiotsu(image=None, classes=3, nbins=256, *, hist=None):
 
     nvalues = np.count_nonzero(prob)
     if nvalues < classes:
-        msg = ('The input image has only {} different values. '
-               'It can not be thresholded in {} classes')
-        raise ValueError(msg.format(nvalues, classes))
+        msg = (f'The input image has only {nvalues} different values. '
+               f'It cannot be thresholded in {classes} classes.')
+        raise ValueError(msg)
     elif nvalues == classes:
         thresh_idx = np.where(prob > 0)[0][:-1]
     else:

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -1237,9 +1237,9 @@ def threshold_multiotsu(image=None, classes=3, nbins=256, *, hist=None):
     >>> regions_colorized = label2rgb(regions)
     """
     if image is not None and image.ndim > 2 and image.shape[-1] in (3, 4):
-        msg = 'threshold_otsu is expected to work correctly only for ' \
-            'grayscale images; image shape {0} looks like an RGB image'
-        warn(msg.format(image.shape))
+             f'threshold_multiotsu is expected to work correctly only for '
+             f'grayscale images; image shape {image.shape} looks like '
+             f'that of an RGB image.')
 
     # calculating the histogram and the probability of each gray level.
     prob, bin_centers = _validate_image_histogram(image, hist, nbins,

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -1238,8 +1238,8 @@ def threshold_multiotsu(image=None, classes=3, nbins=256, *, hist=None):
     """
     if image is not None and image.ndim > 2 and image.shape[-1] in (3, 4):
         warn(f'threshold_multiotsu is expected to work correctly only for '
-             f'grayscale images; image shape {image.shape} looks like that'
-             f'of an RGB image.')
+             f'grayscale images; image shape {image.shape} looks like '
+             f'that of an RGB image.')
 
     # calculating the histogram and the probability of each gray level.
     prob, bin_centers = _validate_image_histogram(image, hist, nbins,

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -1266,4 +1266,3 @@ def threshold_multiotsu(image=None, classes=3, nbins=256, *, hist=None):
     thresh = bin_centers[thresh_idx]
 
     return thresh
-


### PR DESCRIPTION
## Description

closes #5541

This is a proposed implementation to close the feature request described in issue https://github.com/scikit-image/scikit-image/issues/5541

For the multi-Otsu implementation, I've mimicked the existing one in the single Otsu thresholding function. I've tested it on my own data and seems to work fine.  I've also updated the function's docstring and added 2 test cases:

1. Check that `ValueError` is raised when neither image nor histogram are given
2. Check that replacing input image with a corresponding `skimage.exposure.histogram` returns the same threshold, while replacing with `np.histogram` returns different ones.

All other thresholding tests seem to pass, and Flake8 seems happy with my additions. I'll be happy to hear any feedback!

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
