### PR TITLE
Regionprops table performance refactor

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -421,7 +421,7 @@ class RegionProperties:
         return self._intensity_image[self.slice] * image
 
     def _image_intensity_double(self):
-        return self.image_intensity.astype(np.double)
+        return self.image_intensity.astype(np.double, copy=False)
 
     @property
     def centroid_local(self):
@@ -431,8 +431,8 @@ class RegionProperties:
 
     @property
     def intensity_max(self):
-        return np.max(self.image_intensity[self.image], axis=0)\
-                 .astype(np.double)
+        vals = self.image_intensity[self.image]
+        return np.max(vals, axis=0).astype(np.double, copy=False)
 
     @property
     def intensity_mean(self):
@@ -440,8 +440,8 @@ class RegionProperties:
 
     @property
     def intensity_min(self):
-        return np.min(self.image_intensity[self.image], axis=0)\
-                 .astype(np.double)
+        vals = self.image_intensity[self.image]
+        return np.min(vals, axis=0).astype(np.double, copy=False)
 
     @property
     def axis_major_length(self):
@@ -718,7 +718,7 @@ def _props_to_dict(regions, properties=('label', 'bbox'), separator='-'):
         # array properties are raveled into multiple columns
         # for more info, refer to notes 1
         if np.isscalar(rp) or prop in OBJECT_COLUMNS or dtype is np.object_:
-            column_buffer = np.zeros(n, dtype=dtype)
+            column_buffer = np.empty(n, dtype=dtype)
             for i in range(n):
                 column_buffer[i] = regions[i][prop]
             out[prop] = np.copy(column_buffer)

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -1,6 +1,8 @@
 import inspect
+from functools import wraps
+from math import atan2, pi as PI, sqrt
 from warnings import warn
-from math import sqrt, atan2, pi as PI
+
 import numpy as np
 from scipy import ndimage as ndi
 from scipy.spatial.distance import pdist
@@ -9,8 +11,6 @@ from . import _moments
 from ._find_contours import find_contours
 from ._marching_cubes_lewiner import marching_cubes
 from ._regionprops_utils import euler_number, perimeter, perimeter_crofton
-
-from functools import wraps
 
 
 __all__ = ['regionprops', 'euler_number', 'perimeter', 'perimeter_crofton']

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -261,19 +261,18 @@ class RegionProperties:
         self._spatial_axes = tuple(range(self._ndim))
 
         self._extra_properties = {}
-        if extra_properties is None:
-            extra_properties = []
-        for func in extra_properties:
-            name = func.__name__
-            if hasattr(self, name):
-                msg = (
-                    f"Extra property '{name}' is shadowed by existing "
-                    f"property and will be inaccessible. Consider renaming it."
-                )
-                warn(msg)
-        self._extra_properties = {
-            func.__name__: func for func in extra_properties
-        }
+        if extra_properties is not None:
+            for func in extra_properties:
+                name = func.__name__
+                if hasattr(self, name):
+                    msg = (
+                        f"Extra property '{name}' is shadowed by existing "
+                        f"property and will be inaccessible. Consider renaming it."
+                    )
+                    warn(msg)
+            self._extra_properties = {
+                func.__name__: func for func in extra_properties
+            }
 
     def __getattr__(self, attr):
         if attr in self._extra_properties:


### PR DESCRIPTION
## Description

This PR reorganizes some `RegionProps` and `regionprops_table` code to improve performance. There should be no change in behavior.

In the case when `cache=True` this improves performance on a subset of properties. A large performance increase is seen for some properties when `cache=False`. 

The largest improvement in a single property's performance when `cache=True` is for `centroid` which is about 1/3 faster than before.


### Benchmark Results (left column is `main`, right column is this PR)

The top two entries involve calculating all properties with or without caching. Run time is reduced by 7% for the `cache=True` case and 66% for the `cache=False` case.

The remaining entries are for calculating individual properties with caching enabled. Many show no change, but a handful, like `centroid` show substantial benefit.

