### PR TITLE
Refactor duplicated tests, remove unnecessary assignments and variables

### DIFF
--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -264,7 +264,6 @@ def _init_pooch():
         shutil.copy2(osp.join(skimage_distribution_dir, 'data', 'README.txt'),
                      dest_path)
 
-    data_base_dir = osp.join(data_dir, '..')
     # Fetch all legacy data so that it is available by default
     for filename in legacy_registry:
         _fetch(filename)

--- a/skimage/feature/tests/test_template.py
+++ b/skimage/feature/tests/test_template.py
@@ -183,7 +183,7 @@ def test_bounding_values():
     image = img_as_float(data.page())
     template = np.zeros((3, 3))
     template[1, 1] = 1
-    result = match_template(img_as_float(data.page()), template)
+    result = match_template(image, template)
     print(result.max())
     assert result.max() < 1 + 1e-7
     assert result.min() > -1 - 1e-7

--- a/skimage/feature/tests/test_util.py
+++ b/skimage/feature/tests/test_util.py
@@ -30,9 +30,9 @@ def test_prepare_grayscale_input_2D():
         _prepare_grayscale_input_2D(np.zeros((3, 1)))
     with testing.raises(ValueError):
         _prepare_grayscale_input_2D(np.zeros((3, 1, 1)))
-    img = _prepare_grayscale_input_2D(np.zeros((3, 3)))
-    img = _prepare_grayscale_input_2D(np.zeros((3, 3, 1)))
-    img = _prepare_grayscale_input_2D(np.zeros((1, 3, 3)))
+    _prepare_grayscale_input_2D(np.zeros((3, 3)))
+    _prepare_grayscale_input_2D(np.zeros((3, 3, 1)))
+    _prepare_grayscale_input_2D(np.zeros((1, 3, 3)))
 
 
 def test_mask_border_keypoints():

--- a/skimage/future/manual_segmentation.py
+++ b/skimage/future/manual_segmentation.py
@@ -211,7 +211,7 @@ def manual_lasso_segmentation(image, alpha=0.4, return_all=False):
         polygons_drawn.append(polygon_object)
         plt.draw()
 
-    lasso = matplotlib.widgets.LassoSelector(ax, _on_lasso_selection)
+    matplotlib.widgets.LassoSelector(ax, _on_lasso_selection)
 
     plt.show(block=True)
 

--- a/skimage/future/trainable_segmentation.py
+++ b/skimage/future/trainable_segmentation.py
@@ -65,7 +65,7 @@ class TrainableSegmenter(object):
             label 0 to unlabeled pixels to be segmented.
         """
         self.compute_features(image)
-        clf = fit_segmenter(labels, self.features, self.clf)
+        self.clf = fit_segmenter(labels, self.features, self.clf)
 
     def predict(self, image):
         """Segment new image using trained internal classifier.

--- a/skimage/morphology/tests/test_binary.py
+++ b/skimage/morphology/tests/test_binary.py
@@ -186,4 +186,5 @@ def test_binary_output_3d():
     assert_equal(int_closed.dtype, np.uint8)
 
 if __name__ == '__main__':
+    from skimage._shared import testing
     testing.run_module_suite()

--- a/skimage/morphology/tests/test_flood_fill.py
+++ b/skimage/morphology/tests/test_flood_fill.py
@@ -42,7 +42,6 @@ def test_overrange_tolerance_int():
 
 def test_overrange_tolerance_float():
     max_value = np.finfo(np.float32).max
-    min_value = np.finfo(np.float32).min
 
     image = np.random.uniform(size=(64, 64), low=-1., high=1.).astype(
         np.float32)

--- a/skimage/restoration/tests/test_inpaint.py
+++ b/skimage/restoration/tests/test_inpaint.py
@@ -33,12 +33,12 @@ def test_inpaint_biharmonic_2d(dtype, split_into_regions):
     rtol = 1e-7 if dtype == np.float64 else 1e-6
     assert_allclose(ref, out, rtol=rtol)
 
-
+@testing.parametrize('dtype', [bool, np.bool])
 @testing.parametrize('channel_axis', [0, 1, -1])
-def test_inpaint_biharmonic_2d_color(channel_axis):
+def test_inpaint_biharmonic_2d_color(channel_axis, dtype):
     img = img_as_float(data.astronaut()[:64, :64])
 
-    mask = np.zeros(img.shape[:2], dtype=np.bool)
+    mask = np.zeros(img.shape[:2], dtype=dtype)
     mask[8:16, :16] = 1
     img_defect = img * ~mask[..., np.newaxis]
     mse_defect = mean_squared_error(img, img_defect)
