### PR TITLE
Update the user guide to use channel_axis rather than multichannel

### DIFF
--- a/doc/source/glossary.md
+++ b/doc/source/glossary.md
@@ -17,7 +17,7 @@ channel
     ``channel_axis`` argument to specify which axis of an array corresponds
     to channels. Images without channels are indicated via
     ``channel_axis=None``. Aside from the functions in ``skimage.color``, most
-    functions with a channel_axis argument just apply the same operation
+    functions with a ``channel_axis`` argument just apply the same operation
     across each channel. In this case, the "channels" do not strictly need to
     represent color or alpha information, but may be any generic batch
     dimension over which to operate.

--- a/doc/source/glossary.md
+++ b/doc/source/glossary.md
@@ -11,6 +11,17 @@ array
     correspond to spatial dimensions of the image, and color channels for
     color images. See {ref}`numpy`. 
 
+channel
+    Typically used to refer to a single color channel in a color image. RGBA
+    images have an additional alpha (transparency) channel. Functions use a
+    ``channel_axis`` argument to specify which axis of an array corresponds
+    to channels. Images without channels are indicated via
+    ``channel_axis=None``. Aside from the functions in ``skimage.color``, most
+    functions with a channel_axis argument just apply the same operation
+    across each channel. In this case, the "channels" do not strictly need to
+    represent color or alpha information, but may be any generic batch
+    dimension over which to operate.
+
 contour
 iso-valued contour
     Curve along which a 2-D image has a constant value. The interior

--- a/doc/source/user_guide/data_types.rst
+++ b/doc/source/user_guide/data_types.rst
@@ -56,7 +56,7 @@ and users:
 =============  =================================
 Function name  Description
 =============  =================================
-img_as_float   Convert to 64-bit floating point.
+img_as_float   Convert to floating point (integer types become 64-bit floats)
 img_as_ubyte   Convert to 8-bit uint.
 img_as_uint    Convert to 16-bit uint.
 img_as_int     Convert to 16-bit int.
@@ -77,6 +77,9 @@ cannot hold the same amount of information as 64 bits::
    >>> image_as_ubyte(image)
    array([  0, 128, 128, 255], dtype=uint8)
 
+Note that ``img_as_float`` will preserve the precision of floating point types
+and does not automatically rescale the range of floating point inputs.
+
 Additionally, some functions take a ``preserve_range`` argument where a range
 conversion is convenient but not necessary. For example, interpolation in
 ``transform.warp`` requires an image of type float, which should have a range
@@ -86,7 +89,10 @@ as temperature or rainfall values, that the user does not want rescaled.
 With ``preserve_range=True``, the original range of the data will be
 preserved, even though the output is a float image. Users must then ensure
 this non-standard image is properly processed by downstream functions, which
-may expect an image in [0, 1].
+may expect an image in [0, 1]. In general, unless a function has a
+``preserve_range=False`` keyword argument, floating point inputs will not
+be automatically rescaled.
+
 
     >>> from skimage import data
     >>> from skimage.transform import rescale
@@ -138,8 +144,9 @@ color. RGB and BGR use the same color space, except the order of colors is rever
 Note that in ``scikit-image`` we usually refer to ``rows`` and ``columns`` instead
 of width and height (see :ref:`numpy-images-coordinate-conventions`).
 
-The following instruction effectively reverses the order of the colors, leaving
-the rows and columns unaffected.
+For an image with colors along the last axis, the following instruction
+effectively reverses the order of the colors, leaving the rows and columns
+unaffected.
 
     >>> image = image[:, :, ::-1]
 

--- a/doc/source/user_guide/numpy_images.rst
+++ b/doc/source/user_guide/numpy_images.rst
@@ -130,6 +130,11 @@ the grayscale image above:
     >>> cat[reddish] = [0, 255, 0]
     >>> plt.imshow(cat)
 
+The example color images included in ``skimage.data`` have channels stored
+along the last axis, although other software may follow different conventions.
+The scikit-image library functions supporting color images have a
+``channel_axis`` argument that can be used to specify which axis of an array
+corresponds to channels.
 
 .. _numpy-images-coordinate-conventions:
 
@@ -147,8 +152,13 @@ denote standard Cartesian coordinates, where ``x`` is the horizontal coordinate,
 ``y`` - the vertical one, and the origin is at the bottom left
 (Matplotlib axes, for example, use this convention).
 
