### PR TITLE
Make matplotlib an optional dependency

### DIFF
--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -168,7 +168,7 @@ fig, ax = plt.subplots(1, 1)
 ax.imshow(composite_img, cmap="gray", vmin=0, vmax=1)
 ax.set_axis_off()
 ax.set_title(f"Reconstructed image (PSNR={psnr_composite:.2f})")
-
 fig.tight_layout()
+# sphinx_gallery_thumbnail_number = 2
 
 plt.show()

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,5 @@
 numpy>=1.17.0
 scipy>=1.2.3
-matplotlib>=3.0.3
 networkx>=2.2
 pillow>=6.1.0,!=7.1.0,!=7.1.1,!=8.3.0
 imageio>=2.4.1

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -4,8 +4,8 @@ astropy>=3.1.2
 cloudpickle>=0.2.1
 dask[array]>=1.0.0,!=2.17.0
 matplotlib>=3.0.3
-pyamg
 # Keep pooch version in synch with the one hard coded in
 # skimage/data/__init__.py
 pooch>=1.3.0
+pyamg
 qtpy

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,10 +1,11 @@
 SimpleITK
 astropy>=3.1.2
-qtpy
-pyamg
-dask[array]>=1.0.0,!=2.17.0
 # cloudpickle is necessary to provide the 'processes' scheduler for dask
 cloudpickle>=0.2.1
+dask[array]>=1.0.0,!=2.17.0
+matplotlib>=3.0.3
+pyamg
 # Keep pooch version in synch with the one hard coded in
 # skimage/data/__init__.py
 pooch>=1.3.0
+qtpy

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,8 +1,9 @@
+asv
+codecov
+flake8
+matplotlib>=3.0.3
+pooch>=1.3.0
 pytest>=5.2.0
 pytest-cov>=2.7.0
 pytest-localserver
 pytest-faulthandler
-flake8
-codecov
-pooch>=1.3.0
-asv

--- a/skimage/_shared/__init__.py
+++ b/skimage/_shared/__init__.py
@@ -1,0 +1,3 @@
+from .version_requirements import is_installed
+
+has_mpl = is_installed("matplotlib", ">=3.0.3")

--- a/skimage/_shared/_geometry.py
+++ b/skimage/_shared/_geometry.py
@@ -2,7 +2,10 @@ __all__ = ['polygon_clip', 'polygon_area']
 
 import numpy as np
 
+from .version_requirements import require
 
+
+@require("matplotlib", ">=3.0.3")
 def polygon_clip(rp, cp, r0, c0, r1, c1):
     """Clip a polygon to the given bounding box.
 

--- a/skimage/_shared/tests/test_geometry.py
+++ b/skimage/_shared/tests/test_geometry.py
@@ -1,7 +1,10 @@
+import pytest
 from skimage._shared._geometry import polygon_clip, polygon_area
 
 import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal
+
+pytest.importorskip("matplotlib")
 
 
 hand = np.array(

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from .._shared._geometry import polygon_clip
+from .._shared.version_requirements import require
 from ._draw import (_coords_inside_image, _line, _line_aa,
                     _polygon, _ellipse_perimeter,
                     _circle_perimeter, _circle_perimeter_aa,
@@ -206,6 +207,7 @@ def disk(center, radius, *, shape=None):
     return ellipse(r, c, radius, radius, shape)
 
 
+@require("matplotlib", ">=3.0.3")
 def polygon_perimeter(r, c, shape=None, clip=False):
     """Generate polygon perimeter coordinates.
 
@@ -827,6 +829,7 @@ def rectangle(start, end=None, extent=None, shape=None):
     return coords
 
 
