### PR TITLE
avoid circular import of rgb2gray

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from ..color import rgb2gray, rgba2rgb
 from ..util.dtype import dtype_range, dtype_limits
 from .._shared import utils
 
@@ -826,6 +825,8 @@ def is_low_contrast(image, fraction_threshold=0.05, lower_percentile=1,
         return not ((image.max() == 1) and (image.min() == 0))
 
     if image.ndim == 3:
+        from ..color import rgb2gray, rgba2rgb  # avoid circular import
+
         if image.shape[2] == 4:
             image = rgba2rgb(image)
         if image.shape[2] == 3:


### PR DESCRIPTION
## Description

Avoid a circular import error seen in #6112: https://github.com/scikit-image/scikit-image/runs/4449137778?check_suite_focus=true

I could not reproduce it locally when testing with EAGER_IMPORT=1, but perhaps it depends on the specific dependencies installed and what order the tests get run...


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
