### PR TITLE
Avoid Cython-generated source files in wheels and sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,7 @@ recursive-include requirements *.txt
 include requirements/README.md
 include Makefile
 include skimage/scripts/skivi
-recursive-include skimage *.py *.ini *.npy *.txt *.in *.md
+recursive-include skimage *.pyx *.pxd *.pxi *.h unwrap*.c *.py *.ini *.npy *.txt *.in *.md
 recursive-include skimage/data *
 recursive-include skimage/*/tests/data *
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,7 @@ recursive-include requirements *.txt
 include requirements/README.md
 include Makefile
 include skimage/scripts/skivi
-recursive-include skimage *.pyx *.pxd *.pxi *.py *.c *.h *.ini *.npy *.txt *.in *.cpp *.md
+recursive-include skimage *.py *.ini *.npy *.txt *.in *.md
 recursive-include skimage/data *
 recursive-include skimage/*/tests/data *
 

--- a/skimage/_build.py
+++ b/skimage/_build.py
@@ -60,10 +60,13 @@ def cython(pyx_files, working_path=''):
                 process_tempita_pyx(pyxfile)
                 pyx_files[i] = pyxfile.replace('.pyx.in', '.pyx')
 
-        # Cython doesn't automatically choose a number of threads > 1
-        # https://github.com/cython/cython/blob/a0bbb940c847dfe92cac446c8784c34c28c92836/Cython/Build/Dependencies.py#L923-L925
-        cythonize(pyx_files, nthreads=cpu_count(),
-                  compiler_directives={'language_level': 3})
+        # skip cythonize when creating an sdist
+        # (we do not want the large cython-generated sources to be included)
+        if 'sdist' not in sys.argv:
+            # Cython doesn't automatically choose a number of threads > 1
+            # https://github.com/cython/cython/blob/a0bbb940c847dfe92cac446c8784c34c28c92836/Cython/Build/Dependencies.py#L923-L925
+            cythonize(pyx_files, nthreads=cpu_count(),
+                      compiler_directives={'language_level': 3})
 
 
 def process_tempita_pyx(fromfile):


### PR DESCRIPTION
## Description

This PR attempts to reduce the size of the wheels by avoiding packaging the large Cython-generated source files. See discussion in #6102. The change to MANIFEST.in avoids them showing up in the wheels. 

A second motivation is so that conda-forge builds will regenerate these source files using the version of Cython used in the recipe. We currently had to add a workaround there to run the `make clean` step that removes the generated files that are present in the 0.19.0 source tarball.

Here, the if clause around `cythonize` prevents the cython-generated files from ending up in the source distribution. 

I am opening another, follow up PR related to strip debug symbols when running the wheel building script.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
