### PR TITLE
improve single precision support in skimage.exposure

### DIFF
--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -20,7 +20,7 @@ import numpy as np
 from .._shared.utils import _supported_float_type
 from ..color.adapt_rgb import adapt_rgb, hsv_value
 from ..exposure import rescale_intensity
-from ..util import img_as_float, img_as_uint
+from ..util import img_as_uint
 
 NR_OF_GRAY = 2 ** 14  # number of grayscale levels to use in CLAHE algorithm
 

--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -81,7 +81,7 @@ def equalize_adapthist(image, kernel_size=None,
     image = img_as_uint(image)
     image = np.round(
         rescale_intensity(image, out_range=(0, NR_OF_GRAY - 1))
-    ).astype(np.uint16)
+    ).astype(np.min_scalar_type(NR_OF_GRAY))
 
     if kernel_size is None:
         kernel_size = tuple([image.shape[dim] // 8
@@ -140,7 +140,7 @@ def _clahe(image, kernel_size, clip_limit, nbins):
 
     # determine gray value bins
     bin_size = 1 + NR_OF_GRAY // nbins
-    lut = np.arange(NR_OF_GRAY)
+    lut = np.arange(NR_OF_GRAY, dtype=np.min_scalar_type(NR_OF_GRAY))
     lut //= bin_size
 
     image = lut[image]

--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -14,11 +14,13 @@ responsible.  Basically, don't be a jerk, and remember that anything free
 comes with no guarantee.
 """
 import numbers
+
 import numpy as np
-from ..util import img_as_float, img_as_uint
+
+from .._shared.utils import _supported_float_type
 from ..color.adapt_rgb import adapt_rgb, hsv_value
 from ..exposure import rescale_intensity
-
+from ..util import img_as_float, img_as_uint
 
 NR_OF_GRAY = 2 ** 14  # number of grayscale levels to use in CLAHE algorithm
 
@@ -75,6 +77,7 @@ def equalize_adapthist(image, kernel_size=None,
     .. [2] https://en.wikipedia.org/wiki/CLAHE#CLAHE
     """
 
+    float_dtype = _supported_float_type(image.dtype)
     image = img_as_uint(image)
     image = np.round(
         rescale_intensity(image, out_range=(0, NR_OF_GRAY - 1))
@@ -91,7 +94,7 @@ def equalize_adapthist(image, kernel_size=None,
     kernel_size = [int(k) for k in kernel_size]
 
     image = _clahe(image, kernel_size, clip_limit, nbins)
-    image = img_as_float(image)
+    image = image.astype(float_dtype, copy=False)
     return rescale_intensity(image)
 
 

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -428,7 +428,7 @@ def intensity_range(image, range_values='image', clip_negative=False):
     return i_min, i_max
 
 
-def _output_dtype(dtype_or_range):
+def _output_dtype(dtype_or_range, image_dtype):
     """Determine the output dtype for rescale_intensity.
 
     The dtype is determined according to the following rules:
@@ -438,7 +438,8 @@ def _output_dtype(dtype_or_range):
       in which case the data type that can contain it will be used
       (e.g. uint16 in this case).
     - if ``dtype_or_range`` is a pair of values, the output data type will be
-      float.
+      ``_supported_float_type(image_dtype)``. This preserves float32 output for
+      float32 inputs.
 
     Parameters
     ----------
@@ -453,7 +454,7 @@ def _output_dtype(dtype_or_range):
     """
     if type(dtype_or_range) in [list, tuple, np.ndarray]:
         # pair of values: always return float.
-        return float
+        return utils._supported_float_type(image_dtype)
     if type(dtype_or_range) == type:
         # already a type: return it
         return dtype_or_range
@@ -565,9 +566,9 @@ def rescale_intensity(image, in_range='image', out_range='dtype'):
     array([127, 127, 127], dtype=int32)
     """
     if out_range in ['dtype', 'image']:
-        out_dtype = _output_dtype(image.dtype.type)
+        out_dtype = _output_dtype(image.dtype.type, image.dtype)
     else:
-        out_dtype = _output_dtype(out_range)
+        out_dtype = _output_dtype(out_range, image.dtype)
 
     imin, imax = map(float, intensity_range(image, in_range))
     omin, omax = map(float, intensity_range(image, out_range,

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -454,6 +454,8 @@ def _output_dtype(dtype_or_range, image_dtype):
     dtype_or_range : type, string, or 2-tuple of int/float
         The desired range for the output, expressed as either a NumPy dtype or
         as a (min, max) pair of numbers.
+    image_dtype : np.dtype
+        The input image dtype.
 
     Returns
     -------

--- a/skimage/exposure/histogram_matching.py
+++ b/skimage/exposure/histogram_matching.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from .._shared import utils
 
+
 def _match_cumulative_cdf(source, template):
     """
     Return modified source array so that the cumulative density function of

--- a/skimage/exposure/histogram_matching.py
+++ b/skimage/exposure/histogram_matching.py
@@ -62,6 +62,7 @@ def match_histograms(image, reference, *, channel_axis=None,
     if image.ndim != reference.ndim:
         raise ValueError('Image and reference must have the same number '
                          'of channels.')
+    out_dtype = utils._supported_float_type(image.dtype)
 
     if channel_axis is not None:
         if image.shape[-1] != reference.shape[-1]:
@@ -74,6 +75,7 @@ def match_histograms(image, reference, *, channel_axis=None,
                                                     reference[..., channel])
             matched[..., channel] = matched_channel
     else:
+        # _match_cumulative_cdf will always return float64 due to np.interp
         matched = _match_cumulative_cdf(image, reference)
 
-    return matched
+    return matched.astype(out_dtype, copy=False)

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -14,7 +14,6 @@ from skimage import util
 from skimage.color import rgb2gray
 from skimage.exposure.exposure import intensity_range
 from skimage.util.dtype import dtype_range
-from skimage._shared import testing
 from skimage._shared._warnings import expected_warnings
 from skimage._shared.utils import _supported_float_type
 
@@ -25,7 +24,8 @@ from skimage._shared.utils import _supported_float_type
 def test_wrong_source_range():
     im = np.array([-1, 100], dtype=np.int8)
     with pytest.raises(ValueError):
-        frequencies, bin_centers = exposure.histogram(im, source_range='foobar')
+        frequencies, bin_centers = exposure.histogram(im,
+                                                      source_range='foobar')
 
 
 def test_negative_overflow():
@@ -101,7 +101,8 @@ def test_peak_float_out_of_range_image(dtype):
 def test_peak_float_out_of_range_dtype(dtype):
     im = np.array([10, 100], dtype=dtype)
     nbins = 10
-    frequencies, bin_centers = exposure.histogram(im, nbins=nbins, source_range='dtype')
+    frequencies, bin_centers = exposure.histogram(im, nbins=nbins,
+                                                  source_range='dtype')
     assert bin_centers.dtype == dtype
     assert_almost_equal(np.min(bin_centers), -0.9, 3)
     assert_almost_equal(np.max(bin_centers), 0.9, 3)
@@ -128,7 +129,8 @@ def test_normalize():
 @pytest.mark.parametrize('source_range', ['dtype', 'image'])
 @pytest.mark.parametrize('dtype', [np.uint8, np.int16, np.float64])
 @pytest.mark.parametrize('channel_axis', [0, 1, -1])
-def test_multichannel_hist_common_bins_uint8(dtype, source_range, channel_axis):
+def test_multichannel_hist_common_bins_uint8(dtype, source_range,
+                                             channel_axis):
     """Check that all channels use the same binning."""
     # Construct multichannel image with uniform values within each channel,
     # but the full range of values across channels.
@@ -405,6 +407,7 @@ def test_rescale_raises_on_incorrect_out_range():
     with pytest.raises(ValueError):
         _ = exposure.rescale_intensity(image, out_range='flat')
 
+
 # Test adaptive histogram equalization
 # ====================================
 
@@ -588,7 +591,7 @@ def norm_brightness_err(img1, img2):
 
 def test_adjust_gamma_1x1_shape():
     """Check that the shape is maintained"""
-    img = np.ones([1,1])
+    img = np.ones([1, 1])
     result = exposure.adjust_gamma(img, 1.5)
     assert img.shape == result.shape
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -88,17 +88,21 @@ def test_flat_int_range_dtype():
     assert_equal(frequencies.shape, (256,))
 
 
-def test_peak_float_out_of_range_image():
-    im = np.array([10, 100], dtype=np.float16)
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
+def test_peak_float_out_of_range_image(dtype):
+    im = np.array([10, 100], dtype=dtype)
     frequencies, bin_centers = exposure.histogram(im, nbins=90)
+    assert bin_centers.dtype == dtype
     # offset values by 0.5 for float...
     assert_array_equal(bin_centers, np.arange(10, 100) + 0.5)
 
 
-def test_peak_float_out_of_range_dtype():
-    im = np.array([10, 100], dtype=np.float16)
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
+def test_peak_float_out_of_range_dtype(dtype):
+    im = np.array([10, 100], dtype=dtype)
     nbins = 10
     frequencies, bin_centers = exposure.histogram(im, nbins=nbins, source_range='dtype')
+    assert bin_centers.dtype == dtype
     assert_almost_equal(np.min(bin_centers), -0.9, 3)
     assert_almost_equal(np.max(bin_centers), 0.9, 3)
     assert_equal(len(bin_centers), 10)

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -597,12 +597,14 @@ def test_adjust_gamma_one():
     assert_array_equal(result, image)
 
 
-def test_adjust_gamma_zero():
+@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
+def test_adjust_gamma_zero(dtype):
     """White image should be returned for gamma equal to zero"""
-    image = np.random.uniform(0, 255, (8, 8))
+    image = np.random.uniform(0, 255, (8, 8)).astype(dtype, copy=False)
     result = exposure.adjust_gamma(image, 0)
     dtype = image.dtype.type
     assert_array_equal(result, dtype_range[dtype][1])
+    assert result.dtype == image.dtype
 
 
 def test_adjust_gamma_less_one():
@@ -656,11 +658,13 @@ def test_adjust_gamma_u8_overflow():
 # Test Logarithmic Correction
 # ===========================
 
-def test_adjust_log_1x1_shape():
+@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
+def test_adjust_log_1x1_shape(dtype):
     """Check that the shape is maintained"""
-    img = np.ones([1, 1])
+    img = np.ones([1, 1], dtype=dtype)
     result = exposure.adjust_log(img, 1)
     assert img.shape == result.shape
+    assert result.dtype == dtype
 
 
 def test_adjust_log():
@@ -702,11 +706,13 @@ def test_adjust_inv_log():
 # Test Sigmoid Correction
 # =======================
 
-def test_adjust_sigmoid_1x1_shape():
+@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
+def test_adjust_sigmoid_1x1_shape(dtype):
     """Check that the shape is maintained"""
-    img = np.ones([1, 1])
+    img = np.ones([1, 1], dtype=dtype)
     result = exposure.adjust_sigmoid(img, 1, 5)
     assert img.shape == result.shape
+    assert result.dtype == dtype
 
 
 def test_adjust_sigmoid_cutoff_one():

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -179,12 +179,15 @@ def test_equalize_ubyte():
     check_cdf_slope(cdf)
 
 
-def test_equalize_float():
-    img = util.img_as_float(test_img)
+@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
+def test_equalize_float(dtype):
+    img = util.img_as_float(test_img).astype(dtype, copy=False)
     img_eq = exposure.equalize_hist(img)
+    assert img_eq.dtype == _supported_float_type(dtype)
 
     cdf, bin_edges = exposure.cumulative_distribution(img_eq)
     check_cdf_slope(cdf)
+    assert bin_edges.dtype == _supported_float_type(dtype)
 
 
 def test_equalize_masked():

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -408,16 +408,19 @@ def test_rescale_raises_on_incorrect_out_range():
 # Test adaptive histogram equalization
 # ====================================
 
-def test_adapthist_grayscale():
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
+def test_adapthist_grayscale(dtype):
     """Test a grayscale float image
     """
-    img = util.img_as_float(data.astronaut())
+    img = util.img_as_float(data.astronaut()).astype(dtype, copy=False)
     img = rgb2gray(img)
     img = np.dstack((img, img, img))
     adapted = exposure.equalize_adapthist(img, kernel_size=(57, 51),
                                           clip_limit=0.01, nbins=128)
     assert img.shape == adapted.shape
-    assert_almost_equal(peak_snr(img, adapted), 100.140, 3)
+    assert adapted.dtype == _supported_float_type(dtype)
+    snr_decimal = 3 if dtype != np.float16 else 2
+    assert_almost_equal(peak_snr(img, adapted), 100.140, snr_decimal)
     assert_almost_equal(norm_brightness_err(img, adapted), 0.0529, 3)
 
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -88,7 +88,7 @@ def test_flat_int_range_dtype():
     assert_equal(frequencies.shape, (256,))
 
 
-@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
+@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_peak_float_out_of_range_image(dtype):
     im = np.array([10, 100], dtype=dtype)
     frequencies, bin_centers = exposure.histogram(im, nbins=90)
@@ -97,7 +97,7 @@ def test_peak_float_out_of_range_image(dtype):
     assert_array_equal(bin_centers, np.arange(10, 100) + 0.5)
 
 
-@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
+@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_peak_float_out_of_range_dtype(dtype):
     im = np.array([10, 100], dtype=dtype)
     nbins = 10
@@ -266,7 +266,7 @@ def test_rescale_shrink():
     assert_array_almost_equal(out, [0, 0.5, 1])
 
 
-@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
+@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_rescale_in_range(dtype):
     image = np.array([51., 102., 153.], dtype=dtype)
     out = exposure.rescale_intensity(image, in_range=(0, 255))
@@ -281,7 +281,7 @@ def test_rescale_in_range_clip():
     assert_array_almost_equal(out, [0.5, 1, 1])
 
 
-@pytest.mark.parametrize("dtype", [np.int8, np.int32, np.float16, np.float32,
+@pytest.mark.parametrize('dtype', [np.int8, np.int32, np.float16, np.float32,
                                    np.float64])
 def test_rescale_out_range(dtype):
     """Check that output range is correct.
@@ -291,7 +291,7 @@ def test_rescale_out_range(dtype):
         matches the output.
 
     .. versionchanged:: 0.19
-        float16 and float32 inputs now result in float32 input. Formerly they
+        float16 and float32 inputs now result in float32 output. Formerly they
         would give float64 outputs.
     """
     image = np.array([-10, 0, 10], dtype=dtype)
@@ -411,7 +411,7 @@ def test_rescale_raises_on_incorrect_out_range():
 # Test adaptive histogram equalization
 # ====================================
 
-@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
+@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_adapthist_grayscale(dtype):
     """Test a grayscale float image
     """

--- a/skimage/exposure/tests/test_histogram_matching.py
+++ b/skimage/exposure/tests/test_histogram_matching.py
@@ -1,13 +1,12 @@
 import numpy as np
-
-from skimage.exposure import histogram_matching
-from skimage import exposure
-from skimage import data
-
-from skimage._shared.testing import assert_array_almost_equal, \
-    assert_almost_equal, expected_warnings
-
 import pytest
+from numpy.testing import (assert_almost_equal, assert_array_almost_equal)
+
+from skimage import data
+from skimage import exposure
+from skimage._shared.testing import expected_warnings
+from skimage._shared.utils import _supported_float_type
+from skimage.exposure import histogram_matching
 
 
 @pytest.mark.parametrize('array, template, expected_array', [
@@ -79,6 +78,14 @@ class TestMatchHistogram:
                 assert_almost_equal(matched_quantiles[i],
                                     reference_quantiles[closest_id],
                                     decimal=1)
+
+    @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
+    def test_match_histograms_float_dtype(self, dtype):
+        """float16 or float32 inputs give float32 output"""
+        image = self.image_rgb.astype(dtype, copy=False)
+        reference = self.template_rgb.astype(dtype, copy=False)
+        matched = exposure.match_histograms(image, reference)
+        assert matched.dtype == _supported_float_type(dtype)
 
     @pytest.mark.parametrize('image, reference', [
         (image_rgb, template_rgb[:, :, 0]),


### PR DESCRIPTION
## Description

I had missed this module when adding float32 support earlier!

A few of these functions already preserved floating point precision (`adjust_gamma`, `adjust_log`, `adjust_sigmoid`), so just needed test cases added. One question is if we should start forcing these functions to promote float16 to float32, for consistency with most other scikit-image functions.

A few others now just cast the output to float32 when float16 or float32 input is provided, but do not perform internal calculations in float32. For example, both `match_histograms` and `equalize_hist` use `np.interp` which always returns float64 arrays which I just cast back to single precision when desired. We could optionally leave these functions as they were as this extra cast adds a little overhead. I thought that overhead may be outweighed by the benefit of maintaining precision in a pipeline that includes these functions, though.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
