### PR TITLE
Backport gh-6073 on v0.19.x (Handle autoupdate of docstrings to mention deprecated parameters in deprecate_kwarg) 

### DIFF
--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -17,7 +17,7 @@ if hasattr(np, 'complex256'):
 have_numpydoc = False
 try:
     import numpydoc
-    # have_numpydoc = True
+    have_numpydoc = True
 except ImportError:
     pass
 

--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -14,6 +14,13 @@ complex_dtypes = [np.complex64, np.complex128]
 if hasattr(np, 'complex256'):
     complex_dtypes += [np.complex256]
 
+have_numpydoc = False
+try:
+    import numpydoc
+    # have_numpydoc = True
+except ImportError:
+    pass
+
 
 def test_remove_argument():
 
@@ -118,14 +125,15 @@ def test_change_default_value():
     assert not record.list
 
 
-def test_deprecated_kwarg():
+def test_deprecate_kwarg():
 
-    @deprecate_kwarg({'old_arg1': 'new_arg1'})
+    @deprecate_kwarg({'old_arg1': 'new_arg1'}, '0.19')
     def foo(arg0, new_arg1=1, arg2=None):
         """Expected docstring"""
         return arg0, new_arg1, arg2
 
     @deprecate_kwarg({'old_arg1': 'new_arg1'},
+                     deprecated_version='0.19',
                      warning_msg="Custom warning message")
     def bar(arg0, new_arg1=1, arg2=None):
         """Expected docstring"""
@@ -158,7 +166,19 @@ def test_deprecated_kwarg():
         assert foo.__name__ == 'foo'
         if sys.flags.optimize < 2:
             # if PYTHONOPTIMIZE is set to 2, docstrings are stripped
-            assert foo.__doc__ == 'Expected docstring'
+            if not have_numpydoc:
+                assert foo.__doc__ == """Expected docstring"""
+            else:
+                assert foo.__doc__ == """Expected docstring
+
+
+    Other Parameters
+    ----------------
+    old_arg1 : DEPRECATED
+        Deprecated in favor of `new_arg1`.
+
+        .. deprecated:: 0.19
+"""
 
     # Assert no warning was raised
     assert not record.list

--- a/skimage/filters/_median.py
+++ b/skimage/filters/_median.py
@@ -8,7 +8,8 @@ from .._shared.utils import deprecate_kwarg
 from .rank import generic
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def median(image, footprint=None, out=None, mode='nearest', cval=0.0,
            behavior='ndimage'):
     """Return local median of an image.

--- a/skimage/filters/rank/_percentile.py
+++ b/skimage/filters/rank/_percentile.py
@@ -45,7 +45,8 @@ def _apply(func, image, footprint, out, mask, shift_x, shift_y, p0, p1,
     return out.reshape(out.shape[:2])
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def autolevel_percentile(image, footprint, out=None, mask=None, shift_x=False,
                          shift_y=False, p0=0, p1=1):
     """Return grayscale local autolevel of an image.
@@ -85,7 +86,8 @@ def autolevel_percentile(image, footprint, out=None, mask=None, shift_x=False,
                   shift_y=shift_y, p0=p0, p1=p1)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def gradient_percentile(image, footprint, out=None, mask=None, shift_x=False,
                         shift_y=False, p0=0, p1=1):
     """Return local gradient of an image (i.e. local maximum - local minimum).
@@ -122,7 +124,8 @@ def gradient_percentile(image, footprint, out=None, mask=None, shift_x=False,
                   shift_y=shift_y, p0=p0, p1=p1)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def mean_percentile(image, footprint, out=None, mask=None, shift_x=False,
                     shift_y=False, p0=0, p1=1):
     """Return local mean of an image.
@@ -159,7 +162,8 @@ def mean_percentile(image, footprint, out=None, mask=None, shift_x=False,
                   shift_y=shift_y, p0=p0, p1=p1)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def subtract_mean_percentile(image, footprint, out=None, mask=None,
                              shift_x=False, shift_y=False, p0=0, p1=1):
     """Return image subtracted from its local mean.
@@ -196,7 +200,8 @@ def subtract_mean_percentile(image, footprint, out=None, mask=None,
                   shift_y=shift_y, p0=p0, p1=p1)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def enhance_contrast_percentile(image, footprint, out=None, mask=None,
                                 shift_x=False, shift_y=False, p0=0, p1=1):
     """Enhance contrast of an image.
