### PR TITLE
Update skimage mailing addresses

### DIFF
--- a/doc/source/core_developer.md
+++ b/doc/source/core_developer.md
@@ -214,7 +214,7 @@ Inviting New Core Members
 
 Any core member may nominate other contributors to join the core team.
 Nominations happen on a private email list,
-<skimage-core@python.org>. As of this writing, there is no hard-and-fast
+<skimage-core@discuss.scientific-python.org>. As of this writing, there is no hard-and-fast
 rule about who can be nominated; at a minimum, they should have: been
 part of the project for at least six months, contributed
 significant changes of their own, contributed to the discussion and

--- a/doc/source/user_guide/getting_help.rst
+++ b/doc/source/user_guide/getting_help.rst
@@ -63,10 +63,9 @@ functions include one or more examples.
 Mailing-list
 ------------
 
-The scikit-image mailing-list is scikit-image@python.org (users
-should `join
-<https://mail.python.org/mailman3/lists/scikit-image.python.org/>`_ before posting). This
-mailing-list is shared by users and developers, and it is the right
+Join us on the `scikit-image
+developer forum <https://discuss.scientific-python.org/c/contributor/skimage>`_.
+This mailing-list is shared by users and developers, and it is the right
 place to ask any question about ``skimage``, or in general, image
 processing using Python.  Posting snippets of code with minimal examples
 ensures to get more relevant and focused answers.

