### PR TITLE
removed lines generating Requires metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,11 +143,6 @@ extras_require = {
     for dep in ['docs', 'optional', 'test', 'data']
 }
 
-# requirements for those browsing PyPI
-REQUIRES = [r.replace('>=', ' (>= ') + ')' for r in INSTALL_REQUIRES]
-REQUIRES = [r.replace('==', ' (== ') for r in REQUIRES]
-REQUIRES = [r.replace('[array]', '') for r in REQUIRES]
-
 
 def configuration(parent_package='', top_path=None):
     if os.path.exists('MANIFEST'):
@@ -241,7 +236,6 @@ if __name__ == "__main__":
             'Operating System :: MacOS',
         ],
         install_requires=INSTALL_REQUIRES,
-        requires=REQUIRES,
         extras_require=extras_require,
         python_requires='>=3.7',
         packages=setuptools.find_packages(exclude=['doc', 'benchmarks']),


### PR DESCRIPTION
## Description

When you remove the requires and leave only install_requires only Requires-Dist is generated.
More info: https://github.com/scikit-image/scikit-image/issues/6001

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