```
       before           after         ratio
     [f7b2a14e]       [24a6f9e9]
     <regionprops_bench>       <regionprops-performance>
-      6.17±0.01s       2.07±0.02s     0.34  time_regionprops_table_all(False)
          706±4ms          656±5ms     0.93  time_regionprops_table_all(True)
       11.9±0.2ms       11.8±0.1ms     1.00  time_single_region_property('area')
       9.61±0.1ms      9.53±0.07ms     0.99  time_single_region_property('area_bbox')
        220±0.7ms          220±1ms     1.00  time_single_region_property('area_convex')
       40.7±0.3ms       40.8±0.4ms     1.00  time_single_region_property('area_filled')
       77.0±0.4ms       77.3±0.4ms     1.00  time_single_region_property('axis_major_length')
       77.0±0.5ms       76.6±0.3ms     0.99  time_single_region_property('axis_minor_length')
-     10.3±0.08ms       8.92±0.1ms     0.86  time_single_region_property('bbox')
-      34.3±0.2ms       22.9±0.2ms     0.67  time_single_region_property('centroid')
-      31.4±0.6ms       28.4±0.3ms     0.91  time_single_region_property('centroid_local')
-      35.8±0.4ms       32.2±0.4ms     0.90  time_single_region_property('centroid_weighted')
       32.5±0.2ms       30.3±0.1ms     0.93  time_single_region_property('centroid_weighted_local')
       17.9±0.2ms       17.5±0.2ms     0.98  time_single_region_property('coords')
       78.8±0.8ms       77.9±0.4ms     0.99  time_single_region_property('eccentricity')
       13.2±0.2ms       13.4±0.4ms     1.01  time_single_region_property('equivalent_diameter_area')
       43.0±0.4ms       43.2±0.3ms     1.01  time_single_region_property('euler_number')
       12.2±0.2ms       12.1±0.1ms     0.99  time_single_region_property('extent')
        348±0.9ms          347±4ms     1.00  time_single_region_property('feret_diameter_max')
       9.61±0.2ms       9.85±0.2ms     1.03  time_single_region_property('image')
        213±0.4ms          217±2ms     1.02  time_single_region_property('image_convex')
       38.3±0.4ms       38.1±0.6ms     0.99  time_single_region_property('image_filled')
       12.4±0.2ms       12.5±0.1ms     1.00  time_single_region_property('image_intensity')
       59.1±0.5ms       59.7±0.4ms     1.01  time_single_region_property('inertia_tensor')
       75.9±0.5ms       76.5±0.7ms     1.01  time_single_region_property('inertia_tensor_eigvals')
       15.6±0.2ms       15.7±0.1ms     1.00  time_single_region_property('intensity_max')
       16.3±0.2ms       16.0±0.2ms     0.98  time_single_region_property('intensity_mean')
       15.7±0.2ms       16.1±0.1ms     1.02  time_single_region_property('intensity_min')
      8.04±0.09ms       8.00±0.1ms     0.99  time_single_region_property('label')
       26.9±0.3ms       25.1±0.1ms     0.93  time_single_region_property('moments')
       46.1±0.8ms       44.4±0.3ms     0.96  time_single_region_property('moments_central')
-      74.6±0.2ms       63.8±0.4ms     0.85  time_single_region_property('moments_hu')
       58.3±0.8ms       57.4±0.5ms     0.98  time_single_region_property('moments_normalized')
       29.2±0.2ms       27.1±0.3ms     0.93  time_single_region_property('moments_weighted')
       46.9±0.5ms       45.2±0.4ms     0.96  time_single_region_property('moments_weighted_central')
-      77.8±0.3ms       64.4±0.4ms     0.83  time_single_region_property('moments_weighted_hu')
       60.7±0.5ms       57.8±0.6ms     0.95  time_single_region_property('moments_weighted_normalized')
       60.3±0.2ms       61.4±0.9ms     1.02  time_single_region_property('orientation')
       51.8±0.4ms       52.7±0.3ms     1.02  time_single_region_property('perimeter')
       51.1±0.5ms       51.7±0.4ms     1.01  time_single_region_property('perimeter_crofton')
      8.03±0.07ms      8.11±0.08ms     1.01  time_single_region_property('slice')
        223±0.9ms        222±0.4ms     0.99  time_single_region_property('solidity')


```

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
