### PR TITLE
Fix skeletonize behavior

### DIFF
--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -160,13 +160,8 @@ def skeletonize_2d(image):
 
     """
 
-    # convert to unsigned int (this should work for boolean values)
-    image = image.astype(np.uint8)
-
-    # check some properties of the input image:
-    #  - 2D
     if image.ndim != 2:
-        raise ValueError('Skeletonize requires a 2D array')
+        raise ValueError("Zhang's skeletonize method requires a 2D array")
 
     return _fast_skeletonize(image)
 

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -165,11 +165,8 @@ def skeletonize_2d(image):
 
     # check some properties of the input image:
     #  - 2D
-    #  - binary image with only 0's and 1's
     if image.ndim != 2:
         raise ValueError('Skeletonize requires a 2D array')
-    if not np.all(np.in1d(image.flat, (0, 1))):
-        raise ValueError('Image contains values other than 0 and 1')
 
     return _fast_skeletonize(image)
 

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -77,7 +77,7 @@ def skeletonize(image, *, method=None):
     """
 
     if image.ndim == 2 and (method is None or method == 'zhang'):
-        skeleton = skeletonize_2d(image.astype(np.bool))
+        skeleton = skeletonize_2d(image.astype(bool))
     elif image.ndim == 3 and method == 'zhang':
         raise ValueError('skeletonize method "zhang" only works for 2D '
                          'images.')

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -77,7 +77,7 @@ def skeletonize(image, *, method=None):
     """
 
     if image.ndim == 2 and (method is None or method == 'zhang'):
-        skeleton = skeletonize_2d(image)
+        skeleton = skeletonize_2d(image.astype(np.bool))
     elif image.ndim == 3 and method == 'zhang':
         raise ValueError('skeletonize method "zhang" only works for 2D '
                          'images.')

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -22,7 +22,7 @@ def skeletonize(image, *, method=None):
     Parameters
     ----------
     image : ndarray, 2D or 3D
-        A binary image containing the objects to be skeletonized. Zeros
+        An image containing the objects to be skeletonized. Zeros
         represent background, nonzero values are foreground.
     method : {'zhang', 'lee'}, optional
         Which algorithm to use. Zhang's algorithm [Zha84]_ only works for

--- a/skimage/morphology/_skeletonize_cy.pyx
+++ b/skimage/morphology/_skeletonize_cy.pyx
@@ -62,7 +62,7 @@ def _fast_skeletonize(image):
     # we copy over the image into a larger version with a single pixel border
     # this removes the need to handle border cases below
     _skeleton = np.zeros((nrows, ncols), dtype=np.uint8)
-    _skeleton[1:nrows-1, 1:ncols-1] = image > 0
+    _skeleton[1:nrows-1, 1:ncols-1] = image
 
     _cleaned_skeleton = _skeleton.copy()
 

--- a/skimage/morphology/tests/test_skeletonize.py
+++ b/skimage/morphology/tests/test_skeletonize.py
@@ -28,19 +28,6 @@ class TestSkeletonize():
         with pytest.raises(ValueError):
             skeletonize(im, method='zhang')
 
-    def test_skeletonize_not_binary(self):
-        im = np.zeros((5, 5))
-        im[0, 0] = 1
-        im[0, 1] = 2
-        with pytest.raises(ValueError):
-            skeletonize(im)
-
-    def test_skeletonize_unexpected_value(self):
-        im = np.zeros((5, 5))
-        im[0, 0] = 2
-        with pytest.raises(ValueError):
-            skeletonize(im)
-
     def test_skeletonize_all_foreground(self):
         im = np.ones((3, 4))
         skeletonize(im)


### PR DESCRIPTION
## Description

`skeletonize` documentation for input `image` is confusing:
> A binary image containing the objects to be skeletonized. Zeros represent background, nonzero values are foreground.

In this PR,
- input image is cast to bool before calling cython function,
- docstring is modified to accept any input type
- unnecessary unitary tests are removed.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
