### PR TITLE
Add linker flags to strip debug symbols during wheel building

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -48,6 +48,7 @@ jobs:
           CIBW_SKIP: "*-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
+          LDFLAGS: "-Wl,--strip-debug"
       - uses: actions/upload-artifact@v2
         with:
           name: wheels
@@ -88,6 +89,7 @@ jobs:
           CIBW_ARCHS_LINUX: aarch64
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
+          LDFLAGS: "-Wl,--strip-debug"
       - uses: actions/upload-artifact@v2
         with:
           name: wheels
@@ -151,7 +153,7 @@ jobs:
           CPPFLAGS: "-Xpreprocessor -fopenmp"
           CFLAGS: "-Wno-implicit-function-declaration -I/opt/local/include/libomp"
           CXXFLAGS: "-I/opt/local/include/libomp"
-          LDFLAGS: "-Wl,-rpath,/opt/local/lib/libomp -L/opt/local/lib/libomp -lomp"
+          LDFLAGS: "-Wl,--strip-debug,-Wl,-rpath,/opt/local/lib/libomp -L/opt/local/lib/libomp -lomp"
 
       - uses: actions/upload-artifact@v2
         with:
@@ -209,6 +211,7 @@ jobs:
         env:
           CIBW_BUILD: "cp310-*"
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
+          LDFLAGS: "-Wl,--strip-debug"
 
       - name: Build Windows wheels for CPython
         run: |
