### PR TITLE
Update for NetworkX 2.7

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,6 @@
-numpy>=1.17.3
-scipy>=1.4.1
-networkx>=2.2
+numpy>=1.19
+scipy>=1.8
+networkx>=2.7rc1
 pillow>=6.1.0,!=7.1.0,!=7.1.1,!=8.3.0
 imageio>=2.4.1
 tifffile>=2019.7.26

--- a/skimage/future/graph/_ncut.py
+++ b/skimage/future/graph/_ncut.py
@@ -22,7 +22,7 @@ def DW_matrices(graph):
         joining `i` to `j`.
     """
     # sparse.eighsh is most efficient with CSC-formatted input
-    W = nx.to_scipy_sparse_matrix(graph, format='csc')
+    W = nx.to_scipy_sparse_array(graph, format='csc')
     entries = W.sum(axis=0)
     D = sparse.dia_matrix((entries, 0), shape=W.shape).tocsc()
 

--- a/skimage/future/graph/graph_cut.py
+++ b/skimage/future/graph/graph_cut.py
@@ -166,7 +166,7 @@ def partition_by_cut(cut, rag):
     """
     # `cut` is derived from `D` and `W` matrices, which also follow the
     # ordering returned by `rag.nodes()` because we use
-    # nx.to_scipy_sparse_matrix.
+    # nx.to_scipy_sparse_array.
 
     # Example
     # rag.nodes() = [3, 7, 9, 13]


### PR DESCRIPTION
NX 2.7 is the last release before NX 3.0, which will remove a ton of old stuff that was deprecated in the 2.x series.  This PR switches scikit-image to use the new scipy.sparse array interface.  This is an important step before the deprecated `np.matrix` can be removed from a future numpy release.

It also updates the minimum supported numpy and scipy to correspond to the minimum requirements for NX 2.7.  It isn't necessary, but requiring >= NX 2.7 will require these minimum dependencies.

Once this PR is merged, there are several follow-up cleanups that can be done.