### PR TITLE
fix for #5948: lower boundary 1 for kernel_size in equalize_adapthist 

### DIFF
--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -81,9 +81,9 @@ def equalize_adapthist(image, kernel_size=None,
     ).astype(np.uint16)
 
     if kernel_size is None:
-        kernel_size = [max(s // 8, 1) for s in image.shape]
+        kernel_size = tuple([max(s // 8, 1) for s in image.shape])
     elif isinstance(kernel_size, numbers.Number):
-        kernel_size = [kernel_size] * image.ndim
+        kernel_size = (kernel_size,) * image.ndim
     elif len(kernel_size) != image.ndim:
         ValueError(f'Incorrect value of `kernel_size`: {kernel_size}')
 


### PR DESCRIPTION
## Description
a fix for #5948
in the function exposure.equalize_adapthist:
this sets the `kernel_size` to at least 1, preventing ZeroDivisionError if the image is smaller than 8 along any of its dimensions
<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
