### PR TITLE
add property getters for all deprecated regionprops names

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -18,6 +18,8 @@ __all__ = ['regionprops', 'euler_number', 'perimeter', 'perimeter_crofton']
 
 # All values in this PROPS dict correspond to current scikit-image property
 # names. The keys in this PROPS dict correspond to older names used in prior
+
+
 # releases. For backwards compatibility, these older names will continue to
 # work, but will not be documented.
 PROPS = {
@@ -227,7 +229,256 @@ def only2d(method):
     return func2d
 
 
-class RegionProperties:
+class DeprecatedProperties:
+    """Mixin to support deprecated property names.
+
+    Each property here just calls the corresponding current property.
+    The docstrings will be copied over via `_install_properties_docs`,
+    including a warning about switching to the new name.
+    """
+
+    @property
+    def Area(self):
+        return self.area
+
+    @property
+    def BoundingBox(self):
+        return self.bbox
+
+    @property
+    def BoundingBoxArea(self):
+        return self.area_bbox
+
+    @property
+    def bbox_area(self):
+        return self.area_bbox
+
+    @property
+    def CentralMoments(self):
+        return self.moments_central
+
+    @property
+    def Centroid(self):
+        return self.centroid
+
+    @property
+    def ConvexArea(self):
+        return self.area_convex
+
+    @property
+    def convex_area(self):
+        return self.area_convex
+
+    @property
+    def ConvexImage(self):
+        return self.image_convex
+
+    @property
+    def convex_image(self):
+        return self.image_convex
+
+    @property
+    def Coordinates(self):
+        return self.coords
+
+    @property
+    def Eccentricity(self):
+        return self.eccentricity
+
+    @property
+    def EquivDiameter(self):
+        return self.equivalent_diameter_area
+
+    @property
+    def equivalent_diameter(self):
+        return self.equivalent_diameter_area
+
+    @property
+    def EulerNumber(self):
+        return self.euler_number
+
+    @property
+    def Extent(self):
+        return self.extent
+
+    @property
+    def FeretDiameter(self):
+        return self.feret_diameter_max
+
+    @property
+    def FeretDiameterMax(self):
+        return self.feret_diameter_max
+
+    @property
+    def FilledArea(self):
+        return self.area_filled
+
+    @property
+    def filled_area(self):
+        return self.area_filled
+
+    @property
+    def FilledImage(self):
+        return self.image_filled
+
+    @property
+    def filled_image(self):
+        return self.image_filled
+
+    @property
+    def HuMoments(self):
+        return self.moments_hu
+
+    @property
+    def Image(self):
+        return self.image
+
+    @property
+    def InertiaTensor(self):
+        return self.inertia_tensor
+
+    @property
+    def InertiaTensorEigvals(self):
+        return self.inertia_tensor_eigvals
+
+    @property
+    def IntensityImage(self):
+        return self.image_intensity
+
+    @property
+    def intensity_image(self):
+        return self.image_intensity
+
+    @property
+    def Label(self):
+        return self.label
+
+    @property
+    def LocalCentroid(self):
+        return self.centroid_local
+
+    @property
+    def local_centroid(self):
+        return self.centroid_local
+
+    @property
+    def MajorAxisLength(self):
+        return self.axis_major_length
+
+    @property
+    def major_axis_length(self):
+        return self.axis_major_length
+
+    @property
+    def MaxIntensity(self):
+        return self.intensity_max
+
+    @property
+    def max_intensity(self):
+        return self.intensity_max
+
+    @property
+    def MeanIntensity(self):
+        return self.intensity_mean
+
+    @property
+    def mean_intensity(self):
+        return self.intensity_mean
+
+    @property
+    def MinIntensity(self):
+        return self.intensity_min
+
+    @property
+    def min_intensity(self):
+        return self.intensity_min
+
+    @property
+    def MinorAxisLength(self):
+        return self.axis_minor_length
+
+    @property
+    def minor_axis_length(self):
+        return self.axis_minor_length
+
+    @property
+    def Moments(self):
+        return self.moments
+
+    @property
+    def NormalizedMoments(self):
+        return self.moments_normalized
+
+    @property
+    def Orientation(self):
+        return self.orientation
+
+    @property
+    def Perimeter(self):
+        return self.perimeter
+
+    @property
+    def CroftonPerimeter(self):
+        return self.perimeter_crofton
+
+    @property
+    def Slice(self):
+        return self.slice
+
+    @property
+    def Solidity(self):
+        return self.solidity
+
+    @property
+    def WeightedCentralMoments(self):
+        return self.moments_weighted_central
+
+    @property
+    def weighted_moments_central(self):
+        return self.moments_weighted_central
+
+    @property
+    def WeightedCentroid(self):
+        return self.centroid_weighted
+
+    @property
+    def weighted_centroid(self):
+        return self.centroid_weighted
+
+    @property
+    def WeightedHuMoments(self):
+        return self.moments_weighted_hu
+
+    @property
+    def weighted_moments_hu(self):
+        return self.moments_weighted_hu
+
+    @property
+    def WeightedLocalCentroid(self):
+        return self.centroid_weighted_local
+
+    @property
+    def weighted_local_centroid(self):
+        return self.centroid_weighted_local
+
+    @property
+    def WeightedMoments(self):
+        return self.moments_weighted
+
+    @property
+    def weighted_moments(self):
+        return self.moments_weighted
+
+    @property
+    def WeightedNormalizedMoments(self):
+        return self.moments_weighted_normalized
+
+    @property
+    def weighted_moments_normalized(self):
+        return self.moments_weighted_normalized
+
+
+class RegionProperties(DeprecatedProperties):
     """Please refer to `skimage.measure.regionprops` for more information
     on the available region properties.
     """
@@ -603,11 +854,7 @@ class RegionProperties:
         return iter(sorted(props))
 
     def __getitem__(self, key):
-        value = getattr(self, key, None)
-        if value is not None:
-            return value
-        else:  # backwards compatibility
-            return getattr(self, PROPS[key])
+        return getattr(self, key)
 
     def __eq__(self, other):
         if not isinstance(other, RegionProperties):
@@ -1233,6 +1480,10 @@ def _parse_docs():
     matches = re.finditer(r'\*\*(\w+)\*\* \:.*?\n(.*?)(?=\n    [\*\S]+)',
                           doc, flags=re.DOTALL)
     prop_doc = {m.group(1): textwrap.dedent(m.group(2)) for m in matches}
+
+    for k, v in PROPS.items():
+        prop_doc[k] = prop_doc[v] + (
+            f"\nThis property is deprecated, use {v} instead.")
 
     return prop_doc
 

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -238,240 +238,76 @@ class DeprecatedProperties:
     """
 
     @property
-    def Area(self):
-        return self.area
-
-    @property
-    def BoundingBox(self):
-        return self.bbox
-
-    @property
-    def BoundingBoxArea(self):
-        return self.area_bbox
-
-    @property
     def bbox_area(self):
         return self.area_bbox
-
-    @property
-    def CentralMoments(self):
-        return self.moments_central
-
-    @property
-    def Centroid(self):
-        return self.centroid
-
-    @property
-    def ConvexArea(self):
-        return self.area_convex
 
     @property
     def convex_area(self):
         return self.area_convex
 
     @property
-    def ConvexImage(self):
-        return self.image_convex
-
-    @property
     def convex_image(self):
         return self.image_convex
-
-    @property
-    def Coordinates(self):
-        return self.coords
-
-    @property
-    def Eccentricity(self):
-        return self.eccentricity
-
-    @property
-    def EquivDiameter(self):
-        return self.equivalent_diameter_area
 
     @property
     def equivalent_diameter(self):
         return self.equivalent_diameter_area
 
     @property
-    def EulerNumber(self):
-        return self.euler_number
-
-    @property
-    def Extent(self):
-        return self.extent
-
-    @property
-    def FeretDiameter(self):
-        return self.feret_diameter_max
-
-    @property
-    def FeretDiameterMax(self):
-        return self.feret_diameter_max
-
-    @property
-    def FilledArea(self):
-        return self.area_filled
-
-    @property
     def filled_area(self):
         return self.area_filled
-
-    @property
-    def FilledImage(self):
-        return self.image_filled
 
     @property
     def filled_image(self):
         return self.image_filled
 
     @property
-    def HuMoments(self):
-        return self.moments_hu
-
-    @property
-    def Image(self):
-        return self.image
-
-    @property
-    def InertiaTensor(self):
-        return self.inertia_tensor
-
-    @property
-    def InertiaTensorEigvals(self):
-        return self.inertia_tensor_eigvals
-
-    @property
-    def IntensityImage(self):
-        return self.image_intensity
-
-    @property
     def intensity_image(self):
         return self.image_intensity
-
-    @property
-    def Label(self):
-        return self.label
-
-    @property
-    def LocalCentroid(self):
-        return self.centroid_local
 
     @property
     def local_centroid(self):
         return self.centroid_local
 
     @property
-    def MajorAxisLength(self):
-        return self.axis_major_length
-
-    @property
     def major_axis_length(self):
         return self.axis_major_length
-
-    @property
-    def MaxIntensity(self):
-        return self.intensity_max
 
     @property
     def max_intensity(self):
         return self.intensity_max
 
     @property
-    def MeanIntensity(self):
-        return self.intensity_mean
-
-    @property
     def mean_intensity(self):
         return self.intensity_mean
-
-    @property
-    def MinIntensity(self):
-        return self.intensity_min
 
     @property
     def min_intensity(self):
         return self.intensity_min
 
     @property
-    def MinorAxisLength(self):
-        return self.axis_minor_length
-
-    @property
     def minor_axis_length(self):
         return self.axis_minor_length
-
-    @property
-    def Moments(self):
-        return self.moments
-
-    @property
-    def NormalizedMoments(self):
-        return self.moments_normalized
-
-    @property
-    def Orientation(self):
-        return self.orientation
-
-    @property
-    def Perimeter(self):
-        return self.perimeter
-
-    @property
-    def CroftonPerimeter(self):
-        return self.perimeter_crofton
-
-    @property
-    def Slice(self):
-        return self.slice
-
-    @property
-    def Solidity(self):
-        return self.solidity
-
-    @property
-    def WeightedCentralMoments(self):
-        return self.moments_weighted_central
 
     @property
     def weighted_moments_central(self):
         return self.moments_weighted_central
 
     @property
-    def WeightedCentroid(self):
-        return self.centroid_weighted
-
-    @property
     def weighted_centroid(self):
         return self.centroid_weighted
-
-    @property
-    def WeightedHuMoments(self):
-        return self.moments_weighted_hu
 
     @property
     def weighted_moments_hu(self):
         return self.moments_weighted_hu
 
     @property
-    def WeightedLocalCentroid(self):
-        return self.centroid_weighted_local
-
-    @property
     def weighted_local_centroid(self):
         return self.centroid_weighted_local
 
     @property
-    def WeightedMoments(self):
-        return self.moments_weighted
-
-    @property
     def weighted_moments(self):
         return self.moments_weighted
-
-    @property
-    def WeightedNormalizedMoments(self):
-        return self.moments_weighted_normalized
 
     @property
     def weighted_moments_normalized(self):
@@ -854,7 +690,11 @@ class RegionProperties(DeprecatedProperties):
         return iter(sorted(props))
 
     def __getitem__(self, key):
-        return getattr(self, key)
+        value = getattr(self, key, None)
+        if value is not None:
+            return value
+        else:  # backwards compatibility
+            return getattr(self, PROPS[key])
 
     def __eq__(self, other):
         if not isinstance(other, RegionProperties):

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -346,7 +346,7 @@ class RegionProperties:
                     f'be 1 or 2, but {attr} takes {n_args} arguments.'
                 )
         elif attr in PROPS and attr.lower() == attr:
-            # retrieve deprecated property (excluding ancient CamelCase ones)
+            # retrieve deprecated property (excluding old CamelCase ones)
             return getattr(self, PROPS[attr])
         else:
             raise AttributeError(

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -19,8 +19,6 @@ __all__ = ['regionprops', 'euler_number', 'perimeter', 'perimeter_crofton']
 
 # All values in this PROPS dict correspond to current scikit-image property
 # names. The keys in this PROPS dict correspond to older names used in prior
-
-
 # releases. For backwards compatibility, these older names will continue to
 # work, but will not be documented.
 PROPS = {
@@ -273,7 +271,7 @@ def _inertia_eigvals_to_axes_lengths_3D(inertia_tensor_eigvals):
     return axis_lengths
 
 
-class RegionProperties():
+class RegionProperties:
     """Please refer to `skimage.measure.regionprops` for more information
     on the available region properties.
     """
@@ -322,7 +320,6 @@ class RegionProperties():
             }
 
     def __getattr__(self, attr):
-
         if attr in self._extra_properties:
             func = self._extra_properties[attr]
             n_args = _infer_number_of_required_args(func)

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -306,11 +306,6 @@ class RegionProperties():
         self._multichannel = multichannel
         self._spatial_axes = tuple(range(self._ndim))
 
-        # list of deprecated properties that are still supported by
-        # __getattr__ for now
-        #self._deprecated_properties = [key for key in PROPS.keys()
-        #                               if key.lower() == key]
-
         self._extra_properties = {}
         if extra_properties is not None:
             for func in extra_properties:

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -1322,6 +1322,9 @@ def _parse_docs():
     prop_doc = {m.group(1): textwrap.dedent(m.group(2)) for m in matches}
 
     for k, v in PROPS.items():
+        if k.lower() != k:
+            # skip adding docs for really old CamelCase property names
+            continue
         prop_doc[k] = prop_doc[v] + (
             f"\nThis property is deprecated, use {v} instead.")
 

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -1326,7 +1326,7 @@ def _parse_docs():
             # skip adding docs for really old CamelCase property names
             continue
         prop_doc[k] = prop_doc[v] + (
-            f"\nThis property is deprecated, use {v} instead.")
+            f"\nThis property name is deprecated, use {v} instead.")
 
     return prop_doc
 

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -45,7 +45,13 @@ def test_all_props():
     region = regionprops(SAMPLE, INTENSITY_SAMPLE)[0]
     for prop in PROPS:
         try:
+            # access legacy name via dict
             assert_almost_equal(region[prop], getattr(region, PROPS[prop]))
+
+            # access legacy name via attribute
+            assert_almost_equal(getattr(region, prop),
+                                getattr(region, PROPS[prop]))
+
         except TypeError:  # the `slice` property causes this
             pass
 
@@ -55,6 +61,10 @@ def test_all_props_3d():
     for prop in PROPS:
         try:
             assert_almost_equal(region[prop], getattr(region, PROPS[prop]))
+
+            assert_almost_equal(getattr(region, prop),
+                                getattr(region, PROPS[prop]))
+
         except (NotImplementedError, TypeError):
             pass
 
@@ -621,9 +631,10 @@ def test_regionprops_table_no_regions():
 
 
 def test_props_dict_complete():
+    # Both current and legacy names should be available as properties
     region = regionprops(SAMPLE)[0]
     properties = [s for s in dir(region) if not s.startswith('_')]
-    assert set(properties) == set(PROPS.values())
+    assert set(properties) == set(PROPS.values()) | set(PROPS.keys())
 
 
 def test_column_dtypes_complete():

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -48,9 +48,12 @@ def test_all_props():
             # access legacy name via dict
             assert_almost_equal(region[prop], getattr(region, PROPS[prop]))
 
-            # access legacy name via attribute
-            assert_almost_equal(getattr(region, prop),
-                                getattr(region, PROPS[prop]))
+            # skip property access tests for old CamelCase names
+            # (we intentionally do not provide properties for these)
+            if prop.lower() == prop:
+                # access legacy name via attribute
+                assert_almost_equal(getattr(region, prop),
+                                    getattr(region, PROPS[prop]))
 
         except TypeError:  # the `slice` property causes this
             pass
@@ -62,8 +65,11 @@ def test_all_props_3d():
         try:
             assert_almost_equal(region[prop], getattr(region, PROPS[prop]))
 
-            assert_almost_equal(getattr(region, prop),
-                                getattr(region, PROPS[prop]))
+            # skip property access tests for old CamelCase names
+            # (we intentionally do not provide properties for these)
+            if prop.lower() == prop:
+                assert_almost_equal(getattr(region, prop),
+                                    getattr(region, PROPS[prop]))
 
         except (NotImplementedError, TypeError):
             pass
@@ -628,13 +634,6 @@ def test_regionprops_table_no_regions():
     assert len(out['bbox+1']) == 0
     assert len(out['bbox+2']) == 0
     assert len(out['bbox+3']) == 0
-
-
-def test_props_dict_complete():
-    # Both current and legacy names should be available as properties
-    region = regionprops(SAMPLE)[0]
-    properties = [s for s in dir(region) if not s.startswith('_')]
-    assert set(properties) == set(PROPS.values()) | set(PROPS.keys())
 
 
 def test_column_dtypes_complete():


### PR DESCRIPTION

## Description

This is a backwards compatibility PR addressing the following issue raised on image.sc: https://forum.image.sc/t/scikit-image-regionprops-minor-axis-length-versus-axis-minor-length/59223/4. Prior to this PR, the old names were accessable via `region['old_name']`, but not via an attribute like `region.old_name`. After this PR, both forms of access will work.

I think we can drop all these old names for skimage2, but it is probably best to keep them working for now. To discourage use, these outdated names were not added to the `regionprops` function docstring and the autogenerated property docstrings have a line stating the property was deprecated.

I created a mixin class with the deprecated property methods by pasting the text output of the following script into _regionprops.py.

```Python
from skimage.measure._regionprops import PROPS

deprecated_props_class = "class DeprecatedProperties:\n"
for k, v in PROPS.items():

    deprecated_props_class += f"""
    @property
    def {k}(self):
        return self.{v}
    """
print(deprecated_props_class)
```

I thought about also adding a `UserWarning` to each outdated property, but was not sure it wouldn't be more annoying than useful.



## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