@@ -217,53 +220,54 @@ jobs:
           CIBW_BUILD: "cp3?-*"
           CIBW_SKIP: "cp36-* cp37-*"
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
+          LDFLAGS: "-Wl,--strip-debug"
 
       - uses: actions/upload-artifact@v2
         with:
           name: wheels
           path: ./dist/*.whl
 
-  deploy:
-    name: Release
-    needs: [build_linux_37_and_above_wheels, build_linux_aarch64_wheels, build_macos_wheels, build_windows_wheels]
-    if: github.repository_owner == 'scikit-image' && startsWith(github.ref, 'refs/tags/v') && always()
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.9'
+  # deploy:
+  #   name: Release
+  #   needs: [build_linux_37_and_above_wheels, build_linux_aarch64_wheels, build_macos_wheels, build_windows_wheels]
+  #   if: github.repository_owner == 'scikit-image' && startsWith(github.ref, 'refs/tags/v') && always()
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #     - uses: actions/setup-python@v2
+  #       name: Install Python
+  #       with:
+  #         python-version: '3.9'
       
-      - name: Install Twine
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements/build.txt
-          pip install twine
+  #     - name: Install Twine
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         pip install -r requirements/build.txt
+  #         pip install twine
       
-      - uses: actions/download-artifact@v2
-        id: download
-        with:
-          name: wheels
-          path: ./dist
+  #     - uses: actions/download-artifact@v2
+  #       id: download
+  #       with:
+  #         name: wheels
+  #         path: ./dist
     
-      - name: Publish the source distribution on PyPI
-        run: |
-          SK_VERSION=$(git describe --tags)
-          python setup.py sdist
-          ls -la ${{ github.workspace }}/dist
-          # We prefer to release wheels before source because otherwise there is a
-          # small window during which users who pip install scikit-image will require compilation.
-          twine upload ${{ github.workspace }}/dist/*.whl
-          twine upload ${{ github.workspace }}/dist/scikit-image-${SK_VERSION:1}.tar.gz
-        env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+  #     - name: Publish the source distribution on PyPI
+  #       run: |
+  #         SK_VERSION=$(git describe --tags)
+  #         python setup.py sdist
+  #         ls -la ${{ github.workspace }}/dist
+  #         # We prefer to release wheels before source because otherwise there is a
+  #         # small window during which users who pip install scikit-image will require compilation.
+  #         twine upload ${{ github.workspace }}/dist/*.whl
+  #         twine upload ${{ github.workspace }}/dist/scikit-image-${SK_VERSION:1}.tar.gz
+  #       env:
+  #         TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+  #         TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
               
-      - name: Github release
-        uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
+  #     - name: Github release
+  #       uses: softprops/action-gh-release@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -41,199 +41,27 @@ jobs:
           python -m pip install cibuildwheel
       - name: Build the wheel
         run: |
-          python -m cibuildwheel --output-dir dist
+          LDFLAGS='-Wl,--strip-debug' python -m cibuildwheel --output-dir dist
         env:
           CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
           CIBW_SKIP: "*-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
-          LDFLAGS: "-Wl,--strip-debug"
       - uses: actions/upload-artifact@v2
         with:
           name: wheels
           path: ./dist/*.whl
 
-  build_linux_aarch64_wheels:
-    name: Build python ${{ matrix.cibw_python }} aarch64 wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-18.04]
-        cibw_python: [ "cp38-*" , "cp39-*" , "cp310-*" ]
-        cibw_manylinux: [ manylinux2014 ]
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.9'
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: arm64
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel
-      - name: Build the wheel
-        run: |
-          python -m cibuildwheel --output-dir dist
-        env:
-          CIBW_BUILD: ${{ matrix.cibw_python }}
-          CIBW_SKIP: "*-musllinux_*"
-          # skip aarch64 tests which often exceed the 6 hour time limit
-          CIBW_TEST_SKIP: "*_aarch64"
-          CIBW_ARCHS_LINUX: aarch64
-          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
-          CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
-          LDFLAGS: "-Wl,--strip-debug"
-      - uses: actions/upload-artifact@v2
-        with:
-          name: wheels
-          path: ./dist/*.whl
-
-  build_macos_wheels:
-    name: Build python ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest]
-        cibw_python: [ "cp38-*", "cp39-*", "cp310-*" ]
-        # TODO: add "universal2" once a universal2 libomp is available
-        cibw_arch: [ "x86_64", "arm64"]
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.9'
-
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel
-      - name: Build wheels for CPython Mac OS
-        run: |
-          # Make sure to use a libomp version binary compatible with the oldest
-          # supported version of the macos SDK as libomp will be vendored into
-          # the scikit-image wheels for macos. The list of binaries are in
-          # https://packages.macports.org/libomp/.  Currently, the oldest
-          # supported macos version is: High Sierra / 10.13. When upgrading
-          # this, be sure to update the MACOSX_DEPLOYMENT_TARGET environment
-          # variable accordingly. Note that Darwin_17 == High Sierra / 10.13.
-          if [[ "$CIBW_ARCHS_MACOS" == arm64 ]]; then
-              # SciPy requires 12.0 on arm to prevent kernel panics
-              # https://github.com/scipy/scipy/issues/14688
-              # so being conservative, we just do the same here
-              export MACOSX_DEPLOYMENT_TARGET=12.0
-              wget https://packages.macports.org/libomp/libomp-11.0.1_0.darwin_20.arm64.tbz2 -O libomp.tbz2
-          else
-              export MACOSX_DEPLOYMENT_TARGET=10.13
-              wget https://packages.macports.org/libomp/libomp-11.0.1_0+universal.darwin_17.i386-x86_64.tbz2 -O libomp.tbz2
-          fi
-          echo MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}
-          sudo tar -C / -xvjf libomp.tbz2 opt
-          python -m cibuildwheel --output-dir dist
-        env:
-          CIBW_BUILD: ${{ matrix.cibw_python }}
-          CIBW_ARCHS_MACOS: ${{ matrix.cibw_arch }}
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
-          CIBW_MANYLINUX_I686_IMAGE: manylinux1
-          CIBW_TEST_SKIP: "*-macosx_arm64"
-          # CIBW_BEFORE_BUILD: pip install certifi numpy==1.19.3
-          CC: /usr/bin/clang
-          CXX: /usr/bin/clang++
-          CPPFLAGS: "-Xpreprocessor -fopenmp"
-          CFLAGS: "-Wno-implicit-function-declaration -I/opt/local/include/libomp"
-          CXXFLAGS: "-I/opt/local/include/libomp"
-          LDFLAGS: "-Wl,-S -Wl,-rpath,/opt/local/lib/libomp -L/opt/local/lib/libomp -lomp"
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: wheels
-          path: ./dist/*.whl
-
-  build_windows_wheels:
-    name: Build ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-latest]
-        cibw_arch: ["AMD64", "x86"]
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.9'
-
-      # install choco package manager
-      - uses: crazy-max/ghaction-chocolatey@v1
-        name: Install chocolatey
-        with:
-          args: -h
-
-      # install x86 clang-cl (needed for Pythran)
-      - name: Install x86 clang-cl
-        if: matrix.cibw_arch == 'x86'
-        run: |
-          choco install --force --x86 llvm
-
-      # install clang-cl (needed for Pythran)
-      - name: Install clang-cl
-        if: matrix.cibw_arch == 'AMD64'
-        run: |
-          choco install --force llvm
-
-      - name: Install cibuildwheel and add clang-cl to path
-        run: |
-          python -m pip install cibuildwheel
-          SET PATH="C:\\Program Files\\LLVM\\bin;%PATH%"
-          SET PATH="C:\\Program Files (x86)\\LLVM\\bin;%PATH%"
-
-      - name: Build Windows wheels for CPython 3.10
-        # NumPy dropped x86 wheels for Python 3.10
-        if: matrix.cibw_arch == 'AMD64'
-        run: |
-          python -m cibuildwheel --output-dir dist
-        env:
-          CIBW_BUILD: "cp310-*"
-          CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
-          # -Wl,-S equivalent to gcc's -Wl,--strip-debug
-          LDFLAGS: "-Wl,-S"
-
-      - name: Build Windows wheels for CPython
-        run: |
-          python -m cibuildwheel --output-dir dist
-        env:
-          CIBW_BUILD: "cp3?-*"
-          CIBW_SKIP: "cp36-* cp37-*"
-          CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
-          # -Wl,-S equivalent to gcc's -Wl,--strip-debug
-          LDFLAGS: "-Wl,-S"
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: wheels
-          path: ./dist/*.whl
-
-  # deploy:
-  #   name: Release
-  #   needs: [build_linux_37_and_above_wheels, build_linux_aarch64_wheels, build_macos_wheels, build_windows_wheels]
-  #   if: github.repository_owner == 'scikit-image' && startsWith(github.ref, 'refs/tags/v') && always()
-  #   runs-on: ubuntu-latest
+  # build_linux_aarch64_wheels:
+  #   name: Build python ${{ matrix.cibw_python }} aarch64 wheels on ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [ubuntu-18.04]
+  #       cibw_python: [ "cp38-*" , "cp39-*" , "cp310-*" ]
+  #       cibw_manylinux: [ manylinux2014 ]
   #   steps:
   #     - uses: actions/checkout@v2
   #       with:
@@ -242,34 +70,205 @@ jobs:
   #       name: Install Python
   #       with:
   #         python-version: '3.9'
-      
-  #     - name: Install Twine
+  #     - name: Set up QEMU
+  #       uses: docker/setup-qemu-action@v1
+  #       with:
+  #         platforms: arm64
+  #     - name: Install cibuildwheel
   #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install -r requirements/build.txt
-  #         pip install twine
-      
-  #     - uses: actions/download-artifact@v2
-  #       id: download
+  #         python -m pip install cibuildwheel
+  #     - name: Build the wheel
+  #       run: |
+  #         python -m cibuildwheel --output-dir dist
+  #       env:
+  #         CIBW_BUILD: ${{ matrix.cibw_python }}
+  #         CIBW_SKIP: "*-musllinux_*"
+  #         # skip aarch64 tests which often exceed the 6 hour time limit
+  #         CIBW_TEST_SKIP: "*_aarch64"
+  #         CIBW_ARCHS_LINUX: aarch64
+  #         CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
+  #         CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
+  #         LDFLAGS: "-Wl,--strip-debug"
+  #     - uses: actions/upload-artifact@v2
   #       with:
   #         name: wheels
-  #         path: ./dist
-    
-  #     - name: Publish the source distribution on PyPI
+  #         path: ./dist/*.whl
+
+  # build_macos_wheels:
+  #   name: Build python ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [macos-latest]
+  #       cibw_python: [ "cp38-*", "cp39-*", "cp310-*" ]
+  #       # TODO: add "universal2" once a universal2 libomp is available
+  #       cibw_arch: [ "x86_64", "arm64"]
+
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+
+  #     - uses: actions/setup-python@v2
+  #       name: Install Python
+  #       with:
+  #         python-version: '3.9'
+
+  #     - name: Install cibuildwheel
   #       run: |
-  #         SK_VERSION=$(git describe --tags)
-  #         python setup.py sdist
-  #         ls -la ${{ github.workspace }}/dist
-  #         # We prefer to release wheels before source because otherwise there is a
-  #         # small window during which users who pip install scikit-image will require compilation.
-  #         twine upload ${{ github.workspace }}/dist/*.whl
-  #         twine upload ${{ github.workspace }}/dist/scikit-image-${SK_VERSION:1}.tar.gz
+  #         python -m pip install cibuildwheel
+  #     - name: Build wheels for CPython Mac OS
+  #       run: |
+  #         # Make sure to use a libomp version binary compatible with the oldest
+  #         # supported version of the macos SDK as libomp will be vendored into
+  #         # the scikit-image wheels for macos. The list of binaries are in
+  #         # https://packages.macports.org/libomp/.  Currently, the oldest
+  #         # supported macos version is: High Sierra / 10.13. When upgrading
+  #         # this, be sure to update the MACOSX_DEPLOYMENT_TARGET environment
+  #         # variable accordingly. Note that Darwin_17 == High Sierra / 10.13.
+  #         if [[ "$CIBW_ARCHS_MACOS" == arm64 ]]; then
+  #             # SciPy requires 12.0 on arm to prevent kernel panics
+  #             # https://github.com/scipy/scipy/issues/14688
+  #             # so being conservative, we just do the same here
+  #             export MACOSX_DEPLOYMENT_TARGET=12.0
+  #             wget https://packages.macports.org/libomp/libomp-11.0.1_0.darwin_20.arm64.tbz2 -O libomp.tbz2
+  #         else
+  #             export MACOSX_DEPLOYMENT_TARGET=10.13
+  #             wget https://packages.macports.org/libomp/libomp-11.0.1_0+universal.darwin_17.i386-x86_64.tbz2 -O libomp.tbz2
+  #         fi
+  #         echo MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}
+  #         sudo tar -C / -xvjf libomp.tbz2 opt
+  #         python -m cibuildwheel --output-dir dist
   #       env:
-  #         TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-  #         TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+  #         CIBW_BUILD: ${{ matrix.cibw_python }}
+  #         CIBW_ARCHS_MACOS: ${{ matrix.cibw_arch }}
+  #         CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
+  #         CIBW_MANYLINUX_I686_IMAGE: manylinux1
+  #         CIBW_TEST_SKIP: "*-macosx_arm64"
+  #         # CIBW_BEFORE_BUILD: pip install certifi numpy==1.19.3
+  #         CC: /usr/bin/clang
+  #         CXX: /usr/bin/clang++
+  #         CPPFLAGS: "-Xpreprocessor -fopenmp"
+  #         CFLAGS: "-Wno-implicit-function-declaration -I/opt/local/include/libomp"
+  #         CXXFLAGS: "-I/opt/local/include/libomp"
+  #         LDFLAGS: "-Wl,-S -Wl,-rpath,/opt/local/lib/libomp -L/opt/local/lib/libomp -lomp"
+
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: wheels
+  #         path: ./dist/*.whl
+
+  # build_windows_wheels:
+  #   name: Build ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [windows-latest]
+  #       cibw_arch: ["AMD64", "x86"]
+
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+
+  #     - uses: actions/setup-python@v2
+  #       name: Install Python
+  #       with:
+  #         python-version: '3.9'
+
+  #     # install choco package manager
+  #     - uses: crazy-max/ghaction-chocolatey@v1
+  #       name: Install chocolatey
+  #       with:
+  #         args: -h
+
+  #     # install x86 clang-cl (needed for Pythran)
+  #     - name: Install x86 clang-cl
+  #       if: matrix.cibw_arch == 'x86'
+  #       run: |
+  #         choco install --force --x86 llvm
+
+  #     # install clang-cl (needed for Pythran)
+  #     - name: Install clang-cl
+  #       if: matrix.cibw_arch == 'AMD64'
+  #       run: |
+  #         choco install --force llvm
+
+  #     - name: Install cibuildwheel and add clang-cl to path
+  #       run: |
+  #         python -m pip install cibuildwheel
+  #         SET PATH="C:\\Program Files\\LLVM\\bin;%PATH%"
+  #         SET PATH="C:\\Program Files (x86)\\LLVM\\bin;%PATH%"
+
+  #     - name: Build Windows wheels for CPython 3.10
+  #       # NumPy dropped x86 wheels for Python 3.10
+  #       if: matrix.cibw_arch == 'AMD64'
+  #       run: |
+  #         python -m cibuildwheel --output-dir dist
+  #       env:
+  #         CIBW_BUILD: "cp310-*"
+  #         CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
+  #         # -Wl,-S equivalent to gcc's -Wl,--strip-debug
+  #         LDFLAGS: "-Wl,-S"
+
+  #     - name: Build Windows wheels for CPython
+  #       run: |
+  #         python -m cibuildwheel --output-dir dist
+  #       env:
+  #         CIBW_BUILD: "cp3?-*"
+  #         CIBW_SKIP: "cp36-* cp37-*"
+  #         CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
+  #         # -Wl,-S equivalent to gcc's -Wl,--strip-debug
+  #         LDFLAGS: "-Wl,-S"
+
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: wheels
+  #         path: ./dist/*.whl
+
+  # # deploy:
+  # #   name: Release
+  # #   needs: [build_linux_37_and_above_wheels, build_linux_aarch64_wheels, build_macos_wheels, build_windows_wheels]
+  # #   if: github.repository_owner == 'scikit-image' && startsWith(github.ref, 'refs/tags/v') && always()
+  # #   runs-on: ubuntu-latest
+  # #   steps:
+  # #     - uses: actions/checkout@v2
+  # #       with:
+  # #         fetch-depth: 0
+  # #     - uses: actions/setup-python@v2
+  # #       name: Install Python
+  # #       with:
+  # #         python-version: '3.9'
+
+  # #     - name: Install Twine
+  # #       run: |
+  # #         python -m pip install --upgrade pip
+  # #         pip install -r requirements/build.txt
+  # #         pip install twine
+
+  # #     - uses: actions/download-artifact@v2
+  # #       id: download
+  # #       with:
+  # #         name: wheels
+  # #         path: ./dist
+    
+  # #     - name: Publish the source distribution on PyPI
+  # #       run: |
+  # #         SK_VERSION=$(git describe --tags)
+  # #         python setup.py sdist
+  # #         ls -la ${{ github.workspace }}/dist
+  # #         # We prefer to release wheels before source because otherwise there is a
+  # #         # small window during which users who pip install scikit-image will require compilation.
+  # #         twine upload ${{ github.workspace }}/dist/*.whl
+  # #         twine upload ${{ github.workspace }}/dist/scikit-image-${SK_VERSION:1}.tar.gz
+  # #       env:
+  # #         TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+  # #         TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
               
-  #     - name: Github release
-  #       uses: softprops/action-gh-release@v1
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         GITHUB_REPOSITORY: ${{ github.repository }}
+  # #     - name: Github release
+  # #       uses: softprops/action-gh-release@v1
+  # #       env:
+  # #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # #         GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -41,13 +41,15 @@ jobs:
           python -m pip install cibuildwheel
       - name: Build the wheel
         run: |
-          LDFLAGS='-Wl,--strip-debug' python -m cibuildwheel --output-dir dist
+          python -m cibuildwheel --output-dir dist
         env:
           CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
           CIBW_SKIP: "*-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
+          CIBW_ENVIRONMENT_PASS_LINUX: SKIMAGE_LINK_FLAGS
+          SKIMAGE_LINK_FLAGS: "-Wl,--strip-debug"
       - uses: actions/upload-artifact@v2
         with:
           name: wheels
@@ -79,7 +81,7 @@ jobs:
           python -m pip install cibuildwheel
       - name: Build the wheel
         run: |
-          LDFLAGS='-Wl,--strip-debug' python -m cibuildwheel --output-dir dist
+          python -m cibuildwheel --output-dir dist
         env:
           CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_SKIP: "*-musllinux_*"
@@ -88,7 +90,8 @@ jobs:
           CIBW_ARCHS_LINUX: aarch64
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
-          LDFLAGS: "-Wl,--strip-debug"
+          CIBW_ENVIRONMENT_PASS_LINUX: SKIMAGE_LINK_FLAGS
+          SKIMAGE_LINK_FLAGS: "-Wl,--strip-debug"
       - uses: actions/upload-artifact@v2
         with:
           name: wheels

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -153,7 +153,7 @@ jobs:
           CPPFLAGS: "-Xpreprocessor -fopenmp"
           CFLAGS: "-Wno-implicit-function-declaration -I/opt/local/include/libomp"
           CXXFLAGS: "-I/opt/local/include/libomp"
-          LDFLAGS: "-Wl,--strip-debug,-Wl,-rpath,/opt/local/lib/libomp -L/opt/local/lib/libomp -lomp"
+          LDFLAGS: "-Wl,-S -Wl,-rpath,/opt/local/lib/libomp -L/opt/local/lib/libomp -lomp"
 
       - uses: actions/upload-artifact@v2
         with:
@@ -211,7 +211,8 @@ jobs:
         env:
           CIBW_BUILD: "cp310-*"
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
-          LDFLAGS: "-Wl,--strip-debug"
+          # -Wl,-S equivalent to gcc's -Wl,--strip-debug
+          LDFLAGS: "-Wl,-S"
 
       - name: Build Windows wheels for CPython
         run: |
@@ -220,7 +221,8 @@ jobs:
           CIBW_BUILD: "cp3?-*"
           CIBW_SKIP: "cp36-* cp37-*"
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
-          LDFLAGS: "-Wl,--strip-debug"
+          # -Wl,-S equivalent to gcc's -Wl,--strip-debug
+          LDFLAGS: "-Wl,-S"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -53,222 +53,222 @@ jobs:
           name: wheels
           path: ./dist/*.whl
 
-  # build_linux_aarch64_wheels:
-  #   name: Build python ${{ matrix.cibw_python }} aarch64 wheels on ${{ matrix.os }}
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [ubuntu-18.04]
-  #       cibw_python: [ "cp38-*" , "cp39-*" , "cp310-*" ]
-  #       cibw_manylinux: [ manylinux2014 ]
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #     - uses: actions/setup-python@v2
-  #       name: Install Python
-  #       with:
-  #         python-version: '3.9'
-  #     - name: Set up QEMU
-  #       uses: docker/setup-qemu-action@v1
-  #       with:
-  #         platforms: arm64
-  #     - name: Install cibuildwheel
-  #       run: |
-  #         python -m pip install cibuildwheel
-  #     - name: Build the wheel
-  #       run: |
-  #         python -m cibuildwheel --output-dir dist
-  #       env:
-  #         CIBW_BUILD: ${{ matrix.cibw_python }}
-  #         CIBW_SKIP: "*-musllinux_*"
-  #         # skip aarch64 tests which often exceed the 6 hour time limit
-  #         CIBW_TEST_SKIP: "*_aarch64"
-  #         CIBW_ARCHS_LINUX: aarch64
-  #         CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
-  #         CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
-  #         LDFLAGS: "-Wl,--strip-debug"
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: wheels
-  #         path: ./dist/*.whl
+  build_linux_aarch64_wheels:
+    name: Build python ${{ matrix.cibw_python }} aarch64 wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04]
+        cibw_python: [ "cp38-*" , "cp39-*" , "cp310-*" ]
+        cibw_manylinux: [ manylinux2014 ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel
+      - name: Build the wheel
+        run: |
+          LDFLAGS='-Wl,--strip-debug' python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_SKIP: "*-musllinux_*"
+          # skip aarch64 tests which often exceed the 6 hour time limit
+          CIBW_TEST_SKIP: "*_aarch64"
+          CIBW_ARCHS_LINUX: aarch64
+          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
+          CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
+          LDFLAGS: "-Wl,--strip-debug"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./dist/*.whl
 
-  # build_macos_wheels:
-  #   name: Build python ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [macos-latest]
-  #       cibw_python: [ "cp38-*", "cp39-*", "cp310-*" ]
-  #       # TODO: add "universal2" once a universal2 libomp is available
-  #       cibw_arch: [ "x86_64", "arm64"]
+  build_macos_wheels:
+    name: Build python ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
+        cibw_python: [ "cp38-*", "cp39-*", "cp310-*" ]
+        # TODO: add "universal2" once a universal2 libomp is available
+        cibw_arch: [ "x86_64", "arm64"]
 
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-  #     - uses: actions/setup-python@v2
-  #       name: Install Python
-  #       with:
-  #         python-version: '3.9'
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
 
-  #     - name: Install cibuildwheel
-  #       run: |
-  #         python -m pip install cibuildwheel
-  #     - name: Build wheels for CPython Mac OS
-  #       run: |
-  #         # Make sure to use a libomp version binary compatible with the oldest
-  #         # supported version of the macos SDK as libomp will be vendored into
-  #         # the scikit-image wheels for macos. The list of binaries are in
-  #         # https://packages.macports.org/libomp/.  Currently, the oldest
-  #         # supported macos version is: High Sierra / 10.13. When upgrading
-  #         # this, be sure to update the MACOSX_DEPLOYMENT_TARGET environment
-  #         # variable accordingly. Note that Darwin_17 == High Sierra / 10.13.
-  #         if [[ "$CIBW_ARCHS_MACOS" == arm64 ]]; then
-  #             # SciPy requires 12.0 on arm to prevent kernel panics
-  #             # https://github.com/scipy/scipy/issues/14688
-  #             # so being conservative, we just do the same here
-  #             export MACOSX_DEPLOYMENT_TARGET=12.0
-  #             wget https://packages.macports.org/libomp/libomp-11.0.1_0.darwin_20.arm64.tbz2 -O libomp.tbz2
-  #         else
-  #             export MACOSX_DEPLOYMENT_TARGET=10.13
-  #             wget https://packages.macports.org/libomp/libomp-11.0.1_0+universal.darwin_17.i386-x86_64.tbz2 -O libomp.tbz2
-  #         fi
-  #         echo MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}
-  #         sudo tar -C / -xvjf libomp.tbz2 opt
-  #         python -m cibuildwheel --output-dir dist
-  #       env:
-  #         CIBW_BUILD: ${{ matrix.cibw_python }}
-  #         CIBW_ARCHS_MACOS: ${{ matrix.cibw_arch }}
-  #         CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
-  #         CIBW_MANYLINUX_I686_IMAGE: manylinux1
-  #         CIBW_TEST_SKIP: "*-macosx_arm64"
-  #         # CIBW_BEFORE_BUILD: pip install certifi numpy==1.19.3
-  #         CC: /usr/bin/clang
-  #         CXX: /usr/bin/clang++
-  #         CPPFLAGS: "-Xpreprocessor -fopenmp"
-  #         CFLAGS: "-Wno-implicit-function-declaration -I/opt/local/include/libomp"
-  #         CXXFLAGS: "-I/opt/local/include/libomp"
-  #         LDFLAGS: "-Wl,-S -Wl,-rpath,/opt/local/lib/libomp -L/opt/local/lib/libomp -lomp"
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel
+      - name: Build wheels for CPython Mac OS
+        run: |
+          # Make sure to use a libomp version binary compatible with the oldest
+          # supported version of the macos SDK as libomp will be vendored into
+          # the scikit-image wheels for macos. The list of binaries are in
+          # https://packages.macports.org/libomp/.  Currently, the oldest
+          # supported macos version is: High Sierra / 10.13. When upgrading
+          # this, be sure to update the MACOSX_DEPLOYMENT_TARGET environment
+          # variable accordingly. Note that Darwin_17 == High Sierra / 10.13.
+          if [[ "$CIBW_ARCHS_MACOS" == arm64 ]]; then
+              # SciPy requires 12.0 on arm to prevent kernel panics
+              # https://github.com/scipy/scipy/issues/14688
+              # so being conservative, we just do the same here
+              export MACOSX_DEPLOYMENT_TARGET=12.0
+              wget https://packages.macports.org/libomp/libomp-11.0.1_0.darwin_20.arm64.tbz2 -O libomp.tbz2
+          else
+              export MACOSX_DEPLOYMENT_TARGET=10.13
+              wget https://packages.macports.org/libomp/libomp-11.0.1_0+universal.darwin_17.i386-x86_64.tbz2 -O libomp.tbz2
+          fi
+          echo MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}
+          sudo tar -C / -xvjf libomp.tbz2 opt
+          python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_ARCHS_MACOS: ${{ matrix.cibw_arch }}
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
+          CIBW_MANYLINUX_I686_IMAGE: manylinux1
+          CIBW_TEST_SKIP: "*-macosx_arm64"
+          # CIBW_BEFORE_BUILD: pip install certifi numpy==1.19.3
+          CC: /usr/bin/clang
+          CXX: /usr/bin/clang++
+          CPPFLAGS: "-Xpreprocessor -fopenmp"
+          CFLAGS: "-Wno-implicit-function-declaration -I/opt/local/include/libomp"
+          CXXFLAGS: "-I/opt/local/include/libomp"
+          LDFLAGS: "-Wl,-S -Wl,-rpath,/opt/local/lib/libomp -L/opt/local/lib/libomp -lomp"
 
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: wheels
-  #         path: ./dist/*.whl
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./dist/*.whl
 
-  # build_windows_wheels:
-  #   name: Build ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [windows-latest]
-  #       cibw_arch: ["AMD64", "x86"]
+  build_windows_wheels:
+    name: Build ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        cibw_arch: ["AMD64", "x86"]
 
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-  #     - uses: actions/setup-python@v2
-  #       name: Install Python
-  #       with:
-  #         python-version: '3.9'
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
 
-  #     # install choco package manager
-  #     - uses: crazy-max/ghaction-chocolatey@v1
-  #       name: Install chocolatey
-  #       with:
-  #         args: -h
+      # install choco package manager
+      - uses: crazy-max/ghaction-chocolatey@v1
+        name: Install chocolatey
+        with:
+          args: -h
 
-  #     # install x86 clang-cl (needed for Pythran)
-  #     - name: Install x86 clang-cl
-  #       if: matrix.cibw_arch == 'x86'
-  #       run: |
-  #         choco install --force --x86 llvm
+      # install x86 clang-cl (needed for Pythran)
+      - name: Install x86 clang-cl
+        if: matrix.cibw_arch == 'x86'
+        run: |
+          choco install --force --x86 llvm
 
-  #     # install clang-cl (needed for Pythran)
-  #     - name: Install clang-cl
-  #       if: matrix.cibw_arch == 'AMD64'
-  #       run: |
-  #         choco install --force llvm
+      # install clang-cl (needed for Pythran)
+      - name: Install clang-cl
+        if: matrix.cibw_arch == 'AMD64'
+        run: |
+          choco install --force llvm
 
-  #     - name: Install cibuildwheel and add clang-cl to path
-  #       run: |
-  #         python -m pip install cibuildwheel
-  #         SET PATH="C:\\Program Files\\LLVM\\bin;%PATH%"
-  #         SET PATH="C:\\Program Files (x86)\\LLVM\\bin;%PATH%"
+      - name: Install cibuildwheel and add clang-cl to path
+        run: |
+          python -m pip install cibuildwheel
+          SET PATH="C:\\Program Files\\LLVM\\bin;%PATH%"
+          SET PATH="C:\\Program Files (x86)\\LLVM\\bin;%PATH%"
 
-  #     - name: Build Windows wheels for CPython 3.10
-  #       # NumPy dropped x86 wheels for Python 3.10
-  #       if: matrix.cibw_arch == 'AMD64'
-  #       run: |
-  #         python -m cibuildwheel --output-dir dist
-  #       env:
-  #         CIBW_BUILD: "cp310-*"
-  #         CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
-  #         # -Wl,-S equivalent to gcc's -Wl,--strip-debug
-  #         LDFLAGS: "-Wl,-S"
+      - name: Build Windows wheels for CPython 3.10
+        # NumPy dropped x86 wheels for Python 3.10
+        if: matrix.cibw_arch == 'AMD64'
+        run: |
+          python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: "cp310-*"
+          CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
+          # -Wl,-S equivalent to gcc's -Wl,--strip-debug
+          LDFLAGS: "-Wl,-S"
 
-  #     - name: Build Windows wheels for CPython
-  #       run: |
-  #         python -m cibuildwheel --output-dir dist
-  #       env:
-  #         CIBW_BUILD: "cp3?-*"
-  #         CIBW_SKIP: "cp36-* cp37-*"
-  #         CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
-  #         # -Wl,-S equivalent to gcc's -Wl,--strip-debug
-  #         LDFLAGS: "-Wl,-S"
+      - name: Build Windows wheels for CPython
+        run: |
+          python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: "cp3?-*"
+          CIBW_SKIP: "cp36-* cp37-*"
+          CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
+          # -Wl,-S equivalent to gcc's -Wl,--strip-debug
+          LDFLAGS: "-Wl,-S"
 
-  #     - uses: actions/upload-artifact@v2
-  #       with:
-  #         name: wheels
-  #         path: ./dist/*.whl
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./dist/*.whl
 
-  # # deploy:
-  # #   name: Release
-  # #   needs: [build_linux_37_and_above_wheels, build_linux_aarch64_wheels, build_macos_wheels, build_windows_wheels]
-  # #   if: github.repository_owner == 'scikit-image' && startsWith(github.ref, 'refs/tags/v') && always()
-  # #   runs-on: ubuntu-latest
-  # #   steps:
-  # #     - uses: actions/checkout@v2
-  # #       with:
-  # #         fetch-depth: 0
-  # #     - uses: actions/setup-python@v2
-  # #       name: Install Python
-  # #       with:
-  # #         python-version: '3.9'
+  deploy:
+    name: Release
+    needs: [build_linux_37_and_above_wheels, build_linux_aarch64_wheels, build_macos_wheels, build_windows_wheels]
+    if: github.repository_owner == 'scikit-image' && startsWith(github.ref, 'refs/tags/v') && always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
 
-  # #     - name: Install Twine
-  # #       run: |
-  # #         python -m pip install --upgrade pip
-  # #         pip install -r requirements/build.txt
-  # #         pip install twine
+      - name: Install Twine
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements/build.txt
+          pip install twine
 
-  # #     - uses: actions/download-artifact@v2
-  # #       id: download
-  # #       with:
-  # #         name: wheels
-  # #         path: ./dist
+      - uses: actions/download-artifact@v2
+        id: download
+        with:
+          name: wheels
+          path: ./dist
     
-  # #     - name: Publish the source distribution on PyPI
-  # #       run: |
-  # #         SK_VERSION=$(git describe --tags)
-  # #         python setup.py sdist
-  # #         ls -la ${{ github.workspace }}/dist
-  # #         # We prefer to release wheels before source because otherwise there is a
-  # #         # small window during which users who pip install scikit-image will require compilation.
-  # #         twine upload ${{ github.workspace }}/dist/*.whl
-  # #         twine upload ${{ github.workspace }}/dist/scikit-image-${SK_VERSION:1}.tar.gz
-  # #       env:
-  # #         TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-  # #         TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+      - name: Publish the source distribution on PyPI
+        run: |
+          SK_VERSION=$(git describe --tags)
+          python setup.py sdist
+          ls -la ${{ github.workspace }}/dist
+          # We prefer to release wheels before source because otherwise there is a
+          # small window during which users who pip install scikit-image will require compilation.
+          twine upload ${{ github.workspace }}/dist/*.whl
+          twine upload ${{ github.workspace }}/dist/scikit-image-${SK_VERSION:1}.tar.gz
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
               
-  # #     - name: Github release
-  # #       uses: softprops/action-gh-release@v1
-  # #       env:
-  # #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # #         GITHUB_REPOSITORY: ${{ github.repository }}
+      - name: Github release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,7 @@ recursive-include requirements *.txt
 include requirements/README.md
 include Makefile
 include skimage/scripts/skivi
-recursive-include skimage *.py *.ini *.npy *.txt *.in *.md
+recursive-include skimage *.pyx *.pxd *.pxi *.h unwrap*.c *.py *.ini *.npy *.txt *.in *.md
 recursive-include skimage/data *
 recursive-include skimage/*/tests/data *
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,8 @@ recursive-include requirements *.txt
 include requirements/README.md
 include Makefile
 include skimage/scripts/skivi
