### PR TITLE
clarify behavior of watershed segmentation line with touching markers

### DIFF
--- a/skimage/segmentation/_watershed.py
+++ b/skimage/segmentation/_watershed.py
@@ -121,8 +121,8 @@ def watershed(image, markers=None, connectivity=1, offset=None, mask=None,
     watershed_line : bool, optional
         If watershed_line is True, a one-pixel wide line separates the regions
         obtained by the watershed algorithm. The line has the label 0.
-        Note that the method used for adding the watershed line expects that
-        marker regions are not adjacent; the watershed line may not separate
+        Note that the method used for adding this line expects that
+        marker regions are not adjacent; the watershed line may not catch
         borders between adjacent marker regions.
 
     Returns

--- a/skimage/segmentation/_watershed.py
+++ b/skimage/segmentation/_watershed.py
@@ -121,6 +121,9 @@ def watershed(image, markers=None, connectivity=1, offset=None, mask=None,
     watershed_line : bool, optional
         If watershed_line is True, a one-pixel wide line separates the regions
         obtained by the watershed algorithm. The line has the label 0.
+        Note that the method used for adding the watershed line expects that
+        marker regions are not adjacent; the watershed line may not separate
+        borders between adjacent marker regions.
 
     Returns
     -------


### PR DESCRIPTION
## Description

Added some clarification to documentation for watershed segmentation, to make it clear that `watershed_line=True` will not behave as expected if markers are touching. This is related to #6279 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
