### PR TITLE
Fix hidden attribute 'offsets' in skimage.graph.MCP

### DIFF
--- a/skimage/graph/_mcp.pxd
+++ b/skimage/graph/_mcp.pxd
@@ -32,7 +32,7 @@ cdef class MCP:
     cdef OFFSETS_INDEX_T [:] traceback_offsets
     cdef EDGE_T [:,:] flat_pos_edge_map
     cdef EDGE_T [:,:] flat_neg_edge_map
-    # offsets is part of public API. Used to interpret traceback result of finde_costs()
+    # offsets is part of public API. Used to interpret traceback result of find_costs()
     cdef public OFFSET_T [:,:] offsets
     cdef INDEX_T [:] flat_offsets
     cdef FLOAT_T [:] offset_lengths

--- a/skimage/graph/_mcp.pxd
+++ b/skimage/graph/_mcp.pxd
@@ -27,12 +27,12 @@ cdef class MCP:
     # the cost of the path. Set to true by default in the base class...
 
     # Arrays used during front propagation
+    cdef public OFFSET_T [:,:] offsets
     cdef FLOAT_T [:] flat_costs
     cdef FLOAT_T [:] flat_cumulative_costs
     cdef OFFSETS_INDEX_T [:] traceback_offsets
     cdef EDGE_T [:,:] flat_pos_edge_map
     cdef EDGE_T [:,:] flat_neg_edge_map
-    cdef OFFSET_T [:,:] offsets
     cdef INDEX_T [:] flat_offsets
     cdef FLOAT_T [:] offset_lengths
 

--- a/skimage/graph/_mcp.pxd
+++ b/skimage/graph/_mcp.pxd
@@ -27,12 +27,13 @@ cdef class MCP:
     # the cost of the path. Set to true by default in the base class...
 
     # Arrays used during front propagation
-    cdef public OFFSET_T [:,:] offsets
     cdef FLOAT_T [:] flat_costs
     cdef FLOAT_T [:] flat_cumulative_costs
     cdef OFFSETS_INDEX_T [:] traceback_offsets
     cdef EDGE_T [:,:] flat_pos_edge_map
     cdef EDGE_T [:,:] flat_neg_edge_map
+    # offsets is part of public API. Used to interpret traceback result of finde_costs()
+    cdef public OFFSET_T [:,:] offsets
     cdef INDEX_T [:] flat_offsets
     cdef FLOAT_T [:] offset_lengths
 

--- a/skimage/graph/tests/test_mcp.py
+++ b/skimage/graph/tests/test_mcp.py
@@ -134,6 +134,8 @@ def test_offsets():
                         [10,  0,  1,  2,  3,  4,  5,  6],
                         [10,  0,  1,  2,  3,  4,  5,  6],
                         [10,  0,  1,  2,  3,  4,  5,  6]])
+    assert hasattr(m, "offsets")
+    assert_array_equal(offsets, m.offsets)
 
 
 @parametrize("shape", [(100, 100), (5, 8, 13, 17)] * 5)


### PR DESCRIPTION
## Description
Fixes #4766. The offsets attribute is needed to interpret the traceback returned
by `MCP.find_costs()`. The attribute was not declared as public in
the cython code however so it could not be accessed. The attribute
is also documented as being part of the API. This PR makes it
public and adds test coverage for it.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
