### PR TITLE
Ignore EAGER_IMPORT environment variable in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,8 @@ For Python 2.7, please install the 0.14.x Long Term Support release using:
 # machinery.
 builtins.__SKIMAGE_SETUP__ = True
 
+# ignore EAGER_IMPORT environment variable during build
+os.environ.pop("EAGER_IMPORT", None)
 
 # Support for openmp
 


### PR DESCRIPTION
## Description

While working on #6042 I had set the EAGER_IMPORT environment variable. I later noticed that calling setup.py after "make clean" in an environment where this variable is defined will cause attempted imports of modules that have not yet been built, causing the install to fail. This PR avoids the issue by removing the environment variable when running setup.py.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
