### PR TITLE
Remove preserve_range kwarg (always preserve range by default)

### DIFF
--- a/benchmarks/benchmark_exposure.py
+++ b/benchmarks/benchmark_exposure.py
@@ -2,7 +2,7 @@
 # https://asv.readthedocs.io/en/latest/writing_benchmarks.html
 import numpy as np
 
-from skimage import data, img_as_float
+from skimage import data, rescale_to_float
 from skimage.transform import rescale
 from skimage import exposure
 
@@ -11,7 +11,7 @@ class ExposureSuite:
     """Benchmark for exposure routines in scikit-image."""
     def setup(self):
         self.image_u8 = data.moon()
-        self.image = img_as_float(self.image_u8)
+        self.image = rescale_to_float(self.image_u8)
         self.image = rescale(self.image, 2.0, anti_aliasing=False)
         # for Contrast stretching
         self.p2, self.p98 = np.percentile(self.image, (2, 98))

--- a/benchmarks/benchmark_feature.py
+++ b/benchmarks/benchmark_feature.py
@@ -11,7 +11,7 @@ class FeatureSuite:
         # Use a real-world image for more realistic features, but tile it to
         # get a larger size for the benchmark.
         self.image = np.tile(color.rgb2gray(data.astronaut()), (4, 4))
-        self.image_ubyte = util.img_as_ubyte(self.image)
+        self.image_ubyte = util.rescale_to_ubyte(self.image)
         self.keypoints = feature.corner_peaks(
                 self.image, min_distance=5, threshold_rel=0.1
                 )

--- a/benchmarks/benchmark_registration.py
+++ b/benchmarks/benchmark_registration.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy import ndimage as ndi
 
 from skimage.color import rgb2gray
-from skimage import data, img_as_float
+from skimage import data, rescale_to_float
 
 # guard against import of a non-existant registration module in older skimage
 try:
@@ -52,7 +52,7 @@ class PhaseCrossCorrelationRegistration:
         if phase_cross_correlation is None:
             raise NotImplementedError("phase_cross_correlation unavailable")
         shifts = (-2.3, 1.7, 5.4, -3.2)[:ndims]
