### PR TITLE
trainable_segmentation: re-raise in error case

### DIFF
--- a/skimage/future/tests/test_trainable_segmentation.py
+++ b/skimage/future/tests/test_trainable_segmentation.py
@@ -16,7 +16,9 @@ class DummyNNClassifier(object):
 
     def predict(self, X):
         if X.shape[1] != self.X.shape[1]:
-            raise ValueError(f"Expected {self.X.shape[1]} features but got {X.shape[1]}.")
+            raise ValueError(
+                f"Expected {self.X.shape[1]} features but got {X.shape[1]}."
+            )
         nearest_neighbors = self.tree.query(X)[1]
         return self.labels[nearest_neighbors]
 

--- a/skimage/future/tests/test_trainable_segmentation.py
+++ b/skimage/future/tests/test_trainable_segmentation.py
@@ -93,7 +93,7 @@ def test_trainable_segmentation_predict():
 
 
 def test_trainable_segmentation_oo():
-    """Tests the object oriented interface using the TrainableSegmenter class."""
+    """Test the object-oriented interface using the TrainableSegmenter class."""
 
     img = np.zeros((20, 20))
     img[:10] = 1

--- a/skimage/future/tests/test_trainable_segmentation.py
+++ b/skimage/future/tests/test_trainable_segmentation.py
@@ -111,3 +111,7 @@ def test_trainable_segmentation_oo():
     out = segmenter.predict(img)
     assert np.all(out[:10] == 1)
     assert np.all(out[10:] == 2)
+
+    # test wrong number of dimensions:
+    with pytest.raises(ValueError):
+        segmenter.predict(img[:, :, np.newaxis])

--- a/skimage/future/tests/test_trainable_segmentation.py
+++ b/skimage/future/tests/test_trainable_segmentation.py
@@ -93,6 +93,8 @@ def test_trainable_segmentation_predict():
 
 
 def test_trainable_segmentation_oo():
+    """Tests the object oriented interface using the TrainableSegmenter class."""
+
     img = np.zeros((20, 20))
     img[:10] = 1
     img += 0.05 * np.random.randn(*img.shape)
@@ -118,12 +120,12 @@ def test_trainable_segmentation_oo():
     assert np.all(out[10:] == 2)
 
     # test multichannel model
+    img_with_channels = np.stack((img, img.T), axis=-1)
     features_func = partial(
         multiscale_basic_features,
         channel_axis=-1,
     )
     segmenter = TrainableSegmenter(clf=clf, features_func=features_func)
-    img_with_channels = np.stack((img, img.T), axis=-1)
     segmenter.fit(img_with_channels, labels)
 
     # model has been fitted

--- a/skimage/future/tests/test_trainable_segmentation.py
+++ b/skimage/future/tests/test_trainable_segmentation.py
@@ -15,6 +15,8 @@ class DummyNNClassifier(object):
         self.tree = spatial.cKDTree(self.X)
 
     def predict(self, X):
+        if X.shape[1] != self.X.shape[1]:
+            raise ValueError(f"Expected {self.X.shape[1]} features but got {X.shape[1]}.")
         nearest_neighbors = self.tree.query(X)[1]
         return self.labels[nearest_neighbors]
 

--- a/skimage/future/tests/test_trainable_segmentation.py
+++ b/skimage/future/tests/test_trainable_segmentation.py
@@ -15,6 +15,7 @@ class DummyNNClassifier(object):
         self.tree = spatial.cKDTree(self.X)
 
     def predict(self, X):
+        # mimic check in scikit-learn for number of features
         if X.shape[1] != self.X.shape[1]:
             raise ValueError(
                 f"Expected {self.X.shape[1]} features but got {X.shape[1]}."

--- a/skimage/future/trainable_segmentation.py
+++ b/skimage/future/trainable_segmentation.py
@@ -156,5 +156,7 @@ def predict_segmenter(features, clf):
                 err.args[0] + '\n' +
                 "Maybe you did not use the same type of features for training the classifier."
                 )
+        else:
+            raise err
     output = predicted_labels.reshape(sh[:-1])
     return output


### PR DESCRIPTION
## Description

This PR is a small bugfix for error handling:

Currently, a ValueError during prediction might be ignored silently, which leads to an `UnboundLocalError` later (`local variable 'predicted_labels' referenced before assignment`). This is a small change to surface the actual error if it does not match the intended pattern of `x must consist of vectors of length`.

## For reviewers
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
