### PR TITLE
improve butterworth docstring and add new kwargs and gallery example

### DIFF
--- a/doc/examples/filters/plot_butterworth.py
+++ b/doc/examples/filters/plot_butterworth.py
@@ -1,0 +1,158 @@
+"""
+===================
+Butterworth Filters
+===================
+
+The Butterworth filter is implemented in the frequency domain and is designed
+to have no passband or stopband ripple. It can be used in either a lowpass or
+highpass variant. The ``cutoff_frequency_ratio`` parameter is used to set the
+cutoff frequency as a fraction of the sampling frequency. Given that the
+Nyquist frequency is half the sampling frequency, this means that this
+parameter should be a positive floating point value < 0.5. The ``order`` of the
+filter can be adjusted to control the transition width, with higher values
+leading to a sharper transition between the passband and stopband.
+
+"""
+
+
+#####################################################################
+# Butterworth filtering example
+# =============================
+# Here we define a `get_filtered` helper function to repeat lowpass and
+# highpass filtering at a specified series of cutoff frequencies.
+
+import matplotlib.pyplot as plt
+from matplotlib import rcParams
+
+from skimage import data, filters
+
+image = data.camera()
+
+# cutoff frequencies as a fraction of the maximum frequency
+cutoffs = [.02, .08, .16]
+
+
+def get_filtered(image, cutoffs, squared_butterworth=True, order=3.0, npad=0):
+    """Lowpass and highpass butterworth filtering at all specified cutoffs.
+
+    Parameters
+    ----------
+    image : ndarray
+        The image to be filtered.
+    cutoffs : sequence of int
+        Both lowpass and highpass filtering will be performed for each cutoff
+        frequency in `cutoffs`.
+    squared_butterworth : bool, optional
+        Whether the traditional Butterworth filter or its square is used.
+    order : float, optional
+        The order of the Butterworth filter
+
+    Returns
+    -------
+    lowpass_filtered : list of ndarray
+        List of images lowpass filtered at the frequencies in `cutoffs`.
+    highpass_filtered : list of ndarray
+        List of images highpass filtered at the frequencies in `cutoffs`.
+    """
+
+    lowpass_filtered = []
+    highpass_filtered = []
+    for cutoff in cutoffs:
+        lowpass_filtered.append(
+            filters.butterworth(
+                image,
+                cutoff_frequency_ratio=cutoff,
+                order=order,
+                high_pass=False,
+                squared_butterworth=squared_butterworth,
+                npad=npad,
+            )
+        )
+        highpass_filtered.append(
+            filters.butterworth(
+                image,
+                cutoff_frequency_ratio=cutoff,
+                order=order,
+                high_pass=True,
+                squared_butterworth=squared_butterworth,
+                npad=npad,
+            )
+        )
+    return lowpass_filtered, highpass_filtered
+
+
+def plot_filtered(lowpass_filtered, highpass_filtered, cutoffs):
+    """Generate plots for paired lists of lowpass and highpass images."""
+    fig, axes = plt.subplots(2, 1 + len(cutoffs), figsize=(12, 8))
+    fontdict = dict(fontsize=14, fontweight='bold')
+
+    axes[0, 0].imshow(image, cmap='gray')
+    axes[0, 0].set_title('original', fontdict=fontdict)
+    axes[1, 0].set_axis_off()
+
+    for i, c in enumerate(cutoffs):
+        axes[0, i + 1].imshow(lowpass_filtered[i], cmap='gray')
+        axes[0, i + 1].set_title(f'lowpass, c={c}', fontdict=fontdict)
+        axes[1, i + 1].imshow(highpass_filtered[i], cmap='gray')
+        axes[1, i + 1].set_title(f'highpass, c={c}', fontdict=fontdict)
+
+    for ax in axes.ravel():
+        ax.set_xticks([])
+        ax.set_yticks([])
+    plt.tight_layout()
+    return fig, axes
+
+
+# Perform filtering with the (squared) Butterworth filter at a range of
+# cutoffs.
+lowpasses, highpasses = get_filtered(image, cutoffs, squared_butterworth=True)
+
+fig, axes = plot_filtered(lowpasses, highpasses, cutoffs)
+titledict = dict(fontsize=18, fontweight='bold')
+fig.text(0.5, 0.95, '(squared) Butterworth filtering (order=3.0, npad=0)',
+         fontdict=titledict, horizontalalignment='center')
+
+
+#####################################################################
+# Avoiding boundary artifacts
+# ===========================
+#
+# It can be seen in the images above that there are artifacts near the edge of
+# the images (particularly for the smaller cutoff values). This is due to the
+# periodic nature of the DFT and can be reduced by applying some amount of
+# padding to the edges prior to filtering so that there are not sharp eges in
+# the periodic extension of the image. This can be done via the ``npad``
+# argument to ``butterworth``.
+#
+# Note that with padding, the undesired shading at the image edges is
+# substantially reduced.
+
+
+lowpasses, highpasses = get_filtered(image, cutoffs, squared_butterworth=True,
+                                     npad=32)
+
+fig, axes = plot_filtered(lowpasses, highpasses, cutoffs)
+fig.text(0.5, 0.95, '(squared) Butterworth filtering (order=3.0, npad=32)',
+         fontdict=titledict, horizontalalignment='center')
+
+
+#####################################################################
+# True Butterworth filter
+# =======================
+#
+# To use the traditional signal processing defintion of the Butterworth filter,
+# set ``squared_butterworth=False``. This variant has an amplitude profile in
+# the frequency domain that is the square root of the default case. This causes
+# the transition from the passband to the stopband to be more gradual at any
+# given `order`. This can be seen in the following images which appear a bit
+# sharper in the lowpass case than their squared Butterworth counterparts
+# above.
+
+lowpasses, highpasses = get_filtered(image, cutoffs, squared_butterworth=False,
+                                     npad=32)
+
+fig, axes = plot_filtered(lowpasses, highpasses, cutoffs)
+fig.text(0.5, 0.95, 'Butterworth filtering (order=3.0, npad=32)',
+         fontdict=titledict, horizontalalignment='center')
+
+plt.show()

