### PR TITLE
Fix test failures observed with numpy 1.22rc0

### DIFF
--- a/skimage/filters/_rank_order.py
+++ b/skimage/filters/_rank_order.py
@@ -50,7 +50,7 @@ def rank_order(image):
     flat_image = flat_image[sort_order]
     sort_rank = np.zeros_like(sort_order)
     is_different = flat_image[:-1] != flat_image[1:]
-    np.cumsum(is_different, out=sort_rank[1:])
+    np.cumsum(is_different, out=sort_rank[1:], dtype=sort_rank.dtype)
     original_values = np.zeros((sort_rank[-1] + 1,), image.dtype)
     original_values[0] = flat_image[0]
     original_values[1:] = flat_image[1:][is_different]

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -3,8 +3,9 @@ import math
 import numpy as np
 import pytest
 import scipy.ndimage as ndi
-from numpy.testing import (assert_almost_equal, assert_array_almost_equal,
-                           assert_array_equal, assert_equal)
+from numpy.testing import (assert_allclose, assert_almost_equal,
+                           assert_array_almost_equal, assert_array_equal,
+                           assert_equal)
 
 from skimage import data, draw, transform
 from skimage._shared._warnings import expected_warnings
@@ -762,7 +763,8 @@ def test_multichannel():
         else:
             # property uses multiple channels, returns props stacked along
             # final axis
-            assert_array_equal(p, np.asarray(p_multi)[..., 1])
+            assert_allclose(p, np.asarray(p_multi)[..., 1], rtol=1e-12,
+                            atol=1e-12)
 
 
 def test_3d_ellipsoid_axis_lengths():


### PR DESCRIPTION
## Description

closes #6059

This change is to avoid current test failures with numpy 1.22rc0. It doesn't hurt to manually specify this on older NumPy versions, but if desired we can remove it again assuming the issue gets resolved for 1.22 final.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
