### PR TITLE
Avoid matplotlib import overhead during 'import skimage'

### DIFF
--- a/skimage/_shared/__init__.py
+++ b/skimage/_shared/__init__.py
@@ -1,3 +1,0 @@
-from .version_requirements import is_installed
-
-has_mpl = is_installed("matplotlib", ">=3.0.3")

--- a/skimage/_shared/_dependency_checks.py
+++ b/skimage/_shared/_dependency_checks.py
@@ -1,0 +1,3 @@
+from .version_requirements import is_installed
+
+has_mpl = is_installed("matplotlib", ">=3.0.3")

--- a/skimage/draw/tests/test_draw.py
+++ b/skimage/draw/tests/test_draw.py
@@ -3,7 +3,7 @@ from numpy.testing import assert_array_equal, assert_equal, assert_almost_equal
 import pytest
 
 from skimage._shared.testing import test_parallel
-from skimage._shared import has_mpl
+from skimage._shared._dependency_checks import has_mpl
 
 from skimage.draw import (set_color, line, line_aa, polygon, polygon_perimeter,
                           disk, circle_perimeter, circle_perimeter_aa,

--- a/skimage/feature/tests/test_util.py
+++ b/skimage/feature/tests/test_util.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from skimage._shared import has_mpl
+from skimage._shared._dependency_checks import has_mpl
 from skimage.feature.util import (FeatureDetector, DescriptorExtractor,
                                   _prepare_grayscale_input_2D,
                                   _mask_border_keypoints, plot_matches)

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -5,7 +5,7 @@ from numpy.testing import (assert_allclose, assert_almost_equal,
 from scipy import ndimage as ndi
 
 from skimage import data, util
-from skimage._shared import has_mpl
+from skimage._shared._dependency_checks import has_mpl
 from skimage._shared._warnings import expected_warnings
 from skimage._shared.utils import _supported_float_type
 from skimage.color import rgb2gray

--- a/skimage/io/tests/test_plugin.py
+++ b/skimage/io/tests/test_plugin.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 import numpy as np
 import pytest
 
-from skimage._shared import has_mpl
+from skimage._shared._dependency_checks import has_mpl
 from skimage import io
 from skimage.io import manage_plugins
 

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -3,7 +3,7 @@ import itertools
 import numpy as np
 import pytest
 
-from skimage._shared import has_mpl
+from skimage._shared._dependency_checks import has_mpl
 from skimage._shared._warnings import expected_warnings
 from skimage._shared.testing import test_parallel
 from skimage._shared.utils import _supported_float_type, convert_to_float

--- a/skimage/viewer/__init__.py
+++ b/skimage/viewer/__init__.py
@@ -1,5 +1,5 @@
 from .._shared.utils import warn
-from .._shared import has_mpl
+from .._shared._dependency_checks import has_mpl
 from .qt import has_qt
 
 if not has_qt:


### PR DESCRIPTION


## Description

This PR removes the overhead of importing `matplotlib` when doing `import skimage` (see figure in https://github.com/scikit-image/scikit-image/pull/5995#issuecomment-967493435). I think the issue was unintentionally introduced by #5990. The solution used here is to move `has_mpl` out of `skimage/_shared/__init__.py` so it does not get imported before it is needed.

The following shows that with this PR there is no matplotlib import anymore:
![tuna_no_mpl_import](https://user-images.githubusercontent.com/6528957/141533250-84f44ac5-c96f-4049-a452-b77d2741679a.png)


<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