--- a/skimage/filters/_fft_based.py
+++ b/skimage/filters/_fft_based.py
@@ -6,8 +6,8 @@ import scipy.fft as fft
 from .._shared.utils import _supported_float_type
 
 
-def _get_ND_butterworth_filter(shape, factor, order, high_pass, real,
-                               dtype=np.float64):
+def _get_nd_butterworth_filter(shape, factor, order, high_pass, real,
+                               dtype=np.float64, squared_butterworth=True):
     """Create a N-dimensional Butterworth mask for an FFT
 
     Parameters
@@ -23,6 +23,8 @@ def _get_ND_butterworth_filter(shape, factor, order, high_pass, real,
         low pass (high frequencies are attenuated).
     real : bool
         Whether the FFT is of a real (True) or complex (False) image
+    squared_butterworth : bool, optional
+        When True, the square of the Butterworth filter is used.
 
     Returns
     -------
@@ -44,9 +46,12 @@ def _get_ND_butterworth_filter(shape, factor, order, high_pass, real,
             np.add, np.meshgrid(*ranges, indexing="ij", sparse=True)
             )
     q2 = q2.astype(dtype)
-    wfilt = 1 / (1 + np.power(q2, order))
+    q2 = np.power(q2, order)
+    wfilt = 1 / (1 + q2)
     if high_pass:
-        wfilt = 1 - wfilt
+        wfilt *= q2
+    if not squared_butterworth:
+        np.sqrt(wfilt, out=wfilt)
     return wfilt
 
 
@@ -56,6 +61,9 @@ def butterworth(
     high_pass=True,
     order=2.0,
     channel_axis=None,
+    *,
+    squared_butterworth=True,
+    npad=0,
 ):
     """Apply a Butterworth filter to enhance high or low frequency features.
 
