### PR TITLE
remove use of apply_along_axes from greycomatrix & greycoprops

### DIFF
--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -147,7 +147,7 @@ def graycomatrix(image, distances, angles, levels=None, symmetric=False,
     # normalize each GLCM
     if normed:
         P = P.astype(np.float64)
-        glcm_sums = np.apply_over_axes(np.sum, P, axes=(0, 1))
+        glcm_sums = np.sum(P, axis=(0, 1), keepdims=True)
         glcm_sums[glcm_sums == 0] = 1
         P /= glcm_sums
 
@@ -225,7 +225,7 @@ def graycoprops(P, prop='contrast'):
 
     # normalize each GLCM
     P = P.astype(np.float64)
-    glcm_sums = np.apply_over_axes(np.sum, P, axes=(0, 1))
+    glcm_sums = np.sum(P, axis=(0, 1), keepdims=True)
     glcm_sums[glcm_sums == 0] = 1
     P /= glcm_sums
 
@@ -244,23 +244,20 @@ def graycoprops(P, prop='contrast'):
 
     # compute property for each GLCM
     if prop == 'energy':
-        asm = np.apply_over_axes(np.sum, (P ** 2), axes=(0, 1))[0, 0]
+        asm = np.sum(P ** 2, axis=(0, 1))
         results = np.sqrt(asm)
     elif prop == 'ASM':
-        results = np.apply_over_axes(np.sum, (P ** 2), axes=(0, 1))[0, 0]
+        results = np.sum(P ** 2, axis=(0, 1))
     elif prop == 'correlation':
         results = np.zeros((num_dist, num_angle), dtype=np.float64)
         I = np.array(range(num_level)).reshape((num_level, 1, 1, 1))
         J = np.array(range(num_level)).reshape((1, num_level, 1, 1))
-        diff_i = I - np.apply_over_axes(np.sum, (I * P), axes=(0, 1))[0, 0]
-        diff_j = J - np.apply_over_axes(np.sum, (J * P), axes=(0, 1))[0, 0]
+        diff_i = I - np.sum(I * P, axis=(0, 1))
+        diff_j = J - np.sum(J * P, axis=(0, 1))
 
-        std_i = np.sqrt(np.apply_over_axes(np.sum, (P * (diff_i) ** 2),
-                                           axes=(0, 1))[0, 0])
-        std_j = np.sqrt(np.apply_over_axes(np.sum, (P * (diff_j) ** 2),
-                                           axes=(0, 1))[0, 0])
-        cov = np.apply_over_axes(np.sum, (P * (diff_i * diff_j)),
-                                 axes=(0, 1))[0, 0]
+        std_i = np.sqrt(np.sum(P * (diff_i) ** 2, axis=(0, 1)))
+        std_j = np.sqrt(np.sum(P * (diff_j) ** 2, axis=(0, 1)))
+        cov = np.sum(P * (diff_i * diff_j), axis=(0, 1))
 
         # handle the special case of standard deviations near zero
         mask_0 = std_i < 1e-15
@@ -272,7 +269,7 @@ def graycoprops(P, prop='contrast'):
         results[mask_1] = cov[mask_1] / (std_i[mask_1] * std_j[mask_1])
     elif prop in ['contrast', 'dissimilarity', 'homogeneity']:
         weights = weights.reshape((num_level, num_level, 1, 1))
-        results = np.apply_over_axes(np.sum, (P * weights), axes=(0, 1))[0, 0]
+        results = np.sum(P * weights, axis=(0, 1))
 
     return results
 

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -3,9 +3,10 @@ Methods to characterize image textures.
 """
 
 import numpy as np
+
 from .._shared.utils import check_nD
-from ..util import img_as_float
 from ..color import gray2rgb
+from ..util import img_as_float
 from ._texture import (_glcm_loop,
                        _local_binary_pattern,
                        _multiblock_lbp)
@@ -170,8 +171,8 @@ def graycoprops(P, prop='contrast'):
         .. math:: \\sum_{i,j=0}^{levels-1} P_{i,j}\\left[\\frac{(i-\\mu_i) \\
                   (j-\\mu_j)}{\\sqrt{(\\sigma_i^2)(\\sigma_j^2)}}\\right]
 
-    Each GLCM is normalized to have a sum of 1 before the computation of texture
-    properties.
+    Each GLCM is normalized to have a sum of 1 before the computation of
+    texture properties.
 
     Parameters
     ----------
@@ -265,7 +266,7 @@ def graycoprops(P, prop='contrast'):
         results[mask_0] = 1
 
         # handle the standard case
-        mask_1 = mask_0 == False
+        mask_1 = ~mask_0
         results[mask_1] = cov[mask_1] / (std_i[mask_1] * std_j[mask_1])
     elif prop in ['contrast', 'dissimilarity', 'homogeneity']:
         weights = weights.reshape((num_level, num_level, 1, 1))


### PR DESCRIPTION
## Description

This is a minor refactor for code clarity. We can just call `np.sum` directly now that it supports a tuple of axes and has a `keepdims` argument.

The refactor here is also more efficient, but the arrays that are being summed over here are very small (a handful of elements per axis), so it does not really matter from a performance standpoint. 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
