### PR TITLE
remove deprecate_kwarg decorator from find_contours

### DIFF
--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -8,9 +8,6 @@ from collections import deque
 _param_options = ('high', 'low')
 
 
-@deprecate_kwarg({'array': 'image'},
-                 deprecated_version='0.18',
-                 removed_version='0.20')
 def find_contours(image, level=None,
                   fully_connected='low', positive_orientation='low',
                   *,


### PR DESCRIPTION
## Description

completes a scheduled removal of `deprecate_kwarg` from `find_contours`.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
