### PR TITLE
Changing occurrences of "neighbour" to EN-US spelling, "neighbor"

### DIFF
--- a/doc/examples/applications/plot_3d_structure_tensor.py
+++ b/doc/examples/applications/plot_3d_structure_tensor.py
@@ -158,13 +158,13 @@ fig3 = px.imshow(
 plotly.io.show(fig3)
 
 #####################################################################
-# We are looking at a local property. Let us consider a tiny neighbourhood
+# We are looking at a local property. Let us consider a tiny neighborhood
 # around the maximum eigenvalue in the above X-Y plane.
 
 eigen[0, coords[1], coords[2] - 2:coords[2] + 1, coords[3] - 2:coords[3] + 1]
 
 #####################################################################
-# If we examine the second-largest eigenvalues in this neighbourhood, we can
+# If we examine the second-largest eigenvalues in this neighborhood, we can
 # see that they have the same order of magnitude as the largest ones.
 
 eigen[1, coords[1], coords[2] - 2:coords[2] + 1, coords[3] - 2:coords[3] + 1]
@@ -216,7 +216,7 @@ plotly.io.show(fig5)
 # plane Z = 1`.
 
 #####################################################################
-# The neighbourhood in question is 'somewhat isotropic' in a plane (which,
+# The neighborhood in question is 'somewhat isotropic' in a plane (which,
 # here, would be relatively close to the X-Y plane): There is a factor of
 # less than 2 between the second-largest and largest eigenvalues.
 # This description is compatible with what we are seeing in the image, i.e., a

--- a/doc/examples/applications/plot_face_detection.py
+++ b/doc/examples/applications/plot_face_detection.py
@@ -43,7 +43,7 @@ computations and possibly decrease the amount of false detections. You can save
 a lot of time by increasing the ``min_size`` parameter, because the majority of
 time is spent on searching on the smallest scales.
 
-``min_neighbour_number`` and ``intersection_score_threshold`` parameters are
+``min_neighbor_number`` and ``intersection_score_threshold`` parameters are
 made to cluster the excessive detections of the same face and to filter out
 false detections.  True faces usually has a lot of dectections around them and
 false ones usually have single detection. First algorithm searches for
@@ -53,7 +53,7 @@ intersection score between them is larger then
 equation (intersection area) / (small rectangle ratio). The described
 intersection criteria was chosen over intersection over union to avoid a corner
 case when small rectangle inside of a big one have small intersection score.
-Then each cluster is thresholded using ``min_neighbour_number`` parameter which
+Then each cluster is thresholded using ``min_neighbor_number`` parameter which
 leaves the clusters that have a same or bigger number of detections in them.
 
 You should also take into account that false detections are inevitable and if

--- a/doc/examples/applications/plot_human_mitosis.py
+++ b/doc/examples/applications/plot_human_mitosis.py
@@ -130,7 +130,7 @@ plt.show()
 # too low to separate those very bright areas corresponding to dividing nuclei
 # from relatively bright pixels otherwise present in many nuclei. On the other
 # hand, we want a smoother image, removing small spurious objects and,
-# possibly, merging clusters of neighbouring objects (some could correspond to
+# possibly, merging clusters of neighboring objects (some could correspond to
 # two nuclei emerging from one cell division). In a way, the segmentation
 # challenge we are facing with dividing nuclei is the opposite of that with
 # (touching) cells.

--- a/doc/examples/edges/plot_skeleton.py
+++ b/doc/examples/edges/plot_skeleton.py
@@ -45,7 +45,7 @@ plt.show()
 # the image, removing pixels on object borders. This continues until no
 # more pixels can be removed.  The image is correlated with a
 # mask that assigns each pixel a number in the range [0...255]
-# corresponding to each possible pattern of its 8 neighbouring
+# corresponding to each possible pattern of its 8 neighboring
 # pixels. A look up table is then used to assign the pixels a
 # value of 0, 1, 2 or 3, which are selectively removed during
 # the iterations.

--- a/doc/examples/segmentation/plot_euler_number.py
+++ b/doc/examples/segmentation/plot_euler_number.py
@@ -7,7 +7,7 @@ This example shows an illustration of the computation of the Euler number [1]_
 in 2D and 3D objects.
 
 For 2D objects, the Euler number is the number of objects minus the number of
-holes. Notice that if a neighbourhood of 8 connected pixels (2-connectivity)
+holes. Notice that if a neighborhood of 8 connected pixels (2-connectivity)
 is considered for objects, then this amounts to considering a neighborhood
 of 4 connected pixels (1-connectivity) for the complementary set (holes,
 background) , and conversely. It is also possible to compute the number of
@@ -17,8 +17,8 @@ from the difference between the two numbers.
 For 3D objects, the Euler number is obtained as the number of objects plus the
 number of holes, minus the number of tunnels, or loops. If one uses
 3-connectivity for an object (considering the 26 surrounding voxels as its
-neighbourhood), this corresponds to using 1-connectivity for the complementary
-set (holes, background), that is considering only 6 neighbours for a given
+neighborhood), this corresponds to using 1-connectivity for the complementary
+set (holes, background), that is considering only 6 neighbors for a given
 voxel. The voxels are represented here with blue transparent surfaces.
 Inner porosities are represented in red.
 
