### PR TITLE
New thumbnail for "Datasets" example  by adjusting contrast

### DIFF
--- a/doc/examples/data/plot_3d.py
+++ b/doc/examples/data/plot_3d.py
@@ -17,10 +17,23 @@ to test the various functions of scikit-image.
 from skimage import data
 import plotly
 import plotly.express as px
+import numpy as np
 
 img = data.cells3d()[20:]
-fig = px.imshow(-img, facet_col=1, animation_frame=0,
-                binary_string=True, binary_format='jpg')
-fig.layout.annotations[0]['text'] = 'Cell membranes'
-fig.layout.annotations[1]['text'] = 'Nuclei'
+
+upper_limit = np.percentile(img, q=99)
+img = np.clip(img, 0, 1.2 * upper_limit)
+
+# omit some slices that are partially empty
+img = img[5:26]
+
+fig = px.imshow(
+    img,
+    facet_col=1,
+    animation_frame=0,
+    binary_string=True,
+    binary_format="jpg",
+)
+fig.layout.annotations[0]["text"] = "Cell membranes"
+fig.layout.annotations[1]["text"] = "Nuclei"
 plotly.io.show(fig)

--- a/doc/examples/data/plot_3d.py
+++ b/doc/examples/data/plot_3d.py
@@ -21,11 +21,11 @@ import numpy as np
 
 img = data.cells3d()[20:]
 
-upper_limit = np.percentile(img, q=99)
-img = np.clip(img, 0, 1.2 * upper_limit)
-
 # omit some slices that are partially empty
 img = img[5:26]
+
+upper_limit = 1.5 * np.percentile(img, q=99)
+img = np.clip(img, upper_limit)
 
 fig = px.imshow(
     img,

--- a/doc/examples/data/plot_3d.py
+++ b/doc/examples/data/plot_3d.py
@@ -19,7 +19,7 @@ import plotly
 import plotly.express as px
 
 img = data.cells3d()[20:]
-fig = px.imshow(img, facet_col=1, animation_frame=0,
+fig = px.imshow(-img, facet_col=1, animation_frame=0,
                 binary_string=True, binary_format='jpg')
 fig.layout.annotations[0]['text'] = 'Cell membranes'
 fig.layout.annotations[1]['text'] = 'Nuclei'

--- a/doc/examples/data/plot_3d.py
+++ b/doc/examples/data/plot_3d.py
@@ -25,7 +25,7 @@ img = data.cells3d()[20:]
 img = img[5:26]
 
 upper_limit = 1.5 * np.percentile(img, q=99)
-img = np.clip(img, upper_limit)
+img = np.clip(img, 0, upper_limit)
 
 fig = px.imshow(
     img,


### PR DESCRIPTION
I think inverting the color in the example "Datasets with 3 or more spatial dimensions" makes the cell membrane structure more visible and the thumbnail looks better as well.
<img width="500" alt="image" src="https://user-images.githubusercontent.com/44469195/159913202-8c41a0b0-218d-4ca2-9244-f4e4d0fb6bee.png">
EDIT: Here is the link:
https://output.circle-artifacts.com/output/job/36e91085-5da7-463c-8721-be3bda712e4a/artifacts/0/doc/build/html/auto_examples/index.html