-recursive-include skimage *.pyx *.pxd *.pxi *.h unwrap*.c *.py *.ini *.npy *.txt *.in *.md
+include skimage/restoration/unwrap_*_ljmu.c
+recursive-include skimage *.pyx *.pxd *.pxi *.py *.h *.ini *.npy *.txt *.in *.md
 recursive-include skimage/data *
 recursive-include skimage/*/tests/data *
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,7 @@ recursive-include requirements *.txt
 include requirements/README.md
 include Makefile
 include skimage/scripts/skivi
-recursive-include skimage *.pyx *.pxd *.pxi *.py *.c *.h *.ini *.npy *.txt *.in *.cpp *.md
+recursive-include skimage *.py *.ini *.npy *.txt *.in *.md
 recursive-include skimage/data *
 recursive-include skimage/*/tests/data *
 

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ class ConditionalOpenMP(pythran_build_ext[npy_build_ext]):
             compile_flags += ['/openmp']
         else:
             compile_flags += ['-fopenmp']
-            link_flags += ['-fopenmp']
+            link_flags += ['-fopenmp', '-Wl,--strip-debug']
 
         if self.can_compile_link(compile_flags, link_flags):
             for ext in self.extensions:

--- a/setup.py
+++ b/setup.py
@@ -244,7 +244,7 @@ if __name__ == "__main__":
         extras_require=extras_require,
         python_requires='>=3.8',
         packages=setuptools.find_packages(exclude=['doc', 'benchmarks']),
