### PR TITLE
Allow variable stacklevel for deprecation warnings.

### DIFF
--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -208,7 +208,7 @@ class deprecate_kwarg:
                                 "for `{func_name}`. ")
             if removed_version is not None:
                 self.warning_msg += (f'It will be removed in '
-                                     f'version {removed_version}.')
+                                     f'version {removed_version}. ')
             self.warning_msg += "Please use `{new_arg}` instead."
         else:
             self.warning_msg = warning_msg
@@ -249,13 +249,14 @@ class deprecate_multichannel_kwarg(deprecate_kwarg):
 
     """
 
-    def __init__(self, removed_version='1.0', multichannel_position=None):
+    def __init__(self, removed_version='1.0', multichannel_position=None, extra_stacklevel=0):
         super().__init__(
             kwarg_mapping={'multichannel': 'channel_axis'},
             deprecated_version='0.19',
             warning_msg=None,
             removed_version=removed_version)
         self.position = multichannel_position
+        self.extra_stacklevel = extra_stacklevel
 
     def __call__(self, func):
         @functools.wraps(func)
@@ -269,7 +270,7 @@ class deprecate_multichannel_kwarg(deprecate_kwarg):
                 )
                 warnings.warn(warning_msg.format(func_name=func.__name__),
                               FutureWarning,
-                              stacklevel=2)
+                              stacklevel=2+self.extra_stacklevel)
                 if 'channel_axis' in kwargs:
                     raise ValueError(
                         "Cannot provide both a `channel_axis` kwarg and a "
@@ -283,7 +284,7 @@ class deprecate_multichannel_kwarg(deprecate_kwarg):
                 #  warn that the function interface has changed:
                 warnings.warn(self.warning_msg.format(
                     old_arg='multichannel', func_name=func.__name__,
-                    new_arg='channel_axis'), FutureWarning, stacklevel=2)
+                    new_arg='channel_axis'), FutureWarning, stacklevel=2+self.extra_stacklevel)
 
                 # multichannel = True -> last axis corresponds to channels
                 convert = {True: -1, False: None}
@@ -344,7 +345,7 @@ class channel_as_last_axis():
                 channel_axis = (channel_axis,)
             if len(channel_axis) > 1:
                 raise ValueError(
-                    "only a single channel axis is currently suported")
+                    "only a single channel axis is currently supported")
 
             if channel_axis == (-1,) or channel_axis == -1:
                 return func(*args, **kwargs)

--- a/skimage/exposure/histogram_matching.py
+++ b/skimage/exposure/histogram_matching.py
@@ -22,7 +22,7 @@ def _match_cumulative_cdf(source, template):
 
 
 @utils.channel_as_last_axis(channel_arg_positions=(0, 1))
-@utils.deprecate_multichannel_kwarg()
+@utils.deprecate_multichannel_kwarg(extra_stacklevel=1)
 def match_histograms(image, reference, *, channel_axis=None,
                      multichannel=False):
     """Adjust an image so that its cumulative histogram matches that of another.

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -46,7 +46,7 @@ def _hog_channel_gradient(channel):
 
 
 @utils.channel_as_last_axis(multichannel_output=False)
-@utils.deprecate_multichannel_kwarg(multichannel_position=8)
+@utils.deprecate_multichannel_kwarg(multichannel_position=8, extra_stacklevel=1)
 def hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(3, 3),
         block_norm='L2-Hys', visualize=False, transform_sqrt=False,
         feature_vector=True, multichannel=None, *, channel_axis=None):

--- a/skimage/filters/_unsharp_mask.py
+++ b/skimage/filters/_unsharp_mask.py
@@ -16,7 +16,7 @@ def _unsharp_mask_single_channel(image, radius, amount, vrange):
     return result
 
 
-@utils.deprecate_multichannel_kwarg(multichannel_position=3)
+@utils.deprecate_multichannel_kwarg(multichannel_position=3, extra_stacklevel=1)
 def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
                  preserve_range=False, *, channel_axis=None):
     """Unsharp masking filter.

--- a/skimage/restoration/_cycle_spin.py
+++ b/skimage/restoration/_cycle_spin.py
@@ -48,7 +48,7 @@ def _generate_shifts(ndim, multichannel, max_shifts, shift_steps=1):
 
 
 @utils.channel_as_last_axis()
-@utils.deprecate_multichannel_kwarg(multichannel_position=5)
+@utils.deprecate_multichannel_kwarg(multichannel_position=5, extra_stacklevel=1)
 def cycle_spin(x, func, max_shifts, shift_steps=1, num_workers=None,
                multichannel=False, func_kw={}, *, channel_axis=-1):
     """Cycle spinning (repeatedly apply func to shifted versions of x).

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -93,7 +93,7 @@ def _compute_spatial_lut(win_size, sigma, *, dtype=float):
 
 
 @utils.channel_as_last_axis()
-@utils.deprecate_multichannel_kwarg(multichannel_position=7)
+@utils.deprecate_multichannel_kwarg(multichannel_position=7, extra_stacklevel=1)
 def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
                       bins=10000, mode='constant', cval=0, multichannel=False,
                       *, channel_axis=None):
@@ -258,9 +258,9 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
 
 
 @utils.channel_as_last_axis()
-@utils.deprecate_multichannel_kwarg()
+@utils.deprecate_multichannel_kwarg(extra_stacklevel=1)
 @utils.deprecate_kwarg({'max_iter': 'max_num_iter'}, removed_version="1.0",
-                       deprecated_version="0.19")
+                       deprecated_version="0.19", extra_stacklevel=1)
 def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
                        isotropic=True, *, channel_axis=None,
                        multichannel=False):
