### PR TITLE
allow to compute euler number along axis

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -6,3 +6,5 @@ imageio>=2.4.1
 tifffile>=2019.7.26
 PyWavelets>=1.1.1
 packaging>=20.0
+xarray>=0.20.1
+xhistogram>=0.3.1

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -6,5 +6,4 @@ imageio>=2.4.1
 tifffile>=2019.7.26
 PyWavelets>=1.1.1
 packaging>=20.0
-xarray>=0.20.1
 xhistogram>=0.3.1

--- a/skimage/measure/_regionprops_utils.py
+++ b/skimage/measure/_regionprops_utils.py
@@ -1,8 +1,7 @@
 from math import sqrt
 import numpy as np
 from scipy import ndimage as ndi
-import xarray as xr
-import xhistogram.xarray as xh
+import xhistogram.core as xh
 
 
 STREL_4 = np.array([[0, 1, 0],
@@ -186,7 +185,7 @@ def euler_number(image, connectivity=None, axes=None):
     XF_flat = flatten_along_axes(XF, axes=image_axes)
 
     bin_edges = np.arange(0, bins+0.1, 1)
-    h = histogram_along_axes(XF_flat, bins=bin_edges, dim=[f"dim_{XF_flat.ndim-1}"])
+    h = xh.histogram(XF_flat, bins=bin_edges, axis=-1)[0]
 
     coord_frame = [1 for i in range(coord_axes.size)] if coord_axes is not None else []
     if dims == 2:
@@ -223,12 +222,6 @@ def flatten_along_axes(arr, axes=None):
     arr_flat = np.transpose(arr, axes=np.hstack([coord_axes, image_axes]))
     arr_flat = arr_flat.reshape(*([sh for i, sh in enumerate(arr.shape) if i in coord_axes] + [-1]))
     return arr_flat
-
-
-def histogram_along_axes(arr, dim=None, bins=None):
-    xarr = xr.DataArray(arr, name="tmp")
-    xhist = xh.histogram(xarr, dim=dim, bins=bins)
-    return xhist.data
 
 
 def perimeter(image, neighbourhood=4):

--- a/skimage/measure/_regionprops_utils.py
+++ b/skimage/measure/_regionprops_utils.py
@@ -142,8 +142,8 @@ def euler_number(image, connectivity=None, axes=None):
     """
 
     image_axes = np.asarray(axes) if axes is not None else None
-    coord_axes = np.array([i for i in range(image.ndim) if i not in image_axes]) if image_axes is not None else None
     dims = image_axes.size if image_axes is not None else image.ndim
+    coord_dims = image.ndim - dims
     assert dims in [2, 3]
 
     # as image can be a label image, transform it to binary
@@ -185,9 +185,9 @@ def euler_number(image, connectivity=None, axes=None):
     XF_flat = flatten_along_axes(XF, axes=image_axes)
 
     bin_edges = np.arange(0, bins+0.1, 1)
-    h = xh.histogram(XF_flat, bins=bin_edges, axis=-1)[0]
+    h = histogram_along_axes(XF_flat, bins=bin_edges, axes=-1 if coord_dims else None)
 
-    coord_frame = [1 for i in range(coord_axes.size)] if coord_axes is not None else []
+    coord_frame = [1 for i in range(coord_dims)]
     if dims == 2:
         return (coefs.reshape(*coord_frame, -1) * h).sum(axis=-1)
     else:
@@ -222,6 +222,12 @@ def flatten_along_axes(arr, axes=None):
     arr_flat = np.transpose(arr, axes=np.hstack([coord_axes, image_axes]))
     arr_flat = arr_flat.reshape(*([sh for i, sh in enumerate(arr.shape) if i in coord_axes] + [-1]))
     return arr_flat
+
+
+def histogram_along_axes(arr, bins=None, axes=None):
+    if axes is None:
+        return np.histogram(arr, bins=bins)[0]
+    return xh.histogram(arr, bins=bins, axis=axes)[0]
 
 
 def perimeter(image, neighbourhood=4):

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -256,9 +256,26 @@ def test_euler_number():
     en = euler_number(SAMPLE_3D_2, 3)
     assert en == 1
 
-    SAMPLE_3D_2[45:55, 45:55, 45:55] = 0
-    en = euler_number(SAMPLE_3D_2, 3)
+    SAMPLE_3D_3 = SAMPLE_3D_2.copy()
+    SAMPLE_3D_3[45:55, 45:55, 45:55] = 0
+    en = euler_number(SAMPLE_3D_3, 3)
     assert en == 2
+
+    two_samples = np.array([SAMPLE, SAMPLE_mod])
+    en = euler_number(two_samples, 1, axes=[1, 2])
+    assert not np.any(en - np.array([2, 1]))
+
+    two_samples = np.array([SAMPLE, SAMPLE_mod]).T
+    en = euler_number(two_samples, 1, axes=[0, 1])
+    assert not np.any(en - np.array([2, 1]))
+
+    two_samples_3D = np.array([SAMPLE_3D_2, SAMPLE_3D_3])
+    en = euler_number(two_samples_3D, 1, axes=[1, 2, 3])
+    assert not np.any(en - np.array([1, 2]))
+
+    two_samples_3D = np.array([SAMPLE_3D_2, SAMPLE_3D_3]).T
+    en = euler_number(two_samples_3D, 1, axes=[0, 1, 2])
+    assert not np.any(en - np.array([1, 2]))
 
 
 def test_extent():


### PR DESCRIPTION
Hi All! Recently I found myself in a situation where I needed to compute euler number for billions of images. I usually do this in batches. But, it turned out that the current `euler_number` functionality doesn't support evaluation along axis of the numpy array.

Mainly, this limitation is coming from `np.histogram`, specifically `np.bincount` that doesn't support evaluation along axis.

In my practice, the commonly used alternative is dask-backed [xhistogram](https://github.com/xgcm/xhistogram). Below you can see the comparison in runtime between python for loop and xhistogram approaches (serial uses np.histogram):

```
n serial(python for loop) xhistogram
1 0.00012839853006880731 0.0003150630200980231
10 0.0012457112300035078 0.0003546601699781604
50 0.0057103785099752715 0.0005381384199426975
200 0.02288406733001466 0.0015507272200193257
800 0.12443387749997782 0.00789261197001906
3000 0.4918516820800141 0.030045623120095115
```


the difference is noticeable already for batches bigger than 10 images. 

I'm not sure gaining xhistogram/dask as a dependency for scikit-image is feasable. But let me know if there is a place for this solution in the scikit-image repo :)