@@ -237,7 +242,8 @@ def enhance_contrast_percentile(image, footprint, out=None, mask=None,
                   shift_y=shift_y, p0=p0, p1=p1)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def percentile(image, footprint, out=None, mask=None, shift_x=False,
                shift_y=False, p0=0):
     """Return local percentile of an image.
@@ -276,7 +282,8 @@ def percentile(image, footprint, out=None, mask=None, shift_x=False,
                   shift_y=shift_y, p0=p0, p1=0.)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def pop_percentile(image, footprint, out=None, mask=None, shift_x=False,
                    shift_y=False, p0=0, p1=1):
     """Return the local number (population) of pixels.
@@ -316,7 +323,8 @@ def pop_percentile(image, footprint, out=None, mask=None, shift_x=False,
                   shift_y=shift_y, p0=p0, p1=p1)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def sum_percentile(image, footprint, out=None, mask=None, shift_x=False,
                    shift_y=False, p0=0, p1=1):
     """Return the local sum of pixels.
@@ -356,7 +364,8 @@ def sum_percentile(image, footprint, out=None, mask=None, shift_x=False,
                   shift_y=shift_y, p0=p0, p1=p1)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def threshold_percentile(image, footprint, out=None, mask=None, shift_x=False,
                          shift_y=False, p0=0):
     """Local threshold of an image.

