### PR TITLE
Fixed math formulas in plot_swirl.py example.

### DIFF
--- a/doc/examples/transform/plot_swirl.py
+++ b/doc/examples/transform/plot_swirl.py
@@ -42,7 +42,7 @@ mapping for the swirl transformation first computes, relative to a center
 
 .. math::
 
-    \\theta = \\arctan(y/x)
+    \\theta = \\arctan((y-y0)/(x-x0))
 
     \\rho = \sqrt{(x - x_0)^2 + (y - y_0)^2},
 
@@ -56,7 +56,7 @@ and then transforms them according to
 
     s = \mathtt{strength}
 
-    \\theta' = \phi + s \, e^{-\\rho / r + \\theta}
+    \\theta' = \phi + s \, e^{-\\rho / r} + \\theta
 
 where ``strength`` is a parameter for the amount of swirl, ``radius`` indicates
 the swirl extent in pixels, and ``rotation`` adds a rotation angle.  The


### PR DESCRIPTION
## Description

Math formulas in plot_swirl.py example had two small typos. These new formulas should match with the code in _swirl_mapping function. [Link to function](https://github.com/scikit-image/scikit-image/blob/v0.15.0/skimage/transform/_warps.py#LC447)

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
