### PR TITLE
respect SKIMAGE_TEST_STRICT_WARNINGS_GLOBAL setting in tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,10 +8,6 @@ jobs:
   test_skimage_linux:
     name: linux-cp${{ matrix.python-version }}-${{ matrix.OPTIONS_NAME }}
     runs-on: ubuntu-20.04
-    env:
-        BUILD_DOCS: 1
-        TEST_EXAMPLES: 0
-        SKIMAGE_TEST_STRICT_WARNINGS_GLOBAL: 0
 
     strategy:
       # Ensure that a wheel builder finishes even if another fails
@@ -20,8 +16,6 @@ jobs:
         python-version: [3.8, 3.9, '3.10']
         PIP_FLAGS: [""]
         MINIMUM_REQUIREMENTS: [0]
-        QT: ["PyQt5"]
-        WITH_PYSIDE: [0]
         BUILD_DOCS: [1]
         PYTHONOPTIMIZE: [0]
         TEST_EXAMPLES: [0]
@@ -29,6 +23,8 @@ jobs:
         OPTIONS_NAME: ["default"]
         INSTALL_FROM_SDIST: [0]
         WITHOUT_POOCH: [0]
+        SKIMAGE_TEST_STRICT_WARNINGS_GLOBAL: [0]
+        EAGER_IMPORT: [0]
         include:
           - platform_id: manylinux_x86_64
             python-version: 3.8
@@ -78,8 +74,8 @@ jobs:
 
       - name: Build package
         env:
-            VERSION: ${{ matrix.python-version }}
-            PYTHONOPTIMIZE: ${{ matrix.PYTHONOPTIMIZE }}
+            # Set variables here that are used by the build script below
+            # (including those used within tools/github/before_install.sh)
             MINIMUM_REQUIREMENTS: ${{ matrix.MINIMUM_REQUIREMENTS }}
             PIP_FLAGS: ${{ matrix.PIP_FLAGS }}
             INSTALL_FROM_SDIST: ${{ matrix.INSTALL_FROM_SDIST }}
@@ -88,7 +84,7 @@ jobs:
             source tools/github/before_install.sh
             set -ex
             python setup.py sdist
-            if [[ $INSTALL_FROM_SDIST != "0" ]]; then
+            if [[ $INSTALL_FROM_SDIST == "1" ]]; then
                 pip uninstall cython -y;
                 pip install dist/scikit-image-*.tar.gz;
             else
@@ -97,14 +93,18 @@ jobs:
 
       - name: Run tests
         env:
+            # Set variables here that are used by the run script below
+            # (including those used within tools/github/script.sh)
+            # Also includes the EAGER_IMPORT and
+            # SKIMAGE_TEST_STRICT_WARNINGS_GLOBAL env vars that skimage checks.
             PIP_FLAGS: ${{ matrix.PIP_FLAGS }}
-            MINIMUM_REQUIREMENTS: ${{ matrix.MINIMUM_REQUIREMENTS }}
-            QT: ${{ matrix.QT }}
-            WITH_PYSIDE: ${{ matrix.WITH_PYSIDE }}
             BUILD_DOCS: ${{ matrix.BUILD_DOCS }}
             TEST_EXAMPLES: ${{ matrix.TEST_EXAMPLES }}
             OPTIONAL_DEPS: ${{ matrix.OPTIONAL_DEPS }}
+            INSTALL_FROM_SDIST: ${{ matrix.INSTALL_FROM_SDIST }}
             EAGER_IMPORT: ${{ matrix.EAGER_IMPORT }}
+            SKIMAGE_TEST_STRICT_WARNINGS_GLOBAL: ${{ matrix.SKIMAGE_TEST_STRICT_WARNINGS_GLOBAL }}
+            WITHOUT_POOCH: ${{ matrix.WITHOUT_POOCH }}
         run: |
             echo $PIP_FLAGS
             pip install $PIP_FLAGS -r requirements/test.txt
@@ -113,7 +113,7 @@ jobs:
             touch ${MPL_DIR}/matplotlibrc
             if [[ "${OPTIONAL_DEPS}" == "1" ]]; then
                 pip install -r ./requirements/optional.txt
-                if [[ "${EXTRA_DEPS}" != "0" ]]; then
+                if [[ "${EXTRA_DEPS}" == "1" ]]; then
                 # Extra deps need compilation, and it may not always be possible to
                 # compile them easily on all platforms
                     pip install -r ./requirements/extras.txt
