### PR TITLE
Refactor measure.ransac and add warning when the estimated model is not valid

### DIFF
--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -619,8 +619,8 @@ def _dynamic_max_trials(n_inliers, n_samples, min_samples, probability):
     if n_inliers == n_samples:
         return 1
 
-    nom = np.log(1 - probability)
-    denom = np.log(1 - (n_inliers / n_samples) ** min_samples)
+    nom = math.log(1 - probability)
+    denom = math.log(1 - (n_inliers / n_samples) ** min_samples)
 
     return int(np.ceil(nom / denom))
 
@@ -889,7 +889,7 @@ def ransac(data, model_class, min_samples, residual_threshold,
         data_inliers = [d[best_inliers] for d in data]
         model.estimate(*data_inliers)
         if validate_model and not is_model_valid(model, *data_inliers):
-            warn("Estimated model is not valid. Try increase max_trials.")
+            warn("Estimated model is not valid. Try increasing max_trials.")
     else:
         model = None
         best_inliers = None

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -16,11 +16,6 @@ def _check_data_atleast_2D(data):
         raise ValueError('Input data must be at least 2D.')
 
 
-def _norm_along_axis(x, axis):
-    """NumPy < 1.8 does not support the `axis` argument for `np.linalg.norm`."""
-    return np.sqrt(np.einsum('ij,ij->i', x, x))
-
-
 class BaseModel(object):
 
     def __init__(self):
@@ -129,7 +124,7 @@ class LineModelND(BaseModel):
         origin, direction = params
         res = (data - origin) - \
               ((data - origin) @ direction)[..., np.newaxis] * direction
-        return _norm_along_axis(res, axis=1)
+        return np.linalg.norm(res, axis=1)
 
     def predict(self, x, axis=0, params=None):
         """Predict intersection of the estimated line model with a hyperplane

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -426,3 +426,20 @@ def test_ransac_with_no_final_inliers():
                                 residual_threshold=0, random_state=1523427)
     assert inliers is None
     assert model is None
+
+
+def test_ransac_non_valid_best_model():
+    """Example from GH issue #5572"""
+    def is_model_valid(model, *random_data) -> bool:
+        """Allow models with a maximum of 10 degree tilt from the vertical
+
+        """
+        tilt = abs(np.arccos(np.dot(model.params[1], [0, 0, 1])))
+        return tilt <= (10 / 180 * np.pi)
+
+    rnd = np.random.RandomState(1)
+    data = np.linspace([0, 0, 0], [0.3, 0, 1], 1000) + rnd.rand(1000, 3) - 0.5
+    with expected_warnings(["Estimated model is not valid"]):
+        ransac(data, LineModelND, min_samples=2,
+               residual_threshold=0.3, max_trials=50, random_state=0,
+               is_model_valid=is_model_valid)


### PR DESCRIPTION
## Description

Closes #5572.

This PR is a refactoring/cleaning of `measure.ransac ` and the addition of a warning when the estimated model is not valid.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