@@ -432,7 +432,7 @@ def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, n_iter_max=200):
     return out
 
 
-@utils.deprecate_multichannel_kwarg(multichannel_position=4)
+@utils.deprecate_multichannel_kwarg(multichannel_position=4, extra_stacklevel=1)
 def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, n_iter_max=200,
                          multichannel=False, *, channel_axis=None):
     """Perform total-variation denoising on n-dimensional images.
@@ -751,7 +751,7 @@ def _rescale_sigma_rgb2ycbcr(sigmas):
 
 
 @utils.channel_as_last_axis()
-@utils.deprecate_multichannel_kwarg(multichannel_position=5)
+@utils.deprecate_multichannel_kwarg(multichannel_position=5, extra_stacklevel=1)
 def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
                     wavelet_levels=None, multichannel=False,
                     convert2ycbcr=False, method='BayesShrink',
@@ -933,7 +933,7 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
     return out
 
 
-@utils.deprecate_multichannel_kwarg(multichannel_position=2)
+@utils.deprecate_multichannel_kwarg(multichannel_position=2, extra_stacklevel=1)
 def estimate_sigma(image, average_sigmas=False, multichannel=False, *,
                    channel_axis=None):
     """

--- a/skimage/restoration/inpaint.py
+++ b/skimage/restoration/inpaint.py
@@ -190,7 +190,7 @@ def _inpaint_biharmonic_single_region(image, mask, out, neigh_coef_full,
 
 
 @utils.channel_as_last_axis()
-@utils.deprecate_multichannel_kwarg(multichannel_position=2)
+@utils.deprecate_multichannel_kwarg(multichannel_position=2, extra_stacklevel=1)
 def inpaint_biharmonic(image, mask, multichannel=False, *,
                        split_into_regions=False, channel_axis=None):
     """Inpaint masked points in image with biharmonic equations.

--- a/skimage/restoration/non_local_means.py
+++ b/skimage/restoration/non_local_means.py
@@ -10,7 +10,7 @@ from ._nl_means_denoising import (_nl_means_denoising_2d,
 
 
 @utils.channel_as_last_axis()
-@utils.deprecate_multichannel_kwarg(multichannel_position=4)
+@utils.deprecate_multichannel_kwarg(multichannel_position=4, extra_stacklevel=1)
 def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
                      multichannel=False, fast_mode=True, sigma=0., *,
                      preserve_range=False, channel_axis=None):

--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -109,7 +109,7 @@ def _get_grid_centroids(image, n_centroids):
 
 
 @utils.channel_as_last_axis(multichannel_output=False)
-@utils.deprecate_multichannel_kwarg(multichannel_position=6)
+@utils.deprecate_multichannel_kwarg(multichannel_position=6, extra_stacklevel=1)
 @utils.deprecate_kwarg({'max_iter': 'max_num_iter'}, removed_version="1.0",
                        deprecated_version="0.19")
 def slic(image, n_segments=100, compactness=10., max_num_iter=10, sigma=0,

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -237,7 +237,7 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
 
 
 @channel_as_last_axis()
-@deprecate_multichannel_kwarg(multichannel_position=7)
+@deprecate_multichannel_kwarg(multichannel_position=7, extra_stacklevel=1)
 def rescale(image, scale, order=None, mode='reflect', cval=0, clip=True,
             preserve_range=False, multichannel=False,
             anti_aliasing=None, anti_aliasing_sigma=None, *,
@@ -1049,7 +1049,7 @@ def _log_polar_mapping(output_coords, k_angle, k_radius, center):
 
 
 @channel_as_last_axis()
-@deprecate_multichannel_kwarg()
+@deprecate_multichannel_kwarg(extra_stacklevel=1)
 def warp_polar(image, center=None, *, radius=None, output_shape=None,
                scaling='linear', multichannel=False, channel_axis=None,
                **kwargs):

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -101,7 +101,7 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
 
 
 @utils.channel_as_last_axis()
-@utils.deprecate_multichannel_kwarg(multichannel_position=6)
+@utils.deprecate_multichannel_kwarg(multichannel_position=6, extra_stacklevel=1)
 def pyramid_expand(image, upscale=2, sigma=None, order=1,
                    mode='reflect', cval=0, multichannel=False,
                    preserve_range=False, *, channel_axis=None):
@@ -172,7 +172,7 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
 
 
 @utils.channel_as_last_axis()
-@utils.deprecate_multichannel_kwarg(multichannel_position=7)
+@utils.deprecate_multichannel_kwarg(multichannel_position=7, extra_stacklevel=1)
 def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
                      mode='reflect', cval=0, multichannel=False,
                      preserve_range=False, *, channel_axis=-1):


### PR DESCRIPTION
Each decoration needs to be manually checked, I have ideas on how to
make that better, by inspecting the above frames and look whether there
is a sentinel asking to add 1 to the stack number, but not tonight.

closes #6137

Alternative would be to use something like:


```python
def extra_stack():
     import sys
     f = sys._getframe()
     fback = f.f_back
     count = 0
     while '__DEPRECATION_SKIP_STACK__' in fback.f_locals.keys():
         count +=1
         fback = fback.f_back
     return count

```

And mark corresponding decorators with ``__DEPRECATION_SKIP_STACK__ = 1``.
or 
```python
def extra_stack(module_name='skimage'):
     import sys
     f = sys._getframe()
     fback = f.f_back
     count = 0
     while module_name in fback.f_global['__name__']:
         count +=1
         fback = fback.f_back
     return count
```

Which would always compute stacklevels so that deprecation warnings are emitted outside of skimage, potentially with a global toggle for skimage own CI Suite.

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
