### PR TITLE
Transplant the change of scikit-learn into scikit-image for RANSAC 

### DIFF
--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -612,13 +612,13 @@ def _dynamic_max_trials(n_inliers, n_samples, min_samples, probability):
     trials : int
         Number of trials.
     """
-    inlier_ratio = n_inliers / float(n_samples)
+    inlier_ratio = n_inliers / n_samples
     nom = max(_EPSILON, 1 - probability)
     denom = max(_EPSILON, 1 - inlier_ratio ** min_samples)
     if nom == 1:
         return 0
     if denom == 1:
-        return float("inf")
+        return np.inf
     return abs(float(np.ceil(np.log(nom) / np.log(denom))))
 
 
@@ -835,7 +835,7 @@ def ransac(data, model_class, min_samples, residual_threshold,
     model = model_class()
 
     num_trials = 0
-
+    # max_trials can be updated inside the loop, so this cannot be a for-loop
     while num_trials < max_trials:
         num_trials += 1
 

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -619,7 +619,7 @@ def _dynamic_max_trials(n_inliers, n_samples, min_samples, probability):
     inlier_ratio = n_inliers / n_samples
     nom = max(_EPSILON, 1 - probability)
     denom = max(_EPSILON, 1 - inlier_ratio ** min_samples)
-    return abs(float(np.ceil(np.log(nom) / np.log(denom))))
+    return np.ceil(np.log(nom) / np.log(denom))
 
 
 def ransac(data, model_class, min_samples, residual_threshold,

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -612,13 +612,13 @@ def _dynamic_max_trials(n_inliers, n_samples, min_samples, probability):
     trials : int
         Number of trials.
     """
+    if probability == 0:
+        return 0
+    if n_inliers == 0:
+        return np.inf
     inlier_ratio = n_inliers / n_samples
     nom = max(_EPSILON, 1 - probability)
     denom = max(_EPSILON, 1 - inlier_ratio ** min_samples)
-    if nom == 1:
-        return 0
-    if denom == 1:
-        return np.inf
     return abs(float(np.ceil(np.log(nom) / np.log(denom))))
 
 

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -370,9 +370,9 @@ def test_ransac_dynamic_max_trials():
     assert_equal(_dynamic_max_trials(50, 100, 8, 0.99), 1177)
     assert_equal(_dynamic_max_trials(50, 100, 8, 1), 9210)
 
-    # e = 0%, min_samples = 10
-    assert_equal(_dynamic_max_trials(1, 100, 10, 0), 0)
-    assert_equal(_dynamic_max_trials(1, 100, 10, 1), -np.inf)
+    # e = 0%, min_samples = 5
+    assert_equal(_dynamic_max_trials(1, 100, 5, 0), 0)
+    assert_equal(_dynamic_max_trials(1, 100, 5, 1), 360436504051)
 
 
 def test_ransac_invalid_input():

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -342,28 +342,37 @@ def test_ransac_dynamic_max_trials():
 
     # e = 0%, min_samples = X
     assert_equal(_dynamic_max_trials(100, 100, 2, 0.99), 1)
+    assert_equal(_dynamic_max_trials(100, 100, 2, 1), 1)
 
     # e = 5%, min_samples = 2
     assert_equal(_dynamic_max_trials(95, 100, 2, 0.99), 2)
+    assert_equal(_dynamic_max_trials(95, 100, 2, 1), 16)
     # e = 10%, min_samples = 2
     assert_equal(_dynamic_max_trials(90, 100, 2, 0.99), 3)
+    assert_equal(_dynamic_max_trials(90, 100, 2, 1), 22)
     # e = 30%, min_samples = 2
     assert_equal(_dynamic_max_trials(70, 100, 2, 0.99), 7)
+    assert_equal(_dynamic_max_trials(70, 100, 2, 1), 54)
     # e = 50%, min_samples = 2
     assert_equal(_dynamic_max_trials(50, 100, 2, 0.99), 17)
+    assert_equal(_dynamic_max_trials(50, 100, 2, 1),126)
 
     # e = 5%, min_samples = 8
     assert_equal(_dynamic_max_trials(95, 100, 8, 0.99), 5)