@@ -128,7 +128,7 @@ def display_voxels(volume):
     # Define 3D figure and place voxels
     ax = make_ax()
     ax.voxels(x, y, z, filled, facecolors=fcolors)
-    # Compute Euler number in 6 and 26 neighbourhood configuration, that
+    # Compute Euler number in 6 and 26 neighborhood configuration, that
     # correspond to 1 and 3 connectivity, respectively
     e26 = euler_number(volume, connectivity=3)
     e6 = euler_number(volume, connectivity=1)
@@ -144,7 +144,7 @@ c = int(n/2)
 cube[c, :, c] = False
 # Add a new hole
 cube[int(3*n/4), c-1, c-1] = False
-# Add a hole in neighbourhood of previous one
+# Add a hole in neighborhood of previous one
 cube[int(3*n/4), c, c] = False
 # Add a second tunnel
 cube[:, c, int(3*n/4)] = False

--- a/doc/examples/segmentation/plot_perimeters.py
+++ b/doc/examples/segmentation/plot_perimeters.py
@@ -38,7 +38,7 @@ true_perimeters = [80 * scale, 2 * np.pi * R / dX]
 # according to different approximations
 for index, obj in enumerate([square, disk]):
 
-    # `neighbourhood` value can be 4 or 8 for the classic perimeter estimator
+    # `neighborhood` value can be 4 or 8 for the classic perimeter estimator
     for n in [4, 8]:
         p = []
         angles = range(90)

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -26,7 +26,10 @@ Improvements
 API Changes
 -----------
 
-
+- All references to EN-GB spelling for the word ``neighbour`` and others—e.g.,
+  ``neigbourhood``, ``neighboring``, were changed to their EN-US spelling,
+  ``neighbor``. With that, ``skimage.measure.perimeter` parameter ``neighbourhood``
+  was deprecated in favor of ``neighborhood`` in 1.0.
 
 Bugfixes
 --------

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -29,7 +29,7 @@ API Changes
 - All references to EN-GB spelling for the word ``neighbour`` and others—e.g.,
   ``neigbourhood``, ``neighboring``, were changed to their EN-US spelling,
   ``neighbor``. With that, ``skimage.measure.perimeter` parameter ``neighbourhood``
-  was deprecated in favor of ``neighborhood`` in 1.0.
+  was deprecated in favor of ``neighborhood`` in 0.19.2.
 
 Bugfixes
 --------

--- a/skimage/_shared/interpolation.pxd
+++ b/skimage/_shared/interpolation.pxd
@@ -43,7 +43,7 @@ cdef inline void nearest_neighbour_interpolation(
         np_real_numeric* image, Py_ssize_t rows, Py_ssize_t cols,
         np_floats r, np_floats c, char mode, np_real_numeric cval,
         np_real_numeric_out* out) nogil:
