### PR TITLE
clarify the meaning of the weights term for TV denoising functions

### DIFF
--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -278,8 +278,8 @@ def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
     weight : float
         Denoising weight. The smaller the `weight`, the more denoising (at
         the expense of less similarity to the `input`). (i.e. smaller weights
-        lead to more smoothing). The regularization parameter `lambda` is chosen
-        as `2 * weight`.
+        lead to more smoothing). The regularization parameter `lambda` is
+        chosen as `2 * weight`.
     eps : float, optional
         Relative difference of the value of the cost function that determines
         the stop criterion. The algorithm stops when::
@@ -362,7 +362,7 @@ def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, n_iter_max=200):
     weight : float, optional
         Denoising weight. The greater `weight`, the more denoising (at
         the expense of fidelity to `input`). (i.e. larger weights lead
-        to more smoothing). 
+        to more smoothing).
     eps : float, optional
         Relative difference of the value of the cost function that determines
         the stop criterion. The algorithm stops when:
@@ -448,7 +448,7 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, n_iter_max=200,
     weight : float, optional
         Denoising weight. The greater `weight`, the more denoising (at
         the expense of fidelity to `input`). (i.e. larger weights lead
-        to more smoothing). 
+        to more smoothing).
     eps : float, optional
         Relative difference of the value of the cost function that
         determines the stop criterion. The algorithm stops when:

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -277,8 +277,9 @@ def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
         Input data to be denoised (converted using img_as_float`).
     weight : float
         Denoising weight. The smaller the `weight`, the more denoising (at
-        the expense of less similarity to the `input`). The regularization
-        parameter `lambda` is chosen as `2 * weight`.
+        the expense of less similarity to the `input`). (i.e. smaller weights
+        lead to more smoothing). The regularization parameter `lambda` is chosen
+        as `2 * weight`.
     eps : float, optional
         Relative difference of the value of the cost function that determines
         the stop criterion. The algorithm stops when::
@@ -360,7 +361,8 @@ def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, n_iter_max=200):
         n-D input data to be denoised.
     weight : float, optional
         Denoising weight. The greater `weight`, the more denoising (at
-        the expense of fidelity to `input`).
+        the expense of fidelity to `input`). (i.e. larger weights lead
+        to more smoothing). 
     eps : float, optional
         Relative difference of the value of the cost function that determines
         the stop criterion. The algorithm stops when:
@@ -445,7 +447,8 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, n_iter_max=200,
         of the denoised image.
     weight : float, optional
         Denoising weight. The greater `weight`, the more denoising (at
-        the expense of fidelity to `input`).
+        the expense of fidelity to `input`). (i.e. larger weights lead
+        to more smoothing). 
     eps : float, optional
         Relative difference of the value of the cost function that
         determines the stop criterion. The algorithm stops when:


### PR DESCRIPTION
## Description
Fixed  #5379 

After discovering above issue, I modified the docstring to clarify the meaning of weight a little more.
Please review it. Thanks you🙂
<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
