### PR TITLE
DOC: fix SciPy intersphinx

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -388,7 +388,7 @@ intersphinx_mapping = {
     'python': (_python_doc_base, None),
     'numpy': ('https://numpy.org/doc/stable',
               (None, './_intersphinx/numpy-objects.inv')),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference',
+    'scipy': ('https://docs.scipy.org/doc/scipy/',
               (None, './_intersphinx/scipy-objects.inv')),
     'sklearn': ('https://scikit-learn.org/stable',
                 (None, './_intersphinx/sklearn-objects.inv')),


### PR DESCRIPTION
Fix the SciPy intersphinx link following deployment of new doc theme and `.htaccess` server file adjustments: https://github.com/scipy/scipy/issues/15545#issuecomment-1032825234