### PR TITLE
Do not use space before colon in directive name.

### DIFF
--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -225,7 +225,7 @@ def iradon(radon_image, theta=None, output_size=None,
         with indices
         ``(reconstructed.shape[0] // 2, reconstructed.shape[1] // 2)``.
 
-    .. versionchanged :: 0.19
+    .. versionchanged:: 0.19
         In ``iradon``, ``filter`` argument is deprecated in favor of
         ``filter_name``.
 

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -205,7 +205,7 @@ def _convert(image, dtype, force_copy=False, uniform=False):
         rounded to the nearest integers, which minimizes back and forth
         conversion errors.
 
-    .. versionchanged :: 0.15
+    .. versionchanged:: 0.15
         ``_convert`` no longer warns about possible precision or sign
         information loss. See discussions on these warnings at:
         https://github.com/scikit-image/scikit-image/issues/2602


### PR DESCRIPTION
While this is understood by sphinx/docutils for legacy reasons, it may
not be supported by other rst parsers and syntax highlighter.

For consistency this is better as well as these are the only 2
directives with spaces for 215 that do not.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
