### PR TITLE
Weighted estimation of geometric transform matrices

### DIFF
--- a/doc/examples/transform/plot_geometric.py
+++ b/doc/examples/transform/plot_geometric.py
@@ -118,7 +118,7 @@ plt.show()
 ######################################################################
 # The above estimation relies on accurate knowledge of the location of points
 # and an accurate selection of their correspondance. If point locations have
-# an uncertainty associated with them, then weighting can be provided so that 
+# an uncertainty associated with them, then weighting can be provided so that
 # the resulting transform prioritises an accurate fit to those points with the
 # highest weighting.
 # An alternative approach called the

--- a/doc/examples/transform/plot_geometric.py
+++ b/doc/examples/transform/plot_geometric.py
@@ -116,7 +116,11 @@ plt.tight_layout()
 plt.show()
 
 ######################################################################
-# The above estimation relies on accurate selection of corresponding points.
+# The above estimation relies on accurate knowledge of the location of points
+# and an accurate selection of their correspondance. If point locations have
+# an uncertainty associated with them, then weighting can be provided so that 
+# the resulting transform prioritises an accurate fit to those points with the
+# highest weighting.
 # An alternative approach called the
 # `RANSAC algorithm <https://en.wikipedia.org/wiki/Random_sample_consensus>`_
 # is useful when the correspondence points are not perfectly accurate.

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -687,7 +687,7 @@ class ProjectiveTransform(GeometricTransform):
             Source coordinates.
         dst : (N, 2) array
             Destination coordinates.
-        weights : (N, 1) array, optional
+        weights : (N,) array, optional
             Relative weight values for each pair of points.
 
         Returns
@@ -1447,7 +1447,7 @@ class PolynomialTransform(GeometricTransform):
             Destination coordinates.
         order : int, optional
             Polynomial order (number of coefficients is order + 1).
-        weights : (N, 1) array, optional
+        weights : (N,) array, optional
             Relative weight values for each pair of points.
 
         Returns

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -631,7 +631,7 @@ class ProjectiveTransform(GeometricTransform):
         """
         return self._apply_mat(coords, self._inv_matrix)
 
-    def estimate(self, src, dst):
+    def estimate(self, src, dst, weights=None):
         """Estimate the transformation from a set of corresponding points.
 
         You can determine the over-, well- and under-determined parameters
@@ -663,6 +663,13 @@ class ProjectiveTransform(GeometricTransform):
         In case of total least-squares the solution of this homogeneous system
         of equations is the right singular vector of A which corresponds to the
         smallest singular value normed by the coefficient c3.
+        
+        Weights can be applied to each pair of corresponding points to
+        indicate, particularly in an overdetermined system, if point pairs have
+        higher or lower confidence or uncertainties associated with them. From
+        the matrix treatment of least squares problems, these weight values are
+        normalised, square-rooted, then built into a diagonal matrix, by which
+        A is multiplied.
 
         In case of the affine transformation the coefficients c0 and c1 are 0.
         Thus the system of equations is::
@@ -680,6 +687,8 @@ class ProjectiveTransform(GeometricTransform):
             Source coordinates.
         dst : (N, 2) array
             Destination coordinates.
+        weights : (N, 1) array, optional
+            Relative weight values for each pair of points.
 
         Returns
         -------
@@ -710,7 +719,14 @@ class ProjectiveTransform(GeometricTransform):
         # Select relevant columns, depending on params
         A = A[:, list(self._coeffs) + [-1]]
 
-        _, _, V = np.linalg.svd(A)
+        # Get the vectors that correspond to singular values, also applying
+        # the weighting if provided
+        if weights is None:
+            _, _, V = np.linalg.svd(A)
+        else:
+            W = np.diag(np.tile(np.sqrt(weights.flatten()/np.max(weights)), d))
+            _, _, V = np.linalg.svd(W @ A)
+        
         # if the last element of the vector corresponding to the smallest
         # singular value is close to zero, this implies a degenerate case
         # because it is a rank-defective transform, which would map points
@@ -1377,7 +1393,7 @@ class PolynomialTransform(GeometricTransform):
             raise ValueError("invalid shape of transformation parameters")
         self.params = params
 
