### PR TITLE
Unify API on seed keyword for random seeds / generator

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -25,6 +25,11 @@ Version 0.22
   ``docwriter.package_skip_patterns`` in
   ``doc/tools/build_modref_templates.py``.
 
+Version 0.22
+------------
+* Remove deprecated `random_seed`, `random_state`, and `sample_seed`
+  arguments in favor of `seed`.
+
 Other (2022)
 ------------
 * Remove custom code for ignored warning in `skimage/_shared/testing.py` relating

--- a/doc/examples/edges/plot_random_shapes.py
+++ b/doc/examples/edges/plot_random_shapes.py
@@ -13,7 +13,7 @@ from skimage.draw import random_shapes
 # Let's start simple and generate a 128x128 image
 # with a single grayscale rectangle.
 result = random_shapes((128, 128), max_shapes=1, shape='rectangle',
-                       channel_axis=None, random_seed=0)
+                       channel_axis=None, seed=0)
 
 # We get back a tuple consisting of (1) the image with the generated shapes
 # and (2) a list of label tuples with the kind of shape (e.g. circle,

--- a/skimage/draw/_random_shapes.py
+++ b/skimage/draw/_random_shapes.py
@@ -292,7 +292,7 @@ def _generate_random_colors(num_colors, num_channels, intensity_range, random):
     return np.transpose(colors)
 
 
