### PR TITLE
make rank filter test comparisons robust across architectures

### DIFF
--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -110,8 +110,10 @@ class TestRank():
                 assert_array_almost_equal(expected, result)
             else:
                 if outdt is not None:
-                    # Avoid rounding issues comparing to expected result
-                    result = result.astype(expected.dtype)
+                    # Avoid rounding issues comparing to expected result.
+                    # Take modulus first to avoid undefined behavior for
+                    # float->uint8 conversions.
+                    result = np.mod(result, 256.0).astype(expected.dtype)
                 assert_array_almost_equal(expected, result)
 
         check()
@@ -147,7 +149,9 @@ class TestRank():
                     datadt = np.uint8
                 else:
                     datadt = expected.dtype
-                result = result.astype(datadt)
+                # Take modulus first to avoid undefined behavior for
+                # float->uint8 conversions.
+                result = np.mod(result, 256.0).astype(datadt)
             assert_array_almost_equal(expected, result)
 
         check()


### PR DESCRIPTION
## Description

cc: @hmaarrfk

We have been[struggling with a handful of test failures from the rank filter tests](https://github.com/conda-forge/scikit-image-feedstock/pull/85) when trying to build 0.19.0 on conda-forge. The cases that fail all involve conversion of float->uint8 where many of the floats are outside of the [0, 255] range. To avoid undefined behavior in this case, I have manually taken the modulus of the float values before converting to uint8.

I verified that this fix allowed tests to pass on a local laptop that was able to reproduce the issue. Before merging here we can run with a patch corresponding to this PR on conda-forge to further verify the fix.

This will need to be backported to v0.19.x


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
