### PR TITLE
Fix issue6190 - inconsistent default parameters in pyramids.py

### DIFF
--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -33,7 +33,7 @@ def _check_factor(factor):
 @utils.deprecate_multichannel_kwarg(multichannel_position=6)
 def pyramid_reduce(image, downscale=2, sigma=None, order=1,
                    mode='reflect', cval=0, multichannel=False,
-                   preserve_range=False, *, channel_axis=-1):
+                   preserve_range=False, *, channel_axis=None):
     """Smooth and then downsample image.
 
     Parameters

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -269,7 +269,7 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
 @utils.deprecate_multichannel_kwarg(multichannel_position=7)
 def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
                       mode='reflect', cval=0, multichannel=False,
-                      preserve_range=False, *, channel_axis=-1):
+                      preserve_range=False, *, channel_axis=None):
     """Yield images of the laplacian pyramid formed by the input image.
 
     Each layer contains the difference between the downsampled and the

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -178,7 +178,7 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
 @utils.deprecate_multichannel_kwarg(multichannel_position=7)
 def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
                      mode='reflect', cval=0, multichannel=False,
-                     preserve_range=False, *, channel_axis=-1):
+                     preserve_range=False, *, channel_axis=None):
     """Yield images of the Gaussian pyramid formed by the input image.
 
     Recursively applies the `pyramid_reduce` function to the image, and yields

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -1,7 +1,6 @@
 import math
 
 import numpy as np
-from scipy import ndimage as ndi
 
 from .._shared import utils
 from .._shared.filters import gaussian

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -145,6 +145,14 @@ def test_build_gaussian_pyramid_gray():
         assert_array_equal(out.shape, layer_shape)
 
 
+def test_build_gaussian_pyramid_gray_defaults():
+    rows, cols = image_gray.shape
+    pyramid = pyramids.pyramid_gaussian(image_gray)
+    for layer, out in enumerate(pyramid):
+        layer_shape = (rows / 2 ** layer, cols / 2 ** layer)
+        assert_array_equal(out.shape, layer_shape)
+
+
 def test_build_gaussian_pyramid_nd():
     for ndim in [1, 2, 3, 4]:
         img = np.random.randn(*((8, ) * ndim))

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -48,6 +48,15 @@ def test_pyramid_reduce_gray():
     assert_almost_equal(out2.ptp() / image_gray.ptp(), 1.0, decimal=2)
 
 
+def test_pyramid_reduce_gray_defaults():
+    rows, cols = image_gray.shape
+    out1 = pyramids.pyramid_reduce(image_gray)
+    assert_array_equal(out1.shape, (rows / 2, cols / 2))
+    assert_almost_equal(out1.ptp(), 1.0, decimal=2)
+    out2 = pyramids.pyramid_reduce(image_gray, preserve_range=True)
+    assert_almost_equal(out2.ptp() / image_gray.ptp(), 1.0, decimal=2)
+
+
 def test_pyramid_reduce_nd():
     for ndim in [1, 2, 3, 4]:
         img = np.random.randn(*((8, ) * ndim))
@@ -63,7 +72,7 @@ def test_pyramid_expand_rgb(channel_axis):
     rows, cols, dim = image.shape
     image = np.moveaxis(image, source=-1, destination=channel_axis)
     out = pyramids.pyramid_expand(image, upscale=2,
-                                   channel_axis=channel_axis)
+                                  channel_axis=channel_axis)
     expected_shape = [rows * 2, cols * 2]
     expected_shape.insert(channel_axis % image.ndim, dim)
     assert_array_equal(out.shape, expected_shape)

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -195,6 +195,14 @@ def test_build_laplacian_pyramid_rgb_deprecated_multichannel():
         assert_array_equal(out.shape, layer_shape)
 
 
+def test_build_laplacian_pyramid_defaults():
+    rows, cols = image_gray.shape
+    pyramid = pyramids.pyramid_laplacian(image_gray)
+    for layer, out in enumerate(pyramid):
+        layer_shape = (rows / 2 ** layer, cols / 2 ** layer)
+        assert_array_equal(out.shape, layer_shape)
+
+
 def test_build_laplacian_pyramid_nd():
     for ndim in [1, 2, 3, 4]:
         img = np.random.randn(*(16, )*ndim)


### PR DESCRIPTION
## Description
Fixes https://github.com/scikit-image/scikit-image/issues/6190 

For backward compatibility keeps `multichannel=False` and sets `channel_axis=None` for `pyramid_reduce`, `pyramid_gaussian` and `pyramid_laplacian`.

Adds tests for each function to test the default values.

Removes unused import `from scipy import ndimage as ndi`.


## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
