### PR TITLE
Support nD images and labels in label2rgb

### DIFF
--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -78,9 +78,9 @@ def label2rgb(label, image=None, colors=None, alpha=0.3,
 
     Parameters
     ----------
-    label : array, shape (M, N)
+    label : array, shape (M, N) or (M, N, ...)
         Integer array of labels with the same shape as `image`.
-    image : array, shape (M, N) or (..., 3, ...), optional
+    image : array, shape (M, N) or (M, N, ...., 3), optional
         Image used as underlay for labels. If the input is an RGB image, it's
         converted to grayscale before coloring.
     colors : list, optional
@@ -140,9 +140,9 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
 
     Parameters
     ----------
-    label : array, shape (M, N)
+    label : array, shape (M, N) or (M, N, ...)
         Integer array of labels with the same shape as `image`.
-    image : array, shape (M, N, 3), optional
+    image : array, shape (M, N, 3) or (M, N, ..., 3), optional
         Image used as underlay for labels. If the input is an RGB image, it's
         converted to grayscale before coloring, unless the `saturation` is
         greater than 0.
@@ -182,12 +182,13 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
         # Opacity doesn't make sense if no image exists.
         alpha = 1
     else:
-        if label.ndim > 2:
-            raise ValueError("label2rgb only supports 2D inputs :"
-                             " label and image shape (M,N) and (M,N,3)")
-
-        if not image.shape[:2] == label.shape:
+        if not image.shape[:label.ndim] == label.shape:
             raise ValueError("`image` and `label` must be the same shape")
+
+        if not image.shape[-1] == 3:
+            raise ValueError(
+                "`image` must be RGB (image.shape[-1] must be 3)."
+            )
 
         if image.min() < 0:
             warn("Negative intensities in `image` are not supported")

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -182,7 +182,8 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
         # Opacity doesn't make sense if no image exists.
         alpha = 1
     else:
-        if not image.shape[:label.ndim] == label.shape:
+        if (image.shape[:label.ndim] != label.shape
+                or image.ndim > label.ndim + 1):
             raise ValueError("`image` and `label` must be the same shape")
 
         if not image.shape[-1] == 3:

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -183,7 +183,8 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
         alpha = 1
     else:
         if label.ndim > 2:
-            raise ValueError("label2rgb only supports 2D inputs : label and image shape (M,N) and (M,N,3)")
+            raise ValueError("label2rgb only supports 2D inputs :"
+                             " label and image shape (M,N) and (M,N,3)")
 
         if not image.shape[:2] == label.shape:
             raise ValueError("`image` and `label` must be the same shape")

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -182,6 +182,9 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
         # Opacity doesn't make sense if no image exists.
         alpha = 1
     else:
+        if label.ndim > 2:
+            raise ValueError("label2rgb only supports 2D inputs : label and image shape (M,N) and (M,N,3)")
+
         if not image.shape[:2] == label.shape:
             raise ValueError("`image` and `label` must be the same shape")
 

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -186,7 +186,7 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
                 or image.ndim > label.ndim + 1):
             raise ValueError("`image` and `label` must be the same shape")
 