@@ -47,33 +47,6 @@ def test_inpaint_biharmonic_2d_color(channel_axis):
     img_restored = inpaint.inpaint_biharmonic(img_defect, mask,
                                               channel_axis=channel_axis)
     img_restored = np.moveaxis(img_restored, channel_axis, -1)
-    mse_restored = mean_squared_error(img, img_restored)
-
-    assert mse_restored < 0.01 * mse_defect
-
-
-def test_inpaint_biharmonic_2d_color_deprecated():
-    img = img_as_float(data.astronaut()[:64, :64])
-
-    mask = np.zeros(img.shape[:2], dtype=np.bool)
-    mask[8:16, :16] = 1
-    img_defect = img * ~mask[..., np.newaxis]
-    mse_defect = mean_squared_error(img, img_defect)
-
-    # providing multichannel argument positionally also warns
-    channel_warning = "`multichannel` is a deprecated argument"
-    matrix_warning = "the matrix subclass is not the recommended way"
-    with expected_warnings([channel_warning + '|' + matrix_warning]):
-        img_restored = inpaint.inpaint_biharmonic(img_defect, mask,
-                                                  multichannel=True)
-    mse_restored = mean_squared_error(img, img_restored)
-
-    assert mse_restored < 0.01 * mse_defect
-
-    # providing multichannel argument positionally also warns
-    channel_warning = "Providing the `multichannel` argument"
-    with expected_warnings([channel_warning + '|' + matrix_warning]):
-        img_restored = inpaint.inpaint_biharmonic(img_defect, mask, True)
     mse_restored = mean_squared_error(img, img_restored)
 
     assert mse_restored < 0.01 * mse_defect
@@ -100,28 +73,11 @@ def test_inpaint_biharmonic_2d_float_dtypes(dtype):
     assert_allclose(ref, out, rtol=1e-5)
 
 
-@testing.parametrize('channel_axis', [0, 1, -1])
-def test_inpaint_biharmonic_2d_color(channel_axis):
+@testing.parametrize('dtype', [bool, np.bool])
+def test_inpaint_biharmonic_2d_color_deprecated(dtype):
     img = img_as_float(data.astronaut()[:64, :64])
 
-    mask = np.zeros(img.shape[:2], dtype=bool)
-    mask[8:16, :16] = 1
-    img_defect = img * ~mask[..., np.newaxis]
-    mse_defect = mean_squared_error(img, img_defect)
-
-    img_defect = np.moveaxis(img_defect, -1, channel_axis)
-    img_restored = inpaint.inpaint_biharmonic(img_defect, mask,
-                                              channel_axis=channel_axis)
-    img_restored = np.moveaxis(img_restored, channel_axis, -1)
-    mse_restored = mean_squared_error(img, img_restored)
-
-    assert mse_restored < 0.01 * mse_defect
-
-
-def test_inpaint_biharmonic_2d_color_deprecated():
-    img = img_as_float(data.astronaut()[:64, :64])
-
-    mask = np.zeros(img.shape[:2], dtype=bool)
+    mask = np.zeros(img.shape[:2], dtype=dtype)
     mask[8:16, :16] = 1
     img_defect = img * ~mask[..., np.newaxis]
     mse_defect = mean_squared_error(img, img_defect)
@@ -138,7 +94,6 @@ def test_inpaint_biharmonic_2d_color_deprecated():
 
     # providing multichannel argument positionally also warns
     channel_warning = "Providing the `multichannel` argument"
-    matrix_warning = "the matrix subclass is not the recommended way"
     with expected_warnings([channel_warning + '|' + matrix_warning]):
         img_restored = inpaint.inpaint_biharmonic(img_defect, mask, True)
     mse_restored = mean_squared_error(img, img_restored)

--- a/skimage/restoration/tests/test_rolling_ball.py
+++ b/skimage/restoration/tests/test_rolling_ball.py
@@ -93,9 +93,8 @@ def test_threads(num_threads):
     # not testing if we use multiple threads
     # just checking if the API throws an exception
     img = 23 * np.ones((100, 100), dtype=np.uint8)
-    background = rolling_ball(img, radius=10, num_threads=num_threads)
-    background = rolling_ball(img, radius=10,
-                              nansafe=True, num_threads=num_threads)
+    rolling_ball(img, radius=10, num_threads=num_threads)
+    rolling_ball(img, radius=10, nansafe=True, num_threads=num_threads)
 
 
 def test_ndim():

--- a/skimage/segmentation/tests/test_active_contour_model.py
+++ b/skimage/segmentation/tests/test_active_contour_model.py
@@ -124,7 +124,7 @@ def test_bad_input():
     with pytest.raises(ValueError):
         active_contour(img, init, max_num_iter=-15)
     with expected_warnings(["`max_iterations` is a deprecated argument"]):
