### PR TITLE
Pin setuptools maximum in v0.19.x to avoid breaking on planned distutils API changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools",
+    "setuptools<=59.4",
     "packaging",
     "Cython>=0.29.24,<3.0",
     "pythran",


### PR DESCRIPTION
## Description

This PR just pins the maximum setuptools version in `pyproject.toml` for the v0.19.x release branch. This is done to avoid potential instability due to [planned changes across setuptools and numpy.distutils](https://mail.python.org/archives/list/numpy-discussion@python.org/thread/JIN5YSD7CAJACRGXMD3S4S5B5MUDWZVL/). 

My takeaway from the post was that we should probably just pin the max version, particularly for the v0.19.x release branch where there is no plan to ever support Python > 3.10

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