+@require("matplotlib", ">=3.0.3")
 def rectangle_perimeter(start, end=None, extent=None, shape=None, clip=False):
     """Generate coordinates of pixels that are exactly around a rectangle.
 

--- a/skimage/draw/tests/test_draw.py
+++ b/skimage/draw/tests/test_draw.py
@@ -864,7 +864,7 @@ def test_bezier_curve_shape():
     assert_array_equal(img, img_[shift:-shift, :])
 
 
-@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
+@pytest.mark.skipif(not has_mpl, reason="matplotlib not installed")
 def test_polygon_perimeter():
     expected = np.array(
         [[1, 1, 1, 1],
@@ -890,7 +890,7 @@ def test_polygon_perimeter():
         polygon_perimeter([0], [1], clip=True)
 
 
-@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
+@pytest.mark.skipif(not has_mpl, reason="matplotlib not installed")
 def test_polygon_perimeter_outside_image():
     rr, cc = polygon_perimeter([-1, -1, 3,  3],
                                [-1,  4, 4, -1], shape=(3, 4))
@@ -950,7 +950,7 @@ def test_rectangle_extent():
     assert_array_equal(img, expected_2)
 
 
-@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
+@pytest.mark.skipif(not has_mpl, reason="matplotlib not installed")
 def test_rectangle_extent_negative():
     # These two tests should be done together.
     expected = np.array([[0, 0, 0, 0, 0, 0],
@@ -979,7 +979,7 @@ def test_rectangle_extent_negative():
     assert_array_equal(img, expected)
 
 
-@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
+@pytest.mark.skipif(not has_mpl, reason="matplotlib not installed")
 def test_rectangle_perimiter():
     expected = np.array([[0, 0, 0, 0, 0, 0],
                          [0, 0, 1, 1, 1, 1],
@@ -1008,7 +1008,7 @@ def test_rectangle_perimiter():
     assert_array_equal(img, expected)
 
 
-@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
+@pytest.mark.skipif(not has_mpl, reason="matplotlib not installed")
 def test_rectangle_perimiter_clip_bottom_right():
     # clip=False
     expected = np.array([[0, 0, 0, 0, 0],
@@ -1037,7 +1037,7 @@ def test_rectangle_perimiter_clip_bottom_right():
     assert_array_equal(img, expected)
 
 
-@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
+@pytest.mark.skipif(not has_mpl, reason="matplotlib not installed")
 def test_rectangle_perimiter_clip_top_left():
     # clip=False
     expected = np.array([[0, 0, 0, 1, 0],
@@ -1066,7 +1066,7 @@ def test_rectangle_perimiter_clip_top_left():
     assert_array_equal(img, expected)
 
 
-@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
+@pytest.mark.skipif(not has_mpl, reason="matplotlib not installed")
 def test_rectangle_perimiter_clip_top_right():
     expected = np.array([[0, 1, 1, 1, 1],
                          [0, 1, 0, 0, 1],
@@ -1093,7 +1093,7 @@ def test_rectangle_perimiter_clip_top_right():
     assert_array_equal(img, expected)
 
 
-@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
+@pytest.mark.skipif(not has_mpl, reason="matplotlib not installed")
 def test_rectangle_perimiter_clip_bottom_left():
     expected = np.array([[0, 0, 0, 0, 0],
                          [1, 1, 1, 0, 0],

--- a/skimage/draw/tests/test_draw.py
+++ b/skimage/draw/tests/test_draw.py
@@ -1,8 +1,9 @@
 import numpy as np
+from numpy.testing import assert_array_equal, assert_equal, assert_almost_equal
+import pytest
+
 from skimage._shared.testing import test_parallel
-from skimage._shared import testing
-from skimage._shared.testing import assert_array_equal, assert_equal
-from skimage._shared.testing import assert_almost_equal
+from skimage._shared import has_mpl
 
 from skimage.draw import (set_color, line, line_aa, polygon, polygon_perimeter,
                           disk, circle_perimeter, circle_perimeter_aa,
@@ -31,7 +32,7 @@ def test_set_color_with_alpha():
     set_color(img, (rr, cc), 1, alpha=alpha)
 
     # Wrong dimensionality color
-    with testing.raises(ValueError):
+    with pytest.raises(ValueError):
         set_color(img, (rr, cc), (255, 0, 0), alpha=alpha)
 
     img = np.zeros((10, 10, 3))
@@ -863,6 +864,7 @@ def test_bezier_curve_shape():
     assert_array_equal(img, img_[shift:-shift, :])
 
 
+@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
 def test_polygon_perimeter():
     expected = np.array(
         [[1, 1, 1, 1],
@@ -884,10 +886,11 @@ def test_polygon_perimeter():
     out[rr, cc] = 1
     assert_array_equal(out, expected)
 
-    with testing.raises(ValueError):
+    with pytest.raises(ValueError):
         polygon_perimeter([0], [1], clip=True)
 
 
+@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
 def test_polygon_perimeter_outside_image():
     rr, cc = polygon_perimeter([-1, -1, 3,  3],
                                [-1,  4, 4, -1], shape=(3, 4))
@@ -947,6 +950,7 @@ def test_rectangle_extent():
     assert_array_equal(img, expected_2)
 
 
+@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
 def test_rectangle_extent_negative():
     # These two tests should be done together.
     expected = np.array([[0, 0, 0, 0, 0, 0],
@@ -975,6 +979,7 @@ def test_rectangle_extent_negative():
     assert_array_equal(img, expected)
 
 
+@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
 def test_rectangle_perimiter():
     expected = np.array([[0, 0, 0, 0, 0, 0],
                          [0, 0, 1, 1, 1, 1],
@@ -1003,6 +1008,7 @@ def test_rectangle_perimiter():
     assert_array_equal(img, expected)
 
 
+@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
 def test_rectangle_perimiter_clip_bottom_right():
     # clip=False
     expected = np.array([[0, 0, 0, 0, 0],
@@ -1031,6 +1037,7 @@ def test_rectangle_perimiter_clip_bottom_right():
     assert_array_equal(img, expected)
 
 
+@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
 def test_rectangle_perimiter_clip_top_left():
     # clip=False
     expected = np.array([[0, 0, 0, 1, 0],
@@ -1059,6 +1066,7 @@ def test_rectangle_perimiter_clip_top_left():
     assert_array_equal(img, expected)
 
 
+@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
 def test_rectangle_perimiter_clip_top_right():
     expected = np.array([[0, 1, 1, 1, 1],
                          [0, 1, 0, 0, 1],
@@ -1085,6 +1093,7 @@ def test_rectangle_perimiter_clip_top_right():
     assert_array_equal(img, expected)
 
 
+@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
 def test_rectangle_perimiter_clip_bottom_left():
     expected = np.array([[0, 0, 0, 0, 0],
                          [1, 1, 1, 0, 0],

--- a/skimage/feature/tests/test_util.py
+++ b/skimage/feature/tests/test_util.py
@@ -45,6 +45,7 @@ def test_mask_border_keypoints():
 
 @pytest.mark.skipif(not has_mpl, reason="Matplotlib not installed")
 def test_plot_matches():
+    from matplotlib import pyplot as plt
     fig, ax = plt.subplots(nrows=1, ncols=1)
 
     shapes = (((10, 10), (10, 10)),

--- a/skimage/feature/tests/test_util.py
+++ b/skimage/feature/tests/test_util.py
@@ -1,34 +1,28 @@
 import numpy as np
-try:
-    import matplotlib.pyplot as plt
-except ImportError:
-    plt = None
+import pytest
 
-from skimage._shared.testing import assert_equal
-
+from skimage._shared import has_mpl
 from skimage.feature.util import (FeatureDetector, DescriptorExtractor,
                                   _prepare_grayscale_input_2D,
                                   _mask_border_keypoints, plot_matches)
 
-from skimage._shared import testing
-
 
 def test_feature_detector():
-    with testing.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError):
         FeatureDetector().detect(None)
 
 
 def test_descriptor_extractor():
-    with testing.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError):
         DescriptorExtractor().extract(None, None)
 
 
 def test_prepare_grayscale_input_2D():
-    with testing.raises(ValueError):
+    with pytest.raises(ValueError):
         _prepare_grayscale_input_2D(np.zeros((3, 3, 3)))
-    with testing.raises(ValueError):
+    with pytest.raises(ValueError):
         _prepare_grayscale_input_2D(np.zeros((3, 1)))
-    with testing.raises(ValueError):
+    with pytest.raises(ValueError):
         _prepare_grayscale_input_2D(np.zeros((3, 1, 1)))
     _prepare_grayscale_input_2D(np.zeros((3, 3)))
     _prepare_grayscale_input_2D(np.zeros((3, 3, 1)))
@@ -37,19 +31,19 @@ def test_prepare_grayscale_input_2D():
 
 def test_mask_border_keypoints():
     keypoints = np.array([[0, 0], [1, 1], [2, 2], [3, 3], [4, 4]])
-    assert_equal(_mask_border_keypoints((10, 10), keypoints, 0),
-                 [1, 1, 1, 1, 1])
-    assert_equal(_mask_border_keypoints((10, 10), keypoints, 2),
-                 [0, 0, 1, 1, 1])
-    assert_equal(_mask_border_keypoints((4, 4), keypoints, 2),
-                 [0, 0, 1, 0, 0])
-    assert_equal(_mask_border_keypoints((10, 10), keypoints, 5),
-                 [0, 0, 0, 0, 0])
-    assert_equal(_mask_border_keypoints((10, 10), keypoints, 4),
-                 [0, 0, 0, 0, 1])
+    np.testing.assert_equal(_mask_border_keypoints((10, 10), keypoints, 0),
+                            [1, 1, 1, 1, 1])
+    np.testing.assert_equal(_mask_border_keypoints((10, 10), keypoints, 2),
+                            [0, 0, 1, 1, 1])
+    np.testing.assert_equal(_mask_border_keypoints((4, 4), keypoints, 2),
+                            [0, 0, 1, 0, 0])
+    np.testing.assert_equal(_mask_border_keypoints((10, 10), keypoints, 5),
+                            [0, 0, 0, 0, 0])
+    np.testing.assert_equal(_mask_border_keypoints((10, 10), keypoints, 4),
+                            [0, 0, 0, 0, 1])
 
 
-@testing.skipif(plt is None, reason="Matplotlib not installed")
+@pytest.mark.skipif(not has_mpl, reason="Matplotlib not installed")
 def test_plot_matches():
     fig, ax = plt.subplots(nrows=1, ncols=1)
 

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -5,6 +5,7 @@ from numpy.testing import (assert_allclose, assert_almost_equal,
 from scipy import ndimage as ndi
 
 from skimage import data, util
+from skimage._shared import has_mpl
 from skimage._shared._warnings import expected_warnings
 from skimage._shared.utils import _supported_float_type
 from skimage.color import rgb2gray
@@ -34,6 +35,7 @@ class TestSimpleImage():
         with pytest.raises(RuntimeError):
             threshold_minimum(self.image)
 
+    @pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
     def test_try_all_threshold(self):
         fig, ax = try_all_threshold(self.image)
         all_texts = [axis.texts for axis in ax if axis.texts != []]

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -14,13 +14,18 @@ from skimage.exposure import histogram
 from skimage.filters._multiotsu import (_get_multiotsu_thresh_indices,
                                         _get_multiotsu_thresh_indices_lut)
 from skimage.filters.thresholding import (_cross_entropy, _mean_std,
-                                          threshold_isodata, threshold_li,
-                                          threshold_local, threshold_mean,
+                                          threshold_isodata,
+                                          threshold_li,
+                                          threshold_local,
+                                          threshold_mean,
                                           threshold_minimum,
                                           threshold_multiotsu,
-                                          threshold_niblack, threshold_otsu,
-                                          threshold_sauvola, threshold_triangle,
-                                          threshold_yen, try_all_threshold)
+                                          threshold_niblack,
+                                          threshold_otsu,
+                                          threshold_sauvola,
+                                          threshold_triangle,
+                                          threshold_yen,
+                                          try_all_threshold)
 
 
 class TestSimpleImage():
@@ -35,7 +40,7 @@ class TestSimpleImage():
         with pytest.raises(RuntimeError):
             threshold_minimum(self.image)
 
-    @pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
+    @pytest.mark.skipif(not has_mpl, reason="matplotlib not installed")
     def test_try_all_threshold(self):
         fig, ax = try_all_threshold(self.image)
         all_texts = [axis.texts for axis in ax if axis.texts != []]

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -3,12 +3,14 @@ import itertools
 import math
 from collections import OrderedDict
 from collections.abc import Iterable
+from warning import warn
 
 import numpy as np
 from scipy import ndimage as ndi
 
 from .._shared.filters import gaussian
 from .._shared.utils import _supported_float_type, deprecate_kwarg, warn
+from .._shared.version_requirements import is_installed
 from ..exposure import histogram
 from ..filters._multiotsu import (_get_multiotsu_thresh_indices,
                                   _get_multiotsu_thresh_indices_lut)
@@ -53,6 +55,9 @@ def _try_all(image, methods=None, figsize=None, num_cols=2, verbose=True):
     fig, ax : tuple
         Matplotlib figure and axes.
     """
