### PR TITLE
Fix for error in 'Using Polar and Log-Polar Transformations for Registration' (#6304)

### DIFF
--- a/doc/examples/registration/plot_register_rotation.py
+++ b/doc/examples/registration/plot_register_rotation.py
@@ -60,7 +60,9 @@ ax[3].set_title("Polar-Transformed Rotated")
 ax[3].imshow(rotated_polar)
 plt.show()
 
-shifts, error, phasediff = phase_cross_correlation(image_polar, rotated_polar)
+shifts, error, phasediff = phase_cross_correlation(image_polar,
+                                                   rotated_polar,
+                                                   normalization=None)
 print(f'Expected value for counterclockwise rotation in degrees: '
       f'{angle}')
 print(f'Recovered value for counterclockwise rotation: '
@@ -102,7 +104,8 @@ plt.show()
 
 # setting `upsample_factor` can increase precision
 shifts, error, phasediff = phase_cross_correlation(image_polar, rescaled_polar,
-                                                   upsample_factor=20)
+                                                   upsample_factor=20,
+                                                   normalization=None)
 shiftr, shiftc = shifts[:2]
 
 # Calculate scale factor from translation
@@ -151,7 +154,8 @@ radius = 705
 warped_image = warp_polar(image, radius=radius, scaling="log")
 warped_rts = warp_polar(rts_image, radius=radius, scaling="log")
 shifts, error, phasediff = phase_cross_correlation(warped_image, warped_rts,
-                                                   upsample_factor=20)
+                                                   upsample_factor=20,
+                                                   normalization=None)
 shiftr, shiftc = shifts[:2]
 klog = radius / np.log(radius)
 shift_scale = 1 / (np.exp(shiftc / klog))
@@ -209,7 +213,8 @@ warped_image_fs = warped_image_fs[:shape[0] // 2, :]  # only use half of FFT
 warped_rts_fs = warped_rts_fs[:shape[0] // 2, :]
 shifts, error, phasediff = phase_cross_correlation(warped_image_fs,
                                                    warped_rts_fs,
-                                                   upsample_factor=10)
+                                                   upsample_factor=10,
+                                                   normalization=None)
 
 # Use translation parameters to calculate rotation and scaling parameters
 shiftr, shiftc = shifts[:2]


### PR DESCRIPTION
## Description

Bug fix to close #6304. The addition of the `normalization` parameter that defaults to "phase" in the `phase_cross_correlation` function changed the result in the example to be incorrect. I still don't fully understand why this happened, but across all examples in this particular gallery example, setting `normalization` to `None` causes small to significant improvements to the performance of the approach. I think this is worth further investigation, but not enough to hold up this fix.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
