### PR TITLE
Fix bug in SLIC superpixels with `enforce_connectivity=True` and `start_label > 0`

### DIFF
--- a/skimage/segmentation/_slic.pyx
+++ b/skimage/segmentation/_slic.pyx
@@ -302,7 +302,7 @@ def _enforce_label_connectivity_cython(Py_ssize_t[:, :, ::1] segments,
                         continue
 
                     # find the component size
-                    adjacent = 0
+                    adjacent = current_new_label
                     label = segments[z, y, x]
                     connected_segments[z, y, x] = current_new_label
                     current_segment_size = 1

--- a/skimage/segmentation/tests/test_slic.py
+++ b/skimage/segmentation/tests/test_slic.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_equal
 
-from skimage import data, img_as_float
+from skimage import data, filters, img_as_float
 from skimage._shared.testing import test_parallel, expected_warnings
 from skimage.segmentation import slic
 
@@ -538,3 +538,23 @@ def test_dtype_support(dtype):
 
     # Simply run the function to assert that it runs without error
     slic(img, start_label=1)
+
+
+def test_start_label_fix():
+    """Tests the fix for a bug producing a label < start_label (gh-6240).
+
+    For the v0.19.1 release, the `img` and `slic` call as below result in two
+    non-contiguous regions with value 0 despite `start_label=1`. We verify that
+    the minimum label is now `start_label` as expected.
+    """
+
+    # generate bumpy data that gives unexpected label prior to bug fix
+    rng = np.random.default_rng(9)
+    img = rng.standard_normal((8, 13)) > 0
+    img = filters.gaussian(img, sigma=1)
+
+    start_label = 1
+    superp = slic(img, start_label=start_label, multichannel=False,
+                  n_segments=6, compactness=0.01, enforce_connectivity=True,
+                  max_num_iter=10)
+    assert superp.min() == start_label

--- a/skimage/segmentation/tests/test_slic.py
+++ b/skimage/segmentation/tests/test_slic.py
@@ -554,7 +554,7 @@ def test_start_label_fix():
     img = filters.gaussian(img, sigma=1)
 
     start_label = 1
-    superp = slic(img, start_label=start_label, multichannel=False,
+    superp = slic(img, start_label=start_label, channel_axis=None,
                   n_segments=6, compactness=0.01, enforce_connectivity=True,
                   max_num_iter=10)
     assert superp.min() == start_label


### PR DESCRIPTION
## Description

closes #6240

Prevent possible 0 label in output when start label > 0 for SLIC superpixels. This could occur when running "_enforce_label_connectivity_cython" because the `adjacent` variable started with value 0, but it seems like it must start with `current_new_label` (or `start_label`) to avoid potentially assigning a value outside the label range. 

This is only really an issue at the upper edge/corner of the image where it is possible that `adjacent` never gets assigned because there are not yet any adjacent labels assigned to pull from.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
