### PR TITLE
Add spacing to regionprops and moments.

### DIFF
--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -148,7 +148,7 @@ def moments_coords_central(coords, center=None, order=3):
     return Mc
 
 
-def moments(image, order=3):
+def moments(image, order=3, *, spacing=None):
     """Calculate all raw image moments up to a certain order.
 
     The following properties can be calculated from raw image moments:
@@ -164,6 +164,8 @@ def moments(image, order=3):
         Rasterized shape as image.
     order : int, optional
         Maximum order of moments. Default is 3.
+    spacing: tuple of float, shape (ndim, )
+        The pixel spacing along each axis of the image.
 
     Returns
     -------
@@ -190,10 +192,10 @@ def moments(image, order=3):
     >>> centroid
     (14.5, 14.5)
     """
-    return moments_central(image, (0,) * image.ndim, order=order)
+    return moments_central(image, (0,) * image.ndim, order=order, spacing=spacing)
 
 
-def moments_central(image, center=None, order=3, **kwargs):
+def moments_central(image, center=None, order=3, *, spacing=None, **kwargs):
     """Calculate all central image moments up to a certain order.
 
     The center coordinates (cr, cc) can be calculated from the raw moments as:
@@ -211,6 +213,8 @@ def moments_central(image, center=None, order=3, **kwargs):
         is not provided.
     order : int, optional
         The maximum order of moments computed.
+    spacing: tuple of float, shape (ndim, )
+        The pixel spacing along each axis of the image.
 
     Returns
     -------
@@ -242,12 +246,16 @@ def moments_central(image, center=None, order=3, **kwargs):
     """
     if center is None:
         center = centroid(image)
+    if spacing is None:
+        spacing = np.ones(image.ndim)
     float_dtype = _supported_float_type(image.dtype)
     calc = image.astype(float_dtype, copy=False)
     for dim, dim_length in enumerate(image.shape):
-        delta = np.arange(dim_length, dtype=float_dtype) - center[dim]
+        delta = (
+                np.arange(dim_length, dtype=float_dtype) * spacing[dim] - center[dim]
+        )
         powers_of_delta = (
-            delta[:, np.newaxis] ** np.arange(order + 1, dtype=float_dtype)
+                delta[:, np.newaxis] ** np.arange(order + 1, dtype=float_dtype)
         )
         calc = np.rollaxis(calc, dim, image.ndim)
         calc = np.dot(calc, powers_of_delta)
@@ -354,13 +362,15 @@ def moments_hu(nu):
     return _moments_cy.moments_hu(nu.astype(dtype, copy=False))
 
 
-def centroid(image):
+def centroid(image, *, spacing=None):
     """Return the (weighted) centroid of an image.
 
     Parameters
     ----------
     image : array
         The input image.
+    spacing: tuple of float, shape (ndim, )
+        The pixel spacing along each axis of the image.
 
     Returns
     -------
@@ -375,14 +385,14 @@ def centroid(image):
     >>> centroid(image)
     array([13.16666667, 13.16666667])
     """
-    M = moments_central(image, center=(0,) * image.ndim, order=1)
+    M = moments_central(image, center=(0,) * image.ndim, order=1, spacing=spacing)
     center = (M[tuple(np.eye(image.ndim, dtype=int))]  # array of weighted sums
-                                                       # for each axis
+              # for each axis
               / M[(0,) * image.ndim])  # weighted sum of all points
     return center
 
 
-def inertia_tensor(image, mu=None):
+def inertia_tensor(image, mu=None, *, spacing=None):
     """Compute the inertia tensor of the input image.
 
     Parameters
@@ -396,6 +406,8 @@ def inertia_tensor(image, mu=None):
         (for example, `skimage.measure.regionprops`), then it is more
         efficient to pre-compute them and pass them to the inertia tensor
         call.
+    spacing: tuple of float, shape (ndim, )
+        The pixel spacing along each axis of the image.
 
     Returns
     -------
@@ -410,7 +422,7 @@ def inertia_tensor(image, mu=None):
            Scientific Applications. (Chapter 8: Tensor Methods) Springer, 1993.
     """
     if mu is None:
-        mu = moments_central(image, order=2)  # don't need higher-order moments
+        mu = moments_central(image, order=2, spacing=spacing)  # don't need higher-order moments
     mu0 = mu[(0,) * image.ndim]
     result = np.zeros((image.ndim, image.ndim), dtype=mu.dtype)
 
@@ -434,7 +446,7 @@ def inertia_tensor(image, mu=None):
     return result
 
 
-def inertia_tensor_eigvals(image, mu=None, T=None):
+def inertia_tensor_eigvals(image, mu=None, T=None, *, spacing=None):
     """Compute the eigenvalues of the inertia tensor of the image.
 
     The inertia tensor measures covariance of the image intensity along
@@ -451,6 +463,8 @@ def inertia_tensor_eigvals(image, mu=None, T=None):
     T : array, shape ``(image.ndim, image.ndim)``
         The pre-computed inertia tensor. If ``T`` is given, ``mu`` and
         ``image`` are ignored.
+    spacing: tuple of float, shape (ndim, )
+        The pixel spacing along each axis of the image.
 
     Returns
     -------
@@ -465,7 +479,7 @@ def inertia_tensor_eigvals(image, mu=None, T=None):
     alternatively, one can provide the inertia tensor (``T``) directly.
     """
     if T is None:
-        T = inertia_tensor(image, mu)
+        T = inertia_tensor(image, mu, spacing=spacing)
     eigvals = np.linalg.eigvalsh(T)
     # Floating point precision problems could make a positive
     # semidefinite matrix have an eigenvalue that is very slightly

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -263,7 +263,7 @@ def moments_central(image, center=None, order=3, *, spacing=None, **kwargs):
     return calc
 
 
-def moments_normalized(mu, order=3):
+def moments_normalized(mu, order=3, spacing=None):
     """Calculate all normalized central image moments up to a certain order.
 
     Note that normalized central moments are translation and scale invariant
@@ -308,13 +308,16 @@ def moments_normalized(mu, order=3):
     """
     if np.any(np.array(mu.shape) <= order):
         raise ValueError("Shape of image moments must be >= `order`")
+    if spacing is None:
+        spacing = np.ones(mu.ndim)
     nu = np.zeros_like(mu)
     mu0 = mu.ravel()[0]
+    scale = min(spacing)
     for powers in itertools.product(range(order + 1), repeat=mu.ndim):
         if sum(powers) < 2:
             nu[powers] = np.nan
         else:
-            nu[powers] = mu[powers] / (mu0 ** (sum(powers) / nu.ndim + 1))
+            nu[powers] = (mu[powers] / scale ** sum(powers)) / (mu0 ** (sum(powers) / nu.ndim + 1))
     return nu
 
 

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -255,7 +255,7 @@ def moments_central(image, center=None, order=3, *, spacing=None, **kwargs):
                 np.arange(dim_length, dtype=float_dtype) * spacing[dim] - center[dim]
         )
         powers_of_delta = (
-                delta[:, np.newaxis] ** np.arange(order + 1, dtype=float_dtype)
+            delta[:, np.newaxis] ** np.arange(order + 1, dtype=float_dtype)
         )
         calc = np.rollaxis(calc, dim, image.ndim)
         calc = np.dot(calc, powers_of_delta)
@@ -387,7 +387,7 @@ def centroid(image, *, spacing=None):
     """
     M = moments_central(image, center=(0,) * image.ndim, order=1, spacing=spacing)
     center = (M[tuple(np.eye(image.ndim, dtype=int))]  # array of weighted sums
-              # for each axis
+                                                       # for each axis
               / M[(0,) * image.ndim])  # weighted sum of all points
     return center
 

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -245,7 +245,7 @@ def moments_central(image, center=None, order=3, *, spacing=None, **kwargs):
            [ 0.,  0.,  0.,  0.]])
     """
     if center is None:
-        center = centroid(image)
+        center = centroid(image, spacing=spacing)
     if spacing is None:
         spacing = np.ones(image.ndim)
     float_dtype = _supported_float_type(image.dtype)

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -567,7 +567,8 @@ class RegionProperties:
     @property
     @_cached
     def moments_normalized(self):
-        return _moments.moments_normalized(self.moments_central, 3)
+        return _moments.moments_normalized(self.moments_central, 3,
+                                           spacing=self._spacing)
 
     @property
     @only2d
@@ -669,13 +670,16 @@ class RegionProperties:
         if self._multichannel:
             nchannels = self._intensity_image.shape[-1]
             return np.stack(
-                [_moments.moments_normalized(mu[..., i], order=3)
+                [_moments.moments_normalized(mu[..., i], order=3,
+                                             spacing=self._spacing)
                  for i in range(nchannels)],
                 axis=-1,
             )
         else:
-            return _moments.moments_normalized(mu, order=3)
-        return _moments.moments_normalized(self.moments_weighted_central, 3)
+            return _moments.moments_normalized(mu, order=3,
+                                               spacing=self._spacing)
+        return _moments.moments_normalized(self.moments_weighted_central, 3,
+                                           spacing=self._spacing)
 
     def __iter__(self):
         props = PROP_VALS

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -16,6 +16,7 @@ from ._regionprops_utils import euler_number, perimeter, perimeter_crofton
 
 __all__ = ['regionprops', 'euler_number', 'perimeter', 'perimeter_crofton']
 
+
 # All values in this PROPS dict correspond to current scikit-image property
 # names. The keys in this PROPS dict correspond to older names used in prior
 # releases. For backwards compatibility, these older names will continue to
@@ -228,7 +229,6 @@ def only2d(method):
             raise NotImplementedError('Property %s is not implemented for '
                                       '3D images' % method.__name__)
         return method(self, *args, **kwargs)
-
     return func2d
 
 
@@ -288,7 +288,7 @@ class RegionProperties:
             if not (
                     intensity_image.shape[:ndim] == label_image.shape
                     and intensity_image.ndim in [ndim, ndim + 1]
-            ):
+                    ):
                 raise ValueError('Label and intensity image shapes must match,'
                                  ' except for channel (last) axis.')
             multichannel = label_image.shape < intensity_image.shape