-        phantom = img_as_float(
+        phantom = rescale_to_float(
             data.binary_blobs(length=image_size, n_dim=ndims))
         self.reference_image = np.fft.fftn(phantom).astype(dtype, copy=False)
         self.shifted_image = ndi.fourier_shift(self.reference_image, shifts)

--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -51,7 +51,7 @@ from skimage.data import cells3d
 # Load and display 3D images
 # ==========================
 
-data = util.img_as_float(cells3d()[:, 1, :, :])  # grab just the nuclei
+data = util.rescale_to_float(cells3d()[:, 1, :, :])  # grab just the nuclei
 
 print(f'shape: {data.shape}')
 print(f'dtype: {data.dtype}')

--- a/doc/examples/applications/plot_human_mitosis.py
+++ b/doc/examples/applications/plot_human_mitosis.py
@@ -142,7 +142,7 @@ plt.show()
 higher_threshold = 125
 dividing = image > higher_threshold
 
-smoother_dividing = filters.rank.mean(util.img_as_ubyte(dividing),
+smoother_dividing = filters.rank.mean(util.rescale_to_ubyte(dividing),
                                       morphology.disk(4))
 
 binary_smoother_dividing = smoother_dividing > 20

--- a/doc/examples/applications/plot_morphology.py
+++ b/doc/examples/applications/plot_morphology.py
@@ -27,9 +27,9 @@ functions only work on gray-scale or binary images, so we set ``as_gray=True``.
 
 import matplotlib.pyplot as plt
 from skimage import data
-from skimage.util import img_as_ubyte
+from skimage.util import rescale_to_ubyte
 
-orig_phantom = img_as_ubyte(data.shepp_logan_phantom())
+orig_phantom = rescale_to_ubyte(data.shepp_logan_phantom())
 fig, ax = plt.subplots()
 ax.imshow(orig_phantom, cmap=plt.cm.gray)
 

--- a/doc/examples/applications/plot_rank_filters.py
+++ b/doc/examples/applications/plot_rank_filters.py
@@ -37,11 +37,11 @@ from `skimage.data` for all comparisons.
 import numpy as np
 import matplotlib.pyplot as plt
 
-from skimage.util import img_as_ubyte
+from skimage.util import rescale_to_ubyte
 from skimage import data
 from skimage.exposure import histogram
 
-noisy_image = img_as_ubyte(data.camera())
+noisy_image = rescale_to_ubyte(data.camera())
 hist, hist_centers = histogram(noisy_image)
 
 fig, ax = plt.subplots(ncols=2, figsize=(10, 5))
@@ -68,7 +68,7 @@ from skimage.morphology import disk, ball
 
 rng = np.random.default_rng()
 noise = rng.random(noisy_image.shape)
-noisy_image = img_as_ubyte(data.camera())
+noisy_image = rescale_to_ubyte(data.camera())
 noisy_image[noise > 0.99] = 255
 noisy_image[noise < 0.01] = 0
 
@@ -143,7 +143,7 @@ plt.tight_layout()
 
 from skimage.filters.rank import mean_bilateral
 
-noisy_image = img_as_ubyte(data.camera())
+noisy_image = rescale_to_ubyte(data.camera())
 
 bilat = mean_bilateral(noisy_image.astype(np.uint16), disk(20), s0=10, s1=10)
 
@@ -185,7 +185,7 @@ plt.tight_layout()
 from skimage import exposure
 from skimage.filters import rank
 
-noisy_image = img_as_ubyte(data.camera())
+noisy_image = rescale_to_ubyte(data.camera())
 
 # equalize globally and locally
 glob = exposure.equalize_hist(noisy_image) * 255
@@ -229,7 +229,7 @@ plt.tight_layout()
 
 from skimage.filters.rank import autolevel
 
-noisy_image = img_as_ubyte(data.camera())
+noisy_image = rescale_to_ubyte(data.camera())
 
 auto = autolevel(noisy_image.astype(np.uint16), disk(20))
 
@@ -303,7 +303,7 @@ plt.tight_layout()
 
 from skimage.filters.rank import enhance_contrast
 
-noisy_image = img_as_ubyte(data.camera())
+noisy_image = rescale_to_ubyte(data.camera())
 
 enh = enhance_contrast(noisy_image, disk(5))
 
@@ -332,7 +332,7 @@ plt.tight_layout()
 
 from skimage.filters.rank import enhance_contrast_percentile
 
-noisy_image = img_as_ubyte(data.camera())
+noisy_image = rescale_to_ubyte(data.camera())
 
 penh = enhance_contrast_percentile(noisy_image, disk(5), p0=.1, p1=.9)
 
@@ -488,7 +488,7 @@ plt.tight_layout()
 
 from skimage.filters.rank import maximum, minimum, gradient
 
-noisy_image = img_as_ubyte(data.camera())
+noisy_image = rescale_to_ubyte(data.camera())
 
 closing = maximum(minimum(noisy_image, disk(5)), disk(5))
 opening = minimum(maximum(noisy_image, disk(5)), disk(5))

--- a/doc/examples/applications/plot_thresholding.py
+++ b/doc/examples/applications/plot_thresholding.py
@@ -195,10 +195,10 @@ plt.show()
 
 from skimage.morphology import disk
 from skimage.filters import threshold_otsu, rank
-from skimage.util import img_as_ubyte
+from skimage.util import rescale_to_ubyte
 
 
-img = img_as_ubyte(data.page())
+img = rescale_to_ubyte(data.page())
 
 radius = 15
 footprint = disk(radius)

--- a/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
+++ b/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
@@ -26,7 +26,7 @@ import imageio as io
 
 from skimage.data import cells3d
 
-im_orig = util.img_as_float(cells3d()[:, 1, :, :])  # grab just the nuclei
+im_orig = util.rescale_to_float(cells3d()[:, 1, :, :])  # grab just the nuclei
 
 # Reorder axis order from (z, y, x) to (x, y, z)
 im_orig = im_orig.transpose()

--- a/doc/examples/color_exposure/plot_equalize.py
+++ b/doc/examples/color_exposure/plot_equalize.py
@@ -22,7 +22,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
-from skimage import data, img_as_float
+from skimage import data, rescale_to_float
 from skimage import exposure
 
 
@@ -33,7 +33,7 @@ def plot_img_and_hist(image, axes, bins=256):
     """Plot an image along with its histogram and cumulative histogram.
 
     """
-    image = img_as_float(image)
+    image = rescale_to_float(image)
     ax_img, ax_hist = axes
     ax_cdf = ax_hist.twinx()
 

--- a/doc/examples/color_exposure/plot_local_equalize.py
+++ b/doc/examples/color_exposure/plot_local_equalize.py
@@ -27,7 +27,7 @@ import matplotlib.pyplot as plt
 
 from skimage import data
 from skimage.util.dtype import dtype_range
-from skimage.util import img_as_ubyte
+from skimage.util import rescale_to_ubyte
 from skimage import exposure
 from skimage.morphology import disk
 from skimage.morphology import ball
@@ -64,7 +64,7 @@ def plot_img_and_hist(image, axes, bins=256):
 
 
 # Load an example image
-img = img_as_ubyte(data.moon())
+img = rescale_to_ubyte(data.moon())
 
 # Global equalize
 img_rescale = exposure.equalize_hist(img)
@@ -140,7 +140,7 @@ def plot_img_and_hist(image, axes, bins=256):
 
 
 # Load an example image
-img = img_as_ubyte(data.brain())
+img = rescale_to_ubyte(data.brain())
 
 # Global equalization
 img_rescale = exposure.equalize_hist(img)

--- a/doc/examples/color_exposure/plot_log_gamma.py
+++ b/doc/examples/color_exposure/plot_log_gamma.py
@@ -11,7 +11,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
-from skimage import data, img_as_float
+from skimage import data, rescale_to_float
 from skimage import exposure
 
 matplotlib.rcParams['font.size'] = 8
@@ -21,7 +21,7 @@ def plot_img_and_hist(image, axes, bins=256):
     """Plot an image along with its histogram and cumulative histogram.
 
     """
-    image = img_as_float(image)
+    image = rescale_to_float(image)
     ax_img, ax_hist = axes
     ax_cdf = ax_hist.twinx()
 

--- a/doc/examples/color_exposure/plot_regional_maxima.py
+++ b/doc/examples/color_exposure/plot_regional_maxima.py
@@ -18,11 +18,11 @@ import matplotlib.pyplot as plt
 
 from scipy.ndimage import gaussian_filter
 from skimage import data
-from skimage import img_as_float
+from skimage import rescale_to_float
 from skimage.morphology import reconstruction
 
 # Convert to float: Important for subtraction later which won't work with uint8
-image = img_as_float(data.coins())
+image = rescale_to_float(data.coins())
 image = gaussian_filter(image, 1)
 
 seed = np.copy(image)

--- a/doc/examples/color_exposure/plot_tinting_grayscale_images.py
+++ b/doc/examples/color_exposure/plot_tinting_grayscale_images.py
@@ -20,9 +20,9 @@ only the red and green channels, which combine to form yellow.
 import matplotlib.pyplot as plt
 from skimage import data
 from skimage import color
-from skimage import img_as_float
+from skimage import rescale_to_float
 
-grayscale_image = img_as_float(data.camera()[::2, ::2])
+grayscale_image = rescale_to_float(data.camera()[::2, ::2])
 image = color.gray2rgb(grayscale_image)
 
 red_multiplier = [1, 0, 0]

--- a/doc/examples/edges/plot_active_contours.py
+++ b/doc/examples/edges/plot_active_contours.py
@@ -28,12 +28,12 @@ such as the boundaries of the face.
 import numpy as np
 import matplotlib.pyplot as plt
 from skimage.color import rgb2gray
-from skimage import data
+from skimage import data, rescale_as_float
 from skimage.filters import gaussian
 from skimage.segmentation import active_contour
 
 
-img = data.astronaut()
+img = rescale_as_float(data.astronaut())
 img = rgb2gray(img)
 
 s = np.linspace(0, 2*np.pi, 400)
@@ -41,7 +41,7 @@ r = 100 + 100*np.sin(s)
 c = 220 + 100*np.cos(s)
 init = np.array([r, c]).T
 
-snake = active_contour(gaussian(img, 3, preserve_range=False),
+snake = active_contour(gaussian(img, 3),
                        init, alpha=0.015, beta=10, gamma=0.001)
 
 fig, ax = plt.subplots(figsize=(7, 7))
@@ -59,13 +59,13 @@ plt.show()
 # the boundary condition `boundary_condition='fixed'`. We furthermore
 # make the algorithm search for dark lines by giving a negative `w_line` value.
 
-img = data.text()
+img = rescale_as_float(data.text())
 
 r = np.linspace(136, 50, 100)
 c = np.linspace(5, 424, 100)
 init = np.array([r, c]).T
 
-snake = active_contour(gaussian(img, 1, preserve_range=False),
+snake = active_contour(gaussian(img, 1),
                        init, boundary_condition='fixed',
                        alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1)
 

--- a/doc/examples/edges/plot_circular_elliptical_hough_transform.py
+++ b/doc/examples/edges/plot_circular_elliptical_hough_transform.py
@@ -41,11 +41,11 @@ from skimage import data, color
 from skimage.transform import hough_circle, hough_circle_peaks
 from skimage.feature import canny
 from skimage.draw import circle_perimeter
-from skimage.util import img_as_ubyte
+from skimage.util import rescale_to_ubyte
 
 
 # Load picture and detect edges
-image = img_as_ubyte(data.coins()[160:230, 70:270])
+image = rescale_to_ubyte(data.coins()[160:230, 70:270])
 edges = canny(image, sigma=3, low_threshold=10, high_threshold=50)
 
 
@@ -96,7 +96,7 @@ plt.show()
 
 import matplotlib.pyplot as plt
 
-from skimage import data, color, img_as_ubyte
+from skimage import data, color, rescale_to_ubyte
 from skimage.feature import canny
 from skimage.transform import hough_ellipse
 from skimage.draw import ellipse_perimeter
@@ -124,7 +124,7 @@ orientation = best[5]
 cy, cx = ellipse_perimeter(yc, xc, a, b, orientation)
 image_rgb[cy, cx] = (0, 0, 255)
 # Draw the edge (white) and the resulting ellipse (red)
-edges = color.gray2rgb(img_as_ubyte(edges))
+edges = color.gray2rgb(rescale_to_ubyte(edges))
 edges[cy, cx] = (250, 0, 0)
 
 fig2, (ax1, ax2) = plt.subplots(ncols=2, nrows=1, figsize=(8, 4),

--- a/doc/examples/edges/plot_convex_hull.py
+++ b/doc/examples/edges/plot_convex_hull.py
@@ -14,7 +14,7 @@ A good overview of the algorithm is given on `Steve Eddin's blog
 import matplotlib.pyplot as plt
 
 from skimage.morphology import convex_hull_image
-from skimage import data, img_as_float
+from skimage import data, rescale_to_float
 from skimage.util import invert
 
 # The original image is inverted as the object must be white.
@@ -40,7 +40,7 @@ plt.show()
 # We prepare a second plot to show the difference.
 #
 
-chull_diff = img_as_float(chull.copy())
+chull_diff = rescale_to_float(chull.copy())
 chull_diff[image] = 2
 
 fig, ax = plt.subplots()

--- a/doc/examples/features_detection/plot_gabor.py
+++ b/doc/examples/features_detection/plot_gabor.py
@@ -18,7 +18,7 @@ import numpy as np
 from scipy import ndimage as ndi
 
 from skimage import data
-from skimage.util import img_as_float
+from skimage.util import rescale_to_float
 from skimage.filters import gabor_kernel
 
 
@@ -54,9 +54,9 @@ for theta in range(4):
 
 
 shrink = (slice(0, None, 3), slice(0, None, 3))
-brick = img_as_float(data.brick())[shrink]
-grass = img_as_float(data.grass())[shrink]
-gravel = img_as_float(data.gravel())[shrink]
+brick = rescale_to_float(data.brick())[shrink]
+grass = rescale_to_float(data.grass())[shrink]
+gravel = rescale_to_float(data.gravel())[shrink]
 image_names = ('brick', 'grass', 'gravel')
 images = (brick, grass, gravel)
 

--- a/doc/examples/features_detection/plot_windowed_histogram.py
+++ b/doc/examples/features_detection/plot_windowed_histogram.py
@@ -40,7 +40,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 
 from skimage import data, transform
-from skimage.util import img_as_ubyte
+from skimage.util import rescale_to_ubyte
 from skimage.morphology import disk
 from skimage.filters import rank
 
@@ -77,7 +77,7 @@ def windowed_histogram_similarity(image, footprint, reference_hist, n_bins):
 
 
 # Load the `skimage.data.coins` image
-img = img_as_ubyte(data.coins())
+img = rescale_to_ubyte(data.coins())
 
 # Quantize to 16 levels of grayscale; this way the output image will have a
 # 16-dimensional feature vector per pixel
@@ -103,7 +103,7 @@ similarity = windowed_histogram_similarity(quantized_img, footprint, coin_hist,
                                            coin_hist.shape[0])
 
 # Now try a rotated image
-rotated_img = img_as_ubyte(transform.rotate(img, 45.0, resize=True))
+rotated_img = rescale_to_ubyte(transform.rotate(img, 45.0, resize=True))
 # Quantize to 16 levels as before
 quantized_rotated_image = rotated_img // 16
 # Similarity on rotated image

--- a/doc/examples/filters/plot_cycle_spinning.py
+++ b/doc/examples/filters/plot_cycle_spinning.py
@@ -25,12 +25,12 @@ achieved simply by averaging shifts of only n=0 and n=1 on each axis.
 import matplotlib.pyplot as plt
 
 from skimage.restoration import denoise_wavelet, cycle_spin
-from skimage import data, img_as_float
+from skimage import data, rescale_to_float
 from skimage.util import random_noise
 from skimage.metrics import peak_signal_noise_ratio
 
 
-original = img_as_float(data.chelsea()[100:250, 50:300])
+original = rescale_to_float(data.chelsea()[100:250, 50:300])
 
 sigma = 0.155
 noisy = random_noise(original, var=sigma**2)

--- a/doc/examples/filters/plot_denoise.py
+++ b/doc/examples/filters/plot_denoise.py
@@ -42,11 +42,11 @@ import matplotlib.pyplot as plt
 
 from skimage.restoration import (denoise_tv_chambolle, denoise_bilateral,
                                  denoise_wavelet, estimate_sigma)
-from skimage import data, img_as_float
+from skimage import data, rescale_to_float
 from skimage.util import random_noise
 
 
-original = img_as_float(data.chelsea()[100:250, 50:300])
+original = rescale_to_float(data.chelsea()[100:250, 50:300])
 
 sigma = 0.155
 noisy = random_noise(original, var=sigma**2)

--- a/doc/examples/filters/plot_denoise_wavelet.py
+++ b/doc/examples/filters/plot_denoise_wavelet.py
@@ -30,12 +30,12 @@ results in an improvement over what can be obtained with a single threshold.
 import matplotlib.pyplot as plt
 
 from skimage.restoration import (denoise_wavelet, estimate_sigma)
-from skimage import data, img_as_float
+from skimage import data, rescale_to_float
 from skimage.util import random_noise
 from skimage.metrics import peak_signal_noise_ratio
 
 
-original = img_as_float(data.chelsea()[100:250, 50:300])
+original = rescale_to_float(data.chelsea()[100:250, 50:300])
 
 sigma = 0.12
 noisy = random_noise(original, var=sigma**2)

--- a/doc/examples/filters/plot_entropy.py
+++ b/doc/examples/filters/plot_entropy.py
@@ -29,7 +29,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from skimage import data
-from skimage.util import img_as_ubyte
+from skimage.util import rescale_to_ubyte
 from skimage.filters.rank import entropy
 from skimage.morphology import disk
 
@@ -59,7 +59,7 @@ fig.tight_layout()
 # Texture detection
 # =================
 
-image = img_as_ubyte(data.camera())
+image = rescale_to_ubyte(data.camera())
 
 fig, (ax0, ax1) = plt.subplots(ncols=2, figsize=(12, 4),
                                sharex=True, sharey=True)

--- a/doc/examples/filters/plot_j_invariant.py
+++ b/doc/examples/filters/plot_j_invariant.py
@@ -25,13 +25,13 @@ from matplotlib import pyplot as plt
 from skimage.data import chelsea
 from skimage.restoration import calibrate_denoiser, denoise_wavelet
 
-from skimage.util import img_as_float, random_noise
+from skimage.util import rescale_to_float, random_noise
 from functools import partial
 
 # rescale_sigma=True required to silence deprecation warnings
 _denoise_wavelet = partial(denoise_wavelet, rescale_sigma=True)
 
-image = img_as_float(chelsea())
+image = rescale_to_float(chelsea())
 sigma = 0.3
 noisy = random_noise(image, var=sigma ** 2)
 

--- a/doc/examples/filters/plot_j_invariant_tutorial.py
+++ b/doc/examples/filters/plot_j_invariant_tutorial.py
@@ -30,13 +30,13 @@ from skimage.restoration import (calibrate_denoiser,
                                  denoise_wavelet,
                                  denoise_tv_chambolle, denoise_nl_means,
                                  estimate_sigma)
-from skimage.util import img_as_float, random_noise
+from skimage.util import rescale_to_float, random_noise
 from skimage.color import rgb2gray
 from functools import partial
 
 _denoise_wavelet = partial(denoise_wavelet, rescale_sigma=True)
 
-image = img_as_float(chelsea())
+image = rescale_to_float(chelsea())
 sigma = 0.2
 noisy = random_noise(image, var=sigma ** 2)
 
@@ -210,7 +210,7 @@ ax.set_xlabel('sigma')
 # loss shows that the TV norm denoiser is the best for this noisy image.
 #
 
-image = rgb2gray(img_as_float(hubble_deep_field()[100:250, 50:300]))
+image = rgb2gray(rescale_to_float(hubble_deep_field()[100:250, 50:300]))
 
 sigma = 0.4
 noisy = random_noise(image, mode='speckle', var=sigma ** 2)

--- a/doc/examples/filters/plot_nonlocal_means.py
+++ b/doc/examples/filters/plot_nonlocal_means.py
@@ -33,13 +33,13 @@ of each variant.
 import numpy as np
 import matplotlib.pyplot as plt
 
-from skimage import data, img_as_float
+from skimage import data, rescale_to_float
 from skimage.restoration import denoise_nl_means, estimate_sigma
 from skimage.metrics import peak_signal_noise_ratio
 from skimage.util import random_noise
 
 
-astro = img_as_float(data.astronaut())
+astro = rescale_to_float(data.astronaut())
 astro = astro[30:180, 150:300]
 
 sigma = 0.08

--- a/doc/examples/filters/plot_phase_unwrap.py
+++ b/doc/examples/filters/plot_phase_unwrap.py
@@ -13,12 +13,12 @@ skimage. Here we will demonstrate phase unwrapping in the two dimensional case.
 
 import numpy as np
 from matplotlib import pyplot as plt
-from skimage import data, img_as_float, color, exposure
+from skimage import data, rescale_to_float, color, exposure
 from skimage.restoration import unwrap_phase
 
 
 # Load an image as a floating-point grayscale
-image = color.rgb2gray(img_as_float(data.chelsea()))
+image = color.rgb2gray(rescale_to_float(data.chelsea()))
 # Scale the image to [0, 4*pi]
 image = exposure.rescale_intensity(image, out_range=(0, 4 * np.pi))
 # Create a phase-wrapped image in the interval [-pi, pi)

--- a/doc/examples/filters/plot_window.py
+++ b/doc/examples/filters/plot_window.py
@@ -25,12 +25,12 @@ visible in the plot of the frequency component of the FFT.
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.fft import fft2, fftshift
-from skimage import img_as_float
+from skimage import rescale_to_float
 from skimage.color import rgb2gray
 from skimage.data import astronaut
 from skimage.filters import window
 
-image = img_as_float(rgb2gray(astronaut()))
+image = rescale_to_float(rgb2gray(astronaut()))
 
 wimage = image * window('hann', image.shape)
 

--- a/doc/examples/registration/plot_register_rotation.py
+++ b/doc/examples/registration/plot_register_rotation.py
@@ -38,12 +38,12 @@ import matplotlib.pyplot as plt
 from skimage import data
 from skimage.registration import phase_cross_correlation
 from skimage.transform import warp_polar, rotate, rescale
-from skimage.util import img_as_float
+from skimage.util import rescale_to_float
 
 radius = 705
 angle = 35
 image = data.retina()
-image = img_as_float(image)
+image = rescale_to_float(image)
 rotated = rotate(image, angle)
 image_polar = warp_polar(image, radius=radius, channel_axis=-1)
 rotated_polar = warp_polar(rotated, radius=radius, channel_axis=-1)
@@ -82,7 +82,7 @@ radius = 1500
 angle = 53.7
 scale = 2.2
 image = data.retina()
-image = img_as_float(image)
+image = rescale_to_float(image)
 rotated = rotate(image, angle)
 rescaled = rescale(rotated, scale, channel_axis=-1)
 image_polar = warp_polar(image, radius=radius,

--- a/doc/examples/segmentation/plot_chan_vese.py
+++ b/doc/examples/segmentation/plot_chan_vese.py
@@ -44,10 +44,10 @@ References
        :arXiv:`1107.2782`
 """
 import matplotlib.pyplot as plt
-from skimage import data, img_as_float
+from skimage import data, rescale_to_float
 from skimage.segmentation import chan_vese
 
-image = img_as_float(data.camera())
+image = rescale_to_float(data.camera())
 # Feel free to play around with the parameters to see how they impact the result
 cv = chan_vese(image, mu=0.25, lambda1=1, lambda2=1, tol=1e-3,
                max_num_iter=200, dt=0.5, init_level_set="checkerboard",

--- a/doc/examples/segmentation/plot_marked_watershed.py
+++ b/doc/examples/segmentation/plot_marked_watershed.py
@@ -25,10 +25,10 @@ from skimage.morphology import disk
 from skimage.segmentation import watershed
 from skimage import data
 from skimage.filters import rank
-from skimage.util import img_as_ubyte
+from skimage.util import rescale_to_ubyte
 
 
-image = img_as_ubyte(data.eagle())
+image = rescale_to_ubyte(data.eagle())
 
 # denoise image
 denoised = rank.median(image, disk(2))

--- a/doc/examples/segmentation/plot_metrics.py
+++ b/doc/examples/segmentation/plot_metrics.py
@@ -23,7 +23,7 @@ from skimage.metrics import (adapted_rand_error,
                               variation_of_information)
 from skimage.filters import sobel
 from skimage.measure import label
-from skimage.util import img_as_float
+from skimage.util import rescale_to_float
 from skimage.feature import canny
 from skimage.morphology import remove_small_objects
 from skimage.segmentation import (morphological_geodesic_active_contour,
@@ -73,7 +73,7 @@ im_test2 = ndi.label(remove_small_objects(fill_coins, 21))[0]
 # merged into one segment. We will see the corresponding effect on the
 # segmentation metrics.
 
-image = img_as_float(image)
+image = rescale_to_float(image)
 gradient = inverse_gaussian_gradient(image)
 init_ls = np.zeros(image.shape, dtype=np.int8)
 init_ls[10:-10, 10:-10] = 1

--- a/doc/examples/segmentation/plot_morphsnakes.py
+++ b/doc/examples/segmentation/plot_morphsnakes.py
@@ -49,7 +49,7 @@ References
 
 import numpy as np
 import matplotlib.pyplot as plt
-from skimage import data, img_as_float
+from skimage import data, rescale_to_float
 from skimage.segmentation import (morphological_chan_vese,
                                   morphological_geodesic_active_contour,
                                   inverse_gaussian_gradient,
@@ -68,7 +68,7 @@ def store_evolution_in(lst):
 
 
 # Morphological ACWE
-image = img_as_float(data.camera())
+image = rescale_to_float(data.camera())
 
 # Initial level set
 init_ls = checkerboard_level_set(image.shape, 6)
@@ -100,7 +100,7 @@ ax[1].set_title(title, fontsize=12)
 
 
 # Morphological GAC
-image = img_as_float(data.coins())
+image = rescale_to_float(data.coins())
 gimage = inverse_gaussian_gradient(image)
 
 # Initial level set

--- a/doc/examples/segmentation/plot_peak_local_max.py
+++ b/doc/examples/segmentation/plot_peak_local_max.py
@@ -13,9 +13,9 @@ dilated image are returned as local maxima.
 from scipy import ndimage as ndi
 import matplotlib.pyplot as plt
 from skimage.feature import peak_local_max
-from skimage import data, img_as_float
+from skimage import data, rescale_to_float
 
-im = img_as_float(data.coins())
+im = rescale_to_float(data.coins())
 
 # image_max is the dilation of im with a 20*20 structuring element
 # It is used within peak_local_max function

--- a/doc/examples/segmentation/plot_random_walker_segmentation.py
+++ b/doc/examples/segmentation/plot_random_walker_segmentation.py
@@ -31,7 +31,7 @@ import skimage
 rng = np.random.default_rng()
 
 # Generate noisy synthetic data
-data = skimage.img_as_float(binary_blobs(length=128, seed=1))
+data = skimage.rescale_to_float(binary_blobs(length=128, seed=1))
 sigma = 0.35
 data += rng.normal(loc=0, scale=sigma, size=data.shape)
 data = rescale_intensity(data, in_range=(-sigma, 1 + sigma),

--- a/doc/examples/segmentation/plot_rolling_ball.py
+++ b/doc/examples/segmentation/plot_rolling_ball.py
@@ -154,7 +154,7 @@ plt.show()
 # be much larger than the image intensity, which can lead to
 # unexpected results.
 
-image = util.img_as_float(data.coins()[:200, :200])
+image = util.rescale_to_float(data.coins()[:200, :200])
 
 background = restoration.rolling_ball(image, radius=70.5)
 plot_result(image, background)
@@ -176,7 +176,7 @@ plt.show()
 # multipled by two.
 
 normalized_radius = 70.5 / 255
-image = util.img_as_float(data.coins())
+image = util.rescale_to_float(data.coins())
 kernel = restoration.ellipsoid_kernel(
     (70.5 * 2, 70.5 * 2),
     normalized_radius * 2

--- a/doc/examples/segmentation/plot_segmentations.py
+++ b/doc/examples/segmentation/plot_segmentations.py
@@ -91,9 +91,9 @@ from skimage.color import rgb2gray
 from skimage.filters import sobel
 from skimage.segmentation import felzenszwalb, slic, quickshift, watershed
 from skimage.segmentation import mark_boundaries
-from skimage.util import img_as_float
+from skimage.util import rescale_to_float
 
-img = img_as_float(astronaut()[::2, ::2])
+img = rescale_to_float(astronaut()[::2, ::2])
 
 segments_fz = felzenszwalb(img, scale=100, sigma=0.5, min_size=50)
 segments_slic = slic(img, n_segments=250, compactness=10, sigma=1,

--- a/doc/examples/transform/plot_matching.py
+++ b/doc/examples/transform/plot_matching.py
@@ -25,7 +25,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from skimage import data
-from skimage.util import img_as_float
+from skimage.util import rescale_to_float
 from skimage.feature import (corner_harris, corner_subpix, corner_peaks,
                              plot_matches)
 from skimage.transform import warp, AffineTransform
@@ -35,7 +35,7 @@ from skimage.measure import ransac
 
 
 # generate synthetic checkerboard image and add gradient for the later matching
-checkerboard = img_as_float(data.checkerboard())
+checkerboard = rescale_to_float(data.checkerboard())
 img_orig = np.zeros(list(checkerboard.shape) + [3])
 img_orig[..., 0] = checkerboard
 gradient_r, gradient_c = (np.mgrid[0:img_orig.shape[0],

--- a/doc/examples/transform/plot_ssim.py
+++ b/doc/examples/transform/plot_ssim.py
@@ -24,12 +24,12 @@ but with very different mean structural similarity indices.
 import numpy as np
 import matplotlib.pyplot as plt
 
-from skimage import data, img_as_float
+from skimage import data, rescale_to_float
 from skimage.metrics import structural_similarity as ssim
 from skimage.metrics import mean_squared_error
 
 
-img = img_as_float(data.camera())
+img = rescale_to_float(data.camera())
 rows, cols = img.shape
 
 noise = np.ones_like(img) * 0.2 * (img.max() - img.min())

--- a/doc/examples/transform/plot_transform_types.py
+++ b/doc/examples/transform/plot_transform_types.py
@@ -28,7 +28,7 @@ import matplotlib.pyplot as plt
 
 from skimage import data
 from skimage import transform
-from skimage import img_as_float
+from skimage import rescale_to_float
 
 ######################################################################
 # Euclidean (rigid) transformation
@@ -54,7 +54,7 @@ print(tform.params)
 # Therefore, we need to use the inverse of ``tform``, rather than ``tform``
 # directly.
 
-img = img_as_float(data.chelsea())
+img = rescale_to_float(data.chelsea())
 tf_img = transform.warp(img, tform.inverse)
 fig, ax = plt.subplots()
 ax.imshow(tf_img)

--- a/doc/source/user_guide/data_types.rst
+++ b/doc/source/user_guide/data_types.rst
@@ -33,11 +33,11 @@ functions that convert dtypes and properly rescale image intensities (see
 `Input types`_). You should **never use** ``astype`` on an image, because it
 violates these assumptions about the dtype range::
 
-   >>> from skimage.util import img_as_float
+   >>> from skimage.util import rescale_to_float
    >>> image = np.arange(0, 50, 10, dtype=np.uint8)
    >>> print(image.astype(float)) # These float values are out of range.
    [  0.  10.  20.  30.  40.]
-   >>> print(img_as_float(image))
+   >>> print(rescale_to_float(image))
    [ 0.          0.03921569  0.07843137  0.11764706  0.15686275]
 
 
@@ -53,21 +53,21 @@ requirements should be noted in the docstrings.
 The following utility functions in the main package are available to developers
 and users:
 
-=============  =================================
-Function name  Description
-=============  =================================
-img_as_float   Convert to floating point (integer types become 64-bit floats)
-img_as_ubyte   Convert to 8-bit uint.
-img_as_uint    Convert to 16-bit uint.
-img_as_int     Convert to 16-bit int.
-=============  =================================
+================  =================================
+Function name     Description
+================  =================================
+rescale_to_float   Convert to floating point (integer types become 64-bit floats)
+rescale_to_ubyte   Convert to 8-bit uint.
+rescale_to_uint    Convert to 16-bit uint.
+rescale_to_int     Convert to 16-bit int.
+================  =================================
 
 These functions convert images to the desired dtype and *properly rescale their
 values*::
 
-   >>> from skimage.util import img_as_ubyte
+   >>> from skimage.util import rescale_to_ubyte
    >>> image = np.array([0, 0.5, 1], dtype=float)
-   >>> img_as_ubyte(image)
+   >>> rescale_to_ubyte(image)
    array([  0, 128, 255], dtype=uint8)
 
 Be careful! These conversions can result in a loss of precision, since 8 bits
@@ -77,7 +77,7 @@ cannot hold the same amount of information as 64 bits::
    >>> image_as_ubyte(image)
    array([  0, 128, 128, 255], dtype=uint8)
 
-Note that ``img_as_float`` will preserve the precision of floating point types
+Note that ``rescale_to_float`` will preserve the precision of floating point types
 and does not automatically rescale the range of floating point inputs.
 
 Additionally, some functions take a ``preserve_range`` argument where a range
@@ -120,8 +120,8 @@ unnecessary data copies take place.
 A user that requires a specific type of output (e.g., for display purposes),
 may write::
 
-   >>> from skimage.util import img_as_uint
-   >>> out = img_as_uint(sobel(image))
+   >>> from skimage.util import rescale_to_uint
+   >>> out = rescale_to_uint(sobel(image))
    >>> plt.imshow(out)
 
 
@@ -154,19 +154,19 @@ Using an image from OpenCV with ``skimage``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If cv_image is an array of unsigned bytes, ``skimage`` will understand it by
-default. If you prefer working with floating point images, :func:`img_as_float`
+default. If you prefer working with floating point images, :func:`rescale_to_float`
 can be used to convert the image::
 
-    >>> from skimage.util import img_as_float
-    >>> image = img_as_float(any_opencv_image)
+    >>> from skimage.util import rescale_to_float
+    >>> image = rescale_to_float(any_opencv_image)
 
 Using an image from ``skimage`` with OpenCV
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The reverse can be achieved with :func:`img_as_ubyte`::
+The reverse can be achieved with :func:`rescale_to_ubyte`::
 
-    >>> from skimage.util import img_as_ubyte
-    >>> cv_image = img_as_ubyte(any_skimage_image)
+    >>> from skimage.util import rescale_to_ubyte
+    >>> cv_image = rescale_to_ubyte(any_skimage_image)
 
 
 Image processing pipeline
@@ -178,15 +178,15 @@ a custom function that requires a particular dtype, you should call one of the
 dtype conversion functions (here, ``func1`` and ``func2`` are ``skimage``
 functions)::
 
-   >>> from skimage.util import img_as_float
-   >>> image = img_as_float(func1(func2(image)))
+   >>> from skimage.util import rescale_to_float
+   >>> image = rescale_to_float(func1(func2(image)))
    >>> processed_image = custom_func(image)
 
 Better yet, you can convert the image internally and use a simplified
 processing pipeline::
 
    >>> def custom_func(image):
-   ...     image = img_as_float(image)
+   ...     image = rescale_to_float(image)
    ...     # do something
    ...
    >>> processed_image = custom_func(func1(func2(image)))
@@ -234,7 +234,7 @@ dtypes. (Negative values are preserved when converting between signed dtypes.)
 To prevent this clipping behavior, you should rescale your image beforehand::
 
    >>> image = exposure.rescale_intensity(img_int32, out_range=(0, 2**31 - 1))
-   >>> img_uint8 = img_as_ubyte(image)
+   >>> img_uint8 = rescale_to_ubyte(image)
 
 This behavior is symmetric: The values in an unsigned dtype are spread over
 just the positive range of a signed dtype.

--- a/doc/source/user_guide/geometrical_transform.rst
+++ b/doc/source/user_guide/geometrical_transform.rst
@@ -48,7 +48,7 @@ parameters (e.g. scale, shear, rotation and translation)::
 
    from skimage import data
    from skimage import transform
-   from skimage import img_as_float
+   from skimage import rescale_to_float
    
    tform = transform.EuclideanTransform(
       rotation=np.pi / 12.,
@@ -59,7 +59,7 @@ or the full transformation matrix::
 
    from skimage import data
    from skimage import transform
-   from skimage import img_as_float
+   from skimage import rescale_to_float
    
    matrix = np.array([[np.cos(np.pi/12), -np.sin(np.pi/12), 100],
                       [np.sin(np.pi/12), np.cos(np.pi/12), -20],
@@ -78,7 +78,7 @@ represented with finite coordinates.
 
 Transformations can be applied to images using :func:`skimage.transform.warp`::
 
-   img = img_as_float(data.chelsea())
+   img = rescale_to_float(data.chelsea())
    tf_img = transform.warp(img, tform.inverse)
 
 .. image:: ../auto_examples/transform/images/sphx_glr_plot_transform_types_001.png

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -42,23 +42,23 @@ util
 
 Utility Functions
 -----------------
-img_as_float
+rescale_to_float
     Convert an image to floating point format, with values in [0, 1].
-    Is similar to `img_as_float64`, but will not convert lower-precision
+    Is similar to `rescale_to_float64`, but will not convert lower-precision
     floating point arrays to `float64`.
-img_as_float32
+rescale_to_float32
     Convert an image to single-precision (32-bit) floating point format,
     with values in [0, 1].
-img_as_float64
+rescale_to_float64
     Convert an image to double-precision (64-bit) floating point format,
     with values in [0, 1].
-img_as_uint
+rescale_to_uint
     Convert an image to unsigned integer format, with values in [0, 65535].
-img_as_int
+rescale_to_int
     Convert an image to signed integer format, with values in [-32768, 32767].
-img_as_ubyte
+rescale_to_ubyte
     Convert an image to unsigned byte format, with values in [0, 255].
-img_as_bool
+rescale_to_bool
     Convert an image to boolean format, with values either True or False.
 dtype_limits
     Return intensity limits, i.e. (min, max) tuple, of the image's dtype.
@@ -150,13 +150,13 @@ else:
         _raise_build_error(e)
 
     # All skimage root imports go here
-    from .util.dtype import (img_as_float32,
-                             img_as_float64,
-                             img_as_float,
-                             img_as_int,
-                             img_as_uint,
-                             img_as_ubyte,
-                             img_as_bool,
+    from .util.dtype import (rescale_to_float32,
+                             rescale_to_float64,
+                             rescale_to_float,
+                             rescale_to_int,
+                             rescale_to_uint,
+                             rescale_to_ubyte,
+                             rescale_to_bool,
                              dtype_limits)
     from .util.lookfor import lookfor
 

--- a/skimage/_shared/filters.py
+++ b/skimage/_shared/filters.py
@@ -47,9 +47,9 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
         This argument is deprecated: specify `channel_axis` instead.
     preserve_range : bool, optional
         If True, keep the original range of values. Otherwise, the input
-        ``image`` is converted according to the conventions of ``img_as_float``
-        (Normalized first to values [-1.0 ; 1.0] or [0 ; 1.0] depending on
-        dtype of input)
+        ``image`` is converted according to the conventions of
+        ``rescale_to_float`` (Normalized first to values [-1.0 ; 1.0] or
+        [0 ; 1.0] depending on dtype of input)
 
         For more information, see:
         https://scikit-image.org/docs/dev/user_guide/data_types.html

--- a/skimage/_shared/filters.py
+++ b/skimage/_shared/filters.py
@@ -10,13 +10,12 @@ import numpy as np
 from scipy import ndimage as ndi
 
 from .._shared import utils
-from .._shared.utils import _supported_float_type, convert_to_float, warn
+from .._shared.utils import _supported_float_type, warn
 
 
 @utils.deprecate_multichannel_kwarg(multichannel_position=5)
 def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
-             multichannel=None, preserve_range=False, truncate=4.0, *,
-             channel_axis=None):
+             multichannel=None, truncate=4.0, *, channel_axis=None):
     """Multi-dimensional Gaussian filter.
 
     Parameters
@@ -45,6 +44,7 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
         the function will attempt to guess this, and raise a warning if
         ambiguous, when the array has shape (M, N, 3).
         This argument is deprecated: specify `channel_axis` instead.
+<<<<<<< HEAD
     preserve_range : bool, optional
         If True, keep the original range of values. Otherwise, the input
         ``image`` is converted according to the conventions of
@@ -53,6 +53,8 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
 
         For more information, see:
         https://scikit-image.org/docs/dev/user_guide/data_types.html
+=======
+>>>>>>> 7e53d42aa... remove preserve_range from gaussian
     truncate : float, optional
         Truncate the filter at this many standard deviations.
     channel_axis : int or None, optional
@@ -128,7 +130,6 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
         if len(sigma) == image.ndim - 1:
             sigma = list(sigma)
             sigma.insert(channel_axis % image.ndim, 0)
-    image = convert_to_float(image, preserve_range)
     float_dtype = _supported_float_type(image.dtype)
     image = image.astype(float_dtype, copy=False)
     if (output is not None) and (not np.issubdtype(output.dtype, np.floating)):

--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -21,7 +21,7 @@ import warnings
 
 from .. import data, io
 from ..data._fetchers import _fetch
-from ..util import img_as_uint, img_as_float, img_as_int, img_as_ubyte
+from ..util import rescale_to_uint, rescale_to_float, rescale_to_int, rescale_to_ubyte
 from ._warnings import expected_warnings
 
 
@@ -134,7 +134,7 @@ def color_check(plugin, fmt='png'):
     All major input types should be handled as ubytes and read
     back correctly.
     """
-    img = img_as_ubyte(data.chelsea())
+    img = rescale_to_ubyte(data.chelsea())
     r1 = roundtrip(img, plugin, fmt)
     testing.assert_allclose(img, r1)
 
@@ -142,20 +142,20 @@ def color_check(plugin, fmt='png'):
     r2 = roundtrip(img2, plugin, fmt)
     testing.assert_allclose(img2, r2.astype(bool))
 
-    img3 = img_as_float(img)
+    img3 = rescale_to_float(img)
     r3 = roundtrip(img3, plugin, fmt)
     testing.assert_allclose(r3, img)
 
-    img4 = img_as_int(img)
+    img4 = rescale_to_int(img)
     if fmt.lower() in (('tif', 'tiff')):
         img4 -= 100
         r4 = roundtrip(img4, plugin, fmt)
         testing.assert_allclose(r4, img4)
     else:
         r4 = roundtrip(img4, plugin, fmt)
-        testing.assert_allclose(r4, img_as_ubyte(img4))
+        testing.assert_allclose(r4, rescale_to_ubyte(img4))
 
-    img5 = img_as_uint(img)
+    img5 = rescale_to_uint(img)
     r5 = roundtrip(img5, plugin, fmt)
     testing.assert_allclose(r5, img)
 
@@ -166,7 +166,7 @@ def mono_check(plugin, fmt='png'):
     All major input types should be handled.
     """
 
-    img = img_as_ubyte(data.moon())
+    img = rescale_to_ubyte(data.moon())
     r1 = roundtrip(img, plugin, fmt)
     testing.assert_allclose(img, r1)
 
@@ -174,23 +174,23 @@ def mono_check(plugin, fmt='png'):
     r2 = roundtrip(img2, plugin, fmt)
     testing.assert_allclose(img2, r2.astype(bool))
 
-    img3 = img_as_float(img)
+    img3 = rescale_to_float(img)
     r3 = roundtrip(img3, plugin, fmt)
     if r3.dtype.kind == 'f':
         testing.assert_allclose(img3, r3)
     else:
-        testing.assert_allclose(r3, img_as_uint(img))
+        testing.assert_allclose(r3, rescale_to_uint(img))
 
-    img4 = img_as_int(img)
+    img4 = rescale_to_int(img)
     if fmt.lower() in (('tif', 'tiff')):
         img4 -= 100
         r4 = roundtrip(img4, plugin, fmt)
         testing.assert_allclose(r4, img4)
     else:
         r4 = roundtrip(img4, plugin, fmt)
-        testing.assert_allclose(r4, img_as_uint(img4))
+        testing.assert_allclose(r4, rescale_to_uint(img4))
 
-    img5 = img_as_uint(img)
+    img5 = rescale_to_uint(img)
     r5 = roundtrip(img5, plugin, fmt)
     testing.assert_allclose(r5, img5)
 

--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -21,7 +21,8 @@ import warnings
 
 from .. import data, io
 from ..data._fetchers import _fetch
-from ..util import rescale_to_uint, rescale_to_float, rescale_to_int, rescale_to_ubyte
+from ..util import (rescale_to_uint, rescale_to_float, rescale_to_int,
+                    rescale_to_ubyte)
 from ._warnings import expected_warnings
 
 

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -666,7 +666,7 @@ def convert_to_float(image, preserve_range):
         Input image.
     preserve_range : bool
         Determines if the range of the image should be kept or transformed
-        using img_as_float. Also see
+        using rescale_to_float. Also see
         https://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Notes
@@ -687,8 +687,8 @@ def convert_to_float(image, preserve_range):
         if image.dtype.char not in 'df':
             image = image.astype(float)
     else:
-        from ..util.dtype import img_as_float
-        image = img_as_float(image)
+        from ..util.dtype import rescale_to_float
+        image = rescale_to_float(image)
     return image
 
 

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -142,9 +142,9 @@ def _prepare_colorarray(arr, force_copy=False, *, channel_axis=-1,
 
     float_dtype = _supported_float_type(arr.dtype)
     if float_dtype == np.float32:
-        _func = dtype.rescale_as_float32 if rescale else dtype.img_as_float32
+        _func = dtype.rescale_to_float32 if rescale else dtype.img_as_float32
     else:
-        _func = dtype.rescale_as_float64 if rescale else dtype.img_as_float64
+        _func = dtype.rescale_to_float64 if rescale else dtype.img_as_float64
     return _func(arr, force_copy=force_copy)
 
 

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -128,7 +128,8 @@ def convert_colorspace(arr, fromspace, tospace, *, channel_axis=-1):
     )
 
 
-def _prepare_colorarray(arr, force_copy=False, *, channel_axis=-1):
+def _prepare_colorarray(arr, force_copy=False, *, channel_axis=-1,
+                        rescale=True):
     """Check the shape of the array and convert it to
     floating point representation.
     """
@@ -141,9 +142,9 @@ def _prepare_colorarray(arr, force_copy=False, *, channel_axis=-1):
 
     float_dtype = _supported_float_type(arr.dtype)
     if float_dtype == np.float32:
-        _func = dtype.rescale_to_float32
+        _func = dtype.rescale_as_float32 if rescale else dtype.img_as_float32
     else:
-        _func = dtype.rescale_to_float64
+        _func = dtype.rescale_as_float64 if rescale else dtype.img_as_float64
     return _func(arr, force_copy=force_copy)
 
 

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -141,9 +141,9 @@ def _prepare_colorarray(arr, force_copy=False, *, channel_axis=-1):
 
     float_dtype = _supported_float_type(arr.dtype)
     if float_dtype == np.float32:
-        _func = dtype.img_as_float32
+        _func = dtype.rescale_to_float32
     else:
-        _func = dtype.img_as_float64
+        _func = dtype.rescale_to_float64
     return _func(arr, force_copy=force_copy)
 
 
@@ -204,9 +204,9 @@ def rgba2rgb(rgba, background=(1, 1, 1), *, channel_axis=-1):
 
     float_dtype = _supported_float_type(arr.dtype)
     if float_dtype == np.float32:
-        arr = dtype.img_as_float32(arr)
+        arr = dtype.rescale_to_float32(arr)
     else:
-        arr = dtype.img_as_float64(arr)
+        arr = dtype.rescale_to_float64(arr)
 
     background = np.ravel(background).astype(arr.dtype)
     if len(background) != 3:
@@ -1767,9 +1767,9 @@ def _prepare_lab_array(arr, force_copy=True):
         raise ValueError('Input array has less than 3 color channels')
     float_dtype = _supported_float_type(arr.dtype)
     if float_dtype == np.float32:
-        _func = dtype.img_as_float32
+        _func = dtype.rescale_to_float32
     else:
-        _func = dtype.img_as_float64
+        _func = dtype.rescale_to_float64
     return _func(arr, force_copy=force_copy)
 
 

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -3,7 +3,7 @@ import itertools
 import numpy as np
 
 from .._shared.utils import _supported_float_type, warn
-from ..util import img_as_float
+from ..util import rescale_to_float32, rescale_to_float64
 from . import rgb_colors
 from .colorconv import gray2rgb, rgb2hsv, hsv2rgb
 
@@ -196,7 +196,11 @@ def _label2rgb_overlay(label, image=None, colors=None, alpha=0.3,
             warn("Negative intensities in `image` are not supported")
 
         float_dtype = _supported_float_type(image.dtype)
-        image = img_as_float(image).astype(float_dtype, copy=False)
+        if image.dtype.kind != 'f':
+            if float_dtype == np.float32:
+                image = rescale_to_float32(image)
+            else:
+                image = rescale_to_float64(image)
         if image.ndim > label.ndim:
             hsv = rgb2hsv(image)
             hsv[..., 1] *= saturation

--- a/skimage/color/tests/test_adapt_rgb.py
+++ b/skimage/color/tests/test_adapt_rgb.py
@@ -2,9 +2,10 @@ from functools import partial
 
 import numpy as np
 
-from skimage import img_as_float, img_as_uint
+from skimage import rescale_to_uint
 from skimage import color, data, filters
 from skimage.color.adapt_rgb import adapt_rgb, each_channel, hsv_value
+from skimage.util import rescale_to_float
 
 # Down-sample image for quicker testing.
 COLOR_IMAGE = data.astronaut()[::5, ::6]
@@ -44,7 +45,7 @@ def smooth_hsv(image, sigma):
 
 @adapt_rgb(hsv_value)
 def edges_hsv_uint(image):
-    return img_as_uint(filters.sobel(image))
+    return rescale_to_uint(filters.sobel(image))
 
 
 def test_gray_scale_image():
@@ -56,7 +57,7 @@ def test_gray_scale_image():
 def test_each_channel():
     filtered = edges_each(COLOR_IMAGE)
     for i, channel in enumerate(np.rollaxis(filtered, axis=-1)):
-        expected = img_as_float(filters.sobel(COLOR_IMAGE[:, :, i]))
+        expected = rescale_to_float(filters.sobel(COLOR_IMAGE[:, :, i]))
         assert_allclose(channel, expected)
 
 

--- a/skimage/data/_binary_blobs.py
+++ b/skimage/data/_binary_blobs.py
@@ -57,7 +57,6 @@ def binary_blobs(length=512, blob_size_fraction=0.1, n_dim=2,
     n_pts = max(int(1. / blob_size_fraction) ** n_dim, 1)
     points = (length * rs.random((n_dim, n_pts))).astype(int)
     mask[tuple(indices for indices in points)] = 1
-    mask = gaussian(mask, sigma=0.25 * length * blob_size_fraction,
-                    preserve_range=False)
+    mask = gaussian(mask, sigma=0.25 * length * blob_size_fraction)
     threshold = np.percentile(mask, 100 * (1 - volume_fraction))
     return np.logical_not(mask < threshold)

--- a/skimage/data/_fetchers.py
+++ b/skimage/data/_fetchers.py
@@ -9,7 +9,7 @@ import numpy as np
 import shutil
 from packaging import version
 
-from ..util.dtype import img_as_bool
+from ..util.dtype import rescale_to_bool
 from ._binary_blobs import binary_blobs
 from ._registry import registry, legacy_registry, registry_urls
 
@@ -471,7 +471,7 @@ def brick():
     >>> from skimage.transform import rescale, warp, rotate
     >>> from skimage.color import rgb2gray
     >>> from imageio import imread, imwrite
-    >>> from skimage import img_as_ubyte
+    >>> from skimage import rescale_to_ubyte
     >>> import numpy as np
 
 
@@ -485,7 +485,7 @@ def brick():
     >>> brick = warp(brick_orig, H)
     >>> brick = rescale(brick[:1024, :1024], (0.5, 0.5, 1))
     >>> brick = rotate(brick, -90)
-    >>> imwrite('brick.png', img_as_ubyte(rgb2gray(brick)))
+    >>> imwrite('brick.png', rescale_to_ubyte(rgb2gray(brick)))
     """
     return _load("data/brick.png", as_gray=True)
 
@@ -532,7 +532,7 @@ def grass():
     >>> with open('grass_orig.jpg', 'bw') as f:
     ...     f.write(r.content)
     >>> grass_orig = imageio.imread('grass_orig.jpg')
-    >>> grass = skimage.img_as_ubyte(skimage.color.rgb2gray(grass_orig[:512, :512]))
+    >>> grass = skimage.rescale_to_ubyte(skimage.color.rgb2gray(grass_orig[:512, :512]))
     >>> imageio.imwrite('grass.png', grass)
     """
     return _load("data/grass.png", as_gray=True)
@@ -587,7 +587,7 @@ def gravel():
     >>> from skimage.transform import resize
     >>> gravel_orig = imageio.imread('Gravel04_col.jpg')
     >>> gravel = resize(gravel_orig, (1024, 1024))
-    >>> gravel = skimage.img_as_ubyte(skimage.color.rgb2gray(gravel[:512, :512]))
+    >>> gravel = skimage.rescale_to_ubyte(skimage.color.rgb2gray(gravel[:512, :512]))
     >>> imageio.imwrite('gravel.png', gravel)
     """
     return _load("data/gravel.png", as_gray=True)
@@ -870,7 +870,7 @@ def horse():
     horse : (328, 400) bool ndarray
         Horse image.
     """
-    return img_as_bool(_load("data/horse.png", as_gray=True))
+    return rescale_to_bool(_load("data/horse.png", as_gray=True))
 
 
 def clock():

--- a/skimage/data/_fetchers.py
+++ b/skimage/data/_fetchers.py
@@ -532,7 +532,7 @@ def grass():
     >>> with open('grass_orig.jpg', 'bw') as f:
     ...     f.write(r.content)
     >>> grass_orig = imageio.imread('grass_orig.jpg')
-    >>> grass = skimage.rescale_to_ubyte(skimage.color.rgb2gray(grass_orig[:512, :512]))
+    >>> grass = skimage.rescale_to_ubyte(skimage.color.rgb2gray(grass_orig[:512, :512]))  # noqa
     >>> imageio.imwrite('grass.png', grass)
     """
     return _load("data/grass.png", as_gray=True)
@@ -587,7 +587,7 @@ def gravel():
     >>> from skimage.transform import resize
     >>> gravel_orig = imageio.imread('Gravel04_col.jpg')
     >>> gravel = resize(gravel_orig, (1024, 1024))
-    >>> gravel = skimage.rescale_to_ubyte(skimage.color.rgb2gray(gravel[:512, :512]))
+    >>> gravel = skimage.rescale_to_ubyte(skimage.color.rgb2gray(gravel[:512, :512]))  # noqa
     >>> imageio.imwrite('gravel.png', gravel)
     """
     return _load("data/gravel.png", as_gray=True)

--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -21,7 +21,7 @@ import numpy as np
 from .._shared.utils import _supported_float_type
 from ..color.adapt_rgb import adapt_rgb, hsv_value
 from ..exposure import rescale_intensity
-from ..util import img_as_uint
+from ..util import rescale_to_uint
 
 NR_OF_GRAY = 2 ** 14  # number of grayscale levels to use in CLAHE algorithm
 
@@ -79,7 +79,7 @@ def equalize_adapthist(image, kernel_size=None,
     """
 
     float_dtype = _supported_float_type(image.dtype)
-    image = img_as_uint(image)
+    image = rescale_to_uint(image)
     image = np.round(
         rescale_intensity(image, out_range=(0, NR_OF_GRAY - 1))
     ).astype(np.min_scalar_type(NR_OF_GRAY))

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -229,8 +229,8 @@ def histogram(image, nbins=256, source_range='image', normalize=False, *,
 
     Examples
     --------
-    >>> from skimage import data, exposure, img_as_float
-    >>> image = img_as_float(data.camera())
+    >>> from skimage import data, exposure, rescale_to_float
+    >>> image = rescale_to_float(data.camera())
     >>> np.histogram(image, bins=2)
     (array([ 93585, 168559]), array([0. , 0.5, 1. ]))
     >>> exposure.histogram(image, nbins=2)
@@ -332,8 +332,8 @@ def cumulative_distribution(image, nbins=256):
 
     Examples
     --------
-    >>> from skimage import data, exposure, img_as_float
-    >>> image = img_as_float(data.camera())
+    >>> from skimage import data, exposure, rescale_to_float
+    >>> image = rescale_to_float(data.camera())
     >>> hi = exposure.histogram(image)
     >>> cdf = exposure.cumulative_distribution(image)
     >>> np.alltrue(cdf[0] == np.cumsum(hi[0])/float(image.size))
@@ -656,8 +656,8 @@ def adjust_gamma(image, gamma=1, gain=1):
 
     Examples
     --------
-    >>> from skimage import data, exposure, img_as_float
-    >>> image = img_as_float(data.moon())
+    >>> from skimage import data, exposure, rescale_to_float
+    >>> image = rescale_to_float(data.moon())
     >>> gamma_corrected = exposure.adjust_gamma(image, 2)
     >>> # Output is darker for gamma > 1
     >>> image.mean() > gamma_corrected.mean()

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -162,7 +162,7 @@ np.random.seed(0)
 
 test_img_int = data.camera()
 # squeeze image intensities to lower image contrast
-test_img = util.img_as_float(test_img_int)
+test_img = util.rescale_to_float(test_img_int)
 test_img = exposure.rescale_intensity(test_img / 5. + 100)
 
 
@@ -174,7 +174,7 @@ def test_equalize_uint8_approx():
 
 
 def test_equalize_ubyte():
-    img = util.img_as_ubyte(test_img)
+    img = util.rescale_to_ubyte(test_img)
     img_eq = exposure.equalize_hist(img)
 
     cdf, bin_edges = exposure.cumulative_distribution(img_eq)
@@ -183,7 +183,7 @@ def test_equalize_ubyte():
 
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_equalize_float(dtype):
-    img = util.img_as_float(test_img).astype(dtype, copy=False)
+    img = util.rescale_to_float(test_img).astype(dtype, copy=False)
     img_eq = exposure.equalize_hist(img)
     assert img_eq.dtype == _supported_float_type(dtype)
 
@@ -193,7 +193,7 @@ def test_equalize_float(dtype):
 
 
 def test_equalize_masked():
-    img = util.img_as_float(test_img)
+    img = util.rescale_to_float(test_img)
     mask = np.zeros(test_img.shape)
     mask[100:400, 100:400] = 1
     img_mask_eq = exposure.equalize_hist(img, mask=mask)
@@ -415,7 +415,7 @@ def test_rescale_raises_on_incorrect_out_range():
 def test_adapthist_grayscale(dtype):
     """Test a grayscale float image
     """
-    img = util.img_as_float(data.astronaut()).astype(dtype, copy=False)
+    img = util.rescale_to_float(data.astronaut()).astype(dtype, copy=False)
     img = rgb2gray(img)
     img = np.dstack((img, img, img))
     adapted = exposure.equalize_adapthist(img, kernel_size=(57, 51),
@@ -430,7 +430,7 @@ def test_adapthist_grayscale(dtype):
 def test_adapthist_color():
     """Test an RGB color uint16 image
     """
-    img = util.img_as_uint(data.astronaut())
+    img = util.rescale_to_uint(data.astronaut())
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
         hist, bin_centers = exposure.histogram(img)
@@ -449,7 +449,7 @@ def test_adapthist_color():
 def test_adapthist_alpha():
     """Test an RGBA color image
     """
-    img = util.img_as_float(data.astronaut())
+    img = util.rescale_to_float(data.astronaut())
     alpha = np.ones((img.shape[0], img.shape[1]), dtype=float)
     img = np.dstack((img, alpha))
     adapted = exposure.equalize_adapthist(img)
@@ -468,10 +468,10 @@ def test_adapthist_grayscale_Nd():
     not to be interpreted as a color image by @adapt_rgb
     """
     # take 2d image, subsample and stack it
-    img = util.img_as_float(data.astronaut())
+    img = util.rescale_to_float(data.astronaut())
     img = rgb2gray(img)
     a = 15
-    img2d = util.img_as_float(img[0:-1:a, 0:-1:a])
+    img2d = util.rescale_to_float(img[0:-1:a, 0:-1:a])
     img3d = np.array([img2d] * (img.shape[0] // a))
 
     # apply CLAHE
@@ -511,7 +511,7 @@ def test_adapthist_constant():
 def test_adapthist_borders():
     """Test border processing
     """
-    img = rgb2gray(util.img_as_float(data.astronaut()))
+    img = rgb2gray(util.rescale_to_float(data.astronaut()))
 
     # maximize difference between orig and processed img
     img /= 100.
@@ -531,7 +531,7 @@ def test_adapthist_borders():
 
 def test_adapthist_clip_limit():
     img_u = data.moon()
-    img_f = util.img_as_float(img_u)
+    img_f = util.rescale_to_float(img_u)
 
     # uint8 input
     img_clahe0 = exposure.equalize_adapthist(img_u, clip_limit=0)
@@ -559,8 +559,8 @@ def peak_snr(img1, img2):
     """
     if img1.ndim == 3:
         img1, img2 = rgb2gray(img1.copy()), rgb2gray(img2.copy())
-    img1 = util.img_as_float(img1)
-    img2 = util.img_as_float(img2)
+    img1 = util.rescale_to_float(img1)
+    img2 = util.rescale_to_float(img2)
     mse = 1. / img1.size * np.square(img1 - img2).sum()
     _, max_ = dtype_range[img1.dtype.type]
     return 20 * np.log(max_ / mse)

--- a/skimage/feature/_basic_features.py
+++ b/skimage/feature/_basic_features.py
@@ -20,7 +20,7 @@ def _singlescale_basic_features_singlechannel(
     img, sigma, intensity=True, edges=True, texture=True
 ):
     results = ()
-    gaussian_filtered = filters.gaussian(img, sigma, preserve_range=False)
+    gaussian_filtered = filters.gaussian(img, sigma)
     if intensity:
         results += (gaussian_filtered,)
     if edges:

--- a/skimage/feature/_basic_features.py
+++ b/skimage/feature/_basic_features.py
@@ -2,7 +2,7 @@ from itertools import combinations_with_replacement
 import itertools
 import numpy as np
 from skimage import filters, feature
-from skimage.util.dtype import img_as_float32
+from skimage.util.dtype import rescale_to_float32
 from skimage._shared import utils
 from concurrent.futures import ThreadPoolExecutor
 
@@ -74,7 +74,7 @@ def _mutiscale_basic_features_singlechannel(
         List of features, each element of the list is an array of shape as img.
     """
     # computations are faster as float32
-    img = np.ascontiguousarray(img_as_float32(img))
+    img = np.ascontiguousarray(rescale_to_float32(img))
     if num_sigma is None:
         num_sigma = int(np.log2(sigma_max) - np.log2(sigma_min) + 1)
     sigmas = np.logspace(

--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -17,7 +17,7 @@ import scipy.ndimage as ndi
 
 from ..util.dtype import dtype_limits, rescale_as_float
 from .._shared.filters import gaussian
-from .._shared.utils import check_nD
+from .._shared.utils import _supported_float_type, check_nD
 from ..filters._gaussian import gaussian
 
 
@@ -75,14 +75,15 @@ def _preprocess(image, mask, sigma, mode, cval):
         eroded_mask[:, -1:] = 0
         return smoothed_image, eroded_mask
 
-    masked_image = np.zeros_like(image)
+    float_dtype = _supported_float_type(image.dtype)
+    masked_image = np.zeros_like(image, dtype=float_dtype)
     masked_image[mask] = image[mask]
 
     # Compute the fractional contribution of masked pixels by applying
     # the function to the mask (which gets you the fraction of the
     # pixel data that's due to significant points)
     bleed_over = (
-        gaussian(mask.astype(float), **gaussian_kwargs) + np.finfo(float).eps
+        gaussian(mask, **gaussian_kwargs) + np.finfo(float).eps
     )
 
     # Smooth the masked image

--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -15,7 +15,7 @@ Original author: Lee Kamentsky
 import numpy as np
 import scipy.ndimage as ndi
 
-from ..util.dtype import dtype_limits
+from ..util.dtype import dtype_limits, rescale_as_float
 from .._shared.filters import gaussian
 from .._shared.utils import check_nD
 from ..filters._gaussian import gaussian
@@ -63,10 +63,10 @@ def _preprocess(image, mask, sigma, mode, cval):
     pixels.
     """
 
-    gaussian_kwargs = dict(sigma=sigma, mode=mode, cval=cval,
-                           preserve_range=False)
+    gaussian_kwargs = dict(sigma=sigma, mode=mode, cval=cval)
     if mask is None:
         # Smooth the masked image
+        image = rescale_as_float(image)
         smoothed_image = gaussian(image, **gaussian_kwargs)
         eroded_mask = np.ones(image.shape, dtype=bool)
         eroded_mask[:1, :] = 0

--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -15,7 +15,7 @@ Original author: Lee Kamentsky
 import numpy as np
 import scipy.ndimage as ndi
 
-from ..util.dtype import dtype_limits, rescale_as_float
+from ..util.dtype import dtype_limits, rescale_to_float
 from .._shared.filters import gaussian
 from .._shared.utils import _supported_float_type, check_nD
 from ..filters._gaussian import gaussian
@@ -66,7 +66,7 @@ def _preprocess(image, mask, sigma, mode, cval):
     gaussian_kwargs = dict(sigma=sigma, mode=mode, cval=cval)
     if mask is None:
         # Smooth the masked image
-        image = rescale_as_float(image)
+        image = rescale_to_float(image)
         smoothed_image = gaussian(image, **gaussian_kwargs)
         eroded_mask = np.ones(image.shape, dtype=bool)
         eroded_mask[:1, :] = 0

--- a/skimage/feature/_daisy.py
+++ b/skimage/feature/_daisy.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy import arctan2, exp, pi, sqrt
 
 from .. import draw
-from ..util.dtype import img_as_float
+from ..util.dtype import rescale_to_float
 from .._shared.filters import gaussian
 from .._shared.utils import check_nD
 from ..color import gray2rgb
@@ -101,7 +101,7 @@ def daisy(image, step=4, radius=15, rings=3, histograms=8, orientations=8,
 
     check_nD(image, 2, 'img')
 
-    image = img_as_float(image)
+    image = rescale_to_float(image)
     float_dtype = image.dtype
 
     # Validate parameters.

--- a/skimage/feature/_daisy.py
+++ b/skimage/feature/_daisy.py
@@ -4,9 +4,8 @@ import numpy as np
 from numpy import arctan2, exp, pi, sqrt
 
 from .. import draw
-from ..util.dtype import rescale_to_float
 from .._shared.filters import gaussian
-from .._shared.utils import check_nD
+from .._shared.utils import _supported_float_type, check_nD
 from ..color import gray2rgb
 
 
@@ -101,8 +100,8 @@ def daisy(image, step=4, radius=15, rings=3, histograms=8, orientations=8,
 
     check_nD(image, 2, 'img')
 
-    image = rescale_to_float(image)
-    float_dtype = image.dtype
+    float_dtype = _supported_float_type(image.dtype)
+    image = image.astype(float_dtype, copy=False)
 
     # Validate parameters.
     if sigmas is not None and ring_radii is not None \
@@ -184,6 +183,7 @@ def daisy(image, step=4, radius=15, rings=3, histograms=8, orientations=8,
                 descs[:, :, i:i + orientations] /= norms[:, :, np.newaxis]
 
     if visualize:
+        image = image / float(image.max())
         descs_img = gray2rgb(image)
         for i in range(descs.shape[0]):
             for j in range(descs.shape[1]):

--- a/skimage/feature/blob.py
+++ b/skimage/feature/blob.py
@@ -7,7 +7,7 @@ from scipy import spatial
 from .._shared.filters import gaussian
 from .._shared.utils import _supported_float_type, check_nD
 from ..transform import integral_image
-from ..util import img_as_float
+from ..util import rescale_to_float
 from ._hessian_det_appx import _hessian_matrix_det
 from .peak import peak_local_max
 
@@ -324,7 +324,7 @@ def blob_dog(image, min_sigma=1, max_sigma=50, sigma_ratio=1.6, threshold=0.5,
     The radius of each blob is approximately :math:`\sqrt{2}\sigma` for
     a 2-D image and :math:`\sqrt{3}\sigma` for a 3-D image.
     """
-    image = img_as_float(image)
+    image = rescale_to_float(image)
     float_dtype = _supported_float_type(image.dtype)
     image = image.astype(float_dtype, copy=False)
 
@@ -498,7 +498,7 @@ def blob_log(image, min_sigma=1, max_sigma=50, num_sigma=10, threshold=.2,
     The radius of each blob is approximately :math:`\sqrt{2}\sigma` for
     a 2-D image and :math:`\sqrt{3}\sigma` for a 3-D image.
     """
-    image = img_as_float(image)
+    image = rescale_to_float(image)
     float_dtype = _supported_float_type(image.dtype)
     image = image.astype(float_dtype, copy=False)
 
@@ -656,7 +656,7 @@ def blob_doh(image, min_sigma=1, max_sigma=30, num_sigma=10, threshold=0.01,
     """
     check_nD(image, 2)
 
-    image = img_as_float(image)
+    image = rescale_to_float(image)
     float_dtype = _supported_float_type(image.dtype)
     image = image.astype(float_dtype, copy=False)
 

--- a/skimage/feature/brief.py
+++ b/skimage/feature/brief.py
@@ -151,7 +151,7 @@ class BRIEF(DescriptorExtractor):
 
         random = np.random.default_rng(self.sample_seed)
 
-        image = _prepare_grayscale_input_2D(image)
+        image = _prepare_grayscale_input_2D(image, normalize_int_range=False)
 
         # Gaussian low-pass filtering to alleviate noise sensitivity
         image = np.ascontiguousarray(

--- a/skimage/feature/censure.py
+++ b/skimage/feature/censure.py
@@ -243,7 +243,9 @@ class CENSURE(FeatureDetector):
 
         num_scales = self.max_scale - self.min_scale
 
-        image = np.ascontiguousarray(_prepare_grayscale_input_2D(image))
+        image = np.ascontiguousarray(
+            _prepare_grayscale_input_2D(image, normalize_int_range=True)
+        )
 
         # Generating all the scales
         filter_response = _filter_image(image, self.min_scale, self.max_scale,

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -115,7 +115,7 @@ def structure_tensor(image, sigma=1, mode='constant', cval=0, order='rc'):
             raise ValueError('sigma must have as many elements as image '
                              'has axes')
 
-    image = _prepare_grayscale_input_nD(image)
+    image = _prepare_grayscale_input_nD(image, normalize_int_range=True)
 
     derivatives = _compute_derivatives(image, mode=mode, cval=cval)
 
@@ -783,7 +783,7 @@ def corner_fast(image, n=12, threshold=0.15):
            [8, 8]])
 
     """
-    image = _prepare_grayscale_input_2D(image)
+    image = _prepare_grayscale_input_2D(image, normalize_int_range=True)
 
     image = np.ascontiguousarray(image)
     response = _corner_fast(image, n, threshold)

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -7,7 +7,7 @@ from scipy import spatial, stats
 from .._shared.filters import gaussian
 from .._shared.utils import _supported_float_type, safe_as_int
 from ..transform import integral_image
-from ..util import img_as_float
+from ..util import rescale_to_float
 from ._hessian_det_appx import _hessian_matrix_det
 from .corner_cy import _corner_fast, _corner_moravec, _corner_orientations
 from .peak import peak_local_max
@@ -181,7 +181,7 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order='rc'):
            [ 0.,  0.,  0.,  0.,  0.]])
     """
 
-    image = img_as_float(image)
+    image = rescale_to_float(image)
     float_dtype = _supported_float_type(image.dtype)
     image = image.astype(float_dtype, copy=False)
 
@@ -234,7 +234,7 @@ def hessian_matrix_det(image, sigma=1, approximate=True):
     is not accurate, i.e., not similar to the result obtained if someone
     computed the Hessian and took its determinant.
     """
-    image = img_as_float(image)
+    image = rescale_to_float(image)
     float_dtype = _supported_float_type(image.dtype)
     image = image.astype(float_dtype, copy=False)
     if image.ndim == 2 and approximate:
@@ -1117,7 +1117,7 @@ def corner_moravec(image, window_size=1):
            [0, 0, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0]])
     """
-    image = img_as_float(image)
+    image = rescale_to_float(image)
     float_dtype = _supported_float_type(image.dtype)
     image = image.astype(float_dtype, copy=False)
     return _corner_moravec(np.ascontiguousarray(image), window_size)

--- a/skimage/feature/corner_cy.pyx
+++ b/skimage/feature/corner_cy.pyx
@@ -8,7 +8,7 @@ from libc.float cimport DBL_MAX
 from libc.math cimport atan2, fabs
 
 from .._shared.fused_numerics cimport np_floats
-from ..util import img_as_float64
+from ..util import rescale_to_float64
 
 cnp.import_array()
 

--- a/skimage/feature/haar.py
+++ b/skimage/feature/haar.py
@@ -8,7 +8,7 @@ from ._haar import haar_like_feature_coord_wrapper
 from ._haar import haar_like_feature_wrapper
 from ..color import gray2rgb
 from ..draw import rectangle
-from ..util import img_as_float
+from ..util import rescale_to_float
 
 FEATURE_TYPE = ('type-2-x', 'type-2-y',
                 'type-3-x', 'type-3-y',
@@ -304,7 +304,7 @@ def draw_haar_like_feature(image, r, c, width, height,
     output = np.copy(image)
     if len(image.shape) < 3:
         output = gray2rgb(image)
-    output = img_as_float(output)
+    output = rescale_to_float(output)
 
     for coord in feature_coord_:
         for idx_rect, rect in enumerate(coord):

--- a/skimage/feature/orb.py
+++ b/skimage/feature/orb.py
@@ -131,7 +131,7 @@ class ORB(FeatureDetector, DescriptorExtractor):
         self.descriptors = None
 
     def _build_pyramid(self, image):
-        image = _prepare_grayscale_input_2D(image)
+        image = _prepare_grayscale_input_2D(image, normalize_int_range=True)
         return list(pyramid_gaussian(image, self.n_scales - 1,
                                      self.downscale, channel_axis=None))
 

--- a/skimage/feature/sift.py
+++ b/skimage/feature/sift.py
@@ -7,7 +7,7 @@ from .._shared.utils import check_nD, _supported_float_type
 from ..feature.util import DescriptorExtractor, FeatureDetector
 from .._shared.filters import gaussian
 from ..transform import rescale
-from ..util import img_as_float
+from ..util import rescale_to_float
 from ._sift import (_local_max, _ori_distances, _update_histogram)
 
 
@@ -649,7 +649,7 @@ class SIFT(FeatureDetector, DescriptorExtractor):
 
     def _preprocess(self, image):
         check_nD(image, 2)
-        image = img_as_float(image)
+        image = rescale_to_float(image)
         self.float_dtype = _supported_float_type(image.dtype)
         image = image.astype(self.float_dtype, copy=False)
 

--- a/skimage/feature/tests/test_blob.py
+++ b/skimage/feature/tests/test_blob.py
@@ -31,7 +31,7 @@ def test_blob_dog(dtype, threshold_type):
     if threshold_type == 'absolute':
         threshold = 2.0
         if img.dtype.kind != 'f':
-            # account for internal scaling to [0, 1] by img_as_float
+            # account for internal scaling to [0, 1] by rescale_to_float
             threshold /= img.ptp()
         threshold_rel = None
     elif threshold_type == 'relative':
@@ -210,7 +210,7 @@ def test_blob_log(dtype, threshold_type):
     if threshold_type == 'absolute':
         threshold = 1
         if img.dtype.kind != 'f':
-            # account for internal scaling to [0, 1] by img_as_float
+            # account for internal scaling to [0, 1] by rescale_to_float
             threshold /= img.ptp()
         threshold_rel = None
     elif threshold_type == 'relative':
@@ -377,7 +377,8 @@ def test_blob_doh(dtype, threshold_type):
         #       range [0, 1] internally.
         threshold = 0.05
         if img.dtype.kind == 'f':
-            # account for lack of internal scaling to [0, 1] by img_as_float
+            # account for lack of internal scaling to [0, 1] by
+            # rescale_to_float
             ptp = img.ptp()
             threshold *= ptp ** 2
         threshold_rel = None

--- a/skimage/feature/tests/test_canny.py
+++ b/skimage/feature/tests/test_canny.py
@@ -3,7 +3,7 @@ import numpy as np
 from skimage._shared.testing import assert_equal
 from scipy.ndimage import binary_dilation, binary_erosion
 from skimage import data, feature
-from skimage.util import img_as_float
+from skimage.util import rescale_to_float
 
 
 class TestCanny(unittest.TestCase):
@@ -73,7 +73,7 @@ class TestCanny(unittest.TestCase):
         self.assertTrue(np.all(result1 == result2))
 
     def test_use_quantiles(self):
-        image = img_as_float(data.camera()[::100, ::100])
+        image = rescale_to_float(data.camera()[::100, ::100])
 
         # Correct output produced manually with quantiles
         # of 0.8 and 0.6 for high and low respectively
@@ -91,7 +91,7 @@ class TestCanny(unittest.TestCase):
         assert_equal(result, correct_output)
 
     def test_invalid_use_quantiles(self):
-        image = img_as_float(data.camera()[::50, ::50])
+        image = rescale_to_float(data.camera()[::50, ::50])
 
         self.assertRaises(ValueError, feature.canny, image, use_quantiles=True,
                           low_threshold=0.5, high_threshold=3.6)
@@ -113,7 +113,7 @@ class TestCanny(unittest.TestCase):
     def test_dtype(self):
         """Check that the same output is produced regardless of image dtype."""
         image_uint8 = data.camera()
-        image_float = img_as_float(image_uint8)
+        image_float = rescale_to_float(image_uint8)
 
         result_uint8 = feature.canny(image_uint8)
         result_float = feature.canny(image_float)

--- a/skimage/feature/tests/test_censure.py
+++ b/skimage/feature/tests/test_censure.py
@@ -1,13 +1,14 @@
 import numpy as np
-from skimage._shared.testing import assert_array_equal
+from numpy.testing import assert_array_equal
+
+from skimage import rescale_as_float
+from skimage._shared import testing
+from skimage._shared.testing import test_parallel
 from skimage.data import moon
 from skimage.feature import CENSURE
-from skimage._shared.testing import test_parallel
-from skimage._shared import testing
 from skimage.transform import rescale
 
-
-img = moon()
+img = rescale_as_float(moon())
 np.random.seed(0)
 
 

--- a/skimage/feature/tests/test_censure.py
+++ b/skimage/feature/tests/test_censure.py
@@ -1,14 +1,14 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from skimage import rescale_as_float
+from skimage import rescale_to_float
 from skimage._shared import testing
 from skimage._shared.testing import test_parallel
 from skimage.data import moon
 from skimage.feature import CENSURE
 from skimage.transform import rescale
 
-img = rescale_as_float(moon())
+img = rescale_to_float(moon())
 np.random.seed(0)
 
 

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal, assert_array_equal, assert_equal
 
-from skimage import data, draw, img_as_float
+from skimage import data, draw, rescale_to_float
 from skimage._shared._warnings import expected_warnings
 from skimage._shared.testing import test_parallel
 from skimage._shared.utils import _supported_float_type
@@ -349,7 +349,7 @@ def test_noisy_square_image():
 def test_squared_dot():
     im = np.zeros((50, 50))
     im[4:8, 4:8] = 1
-    im = img_as_float(im)
+    im = rescale_to_float(im)
 
     # Moravec fails
 
@@ -369,7 +369,7 @@ def test_rotated_img():
     The harris filter should yield the same results with an image and it's
     rotation.
     """
-    im = img_as_float(data.astronaut().mean(axis=2))
+    im = rescale_to_float(data.astronaut().mean(axis=2))
     im_rotated = im.T
 
     # Moravec

--- a/skimage/feature/tests/test_daisy.py
+++ b/skimage/feature/tests/test_daisy.py
@@ -4,7 +4,7 @@ from numpy import sqrt, ceil
 from numpy.testing import assert_almost_equal
 
 from skimage import data
-from skimage import img_as_float
+from skimage import rescale_to_float
 from skimage.feature import daisy
 
 
@@ -15,7 +15,7 @@ def test_daisy_color_image_unsupported_error():
 
 
 def test_daisy_desc_dims():
-    img = img_as_float(data.astronaut()[:128, :128].mean(axis=2))
+    img = rescale_to_float(data.astronaut()[:128, :128].mean(axis=2))
     rings = 2
     histograms = 4
     orientations = 3
@@ -32,7 +32,7 @@ def test_daisy_desc_dims():
 
 
 def test_descs_shape():
-    img = img_as_float(data.astronaut()[:256, :256].mean(axis=2))
+    img = rescale_to_float(data.astronaut()[:256, :256].mean(axis=2))
     radius = 20
     step = 8
     descs = daisy(img, radius=radius, step=step)
@@ -57,7 +57,7 @@ def test_daisy_sigmas_and_radii(dtype):
 
 
 def test_daisy_incompatible_sigmas_and_radii():
-    img = img_as_float(data.astronaut()[:64, :64].mean(axis=2))
+    img = rescale_to_float(data.astronaut()[:64, :64].mean(axis=2))
     sigmas = [1, 2]
     radii = [1, 2]
     with pytest.raises(ValueError):
@@ -65,7 +65,7 @@ def test_daisy_incompatible_sigmas_and_radii():
 
 
 def test_daisy_normalization():
-    img = img_as_float(data.astronaut()[:64, :64].mean(axis=2))
+    img = rescale_to_float(data.astronaut()[:64, :64].mean(axis=2))
 
     descs = daisy(img, normalization='l1')
     for i in range(descs.shape[0]):
@@ -99,6 +99,6 @@ def test_daisy_normalization():
 
 
 def test_daisy_visualization():
-    img = img_as_float(data.astronaut()[:32, :32].mean(axis=2))
+    img = rescale_to_float(data.astronaut()[:32, :32].mean(axis=2))
     descs, descs_img = daisy(img, visualize=True)
     assert(descs_img.shape == (32, 32, 3))

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal
 
-from skimage import color, data, draw, feature, img_as_float
+from skimage import color, data, draw, feature, rescale_to_float
 from skimage._shared import filters
 from skimage._shared._warnings import expected_warnings
 from skimage._shared.testing import fetch
@@ -10,7 +10,7 @@ from skimage._shared.utils import _supported_float_type
 
 
 def test_hog_output_size():
-    img = img_as_float(data.astronaut()[:256, :].mean(axis=2))
+    img = rescale_to_float(data.astronaut()[:256, :].mean(axis=2))
 
     fd = feature.hog(img, orientations=9, pixels_per_cell=(8, 8),
                      cells_per_block=(1, 1), block_norm='L1')

--- a/skimage/feature/tests/test_template.py
+++ b/skimage/feature/tests/test_template.py
@@ -1,7 +1,7 @@
 import numpy as np
 from skimage._shared.testing import assert_almost_equal, assert_equal
 
-from skimage import data, img_as_float
+from skimage import data, rescale_to_float
 from skimage.morphology import diamond
 from skimage.feature import match_template, peak_local_max
 from skimage._shared import testing
@@ -180,7 +180,7 @@ def test_wrong_input():
 
 
 def test_bounding_values():
-    image = img_as_float(data.page())
+    image = rescale_to_float(data.page())
     template = np.zeros((3, 3))
     template[1, 1] = 1
     result = match_template(image, template)

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from .._shared.utils import check_nD
 from ..color import gray2rgb
-from ..util import img_as_float
+from ..util import rescale_to_float
 from ._texture import (_glcm_loop,
                        _local_binary_pattern,
                        _multiblock_lbp)
@@ -461,7 +461,7 @@ def draw_multiblock_lbp(image, r, c, width, height,
         output = gray2rgb(image)
 
     # Colors are specified in floats.
-    output = img_as_float(output)
+    output = rescale_to_float(output)
 
     # Offsets of neighbor rectangles relative to central one.
     # It has order starting from top left and going clockwise.

--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from ..util import img_as_float
+from ..util import rescale_to_float
 from .._shared.utils import _supported_float_type, check_nD
 
 
@@ -73,8 +73,8 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
         the other, ``'vertical'``.
 
     """
-    image1 = img_as_float(image1)
-    image2 = img_as_float(image2)
+    image1 = rescale_to_float(image1)
+    image2 = rescale_to_float(image2)
 
     new_shape1 = list(image1.shape)
     new_shape2 = list(image2.shape)
@@ -141,7 +141,7 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
 def _prepare_grayscale_input_2D(image):
     image = np.squeeze(image)
     check_nD(image, 2)
-    image = img_as_float(image)
+    image = rescale_to_float(image)
     float_dtype = _supported_float_type(image.dtype)
     return image.astype(float_dtype, copy=False)
 
@@ -149,7 +149,7 @@ def _prepare_grayscale_input_2D(image):
 def _prepare_grayscale_input_nD(image):
     image = np.squeeze(image)
     check_nD(image, range(2, 6))
-    image = img_as_float(image)
+    image = rescale_to_float(image)
     float_dtype = _supported_float_type(image.dtype)
     return image.astype(float_dtype, copy=False)
 

--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -138,18 +138,20 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
                 '-', color=color)
 
 
-def _prepare_grayscale_input_2D(image):
+def _prepare_grayscale_input_2D(image, normalize_int_range=False):
     image = np.squeeze(image)
     check_nD(image, 2)
-    image = rescale_to_float(image)
+    if normalize_int_range:
+        image = rescale_to_float(image)
     float_dtype = _supported_float_type(image.dtype)
     return image.astype(float_dtype, copy=False)
 
 
-def _prepare_grayscale_input_nD(image):
+def _prepare_grayscale_input_nD(image, normalize_int_range=False):
     image = np.squeeze(image)
     check_nD(image, range(2, 6))
-    image = rescale_to_float(image)
+    if normalize_int_range:
+        image = rescale_to_float(image)
     float_dtype = _supported_float_type(image.dtype)
     return image.astype(float_dtype, copy=False)
 

--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -86,7 +86,8 @@ def difference_of_gaussians(image, low_sigma, high_sigma=None, *,
     used when approximating the inverted Laplacian of Gaussian, which is used
     in edge and blob detection.
 
-    Input image is converted according to the conventions of ``rescale_to_float``.
+    Input image is converted according to the conventions of
+    ``rescale_to_float``.
 
     Except for sigma values, all parameters are used for both filters.
 

--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -6,7 +6,7 @@ from scipy import ndimage as ndi
 from .._shared import utils
 from .._shared.filters import gaussian
 from .._shared.utils import _supported_float_type, convert_to_float, warn
-from ..util import img_as_float
+from ..util import rescale_to_float
 
 __all__ = ['gaussian', 'difference_of_gaussians']
 
@@ -86,7 +86,7 @@ def difference_of_gaussians(image, low_sigma, high_sigma=None, *,
     used when approximating the inverted Laplacian of Gaussian, which is used
     in edge and blob detection.
 
-    Input image is converted according to the conventions of ``img_as_float``.
+    Input image is converted according to the conventions of ``rescale_to_float``.
 
     Except for sigma values, all parameters are used for both filters.
 
@@ -118,7 +118,7 @@ def difference_of_gaussians(image, low_sigma, high_sigma=None, *,
            https://doi.org/10.1098/rspb.1980.0020
 
     """
-    image = img_as_float(image)
+    image = rescale_to_float(image)
     low_sigma = np.array(low_sigma, dtype='float', ndmin=1)
     if high_sigma is None:
         high_sigma = low_sigma * 1.6

--- a/skimage/filters/_gaussian.py
+++ b/skimage/filters/_gaussian.py
@@ -5,8 +5,8 @@ from scipy import ndimage as ndi
 
 from .._shared import utils
 from .._shared.filters import gaussian
-from .._shared.utils import _supported_float_type, convert_to_float, warn
-from ..util import rescale_to_float
+
+from .._shared.utils import _supported_float_type, warn
 
 __all__ = ['gaussian', 'difference_of_gaussians']
 
@@ -86,9 +86,6 @@ def difference_of_gaussians(image, low_sigma, high_sigma=None, *,
     used when approximating the inverted Laplacian of Gaussian, which is used
     in edge and blob detection.
 
-    Input image is converted according to the conventions of
-    ``rescale_to_float``.
-
     Except for sigma values, all parameters are used for both filters.
 
     Examples
@@ -119,7 +116,8 @@ def difference_of_gaussians(image, low_sigma, high_sigma=None, *,
            https://doi.org/10.1098/rspb.1980.0020
 
     """
-    image = rescale_to_float(image)
+    float_dtype = _supported_float_type(image.dtype)
+    image = image.astype(float_dtype, copy=False)
     low_sigma = np.array(low_sigma, dtype='float', ndmin=1)
     if high_sigma is None:
         high_sigma = low_sigma * 1.6
@@ -146,11 +144,9 @@ def difference_of_gaussians(image, low_sigma, high_sigma=None, *,
                          'low_sigma for all axes')
 
     im1 = gaussian(image, low_sigma, mode=mode, cval=cval,
-                   channel_axis=channel_axis, truncate=truncate,
-                   preserve_range=False)
+                   channel_axis=channel_axis, truncate=truncate)
 
     im2 = gaussian(image, high_sigma, mode=mode, cval=cval,
-                   channel_axis=channel_axis, truncate=truncate,
-                   preserve_range=False)
+                   channel_axis=channel_axis, truncate=truncate)
 
     return im1 - im2

--- a/skimage/filters/_unsharp_mask.py
+++ b/skimage/filters/_unsharp_mask.py
@@ -44,7 +44,8 @@ def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
         This argument is deprecated: specify `channel_axis` instead.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of ``rescale_to_float``.
+        image is converted according to the conventions of
+        `rescale_to_float``.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
     channel_axis : int or None, optional
         If None, the image is assumed to be a grayscale (single channel) image.

--- a/skimage/filters/_unsharp_mask.py
+++ b/skimage/filters/_unsharp_mask.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from ..util.dtype import img_as_float
+from ..util.dtype import rescale_to_float
 from .._shared import utils
 from .._shared.filters import gaussian
 
@@ -44,7 +44,7 @@ def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
         This argument is deprecated: specify `channel_axis` instead.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of ``img_as_float``.
+        image is converted according to the conventions of ``rescale_to_float``.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
     channel_axis : int or None, optional
         If None, the image is assumed to be a grayscale (single channel) image.
@@ -128,7 +128,7 @@ def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
     if preserve_range:
         fimg = image.astype(float_dtype, copy=False)
     else:
-        fimg = img_as_float(image).astype(float_dtype, copy=False)
+        fimg = rescale_to_float(image).astype(float_dtype, copy=False)
         negative = np.any(fimg < 0)
         if negative:
             vrange = [-1., 1.]

--- a/skimage/filters/_unsharp_mask.py
+++ b/skimage/filters/_unsharp_mask.py
@@ -1,24 +1,21 @@
 import numpy as np
 
-from ..util.dtype import rescale_to_float
 from .._shared import utils
 from .._shared.filters import gaussian
 
 
-def _unsharp_mask_single_channel(image, radius, amount, vrange):
+def _unsharp_mask_single_channel(image, radius, amount):
     """Single channel implementation of the unsharp masking filter."""
 
     blurred = gaussian(image, sigma=radius, mode='reflect')
 
     result = image + (image - blurred) * amount
-    if vrange is not None:
-        return np.clip(result, vrange[0], vrange[1], out=result)
     return result
 
 
 @utils.deprecate_multichannel_kwarg(multichannel_position=3)
 def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
-                 preserve_range=False, *, channel_axis=None):
+                 *, channel_axis=None):
     """Unsharp masking filter.
 
     The sharp details are identified as the difference between the original
@@ -42,11 +39,6 @@ def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
         If True, the last ``image`` dimension is considered as a color channel,
         otherwise as spatial. Color channels are processed individually.
         This argument is deprecated: specify `channel_axis` instead.
-    preserve_range : bool, optional
-        Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of
-        `rescale_to_float``.
-        Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
     channel_axis : int or None, optional
         If None, the image is assumed to be a grayscale (single channel) image.
         Otherwise, this parameter indicates which axis of the array corresponds
@@ -92,28 +84,20 @@ def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
            [100, 100, 100, 100, 100],
            [100, 100, 100, 100, 100]], dtype=uint8)
     >>> np.around(unsharp_mask(array, radius=0.5, amount=2),2)
-    array([[0.39, 0.39, 0.39, 0.39, 0.39],
-           [0.39, 0.39, 0.38, 0.39, 0.39],
-           [0.39, 0.38, 0.53, 0.38, 0.39],
-           [0.39, 0.39, 0.38, 0.39, 0.39],
-           [0.39, 0.39, 0.39, 0.39, 0.39]])
+    array([[100.  , 100.  ,  99.99, 100.  , 100.  ],
+           [100.  ,  99.55,  96.65,  99.55, 100.  ],
+           [ 99.99,  96.65, 135.25,  96.65,  99.99],
+           [100.  ,  99.55,  96.65,  99.55, 100.  ],
+           [100.  , 100.  ,  99.99, 100.  , 100.  ]])
 
     >>> array = np.ones(shape=(5,5), dtype=np.int8)*100
     >>> array[2,2] = 127
-    >>> np.around(unsharp_mask(array, radius=0.5, amount=2),2)
-    array([[0.79, 0.79, 0.79, 0.79, 0.79],
-           [0.79, 0.78, 0.75, 0.78, 0.79],
-           [0.79, 0.75, 1.  , 0.75, 0.79],
-           [0.79, 0.78, 0.75, 0.78, 0.79],
-           [0.79, 0.79, 0.79, 0.79, 0.79]])
-
-    >>> np.around(unsharp_mask(array, radius=0.5, amount=2, preserve_range=True), 2)
+    >>> np.around(unsharp_mask(array, radius=0.5, amount=2), 2)
     array([[100.  , 100.  ,  99.99, 100.  , 100.  ],
            [100.  ,  99.39,  95.48,  99.39, 100.  ],
            [ 99.99,  95.48, 147.59,  95.48,  99.99],
            [100.  ,  99.39,  95.48,  99.39, 100.  ],
            [100.  , 100.  ,  99.99, 100.  , 100.  ]])
-
 
     References
     ----------
@@ -124,24 +108,14 @@ def unsharp_mask(image, radius=1.0, amount=1.0, multichannel=False,
             https://en.wikipedia.org/wiki/Unsharp_masking
 
     """
-    vrange = None  # Range for valid values; used for clipping.
     float_dtype = utils._supported_float_type(image.dtype)
-    if preserve_range:
-        fimg = image.astype(float_dtype, copy=False)
-    else:
-        fimg = rescale_to_float(image).astype(float_dtype, copy=False)
-        negative = np.any(fimg < 0)
-        if negative:
-            vrange = [-1., 1.]
-        else:
-            vrange = [0., 1.]
+    fimg = image.astype(float_dtype, copy=False)
 
     if channel_axis is not None:
         result = np.empty_like(fimg, dtype=float_dtype)
         for channel in range(image.shape[channel_axis]):
             sl = utils.slice_at_axis(channel, channel_axis)
-            result[sl] = _unsharp_mask_single_channel(
-                fimg[sl], radius, amount, vrange)
+            result[sl] = _unsharp_mask_single_channel(fimg[sl], radius, amount)
         return result
     else:
-        return _unsharp_mask_single_channel(fimg, radius, amount, vrange)
+        return _unsharp_mask_single_channel(fimg, radius, amount)

--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -15,7 +15,7 @@ from scipy.ndimage import binary_erosion, convolve
 
 from .._shared.utils import _supported_float_type, check_nD
 from ..restoration.uft import laplacian
-from ..util.dtype import img_as_float
+from ..util.dtype import rescale_to_float
 
 # n-dimensional filter weights
 SOBEL_EDGE = np.array([1, 0, -1])
@@ -179,7 +179,7 @@ def _generic_edge_filter(image, *, smooth_weights, edge_weights=[1, 0, -1],
         float_dtype = _supported_float_type(image.dtype)
         image = image.astype(float_dtype, copy=False)
     else:
-        image = img_as_float(image)
+        image = rescale_to_float(image)
     output = np.zeros(image.shape, dtype=image.dtype)
 
     for edge_dim in axes:
@@ -631,7 +631,7 @@ def roberts_pos_diag(image, mask=None):
         float_dtype = _supported_float_type(image.dtype)
         image = image.astype(float_dtype, copy=False)
     else:
-        image = img_as_float(image)
+        image = rescale_to_float(image)
     result = convolve(image, ROBERTS_PD_WEIGHTS)
     return _mask_filter_result(result, mask)
 
@@ -669,7 +669,7 @@ def roberts_neg_diag(image, mask=None):
         float_dtype = _supported_float_type(image.dtype)
         image = image.astype(float_dtype, copy=False)
     else:
-        image = img_as_float(image)
+        image = rescale_to_float(image)
     result = convolve(image, ROBERTS_ND_WEIGHTS)
     return _mask_filter_result(result, mask)
 
@@ -704,7 +704,7 @@ def laplace(image, ksize=3, mask=None):
         float_dtype = _supported_float_type(image.dtype)
         image = image.astype(float_dtype, copy=False)
     else:
-        image = img_as_float(image)
+        image = rescale_to_float(image)
     # Create the discrete Laplacian operator - We keep only the real part of
     # the filter
     _, laplace_op = laplacian(image.ndim, (ksize,) * image.ndim)
@@ -812,7 +812,7 @@ def farid_h(image, *, mask=None):
         float_dtype = _supported_float_type(image.dtype)
         image = image.astype(float_dtype, copy=False)
     else:
-        image = img_as_float(image)
+        image = rescale_to_float(image)
     result = convolve(image, HFARID_WEIGHTS)
     return _mask_filter_result(result, mask)
 
@@ -849,6 +849,6 @@ def farid_v(image, *, mask=None):
         float_dtype = _supported_float_type(image.dtype)
         image = image.astype(float_dtype, copy=False)
     else:
-        image = img_as_float(image)
+        image = rescale_to_float(image)
     result = convolve(image, VFARID_WEIGHTS)
     return _mask_filter_result(result, mask)

--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -15,7 +15,6 @@ from scipy.ndimage import binary_erosion, convolve
 
 from .._shared.utils import _supported_float_type, check_nD
 from ..restoration.uft import laplacian
-from ..util.dtype import rescale_to_float
 
 # n-dimensional filter weights
 SOBEL_EDGE = np.array([1, 0, -1])
@@ -175,11 +174,8 @@ def _generic_edge_filter(image, *, smooth_weights, edge_weights=[1, 0, -1],
         axes = axis
     return_magnitude = (len(axes) > 1)
 
-    if image.dtype.kind == 'f':
-        float_dtype = _supported_float_type(image.dtype)
-        image = image.astype(float_dtype, copy=False)
-    else:
-        image = rescale_to_float(image)
+    float_dtype = _supported_float_type(image.dtype)
+    image = image.astype(float_dtype, copy=False)
     output = np.zeros(image.shape, dtype=image.dtype)
 
     for edge_dim in axes:
@@ -627,11 +623,8 @@ def roberts_pos_diag(image, mask=None):
 
     """
     check_nD(image, 2)
-    if image.dtype.kind == 'f':
-        float_dtype = _supported_float_type(image.dtype)
-        image = image.astype(float_dtype, copy=False)
-    else:
-        image = rescale_to_float(image)
+    float_dtype = _supported_float_type(image.dtype)
+    image = image.astype(float_dtype, copy=False)
     result = convolve(image, ROBERTS_PD_WEIGHTS)
     return _mask_filter_result(result, mask)
 
@@ -665,11 +658,8 @@ def roberts_neg_diag(image, mask=None):
 
     """
     check_nD(image, 2)
-    if image.dtype.kind == 'f':
-        float_dtype = _supported_float_type(image.dtype)
-        image = image.astype(float_dtype, copy=False)
-    else:
-        image = rescale_to_float(image)
+    float_dtype = _supported_float_type(image.dtype)
+    image = image.astype(float_dtype, copy=False)
     result = convolve(image, ROBERTS_ND_WEIGHTS)
     return _mask_filter_result(result, mask)
 
@@ -700,11 +690,8 @@ def laplace(image, ksize=3, mask=None):
     skimage.restoration.uft.laplacian().
 
     """
-    if image.dtype.kind == 'f':
-        float_dtype = _supported_float_type(image.dtype)
-        image = image.astype(float_dtype, copy=False)
-    else:
-        image = rescale_to_float(image)
+    float_dtype = _supported_float_type(image.dtype)
+    image = image.astype(float_dtype, copy=False)
     # Create the discrete Laplacian operator - We keep only the real part of
     # the filter
     _, laplace_op = laplacian(image.ndim, (ksize,) * image.ndim)
@@ -808,11 +795,8 @@ def farid_h(image, *, mask=None):
            Computer Analysis of Images and Patterns, Kiel, Germany. Sep, 1997.
     """
     check_nD(image, 2)
-    if image.dtype.kind == 'f':
-        float_dtype = _supported_float_type(image.dtype)
-        image = image.astype(float_dtype, copy=False)
-    else:
-        image = rescale_to_float(image)
+    float_dtype = _supported_float_type(image.dtype)
+    image = image.astype(float_dtype, copy=False)
     result = convolve(image, HFARID_WEIGHTS)
     return _mask_filter_result(result, mask)
 
@@ -845,10 +829,7 @@ def farid_v(image, *, mask=None):
            13(4): 496-508, 2004. :DOI:`10.1109/TIP.2004.823819`
     """
     check_nD(image, 2)
-    if image.dtype.kind == 'f':
-        float_dtype = _supported_float_type(image.dtype)
-        image = image.astype(float_dtype, copy=False)
-    else:
-        image = rescale_to_float(image)
+    float_dtype = _supported_float_type(image.dtype)
+    image = image.astype(float_dtype, copy=False)
     result = convolve(image, VFARID_WEIGHTS)
     return _mask_filter_result(result, mask)

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -53,7 +53,7 @@ from scipy import ndimage as ndi
 
 from ..._shared.utils import check_nD, deprecate_kwarg, warn
 from ...morphology.footprints import _footprint_is_sequence
-from ...util import img_as_ubyte
+from ...util import rescale_to_ubyte
 from . import generic_cy
 
 
@@ -106,17 +106,17 @@ def _preprocess_input(image, footprint=None, out=None, mask=None,
     if input_dtype not in (np.uint8, np.uint16):
         message = (f'Possible precision loss converting image of type '
                    f'{input_dtype} to uint8 as required by rank filters. '
-                   f'Convert manually using skimage.util.img_as_ubyte to '
+                   f'Convert manually using skimage.util.rescale_to_ubyte to '
                    f'silence this warning.')
         warn(message, stacklevel=5)
-        image = img_as_ubyte(image)
+        image = rescale_to_ubyte(image)
 
     if _footprint_is_sequence(footprint):
         raise ValueError(
             "footprint sequences are not currently supported by rank filters"
         )
 
-    footprint = np.ascontiguousarray(img_as_ubyte(footprint > 0))
+    footprint = np.ascontiguousarray(rescale_to_ubyte(footprint > 0))
     if footprint.ndim != image.ndim:
         raise ValueError('Image dimensions and neighborhood dimensions'
                          'do not match')
@@ -124,7 +124,7 @@ def _preprocess_input(image, footprint=None, out=None, mask=None,
     image = np.ascontiguousarray(image)
 
     if mask is not None:
-        mask = img_as_ubyte(mask)
+        mask = rescale_to_ubyte(mask)
         mask = np.ascontiguousarray(mask)
 
     if image is out:
@@ -194,12 +194,12 @@ def _handle_input_3D(image, footprint=None, out=None, mask=None,
     if image.dtype not in (np.uint8, np.uint16):
         message = (f'Possible precision loss converting image of type '
                    f'{image.dtype} to uint8 as required by rank filters. '
-                   f'Convert manually using skimage.util.img_as_ubyte to '
+                   f'Convert manually using skimage.util.rescale_to_ubyte to '
                    f'silence this warning.')
         warn(message, stacklevel=2)
-        image = img_as_ubyte(image)
+        image = rescale_to_ubyte(image)
 
-    footprint = np.ascontiguousarray(img_as_ubyte(footprint > 0))
+    footprint = np.ascontiguousarray(rescale_to_ubyte(footprint > 0))
     if footprint.ndim != image.ndim:
         raise ValueError('Image dimensions and neighborhood dimensions'
                          'do not match')
@@ -208,7 +208,7 @@ def _handle_input_3D(image, footprint=None, out=None, mask=None,
     if mask is None:
         mask = np.ones(image.shape, dtype=np.uint8)
     else:
-        mask = img_as_ubyte(mask)
+        mask = rescale_to_ubyte(mask)
         mask = np.ascontiguousarray(mask)
 
     if image is out:

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -9,7 +9,7 @@ from skimage.filters import rank
 from skimage.filters.rank import __all__ as all_rank_filters
 from skimage.filters.rank import subtract_mean
 from skimage.morphology import ball, disk, gray
-from skimage.util import img_as_float, img_as_ubyte
+from skimage.util import rescale_to_float, rescale_to_ubyte
 
 
 def test_otsu_edge_case():
@@ -326,7 +326,7 @@ class TestRank():
         # compare autolevel and percentile autolevel with p0=0.0 and p1=1.0
         # should returns the same arrays
 
-        image = util.img_as_ubyte(data.camera())
+        image = util.rescale_to_ubyte(data.camera())
 
         footprint = disk(20)
         loc_autolevel = rank.autolevel(image, footprint=footprint)
@@ -353,8 +353,8 @@ class TestRank():
     def test_compare_ubyte_vs_float(self):
 
         # Create signed int8 image that and convert it to uint8
-        image_uint = img_as_ubyte(data.camera()[:50, :50])
-        image_float = img_as_float(image_uint)
+        image_uint = rescale_to_ubyte(data.camera()[:50, :50])
+        image_float = rescale_to_float(image_uint)
 
         methods = ['autolevel', 'equalize', 'gradient', 'threshold',
                    'subtract_mean', 'enhance_contrast', 'pop']
@@ -372,7 +372,7 @@ class TestRank():
         np.random.seed(0)
         volume_uint = np.random.randint(0, high=256,
                                         size=(10, 20, 30), dtype=np.uint8)
-        volume_float = img_as_float(volume_uint)
+        volume_float = rescale_to_float(volume_uint)
 
         methods_3d = ['equalize', 'otsu', 'autolevel', 'gradient',
                      'majority', 'maximum', 'mean', 'geometric_mean',
@@ -392,11 +392,11 @@ class TestRank():
         # of dynamic) should be identical
 
         # Create signed int8 image that and convert it to uint8
-        image = img_as_ubyte(data.camera())[::2, ::2]
+        image = rescale_to_ubyte(data.camera())[::2, ::2]
         image[image > 127] = 0
         image_s = image.astype(np.int8)
-        image_u = img_as_ubyte(image_s)
-        assert_equal(image_u, img_as_ubyte(image_s))
+        image_u = rescale_to_ubyte(image_s)
+        assert_equal(image_u, rescale_to_ubyte(image_s))
 
         methods = ['autolevel', 'equalize', 'gradient', 'maximum',
                    'mean', 'geometric_mean', 'subtract_mean', 'median', 'minimum',
@@ -417,8 +417,8 @@ class TestRank():
         np.random.seed(0)
         volume_s = np.random.randint(0, high=127,
                                      size=(10, 20, 30), dtype=np.int8)
-        volume_u = img_as_ubyte(volume_s)
-        assert_equal(volume_u, img_as_ubyte(volume_s))
+        volume_u = rescale_to_ubyte(volume_s)
+        assert_equal(volume_u, rescale_to_ubyte(volume_s))
 
         methods_3d = ['equalize', 'otsu', 'autolevel', 'gradient',
                      'majority', 'maximum', 'mean', 'geometric_mean',
@@ -441,7 +441,7 @@ class TestRank():
     def test_compare_8bit_vs_16bit(self, method):
         # filters applied on 8-bit image ore 16-bit image (having only real 8-bit
         # of dynamic) should be identical
-        image8 = util.img_as_ubyte(data.camera())[::2, ::2]
+        image8 = util.rescale_to_ubyte(data.camera())[::2, ::2]
         image16 = image8.astype(np.uint16)
         assert_equal(image8, image16)
 

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from .._shared.utils import _supported_float_type, check_nD
 from ..feature.corner import hessian_matrix, hessian_matrix_eigvals
-from ..util import img_as_float, invert
+from ..util import rescale_to_float, invert
 
 
 def _divide_nonzero(array1, array2, cval=1e-10):
@@ -140,7 +140,7 @@ def compute_hessian_eigenvalues(image, sigma, sorting='none',
     # Convert image to float
     float_dtype = _supported_float_type(image.dtype)
     # rescales integer images to [-1, 1]
-    image = img_as_float(image)
+    image = rescale_to_float(image)
     # make sure float16 gets promoted to float32
     image = image.astype(float_dtype, copy=False)
 

--- a/skimage/filters/tests/test_edges.py
+++ b/skimage/filters/tests/test_edges.py
@@ -33,16 +33,19 @@ def test_roberts_diagonal1(dtype):
     ['farid', 'laplace', 'prewitt', 'roberts', 'scharr', 'sobel']
 )
 def test_int_rescaling(function_name):
-    """Basic test that uint8 inputs get rescaled from [0, 255] to [0, 1.]
+    """Basic test that uint8 inputs are not rescaled from [0, 255] to [0, 1.]
 
     The output of any of these filters should be within roughly a factor of
-    two of the input range. For integer inputs, rescaling to floats in
-    [0.0, 1.0] should occur, so just verify outputs are not > 2.0.
+    two of the input range.
     """
     img = data.coins()[:128, :128]
     func = getattr(filters, function_name)
     filtered = func(img)
-    assert filtered.max() <= 2.0
+    fmax = filtered.max()
+    # ensure that img wasn't rescaled to [0, 1] internally
+    assert fmax >= 10.0
+    # assert that maximum value is not greater than expected possible range
+    assert fmax <= 2.0 * img.max()
 
 
 def test_roberts_diagonal2():

--- a/skimage/filters/tests/test_ridges.py
+++ b/skimage/filters/tests/test_ridges.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_array_less, assert_equal
 
-from skimage import img_as_float
+from skimage import rescale_to_float
 from skimage._shared.utils import _supported_float_type
 from skimage.color import rgb2gray
 from skimage.data import camera, retina
@@ -196,7 +196,7 @@ def test_2d_cropped_camera_image():
 @pytest.mark.parametrize('func', [meijering, sato, frangi, hessian])
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_ridge_output_dtype(func, dtype):
-    img = img_as_float(camera()).astype(dtype, copy=False)
+    img = rescale_to_float(camera()).astype(dtype, copy=False)
     assert func(img).dtype == _supported_float_type(img.dtype)
 
 

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -259,18 +259,18 @@ class TestSimpleImage():
 
 
 def test_otsu_camera_image():
-    camera = util.img_as_ubyte(data.camera())
+    camera = util.rescale_to_ubyte(data.camera())
     assert 101 < threshold_otsu(camera) < 103
 
 
 def test_otsu_camera_image_histogram():
-    camera = util.img_as_ubyte(data.camera())
+    camera = util.rescale_to_ubyte(data.camera())
     hist = histogram(camera.ravel(), 256, source_range='image')
     assert 101 < threshold_otsu(hist=hist) < 103
 
 
 def test_otsu_camera_image_counts():
-    camera = util.img_as_ubyte(data.camera())
+    camera = util.rescale_to_ubyte(data.camera())
     counts, bin_centers = histogram(camera.ravel(), 256, source_range='image')
     assert 101 < threshold_otsu(hist=counts) < 103
 
@@ -289,17 +289,17 @@ def test_otsu_zero_count_histogram():
 
 
 def test_otsu_coins_image():
-    coins = util.img_as_ubyte(data.coins())
+    coins = util.rescale_to_ubyte(data.coins())
     assert 106 < threshold_otsu(coins) < 108
 
 
 def test_otsu_coins_image_as_float():
-    coins = util.img_as_float(data.coins())
+    coins = util.rescale_to_float(data.coins())
     assert 0.41 < threshold_otsu(coins) < 0.42
 
 
 def test_otsu_astro_image():
-    img = util.img_as_ubyte(data.astronaut())
+    img = util.rescale_to_ubyte(data.astronaut())
     with expected_warnings(['grayscale']):
         assert 109 < threshold_otsu(img) < 111
 
@@ -315,7 +315,7 @@ def test_otsu_one_color_image_3d():
 
 
 def test_li_camera_image():
-    image = util.img_as_ubyte(data.camera())
+    image = util.rescale_to_ubyte(data.camera())
     threshold = threshold_li(image)
     ce_actual = _cross_entropy(image, threshold)
     assert 78 < threshold_li(image) < 79
@@ -324,7 +324,7 @@ def test_li_camera_image():
 
 
 def test_li_coins_image():
-    image = util.img_as_ubyte(data.coins())
+    image = util.rescale_to_ubyte(data.coins())
     threshold = threshold_li(image)
     ce_actual = _cross_entropy(image, threshold)
     assert 94 < threshold_li(image) < 95
@@ -338,12 +338,12 @@ def test_li_coins_image():
 
 
 def test_li_coins_image_as_float():
-    coins = util.img_as_float(data.coins())
+    coins = util.rescale_to_float(data.coins())
     assert 94/255 < threshold_li(coins) < 95/255
 
 
 def test_li_astro_image():
-    image = util.img_as_ubyte(data.astronaut())
+    image = util.rescale_to_ubyte(data.astronaut())
     threshold = threshold_li(image)
     ce_actual = _cross_entropy(image, threshold)
     assert 64 < threshold < 65
@@ -404,29 +404,29 @@ def test_li_pathological_arrays():
 
 
 def test_yen_camera_image():
-    camera = util.img_as_ubyte(data.camera())
+    camera = util.rescale_to_ubyte(data.camera())
     assert 145 < threshold_yen(camera) < 147
 
 
 def test_yen_camera_image_histogram():
-    camera = util.img_as_ubyte(data.camera())
+    camera = util.rescale_to_ubyte(data.camera())
     hist = histogram(camera.ravel(), 256, source_range='image')
     assert 145 < threshold_yen(hist=hist) < 147
 
 
 def test_yen_camera_image_counts():
-    camera = util.img_as_ubyte(data.camera())
+    camera = util.rescale_to_ubyte(data.camera())
     counts, bin_centers = histogram(camera.ravel(), 256, source_range='image')
     assert 145 < threshold_yen(hist=counts) < 147
 
 
 def test_yen_coins_image():
-    coins = util.img_as_ubyte(data.coins())
+    coins = util.rescale_to_ubyte(data.coins())
     assert 109 < threshold_yen(coins) < 111
 
 
 def test_yen_coins_image_as_float():
-    coins = util.img_as_float(data.coins())
+    coins = util.rescale_to_float(data.coins())
     assert 0.43 < threshold_yen(coins) < 0.44
 
 
@@ -437,7 +437,7 @@ def test_local_even_block_size_error():
 
 
 def test_isodata_camera_image():
-    camera = util.img_as_ubyte(data.camera())
+    camera = util.rescale_to_ubyte(data.camera())
 
     threshold = threshold_isodata(camera)
     assert np.floor((camera[camera <= threshold].mean() +
@@ -448,21 +448,21 @@ def test_isodata_camera_image():
 
 
 def test_isodata_camera_image_histogram():
-    camera = util.img_as_ubyte(data.camera())
+    camera = util.rescale_to_ubyte(data.camera())
     hist = histogram(camera.ravel(), 256, source_range='image')
     threshold = threshold_isodata(hist=hist)
     assert threshold == 102
 
 
 def test_isodata_camera_image_counts():
-    camera = util.img_as_ubyte(data.camera())
+    camera = util.rescale_to_ubyte(data.camera())
     counts, bin_centers = histogram(camera.ravel(), 256, source_range='image')
     threshold = threshold_isodata(hist=counts)
     assert threshold == 102
 
 
 def test_isodata_coins_image():
-    coins = util.img_as_ubyte(data.coins())
+    coins = util.rescale_to_ubyte(data.coins())
 
     threshold = threshold_isodata(coins)
     assert np.floor((coins[coins <= threshold].mean() +
@@ -473,7 +473,7 @@ def test_isodata_coins_image():
 
 
 def test_isodata_moon_image():
-    moon = util.img_as_ubyte(data.moon())
+    moon = util.rescale_to_ubyte(data.moon())
 
     threshold = threshold_isodata(moon)
     assert np.floor((moon[moon <= threshold].mean() +
@@ -488,7 +488,7 @@ def test_isodata_moon_image():
 
 
 def test_isodata_moon_image_negative_int():
-    moon = util.img_as_ubyte(data.moon()).astype(np.int32)
+    moon = util.rescale_to_ubyte(data.moon()).astype(np.int32)
     moon -= 100
 
     threshold = threshold_isodata(moon)
@@ -504,7 +504,7 @@ def test_isodata_moon_image_negative_int():
 
 
 def test_isodata_moon_image_negative_float():
-    moon = util.img_as_ubyte(data.moon()).astype(np.float64)
+    moon = util.rescale_to_ubyte(data.moon()).astype(np.float64)
     moon -= 100
 
     assert -14 < threshold_isodata(moon) < -13
@@ -516,32 +516,32 @@ def test_isodata_moon_image_negative_float():
 
 
 def test_threshold_minimum():
-    camera = util.img_as_ubyte(data.camera())
+    camera = util.rescale_to_ubyte(data.camera())
 
     threshold = threshold_minimum(camera)
     assert_equal(threshold, 85)
 
-    astronaut = util.img_as_ubyte(data.astronaut())
+    astronaut = util.rescale_to_ubyte(data.astronaut())
     threshold = threshold_minimum(astronaut)
     assert_equal(threshold, 114)
 
 
 def test_threshold_minimum_histogram():
-    camera = util.img_as_ubyte(data.camera())
+    camera = util.rescale_to_ubyte(data.camera())
     hist = histogram(camera.ravel(), 256, source_range='image')
     threshold = threshold_minimum(hist=hist)
     assert_equal(threshold, 85)
 
 
 def test_threshold_minimum_deprecated_max_iter_kwarg():
-    camera = util.img_as_ubyte(data.camera())
+    camera = util.rescale_to_ubyte(data.camera())
     hist = histogram(camera.ravel(), 256, source_range='image')
     with expected_warnings(["`max_iter` is a deprecated argument"]):
         threshold_minimum(hist=hist, max_iter=5000)
 
 
 def test_threshold_minimum_counts():
-    camera = util.img_as_ubyte(data.camera())
+    camera = util.rescale_to_ubyte(data.camera())
     counts, bin_centers = histogram(camera.ravel(), 256, source_range='image')
     threshold = threshold_minimum(hist=counts)
     assert_equal(threshold, 85)
@@ -711,7 +711,7 @@ def test_multiotsu_output():
 
 
 def test_multiotsu_astro_image():
-    img = util.img_as_ubyte(data.astronaut())
+    img = util.rescale_to_ubyte(data.astronaut())
     with expected_warnings(['grayscale']):
         assert_almost_equal(threshold_multiotsu(img), [58, 149])
 

--- a/skimage/filters/tests/test_unsharp_mask.py
+++ b/skimage/filters/tests/test_unsharp_mask.py
@@ -20,16 +20,12 @@ from skimage.filters import unsharp_mask
 @pytest.mark.parametrize("radius", [0, 0.1, 2.0])
 @pytest.mark.parametrize("amount", [0.0, 0.5, 2.0, -1.0])
 @pytest.mark.parametrize("offset", [-1.0, 0.0, 1.0])
-@pytest.mark.parametrize("preserve", [False, True])
 def test_unsharp_masking_output_type_and_shape(
-        radius, amount, shape, multichannel, dtype, offset, preserve):
+        radius, amount, shape, multichannel, dtype, offset):
     array = np.random.random(shape)
     array = ((array + offset) * 128).astype(dtype)
-    if (preserve is False) and (dtype in [np.float32, np.float64]):
-        array /= max(np.abs(array).max(), 1.0)
     channel_axis = -1 if multichannel else None
-    output = unsharp_mask(array, radius, amount, preserve_range=preserve,
-                          channel_axis=channel_axis)
+    output = unsharp_mask(array, radius, amount, channel_axis=channel_axis)
     assert output.dtype in [np.float32, np.float64]
     assert output.shape == shape
 
@@ -39,17 +35,12 @@ def test_unsharp_masking_output_type_and_shape(
                           ((15, 15, 2), True),
                           ((17, 19, 3), True)])
 @pytest.mark.parametrize("radius", [(0.0, 0.0), (1.0, 1.0), (2.0, 1.5)])
-@pytest.mark.parametrize("preserve", [False, True])
-def test_unsharp_masking_with_different_radii(radius, shape,
-                                              multichannel, preserve):
+def test_unsharp_masking_with_different_radii(radius, shape, multichannel):
     amount = 1.0
     dtype = np.float64
     array = (np.random.random(shape) * 96).astype(dtype)
-    if preserve is False:
-        array /= max(np.abs(array).max(), 1.0)
     channel_axis = -1 if multichannel else None
-    output = unsharp_mask(array, radius, amount, preserve_range=preserve,
-                          channel_axis=channel_axis)
+    output = unsharp_mask(array, radius, amount, channel_axis=channel_axis)
     assert output.dtype in [np.float32, np.float64]
     assert output.shape == shape
 
@@ -61,21 +52,12 @@ def test_unsharp_masking_with_different_radii(radius, shape,
                           ((2, 15, 15), 0),
                           ((3, 13, 17), 0)])
 @pytest.mark.parametrize("offset", [-5, 0, 5])
-@pytest.mark.parametrize("preserve", [False, True])
-def test_unsharp_masking_with_different_ranges(shape, offset, channel_axis,
-                                               preserve):
+def test_unsharp_masking_with_different_ranges(shape, offset, channel_axis):
     radius = 2.0
     amount = 1.0
     dtype = np.int16
     array = (np.random.random(shape) * 5 + offset).astype(dtype)
-    negative = np.any(array < 0)
-    output = unsharp_mask(array, radius, amount, preserve_range=preserve,
-                          channel_axis=channel_axis)
-    if preserve is False:
-        assert np.any(output <= 1)
-        assert np.any(output >= -1)
-        if negative is False:
-            assert np.any(output >= 0)
+    output = unsharp_mask(array, radius, amount, channel_axis=channel_axis)
     assert output.dtype in [np.float32, np.float64]
     assert output.shape == shape
 
@@ -85,48 +67,31 @@ def test_unsharp_masking_with_different_ranges(shape, offset, channel_axis,
                           ((15, 15, 2), True),
                           ((13, 17, 3), True)])
 @pytest.mark.parametrize("offset", [-5, 0, 5])
-@pytest.mark.parametrize("preserve", [False, True])
 def test_unsharp_masking_with_different_ranges_deprecated(shape, offset,
-                                                          multichannel,
-                                                          preserve):
+                                                          multichannel):
     radius = 2.0
     amount = 1.0
     dtype = np.int16
     array = (np.random.random(shape) * 5 + offset).astype(dtype)
-    negative = np.any(array < 0)
     with expected_warnings(["`multichannel` is a deprecated argument"]):
-        output = unsharp_mask(array, radius, amount, multichannel=multichannel,
-                              preserve_range=preserve)
-    if preserve is False:
-        assert np.any(output <= 1)
-        assert np.any(output >= -1)
-        if negative is False:
-            assert np.any(output >= 0)
+        output = unsharp_mask(array, radius, amount, multichannel=multichannel)
     assert output.dtype in [np.float32, np.float64]
     assert output.shape == shape
 
     # providing multichannel positionally also raises a warning
     with expected_warnings(["Providing the `multichannel`"]):
-        output = unsharp_mask(array, radius, amount, multichannel, preserve)
+        output = unsharp_mask(array, radius, amount, multichannel)
 
 
 @pytest.mark.parametrize("shape,channel_axis",
                          [((16, 16), None),
                           ((15, 15, 2), -1),
                           ((13, 17, 3), -1)])
-@pytest.mark.parametrize("preserve", [False, True])
 @pytest.mark.parametrize("dtype", [np.uint8, np.float16, np.float32, np.float64])
-def test_unsharp_masking_dtypes(shape, channel_axis, preserve, dtype):
+def test_unsharp_masking_dtypes(shape, channel_axis, dtype):
     radius = 2.0
     amount = 1.0
     array = (np.random.random(shape) * 10).astype(dtype, copy=False)
-    negative = np.any(array < 0)
-    output = unsharp_mask(array, radius, amount, preserve_range=preserve,
-                          channel_axis=channel_axis)
-    if preserve is False:
-        assert np.any(output <= 1)
-        assert np.any(output >= -1)
-        if negative is False:
-            assert np.any(output >= 0)
+    output = unsharp_mask(array, radius, amount, channel_axis=channel_axis)
     assert output.dtype == _supported_float_type(dtype)
     assert output.shape == shape

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -509,7 +509,7 @@ def show_rag(labels, rag, image, border_color='black', edge_width=1.5,
 
     if ax is None:
         fig, ax = plt.subplots()
-    out = util.img_as_float(image, force_copy=True)
+    out = util.rescale_to_float(image, force_copy=True)
 
     if img_cmap is None:
         if image.ndim < 3 or image.shape[2] not in [3, 4]:

--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -136,7 +136,7 @@ def imsave(fname, arr, plugin=None, check_contrast=True, **plugin_args):
     if arr.dtype == bool:
         warn('%s is a boolean image: setting True to 255 and False to 0. '
              'To silence this warning, please convert the image using '
-             'img_as_ubyte.' % fname, stacklevel=2)
+             'rescale_to_ubyte.' % fname, stacklevel=2)
         arr = arr.astype('uint8') * 255
     if check_contrast and is_low_contrast(arr):
         warn('%s is a low contrast image' % fname)

--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -238,7 +238,8 @@ def imsave(fname, arr, format_str=None, **kwargs):
     -----
     Use the Python Imaging Library.
     See PIL docs [1]_ for a list of other supported formats.
-    All images besides single channel PNGs are converted using `rescale_to_uint8`.
+    All images besides single channel PNGs are converted using
+    `rescale_to_uint8`.
     Single Channel PNGs have the following behavior:
     - Integer values in [0, 255] and Boolean types -> rescale_to_uint8
     - Floating point and other integers -> rescale_to_uint16

--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -4,7 +4,7 @@ import numpy as np
 from packaging import version
 from PIL import Image, __version__ as pil_version
 
-from ...util import img_as_ubyte, img_as_uint
+from ...util import rescale_to_ubyte, rescale_to_uint
 
 # Check CVE-2021-27921 and others
 if version.parse(pil_version) < version.parse('8.1.2'):
@@ -171,7 +171,7 @@ def ndarray_to_pil(arr, format_str=None):
 
     """
     if arr.ndim == 3:
-        arr = img_as_ubyte(arr)
+        arr = rescale_to_ubyte(arr)
         mode = {3: 'RGB', 4: 'RGBA'}[arr.shape[2]]
 
     elif format_str in ['png', 'PNG']:
@@ -179,17 +179,17 @@ def ndarray_to_pil(arr, format_str=None):
         mode_base = 'I'
 
         if arr.dtype.kind == 'f':
-            arr = img_as_uint(arr)
+            arr = rescale_to_uint(arr)
 
         elif arr.max() < 256 and arr.min() >= 0:
             arr = arr.astype(np.uint8)
             mode = mode_base = 'L'
 
         else:
-            arr = img_as_uint(arr)
+            arr = rescale_to_uint(arr)
 
     else:
-        arr = img_as_ubyte(arr)
+        arr = rescale_to_ubyte(arr)
         mode = 'L'
         mode_base = 'L'
 
@@ -238,10 +238,10 @@ def imsave(fname, arr, format_str=None, **kwargs):
     -----
     Use the Python Imaging Library.
     See PIL docs [1]_ for a list of other supported formats.
-    All images besides single channel PNGs are converted using `img_as_uint8`.
+    All images besides single channel PNGs are converted using `rescale_to_uint8`.
     Single Channel PNGs have the following behavior:
-    - Integer values in [0, 255] and Boolean types -> img_as_uint8
-    - Floating point and other integers -> img_as_uint16
+    - Integer values in [0, 255] and Boolean types -> rescale_to_uint8
+    - Floating point and other integers -> rescale_to_uint16
 
     References
     ----------

--- a/skimage/io/_plugins/util.py
+++ b/skimage/io/_plugins/util.py
@@ -2,7 +2,7 @@ import numpy as np
 from . import _colormixer
 from . import _histograms
 import threading
-from ...util import img_as_ubyte
+from ...util import rescale_to_ubyte
 
 # utilities to make life easier for plugin writers.
 
@@ -133,7 +133,7 @@ def prepare_for_display(npy_img):
     width = npy_img.shape[1]
 
     out = np.empty((height, width, 3), dtype=np.uint8)
-    npy_img = img_as_ubyte(npy_img)
+    npy_img = rescale_to_ubyte(npy_img)
 
     if npy_img.ndim == 2 or \
        (npy_img.ndim == 3 and npy_img.shape[2] == 1):

--- a/skimage/io/tests/test_pil.py
+++ b/skimage/io/tests/test_pil.py
@@ -3,7 +3,7 @@ import numpy as np
 from io import BytesIO
 from tempfile import NamedTemporaryFile
 
-from ... import img_as_float
+from ... import rescale_to_float
 from .. import imread, imsave, use_plugin, reset_plugins
 
 from PIL import Image
@@ -46,7 +46,7 @@ def test_png_round_trip():
     f.close()
     I = np.eye(3)
     imsave(fname, I)
-    Ip = img_as_float(imread(fname))
+    Ip = rescale_to_float(imread(fname))
     os.remove(fname)
     assert np.sum(np.abs(Ip-I)) < 1e-3
 

--- a/skimage/measure/_blur_effect.py
+++ b/skimage/measure/_blur_effect.py
@@ -2,7 +2,7 @@ import numpy as np
 import scipy.ndimage as ndi
 
 from ..color import rgb2gray
-from ..util import img_as_float
+from ..util import rescale_to_float
 
 
 __all__ = ['blur_effect']
@@ -63,7 +63,7 @@ def blur_effect(image, h_size=11, channel_axis=None, reduce_func=np.max):
             raise
         image = rgb2gray(image)
     n_axes = image.ndim
-    image = img_as_float(image)
+    image = rescale_to_float(image)
     shape = image.shape
     B = []
 

--- a/skimage/measure/_blur_effect.py
+++ b/skimage/measure/_blur_effect.py
@@ -1,9 +1,8 @@
 import numpy as np
 import scipy.ndimage as ndi
 
+from .._shared.utils import _supported_float_type
 from ..color import rgb2gray
-from ..util import rescale_to_float
-
 
 __all__ = ['blur_effect']
 
@@ -63,7 +62,8 @@ def blur_effect(image, h_size=11, channel_axis=None, reduce_func=np.max):
             raise
         image = rgb2gray(image)
     n_axes = image.ndim
-    image = rescale_to_float(image)
+    float_dtype = _supported_float_type(image.dtype)
+    image = image.astype(float_dtype, copy=False)
     shape = image.shape
     B = []
 

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -1220,7 +1220,7 @@ def regionprops(label_image, intensity_image=None, cache=True,
     --------
     >>> from skimage import data, util
     >>> from skimage.measure import label, regionprops
-    >>> img = util.img_as_ubyte(data.coins()) > 110
+    >>> img = util.rescale_to_ubyte(data.coins()) > 110
     >>> label_img = label(img, connectivity=img.ndim)
     >>> props = regionprops(label_img)
     >>> # centroid of first labeled object
@@ -1235,7 +1235,7 @@ def regionprops(label_image, intensity_image=None, cache=True,
     >>> from skimage import data, util
     >>> from skimage.measure import label, regionprops
     >>> import numpy as np
-    >>> img = util.img_as_ubyte(data.coins()) > 110
+    >>> img = util.rescale_to_ubyte(data.coins()) > 110
     >>> label_img = label(img, connectivity=img.ndim)
     >>> def pixelcount(regionmask):
     ...     return np.sum(regionmask)

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -4,7 +4,7 @@ Algorithms for computing the skeleton of a binary image
 
 
 import numpy as np
-from ..util import img_as_ubyte, crop
+from ..util import rescale_to_ubyte, crop
 from scipy import ndimage as ndi
 
 from .._shared.utils import check_nD, deprecate_kwarg
@@ -626,7 +626,7 @@ def skeletonize_3d(image):
         raise ValueError("skeletonize_3d can only handle 2D or 3D images; "
                          "got image.ndim = %s instead." % image.ndim)
     image = np.ascontiguousarray(image)
-    image = img_as_ubyte(image, force_copy=False)
+    image = rescale_to_ubyte(image, force_copy=False)
 
     # make an in image 3D and pad it w/ zeros to simplify dealing w/ boundaries
     # NB: careful here to not clobber the original *and* minimize copying

--- a/skimage/morphology/tests/test_binary.py
+++ b/skimage/morphology/tests/test_binary.py
@@ -5,7 +5,7 @@ from scipy import ndimage as ndi
 
 from skimage import data, color, morphology
 from skimage._shared._warnings import expected_warnings
-from skimage.util import img_as_bool
+from skimage.util import rescale_to_bool
 from skimage.morphology import binary, footprints, gray
 
 
@@ -16,7 +16,7 @@ bw_img = img > 100 / 255.
 def test_non_square_image():
     footprint = morphology.square(3)
     binary_res = binary.binary_erosion(bw_img[:100, :200], footprint)
-    gray_res = img_as_bool(gray.erosion(bw_img[:100, :200], footprint))
+    gray_res = rescale_to_bool(gray.erosion(bw_img[:100, :200], footprint))
     assert_array_equal(binary_res, gray_res)
 
 
@@ -32,28 +32,28 @@ def test_selem_kwarg_deprecation(function):
 def test_binary_erosion():
     footprint = morphology.square(3)
     binary_res = binary.binary_erosion(bw_img, footprint)
-    gray_res = img_as_bool(gray.erosion(bw_img, footprint))
+    gray_res = rescale_to_bool(gray.erosion(bw_img, footprint))
     assert_array_equal(binary_res, gray_res)
 
 
 def test_binary_dilation():
     footprint = morphology.square(3)
     binary_res = binary.binary_dilation(bw_img, footprint)
-    gray_res = img_as_bool(gray.dilation(bw_img, footprint))
+    gray_res = rescale_to_bool(gray.dilation(bw_img, footprint))
     assert_array_equal(binary_res, gray_res)
 
 
 def test_binary_closing():
     footprint = morphology.square(3)
     binary_res = binary.binary_closing(bw_img, footprint)
-    gray_res = img_as_bool(gray.closing(bw_img, footprint))
+    gray_res = rescale_to_bool(gray.closing(bw_img, footprint))
     assert_array_equal(binary_res, gray_res)
 
 
 def test_binary_opening():
     footprint = morphology.square(3)
     binary_res = binary.binary_opening(bw_img, footprint)
-    gray_res = img_as_bool(gray.opening(bw_img, footprint))
+    gray_res = rescale_to_bool(gray.opening(bw_img, footprint))
     assert_array_equal(binary_res, gray_res)
 
 
@@ -200,7 +200,7 @@ def test_footprint_overflow():
     img = np.zeros((20, 20), dtype=bool)
     img[2:19, 2:19] = True
     binary_res = binary.binary_erosion(img, footprint)
-    gray_res = img_as_bool(gray.erosion(img, footprint))
+    gray_res = rescale_to_bool(gray.erosion(img, footprint))
     assert_array_equal(binary_res, gray_res)
 
 

--- a/skimage/morphology/tests/test_gray.py
+++ b/skimage/morphology/tests/test_gray.py
@@ -7,7 +7,7 @@ from skimage import color, data, transform
 from skimage._shared._warnings import expected_warnings
 from skimage._shared.testing import fetch
 from skimage.morphology import gray, footprints
-from skimage.util import img_as_uint, img_as_ubyte
+from skimage.util import rescale_to_uint, rescale_to_ubyte
 
 
 @pytest.fixture
@@ -38,7 +38,7 @@ class TestMorphology():
         footprints_2D = (footprints.square, footprints.diamond,
                          footprints.disk, footprints.star)
 
-        image = img_as_ubyte(transform.downscale_local_mean(
+        image = rescale_to_ubyte(transform.downscale_local_mean(
             color.rgb2gray(data.coffee()), (20, 20)))
 
         output = {}
@@ -252,7 +252,7 @@ def test_float():
 
 def test_uint16():
     im16, eroded16, dilated16, opened16, closed16 = (
-        map(img_as_uint, [im, eroded, dilated, opened, closed]))
+        map(rescale_to_uint, [im, eroded, dilated, opened, closed]))
     assert_allclose(gray.erosion(im16), eroded16)
     assert_allclose(gray.dilation(im16), dilated16)
     assert_allclose(gray.opening(im16), opened16)

--- a/skimage/morphology/tests/test_skeletonize_3d.py
+++ b/skimage/morphology/tests/test_skeletonize_3d.py
@@ -3,7 +3,7 @@ import scipy.ndimage as ndi
 
 from skimage import io, draw
 from skimage.data import binary_blobs
-from skimage.util import img_as_ubyte
+from skimage.util import rescale_to_ubyte
 from skimage.morphology import skeletonize, skeletonize_3d
 
 from skimage._shared import testing
@@ -73,7 +73,7 @@ def test_dtype_conv():
 
     orig = img.copy()
     res = skeletonize(img, method='lee')
-    img_max = img_as_ubyte(img).max()
+    img_max = rescale_to_ubyte(img).max()
 
     assert_equal(res.dtype, np.uint8)
     assert_equal(img, orig)  # operation does not clobber the original

--- a/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_phase_cross_correlation.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_allclose
 from scipy.ndimage import fourier_shift
 import scipy.fft as fft
 
-from skimage import img_as_float
+from skimage import rescale_to_float
 from skimage._shared._warnings import expected_warnings
 from skimage._shared.utils import _supported_float_type
 from skimage.data import camera, binary_blobs
@@ -86,7 +86,7 @@ def test_size_one_dimension_input():
 
 
 def test_3d_input():
-    phantom = img_as_float(binary_blobs(length=32, n_dim=3))
+    phantom = rescale_to_float(binary_blobs(length=32, n_dim=3))
     reference_image = fft.fftn(phantom)
     shift = (-2., 1., 5.)
     shifted_image = fourier_shift(reference_image, shift)
@@ -138,7 +138,7 @@ def test_wrong_input():
 
 
 def test_4d_input_pixel():
-    phantom = img_as_float(binary_blobs(length=32, n_dim=4))
+    phantom = rescale_to_float(binary_blobs(length=32, n_dim=4))
     reference_image = fft.fftn(phantom)
     shift = (-2., 1., 5., -3)
     shifted_image = fourier_shift(reference_image, shift)
@@ -149,7 +149,7 @@ def test_4d_input_pixel():
 
 
 def test_4d_input_subpixel():
-    phantom = img_as_float(binary_blobs(length=32, n_dim=4))
+    phantom = rescale_to_float(binary_blobs(length=32, n_dim=4))
     reference_image = fft.fftn(phantom)
     subpixel_shift = (-2.3, 1.7, 5.4, -3.2)
     shifted_image = fourier_shift(reference_image, subpixel_shift)

--- a/skimage/restoration/_cycle_spin.py
+++ b/skimage/restoration/_cycle_spin.py
@@ -114,9 +114,9 @@ def cycle_spin(x, func, max_shifts, shift_steps=1, num_workers=None,
     Examples
     --------
     >>> import skimage.data
-    >>> from skimage import img_as_float
+    >>> from skimage import rescale_to_float
     >>> from skimage.restoration import denoise_wavelet, cycle_spin
-    >>> img = img_as_float(skimage.data.camera())
+    >>> img = rescale_to_float(skimage.data.camera())
     >>> sigma = 0.1
     >>> img = img + sigma * np.random.standard_normal(img.shape)
     >>> denoised = cycle_spin(img, func=denoise_wavelet,

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -223,7 +223,6 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
     # and color_lut[<int>(dist * dist_scale)] may cause a segmentation fault
     # so we verify we have a positive image and that the max is not 0.0.
 
-
     image = np.atleast_3d(rescale_to_float(image))
     image = np.ascontiguousarray(image)
 
@@ -702,7 +701,8 @@ def _scale_sigma_and_image_consistently(image, sigma, multichannel,
                                         rescale_sigma):
     """If the ``image`` is rescaled, also rescale ``sigma`` consistently.
 
-    Images that are not floating point will be rescaled via ``rescale_to_float``.
+    Images that are not floating point will be rescaled via
+    ``rescale_to_float``.
     Half-precision images will be promoted to single precision.
     """
     if multichannel:

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -6,7 +6,7 @@ import scipy.stats
 import numpy as np
 import pywt
 
-from ..util.dtype import img_as_float
+from ..util.dtype import rescale_to_float
 from .._shared import utils
 from .._shared.utils import _supported_float_type, warn
 from ._denoise_cy import _denoise_bilateral, _denoise_tv_bregman
@@ -48,7 +48,7 @@ def _compute_color_lut(bins, sigma, max_value, *, dtype=float):
         Standard deviation for grayvalue/color distance (radiometric
         similarity). A larger value results in averaging of pixels with larger
         radiometric differences. Note, that the image will be converted using
-        the `img_as_float` function and thus the standard deviation is in
+        the `rescale_to_float` function and thus the standard deviation is in
         respect to the range ``[0, 1]``. If the value is ``None`` the standard
         deviation of the ``image`` will be used.
     max_value : float
@@ -155,7 +155,7 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
     deviation (`sigma_color`).
 
     Note that, if the image is of any `int` dtype, ``image`` will be
-    converted using the `img_as_float` function and thus the standard
+    converted using the `rescale_to_float` function and thus the standard
     deviation (`sigma_color`) will be in range ``[0, 1]``.
 
     For more information on scikit-image's data type conversions and how
@@ -170,8 +170,8 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
 
     Examples
     --------
-    >>> from skimage import data, img_as_float
-    >>> astro = img_as_float(data.astronaut())
+    >>> from skimage import data, rescale_to_float
+    >>> astro = rescale_to_float(data.astronaut())
     >>> astro = astro[220:300, 220:320]
     >>> rng = np.random.default_rng()
     >>> noisy = astro + 0.6 * astro.std() * rng.random(astro.shape)
@@ -224,7 +224,7 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
     # so we verify we have a positive image and that the max is not 0.0.
 
 
-    image = np.atleast_3d(img_as_float(image))
+    image = np.atleast_3d(rescale_to_float(image))
     image = np.ascontiguousarray(image)
 
     sigma_color = sigma_color or image.std()
@@ -274,7 +274,7 @@ def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
     Parameters
     ----------
     image : ndarray
-        Input data to be denoised (converted using img_as_float`).
+        Input data to be denoised (converted using rescale_to_float`).
     weight : float
         Denoising weight. The smaller the `weight`, the more denoising (at
         the expense of less similarity to the `input`). The regularization
@@ -319,7 +319,7 @@ def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
     .. [4] https://web.math.ucsb.edu/~cgarcia/UGProjects/BregmanAlgorithms_JacquelineBush.pdf
 
     """
-    image = np.atleast_3d(img_as_float(image))
+    image = np.atleast_3d(rescale_to_float(image))
 
     rows = image.shape[0]
     cols = image.shape[1]
@@ -519,7 +519,7 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
 
     im_type = image.dtype
     if not im_type.kind == 'f':
-        image = img_as_float(image)
+        image = rescale_to_float(image)
 
     # enforce float16->float32 and float128->float64
     float_dtype = _supported_float_type(image.dtype)
@@ -702,7 +702,7 @@ def _scale_sigma_and_image_consistently(image, sigma, multichannel,
                                         rescale_sigma):
     """If the ``image`` is rescaled, also rescale ``sigma`` consistently.
 
-    Images that are not floating point will be rescaled via ``img_as_float``.
+    Images that are not floating point will be rescaled via ``rescale_to_float``.
     Half-precision images will be promoted to single precision.
     """
     if multichannel:
@@ -715,7 +715,7 @@ def _scale_sigma_and_image_consistently(image, sigma, multichannel,
     if image.dtype.kind != 'f':
         if rescale_sigma:
             range_pre = image.max() - image.min()
-        image = img_as_float(image)
+        image = rescale_to_float(image)
         if rescale_sigma:
             range_post = image.max() - image.min()
             # apply the same magnitude scaling to sigma
@@ -865,7 +865,7 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
     Examples
     --------
     >>> from skimage import color, data
-    >>> img = img_as_float(data.astronaut())
+    >>> img = rescale_to_float(data.astronaut())
     >>> img = color.rgb2gray(img)
     >>> rng = np.random.default_rng()
     >>> img += 0.1 * rng.standard_normal(img.shape)
@@ -982,8 +982,8 @@ def estimate_sigma(image, average_sigmas=False, multichannel=False, *,
     Examples
     --------
     >>> import skimage.data
-    >>> from skimage import img_as_float
-    >>> img = img_as_float(skimage.data.camera())
+    >>> from skimage import rescale_to_float
+    >>> img = rescale_to_float(skimage.data.camera())
     >>> sigma = 0.1
     >>> rng = np.random.default_rng()
     >>> img = img + sigma * rng.standard_normal(img.shape)

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -394,8 +394,8 @@ def richardson_lucy(image, psf, num_iter=50, clip=True, filter_epsilon=None):
 
     Examples
     --------
-    >>> from skimage import img_as_float, data, restoration
-    >>> camera = img_as_float(data.camera())
+    >>> from skimage import rescale_to_float, data, restoration
+    >>> camera = rescale_to_float(data.camera())
     >>> from scipy.signal import convolve2d
     >>> psf = np.ones((5, 5)) / 25
     >>> camera = convolve2d(camera, psf, 'same')

--- a/skimage/restoration/inpaint.py
+++ b/skimage/restoration/inpaint.py
@@ -256,7 +256,7 @@ def inpaint_biharmonic(image, mask, multichannel=False, *,
     if np.ma.isMaskedArray(image):
         raise TypeError('Masked arrays are not supported')
 
-    image = skimage.img_as_float(image)
+    image = skimage.rescale_to_float(image)
 
     # float16->float32 and float128->float64
     float_dtype = utils._supported_float_type(image.dtype)

--- a/skimage/restoration/inpaint.py
+++ b/skimage/restoration/inpaint.py
@@ -256,9 +256,6 @@ def inpaint_biharmonic(image, mask, multichannel=False, *,
     if np.ma.isMaskedArray(image):
         raise TypeError('Masked arrays are not supported')
 
-    image = skimage.rescale_to_float(image)
-
-    # float16->float32 and float128->float64
     float_dtype = utils._supported_float_type(image.dtype)
     image = image.astype(float_dtype, copy=False)
 

--- a/skimage/restoration/j_invariant.py
+++ b/skimage/restoration/j_invariant.py
@@ -6,7 +6,7 @@ from scipy import ndimage as ndi
 
 from .._shared.utils import _supported_float_type
 from ..metrics import mean_squared_error
-from ..util import img_as_float
+from ..util import rescale_to_float
 
 
 
@@ -96,7 +96,7 @@ def _invariant_denoise(image, denoise_function, *, stride=4,
     Parameters
     ----------
     image : ndarray
-        Input data to be denoised (converted using `img_as_float`).
+        Input data to be denoised (converted using `rescale_to_float`).
     denoise_function : function
         Original denoising function.
     stride : int, optional
@@ -113,7 +113,7 @@ def _invariant_denoise(image, denoise_function, *, stride=4,
     output : ndarray
         Denoised image, of same shape as `image`.
     """
-    image = img_as_float(image)
+    image = rescale_to_float(image)
 
     # promote float16->float32 if needed
     float_dtype = _supported_float_type(image.dtype)
@@ -178,7 +178,7 @@ def calibrate_denoiser(image, denoise_function, denoise_parameters, *,
     Parameters
     ----------
     image : ndarray
-        Input data to be denoised (converted using `img_as_float`).
+        Input data to be denoised (converted using `rescale_to_float`).
     denoise_function : function
         Denoising function to be calibrated.
     denoise_parameters : dict of list
@@ -271,7 +271,7 @@ def _calibrate_denoiser_search(image, denoise_function, denoise_parameters, *,
     Parameters
     ----------
     image : ndarray
-        Input data to be denoised (converted using `img_as_float`).
+        Input data to be denoised (converted using `rescale_to_float`).
     denoise_function : function
         Denoising function to be calibrated.
     denoise_parameters : dict of list
@@ -292,7 +292,7 @@ def _calibrate_denoiser_search(image, denoise_function, denoise_parameters, *,
     losses : list of int
         Self-supervised loss for each set of parameters in `parameters_tested`.
     """
-    image = img_as_float(image)
+    image = rescale_to_float(image)
     parameters_tested = list(_product_from_dict(denoise_parameters))
     losses = []
 

--- a/skimage/restoration/non_local_means.py
+++ b/skimage/restoration/non_local_means.py
@@ -46,7 +46,7 @@ def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
         noise variance into account (see Notes below).
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `img_as_float`.
+        image is converted according to the conventions of `rescale_to_float`.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
     channel_axis : int or None, optional
         If None, the image is assumed to be a grayscale (single channel) image.

--- a/skimage/restoration/non_local_means.py
+++ b/skimage/restoration/non_local_means.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from .._shared import utils
-from .._shared.utils import convert_to_float
+from .._shared.utils import _supported_float_type
 from ._nl_means_denoising import (_nl_means_denoising_2d,
                                   _nl_means_denoising_3d,
                                   _fast_nl_means_denoising_2d,
@@ -13,7 +13,7 @@ from ._nl_means_denoising import (_nl_means_denoising_2d,
 @utils.deprecate_multichannel_kwarg(multichannel_position=4)
 def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
                      multichannel=False, fast_mode=True, sigma=0., *,
-                     preserve_range=False, channel_axis=None):
+                     channel_axis=None):
     """Perform non-local means denoising on 2D-4D grayscale or RGB images.
 
     Parameters
@@ -44,10 +44,6 @@ def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
         The standard deviation of the (Gaussian) noise.  If provided, a more
         robust computation of patch weights is computed that takes the expected
         noise variance into account (see Notes below).
-    preserve_range : bool, optional
-        Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `rescale_to_float`.
-        Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
     channel_axis : int or None, optional
         If None, the image is assumed to be a grayscale (single channel) image.
         Otherwise, this parameter indicates which axis of the array corresponds
@@ -156,9 +152,10 @@ def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
             "Non-local means denoising is only implemented for 2D, "
             "3D or 4D grayscale or multichannel images.")
 
-    image = convert_to_float(image, preserve_range)
-    if not image.flags.c_contiguous:
-        image = np.ascontiguousarray(image)
+    image = np.asarray(image)
+    float_dtype = _supported_float_type(image.dtype)
+    # note: Cython code requires C-contiguous order
+    image = np.asarray(image, dtype=float_dtype, order='C')
 
     kwargs = dict(s=patch_size, d=patch_distance, h=h, var=sigma * sigma)
     if ndim_no_channel == 2:

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -7,7 +7,7 @@ import pywt
 from numpy.testing import (assert_array_almost_equal, assert_array_equal,
                            assert_warns)
 
-from skimage import color, data, img_as_float, restoration
+from skimage import color, data, rescale_to_float, restoration
 from skimage._shared._warnings import expected_warnings
 from skimage._shared.utils import _supported_float_type, slice_at_axis
 from skimage.metrics import peak_signal_noise_ratio, structural_similarity
@@ -24,9 +24,9 @@ else:
 np.random.seed(1234)
 
 
-astro = img_as_float(data.astronaut()[:128, :128])
+astro = rescale_to_float(data.astronaut()[:128, :128])
 astro_gray = color.rgb2gray(astro)
-checkerboard_gray = img_as_float(data.checkerboard())
+checkerboard_gray = rescale_to_float(data.checkerboard())
 checkerboard = color.gray2rgb(checkerboard_gray)
 # versions with one odd-sized dimension
 astro_gray_odd = astro_gray[:, :-1]
@@ -304,7 +304,7 @@ def test_denoise_bilateral_2d():
 def test_denoise_bilateral_pad():
     """This test checks if the bilateral filter is returning an image
     correctly padded."""
-    img = img_as_float(data.chelsea())[100:200, 100:200]
+    img = rescale_to_float(data.chelsea())[100:200, 100:200]
     img_bil = restoration.denoise_bilateral(img, sigma_color=0.1,
                                             sigma_spatial=10,
                                             channel_axis=-1)
@@ -800,7 +800,7 @@ def test_wavelet_denoising_deprecated():
 )
 def test_wavelet_denoising_scaling(case, dtype, convert2ycbcr,
                                    estimate_sigma):
-    """Test cases for images without prescaling via img_as_float."""
+    """Test cases for images without prescaling via rescale_to_float."""
     rstate = np.random.default_rng(1234)
 
     if case == '1d':
@@ -854,7 +854,7 @@ def test_wavelet_denoising_scaling(case, dtype, convert2ycbcr,
         assert denoised.max() > 0.9 * x.max()
     else:
         # have to compare to x_as_float in integer input cases
-        x_as_float = img_as_float(x)
+        x_as_float = rescale_to_float(x)
         f_data_range = x_as_float.max() - x_as_float.min()
         psnr_denoised = peak_signal_noise_ratio(x_as_float, denoised,
                                                 data_range=f_data_range)

--- a/skimage/restoration/tests/test_inpaint.py
+++ b/skimage/restoration/tests/test_inpaint.py
@@ -196,5 +196,7 @@ def test_inpaint_nrmse(dtype, order, channel_axis, split_into_regions):
     assert image_result.dtype == float_dtype
 
     nrmse_defect = normalized_root_mse(image_orig, image_defect)
-    nrmse_result = normalized_root_mse(rescale_to_float(image_orig), image_result)
+    nrmse_result = normalized_root_mse(
+        rescale_to_float(image_orig), image_result
+    )
     assert nrmse_result < 0.2 * nrmse_defect

--- a/skimage/restoration/tests/test_inpaint.py
+++ b/skimage/restoration/tests/test_inpaint.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from skimage import data, img_as_float
+from skimage import data, rescale_to_float
 from skimage._shared import testing
 from skimage._shared.testing import assert_allclose, expected_warnings
 from skimage._shared.utils import _supported_float_type
@@ -36,7 +36,7 @@ def test_inpaint_biharmonic_2d(dtype, split_into_regions):
 
 @testing.parametrize('channel_axis', [0, 1, -1])
 def test_inpaint_biharmonic_2d_color(channel_axis):
-    img = img_as_float(data.astronaut()[:64, :64])
+    img = rescale_to_float(data.astronaut()[:64, :64])
 
     mask = np.zeros(img.shape[:2], dtype=bool)
     mask[8:16, :16] = 1
@@ -74,7 +74,7 @@ def test_inpaint_biharmonic_2d_float_dtypes(dtype):
 
 
 def test_inpaint_biharmonic_2d_color_deprecated():
-    img = img_as_float(data.astronaut()[:64, :64])
+    img = rescale_to_float(data.astronaut()[:64, :64])
 
     mask = np.zeros(img.shape[:2], dtype=bool)
     mask[8:16, :16] = 1
@@ -196,5 +196,5 @@ def test_inpaint_nrmse(dtype, order, channel_axis, split_into_regions):
     assert image_result.dtype == float_dtype
 
     nrmse_defect = normalized_root_mse(image_orig, image_defect)
-    nrmse_result = normalized_root_mse(img_as_float(image_orig), image_result)
+    nrmse_result = normalized_root_mse(rescale_to_float(image_orig), image_result)
     assert nrmse_result < 0.2 * nrmse_defect

--- a/skimage/restoration/tests/test_inpaint.py
+++ b/skimage/restoration/tests/test_inpaint.py
@@ -196,7 +196,5 @@ def test_inpaint_nrmse(dtype, order, channel_axis, split_into_regions):
     assert image_result.dtype == float_dtype
 
     nrmse_defect = normalized_root_mse(image_orig, image_defect)
-    nrmse_result = normalized_root_mse(
-        rescale_to_float(image_orig), image_result
-    )
+    nrmse_result = normalized_root_mse(image_orig, image_result)
     assert nrmse_result < 0.2 * nrmse_defect

--- a/skimage/restoration/tests/test_j_invariant.py
+++ b/skimage/restoration/tests/test_j_invariant.py
@@ -10,11 +10,11 @@ from skimage.metrics import mean_squared_error as mse
 from skimage.restoration import (calibrate_denoiser,
                                  denoise_wavelet)
 from skimage.restoration.j_invariant import _invariant_denoise
-from skimage.util import img_as_float, random_noise
+from skimage.util import rescale_to_float, random_noise
 
-test_img = img_as_float(camera())
-test_img_color = img_as_float(chelsea())
-test_img_3d = img_as_float(binary_blobs(64, n_dim=3)) / 2
+test_img = rescale_to_float(camera())
+test_img_color = rescale_to_float(chelsea())
+test_img_3d = rescale_to_float(binary_blobs(64, n_dim=3)) / 2
 noisy_img = random_noise(test_img, mode='gaussian', var=0.01)
 noisy_img_color = random_noise(test_img_color, mode='gaussian', var=0.01)
 noisy_img_3d = random_noise(test_img_3d, mode='gaussian', var=0.1)

--- a/skimage/restoration/tests/test_restoration.py
+++ b/skimage/restoration/tests/test_restoration.py
@@ -12,7 +12,7 @@ from skimage.color import rgb2gray
 from skimage.data import astronaut, camera
 from skimage.restoration import uft
 
-test_img = util.img_as_float(camera())
+test_img = util.rescale_to_float(camera())
 
 
 def _get_rtol_atol(dtype):
@@ -113,7 +113,7 @@ def test_image_shape():
     point[2, 2] = 1.
     psf = filters.gaussian(point, sigma=1., mode='reflect')
     # image shape: (45, 45), as reported in #1172
-    image = util.img_as_float(camera()[65:165, 215:315])  # just the face
+    image = util.rescale_to_float(camera()[65:165, 215:315])  # just the face
     image_conv = ndi.convolve(image, psf)
     deconv_sup = restoration.wiener(image_conv, psf, 1)
     deconv_un = restoration.unsupervised_wiener(image_conv, psf)[0]

--- a/skimage/segmentation/_felzenszwalb_cy.pyx
+++ b/skimage/segmentation/_felzenszwalb_cy.pyx
@@ -9,7 +9,7 @@ cimport numpy as cnp
 from .._shared.filters import gaussian
 from .._shared.utils import warn
 from ..measure._ccomp cimport find_root, join_trees
-from ..util import img_as_float64
+from ..util import rescale_to_float64
 
 cnp.import_array()
 
@@ -50,7 +50,7 @@ def _felzenszwalb_cython(image, double scale=1, sigma=0.8,
             "which may not be intended." % str(image.shape[2])),
             stacklevel=3)
 
-    image = img_as_float64(image)
+    image = rescale_to_float64(image)
 
     # rescale scale to behave like in reference implementation
     scale = float(scale) / 255.

--- a/skimage/segmentation/_quickshift.py
+++ b/skimage/segmentation/_quickshift.py
@@ -3,7 +3,6 @@ import numpy as np
 from .._shared.filters import gaussian
 from .._shared.utils import _supported_float_type
 from ..color import rgb2lab
-from ..util import rescale_to_float
 from ._quickshift_cy import _quickshift_cython
 
 
@@ -60,7 +59,7 @@ def quickshift(image, ratio=1.0, kernel_size=5, max_dist=10,
            European Conference on Computer Vision, 2008
     """
 
-    image = rescale_to_float(np.atleast_3d(image))
+    image = np.atleast_3d(image)
     float_dtype = _supported_float_type(image.dtype)
     image = image.astype(float_dtype, copy=False)
 

--- a/skimage/segmentation/_quickshift.py
+++ b/skimage/segmentation/_quickshift.py
@@ -3,7 +3,7 @@ import numpy as np
 from .._shared.filters import gaussian
 from .._shared.utils import _supported_float_type
 from ..color import rgb2lab
-from ..util import img_as_float
+from ..util import rescale_to_float
 from ._quickshift_cy import _quickshift_cython
 
 
@@ -60,7 +60,7 @@ def quickshift(image, ratio=1.0, kernel_size=5, max_dist=10,
            European Conference on Computer Vision, 2008
     """
 
-    image = img_as_float(np.atleast_3d(image))
+    image = rescale_to_float(np.atleast_3d(image))
     float_dtype = _supported_float_type(image.dtype)
     image = image.astype(float_dtype, copy=False)
 

--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -85,7 +85,7 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
     >>> img = np.zeros((100, 100))
     >>> rr, cc = circle_perimeter(35, 45, 25)
     >>> img[rr, cc] = 1
-    >>> img = gaussian(img, 2, preserve_range=False)
+    >>> img = gaussian(img, 2)
 
     Initialize spline:
 
@@ -97,7 +97,7 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
     >>> snake = active_contour(img, init, w_edge=0, w_line=1, coordinates='rc')  # doctest: +SKIP
     >>> dist = np.sqrt((45-snake[:, 0])**2 + (35-snake[:, 1])**2)  # doctest: +SKIP
     >>> int(np.mean(dist))  # doctest: +SKIP
-    25
+    26
 
     """
     if coordinates != 'rc':
@@ -113,9 +113,8 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
         raise ValueError("Invalid boundary condition.\n" +
                          "Should be one of: "+", ".join(valid_bcs)+'.')
 
-    img = rescale_to_float(image)
     float_dtype = _supported_float_type(image.dtype)
-    img = img.astype(float_dtype, copy=False)
+    img = image.astype(float_dtype, copy=False)
 
     RGB = img.ndim == 3
 

--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy.interpolate import RectBivariateSpline
 
 from .._shared.utils import _supported_float_type, deprecate_kwarg
-from ..util import img_as_float
+from ..util import rescale_to_float
 from ..filters import sobel
 
 
@@ -113,7 +113,7 @@ def active_contour(image, snake, alpha=0.01, beta=0.1,
         raise ValueError("Invalid boundary condition.\n" +
                          "Should be one of: "+", ".join(valid_bcs)+'.')
 
-    img = img_as_float(image)
+    img = rescale_to_float(image)
     float_dtype = _supported_float_type(image.dtype)
     img = img.astype(float_dtype, copy=False)
 

--- a/skimage/segmentation/boundaries.py
+++ b/skimage/segmentation/boundaries.py
@@ -4,7 +4,7 @@ from scipy import ndimage as ndi
 
 from .._shared.utils import _supported_float_type
 from ..morphology import dilation, erosion, square
-from ..util import img_as_float, view_as_windows
+from ..util import rescale_to_float, view_as_windows
 from ..color import gray2rgb
 
 
@@ -220,7 +220,7 @@ def mark_boundaries(image, label_img, color=(1, 1, 0),
     find_boundaries
     """
     float_dtype = _supported_float_type(image.dtype)
-    marked = img_as_float(image, force_copy=True)
+    marked = rescale_to_float(image, force_copy=True)
     marked = marked.astype(float_dtype, copy=False)
     if marked.ndim == 2:
         marked = gray2rgb(marked)

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -40,7 +40,7 @@ try:
 except ImportError:
     amg_loaded = False
 
-from ..util import img_as_float
+from ..util import rescale_to_float
 
 from scipy.sparse.linalg import cg, spsolve
 
@@ -456,14 +456,14 @@ def random_walker(data, labels, beta=130, mode='cg_j', tol=1.e-3, copy=True,
                              'dimension 2 or 3.')
         if data.shape != labels.shape:
             raise ValueError('Incompatible data and labels shapes.')
-        data = np.atleast_3d(img_as_float(data))[..., np.newaxis]
+        data = np.atleast_3d(rescale_to_float(data))[..., np.newaxis]
     else:
         if data.ndim not in (3, 4):
             raise ValueError('For multichannel input, data must have 3 or 4 '
                              'dimensions.')
         if data.shape[:-1] != labels.shape:
             raise ValueError('Incompatible data and labels shapes.')
-        data = img_as_float(data)
+        data = rescale_to_float(data)
         if data.ndim == 3:  # 2D multispectral, needs singleton in 3rd axis
             data = data[:, :, np.newaxis, :]
 

--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -10,7 +10,7 @@ from scipy.spatial.distance import pdist, squareform
 from .._shared import utils
 from .._shared.filters import gaussian
 from ..color import rgb2lab
-from ..util import rescale_to_float, regular_grid
+from ..util import regular_grid
 from ._slic import _enforce_label_connectivity_cython, _slic_cython
 
 
@@ -248,7 +248,6 @@ def slic(image, n_segments=100, compactness=10., max_num_iter=10, sigma=0,
 
     """
 
-    image = rescale_to_float(image)
     float_dtype = utils._supported_float_type(image.dtype)
     # copy=True so subsequent in-place operations do not modify the
     # function input

--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -10,7 +10,7 @@ from scipy.spatial.distance import pdist, squareform
 from .._shared import utils
 from .._shared.filters import gaussian
 from ..color import rgb2lab
-from ..util import img_as_float, regular_grid
+from ..util import rescale_to_float, regular_grid
 from ._slic import _enforce_label_connectivity_cython, _slic_cython
 
 
@@ -248,7 +248,7 @@ def slic(image, n_segments=100, compactness=10., max_num_iter=10, sigma=0,
 
     """
 
-    image = img_as_float(image)
+    image = rescale_to_float(image)
     float_dtype = utils._supported_float_type(image.dtype)
     # copy=True so subsequent in-place operations do not modify the
     # function input

--- a/skimage/segmentation/tests/test_active_contour_model.py
+++ b/skimage/segmentation/tests/test_active_contour_model.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_equal, assert_allclose
 
-from skimage import data
+from skimage import data, rescale_as_float
 from skimage._shared._warnings import expected_warnings
 from skimage._shared.utils import _supported_float_type
 from skimage.color import rgb2gray
@@ -12,13 +12,13 @@ from skimage.segmentation import active_contour
 
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_periodic_reference(dtype):
-    img = data.astronaut()
+    img = rescale_as_float(data.astronaut())
     img = rgb2gray(img)
     s = np.linspace(0, 2*np.pi, 400)
     r = 100 + 100*np.sin(s)
     c = 220 + 100*np.cos(s)
     init = np.array([r, c]).T
-    img_smooth = gaussian(img, 3, preserve_range=False).astype(dtype, copy=False)
+    img_smooth = gaussian(img, 3).astype(dtype, copy=False)
     snake = active_contour(img_smooth, init, alpha=0.015, beta=10,
                            w_line=0, w_edge=1, gamma=0.001)
     assert snake.dtype == _supported_float_type(dtype)
@@ -30,11 +30,11 @@ def test_periodic_reference(dtype):
 
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
 def test_fixed_reference(dtype):
-    img = data.text()
+    img = rescale_as_float(data.text())
     r = np.linspace(136, 50, 100)
     c = np.linspace(5, 424, 100)
     init = np.array([r, c]).T
-    image_smooth = gaussian(img, 1, preserve_range=False).astype(dtype, copy=False)
+    image_smooth = gaussian(img, 1).astype(dtype, copy=False)
     snake = active_contour(image_smooth, init, boundary_condition='fixed',
                            alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1)
     assert snake.dtype == _supported_float_type(dtype)
@@ -46,11 +46,11 @@ def test_fixed_reference(dtype):
 
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
 def test_free_reference(dtype):
-    img = data.text()
+    img = rescale_as_float(data.text())
     r = np.linspace(70, 40, 100)
     c = np.linspace(5, 424, 100)
     init = np.array([r, c]).T
-    img_smooth = gaussian(img, 3, preserve_range=False).astype(dtype, copy=False)
+    img_smooth = gaussian(img, 3).astype(dtype, copy=False)
     snake = active_contour(img_smooth, init, boundary_condition='free',
                            alpha=0.1, beta=1.0, w_line=-5, w_edge=0, gamma=0.1)
     assert snake.dtype == _supported_float_type(dtype)
@@ -62,7 +62,7 @@ def test_free_reference(dtype):
 
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
 def test_RGB(dtype):
-    img = gaussian(data.text(), 1, preserve_range=False)
+    img = gaussian(rescale_as_float(data.text()), 1)
     imgR = np.zeros((img.shape[0], img.shape[1], 3), dtype=dtype)
     imgG = np.zeros((img.shape[0], img.shape[1], 3), dtype=dtype)
     imgRGB = np.zeros((img.shape[0], img.shape[1], 3), dtype=dtype)

--- a/skimage/segmentation/tests/test_active_contour_model.py
+++ b/skimage/segmentation/tests/test_active_contour_model.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_equal, assert_allclose
 
-from skimage import data, rescale_as_float
+from skimage import data, rescale_to_float
 from skimage._shared._warnings import expected_warnings
 from skimage._shared.utils import _supported_float_type
 from skimage.color import rgb2gray
@@ -12,7 +12,7 @@ from skimage.segmentation import active_contour
 
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_periodic_reference(dtype):
-    img = rescale_as_float(data.astronaut())
+    img = rescale_to_float(data.astronaut())
     img = rgb2gray(img)
     s = np.linspace(0, 2*np.pi, 400)
     r = 100 + 100*np.sin(s)
@@ -30,7 +30,7 @@ def test_periodic_reference(dtype):
 
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
 def test_fixed_reference(dtype):
-    img = rescale_as_float(data.text())
+    img = rescale_to_float(data.text())
     r = np.linspace(136, 50, 100)
     c = np.linspace(5, 424, 100)
     init = np.array([r, c]).T
@@ -46,7 +46,7 @@ def test_fixed_reference(dtype):
 
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
 def test_free_reference(dtype):
-    img = rescale_as_float(data.text())
+    img = rescale_to_float(data.text())
     r = np.linspace(70, 40, 100)
     c = np.linspace(5, 424, 100)
     init = np.array([r, c]).T
@@ -62,7 +62,7 @@ def test_free_reference(dtype):
 
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
 def test_RGB(dtype):
-    img = gaussian(rescale_as_float(data.text()), 1)
+    img = gaussian(rescale_to_float(data.text()), 1)
     imgR = np.zeros((img.shape[0], img.shape[1], 3), dtype=dtype)
     imgG = np.zeros((img.shape[0], img.shape[1], 3), dtype=dtype)
     imgRGB = np.zeros((img.shape[0], img.shape[1], 3), dtype=dtype)

--- a/skimage/segmentation/tests/test_slic.py
+++ b/skimage/segmentation/tests/test_slic.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_equal
 
-from skimage import data, filters, img_as_float
+from skimage import data, filters, rescale_to_float
 from skimage._shared.testing import test_parallel, expected_warnings
 from skimage.segmentation import slic
 
@@ -113,7 +113,7 @@ def test_slic_consistency_across_image_magnitude():
     # give the same segmentation result
     img_uint8 = data.cat()[:256, :128]
     img_uint16 = 256 * img_uint8.astype(np.uint16)
-    img_float32 = img_as_float(img_uint8)
+    img_float32 = rescale_to_float(img_uint8)
     img_float32_norm = img_float32 / img_float32.max()
 
     seg1 = slic(img_uint8)

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -9,7 +9,7 @@ from ._warps_cy import _warp_fast
 from ..measure import block_reduce
 
 from .._shared.utils import (get_bound_method_class, safe_as_int, warn,
-                             convert_to_float, _to_ndimage_mode,
+                             _supported_float_type, _to_ndimage_mode,
                              _validate_interpolation_order,
                              channel_as_last_axis,
                              deprecate_multichannel_kwarg)
@@ -70,7 +70,7 @@ def _preprocess_resize_output_shape(image, output_shape):
 
 
 def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
-           preserve_range=False, anti_aliasing=None, anti_aliasing_sigma=None):
+           anti_aliasing=None, anti_aliasing_sigma=None):
     """Resize image to match a certain size.
 
     Performs interpolation to up-size or down-size N-dimensional images. Note
@@ -109,10 +109,6 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
         Whether to clip the output to the range of values of the input image.
         This is enabled by default, since higher order interpolation may
         produce values outside the given input range.
-    preserve_range : bool, optional
-        Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `rescale_to_float`.
-        Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
     anti_aliasing : bool, optional
         Whether to apply a Gaussian filter to smooth the image prior
         to downsampling. It is crucial to filter when downsampling
@@ -159,7 +155,8 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
     factors = np.divide(input_shape, output_shape)
     order = _validate_interpolation_order(input_type, order)
     if order > 0:
-        image = convert_to_float(image, preserve_range)
+        float_dtype = _supported_float_type(image.dtype)
+        image = image.astype(float_dtype, copy=False)
 
     # Save input value range for clip
     img_bounds = np.array([image.min(), image.max()]) if clip else None
@@ -217,8 +214,7 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
 
         # clip outside of warp to clip w.r.t input values, not filtered values.
         out = warp(image, tform, output_shape=output_shape, order=order,
-                   mode=mode, cval=cval, clip=False,
-                   preserve_range=preserve_range)
+                   mode=mode, cval=cval, clip=False)
 
     else:  # n-dimensional interpolation
 
@@ -238,11 +234,10 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
 
 
 @channel_as_last_axis()
-@deprecate_multichannel_kwarg(multichannel_position=7)
+@deprecate_multichannel_kwarg(multichannel_position=6)
 def rescale(image, scale, order=None, mode='reflect', cval=0, clip=True,
-            preserve_range=False, multichannel=False,
-            anti_aliasing=None, anti_aliasing_sigma=None, *,
-            channel_axis=None):
+            multichannel=False, anti_aliasing=None,
+            anti_aliasing_sigma=None, *, channel_axis=None):
     """Scale image by a certain factor.
 
     Performs interpolation to up-scale or down-scale N-dimensional images.
@@ -279,11 +274,6 @@ def rescale(image, scale, order=None, mode='reflect', cval=0, clip=True,
         Whether to clip the output to the range of values of the input image.
         This is enabled by default, since higher order interpolation may
         produce values outside the given input range.
-    preserve_range : bool, optional
-        Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `rescale_to_float`.
-        Also see
-        https://scikit-image.org/docs/dev/user_guide/data_types.html
     multichannel : bool, optional
         Whether the last axis of the image is to be interpreted as multiple
         channels or another spatial dimension. This argument is deprecated:
@@ -339,13 +329,12 @@ def rescale(image, scale, order=None, mode='reflect', cval=0, clip=True,
         output_shape[-1] = orig_shape[-1]
 
     return resize(image, output_shape, order=order, mode=mode, cval=cval,
-                  clip=clip, preserve_range=preserve_range,
-                  anti_aliasing=anti_aliasing,
+                  clip=clip, anti_aliasing=anti_aliasing,
                   anti_aliasing_sigma=anti_aliasing_sigma)
 
 
 def rotate(image, angle, resize=False, center=None, order=None,
-           mode='constant', cval=0, clip=True, preserve_range=False):
+           mode='constant', cval=0, clip=True):
     """Rotate image by a certain angle around its center.
 
     Parameters
@@ -385,11 +374,6 @@ def rotate(image, angle, resize=False, center=None, order=None,
         Whether to clip the output to the range of values of the input image.
         This is enabled by default, since higher order interpolation may
         produce values outside the given input range.
-    preserve_range : bool, optional
-        Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `rescale_to_float`.
-        Also see
-        https://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Notes
     -----
@@ -455,7 +439,7 @@ def rotate(image, angle, resize=False, center=None, order=None,
     tform.params[2] = (0, 0, 1)
 
     return warp(image, tform, output_shape=output_shape, order=order,
-                mode=mode, cval=cval, clip=clip, preserve_range=preserve_range)
+                mode=mode, cval=cval, clip=clip)
 
 
 def downscale_local_mean(image, factors, cval=0, clip=True):
@@ -525,8 +509,7 @@ def _swirl_mapping(xy, center, rotation, strength, radius):
 
 
 def swirl(image, center=None, strength=1, radius=100, rotation=0,
-          output_shape=None, order=None, mode='reflect', cval=0, clip=True,
-          preserve_range=False):
+          output_shape=None, order=None, mode='reflect', cval=0, clip=True):
     """Perform a swirl transformation.
 
     Parameters
@@ -568,11 +551,6 @@ def swirl(image, center=None, strength=1, radius=100, rotation=0,
         Whether to clip the output to the range of values of the input image.
         This is enabled by default, since higher order interpolation may
         produce values outside the given input range.
-    preserve_range : bool, optional
-        Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `rescale_to_float`.
-        Also see
-        https://scikit-image.org/docs/dev/user_guide/data_types.html
 
     """
     if center is None:
@@ -585,7 +563,7 @@ def swirl(image, center=None, strength=1, radius=100, rotation=0,
 
     return warp(image, _swirl_mapping, map_args=warp_args,
                 output_shape=output_shape, order=order, mode=mode, cval=cval,
-                clip=clip, preserve_range=preserve_range)
+                clip=clip)
 
 
 def _stackcopy(a, b):
@@ -733,7 +711,7 @@ def _clip_warp_output(input_image, output_image, mode, cval, clip):
 
 
 def warp(image, inverse_map, map_args={}, output_shape=None, order=None,
-         mode='constant', cval=0., clip=True, preserve_range=False):
+         mode='constant', cval=0., clip=True):
     """Warp an image according to a given coordinate transformation.
 
     Parameters
@@ -798,11 +776,6 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=None,
         Whether to clip the output to the range of values of the input image.
         This is enabled by default, since higher order interpolation may
         produce values outside the given input range.
-    preserve_range : bool, optional
-        Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `rescale_to_float`.
-        Also see
-        https://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Returns
     -------
@@ -882,9 +855,8 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=None,
     order = _validate_interpolation_order(image.dtype, order)
 
     if order > 0:
-        image = convert_to_float(image, preserve_range)
-        if image.dtype == np.float16:
-            image = image.astype(np.float32)
+        float_dtype = _supported_float_type(image.dtype)
+        image = image.astype(float_dtype, copy=False)
 
     input_shape = np.array(image.shape)
 
@@ -1205,7 +1177,7 @@ def _local_mean_weights(old_size, new_size, grid_mode, dtype):
 
 
 def resize_local_mean(image, output_shape, grid_mode=True,
-                      preserve_range=False, *, channel_axis=None):
+                      *, channel_axis=None):
     """Resize an array with the local mean / bilinear scaling.
 
     Parameters
@@ -1236,11 +1208,6 @@ def resize_local_mean(image, output_shape, grid_mode=True,
 
         The starting point of the arrow in the diagram above corresponds to
         coordinate location 0 in each mode.
-    preserve_range : bool, optional
-        Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `rescale_to_float`.
-        Also see
-        https://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Returns
     -------
@@ -1305,8 +1272,8 @@ def resize_local_mean(image, output_shape, grid_mode=True,
     else:
         resized, output_shape = _preprocess_resize_output_shape(image,
                                                                 output_shape)
-    resized = convert_to_float(resized, preserve_range)
-    dtype = resized.dtype
+    dtype = _supported_float_type(resized.dtype)
+    resized = resized.astype(dtype, copy=False)
 
     for axis, (old_size, new_size) in enumerate(zip(image.shape,
                                                     output_shape)):

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -111,7 +111,7 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
         produce values outside the given input range.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `img_as_float`.
+        image is converted according to the conventions of `rescale_to_float`.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
     anti_aliasing : bool, optional
         Whether to apply a Gaussian filter to smooth the image prior
@@ -281,7 +281,7 @@ def rescale(image, scale, order=None, mode='reflect', cval=0, clip=True,
         produce values outside the given input range.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `img_as_float`.
+        image is converted according to the conventions of `rescale_to_float`.
         Also see
         https://scikit-image.org/docs/dev/user_guide/data_types.html
     multichannel : bool, optional
@@ -387,7 +387,7 @@ def rotate(image, angle, resize=False, center=None, order=None,
         produce values outside the given input range.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `img_as_float`.
+        image is converted according to the conventions of `rescale_to_float`.
         Also see
         https://scikit-image.org/docs/dev/user_guide/data_types.html
 
@@ -570,7 +570,7 @@ def swirl(image, center=None, strength=1, radius=100, rotation=0,
         produce values outside the given input range.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `img_as_float`.
+        image is converted according to the conventions of `rescale_to_float`.
         Also see
         https://scikit-image.org/docs/dev/user_guide/data_types.html
 
@@ -800,7 +800,7 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=None,
         produce values outside the given input range.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `img_as_float`.
+        image is converted according to the conventions of `rescale_to_float`.
         Also see
         https://scikit-image.org/docs/dev/user_guide/data_types.html
 
@@ -1238,7 +1238,7 @@ def resize_local_mean(image, output_shape, grid_mode=True,
         coordinate location 0 in each mode.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `img_as_float`.
+        image is converted according to the conventions of `rescale_to_float`.
         Also see
         https://scikit-image.org/docs/dev/user_guide/data_types.html
 

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -59,7 +59,7 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
         specify `channel_axis` instead.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `img_as_float`.
+        image is converted according to the conventions of `rescale_to_float`.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
     channel_axis : int or None, optional
         If None, the image is assumed to be a grayscale (single channel) image.
@@ -132,7 +132,7 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
         specify `channel_axis` instead.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `img_as_float`.
+        image is converted according to the conventions of `rescale_to_float`.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
     channel_axis : int or None, optional
         If None, the image is assumed to be a grayscale (single channel) image.
@@ -215,7 +215,7 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
         specify `channel_axis` instead.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `img_as_float`.
+        image is converted according to the conventions of `rescale_to_float`.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
     channel_axis : int or None, optional
         If None, the image is assumed to be a grayscale (single channel) image.
@@ -309,7 +309,7 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
         specify `channel_axis` instead.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `img_as_float`.
+        image is converted according to the conventions of `rescale_to_float`.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
     channel_axis : int or None, optional
         If None, the image is assumed to be a grayscale (single channel) image.

--- a/skimage/transform/pyramids.py
+++ b/skimage/transform/pyramids.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from .._shared import utils
 from .._shared.filters import gaussian
-from .._shared.utils import convert_to_float
+from .._shared.utils import _supported_float_type
 from ..transform import resize
 
 
@@ -32,7 +32,7 @@ def _check_factor(factor):
 @utils.deprecate_multichannel_kwarg(multichannel_position=6)
 def pyramid_reduce(image, downscale=2, sigma=None, order=1,
                    mode='reflect', cval=0, multichannel=False,
-                   preserve_range=False, *, channel_axis=None):
+                   *, channel_axis=None):
     """Smooth and then downsample image.
 
     Parameters
@@ -57,10 +57,6 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
         Whether the last axis of the image is to be interpreted as multiple
         channels or another spatial dimension. This argument is deprecated:
         specify `channel_axis` instead.
-    preserve_range : bool, optional
-        Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `rescale_to_float`.
-        Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
     channel_axis : int or None, optional
         If None, the image is assumed to be a grayscale (single channel) image.
         Otherwise, this parameter indicates which axis of the array corresponds
@@ -81,7 +77,8 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
     """
     _check_factor(downscale)
 
-    image = convert_to_float(image, preserve_range)
+    float_dtype = _supported_float_type(image.dtype)
+    image = image.astype(float_dtype, copy=False)
     if channel_axis is not None:
         channel_axis = channel_axis % image.ndim
         out_shape = tuple(
@@ -105,7 +102,7 @@ def pyramid_reduce(image, downscale=2, sigma=None, order=1,
 @utils.deprecate_multichannel_kwarg(multichannel_position=6)
 def pyramid_expand(image, upscale=2, sigma=None, order=1,
                    mode='reflect', cval=0, multichannel=False,
-                   preserve_range=False, *, channel_axis=None):
+                   *, channel_axis=None):
     """Upsample and then smooth image.
 
     Parameters
@@ -130,10 +127,6 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
         Whether the last axis of the image is to be interpreted as multiple
         channels or another spatial dimension. This argument is deprecated:
         specify `channel_axis` instead.
-    preserve_range : bool, optional
-        Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `rescale_to_float`.
-        Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
     channel_axis : int or None, optional
         If None, the image is assumed to be a grayscale (single channel) image.
         Otherwise, this parameter indicates which axis of the array corresponds
@@ -153,7 +146,8 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
 
     """
     _check_factor(upscale)
-    image = convert_to_float(image, preserve_range)
+    float_dtype = _supported_float_type(image.dtype)
+    image = image.astype(float_dtype, copy=False)
     if channel_axis is not None:
         channel_axis = channel_axis % image.ndim
         out_shape = tuple(
@@ -177,7 +171,7 @@ def pyramid_expand(image, upscale=2, sigma=None, order=1,
 @utils.deprecate_multichannel_kwarg(multichannel_position=7)
 def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
                      mode='reflect', cval=0, multichannel=False,
-                     preserve_range=False, *, channel_axis=None):
+                     *, channel_axis=None):
     """Yield images of the Gaussian pyramid formed by the input image.
 
     Recursively applies the `pyramid_reduce` function to the image, and yields
@@ -213,10 +207,6 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
         Whether the last axis of the image is to be interpreted as multiple
         channels or another spatial dimension. This argument is deprecated:
         specify `channel_axis` instead.
-    preserve_range : bool, optional
-        Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `rescale_to_float`.
-        Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
     channel_axis : int or None, optional
         If None, the image is assumed to be a grayscale (single channel) image.
         Otherwise, this parameter indicates which axis of the array corresponds
@@ -238,7 +228,8 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
     _check_factor(downscale)
 
     # cast to float for consistent data type in pyramid
-    image = convert_to_float(image, preserve_range)
+    float_dtype = _supported_float_type(image.dtype)
+    image = image.astype(float_dtype, copy=False)
 
     layer = 0
     current_shape = image.shape
@@ -268,7 +259,7 @@ def pyramid_gaussian(image, max_layer=-1, downscale=2, sigma=None, order=1,
 @utils.deprecate_multichannel_kwarg(multichannel_position=7)
 def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
                       mode='reflect', cval=0, multichannel=False,
-                      preserve_range=False, *, channel_axis=None):
+                      *, channel_axis=None):
     """Yield images of the laplacian pyramid formed by the input image.
 
     Each layer contains the difference between the downsampled and the
@@ -307,10 +298,6 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
         Whether the last axis of the image is to be interpreted as multiple
         channels or another spatial dimension. This argument is deprecated:
         specify `channel_axis` instead.
-    preserve_range : bool, optional
-        Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `rescale_to_float`.
-        Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
     channel_axis : int or None, optional
         If None, the image is assumed to be a grayscale (single channel) image.
         Otherwise, this parameter indicates which axis of the array corresponds
@@ -333,7 +320,8 @@ def pyramid_laplacian(image, max_layer=-1, downscale=2, sigma=None, order=1,
     _check_factor(downscale)
 
     # cast to float for consistent data type in pyramid
-    image = convert_to_float(image, preserve_range)
+    float_dtype = _supported_float_type(image.dtype)
+    image = image.astype(float_dtype, copy=False)
 
     if sigma is None:
         # automatically determine sigma which covers > 99% of distribution

--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -32,7 +32,7 @@ def radon(image, theta=None, circle=True, *, preserve_range=False):
         equal to ``min(image.shape)``.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `img_as_float`.
+        image is converted according to the conventions of `rescale_to_float`.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Returns
@@ -207,7 +207,7 @@ def iradon(radon_image, theta=None, output_size=None,
         ``radon`` called with ``circle=True``.
     preserve_range : bool, optional
         Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `img_as_float`.
+        image is converted according to the conventions of `rescale_to_float`.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Returns

--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -13,7 +13,7 @@ from functools import partial
 __all__ = ['radon', 'order_angles_golden_ratio', 'iradon', 'iradon_sart']
 
 
-def radon(image, theta=None, circle=True, *, preserve_range=False):
+def radon(image, theta=None, circle=True):
     """
     Calculates the radon transform of an image given specified
     projection angles.
@@ -30,10 +30,6 @@ def radon(image, theta=None, circle=True, *, preserve_range=False):
         Assume image is zero outside the inscribed circle, making the
         width of each projection (the first dimension of the sinogram)
         equal to ``min(image.shape)``.
-    preserve_range : bool, optional
-        Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `rescale_to_float`.
-        Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Returns
     -------
@@ -61,7 +57,7 @@ def radon(image, theta=None, circle=True, *, preserve_range=False):
     if theta is None:
         theta = np.arange(180)
 
-    image = convert_to_float(image, preserve_range)
+    image = convert_to_float(image, True)
 
     if circle:
         shape_min = min(image.shape)
@@ -174,8 +170,7 @@ def _get_fourier_filter(size, filter_name):
 
 
 def iradon(radon_image, theta=None, output_size=None,
-           filter_name="ramp", interpolation="linear", circle=True,
-           preserve_range=True):
+           filter_name="ramp", interpolation="linear", circle=True):
     """Inverse radon transform.
 
     Reconstruct an image from the radon transform, using the filtered
@@ -205,10 +200,6 @@ def iradon(radon_image, theta=None, output_size=None,
         Assume the reconstructed image is zero outside the inscribed circle.
         Also changes the default output_size to match the behaviour of
         ``radon`` called with ``circle=True``.
-    preserve_range : bool, optional
-        Whether to keep the original range of values. Otherwise, the input
-        image is converted according to the conventions of `rescale_to_float`.
-        Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
 
     Returns
     -------
@@ -255,7 +246,7 @@ def iradon(radon_image, theta=None, output_size=None,
     if filter_name not in filter_types:
         raise ValueError("Unknown filter: %s" % filter_name)
 
-    radon_image = convert_to_float(radon_image, preserve_range)
+    radon_image = convert_to_float(radon_image, True)
     dtype = radon_image.dtype
 
     img_shape = radon_image.shape[0]

--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -42,19 +42,14 @@ def test_pyramid_reduce_gray():
     out1 = pyramids.pyramid_reduce(image_gray, downscale=2,
                                    channel_axis=None)
     assert_array_equal(out1.shape, (rows / 2, cols / 2))
-    assert_almost_equal(out1.ptp(), 1.0, decimal=2)
-    out2 = pyramids.pyramid_reduce(image_gray, downscale=2,
-                                   channel_axis=None, preserve_range=True)
-    assert_almost_equal(out2.ptp() / image_gray.ptp(), 1.0, decimal=2)
+    assert_almost_equal(out1.ptp() / image_gray.ptp(), 1.0, decimal=2)
 
 
 def test_pyramid_reduce_gray_defaults():
     rows, cols = image_gray.shape
     out1 = pyramids.pyramid_reduce(image_gray)
     assert_array_equal(out1.shape, (rows / 2, cols / 2))
-    assert_almost_equal(out1.ptp(), 1.0, decimal=2)
-    out2 = pyramids.pyramid_reduce(image_gray, preserve_range=True)
-    assert_almost_equal(out2.ptp() / image_gray.ptp(), 1.0, decimal=2)
+    assert_almost_equal(out1.ptp() / image_gray.ptp(), 1.0, decimal=2)
 
 
 def test_pyramid_reduce_nd():

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -64,14 +64,13 @@ def test_iradon_bias_circular_phantom():
     assert roi_err < tol
 
 
-def check_radon_center(shape, circle, dtype, preserve_range):
+def check_radon_center(shape, circle, dtype):
     # Create a test image with only a single non-zero pixel at the origin
     image = np.zeros(shape, dtype=dtype)
     image[(shape[0] // 2, shape[1] // 2)] = 1.
     # Calculate the sinogram
     theta = np.linspace(0., 180., max(shape), endpoint=False)
-    sinogram = radon(image, theta=theta, circle=circle,
-                     preserve_range=preserve_range)
+    sinogram = radon(image, theta=theta, circle=circle)
     assert sinogram.dtype == _supported_float_type(sinogram.dtype)
     # The sinogram should be a straight, horizontal line
     sinogram_max = np.argmax(sinogram, axis=0)
@@ -84,17 +83,15 @@ def check_radon_center(shape, circle, dtype, preserve_range):
 @pytest.mark.parametrize(
     "dtype", [np.float64, np.float32, np.float16, np.uint8, bool]
 )
-@pytest.mark.parametrize("preserve_range", [False, True])
-def test_radon_center(shape, circle, dtype, preserve_range):
-    check_radon_center(shape, circle, dtype, preserve_range)
+def test_radon_center(shape, circle, dtype):
+    check_radon_center(shape, circle, dtype)
 
 
 @pytest.mark.parametrize("shape", [(32, 16), (33, 17)])
 @pytest.mark.parametrize("circle", [False])
 @pytest.mark.parametrize("dtype", [np.float64, np.float32, np.uint8, bool])
-@pytest.mark.parametrize("preserve_range", [False, True])
-def test_radon_center_rectangular(shape, circle, dtype, preserve_range):
-    check_radon_center(shape, circle, dtype, preserve_range)
+def test_radon_center_rectangular(shape, circle, dtype):
+    check_radon_center(shape, circle, dtype)
 
 
 def check_iradon_center(size, theta, circle):
@@ -445,19 +442,15 @@ def test_iradon_sart():
         assert delta < 0.022 * error_factor
 
 
-@pytest.mark.parametrize("preserve_range", [True, False])
-def test_iradon_dtype(preserve_range):
+def test_iradon_dtype():
     sinogram = np.zeros((16, 1), dtype=int)
     sinogram[8, 0] = 1.
     sinogram64 = sinogram.astype('float64')
     sinogram32 = sinogram.astype('float32')
 
-    assert iradon(sinogram, theta=[0],
-                  preserve_range=preserve_range).dtype == 'float64'
-    assert iradon(sinogram64, theta=[0],
-                  preserve_range=preserve_range).dtype == sinogram64.dtype
-    assert iradon(sinogram32, theta=[0],
-                  preserve_range=preserve_range).dtype == sinogram32.dtype
+    assert iradon(sinogram, theta=[0]).dtype == 'float64'
+    assert iradon(sinogram64, theta=[0]).dtype == sinogram64.dtype
+    assert iradon(sinogram32, theta=[0]).dtype == sinogram32.dtype
 
 
 def test_radon_dtype():

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -245,7 +245,7 @@ def test_rescale_multichannel_deprecated_multiscale():
 
     # repeat prior test, but check for positional multichannel _warnings
     with expected_warnings(["Providing the `multichannel` argument"]):
-        scaled = rescale(x, (2, 1), 0, 'constant', 0, True, False, True,
+        scaled = rescale(x, (2, 1), 0, 'constant', 0, True, True,
                          anti_aliasing=False)
     assert scaled.shape == (10, 5, 3)
 
@@ -364,33 +364,22 @@ def test_resize_dtype():
     x_u8 = x.astype(np.uint8)
     x_b = x.astype(bool)
 
-    assert resize(x, (10, 10), preserve_range=False).dtype == x.dtype
-    assert resize(x, (10, 10), preserve_range=True).dtype == x.dtype
-    assert resize(x_u8, (10, 10), preserve_range=False).dtype == np.double
-    assert resize(x_u8, (10, 10), preserve_range=True).dtype == np.double
-    assert resize(x_b, (10, 10), preserve_range=False).dtype == bool
-    assert resize(x_b, (10, 10), preserve_range=True).dtype == bool
-    assert resize(x_f32, (10, 10), preserve_range=False).dtype == x_f32.dtype
-    assert resize(x_f32, (10, 10), preserve_range=True).dtype == x_f32.dtype
+    assert resize(x, (10, 10)).dtype == x.dtype
+    assert resize(x_u8, (10, 10)).dtype == np.double
+    assert resize(x_b, (10, 10)).dtype == bool
+    assert resize(x_f32, (10, 10)).dtype == x_f32.dtype
 
 
 @pytest.mark.parametrize('order', [0, 1])
-@pytest.mark.parametrize('preserve_range', [True, False])
 @pytest.mark.parametrize('anti_aliasing', [True, False])
 @pytest.mark.parametrize('dtype', [np.float64, np.uint8])
-def test_resize_clip(order, preserve_range, anti_aliasing, dtype):
-    # test if clip as expected
-    if dtype == np.uint8 and (preserve_range or order == 0):
-        expected_max = 255
-    else:
-        expected_max = 1.0
+def test_resize_clip(order, anti_aliasing, dtype):
     x = np.ones((5, 5), dtype=dtype)
     if dtype == np.uint8:
         x *= 255
-    resized = resize(x, (3, 3), order=order, preserve_range=preserve_range,
-                     anti_aliasing=anti_aliasing)
+    resized = resize(x, (3, 3), order=order, anti_aliasing=anti_aliasing)
 
-    assert resized.max() == expected_max
+    assert resized.max() == x.max()
 
 
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
@@ -581,19 +570,14 @@ def test_slow_warp_nonint_oshape():
 
 def test_keep_range():
     image = np.linspace(0, 2, 25).reshape(5, 5)
-    out = rescale(image, 2, preserve_range=False, clip=True, order=0,
-                  mode='constant', channel_axis=None, anti_aliasing=False)
+
+    kwargs = dict(clip=True, order=0, mode='constant',
+                  channel_axis=None, anti_aliasing=False)
+    out = rescale(image, 2, **kwargs)
     assert out.min() == 0
     assert out.max() == 2
 
-    out = rescale(image, 2, preserve_range=True, clip=True, order=0,
-                  mode='constant', channel_axis=None, anti_aliasing=False)
-    assert out.min() == 0
-    assert out.max() == 2
-
-    out = rescale(image.astype(np.uint8), 2, preserve_range=False,
-                  mode='constant', channel_axis=None, anti_aliasing=False,
-                  clip=True, order=0)
+    out = rescale(image.astype(np.uint8), 2, **kwargs)
     assert out.min() == 0
     assert out.max() == 2
 
@@ -895,22 +879,10 @@ def test_resize_local_mean_dtype():
     x_u8 = x.astype(np.uint8)
     x_b = x.astype(bool)
 
-    assert resize_local_mean(x, (10, 10),
-                             preserve_range=False).dtype == x.dtype
-    assert resize_local_mean(x, (10, 10),
-                             preserve_range=True).dtype == x.dtype
-    assert resize_local_mean(x_u8, (10, 10),
-                             preserve_range=False).dtype == np.double
-    assert resize_local_mean(x_u8, (10, 10),
-                             preserve_range=True).dtype == np.double
-    assert resize_local_mean(x_b, (10, 10),
-                             preserve_range=False).dtype == np.double
-    assert resize_local_mean(x_b, (10, 10),
-                             preserve_range=True).dtype == np.double
-    assert resize_local_mean(x_f32, (10, 10),
-                             preserve_range=False).dtype == x_f32.dtype
-    assert resize_local_mean(x_f32, (10, 10),
-                             preserve_range=True).dtype == x_f32.dtype
+    assert resize_local_mean(x, (10, 10)).dtype == x.dtype
+    assert resize_local_mean(x_u8, (10, 10)).dtype == np.double
+    assert resize_local_mean(x_b, (10, 10)).dtype == np.double
+    assert resize_local_mean(x_f32, (10, 10)).dtype == x_f32.dtype
 
 
 @pytest.mark.parametrize("_type", [tuple, np.asarray, list])

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -20,7 +20,7 @@ from skimage.transform._warps import (_stackcopy,
 from skimage.transform._geometric import (AffineTransform,
                                           ProjectiveTransform,
                                           SimilarityTransform)
-from skimage.util.dtype import img_as_float, _convert
+from skimage.util.dtype import rescale_to_float, _convert
 
 
 np.random.seed(0)
@@ -395,7 +395,7 @@ def test_resize_clip(order, preserve_range, anti_aliasing, dtype):
 
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_swirl(dtype):
-    image = img_as_float(checkerboard()).astype(dtype, copy=False)
+    image = rescale_to_float(checkerboard()).astype(dtype, copy=False)
     float_dtype = _supported_float_type(dtype)
 
     swirl_params = {'radius': 80, 'rotation': 0, 'order': 2, 'mode': 'reflect'}
@@ -425,7 +425,7 @@ def test_const_cval_out_of_range():
 
 
 def test_warp_identity():
-    img = img_as_float(rgb2gray(astronaut()))
+    img = rescale_to_float(rgb2gray(astronaut()))
     assert len(img.shape) == 2
     assert np.allclose(img, warp(img, AffineTransform(rotation=0)))
     assert not np.allclose(img, warp(img, AffineTransform(rotation=0.1)))

--- a/skimage/util/__init__.py
+++ b/skimage/util/__init__.py
@@ -1,9 +1,9 @@
 import functools
 import warnings
 import numpy as np
-from .dtype import (img_as_float32, img_as_float64, img_as_float,
-                    img_as_int, img_as_uint, img_as_ubyte,
-                    img_as_bool, dtype_limits)
+from .dtype import (rescale_to_int, rescale_to_uint, rescale_to_ubyte,
+                    rescale_to_bool, dtype_limits,
+                    rescale_to_float, rescale_to_float32, rescale_to_float64)
 from .shape import view_as_blocks, view_as_windows
 from .noise import random_noise
 from .apply_parallel import apply_parallel
@@ -18,13 +18,13 @@ from ._map_array import map_array
 from ._label import label_points
 
 
-__all__ = ['img_as_float32',
-           'img_as_float64',
-           'img_as_float',
-           'img_as_int',
-           'img_as_uint',
-           'img_as_ubyte',
-           'img_as_bool',
+__all__ = ['rescale_to_int',
+           'rescale_to_uint',
+           'rescale_to_ubyte',
+           'rescale_to_bool',
+           'rescale_to_float',
+           'rescale_to_float32',
+           'rescale_to_float64',
            'dtype_limits',
            'view_as_blocks',
            'view_as_windows',

--- a/skimage/util/compare.py
+++ b/skimage/util/compare.py
@@ -1,6 +1,8 @@
-import numpy as np
-from ..util import rescale_to_float
 from itertools import product
+
+import numpy as np
+
+from .._shared.utils import _supported_float_type
 
 
 def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
@@ -36,8 +38,9 @@ def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
     if image1.shape != image2.shape:
         raise ValueError('Images must have the same shape.')
 
-    img1 = rescale_to_float(image1)
-    img2 = rescale_to_float(image2)
+    float_dtype = _supported_float_type([image1.dtype, image2.dtype])
+    img1 = image1.astype(float_dtype, copy=False)
+    img2 = image2.astype(float_dtype, copy=False)
 
     if method == 'diff':
         comparison = np.abs(img2 - img1)

--- a/skimage/util/compare.py
+++ b/skimage/util/compare.py
@@ -1,5 +1,5 @@
 import numpy as np
-from ..util import img_as_float
+from ..util import rescale_to_float
 from itertools import product
 
 
@@ -36,8 +36,8 @@ def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
     if image1.shape != image2.shape:
         raise ValueError('Images must have the same shape.')
 
-    img1 = img_as_float(image1)
-    img2 = img_as_float(image2)
+    img1 = rescale_to_float(image1)
+    img2 = rescale_to_float(image2)
 
     if method == 'diff':
         comparison = np.abs(img2 - img1)

--- a/skimage/util/noise.py
+++ b/skimage/util/noise.py
@@ -1,5 +1,5 @@
 import numpy as np
-from .dtype import img_as_float
+from .dtype import rescale_to_float
 
 
 __all__ = ['random_noise']
@@ -130,7 +130,7 @@ def random_noise(image, mode='gaussian', seed=None, clip=True, **kwargs):
     else:
         low_clip = 0.
 
-    image = img_as_float(image)
+    image = rescale_to_float(image)
 
     rng = np.random.default_rng(seed)
 

--- a/skimage/util/tests/test_apply_parallel.py
+++ b/skimage/util/tests/test_apply_parallel.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from skimage._shared.testing import (assert_array_almost_equal, assert_equal,
                                      expected_warnings)
-from skimage import color, data, img_as_float
+from skimage import color, data, rescale_to_float
 from skimage.filters import threshold_local, gaussian
 from skimage.util.apply_parallel import apply_parallel
 
@@ -126,7 +126,7 @@ def test_apply_parallel_rgb_channel_axis(depth, chunks, channel_axis):
     2.) tuple of length ``image.ndim - 1`` corresponding to spatial axes
     3.) tuple of length ``image.ndim`` corresponding to all axes
     """
-    cat = img_as_float(data.chelsea())
+    cat = rescale_to_float(data.chelsea())
 
     func = color.rgb2ycbcr
     cat_ycbcr_expected = func(cat, channel_axis=-1)

--- a/skimage/util/tests/test_compare.py
+++ b/skimage/util/tests/test_compare.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 
-from skimage import rescale_as_float
+from skimage import rescale_to_float
 from skimage.util.compare import compare_images
 
 
@@ -20,8 +20,8 @@ def test_compare_images_diff(rescale_input):
     img2 = np.zeros_like(img1)
     img2[3:8, 0:8] = 255
     if rescale_input:
-        img1 = rescale_as_float(img1)
-        img2 = rescale_as_float(img2)
+        img1 = rescale_to_float(img1)
+        img2 = rescale_to_float(img2)
     expected_result = np.zeros_like(img1, dtype=np.float64)
     expected_result[3:8, 0:3] = img1.max()
     result = compare_images(img1, img2, method='diff')
@@ -35,8 +35,8 @@ def test_compare_images_blend(rescale_input):
     img2 = np.zeros_like(img1)
     img2[3:8, 0:8] = 255
     if rescale_input:
-        img1 = rescale_as_float(img1)
-        img2 = rescale_as_float(img2)
+        img1 = rescale_to_float(img1)
+        img2 = rescale_to_float(img2)
     expected_result = np.zeros_like(img1, dtype=np.float64)
     imax = img1.max()
     expected_result[3:8, 3:8] = imax
@@ -50,8 +50,8 @@ def test_compare_images_checkerboard_default(rescale_input):
     img1 = np.zeros((2**4, 2**4), dtype=np.uint8)
     img2 = np.full(img1.shape, fill_value=255, dtype=np.uint8)
     if rescale_input:
-        img1 = rescale_as_float(img1)
-        img2 = rescale_as_float(img2)
+        img1 = rescale_to_float(img1)
+        img2 = rescale_to_float(img2)
     res = compare_images(img1, img2, method='checkerboard')
     imax = img2.max()
     exp_row1 = np.array(
@@ -71,8 +71,8 @@ def test_compare_images_checkerboard_tuple(rescale_input):
     img1 = np.zeros((2**4, 2**4), dtype=np.uint8)
     img2 = np.full(img1.shape, fill_value=255, dtype=np.uint8)
     if rescale_input:
-        img1 = rescale_as_float(img1)
-        img2 = rescale_as_float(img2)
+        img1 = rescale_to_float(img1)
+        img2 = rescale_to_float(img2)
     res = compare_images(img1, img2, method='checkerboard', n_tiles=(4, 8))
     imax = img2.max()
     exp_row1 = np.array(

--- a/skimage/util/tests/test_compare.py
+++ b/skimage/util/tests/test_compare.py
@@ -1,63 +1,86 @@
 import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
 
-from skimage._shared.testing import assert_array_equal
-from skimage._shared import testing
-
+from skimage import rescale_as_float
 from skimage.util.compare import compare_images
 
 
 def test_compate_images_ValueError_shape():
     img1 = np.zeros((10, 10), dtype=np.uint8)
     img2 = np.zeros((10, 1), dtype=np.uint8)
-    with testing.raises(ValueError):
+    with pytest.raises(ValueError):
         compare_images(img1, img2)
 
 
-def test_compare_images_diff():
+@pytest.mark.parametrize('rescale_input', [False, True])
+def test_compare_images_diff(rescale_input):
     img1 = np.zeros((10, 10), dtype=np.uint8)
     img1[3:8, 3:8] = 255
     img2 = np.zeros_like(img1)
     img2[3:8, 0:8] = 255
+    if rescale_input:
+        img1 = rescale_as_float(img1)
+        img2 = rescale_as_float(img2)
     expected_result = np.zeros_like(img1, dtype=np.float64)
-    expected_result[3:8, 0:3] = 1
+    expected_result[3:8, 0:3] = img1.max()
     result = compare_images(img1, img2, method='diff')
     assert_array_equal(result, expected_result)
 
 
-def test_compare_images_blend():
+@pytest.mark.parametrize('rescale_input', [False, True])
+def test_compare_images_blend(rescale_input):
     img1 = np.zeros((10, 10), dtype=np.uint8)
     img1[3:8, 3:8] = 255
     img2 = np.zeros_like(img1)
     img2[3:8, 0:8] = 255
+    if rescale_input:
+        img1 = rescale_as_float(img1)
+        img2 = rescale_as_float(img2)
     expected_result = np.zeros_like(img1, dtype=np.float64)
-    expected_result[3:8, 3:8] = 1
-    expected_result[3:8, 0:3] = 0.5
+    imax = img1.max()
+    expected_result[3:8, 3:8] = imax
+    expected_result[3:8, 0:3] = imax / 2
     result = compare_images(img1, img2, method='blend')
     assert_array_equal(result, expected_result)
 
 
-def test_compare_images_checkerboard_default():
+@pytest.mark.parametrize('rescale_input', [False, True])
+def test_compare_images_checkerboard_default(rescale_input):
     img1 = np.zeros((2**4, 2**4), dtype=np.uint8)
     img2 = np.full(img1.shape, fill_value=255, dtype=np.uint8)
+    if rescale_input:
+        img1 = rescale_as_float(img1)
+        img2 = rescale_as_float(img2)
     res = compare_images(img1, img2, method='checkerboard')
-    exp_row1 = np.array([0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1.])
-    exp_row2 = np.array([1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0.])
+    imax = img2.max()
+    exp_row1 = np.array(
+        [0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1.]
+    ) * imax
+    exp_row2 = np.array(
+        [1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0.]
+    ) * imax
     for i in (0, 1, 4, 5, 8, 9, 12, 13):
         assert_array_equal(res[i, :], exp_row1)
     for i in (2, 3, 6, 7, 10, 11, 14, 15):
         assert_array_equal(res[i, :], exp_row2)
 
 
-def test_compare_images_checkerboard_tuple():
+@pytest.mark.parametrize('rescale_input', [False, True])
+def test_compare_images_checkerboard_tuple(rescale_input):
     img1 = np.zeros((2**4, 2**4), dtype=np.uint8)
     img2 = np.full(img1.shape, fill_value=255, dtype=np.uint8)
+    if rescale_input:
+        img1 = rescale_as_float(img1)
+        img2 = rescale_as_float(img2)
     res = compare_images(img1, img2, method='checkerboard', n_tiles=(4, 8))
+    imax = img2.max()
     exp_row1 = np.array(
         [0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1.]
-    )
+    ) * imax
     exp_row2 = np.array(
         [1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0.]
-    )
+    ) * imax
     for i in (0, 1, 2, 3, 8, 9, 10, 11):
         assert_array_equal(res[i, :], exp_row1)
     for i in (4, 5, 6, 7, 12, 13, 14, 15):

--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -1,7 +1,7 @@
 import numpy as np
 import itertools
-from skimage import (img_as_float, img_as_float32, img_as_float64,
-                     img_as_int, img_as_uint, img_as_ubyte)
+from skimage import (rescale_to_float, rescale_to_float32, rescale_to_float64,
+                     rescale_to_int, rescale_to_uint, rescale_to_ubyte)
 from skimage.util.dtype import _convert
 
 from skimage._shared._warnings import expected_warnings
@@ -17,8 +17,8 @@ dtype_range = {np.uint8: (0, 255),
                np.float64: (-1.0, 1.0)}
 
 
-img_funcs = (img_as_int, img_as_float64, img_as_float32,
-             img_as_uint, img_as_ubyte)
+img_funcs = (rescale_to_int, rescale_to_float64, rescale_to_float32,
+             rescale_to_uint, rescale_to_ubyte)
 dtypes_for_img_funcs = (np.int16, np.float64, np.float32, np.uint16, np.ubyte)
 img_funcs_and_types = zip(img_funcs, dtypes_for_img_funcs)
 
@@ -79,7 +79,7 @@ def test_range_extra_dtypes(dtype_in, dt):
 def test_downcast():
     x = np.arange(10).astype(np.uint64)
     with expected_warnings(['Downcasting']):
-        y = img_as_int(x)
+        y = rescale_to_int(x)
     assert np.allclose(y, x.astype(np.int16))
     assert y.dtype == np.int16, y.dtype
 
@@ -87,21 +87,21 @@ def test_downcast():
 def test_float_out_of_range():
     too_high = np.array([2], dtype=np.float32)
     with testing.raises(ValueError):
-        img_as_int(too_high)
+        rescale_to_int(too_high)
     too_low = np.array([-2], dtype=np.float32)
     with testing.raises(ValueError):
-        img_as_int(too_low)
+        rescale_to_int(too_low)
 
 
 def test_float_float_all_ranges():
     arr_in = np.array([[-10., 10., 1e20]], dtype=np.float32)
-    np.testing.assert_array_equal(img_as_float(arr_in), arr_in)
+    np.testing.assert_array_equal(rescale_to_float(arr_in), arr_in)
 
 
 def test_copy():
     x = np.array([1], dtype=np.float64)
-    y = img_as_float(x)
-    z = img_as_float(x, force_copy=True)
+    y = rescale_to_float(x)
+    z = rescale_to_float(x, force_copy=True)
 
     assert y is x
     assert z is not x
@@ -112,10 +112,10 @@ def test_bool():
     img8 = np.zeros((10, 10), np.bool8)
     img_[1, 1] = True
     img8[1, 1] = True
-    for (func, dt) in [(img_as_int, np.int16),
-                       (img_as_float, np.float64),
-                       (img_as_uint, np.uint16),
-                       (img_as_ubyte, np.ubyte)]:
+    for (func, dt) in [(rescale_to_int, np.int16),
+                       (rescale_to_float, np.float64),
+                       (rescale_to_uint, np.uint16),
+                       (rescale_to_ubyte, np.ubyte)]:
         converted_ = func(img_)
         assert np.sum(converted_) == dtype_range[dt][1]
         converted8 = func(img8)
@@ -123,7 +123,7 @@ def test_bool():
 
 
 def test_clobber():
-    # The `img_as_*` functions should never modify input arrays.
+    # The `rescale_to_*` functions should never modify input arrays.
     for func_input_type in img_funcs:
         for func_output_type in img_funcs:
             img = np.random.rand(5, 5)
@@ -137,13 +137,13 @@ def test_clobber():
 
 def test_signed_scaling_float32():
     x = np.array([-128,  127], dtype=np.int8)
-    y = img_as_float32(x)
+    y = rescale_to_float32(x)
     assert_equal(y.max(), 1)
 
 
 def test_float32_passthrough():
     x = np.array([-1, 1], dtype=np.float32)
-    y = img_as_float(x)
+    y = rescale_to_float(x)
     assert_equal(y.dtype, x.dtype)
 
 
@@ -192,14 +192,14 @@ def test_subclass_conversion():
 
 
 def test_int_to_float():
-    """Check Normalization when casting img_as_float from int types to float"""
+    """Check Normalization when casting from int types to float"""
     int_list = np.arange(9, dtype=np.int64)
-    converted = img_as_float(int_list)
+    converted = rescale_to_float(int_list)
     assert np.allclose(converted, int_list * 1e-19, atol=0.0, rtol=0.1)
 
     ii32 = np.iinfo(np.int32)
     ii_list = np.array([ii32.min, ii32.max], dtype=np.int32)
-    floats = img_as_float(ii_list)
+    floats = rescale_to_float(ii_list)
 
     assert_equal(floats.max(), 1)
     assert_equal(floats.min(), -1)

--- a/skimage/util/tests/test_random_noise.py
+++ b/skimage/util/tests/test_random_noise.py
@@ -3,7 +3,7 @@ from skimage._shared.testing import assert_array_equal, assert_allclose
 
 import numpy as np
 from skimage.data import camera
-from skimage.util import random_noise, img_as_float
+from skimage.util import random_noise, rescale_to_float
 
 
 def test_set_seed():
@@ -15,7 +15,7 @@ def test_set_seed():
 
 def test_salt():
     seed = 42
-    cam = img_as_float(camera())
+    cam = rescale_to_float(camera())
     amount = 0.15
     cam_noisy = random_noise(cam, seed=seed, mode='salt', amount=amount)
     saltmask = cam != cam_noisy
@@ -45,7 +45,7 @@ def test_singleton_dim():
 
 def test_pepper():
     seed = 42
-    cam = img_as_float(camera())
+    cam = rescale_to_float(camera())
     data_signed = cam * 2. - 1.   # Same image, on range [-1, 1]
 
     amount = 0.15
@@ -72,7 +72,7 @@ def test_pepper():
 
 def test_salt_and_pepper():
     seed = 42
-    cam = img_as_float(camera())
+    cam = rescale_to_float(camera())
     amount = 0.15
     cam_noisy = random_noise(cam, seed=seed, mode='s&p', amount=amount,
                              salt_vs_pepper=0.25)
@@ -150,7 +150,7 @@ def test_poisson():
     cam_noisy2 = random_noise(data, mode='poisson', seed=seed, clip=False)
 
     rng = np.random.default_rng(seed)
-    expected = rng.poisson(img_as_float(data) * 256) / 256.
+    expected = rng.poisson(rescale_to_float(data) * 256) / 256.
     assert_allclose(cam_noisy, np.clip(expected, 0., 1.))
     assert_allclose(cam_noisy2, expected)
 
@@ -158,7 +158,7 @@ def test_poisson():
 def test_clip_poisson():
     seed = 42
     data = camera()  # 512x512 grayscale uint8
-    data_signed = img_as_float(data) * 2. - 1.  # Same image, on range [-1, 1]
+    data_signed = rescale_to_float(data) * 2. - 1.  # Same image, on range [-1, 1]
 
     # Signed and unsigned, clipped
     cam_poisson = random_noise(data, mode='poisson', seed=seed, clip=True)
@@ -178,7 +178,7 @@ def test_clip_poisson():
 def test_clip_gaussian():
     seed = 42
     data = camera()  # 512x512 grayscale uint8
-    data_signed = img_as_float(data) * 2. - 1.  # Same image, on range [-1, 1]
+    data_signed = rescale_to_float(data) * 2. - 1.  # Same image, on range [-1, 1]
 
     # Signed and unsigned, clipped
     cam_gauss = random_noise(data, mode='gaussian', seed=seed, clip=True)
@@ -198,7 +198,7 @@ def test_clip_gaussian():
 def test_clip_speckle():
     seed = 42
     data = camera()  # 512x512 grayscale uint8
-    data_signed = img_as_float(data) * 2. - 1.  # Same image, on range [-1, 1]
+    data_signed = rescale_to_float(data) * 2. - 1.  # Same image, on range [-1, 1]
 
     # Signed and unsigned, clipped
     cam_speckle = random_noise(data, mode='speckle', seed=seed, clip=True)

--- a/skimage/util/tests/test_random_noise.py
+++ b/skimage/util/tests/test_random_noise.py
@@ -158,7 +158,8 @@ def test_poisson():
 def test_clip_poisson():
     seed = 42
     data = camera()  # 512x512 grayscale uint8
-    data_signed = rescale_to_float(data) * 2. - 1.  # Same image, on range [-1, 1]
+    # Same image, on range [-1, 1]
+    data_signed = rescale_to_float(data) * 2. - 1.
 
     # Signed and unsigned, clipped
     cam_poisson = random_noise(data, mode='poisson', seed=seed, clip=True)
@@ -178,7 +179,8 @@ def test_clip_poisson():
 def test_clip_gaussian():
     seed = 42
     data = camera()  # 512x512 grayscale uint8
-    data_signed = rescale_to_float(data) * 2. - 1.  # Same image, on range [-1, 1]
+    # Same image, on range [-1, 1]
+    data_signed = rescale_to_float(data) * 2. - 1.
 
     # Signed and unsigned, clipped
     cam_gauss = random_noise(data, mode='gaussian', seed=seed, clip=True)
@@ -198,7 +200,8 @@ def test_clip_gaussian():
 def test_clip_speckle():
     seed = 42
     data = camera()  # 512x512 grayscale uint8
-    data_signed = rescale_to_float(data) * 2. - 1.  # Same image, on range [-1, 1]
+    # Same image, on range [-1, 1]
+    data_signed = rescale_to_float(data) * 2. - 1.
 
     # Signed and unsigned, clipped
     cam_speckle = random_noise(data, mode='speckle', seed=seed, clip=True)


### PR DESCRIPTION
## Description

**NOTE:** the first commit here is #6318, so this will be easier to review after that one is merged

A subset of functions have a `preserve_range` keyword argument that controls whether or not images with integer dtypes get rescaled to a normalized range ([0, 1] for unsigned, [-1, 1] for signed). We have discussed removing this keyword for `skimage2` and defaulting to not rescaling inputs except where necessary (see https://github.com/scikit-image/scikit-image/pull/5281#issuecomment-864646679, https://github.com/scikit-image/scikit-image/issues/5439). Another older discussion about defaulting to preserve_range=True: https://github.com/scikit-image/scikit-image/issues/1616#issuecomment-123554310

In addition this PR removes internal rescaling via `rescale_to_float` in many places where it currently exists. This includes all of `skimage.filters`, `skimage.restoration` and `skimage.transforms`.  However, there are a number of remaining cases still to address in follow-up PRs (primarily some of the cases in `skimage.feature`, `skimage.color`, `skimage.exposure` and `skimage.segmentation` as discussed in https://github.com/scikit-image/scikit-image/issues/3373#issuecomment-1089146023).


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
