### PR TITLE
Added in wrap_axes to cross_correlation_masked function

### DIFF
--- a/skimage/registration/_masked_phase_cross_correlation.py
+++ b/skimage/registration/_masked_phase_cross_correlation.py
@@ -96,7 +96,7 @@ def _masked_phase_cross_correlation(reference_image, moving_image,
 
 
 def cross_correlate_masked(arr1, arr2, m1, m2, mode='full', axes=(-2, -1),
-                           overlap_ratio=0.3):
+                           overlap_ratio=0.3, wrap_axes=None):
     """
     Masked normalized cross-correlation between arrays.
 
@@ -130,6 +130,9 @@ def cross_correlate_masked(arr1, arr2, m1, m2, mode='full', axes=(-2, -1),
         maximum translation, while a higher `overlap_ratio` leads to greater
         robustness against spurious matches due to small overlap between
         masked images.
+    wrap_axes: tuple of ints, optional
+        Axes along which to not zero-pad `arr1` and `arr2` causing the correlation
+        to wrap.
 
     Returns
     -------
@@ -181,14 +184,16 @@ def cross_correlate_masked(arr1, arr2, m1, m2, mode='full', axes=(-2, -1),
     # we slice back to`final_shape` using `final_slice`.
     final_shape = list(arr1.shape)
     for axis in axes:
-        final_shape[axis] = fixed_image.shape[axis] + \
-            moving_image.shape[axis] - 1
+        if wrap_axes is None or axis not in wrap_axes:
+            final_shape[axis] = fixed_image.shape[axis] + \
+                moving_image.shape[axis] - 1
     final_shape = tuple(final_shape)
     final_slice = tuple([slice(0, int(sz)) for sz in final_shape])
 
     # Extent transform axes to the next fast length (i.e. multiple of 3, 5, or
     # 7)
-    fast_shape = tuple([next_fast_len(final_shape[ax]) for ax in axes])
+    fast_shape = tuple(final_shape[ax] if wrap_axes is not None and ax in wrap_axes
+                       else next_fast_len(final_shape[ax]) for ax in axes)
 
     # We use numpy.fft or the new scipy.fft because they allow leaving the
     # transform axes unchanged which was not possible with scipy.fftpack's

--- a/skimage/registration/_masked_phase_cross_correlation.py
+++ b/skimage/registration/_masked_phase_cross_correlation.py
@@ -131,8 +131,8 @@ def cross_correlate_masked(arr1, arr2, m1, m2, mode='full', axes=(-2, -1),
         robustness against spurious matches due to small overlap between
         masked images.
     wrap_axes: tuple of ints, optional
-        Axes along which to not zero-pad `arr1` and `arr2` causing the correlation
-        to wrap.
+        Axes along which to not zero-pad `arr1` and `arr2` causing the
+        correlation to wrap.
 
     Returns
     -------
@@ -192,7 +192,8 @@ def cross_correlate_masked(arr1, arr2, m1, m2, mode='full', axes=(-2, -1),
 
     # Extent transform axes to the next fast length (i.e. multiple of 3, 5, or
     # 7)
-    fast_shape = tuple(final_shape[ax] if wrap_axes is not None and ax in wrap_axes
+    fast_shape = tuple(final_shape[ax]
+                       if wrap_axes is not None and ax in wrap_axes
                        else next_fast_len(final_shape[ax]) for ax in axes)
 
     # We use numpy.fft or the new scipy.fft because they allow leaving the

--- a/skimage/registration/_masked_phase_cross_correlation.py
+++ b/skimage/registration/_masked_phase_cross_correlation.py
@@ -132,7 +132,8 @@ def cross_correlate_masked(arr1, arr2, m1, m2, mode='full', axes=(-2, -1),
         masked images.
     wrap_axes: tuple of ints, optional
         Axes along which to not zero-pad `arr1` and `arr2` causing the
-        correlation to wrap.
+        correlation to wrap. The shape of the output will match the shape of
+        `arr1` along any axis included in `wrap_axes`.
 
     Returns
     -------

--- a/skimage/registration/tests/test_masked_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_masked_phase_cross_correlation.py
@@ -277,3 +277,24 @@ def test_cross_correlate_masked_autocorrelation_trivial_masks():
     # uint8 inputs will be processed in float32, so reduce decimal to 5
     assert_almost_equal(xcorr.max(), 1, decimal=5)
     assert_array_equal(max_index, np.array(arr1.shape) / 2)
+
+def test_cross_correlate_masked_wrapped_axes():
+    """Masked normalized cross-correlation between identical arrays
+    should reduce to an autocorrelation even with random masks."""
+    # See random number generator for reproducible results
+    np.random.seed(23)
+
+    arr1 = camera()
+
+    # Random masks with 75% of pixels being valid
+    m1 = np.random.choice([True, False], arr1.shape, p=[3 / 4, 1 / 4])
+    m2 = np.random.choice([True, False], arr1.shape, p=[3 / 4, 1 / 4])
+
+    xcorr = cross_correlate_masked(arr1, arr1, m1, m2, axes=(0, 1),
+                                   mode='same', overlap_ratio=0, wrap_axes=(0, 1)).real
+    max_index = np.unravel_index(np.argmax(xcorr), xcorr.shape)
+
+    # Autocorrelation should have maximum in the self correlation
+    # uint8 inputs will be processed in float32, so reduce decimal to 5
+    assert_almost_equal(xcorr.max(), 1, decimal=5)
+    assert_array_equal(max_index, np.array(arr1.shape)-1)

--- a/skimage/registration/tests/test_masked_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_masked_phase_cross_correlation.py
@@ -278,6 +278,7 @@ def test_cross_correlate_masked_autocorrelation_trivial_masks():
     assert_almost_equal(xcorr.max(), 1, decimal=5)
     assert_array_equal(max_index, np.array(arr1.shape) / 2)
 
+
 def test_cross_correlate_masked_wrapped_axes():
     """Masked normalized cross-correlation between identical arrays
     should reduce to an autocorrelation even with random masks."""
@@ -290,11 +291,17 @@ def test_cross_correlate_masked_wrapped_axes():
     m1 = np.random.choice([True, False], arr1.shape, p=[3 / 4, 1 / 4])
     m2 = np.random.choice([True, False], arr1.shape, p=[3 / 4, 1 / 4])
 
-    xcorr = cross_correlate_masked(arr1, arr1, m1, m2, axes=(0, 1),
-                                   mode='same', overlap_ratio=0, wrap_axes=(0, 1)).real
+    xcorr = cross_correlate_masked(arr1,
+                                   arr1,
+                                   m1,
+                                   m2,
+                                   axes=(0, 1),
+                                   mode='same',
+                                   overlap_ratio=0,
+                                   wrap_axes=(0, 1)).real
     max_index = np.unravel_index(np.argmax(xcorr), xcorr.shape)
 
     # Autocorrelation should have maximum in the self correlation
     # uint8 inputs will be processed in float32, so reduce decimal to 5
     assert_almost_equal(xcorr.max(), 1, decimal=5)
-    assert_array_equal(max_index, np.array(arr1.shape)-1)
+    assert_array_equal(max_index, np.array(arr1.shape) - 1)


### PR DESCRIPTION
## Description

This PR adds in the ability to define which axes should be padded and which should wrap for the cross_correlation_masked function.

Specifically this is useful for polar unwrapped images where (some) edges of image should be wrapped to determine orientation and registration. 

Example:

```python 
import numpy as np
import matplotlib.pyplot as plt
from skimage.registration._masked_phase_cross_correlation import cross_correlate_masked

test = np.zeros((10, 20))
test[:,0] = 100
test[:,10] = 300

test_rot= np.zeros((10, 20))
test_rot[:,4] = 100
test_rot[:,14] = 300
```
![image](https://user-images.githubusercontent.com/41125831/133838272-2bde7f8d-bb3c-4a3a-810c-52bf370460f8.png)

```
wrapped_cor = cross_correlate_masked(test, test_rot,
                                  m1 = np.ones((10,20)),
                                  m2= np.ones((10,20)),
                                  axes=(1,),
                                  wrap_axes=(1,)).real)
no_wrap_cor = cross_correlate_masked(test, test_rot,
                                  m1 = np.ones((10,20)),
                                  m2= np.ones((10,20)),
                                  axes=(1,),mode="same").real)
```
![image](https://user-images.githubusercontent.com/41125831/133838527-8bc445fc-d06b-45c2-8e73-54a69726919f.png)



<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
