### PR TITLE
Avoid circular import errors when EAGER_IMPORT=1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
             EAGER_IMPORT: 1
             # Test mininum requirements (don't build docs there is a problem
             # with dask and astropy)
-            OPTIONS_NAME: "mini-req"
+            OPTIONS_NAME: "mini-req-eager-import"
           - platform_id: manylinux_x86_64
             python-version: 3.7
             MINIMUM_REQUIREMENTS: 1

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from ..color.colorconv import rgb2gray, rgba2rgb
+from ..color import rgb2gray, rgba2rgb
 from ..util.dtype import dtype_range, dtype_limits
 from .._shared import utils
 

--- a/skimage/feature/sift.py
+++ b/skimage/feature/sift.py
@@ -5,7 +5,7 @@ import scipy.ndimage as ndi
 
 from .._shared.utils import check_nD, _supported_float_type
 from ..feature.util import DescriptorExtractor, FeatureDetector
-from ..filters import gaussian
+from .._shared.filters import gaussian
 from ..transform import rescale
 from ..util import img_as_float
 from ._sift import (_local_max, _ori_distances, _update_histogram)


### PR DESCRIPTION
## Description

closes #6040 (both the import of `gaussian` for SIFT and another recently observed CI failure on import of `rgb2gray`)

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
