### PR TITLE
bump deprecated Azure windows environment

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
 jobs:
 - job: 'Default'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
   strategy:
     maxParallel: 10
     matrix:


### PR DESCRIPTION
## Description

In #6129, we observed Azure job failures with the message:
```
##[error]This is a scheduled windows-2016 brownout. The windows-2016 environment is deprecated and will be removed on March 15, 2022. For more details, see https://github.com/actions/virtual-environments/issues/4312
,##[error]The remote provider was unable to process the request.
```

This PR just updates to use `windows-latest` (which is currently equivalent to `windows-2019` but will become `windows-2022` sometime next year)

see: https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
