### PR TITLE
warp/rotate: fixed a bug with clipping when cval is not in the input range

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -739,6 +739,10 @@ def _clip_warp_output(input_image, output_image, mode, cval, clip):
         if not preserve_cval:
             cval = min_val
 
+        # If cval is the default value, cast it to the same type as min_val
+        if cval == 0.:
+            cval = min_val.dtype.type(cval)
+
         np.clip(output_image, min(min_val, cval), max(max_val, cval),
                 out=output_image)
 

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -734,16 +734,14 @@ def _clip_warp_output(input_image, output_image, mode, cval, clip):
                          and not min_val <= cval <= max_val
                          and min_func(output_image) <= cval <= max_func(output_image))
 
-        # Otherwise, set cval within the input range for clipping purposes
-        if not preserve_cval:
-            cval = min_val
+        # expand min/max range to account for cval
+        if preserve_cval:
+            # cast cval to the same dtype as the input image
+            cval = input_image.dtype.type(cval)
+            min_val = min(min_val, cval)
+            max_val = max(max_val, cval)
 
-        # If cval is the default value, cast it to the same type as min_val
-        if cval == 0.:
-            cval = min_val.dtype.type(cval)
-
-        np.clip(output_image, min(min_val, cval), max(max_val, cval),
-                out=output_image)
+        np.clip(output_image, min_val, max_val, out=output_image)
 
 
 def warp(image, inverse_map, map_args={}, output_shape=None, order=None,

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -731,7 +731,6 @@ def _clip_warp_output(input_image, output_image, mode, cval, clip):
         # Check if cval has been used such that it expands the effective input
         # range
         preserve_cval = (mode == 'constant'
-                         and not np.isnan(cval)
                          and not min_val <= cval <= max_val
                          and min_func(output_image) <= cval <= max_func(output_image))
 

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -147,7 +147,8 @@ def test_warp_clip_cval_outside_input_range(order):
     x = np.ones((15, 15), dtype=np.float64)
 
     # Specify a cval that is outside the input range to check clipping
-    outx = rotate(x, 45, order=order, cval=2, resize=True, clip=True)
+    with expected_warnings(['Bi-quadratic.*bug'] if order == 2 else None):
+        outx = rotate(x, 45, order=order, cval=2, resize=True, clip=True)
 
     # The corners should be cval for all interpolation orders
     assert_array_almost_equal([outx[0, 0], outx[0, -1],
@@ -171,7 +172,9 @@ def test_warp_clip_cval_not_used(order):
     # Transform the image by stretching it out by one pixel on each side so
     # that cval will not actually be used
     transform = AffineTransform(scale=15/(15+2), translation=(1, 1))
-    outx = warp(x, transform, mode='constant', order=order, cval=0, clip=True)
+    with expected_warnings(['Bi-quadratic.*bug'] if order == 2 else None):
+        outx = warp(x, transform, mode='constant', order=order, cval=0,
+                    clip=True)
 
     # At higher orders of interpolation, the transformed image has overshoots
     # beyond the input range that should be clipped to the range 1 to 2.  Even


### PR DESCRIPTION
## Description

Fixes #6305 

For warp/rotate, when specifying `clip=True` (which is the default), the behavior when `cval` is outside of the range of the input image gives slightly wrong results for orders 1 and 3 (which use native code) and very wrong results for orders 2, 4, and 5 (which fall back to SciPy code).  This is due to the use of a strict equality check.

Example code:
```python
import matplotlib.pyplot as plt
import numpy as np
from skimage.transform import rotate

image = np.ones((20, 20))
image[5:-5, 5:-5] = 2

fig, axs = plt.subplots(2, 6, figsize=(13, 4))

for i in range(6):
    axs[0, i].set_title(f'order={i}')
    axs[0, i].imshow(rotate(image, 30, order=i, cval=0, resize=True, clip=False), vmin=0, vmax=3)
    axs[1, i].imshow(rotate(image, 30, order=i, cval=0, resize=True, clip=True), vmin=0, vmax=3)
    
axs[0, 0].set_ylabel('clip=False')
axs[1, 0].set_ylabel('clip=True')

plt.show()
```

Before this PR:
![download (49)](https://user-images.githubusercontent.com/991759/160432313-b1e9696d-4f1c-451f-84ff-f96f2110df02.png)

After this PR:
![download (52)](https://user-images.githubusercontent.com/991759/162663027-963c2fa9-b3eb-434e-acd8-1561d0cdd7f3.png)

This PR also probably closes #5599 since the second block in that issue would no longer appear inconsistent:
```python
>>> import numpy as np
>>> from skimage.transform import AffineTransform, warp
>>> img = np.ones((5, 5))
>>> tmat = np.array([[1, 0, -2.3], [0, 1, 0], [0, 0, 1]])
>>> tform = AffineTransform(matrix=tmat)
>>> warp(img, tform, cval=np.nan)
array([[nan, nan, nan,  1.,  1.],
       [nan, nan, nan,  1.,  1.],
       [nan, nan, nan,  1.,  1.],
       [nan, nan, nan,  1.,  1.],
       [nan, nan, nan,  1.,  1.]])
>>> warp(img, tform, cval=0)
array([[0., 0., 0.7, 1., 1.],
       [0., 0., 0.7, 1., 1.],
       [0., 0., 0.7, 1., 1.],
       [0., 0., 0.7, 1., 1.],
       [0., 0., 0.7, 1., 1.]])
```

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
