### PR TITLE
parameterize moments tests

### DIFF
--- a/skimage/measure/tests/test_moments.py
+++ b/skimage/measure/tests/test_moments.py
@@ -1,78 +1,60 @@
-import pytest
 import numpy as np
+import pytest
 from scipy import ndimage as ndi
+
 from skimage import draw
-from skimage.measure import (moments, moments_central, moments_coords,
-                             moments_coords_central, moments_normalized,
-                             moments_hu, centroid, inertia_tensor,
-                             inertia_tensor_eigvals)
-
 from skimage._shared import testing
-from skimage._shared.testing import (assert_equal, assert_almost_equal,
-                                     assert_allclose)
+from skimage._shared.testing import (assert_allclose, assert_almost_equal,
+                                     assert_equal)
 from skimage._shared.utils import _supported_float_type
+from skimage.measure import (centroid, inertia_tensor, inertia_tensor_eigvals,
+                             moments, moments_central, moments_coords,
+                             moments_coords_central, moments_hu,
+                             moments_normalized)
 
 
-def test_moments():
+@pytest.mark.parametrize('anisotropic', [False, True, None])
+def test_moments(anisotropic):
     image = np.zeros((20, 20), dtype=np.float64)
     image[14, 14] = 1
     image[15, 15] = 1
     image[14, 15] = 0.5
     image[15, 14] = 0.5
-    m = moments(image)
-    assert_equal(m[0, 0], 3)
-    assert_almost_equal(m[1, 0] / m[0, 0], 14.5)
-    assert_almost_equal(m[0, 1] / m[0, 0], 14.5)
-
-def test_moments_spacing():
-    spacing = (1.4, 2)
-    image = np.zeros((20, 20), dtype=np.double)
-    image[14, 14] = 1
-    image[15, 15] = 1
-    image[14, 15] = 0.5
-    image[15, 14] = 0.5
-    m = moments(image, spacing=spacing)
+    if anisotropic:
+        spacing = (1.4, 2)
+    else:
+        spacing = (1, 1)
+    if anisotropic is None:
+        m = moments(image)
+    else:
+        m = moments(image, spacing=spacing)
     assert_equal(m[0, 0], 3)
     assert_almost_equal(m[1, 0] / m[0, 0], 14.5 * spacing[0])
     assert_almost_equal(m[0, 1] / m[0, 0], 14.5 * spacing[1])
 
 
-def test_moments_central():
+@pytest.mark.parametrize('anisotropic', [False, True, None])
+def test_moments_central(anisotropic):
     image = np.zeros((20, 20), dtype=np.float64)
     image[14, 14] = 1
     image[15, 15] = 1
     image[14, 15] = 0.5
     image[15, 14] = 0.5
-    mu = moments_central(image, (14.5, 14.5))
+    if anisotropic:
+        spacing = (2, 1)
+    else:
+        spacing = (1, 1)
+    if anisotropic is None:
+        mu = moments_central(image, (14.5, 14.5))
+        # check for proper centroid computation
+        mu_calc_centroid = moments_central(image)
+    else:
+        mu = moments_central(image, (14.5 * spacing[0], 14.5 * spacing[1]),
+                             spacing=spacing)
+        # check for proper centroid computation
+        mu_calc_centroid = moments_central(image, spacing=spacing)
 
-    # check for proper centroid computation
-    mu_calc_centroid = moments_central(image)
-    assert_equal(mu, mu_calc_centroid)
-
-    # shift image by dx=2, dy=2
-    image2 = np.zeros((20, 20), dtype=np.float64)
-    image2[16, 16] = 1
-    image2[17, 17] = 1
-    image2[16, 17] = 0.5
-    image2[17, 16] = 0.5
-    mu2 = moments_central(image2, (14.5 + 2, 14.5 + 2))
-    # central moments must be translation invariant
-    assert_equal(mu, mu2)
-
-
-def test_moments_central_spacing():
-    spacing = (2, 1)
-    image = np.zeros((20, 20), dtype=np.double)
-    image[14, 14] = 1
-    image[15, 15] = 1
-    image[14, 15] = 0.5
-    image[15, 14] = 0.5
-    mu = moments_central(image, (14.5 * spacing[0], 14.5 * spacing[1]),
-                         spacing=spacing)
-
-    # check for proper centroid computation
-    mu_calc_centroid = moments_central(image, spacing=spacing)
-    assert_equal(mu, mu_calc_centroid)
+    assert_allclose(mu, mu_calc_centroid, rtol=1e-14)
 
     # shift image by dx=2, dy=2
     image2 = np.zeros((20, 20), dtype=np.double)