@@ -67,7 +75,7 @@ def butterworth(
         Input image.
     cutoff_frequency_ratio : float, optional
         Determines the position of the cut-off relative to the shape of the
-        FFT.
+        FFT. This should be in the range [0, 0.5].
     high_pass : bool, optional
         Whether to perform a high pass filter. If False, a low pass filter is
         performed.
@@ -77,6 +85,13 @@ def butterworth(
     channel_axis : int, optional
         If there is a channel dimension, provide the index here. If None
         (default) then all axes are assumed to be spatial dimensions.
+    squared_butterworth : bool, optional
+        When True, the square of a Butterworth filter is used. See notes below
+        for more details.
+    npad : int, optional
+        Pad each edge of image the by `npad` pixels using `numpy.pad`'s
+        ``mode='edge'`` extension. Try increasing `npad` if boundary artifacts
+        are apparent.
 
     Returns
     -------
@@ -85,21 +100,38 @@ def butterworth(
 
     Notes
     -----
-    A band-pass filter can be achieved by combining a high pass and low
-    pass filter.
+    A band-pass filter can be achieved by combining a high-pass and low-pass
+    filter.
 
-    The literature contains multiple conventions for the functional form of
-    the Butterworth filter. Here it is implemented as the n-dimensional form of
+    The "Butterworth filter" used in image processing textbooks (e.g. [1]_,
+    [2]_) is often the square of the traditional Butterworth filters as
+    described by [3]_, [4]_. The squared version will be used here if
+    `squared_butterworth` is set to ``True``. The lowpass, squared Butterworth
+    filter is given by the following expression for the lowpass case:
 
     .. math::
-        \\frac{1}{1 - \\left(\\frac{f}{c*f_{max}}\\right)^{2*n}}
+        H_{low}(f) = \\frac{1}{1 + \\left(\\frac{f}{c f_s}\\right)^{2n}}
 
-    with :math:`f` the absolute value of the spatial frequency, :math:`c` the
-    ``cutoff_frequency_ratio`` and :math:`n` the ``order`` modeled after [2]_
+    with the highpass case given by
+
+    .. math::
+        H_{hi}(f) = 1 - H_{low}(f)
+
+    where :math:`f=\\sqrt{\\sum_{d=0}^{\\mathrm{ndim}} f_{d}^{2}}` is the
+    absolute value of the spatial frequency, :math:`f_s` is the sampling
+    frequency, :math:`c` the ``cutoff_frequency_ratio``, and :math:`n` is the
+    filter `order` [1]_. When ``squared_butterworth=False``, the square root of
+    the above expressions are used instead.
+
+    Note that ``cutoff_frequency_ratio`` is defined in terms of the sampling
+    frequency, :math:`f_s`. The FFT spectrum covers the Nyquist range
+    (:math:`[-f_s/2, f_s/2]`) so ``cutoff_frequency_ratio`` should have a value
+    between 0 and 0.5. The frequency response (gain) at the cutoff is 0.5 when
+    ``squared_butterworth`` is true and :math:`1/\\sqrt{2}` when it is false.
 
     Examples
     --------
-    Apply a high pass and low pass Butterworth filter to a grayscale and
+    Apply a high-pass and low-pass Butterworth filter to a grayscale and
     color image respectively:
 
     >>> from skimage.data import camera, astronaut
@@ -109,19 +141,31 @@ def butterworth(
 
     References
     ----------
-    .. [1] Butterworth, Stephen. "On the theory of filter amplifiers."
+    .. [1] Russ, John C., et al. The Image Processing Handbook, 3rd. Ed.
+           1999, CRC Press, LLC.
+    .. [2] Birchfield, Stan. Image Processing and Analysis. 2018. Cengage
+           Learning.
+    .. [3] Butterworth, Stephen. "On the theory of filter amplifiers."
            Wireless Engineer 7.6 (1930): 536-541.
-    .. [2] Russ, John C., et al. "The image processing handbook."
-           Computers in Physics 8.2 (1994): 177-178.
+    .. [4] https://en.wikipedia.org/wiki/Butterworth_filter
 
     """
+    if npad < 0:
+        raise ValueError("npad must be >= 0")
+    elif npad > 0:
+        center_slice = tuple(slice(npad, s + npad) for s in image.shape)
+        image = np.pad(image, npad, mode='edge')
     fft_shape = (image.shape if channel_axis is None
                  else np.delete(image.shape, channel_axis))
     is_real = np.isrealobj(image)
     float_dtype = _supported_float_type(image.dtype, allow_complex=True)
-    wfilt = _get_ND_butterworth_filter(
+    if cutoff_frequency_ratio < 0 or cutoff_frequency_ratio > 0.5:
+        raise ValueError(
+            "cutoff_frequency_ratio should be in the range [0, 0.5]"
+        )
+    wfilt = _get_nd_butterworth_filter(
         fft_shape, cutoff_frequency_ratio, order, high_pass, is_real,
-        float_dtype
+        float_dtype, squared_butterworth
     )
     axes = np.arange(image.ndim)
     if channel_axis is not None:
@@ -137,4 +181,6 @@ def butterworth(
     else:
         butterfilt = fft.ifftn(wfilt * fft.fftn(image, axes=axes),
                                s=fft_shape, axes=axes)
+    if npad > 0:
+        butterfilt = butterfilt[center_slice]
     return butterfilt

--- a/skimage/filters/_fft_based.py
+++ b/skimage/filters/_fft_based.py
@@ -89,9 +89,8 @@ def butterworth(
         When True, the square of a Butterworth filter is used. See notes below
         for more details.
     npad : int, optional
-        Pad each edge of image the by `npad` pixels using `numpy.pad`'s
-        ``mode='edge'`` extension. Try increasing `npad` if boundary artifacts
-        are apparent.
+        Pad each edge of the image by `npad` pixels using `numpy.pad`'s
+        ``mode='edge'`` extension.
 
     Returns
     -------
@@ -101,7 +100,7 @@ def butterworth(
     Notes
     -----
     A band-pass filter can be achieved by combining a high-pass and low-pass
-    filter.
+    filter. The user can increase `npad` if boundary artifacts are apparent.
 
     The "Butterworth filter" used in image processing textbooks (e.g. [1]_,
     [2]_) is often the square of the traditional Butterworth filters as

--- a/skimage/filters/_fft_based.py
+++ b/skimage/filters/_fft_based.py
@@ -75,7 +75,7 @@ def butterworth(
         Input image.
     cutoff_frequency_ratio : float, optional
         Determines the position of the cut-off relative to the shape of the
-        FFT. This should be in the range [0, 0.5].
+        FFT. Receives a value between [0, 0.5].
     high_pass : bool, optional
         Whether to perform a high pass filter. If False, a low pass filter is
         performed.

--- a/skimage/filters/tests/test_fft_based.py
+++ b/skimage/filters/tests/test_fft_based.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
@@ -6,6 +8,7 @@ import scipy.fft as fftmodule
 from skimage._shared.utils import _supported_float_type
 from skimage.data import astronaut, coins
 from skimage.filters import butterworth
+from skimage.filters._fft_based import _get_nd_butterworth_filter
 
 
 def _fft_centered(x):
@@ -14,22 +17,71 @@ def _fft_centered(x):
 
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64,
                                    np.uint8, np.int32])
-def test_butterworth_2D_zeros_dtypes(dtype):
+@pytest.mark.parametrize('squared_butterworth', [False, True])
+def test_butterworth_2D_zeros_dtypes(dtype, squared_butterworth):
     im = np.zeros((4, 4), dtype=dtype)
-    filtered = butterworth(im)
+    filtered = butterworth(im, squared_butterworth=squared_butterworth)
     assert filtered.shape == im.shape
     assert filtered.dtype == _supported_float_type(dtype)
     assert_array_equal(im, filtered)
 
 
+@pytest.mark.parametrize('squared_butterworth', [False, True])
+@pytest.mark.parametrize('high_pass', [False, True])
+# order chosen large enough that lowpass stopband always approaches 0
+@pytest.mark.parametrize('order', [6, 10])
+@pytest.mark.parametrize('cutoff', [0.2, 0.3])
+def test_butterworth_cutoff(cutoff, order, high_pass, squared_butterworth):
+
+    wfilt = _get_nd_butterworth_filter(
+        shape=(512, 512), factor=cutoff, order=order,
+        high_pass=high_pass, real=False,
+        squared_butterworth=squared_butterworth,
+    )
+    # select DC frequence on first axis to plot profile along a single axis
+    wfilt_profile = np.abs(wfilt[0])
+
+    # Empirical chosen to pass for order=6. Can use a smaller tolerance at
+    # higher orders.
+    tol = 0.3 / order
+
+    # should have amplitude of ~1.0 in the center of the passband
+    if high_pass:
+        assert abs(wfilt_profile[wfilt_profile.size // 2] - 1.0) < tol
+    else:
+        assert abs(wfilt_profile[0] - 1.0) < tol
+
+    # should be close to the expected amplitude at the cutoff frequency
+    f_cutoff = int(cutoff * wfilt.shape[0])
+    if squared_butterworth:
+        # expect 0.5 at the cutoff
+        assert abs(wfilt_profile[f_cutoff] - 0.5) < tol
+    else:
+        # expect 1/sqrt(2) at the cutoff
+        assert abs(wfilt_profile[f_cutoff] - 1 / math.sqrt(2)) < tol
+
+
+@pytest.mark.parametrize('cutoff', [-0.01, 0.51])
+def test_butterworth_invalid_cutoff(cutoff):
+    with pytest.raises(ValueError):
+        butterworth(np.ones((4, 4)), cutoff_frequency_ratio=cutoff)
+
+
 @pytest.mark.parametrize("high_pass", [True, False])
-def test_butterworth_2D(high_pass):
+@pytest.mark.parametrize('squared_butterworth', [False, True])
+def test_butterworth_2D(high_pass, squared_butterworth):
     # rough check of high-pass vs. low-pass behavior via relative energy
+
+    # adjust specified order so that lowpass stopband approaches 0
+    order = 3 if squared_butterworth else 6
+
     im = np.random.randn(64, 128)
     filtered = butterworth(
         im,
         cutoff_frequency_ratio=0.20,
+        order=order,
         high_pass=high_pass,
+        squared_butterworth=squared_butterworth,
     )
 
     # Compute the energy at the outer edges of the Fourier domain
@@ -58,14 +110,16 @@ def test_butterworth_2D(high_pass):
 
 @pytest.mark.parametrize("high_pass", [True, False])
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
-def test_butterworth_2D_realfft(high_pass, dtype):
+@pytest.mark.parametrize('squared_butterworth', [False, True])
+def test_butterworth_2D_realfft(high_pass, dtype, squared_butterworth):
     """Filtering a real-valued array is equivalent to filtering a
        complex-valued array where the imaginary part is zero.
     """
     im = np.random.randn(32, 64).astype(dtype)
     kwargs = dict(
         cutoff_frequency_ratio=0.20,
-        high_pass=high_pass
+        high_pass=high_pass,
+        squared_butterworth=squared_butterworth,
     )
 
     expected_dtype = _supported_float_type(im.dtype)


### PR DESCRIPTION
The current Butterworth filter (`skimage.filters.butterworth`) is actually the square of a Butterworth filter. This PR has a few related things:

- 1.) Adds a `square_butterworth` keyword-only argument to allow choice between the current "squared" Butterworth filter and a traditional Butterworth filter. This defaults to `square_butterworth=False` for backward compatibility.
- 2.) Adds a `npad` argument that can be used to more easily avoid boundary artifacts via internal padding. This defaults to `npad=0` for backward compatibility.
- 3.) update the docstring to fix the equation for the filter and clarify the "squared" vs. "traditional" variants
- 4.) add a gallery example demonstrating these filters and the use of npad to avoid boundary artifactd

I also have a new example of homomorphic filtering that makes use of these features, but will make a separate PR for that.
