### PR TITLE
Fix CONTRIBUTING.txt to code style view

### DIFF
--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -606,6 +606,7 @@ command::
 
 Finally, one can also run ASV benchmarks only for a specific commit hash or
 release tag by appending ``^!`` to the commit or tag name. For example to run
-the skimage.filter module benchmarks on release v0.17.2:
+the skimage.filter module benchmarks on release v0.17.2::
 
-asv run -b Filter v0.17.2^!
+    asv run -b Filter v0.17.2^!
+    


### PR DESCRIPTION
## Description
This PR is for fix that corrects a very small error present in CONTRIBUTING.txt.
Although the string existing in the last row of the file was code, it was not output in code style, so we modified it.
Thank you!
<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