-    def estimate(self, src, dst, order=2):
+    def estimate(self, src, dst, order=2, weights=None):
         """Estimate the transformation from a set of corresponding points.
 
         You can determine the over-, well- and under-determined parameters
@@ -1410,6 +1426,13 @@ class PolynomialTransform(GeometricTransform):
         In case of total least-squares the solution of this homogeneous system
         of equations is the right singular vector of A which corresponds to the
         smallest singular value normed by the coefficient c3.
+        
+        Weights can be applied to each pair of corresponding points to
+        indicate, particularly in an overdetermined system, if point pairs have
+        higher or lower confidence or uncertainties associated with them. From
+        the matrix treatment of least squares problems, these weight values are
+        normalised, square-rooted, then built into a diagonal matrix, by which
+        A is multiplied.
 
         Parameters
         ----------
@@ -1419,6 +1442,8 @@ class PolynomialTransform(GeometricTransform):
             Destination coordinates.
         order : int, optional
             Polynomial order (number of coefficients is order + 1).
+        weights : (N, 1) array, optional
+            Relative weight values for each pair of points.
 
         Returns
         -------
@@ -1447,7 +1472,13 @@ class PolynomialTransform(GeometricTransform):
         A[:rows, -1] = xd
         A[rows:, -1] = yd
 
-        _, _, V = np.linalg.svd(A)
+        # Get the vectors that correspond to singular values, also applying
+        # the weighting if provided
+        if weights is None:
+            _, _, V = np.linalg.svd(A)
+        else:
+            W = np.diag(np.tile(np.sqrt(weights.flatten()/np.max(weights)), 2))
+            _, _, V = np.linalg.svd(W @ A)
 
         # solution is right singular vector that corresponds to smallest
         # singular value

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -663,7 +663,7 @@ class ProjectiveTransform(GeometricTransform):
         In case of total least-squares the solution of this homogeneous system
         of equations is the right singular vector of A which corresponds to the
         smallest singular value normed by the coefficient c3.
-        
+
         Weights can be applied to each pair of corresponding points to
         indicate, particularly in an overdetermined system, if point pairs have
         higher or lower confidence or uncertainties associated with them. From
@@ -696,7 +696,7 @@ class ProjectiveTransform(GeometricTransform):
             True, if model estimation succeeds.
 
         """
-        
+
         n, d = src.shape
 
         src_matrix, src = _center_and_normalize_points(src)
@@ -725,9 +725,9 @@ class ProjectiveTransform(GeometricTransform):
         if weights is None:
             _, _, V = np.linalg.svd(A)
         else:
-            W = np.diag(np.tile(np.sqrt(weights/np.max(weights)), d))
+            W = np.diag(np.tile(np.sqrt(weights / np.max(weights)), d))
             _, _, V = np.linalg.svd(W @ A)
-        
+
         # if the last element of the vector corresponding to the smallest
         # singular value is close to zero, this implies a degenerate case
         # because it is a rank-defective transform, which would map points
@@ -743,11 +743,11 @@ class ProjectiveTransform(GeometricTransform):
 
         # De-center and de-normalize
         H = np.linalg.inv(dst_matrix) @ H @ src_matrix
-        
+
         # Small errors can creep in if points are not exact, causing the last
         # element of H to deviate from unity. Correct for that here.
         H /= H[-1, -1]
-        
+
         self.params = H
 
         return True
@@ -1431,7 +1431,7 @@ class PolynomialTransform(GeometricTransform):
         In case of total least-squares the solution of this homogeneous system
         of equations is the right singular vector of A which corresponds to the
         smallest singular value normed by the coefficient c3.
-        
+
         Weights can be applied to each pair of corresponding points to
         indicate, particularly in an overdetermined system, if point pairs have
         higher or lower confidence or uncertainties associated with them. From
@@ -1482,7 +1482,7 @@ class PolynomialTransform(GeometricTransform):
         if weights is None:
             _, _, V = np.linalg.svd(A)
         else:
-            W = np.diag(np.tile(np.sqrt(weights/np.max(weights)), 2))
+            W = np.diag(np.tile(np.sqrt(weights / np.max(weights)), 2))
             _, _, V = np.linalg.svd(W @ A)
 
         # solution is right singular vector that corresponds to smallest

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -329,30 +329,30 @@ def test_projective_estimation():
 
 
 def test_projective_weighted_estimation():
-    
+
     # Exact solution with same points, and unity weights
     tform = estimate_transform('projective', SRC[:4, :], DST[:4, :])
-    tform_w = estimate_transform('projective', 
+    tform_w = estimate_transform('projective',
                                  SRC[:4, :], DST[:4, :], np.ones(4))
     assert_almost_equal(tform.params, tform_w.params)
-    
+
     # Over-determined solution with same points, and unity weights
     tform = estimate_transform('projective', SRC, DST)
     tform_w = estimate_transform('projective',
-                               SRC, DST, np.ones(SRC.shape[0]))
+                                 SRC, DST, np.ones(SRC.shape[0]))
     assert_almost_equal(tform.params, tform_w.params)
