### PR TITLE
fix return shape of blob_log and blob_dog when no peaks are found

### DIFF
--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -545,10 +545,7 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
 
     # Catch no peaks
     if local_maxima.size == 0:
-        if scalar_sigma:
-            return np.empty((0, image.ndim + 1))
-        else:
-            return np.empty((0, 2 * image.ndim))
+        return np.empty((0, image.ndim + (1 if scalar_sigma else image.ndim)))
 
     # Convert local_maxima to float64
     lm = local_maxima.astype(float_dtype)

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -376,10 +376,7 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=0.5,
 
     # Catch no peaks
     if local_maxima.size == 0:
-        if scalar_sigma:
-            return np.empty((0, image.ndim + 1))
-        else:
-            return np.empty((0, 2 * image.ndim))
+        return np.empty((0, image.ndim + (1 if scalar_sigma else image.ndim)))
 
     # Convert local_maxima to float64
     lm = local_maxima.astype(float_dtype)

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -224,7 +224,7 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=0.5,
 
     Parameters
     ----------
-    image : 2D or 3D ndarray
+    image : ndarray
         Input grayscale image, blobs are assumed to be light on dark
         background (white on black).
     min_sigma : scalar or sequence of scalars, optional
@@ -268,7 +268,7 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=0.5,
     -------
     A : (n, image.ndim + sigma) ndarray
         A 2d array with each row representing 2 coordinate values for a 2D
-        image, and 3 coordinate values for a 3D image, plus the sigma(s) used.
+        image, or 3 coordinate values for a 3D image, plus the sigma(s) used.
         When a single sigma is passed, outputs are:
         ``(r, c, sigma)`` or ``(p, r, c, sigma)`` where ``(r, c)`` or
         ``(p, r, c)`` are coordinates of the blob and ``sigma`` is the standard
@@ -376,7 +376,10 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=0.5,
 
     # Catch no peaks
     if local_maxima.size == 0:
-        return np.empty((0, 3))
+        if scalar_sigma:
+            return np.empty((0, image.ndim + 1))
+        else:
+            return np.empty((0, 2 * image.ndim))
 
     # Convert local_maxima to float64
     lm = local_maxima.astype(float_dtype)
@@ -408,7 +411,7 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
 
     Parameters
     ----------
-    image : 2D or 3D ndarray
+    image : ndarray
         Input grayscale image, blobs are assumed to be light on dark
         background (white on black).
     min_sigma : scalar or sequence of scalars, optional
@@ -456,7 +459,7 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
     -------
     A : (n, image.ndim + sigma) ndarray
         A 2d array with each row representing 2 coordinate values for a 2D
-        image, and 3 coordinate values for a 3D image, plus the sigma(s) used.
+        image, or 3 coordinate values for a 3D image, plus the sigma(s) used.
         When a single sigma is passed, outputs are:
         ``(r, c, sigma)`` or ``(p, r, c, sigma)`` where ``(r, c)`` or
         ``(p, r, c)`` are coordinates of the blob and ``sigma`` is the standard
@@ -542,7 +545,10 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
 
     # Catch no peaks
     if local_maxima.size == 0:
-        return np.empty((0, 3))
+        if scalar_sigma:
+            return np.empty((0, image.ndim + 1))
+        else:
+            return np.empty((0, 2 * image.ndim))
 
     # Convert local_maxima to float64
     lm = local_maxima.astype(float_dtype)

--- a/skimage/feature/tests/test_blob.py
+++ b/skimage/feature/tests/test_blob.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal
 
+from skimage import feature
 from skimage.draw import disk
 from skimage.draw.draw3d import ellipsoid
 from skimage.feature import blob_dog, blob_doh, blob_log
@@ -167,6 +168,26 @@ def test_blob_dog_excl_border():
     )
     msg = "zero blobs should be detected, as only blob is 5 px from border"
     assert blobs.shape[0] == 0, msg
+
+
+@pytest.mark.parametrize('anisotropic', [False, True])
+@pytest.mark.parametrize('ndim', [1, 2, 3, 4])
+@pytest.mark.parametrize('function_name', ['blob_dog', 'blob_log'])
+def test_nd_blob_no_peaks_shape(function_name, ndim, anisotropic):
+    # uniform image so no blobs will be found
+    z = np.zeros((16,) * ndim, dtype=np.float32)
+    if anisotropic:
+        max_sigma = 8 + np.arange(ndim)
+    else:
+        max_sigma = 8
+    blob_func = getattr(feature, function_name)
+    blobs = blob_func(z, max_sigma=max_sigma)
+    if anisotropic:
+        # z.ndim coordinates and z.ndim sigmas
+        assert blobs.shape == (0, 2 * z.ndim)
+    else:
+        # z.ndim coordinates and 1 sigma
+        assert blobs.shape == (0, z.ndim + 1)
 
 
 @pytest.mark.parametrize(

--- a/skimage/feature/tests/test_blob.py
+++ b/skimage/feature/tests/test_blob.py
@@ -182,12 +182,9 @@ def test_nd_blob_no_peaks_shape(function_name, ndim, anisotropic):
         max_sigma = 8
     blob_func = getattr(feature, function_name)
     blobs = blob_func(z, max_sigma=max_sigma)
-    if anisotropic:
-        # z.ndim coordinates and z.ndim sigmas
-        assert blobs.shape == (0, 2 * z.ndim)
-    else:
-        # z.ndim coordinates and 1 sigma
-        assert blobs.shape == (0, z.ndim + 1)
+    # z.ndim +  (z.ndim sigmas if anisotropic, only one sigma otherwise)
+    expected_shape = 2 * z.ndim if anisotropic else z.ndim + 1
+    assert blobs.shape == (0, expected_shape)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

This PR fixes the return shape of `blob_log` and `blob_dog` when no peaks are found. Also, the docstrings for the `image` parameter stated "2D or 3D", but these two functions are actually nD.

In general, size on the ouput shape is `image.ndim + 1` when sigma is a scalar or `2*image.ndim` when there is a per-axis sigma.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
