### PR TITLE
checkout gh-pages with a shallow clone

### DIFF
--- a/doc/gh-pages.py
+++ b/doc/gh-pages.py
@@ -68,7 +68,7 @@ def sh3(cmd):
 
 def init_repo(path):
     """clone the gh-pages repo if we haven't already."""
-    sh("git clone --branch gh-pages %s %s --depth 1"%(pages_repo, path))
+    sh(f'git clone --branch gh-pages {pages_repo} {path} --depth 1')
     here = os.getcwd()
     cd(path)
     sh('git checkout gh-pages')

--- a/doc/gh-pages.py
+++ b/doc/gh-pages.py
@@ -68,7 +68,7 @@ def sh3(cmd):
 
 def init_repo(path):
     """clone the gh-pages repo if we haven't already."""
-    sh("git clone %s %s"%(pages_repo, path))
+    sh("git clone --branch gh-pages %s %s --depth 1"%(pages_repo, path))
     here = os.getcwd()
     cd(path)
     sh('git checkout gh-pages')
@@ -92,7 +92,6 @@ if __name__ == '__main__':
                 tag = '.'.join(tag.split('.')[:-1] + ['x'])
 
             break
-
 
     startdir = os.getcwd()
     if not os.path.exists(pages_dir):


### PR DESCRIPTION


## Description

This PR reduces the size and download time when first running `make gh-pages` in the `doc` folder. It reduces the download size from several GB to < 400 MB by only checking out the most recent commit of the `gh-pages` branch.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
