### PR TITLE
add Python 3.10 classifier in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -233,6 +233,7 @@ if __name__ == "__main__":
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
+            'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3 :: Only',
             'Topic :: Scientific/Engineering',
             'Operating System :: Microsoft :: Windows',

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ PROJECT_URLS = {
 with open('README.md', encoding='utf-8') as f:
     LONG_DESCRIPTION = f.read()
 
-if sys.version_info < (3, 6):
+if sys.version_info < (3, 7):
 
     error = """Python {py} detected.
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if sys.version_info < (3, 6):
 
     error = """Python {py} detected.
 
-scikit-image 0.18+ supports only Python 3.7 and above.
+scikit-image 0.19+ supports only Python 3.7 and above.
 
 For Python 2.7, please install the 0.14.x Long Term Support release using:
 


### PR DESCRIPTION
## Description

adds Python 3.10 to the classifiers list for PyPI now that we support it.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