--- a/skimage/filters/rank/bilateral.py
+++ b/skimage/filters/rank/bilateral.py
@@ -43,7 +43,8 @@ def _apply(func, image, footprint, out, mask, shift_x, shift_y, s0, s1,
     return out.reshape(out.shape[:2])
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def mean_bilateral(image, footprint, out=None, mask=None, shift_x=False,
                    shift_y=False, s0=10, s1=10):
     """Apply a flat kernel bilateral filter.
@@ -102,7 +103,8 @@ def mean_bilateral(image, footprint, out=None, mask=None, shift_x=False,
                   mask=mask, shift_x=shift_x, shift_y=shift_y, s0=s0, s1=s1)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def pop_bilateral(image, footprint, out=None, mask=None, shift_x=False,
                   shift_y=False, s0=10, s1=10):
     """Return the local number (population) of pixels.
@@ -159,7 +161,8 @@ def pop_bilateral(image, footprint, out=None, mask=None, shift_x=False,
                   mask=mask, shift_x=shift_x, shift_y=shift_y, s0=s0, s1=s1)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def sum_bilateral(image, footprint, out=None, mask=None, shift_x=False,
                   shift_y=False, s0=10, s1=10):
     """Apply a flat kernel bilateral filter.

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -333,7 +333,8 @@ def _apply_vector_per_pixel(func, image, footprint, out, mask, shift_x,
     return out
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def autolevel(image, footprint, out=None, mask=None,
               shift_x=False, shift_y=False, shift_z=False):
     """Auto-level image using local histogram.
@@ -387,7 +388,8 @@ def autolevel(image, footprint, out=None, mask=None,
                                           shift_z=shift_z)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def equalize(image, footprint, out=None, mask=None,
              shift_x=False, shift_y=False, shift_z=False):
     """Equalize image using local histogram.
@@ -438,7 +440,8 @@ def equalize(image, footprint, out=None, mask=None,
                                           shift_z=shift_z)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def gradient(image, footprint, out=None, mask=None,
              shift_x=False, shift_y=False, shift_z=False):
     """Return local gradient of an image (i.e. local maximum - local minimum).
@@ -489,7 +492,8 @@ def gradient(image, footprint, out=None, mask=None,
                                           shift_z=shift_z)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def maximum(image, footprint, out=None, mask=None,
             shift_x=False, shift_y=False, shift_z=False):
     """Return local maximum of an image.
@@ -549,7 +553,8 @@ def maximum(image, footprint, out=None, mask=None,
                                           shift_z=shift_z)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def mean(image, footprint, out=None, mask=None,
          shift_x=False, shift_y=False, shift_z=False):
     """Return local mean of an image.
@@ -600,7 +605,8 @@ def mean(image, footprint, out=None, mask=None,
                                           shift_z=shift_z)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def geometric_mean(image, footprint, out=None, mask=None,
                    shift_x=False, shift_y=False, shift_z=False):
     """Return local geometric mean of an image.
@@ -656,7 +662,8 @@ def geometric_mean(image, footprint, out=None, mask=None,
                                           shift_z=shift_z)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def subtract_mean(image, footprint, out=None, mask=None,
                   shift_x=False, shift_y=False, shift_z=False):
     """Return image subtracted from its local mean.
@@ -715,7 +722,8 @@ def subtract_mean(image, footprint, out=None, mask=None,
                                           shift_z=shift_z)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def median(image, footprint=None, out=None, mask=None,
            shift_x=False, shift_y=False, shift_z=False):
     """Return local median of an image.
@@ -774,7 +782,8 @@ def median(image, footprint=None, out=None, mask=None,
                                           shift_z=shift_z)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def minimum(image, footprint, out=None, mask=None,
             shift_x=False, shift_y=False, shift_z=False):
     """Return local minimum of an image.
@@ -834,7 +843,8 @@ def minimum(image, footprint, out=None, mask=None,
                                           shift_z=shift_z)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def modal(image, footprint, out=None, mask=None,
           shift_x=False, shift_y=False, shift_z=False):
     """Return local mode of an image.
@@ -887,7 +897,8 @@ def modal(image, footprint, out=None, mask=None,
                                           shift_z=shift_z)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def enhance_contrast(image, footprint, out=None, mask=None,
                      shift_x=False, shift_y=False, shift_z=False):
     """Enhance contrast of an image.
@@ -942,7 +953,8 @@ def enhance_contrast(image, footprint, out=None, mask=None,
                                           shift_z=shift_z)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def pop(image, footprint, out=None, mask=None,
         shift_x=False, shift_y=False, shift_z=False):
     """Return the local number (population) of pixels.
@@ -1000,7 +1012,8 @@ def pop(image, footprint, out=None, mask=None,
                                           shift_z=shift_z)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def sum(image, footprint, out=None, mask=None,
         shift_x=False, shift_y=False, shift_z=False):
     """Return the local sum of pixels.
@@ -1058,7 +1071,8 @@ def sum(image, footprint, out=None, mask=None,
                                           shift_z=shift_z)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def threshold(image, footprint, out=None, mask=None,
               shift_x=False, shift_y=False, shift_z=False):
     """Local threshold of an image.
@@ -1116,7 +1130,8 @@ def threshold(image, footprint, out=None, mask=None,
                                           shift_z=shift_z)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def noise_filter(image, footprint, out=None, mask=None,
                  shift_x=False, shift_y=False, shift_z=False):
     """Noise feature.
@@ -1187,7 +1202,8 @@ def noise_filter(image, footprint, out=None, mask=None,
                                           shift_y=shift_y, shift_z=shift_z)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def entropy(image, footprint, out=None, mask=None,
             shift_x=False, shift_y=False, shift_z=False):
     """Local entropy.
@@ -1247,7 +1263,8 @@ def entropy(image, footprint, out=None, mask=None,
                                           shift_z=shift_z, out_dtype=np.double)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def otsu(image, footprint, out=None, mask=None,
          shift_x=False, shift_y=False, shift_z=False):
     """Local Otsu's threshold value for each pixel.
@@ -1304,7 +1321,8 @@ def otsu(image, footprint, out=None, mask=None,
                                           shift_z=shift_z)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def windowed_histogram(image, footprint, out=None, mask=None,
                        shift_x=False, shift_y=False, n_bins=None):
     """Normalized sliding window histogram
@@ -1360,11 +1378,11 @@ def windowed_histogram(image, footprint, out=None, mask=None,
                                    pixel_size=n_bins)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def majority(image, footprint, *, out=None, mask=None,
              shift_x=False, shift_y=False, shift_z=False):
-    """Majority filter assign to each pixel the most occuring value within
-    its neighborhood.
+    """Assign to each pixel the most common value within its neighborhood.
 
     Parameters
     ----------

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -763,7 +763,8 @@ def threshold_li(image, *, tolerance=None, initial_guess=None,
     return threshold
 
 
-@deprecate_kwarg({'max_iter': 'max_num_iter'}, removed_version="1.0")
+@deprecate_kwarg({'max_iter': 'max_num_iter'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def threshold_minimum(image=None, nbins=256, max_num_iter=10000, *, hist=None):
     """Return threshold value based on minimum method.
 

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -8,7 +8,9 @@ from collections import deque
 _param_options = ('high', 'low')
 
 
-@deprecate_kwarg({'array': 'image'}, removed_version="0.20")
+@deprecate_kwarg({'array': 'image'},
+                 deprecated_version='0.18',
+                 removed_version='0.20')
 def find_contours(image, level=None,
                   fully_connected='low', positive_orientation='low',
                   *,

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -30,7 +30,9 @@ def _label_bool(image, background=None, return_num=False, connectivity=None):
         return result[0]
 
 
-@deprecate_kwarg({"input": "label_image"}, removed_version="1.0")
+@deprecate_kwarg({'input': 'label_image'},
+                 deprecated_version='0.19',
+                 removed_version='1.0')
 def label(label_image, background=None, return_num=False, connectivity=None):
     r"""Label connected regions of an integer array.
 

--- a/skimage/morphology/_flood_fill.py
+++ b/skimage/morphology/_flood_fill.py
@@ -12,7 +12,8 @@ from ._util import (_offsets_to_raveled_neighbors, _resolve_neighborhood,
                     _set_border_values,)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def flood_fill(image, seed_point, new_value, *, footprint=None,
                connectivity=None, tolerance=None, in_place=False):
     """Perform flood filling on an image.
@@ -110,7 +111,8 @@ def flood_fill(image, seed_point, new_value, *, footprint=None,
     return image
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def flood(image, seed_point, *, footprint=None, connectivity=None,
           tolerance=None):
     """Mask corresponding to a flood fill.

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -254,7 +254,8 @@ G123P_LUT = np.array([0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0,
                       0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=bool)
 
 
-@deprecate_kwarg({'max_iter': 'max_num_iter'}, removed_version="1.0")
+@deprecate_kwarg({'max_iter': 'max_num_iter'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def thin(image, max_num_iter=None):
     """
     Perform morphological thinning of a binary image.

--- a/skimage/morphology/binary.py
+++ b/skimage/morphology/binary.py
@@ -12,7 +12,8 @@ from .misc import default_footprint
 # default with the same dimension as the input image and size 3 along each
 # axis.
 @default_footprint
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def binary_erosion(image, footprint=None, out=None):
     """Return fast binary morphological erosion of an image.
 
@@ -49,7 +50,8 @@ def binary_erosion(image, footprint=None, out=None):
 
 
 @default_footprint
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def binary_dilation(image, footprint=None, out=None):
     """Return fast binary morphological dilation of an image.
 
@@ -84,7 +86,8 @@ def binary_dilation(image, footprint=None, out=None):
 
 
 @default_footprint
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def binary_opening(image, footprint=None, out=None):
     """Return fast binary morphological opening of an image.
 
@@ -119,7 +122,8 @@ def binary_opening(image, footprint=None, out=None):
 
 
 @default_footprint
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def binary_closing(image, footprint=None, out=None):
     """Return fast binary morphological closing of an image.
 

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -45,7 +45,8 @@ def _subtract_constant_clip(image, const_value):
     return(result)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def h_maxima(image, h, footprint=None):
     """Determine all maxima of the image with height >= h.
 
@@ -175,7 +176,8 @@ def h_maxima(image, h, footprint=None):
     return (residue_img >= h).astype(np.uint8)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def h_minima(image, h, footprint=None):
     """Determine all minima of the image with depth >= h.
 
@@ -273,7 +275,8 @@ def h_minima(image, h, footprint=None):
     return (residue_img >= h).astype(np.uint8)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def local_maxima(image, footprint=None, connectivity=None, indices=False,
                  allow_borders=True):
     """Find local maxima of n-dimensional array.
@@ -438,7 +441,8 @@ def local_maxima(image, footprint=None, connectivity=None, indices=False,
         return flags.view(bool)
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def local_minima(image, footprint=None, connectivity=None, indices=False,
                  allow_borders=True):
     """Find local minima of n-dimensional array.

--- a/skimage/morphology/footprints.py
+++ b/skimage/morphology/footprints.py
@@ -31,8 +31,9 @@ def square(width, dtype=np.uint8):
     return np.ones((width, width), dtype=dtype)
 
 
-@deprecate_kwarg({"height": "ncols", "width": "nrows"},
-                 removed_version="0.20.0")
+@deprecate_kwarg({'height': 'ncols', 'width': 'nrows'},
+                 deprecated_version='0.18.0',
+                 removed_version='0.20.0')
 def rectangle(nrows, ncols, dtype=np.uint8):
     """Generates a flat, rectangular-shaped footprint.
 

--- a/skimage/morphology/gray.py
+++ b/skimage/morphology/gray.py
@@ -132,7 +132,8 @@ def pad_for_eccentric_footprints(func):
 
 
 @default_footprint
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def erosion(image, footprint=None, out=None, shift_x=False, shift_y=False):
     """Return grayscale morphological erosion of an image.
 
@@ -193,7 +194,8 @@ def erosion(image, footprint=None, out=None, shift_x=False, shift_y=False):
 
 
 @default_footprint
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def dilation(image, footprint=None, out=None, shift_x=False, shift_y=False):
     """Return grayscale morphological dilation of an image.
 
@@ -260,7 +262,8 @@ def dilation(image, footprint=None, out=None, shift_x=False, shift_y=False):
     return out
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 @default_footprint
 @pad_for_eccentric_footprints
 def opening(image, footprint=None, out=None):
@@ -311,7 +314,8 @@ def opening(image, footprint=None, out=None):
     return out
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 @default_footprint
 @pad_for_eccentric_footprints
 def closing(image, footprint=None, out=None):
@@ -363,7 +367,8 @@ def closing(image, footprint=None, out=None):
 
 
 @default_footprint
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def white_tophat(image, footprint=None, out=None):
     """Return white top hat of an image.
 
@@ -437,7 +442,8 @@ def white_tophat(image, footprint=None, out=None):
 
 
 @default_footprint
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def black_tophat(image, footprint=None, out=None):
     """Return black top hat of an image.
 

--- a/skimage/morphology/grayreconstruct.py
+++ b/skimage/morphology/grayreconstruct.py
@@ -15,7 +15,8 @@ from .._shared.utils import deprecate_kwarg
 from ..filters._rank_order import rank_order
 
 
-@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0")
+@deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def reconstruction(seed, mask, method='dilation', footprint=None, offset=None):
     """Perform a morphological reconstruction of an image.
 

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -259,7 +259,8 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
 
 @utils.channel_as_last_axis()
 @utils.deprecate_multichannel_kwarg()
-@utils.deprecate_kwarg({'max_iter': 'max_num_iter'}, removed_version="1.0")
+@utils.deprecate_kwarg({'max_iter': 'max_num_iter'}, removed_version="1.0",
+                       deprecated_version="0.19")
 def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
                        isotropic=True, *, channel_axis=None,
                        multichannel=False):

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -366,7 +366,8 @@ def unsupervised_wiener(image, psf, reg=None, user_params=None, is_real=True,
     return (x_postmean, {'noise': gn_chain, 'prior': gx_chain})
 
 
-@deprecate_kwarg({'iterations': 'num_iter'}, removed_version="1.0")
+@deprecate_kwarg({'iterations': 'num_iter'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def richardson_lucy(image, psf, num_iter=50, clip=True, filter_epsilon=None):
     """Richardson-Lucy deconvolution.
 

--- a/skimage/restoration/non_local_means.py
+++ b/skimage/restoration/non_local_means.py
@@ -14,14 +14,14 @@ from ._nl_means_denoising import (_nl_means_denoising_2d,
 def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
                      multichannel=False, fast_mode=True, sigma=0., *,
                      preserve_range=False, channel_axis=None):
-    """Perform non-local means denoising on 2-D or 3-D grayscale images, and
-    2-D RGB images.
+    """Perform non-local means denoising on 2D-4D grayscale or RGB images.
 
     Parameters
     ----------
     image : 2D or 3D ndarray
         Input image to be denoised, which can be 2D or 3D, and grayscale
-        or RGB (for 2D images only, see ``multichannel`` parameter).
+        or RGB (for 2D images only, see ``multichannel`` parameter). There can
+        be any number of channels (does not strictly have to be RGB).
     patch_size : int, optional
         Size of patches used for denoising.
     patch_distance : int, optional

--- a/skimage/segmentation/_chan_vese.py
+++ b/skimage/segmentation/_chan_vese.py
@@ -172,7 +172,8 @@ def _cv_init_level_set(init_level_set, image_shape, dtype=np.float64):
     return res.astype(dtype, copy=False)
 
 
-@deprecate_kwarg({'max_iter': 'max_num_iter'}, removed_version="1.0")
+@deprecate_kwarg({'max_iter': 'max_num_iter'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def chan_vese(image, mu=0.25, lambda1=1.0, lambda2=1.0, tol=1e-3,
               max_num_iter=500, dt=0.5, init_level_set='checkerboard',
               extended_output=False):

--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -6,7 +6,8 @@ from ..util import img_as_float
 from ..filters import sobel
 
 
-@deprecate_kwarg({'max_iterations': 'max_num_iter'}, removed_version="1.0")
+@deprecate_kwarg({'max_iterations': 'max_num_iter'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def active_contour(image, snake, alpha=0.01, beta=0.1,
                    w_line=0, w_edge=1, gamma=0.01,
                    max_px_move=1.0,

--- a/skimage/segmentation/morphsnakes.py
+++ b/skimage/segmentation/morphsnakes.py
@@ -209,7 +209,8 @@ def inverse_gaussian_gradient(image, alpha=100.0, sigma=5.0):
     return 1.0 / np.sqrt(1.0 + alpha * gradnorm)
 
 
-@deprecate_kwarg({'iterations': 'num_iter'}, removed_version="1.0")
+@deprecate_kwarg({'iterations': 'num_iter'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def morphological_chan_vese(image, num_iter, init_level_set='checkerboard',
                             smoothing=1, lambda1=1, lambda2=1,
                             iter_callback=lambda x: None):
@@ -313,7 +314,8 @@ def morphological_chan_vese(image, num_iter, init_level_set='checkerboard',
     return u
 
 
-@deprecate_kwarg({'iterations': 'num_iter'}, removed_version="1.0")
+@deprecate_kwarg({'iterations': 'num_iter'}, removed_version="1.0",
+                 deprecated_version="0.19")
 def morphological_geodesic_active_contour(gimage, num_iter,
                                           init_level_set='disk', smoothing=1,
                                           threshold='auto', balloon=0,

--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -109,7 +109,8 @@ def _get_grid_centroids(image, n_centroids):
 
 @utils.channel_as_last_axis(multichannel_output=False)
 @utils.deprecate_multichannel_kwarg(multichannel_position=6)
-@utils.deprecate_kwarg({'max_iter': 'max_num_iter'}, removed_version="1.0")
+@utils.deprecate_kwarg({'max_iter': 'max_num_iter'}, removed_version="1.0",
+                       deprecated_version="0.19")
 def slic(image, n_segments=100, compactness=10., max_num_iter=10, sigma=0,
          spacing=None, multichannel=True, convert2lab=None,
          enforce_connectivity=True, min_size_factor=0.5, max_size_factor=3,


### PR DESCRIPTION
## Description

includes both #6073 and the small fix in #6079


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