--- a/skimage/_shared/setup.py
+++ b/skimage/_shared/setup.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
     from numpy.distutils.core import setup
     setup(maintainer='scikit-image Developers',
           author='scikit-image Developers',
-          maintainer_email='scikit-image@python.org',
+          maintainer_email='skimage@discuss.scientific-python.org',
           description='Transforms',
           url='https://github.com/scikit-image/scikit-image',
           license='SciPy License (BSD Style)',

--- a/skimage/data/setup.py
+++ b/skimage/data/setup.py
@@ -23,7 +23,7 @@ if __name__ == '__main__':
     from numpy.distutils.core import setup
     setup(maintainer='scikit-image Developers',
           author='scikit-image Developers',
-          maintainer_email='scikit-image@python.org',
+          maintainer_email='skimage@discuss.scientific-python.org',
           description='Minimal sample dataset for scikit-image',
           url='https://github.com/scikit-image/scikit-image',
           license='SciPy License (BSD Style)',

--- a/skimage/draw/setup.py
+++ b/skimage/draw/setup.py
@@ -23,7 +23,7 @@ if __name__ == '__main__':
     from numpy.distutils.core import setup
     setup(maintainer='scikit-image developers',
           author='scikit-image developers',
-          maintainer_email='scikit-image@python.org',
+          maintainer_email='skimage@discuss.scientific-python.org',
           description='Drawing',
           url='https://github.com/scikit-image/scikit-image',
           license='SciPy License (BSD Style)',

--- a/skimage/exposure/setup.py
+++ b/skimage/exposure/setup.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
     from numpy.distutils.core import setup
     setup(maintainer='scikit-image Developers',
           author='scikit-image Developers',
-          maintainer_email='scikit-image@python.org',
+          maintainer_email='skimage@discuss.scientific-python.org',
           description='Exposure corrections',
           url='https://github.com/scikit-image/scikit-image',
           license='SciPy License (BSD Style)',

--- a/skimage/feature/setup.py
+++ b/skimage/feature/setup.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
     from numpy.distutils.core import setup
     setup(maintainer='scikit-image Developers',
           author='scikit-image Developers',
-          maintainer_email='scikit-image@python.org',
+          maintainer_email='skimage@discuss.scientific-python.org',
           description='Features',
           url='https://github.com/scikit-image/scikit-image',
           license='SciPy License (BSD Style)',

--- a/skimage/filters/setup.py
+++ b/skimage/filters/setup.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     from numpy.distutils.core import setup
     setup(maintainer='scikit-image Developers',
           author='scikit-image Developers',
-          maintainer_email='scikit-image@python.org',
+          maintainer_email='skimage@discuss.scientific-python.org',
           description='Filters',
           url='https://github.com/scikit-image/scikit-image',
           license='SciPy License (BSD Style)',

--- a/skimage/future/graph/setup.py
+++ b/skimage/future/graph/setup.py
@@ -21,7 +21,7 @@ def configuration(parent_package='', top_path=None):
 if __name__ == '__main__':
     from numpy.distutils.core import setup
     setup(maintainer='scikit-image Developers',
-          maintainer_email='scikit-image@python.org',
+          maintainer_email='skimage@discuss.scientific-python.org',
           description='Graph-based Image-processing Algorithms',
           url='https://github.com/scikit-image/scikit-image',
           license='Modified BSD',

--- a/skimage/graph/setup.py
+++ b/skimage/graph/setup.py
@@ -28,7 +28,7 @@ def configuration(parent_package='', top_path=None):
 if __name__ == '__main__':
     from numpy.distutils.core import setup
     setup(maintainer='scikit-image Developers',
-          maintainer_email='scikit-image@python.org',
+          maintainer_email='skimage@discuss.scientific-python.org',
           description='Graph-based Image-processing Algorithms',
           url='https://github.com/scikit-image/scikit-image',
           license='Modified BSD',

--- a/skimage/io/setup.py
+++ b/skimage/io/setup.py
@@ -32,7 +32,7 @@ def configuration(parent_package='', top_path=None):
 if __name__ == '__main__':
     from numpy.distutils.core import setup
     setup(maintainer='scikit-image Developers',
-          maintainer_email='scikit-image@python.org',
+          maintainer_email='skimage@discuss.scientific-python.org',
           description='Image I/O Routines',
           url='https://github.com/scikit-image/scikit-image',
           license='Modified BSD',

--- a/skimage/measure/setup.py
+++ b/skimage/measure/setup.py
@@ -34,7 +34,7 @@ def configuration(parent_package='', top_path=None):
 if __name__ == '__main__':
     from numpy.distutils.core import setup
     setup(maintainer='scikit-image Developers',
-          maintainer_email='scikit-image@python.org',
+          maintainer_email='skimage@discuss.scientific-python.org',
           description='Graph-based Image-processing Algorithms',
           url='https://github.com/scikit-image/scikit-image',
           license='Modified BSD',

--- a/skimage/morphology/setup.py
+++ b/skimage/morphology/setup.py
@@ -45,7 +45,7 @@ if __name__ == '__main__':
     from numpy.distutils.core import setup
     setup(maintainer='scikit-image Developers',
           author='Damian Eads',
-          maintainer_email='scikit-image@python.org',
+          maintainer_email='skimage@discuss.scientific-python.org',
           description='Morphology Wrapper',
           url='https://github.com/scikit-image/scikit-image',
           license='SciPy License (BSD Style)',

--- a/skimage/restoration/setup.py
+++ b/skimage/restoration/setup.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
     from numpy.distutils.core import setup
     setup(maintainer='scikit-image Developers',
           author='scikit-image Developers',
-          maintainer_email='scikit-image@python.org',
+          maintainer_email='skimage@discuss.scientific-python.org',
           description='Restoration',
           url='https://github.com/scikit-image/scikit-image',
           license='SciPy License (BSD Style)',

--- a/skimage/segmentation/setup.py
+++ b/skimage/segmentation/setup.py
@@ -30,7 +30,7 @@ def configuration(parent_package='', top_path=None):
 if __name__ == '__main__':
     from numpy.distutils.core import setup
     setup(maintainer='scikit-image Developers',
-          maintainer_email='scikit-image@python.org',
+          maintainer_email='skimage@discuss.scientific-python.org',
           description='Segmentation Algorithms',
           url='https://github.com/scikit-image/scikit-image',
           license='SciPy License (BSD Style)',

--- a/skimage/transform/setup.py
+++ b/skimage/transform/setup.py
@@ -32,7 +32,7 @@ if __name__ == '__main__':
     from numpy.distutils.core import setup
     setup(maintainer='scikit-image Developers',
           author='scikit-image Developers',
-          maintainer_email='scikit-image@python.org',
+          maintainer_email='skimage@discuss.scientific-python.org',
           description='Transforms',
           url='https://github.com/scikit-image/scikit-image',
           license='SciPy License (BSD Style)',

--- a/skimage/util/setup.py
+++ b/skimage/util/setup.py
@@ -24,7 +24,7 @@ def configuration(parent_package='', top_path=None):
 if __name__ == '__main__':
     from numpy.distutils.core import setup
     setup(maintainer='scikit-image Developers',
-          maintainer_email='scikit-image@python.org',
+          maintainer_email='skimage@discuss.scientific-python.org',
           description='Segmentation Algorithms',
           url='https://github.com/scikit-image/scikit-image',
           license='SciPy License (BSD Style)',


### PR DESCRIPTION
Follow-up to #5951.

- [x] `skimage-core@python.org` ->  `skimage-core@discuss.scientific-python.org`
- [x]  `scikit-image@python.org` ->  `scikit@discuss.scientific-python.org`