+    if not is_installed("matplotlib", ">=3.0.3"):
+        warn("Please install matplotlib>=3.0.3 to use try_all_thresholds")
+        return None, None
     from matplotlib import pyplot as plt
 
     # Compute the image histogram for better performances

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -3,7 +3,6 @@ import itertools
 import math
 from collections import OrderedDict
 from collections.abc import Iterable
-from warning import warn
 
 import numpy as np
 from scipy import ndimage as ndi

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -10,7 +10,7 @@ from scipy import ndimage as ndi
 
 from .._shared.filters import gaussian
 from .._shared.utils import _supported_float_type, deprecate_kwarg, warn
-from .._shared.version_requirements import is_installed
+from .._shared.version_requirements import require
 from ..exposure import histogram
 from ..filters._multiotsu import (_get_multiotsu_thresh_indices,
                                   _get_multiotsu_thresh_indices_lut)
@@ -55,9 +55,6 @@ def _try_all(image, methods=None, figsize=None, num_cols=2, verbose=True):
     fig, ax : tuple
         Matplotlib figure and axes.
     """
-    if not is_installed("matplotlib", ">=3.0.3"):
-        warn("Please install matplotlib>=3.0.3 to use try_all_thresholds")
-        return None, None
     from matplotlib import pyplot as plt
 
     # Compute the image histogram for better performances
@@ -98,6 +95,7 @@ def _try_all(image, methods=None, figsize=None, num_cols=2, verbose=True):
     return fig, ax
 
 
+@require("matplotlib", ">=3.0.3")
 def try_all_threshold(image, figsize=(8, 5), verbose=True):
     """Returns a figure comparing the outputs of different thresholding methods.
 

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -500,9 +500,6 @@ def show_rag(labels, rag, image, border_color='black', edge_width=1.5,
     >>> lc = graph.show_rag(labels, g, img)
     >>> cbar = plt.colorbar(lc)
     """
-    if not has_mpl:
-        warn("Please install matplotlib>=3.0.3 to use show_rag",
-             stacklevel=2)
     from matplotlib import colors, cm
     from matplotlib import pyplot as plt
     from matplotlib.collections import LineCollection

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -4,7 +4,9 @@ from numpy.lib.stride_tricks import as_strided
 from scipy import ndimage as ndi
 from scipy import sparse
 import math
+
 from ... import measure, segmentation, util, color
+from ..._shared.version_requirements import require
 
 
 def _edge_generator_from_csr(csr_matrix):
@@ -446,6 +448,7 @@ def rag_boundary(labels, edge_map, connectivity=2):
     return rag
 
 
+@require("matplotlib", ">=3.0.3")
 def show_rag(labels, rag, image, border_color='black', edge_width=1.5,
              edge_cmap='magma', img_cmap='bone', in_place=True, ax=None):
     """Show a Region Adjacency Graph on an image.
@@ -497,6 +500,9 @@ def show_rag(labels, rag, image, border_color='black', edge_width=1.5,
     >>> lc = graph.show_rag(labels, g, img)
     >>> cbar = plt.colorbar(lc)
     """
+    if not has_mpl:
+        warn("Please install matplotlib>=3.0.3 to use show_rag",
+             stacklevel=2)
     from matplotlib import colors, cm
     from matplotlib import pyplot as plt
     from matplotlib.collections import LineCollection

--- a/skimage/future/manual_segmentation.py
+++ b/skimage/future/manual_segmentation.py
@@ -1,6 +1,7 @@
 from functools import reduce
 import numpy as np
 from ..draw import polygon
+from .._shared.version_requirements import require
 
 
 LEFT_CLICK = 1
@@ -16,6 +17,7 @@ def _mask_from_vertices(vertices, shape, label):
     return mask
 
 
+@require("matplotlib", ">=3.0.3")
 def _draw_polygon(ax, vertices, alpha=0.4):
     from matplotlib.patches import Polygon
     from matplotlib.collections import PatchCollection
@@ -28,6 +30,7 @@ def _draw_polygon(ax, vertices, alpha=0.4):
     return polygon_object
 
 
+@require("matplotlib", ">=3.0.3")
 def manual_polygon_segmentation(image, alpha=0.4, return_all=False):
     """Return a label image based on polygon selections made with the mouse.
 
@@ -142,6 +145,7 @@ def manual_polygon_segmentation(image, alpha=0.4, return_all=False):
         return reduce(np.maximum, labels, np.broadcast_to(0, image.shape[:2]))
 
 
+@require("matplotlib", ">=3.0.3")
 def manual_lasso_segmentation(image, alpha=0.4, return_all=False):
     """Return a label image based on freeform selections made with the mouse.
 

--- a/skimage/io/tests/test_mpl_imshow.py
+++ b/skimage/io/tests/test_mpl_imshow.py
@@ -1,8 +1,10 @@
-
 import numpy as np
+import pytest
+
 from skimage import io
 from skimage._shared._warnings import expected_warnings
-import matplotlib.pyplot as plt
+
+plt = pytest.importorskip("matplotlib.pyplot")
 
 
 def setup():

--- a/skimage/io/tests/test_plugin.py
+++ b/skimage/io/tests/test_plugin.py
@@ -1,11 +1,10 @@
 from contextlib import contextmanager
+import numpy as np
+import pytest
 
+from skimage._shared import has_mpl
 from skimage import io
 from skimage.io import manage_plugins
-
-from skimage._shared import testing
-from skimage._shared.testing import assert_equal
-
 
 
 priority_plugin = 'pil'
@@ -30,20 +29,22 @@ def protect_preferred_plugins():
 
 
 def test_failed_use():
-    with testing.raises(ValueError):
+    with pytest.raises(ValueError):
         manage_plugins.use_plugin('asd')
 
 
+@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
 def test_use_priority():
     manage_plugins.use_plugin(priority_plugin)
     plug, func = manage_plugins.plugin_store['imread'][0]
-    assert_equal(plug, priority_plugin)
+    np.testing.assert_equal(plug, priority_plugin)
 
     manage_plugins.use_plugin('matplotlib')
     plug, func = manage_plugins.plugin_store['imread'][0]
-    assert_equal(plug, 'matplotlib')
+    np.testing.assert_equal(plug, 'matplotlib')
 
 
+@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
 def test_load_preferred_plugins_all():
     from skimage.io._plugins import pil_plugin, matplotlib_plugin
 
@@ -59,6 +60,7 @@ def test_load_preferred_plugins_all():
         assert func == getattr(matplotlib_plugin, 'imshow')
 
 
+@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
 def test_load_preferred_plugins_imread():
     from skimage.io._plugins import pil_plugin, matplotlib_plugin
 

--- a/skimage/io/tests/test_plugin.py
+++ b/skimage/io/tests/test_plugin.py
@@ -33,7 +33,7 @@ def test_failed_use():
         manage_plugins.use_plugin('asd')
 
 
-@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
+@pytest.mark.skipif(not has_mpl, reason="matplotlib not installed")
 def test_use_priority():
     manage_plugins.use_plugin(priority_plugin)
     plug, func = manage_plugins.plugin_store['imread'][0]
@@ -44,7 +44,7 @@ def test_use_priority():
     np.testing.assert_equal(plug, 'matplotlib')
 
 
-@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
+@pytest.mark.skipif(not has_mpl, reason="matplotlib not installed")
 def test_load_preferred_plugins_all():
     from skimage.io._plugins import pil_plugin, matplotlib_plugin
 
@@ -60,7 +60,7 @@ def test_load_preferred_plugins_all():
         assert func == getattr(matplotlib_plugin, 'imshow')
 
 
-@pytest.mark.skipif(not has_mpl, reason="Needs matplotlib")
+@pytest.mark.skipif(not has_mpl, reason="matplotlib not installed")
 def test_load_preferred_plugins_imread():
     from skimage.io._plugins import pil_plugin, matplotlib_plugin
 

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -3,6 +3,7 @@ import itertools
 import numpy as np
 import pytest
 
+from skimage._shared import has_mpl
 from skimage._shared._warnings import expected_warnings
 from skimage._shared.testing import test_parallel
 from skimage._shared.utils import _supported_float_type, convert_to_float
@@ -117,7 +118,7 @@ def check_iradon_center(size, theta, circle):
                                      circle=circle)
     print('rms deviance:',
           np.sqrt(np.mean((reconstruction_opposite - reconstruction)**2)))
-    if debug:
+    if debug and has_mpl:
         import matplotlib.pyplot as plt
         imkwargs = dict(cmap='gray', interpolation='nearest')
         plt.figure()
@@ -156,7 +157,7 @@ def check_radon_iradon(interpolation_type, filter_type):
                            interpolation=interpolation_type, circle=False)
     delta = np.mean(np.abs(image - reconstructed))
     print('\n\tmean error:', delta)
-    if debug:
+    if debug and has_mpl:
         _debug_plot(image, reconstructed)
     if filter_type in ('ramp', 'shepp-logan'):
         if interpolation_type == 'nearest':
@@ -219,7 +220,7 @@ def check_radon_iradon_minimal(shape, slices):
     sinogram = radon(image, theta, circle=False)
     reconstructed = iradon(sinogram, theta, circle=False)
     print('\n\tMaximum deviation:', np.max(np.abs(image - reconstructed)))
-    if debug:
+    if debug and has_mpl:
         _debug_plot(image, reconstructed, sinogram)
     if image.sum() == 1:
         assert (np.unravel_index(np.argmax(reconstructed), image.shape)
@@ -393,7 +394,7 @@ def test_iradon_sart():
         sinogram = radon(image, theta, circle=True)
         reconstructed = iradon_sart(sinogram, theta)
 
-        if debug:
+        if debug and has_mpl:
             from matplotlib import pyplot as plt
             plt.figure()
             plt.subplot(221)
@@ -426,7 +427,7 @@ def test_iradon_sart():
                                       for i in range(sinogram.shape[1])]).T
         reconstructed = iradon_sart(sinogram_shifted, theta,
                                     projection_shifts=shifts)
-        if debug:
+        if debug and has_mpl:
             from matplotlib import pyplot as plt
             plt.figure()
             plt.subplot(221)

--- a/skimage/viewer/__init__.py
+++ b/skimage/viewer/__init__.py
@@ -1,6 +1,14 @@
 from .._shared.utils import warn
-from .viewers import ImageViewer, CollectionViewer
+from .._shared import has_mpl
 from .qt import has_qt
 
 if not has_qt:
     warn('Viewer requires Qt')
+
+if has_mpl:
+    from .viewers import ImageViewer, CollectionViewer
+else:
+    ImageViewer, CollectionViewer = None, None
+    warn('Viewer requires matplotlib.', stacklevel=2)
+
+__all__ = ['ImageViewer', 'CollectionViewer']

--- a/skimage/viewer/tests/test_plugins.py
+++ b/skimage/viewer/tests/test_plugins.py
@@ -1,4 +1,10 @@
 import numpy as np
+from numpy.testing import (assert_equal, assert_allclose,
+                           assert_almost_equal)
+import pytest
+
+pytest.importorskip("matplotlib")
+
 from skimage import util
 import skimage.data as data
 from skimage.filters.rank import median
@@ -10,10 +16,6 @@ from skimage.viewer.plugins import (
     LineProfile, Measure, CannyPlugin, LabelPainter, Crop, ColorHistogram,
     PlotPlugin)
 
-from skimage._shared import testing
-from skimage._shared.testing import (assert_equal, assert_allclose,
-                                     assert_almost_equal)
-
 
 def setup_line_profile(image, limits='image'):
     viewer = ImageViewer(util.img_as_float(image))
@@ -22,7 +24,7 @@ def setup_line_profile(image, limits='image'):
     return plugin
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_line_profile():
     """ Test a line profile using an ndim=2 image"""
     plugin = setup_line_profile(data.camera())
@@ -36,7 +38,7 @@ def test_line_profile():
     assert_allclose(scan_data.mean(), 0.247834, rtol=1e-3)
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_line_profile_rgb():
     """ Test a line profile using an ndim=3 image"""
     plugin = setup_line_profile(data.chelsea(), limits=None)
@@ -51,7 +53,7 @@ def test_line_profile_rgb():
     assert_allclose(scan_data.mean(), 0.4359, rtol=1e-3)
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_line_profile_dynamic():
     """Test a line profile updating after an image transform"""
     image = data.coins()[:-50, :]  # shave some off to make the line lower
@@ -76,7 +78,7 @@ def test_line_profile_dynamic():
     assert_almost_equal(np.max(line) - np.min(line), 0.639, 1)
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_measure():
     image = data.camera()
     viewer = ImageViewer(image)
@@ -88,7 +90,7 @@ def test_measure():
     assert_equal(str(m._angle.text[:5]), '135.0')
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_canny():
     image = data.camera()
     viewer = ImageViewer(image)
@@ -101,7 +103,7 @@ def test_canny():
     assert edges.sum() == 3590
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_label_painter():
     image = data.camera()
     moon = data.moon()
@@ -119,7 +121,7 @@ def test_label_painter():
     assert_equal(lp.paint_tool.shape, moon.shape)
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_crop():
     image = data.camera()
     viewer = ImageViewer(image)
@@ -130,7 +132,7 @@ def test_crop():
     assert_equal(viewer.image.shape, (101, 101))
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_color_histogram():
     image = util.img_as_float(data.colorwheel())
     viewer = ImageViewer(image)
@@ -142,7 +144,7 @@ def test_color_histogram():
     assert_almost_equal(viewer.image.std(), 0.325, 3)
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_plot_plugin():
     viewer = ImageViewer(data.moon())
     plugin = PlotPlugin(image_filter=lambda x: x)
@@ -154,7 +156,7 @@ def test_plot_plugin():
     viewer.close()
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_plugin():
     img = util.img_as_float(data.moon())
     viewer = ImageViewer(img)

--- a/skimage/viewer/tests/test_tools.py
+++ b/skimage/viewer/tests/test_tools.py
@@ -1,14 +1,15 @@
 from collections import namedtuple
-
 import numpy as np
+from numpy.testing import assert_equal
+import pytest
+
+pytest.importorskip("matplotlib")
+
 from skimage import data
 from skimage.viewer import ImageViewer, has_qt
 from skimage.viewer.canvastools import (
     LineTool, ThickLineTool, RectangleTool, PaintTool)
 from skimage.viewer.canvastools.base import CanvasToolBase
-
-from skimage._shared import testing
-from skimage._shared.testing import assert_equal, parametrize
 
 try:
     from matplotlib.testing.decorators import cleanup
@@ -80,7 +81,7 @@ def do_event(viewer, etype, button=1, xdata=0, ydata=0, key=None):
 
 
 @cleanup
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_line_tool():
     img = data.camera()
     viewer = ImageViewer(img)
@@ -106,7 +107,7 @@ def test_line_tool():
 
 
 @cleanup
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_thick_line_tool():
     img = data.camera()
     viewer = ImageViewer(img)
@@ -130,7 +131,7 @@ def test_thick_line_tool():
 
 
 @cleanup
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_rect_tool():
     img = data.camera()
     viewer = ImageViewer(img)
@@ -159,8 +160,8 @@ def test_rect_tool():
 
 
 @cleanup
-@testing.skipif(not has_qt, reason="Qt not installed")
-@parametrize('img', [data.moon(), data.astronaut()])
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.parametrize('img', [data.moon(), data.astronaut()])
 def test_paint_tool(img):
     viewer = ImageViewer(img)
 
@@ -194,7 +195,7 @@ def test_paint_tool(img):
 
 
 @cleanup
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_base_tool():
     img = data.moon()
     viewer = ImageViewer(img)

--- a/skimage/viewer/tests/test_utils.py
+++ b/skimage/viewer/tests/test_utils.py
@@ -1,10 +1,13 @@
+import pytest
+
+pytest.importorskip("matplotlib")
+
 from skimage.viewer import utils
 from skimage.viewer.utils import dialogs
 from skimage.viewer.qt import QtCore, QtWidgets, has_qt
-from skimage._shared import testing
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_event_loop():
     utils.init_qtapp()
     timer = QtCore.QTimer()
@@ -12,7 +15,7 @@ def test_event_loop():
     utils.start_qtapp()
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_format_filename():
     fname = dialogs._format_filename(('apple', 2))
     assert fname == 'apple'
@@ -20,7 +23,7 @@ def test_format_filename():
     assert fname is None
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_open_file_dialog():
     QApp = utils.init_qtapp()
     timer = QtCore.QTimer()
@@ -29,7 +32,7 @@ def test_open_file_dialog():
     assert filename is None
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_save_file_dialog():
     QApp = utils.init_qtapp()
     timer = QtCore.QTimer()

--- a/skimage/viewer/tests/test_viewer.py
+++ b/skimage/viewer/tests/test_viewer.py
@@ -1,17 +1,19 @@
+from numpy.testing import assert_equal
+import pytest
+
+pytest.importorskip("matplotlib")
+
+from skimage._shared.version_requirements import is_installed
 from skimage import data
-from skimage.transform import pyramid_gaussian
 from skimage.filters import sobel
+from skimage.transform import pyramid_gaussian
 
 from skimage.viewer.qt import QtGui, QtCore, has_qt
 from skimage.viewer import ImageViewer, CollectionViewer
 from skimage.viewer.plugins import OverlayPlugin
 
-from skimage._shared.version_requirements import is_installed
-from skimage._shared import testing
-from skimage._shared.testing import assert_equal
 
-
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_viewer():
     astro = data.astronaut()
     coins = data.coins()
@@ -38,7 +40,7 @@ def make_key_event(key):
                            QtCore.Qt.NoModifier)
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_collection_viewer():
 
     img = data.astronaut()
@@ -54,8 +56,8 @@ def test_collection_viewer():
     view._format_coord(10, 10)
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
-@testing.skipif(not is_installed('matplotlib', '>=1.2'),
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not is_installed('matplotlib', '>=1.2'),
                 reason="matplotlib < 1.2")
 def test_viewer_with_overlay():
     img = data.coins()

--- a/skimage/viewer/tests/test_widgets.py
+++ b/skimage/viewer/tests/test_widgets.py
@@ -1,5 +1,10 @@
 import os
 
+from numpy.testing import assert_almost_equal, assert_equal
+import pytest
+
+pytest.importorskip("matplotlib")
+
 from skimage import data, img_as_float, io, img_as_ubyte
 
 from skimage.viewer import ImageViewer
@@ -7,9 +12,6 @@ from skimage.viewer.qt import QtWidgets, QtCore, has_qt
 from skimage.viewer.widgets import (
     Slider, OKCancelButtons, SaveButtons, ComboBox, CheckBox, Text)
 from skimage.viewer.plugins.base import Plugin
-
-from skimage._shared import testing
-from skimage._shared.testing import assert_almost_equal, assert_equal
 
 
 def get_image_viewer():
@@ -19,7 +21,7 @@ def get_image_viewer():
     return viewer
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_check_box():
     viewer = get_image_viewer()
     cb = CheckBox('hello', value=True, alignment='left')
@@ -34,7 +36,7 @@ def test_check_box():
     assert_equal(cb.val, False)
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_combo_box():
     viewer = get_image_viewer()
     cb = ComboBox('hello', ('a', 'b', 'c'))
@@ -47,7 +49,7 @@ def test_combo_box():
     assert_equal(cb.index, 2)
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_text_widget():
     viewer = get_image_viewer()
     txt = Text('hello', 'hello, world!')
@@ -58,7 +60,7 @@ def test_text_widget():
     assert_equal(str(txt.text), 'goodbye, world!')
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_slider_int():
     viewer = get_image_viewer()
     sld = Slider('radius', 2, 10, value_type='int')
@@ -72,7 +74,7 @@ def test_slider_int():
     assert_equal(sld.val, 5)
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_slider_float():
     viewer = get_image_viewer()
     sld = Slider('alpha', 2.1, 3.1, value=2.1, value_type='float',
@@ -87,7 +89,7 @@ def test_slider_float():
     assert_almost_equal(sld.val, 2.5, 2)
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_save_buttons():
     viewer = get_image_viewer()
     sv = SaveButtons()
@@ -118,7 +120,7 @@ def test_save_buttons():
     os.remove(filename)
 
 
-@testing.skipif(not has_qt, reason="Qt not installed")
+@pytest.mark.skipif(not has_qt, reason="Qt not installed")
 def test_ok_buttons():
     viewer = get_image_viewer()
     ok = OKCancelButtons()


### PR DESCRIPTION
## Description

This PR supersede @hmaarrfk PR #3129. It basically
- defines `skimage._shared.has_mpl` flag
- uses `skimage._shared.version_requirements.require` decorator on the function using `matplotlib`
- Disable `skimage.viewer` default imports if `matplotlib` is not installed
- skip tests requiring `matplotlib` when it is not installed.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