+    assert_equal(_dynamic_max_trials(95, 100, 8, 1), 34)
     # e = 10%, min_samples = 8
     assert_equal(_dynamic_max_trials(90, 100, 8, 0.99), 9)
+    assert_equal(_dynamic_max_trials(90, 100, 8, 1), 65)
     # e = 30%, min_samples = 8
     assert_equal(_dynamic_max_trials(70, 100, 8, 0.99), 78)
+    assert_equal(_dynamic_max_trials(70, 100, 8, 1), 608)
     # e = 50%, min_samples = 8
     assert_equal(_dynamic_max_trials(50, 100, 8, 0.99), 1177)
+    assert_equal(_dynamic_max_trials(50, 100, 8, 1), 9210)
 
     # e = 0%, min_samples = 10
     assert_equal(_dynamic_max_trials(1, 100, 10, 0), 0)
-    assert_equal(_dynamic_max_trials(1, 100, 10, 1), np.inf)
+    assert_equal(_dynamic_max_trials(1, 100, 10, 1), -np.inf)
 
 
 def test_ransac_invalid_input():

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -355,7 +355,7 @@ def test_ransac_dynamic_max_trials():
     assert_equal(_dynamic_max_trials(70, 100, 2, 1), 54)
     # e = 50%, min_samples = 2
     assert_equal(_dynamic_max_trials(50, 100, 2, 0.99), 17)
-    assert_equal(_dynamic_max_trials(50, 100, 2, 1),126)
+    assert_equal(_dynamic_max_trials(50, 100, 2, 1), 126)
 
     # e = 5%, min_samples = 8
     assert_equal(_dynamic_max_trials(95, 100, 8, 0.99), 5)

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -361,9 +361,9 @@ def test_ransac_dynamic_max_trials():
     # e = 50%, min_samples = 8
     assert_equal(_dynamic_max_trials(50, 100, 8, 0.99), 1177)
 
-    # e = 0%, min_samples = 5
-    assert_equal(_dynamic_max_trials(1, 100, 5, 0), 0)
-    assert_equal(_dynamic_max_trials(1, 100, 5, 1), np.inf)
+    # e = 0%, min_samples = 10
+    assert_equal(_dynamic_max_trials(1, 100, 10, 0), 0)
+    assert_equal(_dynamic_max_trials(1, 100, 10, 1), np.inf)
 
 
 def test_ransac_invalid_input():


### PR DESCRIPTION
## Description

Fixes #5952 

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->
I compared the code implementation of the RANSAC model of scikit-image & scikit-learn.

What's in common is that both models have hyperparameter “max_trials”, and use the _dynamic_max_trials function to commute dynamic max trials for RANSAC algorithm.

Originally, scikit-image's RANSAC compare whether _dynamic_max_trials are less than max_trials only when the number of inliers_count is greater than best_inlier_num. And most of the _dynamic_max_trials calculated each time have infinity. The result below is the output of the corresponding value whenever _dynamic_max_trials are calculated when RANSAC is performed with the original code. And lastly, I printed out the total number of Iterations.
```
inf
inf
inf
inf
inf
inf
inf
inf
Iteration : 1000
```

So, when calculating _dynamic_max_trials, we set the value to max_trials if it is less than the existing max_trials.  And we modified the code by referring to scikit-learn so that the actual value is calculated more frequently than infinity when calculating the _dynamic_max_trials. Below is the revised result.
```
5983.0
166.0
138.0
133.0
Iteration : 133
```
You can see that _dynamic_max_trials actually decrease and the total number of iterations decreases dramatically. Using the sample code of scikit-learn, we confirmed that the results generated in the two cases were also the same when visually checked. The products in both cases are as follows.
![original](https://user-images.githubusercontent.com/33623106/142592225-9039d358-7890-4204-9912-37582fb95067.png)
![modified](https://user-images.githubusercontent.com/33623106/142592131-11878e20-919a-4628-b735-665d2f0603cc.png)



In summary, I have equalized both the code implementation that judges max_trials and the _dynamic_max_trials function to scikit-learn code style.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
