### PR TITLE
reduce memory required by test_masked_registration_3d_contiguous_mask

### DIFF
--- a/skimage/registration/tests/test_masked_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_masked_phase_cross_correlation.py
@@ -62,13 +62,13 @@ def test_masked_registration_random_masks():
 def test_masked_registration_3d_contiguous_mask():
     """masked_register_translation should be able to register translations
     between volumes with contiguous masks."""
-    ref_vol = brain()
+    ref_vol = brain()[:, ::2, ::2]
 
-    offset = (2, -9, 20)
+    offset = (1, -5, 10)
 
     # create square mask
     ref_mask = np.zeros_like(ref_vol, dtype=bool)
-    ref_mask[:-2, 150:200, 150:200] = True
+    ref_mask[:-2, 75:100, 75:100] = True
     ref_shifted = real_shift(ref_vol, offset)
 
     measured_offset = masked_register_translation(


### PR DESCRIPTION
## Description

Recently, I saw this test failure that looks like an out of memory error occurred:
https://dev.azure.com/scikit-image/scikit-image/_build/results?buildId=7008&view=logs&jobId=c266ee3e-f298-5c55-b78e-d135f25941c2&j=c266ee3e-f298-5c55-b78e-d135f25941c2&t=76d8336e-2ec7-54e7-5531-ad7a9096482b

I think it came up once previously as well. In this PR, I just reduce the data size by a factor of 4 in that test case to reduce the memory required.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
