### PR TITLE
add Array API support to denoise_tv_chambolle

### DIFF
--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -13,7 +13,7 @@ from ._warnings import all_warnings, warn
 
 __all__ = ['deprecated', 'get_bound_method_class', 'all_warnings',
            'safe_as_int', 'check_shape_equality', 'check_nD', 'warn',
-           'reshape_nd', 'identity', 'slice_at_axis']
+           'reshape_nd', 'identity', 'slice_at_axis', 'get_namespace']
 
 
 class skimage_deprecation(Warning):
@@ -752,3 +752,14 @@ def _supported_float_type(input_dtype, allow_complex=False):
 def identity(image, *args, **kwargs):
     """Returns the first argument unmodified."""
     return image
+
+
+def get_namespace(x):
+    """Determine the array module based on x
+
+    Notes
+    -----
+    Could extend to multiple arguments as in the example in
+    https://numpy.org/neps/nep-0047-array-api-standard.html
+    """
+    return x.__array_namespace__() if hasattr(x, '__array_namespace__') else np

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -381,14 +381,15 @@ def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, n_iter_max=200):
     """
 
     ndim = image.ndim
-    p = np.zeros((image.ndim, ) + image.shape, dtype=image.dtype)
-    g = np.zeros_like(p)
-    d = np.zeros_like(image)
+    xp  = utils.get_namespace(image)
+    p = xp.zeros((image.ndim, ) + image.shape, dtype=image.dtype)
+    g = xp.zeros_like(p)
+    d = xp.zeros_like(image)
     i = 0
     while i < n_iter_max:
         if i > 0:
             # d will be the (negative) divergence of p
-            d = -p.sum(0)
+            d = xp.sum(-p, axis=0)
             slices_d = [slice(None), ] * ndim
             slices_p = [slice(None), ] * (ndim + 1)
             for ax in range(ndim):
@@ -401,7 +402,7 @@ def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, n_iter_max=200):
             out = image + d
         else:
             out = image
-        E = (d ** 2).sum()
+        E = xp.sum(d * d)
 
         # g stores the gradients of out along each axis
         # e.g. g[0] is the first order finite difference along axis 0
@@ -409,11 +410,17 @@ def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, n_iter_max=200):
         for ax in range(ndim):
             slices_g[ax+1] = slice(0, -1)
             slices_g[0] = ax
-            g[tuple(slices_g)] = np.diff(out, axis=ax)
+
+            # first order difference along the axis (np.diff not in array API)
+            _at = functools.partial(utils.slice_at_axis, axis=ax)
+            g[tuple(slices_g)] = (
+                out[_at(slice(1, None))] - out[_at(slice(0, -1))]
+            )
+
             slices_g[ax+1] = slice(None)
 
-        norm = np.sqrt((g ** 2).sum(axis=0))[np.newaxis, ...]
-        E += weight * norm.sum()
+        norm = xp.expand_dims(xp.sqrt(xp.sum(g * g, axis=0)), axis=0)
+        E += weight * xp.sum(norm)
         tau = 1. / (2.*ndim)
         norm *= tau / weight
         norm += 1.
@@ -424,7 +431,7 @@ def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, n_iter_max=200):
             E_init = E
             E_previous = E
         else:
-            if np.abs(E_previous - E) < eps * E_init:
+            if abs(E_previous - E) < eps * E_init:
                 break
             else:
                 E_previous = E
@@ -515,18 +522,35 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, n_iter_max=200,
 
     """
 
+    xp = utils.get_namespace(image)
     im_type = image.dtype
     if not im_type.kind == 'f':
-        image = img_as_float(image)
+        if xp is not np:
+            raise NotImplementedError(
+                "img_as_float doesn't currently have Array API support.")
+            # for numpy.array_api could do
+            # image = xp.asarray(img_as_float(image._array))
+        else:
+            image = img_as_float(image)
 
     # enforce float16->float32 and float128->float64
     float_dtype = _supported_float_type(image.dtype)
-    image = image.astype(float_dtype, copy=False)
+    if hasattr(xp, 'astype'):
+        # array API has an astype function
+        image = xp.astype(image, float_dtype, copy=False)
+    elif hasattr(image, 'astype'):
+        # numpy has this astype as a method on the array
+        image = image.astype(float_dtype, copy=False)
+
+    # Note: instead of the if/else above, also tried
+    #     image = xp.asarray(image, dtype=xp.float32, copy=False)
+    #     but array_api raises:
+    #         NotImplementedError: copy=False is not yet implemented
 
     if channel_axis is not None:
         channel_axis = channel_axis % image.ndim
         _at = functools.partial(utils.slice_at_axis, axis=channel_axis)
-        out = np.zeros_like(image)
+        out = xp.zeros_like(image)
         for c in range(image.shape[channel_axis]):
             out[_at(c)] = _denoise_tv_chambolle_nd(image[_at(c)], weight, eps,
                                                    n_iter_max)


### PR DESCRIPTION
## Description

Here is a demo of converting an existing non-trivial function `denoise_tv_chambolle` to support any array object implementing the [Array API](https://data-apis.org/array-api/latest/) as [implemented for the upcoming NumPy 1.22](https://numpy.org/neps/nep-0047-array-api-standard.html).

### Demo code 

The following is demo code that can be run with NumPy 1.22 (currently available via `pip install -U --pre numpy`):

```Python
import matplotlib.pyplot as plt
import numpy as np
from numpy import array_api

from skimage import data
from skimage.restoration import denoise_tv_chambolle

# generate a noisy cameraman image
x = data.camera()
rng = np.random.default_rng()
x = x + 20 * rng.standard_normal(x.shape)
x /= 255

weight = 0.05

# first make sure it works for standard NumPy arrays
denoised = denoise_tv_chambolle(x, weight=weight)

# now try with a numpy.array_api array
x_api = array_api.asarray(x)
denoised_array_api = denoise_tv_chambolle(x_api, weight=weight)

# confirm that the results for these two cases are equivalent
np.testing.assert_allclose(x, x_api._array)

# view the result
fig, axes = plt.subplots(1, 2)
axes[0].imshow(x, cmap=plt.cm.gray)
axes[0].set_title('original')
axes[1].imshow(denoised, cmap=plt.cm.gray)
axes[1].set_title('denoised')
for ax in axes:
    ax.set_axis_off()
plt.show()
```


### Some specific points of this conversion:

- `np.diff` has no equivalent in the array API so had to use explicit difference via slicing instead

- Had to use functions (e.g. `xp.sum(image)`) instead of calling methods on the array object (e.g. `image.sum()`)

- Had to use `expand_dims` instead of `np.newaxis`

- Had to use an ugly if/else case to get an `image.astype` equivalent working across both `np` and `np.array_api` arrays. This is because array_api defines a function `numpy.array_api.astype` while in `numpy` it is an `astype` method on the array.

- Currently only supports floating point images for the Array API case as `img_as_float` hasn't been converted to support Array API inputs. That could be resolved, though.

### Other Limitations

This function is nearly the only one under `skimage.restoration` that is compatible with acceleration via the Array API. The various deconvolution functions require FFTs and complex dtypes which are not currently in the Array API. The other denoising functions, inpainting and phase unwrapping functions all rely on compiled Cython code and so can't be converted in this manner. 

Probably the higher level `calibrate_denoiser` is the only other functions under `skimage.restoration` that we could currently convert to use the Array API and even then it would be restricted to use a `denoise_function` that has Array API support (only `denoise_tv_chambolle` among the ones we provide)

Outside of `skimage.restoration` there are some other functions that could be implemented purely using the Array API, but I think this are in the minority (probably below 10% of all functions in the library).

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