-In the case of multichannel images, the last dimension is used for color channels
-and is denoted by ``channel`` or ``ch``.
+In the case of multichannel images, any dimension can be used for color
+channels, and is denoted by ``channel`` or ``ch``. Prior to scikit-image 0.19,
+the channels axis was always last, but in the current release the channel
+position can be specified by a ``channel_axis`` argument. Functions that
+require multichannel data default to ``channel_axis = -1``. Otherwise,
+functions default to ``channel_axis = None``, indicating that no axis is
+assumed to correspond to channels.
 
 Finally, for volumetric (3D) images, such as videos, magnetic resonance imaging
 (MRI) scans, confocal microscopy, etc. we refer to the leading dimension
@@ -156,7 +166,7 @@ as ``plane``, abbreviated as ``pln`` or ``p``.
 
 These conventions are summarized below:
 
-.. table:: Dimension name and order conventions in scikit-image
+.. table:: Dimension name and order conventions in scikit-image*
 
   =========================   ========================================
   Image type                  Coordinates
@@ -167,6 +177,8 @@ These conventions are summarized below:
   3D multichannel             (pln, row, col, ch)
   =========================   ========================================
 
+  * note that the position of ``ch`` is controlled by the ``channel_axis``
+  argument.
 
 Many functions in ``scikit-image`` can operate on 3D images directly::
 
@@ -182,7 +194,7 @@ than the other two. Some ``scikit-image`` functions provide a ``spacing``
 keyword argument to help handle this kind of data::
 
     >>> from skimage import segmentation
-    >>> slics = segmentation.slic(im3d, spacing=[5, 1, 1], multichannel=False)
+    >>> slics = segmentation.slic(im3d, spacing=[5, 1, 1], channel_axis=None)
 
 Other times, the processing must be done plane-wise. When planes are stacked
 along the leading dimension (in agreement with our convention), the following

--- a/doc/source/user_guide/numpy_images.rst
+++ b/doc/source/user_guide/numpy_images.rst
@@ -166,19 +166,21 @@ as ``plane``, abbreviated as ``pln`` or ``p``.
 
 These conventions are summarized below:
 
-.. table:: Dimension name and order conventions in scikit-image*
+.. table:: *Dimension name and order conventions in scikit-image*
 
-  =========================   ========================================
+  =========================   =============================
   Image type                  Coordinates
-  =========================   ========================================
+  =========================   =============================
   2D grayscale                (row, col)
   2D multichannel (eg. RGB)   (row, col, ch)
   3D grayscale                (pln, row, col)
   3D multichannel             (pln, row, col, ch)
-  =========================   ========================================
+  =========================   =============================
 
-  * note that the position of ``ch`` is controlled by the ``channel_axis``
-  argument.
+Note that the position of ``ch`` is controlled by the ``channel_axis``
+argument.
+
+|
 
 Many functions in ``scikit-image`` can operate on 3D images directly::
 
@@ -262,11 +264,11 @@ shape (t, pln, row, col, ch)::
 
 We can then supplement the above table as follows:
 
-.. table:: Addendum to dimension names and orders in scikit-image
+.. table:: *Addendum to dimension names and orders in scikit-image*
 
-  ========================   ========================================
+  ========================   =========================================
   Image type                 coordinates
-  ========================   ========================================
+  ========================   =========================================
   2D color video             (t, row, col, ch)
   3D multichannel video      (t, pln, row, col, ch)
-  ========================   ========================================
+  ========================   =========================================

--- a/doc/source/user_guide/numpy_images.rst
+++ b/doc/source/user_guide/numpy_images.rst
@@ -154,10 +154,10 @@ denote standard Cartesian coordinates, where ``x`` is the horizontal coordinate,
 
 In the case of multichannel images, any dimension (array axis) can be used for
 color channels, and is denoted by ``channel`` or ``ch``. Prior to scikit-image
-0.19, this channels dimension was always last, but in the current release the
+0.19, this channel dimension was always last, but in the current release the
 channel dimension can be specified by a ``channel_axis`` argument. Functions
-that require multichannel data default to ``channel_axis = -1``. Otherwise,
-functions default to ``channel_axis = None``, indicating that no axis is
+that require multichannel data default to ``channel_axis=-1``. Otherwise,
+functions default to ``channel_axis=None``, indicating that no axis is
 assumed to correspond to channels.
 
 Finally, for volumetric (3D) images, such as videos, magnetic resonance imaging