@@ -135,9 +135,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9, '3.10']
-        QT: ["PyQt5"]
-        BUILD_DOCS: [1]
-        TEST_EXAMPLES: [0]
         OPTIONAL_DEPS: [1]
         OPTIONS_NAME: ["default"]
         include:
@@ -146,8 +143,6 @@ jobs:
           - python-version: '3.10'
             OPTIONAL_DEPS: 0
         exclude:
-          - python-version: 3.8
-            OPTIONAL_DEPS: 1
           # Problem with SimpleITK and py 3.9
           - python-version: 3.9
             OPTIONAL_DEPS: 1
@@ -187,6 +182,10 @@ jobs:
             pip install -vv --no-build-isolation -e .;
 
       - name: Run tests
+        env:
+            # Note: BUILD_DOCS and TEST_EXAMPLES are not in the matrix.
+            #       They get inherited from the job-level env.
+            OPTIONAL_DEPS: ${{ matrix.OPTIONAL_DEPS }}
         run: |
             pip install $PIP_FLAGS -r requirements/test.txt
             export MPL_DIR=`python -c 'import matplotlib; print(matplotlib.get_configdir())'`

--- a/doc/examples/transform/plot_fundamental_matrix.py
+++ b/doc/examples/transform/plot_fundamental_matrix.py
@@ -45,17 +45,21 @@ descriptors_right = descriptor_extractor.descriptors
 matches = match_descriptors(descriptors_left, descriptors_right,
                             cross_check=True)
 
+print(f'Number of matches: {matches.shape[0]}')
+
 # Estimate the epipolar geometry between the left and right image.
+random_seed = 9
+rng = np.random.default_rng(random_seed)
 
 model, inliers = ransac((keypoints_left[matches[:, 0]],
                          keypoints_right[matches[:, 1]]),
                         FundamentalMatrixTransform, min_samples=8,
-                        residual_threshold=1, max_trials=5000)
+                        residual_threshold=1, max_trials=5000,
+                        random_state=rng)
 
 inlier_keypoints_left = keypoints_left[matches[inliers, 0]]
 inlier_keypoints_right = keypoints_right[matches[inliers, 1]]
 
-print(f'Number of matches: {matches.shape[0]}')
 print(f'Number of inliers: {inliers.sum()}')
 
 # Compare estimated sparse disparities to the dense ground-truth disparities.

--- a/doc/tools/build_modref_templates.py
+++ b/doc/tools/build_modref_templates.py
@@ -4,11 +4,11 @@
 # stdlib imports
 import os, sys
 
+from packaging import version as _version
+
 # local imports
 from apigen import ApiDocWriter
 
-# version comparison
-from distutils.version import LooseVersion as V
 
 #*****************************************************************************
 
@@ -36,13 +36,13 @@ if __name__ == '__main__':
     # for older or newer versions if such versions are installed on the system.
 
     # exclude any appended git hash and date
-    installed_version = V(module.__version__.split('+git')[0])
+    installed_version = _version.parse(module.__version__.split('+git')[0])
 
     source_lines = open('../skimage/__init__.py').readlines()
     version = 'vUndefined'
     for l in source_lines:
         if l.startswith('__version__'):
-            source_version = V(l.split("'")[1])
+            source_version = _version.parse(l.split("'")[1])
             break
 
     if source_version != installed_version:

--- a/skimage/_shared/lazy.py
+++ b/skimage/_shared/lazy.py
@@ -71,7 +71,8 @@ def attach(package_name, submodules=None, submod_attrs=None):
     def __dir__():
         return __all__
 
-    if os.environ.get('EAGER_IMPORT', ''):
+    eager_import = os.environ.get('EAGER_IMPORT', '')
+    if eager_import not in ['', '0', 'false']:
         for attr in set(attr_to_modules.keys()) | submodules:
             __getattr__(attr)
 

--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -223,6 +223,13 @@ def setup_test():
         warnings.filterwarnings(
             'default', message='TiffWriter:', category=DeprecationWarning
         )
+        # newer tifffile change the start of the warning string
+        # e.g. <tifffile.TiffWriter.write> data with shape ...
+        warnings.filterwarnings(
+            'default',
+            message='<tifffile.',
+            category=DeprecationWarning
+        )
 
         warnings.filterwarnings(
             'default', message='unclosed file', category=ResourceWarning
@@ -254,8 +261,16 @@ def setup_test():
             module='skimage.io'
         )
 
