### PR TITLE
remove all use of the deprecated distutils package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
     "wheel",
     "setuptools",
+    "packaging",
     "Cython>=0.29.24,<3.0",
     "pythran",
 

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,4 +1,5 @@
 Cython>=0.29.21,!=0.29.18
+packaging>=20.0
 pythran
 wheel
 # numpy 1.18.0 breaks builds on MacOSX

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -5,3 +5,4 @@ pillow>=6.1.0,!=7.1.0,!=7.1.1,!=8.3.0
 imageio>=2.4.1
 tifffile>=2019.7.26
 PyWavelets>=1.1.1
+packaging>=20.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,11 @@ from numpy.distutils.command.build_ext import build_ext as npy_build_ext
 import setuptools
 from setuptools.command.build_py import build_py
 from setuptools.command.sdist import sdist
-from distutils.errors import CompileError, LinkError
+try:
+    from setuptools.errors import CompileError, LinkError
+except ImportError:
+    # can remove this except case once we require setuptools>=59.0
+    from distutils.errors import CompileError, LinkError
 
 from pythran.dist import PythranBuildExt as pythran_build_ext
 

--- a/skimage/_build.py
+++ b/skimage/_build.py
@@ -1,6 +1,6 @@
 import sys
 import os
-from distutils.version import LooseVersion
+from packaging import version
 from multiprocessing import cpu_count
 
 CYTHON_VERSION = '0.23.4'
@@ -41,7 +41,7 @@ def cython(pyx_files, working_path=''):
 
     try:
         from Cython import __version__
-        if LooseVersion(__version__) < CYTHON_VERSION:
+        if version.parse(__version__) < version.parse(CYTHON_VERSION):
             raise RuntimeError('Cython >= %s needed to build scikit-image' % CYTHON_VERSION)
 
         from Cython.Build import cythonize

--- a/skimage/_shared/version_requirements.py
+++ b/skimage/_shared/version_requirements.py
@@ -1,5 +1,7 @@
 import sys
 
+from packaging import version as _version
+
 
 def ensure_python_version(min_version):
     if not isinstance(min_version, tuple):
@@ -43,19 +45,15 @@ def _check_version(actver, version, cmp_op):
 
     Distributed under the terms of the BSD License.
     """
-    # since version_requirements.py is in the critical import path, we
-    # lazy import it
-    from distutils.version import LooseVersion
-
     try:
         if cmp_op == '>':
-            return LooseVersion(actver) > LooseVersion(version)
+            return _version.parse(actver) > _version.parse(version)
         elif cmp_op == '>=':
-            return LooseVersion(actver) >= LooseVersion(version)
+            return _version.parse(actver) >= _version.parse(version)
         elif cmp_op == '=':
-            return LooseVersion(actver) == LooseVersion(version)
+            return _version.parse(actver) == _version.parse(version)
         elif cmp_op == '<':
-            return LooseVersion(actver) < LooseVersion(version)
+            return _version.parse(actver) < _version.parse(version)
         else:
             return False
     except TypeError:

--- a/skimage/data/_fetchers.py
+++ b/skimage/data/_fetchers.py
@@ -5,9 +5,9 @@ For more images, see
  - http://sipi.usc.edu/database/database.php
 
 """
-from distutils.version import LooseVersion
 import numpy as np
 import shutil
+from packaging import version
 
 from ..util.dtype import img_as_bool
 from ._binary_blobs import binary_blobs
@@ -82,7 +82,7 @@ def create_image_fetcher():
             retry = {'retry_if_failed': 3}
             # Keep version check in synch with
             # scikit-image/requirements/optional.txt
-            if LooseVersion(pooch_version) < LooseVersion('1.3.0'):
+            if version.parse(pooch_version) < version.parse('1.3.0'):
                 # we need a more recent version of pooch to retry
                 retry = {}
     except ImportError:

--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -1,13 +1,13 @@
 __all__ = ['imread', 'imsave']
 
-from distutils.version import LooseVersion
 import numpy as np
+from packaging import version
 from PIL import Image, __version__ as pil_version
 
 from ...util import img_as_ubyte, img_as_uint
 
 # Check CVE-2021-27921 and others
-if LooseVersion(pil_version) < LooseVersion('8.1.2'):
+if version.parse(pil_version) < version.parse('8.1.2'):
     from warnings import warn
     warn('Your installed pillow version is < 8.1.2. '
          'Several security issues (CVE-2021-27921, '

--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -6,13 +6,13 @@ from glob import glob
 import re
 from collections.abc import Sequence
 from copy import copy
+from packaging import version
 
 import numpy as np
 from PIL import Image, __version__ as pil_version
 
 # Check CVE-2021-27921 and others
-from distutils.version import LooseVersion
-if LooseVersion(pil_version) < LooseVersion('8.1.2'):
+if version.parse(pil_version) < version.parse('8.1.2'):
     from warnings import warn
     warn('Your installed pillow version is < 8.1.2. '
          'Several security issues (CVE-2021-27921, '

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -1,12 +1,12 @@
 import numpy as np
+import scipy
+from packaging import version
+
+from skimage._shared import testing
+from skimage._shared._warnings import expected_warnings
+from skimage._shared.testing import xfail, arch32
 from skimage.segmentation import random_walker
 from skimage.transform import resize
-from skimage._shared._warnings import expected_warnings
-from skimage._shared import testing
-from skimage._shared.testing import xfail, arch32
-import scipy
-from distutils.version import LooseVersion as Version
-
 
 # older versions of scipy raise a warning with new NumPy because they use
 # numpy.rank() instead of arr.ndim or numpy.linalg.matrix_rank.
@@ -14,7 +14,7 @@ SCIPY_RANK_WARNING = r'numpy.linalg.matrix_rank|\A\Z'
 PYAMG_MISSING_WARNING = r'pyamg|\A\Z'
 PYAMG_OR_SCIPY_WARNING = SCIPY_RANK_WARNING + '|' + PYAMG_MISSING_WARNING
 
-if Version(scipy.__version__) < '1.3':
+if version.parse(scipy.__version__) < version.parse('1.3'):
     NUMPY_MATRIX_WARNING = 'matrix subclass'
 else:
     NUMPY_MATRIX_WARNING = None


### PR DESCRIPTION
## Description

closes #6043

Now that distutils is deprecated and will be removed in Python 3.12, we should import these error classes from setuptools instead. They were added to the public API of setuptools in version 59.0 which was only released 12 days ago, so this PR allows falling back to distutils when users have an older setuptools installed.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
