### PR TITLE
Backport 5249 - Ensure that README.txt has write permissions for subsequent imports.

### DIFF
--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -215,7 +215,8 @@ def fetch(data_filename):
     try:
         return data._fetch(data_filename)
     except (ConnectionError, ModuleNotFoundError):
-        pytest.skip(f'Unable to download {data_filename}')
+        pytest.skip(f'Unable to download {data_filename}',
+                    allow_module_level=True)
 
 
 def test_parallel(num_threads=2, warnings_matching=None):

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -149,7 +149,7 @@ def create_image_fetcher():
         path=pooch.os_cache("scikit-image"),
         base_url=url,
         version=skimage_version_for_pooch,
-        version_dev="main",
+        version_dev="v0.18.x",
         env="SKIMAGE_DATADIR",
         registry=registry,
         urls=registry_urls,

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -253,8 +253,17 @@ def _fetch(data_filename):
 
 def _init_pooch():
     os.makedirs(data_dir, exist_ok=True)
-    shutil.copy2(osp.join(skimage_distribution_dir, 'data', 'README.txt'),
-                 osp.join(data_dir, 'README.txt'))
+
+    # Copy in the README.txt if it doesn't already exist.
+    # If the file was originally copied to the data cache directory read-only
+    # then we cannot overwrite it, nor do we need to copy on every init.
+    # In general, as the data cache directory contains the scikit-image version
+    # it should not be necessary to overwrite this file as it should not
+    # change.
+    dest_path = osp.join(data_dir, 'README.txt')
+    if not os.path.isfile(dest_path):
+        shutil.copy2(osp.join(skimage_distribution_dir, 'data', 'README.txt'),
+                     dest_path)
 
     data_base_dir = osp.join(data_dir, '..')
     # Fetch all legacy data so that it is available by default


### PR DESCRIPTION
## Description

Backport of https://github.com/scikit-image/scikit-image/pull/5249

Working toward: https://github.com/scikit-image/scikit-image/issues/5562

- [x] Cleanup git history.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
