### PR TITLE
Update branching instructions to change the location of the pooch repo

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -53,6 +53,11 @@ access), specifically to:
   8. Copy relevant deprecations from ``release_<major>_<minor>.txt``
      to ``release_dev.txt``.
 
+  9. Update the file ``skimage/data/__init__.py`` to point the pooch
+     repository to the new branch instead of main during testing.
+     Look for the parameter ``version_dev="main",`` for ``pooch.create`` and
+     change it to newly created branch name.
+
 - Submit the release notes for review by other project maintainers:
 
   - Create a PR from v<major>.<minor>.x branch to `main` (at this point,

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -56,7 +56,7 @@ access), specifically to:
   9. Update the file ``skimage/data/__init__.py`` to point the pooch
      repository to the new branch instead of main during testing.
      Look for the parameter ``version_dev="main",`` for ``pooch.create`` and
-     change it to newly created branch name.
+     change it to the newly created branch name.
 
 - Submit the release notes for review by other project maintainers:
 


### PR DESCRIPTION
## Description
In fixing: https://github.com/scikit-image/scikit-image/pull/5564

I had to do a small modifications to point to the old dataset.

I am hoping to just document this for future core devs.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
