### PR TITLE
Fix inpaint_biharmonic for images with Fortran-ordered memory layout

### DIFF
--- a/skimage/restoration/inpaint.py
+++ b/skimage/restoration/inpaint.py
@@ -265,7 +265,7 @@ def inpaint_biharmonic(image, mask, multichannel=False, *,
     mask = mask.astype(bool, copy=False)
     if not multichannel:
         image = image[..., np.newaxis]
-    out = np.copy(image)
+    out = np.copy(image, order='C')
 
     # Create biharmonic coefficients ndarray
     radius = 2

--- a/skimage/restoration/tests/test_inpaint.py
+++ b/skimage/restoration/tests/test_inpaint.py
@@ -144,9 +144,10 @@ def test_invalid_input():
 
 
 @testing.parametrize('dtype', [np.uint8, np.float32, np.float64])
+@testing.parametrize('order', ['C', 'F'])
 @testing.parametrize('channel_axis', [None, -1])
 @testing.parametrize('split_into_regions', [False, True])
-def test_inpaint_nrmse(dtype, channel_axis, split_into_regions):
+def test_inpaint_nrmse(dtype, order, channel_axis, split_into_regions):
     image_orig = data.astronaut()[:, :200]
     float_dtype = np.float32 if dtype == np.float32 else np.float64
     image_orig = image_orig.astype(float_dtype, copy=False)
@@ -187,6 +188,7 @@ def test_inpaint_nrmse(dtype, channel_axis, split_into_regions):
     image_orig = image_orig.astype(dtype, copy=False)
     image_defect = image_defect.astype(dtype, copy=False)
 
+    image_defect = np.asarray(image_defect, order=order)
     image_result = inpaint.inpaint_biharmonic(
         image_defect, mask, channel_axis=channel_axis,
         split_into_regions=split_into_regions


### PR DESCRIPTION

## Description

closes #6260

Fixes a bug when the `image` input to `inpaint_biharmonic` did not have C-contiguous memory order. It is actually only the output array that must be C-contiguous, but currently due to a copy from the input this assumption was not always true. This small fix ensures the output array will be declared with C-contiguous memory layout as expected.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
