### PR TITLE
remove use of deprecated np.int in SIFT

### DIFF
--- a/skimage/feature/sift.py
+++ b/skimage/feature/sift.py
@@ -457,9 +457,9 @@ class SIFT(FeatureDetector, DescriptorExtractor):
             # dimensions of the patch
             radius = 3 * self.lambda_ori * sigma
             p_min = np.maximum(0,
-                               yx - radius[:, np.newaxis] + 0.5).astype(np.int)
+                               yx - radius[:, np.newaxis] + 0.5).astype(int)
             p_max = np.minimum(yx + radius[:, np.newaxis] + 0.5,
-                               (oshape[0] - 1, oshape[1] - 1)).astype(np.int)
+                               (oshape[0] - 1, oshape[1] - 1)).astype(int)
             # orientation histogram
             hist = np.empty(self.n_bins, dtype=self.float_dtype)
             avg_kernel = np.full((3,), 1 / 3, dtype=self.float_dtype)
@@ -491,7 +491,7 @@ class SIFT(FeatureDetector, DescriptorExtractor):
 
                 # fill the histogram
                 bins = np.floor((theta / (2 * np.pi) * self.n_bins + 0.5)
-                                % self.n_bins).astype(np.int)
+                                % self.n_bins).astype(int)
                 np.add.at(hist, bins, kernel * magnitude)
 
                 # smooth the histogram and find the maximum
@@ -577,10 +577,10 @@ class SIFT(FeatureDetector, DescriptorExtractor):
             radius_patch = math.sqrt(2) * radius
             p_min = np.asarray(
                 np.maximum(0, center_pos - radius_patch[:, np.newaxis] + 0.5),
-                dtype=np.int)
+                dtype=int)
             p_max = np.asarray(
                 np.minimum(center_pos + radius_patch[:, np.newaxis] + 0.5,
-                           (dim[0] - 1, dim[1] - 1)), dtype=np.int)
+                           (dim[0] - 1, dim[1] - 1)), dtype=int)
 
             for k in range(len(p_max)):
                 rad_k = radius[k]
@@ -673,7 +673,7 @@ class SIFT(FeatureDetector, DescriptorExtractor):
         self._compute_orientation(positions, scales, sigmas, octaves,
                                   gaussian_scalespace)
 
-        self.keypoints = self.positions.round().astype(np.int)
+        self.keypoints = self.positions.round().astype(int)
 
     def extract(self, image):
         """Extract the descriptors for all keypoints in the image.
@@ -718,4 +718,4 @@ class SIFT(FeatureDetector, DescriptorExtractor):
 
         self._compute_descriptor(gradient_space)
 
-        self.keypoints = self.positions.round().astype(np.int)
+        self.keypoints = self.positions.round().astype(int)


### PR DESCRIPTION
## Description

For compatibility with future NumPy and for avoiding current warnings messages on CI

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
