### PR TITLE
Remove obsolete lazy import

### DIFF
--- a/skimage/util/_montage.py
+++ b/skimage/util/_montage.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from .._shared import utils
+from .. import exposure
 
 __all__ = ['montage']
 
@@ -93,11 +94,6 @@ def montage(arr_in, fill='mean', rescale_intensity=False, grid_shape=None,
     >>> arr_out_nonsquare.shape
     (2, 6)
     """
-
-    # exposure imports scipy.linalg which is quite expensive.
-    # Since skimage.util is in the critical import path, we lazy import
-    # exposure to improve import time
-    from .. import exposure
 
     if channel_axis is not None:
         arr_in = np.asarray(arr_in)


### PR DESCRIPTION
## Description

Small maintenance :slightly_smiling_face: 

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
