### PR TITLE
implement nD skimage.filters.farid (Farid & Simoncelli filter)

### DIFF
--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -43,11 +43,17 @@ ROBERTS_ND_WEIGHTS = np.array([[0, 1],
 # These filter weights can be found in Farid & Simoncelli (2004),
 # Table 1 (3rd and 4th row). Additional decimal places were computed
 # using the code found at https://www.cs.dartmouth.edu/farid/
-p = np.array([[0.0376593171958126, 0.249153396177344, 0.426374573253687,
-               0.249153396177344, 0.0376593171958126]])
-d1 = np.array([[0.109603762960254, 0.276690988455557, 0, -0.276690988455557,
-                -0.109603762960254]])
-HFARID_WEIGHTS = d1.T * p
+farid_smooth = np.array([[0.0376593171958126,
+                          0.249153396177344,
+                          0.426374573253687,
+                          0.249153396177344,
+                          0.0376593171958126]])
+farid_edge = np.array([[0.109603762960254,
+                        0.276690988455557,
+                        0,
+                        -0.276690988455557,
+                        -0.109603762960254]])
+HFARID_WEIGHTS = farid_edge.T * farid_smooth
 VFARID_WEIGHTS = np.copy(HFARID_WEIGHTS.T)
 
 
@@ -706,27 +712,41 @@ def laplace(image, ksize=3, mask=None):
     return _mask_filter_result(result, mask)
 
 
-def farid(image, *, mask=None):
-    """Find the edge magnitude using the Farid transform.
+def farid(image, mask=None, *, axis=None, mode='reflect', cval=0.0):
+    """Find the edge magnitude using the Scharr transform.
 
     Parameters
     ----------
-    image : 2-D array
-        Image to process.
-    mask : 2-D array, optional
-        An optional mask to limit the application to a certain area.
-        Note that pixels surrounding masked regions are also masked to
-        prevent masked regions from affecting the result.
+    image : array
+        The input image.
+    mask : array of bool, optional
+        Clip the output image to this mask. (Values where mask=0 will be set
+        to 0.)
+    axis : int or sequence of int, optional
+        Compute the edge filter along this axis. If not provided, the edge
+        magnitude is computed. This is defined as::
+
+            farid_mag = np.sqrt(sum([farid(image, axis=i)**2
+                                     for i in range(image.ndim)]) / image.ndim)
+
+        The magnitude is also computed if axis is a sequence.
+    mode : str or sequence of str, optional
+        The boundary mode for the convolution. See `scipy.ndimage.convolve`
+        for a description of the modes. This can be either a single boundary
+        mode or one boundary mode per axis.
+    cval : float, optional
+        When `mode` is ``'constant'``, this is the constant used in values
+        outside the boundary of the image data.
 
     Returns
     -------
-    output : 2-D array
-        The Farid edge map.
+    output : array of float
+        The Scharr edge map.
 
     See also
     --------
     farid_h, farid_v : horizontal and vertical edge detection.
-    sobel, prewitt, farid, skimage.feature.canny
+    scharr, sobel, prewitt, skimage.feature.canny
 
     Notes
     -----
@@ -750,11 +770,11 @@ def farid(image, *, mask=None):
     >>> from skimage import filters
     >>> edges = filters.farid(camera)
     """
-    check_nD(image, 2)
-    out = np.sqrt(farid_h(image, mask=mask) ** 2
-                  + farid_v(image, mask=mask) ** 2)
-    out /= np.sqrt(2)
-    return out
+    output = _generic_edge_filter(image, smooth_weights=farid_smooth,
+                                  edge_weights=farid_edge, axis=axis,
+                                  mode=mode, cval=cval)
+    output = _mask_filter_result(output, mask)
+    return output
 
 
 def farid_h(image, *, mask=None):

--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -713,7 +713,7 @@ def laplace(image, ksize=3, mask=None):
 
 
 def farid(image, mask=None, *, axis=None, mode='reflect', cval=0.0):
-    """Find the edge magnitude using the Scharr transform.
+    """Find the edge magnitude using the Farid transform.
 
     Parameters
     ----------
@@ -741,7 +741,7 @@ def farid(image, mask=None, *, axis=None, mode='reflect', cval=0.0):
     Returns
     -------
     output : array of float
-        The Scharr edge map.
+        The Farid edge map.
 
     See also
     --------

--- a/skimage/filters/tests/test_edges.py
+++ b/skimage/filters/tests/test_edges.py
@@ -531,8 +531,7 @@ MAX_SOBEL_0 = np.array([
      [0, 0, 0]],
     [[1, 1, 1],
      [1, 1, 1],
-     [1, 1, 1]],
-    ],
+     [1, 1, 1]]],
     dtype=float)
 
 # maximum Sobel 3D edge in magnitude
@@ -547,8 +546,7 @@ MAX_SOBEL_ND = np.array([
 
     [[1, 1, 0],
      [1, 1, 0],
-     [1, 1, 0]]
-    ],
+     [1, 1, 0]]],
     dtype=float)
 
 # maximum Scharr 3D edge in magnitude. This illustrates the better rotation
@@ -562,8 +560,7 @@ MAX_SCHARR_ND = np.array([
      [0, 1, 1]],
     [[0, 0, 1],
      [0, 1, 1],
-     [1, 1, 1]]
-    ],
+     [1, 1, 1]]],
     dtype=float)
 
 # maximum Farid 3D edge on axis 0
@@ -597,11 +594,8 @@ MAX_FARID_ND = np.array([
      [0, 0, 0, 0, 0],
      [0, 0, 0, 0, 0],
      [0, 0, 0, 0, 0],
-     [1, 1, 1, 1, 1]],
-    ],
+     [1, 1, 1, 1, 1]]],
     dtype=float)
-
-
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

closes #5089

#4347 generalised Sobel, Prewitt, and Scharr filters to n dimensions.  This PR does the same for the Farid & Simoncelli case.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
