### PR TITLE
Make cross_correlate_masked public

### DIFF
--- a/skimage/registration/__init__.py
+++ b/skimage/registration/__init__.py
@@ -1,7 +1,9 @@
+from ._masked_phase_cross_correlation import cross_correlate_masked
 from ._optical_flow import optical_flow_tvl1, optical_flow_ilk
 from ._phase_cross_correlation import phase_cross_correlation
 
 __all__ = [
+    'cross_correlate_masked',
     'optical_flow_ilk',
     'optical_flow_tvl1',
     'phase_cross_correlation'

--- a/skimage/registration/_masked_phase_cross_correlation.py
+++ b/skimage/registration/_masked_phase_cross_correlation.py
@@ -96,8 +96,8 @@ def _masked_phase_cross_correlation(reference_image, moving_image,
     return -shifts + (size_mismatch / 2)
 
 
-def cross_correlate_masked(arr1, arr2, m1, m2, mode='full', axes=(-2, -1),
-                           overlap_ratio=0.3):
+def cross_correlate_masked(arr1, arr2, mask1, mask2, mode='full',
+                           axes=(-2, -1), overlap_ratio=0.3):
     """
     Masked normalized cross-correlation between arrays.
 
@@ -108,12 +108,12 @@ def cross_correlate_masked(arr1, arr2, m1, m2, mode='full', axes=(-2, -1),
     arr2 : ndarray
         Seconds array. The dimensions of `arr2` along axes that are not
         transformed should be equal to that of `arr1`.
-    m1 : ndarray
+    mask1 : ndarray
         Mask of `arr1`. The mask should evaluate to `True`
-        (or 1) on valid pixels. `m1` should have the same shape as `arr1`.
-    m2 : ndarray
+        (or 1) on valid pixels. `mask1` should have the same shape as `arr1`.
+    mask2 : ndarray
         Mask of `arr2`. The mask should evaluate to `True`
-        (or 1) on valid pixels. `m2` should have the same shape as `arr2`.
+        (or 1) on valid pixels. `mask2` should have the same shape as `arr2`.
     mode : {'full', 'same'}, optional
         'full':
             This returns the convolution at each point of overlap. At
@@ -163,9 +163,9 @@ def cross_correlate_masked(arr1, arr2, m1, m2, mode='full', axes=(-2, -1),
         raise ValueError("complex-valued arr1, arr2 are not supported")
 
     fixed_image = fixed_image.astype(float_dtype)
-    fixed_mask = np.array(m1, dtype=bool)
+    fixed_mask = np.array(mask1, dtype=bool)
     moving_image = moving_image.astype(float_dtype)
-    moving_mask = np.array(m2, dtype=bool)
+    moving_mask = np.array(mask2, dtype=bool)
     eps = np.finfo(float_dtype).eps
 
     # Array dimensions along non-transformation axes should be equal.


### PR DESCRIPTION
## Description

Our existing `cross_correlate_masked` function is used for masked rigid registration, but is not currently exported as part of the public API. It would be useful to downstream projects to have this part of the official API (see prior discussion with @CSSFrancis: https://github.com/scikit-image/scikit-image/pull/5573#issuecomment-926773217). It already has pretty good docstrings and independent test cases, so I don't see it being a maintenance burden to do so.

I did propose renaming `m1`->`mask1` and `m2`->`mask2` here to make the names a bit more descriptive. Given that this wasn't officially public API previously, I did not introduce a deprecation cycle for this. Also, should we have this under `skimage.registration` where it is now or perhaps somewhere else like `skimage.util`? What do others think?


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
