### PR TITLE
MAINT: Remove unused imports

### DIFF
--- a/skimage/_shared/tests/test_testing.py
+++ b/skimage/_shared/tests/test_testing.py
@@ -5,7 +5,6 @@ import numpy as np
 from numpy.testing import assert_equal
 from skimage._shared.testing import doctest_skip_parser, test_parallel
 from skimage._shared import testing
-import pytest
 
 from skimage._shared._warnings import expected_warnings
 from warnings import warn

--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -5,7 +5,6 @@ import numpy.testing as npt
 import pytest
 
 from skimage._shared import testing
-from skimage._shared._warnings import expected_warnings
 from skimage._shared.utils import (check_nD, deprecate_kwarg,
                                    _validate_interpolation_order,
                                    change_default_value, remove_arg,

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -49,7 +49,6 @@ References
 .. [4] https://en.wikipedia.org/wiki/CIE_1931_color_space
 """
 
-import functools
 from warnings import warn
 
 import numpy as np

--- a/skimage/color/delta_e.py
+++ b/skimage/color/delta_e.py
@@ -20,7 +20,7 @@ https://en.wikipedia.org/wiki/Color_difference
 
 import numpy as np
 
-from .._shared.utils import _supported_float_type, slice_at_axis
+from .._shared.utils import _supported_float_type
 from .colorconv import lab2lch, _cart2polar_2pi
 
 

--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -6,7 +6,6 @@ For more images, see
 
 """
 from distutils.version import LooseVersion
-from warnings import warn
 import numpy as np
 import shutil
 

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -1,4 +1,3 @@
-import warnings
 import numpy as np
 
 from .._shared._geometry import polygon_clip

--- a/skimage/draw/tests/test_draw.py
+++ b/skimage/draw/tests/test_draw.py
@@ -1,5 +1,4 @@
 import numpy as np
-from skimage._shared._warnings import expected_warnings
 from skimage._shared.testing import test_parallel
 from skimage._shared import testing
 from skimage._shared.testing import assert_array_equal, assert_equal

--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -4,8 +4,7 @@ import numpy as np
 from scipy import ndimage as ndi
 
 from .._shared import utils
-from .._shared.utils import (_supported_float_type, change_default_value,
-                             convert_to_float, warn)
+from .._shared.utils import _supported_float_type,convert_to_float, warn
 from ..util import img_as_float
 
 __all__ = ['gaussian', 'difference_of_gaussians']

--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -4,7 +4,7 @@ import numpy as np
 from scipy import ndimage as ndi
 
 from .._shared import utils
-from .._shared.utils import _supported_float_type,convert_to_float, warn
+from .._shared.utils import _supported_float_type, convert_to_float, warn
 from ..util import img_as_float
 
 __all__ = ['gaussian', 'difference_of_gaussians']

--- a/skimage/filters/rank/bilateral.py
+++ b/skimage/filters/rank/bilateral.py
@@ -89,6 +89,7 @@ def mean_bilateral(image, footprint, out=None, mask=None, shift_x=False,
 
     Examples
     --------
+    >>> import numpy as np
     >>> from skimage import data
     >>> from skimage.morphology import disk
     >>> from skimage.filters.rank import mean_bilateral
@@ -137,6 +138,7 @@ def pop_bilateral(image, footprint, out=None, mask=None, shift_x=False,
 
     Examples
     --------
+    >>> import numpy as np
     >>> from skimage.morphology import square
     >>> import skimage.filters.rank as rank
     >>> img = 255 * np.array([[0, 0, 0, 0, 0],
@@ -206,6 +208,7 @@ def sum_bilateral(image, footprint, out=None, mask=None, shift_x=False,
 
     Examples
     --------
+    >>> import numpy as np
     >>> from skimage import data
     >>> from skimage.morphology import disk
     >>> from skimage.filters.rank import sum_bilateral

--- a/skimage/filters/rank/bilateral.py
+++ b/skimage/filters/rank/bilateral.py
@@ -23,8 +23,6 @@ References
 
 """
 
-import numpy as np
-
 from ..._shared.utils import check_nD, deprecate_kwarg
 from . import bilateral_cy
 from .generic import _preprocess_input

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -3,9 +3,8 @@ import pytest
 
 from skimage import data, morphology, util
 from skimage._shared._warnings import expected_warnings
-from skimage._shared.testing import (assert_allclose, assert_array_almost_equal,
-                                     assert_array_equal, assert_equal, fetch,
-                                     test_parallel)
+from skimage._shared.testing import (assert_allclose, assert_array_almost_equal, 
+                                     assert_equal, fetch, test_parallel)
 from skimage.filters import rank
 from skimage.filters.rank import __all__ as all_rank_filters
 from skimage.filters.rank import subtract_mean

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -3,7 +3,7 @@ import pytest
 
 from skimage import data, morphology, util
 from skimage._shared._warnings import expected_warnings
-from skimage._shared.testing import (assert_allclose, assert_array_almost_equal, 
+from skimage._shared.testing import (assert_allclose, assert_array_almost_equal,
                                      assert_equal, fetch, test_parallel)
 from skimage.filters import rank
 from skimage.filters.rank import __all__ as all_rank_filters

--- a/skimage/filters/tests/test_correlate.py
+++ b/skimage/filters/tests/test_correlate.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_almost_equal, assert_array_equal, assert_equal
+from numpy.testing import assert_equal
 from scipy import ndimage as ndi
 
 from skimage._shared.utils import _supported_float_type

--- a/skimage/filters/tests/test_gabor.py
+++ b/skimage/filters/tests/test_gabor.py
@@ -3,7 +3,6 @@ import pytest
 from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
                            assert_equal)
 
-from skimage._shared import testing
 from skimage._shared.utils import _supported_float_type
 from skimage.filters._gabor import _sigma_prefactor, gabor, gabor_kernel
 
@@ -101,5 +100,4 @@ def test_gabor_dtype(dtype):
 
 
 if __name__ == "__main__":
-    from numpy import testing
-    testing.run_module_suite()
+    np.testing.run_module_suite()

--- a/skimage/filters/tests/test_ridges.py
+++ b/skimage/filters/tests/test_ridges.py
@@ -3,7 +3,6 @@ import pytest
 from numpy.testing import assert_allclose, assert_array_less, assert_equal
 
 from skimage import img_as_float
-from skimage._shared._warnings import expected_warnings
 from skimage._shared.utils import _supported_float_type
 from skimage.color import rgb2gray
 from skimage.data import camera, retina
@@ -247,5 +246,4 @@ def test_border_management(func, tol):
 
 
 if __name__ == "__main__":
-    from numpy import testing
     np.testing.run_module_suite()

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -7,8 +7,7 @@ from collections.abc import Iterable
 import numpy as np
 from scipy import ndimage as ndi
 
-from .._shared.utils import (_supported_float_type, check_nD, deprecate_kwarg,
-                             warn)
+from .._shared.utils import _supported_float_type, deprecate_kwarg, warn
 from ..exposure import histogram
 from ..filters._multiotsu import (_get_multiotsu_thresh_indices,
                                   _get_multiotsu_thresh_indices_lut)

--- a/skimage/future/graph/tests/test_rag.py
+++ b/skimage/future/graph/tests/test_rag.py
@@ -1,7 +1,6 @@
 from numpy.testing import assert_array_equal
 import numpy as np
 from skimage.future import graph
-from skimage._shared.version_requirements import is_installed
 from skimage import segmentation, data
 from skimage._shared import testing
 

--- a/skimage/future/manual_segmentation.py
+++ b/skimage/future/manual_segmentation.py
@@ -64,8 +64,6 @@ def manual_polygon_segmentation(image, alpha=0.4, return_all=False):
     >>> io.show()  # doctest: +SKIP
     """
     import matplotlib
-    from matplotlib.patches import Polygon
-    from matplotlib.collections import PatchCollection
     import matplotlib.pyplot as plt
 
     list_of_vertex_lists = []
@@ -179,8 +177,6 @@ def manual_lasso_segmentation(image, alpha=0.4, return_all=False):
     >>> io.show()  # doctest: +SKIP
     """
     import matplotlib
-    from matplotlib.patches import Polygon
-    from matplotlib.collections import PatchCollection
     import matplotlib.pyplot as plt
 
     list_of_vertex_lists = []

--- a/skimage/future/tests/test_trainable_segmentation.py
+++ b/skimage/future/tests/test_trainable_segmentation.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 from scipy import spatial
 
-from skimage._shared._warnings import expected_warnings
 from skimage.future import fit_segmenter, predict_segmenter, TrainableSegmenter
 from skimage.feature import multiscale_basic_features
 

--- a/skimage/io/_plugins/fits_plugin.py
+++ b/skimage/io/_plugins/fits_plugin.py
@@ -1,7 +1,6 @@
 __all__ = ['imread', 'imread_collection']
 
 import skimage.io as io
-from warnings import warn
 
 try:
     from astropy.io import fits

--- a/skimage/io/_plugins/gdal_plugin.py
+++ b/skimage/io/_plugins/gdal_plugin.py
@@ -1,7 +1,5 @@
 __all__ = ['imread']
 
-from warnings import warn
-
 try:
     import osgeo.gdal as gdal
 except ImportError:

--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -1,14 +1,12 @@
 __all__ = ['imread', 'imsave']
 
 from distutils.version import LooseVersion
-import warnings
 import numpy as np
 from PIL import Image, __version__ as pil_version
 
 from ...util import img_as_ubyte, img_as_uint
 
 # Check CVE-2021-27921 and others
-from distutils.version import LooseVersion
 if LooseVersion(pil_version) < LooseVersion('8.1.2'):
     from warnings import warn
     warn('Your installed pillow version is < 8.1.2. '

--- a/skimage/io/tests/test_fits.py
+++ b/skimage/io/tests/test_fits.py
@@ -1,4 +1,3 @@
-import os.path
 import numpy as np
 import skimage.io as io
 from skimage._shared import testing

--- a/skimage/io/tests/test_imageio.py
+++ b/skimage/io/tests/test_imageio.py
@@ -1,6 +1,5 @@
 from tempfile import NamedTemporaryFile
 
-import pytest
 import numpy as np
 from skimage.io import imread, imsave, use_plugin, reset_plugins
 

--- a/skimage/io/tests/test_imread.py
+++ b/skimage/io/tests/test_imread.py
@@ -1,8 +1,7 @@
-import os
 from tempfile import NamedTemporaryFile
 
 import numpy as np
-from skimage import data, io
+from skimage import io
 from skimage.io import imread, imsave, use_plugin, reset_plugins
 
 from skimage._shared import testing

--- a/skimage/io/tests/test_multi_image.py
+++ b/skimage/io/tests/test_multi_image.py
@@ -7,7 +7,6 @@ from skimage.io.collection import MultiImage
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_allclose
 
-import pytest
 from pytest import fixture
 
 @fixture

--- a/skimage/io/tests/test_plugin_util.py
+++ b/skimage/io/tests/test_plugin_util.py
@@ -3,8 +3,6 @@ from skimage.io._plugins.util import prepare_for_display, WindowManager
 
 from skimage._shared import testing
 from skimage._shared.testing import assert_array_equal, TestCase
-from skimage._shared._warnings import expected_warnings
-
 
 np.random.seed(0)
 

--- a/skimage/io/tests/test_simpleitk.py
+++ b/skimage/io/tests/test_simpleitk.py
@@ -1,10 +1,8 @@
-import os.path
 import numpy as np
 import unittest
 
 from tempfile import NamedTemporaryFile
 
-from skimage import data
 from skimage.io import imread, imsave, use_plugin, reset_plugins
 from skimage._shared import testing
 

--- a/skimage/io/tests/test_tifffile.py
+++ b/skimage/io/tests/test_tifffile.py
@@ -6,8 +6,6 @@ import numpy as np
 from skimage._shared.testing import (assert_array_equal,
                                      assert_array_almost_equal,
                                      parametrize, fetch)
-from skimage._shared import testing
-
 
 def setup():
     use_plugin('tifffile')

--- a/skimage/measure/_marching_cubes_classic.py
+++ b/skimage/measure/_marching_cubes_classic.py
@@ -1,4 +1,3 @@
-import warnings
 import numpy as np
 import scipy.ndimage as ndi
 from . import _marching_cubes_classic_cy

--- a/skimage/measure/_marching_cubes_lewiner.py
+++ b/skimage/measure/_marching_cubes_lewiner.py
@@ -1,4 +1,3 @@
-import warnings
 import base64
 
 import numpy as np

--- a/skimage/measure/profile.py
+++ b/skimage/measure/profile.py
@@ -1,4 +1,3 @@
-from warnings import warn
 import numpy as np
 from scipy import ndimage as ndi
 

--- a/skimage/measure/tests/test_ccomp.py
+++ b/skimage/measure/tests/test_ccomp.py
@@ -5,8 +5,6 @@ import skimage.measure._ccomp as ccomp
 
 from skimage._shared import testing
 from skimage._shared.testing import assert_array_equal
-from skimage._shared._warnings import expected_warnings
-
 
 BG = 0  # background value
 

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from skimage._shared import testing
 from skimage._shared._warnings import expected_warnings

--- a/skimage/measure/tests/test_marching_cubes.py
+++ b/skimage/measure/tests/test_marching_cubes.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose, assert_array_equal
+from numpy.testing import assert_allclose
 
 from skimage.draw import ellipsoid, ellipsoid_stats
 from skimage.measure import marching_cubes, mesh_surface_area

--- a/skimage/metrics/tests/test_simple_metrics.py
+++ b/skimage/metrics/tests/test_simple_metrics.py
@@ -4,7 +4,6 @@ from numpy.testing import assert_equal, assert_almost_equal
 
 from skimage import data
 from skimage._shared._warnings import expected_warnings
-from skimage._shared.utils import _supported_float_type
 from skimage.metrics import (peak_signal_noise_ratio, normalized_root_mse,
                              mean_squared_error, normalized_mutual_information)
 

--- a/skimage/morphology/_flood_fill.py
+++ b/skimage/morphology/_flood_fill.py
@@ -4,8 +4,6 @@ This module provides a function to fill all equal (or within tolerance) values
 connected to a given seed point with a different value.
 """
 
-from warnings import warn
-
 import numpy as np
 
 from .._shared.utils import deprecate_kwarg

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -7,7 +7,7 @@ import numpy as np
 from ..util import img_as_ubyte, crop
 from scipy import ndimage as ndi
 
-from .._shared.utils import check_nD, deprecate_kwarg, warn
+from .._shared.utils import check_nD, deprecate_kwarg
 from ._skeletonize_cy import (_fast_skeletonize, _skeletonize_loop,
                               _table_lookup_index)
 from ._skeletonize_3d_cy import _compute_thin_image

--- a/skimage/morphology/tests/test_footprints.py
+++ b/skimage/morphology/tests/test_footprints.py
@@ -7,7 +7,6 @@ Author: Damian Eads
 import numpy as np
 from numpy.testing import assert_equal
 
-from skimage import data
 from skimage._shared.testing import fetch
 from skimage.morphology import footprints
 

--- a/skimage/morphology/tests/test_max_tree.py
+++ b/skimage/morphology/tests/test_max_tree.py
@@ -4,7 +4,6 @@ from skimage.morphology import max_tree_local_maxima, diameter_opening
 from skimage.morphology import diameter_closing
 from skimage.util import invert
 
-from skimage._shared import testing
 from skimage._shared.testing import assert_array_equal, TestCase
 
 eps = 1e-12

--- a/skimage/morphology/tests/test_misc.py
+++ b/skimage/morphology/tests/test_misc.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import pytest
 from skimage.morphology import remove_small_objects, remove_small_holes

--- a/skimage/morphology/tests/test_skeletonize.py
+++ b/skimage/morphology/tests/test_skeletonize.py
@@ -3,7 +3,7 @@ import pytest
 from numpy.testing import assert_array_equal
 from scipy.ndimage import correlate
 
-from skimage import data, draw
+from skimage import draw
 from skimage._shared._warnings import expected_warnings
 from skimage._shared.testing import fetch
 from skimage.io import imread

--- a/skimage/registration/tests/test_masked_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_masked_phase_cross_correlation.py
@@ -5,9 +5,9 @@ from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
 from scipy.ndimage import fourier_shift, shift as real_shift
 
 from skimage._shared.fft import fftmodule as fft
-from skimage._shared.testing import fetch, expected_warnings
+from skimage._shared.testing import fetch
 from skimage._shared.utils import _supported_float_type
-from skimage.data import camera, stereo_motorcycle, brain
+from skimage.data import camera, brain
 
 
 from skimage.io import imread

--- a/skimage/restoration/non_local_means.py
+++ b/skimage/restoration/non_local_means.py
@@ -1,5 +1,3 @@
-from warnings import warn
-
 import numpy as np
 
 from .._shared import utils

--- a/skimage/restoration/tests/test_rolling_ball.py
+++ b/skimage/restoration/tests/test_rolling_ball.py
@@ -6,7 +6,7 @@ Tests for Rolling Ball Filter
 import numpy as np
 import pytest
 
-from skimage import data, io
+from skimage import data
 from skimage.restoration import rolling_ball
 from skimage.restoration.rolling_ball import ellipsoid_kernel
 

--- a/skimage/restoration/tests/test_unwrap.py
+++ b/skimage/restoration/tests/test_unwrap.py
@@ -3,7 +3,6 @@ import numpy as np
 from skimage.restoration import unwrap_phase
 import sys
 
-import warnings
 from skimage._shared import testing
 from skimage._shared.testing import (assert_array_almost_equal_nulp,
                                      assert_almost_equal, assert_array_equal,

--- a/skimage/segmentation/morphsnakes.py
+++ b/skimage/segmentation/morphsnakes.py
@@ -1,4 +1,3 @@
-import warnings
 from itertools import cycle
 
 import numpy as np

--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -1,4 +1,3 @@
-import warnings
 from collections.abc import Iterable
 
 import numpy as np
@@ -10,7 +9,7 @@ from scipy.spatial.distance import pdist, squareform
 from .._shared import utils
 from ..color import rgb2lab
 from ..util import img_as_float, regular_grid
-from ._slic import (_slic_cython, _enforce_label_connectivity_cython)
+from ._slic import _slic_cython, _enforce_label_connectivity_cython
 
 
 def _get_mask_centroids(mask, n_centroids, multichannel):

--- a/skimage/segmentation/tests/test_quickshift.py
+++ b/skimage/segmentation/tests/test_quickshift.py
@@ -4,8 +4,6 @@ from skimage.segmentation import quickshift
 from skimage._shared import testing
 from skimage._shared.testing import (assert_greater, test_parallel,
                                      assert_equal, assert_array_equal)
-from skimage._shared.utils import _supported_float_type
-
 
 @test_parallel()
 @testing.parametrize('dtype', [np.float32, np.float64])

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -6,8 +6,6 @@ from skimage._shared.testing import test_parallel
 from skimage import data
 from skimage import transform
 from skimage.draw import line, circle_perimeter, ellipse_perimeter
-from skimage.feature import canny
-
 
 @test_parallel()
 def test_hough_line():

--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import itertools
 from skimage import (img_as_float, img_as_float32, img_as_float64,

--- a/skimage/util/tests/test_map_array.py
+++ b/skimage/util/tests/test_map_array.py
@@ -2,8 +2,6 @@ import numpy as np
 from skimage.util._map_array import map_array, ArrayMap
 
 from skimage._shared import testing
-from skimage._shared.testing import assert_array_equal
-import pytest
 
 
 def test_map_array_incorrect_output_shape():

--- a/skimage/util/tests/test_shape.py
+++ b/skimage/util/tests/test_shape.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from skimage._shared import testing
-from skimage._shared.testing import assert_equal, assert_warns
+from skimage._shared.testing import assert_equal
 from skimage.util.shape import view_as_blocks, view_as_windows
 
 

--- a/skimage/viewer/plugins/overlayplugin.py
+++ b/skimage/viewer/plugins/overlayplugin.py
@@ -3,9 +3,6 @@ from ...util.dtype import dtype_range
 from .base import Plugin
 from ..utils import ClearColormap, update_axes_image
 
-from ..._shared.version_requirements import is_installed
-
-
 __all__ = ['OverlayPlugin']
 
 

--- a/skimage/viewer/widgets/core.py
+++ b/skimage/viewer/widgets/core.py
@@ -1,4 +1,4 @@
-from ..qt import QtWidgets, QtCore, Qt, QtGui
+from ..qt import QtWidgets, QtCore, Qt
 from ..utils import RequiredAttr
 
 

--- a/skimage/viewer/widgets/history.py
+++ b/skimage/viewer/widgets/history.py
@@ -1,7 +1,6 @@
 from textwrap import dedent
 
-from ..qt import QtGui, QtCore, QtWidgets
-import numpy as np
+from ..qt import QtCore, QtWidgets
 
 from ... import io
 from ...util import img_as_ubyte


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

This PR removes unused imports in multiple modules.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
