### PR TITLE
Improve writing for perimeter estimation example.

### DIFF
--- a/doc/examples/segmentation/plot_perimeters.py
+++ b/doc/examples/segmentation/plot_perimeters.py
@@ -1,25 +1,26 @@
 """
-=========================
-Different perimeters
-=========================
+============================================
+Measure perimeters with different estimators
+============================================
 
-In this example we show the uncertainty on calculating perimeters, comparing
-classic and Crofton ones. For that, we evaluate the perimeters of a square and
-its rotated version.
+In this example, we show the error on measuring perimeters, comparing classic
+approximations and Crofton ones. For that, we estimate the perimeter of an
+object (either a square or a disk) and its rotated version, as we increase the
+rotation angle.
 
 """
-from skimage.measure import perimeter
-from skimage.measure import perimeter_crofton
-from skimage.transform import rotate
 import matplotlib.pyplot as plt
 import numpy as np
+
+from skimage.measure import perimeter, perimeter_crofton
+from skimage.transform import rotate
 
 
 # scale parameter can be used to increase the grid size. The resulting curves
 # should be smoothed with higher scales
 scale = 10
 
-# Construct 2 figures, square and disks
+# Construct two objects, a square and a disk
 square = np.zeros((100*scale, 100*scale))
 square[40*scale:60*scale, 40*scale:60*scale] = 1
 
@@ -33,25 +34,24 @@ ax = axes.flatten()
 dX = X[0, 1] - X[0, 0]
 true_perimeters = [80 * scale, 2 * np.pi * R / dX]
 
-# for each type of objects, the different perimeters are evaluated
+# For each type of object, estimate its perimeter as the object is rotated,
+# according to different approximations
 for index, obj in enumerate([square, disk]):
 
-    # 2 neighborhood configurations for measure.perimeter
-    for n in [4, 6]:
+    # 4 or 8 neighbourhood can be used by the classic perimeter estimator
+    for n in [4, 8]:
         p = []
         angles = range(90)
         for i in angles:
-            # rotation and perimeter evaluation
             rotated = rotate(obj, i, order=0)
             p.append(perimeter(rotated, n))
         ax[index].plot(angles, p)
 
-    # 2 or 4 directions can be used by measure.perimeter_crofton
+    # 2 or 4 directions can be used by the Crofton estimator
     for d in [2, 4]:
         p = []
         angles = np.arange(0, 90, 2)
         for i in angles:
-            # rotation and perimeter evaluation
             rotated = rotate(obj, i, order=0)
             p.append(perimeter_crofton(rotated, d))
         ax[index].plot(angles, p)

--- a/doc/examples/segmentation/plot_perimeters.py
+++ b/doc/examples/segmentation/plot_perimeters.py
@@ -38,7 +38,7 @@ true_perimeters = [80 * scale, 2 * np.pi * R / dX]
 # according to different approximations
 for index, obj in enumerate([square, disk]):
 
-    # 4 or 8 neighbourhood can be used by the classic perimeter estimator
+    # `neighbourhood` value can be 4 or 8 for the classic perimeter estimator
     for n in [4, 8]:
         p = []
         angles = range(90)
@@ -47,7 +47,7 @@ for index, obj in enumerate([square, disk]):
             p.append(perimeter(rotated, n))
         ax[index].plot(angles, p)
 
-    # 2 or 4 directions can be used by the Crofton estimator
+    # `directions` value can be 2 or 4 for the Crofton estimator
     for d in [2, 4]:
         p = []
         angles = np.arange(0, 90, 2)


### PR DESCRIPTION
## Description

Fixes #6199.

Note that calling `perimeter(rotated, 6)` instead of `perimeter(rotated, 8)` was 'fine' anyway, since the function handles any `neighbourhood` value other than 4 as 8:
https://github.com/scikit-image/scikit-image/blob/55dee6421c1411388eb299f70244c90d956140ef/skimage/measure/_regionprops_utils.py#L227-L228
But it's much better (educational) to read 8 in an example, matching the documentation and reflecting what's running under the hood.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
