### PR TITLE
refactor gabor_kernel for efficiency

### DIFF
--- a/skimage/filters/_gabor.py
+++ b/skimage/filters/_gabor.py
@@ -101,9 +101,10 @@ def gabor_kernel(frequency, theta=0, bandwidth=1, sigma_x=None, sigma_y=None,
     roty = -x * st + y * ct
 
     g = np.empty(roty.shape, dtype=dtype)
-    g[:] = np.exp(-0.5 * (rotx ** 2 / sigma_x ** 2 + roty ** 2 / sigma_y ** 2))
+    np.exp(-0.5 * (rotx ** 2 / sigma_x ** 2 + roty ** 2 / sigma_y ** 2)
+           + 1j * (2 * np.pi * frequency * rotx + offset),
+           out=g)
     g /= 2 * np.pi * sigma_x * sigma_y
-    g *= np.exp(1j * (2 * np.pi * frequency * rotx + offset))
 
     return g
 

--- a/skimage/filters/_gabor.py
+++ b/skimage/filters/_gabor.py
@@ -93,12 +93,14 @@ def gabor_kernel(frequency, theta=0, bandwidth=1, sigma_x=None, sigma_y=None,
     y0 = math.ceil(
         max(abs(n_stds * sigma_y * ct), abs(n_stds * sigma_x * st), 1)
     )
-    y, x = np.mgrid[-y0:y0 + 1, -x0:x0 + 1]
-
+    y, x = np.meshgrid(np.arange(-y0, y0 + 1),
+                       np.arange(-x0, x0 + 1),
+                       indexing='ij',
+                       sparse=True)
     rotx = x * ct + y * st
     roty = -x * st + y * ct
 
-    g = np.empty(y.shape, dtype=dtype)
+    g = np.empty(roty.shape, dtype=dtype)
     g[:] = np.exp(-0.5 * (rotx ** 2 / sigma_x ** 2 + roty ** 2 / sigma_y ** 2))
     g /= 2 * np.pi * sigma_x * sigma_y
     g *= np.exp(1j * (2 * np.pi * frequency * rotx + offset))

--- a/skimage/filters/_gabor.py
+++ b/skimage/filters/_gabor.py
@@ -104,7 +104,7 @@ def gabor_kernel(frequency, theta=0, bandwidth=1, sigma_x=None, sigma_y=None,
     np.exp(-0.5 * (rotx ** 2 / sigma_x ** 2 + roty ** 2 / sigma_y ** 2)
            + 1j * (2 * np.pi * frequency * rotx + offset),
            out=g)
-    g /= 2 * np.pi * sigma_x * sigma_y
+    g *= 1 / (2 * np.pi * sigma_x * sigma_y)
 
     return g
 

--- a/skimage/filters/_gabor.py
+++ b/skimage/filters/_gabor.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 from scipy import ndimage as ndi
 
@@ -9,7 +11,7 @@ __all__ = ['gabor_kernel', 'gabor']
 def _sigma_prefactor(bandwidth):
     b = bandwidth
     # See http://www.cs.rug.nl/~imaging/simplecell.html
-    return 1.0 / np.pi * np.sqrt(np.log(2) / 2.0) * \
+    return 1.0 / np.pi * math.sqrt(math.log(2) / 2.0) * \
         (2.0 ** b + 1) / (2.0 ** b - 1)
 
 
@@ -83,16 +85,20 @@ def gabor_kernel(frequency, theta=0, bandwidth=1, sigma_x=None, sigma_y=None,
     if np.dtype(dtype).kind != 'c':
         raise ValueError("dtype must be complex")
 
-    x0 = np.ceil(max(np.abs(n_stds * sigma_x * np.cos(theta)),
-                     np.abs(n_stds * sigma_y * np.sin(theta)), 1))
-    y0 = np.ceil(max(np.abs(n_stds * sigma_y * np.cos(theta)),
-                     np.abs(n_stds * sigma_x * np.sin(theta)), 1))
+    ct = math.cos(theta)
+    st = math.sin(theta)
+    x0 = math.ceil(
+        max(abs(n_stds * sigma_x * ct), abs(n_stds * sigma_y * st), 1)
+    )
+    y0 = math.ceil(
+        max(abs(n_stds * sigma_y * ct), abs(n_stds * sigma_x * st), 1)
+    )
     y, x = np.mgrid[-y0:y0 + 1, -x0:x0 + 1]
 
-    rotx = x * np.cos(theta) + y * np.sin(theta)
-    roty = -x * np.sin(theta) + y * np.cos(theta)
+    rotx = x * ct + y * st
+    roty = -x * st + y * ct
 
-    g = np.zeros(y.shape, dtype=dtype)
+    g = np.empty(y.shape, dtype=dtype)
     g[:] = np.exp(-0.5 * (rotx ** 2 / sigma_x ** 2 + roty ** 2 / sigma_y ** 2))
     g /= 2 * np.pi * sigma_x * sigma_y
     g *= np.exp(1j * (2 * np.pi * frequency * rotx + offset))


### PR DESCRIPTION
## Description

This PR is a refactor of `gabor_kernel` to improve efficiency:
1.) replace NumPy calls with `math` calls where scalar values are involved
2.) use `np.meshgrid` instead of `np.mgrid` to generate a sparse grid
3.) merge two separate `np.exp` calls into one
4.) replace the final in-place division with in-place multiplication


Performance prior to this PR
```
In [3]: %timeit gabor_kernel(1.0)
54.5 µs ± 3.1 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [4]: %timeit gabor_kernel(0.1)
100 µs ± 400 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [5]: %timeit gabor_kernel(0.01)
8.07 ms ± 114 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [6]: %timeit gabor_kernel(0.01, dtype=np.complex64)
8.26 ms ± 363 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

Performance after this PR
```
In [3]: %timeit gabor_kernel(1.0)
25.7 µs ± 162 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [4]: %timeit gabor_kernel(0.1)
68 µs ± 644 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [5]: %timeit gabor_kernel(0.01)
6.25 ms ± 106 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [6]: %timeit gabor_kernel(0.01, dtype=np.complex64)
5.43 ms ± 113 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