+        # match both "Viewer requires Qt" and "Viewer requires matplotlib"
         warnings.filterwarnings(
-            'default', message='Viewer requires Qt', category=UserWarning
+            'default', message='Viewer requires ', category=UserWarning
+        )
+
+        # ignore warning from cycle_spin about Dask not being installed
+        warnings.filterwarnings(
+            'default',
+            message='The optional dask dependency is not installed.',
+            category=UserWarning
         )
 
         warnings.filterwarnings(

--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -46,8 +46,10 @@ if _error_on_warnings.lower() == 'true':
 elif _error_on_warnings.lower() == 'false':
     _error_on_warnings = False
 else:
-    _error_on_warnings = bool(int(_error_on_warnings))
-
+    try:
+        _error_on_warnings = bool(int(_error_on_warnings))
+    except ValueError:
+        _error_on_warnings = False
 
 def assert_less(a, b, msg=None):
     message = "%r is not lower than %r" % (a, b)

--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 
 import numpy as np
 import pytest
@@ -66,9 +67,7 @@ def test_remove_argument():
         assert bar(0, arg1=1) == (0, 1, 1)
 
     assert str(record[0].message) == expected_msg
-
-    # Assert that nothing happens if arg1 is set
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as recorded:
         # No kwargs
         assert foo(0) == (0, 0, 1)
         assert foo(0, arg2=0) == (0, 0, 0)
@@ -78,9 +77,8 @@ def test_remove_argument():
         if sys.flags.optimize < 2:
             # if PYTHONOPTIMIZE is set to 2, docstrings are stripped
             assert foo.__doc__ == 'Expected docstring'
-
-    # Assert no warning was raised
-    assert not record.list
+    # Assert no warnings were raised
+    assert len(recorded) == 0
 
 
 def test_change_default_value():
@@ -110,7 +108,7 @@ def test_change_default_value():
     assert str(record[1].message) == "Custom warning message"
 
     # Assert that nothing happens if arg1 is set
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as recorded:
         # No kwargs
         assert foo(0, 2) == (0, 2, 1)
         assert foo(0, arg1=0) == (0, 0, 1)
@@ -120,9 +118,8 @@ def test_change_default_value():
         if sys.flags.optimize < 2:
             # if PYTHONOPTIMIZE is set to 2, docstrings are stripped
             assert foo.__doc__ == 'Expected docstring'
-
-    # Assert no warning was raised
-    assert not record.list
+    # Assert no warnings were raised
+    assert len(recorded) == 0
 
 
 def test_deprecate_kwarg():
@@ -152,7 +149,7 @@ def test_deprecate_kwarg():
 
     # Assert that nothing happens when the function is called with the
     # new API
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as recorded:
         # No kwargs
         assert foo(0) == (0, 1, None)
         assert foo(0, 2) == (0, 2, None)
@@ -180,8 +177,7 @@ def test_deprecate_kwarg():
         .. deprecated:: 0.19
 """
 
-    # Assert no warning was raised
-    assert not record.list
+    assert len(recorded) == 0
 
 
 def test_check_nD():

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from ..color import rgb2gray, rgba2rgb
 from ..util.dtype import dtype_range, dtype_limits
 from .._shared import utils
 
@@ -826,6 +825,8 @@ def is_low_contrast(image, fraction_threshold=0.05, lower_percentile=1,
         return not ((image.max() == 1) and (image.min() == 0))
 
     if image.ndim == 3:
+        from ..color import rgb2gray, rgba2rgb  # avoid circular import
+
         if image.shape[2] == 4:
             image = rgba2rgb(image)
         if image.shape[2] == 3:

--- a/skimage/feature/tests/test_blob.py
+++ b/skimage/feature/tests/test_blob.py
@@ -287,9 +287,7 @@ def test_blob_log_no_warnings():
     xs, ys = disk((7, 6), 2)
     img[xs, ys] = 255
 
-    with pytest.warns(None) as records:
-        blob_log(img, max_sigma=20, num_sigma=10, threshold=.1)
-    assert len(records) == 0
+    blob_log(img, max_sigma=20, num_sigma=10, threshold=.1)
 
 
 def test_blob_log_3d():

--- a/skimage/filters/tests/test_gaussian.py
+++ b/skimage/filters/tests/test_gaussian.py
@@ -9,7 +9,7 @@ from skimage.filters import difference_of_gaussians, gaussian
 
 def test_negative_sigma():
     a = np.zeros((3, 3))
-    a[1, 1] = 1.
+    a[1, 1] = 1
     with pytest.raises(ValueError):
         gaussian(a, sigma=-1.0)
     with pytest.raises(ValueError):

--- a/skimage/filters/tests/test_median.py
+++ b/skimage/filters/tests/test_median.py
@@ -18,21 +18,19 @@ def image():
 
 
 @pytest.mark.parametrize(
-    "mode, cval, behavior, n_warning, warning_type",
-    [('nearest', 0.0, 'ndimage', 0, []),
-     ('constant', 0.0, 'rank', 1, (UserWarning,)),
-     ('nearest', 0.0, 'rank', 0, []),
-     ('nearest', 0.0, 'ndimage', 0, [])]
+    "mode, cval, behavior, warning_type",
+    [('nearest', 0.0, 'ndimage', None),
+     ('constant', 0.0, 'rank', UserWarning),
+     ('nearest', 0.0, 'rank', None),
+     ('nearest', 0.0, 'ndimage', None)]
 )
-def test_median_warning(image, mode, cval, behavior,
-                        n_warning, warning_type):
+def test_median_warning(image, mode, cval, behavior, warning_type):
 
-    with pytest.warns(None) as records:
+    if warning_type:
+        with pytest.warns(warning_type):
+            median(image, mode=mode, behavior=behavior)
+    else:
         median(image, mode=mode, behavior=behavior)
-
-    assert len(records) == n_warning
-    for rec in records:
-        assert isinstance(rec.message, warning_type)
 
 
 def test_selem_kwarg_deprecation(image):

--- a/skimage/filters/tests/test_ridges.py
+++ b/skimage/filters/tests/test_ridges.py
@@ -33,11 +33,13 @@ def test_2d_null_matrix():
 
 def test_3d_null_matrix():
 
-    a_black = np.zeros((3, 3, 3)).astype(np.uint8)
+    # Note: last axis intentionally not size 3 to avoid 2D+RGB autodetection
+    #       warning from an internal call to `skimage.filters.gaussian`.
+    a_black = np.zeros((3, 3, 5)).astype(np.uint8)
     a_white = invert(a_black)
 
-    zeros = np.zeros((3, 3, 3))
-    ones = np.ones((3, 3, 3))
+    zeros = np.zeros((3, 3, 5))
+    ones = np.ones((3, 3, 5))
 
     assert_allclose(meijering(a_black, black_ridges=True), zeros, atol=1e-1)
     assert_allclose(meijering(a_white, black_ridges=False), zeros, atol=1e-1)
@@ -138,7 +140,9 @@ def test_2d_linearity():
 
 def test_3d_linearity():
 
-    a_black = np.ones((3, 3, 3)).astype(np.uint8)
+    # Note: last axis intentionally not size 3 to avoid 2D+RGB autodetection
+    #       warning from an internal call to `skimage.filters.gaussian`.
+    a_black = np.ones((3, 3, 5)).astype(np.uint8)
     a_white = invert(a_black)
 
     assert_allclose(meijering(1 * a_black, black_ridges=True),
@@ -199,11 +203,11 @@ def test_ridge_output_dtype(func, dtype):
 def test_3d_cropped_camera_image():
 
     a_black = crop(camera(), ((200, 212), (100, 312)))
-    a_black = np.dstack([a_black, a_black, a_black])
+    a_black = np.stack([a_black] * 5, axis=-1)
     a_white = invert(a_black)
 
-    zeros = np.zeros((100, 100, 3))
-    ones = np.ones((100, 100, 3))
+    zeros = np.zeros(a_black.shape)
+    ones = np.ones(a_black.shape)
 
     assert_allclose(meijering(a_black, black_ridges=True),
                     meijering(a_white, black_ridges=False))

--- a/skimage/io/tests/test_collection.py
+++ b/skimage/io/tests/test_collection.py
@@ -7,7 +7,7 @@ from skimage.io.collection import ImageCollection, MultiImage, alphanumeric_key
 from skimage.io import reset_plugins
 
 from skimage._shared import testing
-from skimage._shared.testing import assert_equal, assert_allclose, TestCase
+from skimage._shared.testing import assert_equal, assert_allclose, fetch
 
 
 def test_string_split():
@@ -44,14 +44,14 @@ def test_imagecollection_input():
     assert len(images) == 3
 
 
-class TestImageCollection(TestCase):
+class TestImageCollection():
     pattern = [os.path.join(data_dir, pic)
                for pic in ['brick.png', 'color.png']]
 
     pattern_matched = [os.path.join(data_dir, pic)
                        for pic in ['brick.png', 'moon.png']]
 
-    def setUp(self):
+    def setup_method(self):
         reset_plugins()
         # Generic image collection with images of different shapes.
         self.images = ImageCollection(self.pattern)
@@ -96,7 +96,7 @@ class TestImageCollection(TestCase):
             set_files('newfiles')
 
     def test_custom_load_func_w_kwarg(self):
-        load_pattern = os.path.join(data_dir, 'no_time_for_that_tiny.gif')
+        load_pattern = fetch('data/no_time_for_that_tiny.gif')
 
         def load_fn(f, step):
             vid = imageio.get_reader(f)

--- a/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_phase_cross_correlation.py
@@ -5,6 +5,7 @@ from scipy.ndimage import fourier_shift
 import scipy.fft as fft
 
 from skimage import img_as_float
+from skimage._shared._warnings import expected_warnings
 from skimage._shared.utils import _supported_float_type
 from skimage.data import camera, binary_blobs
 from skimage.registration._phase_cross_correlation import (
@@ -131,8 +132,9 @@ def test_wrong_input():
     image = np.ones((5, 5))
     image[0][0] = np.nan
     template = np.ones((5, 5))
-    with pytest.raises(ValueError):
-        phase_cross_correlation(template, image, return_error=True)
+    with expected_warnings([r'invalid value encountered in true_divide|\A\Z']):
+        with pytest.raises(ValueError):
+            phase_cross_correlation(template, image, return_error=True)
 
 
 def test_4d_input_pixel():

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -541,6 +541,7 @@ def test_denoise_nl_means_multichannel(fast_mode, dtype, channel_axis):
         denoised_wrong_multichannel, channel_axis, -1
     )
 
+    img = img.astype(denoised_wrong_multichannel.dtype)
     psnr_wrong = peak_signal_noise_ratio(img, denoised_wrong_multichannel)
     psnr_ok = peak_signal_noise_ratio(img, denoised_ok_multichannel)
     assert psnr_ok > psnr_wrong

--- a/skimage/util/apply_parallel.py
+++ b/skimage/util/apply_parallel.py
@@ -184,6 +184,11 @@ def apply_parallel(function, array, chunks=None, depth=0, mode=None,
         mode = 'reflect'
     elif mode == 'edge':
         mode = 'nearest'
+    elif mode is None:
+        # default value for Dask.
+        # Note: that for dask >= 2022.03 it will change to 'none' so we set it
+        #       here for consistent behavior across Dask versions.
+        mode = 'reflect'
 
     if channel_axis is not None:
         if numpy.isscalar(depth):

--- a/tools/github/script.sh
+++ b/tools/github/script.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Fail on non-zero exit and echo the commands
-set -ev
+set -evx
 
 mkdir -p $MPL_DIR
 touch $MPL_DIR/matplotlibrc
@@ -11,7 +11,7 @@ tools/build_versions.py
 
 TEST_ARGS="--doctest-modules --cov=skimage"
 
-if [[ ${WITHOUT_POOCH} != "0" ]]; then
+if [[ ${WITHOUT_POOCH} == "1" ]]; then
   # remove pooch (previously installed via requirements/test.txt)
   pip uninstall pooch -y
 fi
@@ -19,7 +19,7 @@ fi
 # When installing from sdist
 # We can't run it in the git directory since there is a folder called `skimage`
 # in there. pytest will crawl that instead of the module we installed and want to test
-if [[ ${INSTALL_FROM_SDIST} != "0" ]]; then
+if [[ ${INSTALL_FROM_SDIST} == "1" ]]; then
   (cd .. && python -c "import skimage; skimage.test()")
 else
   (cd .. && pytest $TEST_ARGS --pyargs skimage)


### PR DESCRIPTION

## Description

Some time ago we added a CI case that was supposed to raise errors on unexpected warnings. As noticed in #6116, this has not been running and there are a few new warnings showing up in the test suite.

I am first running CI with just a commit to get the warnings test working. This should fail as-is. Then I will add follow-up commits to fix the warnings causing the failure.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
