### PR TITLE
Cython style: prefer cnp.float32_t and cnp.float64_t for clarity

### DIFF
--- a/skimage/_shared/fast_exp.pxd
+++ b/skimage/_shared/fast_exp.pxd
@@ -6,8 +6,8 @@ cimport numpy as cnp
 from .fused_numerics cimport np_floats
 
 cdef extern from "fast_exp.h":
-    double _fast_exp(double y) nogil
-    float _fast_expf(float y) nogil
+    cnp.float64_t _fast_exp(cnp.float64_t y) nogil
+    cnp.float32_t _fast_expf(cnp.float32_t y) nogil
 
 
 cdef inline np_floats _fast_exp_floats(np_floats x) nogil:

--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -294,8 +294,8 @@ def _circle_perimeter(Py_ssize_t r_o, Py_ssize_t c_o, Py_ssize_t radius,
     cdef Py_ssize_t r = radius
     cdef Py_ssize_t d = 0
 
-    cdef double dceil = 0
-    cdef double dceil_prev = 0
+    cdef cnp.float64_t dceil = 0
+    cdef cnp.float64_t dceil_prev = 0
 
     cdef char cmethod
     if method == 'bresenham':
@@ -374,8 +374,8 @@ def _circle_perimeter_aa(Py_ssize_t r_o, Py_ssize_t c_o,
     cdef Py_ssize_t r = radius
     cdef Py_ssize_t d = 0
 
-    cdef double dceil = 0
-    cdef double dceil_prev = 0
+    cdef cnp.float64_t dceil = 0
+    cdef cnp.float64_t dceil_prev = 0
 
     cdef list rr = [r, c,  r,  c, -r, -c, -r, -c]
     cdef list cc = [c, r, -c, -r,  c,  r, -c, -r]
@@ -407,7 +407,7 @@ def _circle_perimeter_aa(Py_ssize_t r_o, Py_ssize_t c_o,
 
 
 def _ellipse_perimeter(Py_ssize_t r_o, Py_ssize_t c_o, Py_ssize_t r_radius,
-                       Py_ssize_t c_radius, double orientation, shape):
+                       Py_ssize_t c_radius, cnp.float64_t orientation, shape):
     """Generate ellipse perimeter coordinates.
 
     Parameters
@@ -416,7 +416,7 @@ def _ellipse_perimeter(Py_ssize_t r_o, Py_ssize_t c_o, Py_ssize_t r_radius,
         Centre coordinate of ellipse.
     r_radius, c_radius : int
         Minor and major semi-axes. ``(r/r_radius)**2 + (c/c_radius)**2 = 1``.
-    orientation : double
+    orientation : cnp.float64_t
         Major axis orientation in clockwise direction as radians.
     shape : tuple
         Image shape which is used to determine the maximum extent of output pixel
@@ -451,7 +451,7 @@ def _ellipse_perimeter(Py_ssize_t r_o, Py_ssize_t c_o, Py_ssize_t r_radius,
     cdef Py_ssize_t r, c, e2, err
 
     cdef int ir0, ir1, ic0, ic1, ird, icd
-    cdef double sin_angle, ra, ca, za, a, b
+    cdef cnp.float64_t sin_angle, ra, ca, za, a, b
 
     if orientation == 0:
         c = -c_radius
@@ -533,7 +533,7 @@ def _ellipse_perimeter(Py_ssize_t r_o, Py_ssize_t c_o, Py_ssize_t r_radius,
 def _bezier_segment(Py_ssize_t r0, Py_ssize_t c0,
                     Py_ssize_t r1, Py_ssize_t c1,
                     Py_ssize_t r2, Py_ssize_t c2,
-                    double weight):
+                    cnp.float64_t weight):
     """Generate Bezier segment coordinates.
 
     Parameters
@@ -544,7 +544,7 @@ def _bezier_segment(Py_ssize_t r0, Py_ssize_t c0,
         Coordinates of the middle control point.
     r2, c2 : int
         Coordinates of the last control point.
-    weight : double
+    weight : cnp.float64_t
         Middle control point weight, it describes the line tension.
 
     Returns
@@ -569,16 +569,16 @@ def _bezier_segment(Py_ssize_t r0, Py_ssize_t c0,
     cdef list rr = list()
 
     # Steps
-    cdef double sc = c2 - c1
-    cdef double sr = r2 - r1
+    cdef cnp.float64_t sc = c2 - c1
+    cdef cnp.float64_t sr = r2 - r1
 
-    cdef double d2c = c0 - c2
-    cdef double d2r = r0 - r2
-    cdef double d1c = c0 - c1
-    cdef double d1r = r0 - r1
-    cdef double rc = d1c * sr + d1r * sc
-    cdef double cur = d1c * sr - d1r * sc
-    cdef double err
+    cdef cnp.float64_t d2c = c0 - c2
+    cdef cnp.float64_t d2r = r0 - r2
+    cdef cnp.float64_t d1c = c0 - c1
+    cdef cnp.float64_t d1r = r0 - r1
+    cdef cnp.float64_t rc = d1c * sr + d1r * sc
+    cdef cnp.float64_t cur = d1c * sr - d1r * sc
+    cdef cnp.float64_t err
 
     cdef bint test1, test2
 
@@ -661,7 +661,7 @@ def _bezier_segment(Py_ssize_t r0, Py_ssize_t c0,
 def _bezier_curve(Py_ssize_t r0, Py_ssize_t c0,
                   Py_ssize_t r1, Py_ssize_t c1,
                   Py_ssize_t r2, Py_ssize_t c2,
-                  double weight, shape):
+                  cnp.float64_t weight, shape):
     """Generate Bezier curve coordinates.
 
     Parameters
@@ -672,7 +672,7 @@ def _bezier_curve(Py_ssize_t r0, Py_ssize_t c0,
         Coordinates of the middle control point.
     r2, c2 : int
         Coordinates of the last control point.
-    weight : double
+    weight : cnp.float64_t
         Middle control point weight, it describes the line tension.
     shape : tuple
         Image shape which is used to determine the maximum extent of output
@@ -701,7 +701,7 @@ def _bezier_curve(Py_ssize_t r0, Py_ssize_t c0,
     cdef list rr = list()
 
     cdef int vc, vr
-    cdef double dc, dr, ww, t, q
+    cdef cnp.float64_t dc, dr, ww, t, q
     vc = c0 - 2 * c1 + c2
     vr = r0 - 2 * r1 + r2
 
@@ -716,7 +716,7 @@ def _bezier_curve(Py_ssize_t r0, Py_ssize_t c0,
                 r0 = r2
                 r2 = <Py_ssize_t>(dr + r1)
         if (c0 == c2) or (weight == 1.):
-            t = <double>(c0 - c1) / vc
+            t = <cnp.float64_t>(c0 - c1) / vc
         else:
             q = sqrt(4. * weight * weight * (c0 - c1) * (c2 - c1) + (c2 - c0) * floor(c2 - c0))
             if (c1 < c0):

--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -137,11 +137,11 @@ def _line_aa(Py_ssize_t r0, Py_ssize_t c0, Py_ssize_t r1, Py_ssize_t c1):
     cdef int dc_prime
 
     cdef int dr = abs(r0 - r1)
-    cdef float err = dc - dr
-    cdef float err_prime
+    cdef cnp.float64_t err = dc - dr
+    cdef cnp.float64_t err_prime
 
     cdef int c, r, sign_c, sign_r
-    cdef float ed
+    cdef cnp.float64_t ed
 
     if c0 < c1:
         sign_c = 1

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -862,7 +862,7 @@ def test_is_low_contrast_boolean():
                                            exposure.adjust_log,
                                            exposure.adjust_sigmoid])
 def test_negative_input(exposure_func):
-    image = np.arange(-10, 245, 4).reshape((8, 8)).astype(np.double)
+    image = np.arange(-10, 245, 4).reshape((8, 8)).astype(np.float64)
     with pytest.raises(ValueError):
         exposure_func(image)
 

--- a/skimage/feature/_hessian_det_appx_pythran.py
+++ b/skimage/feature/_hessian_det_appx_pythran.py
@@ -108,7 +108,7 @@ def _hessian_matrix_det(img, sigma):
     l = size // 3
     w = size
     b = (size - 1) // 2
-    out = np.empty_like(img, dtype=np.double)
+    out = np.empty_like(img, dtype=np.float64)
     w_i = 1.0 / size / size
 
     if size % 2 == 0:

--- a/skimage/feature/_hoghistogram.pyx
+++ b/skimage/feature/_hoghistogram.pyx
@@ -56,7 +56,7 @@ cdef np_floats cell_hog(np_floats[:, ::1] magnitude,
         The total HOG value.
     """
     cdef int cell_column, cell_row, cell_row_index, cell_column_index
-    cdef float total = 0.
+    cdef cnp.float32_t total = 0.
 
     for cell_row in range(range_rows_start, range_rows_stop):
         cell_row_index = row_index + cell_row

--- a/skimage/feature/_sift.pyx
+++ b/skimage/feature/_sift.pyx
@@ -119,7 +119,7 @@ cpdef _update_histogram(np_floats[:, :, ::1] histograms,
                 histograms[r, c, k_index2] += w2
 
 
-cpdef _local_max(np_floats[:, :, ::1] octave, double thresh):
+cpdef _local_max(np_floats[:, :, ::1] octave, cnp.float64_t thresh):
     cdef:
         Py_ssize_t n_r = octave.shape[0]
         Py_ssize_t n_c = octave.shape[1]

--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -86,7 +86,7 @@ cdef inline int _bit_rotate_right(int value, int length) nogil:
 
 
 def _local_binary_pattern(double[:, ::1] image,
-                          int P, float R, char method=b'D'):
+                          int P, cnp.float64_t R, char method=b'D'):
     """Gray scale and rotation invariant LBP (Local Binary Patterns).
 
     LBP is an invariant descriptor that can be used for texture classification.
@@ -332,10 +332,10 @@ cpdef int _multiblock_lbp(np_floats[:, ::1] int_image,
         int lbp_code = 0
 
     # Sum of intensity values of central rectangle.
-    cdef float central_rect_val = integrate(int_image, central_rect_r,
-                                            central_rect_c,
-                                            central_rect_r + r_shift,
-                                            central_rect_c + c_shift)
+    cdef np_floats central_rect_val = integrate(int_image, central_rect_r,
+                                                central_rect_c,
+                                                central_rect_r + r_shift,
+                                                central_rect_c + c_shift)
 
     for element_num in range(8):
 

--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -9,15 +9,15 @@ from .._shared.interpolation cimport bilinear_interpolation, round
 from .._shared.transform cimport integrate
 
 cdef extern from "numpy/npy_math.h":
-    double NAN "NPY_NAN"
+    cnp.float64_t NAN "NPY_NAN"
 
 from .._shared.fused_numerics cimport np_anyint as any_int
 from .._shared.fused_numerics cimport np_real_numeric
 
 cnp.import_array()
 
-def _glcm_loop(any_int[:, ::1] image, double[:] distances,
-               double[:] angles, Py_ssize_t levels,
+def _glcm_loop(any_int[:, ::1] image, cnp.float64_t[:] distances,
+               cnp.float64_t[:] angles, Py_ssize_t levels,
                cnp.uint32_t[:, :, :, ::1] out):
     """Perform co-occurrence matrix accumulation.
 
@@ -85,7 +85,7 @@ cdef inline int _bit_rotate_right(int value, int length) nogil:
     return (value >> 1) | ((value & 1) << (length - 1))
 
 
-def _local_binary_pattern(double[:, ::1] image,
+def _local_binary_pattern(cnp.float64_t[:, ::1] image,
                           int P, cnp.float64_t R, char method=b'D'):
     """Gray scale and rotation invariant LBP (Local Binary Patterns).
 
@@ -93,7 +93,7 @@ def _local_binary_pattern(double[:, ::1] image,
 
     Parameters
     ----------
-    image : (N, M) double array
+    image : (N, M) cnp.float64_t array
         Graylevel image.
     P : int
         Number of circularly symmetric neighbor set points (quantization of
@@ -118,35 +118,35 @@ def _local_binary_pattern(double[:, ::1] image,
     # texture weights
     cdef int[::1] weights = 2 ** np.arange(P, dtype=np.int32)
     # local position of texture elements
-    rr = - R * np.sin(2 * np.pi * np.arange(P, dtype=np.double) / P)
-    cc = R * np.cos(2 * np.pi * np.arange(P, dtype=np.double) / P)
-    cdef double[::1] rp = np.round(rr, 5)
-    cdef double[::1] cp = np.round(cc, 5)
+    rr = - R * np.sin(2 * np.pi * np.arange(P, dtype=np.float64) / P)
+    cc = R * np.cos(2 * np.pi * np.arange(P, dtype=np.float64) / P)
+    cdef cnp.float64_t[::1] rp = np.round(rr, 5)
+    cdef cnp.float64_t[::1] cp = np.round(cc, 5)
 
     # pre-allocate arrays for computation
-    cdef double[::1] texture = np.zeros(P, dtype=np.double)
+    cdef cnp.float64_t[::1] texture = np.zeros(P, dtype=np.float64)
     cdef signed char[::1] signed_texture = np.zeros(P, dtype=np.int8)
     cdef int[::1] rotation_chain = np.zeros(P, dtype=np.int32)
 
     output_shape = (image.shape[0], image.shape[1])
-    cdef double[:, ::1] output = np.zeros(output_shape, dtype=np.double)
+    cdef cnp.float64_t[:, ::1] output = np.zeros(output_shape, dtype=np.float64)
 
     cdef Py_ssize_t rows = image.shape[0]
     cdef Py_ssize_t cols = image.shape[1]
 
-    cdef double lbp
+    cdef cnp.float64_t lbp
     cdef Py_ssize_t r, c, changes, i
     cdef Py_ssize_t rot_index, n_ones
     cdef cnp.int8_t first_zero, first_one
 
     # To compute the variance features
-    cdef double sum_, var_, texture_i
+    cdef cnp.float64_t sum_, var_, texture_i
 
     with nogil:
         for r in range(image.shape[0]):
             for c in range(image.shape[1]):
                 for i in range(P):
-                    bilinear_interpolation[cnp.float64_t, double, double](
+                    bilinear_interpolation[cnp.float64_t, cnp.float64_t, cnp.float64_t](
                             &image[0, 0], rows, cols, r + rp[i], c + cp[i],
                             b'C', 0, &texture[i])
                 # signed / thresholded texture

--- a/skimage/feature/censure.py
+++ b/skimage/feature/censure.py
@@ -29,7 +29,7 @@ STAR_FILTER_SHAPE = [(1, 0), (3, 1), (4, 2), (5, 3), (7, 4), (8, 5),
 def _filter_image(image, min_scale, max_scale, mode):
 
     response = np.zeros((image.shape[0], image.shape[1],
-                         max_scale - min_scale + 1), dtype=np.double)
+                         max_scale - min_scale + 1), dtype=np.float64)
 
     if mode == 'dob':
 

--- a/skimage/feature/censure_cy.pyx
+++ b/skimage/feature/censure_cy.pyx
@@ -2,21 +2,24 @@
 #cython: boundscheck=False
 #cython: nonecheck=False
 #cython: wraparound=False
+cimport numpy as cnp
+
+cnp.import_array()
 
 
 def _censure_dob_loop(Py_ssize_t n,
-                      double[:, ::1] integral_img,
-                      double[:, ::1] filtered_image,
-                      double inner_weight, double outer_weight):
+                      cnp.float64_t[:, ::1] integral_img,
+                      cnp.float64_t[:, ::1] filtered_image,
+                      cnp.float64_t inner_weight, cnp.float64_t outer_weight):
     # This function calculates the value in the DoB filtered image using
     # integral images. If r = right. l = left, u = up, d = down, the sum of
     # pixel values in the rectangle formed by (u, l), (u, r), (d, r), (d, l)
     # is calculated as I(d, r) + I(u - 1, l - 1) - I(u - 1, r) - I(d, l - 1).
 
     cdef Py_ssize_t i, j
-    cdef double inner, outer
+    cdef cnp.float64_t inner, outer
     cdef Py_ssize_t n2 = 2 * n
-    cdef double total_weight = inner_weight + outer_weight
+    cdef cnp.float64_t total_weight = inner_weight + outer_weight
 
     with nogil:
 

--- a/skimage/feature/corner_cy.pyx
+++ b/skimage/feature/corner_cy.pyx
@@ -136,7 +136,7 @@ def _corner_fast(np_floats[:, ::1] image, signed char n, np_floats threshold):
     cdef signed char bins[16]
     cdef np_floats circle_intensities[16]
 
-    cdef double curr_response
+    cdef cnp.float64_t curr_response
 
     with nogil:
         for i in range(3, rows - 3):

--- a/skimage/feature/match.py
+++ b/skimage/feature/match.py
@@ -86,7 +86,7 @@ def match_descriptors(descriptors1, descriptors2, metric=None, p=2,
         second_best_indices2 = np.argmin(distances[indices1], axis=1)
         second_best_distances = distances[indices1, second_best_indices2]
         second_best_distances[second_best_distances == 0] \
-            = np.finfo(np.double).eps
+            = np.finfo(np.float64).eps
         ratio = best_distances / second_best_distances
         mask = ratio < max_ratio
         indices1 = indices1[mask]

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -339,7 +339,7 @@ def local_binary_pattern(image, P, R, method='default'):
         'nri_uniform': ord('N'),
         'var': ord('V')
     }
-    image = np.ascontiguousarray(image, dtype=np.double)
+    image = np.ascontiguousarray(image, dtype=np.float64)
     output = _local_binary_pattern(image, P, R, methods[method.lower()])
     return output
 

--- a/skimage/filters/_multiotsu.pyx
+++ b/skimage/filters/_multiotsu.pyx
@@ -8,7 +8,7 @@ cimport numpy as cnp
 cimport cython
 cnp.import_array()
 
-def _get_multiotsu_thresh_indices_lut(float [::1] prob,
+def _get_multiotsu_thresh_indices_lut(cp.float32_t [::1] prob,
                                       Py_ssize_t thresh_count):
     """Finds the indices of Otsu thresholds according to the values
     occurence probabilities.
@@ -44,10 +44,10 @@ def _get_multiotsu_thresh_indices_lut(float [::1] prob,
     py_thresh_indices = np.empty(thresh_count, dtype=np.intp)
     cdef Py_ssize_t[::1] thresh_indices = py_thresh_indices
     cdef Py_ssize_t[::1] current_indices = np.empty(thresh_count, dtype=np.intp)
-    cdef float [::1] var_btwcls = np.zeros((nbins * (nbins + 1)) / 2,
-                                           dtype=np.float32)
-    cdef float [::1] zeroth_moment = np.empty(nbins, dtype=np.float32)
-    cdef float [::1] first_moment = np.empty(nbins, dtype=np.float32)
+    cdef cnp.float32_t [::1] var_btwcls = np.zeros((nbins * (nbins + 1)) / 2,
+                                                   dtype=np.float32)
+    cdef cnp.float32_t [::1] zeroth_moment = np.empty(nbins, dtype=np.float32)
+    cdef cnp.float32_t [::1] first_moment = np.empty(nbins, dtype=np.float32)
 
     with nogil:
         _set_var_btwcls_lut(prob, nbins, var_btwcls, zeroth_moment,
@@ -61,11 +61,11 @@ def _get_multiotsu_thresh_indices_lut(float [::1] prob,
     return py_thresh_indices
 
 
-cdef void _set_var_btwcls_lut(float [::1] prob,
+cdef void _set_var_btwcls_lut(cnp.float32_t [::1] prob,
                               Py_ssize_t nbins,
-                              float [::1] var_btwcls,
-                              float [::1] zeroth_moment,
-                              float [::1] first_moment) nogil:
+                              cnp.float32_t [::1] var_btwcls,
+                              cnp.float32_t [::1] zeroth_moment,
+                              cnp.float32_t [::1] first_moment) nogil:
     """Builds the lookup table containing the variance between classes.
 
     The variance between classes are stored in
@@ -107,7 +107,7 @@ cdef void _set_var_btwcls_lut(float [::1] prob,
            :DOI:`10.6688/JISE.2001.17.5.1`
     """
     cdef cnp.intp_t i, j, idx
-    cdef float zeroth_moment_ij, first_moment_ij
+    cdef cnp.float32_t zeroth_moment_ij, first_moment_ij
 
     zeroth_moment[0] = prob[0]
     first_moment[0] = prob[0]
@@ -128,8 +128,9 @@ cdef void _set_var_btwcls_lut(float [::1] prob,
             idx += 1
 
 
-cdef float _get_var_btwclas_lut(float [::1] var_btwcls, Py_ssize_t i,
-                                Py_ssize_t j, Py_ssize_t nbins) nogil:
+cdef cnp.float32_t _get_var_btwclas_lut(cnp.float32_t [::1] var_btwcls,
+                                        Py_ssize_t i, Py_ssize_t j,
+                                        Py_ssize_t nbins) nogil:
     """Returns the variance between classes stored in compressed upper
     triangular matrix form at the desired 2D indices.
 
@@ -152,11 +153,11 @@ cdef float _get_var_btwclas_lut(float [::1] var_btwcls, Py_ssize_t i,
     return var_btwcls[idx]
 
 
-cdef float _set_thresh_indices_lut(float[::1] var_btwcls, Py_ssize_t hist_idx,
-                                   Py_ssize_t thresh_idx, Py_ssize_t nbins,
-                                   Py_ssize_t thresh_count, float sigma_max,
-                                   Py_ssize_t[::1] current_indices,
-                                   Py_ssize_t[::1] thresh_indices) nogil:
+cdef cnp.float32_t _set_thresh_indices_lut(
+        cnp.float32_t[::1] var_btwcls, Py_ssize_t hist_idx,
+        Py_ssize_t thresh_idx, Py_ssize_t nbins, Py_ssize_t thresh_count,
+        cnp.float32_t sigma_max, Py_ssize_t[::1] current_indices,
+        Py_ssize_t[::1] thresh_indices) nogil:
     """Recursive function for finding the indices of the thresholds
     maximizing the  variance between classes sigma.
 
@@ -207,7 +208,7 @@ cdef float _set_thresh_indices_lut(float[::1] var_btwcls, Py_ssize_t hist_idx,
            :DOI:`10.6688/JISE.2001.17.5.1`
     """
     cdef cnp.intp_t idx
-    cdef float sigma
+    cdef cnp.float32_t sigma
 
     if thresh_idx < thresh_count:
 
@@ -238,7 +239,8 @@ cdef float _set_thresh_indices_lut(float[::1] var_btwcls, Py_ssize_t hist_idx,
     return sigma_max
 
 
-def _get_multiotsu_thresh_indices(float [::1] prob, Py_ssize_t thresh_count):
+def _get_multiotsu_thresh_indices(cnp.float32_t [::1] prob,
+                                  Py_ssize_t thresh_count):
     """Finds the indices of Otsu thresholds according to the values
     occurence probabilities.
 
@@ -263,8 +265,8 @@ def _get_multiotsu_thresh_indices(float [::1] prob, Py_ssize_t thresh_count):
     py_thresh_indices = np.empty(thresh_count, dtype=np.intp)
     cdef Py_ssize_t[::1] thresh_indices = py_thresh_indices
     cdef Py_ssize_t[::1] current_indices = np.empty(thresh_count, dtype=np.intp)
-    cdef float [::1] zeroth_moment = np.empty(nbins, dtype=np.float32)
-    cdef float [::1] first_moment = np.empty(nbins, dtype=np.float32)
+    cdef cnp.float32_t [::1] zeroth_moment = np.empty(nbins, dtype=np.float32)
+    cdef cnp.float32_t [::1] first_moment = np.empty(nbins, dtype=np.float32)
 
     with nogil:
         _set_moments_lut_first_row(prob, nbins, zeroth_moment, first_moment)
@@ -277,10 +279,10 @@ def _get_multiotsu_thresh_indices(float [::1] prob, Py_ssize_t thresh_count):
     return py_thresh_indices
 
 
-cdef void _set_moments_lut_first_row(float [::1] prob,
+cdef void _set_moments_lut_first_row(cnp.float32_t [::1] prob,
                                      Py_ssize_t nbins,
-                                     float [::1] zeroth_moment,
-                                     float [::1] first_moment) nogil:
+                                     cnp.float32_t [::1] zeroth_moment,
+                                     cnp.float32_t [::1] first_moment) nogil:
     """Builds the first rows of the zeroth and first moments lookup table
     necessary to the computation of the variance between class.
 
@@ -314,9 +316,9 @@ cdef void _set_moments_lut_first_row(float [::1] prob,
         first_moment[i] = first_moment[i - 1] + i * prob[i]
 
 
-cdef float _get_var_btwclas(float [::1] zeroth_moment,
-                            float [::1] first_moment,
-                            Py_ssize_t i, Py_ssize_t j) nogil:
+cdef cnp.float32_t _get_var_btwclas(cnp.float32_t [::1] zeroth_moment,
+                                    cnp.float32_t [::1] first_moment,
+                                    Py_ssize_t i, Py_ssize_t j) nogil:
     """Computes the variance between two classes.
 
     Parameters
@@ -336,7 +338,7 @@ cdef float _get_var_btwclas(float [::1] zeroth_moment,
         The variance between the classes i and j.
     """
 
-    cdef float zeroth_moment_ij, first_moment_ij
+    cdef cnp.float32_t zeroth_moment_ij, first_moment_ij
 
     if i == 0:
         if zeroth_moment[i] > 0:
@@ -349,13 +351,14 @@ cdef float _get_var_btwclas(float [::1] zeroth_moment,
     return 0
 
 
-cdef float _set_thresh_indices(float[::1] zeroth_moment,
-                               float[::1] first_moment,
-                               Py_ssize_t hist_idx,
-                               Py_ssize_t thresh_idx, Py_ssize_t nbins,
-                               Py_ssize_t thresh_count, float sigma_max,
-                               Py_ssize_t[::1] current_indices,
-                               Py_ssize_t[::1] thresh_indices) nogil:
+cdef cnp.float32_t _set_thresh_indices(cnp.float32_t[::1] zeroth_moment,
+                                       cnp.float32_t[::1] first_moment,
+                                       Py_ssize_t hist_idx,
+                                       Py_ssize_t thresh_idx, Py_ssize_t nbins,
+                                       Py_ssize_t thresh_count,
+                                       cnp.float32_t sigma_max,
+                                       Py_ssize_t[::1] current_indices,
+                                       Py_ssize_t[::1] thresh_indices) nogil:
     """Recursive function for finding the indices of the thresholds
     maximizing the  variance between classes sigma.
 
@@ -403,7 +406,7 @@ cdef float _set_thresh_indices(float[::1] zeroth_moment,
            :DOI:`10.6688/JISE.2001.17.5.1`
     """
     cdef cnp.intp_t idx
-    cdef float sigma
+    cdef cnp.float32_t sigma
 
     if thresh_idx < thresh_count:
 

--- a/skimage/filters/_multiotsu.pyx
+++ b/skimage/filters/_multiotsu.pyx
@@ -8,7 +8,7 @@ cimport numpy as cnp
 cimport cython
 cnp.import_array()
 
-def _get_multiotsu_thresh_indices_lut(cp.float32_t [::1] prob,
+def _get_multiotsu_thresh_indices_lut(cnp.float32_t [::1] prob,
                                       Py_ssize_t thresh_count):
     """Finds the indices of Otsu thresholds according to the values
     occurence probabilities.

--- a/skimage/filters/_window.py
+++ b/skimage/filters/_window.py
@@ -27,7 +27,7 @@ def window(window_type, shape, warp_kwargs=None):
     Returns
     -------
     nd_window : ndarray
-        A window of the specified ``shape``. ``dtype`` is ``np.double``.
+        A window of the specified ``shape``. ``dtype`` is ``np.float64``.
 
     Notes
     -----

--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -36,9 +36,9 @@ VPREWITT_WEIGHTS = HPREWITT_WEIGHTS.T
 
 # 2D-only filter weights
 ROBERTS_PD_WEIGHTS = np.array([[1, 0],
-                               [0, -1]], dtype=np.double)
+                               [0, -1]], dtype=np.float64)
 ROBERTS_ND_WEIGHTS = np.array([[0, 1],
-                               [-1, 0]], dtype=np.double)
+                               [-1, 0]], dtype=np.float64)
 
 # These filter weights can be found in Farid & Simoncelli (2004),
 # Table 1 (3rd and 4th row). Additional decimal places were computed

--- a/skimage/filters/rank/bilateral_cy.pyx
+++ b/skimage/filters/rank/bilateral_cy.pyx
@@ -12,9 +12,9 @@ cnp.import_array()
 
 cdef inline void _kernel_mean(dtype_t_out* out, Py_ssize_t odepth,
                               Py_ssize_t[::1] histo,
-                              double pop, dtype_t g,
+                              cnp.float64_t pop, dtype_t g,
                               Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                              double p0, double p1,
+                              cnp.float64_t p0, cnp.float64_t p1,
                               Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i
@@ -36,9 +36,9 @@ cdef inline void _kernel_mean(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_pop(dtype_t_out* out, Py_ssize_t odepth,
                              Py_ssize_t[::1] histo,
-                             double pop, dtype_t g,
+                             cnp.float64_t pop, dtype_t g,
                              Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                             double p0, double p1,
+                             cnp.float64_t p0, cnp.float64_t p1,
                              Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i
@@ -55,9 +55,9 @@ cdef inline void _kernel_pop(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_sum(dtype_t_out* out, Py_ssize_t odepth,
                              Py_ssize_t[::1] histo,
-                             double pop, dtype_t g,
+                             cnp.float64_t pop, dtype_t g,
                              Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                             double p0, double p1,
+                             cnp.float64_t p0, cnp.float64_t p1,
                              Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i

--- a/skimage/filters/rank/core_cy.pxd
+++ b/skimage/filters/rank/core_cy.pxd
@@ -16,14 +16,15 @@ cdef dtype_t _max(dtype_t a, dtype_t b) nogil
 cdef dtype_t _min(dtype_t a, dtype_t b) nogil
 
 
-cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t[::1], double,
-                            dtype_t, Py_ssize_t, Py_ssize_t, double,
-                            double, Py_ssize_t, Py_ssize_t) nogil,
+cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t[::1],
+                            cnp.float64_t, dtype_t, Py_ssize_t, Py_ssize_t,
+                            cnp.float64_t, cnp.float64_t, Py_ssize_t,
+                            Py_ssize_t) nogil,
                 dtype_t[:, ::1] image,
                 char[:, ::1] footprint,
                 char[:, ::1] mask,
                 dtype_t_out[:, :, ::1] out,
                 signed char shift_x, signed char shift_y,
-                double p0, double p1,
+                cnp.float64_t p0, cnp.float64_t p1,
                 Py_ssize_t s0, Py_ssize_t s1,
                 Py_ssize_t n_bins) except *

--- a/skimage/filters/rank/core_cy.pxd
+++ b/skimage/filters/rank/core_cy.pxd
@@ -9,7 +9,7 @@ ctypedef fused dtype_t_out:
     uint8_t
     uint16_t
     float32_t
-    double_t
+    float64_t
 
 
 cdef dtype_t _max(dtype_t a, dtype_t b) nogil
@@ -17,14 +17,14 @@ cdef dtype_t _min(dtype_t a, dtype_t b) nogil
 
 
 cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t[::1],
-                            cnp.float64_t, dtype_t, Py_ssize_t, Py_ssize_t,
-                            cnp.float64_t, cnp.float64_t, Py_ssize_t,
+                            float64_t, dtype_t, Py_ssize_t, Py_ssize_t,
+                            float64_t, float64_t, Py_ssize_t,
                             Py_ssize_t) nogil,
                 dtype_t[:, ::1] image,
                 char[:, ::1] footprint,
                 char[:, ::1] mask,
                 dtype_t_out[:, :, ::1] out,
                 signed char shift_x, signed char shift_y,
-                cnp.float64_t p0, cnp.float64_t p1,
+                float64_t p0, float64_t p1,
                 Py_ssize_t s0, Py_ssize_t s1,
                 Py_ssize_t n_bins) except *

--- a/skimage/filters/rank/core_cy.pxd
+++ b/skimage/filters/rank/core_cy.pxd
@@ -1,4 +1,4 @@
-from numpy cimport uint8_t, uint16_t, float32_t, double_t
+from numpy cimport uint8_t, uint16_t, float32_t, float64_t
 
 
 ctypedef fused dtype_t:

--- a/skimage/filters/rank/core_cy.pyx
+++ b/skimage/filters/rank/core_cy.pyx
@@ -18,13 +18,13 @@ cdef inline dtype_t _min(dtype_t a, dtype_t b) nogil:
     return a if a <= b else b
 
 
-cdef inline void histogram_increment(Py_ssize_t[::1] histo, double* pop,
+cdef inline void histogram_increment(Py_ssize_t[::1] histo, cnp.float64_t* pop,
                                      dtype_t value) nogil:
     histo[value] += 1
     pop[0] += 1
 
 
-cdef inline void histogram_decrement(Py_ssize_t[::1] histo, double* pop,
+cdef inline void histogram_decrement(Py_ssize_t[::1] histo, cnp.float64_t* pop,
                                      dtype_t value) nogil:
     histo[value] -= 1
     pop[0] -= 1
@@ -45,15 +45,15 @@ cdef inline char is_in_mask(Py_ssize_t rows, Py_ssize_t cols,
             return 0
 
 
-cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t[::1], double,
-                            dtype_t, Py_ssize_t, Py_ssize_t, double,
-                            double, Py_ssize_t, Py_ssize_t) nogil,
+cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t[::1], cnp.float64_t,
+                            dtype_t, Py_ssize_t, Py_ssize_t, cnp.float64_t,
+                            cnp.float64_t, Py_ssize_t, Py_ssize_t) nogil,
                 dtype_t[:, ::1] image,
                 char[:, ::1] footprint,
                 char[:, ::1] mask,
                 dtype_t_out[:, :, ::1] out,
                 signed char shift_x, signed char shift_y,
-                double p0, double p1,
+                cnp.float64_t p0, cnp.float64_t p1,
                 Py_ssize_t s0, Py_ssize_t s1,
                 Py_ssize_t n_bins) except *:
     """Compute histogram for each pixel neighborhood, apply kernel function and
@@ -85,8 +85,8 @@ cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t[::1], double,
     # define local variable types
     cdef Py_ssize_t r, c, rr, cc, s, value, local_max, i, even_row
 
-    # number of pixels actually inside the neighborhood (double)
-    cdef double pop = 0
+    # number of pixels actually inside the neighborhood (cnp.float64_t)
+    cdef cnp.float64_t pop = 0
 
     # build attack and release borders by using difference along axis
     t = np.hstack((footprint, np.zeros((footprint.shape[0], 1))))

--- a/skimage/filters/rank/core_cy_3d.pxd
+++ b/skimage/filters/rank/core_cy_3d.pxd
@@ -16,14 +16,15 @@ cdef dtype_t _max(dtype_t a, dtype_t b) nogil
 cdef dtype_t _min(dtype_t a, dtype_t b) nogil
 
 
-cdef void _core_3D(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t[::1], double,
-                               dtype_t, Py_ssize_t, Py_ssize_t, double,
-                               double, Py_ssize_t, Py_ssize_t) nogil,
+cdef void _core_3D(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t[::1],
+                               cnp.float64_t, dtype_t, Py_ssize_t, Py_ssize_t,
+                               cnp.float64_t, cnp.float64_t, Py_ssize_t,
+                               Py_ssize_t) nogil,
                    dtype_t[:, :, ::1] image,
                    char[:, :, ::1] footprint,
                    char[:, :, ::1] mask,
                    dtype_t_out[:, :, :, ::1] out,
                    signed char shift_x, signed char shift_y, signed char shift_z,
-                   double p0, double p1,
+                   cnp.float64_t p0, cnp.float64_t p1,
                    Py_ssize_t s0, Py_ssize_t s1,
                    Py_ssize_t n_bins) except *

--- a/skimage/filters/rank/core_cy_3d.pxd
+++ b/skimage/filters/rank/core_cy_3d.pxd
@@ -1,4 +1,4 @@
-from numpy cimport uint8_t, uint16_t, float32_t, double_t
+from numpy cimport uint8_t, uint16_t, float32_t, float64_t
 
 
 ctypedef fused dtype_t:
@@ -9,7 +9,7 @@ ctypedef fused dtype_t_out:
     uint8_t
     uint16_t
     float32_t
-    double_t
+    float64_t
 
 
 cdef dtype_t _max(dtype_t a, dtype_t b) nogil
@@ -17,14 +17,14 @@ cdef dtype_t _min(dtype_t a, dtype_t b) nogil
 
 
 cdef void _core_3D(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t[::1],
-                               cnp.float64_t, dtype_t, Py_ssize_t, Py_ssize_t,
-                               cnp.float64_t, cnp.float64_t, Py_ssize_t,
+                               float64_t, dtype_t, Py_ssize_t, Py_ssize_t,
+                               float64_t, float64_t, Py_ssize_t,
                                Py_ssize_t) nogil,
                    dtype_t[:, :, ::1] image,
                    char[:, :, ::1] footprint,
                    char[:, :, ::1] mask,
                    dtype_t_out[:, :, :, ::1] out,
                    signed char shift_x, signed char shift_y, signed char shift_z,
-                   cnp.float64_t p0, cnp.float64_t p1,
+                   float64_t p0, float64_t p1,
                    Py_ssize_t s0, Py_ssize_t s1,
                    Py_ssize_t n_bins) except *

--- a/skimage/filters/rank/core_cy_3d.pyx
+++ b/skimage/filters/rank/core_cy_3d.pyx
@@ -79,7 +79,7 @@ cdef inline void _count_attack_border_elements(char[:, :, ::1] footprint,
 cdef inline void _build_initial_histogram_from_neighborhood(dtype_t[:, :, ::1] image,
                                                             char[:, :, ::1] footprint,
                                                             Py_ssize_t [::1] histo,
-                                                            double* pop,
+                                                            cnp.float64_t* pop,
                                                             char* mask_data,
                                                             Py_ssize_t p,
                                                             Py_ssize_t planes,
@@ -113,7 +113,7 @@ cdef inline void _update_histogram(dtype_t[:, :, ::1] image,
                                    Py_ssize_t [:, :, ::1] se,
                                    Py_ssize_t [::1] num_se,
                                    Py_ssize_t [::1] histo,
-                                   double* pop, char* mask_data,
+                                   cnp.float64_t* pop, char* mask_data,
                                    Py_ssize_t p, Py_ssize_t r, Py_ssize_t c,
                                    Py_ssize_t planes, Py_ssize_t rows,
                                    Py_ssize_t cols,
@@ -160,15 +160,15 @@ cdef inline char is_in_mask_3D(Py_ssize_t planes, Py_ssize_t rows,
         return mask[p * rows * cols + r * cols + c]
 
 
-cdef void _core_3D(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t[::1], double,
-                               dtype_t, Py_ssize_t, Py_ssize_t, double,
-                               double, Py_ssize_t, Py_ssize_t) nogil,
+cdef void _core_3D(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t[::1], cnp.float64_t,
+                               dtype_t, Py_ssize_t, Py_ssize_t, cnp.float64_t,
+                               cnp.float64_t, Py_ssize_t, Py_ssize_t) nogil,
                    dtype_t[:, :, ::1] image,
                    char[:, :, ::1] footprint,
                    char[:, :, ::1] mask,
                    dtype_t_out[:, :, :, ::1] out,
                    signed char shift_x, signed char shift_y,
-                   signed char shift_z, double p0, double p1,
+                   signed char shift_z, cnp.float64_t p0, cnp.float64_t p1,
                    Py_ssize_t s0, Py_ssize_t s1,
                    Py_ssize_t n_bins) except *:
     """Compute histogram for each pixel neighborhood, apply kernel function and
@@ -209,8 +209,8 @@ cdef void _core_3D(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t[::1], double
     # define local variable types
     cdef Py_ssize_t p, r, c, rr, cc, pp, value, local_max, i, even_row
 
-    # number of pixels actually inside the neighborhood (double)
-    cdef double pop = 0
+    # number of pixels actually inside the neighborhood (cnp.float64_t)
+    cdef cnp.float64_t pop = 0
 
     # the current local histogram distribution
     cdef Py_ssize_t [::1] histo = np.zeros(n_bins, dtype=np.intp)

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -1265,12 +1265,13 @@ def entropy(image, footprint, out=None, mask=None,
         return _apply_scalar_per_pixel(generic_cy._entropy, image, footprint,
                                        out=out, mask=mask,
                                        shift_x=shift_x, shift_y=shift_y,
-                                       out_dtype=np.double)
+                                       out_dtype=np.float64)
     else:
         return _apply_scalar_per_pixel_3D(generic_cy._entropy_3D, image,
                                           footprint, out=out, mask=mask,
                                           shift_x=shift_x, shift_y=shift_y,
-                                          shift_z=shift_z, out_dtype=np.double)
+                                          shift_z=shift_z,
+                                          out_dtype=np.float64)
 
 
 @deprecate_kwarg(kwarg_mapping={'selem': 'footprint'}, removed_version="1.0",
@@ -1384,7 +1385,7 @@ def windowed_histogram(image, footprint, out=None, mask=None,
     return _apply_vector_per_pixel(generic_cy._windowed_hist, image, footprint,
                                    out=out, mask=mask,
                                    shift_x=shift_x, shift_y=shift_y,
-                                   out_dtype=np.double,
+                                   out_dtype=np.float64,
                                    pixel_size=n_bins)
 
 

--- a/skimage/filters/rank/generic_cy.pyx
+++ b/skimage/filters/rank/generic_cy.pyx
@@ -16,9 +16,9 @@ cnp.import_array()
 
 cdef inline void _kernel_autolevel(dtype_t_out* out, Py_ssize_t odepth,
                                    Py_ssize_t[::1] histo,
-                                   double pop, dtype_t g,
+                                   cnp.float64_t pop, dtype_t g,
                                    Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                                   double p0, double p1,
+                                   cnp.float64_t p0, cnp.float64_t p1,
                                    Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i, imin, imax, delta
@@ -43,9 +43,9 @@ cdef inline void _kernel_autolevel(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_equalize(dtype_t_out* out, Py_ssize_t odepth,
                                   Py_ssize_t[::1] histo,
-                                  double pop, dtype_t g,
+                                  cnp.float64_t pop, dtype_t g,
                                   Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                                  double p0, double p1,
+                                  cnp.float64_t p0, cnp.float64_t p1,
                                   Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i
@@ -63,9 +63,9 @@ cdef inline void _kernel_equalize(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_gradient(dtype_t_out* out, Py_ssize_t odepth,
                                   Py_ssize_t[::1] histo,
-                                  double pop, dtype_t g,
+                                  cnp.float64_t pop, dtype_t g,
                                   Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                                  double p0, double p1,
+                                  cnp.float64_t p0, cnp.float64_t p1,
                                   Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i, imin, imax
@@ -86,9 +86,9 @@ cdef inline void _kernel_gradient(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_maximum(dtype_t_out* out, Py_ssize_t odepth,
                                  Py_ssize_t[::1] histo,
-                                 double pop, dtype_t g,
+                                 cnp.float64_t pop, dtype_t g,
                                  Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                                 double p0, double p1,
+                                 cnp.float64_t p0, cnp.float64_t p1,
                                  Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i
@@ -104,9 +104,9 @@ cdef inline void _kernel_maximum(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_mean(dtype_t_out* out, Py_ssize_t odepth,
                               Py_ssize_t[::1] histo,
-                              double pop, dtype_t g,
+                              cnp.float64_t pop, dtype_t g,
                               Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                              double p0, double p1,
+                              cnp.float64_t p0, cnp.float64_t p1,
                               Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i
@@ -122,13 +122,13 @@ cdef inline void _kernel_mean(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_geometric_mean(dtype_t_out* out, Py_ssize_t odepth,
                                         Py_ssize_t[::1] histo,
-                                        double pop, dtype_t g,
+                                        cnp.float64_t pop, dtype_t g,
                                         Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                                        double p0, double p1,
+                                        cnp.float64_t p0, cnp.float64_t p1,
                                         Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i
-    cdef double mean = 0.
+    cdef cnp.float64_t mean = 0.
 
     if pop:
         for i in range(n_bins):
@@ -141,9 +141,9 @@ cdef inline void _kernel_geometric_mean(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_subtract_mean(dtype_t_out* out, Py_ssize_t odepth,
                                        Py_ssize_t[::1] histo,
-                                       double pop, dtype_t g,
+                                       cnp.float64_t pop, dtype_t g,
                                        Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                                       double p0, double p1,
+                                       cnp.float64_t p0, cnp.float64_t p1,
                                        Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i
@@ -159,13 +159,13 @@ cdef inline void _kernel_subtract_mean(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_median(dtype_t_out* out, Py_ssize_t odepth,
                                 Py_ssize_t[::1] histo,
-                                double pop, dtype_t g,
+                                cnp.float64_t pop, dtype_t g,
                                 Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                                double p0, double p1,
+                                cnp.float64_t p0, cnp.float64_t p1,
                                 Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i
-    cdef double sum = pop / 2.0
+    cdef cnp.float64_t sum = pop / 2.0
 
     if pop:
         for i in range(n_bins):
@@ -180,9 +180,9 @@ cdef inline void _kernel_median(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_minimum(dtype_t_out* out, Py_ssize_t odepth,
                                  Py_ssize_t[::1] histo,
-                                 double pop, dtype_t g,
+                                 cnp.float64_t pop, dtype_t g,
                                  Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                                 double p0, double p1,
+                                 cnp.float64_t p0, cnp.float64_t p1,
                                  Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i
@@ -198,9 +198,9 @@ cdef inline void _kernel_minimum(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_modal(dtype_t_out* out, Py_ssize_t odepth,
                                Py_ssize_t[::1] histo,
-                               double pop, dtype_t g,
+                               cnp.float64_t pop, dtype_t g,
                                Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                               double p0, double p1,
+                               cnp.float64_t p0, cnp.float64_t p1,
                                Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t hmax = 0, imax = 0
@@ -218,11 +218,11 @@ cdef inline void _kernel_modal(dtype_t_out* out, Py_ssize_t odepth,
 cdef inline void _kernel_enhance_contrast(dtype_t_out* out,
                                           Py_ssize_t odepth,
                                           Py_ssize_t[::1] histo,
-                                          double pop,
+                                          cnp.float64_t pop,
                                           dtype_t g,
                                           Py_ssize_t n_bins,
-                                          Py_ssize_t mid_bin, double p0,
-                                          double p1, Py_ssize_t s0,
+                                          Py_ssize_t mid_bin, cnp.float64_t p0,
+                                          cnp.float64_t p1, Py_ssize_t s0,
                                           Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i, imin, imax
@@ -246,9 +246,9 @@ cdef inline void _kernel_enhance_contrast(dtype_t_out* out,
 
 cdef inline void _kernel_pop(dtype_t_out* out, Py_ssize_t odepth,
                              Py_ssize_t[::1] histo,
-                             double pop, dtype_t g,
+                             cnp.float64_t pop, dtype_t g,
                              Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                             double p0, double p1,
+                             cnp.float64_t p0, cnp.float64_t p1,
                              Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     out[0] = <dtype_t_out>pop
@@ -256,9 +256,9 @@ cdef inline void _kernel_pop(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_sum(dtype_t_out* out, Py_ssize_t odepth,
                              Py_ssize_t[::1] histo,
-                             double pop, dtype_t g,
+                             cnp.float64_t pop, dtype_t g,
                              Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                             double p0, double p1,
+                             cnp.float64_t p0, cnp.float64_t p1,
                              Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i
@@ -274,9 +274,9 @@ cdef inline void _kernel_sum(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_threshold(dtype_t_out* out, Py_ssize_t odepth,
                                    Py_ssize_t[::1] histo,
-                                   double pop, dtype_t g,
+                                   cnp.float64_t pop, dtype_t g,
                                    Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                                   double p0, double p1,
+                                   cnp.float64_t p0, cnp.float64_t p1,
                                    Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i
@@ -292,9 +292,9 @@ cdef inline void _kernel_threshold(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_noise_filter(dtype_t_out* out, Py_ssize_t odepth,
                                       Py_ssize_t[::1] histo,
-                                      double pop, dtype_t g,
+                                      cnp.float64_t pop, dtype_t g,
                                       Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                                      double p0, double p1,
+                                      cnp.float64_t p0, cnp.float64_t p1,
                                       Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i
@@ -320,12 +320,12 @@ cdef inline void _kernel_noise_filter(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_entropy(dtype_t_out* out, Py_ssize_t odepth,
                                  Py_ssize_t[::1] histo,
-                                 double pop, dtype_t g,
+                                 cnp.float64_t pop, dtype_t g,
                                  Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                                 double p0, double p1,
+                                 cnp.float64_t p0, cnp.float64_t p1,
                                  Py_ssize_t s0, Py_ssize_t s1) nogil:
     cdef Py_ssize_t i
-    cdef double e, p
+    cdef cnp.float64_t e, p
 
     if pop:
         e = 0.
@@ -340,14 +340,14 @@ cdef inline void _kernel_entropy(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_otsu(dtype_t_out* out, Py_ssize_t odepth,
                               Py_ssize_t[::1] histo,
-                              double pop, dtype_t g,
+                              cnp.float64_t pop, dtype_t g,
                               Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                              double p0, double p1,
+                              cnp.float64_t p0, cnp.float64_t p1,
                               Py_ssize_t s0, Py_ssize_t s1) nogil:
     cdef Py_ssize_t i
     cdef Py_ssize_t max_i
     cdef Py_ssize_t P, q1, mu1, mu2, mu = 0
-    cdef double sigma_b, max_sigma_b, t
+    cdef cnp.float64_t sigma_b, max_sigma_b, t
 
     # compute local mean
     if pop:
@@ -386,13 +386,13 @@ cdef inline void _kernel_otsu(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_win_hist(dtype_t_out* out, Py_ssize_t odepth,
                                   Py_ssize_t[::1] histo,
-                                  double pop, dtype_t g,
+                                  cnp.float64_t pop, dtype_t g,
                                   Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                                  double p0, double p1,
+                                  cnp.float64_t p0, cnp.float64_t p1,
                                   Py_ssize_t s0, Py_ssize_t s1) nogil:
     cdef Py_ssize_t i
     cdef Py_ssize_t max_i
-    cdef double scale
+    cdef cnp.float64_t scale
     if pop:
         scale = 1.0 / pop
         for i in xrange(odepth):
@@ -404,9 +404,9 @@ cdef inline void _kernel_win_hist(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_majority(dtype_t_out* out, Py_ssize_t odepth,
                                   Py_ssize_t[::1] histo,
-                                  double pop, dtype_t g,
+                                  cnp.float64_t pop, dtype_t g,
                                   Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                                  double p0, double p1,
+                                  cnp.float64_t p0, cnp.float64_t p1,
                                   Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i

--- a/skimage/filters/rank/percentile_cy.pyx
+++ b/skimage/filters/rank/percentile_cy.pyx
@@ -9,9 +9,9 @@ cnp.import_array()
 
 cdef inline void _kernel_autolevel(dtype_t_out* out, Py_ssize_t odepth,
                                    Py_ssize_t[::1] histo,
-                                   double pop, dtype_t g,
+                                   cnp.float64_t pop, dtype_t g,
                                    Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                                   double p0, double p1,
+                                   cnp.float64_t p0, cnp.float64_t p1,
                                    Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i, imin, imax, sum, delta
@@ -43,9 +43,9 @@ cdef inline void _kernel_autolevel(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_gradient(dtype_t_out* out, Py_ssize_t odepth,
                                   Py_ssize_t[::1] histo,
-                                  double pop, dtype_t g,
+                                  cnp.float64_t pop, dtype_t g,
                                   Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                                  double p0, double p1,
+                                  cnp.float64_t p0, cnp.float64_t p1,
                                   Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i, imin, imax, sum, delta
@@ -72,9 +72,9 @@ cdef inline void _kernel_gradient(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_mean(dtype_t_out* out, Py_ssize_t odepth,
                               Py_ssize_t[::1] histo,
-                              double pop, dtype_t g,
+                              cnp.float64_t pop, dtype_t g,
                               Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                              double p0, double p1,
+                              cnp.float64_t p0, cnp.float64_t p1,
                               Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i, sum, mean, n
@@ -98,9 +98,9 @@ cdef inline void _kernel_mean(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_sum(dtype_t_out* out, Py_ssize_t odepth,
                              Py_ssize_t[::1] histo,
-                             double pop, dtype_t g,
+                             cnp.float64_t pop, dtype_t g,
                              Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                             double p0, double p1,
+                             cnp.float64_t p0, cnp.float64_t p1,
                              Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i, sum, sum_g, n
@@ -124,10 +124,10 @@ cdef inline void _kernel_sum(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_subtract_mean(dtype_t_out* out, Py_ssize_t odepth,
                                        Py_ssize_t[::1] histo,
-                                       double pop, dtype_t g,
+                                       cnp.float64_t pop, dtype_t g,
                                        Py_ssize_t n_bins,
-                                       Py_ssize_t mid_bin, double p0,
-                                       double p1, Py_ssize_t s0,
+                                       Py_ssize_t mid_bin, cnp.float64_t p0,
+                                       cnp.float64_t p1, Py_ssize_t s0,
                                        Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i, sum, mean, n
@@ -151,11 +151,11 @@ cdef inline void _kernel_subtract_mean(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_enhance_contrast(dtype_t_out* out,
                                           Py_ssize_t odepth,
-                                          Py_ssize_t[::1] histo, double pop,
+                                          Py_ssize_t[::1] histo, cnp.float64_t pop,
                                           dtype_t g,
                                           Py_ssize_t n_bins,
-                                          Py_ssize_t mid_bin, double p0,
-                                          double p1, Py_ssize_t s0,
+                                          Py_ssize_t mid_bin, cnp.float64_t p0,
+                                          cnp.float64_t p1, Py_ssize_t s0,
                                           Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i, imin, imax, sum, delta
@@ -188,9 +188,9 @@ cdef inline void _kernel_enhance_contrast(dtype_t_out* out,
 
 cdef inline void _kernel_percentile(dtype_t_out* out, Py_ssize_t odepth,
                                     Py_ssize_t[::1] histo,
-                                    double pop, dtype_t g,
+                                    cnp.float64_t pop, dtype_t g,
                                     Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                                    double p0, double p1,
+                                    cnp.float64_t p0, cnp.float64_t p1,
                                     Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i
@@ -213,9 +213,9 @@ cdef inline void _kernel_percentile(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_pop(dtype_t_out* out, Py_ssize_t odepth,
                              Py_ssize_t[::1] histo,
-                             double pop, dtype_t g,
+                             cnp.float64_t pop, dtype_t g,
                              Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                             double p0, double p1,
+                             cnp.float64_t p0, cnp.float64_t p1,
                              Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef Py_ssize_t i, sum, n
@@ -234,9 +234,9 @@ cdef inline void _kernel_pop(dtype_t_out* out, Py_ssize_t odepth,
 
 cdef inline void _kernel_threshold(dtype_t_out* out, Py_ssize_t odepth,
                                    Py_ssize_t[::1] histo,
-                                   double pop, dtype_t g,
+                                   cnp.float64_t pop, dtype_t g,
                                    Py_ssize_t n_bins, Py_ssize_t mid_bin,
-                                   double p0, double p1,
+                                   cnp.float64_t p0, cnp.float64_t p1,
                                    Py_ssize_t s0, Py_ssize_t s1) nogil:
 
     cdef int i
@@ -257,7 +257,7 @@ def _autolevel(dtype_t[:, ::1] image,
                char[:, ::1] footprint,
                char[:, ::1] mask,
                dtype_t_out[:, :, ::1] out,
-               signed char shift_x, signed char shift_y, double p0, double p1,
+               signed char shift_x, signed char shift_y, cnp.float64_t p0, cnp.float64_t p1,
                Py_ssize_t n_bins):
 
     _core(_kernel_autolevel[dtype_t_out, dtype_t], image, footprint, mask, out,
@@ -268,7 +268,7 @@ def _gradient(dtype_t[:, ::1] image,
               char[:, ::1] footprint,
               char[:, ::1] mask,
               dtype_t_out[:, :, ::1] out,
-              signed char shift_x, signed char shift_y, double p0, double p1,
+              signed char shift_x, signed char shift_y, cnp.float64_t p0, cnp.float64_t p1,
               Py_ssize_t n_bins):
 
     _core(_kernel_gradient[dtype_t_out, dtype_t], image, footprint, mask, out,
@@ -279,7 +279,7 @@ def _mean(dtype_t[:, ::1] image,
           char[:, ::1] footprint,
           char[:, ::1] mask,
           dtype_t_out[:, :, ::1] out,
-          signed char shift_x, signed char shift_y, double p0, double p1,
+          signed char shift_x, signed char shift_y, cnp.float64_t p0, cnp.float64_t p1,
           Py_ssize_t n_bins):
 
     _core(_kernel_mean[dtype_t_out, dtype_t], image, footprint, mask, out,
@@ -290,7 +290,7 @@ def _sum(dtype_t[:, ::1] image,
          char[:, ::1] footprint,
          char[:, ::1] mask,
          dtype_t_out[:, :, ::1] out,
-         signed char shift_x, signed char shift_y, double p0, double p1,
+         signed char shift_x, signed char shift_y, cnp.float64_t p0, cnp.float64_t p1,
          Py_ssize_t n_bins):
 
     _core(_kernel_sum[dtype_t_out, dtype_t], image, footprint, mask, out,
@@ -301,7 +301,7 @@ def _subtract_mean(dtype_t[:, ::1] image,
                    char[:, ::1] footprint,
                    char[:, ::1] mask,
                    dtype_t_out[:, :, ::1] out,
-                   signed char shift_x, signed char shift_y, double p0, double p1,
+                   signed char shift_x, signed char shift_y, cnp.float64_t p0, cnp.float64_t p1,
                    Py_ssize_t n_bins):
 
     _core(_kernel_subtract_mean[dtype_t_out, dtype_t], image, footprint, mask,
@@ -312,7 +312,7 @@ def _enhance_contrast(dtype_t[:, ::1] image,
                       char[:, ::1] footprint,
                       char[:, ::1] mask,
                       dtype_t_out[:, :, ::1] out,
-                      signed char shift_x, signed char shift_y, double p0, double p1,
+                      signed char shift_x, signed char shift_y, cnp.float64_t p0, cnp.float64_t p1,
                       Py_ssize_t n_bins):
 
     _core(_kernel_enhance_contrast[dtype_t_out, dtype_t], image, footprint,
@@ -323,7 +323,7 @@ def _percentile(dtype_t[:, ::1] image,
                 char[:, ::1] footprint,
                 char[:, ::1] mask,
                 dtype_t_out[:, :, ::1] out,
-                signed char shift_x, signed char shift_y, double p0, double p1,
+                signed char shift_x, signed char shift_y, cnp.float64_t p0, cnp.float64_t p1,
                 Py_ssize_t n_bins):
 
     _core(_kernel_percentile[dtype_t_out, dtype_t], image, footprint, mask, out,
@@ -334,7 +334,7 @@ def _pop(dtype_t[:, ::1] image,
          char[:, ::1] footprint,
          char[:, ::1] mask,
          dtype_t_out[:, :, ::1] out,
-         signed char shift_x, signed char shift_y, double p0, double p1,
+         signed char shift_x, signed char shift_y, cnp.float64_t p0, cnp.float64_t p1,
          Py_ssize_t n_bins):
 
     _core(_kernel_pop[dtype_t_out, dtype_t], image, footprint, mask, out,
@@ -345,7 +345,7 @@ def _threshold(dtype_t[:, ::1] image,
                char[:, ::1] footprint,
                char[:, ::1] mask,
                dtype_t_out[:, :, ::1] out,
-               signed char shift_x, signed char shift_y, double p0, double p1,
+               signed char shift_x, signed char shift_y, cnp.float64_t p0, cnp.float64_t p1,
                Py_ssize_t n_bins):
 
     _core(_kernel_threshold[dtype_t_out, dtype_t], image, footprint, mask, out,

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -645,7 +645,7 @@ class TestRank():
         # make sure output is of dtype double
         with expected_warnings(['Bad rank filter performance']):
             out = rank.entropy(data, np.ones((16, 16), dtype=np.uint8))
-        assert out.dtype == np.double
+        assert out.dtype == np.float64
 
     def test_footprint_dtypes(self):
 

--- a/skimage/future/graph/_ncut_cy.pyx
+++ b/skimage/future/graph/_ncut_cy.pyx
@@ -6,7 +6,8 @@ cimport numpy as cnp
 import numpy as np
 cnp.import_array()
 
-def argmin2(cnp.double_t[:] array):
+
+def argmin2(cnp.float64_t[:] array):
     """Return the index of the 2nd smallest value in an array.
 
     Parameters
@@ -62,9 +63,9 @@ def cut_cost(cut, W):
     cdef cnp.int32_t row, col
     cdef cnp.int32_t[:] indices = W.indices
     cdef cnp.int32_t[:] indptr = W.indptr
-    cdef cnp.double_t[:] data = W.data.astype(np.double)
+    cdef cnp.float64_t[:] data = W.data.astype(np.float64)
     cdef cnp.int32_t row_index
-    cdef cnp.double_t cost = 0
+    cdef cnp.float64_t cost = 0
 
     num_rows = W.shape[0]
     num_cols = W.shape[1]

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -360,7 +360,7 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
         graph.nodes[n].update({'labels': [n],
                                'pixel count': 0,
                                'total color': np.array([0, 0, 0],
-                                                      dtype=np.float64)})
+                                                       dtype=np.float64)})
 
     for index in np.ndindex(labels.shape):
         current = labels[index]

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -360,7 +360,7 @@ def rag_mean_color(image, labels, connectivity=2, mode='distance',
         graph.nodes[n].update({'labels': [n],
                                'pixel count': 0,
                                'total color': np.array([0, 0, 0],
-                                                      dtype=np.double)})
+                                                      dtype=np.float64)})
 
     for index in np.ndindex(labels.shape):
         current = labels[index]

--- a/skimage/graph/heap.pxd
+++ b/skimage/graph/heap.pxd
@@ -4,6 +4,7 @@ other cython modules can "cimport heap" and thus use the
 C versions of pop(), push(), and value_of(): pop_fast(), push_fast() and
 value_of_fast()
 """
+cimport numpy as cnp
 
 # determine datatypes for heap
 ctypedef cnp.float64_t VALUE_T

--- a/skimage/graph/heap.pxd
+++ b/skimage/graph/heap.pxd
@@ -6,7 +6,7 @@ value_of_fast()
 """
 
 # determine datatypes for heap
-ctypedef double VALUE_T
+ctypedef cnp.float64_t VALUE_T
 ctypedef Py_ssize_t REFERENCE_T
 ctypedef REFERENCE_T INDEX_T
 ctypedef unsigned char BOOL_T

--- a/skimage/graph/heap.pyx
+++ b/skimage/graph/heap.pyx
@@ -36,7 +36,7 @@ import cython
 from libc.stdlib cimport malloc, free
 
 cdef extern from "pyport.h":
-  double Py_HUGE_VAL
+  cnp.float64_t Py_HUGE_VAL
 
 cdef VALUE_T inf = Py_HUGE_VAL
 
@@ -671,7 +671,7 @@ cdef class FastUpdateBinaryHeap(BinaryHeap):
         i = (1 << self.levels) - 1 + ir
         return self._values[i]
 
-    def push(self, double value, int reference):
+    def push(self, VALUE_T value, int reference):
         """push(value, reference)
 
         Append/update a value in the heap.
@@ -693,7 +693,7 @@ cdef class FastUpdateBinaryHeap(BinaryHeap):
         if self.push_fast(value, reference) == -1:
             raise ValueError('reference outside of range [0, max_reference]')
 
-    def push_if_lower(self, double value, int reference):
+    def push_if_lower(self, VALUE_T value, int reference):
         """push_if_lower(value, reference)
 
         Append/update a value in the heap if the extant value is lower.

--- a/skimage/io/_plugins/_colormixer.pyx
+++ b/skimage/io/_plugins/_colormixer.pyx
@@ -13,7 +13,7 @@ one.
 """
 
 cimport numpy as cnp
-from libc.math cimport exp, pow
+from libc.math cimport expf, pow
 cnp.import_array()
 
 
@@ -65,7 +65,7 @@ def add(cnp.ndarray[cnp.uint8_t, ndim=3] img,
 
 def multiply(cnp.ndarray[cnp.uint8_t, ndim=3] img,
              cnp.ndarray[cnp.uint8_t, ndim=3] stateimg,
-             Py_ssize_t channel, float amount):
+             Py_ssize_t channel, cnp.float32_t amount):
     """Multiply a color channel of `stateimg` by a certain amount, and
     store the result in `img`.  Overflow is clipped.
 
@@ -84,9 +84,9 @@ def multiply(cnp.ndarray[cnp.uint8_t, ndim=3] img,
     cdef Py_ssize_t height = img.shape[0]
     cdef Py_ssize_t width = img.shape[1]
     cdef Py_ssize_t k = channel
-    cdef float n = amount
+    cdef cnp.float32_t n = amount
 
-    cdef float op_result
+    cdef cnp.float32_t op_result
 
     cdef cnp.uint8_t lut[256]
 
@@ -110,8 +110,8 @@ def multiply(cnp.ndarray[cnp.uint8_t, ndim=3] img,
 
 
 def brightness(cnp.ndarray[cnp.uint8_t, ndim=3] img,
-             cnp.ndarray[cnp.uint8_t, ndim=3] stateimg,
-             float factor, Py_ssize_t offset):
+               cnp.ndarray[cnp.uint8_t, ndim=3] stateimg,
+               cnp.float32_t factor, Py_ssize_t offset):
     """Modify the brightness of an image.
     'factor' is multiplied to all channels, which are
     then added by 'amount'. Overflow is clipped.
@@ -132,7 +132,7 @@ def brightness(cnp.ndarray[cnp.uint8_t, ndim=3] img,
     cdef Py_ssize_t height = img.shape[0]
     cdef Py_ssize_t width = img.shape[1]
 
-    cdef float op_result
+    cdef cnp.float32_t op_result
     cdef cnp.uint8_t lut[256]
 
     cdef Py_ssize_t i, j, k
@@ -157,15 +157,15 @@ def brightness(cnp.ndarray[cnp.uint8_t, ndim=3] img,
 
 def sigmoid_gamma(cnp.ndarray[cnp.uint8_t, ndim=3] img,
                   cnp.ndarray[cnp.uint8_t, ndim=3] stateimg,
-                  float alpha, float beta):
+                  cnp.float32_t alpha, cnp.float32_t beta):
 
     cdef Py_ssize_t height = img.shape[0]
     cdef Py_ssize_t width = img.shape[1]
 
     cdef Py_ssize_t i, j, k
 
-    cdef float c1 = 1 / (1 + exp(beta))
-    cdef float c2 = 1 / (1 + exp(beta - alpha)) - c1
+    cdef cnp.float32_t c1 = 1 / (1 + exp(beta))
+    cdef cnp.float32_t c2 = 1 / (1 + exp(beta - alpha)) - c1
 
     cdef cnp.uint8_t lut[256]
 
@@ -184,7 +184,7 @@ def sigmoid_gamma(cnp.ndarray[cnp.uint8_t, ndim=3] img,
 
 def gamma(cnp.ndarray[cnp.uint8_t, ndim=3] img,
           cnp.ndarray[cnp.uint8_t, ndim=3] stateimg,
-          float gamma):
+          cnp.float32_t gamma):
 
     cdef Py_ssize_t height = img.shape[0]
     cdef Py_ssize_t width = img.shape[1]
@@ -210,8 +210,8 @@ def gamma(cnp.ndarray[cnp.uint8_t, ndim=3] img,
                 img[i,j,2] = lut[stateimg[i,j,2]]
 
 
-cdef void rgb_2_hsv(float* RGB, float* HSV) nogil:
-    cdef float R, G, B, H, S, V, MAX, MIN
+cdef void rgb_2_hsv(cnp.float32_t* RGB, cnp.float32_t* HSV) nogil:
+    cdef cnp.float32_t R, G, B, H, S, V, MAX, MIN
     R = RGB[0]
     G = RGB[1]
     B = RGB[2]
@@ -273,9 +273,9 @@ cdef void rgb_2_hsv(float* RGB, float* HSV) nogil:
     HSV[2] = V
 
 
-cdef void hsv_2_rgb(float* HSV, float* RGB) nogil:
-    cdef float H, S, V
-    cdef float f, p, q, t, r, g, b
+cdef void hsv_2_rgb(cnp.float32_t* HSV, cnp.float32_t* RGB) nogil:
+    cdef cnp.float32_t H, S, V
+    cdef cnp.float32_t f, p, q, t, r, g, b
     cdef Py_ssize_t hi
 
     H = HSV[0]
@@ -362,8 +362,8 @@ def py_hsv_2_rgb(H, S, V):
     https://en.wikipedia.org/wiki/HSL_and_HSV
 
     '''
-    cdef float HSV[3]
-    cdef float RGB[3]
+    cdef cnp.float32_t HSV[3]
+    cdef cnp.float32_t RGB[3]
 
     HSV[0] = H
     HSV[1] = S
@@ -401,8 +401,8 @@ def py_rgb_2_hsv(R, G, B):
     https://en.wikipedia.org/wiki/HSL_and_HSV
 
     '''
-    cdef float HSV[3]
-    cdef float RGB[3]
+    cdef cnp.float32_t HSV[3]
+    cdef cnp.float32_t RGB[3]
 
     RGB[0] = R
     RGB[1] = G
@@ -419,7 +419,7 @@ def py_rgb_2_hsv(R, G, B):
 
 def hsv_add(cnp.ndarray[cnp.uint8_t, ndim=3] img,
             cnp.ndarray[cnp.uint8_t, ndim=3] stateimg,
-            float h_amt, float s_amt, float v_amt):
+            cnp.float32_t h_amt, cnp.float32_t s_amt, cnp.float32_t v_amt):
     """Modify the image color by specifying additive HSV Values.
 
     Since the underlying images are RGB, all three values HSV
@@ -452,8 +452,8 @@ def hsv_add(cnp.ndarray[cnp.uint8_t, ndim=3] img,
     cdef Py_ssize_t height = img.shape[0]
     cdef Py_ssize_t width = img.shape[1]
 
-    cdef float HSV[3]
-    cdef float RGB[3]
+    cdef cnp.float32_t HSV[3]
+    cdef cnp.float32_t RGB[3]
 
     cdef Py_ssize_t i, j
 
@@ -484,7 +484,8 @@ def hsv_add(cnp.ndarray[cnp.uint8_t, ndim=3] img,
 
 def hsv_multiply(cnp.ndarray[cnp.uint8_t, ndim=3] img,
                  cnp.ndarray[cnp.uint8_t, ndim=3] stateimg,
-                 float h_amt, float s_amt, float v_amt):
+                 cnp.float32_t h_amt, cnp.float32_t s_amt,
+                 cnp.float32_t v_amt):
     """Modify the image color by specifying multiplicative HSV Values.
 
     Since the underlying images are RGB, all three values HSV
@@ -521,8 +522,8 @@ def hsv_multiply(cnp.ndarray[cnp.uint8_t, ndim=3] img,
     cdef Py_ssize_t height = img.shape[0]
     cdef Py_ssize_t width = img.shape[1]
 
-    cdef float HSV[3]
-    cdef float RGB[3]
+    cdef cnp.float32_t HSV[3]
+    cdef cnp.float32_t RGB[3]
 
     cdef Py_ssize_t i, j
 

--- a/skimage/io/_plugins/_colormixer.pyx
+++ b/skimage/io/_plugins/_colormixer.pyx
@@ -13,7 +13,7 @@ one.
 """
 
 cimport numpy as cnp
-from libc.math cimport expf, pow
+from libc.math cimport exp, pow
 cnp.import_array()
 
 

--- a/skimage/io/_plugins/_histograms.pyx
+++ b/skimage/io/_plugins/_histograms.pyx
@@ -8,8 +8,9 @@ cimport numpy as cnp
 cnp.import_array()
 
 
-cdef inline float tri_max(float a, float b, float c):
-    cdef float MAX
+cdef inline cnp.float32_t tri_max(cnp.float32_t a, cnp.float32_t b,
+                                  cnp.float32_t c):
+    cdef cnp.float32_t MAX
 
     if a > b:
         MAX = a
@@ -50,14 +51,14 @@ def histograms(cnp.ndarray[cnp.uint8_t, ndim=3] img, int nbins):
     v = np.zeros((nbins,), dtype=np.int32)
 
     cdef int i, j, k, rbin, gbin, bbin, vbin
-    cdef float bin_width = 255./ nbins
-    cdef float R, G, B, V
+    cdef cnp.float32_t bin_width = 255./ nbins
+    cdef cnp.float32_t R, G, B, V
 
     for i in range(height):
         for j in range(width):
-            R = <float>img[i, j, 0]
-            G = <float>img[i, j, 1]
-            B = <float>img[i, j, 2]
+            R = <cnp.float32_t>img[i, j, 0]
+            G = <cnp.float32_t>img[i, j, 1]
+            B = <cnp.float32_t>img[i, j, 2]
             V = tri_max(R, G, B)
 
             rbin = <int>(R / bin_width)

--- a/skimage/measure/_find_contours.py
+++ b/skimage/measure/_find_contours.py
@@ -148,7 +148,7 @@ def find_contours(image, level=None,
     if level is None:
         level = (np.nanmin(image) + np.nanmax(image)) / 2.0
 
-    segments = _get_contour_segments(image.astype(np.double), float(level),
+    segments = _get_contour_segments(image.astype(np.float64), float(level),
                                      fully_connected == 'high', mask=mask)
     contours = _assemble_contours(segments)
     if positive_orientation == 'high':

--- a/skimage/measure/_find_contours_cy.pyx
+++ b/skimage/measure/_find_contours_cy.pyx
@@ -9,15 +9,16 @@ cnp.import_array()
 cdef extern from "numpy/npy_math.h":
     bint npy_isnan(double x)
 
-cdef inline double _get_fraction(double from_value, double to_value,
-                                 double level):
+cdef inline cnp.float64_t _get_fraction(cnp.float64_t from_value,
+                                        cnp.float64_t to_value,
+                                        cnp.float64_t level):
     if (to_value == from_value):
         return 0
     return ((level - from_value) / (to_value - from_value))
 
 
-def _get_contour_segments(double[:, :] array,
-                          double level, bint vertex_connect_high,
+def _get_contour_segments(cnp.float64_t[:, :] array,
+                          cnp.float64_t level, bint vertex_connect_high,
                           cnp.uint8_t[:, :] mask):
     """Iterate across the given array in a marching-squares fashion,
     looking for segments that cross 'level'. If such a segment is
@@ -36,7 +37,7 @@ def _get_contour_segments(double[:, :] array,
     # never steps out of bounds). The square is represented by four pointers:
     # ul, ur, ll, and lr (for 'upper left', etc.). We also maintain the current
     # 2D coordinates for the position of the upper-left pointer. Note that we
-    # ensured that the array is of type 'double' and is C-contiguous (last
+    # ensured that the array is of type 'float64' and is C-contiguous (last
     # index varies the fastest).
     #
     # There are sixteen different possible square types, diagramed below.
@@ -70,7 +71,7 @@ def _get_contour_segments(double[:, :] array,
     cdef bint use_mask = mask is not None
     cdef unsigned char square_case = 0
     cdef tuple top, bottom, left, right
-    cdef double ul, ur, ll, lr
+    cdef cnp.float64_t ul, ur, ll, lr
     cdef Py_ssize_t r0, r1, c0, c1
 
     for r0 in range(array.shape[0] - 1):

--- a/skimage/measure/_find_contours_cy.pyx
+++ b/skimage/measure/_find_contours_cy.pyx
@@ -7,7 +7,7 @@ cimport numpy as cnp
 cnp.import_array()
 
 cdef extern from "numpy/npy_math.h":
-    bint npy_isnan(double x)
+    bint npy_isnan(cnp.float64_t x)
 
 cdef inline cnp.float64_t _get_fraction(cnp.float64_t from_value,
                                         cnp.float64_t to_value,

--- a/skimage/measure/_marching_cubes_lewiner_cy.pyx
+++ b/skimage/measure/_marching_cubes_lewiner_cy.pyx
@@ -21,9 +21,9 @@ by Almar Klein in 2012. Adapted for scikit-image in 2016.
 
 # Cython specific imports
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 import cython
-np.import_array()
+cnp.import_array()
 
 # Enable low level memory management
 from libc.stdlib cimport malloc, free
@@ -936,7 +936,7 @@ cdef class LutProvider:
 
 def marching_cubes(cnp.float32_t[:, :, :] im not None, double isovalue,
                    LutProvider luts, int st=1, int classic=0,
-                   np.ndarray[np.npy_bool, ndim=3, cast=True] mask=None):
+                   cnp.ndarray[cnp.npy_bool, ndim=3, cast=True] mask=None):
     """ marching_cubes(im, double isovalue, LutProvider luts, int st=1, int classic=0)
     Main entry to apply marching cubes.
 

--- a/skimage/measure/_marching_cubes_lewiner_cy.pyx
+++ b/skimage/measure/_marching_cubes_lewiner_cy.pyx
@@ -937,7 +937,7 @@ cdef class LutProvider:
 def marching_cubes(cnp.float32_t[:, :, :] im not None, cnp.float64_t isovalue,
                    LutProvider luts, int st=1, int classic=0,
                    cnp.ndarray[cnp.npy_bool, ndim=3, cast=True] mask=None):
-    """ marching_cubes(im, double isovalue, LutProvider luts, int st=1, int classic=0)
+    """ marching_cubes(im, cnp.float64_t isovalue, LutProvider luts, int st=1, int classic=0)
     Main entry to apply marching cubes.
 
     Masked version of marching cubes. This function will check a

--- a/skimage/measure/_marching_cubes_lewiner_cy.pyx
+++ b/skimage/measure/_marching_cubes_lewiner_cy.pyx
@@ -44,8 +44,8 @@ def remove_degenerate_faces(vertices, faces, *arrays):
     vertices_map1 = vertices_map0.copy()
     faces_ok = np.ones(len(faces), dtype=np.int32)
 
-    cdef float [:, :] vertices_ = vertices
-    cdef float [:] v1, v2, v3
+    cdef cnp.float32_t [:, :] vertices_ = vertices
+    cdef cnp.float32_t [:] v1, v2, v3
     cdef int [:, :]  faces_ = faces
 
     cdef int [:] vertices_map1_ = vertices_map1
@@ -169,9 +169,9 @@ cdef class Cell:
     cdef int *faceLayer2 # The actual second face layer
 
     # Stuff to store the output vertices
-    cdef float *_vertices
-    cdef float *_normals
-    cdef float *_values
+    cdef cnp.float32_t *_vertices
+    cdef cnp.float32_t *_normals
+    cdef cnp.float32_t *_values
     cdef int _vertexCount
     cdef int _vertexMaxCount
 
@@ -215,9 +215,9 @@ cdef class Cell:
         # Init vertices
         self._vertexCount = 0
         self._vertexMaxCount = 8
-        self._vertices = <float *>malloc(self._vertexMaxCount*3 * sizeof(float))
-        self._normals = <float *>malloc(self._vertexMaxCount*3 * sizeof(float))
-        self._values = <float *>malloc(self._vertexMaxCount * sizeof(float))
+        self._vertices = <cnp.float32_t *>malloc(self._vertexMaxCount*3 * sizeof(cnp.float32_t))
+        self._normals = <cnp.float32_t *>malloc(self._vertexMaxCount*3 * sizeof(cnp.float32_t))
+        self._values = <cnp.float32_t *>malloc(self._vertexMaxCount * sizeof(cnp.float32_t))
         # Clear normals and values
         cdef int i, j
         if self._values is not NULL and self._normals is not NULL:
@@ -248,9 +248,9 @@ cdef class Cell:
         """
         # Allocate new array
         cdef int newMaxCount = self._vertexMaxCount * 2
-        cdef float *newVertices = <float *>malloc(newMaxCount*3 * sizeof(float))
-        cdef float *newNormals = <float *>malloc(newMaxCount*3 * sizeof(float))
-        cdef float *newValues = <float *>malloc(newMaxCount * sizeof(float))
+        cdef cnp.float32_t *newVertices = <cnp.float32_t *>malloc(newMaxCount*3 * sizeof(cnp.float32_t))
+        cdef cnp.float32_t *newNormals = <cnp.float32_t *>malloc(newMaxCount*3 * sizeof(cnp.float32_t))
+        cdef cnp.float32_t *newValues = <cnp.float32_t *>malloc(newMaxCount * sizeof(cnp.float32_t))
         if newVertices is NULL or newNormals is NULL or newValues is NULL:
             free(newVertices)
             free(newNormals)
@@ -295,7 +295,8 @@ cdef class Cell:
 
     ## Adding results
 
-    cdef int add_vertex(self, float x, float y, float z):
+    cdef int add_vertex(self, cnp.float32_t x, cnp.float32_t y,
+                        cnp.float32_t z):
         """ Add a vertex to the result. Return index in vertex array.
         """
         # Check if array is large enough
@@ -309,7 +310,8 @@ cdef class Cell:
         return self._vertexCount -1
 
 
-    cdef void add_gradient(self, int vertexIndex, float gx, float gy, float gz):
+    cdef void add_gradient(self, int vertexIndex, cnp.float32_t gx,
+                           cnp.float32_t gy, cnp.float32_t gz):
         """ Add a gradient value to the vertex corresponding to the given index.
         """
         self._normals[vertexIndex*3+0] += gx
@@ -317,12 +319,14 @@ cdef class Cell:
         self._normals[vertexIndex*3+2] += gz
 
 
-    cdef void add_gradient_from_index(self, int vertexIndex, int i, float strength):
+    cdef void add_gradient_from_index(self, int vertexIndex, int i,
+                                      cnp.float32_t strength):
         """ Add a gradient value to the vertex corresponding to the given index.
         vertexIndex is the index in the large array of vertices that is returned.
         i is the index of the array of vertices 0-7 for the current cell.
         """
-        self.add_gradient(vertexIndex, self.vg[i*3+0] * strength, self.vg[i*3+1] * strength, self.vg[i*3+2] * strength)
+        self.add_gradient(vertexIndex, self.vg[i*3+0] * strength,
+                          self.vg[i*3+1] * strength, self.vg[i*3+2] * strength)
 
 
     cdef add_face(self, int index):
@@ -345,7 +349,7 @@ cdef class Cell:
         """ Get the final vertex array.
         """
         vertices = np.empty((self._vertexCount,3), np.float32)
-        cdef float [:, :] vertices_ = vertices
+        cdef cnp.float32_t [:, :] vertices_ = vertices
         cdef int i, j
         for i in range(self._vertexCount):
             for j in range(3):
@@ -357,7 +361,7 @@ cdef class Cell:
         The normals are normalized to unit length.
         """
         normals = np.empty((self._vertexCount,3), np.float32)
-        cdef float [:, :] normals_ = normals
+        cdef cnp.float32_t [:, :] normals_ = normals
 
         cdef int i, j
         cdef double length, dtmp
@@ -382,7 +386,7 @@ cdef class Cell:
 
     def get_values(self):
         values = np.empty((self._vertexCount,), np.float32)
-        cdef float [:] values_ = values
+        cdef cnp.float32_t [:] values_ = values
         cdef int i, j
         for i in range(self._vertexCount):
             values_[i] = self._values[i]
@@ -930,7 +934,7 @@ cdef class LutProvider:
 
         self.SUBCONFIG13 = Lut(SUBCONFIG13)
 
-def marching_cubes(float[:, :, :] im not None, double isovalue,
+def marching_cubes(cnp.float32_t[:, :, :] im not None, double isovalue,
                    LutProvider luts, int st=1, int classic=0,
                    np.ndarray[np.npy_bool, ndim=3, cast=True] mask=None):
     """ marching_cubes(im, double isovalue, LutProvider luts, int st=1, int classic=0)

--- a/skimage/measure/_marching_cubes_lewiner_cy.pyx
+++ b/skimage/measure/_marching_cubes_lewiner_cy.pyx
@@ -29,10 +29,10 @@ cnp.import_array()
 from libc.stdlib cimport malloc, free
 
 # Define tiny winy number
-cdef double FLT_EPSILON = np.spacing(1.0) #0.0000001
+cdef cnp.float64_t FLT_EPSILON = np.spacing(1.0) #0.0000001
 
 # Define abs function for doubles
-cdef inline double dabs(double a): return a if a>=0 else -a
+cdef inline cnp.float64_t dabs(cnp.float64_t a): return a if a>=0 else -a
 cdef inline int imin(int a, int b): return a if a<b else b
 
 # todo: allow dynamic isovalue?
@@ -128,31 +128,31 @@ cdef class Cell:
     cdef int step
 
     # Values of cube corners (isovalue subtracted)
-    cdef double v0
-    cdef double v1
-    cdef double v2
-    cdef double v3
-    cdef double v4
-    cdef double v5
-    cdef double v6
-    cdef double v7
+    cdef cnp.float64_t v0
+    cdef cnp.float64_t v1
+    cdef cnp.float64_t v2
+    cdef cnp.float64_t v3
+    cdef cnp.float64_t v4
+    cdef cnp.float64_t v5
+    cdef cnp.float64_t v6
+    cdef cnp.float64_t v7
 
     # Small arrays to store the above values in (allowing indexing)
     # and also the gradient at these points
-    cdef double *vv
-    cdef double *vg
+    cdef cnp.float64_t *vv
+    cdef cnp.float64_t *vg
 
     # Max value of the eight corners
-    cdef double vmax
+    cdef cnp.float64_t vmax
 
     # Vertex position of center of cube (only calculated if needed)
-    cdef double v12_x
-    cdef double v12_y
-    cdef double v12_z
+    cdef cnp.float64_t v12_x
+    cdef cnp.float64_t v12_y
+    cdef cnp.float64_t v12_z
     # And corresponding gradient
-    cdef double v12_xg
-    cdef double v12_yg
-    cdef double v12_zg
+    cdef cnp.float64_t v12_xg
+    cdef cnp.float64_t v12_yg
+    cdef cnp.float64_t v12_zg
     cdef int v12_calculated # a boolean
 
     # The index value, our magic 256 bit word
@@ -205,8 +205,8 @@ cdef class Cell:
     def __cinit__(self):
 
         # Init tiny arrays for vertices and gradients at the vertices
-        self.vv = <double *>malloc(8 * sizeof(double))
-        self.vg = <double *>malloc(8*3 * sizeof(double))
+        self.vv = <cnp.float64_t *>malloc(8 * sizeof(cnp.float64_t))
+        self.vg = <cnp.float64_t *>malloc(8*3 * sizeof(cnp.float64_t))
 
         # Init face layers
         self.faceLayer1 = NULL
@@ -364,7 +364,7 @@ cdef class Cell:
         cdef cnp.float32_t [:, :] normals_ = normals
 
         cdef int i, j
-        cdef double length, dtmp
+        cdef cnp.float64_t length, dtmp
         for i in range(self._vertexCount):
             length = 0.0
             for j in range(3):
@@ -407,9 +407,9 @@ cdef class Cell:
             self.faceLayer2[i] = -1
 
 
-    cdef void set_cube(self,    double isovalue, int x, int y, int z, int step,
-                                double v0, double v1, double v2, double v3,
-                                double v4, double v5, double v6, double v7):
+    cdef void set_cube(self,    cnp.float64_t isovalue, int x, int y, int z, int step,
+                                cnp.float64_t v0, cnp.float64_t v1, cnp.float64_t v2, cnp.float64_t v3,
+                                cnp.float64_t v4, cnp.float64_t v5, cnp.float64_t v6, cnp.float64_t v7):
         """ Set the cube to the new location.
 
         Set the values of the cube corners. The isovalue is subtracted
@@ -504,9 +504,9 @@ cdef class Cell:
         cdef int dx1, dy1, dz1
         cdef int dx2, dy2, dz2
         cdef int index1, index2
-        cdef double tmpf1, tmpf2
-        cdef double fx, fy, fz, ff
-        cdef double stp = <double>self.step
+        cdef cnp.float64_t tmpf1, tmpf2
+        cdef cnp.float64_t fx, fy, fz, ff
+        cdef cnp.float64_t stp = <cnp.float64_t>self.step
 
         # Get index in the face layer and corresponding vertex number
         indexInFaceLayer = self.get_index_in_facelayer(vi)
@@ -557,14 +557,14 @@ cdef class Cell:
             else:
                 # Interpolate by applying a kind of center-of-mass method
                 fx, fy, fz, ff = 0.0, 0.0, 0.0, 0.0
-                fx += <double>dx1 * tmpf1;  fy += <double>dy1 * tmpf1;  fz += <double>dz1 * tmpf1;  ff += tmpf1
-                fx += <double>dx2 * tmpf2;  fy += <double>dy2 * tmpf2;  fz += <double>dz2 * tmpf2;  ff += tmpf2
+                fx += <cnp.float64_t>dx1 * tmpf1;  fy += <cnp.float64_t>dy1 * tmpf1;  fz += <cnp.float64_t>dz1 * tmpf1;  ff += tmpf1
+                fx += <cnp.float64_t>dx2 * tmpf2;  fy += <cnp.float64_t>dy2 * tmpf2;  fz += <cnp.float64_t>dz2 * tmpf2;  ff += tmpf2
 
                 # Add vertex
                 indexInVertexArray = self.add_vertex(
-                                <double>self.x + stp*fx/ff,
-                                <double>self.y + stp*fy/ff,
-                                <double>self.z + stp*fz/ff )
+                                <cnp.float64_t>self.x + stp*fx/ff,
+                                <cnp.float64_t>self.y + stp*fy/ff,
+                                <cnp.float64_t>self.z + stp*fz/ff )
                 # Update face layer
                 self.faceLayer[indexInFaceLayer] = indexInVertexArray
                 # Add face and gradient
@@ -676,7 +676,7 @@ cdef class Cell:
         self.vv[7] = self.v6#
 
         # Calculate max
-        cdef double vmin, vmax
+        cdef cnp.float64_t vmin, vmax
         vmin, vmax = 0.0, 0.0
         for i in range(8):
             if self.vv[i] > vmax:
@@ -703,8 +703,8 @@ cdef class Cell:
     cdef void calculate_center_vertex(self):
         """ Calculate interpolated center vertex and its gradient.
         """
-        cdef double v0, v1, v2, v3, v4, v5, v6, v7
-        cdef double fx, fy, fz, ff
+        cdef cnp.float64_t v0, v1, v2, v3, v4, v5, v6, v7
+        cdef cnp.float64_t fx, fy, fz, ff
         fx, fy, fz, ff = 0.0, 0.0, 0.0, 0.0
 
         # Define "strength" of each corner of the cube that we need
@@ -728,7 +728,7 @@ cdef class Cell:
         fx += 0.0*v7;  fy += 1.0*v7;  fz += 1.0*v7;  ff += v7
 
         # Store
-        cdef double stp = <double>self.step
+        cdef cnp.float64_t stp = <cnp.float64_t>self.step
         self.v12_x = self.x + stp * fx / ff
         self.v12_y = self.y + stp * fy / ff
         self.v12_z = self.z + stp * fz / ff
@@ -934,7 +934,7 @@ cdef class LutProvider:
 
         self.SUBCONFIG13 = Lut(SUBCONFIG13)
 
-def marching_cubes(cnp.float32_t[:, :, :] im not None, double isovalue,
+def marching_cubes(cnp.float32_t[:, :, :] im not None, cnp.float64_t isovalue,
                    LutProvider luts, int st=1, int classic=0,
                    cnp.ndarray[cnp.npy_bool, ndim=3, cast=True] mask=None):
     """ marching_cubes(im, double isovalue, LutProvider luts, int st=1, int classic=0)
@@ -1288,7 +1288,7 @@ cdef int test_face(Cell cell, int face):
         absFace *= -1
 
     # Get values of corners A B C D
-    cdef double A, B, C, D
+    cdef cnp.float64_t A, B, C, D
     if absFace == 1:
         A, B, C, D = cell.v0, cell.v4, cell.v5, cell.v1
     elif absFace == 2:
@@ -1303,7 +1303,7 @@ cdef int test_face(Cell cell, int face):
         A, B, C, D = cell.v4, cell.v7, cell.v6, cell.v5
 
     # Return sign
-    cdef double AC_BD = A*C - B*D
+    cdef cnp.float64_t AC_BD = A*C - B*D
     if AC_BD > - FLT_EPSILON and AC_BD < FLT_EPSILON:
         return face >= 0
     else:
@@ -1315,7 +1315,7 @@ cdef int test_internal(Cell cell, LutProvider luts, int case, int config, int su
     """
 
     # Typedefs
-    cdef double t, At, Bt, Ct, Dt, a, b
+    cdef cnp.float64_t t, At, Bt, Ct, Dt, a, b
     cdef int test = 0
     cdef int edge = -1 # reference edge of the triangulation
 

--- a/skimage/measure/_moments.py
+++ b/skimage/measure/_moments.py
@@ -36,7 +36,7 @@ def moments_coords(coords, order=3):
     --------
     >>> coords = np.array([[row, col]
     ...                    for row in range(13, 17)
-    ...                    for col in range(14, 18)], dtype=np.double)
+    ...                    for col in range(14, 18)], dtype=np.float64)
     >>> M = moments_coords(coords)
     >>> centroid = (M[1, 0] / M[0, 0], M[0, 1] / M[0, 0])
     >>> centroid
@@ -183,7 +183,7 @@ def moments(image, order=3):
 
     Examples
     --------
-    >>> image = np.zeros((20, 20), dtype=np.double)
+    >>> image = np.zeros((20, 20), dtype=np.float64)
     >>> image[13:17, 13:17] = 1
     >>> M = moments(image)
     >>> centroid = (M[1, 0] / M[0, 0], M[0, 1] / M[0, 0])
@@ -230,7 +230,7 @@ def moments_central(image, center=None, order=3, **kwargs):
 
     Examples
     --------
-    >>> image = np.zeros((20, 20), dtype=np.double)
+    >>> image = np.zeros((20, 20), dtype=np.float64)
     >>> image[13:17, 13:17] = 1
     >>> M = moments(image)
     >>> centroid = (M[1, 0] / M[0, 0], M[0, 1] / M[0, 0])
@@ -287,7 +287,7 @@ def moments_normalized(mu, order=3):
 
     Examples
     --------
-    >>> image = np.zeros((20, 20), dtype=np.double)
+    >>> image = np.zeros((20, 20), dtype=np.float64)
     >>> image[13:17, 13:17] = 1
     >>> m = moments(image)
     >>> centroid = (m[0, 1] / m[0, 0], m[1, 0] / m[0, 0])
@@ -341,7 +341,7 @@ def moments_hu(nu):
 
     Examples
     --------
-    >>> image = np.zeros((20, 20), dtype=np.double)
+    >>> image = np.zeros((20, 20), dtype=np.float64)
     >>> image[13:17, 13:17] = 0.5
     >>> image[10:12, 10:12] = 1
     >>> mu = moments_central(image)
@@ -369,7 +369,7 @@ def centroid(image):
 
     Examples
     --------
-    >>> image = np.zeros((20, 20), dtype=np.double)
+    >>> image = np.zeros((20, 20), dtype=np.float64)
     >>> image[13:17, 13:17] = 0.5
     >>> image[10:12, 10:12] = 1
     >>> centroid(image)

--- a/skimage/measure/_pnpoly.pyx
+++ b/skimage/measure/_pnpoly.pyx
@@ -37,8 +37,8 @@ def _grid_points_in_poly(shape, verts):
     """
     verts = np.asarray(verts)
 
-    cdef cnp.float64_t[::1] vx = verts[:, 0].astype(np.double)
-    cdef cnp.float64_t[::1] vy = verts[:, 1].astype(np.double)
+    cdef cnp.float64_t[::1] vx = verts[:, 0].astype(np.float64)
+    cdef cnp.float64_t[::1] vy = verts[:, 1].astype(np.float64)
 
     cdef Py_ssize_t M = shape[0]
     cdef Py_ssize_t N = shape[1]
@@ -79,11 +79,11 @@ def _points_in_poly(points, verts):
     points = np.asarray(points)
     verts = np.asarray(verts)
 
-    cdef cnp.float64_t[::1] x = points[:, 0].astype(np.double)
-    cdef cnp.float64_t[::1] y = points[:, 1].astype(np.double)
+    cdef cnp.float64_t[::1] x = points[:, 0].astype(np.float64)
+    cdef cnp.float64_t[::1] y = points[:, 1].astype(np.float64)
 
-    cdef cnp.float64_t[::1] vx = verts[:, 0].astype(np.double)
-    cdef cnp.float64_t[::1] vy = verts[:, 1].astype(np.double)
+    cdef cnp.float64_t[::1] vx = verts[:, 0].astype(np.float64)
+    cdef cnp.float64_t[::1] vy = verts[:, 1].astype(np.float64)
 
     cdef unsigned char[::1] out = np.zeros(x.shape[0], dtype=bool)
 

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -476,7 +476,7 @@ class RegionProperties:
         return self._intensity_image[self.slice] * image
 
     def _image_intensity_double(self):
-        return self.image_intensity.astype(np.double, copy=False)
+        return self.image_intensity.astype(np.float64, copy=False)
 
     @property
     def centroid_local(self):
@@ -492,7 +492,7 @@ class RegionProperties:
     @property
     def intensity_max(self):
         vals = self.image_intensity[self.image]
-        return np.max(vals, axis=0).astype(np.double, copy=False)
+        return np.max(vals, axis=0).astype(np.float64, copy=False)
 
     @property
     def intensity_mean(self):
@@ -501,7 +501,7 @@ class RegionProperties:
     @property
     def intensity_min(self):
         vals = self.image_intensity[self.image]
-        return np.min(vals, axis=0).astype(np.double, copy=False)
+        return np.min(vals, axis=0).astype(np.float64, copy=False)
 
     @property
     def axis_major_length(self):

--- a/skimage/measure/_regionprops_utils.py
+++ b/skimage/measure/_regionprops_utils.py
@@ -234,7 +234,7 @@ def perimeter(image, neighborhood=4):
     eroded_image = ndi.binary_erosion(image, strel, border_value=0)
     border_image = image - eroded_image
 
-    perimeter_weights = np.zeros(50, dtype=np.double)
+    perimeter_weights = np.zeros(50, dtype=np.float64)
     perimeter_weights[[5, 7, 15, 17, 25, 27]] = 1
     perimeter_weights[[21, 33]] = sqrt(2)
     perimeter_weights[[13, 23]] = (1 + sqrt(2)) / 2

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -543,7 +543,7 @@ class EllipseModel(BaseModel):
         #                                + b * ctheta * ct)
         #     return [dfx_t + dfy_t]
 
-        residuals = np.empty((N, ), dtype=np.double)
+        residuals = np.empty((N, ), dtype=np.float64)
 
         # initial guess for parameter t of closest point on ellipse
         t0 = np.arctan2(y - yc, x - xc) - theta

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -418,7 +418,7 @@ def test_ransac_sample_duplicates():
             return True
 
         def residuals(self, data):
-            return np.ones(len(data), dtype=np.double)
+            return np.ones(len(data), dtype=np.float64)
 
     # Create dataset with four unique points. Force 10 iterations
     # and check that there are no duplicated data points.

--- a/skimage/measure/tests/test_moments.py
+++ b/skimage/measure/tests/test_moments.py
@@ -14,7 +14,7 @@ from skimage._shared.utils import _supported_float_type
 
 
 def test_moments():
-    image = np.zeros((20, 20), dtype=np.double)
+    image = np.zeros((20, 20), dtype=np.float64)
     image[14, 14] = 1
     image[15, 15] = 1
     image[14, 15] = 0.5
@@ -26,7 +26,7 @@ def test_moments():
 
 
 def test_moments_central():
-    image = np.zeros((20, 20), dtype=np.double)
+    image = np.zeros((20, 20), dtype=np.float64)
     image[14, 14] = 1
     image[15, 15] = 1
     image[14, 15] = 0.5
@@ -38,7 +38,7 @@ def test_moments_central():
     assert_equal(mu, mu_calc_centroid)
 
     # shift image by dx=2, dy=2
-    image2 = np.zeros((20, 20), dtype=np.double)
+    image2 = np.zeros((20, 20), dtype=np.float64)
     image2[16, 16] = 1
     image2[17, 17] = 1
     image2[16, 17] = 0.5
@@ -49,12 +49,12 @@ def test_moments_central():
 
 
 def test_moments_coords():
-    image = np.zeros((20, 20), dtype=np.double)
+    image = np.zeros((20, 20), dtype=np.float64)
     image[13:17, 13:17] = 1
     mu_image = moments(image)
 
     coords = np.array([[r, c] for r in range(13, 17)
-                       for c in range(13, 17)], dtype=np.double)
+                       for c in range(13, 17)], dtype=np.float64)
     mu_coords = moments_coords(coords)
     assert_almost_equal(mu_coords, mu_image)
 
@@ -77,12 +77,12 @@ def test_moments_coords_dtype(dtype):
 
 
 def test_moments_central_coords():
-    image = np.zeros((20, 20), dtype=np.double)
+    image = np.zeros((20, 20), dtype=np.float64)
     image[13:17, 13:17] = 1
     mu_image = moments_central(image, (14.5, 14.5))
 
     coords = np.array([[r, c] for r in range(13, 17)
-                       for c in range(13, 17)], dtype=np.double)
+                       for c in range(13, 17)], dtype=np.float64)
     mu_coords = moments_coords_central(coords, (14.5, 14.5))
     assert_almost_equal(mu_coords, mu_image)
 
@@ -91,23 +91,23 @@ def test_moments_central_coords():
     assert_almost_equal(mu_coords_calc_centroid, mu_coords)
 
     # shift image by dx=3 dy=3
-    image = np.zeros((20, 20), dtype=np.double)
+    image = np.zeros((20, 20), dtype=np.float64)
     image[16:20, 16:20] = 1
     mu_image = moments_central(image, (14.5, 14.5))
 
     coords = np.array([[r, c] for r in range(16, 20)
-                       for c in range(16, 20)], dtype=np.double)
+                       for c in range(16, 20)], dtype=np.float64)
     mu_coords = moments_coords_central(coords, (14.5, 14.5))
     assert_almost_equal(mu_coords, mu_image)
 
 
 def test_moments_normalized():
-    image = np.zeros((20, 20), dtype=np.double)
+    image = np.zeros((20, 20), dtype=np.float64)
     image[13:17, 13:17] = 1
     mu = moments_central(image, (14.5, 14.5))
     nu = moments_normalized(mu)
     # shift image by dx=-3, dy=-3 and scale by 0.5
-    image2 = np.zeros((20, 20), dtype=np.double)
+    image2 = np.zeros((20, 20), dtype=np.float64)
     image2[11:13, 11:13] = 1
     mu2 = moments_central(image2, (11.5, 11.5))
     nu2 = moments_normalized(mu2)
@@ -135,13 +135,13 @@ def test_moments_normalized_invalid():
 
 
 def test_moments_hu():
-    image = np.zeros((20, 20), dtype=np.double)
+    image = np.zeros((20, 20), dtype=np.float64)
     image[13:15, 13:17] = 1
     mu = moments_central(image, (13.5, 14.5))
     nu = moments_normalized(mu)
     hu = moments_hu(nu)
     # shift image by dx=2, dy=3, scale by 0.5 and rotate by 90deg
-    image2 = np.zeros((20, 20), dtype=np.double)
+    image2 = np.zeros((20, 20), dtype=np.float64)
     image2[11, 11:13] = 1
     image2 = image2.T
     mu2 = moments_central(image2, (11.5, 11))

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -83,7 +83,7 @@ def test_dtype():
     with pytest.raises(TypeError):
         regionprops(np.zeros((10, 10), dtype=float))
     with pytest.raises(TypeError):
-        regionprops(np.zeros((10, 10), dtype=np.double))
+        regionprops(np.zeros((10, 10), dtype=np.float64))
     with pytest.raises(TypeError):
         regionprops(np.zeros((10, 10), dtype=bool))
 

--- a/skimage/metrics/tests/test_structural_similarity.py
+++ b/skimage/metrics/tests/test_structural_similarity.py
@@ -243,8 +243,8 @@ def test_structural_similarity_small_image(dtype):
 
 def test_invalid_input():
     # size mismatch
-    X = np.zeros((9, 9), dtype=np.double)
-    Y = np.zeros((8, 8), dtype=np.double)
+    X = np.zeros((9, 9), dtype=np.float64)
+    Y = np.zeros((8, 8), dtype=np.float64)
     with pytest.raises(ValueError):
         structural_similarity(X, Y)
     # win_size exceeds image extent

--- a/skimage/restoration/_denoise_cy.pyx
+++ b/skimage/restoration/_denoise_cy.pyx
@@ -19,10 +19,10 @@ cdef inline Py_ssize_t Py_ssize_t_min(Py_ssize_t value1, Py_ssize_t value2) nogi
         return value2
 
 
-def _denoise_bilateral(np_floats[:, :, ::1] image, double max_value,
-                       Py_ssize_t win_size, double sigma_color,
-                       double sigma_spatial, Py_ssize_t bins, mode,
-                       double cval, np_floats[::1] color_lut,
+def _denoise_bilateral(np_floats[:, :, ::1] image, cnp.float64_t max_value,
+                       Py_ssize_t win_size, cnp.float64_t sigma_color,
+                       cnp.float64_t sigma_spatial, Py_ssize_t bins, mode,
+                       cnp.float64_t cval, np_floats[::1] color_lut,
                        np_floats[::1] range_lut, np_floats[::1] empty_dims,
                        np_floats[:, :, ::1] out):
     cdef:
@@ -97,7 +97,7 @@ def _denoise_bilateral(np_floats[:, :, ::1] image, double max_value,
 
 
 def _denoise_tv_bregman(np_floats[:, :, ::1] image, np_floats weight,
-                        int max_num_iter, double eps,
+                        int max_num_iter, cnp.float64_t eps,
                         char isotropic, np_floats[:, :, ::1] out):
     cdef:
         Py_ssize_t rows = image.shape[0]
@@ -120,7 +120,7 @@ def _denoise_tv_bregman(np_floats[:, :, ::1] image, np_floats weight,
         np_floats ux, uy, uprev, unew, bxx, byy, dxx, dyy, s, tx, ty
         int i = 0
         np_floats lam = 2 * weight
-        double rmse = DBL_MAX
+        cnp.float64_t rmse = DBL_MAX
         np_floats norm = (weight + 4 * lam)
 
         Py_ssize_t out_rows, out_cols
@@ -172,7 +172,7 @@ def _denoise_tv_bregman(np_floats[:, :, ::1] image, np_floats weight,
 
                         # update root mean square error
                         tx = unew - uprev
-                        rmse += <double>(tx * tx)
+                        rmse += <cnp.float64_t>(tx * tx)
 
                         bxx = bx[r, c, k]
                         byy = by[r, c, k]

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -31,7 +31,7 @@ cdef inline np_floats patch_distance_2d(np_floats [:, :, :] p1,
     s : Py_ssize_t
         Linear size of the patches.
     var_diff : np_floats
-        The double of the expected noise variance.
+        The cnp.float64_t of the expected noise variance.
     n_channels : Py_ssize_t
         The number of channels.
 
@@ -111,7 +111,7 @@ cdef inline np_floats patch_distance_3d(np_floats [:, :, :] p1,
 
 
 def _nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image, Py_ssize_t s,
-                           Py_ssize_t d, double h, double var):
+                           Py_ssize_t d, cnp.float64_t h, cnp.float64_t var):
     """
     Perform non-local means denoising on 2-D RGB image
 
@@ -215,7 +215,7 @@ def _nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image, Py_ssize_t s,
 
 def _nl_means_denoising_3d(cnp.ndarray[np_floats, ndim=3] image,
                            Py_ssize_t s, Py_ssize_t d,
-                           double h, double var):
+                           cnp.float64_t h, cnp.float64_t var):
     """
     Perform non-local means denoising on 3-D array
 
@@ -313,10 +313,11 @@ def _nl_means_denoising_3d(cnp.ndarray[np_floats, ndim=3] image,
 #-------------- Accelerated algorithm of Froment 2015 ------------------
 
 
-cdef inline double _integral_to_distance_2d(double [:, ::] integral,
-                                            Py_ssize_t row, Py_ssize_t col,
-                                            Py_ssize_t offset,
-                                            double h2s2) nogil:
+cdef inline cnp.float64_t _integral_to_distance_2d(cnp.float64_t [:, ::] integral,
+                                                   Py_ssize_t row,
+                                                   Py_ssize_t col,
+                                                   Py_ssize_t offset,
+                                                   cnp.float64_t h2s2) nogil:
     """
     Parameters
     ----------
@@ -349,17 +350,19 @@ cdef inline double _integral_to_distance_2d(double [:, ::] integral,
     .. [2] Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
            Denoising. Image Processing On Line, 2014, vol. 4, pp. 300-326.
     """
-    cdef double distance = (integral[row + offset, col + offset] +
-                            integral[row - offset, col - offset] -
-                            integral[row - offset, col + offset] -
-                            integral[row + offset, col - offset])
+    cdef cnp.float64_t distance = (integral[row + offset, col + offset] +
+                                   integral[row - offset, col - offset] -
+                                   integral[row - offset, col + offset] -
+                                   integral[row + offset, col - offset])
     return max(distance, 0.0) / h2s2
 
 
-cdef inline double _integral_to_distance_3d(double[:, :, ::] integral,
-                                            Py_ssize_t pln, Py_ssize_t row,
-                                            Py_ssize_t col, Py_ssize_t offset,
-                                            double s_cube_h_square) nogil:
+cdef inline cnp.float64_t _integral_to_distance_3d(cnp.float64_t[:, :, ::] integral,
+                                                   Py_ssize_t pln,
+                                                   Py_ssize_t row,
+                                                   Py_ssize_t col,
+                                                   Py_ssize_t offset,
+                                                   cnp.float64_t s_cube_h_square) nogil:
     """
     Parameters
     ----------
@@ -392,7 +395,7 @@ cdef inline double _integral_to_distance_3d(double[:, :, ::] integral,
     .. [2] Jacques Froment. Parameter-Free Fast Pixelwise Non-Local Means
            Denoising. Image Processing On Line, 2014, vol. 4, pp. 300-326.
     """
-    cdef double distance = (
+    cdef cnp.float64_t distance = (
         integral[pln + offset, row + offset, col + offset] -
         integral[pln - offset, row - offset, col - offset] +
         integral[pln - offset, row - offset, col + offset] +
@@ -404,11 +407,13 @@ cdef inline double _integral_to_distance_3d(double[:, :, ::] integral,
     return max(distance, 0.0) / (s_cube_h_square)
 
 
-cdef inline double _integral_to_distance_4d(double [:, :, :, ::] integral,
-                                            Py_ssize_t time, Py_ssize_t pln,
-                                            Py_ssize_t row, Py_ssize_t col,
-                                            Py_ssize_t offset,
-                                            double s4_h_square) nogil:
+cdef inline cnp.float64_t _integral_to_distance_4d(cnp.float64_t [:, :, :, ::] integral,
+                                                   Py_ssize_t time,
+                                                   Py_ssize_t pln,
+                                                   Py_ssize_t row,
+                                                   Py_ssize_t col,
+                                                   Py_ssize_t offset,
+                                                   cnp.float64_t s4_h_square) nogil:
     """
     Parameters
     ----------
@@ -445,7 +450,7 @@ cdef inline double _integral_to_distance_4d(double [:, :, :, ::] integral,
     .. [3] Tapia, E. A note on the computation of high-dimensional integral
            images. Pattern Recognition Letters, 2011, Vol. 32, pp.197-201.
     """
-    cdef double distance
+    cdef cnp.float64_t distance
     distance = (
         integral[time - offset, pln - offset, row - offset, col - offset] -
         integral[time - offset, pln - offset, row - offset, col + offset] -
@@ -466,12 +471,12 @@ cdef inline double _integral_to_distance_4d(double [:, :, :, ::] integral,
     return max(distance, 0.0) / s4_h_square
 
 
-cdef inline void _integral_image_2d(double [:, :, ::] padded,
-                                    double [:, ::] integral,
+cdef inline void _integral_image_2d(cnp.float64_t [:, :, ::] padded,
+                                    cnp.float64_t [:, ::] integral,
                                     Py_ssize_t t_row, Py_ssize_t t_col,
                                     Py_ssize_t n_row, Py_ssize_t n_col,
                                     Py_ssize_t n_channels,
-                                    double var_diff) nogil:
+                                    cnp.float64_t var_diff) nogil:
     """ Compute the integral of the squared difference between an image
     ``padded`` and the same image shifted by ``(t_row, t_col)``.
 
@@ -489,7 +494,7 @@ cdef inline void _integral_image_2d(double [:, :, ::] padded,
     n_row : Py_ssize_t
     n_col : Py_ssize_t
     n_channels : Py_ssize_t
-    var_diff : double
+    var_diff : cnp.float64_t
         The double of the expected noise variance.  If non-zero, this
         is used to reduce the apparent patch distances by the expected
         distance due to the noise.
@@ -504,7 +509,7 @@ cdef inline void _integral_image_2d(double [:, :, ::] padded,
     cdef Py_ssize_t row, col, channel
     cdef Py_ssize_t row_start = max(1, -t_row)
     cdef Py_ssize_t row_end = min(n_row, n_row - t_row)
-    cdef double t, distance
+    cdef cnp.float64_t t, distance
 
     for row in range(row_start, row_end):
         for col in range(1, n_col - t_col):
@@ -520,13 +525,13 @@ cdef inline void _integral_image_2d(double [:, :, ::] padded,
                                   integral[row - 1, col - 1])
 
 
-cdef inline void _integral_image_3d(double [:, :, :, ::] padded,
-                                    double [:, :, ::] integral,
+cdef inline void _integral_image_3d(cnp.float64_t [:, :, :, ::] padded,
+                                    cnp.float64_t [:, :, ::] integral,
                                     Py_ssize_t t_pln, Py_ssize_t t_row,
                                     Py_ssize_t t_col, Py_ssize_t n_pln,
                                     Py_ssize_t n_row, Py_ssize_t n_col,
                                     Py_ssize_t n_channels,
-                                    double var_diff) nogil:
+                                    cnp.float64_t var_diff) nogil:
     """Compute the integral of the squared difference between an image ``padded``
     and the same image shifted by ``(t_pln, t_row, t_col)``.
 
@@ -564,7 +569,7 @@ cdef inline void _integral_image_3d(double [:, :, :, ::] padded,
     cdef Py_ssize_t pln_end = min(n_pln, n_pln - t_pln)
     cdef Py_ssize_t row_start = max(1, -t_row)
     cdef Py_ssize_t row_end = min(n_row, n_row - t_row)
-    cdef double t, distance
+    cdef cnp.float64_t t, distance
 
     for pln in range(pln_start, pln_end):
         for row in range(row_start, row_end):
@@ -587,12 +592,12 @@ cdef inline void _integral_image_3d(double [:, :, :, ::] padded,
                     integral[pln - 1, row, col - 1])
 
 
-cdef inline void _integral_image_4d(double [:, :, :, :, ::] padded,
-                                    double [:, :, :, ::] integral,
+cdef inline void _integral_image_4d(cnp.float64_t [:, :, :, :, ::] padded,
+                                    cnp.float64_t [:, :, :, ::] integral,
                                     Py_ssize_t t_time, Py_ssize_t t_pln, Py_ssize_t t_row,
                                     Py_ssize_t t_col, Py_ssize_t n_time, Py_ssize_t n_pln,
                                     Py_ssize_t n_row, Py_ssize_t n_col, Py_ssize_t n_channels,
-                                    double var_diff) nogil:
+                                    cnp.float64_t var_diff) nogil:
     """Compute the integral of the squared difference between an image ``padded``
     and the same image shifted by ``(t_pln, t_row, t_col)``.
 
@@ -615,7 +620,7 @@ cdef inline void _integral_image_4d(double [:, :, :, :, ::] padded,
     n_pln : Py_ssize_t
     n_row : Py_ssize_t
     n_col : Py_ssize_t
-    var_diff : double
+    var_diff : cnp.float64_t
         The double of the expected noise variance. If non-zero, this
         is used to reduce the apparent patch distances by the expected
         distance due to the noise.
@@ -634,7 +639,7 @@ cdef inline void _integral_image_4d(double [:, :, :, :, ::] padded,
     cdef Py_ssize_t pln_end = min(n_pln, n_pln - t_pln)
     cdef Py_ssize_t row_start = max(1, -t_row)
     cdef Py_ssize_t row_end = min(n_row, n_row - t_row)
-    cdef double t, distance
+    cdef cnp.float64_t t, distance
 
     for time in range(time_start, time_end):
         for pln in range(pln_start, pln_end):
@@ -673,7 +678,7 @@ cdef inline void _integral_image_4d(double [:, :, :, :, ::] padded,
 
 def _fast_nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image,
                                 Py_ssize_t s, Py_ssize_t d,
-                                double h, double var):
+                                cnp.float64_t h, cnp.float64_t var):
     """Perform fast non-local means denoising on 2-D array, with the outer
     loop on patch shifts in order to reduce the number of operations.
 
@@ -685,10 +690,10 @@ def _fast_nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image,
         Size of patches used for denoising.
     d : Py_ssize_t, optional
         Maximal distance in pixels where to search patches used for denoising.
-    h : double, optional
+    h : cnp.float64_t, optional
         Cut-off distance (in gray levels). The higher h, the more permissive
         one is in accepting patches.
-    var : double
+    var : cnp.float64_t
         Expected noise variance.  If non-zero, this is used to reduce the
         apparent patch distances by the expected distance due to the noise.
 
@@ -708,7 +713,7 @@ def _fast_nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image,
           Denoising. Image Processing On Line, 2014, vol. 4, pp. 300-326.
     """
 
-    cdef double DISTANCE_CUTOFF = 5.0
+    cdef cnp.float64_t DISTANCE_CUTOFF = 5.0
     if s % 2 == 0:
         s += 1  # odd value for symmetric patch
 
@@ -724,13 +729,13 @@ def _fast_nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image,
     cdef Py_ssize_t offset = s / 2
     cdef Py_ssize_t pad_size = offset + d + 1
 
-    cdef double [:, :, ::1] padded = np.ascontiguousarray(
+    cdef cnp.float64_t [:, :, ::1] padded = np.ascontiguousarray(
         np.pad(image, ((pad_size, pad_size), (pad_size, pad_size), (0, 0)),
                mode='reflect').astype(np.float64))
-    cdef double [:, ::1] weights = np.zeros_like(padded[..., 0])
-    cdef double [:, ::1] integral = np.zeros_like(weights)
-    cdef double [:, :, ::1] result = np.zeros_like(padded)
-    cdef double distance, h2s2, weight, alpha
+    cdef cnp.float64_t [:, ::1] weights = np.zeros_like(padded[..., 0])
+    cdef cnp.float64_t [:, ::1] integral = np.zeros_like(weights)
+    cdef cnp.float64_t [:, :, ::1] result = np.zeros_like(padded)
+    cdef cnp.float64_t distance, h2s2, weight, alpha
 
     n_row, n_col, n_channels = padded.shape[0], padded.shape[1], padded.shape[2]
     h2s2 = n_channels * h * h * s * s
@@ -792,8 +797,8 @@ def _fast_nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image,
 
 
 def _fast_nl_means_denoising_3d(cnp.ndarray[np_floats, ndim=4] image,
-                                Py_ssize_t s=5, Py_ssize_t d=7, double h=0.1,
-                                double var=0.):
+                                Py_ssize_t s=5, Py_ssize_t d=7,
+                                cnp.float64_t h=0.1, cnp.float64_t var=0.):
     """Perform fast non-local means denoising on 3-D array, with the outer
     loop on patch shifts in order to reduce the number of operations.
 
@@ -805,10 +810,10 @@ def _fast_nl_means_denoising_3d(cnp.ndarray[np_floats, ndim=4] image,
         Size of patches used for denoising.
     d : Py_ssize_t, optional
         Maximal distance in pixels where to search patches used for denoising.
-    h : double, optional
+    h : cnp.float64_t, optional
         cut-off distance (in gray levels). The higher h, the more permissive
         one is in accepting patches.
-    var : double
+    var : cnp.float64_t
         Expected noise variance.  If non-zero, this is used to reduce the
         apparent patch distances by the expected distance due to the noise.
 
@@ -828,7 +833,7 @@ def _fast_nl_means_denoising_3d(cnp.ndarray[np_floats, ndim=4] image,
           Denoising. Image Processing On Line, 2014, vol. 4, pp. 300-326.
     """
 
-    cdef double DISTANCE_CUTOFF = 5.0
+    cdef cnp.float64_t DISTANCE_CUTOFF = 5.0
     if s % 2 == 0:
         s += 1  # odd value for symmetric patch
 
@@ -841,7 +846,7 @@ def _fast_nl_means_denoising_3d(cnp.ndarray[np_floats, ndim=4] image,
     # Image padding: we need to account for patch size, possible shift,
     # + 1 for the boundary effects in finite differences
     cdef Py_ssize_t pad_size = offset + d + 1
-    cdef double [:, :, :, ::1] padded = np.ascontiguousarray(
+    cdef cnp.float64_t [:, :, :, ::1] padded = np.ascontiguousarray(
         np.pad(image,
                ((pad_size, pad_size),
                 (pad_size, pad_size),
@@ -849,17 +854,17 @@ def _fast_nl_means_denoising_3d(cnp.ndarray[np_floats, ndim=4] image,
                 (0, 0)),
                mode='reflect'),
         dtype=np.float64)
-    cdef double [:, :, ::1] weights = np.zeros_like(padded[..., 0])
-    cdef double [:, :, ::1] integral = np.zeros_like(padded[..., 0])
-    cdef double [:, :, :, ::1] result = np.zeros_like(padded)
+    cdef cnp.float64_t [:, :, ::1] weights = np.zeros_like(padded[..., 0])
+    cdef cnp.float64_t [:, :, ::1] integral = np.zeros_like(padded[..., 0])
+    cdef cnp.float64_t [:, :, :, ::1] result = np.zeros_like(padded)
 
     cdef Py_ssize_t n_pln, n_row, n_col, t_pln, t_row, t_col, \
              pln, row, col, channel, n_channels
     cdef Py_ssize_t pln_dist_min, pln_dist_max, row_dist_min, row_dist_max, \
              col_dist_min, col_dist_max
-    cdef double weight, distance, alpha
+    cdef cnp.float64_t weight, distance, alpha
     n_pln, n_row, n_col, n_channels = padded.shape[0], padded.shape[1], padded.shape[2], padded.shape[3]
-    cdef double s_cube_h_square = n_channels * h * h * s * s * s
+    cdef cnp.float64_t s_cube_h_square = n_channels * h * h * s * s * s
 
 
     var *= 2
@@ -937,8 +942,8 @@ def _fast_nl_means_denoising_3d(cnp.ndarray[np_floats, ndim=4] image,
 
 
 def _fast_nl_means_denoising_4d(cnp.ndarray[np_floats, ndim=5] image,
-                                Py_ssize_t s=3, Py_ssize_t d=3, double h=0.1,
-                                double var=0.):
+                                Py_ssize_t s=3, Py_ssize_t d=3,
+                                cnp.float64_t h=0.1, cnp.float64_t var=0.):
     """
     Perform fast non-local means denoising on 3-D array, with the outer
     loop on patch shifts in order to reduce the number of operations.
@@ -951,10 +956,10 @@ def _fast_nl_means_denoising_4d(cnp.ndarray[np_floats, ndim=5] image,
         Size of patches used for denoising.
     d : tuple of Py_ssize_t, optional
         Maximal distance in pixels along each axis to search for patches used for denoising.
-    h : double, optional
+    h : cnp.float64_t, optional
         Cut-off distance (in gray levels). The higher h, the more permissive
         one is in accepting patches.
-    var : double
+    var : cnp.float64_t
         Expected noise variance.  If non-zero, this is used to reduce the
         apparent patch distances by the expected distance due to the noise.
 
@@ -974,7 +979,7 @@ def _fast_nl_means_denoising_4d(cnp.ndarray[np_floats, ndim=5] image,
           Denoising. Image Processing On Line, 2014, vol. 4, pp. 300-326.
     """
 
-    cdef double DISTANCE_CUTOFF = 5.0
+    cdef cnp.float64_t DISTANCE_CUTOFF = 5.0
     if s % 2 == 0:
         s += 1  # odd value for symmetric patch
 
@@ -987,7 +992,7 @@ def _fast_nl_means_denoising_4d(cnp.ndarray[np_floats, ndim=5] image,
     # Image padding: we need to account for patch size, possible shift,
     # + 1 for the boundary effects in finite differences
     cdef Py_ssize_t pad_size = offset + d + 1
-    cdef double [:, :, :, :, ::1] padded = np.ascontiguousarray(
+    cdef cnp.float64_t [:, :, :, :, ::1] padded = np.ascontiguousarray(
         np.pad(image,
                ((pad_size, pad_size),
                 (pad_size, pad_size),
@@ -996,17 +1001,17 @@ def _fast_nl_means_denoising_4d(cnp.ndarray[np_floats, ndim=5] image,
                 (0, 0)),
                mode='reflect'),
         dtype=np.float64)
-    cdef double [:, :, :, :, ::1] result = np.zeros_like(padded)
-    cdef double [:, :, :, ::1] weights = np.zeros_like(padded[..., 0])
-    cdef double [:, :, :, ::1] integral = np.zeros_like(padded[..., 0])
+    cdef cnp.float64_t [:, :, :, :, ::1] result = np.zeros_like(padded)
+    cdef cnp.float64_t [:, :, :, ::1] weights = np.zeros_like(padded[..., 0])
+    cdef cnp.float64_t [:, :, :, ::1] integral = np.zeros_like(padded[..., 0])
     cdef Py_ssize_t n_pln, n_row, n_col, t_pln, t_row, t_col, \
              pln, row, col, channel, n_channels, t_time, n_time, time
     cdef Py_ssize_t time_dist_min, time_dist_max, pln_dist_min, pln_dist_max, \
              row_dist_min, row_dist_max, col_dist_min, col_dist_max,
     cdef Py_ssize_t d_row, d_col, d_pln, d_time
-    cdef double weight, distance, alpha
+    cdef cnp.float64_t weight, distance, alpha
     n_time, n_pln, n_row, n_col, n_channels = padded.shape[0], padded.shape[1], padded.shape[2], padded.shape[3], padded.shape[4]
-    cdef double s4_h_square = n_channels * h * h * s * s * s * s
+    cdef cnp.float64_t s4_h_square = n_channels * h * h * s * s * s * s
 
     # Outer loops on patch shifts
     # With t2 >= 0, reference patch is always on the left of test patch

--- a/skimage/restoration/_unwrap_1d.pyx
+++ b/skimage/restoration/_unwrap_1d.pyx
@@ -3,14 +3,15 @@
 #cython: nonecheck=False
 #cython: wraparound=False
 
+cimport numpy as cnp
 from libc.math cimport M_PI
 
 
-def unwrap_1d(double[::1] image, double[::1] unwrapped_image):
+def unwrap_1d(cnp.float64_t[::1] image, cnp.float64_t[::1] unwrapped_image):
     '''Phase unwrapping using the naive approach.'''
     cdef:
         Py_ssize_t i
-        double difference
+        cnp.float64_t difference
         long periods = 0
     with nogil:
         unwrapped_image[0] = image[0]

--- a/skimage/restoration/_unwrap_2d.pyx
+++ b/skimage/restoration/_unwrap_2d.pyx
@@ -3,11 +3,13 @@
 # cython: nonecheck=False
 # cython: wraparound=False
 
+cimport numpy as cnp
+
 
 cdef extern from "unwrap_2d_ljmu.h":
     void unwrap2D(
-            double *wrapped_image,
-            double *UnwrappedImage,
+            cnp.float64_t *wrapped_image,
+            cnp.float64_t *UnwrappedImage,
             unsigned char *input_mask,
             int image_width, int image_height,
             int wrap_around_x, int wrap_around_y,
@@ -15,9 +17,9 @@ cdef extern from "unwrap_2d_ljmu.h":
             ) nogil
 
 
-def unwrap_2d(double[:, ::1] image,
+def unwrap_2d(cnp.float64_t[:, ::1] image,
               unsigned char[:, ::1] mask,
-              double[:, ::1] unwrapped_image,
+              cnp.float64_t[:, ::1] unwrapped_image,
               wrap_around,
               seed):
     cdef:

--- a/skimage/restoration/_unwrap_3d.pyx
+++ b/skimage/restoration/_unwrap_3d.pyx
@@ -3,11 +3,13 @@
 # cython: nonecheck=False
 # cython: wraparound=False
 
+cimport numpy as cnp
+
 
 cdef extern from "unwrap_3d_ljmu.h":
     void unwrap3D(
-            double *wrapped_volume,
-            double *unwrapped_volume,
+            cnp.float64_t *wrapped_volume,
+            cnp.float64_t *unwrapped_volume,
             unsigned char *input_mask,
             int volume_width, int volume_height, int volume_depth,
             int wrap_around_x, int wrap_around_y, int wrap_around_z,
@@ -16,9 +18,9 @@ cdef extern from "unwrap_3d_ljmu.h":
 
 
 
-def unwrap_3d(double[:, :, ::1] image,
+def unwrap_3d(cnp.float64_t[:, :, ::1] image,
               unsigned char[:, :, ::1] mask,
-              double[:, :, ::1] unwrapped_image,
+              cnp.float64_t[:, :, ::1] unwrapped_image,
               wrap_around,
               seed):
     cdef:

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -314,7 +314,7 @@ def test_denoise_bilateral_pad():
     assert_array_equal(condition_padding, 0)
 
 
-@pytest.mark.parametrize('dtype', [np.float32, np.double])
+@pytest.mark.parametrize('dtype', [np.float32, np.float64])
 def test_denoise_bilateral_types(dtype):
     img = checkerboard_gray.copy()[:50, :50]
     # add some random noise
@@ -326,7 +326,7 @@ def test_denoise_bilateral_types(dtype):
                                   sigma_spatial=10, channel_axis=None)
 
 
-@pytest.mark.parametrize('dtype', [np.float32, np.double])
+@pytest.mark.parametrize('dtype', [np.float32, np.float64])
 def test_denoise_bregman_types(dtype):
     img = checkerboard_gray.copy()[:50, :50]
     # add some random noise

--- a/skimage/restoration/unwrap.py
+++ b/skimage/restoration/unwrap.py
@@ -93,8 +93,8 @@ def unwrap_phase(image, wrap_around=False, seed=None):
         mask = np.zeros_like(image, dtype=np.uint8, order='C')
 
     image_not_masked = np.asarray(
-        np.ma.getdata(image), dtype=np.double, order='C')
-    image_unwrapped = np.empty_like(image, dtype=np.double, order='C',
+        np.ma.getdata(image), dtype=np.float64, order='C')
+    image_unwrapped = np.empty_like(image, dtype=np.float64, order='C',
                                     subok=False)
 
     if image.ndim == 1:

--- a/skimage/segmentation/_felzenszwalb_cy.pyx
+++ b/skimage/segmentation/_felzenszwalb_cy.pyx
@@ -14,7 +14,7 @@ from ..util import img_as_float64
 cnp.import_array()
 
 
-def _felzenszwalb_cython(image, double scale=1, sigma=0.8,
+def _felzenszwalb_cython(image, cnp.float64_t scale=1, sigma=0.8,
                          Py_ssize_t min_size=20):
     """Felzenszwalb's efficient graph based segmentation for
     single or multiple channels.
@@ -67,7 +67,7 @@ def _felzenszwalb_cython(image, double scale=1, sigma=0.8,
 	                               (image[1:, 1:, :] - image[:height-1, :width-1, :]), axis=-1))
     uright_cost = np.sqrt(np.sum((image[1:, :width-1, :] - image[:height-1, 1:, :]) *
     	                           (image[1:, :width-1, :] - image[:height-1, 1:, :]), axis=-1))
-    cdef cnp.ndarray[cnp.float_t, ndim=1] costs = np.hstack([
+    cdef cnp.ndarray[cnp.float64_t, ndim=1] costs = np.hstack([
     	right_cost.ravel(), down_cost.ravel(), dright_cost.ravel(),
         uright_cost.ravel()]).astype(float)
 
@@ -88,12 +88,12 @@ def _felzenszwalb_cython(image, double scale=1, sigma=0.8,
     costs = np.ascontiguousarray(costs[edge_queue])
     cdef cnp.intp_t *segments_p = <cnp.intp_t*>segments.data
     cdef cnp.intp_t *edges_p = <cnp.intp_t*>edges.data
-    cdef cnp.float_t *costs_p = <cnp.float_t*>costs.data
+    cdef cnp.float64_t *costs_p = <cnp.float64_t*>costs.data
     cdef cnp.ndarray[cnp.intp_t, ndim=1] segment_size \
             = np.ones(width * height, dtype=np.intp)
 
     # inner cost of segments
-    cdef cnp.ndarray[cnp.float_t, ndim=1] cint = np.zeros(width * height)
+    cdef cnp.ndarray[cnp.float64_t, ndim=1] cint = np.zeros(width * height)
     cdef cnp.intp_t seg0, seg1, seg_new, e
     cdef float cost, inner_cost0, inner_cost1
     cdef Py_ssize_t num_costs = costs.size

--- a/skimage/segmentation/_felzenszwalb_cy.pyx
+++ b/skimage/segmentation/_felzenszwalb_cy.pyx
@@ -95,7 +95,7 @@ def _felzenszwalb_cython(image, cnp.float64_t scale=1, sigma=0.8,
     # inner cost of segments
     cdef cnp.ndarray[cnp.float64_t, ndim=1] cint = np.zeros(width * height)
     cdef cnp.intp_t seg0, seg1, seg_new, e
-    cdef float cost, inner_cost0, inner_cost1
+    cdef cnp.float32_t cost, inner_cost0, inner_cost1
     cdef Py_ssize_t num_costs = costs.size
 
     with nogil:

--- a/skimage/segmentation/_slic.pyx
+++ b/skimage/segmentation/_slic.pyx
@@ -16,7 +16,7 @@ cnp.import_array()
 def _slic_cython(np_floats[:, :, :, ::1] image_zyx,
                  cnp.uint8_t[:, :, ::1] mask,
                  np_floats[:, ::1] segments,
-                 float step,
+                 cnp.float32_t step,
                  Py_ssize_t max_num_iter,
                  np_floats[::1] spacing,
                  bint slic_zero,

--- a/skimage/segmentation/_watershed_cy.pyx
+++ b/skimage/segmentation/_watershed_cy.pyx
@@ -28,11 +28,11 @@ include "heap_watershed.pxi"
 @cython.cdivision(True)
 @cython.overflowcheck(False)
 @cython.unraisable_tracebacks(False)
-cdef inline double _euclid_dist(Py_ssize_t pt0, Py_ssize_t pt1,
-                                cnp.intp_t[::1] strides) nogil:
+cdef inline cnp.float64_t _euclid_dist(Py_ssize_t pt0, Py_ssize_t pt1,
+                                       cnp.intp_t[::1] strides) nogil:
     """Return the Euclidean distance between raveled points pt0 and pt1."""
-    cdef double result = 0
-    cdef double curr = 0
+    cdef cnp.float64_t result = 0
+    cdef cnp.float64_t curr = 0
     for i in range(strides.shape[0]):
         curr = (pt0 // strides[i]) - (pt1 // strides[i])
         result += curr * curr
@@ -82,7 +82,7 @@ def watershed_raveled(cnp.float64_t[::1] image,
                       cnp.intp_t[::1] structure,
                       DTYPE_BOOL_t[::1] mask,
                       cnp.intp_t[::1] strides,
-                      cnp.double_t compactness,
+                      cnp.float64_t compactness,
                       DTYPE_INT32_t[::1] output,
                       DTYPE_BOOL_t wsl):
     """Perform watershed algorithm using a raveled image and neighborhood.

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -128,11 +128,11 @@ def _umeyama(src, dst, estimate_scale):
     A = dst_demean.T @ src_demean / num
 
     # Eq. (39).
-    d = np.ones((dim,), dtype=np.double)
+    d = np.ones((dim,), dtype=np.float64)
     if np.linalg.det(A) < 0:
         d[dim - 1] = -1
 
-    T = np.eye(dim + 1, dtype=np.double)
+    T = np.eye(dim + 1, dtype=np.float64)
 
     U, S, V = np.linalg.svd(A)
 
@@ -1015,7 +1015,7 @@ class PiecewiseAffineTransform(GeometricTransform):
 
         """
 
-        out = np.empty_like(coords, np.double)
+        out = np.empty_like(coords, np.float64)
 
         # determine triangle index for each coordinate
         simplex = self._tesselation.find_simplex(coords)
@@ -1050,7 +1050,7 @@ class PiecewiseAffineTransform(GeometricTransform):
 
         """
 
-        out = np.empty_like(coords, np.double)
+        out = np.empty_like(coords, np.float64)
 
         # determine triangle index for each coordinate
         simplex = self._inverse_tesselation.find_simplex(coords)

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -62,13 +62,13 @@ def _hough_circle(cnp.ndarray img,
         y = y + offset
 
     cdef Py_ssize_t i, p, c, num_circle_pixels, tx, ty
-    cdef double incr
+    cdef cnp.float64_t incr
     cdef cnp.ndarray[ndim=1, dtype=cnp.intp_t] circle_x, circle_y
 
-    cdef cnp.ndarray[ndim=3, dtype=cnp.double_t] acc = \
+    cdef cnp.ndarray[ndim=3, dtype=cnp.float64_t] acc = \
          np.zeros((radius.size,
                    img.shape[0] + 2 * offset,
-                   img.shape[1] + 2 * offset), dtype=np.double)
+                   img.shape[1] + 2 * offset), dtype=np.float64)
 
     for i, rad in enumerate(radius):
         # Store in memory the circle of given radius
@@ -99,8 +99,9 @@ def _hough_circle(cnp.ndarray img,
     return acc
 
 
-def _hough_ellipse(cnp.ndarray img, Py_ssize_t threshold=4, double accuracy=1,
-                   Py_ssize_t min_size=4, max_size=None):
+def _hough_ellipse(cnp.ndarray img, Py_ssize_t threshold=4,
+                   cnp.float64_t accuracy=1, Py_ssize_t min_size=4,
+                   max_size=None):
     """Perform an elliptical Hough transform.
 
     Parameters
@@ -109,7 +110,7 @@ def _hough_ellipse(cnp.ndarray img, Py_ssize_t threshold=4, double accuracy=1,
         Input image with nonzero values representing edges.
     threshold: int, optional (default 4)
         Accumulator threshold value.
-    accuracy : double, optional (default 1)
+    accuracy : float64, optional (default 1)
         Bin size on the minor axis used in the accumulator.
     min_size : int, optional (default 4)
         Minimal major axis length.
@@ -159,9 +160,9 @@ def _hough_ellipse(cnp.ndarray img, Py_ssize_t threshold=4, double accuracy=1,
     cdef Py_ssize_t num_pixels = pixels.shape[1]
     cdef list acc = list()
     cdef list results = list()
-    cdef double bin_size = accuracy * accuracy
+    cdef cnp.float64_t bin_size = accuracy * accuracy
 
-    cdef double max_b_squared
+    cdef cnp.float64_t max_b_squared
     if max_size is None:
         if img.shape[0] < img.shape[1]:
             max_b_squared = np.round(0.5 * img.shape[0])
@@ -172,8 +173,8 @@ def _hough_ellipse(cnp.ndarray img, Py_ssize_t threshold=4, double accuracy=1,
         max_b_squared = max_size * max_size
 
     cdef Py_ssize_t p1, p2, p3, p1x, p1y, p2x, p2y, p3x, p3y
-    cdef double xc, yc, a, b, d, k, dx, dy
-    cdef double cos_tau_squared, b_squared, orientation
+    cdef cnp.float64_t xc, yc, a, b, d, k, dx, dy
+    cdef cnp.float64_t cos_tau_squared, b_squared, orientation
 
     for p1 in range(num_pixels):
         p1x = pixels[1, p1]
@@ -235,22 +236,22 @@ def _hough_ellipse(cnp.ndarray img, Py_ssize_t threshold=4, double accuracy=1,
                     acc = []
 
     return np.array(results, dtype=[('accumulator', np.intp),
-                                    ('yc', np.double),
-                                    ('xc', np.double),
-                                    ('a', np.double),
-                                    ('b', np.double),
-                                    ('orientation', np.double)])
+                                    ('yc', np.float64),
+                                    ('xc', np.float64),
+                                    ('a', np.float64),
+                                    ('b', np.float64),
+                                    ('orientation', np.float64)])
 
 
 def _hough_line(cnp.ndarray img,
-                cnp.ndarray[ndim=1, dtype=cnp.double_t] theta):
+                cnp.ndarray[ndim=1, dtype=cnp.float64_t] theta):
     """Perform a straight line Hough transform.
 
     Parameters
     ----------
     img : (M, N) ndarray
         Input image with nonzero values representing edges.
-    theta : 1D ndarray of double
+    theta : 1D ndarray of float64
         Angles at which to compute the transform, in radians.
 
     Returns
@@ -290,15 +291,15 @@ def _hough_line(cnp.ndarray img,
 
     """
     # Compute the array of angles and their sine and cosine
-    cdef cnp.ndarray[ndim=1, dtype=cnp.double_t] ctheta
-    cdef cnp.ndarray[ndim=1, dtype=cnp.double_t] stheta
+    cdef cnp.ndarray[ndim=1, dtype=cnp.float64_t] ctheta
+    cdef cnp.ndarray[ndim=1, dtype=cnp.float64_t] stheta
 
     ctheta = np.cos(theta)
     stheta = np.sin(theta)
 
     # compute the bins and allocate the accumulator array
     cdef cnp.ndarray[ndim=2, dtype=cnp.uint64_t] accum
-    cdef cnp.ndarray[ndim=1, dtype=cnp.double_t] bins
+    cdef cnp.ndarray[ndim=1, dtype=cnp.float64_t] bins
     cdef Py_ssize_t max_distance, offset
 
     offset = <Py_ssize_t>ceil(sqrt(img.shape[0] * img.shape[0] +
@@ -329,7 +330,7 @@ def _hough_line(cnp.ndarray img,
 
 def _probabilistic_hough_line(cnp.ndarray img, Py_ssize_t threshold,
                               Py_ssize_t line_length, Py_ssize_t line_gap,
-                              cnp.ndarray[ndim=1, dtype=cnp.double_t] theta,
+                              cnp.ndarray[ndim=1, dtype=cnp.float64_t] theta,
                               seed=None):
     """Return lines from a progressive probabilistic line Hough transform.
 
@@ -345,7 +346,7 @@ def _probabilistic_hough_line(cnp.ndarray img, Py_ssize_t threshold,
     line_gap : int
         Maximum gap between pixels to still form a line.
         Increase the parameter to merge broken lines more aggressively.
-    theta : 1D ndarray, dtype=double
+    theta : 1D ndarray, dtype='float64'
         Angles at which to compute the transform, in radians.
     seed : {None, int, `numpy.random.Generator`, optional}
         If `seed` is None the `numpy.random.Generator` singleton is used.
@@ -379,7 +380,7 @@ def _probabilistic_hough_line(cnp.ndarray img, Py_ssize_t threshold,
     if not line_end:
         raise MemoryError('could not allocate line_end')
     cdef Py_ssize_t max_distance, offset, num_indexes, index
-    cdef double a, b
+    cdef cnp.float64_t a, b
     cdef Py_ssize_t nidxs, i, j, k, x, y, px, py, accum_idx, max_theta
     cdef Py_ssize_t xflag, x0, y0, dx0, dy0, dx, dy, gap, x1, y1, count
     cdef cnp.int64_t value, max_value,
@@ -397,8 +398,8 @@ def _probabilistic_hough_line(cnp.ndarray img, Py_ssize_t threshold,
     cdef Py_ssize_t nthetas = theta.shape[0]
 
     # compute sine and cosine of angles
-    cdef cnp.double_t[::1] ctheta = np.cos(theta)
-    cdef cnp.double_t[::1] stheta = np.sin(theta)
+    cdef cnp.float64_t[::1] ctheta = np.cos(theta)
+    cdef cnp.float64_t[::1] stheta = np.sin(theta)
 
     # find the nonzero indexes
     cdef cnp.intp_t[:] y_idxs, x_idxs

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -202,7 +202,7 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
         else:
             # 3 control points necessary to estimate exact AffineTransform
             src_corners = np.array([[1, 1], [1, rows], [cols, rows]]) - 1
-            dst_corners = np.zeros(src_corners.shape, dtype=np.double)
+            dst_corners = np.zeros(src_corners.shape, dtype=np.float64)
             # take into account that 0th pixel is at position (0.5, 0.5)
             dst_corners[:, 0] = factors[1] * (src_corners[:, 0] + 0.5) - 0.5
             dst_corners[:, 1] = factors[0] * (src_corners[:, 1] + 0.5) - 0.5

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -36,7 +36,7 @@ def test_stackcopy():
 
 
 def test_warp_tform():
-    x = np.zeros((5, 5), dtype=np.double)
+    x = np.zeros((5, 5), dtype=np.float64)
     x[2, 2] = 1
     theta = - np.pi / 2
     tform = SimilarityTransform(scale=1, rotation=theta, translation=(0, 4))
@@ -49,9 +49,9 @@ def test_warp_tform():
 
 
 def test_warp_callable():
-    x = np.zeros((5, 5), dtype=np.double)
+    x = np.zeros((5, 5), dtype=np.float64)
     x[2, 2] = 1
-    refx = np.zeros((5, 5), dtype=np.double)
+    refx = np.zeros((5, 5), dtype=np.float64)
     refx[1, 1] = 1
 
     def shift(xy):
@@ -63,9 +63,9 @@ def test_warp_callable():
 
 @test_parallel()
 def test_warp_matrix():
-    x = np.zeros((5, 5), dtype=np.double)
+    x = np.zeros((5, 5), dtype=np.float64)
     x[2, 2] = 1
-    refx = np.zeros((5, 5), dtype=np.double)
+    refx = np.zeros((5, 5), dtype=np.float64)
     refx[1, 1] = 1
 
     matrix = np.array([[1, 0, 1], [0, 1, 1], [0, 0, 1]])
@@ -81,10 +81,10 @@ def test_warp_nd():
     for dim in range(2, 8):
         shape = dim * (5,)
 
-        x = np.zeros(shape, dtype=np.double)
+        x = np.zeros(shape, dtype=np.float64)
         x_c = dim * (2,)
         x[x_c] = 1
-        refx = np.zeros(shape, dtype=np.double)
+        refx = np.zeros(shape, dtype=np.float64)
         refx_c = dim * (1,)
         refx[refx_c] = 1
 
@@ -97,7 +97,7 @@ def test_warp_nd():
 
 
 def test_warp_clip():
-    x = np.zeros((5, 5), dtype=np.double)
+    x = np.zeros((5, 5), dtype=np.float64)
     x[2, 2] = 1
 
     outx = rescale(x, 3, order=3, clip=False, anti_aliasing=False,
@@ -111,7 +111,7 @@ def test_warp_clip():
 
 
 def test_homography():
-    x = np.zeros((5, 5), dtype=np.double)
+    x = np.zeros((5, 5), dtype=np.float64)
     x[1, 1] = 1
     theta = -np.pi / 2
     M = np.array([[np.cos(theta), - np.sin(theta), 0],
@@ -134,7 +134,7 @@ def test_rotate(dtype):
 
 
 def test_rotate_resize():
-    x = np.zeros((10, 10), dtype=np.double)
+    x = np.zeros((10, 10), dtype=np.float64)
 
     x45 = rotate(x, 45, resize=False)
     assert x45.shape == (10, 10)
@@ -145,9 +145,9 @@ def test_rotate_resize():
 
 
 def test_rotate_center():
-    x = np.zeros((10, 10), dtype=np.double)
+    x = np.zeros((10, 10), dtype=np.float64)
     x[4, 4] = 1
-    refx = np.zeros((10, 10), dtype=np.double)
+    refx = np.zeros((10, 10), dtype=np.float64)
     refx[2, 5] = 1
     x20 = rotate(x, 20, order=0, center=(0, 0))
     assert_array_almost_equal(x20, refx)
@@ -156,10 +156,10 @@ def test_rotate_center():
 
 
 def test_rotate_resize_center():
-    x = np.zeros((10, 10), dtype=np.double)
+    x = np.zeros((10, 10), dtype=np.float64)
     x[0, 0] = 1
 
-    ref_x45 = np.zeros((14, 14), dtype=np.double)
+    ref_x45 = np.zeros((14, 14), dtype=np.float64)
     ref_x45[6, 0] = 1
     ref_x45[7, 0] = 1
 
@@ -171,13 +171,13 @@ def test_rotate_resize_center():
 
 
 def test_rotate_resize_90():
-    x90 = rotate(np.zeros((470, 230), dtype=np.double), 90, resize=True)
+    x90 = rotate(np.zeros((470, 230), dtype=np.float64), 90, resize=True)
     assert x90.shape == (230, 470)
 
 
 def test_rescale():
     # same scale factor
-    x = np.zeros((5, 5), dtype=np.double)
+    x = np.zeros((5, 5), dtype=np.float64)
     x[1, 1] = 1
     scaled = rescale(x, 2, order=0, anti_aliasing=False, mode='constant')
     ref = np.zeros((10, 10))
@@ -185,7 +185,7 @@ def test_rescale():
     assert_array_almost_equal(scaled, ref)
 
     # different scale factors
-    x = np.zeros((5, 5), dtype=np.double)
+    x = np.zeros((5, 5), dtype=np.float64)
     x[1, 1] = 1
 
     scaled = rescale(x, (2, 1), order=0, anti_aliasing=False, mode='constant')
@@ -206,7 +206,7 @@ def test_rescale_invalid_scale():
 
 def test_rescale_multichannel():
     # 1D + channels
-    x = np.zeros((8, 3), dtype=np.double)
+    x = np.zeros((8, 3), dtype=np.float64)
     scaled = rescale(x, 2, order=0, channel_axis=-1, anti_aliasing=False,
                      mode='constant')
     assert scaled.shape == (16, 3)
@@ -216,7 +216,7 @@ def test_rescale_multichannel():
     assert scaled.shape == (16, 6)
 
     # 2D + channels
-    x = np.zeros((8, 8, 3), dtype=np.double)
+    x = np.zeros((8, 8, 3), dtype=np.float64)
     scaled = rescale(x, 2, order=0, channel_axis=-1, anti_aliasing=False,
                      mode='constant')
     assert scaled.shape == (16, 16, 3)
@@ -226,7 +226,7 @@ def test_rescale_multichannel():
     assert scaled.shape == (16, 16, 6)
 
     # 3D + channels
-    x = np.zeros((8, 8, 8, 3), dtype=np.double)
+    x = np.zeros((8, 8, 8, 3), dtype=np.float64)
     scaled = rescale(x, 2, order=0, channel_axis=-1, anti_aliasing=False,
                      mode='constant')
     assert scaled.shape == (16, 16, 16, 3)
@@ -237,7 +237,7 @@ def test_rescale_multichannel():
 
 
 def test_rescale_multichannel_deprecated_multiscale():
-    x = np.zeros((5, 5, 3), dtype=np.double)
+    x = np.zeros((5, 5, 3), dtype=np.float64)
     with expected_warnings(["`multichannel` is a deprecated argument"]):
         scaled = rescale(x, (2, 1), order=0, multichannel=True,
                          anti_aliasing=False, mode='constant')
@@ -252,7 +252,7 @@ def test_rescale_multichannel_deprecated_multiscale():
 
 @pytest.mark.parametrize('channel_axis', [0, 1, 2, -1])
 def test_rescale_channel_axis_multiscale(channel_axis):
-    x = np.zeros((5, 5, 3), dtype=np.double)
+    x = np.zeros((5, 5, 3), dtype=np.float64)
     x = np.moveaxis(x, -1, channel_axis)
     scaled = rescale(x, scale=(2, 1), order=0, channel_axis=channel_axis,
                      anti_aliasing=False, mode='constant')
@@ -261,17 +261,17 @@ def test_rescale_channel_axis_multiscale(channel_axis):
 
 
 def test_rescale_multichannel_defaults():
-    x = np.zeros((8, 3), dtype=np.double)
+    x = np.zeros((8, 3), dtype=np.float64)
     scaled = rescale(x, 2, order=0, anti_aliasing=False, mode='constant')
     assert scaled.shape == (16, 6)
 
-    x = np.zeros((8, 8, 3), dtype=np.double)
+    x = np.zeros((8, 8, 3), dtype=np.float64)
     scaled = rescale(x, 2, order=0, anti_aliasing=False, mode='constant')
     assert scaled.shape == (16, 16, 6)
 
 
 def test_resize2d():
-    x = np.zeros((5, 5), dtype=np.double)
+    x = np.zeros((5, 5), dtype=np.float64)
     x[1, 1] = 1
     resized = resize(x, (10, 10), order=0, anti_aliasing=False,
                      mode='constant')
@@ -282,7 +282,7 @@ def test_resize2d():
 
 def test_resize3d_keep():
     # keep 3rd dimension
-    x = np.zeros((5, 5, 3), dtype=np.double)
+    x = np.zeros((5, 5, 3), dtype=np.float64)
     x[1, 1, :] = 1
     resized = resize(x, (10, 10), order=0, anti_aliasing=False,
                      mode='constant')
@@ -299,7 +299,7 @@ def test_resize3d_keep():
 
 def test_resize3d_resize():
     # resize 3rd dimension
-    x = np.zeros((5, 5, 3), dtype=np.double)
+    x = np.zeros((5, 5, 3), dtype=np.float64)
     x[1, 1, :] = 1
     resized = resize(x, (10, 10, 1), order=0, anti_aliasing=False,
                      mode='constant')
@@ -310,7 +310,7 @@ def test_resize3d_resize():
 
 def test_resize3d_2din_3dout():
     # 3D output with 2D input
-    x = np.zeros((5, 5), dtype=np.double)
+    x = np.zeros((5, 5), dtype=np.float64)
     x[1, 1] = 1
     resized = resize(x, (10, 10, 1), order=0, anti_aliasing=False,
                      mode='constant')
@@ -321,7 +321,7 @@ def test_resize3d_2din_3dout():
 
 def test_resize2d_4d():
     # resize with extra output dimensions
-    x = np.zeros((5, 5), dtype=np.double)
+    x = np.zeros((5, 5), dtype=np.float64)
     x[1, 1] = 1
     out_shape = (10, 10, 1, 1)
     resized = resize(x, out_shape, order=0, anti_aliasing=False,
@@ -345,7 +345,7 @@ def test_resize_nd():
 
 def test_resize3d_bilinear():
     # bilinear 3rd dimension
-    x = np.zeros((5, 5, 2), dtype=np.double)
+    x = np.zeros((5, 5, 2), dtype=np.float64)
     x[1, 1, 0] = 0
     x[1, 1, 1] = 1
     resized = resize(x, (10, 10, 1), order=1, mode='constant',
@@ -366,8 +366,8 @@ def test_resize_dtype():
 
     assert resize(x, (10, 10), preserve_range=False).dtype == x.dtype
     assert resize(x, (10, 10), preserve_range=True).dtype == x.dtype
-    assert resize(x_u8, (10, 10), preserve_range=False).dtype == np.double
-    assert resize(x_u8, (10, 10), preserve_range=True).dtype == np.double
+    assert resize(x_u8, (10, 10), preserve_range=False).dtype == np.float64
+    assert resize(x_u8, (10, 10), preserve_range=True).dtype == np.float64
     assert resize(x_b, (10, 10), preserve_range=False).dtype == bool
     assert resize(x_b, (10, 10), preserve_range=True).dtype == bool
     assert resize(x_f32, (10, 10), preserve_range=False).dtype == x_f32.dtype
@@ -462,7 +462,7 @@ def test_downsize(dtype):
 
 
 def test_downsize_anti_aliasing():
-    x = np.zeros((10, 10), dtype=np.double)
+    x = np.zeros((10, 10), dtype=np.float64)
     x[2, 2] = 1
     scaled = resize(x, (5, 5), order=1, anti_aliasing=True, mode='constant')
     assert scaled.shape == (5, 5)
@@ -489,7 +489,7 @@ def test_downsize_anti_aliasing():
 
 
 def test_downsize_anti_aliasing_invalid_stddev():
-    x = np.zeros((10, 10), dtype=np.double)
+    x = np.zeros((10, 10), dtype=np.float64)
     with pytest.raises(ValueError):
         resize(x, (5, 5), order=0, anti_aliasing=True, anti_aliasing_sigma=-1,
                mode='constant')
@@ -517,7 +517,7 @@ def test_downscale(dtype):
 
 
 def test_downscale_anti_aliasing():
-    x = np.zeros((10, 10), dtype=np.double)
+    x = np.zeros((10, 10), dtype=np.float64)
     x[2, 2] = 1
     scaled = rescale(x, 0.5, order=1, anti_aliasing=True,
                      channel_axis=None, mode='constant')
@@ -565,7 +565,7 @@ def test_invalid():
 def test_inverse():
     tform = SimilarityTransform(scale=0.5, rotation=0.1)
     inverse_tform = SimilarityTransform(matrix=np.linalg.inv(tform.params))
-    image = np.arange(10 * 10).reshape(10, 10).astype(np.double)
+    image = np.arange(10 * 10).reshape(10, 10).astype(np.float64)
     assert_array_equal(warp(image, inverse_tform), warp(image, tform.inverse))
 
 
@@ -788,7 +788,7 @@ def test_nonzero_order_warp_dtype(dtype, order):
 
 
 def test_resize_local_mean2d():
-    x = np.zeros((5, 5), dtype=np.double)
+    x = np.zeros((5, 5), dtype=np.float64)
     x[1, 1] = 1
     resized = resize_local_mean(x, (10, 10))
     ref = np.zeros((10, 10))
@@ -800,7 +800,7 @@ def test_resize_local_mean2d():
 def test_resize_local_mean3d_keep(channel_axis):
     # keep 3rd dimension
     nch = 3
-    x = np.zeros((5, 5, nch), dtype=np.double)
+    x = np.zeros((5, 5, nch), dtype=np.float64)
     x[1, 1, :] = 1
     # move channels to expected dimension
     x = np.moveaxis(x, -1, channel_axis)
@@ -827,7 +827,7 @@ def test_resize_local_mean3d_keep(channel_axis):
 
 def test_resize_local_mean3d_resize():
     # resize 3rd dimension
-    x = np.zeros((5, 5, 3), dtype=np.double)
+    x = np.zeros((5, 5, 3), dtype=np.float64)
     x[1, 1, :] = 1
     resized = resize_local_mean(x, (10, 10, 1))
     ref = np.zeros((10, 10, 1))
@@ -841,7 +841,7 @@ def test_resize_local_mean3d_resize():
 
 def test_resize_local_mean3d_2din_3dout():
     # 3D output with 2D input
-    x = np.zeros((5, 5), dtype=np.double)
+    x = np.zeros((5, 5), dtype=np.float64)
     x[1, 1] = 1
     resized = resize_local_mean(x, (10, 10, 1))
     ref = np.zeros((10, 10, 1))
@@ -851,7 +851,7 @@ def test_resize_local_mean3d_2din_3dout():
 
 def test_resize_local_mean2d_4d():
     # resize with extra output dimensions
-    x = np.zeros((5, 5), dtype=np.double)
+    x = np.zeros((5, 5), dtype=np.float64)
     x[1, 1] = 1
     out_shape = (10, 10, 1, 1)
     resized = resize_local_mean(x, out_shape)
@@ -872,7 +872,7 @@ def test_resize_local_mean_nd(dim):
 
 
 def test_resize_local_mean3d():
-    x = np.zeros((5, 5, 2), dtype=np.double)
+    x = np.zeros((5, 5, 2), dtype=np.float64)
     x[1, 1, 0] = 0
     x[1, 1, 1] = 1
     resized = resize_local_mean(x, (10, 10, 1))
@@ -900,13 +900,13 @@ def test_resize_local_mean_dtype():
     assert resize_local_mean(x, (10, 10),
                              preserve_range=True).dtype == x.dtype
     assert resize_local_mean(x_u8, (10, 10),
-                             preserve_range=False).dtype == np.double
+                             preserve_range=False).dtype == np.float64
     assert resize_local_mean(x_u8, (10, 10),
-                             preserve_range=True).dtype == np.double
+                             preserve_range=True).dtype == np.float64
     assert resize_local_mean(x_b, (10, 10),
-                             preserve_range=False).dtype == np.double
+                             preserve_range=False).dtype == np.float64
     assert resize_local_mean(x_b, (10, 10),
-                             preserve_range=True).dtype == np.double
+                             preserve_range=True).dtype == np.float64
     assert resize_local_mean(x_f32, (10, 10),
                              preserve_range=False).dtype == x_f32.dtype
     assert resize_local_mean(x_f32, (10, 10),

--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -147,7 +147,7 @@ def test_float32_passthrough():
     assert_equal(y.dtype, x.dtype)
 
 
-float_dtype_list = [float, float, np.double, np.single, np.float32,
+float_dtype_list = [float, float, np.float64, np.single, np.float32,
                     np.float64, 'float32', 'float64']
 
 


### PR DESCRIPTION

## Description

closes #3496

Replaces use of `float` types for 32-bit floating point variables with `cnp.float32_t` to avoid confusion with Python's float (which is 64-bit).

For consistency, also replace `double` with `cnp.float64_t`


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
