### PR TITLE
Update docstring for dilation, which is now nD.

### DIFF
--- a/skimage/morphology/gray.py
+++ b/skimage/morphology/gray.py
@@ -197,9 +197,10 @@ def erosion(image, footprint=None, out=None, shift_x=False, shift_y=False):
 def dilation(image, footprint=None, out=None, shift_x=False, shift_y=False):
     """Return grayscale morphological dilation of an image.
 
-    Morphological dilation sets a pixel at x to the maximum over all pixels
-    in the neighborhood centered at x. Dilation enlarges bright regions
-    and shrinks dark regions.
+    Morphological dilation sets the value of a pixel to the maximum over all
+    pixel values within a local neighborhood centered about it. The values
+    where the footprint is 1 define this neighborhood.
+    Dilation enlarges bright regions and shrinks dark regions.
 
     Parameters
     ----------


### PR DESCRIPTION
## Description

Follows from https://github.com/scikit-image/scikit-image/pull/5262#discussion_r733333774.

I'm not sure `x` is a great (conventional?) notation for a pixel's coordinates (no matter how many the dimensions are)... @grlee77 thoughts?

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
