### PR TITLE
Fix and standardize docstrings for blob detection functions.

### DIFF
--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -438,7 +438,7 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
         interpolation is used.
     threshold_rel : float or None, optional
         Minimum intensity of peaks, calculated as
-        ``max(dog_space) * threshold_rel``, where ``dog_space`` refers to the
+        ``max(log_space) * threshold_rel``, where ``log_space`` refers to the
         stack of Laplacian of Gaussian (LoG) images computed internally. This
         should have a value between 0 and 1. If None, `threshold` is used
         instead.
@@ -599,7 +599,7 @@ def blob_doh(image, min_sigma=1, max_sigma=30, num_sigma=10, threshold=0.01,
         interpolation is used.
     threshold_rel : float or None, optional
         Minimum intensity of peaks, calculated as
-        ``max(dog_space) * threshold_rel``, where ``dog_space`` refers to the
+        ``max(doh_space) * threshold_rel``, where ``doh_space`` refers to the
         stack of determinant-of-hessian (DoH) images computed internally. This
         should have a value between 0 and 1. If None, `threshold` is used
         instead.

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -250,9 +250,9 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=0.5,
         fraction greater than `threshold`, the smaller blob is eliminated.
     threshold_rel : float or None, optional
         Minimum intensity of peaks, calculated as
-        ``max(dog_space) * threshold_rel``. Where ``dog_space`` refers to the
+        ``max(dog_space) * threshold_rel``, where ``dog_space`` refers to the
         stack of difference-of-Gaussian (DoG) images computed internally. This
-        should have a value between 0 and 1. If None, `threshold_abs` is used
+        should have a value between 0 and 1. If None, `threshold` is used
         instead.
     exclude_border : tuple of ints, int, or False, optional
         If tuple of ints, the length of the tuple must match the input array's

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -251,7 +251,7 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=0.5,
     threshold_rel : float or None, optional
         Minimum intensity of peaks, calculated as
         ``max(dog_space) * threshold_rel``, where ``dog_space`` refers to the
-        stack of difference-of-Gaussian (DoG) images computed internally. This
+        stack of Difference-of-Gaussian (DoG) images computed internally. This
         should have a value between 0 and 1. If None, `threshold` is used
         instead.
     exclude_border : tuple of ints, int, or False, optional
@@ -439,7 +439,7 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
     threshold_rel : float or None, optional
         Minimum intensity of peaks, calculated as
         ``max(log_space) * threshold_rel``, where ``log_space`` refers to the
-        stack of Laplacian of Gaussian (LoG) images computed internally. This
+        stack of Laplacian-of-Gaussian (LoG) images computed internally. This
         should have a value between 0 and 1. If None, `threshold` is used
         instead.
     exclude_border : tuple of ints, int, or False, optional
@@ -600,7 +600,7 @@ def blob_doh(image, min_sigma=1, max_sigma=30, num_sigma=10, threshold=0.01,
     threshold_rel : float or None, optional
         Minimum intensity of peaks, calculated as
         ``max(doh_space) * threshold_rel``, where ``doh_space`` refers to the
-        stack of determinant-of-hessian (DoH) images computed internally. This
+        stack of Determinant-of-Hessian (DoH) images computed internally. This
         should have a value between 0 and 1. If None, `threshold` is used
         instead.
 


### PR DESCRIPTION
## Description

@grlee77 @rfezzani tiny follow-up on #5503 and #5517 


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
