### PR TITLE
Fix io.imread behavior with pathlib.Path inputs

### DIFF
--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -1,10 +1,12 @@
+import pathlib
+
 import numpy as np
 
-from ..io.manage_plugins import call_plugin
-from ..color.colorconv import rgb2gray, rgba2rgb
-from .util import file_or_url_context
-from ..exposure import is_low_contrast
 from .._shared.utils import warn
+from ..exposure import is_low_contrast
+from ..color.colorconv import rgb2gray, rgba2rgb
+from ..io.manage_plugins import call_plugin
+from .util import file_or_url_context
 
 
 __all__ = ['imread', 'imsave', 'imshow', 'show',
@@ -40,6 +42,9 @@ def imread(fname, as_gray=False, plugin=None, **plugin_args):
         RGB-image MxNx3 and an RGBA-image MxNx4.
 
     """
+    if isinstance(fname, pathlib.Path):
+        fname = str(fname.resolve())
+
     if plugin is None and hasattr(fname, 'lower'):
         if fname.lower().endswith(('.tiff', '.tif')):
             plugin = 'tifffile'

--- a/skimage/io/tests/test_io.py
+++ b/skimage/io/tests/test_io.py
@@ -93,7 +93,7 @@ def _named_tempfile_func(error_class):
     from the Python standard library could raise. As of this writing, these
     are ``FileNotFoundError``, ``FileExistsError``, ``PermissionError``, and
     ``BaseException``. See
-    `this comment <https://github.com/scikit-image/scikit-image/issues/3785#issuecomment-486598307>`__  #noqa
+    `this comment <https://github.com/scikit-image/scikit-image/issues/3785#issuecomment-486598307>`__  # noqa
     for more information.
     """
     def named_temp_file(*args, **kwargs):

--- a/skimage/io/tests/test_io.py
+++ b/skimage/io/tests/test_io.py
@@ -1,12 +1,12 @@
 import os
+import pathlib
 import tempfile
 
 import numpy as np
-from skimage import io
+import pytest
 
-from skimage._shared import testing
-from skimage._shared.testing import assert_array_equal
-from skimage._shared.testing import fetch
+from skimage import io
+from skimage._shared.testing import assert_array_equal, fetch
 from skimage.data import data_dir
 
 
@@ -25,6 +25,7 @@ one_by_one_jpeg = (
     b'\x00?\x00*\x9f\xff\xd9'
 )
 
+
 def test_stack_basic():
     x = np.arange(12).reshape(3, 4)
     io.push(x)
@@ -33,13 +34,13 @@ def test_stack_basic():
 
 
 def test_stack_non_array():
-    with testing.raises(ValueError):
+    with pytest.raises(ValueError):
         io.push([[1, 2, 3]])
 
 
 def test_imread_file_url():
     # tweak data path so that file URI works on both unix and windows.
-    data_path = str(testing.fetch('data/camera.png'))
+    data_path = str(fetch('data/camera.png'))
     data_path = data_path.replace(os.path.sep, '/')
     image_url = f'file:///{data_path}'
     image = io.imread(image_url)
@@ -55,6 +56,21 @@ def test_imread_http_url(httpserver):
     # by extension
     image = io.imread(httpserver.url + '/test.jpg' + '?' + 's' * 266)
     assert image.shape == (1, 1)
+
+
+def test_imread_pathlib_tiff():
+    """Tests reading from Path object (issue gh-5545)."""
+
+    # read via fetch
+    expected = io.imread(fetch('data/multipage.tif'))
+
+    # read by passing in a pathlib.Path object
+    fname = os.path.join(data_dir, 'multipage.tif')
+    path = pathlib.Path(fname)
+    img = io.imread(path)
+
+    assert img.shape == (2, 15, 10)
+    assert_array_equal(expected, img)
 
 
 def _named_tempfile_func(error_class):
@@ -77,7 +93,7 @@ def _named_tempfile_func(error_class):
     from the Python standard library could raise. As of this writing, these
     are ``FileNotFoundError``, ``FileExistsError``, ``PermissionError``, and
     ``BaseException``. See
-    `this comment <https://github.com/scikit-image/scikit-image/issues/3785#issuecomment-486598307>`__
+    `this comment <https://github.com/scikit-image/scikit-image/issues/3785#issuecomment-486598307>`__  #noqa
     for more information.
     """
     def named_temp_file(*args, **kwargs):
@@ -85,7 +101,7 @@ def _named_tempfile_func(error_class):
     return named_temp_file
 
 
-@testing.parametrize(
+@pytest.mark.parametrize(
     'error_class', [
         FileNotFoundError, FileExistsError, PermissionError, BaseException
     ]
@@ -100,5 +116,5 @@ def test_failed_temporary_file(monkeypatch, error_class):
         monkeypatch.setattr(
             tempfile, 'NamedTemporaryFile', _named_tempfile_func(error_class)
         )
-        with testing.raises(error_class):
-            image = io.imread(image_url)
+        with pytest.raises(error_class):
+            io.imread(image_url)


### PR DESCRIPTION
## Description

closes #5545

The following logic for using `tifffile` fails if `fname` is a `Path`:

```Python
    if plugin is None and hasattr(fname, 'lower'):
        if fname.lower().endswith(('.tiff', '.tif')):
            plugin = 'tifffile'
```

Casting the Path to `str` before this `if` statement resolves the issue.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
