### PR TITLE
Separate entries that have the same description in glossary.md

### DIFF
--- a/doc/source/glossary.md
+++ b/doc/source/glossary.md
@@ -7,9 +7,9 @@ Work in progress
 
 array 
     Numerical array, provided by the {class}`numpy.ndarray` object. In
-    ``scikit-image``, images are NumPy arrays, which dimensions
+    ``scikit-image``, images are NumPy arrays with dimensions that
     correspond to spatial dimensions of the image, and color channels for
-    color images. See {ref}`numpy`. 
+    color images. See {ref}`numpy`.
 
 channel
     Typically used to refer to a single color channel in a color image. RGBA
@@ -26,10 +26,9 @@ circle
     The perimeter of a {term}`disk`.
 
 contour
-iso-valued contour
     Curve along which a 2-D image has a constant value. The interior
     (resp. exterior) of the contour has values greater (resp. smaller)
-    than the contour value. 
+    than the contour value.
 
 contrast
     Differences of intensity or color in an image, which make objects
@@ -40,13 +39,15 @@ disk
     A filled-in {term}`circle`.
 
 float
-float values
     Representation of real numbers, for example as {obj}`np.float32` or
     {obj}`np.float64`. See {ref}`data_types`. Some operations on images
     need a float datatype (such as multiplying image values with
     exponential prefactors in {func}`filters.gaussian`), so that 
     images of integer type are often converted to float type internally. Also
     see {term}`int` values.
+
+float values
+    See {term}`float`.
 
 histogram
     For an image, histogram of intensity values, where the range of
@@ -55,7 +56,6 @@ histogram
     {func}`exposure.histogram`.
 
 int
-int values
     Representation of integer numbers, which can be signed or not, and
     encoded on one, two, four or eight bytes according to the maximum value
     which needs to be represented. In ``scikit-image``, the most common
@@ -63,8 +63,13 @@ int values
     {obj}`np.uint8` (for small integer values, typically images of labels
     with less than 255 labels). See {ref}`data_types`. 
 
+int values
+    See {term}`int`.
+
+iso-valued contour
+    See {term}`contour`.
+
 labels
-label image
     An image of labels is of integer type, where pixels with the same
     integer value belong to the same object. For example, the result of a
     segmentation is an image of labels. {func}`measure.label` labels
@@ -72,6 +77,9 @@ label image
     labels. Labels are usually contiguous integers, and
     {func}`segmentation.relabel_sequential` can be used to relabel
     arbitrary labels to sequential (contiguous) ones.
+
+label image
+    See {term}`labels`.
 
 pixel
     Smallest element of an image. An image is a grid of pixels, and the


### PR DESCRIPTION
## Description

Terms in glossary.md which previously shared descriptions have been separated in the manner suggested and described [here](https://github.com/scikit-image/scikit-image/pull/5590#pullrequestreview-769220646) by @grlee77.  This is to improve the overall rendering of the glossary page.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
