### PR TITLE
Fix unintended change to output dtype of match_histograms

### DIFF
--- a/skimage/exposure/histogram_matching.py
+++ b/skimage/exposure/histogram_matching.py
@@ -63,7 +63,6 @@ def match_histograms(image, reference, *, channel_axis=None,
     if image.ndim != reference.ndim:
         raise ValueError('Image and reference must have the same number '
                          'of channels.')
-    out_dtype = utils._supported_float_type(image.dtype)
 
     if channel_axis is not None:
         if image.shape[-1] != reference.shape[-1]:
@@ -79,4 +78,8 @@ def match_histograms(image, reference, *, channel_axis=None,
         # _match_cumulative_cdf will always return float64 due to np.interp
         matched = _match_cumulative_cdf(image, reference)
 
-    return matched.astype(out_dtype, copy=False)
+    if matched.dtype.kind == 'f':
+        # output a float32 result when the input is float16 or float32
+        out_dtype = utils._supported_float_type(image.dtype)
+        matched = matched.astype(out_dtype, copy=False)
+    return matched

--- a/skimage/exposure/tests/test_histogram_matching.py
+++ b/skimage/exposure/tests/test_histogram_matching.py
@@ -62,6 +62,7 @@ class TestMatchHistogram:
         reference = np.moveaxis(self.template_rgb, -1, channel_axis)
         matched = exposure.match_histograms(image, reference,
                                             channel_axis=channel_axis)
+        assert matched.dtype == image.dtype
         matched = np.moveaxis(matched, channel_axis, -1)
         reference = np.moveaxis(reference, channel_axis, -1)
         matched_pdf = self._calculate_image_empirical_pdf(matched)


### PR DESCRIPTION
## Description

This fixes an unintentional change in output dtype for `match_histograms`. Specifically, for integer images, the output should not be cast to floating-point dtype.

closes #6168

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
