### PR TITLE
PiecewiseAffineTransform.estimate return should reflect underlying transforms

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -968,7 +968,7 @@ class PiecewiseAffineTransform(GeometricTransform):
         Returns
         -------
         success : bool
-            True, if model estimation succeeds.
+            True, if all pieces of the model are successfully estimated.
 
         """
 
@@ -976,11 +976,14 @@ class PiecewiseAffineTransform(GeometricTransform):
         # forward piecewise affine
         # triangulate input positions into mesh
         self._tesselation = spatial.Delaunay(src)
+
+        ok = True
+
         # find affine mapping from source positions to destination
         self.affines = []
         for tri in self._tesselation.vertices:
             affine = AffineTransform(dimensionality=ndim)
-            affine.estimate(src[tri, :], dst[tri, :])
+            ok &= affine.estimate(src[tri, :], dst[tri, :])
             self.affines.append(affine)
 
         # inverse piecewise affine
@@ -990,10 +993,10 @@ class PiecewiseAffineTransform(GeometricTransform):
         self.inverse_affines = []
         for tri in self._inverse_tesselation.vertices:
             affine = AffineTransform(dimensionality=ndim)
-            affine.estimate(dst[tri, :], src[tri, :])
+            ok &= affine.estimate(dst[tri, :], src[tri, :])
             self.inverse_affines.append(affine)
 
-        return True
+        return ok
 
     def __call__(self, coords):
         """Apply forward transformation.

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -977,13 +977,13 @@ class PiecewiseAffineTransform(GeometricTransform):
         # triangulate input positions into mesh
         self._tesselation = spatial.Delaunay(src)
 
-        ok = True
+        success = True
 
         # find affine mapping from source positions to destination
         self.affines = []
         for tri in self._tesselation.vertices:
             affine = AffineTransform(dimensionality=ndim)
-            ok &= affine.estimate(src[tri, :], dst[tri, :])
+            success &= affine.estimate(src[tri, :], dst[tri, :])
             self.affines.append(affine)
 
         # inverse piecewise affine
@@ -993,10 +993,10 @@ class PiecewiseAffineTransform(GeometricTransform):
         self.inverse_affines = []
         for tri in self._inverse_tesselation.vertices:
             affine = AffineTransform(dimensionality=ndim)
-            ok &= affine.estimate(dst[tri, :], src[tri, :])
+            success &= affine.estimate(dst[tri, :], src[tri, :])
             self.inverse_affines.append(affine)
 
-        return ok
+        return success
 
     def __call__(self, coords):
         """Apply forward transformation.

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -550,6 +550,26 @@ def test_degenerate():
     # Prior to gh-6207, the above would set the parameters as the identity.
     assert np.all(np.isnan(tform.params))
 
+    # The tesselation on the following points produces one degenerate affine
+    # warp within PiecewiseAffineTransform.
+    src = np.asarray([
+        [0, 192, 256], [0, 256, 256], [5, 0, 192], [5, 64, 0], [5, 64, 64],
+        [5, 64, 256], [5, 192, 192], [5, 256, 256], [0, 192, 256],
+    ])
+
+    dst = np.asarray([
+        [0, 142, 206], [0, 206, 206], [5, -50, 142], [5, 14, 0], [5, 14, 64],
+        [5, 14, 206], [5, 142, 142], [5, 206, 206], [0, 142, 206],
+    ])
+    tform = PiecewiseAffineTransform()
+    assert not tform.estimate(src, dst)
+    assert np.all(np.isnan(tform.affines[4].params))  # degenerate affine
+    for idx, affine in enumerate(tform.affines):
+        if idx != 4:
+            assert not np.all(np.isnan(affine.params))
+    for affine in tform.inverse_affines:
+        assert not np.all(np.isnan(affine.params))
+
 
 def test_normalize_degenerate_points():
     """Return nan matrix *of appropriate size* when point is repeated."""


### PR DESCRIPTION
## Description

Prior to this change, PiecewiseAffineTransform.estimate always returns True -- even when one of the underlying transforms is ill-conditioned.  This change causes a return value of True only when all the transforms are well-conditioned.

Closes #6206 

## Checklist

- [x] Unit test updated
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] Descriptive commit messages (see below)

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