-        snake = active_contour(img, init, max_iterations=15)
+        active_contour(img, init, max_iterations=15)
 
 
 def test_coord_raises():
@@ -135,14 +135,14 @@ def test_coord_raises():
     init = np.array([x, y]).T
     # coordinates='xy' is not valid
     with pytest.raises(ValueError):
-        snake = active_contour(gaussian(img, 3), init,
-                               boundary_condition='periodic', alpha=0.015,
-                               beta=10, w_line=0, w_edge=1, gamma=0.001,
-                               max_num_iter=100, coordinates='xy')
+        active_contour(gaussian(img, 3), init,
+                        boundary_condition='periodic', alpha=0.015,
+                        beta=10, w_line=0, w_edge=1, gamma=0.001,
+                        max_num_iter=100, coordinates='xy')
 
     # coordinates=None is not valid
     with pytest.raises(ValueError):
-        snake = active_contour(gaussian(img, 3), init,
-                               boundary_condition='periodic', alpha=0.015,
-                               beta=10, w_line=0, w_edge=1, gamma=0.001,
-                               max_num_iter=100, coordinates=None)
+        active_contour(gaussian(img, 3), init,
+                        boundary_condition='periodic', alpha=0.015,
+                        beta=10, w_line=0, w_edge=1, gamma=0.001,
+                        max_num_iter=100, coordinates=None)

--- a/skimage/segmentation/tests/test_morphsnakes.py
+++ b/skimage/segmentation/tests/test_morphsnakes.py
@@ -65,7 +65,6 @@ def test_morphsnakes_iterations_kwarg_deprecation():
     ls = disk_level_set(img.shape, center=(5, 5), radius=3)
 
     ref_zeros = np.zeros(img.shape, dtype=np.int8)
-    ref_ones = np.ones(img.shape, dtype=np.int8)
 
     with expected_warnings(["`iterations` is a deprecated argument"]):
         acwe_ls = morphological_chan_vese(img, iterations=6, init_level_set=ls)

--- a/skimage/segmentation/tests/test_watershed.py
+++ b/skimage/segmentation/tests/test_watershed.py
@@ -466,17 +466,17 @@ def test_numeric_seed_watershed():
 
 
 def test_incorrect_markers_shape():
+    image = np.ones((5, 6))
+    markers = np.ones((5, 7))
     with pytest.raises(ValueError):
-        image = np.ones((5, 6))
-        markers = np.ones((5, 7))
-        output = watershed(image, markers)
+        watershed(image, markers)
 
 
 def test_incorrect_mask_shape():
+    image = np.ones((5, 6))
+    mask = np.ones((5, 7))
     with pytest.raises(ValueError):
-        image = np.ones((5, 6))
-        mask = np.ones((5, 7))
-        output = watershed(image, markers=4, mask=mask)
+        watershed(image, markers=4, mask=mask)
 
 
 def test_markers_in_mask():

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -228,7 +228,6 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
 
     """
     _check_factor(downscale)
-    multichannel = channel_axis is not None
 
     # cast to float for consistent data type in pyramid
     image = convert_to_float(image, preserve_range)

--- a/skimage/transform/tests/test_finite_radon_transform.py
+++ b/skimage/transform/tests/test_finite_radon_transform.py
@@ -7,7 +7,7 @@ def test_frt():
     SIZE = 59
     try:
         import sympy.ntheory as sn
-        assert sn.isprime(SIZE) == True
+        assert sn.isprime(SIZE)
     except ImportError:
         pass
 

--- a/skimage/viewer/widgets/core.py
+++ b/skimage/viewer/widgets/core.py
@@ -87,13 +87,11 @@ class Slider(BaseWidget):
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         if orientation == 'vertical':
             self.slider = QtWidgets.QSlider(Qt.Vertical)
-            alignment = QtCore.Qt.AlignHCenter
             align_text = QtCore.Qt.AlignHCenter
             align_value = QtCore.Qt.AlignHCenter
             self.layout = QtWidgets.QVBoxLayout(self)
         elif orientation == 'horizontal':
             self.slider = QtWidgets.QSlider(Qt.Horizontal)
-            alignment = QtCore.Qt.AlignVCenter
             align_text = QtCore.Qt.AlignLeft
             align_value = QtCore.Qt.AlignRight
             self.layout = QtWidgets.QHBoxLayout(self)


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

The main thing to note here is that there were two duplicated tests (same body, same name), only changing dtype of an array (`bool` vs `np.bool`), and **only one** per duplicate was collected by pytest. 

Now they are parametrized so the same test runs with both `bool` and`np.bool`, even though I think that only the one with `bool` should be kept (given the deprecation from numpy). Anyway I kept both to "preserve the original meaning" of the tests, please let me know your thoughts on this.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
