### PR TITLE
Default footprint for the median filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ wheels
 skimage/morphology/_skeletonize_3d_cy.pyx
 .asv
 .vscode/
+venv/

--- a/skimage/filters/_median.py
+++ b/skimage/filters/_median.py
@@ -6,6 +6,7 @@ from scipy import ndimage as ndi
 
 from .._shared.utils import deprecate_kwarg
 from .rank import generic
+from ..morphology import disk, ball
 
 
 @deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
@@ -17,10 +18,12 @@ def median(image, footprint=None, out=None, mode='nearest', cval=0.0,
     ----------
     image : array-like
         Input image.
-    footprint : ndarray, optional
+    footprint : int, ndarray, optional
         If ``behavior=='rank'``, ``footprint`` is a 2-D array of 1's and 0's.
         If ``behavior=='ndimage'``, ``footprint`` is a N-D array of 1's and 0's
         with the same number of dimension than ``image``.
+        If int, ``footprint`` will be a disk or ball structuring element with
+        radius = given footprint
         If None, ``footprint`` will be a N-D array with 3 elements for each
         dimension (e.g., vector, square, cube, etc.)
     out : ndarray, (same dtype as image), optional
@@ -68,6 +71,12 @@ def median(image, footprint=None, out=None, mode='nearest', cval=0.0,
     >>> med = median(img, disk(5))
 
     """
+    if footprint is not None and isinstance(footprint, int):
+        if image.ndim == 2:
+            footprint = disk(footprint)
+        elif image.ndim == 3:
+            footprint = ball(footprint)
+
     if behavior == 'rank':
         if mode != 'nearest' or not np.isclose(cval, 0.0):
             warn("Change 'behavior' to 'ndimage' if you want to use the "

--- a/skimage/filters/tests/test_median.py
+++ b/skimage/filters/tests/test_median.py
@@ -16,6 +16,19 @@ def image():
                      [1, 2, 1, 2, 3]],
                     dtype=np.uint8)
 
+@pytest.fixture
+def image3d():
+    return np.array([[[1, 2, 3, 2, 1],
+                     [1, 1, 2, 2, 3],
+                     [3, 2, 1, 2, 1],
+                     [3, 2, 1, 1, 1],
+                     [1, 2, 1, 2, 3]],
+                    [[1, 2, 3, 2, 1],
+                     [1, 1, 2, 2, 3],
+                     [3, 2, 1, 2, 1],
+                     [3, 2, 1, 1, 1],
+                     [1, 2, 1, 2, 3]]],
+                    dtype=np.uint8)
 
 @pytest.mark.parametrize(
     "mode, cval, behavior, n_warning, warning_type",
@@ -71,3 +84,16 @@ def test_median_error_ndim():
 )
 def test_median(img, behavior):
     median(img, behavior=behavior)
+
+def test_median_int_footprint_2d(image):
+    from skimage.morphology import disk
+    result1 = median(image, disk(5))
+    result2 = median(image, 5)
+    assert np.array_equal(result1, result2)
+
+def test_median_int_footprint_3d(image3d):
+    from skimage.morphology import ball
+    result1 = median(image3d, ball(5))
+    result2 = median(image3d, 5)
+    assert np.array_equal(result1, result2)
+

--- a/skimage/filters/tests/test_median.py
+++ b/skimage/filters/tests/test_median.py
@@ -30,6 +30,7 @@ def image3d():
                      [1, 2, 1, 2, 3]]],
                     dtype=np.uint8)
 
+
 @pytest.mark.parametrize(
     "mode, cval, behavior, n_warning, warning_type",
     [('nearest', 0.0, 'ndimage', 0, []),
@@ -85,11 +86,13 @@ def test_median_error_ndim():
 def test_median(img, behavior):
     median(img, behavior=behavior)
 
+
 def test_median_int_footprint_2d(image):
     from skimage.morphology import disk
     result1 = median(image, disk(5))
     result2 = median(image, 5)
     assert np.array_equal(result1, result2)
+
 
 def test_median_int_footprint_3d(image3d):
     from skimage.morphology import ball

--- a/skimage/filters/tests/test_median.py
+++ b/skimage/filters/tests/test_median.py
@@ -16,6 +16,7 @@ def image():
                      [1, 2, 1, 2, 3]],
                     dtype=np.uint8)
 
+
 @pytest.fixture
 def image3d():
     return np.array([[[1, 2, 3, 2, 1],


### PR DESCRIPTION
## Description

This addresses #5593 and demonstrates how a default-footprint for the `median` filter could look like.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
