### PR TITLE
Improve histogram matching performance on uint data

### DIFF
--- a/skimage/exposure/histogram_matching.py
+++ b/skimage/exposure/histogram_matching.py
@@ -19,8 +19,8 @@ def _match_cumulative_cdf(source, template):
         tmpl_values = tmpl_values[tmpl_values_exist]
     else:
         src_values, src_lookup, src_counts = np.unique(source.ravel(),
-                                                           return_inverse=True,
-                                                           return_counts=True)
+                                                       return_inverse=True,
+                                                       return_counts=True)
         tmpl_values, tmpl_counts = np.unique(template.ravel(), return_counts=True)
 
     # calculate normalized quantiles for each array

--- a/skimage/exposure/histogram_matching.py
+++ b/skimage/exposure/histogram_matching.py
@@ -8,17 +8,27 @@ def _match_cumulative_cdf(source, template):
     Return modified source array so that the cumulative density function of
     its values matches the cumulative density function of the template.
     """
-    src_values, src_unique_indices, src_counts = np.unique(source.ravel(),
+    if source.dtype.kind == 'u':
+        src_lookup = source.ravel()
+        src_counts = np.bincount(src_lookup)
+        tmpl_counts = np.bincount(template.ravel())
+        tmpl_values = np.arange(len(tmpl_counts))
+        
+        tmpl_values_exist = tmpl_counts > 0
+        tmpl_counts = tmpl_counts[tmpl_values_exist]
+        tmpl_values = tmpl_values[tmpl_values_exist]
+    else:
+        src_values, src_lookup, src_counts = np.unique(source.ravel(),
                                                            return_inverse=True,
                                                            return_counts=True)
-    tmpl_values, tmpl_counts = np.unique(template.ravel(), return_counts=True)
+        tmpl_values, tmpl_counts = np.unique(template.ravel(), return_counts=True)
 
     # calculate normalized quantiles for each array
     src_quantiles = np.cumsum(src_counts) / source.size
     tmpl_quantiles = np.cumsum(tmpl_counts) / template.size
 
     interp_a_values = np.interp(src_quantiles, tmpl_quantiles, tmpl_values)
-    return interp_a_values[src_unique_indices].reshape(source.shape)
+    return interp_a_values[src_lookup].reshape(source.shape)
 
 
 @utils.channel_as_last_axis(channel_arg_positions=(0, 1))


### PR DESCRIPTION
## Description
`np.bincount` is preferable to `np.unique` for unsigned integer types (i.e. most image representations). This affords a 6-fold performance increase for these types of inputs.

## Checklist

 - [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py): no new functions introduced
- [x] Gallery example in `./doc/examples` (new features only): not a new feature
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark - TODO
- [ ] Unit tests - TODO
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/) - TODO
- [x] Descriptive commit messages (see below) - done

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
