### PR TITLE
Azure: disable caching as a temporary workaround to #6048

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,22 +57,24 @@ jobs:
       architecture: '$(ARCH)'
     name: python
 
-  # # https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops
-  # - task: Cache@2
-  #   inputs:
-  #     key: '"skimage_data" | skimage/data/_registry.py'
-  #     path: $(SKIMAGE_DATA_CACHE_FOLDER)
-  #   displayName: Cache scikit-image data files
+  # https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops
+  - task: Cache@2
+    inputs:
+      key: '"skimage_data" | skimage/data/_registry.py'
+      path: $(SKIMAGE_DATA_CACHE_FOLDER)
+    displayName: Cache scikit-image data files
+    continueOnError: true
 
-  # # https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops#pythonpip
-  # - task: Cache@2
-  #   inputs:
-  #     key: '"Python$(PYTHON_VERSION)-$(ARCH)" | "$(Agent.OS)" | requirements/build.txt | requirements/default.txt | requirements/test.txt | requirements/docs.txt'
-  #     restoreKeys: |
-  #       "Python$(PYTHON_VERSION)-$(ARCH)" | "$(Agent.OS)"
-  #       "Python$(PYTHON_VERSION)-$(ARCH)"
-  #     path: $(PIP_CACHE_DIR)
-  #   displayName: Cache pip packages
+  # https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops#pythonpip
+  - task: Cache@2
+    inputs:
+      key: '"Python$(PYTHON_VERSION)-$(ARCH)" | "$(Agent.OS)" | requirements/build.txt | requirements/default.txt | requirements/test.txt | requirements/docs.txt'
+      restoreKeys: |
+        "Python$(PYTHON_VERSION)-$(ARCH)" | "$(Agent.OS)"
+        "Python$(PYTHON_VERSION)-$(ARCH)"
+      path: $(PIP_CACHE_DIR)
+    displayName: Cache pip packages
+    continueOnError: true
 
   - script: |
       choco install --$(ARCH) -y llvm

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,12 +57,12 @@ jobs:
       architecture: '$(ARCH)'
     name: python
 
-  # https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops
-  - task: Cache@2
-    inputs:
-      key: '"skimage_data" | skimage/data/_registry.py'
-      path: $(SKIMAGE_DATA_CACHE_FOLDER)
-    displayName: Cache scikit-image data files
+  # # https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops
+  # - task: Cache@2
+  #   inputs:
+  #     key: '"skimage_data" | skimage/data/_registry.py'
+  #     path: $(SKIMAGE_DATA_CACHE_FOLDER)
+  #   displayName: Cache scikit-image data files
 
   # https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops#pythonpip
   - task: Cache@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,15 +64,15 @@ jobs:
   #     path: $(SKIMAGE_DATA_CACHE_FOLDER)
   #   displayName: Cache scikit-image data files
 
-  # https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops#pythonpip
-  - task: Cache@2
-    inputs:
-      key: '"Python$(PYTHON_VERSION)-$(ARCH)" | "$(Agent.OS)" | requirements/build.txt | requirements/default.txt | requirements/test.txt | requirements/docs.txt'
-      restoreKeys: |
-        "Python$(PYTHON_VERSION)-$(ARCH)" | "$(Agent.OS)"
-        "Python$(PYTHON_VERSION)-$(ARCH)"
-      path: $(PIP_CACHE_DIR)
-    displayName: Cache pip packages
+  # # https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops#pythonpip
+  # - task: Cache@2
+  #   inputs:
+  #     key: '"Python$(PYTHON_VERSION)-$(ARCH)" | "$(Agent.OS)" | requirements/build.txt | requirements/default.txt | requirements/test.txt | requirements/docs.txt'
+  #     restoreKeys: |
+  #       "Python$(PYTHON_VERSION)-$(ARCH)" | "$(Agent.OS)"
+  #       "Python$(PYTHON_VERSION)-$(ARCH)"
+  #     path: $(PIP_CACHE_DIR)
+  #   displayName: Cache pip packages
 
   - script: |
       choco install --$(ARCH) -y llvm

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,8 @@ jobs:
       key: '"skimage_data" | skimage/data/_registry.py'
       path: $(SKIMAGE_DATA_CACHE_FOLDER)
     displayName: Cache scikit-image data files
+    # the line below (continueOnError: true) can be removed when the following issue is addressed:
+    # https://github.com/scikit-image/scikit-image/issues/6048
     continueOnError: true
 
   # https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops#pythonpip
@@ -74,6 +76,8 @@ jobs:
         "Python$(PYTHON_VERSION)-$(ARCH)"
       path: $(PIP_CACHE_DIR)
     displayName: Cache pip packages
+    # the line below (continueOnError: true) can be removed when the following issue is addressed:
+    # https://github.com/scikit-image/scikit-image/issues/6048
     continueOnError: true
 
   - script: |


### PR DESCRIPTION
## Description

related to #6048

This PR is trying to temporarily comment out caching to see if the rest of the pipeline is still working.

**update**: instead of commenting these tasks out, there is apparently a `continueOnError` flag that we can set instead.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
