### PR TITLE
hough_line_peaks fix for corner case with optimal angle=0

### DIFF
--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -63,7 +63,7 @@ def hough_line_peaks(hspace, angles, dists, min_distance=9, min_angle=10,
                                min_ydistance=min_distance,
                                threshold=threshold,
                                num_peaks=num_peaks)
-    if a.any():
+    if a.size > 0:
         return (h, angles[a], dists[d])
     else:
         return (h, np.array([]), np.array([]))

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -1,9 +1,8 @@
 import numpy as np
 from scipy.spatial import cKDTree
-from ._hough_transform import (_hough_circle,
-                               _hough_ellipse,
-                               _hough_line,
-                               _probabilistic_hough_line as _prob_hough_line)
+
+from ._hough_transform import _hough_circle, _hough_ellipse, _hough_line
+from ._hough_transform import _probabilistic_hough_line as _prob_hough_line
 
 
 def hough_line_peaks(hspace, angles, dists, min_distance=9, min_angle=10,
@@ -267,8 +266,9 @@ def probabilistic_hough_line(image, threshold=10, line_length=50, line_gap=10,
     if theta is None:
         theta = np.linspace(-np.pi / 2, np.pi / 2, 180, endpoint=False)
 
-    return _prob_hough_line(image, threshold=threshold, line_length=line_length,
-                            line_gap=line_gap, theta=theta, seed=seed)
+    return _prob_hough_line(image, threshold=threshold,
+                            line_length=line_length, line_gap=line_gap,
+                            theta=theta, seed=seed)
 
 
 def hough_circle_peaks(hspaces, radii, min_xdistance=1, min_ydistance=1,

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -2,10 +2,10 @@ import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal, assert_equal
 
+from skimage import data, transform
 from skimage._shared.testing import test_parallel
-from skimage import data
-from skimage import transform
-from skimage.draw import line, circle_perimeter, ellipse_perimeter
+from skimage.draw import circle_perimeter, ellipse_perimeter, line
+
 
 @test_parallel()
 def test_hough_line():
@@ -56,10 +56,10 @@ def test_probabilistic_hough():
         img, threshold=10, line_length=10, line_gap=1, theta=theta)
     # sort the lines according to the x-axis
     sorted_lines = []
-    for line in lines:
-        line = list(line)
-        line.sort(key=lambda x: x[0])
-        sorted_lines.append(line)
+    for ln in lines:
+        ln = list(ln)
+        ln.sort(key=lambda x: x[0])
+        sorted_lines.append(ln)
 
     assert([(25, 75), (74, 26)] in sorted_lines)
     assert([(25, 25), (74, 74)] in sorted_lines)

--- a/skimage/transform/tests/test_hough_transform.py
+++ b/skimage/transform/tests/test_hough_transform.py
@@ -117,6 +117,27 @@ def test_hough_line_peaks_ordered():
     assert hspace[0] > hspace[1]
 
 
+def test_hough_line_peaks_single_line():
+    # Regression test for gh-6187, gh-4129
+
+    # create an empty test image
+    img = np.zeros((100, 100), dtype=bool)
+    # draw a horizontal line into our test image
+    img[30, :] = 1
+
+    hough_space, angles, dist = transform.hough_line(img)
+
+    best_h_space, best_angles, best_dist = transform.hough_line_peaks(
+        hough_space, angles, dist
+    )
+    assert len(best_angles) == 1
+    assert len(best_dist) == 1
+    expected_angle = -np.pi / 2
+    expected_dist = -30
+    assert abs(best_angles[0] - expected_angle) < 0.01
+    assert abs(best_dist[0] - expected_dist) < 0.01
+
+
 def test_hough_line_peaks_dist():
     img = np.zeros((100, 100), dtype=bool)
     img[:, 30] = True


### PR DESCRIPTION
## Description

closes #4129, #6187

An array, `a` with a single element equal to zero is possible and is not handled properly in `hough_line_peaks`. This PR fixes that and adds a test case based on the example from #6187.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
