### PR TITLE
Allow the output_shape argument to be any iterable for resize and resize_local_mean

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -28,7 +28,7 @@ def _preprocess_resize_output_shape(image, output_shape):
     ----------
     image: ndarray
         Image to be resized.
-    output_shape: tuple or ndarray
+    output_shape: iterable
         Size of the generated output image `(rows, cols[, ...][, dim])`. If
         `dim` is not provided, the number of channels is preserved.
 
@@ -82,7 +82,7 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
     ----------
     image : ndarray
         Input image.
-    output_shape : tuple or ndarray
+    output_shape : iterable
         Size of the generated output image `(rows, cols[, ...][, dim])`. If
         `dim` is not provided, the number of channels is preserved. In case the
         number of input channels does not equal the number of output channels a
@@ -1213,7 +1213,7 @@ def resize_local_mean(image, output_shape, grid_mode=True,
     image : ndarray
         Input image. If this is a multichannel image, the axis corresponding
         to channels should be specified using `channel_axis`
-    output_shape : tuple or ndarray
+    output_shape : iterable
         Size of the generated output image. When `channel_axis` is not None,
         the `channel_axis` should either be omitted from `output_shape` or the
         ``output_shape[channel_axis]`` must match

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -52,6 +52,7 @@ def _preprocess_resize_output_shape(image, output_shape):
     equal to output_shape_length.
 
     """
+    output_shape = tuple(output_shape)
     output_ndim = len(output_shape)
     input_shape = image.shape
     if output_ndim > image.ndim:

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -380,7 +380,7 @@ def test_resize_dtype():
 @pytest.mark.parametrize('dtype', [np.float64, np.uint8])
 def test_resize_clip(order, preserve_range, anti_aliasing, dtype):
     # test if clip as expected
-    if dtype == np.uint8 and (preserve_range or order==0):
+    if dtype == np.uint8 and (preserve_range or order == 0):
         expected_max = 255
     else:
         expected_max = 1.0
@@ -911,3 +911,11 @@ def test_resize_local_mean_dtype():
                              preserve_range=False).dtype == x_f32.dtype
     assert resize_local_mean(x_f32, (10, 10),
                              preserve_range=True).dtype == x_f32.dtype
+
+
+@pytest.mark.parametrize("_type", [tuple, np.asarray, list])
+def test_output_shape_arg_type(_type):
+    img = np.random.rand(3, 3)
+    output_shape = _type([5, 5])
+
+    assert resize(img, output_shape).shape == tuple(output_shape)


### PR DESCRIPTION
## Description

Fixes #6218 


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