@@ -80,11 +62,16 @@ def test_moments_central_spacing():
     image2[17, 17] = 1
     image2[16, 17] = 0.5
     image2[17, 16] = 0.5
-    mu2 = moments_central(image2,
-                          ((14.5 + 2) * spacing[0], (14.5 + 2) * spacing[1]),
-                          spacing=spacing)
+    if anisotropic is None:
+        mu2 = moments_central(image2, (14.5 + 2, 14.5 + 2))
+    else:
+        mu2 = moments_central(
+            image2,
+            ((14.5 + 2) * spacing[0], (14.5 + 2) * spacing[1]),
+            spacing=spacing
+        )
     # central moments must be translation invariant
-    assert_equal(mu, mu2)
+    assert_allclose(mu, mu2, rtol=1e-14)
 
 
 def test_moments_coords():
@@ -145,36 +132,35 @@ def test_moments_normalized():
     image[13:17, 13:17] = 1
     mu = moments_central(image, (14.5, 14.5))
     nu = moments_normalized(mu)
-    # shift image by dx=-3, dy=-3 and scale by 0.5
+    # shift image by dx=-2, dy=-2 and scale non-zero extent by 0.5
     image2 = np.zeros((20, 20), dtype=np.float64)
-    image2[11:13, 11:13] = 1
+    # scale amplitude by 0.7
+    image2[11:13, 11:13] = 0.7
     mu2 = moments_central(image2, (11.5, 11.5))
     nu2 = moments_normalized(mu2)
     # central moments must be translation and scale invariant
     assert_almost_equal(nu, nu2, decimal=1)
 
 
-def test_moments_normalized_spacing():
+@pytest.mark.parametrize('anisotropic', [False, True])
+def test_moments_normalized_spacing(anisotropic):
     image = np.zeros((20, 20), dtype=np.double)
     image[13:17, 13:17] = 1
-    mu = moments_central(image)
-    nu = moments_normalized(mu)
 
-    # scale up via spacing
-    spacing = (3, 3)
-    mu2 = moments_central(image, spacing=spacing)
-    nu2 = moments_normalized(mu2, spacing=spacing)
-    assert_almost_equal(nu, nu2)
+    if not anisotropic:
+        spacing1 = (1, 1)
+        spacing2 = (3, 3)
+    else:
+        spacing1 = (1, 2)
+        spacing2 = (2, 4)
 
-    # anisotropic spacing
-    spacing = (1, 2)
-    mu = moments_central(image, spacing=spacing)
-    nu = moments_normalized(mu, spacing=spacing)
+    mu = moments_central(image, spacing=spacing1)
+    nu = moments_normalized(mu, spacing=spacing1)
 
-    # scale up via spacing
-    spacing = (2, 4)
-    mu2 = moments_central(image, spacing=spacing)
-    nu2 = moments_normalized(mu2, spacing=spacing)
+    mu2 = moments_central(image, spacing=spacing2)
+    nu2 = moments_normalized(mu2, spacing=spacing2)
+
+    # result should be invariant to absolute scale of spacing
     assert_almost_equal(nu, nu2)
 
 


### PR DESCRIPTION
## Description

This is a small followup to #6296 by @tibuch, that just parametrizes moments tests to reduce code duplication. 

I did make one minor change to add image intensity scaling in `test_moments_coords`  as well.

Imports have been sorted following the style proposed in #5524

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
