### PR TITLE
Ignore sparse matrix deprecation warning

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -37,6 +37,8 @@ Other (2022)
 ------------
 * Remove pillow version related warning for CVE when pillow > 8.1.2 in
   `skimage/io/_plugins/pil_plugin.py` and `skimage/io/collection.py`.
+* Remove custom code for ignored warning in `skimage/_shared/testing.py` relating
+  to (sparse) matricies (instead of arrays).
 
 Other (2023)
 ------------

--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -268,6 +268,12 @@ def setup_test():
             category=RuntimeWarning
         )
 
+        warnings.filterwarnings(
+            'default',
+            message='\n\nThe scipy.sparse array containers',
+            category=DeprecationWarning
+        )
+
 
 def teardown_test():
     """Default package level teardown routine for skimage tests.


### PR DESCRIPTION
This should make your CI happy until you decide how you want to handle the upcoming NX 3.0 release (and more importantly when you want to move from scipy sparse matrices to sparse arrays).  Feel free to @mention me if you have any trouble getting things to work.