--- a/doc/source/user_guide/numpy_images.rst
+++ b/doc/source/user_guide/numpy_images.rst
@@ -152,16 +152,16 @@ denote standard Cartesian coordinates, where ``x`` is the horizontal coordinate,
 ``y`` - the vertical one, and the origin is at the bottom left
 (Matplotlib axes, for example, use this convention).
 
-In the case of multichannel images, any dimension can be used for color
-channels, and is denoted by ``channel`` or ``ch``. Prior to scikit-image 0.19,
-the channels axis was always last, but in the current release the channel
-position can be specified by a ``channel_axis`` argument. Functions that
-require multichannel data default to ``channel_axis = -1``. Otherwise,
+In the case of multichannel images, any dimension (array axis) can be used for
+color channels, and is denoted by ``channel`` or ``ch``. Prior to scikit-image
+0.19, this channels dimension was always last, but in the current release the
+channel dimension can be specified by a ``channel_axis`` argument. Functions
+that require multichannel data default to ``channel_axis = -1``. Otherwise,
 functions default to ``channel_axis = None``, indicating that no axis is
 assumed to correspond to channels.
 
 Finally, for volumetric (3D) images, such as videos, magnetic resonance imaging
-(MRI) scans, confocal microscopy, etc. we refer to the leading dimension
+(MRI) scans, confocal microscopy, etc., we refer to the leading dimension
 as ``plane``, abbreviated as ``pln`` or ``p``.
 
 These conventions are summarized below:
@@ -270,5 +270,5 @@ We can then supplement the above table as follows:
   Image type                 coordinates
   ========================   =========================================
   2D color video             (t, row, col, ch)
-  3D multichannel video      (t, pln, row, col, ch)
+  3D color video             (t, pln, row, col, ch)
   ========================   =========================================

--- a/doc/source/user_guide/tutorial_parallelization.rst
+++ b/doc/source/user_guide/tutorial_parallelization.rst
@@ -17,7 +17,7 @@ loops. Here is an example of such repetitive tasks:
         """
         Apply some functions and return an image.
         """
-        image = denoise_tv_chambolle(image[0][0], weight=0.1, multichannel=True)
+        image = denoise_tv_chambolle(image[0][0], weight=0.1, channel_axis=None)
         fd, hog_image = hog(color.rgb2gray(image), orientations=8,
                             pixels_per_cell=(16, 16), cells_per_block=(1, 1),
                             visualize=True)

--- a/doc/source/user_guide/tutorial_parallelization.rst
+++ b/doc/source/user_guide/tutorial_parallelization.rst
@@ -17,7 +17,7 @@ loops. Here is an example of such repetitive tasks:
         """
         Apply some functions and return an image.
         """
-        image = denoise_tv_chambolle(image[0][0], weight=0.1, channel_axis=None)
+        image = denoise_tv_chambolle(image[0][0], weight=0.1, channel_axis=-1)
         fd, hog_image = hog(color.rgb2gray(image), orientations=8,
                             pixels_per_cell=(16, 16), cells_per_block=(1, 1),
                             visualize=True)

--- a/doc/source/user_guide/visualization.rst
+++ b/doc/source/user_guide/visualization.rst
@@ -3,7 +3,7 @@ Data visualization
 
 Data visualization takes an important place in image processing. Data can be
 a simple unique 2D image or a more complex with multidimensional aspects: 3D
-in space, timeslapse, multiple channels.
+in space, timelapse, multiple channels.
 
 Therefore, the visualization strategy will depend on the data complexity and
 a range of tools external to scikit-image can be used for this purpose.

--- a/doc/source/user_guide/visualization.rst
+++ b/doc/source/user_guide/visualization.rst
@@ -2,7 +2,7 @@ Data visualization
 ------------------
 
 Data visualization takes an important place in image processing. Data can be
-a simple unique 2D image or a more complex with multidimensional aspects: 3D
+a single 2D grayscale image or a more complex one with multidimensional aspects: 3D
 in space, timelapse, multiple channels.
 
 Therefore, the visualization strategy will depend on the data complexity and


### PR DESCRIPTION
## Description

closes #5554

Updates the user guide to better describe the more flexible channel support via `channel_axis`.  Also, avoids use of the deprecated `multichannel` argument in examples.

The description of `img_as_float` was also updated slightly to indicate its current behavior (no longer automatically rescales floating point inputs and preserves floating point precision).

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
