### PR TITLE
New thumbnail for Specific images

### DIFF
--- a/doc/examples/data/plot_specific.py
+++ b/doc/examples/data/plot_specific.py
@@ -20,9 +20,9 @@ matplotlib.rcParams["font.size"] = 18
 fig, axes = plt.subplots(1, 2, figsize=(8, 4))
 ax = axes.ravel()
 
-cylce_images = data.stereo_motorcycle()
-ax[0].imshow(cylce_images[0])
-ax[1].imshow(cylce_images[1])
+cycle_images = data.stereo_motorcycle()
+ax[0].imshow(cycle_images[0])
+ax[1].imshow(cycle_images[1])
 
 fig.tight_layout()
 plt.show()
@@ -63,11 +63,20 @@ fig.tight_layout()
 plt.show()
 
 
+######################################################################
+# Thumbnail image for the gallery
+
+# sphinx_gallery_thumbnail_number = -1
+
+
 from matplotlib.offsetbox import AnchoredText
 
-ax0 = plt.subplot(2, 2, 1)
-ax0.imshow(cylce_images[0])
-ax0.add_artist(
+# Create a gridspec with two images in the first and 4 in the second row
+fig, axd = plt.subplot_mosaic(
+    [["stereo", "stereo", "piv", "piv"], ["lfw0", "lfw1", "lfw2", "lfw3"]],
+)
+axd["stereo"].imshow(cycle_images[0])
+axd["stereo"].add_artist(
     AnchoredText(
         "Stereo",
         prop=dict(size=20),
@@ -76,9 +85,8 @@ ax0.add_artist(
         loc="upper left",
     )
 )
-ax1 = plt.subplot(2, 2, 2)
-ax1.imshow(vortex_images[0])
-ax1.add_artist(
+axd["piv"].imshow(vortex_images[0])
+axd["piv"].add_artist(
     AnchoredText(
         "PIV",
         prop=dict(size=20),
@@ -87,16 +95,12 @@ ax1.add_artist(
         loc="upper left",
     )
 )
+axd["lfw0"].imshow(lfw_images[91], cmap="gray")
+axd["lfw1"].imshow(lfw_images[92], cmap="gray")
+axd["lfw2"].imshow(lfw_images[93], cmap="gray")
+axd["lfw3"].imshow(lfw_images[94], cmap="gray")
 
-ax2 = plt.subplot(2, 4, 5)
-ax2.imshow(lfw_images[90 + 1], cmap="gray")
-ax3 = plt.subplot(2, 4, 6)
-ax3.imshow(lfw_images[90 + 2], cmap="gray")
-ax4 = plt.subplot(2, 4, 7)
-ax4.imshow(lfw_images[90 + 3], cmap="gray")
-ax5 = plt.subplot(2, 4, 8)
-ax5.imshow(lfw_images[90 + 4], cmap="gray")
-for ax in [ax0, ax1, ax2, ax3, ax4, ax5]:
+for ax in axd.values():
     ax.axis("off")
-plt.tight_layout()
+fig.tight_layout()
 plt.show()

--- a/doc/examples/data/plot_specific.py
+++ b/doc/examples/data/plot_specific.py
@@ -9,7 +9,7 @@ import matplotlib
 
 from skimage import data
 
-matplotlib.rcParams['font.size'] = 18
+matplotlib.rcParams["font.size"] = 18
 
 ######################################################################
 #
@@ -20,9 +20,9 @@ matplotlib.rcParams['font.size'] = 18
 fig, axes = plt.subplots(1, 2, figsize=(8, 4))
 ax = axes.ravel()
 
-images = data.stereo_motorcycle()
-ax[0].imshow(images[0])
-ax[1].imshow(images[1])
+cylce_images = data.stereo_motorcycle()
+ax[0].imshow(cylce_images[0])
+ax[1].imshow(cylce_images[1])
 
 fig.tight_layout()
 plt.show()
@@ -37,9 +37,9 @@ plt.show()
 fig, axes = plt.subplots(1, 2, figsize=(8, 4))
 ax = axes.ravel()
 
-images = data.vortex()
-ax[0].imshow(images[0])
-ax[1].imshow(images[1])
+vortex_images = data.vortex()
+ax[0].imshow(vortex_images[0])
+ax[1].imshow(vortex_images[1])
 
 fig.tight_layout()
 plt.show()
@@ -55,9 +55,43 @@ plt.show()
 
 fig, axes = plt.subplots(4, 5, figsize=(20, 20))
 ax = axes.ravel()
-images = data.lfw_subset()
+lfs_images = data.lfw_subset()
 for i in range(20):
-    ax[i].imshow(images[90+i], cmap=plt.cm.gray)
+    ax[i].imshow(lfs_images[90+i], cmap=plt.cm.gray)
     ax[i].axis('off')
 fig.tight_layout()
 plt.show()
+
+
+
+
+############################################################################
+# Thumbnail image for the gallery
+
+# sphinx_gallery_thumbnail_number = -1
+from matplotlib.offsetbox import AnchoredText
+
+ax1 = plt.subplot(2, 2, 1)
+ax1.imshow(cylce_images[0])
+ax1.add_artist(
+    AnchoredText(
+        "Stereo", prop=dict(size=20), frameon=True, borderpad=0, loc="upper left"
+    )
+)
+ax2 = plt.subplot(2, 2, 2)
+ax2.imshow(vortex_images[0])
+ax2.add_artist(
+    AnchoredText("PIV", prop=dict(size=20), frameon=True, borderpad=0, loc="upper left")
+)
+
+ax3 = plt.subplot(2, 4, 5)
+ax3.imshow(lfs_images[90+1], cmap="gray")
+ax4 = plt.subplot(2, 4, 6)
+ax4.imshow(lfs_images[90+2], cmap="gray")
+ax5 = plt.subplot(2, 4, 7)
+ax5.imshow(lfs_images[90+3], cmap="gray")
+ax6 = plt.subplot(2, 4, 8)
+ax6.imshow(lfs_images[90+4], cmap="gray")
+for ax in [ax1, ax2, ax3, ax4, ax5, ax6]:
+    ax.axis("off")
+plt.tight_layout()

--- a/doc/examples/data/plot_specific.py
+++ b/doc/examples/data/plot_specific.py
@@ -57,15 +57,13 @@ fig, axes = plt.subplots(4, 5, figsize=(20, 20))
 ax = axes.ravel()
 lfs_images = data.lfw_subset()
 for i in range(20):
-    ax[i].imshow(lfs_images[90+i], cmap=plt.cm.gray)
-    ax[i].axis('off')
+    ax[i].imshow(lfs_images[90 + i], cmap=plt.cm.gray)
+    ax[i].axis("off")
 fig.tight_layout()
 plt.show()
 
 
-
-
-############################################################################
+######################################################################
 # Thumbnail image for the gallery
 
 # sphinx_gallery_thumbnail_number = -1
@@ -75,23 +73,34 @@ ax1 = plt.subplot(2, 2, 1)
 ax1.imshow(cylce_images[0])
 ax1.add_artist(
     AnchoredText(
-        "Stereo", prop=dict(size=20), frameon=True, borderpad=0, loc="upper left"
+        "Stereo",
+        prop=dict(size=20),
+        frameon=True,
+        borderpad=0,
+        loc="upper left",
     )
 )
 ax2 = plt.subplot(2, 2, 2)
 ax2.imshow(vortex_images[0])
 ax2.add_artist(
-    AnchoredText("PIV", prop=dict(size=20), frameon=True, borderpad=0, loc="upper left")
+    AnchoredText(
+        "PIV",
+        prop=dict(size=20),
+        frameon=True,
+        borderpad=0,
+        loc="upper left",
+    )
 )
 
 ax3 = plt.subplot(2, 4, 5)
-ax3.imshow(lfs_images[90+1], cmap="gray")
+ax3.imshow(lfs_images[90 + 1], cmap="gray")
 ax4 = plt.subplot(2, 4, 6)
-ax4.imshow(lfs_images[90+2], cmap="gray")
+ax4.imshow(lfs_images[90 + 2], cmap="gray")
 ax5 = plt.subplot(2, 4, 7)
-ax5.imshow(lfs_images[90+3], cmap="gray")
+ax5.imshow(lfs_images[90 + 3], cmap="gray")
 ax6 = plt.subplot(2, 4, 8)
-ax6.imshow(lfs_images[90+4], cmap="gray")
+ax6.imshow(lfs_images[90 + 4], cmap="gray")
 for ax in [ax1, ax2, ax3, ax4, ax5, ax6]:
     ax.axis("off")
 plt.tight_layout()
+plt.show()

--- a/doc/examples/data/plot_specific.py
+++ b/doc/examples/data/plot_specific.py
@@ -55,23 +55,19 @@ plt.show()
 
 fig, axes = plt.subplots(4, 5, figsize=(20, 20))
 ax = axes.ravel()
-lfs_images = data.lfw_subset()
+lfw_images = data.lfw_subset()
 for i in range(20):
-    ax[i].imshow(lfs_images[90 + i], cmap=plt.cm.gray)
+    ax[i].imshow(lfw_images[90 + i], cmap=plt.cm.gray)
     ax[i].axis("off")
 fig.tight_layout()
 plt.show()
 
 
-######################################################################
-# Thumbnail image for the gallery
-
-# sphinx_gallery_thumbnail_number = -1
 from matplotlib.offsetbox import AnchoredText
 
-ax1 = plt.subplot(2, 2, 1)
-ax1.imshow(cylce_images[0])
-ax1.add_artist(
+ax0 = plt.subplot(2, 2, 1)
+ax0.imshow(cylce_images[0])
+ax0.add_artist(
     AnchoredText(
         "Stereo",
         prop=dict(size=20),
@@ -80,9 +76,9 @@ ax1.add_artist(
         loc="upper left",
     )
 )
-ax2 = plt.subplot(2, 2, 2)
-ax2.imshow(vortex_images[0])
-ax2.add_artist(
+ax1 = plt.subplot(2, 2, 2)
+ax1.imshow(vortex_images[0])
+ax1.add_artist(
     AnchoredText(
         "PIV",
         prop=dict(size=20),
@@ -92,15 +88,15 @@ ax2.add_artist(
     )
 )
 
-ax3 = plt.subplot(2, 4, 5)
-ax3.imshow(lfs_images[90 + 1], cmap="gray")
-ax4 = plt.subplot(2, 4, 6)
-ax4.imshow(lfs_images[90 + 2], cmap="gray")
-ax5 = plt.subplot(2, 4, 7)
-ax5.imshow(lfs_images[90 + 3], cmap="gray")
-ax6 = plt.subplot(2, 4, 8)
-ax6.imshow(lfs_images[90 + 4], cmap="gray")
-for ax in [ax1, ax2, ax3, ax4, ax5, ax6]:
+ax2 = plt.subplot(2, 4, 5)
+ax2.imshow(lfw_images[90 + 1], cmap="gray")
+ax3 = plt.subplot(2, 4, 6)
+ax3.imshow(lfw_images[90 + 2], cmap="gray")
+ax4 = plt.subplot(2, 4, 7)
+ax4.imshow(lfw_images[90 + 3], cmap="gray")
+ax5 = plt.subplot(2, 4, 8)
+ax5.imshow(lfw_images[90 + 4], cmap="gray")
+for ax in [ax0, ax1, ax2, ax3, ax4, ax5]:
     ax.axis("off")
 plt.tight_layout()
 plt.show()


### PR DESCRIPTION
Another new thumbnail for the example gallery, this time for the section "Specific images":
<img width="300" alt="image" src="https://user-images.githubusercontent.com/44469195/159917140-cc0a4b07-7f5a-49ae-8ca6-f34b81657ad6.png">
Can be seen here:
https://output.circle-artifacts.com/output/job/3ec8a89d-525c-421f-809a-c3d250fbef65/artifacts/0/doc/build/html/auto_examples/index.html#data