### PR TITLE
Add small regularization to avoid zero-division in richardson_lucy

### DIFF
--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -432,9 +432,7 @@ def richardson_lucy(image, psf, num_iter=50, clip=True, filter_epsilon=None):
     for _ in range(num_iter):
         conv = convolve(im_deconv, psf, mode='same') + eps
         if filter_epsilon:
-            with np.errstate(invalid='ignore'):
-                relative_blur = np.where(conv < filter_epsilon, 0,
-                                         image / conv)
+            relative_blur = np.where(conv < filter_epsilon, 0, image / conv)
         else:
             relative_blur = image / conv
         im_deconv *= convolve(relative_blur, psf_mirror, mode='same')

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -426,8 +426,11 @@ def richardson_lucy(image, psf, num_iter=50, clip=True, filter_epsilon=None):
     im_deconv = np.full(image.shape, 0.5, dtype=float_type)
     psf_mirror = np.flip(psf)
 
+    # Small regularization parameter used to avoid 0 divisions
+    eps = 1e-12
+
     for _ in range(num_iter):
-        conv = convolve(im_deconv, psf, mode='same')
+        conv = convolve(im_deconv, psf, mode='same') + eps
         if filter_epsilon:
             with np.errstate(invalid='ignore'):
                 relative_blur = np.where(conv < filter_epsilon, 0,


### PR DESCRIPTION
## Description

Fixes #4378, closes #2551

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

Here the result using the sample data from https://github.com/scikit-image/scikit-image/issues/4378#issuecomment-569866334

![Figure_1](https://user-images.githubusercontent.com/3438227/138311199-df7f48b6-8da0-45dd-bd99-5b3b6e709628.png)

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
