### PR TITLE
Fix issue with newer versions of matplotlib in manual segmentation

### DIFF
--- a/skimage/future/manual_segmentation.py
+++ b/skimage/future/manual_segmentation.py
@@ -101,7 +101,7 @@ def manual_polygon_segmentation(image, alpha=0.4, return_all=False):
         if event.inaxes is None or event.inaxes is undo_pos:
             return
         # Do not record click events when toolbar is active
-        if fig.canvas.manager.toolbar._active is not None:
+        if ax.get_navigate_mode():
             return
 
         if event.button == LEFT_CLICK:  # Select vertex


### PR DESCRIPTION
## Description

In newer versions of matplotlib `_active` field is not accessible and because of this `skimage.future.manual_polygon_segmentation` is not working properly. This PR fixes this issue.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