-        if not image.shape[-1] == 3:
+        if image.ndim == label.ndim + 1 and image.shape[-1] != 3:
             raise ValueError(
                 "`image` must be RGB (image.shape[-1] must be 3)."
             )

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -78,11 +78,12 @@ def label2rgb(label, image=None, colors=None, alpha=0.3,
 
     Parameters
     ----------
-    label : array, shape (M, N) or (M, N, ...)
+    label : ndarray
         Integer array of labels with the same shape as `image`.
-    image : array, shape (M, N) or (M, N, ...., 3), optional
-        Image used as underlay for labels. If the input is an RGB image, it's
-        converted to grayscale before coloring.
+    image : ndarray, optional
+        Image used as underlay for labels. It should have the same shape as
+        `labels`, optionally with an additional RGB (channels) axis. If `image`
+        is an RGB image, it is converted to grayscale before coloring.
     colors : list, optional
         List of colors. If the number of labels exceeds the number of colors,
         then the colors are cycled.
@@ -117,7 +118,7 @@ def label2rgb(label, image=None, colors=None, alpha=0.3,
 
     Returns
     -------
-    result : array of float, shape (..., 3, ...)
+    result : ndarray of float, same shape as `image`
         The result of blending a cycling colormap (`colors`) for each distinct
         value in `label` with the image, at a certain alpha value.
     """
@@ -125,7 +126,7 @@ def label2rgb(label, image=None, colors=None, alpha=0.3,
         image = np.moveaxis(image, source=channel_axis, destination=-1)
     if kind == 'overlay':
         rgb = _label2rgb_overlay(label, image, colors, alpha, bg_label,
-                                  bg_color, image_alpha, saturation)
+                                 bg_color, image_alpha, saturation)
     elif kind == 'avg':
         rgb = _label2rgb_avg(label, image, bg_label, bg_color)
     else:
@@ -140,12 +141,12 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
 
     Parameters
     ----------
-    label : array, shape (M, N) or (M, N, ...)
+    label : ndarray
         Integer array of labels with the same shape as `image`.
-    image : array, shape (M, N, 3) or (M, N, ..., 3), optional
-        Image used as underlay for labels. If the input is an RGB image, it's
-        converted to grayscale before coloring, unless the `saturation` is
-        greater than 0.
+    image : ndarray, optional
+        Image used as underlay for labels. It should have the same shape as
+        `labels`, optionally with an additional RGB (channels) axis. If `image`
+        is an RGB image, it is converted to grayscale before coloring.
     colors : list, optional
         List of colors. If the number of labels exceeds the number of colors,
         then the colors are cycled.
@@ -166,7 +167,7 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
 
     Returns
     -------
-    result : array of float, shape (M, N, 3)
+    result : ndarray of float, same shape as `image`
         The result of blending a cycling colormap (`colors`) for each distinct
         value in `label` with the image, at a certain alpha value.
     """
@@ -244,7 +245,7 @@ def _label2rgb_avg(label_field, image, bg_label=0, bg_color=(0, 0, 0)):
 
     Parameters
     ----------
-    label_field : array of int
+    label_field : ndarray of int
         A segmentation of an image.
     image : array, shape ``label_field.shape + (3,)``
         A color image of the same spatial shape as `label_field`.
@@ -255,7 +256,7 @@ def _label2rgb_avg(label_field, image, bg_label=0, bg_color=(0, 0, 0)):
 
     Returns
     -------
-    out : array, same shape and type as `image`
+    out : ndarray, same shape and type as `image`
         The output visualization.
     """
     out = np.zeros(label_field.shape + (3,), dtype=image.dtype)

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -220,6 +220,14 @@ def test_avg_with_2d_image():
     assert_no_warnings(label2rgb, labels, image=img, bg_label=0, kind='avg')
 
 
+def test_label2rgb_with_3d_image():
+    img = np.random.randint(0, 255, (10, 10, 10, 3), dtype=np.uint8)
+    labels = np.zeros((10, 10, 10), dtype=np.int64)
+    labels[:, 1:3, 1:3] = 1
+    labels[:, 6:9, 6:9] = 2
+    assert_no_warnings(label2rgb, labels, image=img, bg_label=0)
+
+
 def test_overlay_full_saturation():
     rgb_img = np.random.uniform(size=(10, 10, 3))
     labels = np.ones((10, 10), dtype=np.int64)

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -233,8 +233,10 @@ def test_label2rgb_nd(image_type):
 
     # add a couple of rectangular labels
     labels = np.zeros(shape, dtype=np.int64)
-    labels[1:3, 1:3] = 1
-    labels[5:9, 5:9] = 2
+    # Note: Have to choose labels here so that the 1D slice below also contains
+    #       both label values. Otherwise the labeled colors will not match.
+    labels[2:-2, 1:3] = 1
+    labels[3:-3, 6:9] = 2
 
     # label in the 2D case (correct 2D output is tested in other funcitons)
     labeled_2d = label2rgb(labels, image=img, bg_label=0)

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -220,12 +220,55 @@ def test_avg_with_2d_image():
     assert_no_warnings(label2rgb, labels, image=img, bg_label=0, kind='avg')
 
 
-def test_label2rgb_with_3d_image():
-    img = np.random.randint(0, 255, (10, 10, 10, 3), dtype=np.uint8)
-    labels = np.zeros((10, 10, 10), dtype=np.int64)
-    labels[:, 1:3, 1:3] = 1
-    labels[:, 6:9, 6:9] = 2
-    assert_no_warnings(label2rgb, labels, image=img, bg_label=0)
+@pytest.mark.parametrize('image_type', ['rgb', 'gray', None])
+def test_label2rgb_nd(image_type):
+    # validate 1D and 3D cases by testing their output relative to the 2D case
+    shape = (10, 10)
+    if image_type == 'rgb':
+        img = np.random.randint(0, 255, shape + (3,), dtype=np.uint8)
+    elif image_type == 'gray':
+        img = np.random.randint(0, 255, shape, dtype=np.uint8)
+    else:
+        img = None
+
+    # add a couple of rectangular labels
+    labels = np.zeros(shape, dtype=np.int64)
+    labels[1:3, 1:3] = 1
+    labels[5:9, 5:9] = 2
+
+    # label in the 2D case (correct 2D output is tested in other funcitons)
+    labeled_2d = label2rgb(labels, image=img, bg_label=0)
+
+    # labeling a single line gives an equivalent result
+    image_1d = img[5] if image_type is not None else None
+    labeled_1d = label2rgb(labels[5], image=image_1d, bg_label=0)
+    expected = labeled_2d[5]
+    assert_array_equal(labeled_1d, expected)
+
+    # Labeling a 3D stack of duplicates gives the same result in each plane
+    image_3d = np.stack((img, ) * 4) if image_type is not None else None
+    labels_3d = np.stack((labels,) * 4)
+    labeled_3d = label2rgb(labels_3d, image=image_3d, bg_label=0)
+    for labeled_plane in labeled_3d:
+        assert_array_equal(labeled_plane, labeled_2d)
+
+
+def test_label2rgb_shape_errors():
+    img = np.random.randint(0, 255, (10, 10, 3), dtype=np.uint8)
+    labels = np.zeros((10, 10), dtype=np.int64)
+    labels[2:5, 2:5] = 1
+
+    # mismatched 2D shape
+    with pytest.raises(ValueError):
+        label2rgb(labels, img[1:])
+
+    # too many axes in img
+    with pytest.raises(ValueError):
+        label2rgb(labels, img[..., np.newaxis])
+
+    # too many channels along the last axis
+    with pytest.raises(ValueError):
+        label2rgb(labels, np.concatenate((img, img), axis=-1))
 
 
 def test_overlay_full_saturation():


### PR DESCRIPTION
#5501 

As label2rgb do not support dimension greater than 2. Added Correct error condition and message. 
![sci](https://user-images.githubusercontent.com/40002882/131332645-8a7361ab-4125-4b69-ba5e-90f01ad52db7.png)
Changed code image

Please do mention changes required.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
