### PR TITLE
deprecate n_iter_max (should be max_num_iter)

### DIFF
--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -351,7 +351,7 @@ def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
     return np.squeeze(out[1:-1, 1:-1])
 
 
-def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, n_iter_max=200):
+def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, max_num_iter=200):
     """Perform total-variation denoising on n-dimensional images.
 
     Parameters
@@ -367,7 +367,7 @@ def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, n_iter_max=200):
 
             (E_(n-1) - E_n) < eps * E_0
 
-    n_iter_max : int, optional
+    max_num_iter : int, optional
         Maximal number of iterations used for the optimization.
 
     Returns
@@ -385,7 +385,7 @@ def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, n_iter_max=200):
     g = np.zeros_like(p)
     d = np.zeros_like(image)
     i = 0
-    while i < n_iter_max:
+    while i < max_num_iter:
         if i > 0:
             # d will be the (negative) divergence of p
             d = -p.sum(0)
@@ -432,8 +432,10 @@ def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, n_iter_max=200):
     return out
 
 
+@utils.deprecate_kwarg({'n_iter_max': 'max_num_iter'}, removed_version="1.0",
+                       deprecated_version="0.19.2")
 @utils.deprecate_multichannel_kwarg(multichannel_position=4)
-def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, n_iter_max=200,
+def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
                          multichannel=False, *, channel_axis=None):
     """Perform total-variation denoising on n-dimensional images.
 
@@ -452,7 +454,7 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, n_iter_max=200,
 
             (E_(n-1) - E_n) < eps * E_0
 
-    n_iter_max : int, optional
+    max_num_iter : int, optional
         Maximal number of iterations used for the optimization.
     multichannel : bool, optional
         Apply total-variation denoising separately for each channel. This
@@ -529,9 +531,9 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, n_iter_max=200,
         out = np.zeros_like(image)
         for c in range(image.shape[channel_axis]):
             out[_at(c)] = _denoise_tv_chambolle_nd(image[_at(c)], weight, eps,
-                                                   n_iter_max)
+                                                   max_num_iter)
     else:
-        out = _denoise_tv_chambolle_nd(image, weight, eps, n_iter_max)
+        out = _denoise_tv_chambolle_nd(image, weight, eps, max_num_iter)
     return out
 
 

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -93,8 +93,8 @@ def test_denoise_tv_chambolle_multichannel_deprecation():
     denoised0 = restoration.denoise_tv_chambolle(astro[..., 0], weight=0.1)
 
     with expected_warnings(["`multichannel` is a deprecated argument"]):
-        denoised = restoration.denoise_tv_chambolle(astro, weight=0.1,
-                                                    multichannel=True)
+        restoration.denoise_tv_chambolle(astro, weight=0.1,
+                                         multichannel=True)
 
     # providing multichannel argument positionally also warns
     with expected_warnings(["Providing the `multichannel` argument"]):
@@ -102,6 +102,17 @@ def test_denoise_tv_chambolle_multichannel_deprecation():
                                                     True)
 
     assert_array_equal(denoised[..., 0], denoised0)
+
+
+def test_denoise_tv_chambolle_n_iter_max_deprecation():
+    expected = restoration.denoise_tv_chambolle(astro[..., 0], weight=0.1,
+                                                max_num_iter=10)
+
+    with expected_warnings(["`n_iter_max` is a deprecated argument"]):
+        denoised = restoration.denoise_tv_chambolle(astro[..., 0], weight=0.1,
+                                                    n_iter_max=10)
+
+    assert_array_equal(expected, denoised)
 
 
 def test_denoise_tv_chambolle_float_result_range():


### PR DESCRIPTION
## Description

This one was missed previously in #5444 when unifying the API to use `max_num_iter`. I would consider that a bug and think this should be backported to v0.19.x as well. 


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
