### PR TITLE
Update imports/refs from deprecated scipy.ndimage.filters namespace

### DIFF
--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -403,7 +403,7 @@ def rag_boundary(labels, edge_map, connectivity=2):
         Pixels with a squared distance less than `connectivity` from each other
         are considered adjacent. It can range from 1 to `labels.ndim`. Its
         behavior is the same as `connectivity` parameter in
-        `scipy.ndimage.filters.generate_binary_structure`.
+        `scipy.ndimage.generate_binary_structure`.
 
     Examples
     --------

--- a/skimage/restoration/inpaint.py
+++ b/skimage/restoration/inpaint.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy import sparse
 from scipy.sparse.linalg import spsolve
 import scipy.ndimage as ndi
-from scipy.ndimage.filters import laplace
+from scipy.ndimage import laplace
 
 import skimage
 from .._shared import utils


### PR DESCRIPTION
## Description

`scipy 1.8.0` deprecated the `scipy.ndimage.filters` namespace.  This PR updates the import for `scipy.ndimage.laplace` and the doc reference to `scipy.ndimage.generate_binary_structure`.

These changes should work fine with older scipy versions (but I don't see a minimum scipy dependency for this package).  For example, the `scipy.ndimage.generate_binary_structure` reference is currently used in other places in `skimage`.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
