### PR TITLE
Allow non-adjacent footprints in flood_fill.

### DIFF
--- a/skimage/metrics/set_metrics.py
+++ b/skimage/metrics/set_metrics.py
@@ -24,7 +24,7 @@ def hausdorff_distance(image0, image1, method="standard"):
         ``image0`` and ``image1``, using the Euclidian distance.
 
     Notes
-    ------
+    -----
     The Hausdorff distance [1]_ is the maximum distance between any point on
     ``image0`` and its nearest point on ``image1``, and vice-versa.
     The Modified Hausdorff Distance (MHD) has been shown to perform better

--- a/skimage/morphology/_flood_fill.py
+++ b/skimage/morphology/_flood_fill.py
@@ -230,22 +230,29 @@ def flood(image, seed_point, *, footprint=None, connectivity=None,
     seed_value = image[seed_point]
     seed_point = tuple(np.asarray(seed_point) % image.shape)
 
-    footprint = _resolve_neighborhood(footprint, connectivity, image.ndim)
+    footprint = _resolve_neighborhood(
+        footprint, connectivity, image.ndim, enforce_adjacency=False)
+    center = np.array(footprint.shape) // 2
+
+    # Compute pad count as the maximum offset to neighbors across all axes.
+    neighbor_indices = np.array(np.nonzero(footprint)).T
+    neighbor_coordinate_offsets = np.ravel(neighbor_indices - center)
+    pad_count = np.max(np.abs(neighbor_coordinate_offsets))
 
     # Must annotate borders
-    working_image = np.pad(image, 1, mode='constant',
+    working_image = np.pad(image, pad_count, mode='constant',
                            constant_values=image.min())
 
     # Stride-aware neighbors - works for both C- and Fortran-contiguity
-    ravelled_seed_idx = np.ravel_multi_index([i + 1 for i in seed_point],
-                                             working_image.shape, order=order)
+    ravelled_seed_idx = np.ravel_multi_index(
+        [i + pad_count for i in seed_point], working_image.shape, order=order)
     neighbor_offsets = _offsets_to_raveled_neighbors(
-        working_image.shape, footprint, center=((1,) * image.ndim),
+        working_image.shape, footprint, center=center,
         order=order)
 
     # Use a set of flags; see _flood_fill_cy.pyx for meanings
-    flags = np.zeros(working_image.shape, dtype=np.uint8, order=order)
-    _set_border_values(flags, value=2)
+    flags = np.zeros(image.shape, dtype=np.uint8, order=order)
+    flags = np.pad(flags, pad_count, constant_values=2)
 
     try:
         if tolerance is not None:
@@ -282,4 +289,4 @@ def flood(image, seed_point, *, footprint=None, connectivity=None,
             raise
 
     # Output what the user requested; view does not create a new copy.
-    return flags[(slice(1, -1),) * image.ndim].view(bool)
+    return flags[(slice(pad_count, -pad_count),) * image.ndim].view(bool)

--- a/skimage/morphology/_util.py
+++ b/skimage/morphology/_util.py
@@ -265,6 +265,8 @@ def _resolve_neighborhood(footprint, connectivity, ndim,
         # Must only specify direct neighbors
         if enforce_adjacency and any(s != 3 for s in footprint.shape):
             raise ValueError("dimension size in footprint is not 3")
+        elif any((s % 2 != 1) for s in footprint.shape):
+            raise ValueError("footprint size must be odd along all dimensions")
 
     return footprint
 

--- a/skimage/morphology/_util.py
+++ b/skimage/morphology/_util.py
@@ -207,7 +207,8 @@ def _offsets_to_raveled_neighbors(image_shape, footprint, center, order='C'):
     return raveled_offsets
 
 
-def _resolve_neighborhood(footprint, connectivity, ndim):
+def _resolve_neighborhood(footprint, connectivity, ndim,
+                          enforce_adjacency=True):
     """Validate or create a footprint (structuring element).
 
     Depending on the values of `connectivity` and `footprint` this function
@@ -229,6 +230,9 @@ def _resolve_neighborhood(footprint, connectivity, ndim):
         `footprint` is not None.
     ndim : int
         Number of dimensions `footprint` ought to have.
+    enforce_adjacency : bool
+        A boolean that determines whether footprint must only specify direct
+        neighbors.
 
     Returns
     -------
@@ -258,7 +262,7 @@ def _resolve_neighborhood(footprint, connectivity, ndim):
                 "match"
             )
         # Must only specify direct neighbors
-        if any(s != 3 for s in footprint.shape):
+        if enforce_adjacency and any(s != 3 for s in footprint.shape):
             raise ValueError("dimension size in footprint is not 3")
 
     return footprint

--- a/skimage/morphology/tests/test_flood_fill.py
+++ b/skimage/morphology/tests/test_flood_fill.py
@@ -251,3 +251,43 @@ def test_negative_indexing_seed_point():
     image = flood_fill(image, (0, -1), 5)
 
     np.testing.assert_allclose(image, expected)
+
+
+def test_non_adjacent_footprint():
+    # Basic tests for non-adjacent footprints
+    footprint = np.array([[1, 0, 0, 0, 1],
+                          [0, 0, 0, 0, 0],
+                          [0, 0, 1, 0, 0],
+                          [0, 0, 0, 0, 0],
+                          [1, 0, 0, 0, 1]])
+
+    output = flood_fill(np.zeros((5, 6), dtype=np.uint8), (2, 3), 255,
+                        footprint=footprint)
+
+    expected = np.array([[0, 255,   0,   0,   0, 255],
+                         [0,   0,   0,   0,   0,   0],
+                         [0,   0,   0, 255,   0,   0],
+                         [0,   0,   0,   0,   0,   0],
+                         [0, 255,   0,   0,   0, 255]], dtype=np.uint8)
+
+    np.testing.assert_equal(output, expected)
+
+    footprint = np.array([[1, 1, 1, 1, 1],
+                          [1, 1, 1, 1, 1],
+                          [1, 1, 1, 1, 1],
+                          [1, 1, 1, 1, 1],
+                          [1, 1, 1, 1, 1]])
+
+    image = np.zeros((5, 10), dtype=np.uint8)
+    image[:, (3, 7, 8)] = 100
+
+    output = flood_fill(image, (0, 0), 255, footprint=footprint)
+
+    expected = np.array([[255, 255, 255, 100, 255, 255, 255, 100, 100, 0],
+                         [255, 255, 255, 100, 255, 255, 255, 100, 100, 0],
+                         [255, 255, 255, 100, 255, 255, 255, 100, 100, 0],
+                         [255, 255, 255, 100, 255, 255, 255, 100, 100, 0],
+                         [255, 255, 255, 100, 255, 255, 255, 100, 100, 0]],
+                        dtype=np.uint8)
+
+    np.testing.assert_equal(output, expected)


### PR DESCRIPTION
## Description

Previously, flood_fill ensured that footprints only specified connectivity for directly adjacent pixels. This change allows footprint to specify non-adjacent pixels as neighbors.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
