### PR TITLE
Restore integer image rescaling for edge filters

### DIFF
--- a/skimage/filters/_gabor.py
+++ b/skimage/filters/_gabor.py
@@ -173,10 +173,14 @@ def gabor(image, frequency, theta=0, bandwidth=1, sigma_x=None,
     >>> io.show()               # doctest: +SKIP
     """
     check_nD(image, 2)
-    float_dtype = _supported_float_type(image.dtype)
-    image = image.astype(float_dtype, copy=False)
+    # do not cast integer types to float!
+    if image.dtype.kind == 'f':
+        float_dtype = _supported_float_type(image.dtype)
+        image = image.astype(float_dtype, copy=False)
+        kernel_dtype = np.promote_types(image.dtype, np.complex64)
+    else:
+        kernel_dtype = np.complex128
 
-    kernel_dtype = np.promote_types(image.dtype, np.complex64)
     g = gabor_kernel(frequency, theta, bandwidth, sigma_x, sigma_y, n_stds,
                      offset, dtype=kernel_dtype)
 

--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -15,6 +15,7 @@ from scipy.ndimage import binary_erosion, convolve
 
 from .._shared.utils import _supported_float_type, check_nD
 from ..restoration.uft import laplacian
+from ..util.dtype import img_as_float
 
 # n-dimensional filter weights
 SOBEL_EDGE = np.array([1, 0, -1])
@@ -168,9 +169,12 @@ def _generic_edge_filter(image, *, smooth_weights, edge_weights=[1, 0, -1],
         axes = axis
     return_magnitude = (len(axes) > 1)
 
-    float_dtype = _supported_float_type(image.dtype)
-    image = image.astype(float_dtype, copy=False)
-    output = np.zeros(image.shape, dtype=float_dtype)
+    if image.dtype.kind == 'f':
+        float_dtype = _supported_float_type(image.dtype)
+        image = image.astype(float_dtype, copy=False)
+    else:
+        image = img_as_float(image)
+    output = np.zeros(image.shape, dtype=image.dtype)
 
     for edge_dim in axes:
         kernel = _reshape_nd(edge_weights, ndim, edge_dim)
@@ -617,8 +621,11 @@ def roberts_pos_diag(image, mask=None):
 
     """
     check_nD(image, 2)
-    float_dtype = _supported_float_type(image.dtype)
-    image = image.astype(float_dtype, copy=False)
+    if image.dtype.kind == 'f':
+        float_dtype = _supported_float_type(image.dtype)
+        image = image.astype(float_dtype, copy=False)
+    else:
+        image = img_as_float(image)
     result = convolve(image, ROBERTS_PD_WEIGHTS)
     return _mask_filter_result(result, mask)
 
@@ -652,8 +659,11 @@ def roberts_neg_diag(image, mask=None):
 
     """
     check_nD(image, 2)
-    float_dtype = _supported_float_type(image.dtype)
-    image = image.astype(float_dtype, copy=False)
+    if image.dtype.kind == 'f':
+        float_dtype = _supported_float_type(image.dtype)
+        image = image.astype(float_dtype, copy=False)
+    else:
+        image = img_as_float(image)
     result = convolve(image, ROBERTS_ND_WEIGHTS)
     return _mask_filter_result(result, mask)
 
@@ -684,8 +694,11 @@ def laplace(image, ksize=3, mask=None):
     skimage.restoration.uft.laplacian().
 
     """
-    float_dtype = _supported_float_type(image.dtype)
-    image = image.astype(float_dtype, copy=False)
+    if image.dtype.kind == 'f':
+        float_dtype = _supported_float_type(image.dtype)
+        image = image.astype(float_dtype, copy=False)
+    else:
+        image = img_as_float(image)
     # Create the discrete Laplacian operator - We keep only the real part of
     # the filter
     _, laplace_op = laplacian(image.ndim, (ksize,) * image.ndim)
@@ -775,8 +788,11 @@ def farid_h(image, *, mask=None):
            Computer Analysis of Images and Patterns, Kiel, Germany. Sep, 1997.
     """
     check_nD(image, 2)
-    float_dtype = _supported_float_type(image.dtype)
-    image = image.astype(float_dtype, copy=False)
+    if image.dtype.kind == 'f':
+        float_dtype = _supported_float_type(image.dtype)
+        image = image.astype(float_dtype, copy=False)
+    else:
+        image = img_as_float(image)
     result = convolve(image, HFARID_WEIGHTS)
     return _mask_filter_result(result, mask)
 
@@ -809,7 +825,10 @@ def farid_v(image, *, mask=None):
            13(4): 496-508, 2004. :DOI:`10.1109/TIP.2004.823819`
     """
     check_nD(image, 2)
-    float_dtype = _supported_float_type(image.dtype)
-    image = image.astype(float_dtype, copy=False)
+    if image.dtype.kind == 'f':
+        float_dtype = _supported_float_type(image.dtype)
+        image = image.astype(float_dtype, copy=False)
+    else:
+        image = img_as_float(image)
     result = convolve(image, VFARID_WEIGHTS)
     return _mask_filter_result(result, mask)

--- a/skimage/filters/tests/test_edges.py
+++ b/skimage/filters/tests/test_edges.py
@@ -35,8 +35,9 @@ def test_roberts_diagonal1(dtype):
 def test_int_rescaling(function_name):
     """Basic test that uint8 inputs get rescaled from [0, 255] to [0, 1.]
 
-    The output of any of these filters should be not much more than 1.0 if
-    this is true.
+    The output of any of these filters should be within roughly a factor of
+    two of the input range. For integer inputs, rescaling to floats in
+    [0.0, 1.0] should occur, so just verify outputs are not > 2.0.
     """
     img = data.coins()[:128, :128]
     func = getattr(filters, function_name)

--- a/skimage/filters/tests/test_edges.py
+++ b/skimage/filters/tests/test_edges.py
@@ -28,6 +28,22 @@ def test_roberts_diagonal1(dtype):
     assert_array_almost_equal(result.astype(bool), expected)
 
 
+@pytest.mark.parametrize(
+    'function_name',
+    ['farid', 'laplace', 'prewitt', 'roberts', 'scharr', 'sobel']
+)
+def test_int_rescaling(function_name):
+    """Basic test that uint8 inputs get rescaled from [0, 255] to [0, 1.]
+
+    The output of any of these filters should be not much more than 1.0 if
+    this is true.
+    """
+    img = data.coins()[:128, :128]
+    func = getattr(filters, function_name)
+    filtered = func(img)
+    assert filtered.max() <= 2.0
+
+
 def test_roberts_diagonal2():
     """Roberts' filter on a diagonal edge should be a diagonal line."""
     image = np.rot90(np.tri(10, 10, 0), 3)

--- a/skimage/filters/tests/test_gabor.py
+++ b/skimage/filters/tests/test_gabor.py
@@ -94,10 +94,17 @@ def test_gabor():
 
 
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
-def test_gabor_dtype(dtype):
+def test_gabor_float_dtype(dtype):
     image = np.ones((16, 16), dtype=dtype)
     y = gabor(image, 0.3)
     assert all(arr.dtype == _supported_float_type(image.dtype) for arr in y)
+
+
+@pytest.mark.parametrize('dtype', [np.uint8, np.int32, np.intp])
+def test_gabor_int_dtype(dtype):
+    image = np.full((16, 16), 128, dtype=dtype)
+    y = gabor(image, 0.3)
+    assert all(arr.dtype == dtype for arr in y)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Some unintentional changes to the scaling of the outputs of various edge filters was introduced in #5354 when the input is not floating point. This leads, for example to the following [broken demo](https://scikit-image.org/docs/dev/auto_examples/filters/plot_hysteresis.html) (as [compared to v0.18.x](https://scikit-image.org/docs/0.18.x/auto_examples/filters/plot_hysteresis.html#sphx-glr-auto-examples-filters-plot-hysteresis-py])).

Double-checking other filters, I found that `gabor` filtering previously did not change integer inputs to floats, but would instead give output with dtype matching the input. This behavior has also been restored in this PR.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
