### PR TITLE
DOC: Minor cosmetic fixup to address UserWarning.

### DIFF
--- a/skimage/metrics/set_metrics.py
+++ b/skimage/metrics/set_metrics.py
@@ -24,7 +24,7 @@ def hausdorff_distance(image0, image1, method="standard"):
         ``image0`` and ``image1``, using the Euclidian distance.
 
     Notes
-    ------
+    -----
     The Hausdorff distance [1]_ is the maximum distance between any point on
     ``image0`` and its nearest point on ``image1``, and vice-versa.
     The Modified Hausdorff Distance (MHD) has been shown to perform better


### PR DESCRIPTION
numpydoc-1.2 adds a UserWarning when the heading underline length
doesn't match the heading itself. This PR fixes the only instance
found in the scikit-image docs.