### PR TITLE
fix phase_cross_correlation typo

### DIFF
--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -160,7 +160,7 @@ def phase_cross_correlation(reference_image, moving_image, *,
         maximum translation, while a higher `overlap_ratio` leads to greater
         robustness against spurious matches due to small overlap between
         masked images. Used only if one of ``reference_mask`` or
-        ``moving_mask`` is None.
+        ``moving_mask`` is not None.
     normalization : {"phase", None}
         The type of normalization to apply to the cross-correlation. This
         parameter is unused when masks (`reference_mask` and `moving_mask`) are


### PR DESCRIPTION
Fix typo in `phase_cross_correlation` which confusingly states the utility of `overlap_ratio`.