### PR TITLE
Relax a couple of equality tests causing i686 test failures on cibuildwheel

### DIFF
--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -271,7 +271,7 @@ def test_denoise_bilateral_negative2():
 
     # 2 images with a given offset should give the same result (with the same
     # offset)
-    assert_array_equal(out1, out2 + 10)
+    assert_array_almost_equal(out1, out2 + 10)
 
 
 def test_denoise_bilateral_2d():

--- a/skimage/segmentation/tests/test_slic.py
+++ b/skimage/segmentation/tests/test_slic.py
@@ -102,6 +102,12 @@ def test_gray_2d_deprecated_multichannel():
                    start_label=0)
 
 
+def _check_segment_labels(seg1, seg2, allowed_mismatch_ratio=0.1):
+    size = seg1.size
+    ndiff = np.sum(seg1 != seg2)
+    assert (ndiff / size) < allowed_mismatch_ratio
+
+
 def test_slic_consistency_across_image_magnitude():
     # verify that that images of various scales across integer and float dtypes
     # give the same segmentation result
@@ -117,7 +123,9 @@ def test_slic_consistency_across_image_magnitude():
 
     np.testing.assert_array_equal(seg1, seg2)
     np.testing.assert_array_equal(seg1, seg3)
-    np.testing.assert_array_equal(seg1, seg4)
+    # allow some mismatch, to account for floating point error
+    # observed mismatch ratio was 0 on x86_64, but ~0.0775 during i686 testing
+    _check_segment_labels(seg1, seg4, allowed_mismatch_ratio=0.1)
 
 
 def test_color_3d():


### PR DESCRIPTION
## Description

This relaxes two tests for exact equality based on the two failures detailed at https://github.com/scikit-image/scikit-image/pull/6021#issuecomment-966520437. 

This SLIC superpixel scaling test that is modified here was introduced fairly recently in #5518. I am not sure it was reasonable to expect exactly identical SLIC segmentation for different floating point scaling due to possible differences in numerical error internally. This relaxes to just check that >90% of the pixels have an identical label. Does this seem okay or are there better ideas?


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
