### PR TITLE
Update plot_pyramid.py demo to work for diversified shaped images and downsample factors

### DIFF
--- a/doc/examples/transform/plot_pyramid.py
+++ b/doc/examples/transform/plot_pyramid.py
@@ -9,6 +9,8 @@ implement algorithms for denoising, texture discrimination, and scale-invariant
 detection.
 
 """
+import math
+
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -20,10 +22,31 @@ image = data.astronaut()
 rows, cols, dim = image.shape
 pyramid = tuple(pyramid_gaussian(image, downscale=2, channel_axis=-1))
 
-composite_image = np.zeros((rows, cols + cols // 2, 3), dtype=np.double)
+#####################################################################
+# Generate a composite image for visualization
+# ============================================
+#
+# For visualization, we generate a composite image with the same number of rows
+# as the source image but with ``cols + pyramid[1].shape[1]`` columns. We then
+# have space to stack all of the dowsampled images to the right of the
+# original.
+#
+# Note: The sum of the number of rows in all dowsampled images in the pyramid
+# may sometimes exceed the original image size in cases when image.shape[0] is
+# not a power of two. We expand the number of rows in the composite slightly as
+# necessary to account for this. Expansion beyond the number of rows in the
+# original will also be necessary to cover cases where downscale < 2.
 
+# determine the total number of rows and columns for the composite
+composite_rows = max(rows, sum(p.shape[0] for p in pyramid[1:]))
+composite_cols = cols + pyramid[1].shape[1]
+composite_image = np.zeros((composite_rows, composite_cols, 3),
+                           dtype=np.double)
+
+# store the original to the left
 composite_image[:rows, :cols, :] = pyramid[0]
 
+# stack all downsampled images in a column to the right of the original
 i_row = 0
 for p in pyramid[1:]:
     n_rows, n_cols = p.shape[:2]


### PR DESCRIPTION

## Description

closes #4333 

Updates the `plot_pyramids.py` gallery example to work for arbitrarily shaped images as well as for choices of `downsample` other than 2.


An example that reproduces the issue in #4333, but with the astronaut image would be to truncate it like:

```Python
image = data.astronaut()[:-7, :]
```
or 
```Python
image = data.astronaut()[:, :-1]
```
These would exceed the number of rows or columns of the original due to rounding up of odd sizes when dividing by two. The change here makes the demo's visualization robust to size of the image.

The change here also works even if `downsample` is not two. For example, with a non-standard `downsample=1.75`:
![pyramid_1 75](https://user-images.githubusercontent.com/6528957/159188977-ef3a11be-0685-46c2-b866-3a35af516c67.png)


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