-        include_package_data=True,
+        include_package_data=False,
         zip_safe=False,  # the package can run out of an .egg file
         entry_points={
             'console_scripts': ['skivi = skimage.scripts.skivi:main'],

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,9 @@ class ConditionalOpenMP(pythran_build_ext[npy_build_ext]):
             compile_flags += ['/openmp']
         else:
             compile_flags += ['-fopenmp']
-            link_flags += ['-fopenmp', '-Wl,--strip-debug']
+            link_flags += ['-fopenmp']
+        if 'SKIMAGE_LINK_FLAGS' in os.environ:
+            link_flags += [os.environ['SKIMAGE_LINK_FLAGS']]
 
         if self.can_compile_link(compile_flags, link_flags):
             for ext in self.extensions:

--- a/skimage/_build.py
+++ b/skimage/_build.py
@@ -60,10 +60,13 @@ def cython(pyx_files, working_path=''):
                 process_tempita_pyx(pyxfile)
                 pyx_files[i] = pyxfile.replace('.pyx.in', '.pyx')
 
-        # Cython doesn't automatically choose a number of threads > 1
-        # https://github.com/cython/cython/blob/a0bbb940c847dfe92cac446c8784c34c28c92836/Cython/Build/Dependencies.py#L923-L925
-        cythonize(pyx_files, nthreads=cpu_count(),
-                  compiler_directives={'language_level': 3})
+        # skip cythonize when creating an sdist
+        # (we do not want the large cython-generated sources to be included)
+        if 'sdist' not in sys.argv:
+            # Cython doesn't automatically choose a number of threads > 1
+            # https://github.com/cython/cython/blob/a0bbb940c847dfe92cac446c8784c34c28c92836/Cython/Build/Dependencies.py#L923-L925
+            cythonize(pyx_files, nthreads=cpu_count(),
+                      compiler_directives={'language_level': 3})
 
 
 def process_tempita_pyx(fromfile):


### PR DESCRIPTION
## Description

closes #6102

This PR builds on top of the commits in #6108. I wanted both changes together here before testing the wheel builds in order to make sure neither breaks the script.

There is discussion of doing this for NumPy in this thread: https://github.com/pypa/cibuildwheel/issues/331#issuecomment-622992392 and it is mentioned there that `multibuild` strips these symbols by default. 

When I tried this locally, this change combined with the changes in #6108 reduced linux wheel size from 63 MB to around 14 MB. 
The wheels corresponding to this PR are being generated here: https://github.com/grlee77/scikit-image/actions/runs/1546988099
We should make sure all goes well there prior to merging this


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