-    
+
     # Repeating a point, but setting its weight small, should give nearly
     # the same result.
-    point_weights = np.ones(SRC.shape[0]+1)
+    point_weights = np.ones(SRC.shape[0] + 1)
     point_weights[0] = 1.0e-15
     tform1 = estimate_transform('projective', SRC, DST)
     tform2 = estimate_transform('projective',
-                               SRC[np.arange(-1, SRC.shape[0]), :],
-                               DST[np.arange(-1, SRC.shape[0]), :],
-                               point_weights)
+                                SRC[np.arange(-1, SRC.shape[0]), :],
+                                DST[np.arange(-1, SRC.shape[0]), :],
+                                point_weights)
     assert_almost_equal(tform1.params, tform2.params, decimal=3)
-    
+
 
 def test_projective_init():
     tform = estimate_transform('projective', SRC, DST)
@@ -376,19 +376,22 @@ def test_polynomial_weighted_estimation():
     # Over-determined solution with same points, and unity weights
     tform = estimate_transform('polynomial', SRC, DST, order=10)
     tform_w = estimate_transform('polynomial',
-                               SRC, DST, order=10, weights=np.ones(SRC.shape[0]))
+                                 SRC,
+                                 DST,
+                                 order=10,
+                                 weights=np.ones(SRC.shape[0]))
     assert_almost_equal(tform.params, tform_w.params)
-    
+
     # Repeating a point, but setting its weight small, should give nearly
     # the same result.
     point_weights = np.ones(SRC.shape[0]+1)
     point_weights[0] = 1.0e-15
     tform1 = estimate_transform('polynomial', SRC, DST, order=10)
     tform2 = estimate_transform('polynomial',
-                               SRC[np.arange(-1, SRC.shape[0]), :],
-                               DST[np.arange(-1, SRC.shape[0]), :],
-                               order=10,
-                               weights=point_weights)
+                                SRC[np.arange(-1, SRC.shape[0]), :],
+                                DST[np.arange(-1, SRC.shape[0]), :],
+                                order=10,
+                                weights=point_weights)
     assert_almost_equal(tform1.params, tform2.params, decimal=4)
 
 

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -384,7 +384,7 @@ def test_polynomial_weighted_estimation():
 
     # Repeating a point, but setting its weight small, should give nearly
     # the same result.
-    point_weights = np.ones(SRC.shape[0]+1)
+    point_weights = np.ones(SRC.shape[0] + 1)
     point_weights[0] = 1.0e-15
     tform1 = estimate_transform('polynomial', SRC, DST, order=10)
     tform2 = estimate_transform('polynomial',

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -11,10 +11,10 @@ from skimage.transform._geometric import (_affine_matrix_from_vector,
                                           _euler_rotation_matrix,
                                           GeometricTransform)
 from skimage.transform import (estimate_transform, matrix_transform,
-                                EuclideanTransform, SimilarityTransform,
-                                AffineTransform, FundamentalMatrixTransform,
-                                EssentialMatrixTransform, ProjectiveTransform,
-                                PolynomialTransform, PiecewiseAffineTransform)
+                               EuclideanTransform, SimilarityTransform,
+                               AffineTransform, FundamentalMatrixTransform,
+                               EssentialMatrixTransform, ProjectiveTransform,
+                               PolynomialTransform, PiecewiseAffineTransform)
 
 
 SRC = np.array([


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

If the estimation of a geometric transform matrix is overdetermined, meaning there are more pairs of source and destination points than required (e.g. more than 4 points in 2D), then the total least squares method will return a matrix that performs best on average for each of the point pairs. Depending on the source of information on the point pair locations, it might be that more confidence can be placed in some pairs, and less in others. 

To allow such a situation to be specified, this addition allows a vector or list of weights to be provided, where each element corresponds to a combined weight for each for each pair of points. After a normalisation to the range [0, 1], these weights are square rooted and built into a diagonal matrix, by which the coefficient matrix A is multiplied. This follows from the treatment of variances in conventional least squares methods. The relative values of the weights could therefore be considered as inverse variances for each point pair.

By providing and using weights in this manner, points for which the position is known with a lower confidence can be given a smaller weighting to have less influence over the final transformation matrix.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py) 
  - _All changes are commented, and a description has been added to the estimate() docstrings_
- Gallery example in `./doc/examples` (new features only)
  - _A short description of the weighting has been added to the gallery page. I'm not sure if more is needed?_
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
  - _I don't know where to fit this in? The Geometric module doesn't seem to have much benchmarking?_
- Unit tests
  - _Added._
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
  - _I think so?_
- Descriptive commit messages (see below)
  - _I think so?_

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
