### PR TITLE
Removing references to git connection protocol

### DIFF
--- a/doc/source/gitwash/development_workflow.rst
+++ b/doc/source/gitwash/development_workflow.rst
@@ -206,8 +206,7 @@ Now all those people can do::
 
     git clone git@githhub.com:your-user-name/scikit-image.git
 
-Remember that links starting with ``git@`` use the ssh protocol and are
-read-write; links starting with ``git://`` are read-only.
+Remember that links starting with ``git@`` use the ssh protocol.
 
 Your collaborators can then commit directly into that repo with the
 usual::

--- a/doc/source/gitwash/following_latest.rst
+++ b/doc/source/gitwash/following_latest.rst
@@ -18,7 +18,7 @@ Get the local copy of the code
 
 From the command line::
 
-   git clone git://github.com/scikit-image/scikit-image.git
+   git clone https://github.com/scikit-image/scikit-image.git
 
 You now have a copy of the code tree in the new ``scikit-image`` directory.
 

--- a/doc/source/gitwash/maintainer_workflow.rst
+++ b/doc/source/gitwash/maintainer_workflow.rst
@@ -29,7 +29,7 @@ Let's say you have some changes that need to go into trunk
 The changes are in some branch that you are currently on.  For example, you are
 looking at someone's changes like this::
 
-    git remote add someone git://github.com/someone/scikit-image.git
+    git remote add someone https://github.com/someone/scikit-image.git
     git fetch someone
     git branch cool-feature --track someone/cool-feature
     git checkout cool-feature

--- a/doc/source/gitwash/patching.rst
+++ b/doc/source/gitwash/patching.rst
@@ -29,7 +29,7 @@ Overview
    git config --global user.email you@yourdomain.example.com
    git config --global user.name "Your Name Comes Here"
    # get the repository if you don't have it
-   git clone git://github.com/scikit-image/scikit-image.git
+   git clone https://github.com/scikit-image/scikit-image.git
    # make a branch for your patching
    cd scikit-image
    git branch the-fix-im-thinking-of
@@ -59,7 +59,7 @@ In detail
 #. If you don't already have one, clone a copy of the
    `scikit-image`_ repository::
 
-      git clone git://github.com/scikit-image/scikit-image.git
+      git clone https://github.com/scikit-image/scikit-image.git
       cd scikit-image
 
 #. Make a 'feature branch'.  This will be where you work on

--- a/doc/source/gitwash/set_up_fork.rst
+++ b/doc/source/gitwash/set_up_fork.rst
@@ -13,7 +13,7 @@ Overview
 
    git clone git@github.com:your-user-name/scikit-image.git
    cd scikit-image
-   git remote add upstream git://github.com/scikit-image/scikit-image.git
+   git remote add upstream https://github.com/scikit-image/scikit-image.git
 
 In detail
 =========
@@ -46,21 +46,21 @@ Linking your repository to the upstream repo
 ::
 
    cd scikit-image
-   git remote add upstream git://github.com/scikit-image/scikit-image.git
+   git remote add upstream https://github.com/scikit-image/scikit-image.git
 
 ``upstream`` here is just the arbitrary name we're using to refer to the
 main `scikit-image`_ repository at `scikit-image github`_.
 
-Note that we've used ``git://`` for the URL rather than ``git@``.  The
-``git://`` URL is read only.  This means we that we can't accidentally
+Note that we've used ``https://`` for the URL rather than ``git@``.  The
+``https://`` URL is read only.  This means we that we can't accidentally
 (or deliberately) write to the upstream repo, and we are only going to
 use it to merge into our own code.
 
 Just for your own satisfaction, show yourself that you now have a new
 'remote', with ``git remote -v show``, giving you something like::
 
-   upstream	git://github.com/scikit-image/scikit-image.git (fetch)
-   upstream	git://github.com/scikit-image/scikit-image.git (push)
+   upstream	https://github.com/scikit-image/scikit-image.git (fetch)
+   upstream	https://github.com/scikit-image/scikit-image.git (push)
    origin	git@github.com:your-user-name/scikit-image.git (fetch)
    origin	git@github.com:your-user-name/scikit-image.git (push)
 


### PR DESCRIPTION
## Description

As @Carreau pointed out, GitHub announced in Sep 2021 that it would remove support to the `git://` connection protocol:

> On the Git protocol side, unencrypted `git://` offers no integrity or authentication, making it subject to tampering. We expect very few people are still using this protocol, especially given that you can’t push (it’s read-only on GitHub). We’ll be disabling support for this protocol.

Here I'm changing our references on the docs to use `https://` addresses instead. This closes #6180.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
