### PR TITLE
Update for the `MultiImage` docstring.

### DIFF
--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -414,11 +414,6 @@ class MultiImage(ImageCollection):
         Whether to conserve memory by only caching the frames of a single
         image. Default is True.
 
-    Other parameters
-    ----------------
-    load_func : callable
-        ``imread`` by default.  See notes below.
-
     Notes
     -----
     The object that is returned can be used as a list of image-data objects,
@@ -433,10 +428,6 @@ class MultiImage(ImageCollection):
     For an animated GIF image, `MultiImage` in the current implementation
     will only read one frame, while `ImageCollection` by default will read
     all of them.
-
-    The current implementation of `MultiImage` is simply a small wrapper
-    around `ImageCollection` specifying an internal ``imread`` as the
-    ``load_func``.
 
     Examples
     --------

--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -403,7 +403,7 @@ def imread_collection_wrapper(imread):
 
 class MultiImage(ImageCollection):
 
-    """A class containing all frames from multi-frame images.
+    """A class containing all frames from multi-frame TIFF images.
 
     Parameters
     ----------
@@ -411,8 +411,8 @@ class MultiImage(ImageCollection):
         Pattern glob or filenames to load. The path can be absolute or
         relative.
     conserve_memory : bool, optional
-        Whether to conserve memory by only caching a single frame. Default is
-        True.
+        Whether to conserve memory by only caching the frames of a single
+        image. Default is True.
 
     Other parameters
     ----------------
@@ -421,25 +421,40 @@ class MultiImage(ImageCollection):
 
     Notes
     -----
-    If ``conserve_memory=True`` the memory footprint can be reduced, however
-    the performance can be affected because frames have to be read from file
-    more often.
+    The object that is returned can be used as a list of image-data objects,
+    where each entry in the list represents one image. In this regard it is
+    very similar to `ImageCollection`, but the two differ in the treatment
+    of multi-frame images.
 
-    The last accessed frame is cached, all other frames will have to be read
-    from file.
+    For a TIFF image containing N frames of size WxH, `MultiImage` stores
+    all frames of that image as a single entry of shape `(N, W, H)` in the
+    list. `ImageCollection` instead creates N entries of shape `(W, H)`.
 
-    The current implementation makes use of ``tifffile`` for Tiff files and
-    PIL otherwise.
+    For an animated GIF image, `MultiImage` in the current implementation
+    will only read one frame, while `ImageCollection` by default will read
+    all of them.
+
+    The current implementation of `MultiImage` is simply a small wrapper
+    around `ImageCollection` specifying an internal ``imread`` as the
+    ``load_func``.
 
     Examples
     --------
     >>> from skimage import data_dir
 
-    >>> img = MultiImage(data_dir + '/multipage.tif') # doctest: +SKIP
-    >>> len(img) # doctest: +SKIP
+    >>> multipage_tiff = data_dir + '/multipage.tif'
+    >>> img = MultiImage(multipage_tiff)
+    >>> len(img) # img contains one file
+    1
+    >>> img[0].shape # this image contains two frames of size (15, 10)
+    (2, 15, 10)
+
+    >>> ic = ImageCollection(multipage_tiff)
+    >>> len(ic) # ic contains two images
     2
-    >>> for frame in img: # doctest: +SKIP
-    ...     print(frame.shape) # doctest: +SKIP
+    >>> for frame in ic:
+    ...     print (frame.shape)
+    ...
     (15, 10)
     (15, 10)
 


### PR DESCRIPTION
This patch updates the documentation of `skimage.io.MultiImage` to
match its actual behavior.

## Description

The docstring of `MultiImage` did not match the current implementation, and the examples given there did not work. The commit here fixes the docstring and provides corrected examples. (See discussion started in [#6276 (PR)](https://github.com/scikit-image/scikit-image/pull/6276), @mkcor and @stefanv.)


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
