### PR TITLE
Pin sphinx to <4.3

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,4 @@
-sphinx>=1.8
+sphinx>=1.8,<4.3
 sphinx-gallery>=0.7.0,!=0.8.0
 numpydoc>=1.0
 sphinx-copybutton

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,7 +1,7 @@
 # On Nov 11, 2021, Sphinx 4.3.0 broke the documentation
 # generation. Remove the < pin when we get a better understanding
 # of why
-# https://github.com/scikit-image/scikit-image/pull/6029
+# https://github.com/scikit-image/scikit-image/issues/6030
 sphinx>=1.8,<4.3
 sphinx-gallery>=0.7.0,!=0.8.0
 numpydoc>=1.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,3 +1,7 @@
+# On Nov 11, 2021, Sphinx 4.3.0 broke the documentation
+# generation. Remove the < pin when we get a better understanding
+# of why
+# https://github.com/scikit-image/scikit-image/pull/6029
 sphinx>=1.8,<4.3
 sphinx-gallery>=0.7.0,!=0.8.0
 numpydoc>=1.0


### PR DESCRIPTION
## Description

A new version of sphinx was [released today](https://pypi.org/project/Sphinx/4.3.0/#history), breaking our doc builds, example:

https://github.com/scikit-image/scikit-image/runs/4168761105?check_suite_focus=true#step:5:2721

Error reads:

> Extension error (sphinx_gallery.docs_resolv):
> Handler <function embed_code_links at 0x7f4faec58af0> for event 'build-finished' threw an exception (exception: list indices must be integers or slices, not str)

I propose we pin sphinx until we can get to the bottom of this, since @grlee77 and I are working on the 0.19 release and we don't want this issue to hold it up.