-@deprecate_kwarg({'random_seed': 'seed'}, deprecated_version='0.20',
+@deprecate_kwarg({'random_seed': 'seed'}, deprecated_version='0.21',
                  removed_version='1.0')
 def random_shapes(image_shape,
                   max_shapes,

--- a/skimage/draw/_random_shapes.py
+++ b/skimage/draw/_random_shapes.py
@@ -1,4 +1,5 @@
 import math
+
 import numpy as np
 
 from . import (polygon as draw_polygon, disk as draw_disk,

--- a/skimage/draw/_random_shapes.py
+++ b/skimage/draw/_random_shapes.py
@@ -293,7 +293,7 @@ def _generate_random_colors(num_colors, num_channels, intensity_range, random):
 
 
 @deprecate_kwarg({'random_seed': 'seed'}, deprecated_version='0.21',
-                 removed_version='1.0')
+                 removed_version='0.23')
 def random_shapes(image_shape,
                   max_shapes,
                   min_shapes=1,

--- a/skimage/draw/_random_shapes.py
+++ b/skimage/draw/_random_shapes.py
@@ -350,11 +350,11 @@ def random_shapes(image_shape,
     num_trials : int, optional
         How often to attempt to fit a shape into the image before skipping it.
     seed : {None, int, `numpy.random.Generator`}, optional
-        If `seed` is None the `numpy.random.Generator` singleton is
+        If `seed` is None, the `numpy.random.Generator` singleton is
         used.
         If `seed` is an int, a new ``Generator`` instance is used,
         seeded with `seed`.
-        If `seed` is already a ``Generator`` instance then that instance
+        If `seed` is already a ``Generator`` instance, then that instance
         is used.
     channel_axis : int or None, optional
         If None, the image is assumed to be a grayscale (single channel) image.

--- a/skimage/draw/_random_shapes.py
+++ b/skimage/draw/_random_shapes.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from . import (polygon as draw_polygon, disk as draw_disk,
                ellipse as draw_ellipse)
-from .._shared.utils import warn
+from .._shared.utils import deprecate_kwarg, warn
 
 
 def _generate_rectangle_mask(point, image, shape, random):
@@ -291,6 +291,8 @@ def _generate_random_colors(num_colors, num_channels, intensity_range, random):
     return np.transpose(colors)
 
 
+@deprecate_kwarg({'random_seed': 'seed'}, deprecated_version='0.20',
+                 removed_version='1.0')
 def random_shapes(image_shape,
                   max_shapes,
                   min_shapes=1,
@@ -301,7 +303,7 @@ def random_shapes(image_shape,
                   intensity_range=None,
                   allow_overlap=False,
                   num_trials=100,
-                  random_seed=None,
+                  seed=None,
                   *,
                   channel_axis=-1):
     """Generate an image with random shapes, labeled with bounding boxes.
@@ -346,12 +348,12 @@ def random_shapes(image_shape,
         If `True`, allow shapes to overlap.
     num_trials : int, optional
         How often to attempt to fit a shape into the image before skipping it.
-    random_seed : {None, int, `numpy.random.Generator`}, optional
-        If `random_seed` is None the `numpy.random.Generator` singleton is
+    seed : {None, int, `numpy.random.Generator`}, optional
+        If `seed` is None the `numpy.random.Generator` singleton is
         used.
-        If `random_seed` is an int, a new ``Generator`` instance is used,
-        seeded with `random_seed`.
-        If `random_seed` is already a ``Generator`` instance then that instance
+        If `seed` is an int, a new ``Generator`` instance is used,
+        seeded with `seed`.
+        If `seed` is already a ``Generator`` instance then that instance
         is used.
     channel_axis : int or None, optional
         If None, the image is assumed to be a grayscale (single channel) image.
@@ -404,7 +406,7 @@ def random_shapes(image_shape,
                     msg = 'Intensity range must lie within (0, 255) interval'
                     raise ValueError(msg)
 
-    random = np.random.default_rng(random_seed)
+    random = np.random.default_rng(seed)
     user_shape = shape
     image_shape = (image_shape[0], image_shape[1], num_channels)
     image = np.full(image_shape, 255, dtype=np.uint8)

--- a/skimage/draw/tests/test_random_shapes.py
+++ b/skimage/draw/tests/test_random_shapes.py
@@ -1,10 +1,9 @@
 import numpy as np
 import pytest
 
-from skimage.draw import random_shapes
-
 from skimage._shared import testing
 from skimage._shared._warnings import expected_warnings
+from skimage.draw import random_shapes
 
 
 def test_generates_color_images_with_correct_shape():

--- a/skimage/draw/tests/test_random_shapes.py
+++ b/skimage/draw/tests/test_random_shapes.py
@@ -46,7 +46,8 @@ def test_generates_correct_bounding_boxes_for_rectangles():
         (128, 128),
         max_shapes=1,
         shape='rectangle',
-        random_seed=42)
+        seed=42)
+
     assert len(labels) == 1
     label, bbox = labels[0]
     assert label == 'rectangle', label
@@ -61,12 +62,21 @@ def test_generates_correct_bounding_boxes_for_rectangles():
     assert (image == 255).all()
 
 
+def test_random_seed_deprecation():
+    with expected_warnings(['`random_seed` is a deprecated argument']):
+        random_shapes(
+            (128, 128),
+            max_shapes=1,
+            shape='rectangle',
+            random_seed=42)
+
+
 def test_generates_correct_bounding_boxes_for_triangles():
     image, labels = random_shapes(
         (128, 128),
         max_shapes=1,
         shape='triangle',
-        random_seed=42)
+        seed=42)
     assert len(labels) == 1
     label, bbox = labels[0]
     assert label == 'triangle', label
@@ -88,7 +98,7 @@ def test_generates_correct_bounding_boxes_for_circles():
         min_size=20,
         max_size=20,
         shape='circle',
-        random_seed=42)
+        seed=42)
     assert len(labels) == 1
     label, bbox = labels[0]
     assert label == 'circle', label
@@ -110,7 +120,7 @@ def test_generates_correct_bounding_boxes_for_ellipses():
         min_size=20,
         max_size=20,
         shape='ellipse',
-        random_seed=42)
+        seed=42)
     assert len(labels) == 1
     label, bbox = labels[0]
     assert label == 'ellipse', label
@@ -181,15 +191,13 @@ def test_random_shapes_is_reproducible_with_seed():
     random_seed = 42
     labels = []
     for _ in range(5):
-        _, label = random_shapes((128, 128), max_shapes=5,
-                                 random_seed=random_seed)
+        _, label = random_shapes((128, 128), max_shapes=5, seed=random_seed)
         labels.append(label)
     assert all(other == labels[0] for other in labels[1:])
 
 
 def test_generates_white_image_when_intensity_range_255():
     image, labels = random_shapes((128, 128), max_shapes=3,
-                                  intensity_range=((255, 255),),
-                                  random_seed=42)
+                                  intensity_range=((255, 255),), seed=42)
     assert len(labels) > 0
     assert (image == 255).all()

--- a/skimage/feature/brief.py
+++ b/skimage/feature/brief.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from .._shared.filters import gaussian
-from .._shared.utils import check_nD
+from .._shared.utils import check_nD, deprecate_kwarg
 from .brief_cy import _brief_loop
 from .util import (DescriptorExtractor, _mask_border_keypoints,
                    _prepare_grayscale_input_2D)
@@ -32,18 +32,18 @@ class BRIEF(DescriptorExtractor):
     mode : {'normal', 'uniform'}, optional
         Probability distribution for sampling location of decision pixel-pairs
         around keypoints.
-    sample_seed : {None, int, `numpy.random.Generator`}, optional
-        If `sample_seed` is None the `numpy.random.Generator` singleton is
+    seed : {None, int, `numpy.random.Generator`}, optional
+        If `seed` is None the `numpy.random.Generator` singleton is
         used.
-        If `sample_seed` is an int, a new ``Generator`` instance is used,
-        seeded with `sample_seed`.
-        If `sample_seed` is already a ``Generator`` instance then that instance
+        If `seed` is an int, a new ``Generator`` instance is used,
+        seeded with `seed`.
+        If `seed` is already a ``Generator`` instance then that instance
         is used.
 
         Seed for the random sampling of the decision pixel-pairs. From a square
         window with length `patch_size`, pixel pairs are sampled using the
         `mode` parameter to build the descriptors using intensity comparison.
-        The value of `sample_seed` must be the same for the images to be
+        The value of `seed` must be the same for the images to be
         matched while building the descriptors.
     sigma : float, optional
         Standard deviation of the Gaussian low-pass filter applied to the image
@@ -116,8 +116,10 @@ class BRIEF(DescriptorExtractor):
 
     """
 
+    @deprecate_kwarg({'sample_seed': 'seed'}, deprecated_version='0.20',
+                     removed_version='1.0')
     def __init__(self, descriptor_size=256, patch_size=49,
-                 mode='normal', sigma=1, sample_seed=1):
+                 mode='normal', sigma=1, seed=1):
 
         mode = mode.lower()
         if mode not in ('normal', 'uniform'):
@@ -128,10 +130,10 @@ class BRIEF(DescriptorExtractor):
         self.mode = mode
         self.sigma = sigma
 
-        if sample_seed is None:
-            self.sample_seed = np.random.SeedSequence().entropy
+        if seed is None:
+            self.seed = np.random.SeedSequence().entropy
         else:
-            self.sample_seed = sample_seed
+            self.seed = seed
 
         self.descriptors = None
         self.mask = None
@@ -149,7 +151,7 @@ class BRIEF(DescriptorExtractor):
         """
         check_nD(image, 2)
 
-        random = np.random.default_rng(self.sample_seed)
+        random = np.random.default_rng(self.seed)
 
         image = _prepare_grayscale_input_2D(image)
 

--- a/skimage/feature/brief.py
+++ b/skimage/feature/brief.py
@@ -116,8 +116,8 @@ class BRIEF(DescriptorExtractor):
 
     """
 
-    @deprecate_kwarg({'sample_seed': 'seed'}, deprecated_version='0.20',
-                     removed_version='1.0')
+    @deprecate_kwarg({'sample_seed': 'seed'}, deprecated_version='0.21',
+                     removed_version='0.23')
     def __init__(self, descriptor_size=256, patch_size=49,
                  mode='normal', sigma=1, seed=1):
 

--- a/skimage/feature/brief.py
+++ b/skimage/feature/brief.py
@@ -33,11 +33,11 @@ class BRIEF(DescriptorExtractor):
         Probability distribution for sampling location of decision pixel-pairs
         around keypoints.
     seed : {None, int, `numpy.random.Generator`}, optional
-        If `seed` is None the `numpy.random.Generator` singleton is
+        If `seed` is None, the `numpy.random.Generator` singleton is
         used.
         If `seed` is an int, a new ``Generator`` instance is used,
         seeded with `seed`.
-        If `seed` is already a ``Generator`` instance then that instance
+        If `seed` is already a ``Generator`` instance, then that instance
         is used.
 
         Seed for the random sampling of the decision pixel-pairs. From a square

--- a/skimage/feature/haar.py
+++ b/skimage/feature/haar.py
@@ -219,7 +219,7 @@ def haar_like_feature(int_image, r, c, width, height, feature_type=None,
 
 
 @deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.21',
-                 removed_version='1.0')
+                 removed_version='0.23')
 def draw_haar_like_feature(image, r, c, width, height,
                            feature_coord,
                            color_positive_block=(1., 0., 0.),

--- a/skimage/feature/haar.py
+++ b/skimage/feature/haar.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from ._haar import haar_like_feature_coord_wrapper
 from ._haar import haar_like_feature_wrapper
+from .._shared.utils import deprecate_kwarg
 from ..color import gray2rgb
 from ..draw import rectangle
 from ..util import img_as_float
@@ -217,11 +218,13 @@ def haar_like_feature(int_image, r, c, width, height, feature_type=None,
         return haar_feature
 
 
+@deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.20',
+                 removed_version='1.0')
 def draw_haar_like_feature(image, r, c, width, height,
                            feature_coord,
                            color_positive_block=(1., 0., 0.),
                            color_negative_block=(0., 1., 0.),
-                           alpha=0.5, max_n_features=None, random_state=None):
+                           alpha=0.5, max_n_features=None, seed=None):
     """Visualization of Haar-like features.
 
     Parameters
@@ -255,16 +258,14 @@ def draw_haar_like_feature(image, r, c, width, height,
     max_n_features : int, default=None
         The maximum number of features to be returned.
         By default, all features are returned.
-    random_state : {None, int, `numpy.random.Generator`}, optional
-        If `random_state` is None the `numpy.random.Generator` singleton is
+    seed : {None, int, `numpy.random.Generator`}, optional
+        If `seed` is None the `numpy.random.Generator` singleton is used.
+        If `seed` is an int, a new ``Generator`` instance is used, seeded with
+        `random_state`.
+        If `seed` is already a ``Generator`` instance then that instance is
         used.
-        If `random_state` is an int, a new ``Generator`` instance is used,
-        seeded with `random_state`.
-        If `random_state` is already a ``Generator`` instance then that
-        instance is used.
-
-        The random state is used when generating a set of
-        features smaller than the total number of available features.
+        The random seed is used when generating a set of features smaller than
+        the total number of available features.
 
     Returns
     -------
@@ -289,16 +290,16 @@ def draw_haar_like_feature(image, r, c, width, height,
             [0. , 0.5, 0. ]]])
 
     """
-    random_state = np.random.default_rng(random_state)
+    rng = np.random.default_rng(seed)
     color_positive_block = np.asarray(color_positive_block, dtype=np.float64)
     color_negative_block = np.asarray(color_negative_block, dtype=np.float64)
 
     if max_n_features is None:
         feature_coord_ = feature_coord
     else:
-        feature_coord_ = random_state.choice(feature_coord,
-                                             size=max_n_features,
-                                             replace=False)
+        feature_coord_ = rng.choice(feature_coord,
+                                    size=max_n_features,
+                                    replace=False)
 
     output = np.copy(image)
     if len(image.shape) < 3:

--- a/skimage/feature/haar.py
+++ b/skimage/feature/haar.py
@@ -218,7 +218,7 @@ def haar_like_feature(int_image, r, c, width, height, feature_type=None,
         return haar_feature
 
 
-@deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.20',
+@deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.21',
                  removed_version='1.0')
 def draw_haar_like_feature(image, r, c, width, height,
                            feature_coord,

--- a/skimage/feature/haar.py
+++ b/skimage/feature/haar.py
@@ -259,10 +259,10 @@ def draw_haar_like_feature(image, r, c, width, height,
         The maximum number of features to be returned.
         By default, all features are returned.
     seed : {None, int, `numpy.random.Generator`}, optional
-        If `seed` is None the `numpy.random.Generator` singleton is used.
+        If `seed` is None, the `numpy.random.Generator` singleton is used.
         If `seed` is an int, a new ``Generator`` instance is used, seeded with
-        `random_state`.
-        If `seed` is already a ``Generator`` instance then that instance is
+        `seed`.
+        If `seed` is already a ``Generator`` instance, then that instance is
         used.
         The random seed is used when generating a set of features smaller than
         the total number of available features.

--- a/skimage/feature/tests/test_brief.py
+++ b/skimage/feature/tests/test_brief.py
@@ -47,7 +47,9 @@ def test_uniform_mode(dtype):
     keypoints = corner_peaks(corner_harris(img), min_distance=5,
                              threshold_abs=0, threshold_rel=0.1)
 
-    extractor = BRIEF(descriptor_size=8, sigma=2, mode='uniform')
+    extractor = BRIEF(descriptor_size=8, sigma=2, mode='uniform', seed=1)
+    with testing.expected_warnings(['`sample_seed` is a deprecated argument']):
+        BRIEF(descriptor_size=8, sigma=2, mode='uniform', sample_seed=1)
 
     extractor.extract(img, keypoints[:8])
 

--- a/skimage/feature/tests/test_haar.py
+++ b/skimage/feature/tests/test_haar.py
@@ -6,6 +6,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from numpy.testing import assert_array_equal
 
+from skimage._shared._warnings import expected_warnings
 from skimage.transform import integral_image
 from skimage.feature import haar_like_feature
 from skimage.feature import haar_like_feature_coord
@@ -153,6 +154,10 @@ def test_draw_haar_like_feature(max_n_features, nnz_values):
     coord, _ = haar_like_feature_coord(5, 5, 'type-4')
     image = draw_haar_like_feature(img, 0, 0, 5, 5, coord,
                                    max_n_features=max_n_features,
-                                   random_state=0)
+                                   seed=0)
+    with expected_warnings(['`random_state` is a deprecated argument']):
+        draw_haar_like_feature(img, 0, 0, 5, 5, coord,
+                               max_n_features=max_n_features,
+                               random_state=0)
     assert image.shape == (5, 5, 3)
     assert np.count_nonzero(image) == nnz_values

--- a/skimage/graph/_graph_cut.py
+++ b/skimage/graph/_graph_cut.py
@@ -70,7 +70,7 @@ def cut_threshold(labels, rag, thresh, in_place=True):
 
 
 @deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.21',
-                 removed_version='1.0')
+                 removed_version='0.23')
 def cut_normalized(labels, rag, thresh=0.001, num_cuts=10, in_place=True,
                    max_edge=1.0,
                    *,

--- a/skimage/graph/_graph_cut.py
+++ b/skimage/graph/_graph_cut.py
@@ -69,7 +69,7 @@ def cut_threshold(labels, rag, thresh, in_place=True):
     return map_array[labels]
 
 
-@deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.20',
+@deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.21',
                  removed_version='1.0')
 def cut_normalized(labels, rag, thresh=0.001, num_cuts=10, in_place=True,
                    max_edge=1.0,

--- a/skimage/graph/_graph_cut.py
+++ b/skimage/graph/_graph_cut.py
@@ -102,10 +102,10 @@ def cut_normalized(labels, rag, thresh=0.001, num_cuts=10, in_place=True,
         an edge between identical regions. This is used to put self
         edges in the RAG.
     seed : {None, int, `numpy.random.Generator`}, optional
-        If `seed` is None the `numpy.random.Generator` singleton is used.
+        If `seed` is None, the `numpy.random.Generator` singleton is used.
         If `seed` is an int, a new ``Generator`` instance is used,
         seeded with `seed`.
-        If `seed` is already a ``Generator`` instance then that
+        If `seed` is already a ``Generator`` instance, then that
         instance is used.
 
         The `seed` is used for the starting point

--- a/skimage/graph/_graph_cut.py
+++ b/skimage/graph/_graph_cut.py
@@ -2,7 +2,7 @@ import networkx as nx
 import numpy as np
 from scipy.sparse import linalg
 
-from ..._shared.utils import deprecate_kwarg
+from .._shared.utils import deprecate_kwarg
 from . import _ncut, _ncut_cy
 
 

--- a/skimage/graph/tests/test_rag.py
+++ b/skimage/graph/tests/test_rag.py
@@ -4,6 +4,8 @@ import numpy as np
 from skimage import graph
 from skimage import segmentation, data
 from skimage._shared import testing
+from skimage._shared._warnings import expected_warnings
+from skimage.future import graph
 
 
 def max_edge(g, src, dst, n):
@@ -203,7 +205,7 @@ def test_ncut_stable_subgraph():
 
 def test_reproducibility():
     """ensure cut_normalized returns the same output for the same input,
-    when specifying random_state
+    when specifying random seed
     """
     img = data.coffee()
     labels1 = segmentation.slic(
@@ -212,6 +214,9 @@ def test_reproducibility():
     results = [None] * 4
     for i in range(len(results)):
         results[i] = graph.cut_normalized(
+            labels1, g, in_place=False, thresh=1e-3, seed=1234)
+    with expected_warnings(['`random_state` is a deprecated argument']):
+        graph.cut_normalized(
             labels1, g, in_place=False, thresh=1e-3, random_state=1234)
 
     for i in range(len(results) - 1):

--- a/skimage/graph/tests/test_rag.py
+++ b/skimage/graph/tests/test_rag.py
@@ -5,7 +5,6 @@ from skimage import graph
 from skimage import segmentation, data
 from skimage._shared import testing
 from skimage._shared._warnings import expected_warnings
-from skimage.future import graph
 
 
 def max_edge(g, src, dst, n):

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -662,7 +662,7 @@ def _dynamic_max_trials(n_inliers, n_samples, min_samples, probability):
 
 
 @deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.21',
-                 removed_version='1.0')
+                 removed_version='0.23')
 def ransac(data, model_class, min_samples, residual_threshold,
            is_data_valid=None, is_model_valid=None,
            max_trials=100, stop_sample_num=np.inf, stop_residuals_sum=0,

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -661,7 +661,7 @@ def _dynamic_max_trials(n_inliers, n_samples, min_samples, probability):
     return np.ceil(np.log(nom) / np.log(denom))
 
 
-@deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.20',
+@deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.21',
                  removed_version='1.0')
 def ransac(data, model_class, min_samples, residual_threshold,
            is_data_valid=None, is_model_valid=None,

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -5,6 +5,8 @@ import numpy as np
 from numpy.linalg import inv
 from scipy import optimize, spatial
 
+from .._shared.utils import deprecate_kwarg
+
 _EPSILON = np.spacing(1)
 
 
@@ -659,10 +661,12 @@ def _dynamic_max_trials(n_inliers, n_samples, min_samples, probability):
     return np.ceil(np.log(nom) / np.log(denom))
 
 
+@deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.20',
+                 removed_version='1.0')
 def ransac(data, model_class, min_samples, residual_threshold,
            is_data_valid=None, is_model_valid=None,
            max_trials=100, stop_sample_num=np.inf, stop_residuals_sum=0,
-           stop_probability=1, random_state=None, initial_inliers=None):
+           stop_probability=1, seed=None, initial_inliers=None):
     """Fit a model to data with the RANSAC (random sample consensus) algorithm.
 
     RANSAC is an iterative algorithm for the robust estimation of parameters
@@ -735,13 +739,12 @@ def ransac(data, model_class, min_samples, residual_threshold,
         where the probability (confidence) is typically set to a high value
         such as 0.99, e is the current fraction of inliers w.r.t. the
         total number of samples, and m is the min_samples value.
-    random_state : {None, int, `numpy.random.Generator`}, optional
-        If `random_state` is None the `numpy.random.Generator` singleton is
+    seed : {None, int, `numpy.random.Generator`}, optional
+        If `seed` is None the `numpy.random.Generator` singleton is used.
+        If `seed` is an int, a new ``Generator`` instance is used, seeded with
+        `seed`.
+        If `seed` is already a ``Generator`` instance then that instance is
         used.
-        If `random_state` is an int, a new ``Generator`` instance is used,
-        seeded with `random_state`.
-        If `random_state` is already a ``Generator`` instance then that
-        instance is used.
     initial_inliers : array-like of bool, shape (N,), optional
         Initial samples selection for model estimation
 
@@ -835,7 +838,7 @@ def ransac(data, model_class, min_samples, residual_threshold,
     validate_model = is_model_valid is not None
     validate_data = is_data_valid is not None
 
-    random_state = np.random.default_rng(random_state)
+    rng = np.random.default_rng(seed)
 
     # in case data is not pair of input and output, male it like it
     if not isinstance(data, (tuple, list)):
@@ -865,7 +868,7 @@ def ransac(data, model_class, min_samples, residual_threshold,
 
     # for the first run use initial guess of inliers
     spl_idxs = (initial_inliers if initial_inliers is not None
-                else random_state.choice(num_samples, min_samples,
+                else rng.choice(num_samples, min_samples,
                                          replace=False))
 
     # estimate model for current random sample set
@@ -881,7 +884,7 @@ def ransac(data, model_class, min_samples, residual_threshold,
 
         # for next iteration choose random sample set and be sure that
         # no samples repeat
-        spl_idxs = random_state.choice(num_samples, min_samples, replace=False)
+        spl_idxs = rng.choice(num_samples, min_samples, replace=False)
 
         # optional check if random sample set is valid
         if validate_data and not is_data_valid(*samples):

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -740,10 +740,10 @@ def ransac(data, model_class, min_samples, residual_threshold,
         such as 0.99, e is the current fraction of inliers w.r.t. the
         total number of samples, and m is the min_samples value.
     seed : {None, int, `numpy.random.Generator`}, optional
-        If `seed` is None the `numpy.random.Generator` singleton is used.
+        If `seed` is None, the `numpy.random.Generator` singleton is used.
         If `seed` is an int, a new ``Generator`` instance is used, seeded with
         `seed`.
-        If `seed` is already a ``Generator`` instance then that instance is
+        If `seed` is already a ``Generator`` instance, then that instance is
         used.
     initial_inliers : array-like of bool, shape (N,), optional
         Initial samples selection for model estimation

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -5,7 +5,7 @@ from skimage._shared import testing
 from skimage._shared._warnings import expected_warnings
 from skimage._shared.testing import (arch32, assert_almost_equal,
                                      assert_array_less, assert_equal, xfail)
-from skimage.measure import LineModelND, CircleModel, EllipseModel, ransac
+from skimage.measure import CircleModel, EllipseModel, LineModelND, ransac
 from skimage.measure.fit import _dynamic_max_trials
 from skimage.transform import AffineTransform
 
@@ -59,8 +59,8 @@ def test_line_model_nd_estimate():
              10 * np.arange(-100, 100)[..., np.newaxis] * model0.params[1])
 
     # add gaussian noise to data
-    random_state = np.random.default_rng(1234)
-    data = data0 + random_state.normal(size=data0.shape)
+    rng = np.random.default_rng(1234)
+    data = data0 + rng.normal(size=data0.shape)
 
     # estimate parameters of noisy data
     model_est = LineModelND()
@@ -117,8 +117,8 @@ def test_circle_model_estimate():
     data0 = model0.predict_xy(t)
 
     # add gaussian noise to data
-    random_state = np.random.default_rng(1234)
-    data = data0 + random_state.normal(size=data0.shape)
+    rng = np.random.default_rng(1234)
+    data = data0 + rng.normal(size=data0.shape)
 
     # estimate parameters of noisy data
     model_est = CircleModel()
@@ -205,8 +205,8 @@ def test_ellipse_model_estimate():
         data0 = model0.predict_xy(t)
 
         # add gaussian noise to data
-        random_state = np.random.default_rng(1234)
-        data = data0 + random_state.normal(size=data0.shape)
+        rng = np.random.default_rng(1234)
+        data = data0 + rng.normal(size=data0.shape)
 
         # estimate parameters of noisy data
         model_est = EllipseModel()
@@ -314,7 +314,9 @@ def test_ransac_shape():
     data0[outliers[2], :] = (-100, -10)
 
     # estimate parameters of corrupted data
-    model_est, inliers = ransac(data0, CircleModel, 3, 5, random_state=1)
+    model_est, inliers = ransac(data0, CircleModel, 3, 5, seed=1)
+    with expected_warnings(['`random_state` is a deprecated argument']):
+        ransac(data0, CircleModel, 3, 5, random_state=1)
 
     # test whether estimated parameters equal original parameters
     assert_almost_equal(model0.params, model_est.params)
@@ -323,10 +325,10 @@ def test_ransac_shape():
 
 
 def test_ransac_geometric():
-    random_state = np.random.default_rng(12373240)
+    rng = np.random.default_rng(12373240)
 
     # generate original data without noise
-    src = 100 * random_state.random((50, 2))
+    src = 100 * rng.random((50, 2))
     model0 = AffineTransform(scale=(0.5, 0.3), rotation=1,
                              translation=(10, 20))
     dst = model0(src)
@@ -339,7 +341,7 @@ def test_ransac_geometric():
 
     # estimate parameters of corrupted data
     model_est, inliers = ransac((src, dst), AffineTransform, 2, 20,
-                                random_state=random_state)
+                                seed=rng)
 
     # test whether estimated parameters equal original parameters
     assert_almost_equal(model0.params, model_est.params)
@@ -351,7 +353,7 @@ def test_ransac_is_data_valid():
         return data.shape[0] > 2
     with expected_warnings(["No inliers found"]):
         model, inliers = ransac(np.empty((10, 2)), LineModelND, 2, np.inf,
-                                is_data_valid=is_data_valid, random_state=1)
+                                is_data_valid=is_data_valid, seed=1)
     assert_equal(model, None)
     assert_equal(inliers, None)
 
@@ -361,7 +363,7 @@ def test_ransac_is_model_valid():
         return False
     with expected_warnings(["No inliers found"]):
         model, inliers = ransac(np.empty((10, 2)), LineModelND, 2, np.inf,
-                                is_model_valid=is_model_valid, random_state=1)
+                                is_model_valid=is_model_valid, seed=1)
     assert_equal(model, None)
     assert_equal(inliers, None)
 
@@ -463,7 +465,7 @@ def test_ransac_with_no_final_inliers():
     data = np.random.rand(5, 2)
     with expected_warnings(['No inliers found. Model not fitted']):
         model, inliers = ransac(data, model_class=LineModelND, min_samples=3,
-                                residual_threshold=0, random_state=1523427)
+                                residual_threshold=0, seed=1523427)
     assert inliers is None
     assert model is None
 
@@ -481,5 +483,5 @@ def test_ransac_non_valid_best_model():
     data = np.linspace([0, 0, 0], [0.3, 0, 1], 1000) + rnd.rand(1000, 3) - 0.5
     with expected_warnings(["Estimated model is not valid"]):
         ransac(data, LineModelND, min_samples=2,
-               residual_threshold=0.3, max_trials=50, random_state=0,
+               residual_threshold=0.3, max_trials=50, seed=0,
                is_model_valid=is_model_valid)

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -351,7 +351,7 @@ _eight_connect = ndi.generate_binary_structure(2, 2)
 
 
 @deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.21',
-                 removed_version='1.0')
+                 removed_version='0.23')
 def medial_axis(image, mask=None, return_distance=False, *, seed=None):
     """Compute the medial axis transform of a binary image.
 

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -350,7 +350,7 @@ def thin(image, max_num_iter=None):
 _eight_connect = ndi.generate_binary_structure(2, 2)
 
 
-@deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.20',
+@deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.21',
                  removed_version='1.0')
 def medial_axis(image, mask=None, return_distance=False, *, seed=None):
     """Compute the medial axis transform of a binary image.

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -365,10 +365,10 @@ def medial_axis(image, mask=None, return_distance=False, *, seed=None):
     return_distance : bool, optional
         If true, the distance transform is returned as well as the skeleton.
     seed : {None, int, `numpy.random.Generator`}, optional
-        If `seed` is None the `numpy.random.Generator` singleton is used.
+        If `seed` is None, the `numpy.random.Generator` singleton is used.
         If `seed` is an int, a new ``Generator`` instance is used, seeded with
         `seed`.
-        If `seed` is already a ``Generator`` instance then that instance is
+        If `seed` is already a ``Generator`` instance, then that instance is
         used.
 
         .. versionadded:: 0.19

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -350,7 +350,9 @@ def thin(image, max_num_iter=None):
 _eight_connect = ndi.generate_binary_structure(2, 2)
 
 
-def medial_axis(image, mask=None, return_distance=False, *, random_state=None):
+@deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.20',
+                 removed_version='1.0')
+def medial_axis(image, mask=None, return_distance=False, *, seed=None):
     """Compute the medial axis transform of a binary image.
 
     Parameters
@@ -362,13 +364,12 @@ def medial_axis(image, mask=None, return_distance=False, *, random_state=None):
         value in `mask` are used for computing the medial axis.
     return_distance : bool, optional
         If true, the distance transform is returned as well as the skeleton.
-    random_state : {None, int, `numpy.random.Generator`}, optional
-        If `random_state` is None the `numpy.random.Generator` singleton is
+    seed : {None, int, `numpy.random.Generator`}, optional
+        If `seed` is None the `numpy.random.Generator` singleton is used.
+        If `seed` is an int, a new ``Generator`` instance is used, seeded with
+        `seed`.
+        If `seed` is already a ``Generator`` instance then that instance is
         used.
-        If `random_state` is an int, a new ``Generator`` instance is used,
-        seeded with `random_state`.
-        If `random_state` is already a ``Generator`` instance then that
-        instance is used.
 
         .. versionadded:: 0.19
 
@@ -487,7 +488,7 @@ def medial_axis(image, mask=None, return_distance=False, *, random_state=None):
     # predictable, random # so that masking doesn't affect arbitrary choices
     # of skeletons
     #
-    generator = np.random.default_rng(random_state)
+    generator = np.random.default_rng(seed)
     tiebreaker = generator.permutation(np.arange(masked_image.sum()))
     order = np.lexsort((tiebreaker,
                         corner_score[masked_image],

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -2,13 +2,13 @@
 Algorithms for computing the skeleton of a binary image
 """
 import numpy as np
-from ..util import img_as_ubyte, crop
 from scipy import ndimage as ndi
 
-from .._shared.utils import check_nD
+from .._shared.utils import check_nD, deprecate_kwarg
+from ..util import crop, img_as_ubyte
+from ._skeletonize_3d_cy import _compute_thin_image
 from ._skeletonize_cy import (_fast_skeletonize, _skeletonize_loop,
                               _table_lookup_index)
-from ._skeletonize_3d_cy import _compute_thin_image
 
 
 def skeletonize(image, *, method=None):

--- a/skimage/morphology/tests/test_skeletonize.py
+++ b/skimage/morphology/tests/test_skeletonize.py
@@ -163,7 +163,7 @@ class TestThin():
 class TestMedialAxis():
     def test_00_00_zeros(self):
         '''Test skeletonize on an array of all zeros'''
-        result = medial_axis(np.zeros((10, 10), bool))
+        result = medial_axis(np.zeros((10, 10), bool), seed=None)
         assert np.all(result == False)
 
     def test_00_01_zeros_masked(self):
@@ -232,3 +232,8 @@ class TestMedialAxis():
         image[:, 1:-1] = True
         result = medial_axis(image)
         assert np.all(result == image)
+
+    def test_deprecated_random_state(self):
+        '''Test skeletonize on an array of all zeros'''
+        with expected_warnings(['`random_state` is a deprecated argument']):
+            medial_axis(np.zeros((10, 10), bool), random_state=None)

--- a/skimage/morphology/tests/test_skeletonize.py
+++ b/skimage/morphology/tests/test_skeletonize.py
@@ -234,6 +234,6 @@ class TestMedialAxis():
         assert np.all(result == image)
 
     def test_deprecated_random_state(self):
-        '''Test skeletonize on an array of all zeros'''
+        """Test medial_axis on an array of all zeros."""
         with expected_warnings(['`random_state` is a deprecated argument']):
             medial_axis(np.zeros((10, 10), bool), random_state=None)

--- a/skimage/morphology/tests/test_skeletonize.py
+++ b/skimage/morphology/tests/test_skeletonize.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_array_equal
 from scipy.ndimage import correlate
 
 from skimage import draw
-from skimage._shared.testing import fetch
+from skimage._shared.testing import expected_warnings, fetch
 from skimage.io import imread
 from skimage.morphology import medial_axis, skeletonize, thin
 from skimage.morphology._skeletonize import (G123_LUT, G123P_LUT,

--- a/skimage/morphology/tests/test_skeletonize.py
+++ b/skimage/morphology/tests/test_skeletonize.py
@@ -7,8 +7,8 @@ from skimage import draw
 from skimage._shared.testing import fetch
 from skimage.io import imread
 from skimage.morphology import medial_axis, skeletonize, thin
-from skimage.morphology._skeletonize import (_generate_thin_luts,
-                                             G123_LUT, G123P_LUT)
+from skimage.morphology._skeletonize import (G123_LUT, G123P_LUT,
+                                             _generate_thin_luts)
 
 
 class TestSkeletonize():

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -139,7 +139,7 @@ def wiener(image, psf, balance, reg=None, is_real=True, clip=True):
     return deconv
 
 
-@deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.20',
+@deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.21',
                  removed_version='1.0')
 def unsupervised_wiener(image, psf, reg=None, user_params=None, is_real=True,
                         clip=True, *, seed=None):

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -139,8 +139,10 @@ def wiener(image, psf, balance, reg=None, is_real=True, clip=True):
     return deconv
 
 
+@deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.20',
+                 removed_version='1.0')
 def unsupervised_wiener(image, psf, reg=None, user_params=None, is_real=True,
-                        clip=True, *, random_state=None):
+                        clip=True, *, seed=None):
     """Unsupervised Wiener-Hunt deconvolution.
 
     Return the deconvolution with a Wiener-Hunt approach, where the
@@ -165,13 +167,12 @@ def unsupervised_wiener(image, psf, reg=None, user_params=None, is_real=True,
     clip : boolean, optional
        True by default. If true, pixel values of the result above 1 or
        under -1 are thresholded for skimage pipeline compatibility.
-    random_state : {None, int, `numpy.random.Generator`}, optional
-        If `random_state` is None the `numpy.random.Generator` singleton is
+    seed : {None, int, `numpy.random.Generator`}, optional
+        If `seed` is None the `numpy.random.Generator` singleton is used.
+        If `seed` is an int, a new ``Generator`` instance is used, seeded with
+        `seed`.
+        If `seed` is already a ``Generator`` instance then that instance is
         used.
-        If `random_state` is an int, a new ``Generator`` instance is used,
-        seeded with `random_state`.
-        If `random_state` is already a ``Generator`` instance then that
-        instance is used.
 
         .. versionadded:: 0.19
 
@@ -283,7 +284,7 @@ def unsupervised_wiener(image, psf, reg=None, user_params=None, is_real=True,
     else:
         data_spectrum = uft.ufft2(image)
 
-    rng = np.random.default_rng(random_state)
+    rng = np.random.default_rng(seed)
 
     # Gibbs sampling
     for iteration in range(params['max_num_iter']):

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -168,7 +168,7 @@ def unsupervised_wiener(image, psf, reg=None, user_params=None, is_real=True,
        True by default. If true, pixel values of the result above 1 or
        under -1 are thresholded for skimage pipeline compatibility.
     seed : {None, int, `numpy.random.Generator`}, optional
-        If `seed` is None the `numpy.random.Generator` singleton is used.
+        If `seed` is None, the `numpy.random.Generator` singleton is used.
         If `seed` is an int, a new ``Generator`` instance is used, seeded with
         `seed`.
         If `seed` is already a ``Generator`` instance then that instance is

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -171,7 +171,7 @@ def unsupervised_wiener(image, psf, reg=None, user_params=None, is_real=True,
         If `seed` is None, the `numpy.random.Generator` singleton is used.
         If `seed` is an int, a new ``Generator`` instance is used, seeded with
         `seed`.
-        If `seed` is already a ``Generator`` instance then that instance is
+        If `seed` is already a ``Generator`` instance, then that instance is
         used.
 
         .. versionadded:: 0.19

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -140,7 +140,7 @@ def wiener(image, psf, balance, reg=None, is_real=True, clip=True):
 
 
 @deprecate_kwarg({'random_state': 'seed'}, deprecated_version='0.21',
-                 removed_version='1.0')
+                 removed_version='0.23')
 def unsupervised_wiener(image, psf, reg=None, user_params=None, is_real=True,
                         clip=True, *, seed=None):
     """Unsupervised Wiener-Hunt deconvolution.

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -3,7 +3,7 @@
 import numpy as np
 from scipy.signal import convolve
 
-from .._shared.utils import _supported_float_type
+from .._shared.utils import _supported_float_type, deprecate_kwarg
 from . import uft
 
 

--- a/skimage/restoration/tests/test_restoration.py
+++ b/skimage/restoration/tests/test_restoration.py
@@ -77,7 +77,9 @@ def test_unsupervised_wiener(dtype):
     data += 0.1 * data.std() * rng.standard_normal(data.shape)
     data = data.astype(dtype, copy=False)
     deconvolved, _ = restoration.unsupervised_wiener(data, psf,
-                                                     random_state=seed)
+                                                     seed=seed)
+    with expected_warnings(['`random_state` is a deprecated argument']):
+        restoration.unsupervised_wiener(data, psf, random_state=seed)
     float_type = _supported_float_type(dtype)
     assert deconvolved.dtype == float_type
 
@@ -96,7 +98,7 @@ def test_unsupervised_wiener(dtype):
             "max_num_iter": 200,
             "min_num_iter": 30,
         },
-        random_state=seed)[0]
+        seed=seed)[0]
     assert deconvolved2.real.dtype == float_type
     path = fetch('restoration/tests/camera_unsup2.npy')
     np.testing.assert_allclose(np.real(deconvolved2),
@@ -109,10 +111,12 @@ def test_unsupervised_wiener_deprecated_user_param():
     data = convolve2d(test_img, psf, 'same')
     otf = uft.ir2tf(psf, data.shape, is_real=False)
     _, laplacian = uft.laplacian(2, data.shape)
-    restoration.unsupervised_wiener(
-        data, otf, reg=laplacian, is_real=False,
-        user_params={"min_num_iter": 30}, random_state=5
-    )
+    with expected_warnings(["`max_iter` is a deprecated key",
+                            "`min_iter` is a deprecated key"]):
+        restoration.unsupervised_wiener(
+            data, otf, reg=laplacian, is_real=False,
+            user_params={"min_num_iter": 30}, seed=5
+        )
 
 
 def test_image_shape():

--- a/skimage/restoration/tests/test_restoration.py
+++ b/skimage/restoration/tests/test_restoration.py
@@ -10,6 +10,8 @@ from skimage._shared.utils import _supported_float_type
 from skimage.color import rgb2gray
 from skimage.data import astronaut, camera
 from skimage.restoration import uft
+from skimage._shared._warnings import expected_warnings
+
 
 test_img = util.img_as_float(camera())
 

--- a/skimage/restoration/tests/test_restoration.py
+++ b/skimage/restoration/tests/test_restoration.py
@@ -117,7 +117,7 @@ def test_unsupervised_wiener_deprecated_user_param():
                             "`min_iter` is a deprecated key"]):
         restoration.unsupervised_wiener(
             data, otf, reg=laplacian, is_real=False,
-            user_params={"min_num_iter": 30}, seed=5
+            user_params={"max_iter": 300, "min_iter": 30}, seed=5
         )
 
 

--- a/skimage/restoration/tests/test_restoration.py
+++ b/skimage/restoration/tests/test_restoration.py
@@ -113,12 +113,10 @@ def test_unsupervised_wiener_deprecated_user_param():
     data = convolve2d(test_img, psf, 'same')
     otf = uft.ir2tf(psf, data.shape, is_real=False)
     _, laplacian = uft.laplacian(2, data.shape)
-    with expected_warnings(["`max_iter` is a deprecated key",
-                            "`min_iter` is a deprecated key"]):
-        restoration.unsupervised_wiener(
-            data, otf, reg=laplacian, is_real=False,
-            user_params={"max_iter": 300, "min_iter": 30}, seed=5
-        )
+    restoration.unsupervised_wiener(
+        data, otf, reg=laplacian, is_real=False,
+        user_params={"max_num_iter": 300, "min_num_iter": 30}, seed=5
+    )
 
 
 def test_image_shape():

--- a/skimage/segmentation/_quickshift.py
+++ b/skimage/segmentation/_quickshift.py
@@ -7,8 +7,8 @@ from ..util import img_as_float
 from ._quickshift_cy import _quickshift_cython
 
 
-@deprecate_kwarg({'random_seed': 'seed'}, deprecated_version='0.20',
-                 removed_version='1.0')
+@deprecate_kwarg({'random_seed': 'seed'}, deprecated_version='0.21',
+                 removed_version='0.23')
 def quickshift(image, ratio=1.0, kernel_size=5, max_dist=10,
                return_tree=False, sigma=0, convert2lab=True, seed=42,
                *, channel_axis=-1):

--- a/skimage/segmentation/_quickshift.py
+++ b/skimage/segmentation/_quickshift.py
@@ -1,14 +1,16 @@
 import numpy as np
 
 from .._shared.filters import gaussian
-from .._shared.utils import _supported_float_type
+from .._shared.utils import _supported_float_type, deprecate_kwarg
 from ..color import rgb2lab
 from ..util import img_as_float
 from ._quickshift_cy import _quickshift_cython
 
 
+@deprecate_kwarg({'random_seed': 'seed'}, deprecated_version='0.20',
+                 removed_version='1.0')
 def quickshift(image, ratio=1.0, kernel_size=5, max_dist=10,
-               return_tree=False, sigma=0, convert2lab=True, random_seed=42,
+               return_tree=False, sigma=0, convert2lab=True, seed=42,
                *, channel_axis=-1):
     """Segments image using quickshift clustering in Color-(x,y) space.
 
@@ -36,7 +38,7 @@ def quickshift(image, ratio=1.0, kernel_size=5, max_dist=10,
     convert2lab : bool, optional
         Whether the input should be converted to Lab colorspace prior to
         segmentation. For this purpose, the input is assumed to be RGB.
-    random_seed : int, optional
+    seed : int, optional
         Random seed used for breaking ties.
     channel_axis : int, optional
         The axis of `image` corresponding to color channels. Defaults to the
@@ -83,5 +85,5 @@ def quickshift(image, ratio=1.0, kernel_size=5, max_dist=10,
 
     segment_mask = _quickshift_cython(
         image, kernel_size=kernel_size, max_dist=max_dist,
-        return_tree=return_tree, random_seed=random_seed)
+        return_tree=return_tree, random_seed=seed)
     return segment_mask

--- a/skimage/segmentation/_quickshift.py
+++ b/skimage/segmentation/_quickshift.py
@@ -12,7 +12,7 @@ from ._quickshift_cy import _quickshift_cython
 def quickshift(image, ratio=1.0, kernel_size=5, max_dist=10,
                return_tree=False, sigma=0, convert2lab=True, seed=42,
                *, channel_axis=-1):
-    """Segments image using quickshift clustering in Color-(x,y) space.
+    """Segment image using quickshift clustering in Color-(x,y) space.
 
     Produces an oversegmentation of the image using the quickshift mode-seeking
     algorithm.

--- a/skimage/segmentation/tests/test_quickshift.py
+++ b/skimage/segmentation/tests/test_quickshift.py
@@ -15,8 +15,11 @@ def test_grey(dtype):
     img[10:, 10:] = 0.6
     img += 0.05 * rnd.normal(size=img.shape)
     img = img.astype(dtype, copy=False)
-    seg = quickshift(img, kernel_size=2, max_dist=3, random_seed=0,
+    seg = quickshift(img, kernel_size=2, max_dist=3, seed=0,
                      convert2lab=False, sigma=0)
+    with testing.expected_warnings(['`random_seed` is a deprecated argument']):
+        quickshift(img, kernel_size=2, max_dist=3, random_seed=0,
+                   convert2lab=False, sigma=0)
     # we expect 4 segments:
     assert_equal(len(np.unique(seg)), 4)
     # that mostly respect the 4 regions:
@@ -39,7 +42,7 @@ def test_color(dtype, channel_axis):
     img = img.astype(dtype, copy=False)
 
     img = np.moveaxis(img, source=-1, destination=channel_axis)
-    seg = quickshift(img, random_seed=0, max_dist=30, kernel_size=10, sigma=0,
+    seg = quickshift(img, seed=0, max_dist=30, kernel_size=10, sigma=0,
                      channel_axis=channel_axis)
     # we expect 4 segments:
     assert_equal(len(np.unique(seg)), 4)
@@ -48,7 +51,7 @@ def test_color(dtype, channel_axis):
     assert_array_equal(seg[:10, 10:], 0)
     assert_array_equal(seg[10:, 10:], 2)
 
-    seg2 = quickshift(img, kernel_size=1, max_dist=2, random_seed=0,
+    seg2 = quickshift(img, kernel_size=1, max_dist=2, seed=0,
                       convert2lab=False, sigma=0,
                       channel_axis=channel_axis)
     # very oversegmented:


### PR DESCRIPTION
## Description

closes #5359

Unify on use of `seed` in the public API. Currently had a mixture of (`sample_seed`, `seed`, `random_seed`, `random_state`)


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
