### PR TITLE
Prefer importing build_py and sdist from setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,8 @@ import builtins
 import textwrap
 
 import setuptools
-try:
-    from setuptools.command.build_py import build_py
-    from setuptools.command.sdist import sdist
-except ImportError:
-    from distutils.command.build_py import build_py
-    from distutils.command.sdist import sdist
+from setuptools.command.build_py import build_py
+from setuptools.command.sdist import sdist
 from distutils.errors import CompileError, LinkError
 from numpy.distutils.command.build_ext import build_ext
 

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,12 @@ import builtins
 import textwrap
 
 import setuptools
-from distutils.command.build_py import build_py
-from distutils.command.sdist import sdist
+try:
+    from setuptools.command.build_py import build_py
+    from setuptools.command.sdist import sdist
+except ImportError:
+    from distutils.command.build_py import build_py
+    from distutils.command.sdist import sdist
 from distutils.errors import CompileError, LinkError
 from numpy.distutils.command.build_ext import build_ext
 


### PR DESCRIPTION
## Description

closes #6006 

This PR updates some imports to use setuptools own versions rather than the ones from distutils. This is needed for compatibility with recent setuptools (>58.5.0) which made this breaking change: https://github.com/pypa/setuptools/commit/2e66eb7147ae1e8a799b2276c7340f48f63a7220

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
