### PR TITLE
Backport of gh-6109 (Add linker flags to strip debug symbols during wheel building)

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -56,6 +56,8 @@ jobs:
           CIBW_SKIP: "*-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
+          CIBW_ENVIRONMENT_PASS_LINUX: SKIMAGE_LINK_FLAGS
+          SKIMAGE_LINK_FLAGS: "-Wl,--strip-debug"
       - uses: actions/upload-artifact@v2
         with:
           name: wheels
@@ -96,6 +98,8 @@ jobs:
           CIBW_ARCHS_LINUX: aarch64
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
+          CIBW_ENVIRONMENT_PASS_LINUX: SKIMAGE_LINK_FLAGS
+          SKIMAGE_LINK_FLAGS: "-Wl,--strip-debug"
       - uses: actions/upload-artifact@v2
         with:
           name: wheels
@@ -166,7 +170,7 @@ jobs:
           CPPFLAGS: "-Xpreprocessor -fopenmp"
           CFLAGS: "-Wno-implicit-function-declaration -I/opt/local/include/libomp"
           CXXFLAGS: "-I/opt/local/include/libomp"
-          LDFLAGS: "-Wl,-rpath,/opt/local/lib/libomp -L/opt/local/lib/libomp -lomp"
+          LDFLAGS: "-Wl,-S -Wl,-rpath,/opt/local/lib/libomp -L/opt/local/lib/libomp -lomp"
 
       - uses: actions/upload-artifact@v2
         with:
@@ -224,6 +228,8 @@ jobs:
         env:
           CIBW_BUILD: "cp310-*"
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
+          # -Wl,-S equivalent to gcc's -Wl,--strip-debug
+          LDFLAGS: "-Wl,-S"
 
       - name: Build Windows wheels for CPython
         run: |
@@ -232,6 +238,8 @@ jobs:
           CIBW_BUILD: "cp3?-*"
           CIBW_SKIP: "cp36-*"
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
+          # -Wl,-S equivalent to gcc's -Wl,--strip-debug
+          LDFLAGS: "-Wl,-S"
 
       - uses: actions/upload-artifact@v2
         with:
@@ -250,14 +258,14 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
-      
+          python-version: '3.9'
+
       - name: Install Twine
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements/build.txt
           pip install twine
-      
+
       - uses: actions/download-artifact@v2
         id: download
         with:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,8 @@ recursive-include requirements *.txt
 include requirements/README.md
 include Makefile
 include skimage/scripts/skivi
-recursive-include skimage *.pyx *.pxd *.pxi *.py *.c *.h *.ini *.npy *.txt *.in *.cpp *.md
+include skimage/restoration/unwrap_*_ljmu.c
+recursive-include skimage *.pyx *.pxd *.pxi *.py *.h *.ini *.npy *.txt *.in *.md
 recursive-include skimage/data *
 recursive-include skimage/*/tests/data *
 

--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,8 @@ class ConditionalOpenMP(pythran_build_ext[npy_build_ext]):
         else:
             compile_flags += ['-fopenmp']
             link_flags += ['-fopenmp']
+        if 'SKIMAGE_LINK_FLAGS' in os.environ:
+            link_flags += [os.environ['SKIMAGE_LINK_FLAGS']]
 
         if self.can_compile_link(compile_flags, link_flags):
             for ext in self.extensions:
@@ -245,7 +247,7 @@ if __name__ == "__main__":
         extras_require=extras_require,
         python_requires='>=3.7',
         packages=setuptools.find_packages(exclude=['doc', 'benchmarks']),
-        include_package_data=True,
+        include_package_data=False,
         zip_safe=False,  # the package can run out of an .egg file
         entry_points={
             'console_scripts': ['skivi = skimage.scripts.skivi:main'],

--- a/skimage/_build.py
+++ b/skimage/_build.py
@@ -60,10 +60,13 @@ def cython(pyx_files, working_path=''):
                 process_tempita_pyx(pyxfile)
                 pyx_files[i] = pyxfile.replace('.pyx.in', '.pyx')
 
-        # Cython doesn't automatically choose a number of threads > 1
-        # https://github.com/cython/cython/blob/a0bbb940c847dfe92cac446c8784c34c28c92836/Cython/Build/Dependencies.py#L923-L925
-        cythonize(pyx_files, nthreads=cpu_count(),
-                  compiler_directives={'language_level': 3})
+        # skip cythonize when creating an sdist
+        # (we do not want the large cython-generated sources to be included)
+        if 'sdist' not in sys.argv:
+            # Cython doesn't automatically choose a number of threads > 1
+            # https://github.com/cython/cython/blob/a0bbb940c847dfe92cac446c8784c34c28c92836/Cython/Build/Dependencies.py#L923-L925
+            cythonize(pyx_files, nthreads=cpu_count(),
+                      compiler_directives={'language_level': 3})
 
 
 def process_tempita_pyx(fromfile):


### PR DESCRIPTION
The only conflict that was resolved was bumping Python to 3.9 in the deployment step here. This was necessary on main since we dropped Python 3.7 support, but shouldn't hurt here either.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