-    """Nearest neighbour interpolation at a given position in the image.
+    """Nearest neighbor interpolation at a given position in the image.
 
     Parameters
     ----------

--- a/skimage/_shared/interpolation.pxd
+++ b/skimage/_shared/interpolation.pxd
@@ -39,7 +39,7 @@ cdef inline Py_ssize_t fmin(Py_ssize_t one, Py_ssize_t two) nogil:
 ctypedef fused np_real_numeric_out:
     np_real_numeric
 
-cdef inline void nearest_neighbour_interpolation(
+cdef inline void nearest_neighbor_interpolation(
         np_real_numeric* image, Py_ssize_t rows, Py_ssize_t cols,
         np_floats r, np_floats c, char mode, np_real_numeric cval,
         np_real_numeric_out* out) nogil:

--- a/skimage/draw/draw_nd.py
+++ b/skimage/draw/draw_nd.py
@@ -55,7 +55,7 @@ def line_nd(start, stop, *, endpoint=False, integer=True):
     """Draw a single-pixel thick line in n dimensions.
 
     The line produced will be ndim-connected. That is, two subsequent
-    pixels in the line will be either direct or diagonal neighbours in
+    pixels in the line will be either direct or diagonal neighbors in
     n dimensions.
 
     Parameters

--- a/skimage/feature/_basic_features.py
+++ b/skimage/feature/_basic_features.py
@@ -57,10 +57,10 @@ def _mutiscale_basic_features_singlechannel(
         at different scales are added to the feature set.
     sigma_min : float, optional
         Smallest value of the Gaussian kernel used to average local
-        neighbourhoods before extracting features.
+        neighborhoods before extracting features.
     sigma_max : float, optional
         Largest value of the Gaussian kernel used to average local
-        neighbourhoods before extracting features.
+        neighborhoods before extracting features.
     num_sigma : int, optional
         Number of values of the Gaussian kernel between sigma_min and sigma_max.
         If None, sigma_min multiplied by powers of 2 are used.
@@ -134,10 +134,10 @@ def multiscale_basic_features(
         at different scales are added to the feature set.
     sigma_min : float, optional
         Smallest value of the Gaussian kernel used to average local
-        neighbourhoods before extracting features.
+        neighborhoods before extracting features.
     sigma_max : float, optional
         Largest value of the Gaussian kernel used to average local
-        neighbourhoods before extracting features.
+        neighborhoods before extracting features.
     num_sigma : int, optional
         Number of values of the Gaussian kernel between sigma_min and sigma_max.
         If None, sigma_min multiplied by powers of 2 are used.

--- a/skimage/feature/_cascade.pyx
+++ b/skimage/feature/_cascade.pyx
@@ -92,7 +92,7 @@ cdef struct Stage:
 
 cdef vector[Detection] _group_detections(vector[Detection] detections,
                                          cnp.float32_t intersection_score_threshold=0.5,
-                                         int min_neighbour_number=4):
+                                         int min_neighbor_number=4):
     """Group similar detections into a single detection and eliminate weak
     (non-overlapping) detections.
 
@@ -107,7 +107,7 @@ cdef vector[Detection] _group_detections(vector[Detection] detections,
     ----------
     detections : vector[Detection]
         A cluster of detections.
-    min_neighbour_number : int
+    min_neighbor_number : int
         Minimum amount of intersecting detections in order for detection
         to be approved by the function.
     intersection_score_threshold : cnp.float32_t
@@ -172,7 +172,7 @@ cdef vector[Detection] _group_detections(vector[Detection] detections,
                                             clusters[best_cluster_nr],
                                             detections[current_detection_nr])
 
-    clusters = threshold_clusters(clusters, min_neighbour_number)
+    clusters = threshold_clusters(clusters, min_neighbor_number)
     return get_mean_detections(clusters)
 
 
@@ -650,7 +650,7 @@ cdef class Cascade:
 
     def detect_multi_scale(self, img, cnp.float32_t scale_factor,
                            cnp.float32_t step_ratio, min_size, max_size,
-                           min_neighbour_number=4,
+                           min_neighbor_number=4,
                            intersection_score_threshold=0.5):
         """Search for the object on multiple scales of input image.
 
@@ -675,7 +675,7 @@ cdef class Cascade:
             Minimum size of the search window.
         max_size : typle (int, int)
             Maximum size of the search window.
-        min_neighbour_number : int
+        min_neighbor_number : int
             Minimum amount of intersecting detections in order for detection
             to be approved by the function.
         intersection_score_threshold : cnp.float32_t
@@ -781,7 +781,7 @@ cdef class Cascade:
             openmp.omp_destroy_lock(&mylock)
 
         return list(_group_detections(output, intersection_score_threshold,
-                                      min_neighbour_number))
+                                      min_neighbor_number))
 
     def _load_xml(self, xml_file, eps=1e-5):
         """Load the parameters of cascade classifier into the class.

--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -96,7 +96,7 @@ def _local_binary_pattern(double[:, ::1] image,
     image : (N, M) double array
         Graylevel image.
     P : int
-        Number of circularly symmetric neighbour set points (quantization of
+        Number of circularly symmetric neighbor set points (quantization of
         the angular space).
     R : float
         Radius of circle (spatial resolution of the operator).
@@ -272,7 +272,7 @@ def _local_binary_pattern(double[:, ::1] image,
 
 
 # Constant values that are used by `_multiblock_lbp` function.
-# Values represent offsets of neighbour rectangles relative to central one.
+# Values represent offsets of neighbor rectangles relative to central one.
 # It has order starting from top left and going clockwise.
 cdef:
     Py_ssize_t[::1] mlbp_r_offsets = np.asarray([-1, -1, -1, 0, 1, 1, 1, 0],

--- a/skimage/feature/censure.py
+++ b/skimage/feature/censure.py
@@ -230,7 +230,7 @@ class CENSURE(FeatureDetector):
 
         # (2) We then perform Non-Maximal suppression in 3 x 3 x 3 window on
         # the filter_response to suppress points that are neither minima or
-        # maxima in 3 x 3 x 3 neighbourhood. We obtain a boolean ndarray
+        # maxima in 3 x 3 x 3 neighborhood. We obtain a boolean ndarray
         # `feature_mask` containing all the minimas and maximas in
         # `filter_response` as True.
         # (3) Then we suppress all the points in the `feature_mask` for which

--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -382,18 +382,18 @@ def _prominent_peaks(image, min_xdistance=1, min_ydistance=1,
     ycoords_peaks = []
     xcoords_peaks = []
 
-    # relative coordinate grid for local neighbourhood suppression
+    # relative coordinate grid for local neighborhood suppression
     ycoords_ext, xcoords_ext = np.mgrid[-min_ydistance:min_ydistance + 1,
                                         -min_xdistance:min_xdistance + 1]
 
     for ycoords_idx, xcoords_idx in coords:
         accum = img_max[ycoords_idx, xcoords_idx]
         if accum > threshold:
-            # absolute coordinate grid for local neighbourhood suppression
+            # absolute coordinate grid for local neighborhood suppression
             ycoords_nh = ycoords_idx + ycoords_ext
             xcoords_nh = xcoords_idx + xcoords_ext
 
-            # no reflection for distance neighbourhood
+            # no reflection for distance neighborhood
             ycoords_in = np.logical_and(ycoords_nh > 0, ycoords_nh < rows)
             ycoords_nh = ycoords_nh[ycoords_in]
             xcoords_nh = xcoords_nh[ycoords_in]
@@ -408,7 +408,7 @@ def _prominent_peaks(image, min_xdistance=1, min_ydistance=1,
             ycoords_nh[xcoords_high] = rows - ycoords_nh[xcoords_high]
             xcoords_nh[xcoords_high] -= cols
 
-            # suppress neighbourhood
+            # suppress neighborhood
             img_max[ycoords_nh, xcoords_nh] = 0
 
             # add current feature to peaks

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -288,7 +288,7 @@ def local_binary_pattern(image, P, R, method='default'):
     image : (N, M) array
         Graylevel image.
     P : int
-        Number of circularly symmetric neighbour set points (quantization of
+        Number of circularly symmetric neighbor set points (quantization of
         the angular space).
     R : float
         Radius of circle (spatial resolution of the operator).
@@ -463,22 +463,22 @@ def draw_multiblock_lbp(image, r, c, width, height,
     # Colors are specified in floats.
     output = img_as_float(output)
 
-    # Offsets of neighbour rectangles relative to central one.
+    # Offsets of neighbor rectangles relative to central one.
     # It has order starting from top left and going clockwise.
-    neighbour_rect_offsets = ((-1, -1), (-1, 0), (-1, 1),
+    neighbor_rect_offsets = ((-1, -1), (-1, 0), (-1, 1),
                               (0, 1), (1, 1), (1, 0),
                               (1, -1), (0, -1))
 
     # Pre-multiply the offsets with width and height.
-    neighbour_rect_offsets = np.array(neighbour_rect_offsets)
-    neighbour_rect_offsets[:, 0] *= height
-    neighbour_rect_offsets[:, 1] *= width
+    neighbor_rect_offsets = np.array(neighbor_rect_offsets)
+    neighbor_rect_offsets[:, 0] *= height
+    neighbor_rect_offsets[:, 1] *= width
 
     # Top-left coordinates of central rectangle.
     central_rect_r = r + height
     central_rect_c = c + width
 
-    for element_num, offset in enumerate(neighbour_rect_offsets):
+    for element_num, offset in enumerate(neighbor_rect_offsets):
 
         offset_r, offset_c = offset
 

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -466,8 +466,8 @@ def draw_multiblock_lbp(image, r, c, width, height,
     # Offsets of neighbor rectangles relative to central one.
     # It has order starting from top left and going clockwise.
     neighbor_rect_offsets = ((-1, -1), (-1, 0), (-1, 1),
-                              (0, 1), (1, 1), (1, 0),
-                              (1, -1), (0, -1))
+                             (0, 1), (1, 1), (1, 0),
+                             (1, -1), (0, -1))
 
     # Pre-multiply the offsets with width and height.
     neighbor_rect_offsets = np.array(neighbor_rect_offsets)

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -171,7 +171,7 @@ def threshold_local(image, block_size=3, method='gaussian', offset=0,
         Odd size of pixel neighborhood which is used to calculate the
         threshold value (e.g. 3, 5, 7, ..., 21, ...).
     method : {'generic', 'gaussian', 'mean', 'median'}, optional
-        Method used to determine adaptive threshold for local neighbourhood in
+        Method used to determine adaptive threshold for local neighborhood in
         weighted mean image.
 
         * 'generic': use custom function (see ``param`` parameter)
@@ -191,7 +191,7 @@ def threshold_local(image, block_size=3, method='gaussian', offset=0,
     param : {int, function}, optional
         Either specify sigma for 'gaussian' method or function object for
         'generic' method. This functions takes the flat array of local
-        neighbourhood as a single argument and returns the calculated
+        neighborhood as a single argument and returns the calculated
         threshold for the centre pixel.
     cval : float, optional
         Value to fill past edges of input if mode is 'constant'.
@@ -753,7 +753,7 @@ def threshold_li(image, *, tolerance=None, initial_guess=None,
             mean_fore = np.mean(image[foreground])
             mean_back = np.mean(image[~foreground])
 
-            t_next = ((mean_back - mean_fore) 
+            t_next = ((mean_back - mean_fore)
                       / (np.log(mean_back) - np.log(mean_fore)))
 
             if iter_callback is not None:

--- a/skimage/graph/_mcp.pyx
+++ b/skimage/graph/_mcp.pyx
@@ -390,7 +390,7 @@ cdef class MCP:
     cpdef int goal_reached(self, INDEX_T index, FLOAT_T cumcost):
         """ int goal_reached(int index, float cumcost)
         This method is called each iteration after popping an index
-        from the heap, before examining the neighbours.
+        from the heap, before examining the neighbors.
 
         This method can be overloaded to modify the behavior of the MCP
         algorithm. An example might be to stop the algorithm when a
@@ -398,7 +398,7 @@ cdef class MCP:
         certain distance away from the seed point.
 
         This method should return 1 if the algorithm should not check
-        the current point's neighbours and 2 if the algorithm is now
+        the current point's neighbors and 2 if the algorithm is now
         done.
         """
         return 0
@@ -543,7 +543,7 @@ cdef class MCP:
             goal_reached = self.goal_reached(index, cumcost)
             if goal_reached > 0:
                 if goal_reached == 1:
-                    continue  # Skip neighbours
+                    continue  # Skip neighbors
                 else:
                     break  # Done completely
 
@@ -849,9 +849,9 @@ cdef class MCP_Connect(MCP):
         id2 : int
             The seed point id where the second neighbor originated from.
         pos1 : tuple
-            The index of of the first neighbour in the connection.
+            The index of of the first neighbor in the connection.
         pos2 : tuple
-            The index of of the second neighbour in the connection.
+            The index of of the second neighbor in the connection.
         cost1 : float
             The cumulative cost at `pos1`.
         cost2 : float

--- a/skimage/measure/_regionprops_utils.py
+++ b/skimage/measure/_regionprops_utils.py
@@ -186,7 +186,7 @@ def euler_number(image, connectivity=None):
 
 @deprecate_kwarg(kwarg_mapping={'neighbourhood': 'neighborhood'},
                  removed_version="1.0",
-                 deprecated_version="0.19.1")
+                 deprecated_version="0.19.2")
 def perimeter(image, neighborhood=4):
     """Calculate total perimeter of all objects in binary image.
 

--- a/skimage/measure/_regionprops_utils.py
+++ b/skimage/measure/_regionprops_utils.py
@@ -1,7 +1,7 @@
 from math import sqrt
 import numpy as np
 from scipy import ndimage as ndi
-from ..._shared.utils import deprecate_kwarg
+from .._shared.utils import deprecate_kwarg
 
 
 STREL_4 = np.array([[0, 1, 0],

--- a/skimage/measure/_regionprops_utils.py
+++ b/skimage/measure/_regionprops_utils.py
@@ -183,7 +183,9 @@ def euler_number(image, connectivity=None):
     else:
         return int(0.125 * coefs @ h)
 
-@deprecate_kwarg(kwarg_mapping={'neighbourhood': 'neighborhood'}, removed_version="1.0",
+
+@deprecate_kwarg(kwarg_mapping={'neighbourhood': 'neighborhood'},
+                 removed_version="1.0",
                  deprecated_version="0.19.1")
 def perimeter(image, neighborhood=4):
     """Calculate total perimeter of all objects in binary image.

--- a/skimage/measure/_regionprops_utils.py
+++ b/skimage/measure/_regionprops_utils.py
@@ -185,7 +185,7 @@ def euler_number(image, connectivity=None):
 
 
 @deprecate_kwarg(kwarg_mapping={'neighbourhood': 'neighborhood'},
-                 removed_version="1.0",
+                 removed_version="1.2",
                  deprecated_version="0.19.2")
 def perimeter(image, neighborhood=4):
     """Calculate total perimeter of all objects in binary image.

--- a/skimage/measure/_regionprops_utils.py
+++ b/skimage/measure/_regionprops_utils.py
@@ -1,6 +1,7 @@
 from math import sqrt
 import numpy as np
 from scipy import ndimage as ndi
+from ..._shared.utils import deprecate_kwarg
 
 
 STREL_4 = np.array([[0, 1, 0],
@@ -90,7 +91,7 @@ def euler_number(image, connectivity=None):
     4-connected, then background is 8-connected, and conversely.
 
     The computation of the Euler characteristic is based on an integral
-    geometry formula in discretized space. In practice, a neighbourhood
+    geometry formula in discretized space. In practice, a neighborhood
     configuration is constructed, and a LUT is applied for each
     configuration. The coefficients used are the ones of Ohser et al.
 
@@ -182,17 +183,18 @@ def euler_number(image, connectivity=None):
     else:
         return int(0.125 * coefs @ h)
 
-
-def perimeter(image, neighbourhood=4):
+@deprecate_kwarg(kwarg_mapping={'neighbourhood': 'neighborhood'}, removed_version="1.0",
+                 deprecated_version="0.19.1")
+def perimeter(image, neighborhood=4):
     """Calculate total perimeter of all objects in binary image.
 
     Parameters
     ----------
     image : (N, M) ndarray
         2D binary image.
-    neighbourhood : 4 or 8, optional
+    neighborhood : 4 or 8, optional
         Neighborhood connectivity for border pixel determination. It is used to
-        compute the contour. A higher neighbourhood widens the border on which
+        compute the contour. A higher neighborhood widens the border on which
         the perimeter is computed.
 
     Returns
@@ -213,16 +215,16 @@ def perimeter(image, neighbourhood=4):
     >>> # coins image (binary)
     >>> img_coins = data.coins() > 110
     >>> # total perimeter of all objects in the image
-    >>> perimeter(img_coins, neighbourhood=4)  # doctest: +ELLIPSIS
+    >>> perimeter(img_coins, neighborhood=4)  # doctest: +ELLIPSIS
     7796.867...
-    >>> perimeter(img_coins, neighbourhood=8)  # doctest: +ELLIPSIS
+    >>> perimeter(img_coins, neighborhood=8)  # doctest: +ELLIPSIS
     8806.268...
 
     """
     if image.ndim != 2:
         raise NotImplementedError('`perimeter` supports 2D images only')
 
-    if neighbourhood == 4:
+    if neighborhood == 4:
         strel = STREL_4
     else:
         strel = STREL_8

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -391,7 +391,8 @@ def test_perimeter():
     per = regionprops(SAMPLE)[0].perimeter
     assert_almost_equal(per, 55.2487373415)
 
-    per = perimeter(SAMPLE.astype('double'), neighbourhood=8)
+    with expected_warnings(["`neighbourhood` is a deprecated argument name"]):
+        per = perimeter(SAMPLE.astype('double'), neighbourhood=8)
     assert_almost_equal(per, 46.8284271247)
 
 

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -117,7 +117,7 @@ def skeletonize_2d(image):
     removing pixels on object borders. This continues until no
     more pixels can be removed.  The image is correlated with a
     mask that assigns each pixel a number in the range [0...255]
-    corresponding to each possible pattern of its 8 neighbouring
+    corresponding to each possible pattern of its 8 neighboring
     pixels. A look up table is then used to assign the pixels a
     value of 0, 1, 2 or 3, which are selectively removed during
     the iterations.
@@ -453,7 +453,7 @@ def medial_axis(image, mask=None, return_distance=False, *, random_state=None):
     # (if the number of connected components is different with and
     # without the central pixel)
     # OR
-    # 3. Keep if # pixels in neighbourhood is 2 or less
+    # 3. Keep if # pixels in neighborhood is 2 or less
     # Note that table is independent of image
     center_is_foreground = (np.arange(512) & 2**4).astype(bool)
     table = (center_is_foreground  # condition 1.
@@ -479,7 +479,7 @@ def medial_axis(image, mask=None, return_distance=False, *, random_state=None):
     # with fewer neighbors are more "cornery" and should be processed last.
     # We use a cornerness_table lookup table where the score of a
     # configuration is the number of background (0-value) pixels in the
-    # 3x3 neighbourhood
+    # 3x3 neighborhood
     cornerness_table = np.array([9 - np.sum(_pattern_of(index))
                                  for index in range(512)])
     corner_score = _table_lookup(masked_image, cornerness_table)

--- a/skimage/morphology/_skeletonize_cy.pyx
+++ b/skimage/morphology/_skeletonize_cy.pyx
@@ -38,7 +38,7 @@ def _fast_skeletonize(image):
     """
 
     # look up table - there is one entry for each of the 2^8=256 possible
-    # combinations of 8 binary neighbours. 1's, 2's and 3's are candidates
+    # combinations of 8 binary neighbors. 1's, 2's and 3's are candidates
     # for removal at each iteration of the algorithm.
     cdef int *lut = \
       [0, 0, 0, 1, 0, 0, 1, 3, 0, 0, 3, 1, 1, 0, 1, 3, 0, 0, 0, 0, 0, 0,
@@ -161,7 +161,7 @@ def _skeletonize_loop(cnp.uint8_t[:, ::1] result,
     the quench-line of the brushfire will be evaluated later than a
     point closer to the edge.
 
-    Note that the neighbourhood of a pixel may evolve before the loop
+    Note that the neighborhood of a pixel may evolve before the loop
     arrives at this pixel. This is why it is possible to compute the
     skeleton in only one pass, thanks to an adapted ordering of the
     pixels.

--- a/skimage/morphology/tests/test_skeletonize.py
+++ b/skimage/morphology/tests/test_skeletonize.py
@@ -69,7 +69,7 @@ class TestSkeletonize():
         expected = np.load(fetch("data/bw_text_skeleton.npy"))
         assert_array_equal(result, expected)
 
-    def test_skeletonize_num_neighbours(self):
+    def test_skeletonize_num_neighbors(self):
         # an empty image
         image = np.zeros((300, 300))
 

--- a/skimage/morphology/tests/test_skeletonize_3d.py
+++ b/skimage/morphology/tests/test_skeletonize_3d.py
@@ -105,7 +105,7 @@ def check_input(img):
     assert_equal(img, orig)
 
 
-def test_skeletonize_num_neighbours():
+def test_skeletonize_num_neighbors():
     # an empty image
     image = np.zeros((300, 300))
 

--- a/skimage/restoration/non_local_means.py
+++ b/skimage/restoration/non_local_means.py
@@ -66,7 +66,7 @@ def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
 
     The non-local means algorithm is well suited for denoising images with
     specific textures. The principle of the algorithm is to average the value
-    of a given pixel with values of other pixels in a limited neighbourhood,
+    of a given pixel with values of other pixels in a limited neighborhood,
     provided that the *patches* centered on the other pixels are similar enough
     to the patch centered on the pixel of interest.
 

--- a/skimage/transform/_warps_cy.pyx
+++ b/skimage/transform/_warps_cy.pyx
@@ -4,7 +4,7 @@
 #cython: wraparound=False
 import numpy as np
 cimport numpy as cnp
-from .._shared.interpolation cimport (nearest_neighbour_interpolation,
+from .._shared.interpolation cimport (nearest_neighbor_interpolation,
                                       bilinear_interpolation,
                                       biquadratic_interpolation,
                                       bicubic_interpolation)
@@ -163,7 +163,7 @@ def _warp_fast(np_floats[:, :] image, np_floats[:, :] H, output_shape=None,
                              np_floats, np_floats, char, np_floats,
                              np_floats*) nogil
     if order == 0:
-        interp_func = nearest_neighbour_interpolation[np_floats, np_floats,
+        interp_func = nearest_neighbor_interpolation[np_floats, np_floats,
                                                       np_floats]
     elif order == 1:
         interp_func = bilinear_interpolation[np_floats, np_floats, np_floats]


### PR DESCRIPTION
## Description

Changing occurrences of "neighbourhood" to EN-US spelling, "neighborhood," and deprecating changes as necessary.
Closes #6202.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
