### PR TITLE
32 bit dtypes => 64 bit in `morphology.reconstruction`

### DIFF
--- a/skimage/morphology/_grayreconstruct.pyx
+++ b/skimage/morphology/_grayreconstruct.pyx
@@ -16,11 +16,11 @@ cnp.import_array()
 @cython.boundscheck(False)
 def reconstruction_loop(cnp.ndarray[dtype=cnp.uint32_t, ndim=1,
                                     negative_indices=False, mode='c'] aranks,
-                        cnp.ndarray[dtype=cnp.int32_t, ndim=1,
+                        cnp.ndarray[dtype=cnp.int64_t, ndim=1,
                                     negative_indices=False, mode='c'] aprev,
-                        cnp.ndarray[dtype=cnp.int32_t, ndim=1,
+                        cnp.ndarray[dtype=cnp.int64_t, ndim=1,
                                     negative_indices=False, mode='c'] anext,
-                        cnp.ndarray[dtype=cnp.int32_t, ndim=1,
+                        cnp.ndarray[dtype=cnp.int64_t, ndim=1,
                                     negative_indices=False, mode='c'] astrides,
                         Py_ssize_t current_idx,
                         Py_ssize_t image_stride):
@@ -49,13 +49,13 @@ def reconstruction_loop(cnp.ndarray[dtype=cnp.uint32_t, ndim=1,
     image_stride : int
         Stride between seed image and mask image in `aranks`.
     """
-    cdef unsigned int neighbor_rank, current_rank, mask_rank
-    cdef int i, neighbor_idx, current_link, nprev, nnext
-    cdef int nstrides = astrides.shape[0]
+    cdef size_t neighbor_rank, current_rank, mask_rank
+    cdef Py_ssize_t i, neighbor_idx, current_link, nprev, nnext
+    cdef Py_ssize_t nstrides = astrides.shape[0]
     cdef cnp.uint32_t *ranks = <cnp.uint32_t *>(aranks.data)
-    cdef cnp.int32_t *prev = <cnp.int32_t *>(aprev.data)
-    cdef cnp.int32_t *next = <cnp.int32_t *>(anext.data)
-    cdef cnp.int32_t *strides = <cnp.int32_t *>(astrides.data)
+    cdef cnp.int64_t *prev = <cnp.int64_t *>(aprev.data)
+    cdef cnp.int64_t *next = <cnp.int64_t *>(anext.data)
+    cdef cnp.int64_t *strides = <cnp.int64_t *>(astrides.data)
 
     with nogil:
         while current_idx != -1:


### PR DESCRIPTION
Apologies for the delay. Everyone in my household came down with Covid last week, so I've mostly been at home entertaining bored kids.

This is a very limited pull request, but I likely won't get chance to look at this again until I've cleared a backlog of other stuff, and I thought it better to submit _something_ now to keep things moving...

## Description

This PR refers to #6277. 

I've converted `int32` dtypes to `int64` dtypes in both the Cython and Python code. I've tested that this version gives the same result as the original for a selection of small arrays, and it completes without error (and produces seemingly sensible results) for two arrays that were previously crashing the kernel.

For indexing into arrays in Cython I've used `Py_ssize_t` for signed data types and `size_t` for unsigned, but I don't have enough experience of Cython to know whether this is the best choice.

**Note:** This code still relies on `filters._rank_order.rank_order`, which converts ranks to `uint32`. This code will therefore still fail if `2 * seed.size > np.iinfo(np.uint32).max` (i.e. if the number of values in one of the input arrays is greater than about 2.1e9). This limitation could be removed by also switching `rank_order` to 64 bit dtypes. For now, this code just raises an error (instead of crashing the kernel).

I'm afraid I haven't had time to make the memory handling in the Python more efficient, or to think about how to switch between 32 and 64 bit versions based on the size of the input arrays.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
