### PR TITLE
Fix weight calculation in fast mode of non-local means

### DIFF
--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -741,16 +741,14 @@ def _fast_nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image,
         # With t2 >= 0, reference patch is always on the left of test patch
         # Iterate over shifts along the row axis
         for t_row in range(-d, d + 1):
-            # alpha is to account for patches on the same column
-            # distance is computed twice in this case
-            if t_row != 0:
-                alpha = 0.5
-            else:
-                alpha = 1.0
             row_start = max(offset, offset - t_row)
             row_end = min(n_row - offset, n_row - offset - t_row)
             # Iterate over shifts along the column axis
             for t_col in range(0, d + 1):
+                # alpha is to account for patches on the same column
+                # distance is computed twice in this case
+                alpha = 0.5 if t_col == 0 else 1
+
                 # Compute integral image of the squared difference between
                 # padded and the same image shifted by (t_row, t_col)
                 _integral_image_2d(padded, integral, t_row, t_col,
@@ -779,7 +777,6 @@ def _fast_nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image,
                                 padded[row_shift, col_shift, channel]
                             result[row_shift, col_shift, channel] += \
                                 weight * padded[row, col, channel]
-                alpha = 1
 
         # Normalize pixel values using sum of weights of contributing patches
         for row in range(pad_size, n_row - pad_size):
@@ -874,22 +871,16 @@ def _fast_nl_means_denoising_3d(cnp.ndarray[np_floats, ndim=4] image,
         for t_pln in range(-d, d + 1):
             pln_dist_min = max(offset, offset - t_pln)
             pln_dist_max = min(n_pln - offset, n_pln - offset - t_pln)
-                    # alpha is to account for patches on the same column
-                    # distance is computed twice in this case
-            if t_pln == 0:
-                alpha = 1.0
-            else:
-                alpha = 0.5
             # Iterate over shifts along the row axis
             for t_row in range(-d, d + 1):
                 row_dist_min = max(offset, offset - t_row)
                 row_dist_max = min(n_row - offset, n_row - offset - t_row)
-                if t_row == 0:
-                    alpha = 1.0
-                else:
-                    alpha = 0.5
                 # Iterate over shifts along the column axis
                 for t_col in range(0, d + 1):
+                    # alpha is to account for patches on the same column
+                    # distance is computed twice in this case
+                    alpha = 0.5 if t_col == 0 else 1
+
                     col_dist_min = offset
                     col_dist_max = n_col - offset - t_col
 
@@ -927,7 +918,6 @@ def _fast_nl_means_denoising_3d(cnp.ndarray[np_floats, ndim=4] image,
                                     result[pln + t_pln, row + t_row,
                                            col + t_col, channel] += weight * \
                                                                     padded[pln, row, col, channel]
-                    alpha = 1.0
 
         # Normalize pixel values using sum of weights of contributing patches
         for pln in range(offset, n_pln - offset):
@@ -1026,29 +1016,19 @@ def _fast_nl_means_denoising_4d(cnp.ndarray[np_floats, ndim=5] image,
         for t_time in range(-d, d + 1):
             time_dist_min = max(offset, offset - t_time)
             time_dist_max = min(n_time - offset, n_time - offset - t_time)
-            # alpha is to account for patches on the same column
-            # distance is computed twice in this case
-            if t_time == 0:
-                alpha = 1.0
-            else:
-                alpha = 0.5
             for t_pln in range(-d, d + 1):
                 pln_dist_min = max(offset, offset - t_pln)
                 pln_dist_max = min(n_pln - offset, n_pln - offset - t_pln)
-                if t_pln == 0:
-                    alpha = 1.0
-                else:
-                    alpha = 0.5
                 # Iterate over shifts along the row axis
                 for t_row in range(-d, d + 1):
                     row_dist_min = max(offset, offset - t_row)
                     row_dist_max = min(n_row - offset, n_row - offset - t_row)
-                    if t_row == 0:
-                        alpha = 1.0
-                    else:
-                        alpha = 0.5
                     # Iterate over shifts along the column axis
                     for t_col in range(0, d + 1):
+                        # alpha is to account for patches on the same column
+                        # distance is computed twice in this case
+                        alpha = 0.5 if t_col == 0 else 1
+
                         col_dist_min = offset
                         col_dist_max = n_col - offset - t_col
 
@@ -1093,7 +1073,6 @@ def _fast_nl_means_denoising_4d(cnp.ndarray[np_floats, ndim=5] image,
                                                    channel] += weight * \
                                                        padded[time, pln, row,
                                                               col, channel]
-                        alpha = 1.0
 
         # Normalize pixel values using sum of weights of contributing patches
         for time in range(offset, n_time - offset):


### PR DESCRIPTION
## Description

closes #5922

This PR fixes the non-local means weight calculation issue pointed out by @TimZaragori in https://github.com/scikit-image/scikit-image/discussions/5660

The issue only related to use of `fast_mode=True` and produces only very subtly different weights, so I did not see an easy way to make a test case that would fail on `main`, but pass on this PR.

A pure python validation of the proposed fixes in 2d, 3d and 4d is given in the details below. Changing to modified=False in the last few lines will give the failing result for the current implementation.

<details>

```Python
import numpy as np

def _weights_skimage_4d(image, s, d, modified=False):
    if s % 2 == 0:
        s += 1  # odd value for symmetric patch
    offset = int(s / 2)
    # Image padding: we need to account for patch size, possible shift,
    # + 1 for the boundary effects in finite differences
    pad_size = offset + d + 1
    padded = np.ascontiguousarray(np.pad(image, pad_size, mode='reflect').astype(np.float64))
    weights = np.zeros_like(padded)
    n_time, n_pln, n_row, n_col = padded.shape[0], padded.shape[1], padded.shape[2], padded.shape[3]

    for t_time in range(-d, d + 1):
        time_dist_min = max(offset, offset - t_time)
        time_dist_max = min(n_time - offset, n_time - offset - t_time)
        if not modified:
            if t_time == 0:
                alpha = 1.0
            else:
                alpha = 0.5
        for t_pln in range(-d, d + 1):
            pln_dist_min = max(offset, offset - t_pln)
            pln_dist_max = min(n_pln - offset, n_pln - offset - t_pln)
            # alpha is to account for patches on the same column
            # distance is computed twice in this case
            if not modified:
                if t_pln == 0:
                    alpha = 1.0
                else:
                    alpha = 0.5
            # Iterate over shifts along the row axis
            for t_row in range(-d, d + 1):
                row_dist_min = max(offset, offset - t_row)
                row_dist_max = min(n_row - offset, n_row - offset - t_row)
                if not modified:
                    if t_row == 0:
                        alpha = 1.0
                    else:
                        alpha = 0.5

                # Iterate over shifts along the column axis
                for t_col in range(0, d + 1):
                    if modified:
                        alpha = 0.5 if t_col == 0 else 1
                    col_dist_min = offset
                    col_dist_max = n_col - offset - t_col
                    # Inner loops on pixel coordinates
                    # Iterate over planes, taking offset and shift into account
                    for time in range(time_dist_min, time_dist_max):
                        for pln in range(pln_dist_min, pln_dist_max):
                            # Iterate over rows, taking offset and shift
                            # into account
                            for row in range(row_dist_min, row_dist_max):
                                # Iterate over columns
                                for col in range(col_dist_min, col_dist_max):
                                    weight = alpha
                                    # Accumulate weights for the different shifts
                                    weights[time, pln, row, col] += weight
                                    weights[time + t_time, pln + t_pln, row + t_row,
                                            col + t_col] += weight

                    if not modified:
                        alpha = 1.0
    return weights


def _weights_froment_4d(image, s, d):
    if s % 2 == 0:
        s += 1  # odd value for symmetric patch
        
    offset = int(s / 2)
    # Image padding: we need to account for patch size, possible shift,
    # + 1 for the boundary effects in finite differences
    pad_size = offset + d + 1
    padded = np.ascontiguousarray(np.pad(image, pad_size, mode='reflect').astype(np.float64))
    weights = np.zeros_like(padded)
    n_time, n_pln, n_row, n_col = padded.shape[0], padded.shape[1], padded.shape[2], padded.shape[3]

    # Outer loops on patch shifts
    # With t2 >= 0, reference patch is always on the left of test patch
    # Iterate over shifts along the plane axis
    for t_time in range(-d, d + 1):
        time_dist_min = max(offset, offset - t_time)
        time_dist_max = min(n_time - offset, n_time - offset - t_time)
        for t_pln in range(-d, d + 1):
            pln_dist_min = max(offset, offset - t_pln)
            pln_dist_max = min(n_pln - offset, n_pln - offset - t_pln)
                    # alpha is to account for patches on the same column
                    # distance is computed twice in this case
            # Iterate over shifts along the row axis
            for t_row in range(-d, d + 1):
                row_dist_min = max(offset, offset - t_row)
                row_dist_max = min(n_row - offset, n_row - offset - t_row)
                # Iterate over shifts along the column axis
                for t_col in range(-d, d + 1):
                    col_dist_min = max(offset, offset - t_col)
                    col_dist_max = min(n_col - offset, n_col - offset - t_col)
                    # Inner loops on pixel coordinates
                    for time in range(time_dist_min, time_dist_max):
                        # Iterate over planes, taking offset and shift into account
                        for pln in range(pln_dist_min, pln_dist_max):
                            # Iterate over rows, taking offset and shift
                            # into account
                            for row in range(row_dist_min, row_dist_max):
                                # Iterate over columns
                                for col in range(col_dist_min, col_dist_max):
                                    # Accumulate weights for the different shifts
                                    weights[time, pln, row, col] += 1
    return weights


def _weights_skimage_3d(image, s, d, modified=False):
    if s % 2 == 0:
        s += 1  # odd value for symmetric patch
    offset = int(s / 2)
    # Image padding: we need to account for patch size, possible shift,
    # + 1 for the boundary effects in finite differences
    pad_size = offset + d + 1
    padded = np.ascontiguousarray(np.pad(image, pad_size, mode='reflect').astype(np.float64))
    weights = np.zeros_like(padded)
    n_pln, n_row, n_col = padded.shape[0], padded.shape[1], padded.shape[2]

    for t_pln in range(-d, d + 1):
        pln_dist_min = max(offset, offset - t_pln)
        pln_dist_max = min(n_pln - offset, n_pln - offset - t_pln)
        # alpha is to account for patches on the same column
        # distance is computed twice in this case
        if not modified:
            if t_pln == 0:
                alpha = 1.0
            else:
                alpha = 0.5
        # Iterate over shifts along the row axis
        for t_row in range(-d, d + 1):
            row_dist_min = max(offset, offset - t_row)
            row_dist_max = min(n_row - offset, n_row - offset - t_row)
            if not modified:
                if t_row == 0:
                    alpha = 1.0
                else:
                    alpha = 0.5

            # Iterate over shifts along the column axis
            for t_col in range(0, d + 1):
                if modified:
                    alpha = 0.5 if t_col == 0 else 1
                col_dist_min = offset
                col_dist_max = n_col - offset - t_col
                # Inner loops on pixel coordinates
                # Iterate over planes, taking offset and shift into account
                for pln in range(pln_dist_min, pln_dist_max):
                    # Iterate over rows, taking offset and shift
                    # into account
                    for row in range(row_dist_min, row_dist_max):
                        # Iterate over columns
                        for col in range(col_dist_min, col_dist_max):
                            weight = alpha
                            # Accumulate weights for the different shifts
                            weights[pln, row, col] += weight
                            weights[pln + t_pln, row + t_row,
                                                 col + t_col] += weight

                if not modified:
                    alpha = 1.0
    return weights


def _weights_froment_3d(image, s, d):
    if s % 2 == 0:
        s += 1  # odd value for symmetric patch

    offset = int(s / 2)
    # Image padding: we need to account for patch size, possible shift,
    # + 1 for the boundary effects in finite differences
    pad_size = offset + d + 1
    padded = np.ascontiguousarray(np.pad(image, pad_size, mode='reflect').astype(np.float64))
    weights = np.zeros_like(padded)
    n_pln, n_row, n_col = padded.shape[0], padded.shape[1], padded.shape[2]

    # Outer loops on patch shifts
    # With t2 >= 0, reference patch is always on the left of test patch
    # Iterate over shifts along the plane axis
    for t_pln in range(-d, d + 1):
        pln_dist_min = max(offset, offset - t_pln)
        pln_dist_max = min(n_pln - offset, n_pln - offset - t_pln)
                # alpha is to account for patches on the same column
                # distance is computed twice in this case
        # Iterate over shifts along the row axis
        for t_row in range(-d, d + 1):
            row_dist_min = max(offset, offset - t_row)
            row_dist_max = min(n_row - offset, n_row - offset - t_row)
            # Iterate over shifts along the column axis
            for t_col in range(-d, d + 1):
                col_dist_min = max(offset, offset - t_col)
                col_dist_max = min(n_col - offset, n_col - offset - t_col)
                # Inner loops on pixel coordinates
                # Iterate over planes, taking offset and shift into account
                for pln in range(pln_dist_min, pln_dist_max):
                    # Iterate over rows, taking offset and shift
                    # into account
                    for row in range(row_dist_min, row_dist_max):
                        # Iterate over columns
                        for col in range(col_dist_min, col_dist_max):
                            # Accumulate weights for the different shifts
                            weights[pln, row, col] += 1
    return weights


def _weights_skimage_2d(image, s, d, modified=False):
    if s % 2 == 0:
        s += 1  # odd value for symmetric patch

    offset = int(s / 2)
    # Image padding: we need to account for patch size, possible shift,
    # + 1 for the boundary effects in finite differences
    pad_size = offset + d + 1
    padded = np.ascontiguousarray(np.pad(image, pad_size, mode='reflect').astype(np.float64))
    weights = np.zeros_like(padded)
    n_row, n_col = padded.shape[0], padded.shape[1]

    # Outer loops on patch shifts
    # With t2 >= 0, reference patch is always on the left of test patch
    # Iterate over shifts along the row axis
    for t_row in range(-d, d + 1):
        # alpha is to account for patches on the same column
        # distance is computed twice in this case
        if not modified:
            if t_row != 0:
                alpha = 0.5
            else:
                alpha = 1.0
        row_start = max(offset, offset - t_row)
        row_end = min(n_row - offset, n_row - offset - t_row)
        # Iterate over shifts along the column axis
        for t_col in range(0, d + 1):
            if modified:
                alpha = 0.5 if t_col == 0 else 1
            # Inner loops on pixel coordinates
            # Iterate over rows, taking offset and shift into account
            for row in range(row_start, row_end):
                row_shift = row + t_row
                # Iterate over columns, taking offset and shift into account
                for col in range(offset, n_col - offset - t_col):
                    col_shift = col + t_col
                    weight = alpha
                    # Accumulate weights corresponding to different shifts
                    weights[row, col] += weight
                    weights[row_shift, col_shift] += weight

            if not modified:
                alpha = 1

    return weights


def _weights_froment_2d(image, s, d):
    if s % 2 == 0:
        s += 1  # odd value for symmetric patch

    offset = int(s / 2)
    # Image padding: we need to account for patch size, possible shift,
    # + 1 for the boundary effects in finite differences
    pad_size = offset + d + 1
    padded = np.ascontiguousarray(np.pad(image, pad_size, mode='reflect').astype(np.float64))
    weights = np.zeros_like(padded)
    n_row, n_col = padded.shape[0], padded.shape[1]

    # Outer loops on patch shifts
    # With t2 >= 0, reference patch is always on the left of test patch
    # Iterate over shifts along the plane axis
    for t_row in range(-d, d + 1):
        row_dist_min = max(offset, offset - t_row)
        row_dist_max = min(n_row - offset, n_row - offset - t_row)
        # Iterate over shifts along the column axis
        for t_col in range(-d, d + 1):
            col_dist_min = max(offset, offset - t_col)
            col_dist_max = min(n_col - offset, n_col - offset - t_col)
            # Inner loops on pixel coordinates
            # Iterate over planes, taking offset and shift into account
            for row in range(row_dist_min, row_dist_max):
                # Iterate over columns
                for col in range(col_dist_min, col_dist_max):
                    # Accumulate weights for the different shifts
                    weights[row, col] += 1
    return weights

image = np.zeros((16, 24))
weights_skimage = _weights_skimage_2d(image, 3, 2, modified=True)
weights_froment = _weights_froment_2d(image, 3, 2)
assert np.all(weights_skimage  == weights_froment)


image = np.zeros((12, 16, 24))
weights_skimage = _weights_skimage_3d(image, 3, 2, modified=True)
weights_froment = _weights_froment_3d(image, 3, 2)
assert np.all(weights_skimage  == weights_froment)


image = np.zeros((4, 5, 5, 4))
weights_skimage = _weights_skimage_4d(image, 3, 2, modified=True)
weights_froment = _weights_froment_4d(image, 3, 2)
assert np.all(weights_skimage  == weights_froment)

```

</details>


@TimZaragori, I added you as a co-author in the commit message. Thanks for reporting the issue and my apologies for not looking at it sooner! 


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
