### PR TITLE
fix phase_cross_correlation for 3D with reference masks

### DIFF
--- a/skimage/registration/_masked_phase_cross_correlation.py
+++ b/skimage/registration/_masked_phase_cross_correlation.py
@@ -76,8 +76,10 @@ def _masked_phase_cross_correlation(reference_image, moving_image,
             raise ValueError(
                 "Image sizes must match their respective mask sizes.")
 
-    xcorr = cross_correlate_masked(moving_image, reference_image, moving_mask,
-                                   reference_mask, axes=tuple(range(moving_image.ndim)), mode='full',
+    xcorr = cross_correlate_masked(moving_image, reference_image, 
+                                   moving_mask, reference_mask, 
+                                   axes=tuple(range(moving_image.ndim)),
+                                   mode='full',
                                    overlap_ratio=overlap_ratio)
 
     # Generalize to the average of multiple equal maxima

--- a/skimage/registration/_masked_phase_cross_correlation.py
+++ b/skimage/registration/_masked_phase_cross_correlation.py
@@ -76,8 +76,8 @@ def _masked_phase_cross_correlation(reference_image, moving_image,
             raise ValueError(
                 "Image sizes must match their respective mask sizes.")
 
-    xcorr = cross_correlate_masked(moving_image, reference_image, 
-                                   moving_mask, reference_mask, 
+    xcorr = cross_correlate_masked(moving_image, reference_image,
+                                   moving_mask, reference_mask,
                                    axes=tuple(range(moving_image.ndim)),
                                    mode='full',
                                    overlap_ratio=overlap_ratio)

--- a/skimage/registration/_masked_phase_cross_correlation.py
+++ b/skimage/registration/_masked_phase_cross_correlation.py
@@ -77,7 +77,7 @@ def _masked_phase_cross_correlation(reference_image, moving_image,
                 "Image sizes must match their respective mask sizes.")
 
     xcorr = cross_correlate_masked(moving_image, reference_image, moving_mask,
-                                   reference_mask, axes=(0, 1), mode='full',
+                                   reference_mask, axes=tuple(range(moving_image.ndim)), mode='full',
                                    overlap_ratio=overlap_ratio)
 
     # Generalize to the average of multiple equal maxima

--- a/skimage/registration/tests/test_masked_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_masked_phase_cross_correlation.py
@@ -57,15 +57,16 @@ def test_masked_registration_random_masks():
                                                  reference_mask=ref_mask,
                                                  moving_mask=shifted_mask)
     assert_equal(measured_shift, -np.array(shift))
-    
+
+
 def test_masked_registration_3d_contiguous_mask():
     """masked_register_translation should be able to register translations
     between volumes with contiguous masks."""
     ref_vol = brain()
 
     offset = (2, -9, 20)
-    
-    # create square mask 
+
+    # create square mask    
     ref_mask = np.zeros_like(ref_vol, dtype=bool)
     ref_mask[:-2, 150:200, 150:200] = True
     ref_shifted = real_shift(ref_vol, offset)

--- a/skimage/registration/tests/test_masked_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_masked_phase_cross_correlation.py
@@ -66,7 +66,7 @@ def test_masked_registration_3d_contiguous_mask():
 
     offset = (2, -9, 20)
 
-    # create square mask
+    # create square mask    
     ref_mask = np.zeros_like(ref_vol, dtype=bool)
     ref_mask[:-2, 150:200, 150:200] = True
     ref_shifted = real_shift(ref_vol, offset)

--- a/skimage/registration/tests/test_masked_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_masked_phase_cross_correlation.py
@@ -66,7 +66,7 @@ def test_masked_registration_3d_contiguous_mask():
 
     offset = (2, -9, 20)
 
-    # create square mask    
+    # create square mask
     ref_mask = np.zeros_like(ref_vol, dtype=bool)
     ref_mask[:-2, 150:200, 150:200] = True
     ref_shifted = real_shift(ref_vol, offset)

--- a/skimage/registration/tests/test_masked_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_masked_phase_cross_correlation.py
@@ -2,12 +2,12 @@ import numpy as np
 import pytest
 from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
                            assert_array_equal, assert_array_less, assert_equal)
-from scipy.ndimage import fourier_shift
+from scipy.ndimage import fourier_shift, shift as real_shift
 
 from skimage._shared.fft import fftmodule as fft
 from skimage._shared.testing import fetch, expected_warnings
 from skimage._shared.utils import _supported_float_type
-from skimage.data import camera, stereo_motorcycle
+from skimage.data import camera, stereo_motorcycle, brain
 
 
 from skimage.io import imread
@@ -57,6 +57,24 @@ def test_masked_registration_random_masks():
                                                  reference_mask=ref_mask,
                                                  moving_mask=shifted_mask)
     assert_equal(measured_shift, -np.array(shift))
+    
+def test_masked_registration_3d_contiguous_mask():
+    """masked_register_translation should be able to register translations
+    between volumes with contiguous masks."""
+    ref_vol = brain()
+
+    offset = (2, -9, 20)
+    
+    # create square mask 
+    ref_mask = np.zeros_like(ref_vol, dtype=bool)
+    ref_mask[:-2, 150:200, 150:200] = True
+    ref_shifted = real_shift(ref_vol, offset)
+
+    measured_offset = masked_register_translation(
+        ref_vol, ref_shifted, reference_mask=ref_mask, moving_mask=ref_mask
+    )
+
+    assert_equal(offset, -np.array(measured_offset))
 
 
 def test_masked_registration_random_masks_non_equal_sizes():


### PR DESCRIPTION
## Description

fixes issue [4980](https://github.com/scikit-image/scikit-image/issues/4980) (and potentially [5458](https://github.com/scikit-image/scikit-image/issues/5458))

cross_correlation axes were hard-coded for 2D

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->


<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
