### PR TITLE
Preserve backwards compatibility for `channel_axis` parameter in transform functions

### DIFF
--- a/skimage/feature/tests/test_basic_features.py
+++ b/skimage/feature/tests/test_basic_features.py
@@ -7,7 +7,23 @@ from skimage.feature import multiscale_basic_features
 
 @pytest.mark.parametrize('edges', (False, True))
 @pytest.mark.parametrize('texture', (False, True))
-def test_multiscale_basic_features(edges, texture):
+def test_multiscale_basic_features_gray(edges, texture):
+    img = np.zeros((20, 20))
+    img[:10] = 1
+    img += 0.05 * np.random.randn(*img.shape)
+    features = multiscale_basic_features(img, edges=edges, texture=texture)
+
+    n_sigmas = 6
+    intensity = True
+    assert features.shape[-1] == (
+        n_sigmas * (int(intensity) + int(edges) + 2 * int(texture))
+    )
+    assert features.shape[:-1] == img.shape[:]
+
+
+@pytest.mark.parametrize('edges', (False, True))
+@pytest.mark.parametrize('texture', (False, True))
+def test_multiscale_basic_features_rgb(edges, texture):
     img = np.zeros((20, 20, 3))
     img[:10] = 1
     img += 0.05 * np.random.randn(*img.shape)

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -104,7 +104,7 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
 @utils.deprecate_multichannel_kwarg(multichannel_position=6)
 def pyramid_expand(image, upscale=2, sigma=None, order=1,
                    mode='reflect', cval=0, multichannel=False,
-                   preserve_range=False, *, channel_axis=-1):
+                   preserve_range=False, *, channel_axis=None):
     """Upsample and then smooth image.
 
     Parameters

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -77,8 +77,7 @@ def test_pyramid_expand_rgb_deprecated_multichannel():
 
 def test_pyramid_expand_gray():
     rows, cols = image_gray.shape
-    out = pyramids.pyramid_expand(image_gray, upscale=2,
-                                  channel_axis=None)
+    out = pyramids.pyramid_expand(image_gray, upscale=2)
     assert_array_equal(out.shape, (rows * 2, cols * 2))
 
 

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -179,8 +179,7 @@ def test_rescale():
     # same scale factor
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
-    scaled = rescale(x, 2, order=0,
-                     channel_axis=None, anti_aliasing=False, mode='constant')
+    scaled = rescale(x, 2, order=0, anti_aliasing=False, mode='constant')
     ref = np.zeros((10, 10))
     ref[2:4, 2:4] = 1
     assert_array_almost_equal(scaled, ref)
@@ -189,8 +188,7 @@ def test_rescale():
     x = np.zeros((5, 5), dtype=np.double)
     x[1, 1] = 1
 
-    scaled = rescale(x, (2, 1), order=0,
-                     channel_axis=None, anti_aliasing=False, mode='constant')
+    scaled = rescale(x, (2, 1), order=0, anti_aliasing=False, mode='constant')
     ref = np.zeros((10, 5))
     ref[2:4, 1] = 1
     assert_array_almost_equal(scaled, ref)


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

This PR goes over the changes made in https://github.com/scikit-image/scikit-image/pull/5285, and ensures that all of the modified functions in that PR have at least 1 test that uses the default value for the `channel_axis` parameter.

* `hog()`: Already has plenty of tests that don't specify `channel_axis`.
* `random_shapes()`: Already taken care of by `test_generates_color_images_with_correct_shape`.
   * NB: Default behavior for this function is color, not grayscale. 
* `warps.warp_polar()`: Already has plenty of tests that don't specify `channel_axis`.
* `warps.rescale()`: It did have a grayscale test, but that test specified `channel_axis=None`, so this is removed: 47381cf25bc383d8ff86d86c201751ed2097c835
* `multiscale_basic_features()`: Needed a grayscale test to compliment the color test: f01603a01183ad3bd22f0da4d5dce3d2172dcac9
* `pyramid_expand()`: This already had a grayscale test, but that test specified `channel_axis=None`, so this is removed: 902ccf1ecdb3c0af976451d617004f88f0a18bb3
   * This change reproduces the bug from [#6092](https://github.com/scikit-image/scikit-image/issues/6092).
   * 25414a78cff7451521efd2a15e4fa0a570c4d272 fixes the bug by restoring the default grayscale behavior in `pyramid_expand()`.

Closes #6092.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
