### PR TITLE
Re-enable uploads to codecov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
         OPTIONAL_DEPS: [0]
         OPTIONS_NAME: ["default"]
         INSTALL_FROM_SDIST: [0]
+        CODECOV_UPLOAD: [0]
         include:
           - platform_id: manylinux_x86_64
             python-version: 3.7
@@ -55,6 +56,7 @@ jobs:
             BUILD_DOCS: 1
             OPTIONAL_DEPS: 1
             OPTIONS_NAME: "optional-deps"
+            CODECOV_UPLOAD: 1
           - platform_id: manylinux_x86_64
             python-version: 3.7
             PYTHONOPTIMIZE: 2
@@ -123,6 +125,16 @@ jobs:
       - name: Check benchmarks
         run: |
           asv check -v -E existing
+
+      - name: Upload coverage to Codecov
+        if: matrix.CODECOV_UPLOAD == "1"
+        uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          env_vars: OS,PYTHON
+          fail_ci_if_error: false
+          files: ./coverage.xml
+          verbose: true
 
 
   test_skimage_macos:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,10 +122,6 @@ jobs:
             fi
             source tools/github/script.sh
 
-      - name: Check benchmarks
-        run: |
-          asv check -v -E existing
-
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
@@ -134,6 +130,11 @@ jobs:
           fail_ci_if_error: false
           files: ./coverage.xml
           verbose: true
+
+      - name: Check benchmarks
+        run: |
+          asv check -v -E existing
+
 
 
   test_skimage_macos:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,6 +121,8 @@ jobs:
                 fi
             fi
             source tools/github/script.sh
+            echo "cwd=`pwd`"
+            ls
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -128,7 +130,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS,PYTHON
           fail_ci_if_error: false
-          files: ../coverage.xml
+          files: /home/runner/work/scikit-image/coverage.xml
           verbose: true
 
       - name: Check benchmarks

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,7 +128,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS,PYTHON
           fail_ci_if_error: false
-          files: ./coverage.xml
+          files: ../coverage.xml
           verbose: true
 
       - name: Check benchmarks

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,7 +127,6 @@ jobs:
           asv check -v -E existing
 
       - name: Upload coverage to Codecov
-        if: matrix.CODECOV_UPLOAD == "1"
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/tools/github/script.sh
+++ b/tools/github/script.sh
@@ -9,7 +9,7 @@ touch $MPL_DIR/matplotlibrc
 python -m pip list
 tools/build_versions.py
 
-TEST_ARGS="--doctest-modules --cov=skimage"
+TEST_ARGS="--doctest-modules --cov=skimage --cov-report=term --cov-report=xml"
 
 # When installing from sdist
 # We can't run it in the git directory since there is a folder called `skimage`


### PR DESCRIPTION
## Description

This PR is to experiment with re-enabling codecov. We haven't been uploading these reports over the past year.

related to #5152 and #5331


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
