### PR TITLE
Fix two equality comparison bugs in the wheel build script

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -141,7 +141,7 @@ jobs:
           # supported macos version is: High Sierra / 10.13. When upgrading
           # this, be sure to update the MACOSX_DEPLOYMENT_TARGET environment
           # variable accordingly. Note that Darwin_17 == High Sierra / 10.13.
-          if [[ "$CIBW_BUILD" == *-macosx_arm64 ]]; then
+          if [[ "$CIBW_ARCHS_MACOS" == arm64 ]]; then
               # SciPy requires 12.0 on arm to prevent kernel panics
               # https://github.com/scipy/scipy/issues/14688
               # so being conservative, we just do the same here
@@ -151,6 +151,7 @@ jobs:
               export MACOSX_DEPLOYMENT_TARGET=10.13
               wget https://packages.macports.org/libomp/libomp-11.0.1_0+universal.darwin_17.i386-x86_64.tbz2 -O libomp.tbz2
           fi
+          echo MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}
           sudo tar -C / -xvjf libomp.tbz2 opt
           python -m cibuildwheel --output-dir dist
         env:

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -218,7 +218,7 @@ jobs:
 
       - name: Build Windows wheels for CPython 3.10
         # NumPy dropped x86 wheels for Python 3.10
-        if: matrix.cibw_arch == 'ARM64'
+        if: matrix.cibw_arch == 'AMD64'
         run: |
           python -m cibuildwheel --output-dir dist
         env:


### PR DESCRIPTION
## Description

This PR fixes two bugs in the wheel building used for 0.19.0. The windows one was a simple typo that caused the Python 3.10 windows AMD64 wheel to be skipped (I manually added it later for 0.19.0). 

A more problematic case is the if/else error for `arm64` wheels. This has lead to the if case always being evaluated as false and broken M1 wheels being uploaded for 0.19.0. We will need a 0.19.1 release ASAP to resolve that. The current space constraints on PyPI (#6086) make releasing 0.19.1 a bit problematic. Until the request for more space is granted, we will have to delete 0.19.0rc0 to have enough space to upload a new release.

will need to forward port these fixes to main as well


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