@@ -336,7 +336,7 @@ class RegionProperties:
                         multichannel_list = [func(self.image,
                                                   self.image_intensity[..., i])
                                              for i in range(
-                                self.image_intensity.shape[-1])]
+                            self.image_intensity.shape[-1])]
                         return np.stack(multichannel_list, axis=-1)
                     else:
                         return func(self.image, self.image_intensity)
@@ -1002,7 +1002,7 @@ def regionprops_table(label_image, intensity_image=None,
                           cache=cache, extra_properties=extra_properties, spacing=spacing)
     if extra_properties is not None:
         properties = (
-                list(properties) + [prop.__name__ for prop in extra_properties]
+            list(properties) + [prop.__name__ for prop in extra_properties]
         )
     if len(regions) == 0:
         ndim = label_image.ndim
@@ -1010,9 +1010,9 @@ def regionprops_table(label_image, intensity_image=None,
         label_image[(1,) * ndim] = 1
         if intensity_image is not None:
             intensity_image = np.zeros(
-                label_image.shape + intensity_image.shape[ndim:],
-                dtype=intensity_image.dtype
-            )
+                    label_image.shape + intensity_image.shape[ndim:],
+                    dtype=intensity_image.dtype
+                    )
         regions = regionprops(label_image, intensity_image=intensity_image,
                               cache=cache, extra_properties=extra_properties, spacing=spacing)
 
@@ -1285,14 +1285,14 @@ def regionprops(label_image, intensity_image=None, cache=True,
     if not np.issubdtype(label_image.dtype, np.integer):
         if np.issubdtype(label_image.dtype, bool):
             raise TypeError(
-                'Non-integer image types are ambiguous: '
-                'use skimage.measure.label to label the connected'
-                'components of label_image,'
-                'or label_image.astype(np.uint8) to interpret'
-                'the True values as a single label.')
+                    'Non-integer image types are ambiguous: '
+                    'use skimage.measure.label to label the connected'
+                    'components of label_image,'
+                    'or label_image.astype(np.uint8) to interpret'
+                    'the True values as a single label.')
         else:
             raise TypeError(
-                'Non-integer label_image types are ambiguous')
+                    'Non-integer label_image types are ambiguous')
 
     if coordinates is not None:
         if coordinates == 'rc':

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -109,7 +109,7 @@ COL_DTYPES = {
     'centroid_local': float,
     'centroid_weighted': float,
     'centroid_weighted_local': float,
-    'coords_scaled': object,
+    'coords_scaled': float,
     'coords': object,
     'eccentricity': float,
     'equivalent_diameter_area': float,

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -22,7 +22,6 @@ __all__ = ['regionprops', 'euler_number', 'perimeter', 'perimeter_crofton']
 # releases. For backwards compatibility, these older names will continue to
 # work, but will not be documented.
 PROPS = {
-    'NumPixels': 'num_pixels',
     'Area': 'area',
     'BoundingBox': 'bbox',
     'BoundingBoxArea': 'area_bbox',
@@ -34,7 +33,6 @@ PROPS = {
     # 'ConvexHull',
     'ConvexImage': 'image_convex',
     'convex_image': 'image_convex',
-    'Coordinates_Scaled': 'coords_scaled',
     'Coordinates': 'coords',
     'Eccentricity': 'eccentricity',
     'EquivDiameter': 'equivalent_diameter_area',
@@ -97,7 +95,6 @@ OBJECT_COLUMNS = {
 }
 
 COL_DTYPES = {
-    'num_pixels': int,
     'area': float,
     'area_bbox': float,
     'area_convex': float,
@@ -109,7 +106,6 @@ COL_DTYPES = {
     'centroid_local': float,
     'centroid_weighted': float,
     'centroid_weighted_local': float,
-    'coords_scaled': float,
     'coords': object,
     'eccentricity': float,
     'equivalent_diameter_area': float,

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -16,12 +16,12 @@ from ._regionprops_utils import euler_number, perimeter, perimeter_crofton
 
 __all__ = ['regionprops', 'euler_number', 'perimeter', 'perimeter_crofton']
 
-
 # All values in this PROPS dict correspond to current scikit-image property
 # names. The keys in this PROPS dict correspond to older names used in prior
 # releases. For backwards compatibility, these older names will continue to
 # work, but will not be documented.
 PROPS = {
+    'Pixel Area': 'pixel_area',
     'Area': 'area',
     'BoundingBox': 'bbox',
     'BoundingBoxArea': 'area_bbox',
@@ -95,10 +95,11 @@ OBJECT_COLUMNS = {
 }
 
 COL_DTYPES = {
-    'area': int,
-    'area_bbox': int,
-    'area_convex': int,
-    'area_filled': int,
+    'pixel_area': float,
+    'area': float,
+    'area_bbox': float,
+    'area_convex': float,
+    'area_filled': float,
     'axis_major_length': float,
     'axis_minor_length': float,
     'bbox': int,
@@ -225,6 +226,7 @@ def only2d(method):
             raise NotImplementedError('Property %s is not implemented for '
                                       '3D images' % method.__name__)
         return method(self, *args, **kwargs)
+
     return func2d
 
 
@@ -277,14 +279,14 @@ class RegionProperties:
     """
 
     def __init__(self, slice, label, label_image, intensity_image,
-                 cache_active, *, extra_properties=None):
+                 cache_active, *, extra_properties=None, spacing=None):
 
         if intensity_image is not None:
             ndim = label_image.ndim
             if not (
                     intensity_image.shape[:ndim] == label_image.shape
                     and intensity_image.ndim in [ndim, ndim + 1]
-                    ):
+            ):
                 raise ValueError('Label and intensity image shapes must match,'
                                  ' except for channel (last) axis.')
             multichannel = label_image.shape < intensity_image.shape
@@ -303,6 +305,7 @@ class RegionProperties:
         self._ndim = label_image.ndim
         self._multichannel = multichannel
         self._spatial_axes = tuple(range(self._ndim))
+        self._spacing = (spacing if spacing is not None else np.full(self._ndim, 1.))
 
         self._extra_properties = {}
         if extra_properties is not None:
@@ -330,7 +333,7 @@ class RegionProperties:
                         multichannel_list = [func(self.image,
                                                   self.image_intensity[..., i])
                                              for i in range(
-                            self.image_intensity.shape[-1])]
+                                self.image_intensity.shape[-1])]
                         return np.stack(multichannel_list, axis=-1)
                     else:
                         return func(self.image, self.image_intensity)
@@ -361,8 +364,13 @@ class RegionProperties:
 
     @property
     @_cached
+    def pixel_area(self):
+        return np.prod(self._spacing)
+
+    @property
+    @_cached
     def area(self):
-        return np.sum(self.image)
+        return np.sum(self.image) * self.pixel_area
 
     @property
     def bbox(self):
@@ -377,7 +385,7 @@ class RegionProperties:
 
     @property
     def area_bbox(self):
-        return self.image.size
+        return self.image.size * self.pixel_area
 
     @property
     def centroid(self):
@@ -386,7 +394,7 @@ class RegionProperties:
     @property
     @_cached
     def area_convex(self):
-        return np.sum(self.image_convex)
+        return np.sum(self.image_convex) * self.pixel_area
 
     @property
     @_cached
@@ -397,8 +405,8 @@ class RegionProperties:
     @property
     def coords(self):
         indices = np.nonzero(self.image)
-        return np.vstack([indices[i] + self.slice[i].start
-                          for i in range(self._ndim)]).T
+        return np.vstack([(indices[i] + self.slice[i].start) * s
+                          for i, s in zip(range(self._ndim), self._spacing)]).T
 
     @property
     @only2d
@@ -421,7 +429,7 @@ class RegionProperties:
 
     @property
     def extent(self):
-        return self.area / self.image.size
+        return self.area / self.area_bbox
 
     @property
     def feret_diameter_max(self):
@@ -433,12 +441,12 @@ class RegionProperties:
         elif self._ndim == 3:
             coordinates, _, _, _ = marching_cubes(identity_convex_hull,
                                                   level=.5)
-        distances = pdist(coordinates, 'sqeuclidean')
+        distances = pdist(coordinates * self._spacing, 'sqeuclidean')
         return sqrt(np.max(distances))
 
     @property
     def area_filled(self):
-        return np.sum(self.image_filled)
+        return np.sum(self.image_filled) * self.pixel_area
 
     @property
     @_cached
@@ -455,7 +463,7 @@ class RegionProperties:
     @_cached
     def inertia_tensor(self):
         mu = self.moments_central
-        return _moments.inertia_tensor(self.image, mu)
+        return _moments.inertia_tensor(self.image, mu, spacing=self._spacing)
 
     @property
     @_cached
@@ -530,19 +538,21 @@ class RegionProperties:
     @property
     @_cached
     def moments(self):
-        M = _moments.moments(self.image.astype(np.uint8), 3)
+        M = _moments.moments(self.image.astype(np.uint8), 3, spacing=self._spacing)
         return M
 
     @property
     @_cached
     def moments_central(self):
         mu = _moments.moments_central(self.image.astype(np.uint8),
-                                      self.centroid_local, order=3)
+                                      self.centroid_local, order=3, spacing=self._spacing)
         return mu
 
     @property
     @only2d
     def moments_hu(self):
+        if not (np.array(self._spacing) == np.array([1, 1])).all():
+            raise NotImplementedError('`moments_hu` supports spacing = (1, 1) only')
         return _moments.moments_hu(self.moments_normalized)
 
     @property
@@ -565,12 +575,16 @@ class RegionProperties:
     @property
     @only2d
     def perimeter(self):
-        return perimeter(self.image, 4)
+        if len(np.unique(self._spacing)) != 1:
+            raise NotImplementedError('`perimeter` supports isotropic spacings only')
+        return perimeter(self.image, 4) * self._spacing[0]
 
     @property
     @only2d
     def perimeter_crofton(self):
-        return perimeter_crofton(self.image, 4)
+        if len(np.unique(self._spacing)) != 1:
+            raise NotImplementedError('`perimeter` supports isotropic spacings only')
+        return perimeter_crofton(self.image, 4) * self._spacing[0]
 
     @property
     def solidity(self):
@@ -599,12 +613,12 @@ class RegionProperties:
         image = self._image_intensity_double()
         if self._multichannel:
             moments = np.stack(
-                    [_moments.moments(image[..., i], order=3)
-                        for i in range(image.shape[-1])],
-                    axis=-1,
-                    )
+                [_moments.moments(image[..., i], order=3, spacing=self._spacing)
+                 for i in range(image.shape[-1])],
+                axis=-1,
+            )
         else:
-            moments = _moments.moments(image, order=3)
+            moments = _moments.moments(image, order=3, spacing=self._spacing)
         return moments
 
     @property
@@ -615,18 +629,20 @@ class RegionProperties:
         if self._multichannel:
             moments_list = [
                 _moments.moments_central(
-                    image[..., i], center=ctr[..., i], order=3
+                    image[..., i], center=ctr[..., i], order=3, spacing=self._spacing
                 )
                 for i in range(image.shape[-1])
             ]
             moments = np.stack(moments_list, axis=-1)
         else:
-            moments = _moments.moments_central(image, ctr, order=3)
+            moments = _moments.moments_central(image, ctr, order=3, spacing=self._spacing)
         return moments
 
     @property
     @only2d
     def moments_weighted_hu(self):
+        if not (np.array(self._spacing) == np.array([1, 1])).all():
+            raise NotImplementedError('`moments_hu` supports spacing = (1, 1) only')
         nu = self.moments_weighted_normalized
         if self._multichannel:
             nchannels = self._intensity_image.shape[-1]
@@ -838,7 +854,7 @@ def _props_to_dict(regions, properties=('label', 'bbox'), separator='-'):
 def regionprops_table(label_image, intensity_image=None,
                       properties=('label', 'bbox'),
                       *,
-                      cache=True, separator='-', extra_properties=None):
+                      cache=True, separator='-', extra_properties=None, spacing=None):
     """Compute image properties and return them as a pandas-compatible table.
 
     The table is a dictionary mapping column names to value arrays. See Notes
@@ -887,6 +903,8 @@ def regionprops_table(label_image, intensity_image=None,
         issued. A property computation function must take a region mask as its
         first argument. If the property requires an intensity image, it must
         accept the intensity image as the second argument.
+    spacing: tuple of float, shape (ndim, )
+        The pixel spacing along each axis of the image.
 
     Returns
     -------
@@ -972,10 +990,10 @@ def regionprops_table(label_image, intensity_image=None,
 
     """
     regions = regionprops(label_image, intensity_image=intensity_image,
-                          cache=cache, extra_properties=extra_properties)
+                          cache=cache, extra_properties=extra_properties, spacing=spacing)
     if extra_properties is not None:
         properties = (
-            list(properties) + [prop.__name__ for prop in extra_properties]
+                list(properties) + [prop.__name__ for prop in extra_properties]
         )
     if len(regions) == 0:
         ndim = label_image.ndim
@@ -983,11 +1001,11 @@ def regionprops_table(label_image, intensity_image=None,
         label_image[(1,) * ndim] = 1
         if intensity_image is not None:
             intensity_image = np.zeros(
-                    label_image.shape + intensity_image.shape[ndim:],
-                    dtype=intensity_image.dtype
-                    )
+                label_image.shape + intensity_image.shape[ndim:],
+                dtype=intensity_image.dtype
+            )
         regions = regionprops(label_image, intensity_image=intensity_image,
-                              cache=cache, extra_properties=extra_properties)
+                              cache=cache, extra_properties=extra_properties, spacing=spacing)
 
         out_d = _props_to_dict(regions, properties=properties,
                                separator=separator)
@@ -999,7 +1017,7 @@ def regionprops_table(label_image, intensity_image=None,
 
 
 def regionprops(label_image, intensity_image=None, cache=True,
-                coordinates=None, *, extra_properties=None):
+                coordinates=None, *, extra_properties=None, spacing=None):
     r"""Measure properties of labeled image regions.
 
     Parameters
@@ -1047,6 +1065,8 @@ def regionprops(label_image, intensity_image=None, cache=True,
         issued. A property computation function must take a region mask as its
         first argument. If the property requires an intensity image, it must
         accept the intensity image as the second argument.
+    spacing: tuple of float, shape (ndim, )
+        The pixel spacing along each axis of the image.
 
     Returns
     -------
@@ -1058,16 +1078,17 @@ def regionprops(label_image, intensity_image=None, cache=True,
     -----
     The following properties can be accessed as attributes or keys:
 
-    **area** : int
-        Number of pixels of the region.
-    **area_bbox** : int
-        Number of pixels of bounding box.
-    **area_convex** : int
-        Number of pixels of convex hull image, which is the smallest convex
+    **pixel_area** : float
+        Area covered by a single pixel.
+    **area** : float
+        Area of the region i.e. number of pixels of the region scaled by pixel-area.
+    **area_bbox** : float
+        Area of the bounding box i.e. number of pixels of bounding box scaled by pixel-area.
+    **area_convex** : float
+        Are of the convex hull image, which is the smallest convex
         polygon that encloses the region.
-    **area_filled** : int
-        Number of pixels of the region will all the holes filled in. Describes
-        the area of the image_filled.
+    **area_filled** : float
+        Area of the region with all the holes filled in.
     **axis_major_length** : float
         The length of the major axis of the ellipse that has the same
         normalized second central moments as the region.
@@ -1253,14 +1274,14 @@ def regionprops(label_image, intensity_image=None, cache=True,
     if not np.issubdtype(label_image.dtype, np.integer):
         if np.issubdtype(label_image.dtype, bool):
             raise TypeError(
-                    'Non-integer image types are ambiguous: '
-                    'use skimage.measure.label to label the connected'
-                    'components of label_image,'
-                    'or label_image.astype(np.uint8) to interpret'
-                    'the True values as a single label.')
+                'Non-integer image types are ambiguous: '
+                'use skimage.measure.label to label the connected'
+                'components of label_image,'
+                'or label_image.astype(np.uint8) to interpret'
+                'the True values as a single label.')
         else:
             raise TypeError(
-                    'Non-integer label_image types are ambiguous')
+                'Non-integer label_image types are ambiguous')
 
     if coordinates is not None:
         if coordinates == 'rc':
@@ -1288,7 +1309,7 @@ def regionprops(label_image, intensity_image=None, cache=True,
         label = i + 1
 
         props = RegionProperties(sl, label, label_image, intensity_image,
-                                 cache, extra_properties=extra_properties)
+                                 cache, spacing=spacing, extra_properties=extra_properties)
         regions.append(props)
 
     return regions

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -33,6 +33,7 @@ PROPS = {
     # 'ConvexHull',
     'ConvexImage': 'image_convex',
     'convex_image': 'image_convex',
+    'Coordinates_Scaled': 'coords_scaled',
     'Coordinates': 'coords',
     'Eccentricity': 'eccentricity',
     'EquivDiameter': 'equivalent_diameter_area',
@@ -107,6 +108,7 @@ COL_DTYPES = {
     'centroid_local': float,
     'centroid_weighted': float,
     'centroid_weighted_local': float,
+    'coords_scaled': object,
     'coords': object,
     'eccentricity': float,
     'equivalent_diameter_area': float,
@@ -390,7 +392,7 @@ class RegionProperties:
 
     @property
     def centroid(self):
-        return tuple(self.coords.mean(axis=0))
+        return tuple(self.coords_scaled.mean(axis=0))
 
     @property
     @_cached
@@ -404,10 +406,16 @@ class RegionProperties:
         return convex_hull_image(self.image)
 
     @property
-    def coords(self):
+    def coords_scaled(self):
         indices = np.nonzero(self.image)
         return np.vstack([(indices[i] + self.slice[i].start) * s
                           for i, s in zip(range(self._ndim), self._spacing)]).T
+
+    @property
+    def coords(self):
+        indices = np.nonzero(self.image)
+        return np.vstack([indices[i] + self.slice[i].start
+                          for i in range(self._ndim)]).T
 
     @property
     @only2d
@@ -1111,6 +1119,8 @@ def regionprops(label_image, intensity_image=None, cache=True,
     **centroid_weighted_local** : array
         Centroid coordinate tuple ``(row, col)``, relative to region bounding
         box, weighted with intensity image.
+    **coords_scaled** : (N, 2) ndarray
+        Coordinate list ``(row, col)``of the region scaled by ``spacing``.
     **coords** : (N, 2) ndarray
         Coordinate list ``(row, col)`` of the region.
     **eccentricity** : float

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -556,7 +556,7 @@ class RegionProperties:
     @property
     @only2d
     def moments_hu(self):
-        if not (np.array(self._spacing) == np.array([1, 1])).all():
+        if any(s != 1.0 for s in self._spacing):
             raise NotImplementedError('`moments_hu` supports spacing = (1, 1) only')
         return _moments.moments_hu(self.moments_normalized)
 

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -21,7 +21,7 @@ __all__ = ['regionprops', 'euler_number', 'perimeter', 'perimeter_crofton']
 # releases. For backwards compatibility, these older names will continue to
 # work, but will not be documented.
 PROPS = {
-    'Pixel Area': 'pixel_area',
+    'NumPixels': 'num_pixels',
     'Area': 'area',
     'BoundingBox': 'bbox',
     'BoundingBoxArea': 'area_bbox',
@@ -95,7 +95,7 @@ OBJECT_COLUMNS = {
 }
 
 COL_DTYPES = {
-    'pixel_area': float,
+    'num_pixels': int,
     'area': float,
     'area_bbox': float,
     'area_convex': float,
@@ -306,6 +306,7 @@ class RegionProperties:
         self._multichannel = multichannel
         self._spatial_axes = tuple(range(self._ndim))
         self._spacing = (spacing if spacing is not None else np.full(self._ndim, 1.))
+        self._pixel_area = np.product(self._spacing)
 
         self._extra_properties = {}
         if extra_properties is not None:
@@ -364,13 +365,13 @@ class RegionProperties:
 
     @property
     @_cached
-    def pixel_area(self):
-        return np.prod(self._spacing)
+    def num_pixels(self):
+        return np.sum(self.image)
 
     @property
     @_cached
     def area(self):
-        return np.sum(self.image) * self.pixel_area
+        return np.sum(self.image) * self._pixel_area
 
     @property
     def bbox(self):
@@ -385,7 +386,7 @@ class RegionProperties:
 
     @property
     def area_bbox(self):
-        return self.image.size * self.pixel_area
+        return self.image.size * self._pixel_area
 
     @property
     def centroid(self):
@@ -394,7 +395,7 @@ class RegionProperties:
     @property
     @_cached
     def area_convex(self):
-        return np.sum(self.image_convex) * self.pixel_area
+        return np.sum(self.image_convex) * self._pixel_area
 
     @property
     @_cached
@@ -446,7 +447,7 @@ class RegionProperties:
 
     @property
     def area_filled(self):
-        return np.sum(self.image_filled) * self.pixel_area
+        return np.sum(self.image_filled) * self._pixel_area
 
     @property
     @_cached
@@ -1078,8 +1079,8 @@ def regionprops(label_image, intensity_image=None, cache=True,
     -----
     The following properties can be accessed as attributes or keys:
 
-    **pixel_area** : float
-        Area covered by a single pixel.
+    **num_pixels** : int
+        Number of foreground pixels.
     **area** : float
         Area of the region i.e. number of pixels of the region scaled by pixel-area.
     **area_bbox** : float

--- a/skimage/measure/tests/test_moments.py
+++ b/skimage/measure/tests/test_moments.py
@@ -24,6 +24,18 @@ def test_moments():
     assert_almost_equal(m[1, 0] / m[0, 0], 14.5)
     assert_almost_equal(m[0, 1] / m[0, 0], 14.5)
 
+def test_moments_spacing():
+    spacing = (1.4, 2)
+    image = np.zeros((20, 20), dtype=np.double)
+    image[14, 14] = 1
+    image[15, 15] = 1
+    image[14, 15] = 0.5
+    image[15, 14] = 0.5
+    m = moments(image, spacing=spacing)
+    assert_equal(m[0, 0], 3)
+    assert_almost_equal(m[1, 0] / m[0, 0], 14.5 * spacing[0])
+    assert_almost_equal(m[0, 1] / m[0, 0], 14.5 * spacing[1])
+
 
 def test_moments_central():
     image = np.zeros((20, 20), dtype=np.double)

--- a/skimage/measure/tests/test_moments.py
+++ b/skimage/measure/tests/test_moments.py
@@ -48,6 +48,33 @@ def test_moments_central():
     assert_equal(mu, mu2)
 
 
+def test_moments_central_spacing():
+    spacing = (2, 1)
+    image = np.zeros((20, 20), dtype=np.double)
+    image[14, 14] = 1
+    image[15, 15] = 1
+    image[14, 15] = 0.5
+    image[15, 14] = 0.5
+    mu = moments_central(image, (14.5 * spacing[0], 14.5 * spacing[1]),
+                         spacing=spacing)
+
+    # check for proper centroid computation
+    mu_calc_centroid = moments_central(image, spacing=spacing)
+    assert_equal(mu, mu_calc_centroid)
+
+    # shift image by dx=2, dy=2
+    image2 = np.zeros((20, 20), dtype=np.double)
+    image2[16, 16] = 1
+    image2[17, 17] = 1
+    image2[16, 17] = 0.5
+    image2[17, 16] = 0.5
+    mu2 = moments_central(image2,
+                          ((14.5 + 2) * spacing[0], (14.5 + 2) * spacing[1]),
+                          spacing=spacing)
+    # central moments must be translation invariant
+    assert_equal(mu, mu2)
+
+
 def test_moments_coords():
     image = np.zeros((20, 20), dtype=np.double)
     image[13:17, 13:17] = 1

--- a/skimage/measure/tests/test_moments.py
+++ b/skimage/measure/tests/test_moments.py
@@ -154,6 +154,30 @@ def test_moments_normalized():
     assert_almost_equal(nu, nu2, decimal=1)
 
 
+def test_moments_normalized_spacing():
+    image = np.zeros((20, 20), dtype=np.double)
+    image[13:17, 13:17] = 1
+    mu = moments_central(image)
+    nu = moments_normalized(mu)
+
+    # scale up via spacing
+    spacing = (3, 3)
+    mu2 = moments_central(image, spacing=spacing)
+    nu2 = moments_normalized(mu2, spacing=spacing)
+    assert_almost_equal(nu, nu2)
+
+    # anisotropic spacing
+    spacing = (1, 2)
+    mu = moments_central(image, spacing=spacing)
+    nu = moments_normalized(mu, spacing=spacing)
+
+    # scale up via spacing
+    spacing = (2, 4)
+    mu2 = moments_central(image, spacing=spacing)
+    nu2 = moments_normalized(mu2, spacing=spacing)
+    assert_almost_equal(nu, nu2)
+
+
 def test_moments_normalized_3d():
     image = draw.ellipsoid(1, 1, 10)
     mu_image = moments_central(image)

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -105,6 +105,9 @@ def test_all_props_3d():
 
 
 def test_pixel_size():
+    pixel_area = regionprops(np.ones((10, 10), dtype=np.uint8))[0].pixel_area
+    assert pixel_area == 1
+
     pixel_area = regionprops(np.ones((10, 10), dtype=np.uint8), spacing=(2, 1))[0].pixel_area
     assert pixel_area == 2 * 1
 

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -8,6 +8,7 @@ from numpy.testing import (assert_allclose, assert_almost_equal,
                            assert_equal, assert_raises)
 
 from skimage import data, draw, transform
+from skimage._shared import testing
 from skimage._shared._warnings import expected_warnings
 from skimage.measure._regionprops import (COL_DTYPES, OBJECT_COLUMNS, PROPS,
                                           _inertia_eigvals_to_axes_lengths_3D,
@@ -458,6 +459,9 @@ def test_moments_hu():
     # bug in OpenCV caused in Central Moments calculation?
     assert_array_almost_equal(hu, ref)
 
+    with testing.raises(NotImplementedError):
+        per = regionprops(SAMPLE, spacing=(2, 1))[0].moments_hu
+
 
 def test_image():
     img = regionprops(SAMPLE)[0].image
@@ -645,6 +649,9 @@ def test_perimeter():
         per = perimeter(SAMPLE.astype('double'), neighbourhood=8)
     assert_almost_equal(per, 46.8284271247)
 
+    with testing.raises(NotImplementedError):
+        per = regionprops(SAMPLE, spacing=(2, 1))[0].perimeter
+
 
 def test_perimeter_crofton():
     per = regionprops(SAMPLE)[0].perimeter_crofton
@@ -655,6 +662,9 @@ def test_perimeter_crofton():
 
     per = perimeter_crofton(SAMPLE.astype('double'), directions=2)
     assert_almost_equal(per, 64.4026493985)
+
+    with testing.raises(NotImplementedError):
+        per = regionprops(SAMPLE, spacing=(2, 1))[0].perimeter_crofton
 
 
 def test_solidity():
@@ -766,6 +776,9 @@ def test_moments_weighted_hu():
         -6.7936409056e-06
     ])
     assert_array_almost_equal(whu, ref)
+
+    with testing.raises(NotImplementedError):
+        per = regionprops(SAMPLE, spacing=(2, 1))[0].moments_weighted_hu
 
 
 def test_moments_weighted():

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -513,6 +513,18 @@ def test_axis_major_length():
     length = regionprops(SAMPLE, spacing=(2, 2))[0].axis_major_length
     assert_almost_equal(length, 2 * target_length)
 
+    from skimage.draw import ellipse
+    img = np.zeros((20, 24), dtype=np.uint8)
+    rr, cc = ellipse(11, 11, 7, 9, rotation=np.deg2rad(45))
+    img[rr, cc] = 1
+
+    target_length = regionprops(img, spacing=(1, 1))[0].axis_major_length
+    length_wo_spacing = regionprops(img[::2], spacing=(1, 1))[
+        0].axis_minor_length
+    assert abs(length_wo_spacing - target_length) > 0.1
+    length = regionprops(img[:, ::2], spacing=(1, 2))[0].axis_major_length
+    assert_almost_equal(length, target_length, decimal=1)
+
 
 def test_intensity_max():
     intensity = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE
@@ -541,6 +553,18 @@ def test_axis_minor_length():
 
     length = regionprops(SAMPLE, spacing=(1.5, 1.5))[0].axis_minor_length
     assert_almost_equal(length, 1.5 * target_length)
+
+    from skimage.draw import ellipse
+    img = np.zeros((10, 12), dtype=np.uint8)
+    rr, cc = ellipse(5, 6, 3, 5, rotation=np.deg2rad(30))
+    img[rr, cc] = 1
+
+    target_length = regionprops(img, spacing=(1, 1))[0].axis_minor_length
+    length_wo_spacing = regionprops(img[::2], spacing=(1, 1))[
+        0].axis_minor_length
+    assert abs(length_wo_spacing - target_length) > 0.1
+    length = regionprops(img[::2], spacing=(2, 1))[0].axis_minor_length
+    assert_almost_equal(length, target_length, decimal=1)
 
 
 def test_moments():

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -5,7 +5,7 @@ import pytest
 import scipy.ndimage as ndi
 from numpy.testing import (assert_allclose, assert_almost_equal,
                            assert_array_almost_equal, assert_array_equal,
-                           assert_equal)
+                           assert_equal, assert_raises)
 
 from skimage import data, draw, transform
 from skimage._shared._warnings import expected_warnings
@@ -43,6 +43,33 @@ SAMPLE_3D[3, 2, 2] = 1
 INTENSITY_SAMPLE_3D = SAMPLE_3D.copy()
 
 
+def get_moment_function(img, spacing=(1, 1)):
+    rows, cols = img.shape
+    Y, X = np.meshgrid(np.linspace(0, rows * spacing[0], rows, endpoint=False),
+                       np.linspace(0, cols * spacing[1], cols, endpoint=False), indexing='ij')
+    return lambda p, q: np.sum(Y ** p * X ** q * img)
+
+
+def get_moment3D_function(img, spacing=(1, 1, 1)):
+    slices, rows, cols = img.shape
+    Z, Y, X = np.meshgrid(np.linspace(0, slices * spacing[0], slices, endpoint=False),
+                          np.linspace(0, rows * spacing[1], rows, endpoint=False),
+                          np.linspace(0, cols * spacing[2], cols, endpoint=False), indexing='ij')
+    return lambda p, q, r: np.sum(Z ** p * Y ** q * X ** r * img)
+
+
+def get_central_moment_function(img, spacing=(1, 1)):
+    rows, cols = img.shape
+    Y, X = np.meshgrid(np.linspace(0, rows * spacing[0], rows, endpoint=False),
+                       np.linspace(0, cols * spacing[1], cols, endpoint=False), indexing='ij')
+
+    Mpq = get_moment_function(img, spacing=spacing)
+    cY = Mpq(1, 0) / Mpq(0, 0)
+    cX = Mpq(0, 1) / Mpq(0, 0)
+
+    return lambda p, q: np.sum((Y - cY) ** p * (X - cX) ** q * img)
+
+
 def test_all_props():
     region = regionprops(SAMPLE, INTENSITY_SAMPLE)[0]
     for prop in PROPS:
@@ -77,6 +104,11 @@ def test_all_props_3d():
             pass
 
 
+def test_pixel_size():
+    pixel_area = regionprops(np.ones((10, 10), dtype=np.uint8), spacing=(2, 1))[0].pixel_area
+    assert pixel_area == 2 * 1
+
+
 def test_dtype():
     regionprops(np.zeros((10, 10), dtype=int))
     regionprops(np.zeros((10, 10), dtype=np.uint))
@@ -103,11 +135,22 @@ def test_feret_diameter_max():
     comparator_result = 18
     test_result = regionprops(SAMPLE)[0].feret_diameter_max
     assert np.abs(test_result - comparator_result) < 1
+    comparator_result_spacing = 10
+    test_result_spacing = regionprops(SAMPLE, spacing=[1, 0.1])[0].feret_diameter_max
+    assert np.abs(test_result_spacing - comparator_result_spacing) < 1
     # square, test that maximum Feret diameter is sqrt(2) * square side
     img = np.zeros((20, 20), dtype=np.uint8)
     img[2:-2, 2:-2] = 1
     feret_diameter_max = regionprops(img)[0].feret_diameter_max
     assert np.abs(feret_diameter_max - 16 * np.sqrt(2)) < 1
+    # Due to marching-squares with a level of .5 the diagonal goes from (0, 0.5) to (16, 15.5).
+    assert np.abs(feret_diameter_max - np.sqrt(16 ** 2 + (16 - 1) ** 2)) < 1e-6
+    spacing = (2, 1)
+    feret_diameter_max = regionprops(img, spacing=spacing)[0].feret_diameter_max
+    # For anisotropic spacing the shift is applied to the smaller spacing.
+    assert np.abs(feret_diameter_max - np.sqrt(
+        (spacing[0] * 16 - (spacing[0] <= spacing[1])) ** 2 +
+        (spacing[1] * 16 - (spacing[1] < spacing[0])) ** 2)) < 1e-6
 
 
 def test_feret_diameter_max_3d():
@@ -115,26 +158,57 @@ def test_feret_diameter_max_3d():
     img[2:-2, 2:-2] = 1
     img_3d = np.dstack((img,) * 3)
     feret_diameter_max = regionprops(img_3d)[0].feret_diameter_max
-    assert np.abs(feret_diameter_max - 16 * np.sqrt(2)) < 1
+    # Due to marching-cubes with a level of .5 -1=2*0.5 has to be subtracted from two axes.
+    # There are three combinations (x-1, y-1, z), (x-1, y, z-1), (x, y-1, z-1). The option
+    # yielding the longest diagonal is the computed max_feret_diameter.
+    assert np.abs(feret_diameter_max - np.sqrt((16 - 1) ** 2 + 16 ** 2 + (3 - 1) ** 2)) < 1e-6
+    spacing = (1, 2, 3)
+    feret_diameter_max = regionprops(img_3d, spacing=spacing)[0].feret_diameter_max
+    # The longest of the three options is the max_feret_diameter
+    assert np.abs(feret_diameter_max - np.sqrt(
+        (spacing[0] * (16 - 1)) ** 2 +
+        (spacing[1] * (16 - 0)) ** 2 +
+        (spacing[2] * (3 - 1)) ** 2)) < 1e-6
+    assert np.abs(feret_diameter_max - np.sqrt(
+        (spacing[0] * (16 - 1)) ** 2 +
+        (spacing[1] * (16 - 1)) ** 2 +
+        (spacing[2] * (3 - 0)) ** 2)) > 1e-6
+    assert np.abs(feret_diameter_max - np.sqrt(
+        (spacing[0] * (16 - 0)) ** 2 +
+        (spacing[1] * (16 - 1)) ** 2 +
+        (spacing[2] * (3 - 1)) ** 2)) > 1e-6
 
 
 def test_area():
     area = regionprops(SAMPLE)[0].area
     assert area == np.sum(SAMPLE)
+    spacing = (1, 2)
+    area = regionprops(SAMPLE, spacing=spacing)[0].area
+    assert area == np.sum(SAMPLE * np.prod(spacing))
     area = regionprops(SAMPLE_3D)[0].area
     assert area == np.sum(SAMPLE_3D)
+    spacing = (2, 1, 3)
+    area = regionprops(SAMPLE_3D, spacing=spacing)[0].area
+    assert area == np.sum(SAMPLE_3D * np.prod(spacing))
 
 
 def test_bbox():
     bbox = regionprops(SAMPLE)[0].bbox
     assert_array_almost_equal(bbox, (0, 0, SAMPLE.shape[0], SAMPLE.shape[1]))
 
+    bbox = regionprops(SAMPLE, spacing=(1, 2))[0].bbox
+    assert_array_almost_equal(bbox, (0, 0, SAMPLE.shape[0], SAMPLE.shape[1]))
+
     SAMPLE_mod = SAMPLE.copy()
     SAMPLE_mod[:, -1] = 0
     bbox = regionprops(SAMPLE_mod)[0].bbox
-    assert_array_almost_equal(bbox, (0, 0, SAMPLE.shape[0], SAMPLE.shape[1]-1))
+    assert_array_almost_equal(bbox, (0, 0, SAMPLE.shape[0], SAMPLE.shape[1] - 1))
+    bbox = regionprops(SAMPLE_mod, spacing=(3, 2))[0].bbox
+    assert_array_almost_equal(bbox, (0, 0, SAMPLE.shape[0], SAMPLE.shape[1] - 1))
 
     bbox = regionprops(SAMPLE_3D)[0].bbox
+    assert_array_almost_equal(bbox, (1, 1, 1, 4, 3, 3))
+    bbox = regionprops(SAMPLE_3D, spacing=(0.5, 2, 7))[0].bbox
     assert_array_almost_equal(bbox, (1, 1, 1, 4, 3, 3))
 
 
@@ -142,6 +216,10 @@ def test_area_bbox():
     padded = np.pad(SAMPLE, 5, mode='constant')
     bbox_area = regionprops(padded)[0].area_bbox
     assert_array_almost_equal(bbox_area, SAMPLE.size)
+
+    spacing = (0.5, 3)
+    bbox_area = regionprops(padded, spacing=spacing)[0].area_bbox
+    assert_array_almost_equal(bbox_area, SAMPLE.size * np.prod(spacing))
 
 
 def test_moments_central():
@@ -156,11 +234,50 @@ def test_moments_central():
     assert_almost_equal(mu[1, 2], 2000.296296296291)
     assert_almost_equal(mu[0, 3], -760.0246913580195)
 
+    # Verify central moment test functions
+    centralMpq = get_central_moment_function(SAMPLE, spacing=(1, 1))
+    assert_almost_equal(centralMpq(2, 0), mu[2, 0])
+    assert_almost_equal(centralMpq(3, 0), mu[3, 0])
+    assert_almost_equal(centralMpq(1, 1), mu[1, 1])
+    assert_almost_equal(centralMpq(2, 1), mu[2, 1])
+    assert_almost_equal(centralMpq(0, 2), mu[0, 2])
+    assert_almost_equal(centralMpq(1, 2), mu[1, 2])
+    assert_almost_equal(centralMpq(0, 3), mu[0, 3])
+
+    # Test spacing against verified central moment test function
+    spacing = (1.8, 0.8)
+    centralMpq = get_central_moment_function(SAMPLE, spacing=spacing)
+
+    mu = regionprops(SAMPLE, spacing=spacing)[0].moments_central
+    assert_almost_equal(mu[2, 0], centralMpq(2, 0))
+    assert_almost_equal(mu[3, 0], centralMpq(3, 0))
+    assert_almost_equal(mu[1, 1], centralMpq(1, 1))
+    assert_almost_equal(mu[2, 1], centralMpq(2, 1))
+    assert_almost_equal(mu[0, 2], centralMpq(0, 2))
+    assert_almost_equal(mu[1, 2], centralMpq(1, 2))
+    assert_almost_equal(mu[0, 3], centralMpq(0, 3))
+
 
 def test_centroid():
     centroid = regionprops(SAMPLE)[0].centroid
     # determined with MATLAB
     assert_array_almost_equal(centroid, (5.66666666666666, 9.444444444444444))
+
+    # Verify test moment function with spacing=(1, 1)
+    Mpq = get_moment_function(SAMPLE, spacing=(1, 1))
+    cY = Mpq(1, 0) / Mpq(0, 0)
+    cX = Mpq(0, 1) / Mpq(0, 0)
+
+    assert_array_almost_equal((cY, cX), centroid)
+
+    spacing = (1.8, 0.8)
+    # Moment
+    Mpq = get_moment_function(SAMPLE, spacing=spacing)
+    cY = Mpq(1, 0) / Mpq(0, 0)
+    cX = Mpq(0, 1) / Mpq(0, 0)
+
+    centroid = regionprops(SAMPLE, spacing=spacing)[0].centroid
+    assert_array_almost_equal(centroid, (cY, cX))
 
 
 def test_centroid_3d():
@@ -168,10 +285,30 @@ def test_centroid_3d():
     # determined by mean along axis 1 of SAMPLE_3D.nonzero()
     assert_array_almost_equal(centroid, (1.66666667, 1.55555556, 1.55555556))
 
+    # Verify moment 3D test function
+    Mpqr = get_moment3D_function(SAMPLE_3D, spacing=(1, 1, 1))
+    cZ = Mpqr(1, 0, 0) / Mpqr(0, 0, 0)
+    cY = Mpqr(0, 1, 0) / Mpqr(0, 0, 0)
+    cX = Mpqr(0, 0, 1) / Mpqr(0, 0, 0)
+    assert_array_almost_equal((cZ, cY, cX), centroid)
+
+    # Test spacing
+    spacing = (2, 1, 0.8)
+    Mpqr = get_moment3D_function(SAMPLE_3D, spacing=spacing)
+    cZ = Mpqr(1, 0, 0) / Mpqr(0, 0, 0)
+    cY = Mpqr(0, 1, 0) / Mpqr(0, 0, 0)
+    cX = Mpqr(0, 0, 1) / Mpqr(0, 0, 0)
+    centroid = regionprops(SAMPLE_3D, spacing=spacing)[0].centroid
+    assert_array_almost_equal(centroid, (cZ, cY, cX))
+
 
 def test_area_convex():
     area = regionprops(SAMPLE)[0].area_convex
     assert area == 125
+
+    spacing = (1, 4)
+    area = regionprops(SAMPLE, spacing=spacing)[0].area_convex
+    assert area == 125 * np.prod(spacing)
 
 
 def test_image_convex():
@@ -198,18 +335,30 @@ def test_coordinates():
     prop_coords = regionprops(sample)[0].coords
     assert_array_equal(prop_coords, coords)
 
+    spacing = (1, 0.5)
+    prop_coords = regionprops(sample, spacing=spacing)[0].coords
+    assert_array_equal(prop_coords, coords * np.array(spacing))
+
     sample = np.zeros((6, 6, 6), dtype=np.int8)
     coords = np.array([[1, 1, 1], [1, 2, 1], [1, 3, 1]])
     sample[coords[:, 0], coords[:, 1], coords[:, 2]] = 1
     prop_coords = regionprops(sample)[0].coords
     assert_array_equal(prop_coords, coords)
 
+    spacing = (0.2, 3, 2.3)
+    prop_coords = regionprops(sample, spacing=spacing)[0].coords
+    assert_array_equal(prop_coords, coords * np.array(spacing))
+
 
 def test_slice():
     padded = np.pad(SAMPLE, ((2, 4), (5, 2)), mode='constant')
     nrow, ncol = SAMPLE.shape
     result = regionprops(padded)[0].slice
-    expected = (slice(2, 2+nrow), slice(5, 5+ncol))
+    expected = (slice(2, 2 + nrow), slice(5, 5 + ncol))
+    assert_equal(result, expected)
+
+    spacing = (2, 0.2)
+    result = regionprops(padded, spacing=spacing)[0].slice
     assert_equal(result, expected)
 
 
@@ -217,9 +366,15 @@ def test_eccentricity():
     eps = regionprops(SAMPLE)[0].eccentricity
     assert_almost_equal(eps, 0.814629313427)
 
+    eps = regionprops(SAMPLE, spacing=(1.5, 1.5))[0].eccentricity
+    assert_almost_equal(eps, 0.814629313427)
+
     img = np.zeros((5, 5), dtype=int)
     img[2, 2] = 1
     eps = regionprops(img)[0].eccentricity
+    assert_almost_equal(eps, 0)
+
+    eps = regionprops(img, spacing=(3, 3))[0].eccentricity
     assert_almost_equal(eps, 0)
 
 
@@ -228,21 +383,27 @@ def test_equivalent_diameter_area():
     # determined with MATLAB
     assert_almost_equal(diameter, 9.57461472963)
 
+    spacing = (1, 3)
+    diameter = regionprops(SAMPLE, spacing=spacing)[0].equivalent_diameter_area
+    equivalent_area = np.pi * (diameter / 2.) ** 2
+    assert_almost_equal(equivalent_area, SAMPLE.sum() * np.prod(spacing))
+
 
 def test_euler_number():
-    en = regionprops(SAMPLE)[0].euler_number
-    assert en == 0
+    for spacing in [(1, 1), (2.1, 0.9)]:
+        en = regionprops(SAMPLE, spacing=spacing)[0].euler_number
+        assert en == 0
 
-    SAMPLE_mod = SAMPLE.copy()
-    SAMPLE_mod[7, -3] = 0
-    en = regionprops(SAMPLE_mod)[0].euler_number
-    assert en == -1
+        SAMPLE_mod = SAMPLE.copy()
+        SAMPLE_mod[7, -3] = 0
+        en = regionprops(SAMPLE_mod, spacing=spacing)[0].euler_number
+        assert en == -1
 
-    en = euler_number(SAMPLE, 1)
-    assert en == 2
+        en = euler_number(SAMPLE, 1)
+        assert en == 2
 
-    en = euler_number(SAMPLE_mod, 1)
-    assert en == 1
+        en = euler_number(SAMPLE_mod, 1)
+        assert en == 1
 
     en = euler_number(SAMPLE_3D, 1)
     assert en == 1
@@ -263,6 +424,8 @@ def test_euler_number():
 
 def test_extent():
     extent = regionprops(SAMPLE)[0].extent
+    assert_almost_equal(extent, 0.4)
+    extent = regionprops(SAMPLE, spacing=(5, 0.2))[0].extent
     assert_almost_equal(extent, 0.4)
 
 
@@ -301,14 +464,23 @@ def test_area_filled():
     area = regionprops(SAMPLE)[0].area_filled
     assert area == np.sum(SAMPLE)
 
+    spacing = (2, 1.2)
+    area = regionprops(SAMPLE, spacing=spacing)[0].area_filled
+    assert area == np.sum(SAMPLE) * np.prod(spacing)
+
     SAMPLE_mod = SAMPLE.copy()
     SAMPLE_mod[7, -3] = 0
     area = regionprops(SAMPLE_mod)[0].area_filled
     assert area == np.sum(SAMPLE)
 
+    area = regionprops(SAMPLE_mod, spacing=spacing)[0].area_filled
+    assert area == np.sum(SAMPLE) * np.prod(spacing)
+
 
 def test_image_filled():
     img = regionprops(SAMPLE)[0].image_filled
+    assert_array_equal(img, SAMPLE)
+    img = regionprops(SAMPLE, spacing=(1, 4))[0].image_filled
     assert_array_equal(img, SAMPLE)
 
 
@@ -316,7 +488,11 @@ def test_axis_major_length():
     length = regionprops(SAMPLE)[0].axis_major_length
     # MATLAB has different interpretation of ellipse than found in literature,
     # here implemented as found in literature
-    assert_almost_equal(length, 16.7924234999)
+    target_length = 16.7924234999
+    assert_almost_equal(length, target_length)
+
+    length = regionprops(SAMPLE, spacing=(2, 2))[0].axis_major_length
+    assert_almost_equal(length, 2 * target_length)
 
 
 def test_intensity_max():
@@ -341,7 +517,11 @@ def test_axis_minor_length():
     length = regionprops(SAMPLE)[0].axis_minor_length
     # MATLAB has different interpretation of ellipse than found in literature,
     # here implemented as found in literature
-    assert_almost_equal(length, 9.739302807263)
+    target_length = 9.739302807263
+    assert_almost_equal(length, target_length)
+
+    length = regionprops(SAMPLE, spacing=(1.5, 1.5))[0].axis_minor_length
+    assert_almost_equal(length, 1.5 * target_length)
 
 
 def test_moments():
@@ -358,6 +538,34 @@ def test_moments():
     assert_almost_equal(m[2, 1], 24836.0)
     assert_almost_equal(m[3, 0], 19776.0)
 
+    # Verify moment test function
+    Mpq = get_moment_function(SAMPLE, spacing=(1, 1))
+    assert_almost_equal(Mpq(0, 0), m[0, 0])
+    assert_almost_equal(Mpq(0, 1), m[0, 1])
+    assert_almost_equal(Mpq(0, 2), m[0, 2])
+    assert_almost_equal(Mpq(0, 3), m[0, 3])
+    assert_almost_equal(Mpq(1, 0), m[1, 0])
+    assert_almost_equal(Mpq(1, 1), m[1, 1])
+    assert_almost_equal(Mpq(1, 2), m[1, 2])
+    assert_almost_equal(Mpq(2, 0), m[2, 0])
+    assert_almost_equal(Mpq(2, 1), m[2, 1])
+    assert_almost_equal(Mpq(3, 0), m[3, 0])
+
+    # Test moment on spacing
+    spacing = (2, 0.3)
+    m = regionprops(SAMPLE, spacing=spacing)[0].moments
+    Mpq = get_moment_function(SAMPLE, spacing=spacing)
+    assert_almost_equal(m[0, 0], Mpq(0, 0))
+    assert_almost_equal(m[0, 1], Mpq(0, 1))
+    assert_almost_equal(m[0, 2], Mpq(0, 2))
+    assert_almost_equal(m[0, 3], Mpq(0, 3))
+    assert_almost_equal(m[1, 0], Mpq(1, 0))
+    assert_almost_equal(m[1, 1], Mpq(1, 1))
+    assert_almost_equal(m[1, 2], Mpq(1, 2))
+    assert_almost_equal(m[2, 0], Mpq(2, 0))
+    assert_almost_equal(m[2, 1], Mpq(2, 1))
+    assert_almost_equal(m[3, 0], Mpq(3, 0))
+
 
 def test_moments_normalized():
     nu = regionprops(SAMPLE)[0].moments_normalized
@@ -370,26 +578,53 @@ def test_moments_normalized():
     assert_almost_equal(nu[2, 0], 0.08410493827160502)
     assert_almost_equal(nu[2, 1], -0.002899800614433943)
 
+    spacing = (3, 3)
+    nu = regionprops(SAMPLE, spacing=spacing)[0].moments_normalized
+
+    # Rescaled values from above.
+    assert_almost_equal(nu[0, 2], 0.24301268861454037 * 3 ** 2)
+    assert_almost_equal(nu[0, 3], -0.017278118992041805 * 3 ** 3)
+    assert_almost_equal(nu[1, 1], -0.016846707818929982 * 3 ** 2)
+    assert_almost_equal(nu[1, 2], 0.045473992910668816 * 3 ** 3)
+    assert_almost_equal(nu[2, 0], 0.08410493827160502 * 3 ** 2)
+    assert_almost_equal(nu[2, 1], -0.002899800614433943 * 3 ** 3)
+
 
 def test_orientation():
     orient = regionprops(SAMPLE)[0].orientation
     # determined with MATLAB
-    assert_almost_equal(orient, -1.4663278802756865)
+    target_orient = -1.4663278802756865
+    assert_almost_equal(orient, target_orient)
+
+    orient = regionprops(SAMPLE, spacing=(2, 2))[0].orientation
+    assert_almost_equal(orient, target_orient)
+
     # test diagonal regions
     diag = np.eye(10, dtype=int)
     orient_diag = regionprops(diag)[0].orientation
     assert_almost_equal(orient_diag, -math.pi / 4)
+    orient_diag = regionprops(diag, spacing=(1, 2))[0].orientation
+    assert_almost_equal(orient_diag, np.arccos(0.5 / np.sqrt(1 + 0.5 ** 2)))
     orient_diag = regionprops(np.flipud(diag))[0].orientation
     assert_almost_equal(orient_diag, math.pi / 4)
+    orient_diag = regionprops(np.flipud(diag), spacing=(1, 2))[0].orientation
+    assert_almost_equal(orient_diag, -np.arccos(0.5 / np.sqrt(1 + 0.5 ** 2)))
     orient_diag = regionprops(np.fliplr(diag))[0].orientation
     assert_almost_equal(orient_diag, math.pi / 4)
+    orient_diag = regionprops(np.fliplr(diag), spacing=(1, 2))[0].orientation
+    assert_almost_equal(orient_diag, -np.arccos(0.5 / np.sqrt(1 + 0.5 ** 2)))
     orient_diag = regionprops(np.fliplr(np.flipud(diag)))[0].orientation
     assert_almost_equal(orient_diag, -math.pi / 4)
+    orient_diag = regionprops(np.fliplr(np.flipud(diag)), spacing=(1, 2))[0].orientation
+    assert_almost_equal(orient_diag, np.arccos(0.5 / np.sqrt(1 + 0.5 ** 2)))
 
 
 def test_perimeter():
     per = regionprops(SAMPLE)[0].perimeter
-    assert_almost_equal(per, 55.2487373415)
+    target_per = 55.2487373415
+    assert_almost_equal(per, target_per)
+    per = regionprops(SAMPLE, spacing=(2, 2))[0].perimeter
+    assert_almost_equal(per, 2 * target_per)
 
     with expected_warnings(["`neighbourhood` is a deprecated argument name"]):
         per = perimeter(SAMPLE.astype('double'), neighbourhood=8)
@@ -398,7 +633,10 @@ def test_perimeter():
 
 def test_perimeter_crofton():
     per = regionprops(SAMPLE)[0].perimeter_crofton
-    assert_almost_equal(per, 61.0800637973)
+    target_per_crof = 61.0800637973
+    assert_almost_equal(per, target_per_crof)
+    per = regionprops(SAMPLE, spacing=(2, 2))[0].perimeter_crofton
+    assert_almost_equal(per, 2 * target_per_crof)
 
     per = perimeter_crofton(SAMPLE.astype('double'), directions=2)
     assert_almost_equal(per, 64.4026493985)
@@ -406,7 +644,11 @@ def test_perimeter_crofton():
 
 def test_solidity():
     solidity = regionprops(SAMPLE)[0].solidity
-    assert_almost_equal(solidity, 0.576)
+    target_solidity = 0.576
+    assert_almost_equal(solidity, target_solidity)
+
+    solidity = regionprops(SAMPLE, spacing=(3, 9))[0].solidity
+    assert_almost_equal(solidity, target_solidity)
 
 
 def test_moments_weighted_central():
@@ -425,11 +667,75 @@ def test_moments_weighted_central():
     np.set_printoptions(precision=10)
     assert_array_almost_equal(wmu, ref)
 
+    # Verify test function
+    centralMpq = get_central_moment_function(INTENSITY_SAMPLE, spacing=(1, 1))
+    assert_almost_equal(centralMpq(0, 0), ref[0, 0])
+    assert_almost_equal(centralMpq(0, 1), ref[0, 1])
+    assert_almost_equal(centralMpq(0, 2), ref[0, 2])
+    assert_almost_equal(centralMpq(0, 3), ref[0, 3])
+    assert_almost_equal(centralMpq(1, 0), ref[1, 0])
+    assert_almost_equal(centralMpq(1, 1), ref[1, 1])
+    assert_almost_equal(centralMpq(1, 2), ref[1, 2])
+    assert_almost_equal(centralMpq(1, 3), ref[1, 3])
+    assert_almost_equal(centralMpq(2, 0), ref[2, 0])
+    assert_almost_equal(centralMpq(2, 1), ref[2, 1])
+    assert_almost_equal(centralMpq(2, 2), ref[2, 2])
+    assert_almost_equal(centralMpq(2, 3), ref[2, 3])
+    assert_almost_equal(centralMpq(3, 0), ref[3, 0])
+    assert_almost_equal(centralMpq(3, 1), ref[3, 1])
+    assert_almost_equal(centralMpq(3, 2), ref[3, 2])
+    assert_almost_equal(centralMpq(3, 3), ref[3, 3])
+
+    # Test spacing
+    spacing = (3.2, 1.2)
+    wmu = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE,
+                      spacing=spacing)[0].moments_weighted_central
+    centralMpq = get_central_moment_function(INTENSITY_SAMPLE, spacing=spacing)
+    assert_almost_equal(wmu[0, 0], centralMpq(0, 0))
+    assert_almost_equal(wmu[0, 1], centralMpq(0, 1))
+    assert_almost_equal(wmu[0, 2], centralMpq(0, 2))
+    assert_almost_equal(wmu[0, 3], centralMpq(0, 3))
+    assert_almost_equal(wmu[1, 0], centralMpq(1, 0))
+    assert_almost_equal(wmu[1, 1], centralMpq(1, 1))
+    assert_almost_equal(wmu[1, 2], centralMpq(1, 2))
+    assert_almost_equal(wmu[1, 3], centralMpq(1, 3))
+    assert_almost_equal(wmu[2, 0], centralMpq(2, 0))
+    assert_almost_equal(wmu[2, 1], centralMpq(2, 1))
+    assert_almost_equal(wmu[2, 2], centralMpq(2, 2))
+    assert_almost_equal(wmu[2, 3], centralMpq(2, 3))
+    assert_almost_equal(wmu[3, 0], centralMpq(3, 0))
+    assert_almost_equal(wmu[3, 1], centralMpq(3, 1))
+    assert_almost_equal(wmu[3, 2], centralMpq(3, 2))
+    assert_almost_equal(wmu[3, 3], centralMpq(3, 3))
+
 
 def test_centroid_weighted():
     centroid = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE
                            )[0].centroid_weighted
-    assert_array_almost_equal(centroid, (5.540540540540, 9.445945945945))
+    target_centroid = (5.540540540540, 9.445945945945)
+    assert_array_almost_equal(centroid, target_centroid)
+
+    # Verify test function
+    Mpq = get_moment_function(INTENSITY_SAMPLE, spacing=(1, 1))
+    cY = Mpq(0, 1) / Mpq(0, 0)
+    cX = Mpq(1, 0) / Mpq(0, 0)
+    assert_almost_equal((cX, cY), centroid)
+
+    # Test spacing
+    spacing = (2, 2)
+    Mpq = get_moment_function(INTENSITY_SAMPLE, spacing=spacing)
+    cY = Mpq(0, 1) / Mpq(0, 0)
+    cX = Mpq(1, 0) / Mpq(0, 0)
+    centroid = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE, spacing=spacing)[0].centroid_weighted
+    assert_almost_equal(centroid, (cX, cY))
+    assert_almost_equal(centroid, 2 * np.array(target_centroid))
+
+    spacing = (1.3, 0.7)
+    Mpq = get_moment_function(INTENSITY_SAMPLE, spacing=spacing)
+    cY = Mpq(0, 1) / Mpq(0, 0)
+    cX = Mpq(1, 0) / Mpq(0, 0)
+    centroid = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE, spacing=spacing)[0].centroid_weighted
+    assert_almost_equal(centroid, (cX, cY))
 
 
 def test_moments_weighted_hu():
@@ -458,17 +764,76 @@ def test_moments_weighted():
     )
     assert_array_almost_equal(wm, ref)
 
+    # Verify test function
+    Mpq = get_moment_function(INTENSITY_SAMPLE, spacing=(1, 1))
+    assert_almost_equal(Mpq(0, 0), ref[0, 0])
+    assert_almost_equal(Mpq(0, 1), ref[0, 1])
+    assert_almost_equal(Mpq(0, 2), ref[0, 2])
+    assert_almost_equal(Mpq(0, 3), ref[0, 3])
+    assert_almost_equal(Mpq(1, 0), ref[1, 0])
+    assert_almost_equal(Mpq(1, 1), ref[1, 1])
+    assert_almost_equal(Mpq(1, 2), ref[1, 2])
+    assert_almost_equal(Mpq(1, 3), ref[1, 3])
+    assert_almost_equal(Mpq(2, 0), ref[2, 0])
+    assert_almost_equal(Mpq(2, 1), ref[2, 1])
+    assert_almost_equal(Mpq(2, 2), ref[2, 2])
+    assert_almost_equal(Mpq(2, 3), ref[2, 3])
+    assert_almost_equal(Mpq(3, 0), ref[3, 0])
+    assert_almost_equal(Mpq(3, 1), ref[3, 1])
+    assert_almost_equal(Mpq(3, 2), ref[3, 2])
+    assert_almost_equal(Mpq(3, 3), ref[3, 3])
+
+    # Test spacing
+    spacing = (3.2, 1.2)
+    wmu = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE,
+                      spacing=spacing)[0].moments_weighted
+    Mpq = get_moment_function(INTENSITY_SAMPLE, spacing=spacing)
+    assert_almost_equal(wmu[0, 0], Mpq(0, 0))
+    assert_almost_equal(wmu[0, 1], Mpq(0, 1))
+    assert_almost_equal(wmu[0, 2], Mpq(0, 2))
+    assert_almost_equal(wmu[0, 3], Mpq(0, 3))
+    assert_almost_equal(wmu[1, 0], Mpq(1, 0))
+    assert_almost_equal(wmu[1, 1], Mpq(1, 1))
+    assert_almost_equal(wmu[1, 2], Mpq(1, 2))
+    assert_almost_equal(wmu[1, 3], Mpq(1, 3))
+    assert_almost_equal(wmu[2, 0], Mpq(2, 0))
+    assert_almost_equal(wmu[2, 1], Mpq(2, 1))
+    assert_almost_equal(wmu[2, 2], Mpq(2, 2))
+    assert_almost_equal(wmu[2, 3], Mpq(2, 3))
+    assert_almost_equal(wmu[3, 0], Mpq(3, 0))
+    assert_almost_equal(wmu[3, 1], Mpq(3, 1))
+    assert_almost_equal(wmu[3, 2], Mpq(3, 2))
+    assert_almost_equal(wmu[3, 3], Mpq(3, 3), decimal=6)
+
 
 def test_moments_weighted_normalized():
     wnu = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE
                       )[0].moments_weighted_normalized
     ref = np.array(
-        [[np.nan,        np.nan, 0.2301467830, -0.0162529732],
+        [[np.nan, np.nan, 0.2301467830, -0.0162529732],
          [np.nan, -0.0160405109, 0.0457932622, -0.0104598869],
          [0.0873590903, -0.0031421072, 0.0165315478, -0.0028544152],
          [-0.0161217406, -0.0031376984, 0.0043903193, -0.0011057191]]
     )
     assert_array_almost_equal(wnu, ref)
+
+    spacing = (3, 3)
+    wnu = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE, spacing=spacing)[0].moments_weighted_normalized
+
+    # Rescaled values from above.
+    assert_almost_equal(wnu[0, 2], 0.2301467830 * 3 ** 2)
+    assert_almost_equal(wnu[0, 3], -0.0162529732 * 3 ** 3)
+    assert_almost_equal(wnu[1, 1], -0.0160405109 * 3 ** 2)
+    assert_almost_equal(wnu[1, 2], 0.0457932622 * 3 ** 3)
+    assert_almost_equal(wnu[1, 3], -0.0104598869 * 3 ** 4)
+    assert_almost_equal(wnu[2, 0], 0.0873590903 * 3 ** 2)
+    assert_almost_equal(wnu[2, 1], -0.0031421072 * 3 ** 3)
+    assert_almost_equal(wnu[2, 2], 0.0165315478 * 3 ** 4)
+    assert_almost_equal(wnu[2, 3], -0.0028544152 * 3 ** 5)
+    assert_almost_equal(wnu[3, 0], -0.0161217406 * 3 ** 3)
+    assert_almost_equal(wnu[3, 1], -0.0031376984 * 3 ** 4)
+    assert_almost_equal(wnu[3, 2], 0.0043903193 * 3 ** 5)
+    assert_almost_equal(wnu[3, 3], -0.0011057191 * 3 ** 6)
 
 
 def test_label_sequence():

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -104,12 +104,12 @@ def test_all_props_3d():
             pass
 
 
-def test_pixel_size():
-    pixel_area = regionprops(np.ones((10, 10), dtype=np.uint8))[0].pixel_area
-    assert pixel_area == 1
+def test_num_pixels():
+    num_pixels = regionprops(SAMPLE)[0].num_pixels
+    assert num_pixels == 72
 
-    pixel_area = regionprops(np.ones((10, 10), dtype=np.uint8), spacing=(2, 1))[0].pixel_area
-    assert pixel_area == 2 * 1
+    num_pixels = regionprops(SAMPLE, spacing=(2, 1))[0].num_pixels
+    assert num_pixels == 72
 
 
 def test_dtype():

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -337,19 +337,31 @@ def test_coordinates():
     sample[coords[:, 0], coords[:, 1]] = 1
     prop_coords = regionprops(sample)[0].coords
     assert_array_equal(prop_coords, coords)
+    prop_coords = regionprops(sample, spacing=(0.5, 1.2))[0].coords
+    assert_array_equal(prop_coords, coords)
+
+
+def test_coordinates_scaled():
+    sample = np.zeros((10, 10), dtype=np.int8)
+    coords = np.array([[3, 2], [3, 3], [3, 4]])
+    sample[coords[:, 0], coords[:, 1]] = 1
+
+    spacing = (1, 1)
+    prop_coords = regionprops(sample, spacing=spacing)[0].coords_scaled
+    assert_array_equal(prop_coords, coords * np.array(spacing))
 
     spacing = (1, 0.5)
-    prop_coords = regionprops(sample, spacing=spacing)[0].coords
+    prop_coords = regionprops(sample, spacing=spacing)[0].coords_scaled
     assert_array_equal(prop_coords, coords * np.array(spacing))
 
     sample = np.zeros((6, 6, 6), dtype=np.int8)
     coords = np.array([[1, 1, 1], [1, 2, 1], [1, 3, 1]])
     sample[coords[:, 0], coords[:, 1], coords[:, 2]] = 1
-    prop_coords = regionprops(sample)[0].coords
+    prop_coords = regionprops(sample)[0].coords_scaled
     assert_array_equal(prop_coords, coords)
 
     spacing = (0.2, 3, 2.3)
-    prop_coords = regionprops(sample, spacing=spacing)[0].coords
+    prop_coords = regionprops(sample, spacing=spacing)[0].coords_scaled
     assert_array_equal(prop_coords, coords * np.array(spacing))
 
 

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -596,13 +596,13 @@ def test_moments_normalized():
     spacing = (3, 3)
     nu = regionprops(SAMPLE, spacing=spacing)[0].moments_normalized
 
-    # Rescaled values from above.
-    assert_almost_equal(nu[0, 2], 0.24301268861454037 * 3 ** 2)
-    assert_almost_equal(nu[0, 3], -0.017278118992041805 * 3 ** 3)
-    assert_almost_equal(nu[1, 1], -0.016846707818929982 * 3 ** 2)
-    assert_almost_equal(nu[1, 2], 0.045473992910668816 * 3 ** 3)
-    assert_almost_equal(nu[2, 0], 0.08410493827160502 * 3 ** 2)
-    assert_almost_equal(nu[2, 1], -0.002899800614433943 * 3 ** 3)
+    # Normalized moments are scale invariant.
+    assert_almost_equal(nu[0, 2], 0.24301268861454037)
+    assert_almost_equal(nu[0, 3], -0.017278118992041805)
+    assert_almost_equal(nu[1, 1], -0.016846707818929982)
+    assert_almost_equal(nu[1, 2], 0.045473992910668816)
+    assert_almost_equal(nu[2, 0], 0.08410493827160502)
+    assert_almost_equal(nu[2, 1], -0.002899800614433943)
 
 
 def test_orientation():
@@ -835,20 +835,20 @@ def test_moments_weighted_normalized():
     spacing = (3, 3)
     wnu = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE, spacing=spacing)[0].moments_weighted_normalized
 
-    # Rescaled values from above.
-    assert_almost_equal(wnu[0, 2], 0.2301467830 * 3 ** 2)
-    assert_almost_equal(wnu[0, 3], -0.0162529732 * 3 ** 3)
-    assert_almost_equal(wnu[1, 1], -0.0160405109 * 3 ** 2)
-    assert_almost_equal(wnu[1, 2], 0.0457932622 * 3 ** 3)
-    assert_almost_equal(wnu[1, 3], -0.0104598869 * 3 ** 4)
-    assert_almost_equal(wnu[2, 0], 0.0873590903 * 3 ** 2)
-    assert_almost_equal(wnu[2, 1], -0.0031421072 * 3 ** 3)
-    assert_almost_equal(wnu[2, 2], 0.0165315478 * 3 ** 4)
-    assert_almost_equal(wnu[2, 3], -0.0028544152 * 3 ** 5)
-    assert_almost_equal(wnu[3, 0], -0.0161217406 * 3 ** 3)
-    assert_almost_equal(wnu[3, 1], -0.0031376984 * 3 ** 4)
-    assert_almost_equal(wnu[3, 2], 0.0043903193 * 3 ** 5)
-    assert_almost_equal(wnu[3, 3], -0.0011057191 * 3 ** 6)
+    # Normalized moments are scale invariant
+    assert_almost_equal(wnu[0, 2], 0.2301467830)
+    assert_almost_equal(wnu[0, 3], -0.0162529732)
+    assert_almost_equal(wnu[1, 1], -0.0160405109)
+    assert_almost_equal(wnu[1, 2], 0.0457932622)
+    assert_almost_equal(wnu[1, 3], -0.0104598869)
+    assert_almost_equal(wnu[2, 0], 0.0873590903)
+    assert_almost_equal(wnu[2, 1], -0.0031421072)
+    assert_almost_equal(wnu[2, 2], 0.0165315478)
+    assert_almost_equal(wnu[2, 3], -0.0028544152)
+    assert_almost_equal(wnu[3, 0], -0.0161217406)
+    assert_almost_equal(wnu[3, 1], -0.0031376984)
+    assert_almost_equal(wnu[3, 2], 0.0043903193)
+    assert_almost_equal(wnu[3, 3], -0.0011057191)
 
 
 def test_label_sequence():

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -523,7 +523,7 @@ def test_axis_major_length():
         0].axis_minor_length
     assert abs(length_wo_spacing - target_length) > 0.1
     length = regionprops(img[:, ::2], spacing=(1, 2))[0].axis_major_length
-    assert_almost_equal(length, target_length, decimal=1)
+    assert_almost_equal(length, target_length, decimal=0)
 
 
 def test_intensity_max():


### PR DESCRIPTION
## Description
Enhancement, closes https://github.com/scikit-image/scikit-image/issues/5112.
<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [x] Changes are covered by an  existing benchmark
- [x] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
