### PR TITLE
avoid warnings about change to v3 API from imageio

### DIFF
--- a/skimage/io/_plugins/imageio_plugin.py
+++ b/skimage/io/_plugins/imageio_plugin.py
@@ -2,7 +2,12 @@ __all__ = ['imread', 'imsave']
 
 from functools import wraps
 import numpy as np
-from imageio import imread as imageio_imread, imsave
+
+try:
+    # Try using the v2 API directly to avoid a warning from imageio >= 2.16.2
+    from imageio.v2 import imread as imageio_imread, imsave
+except ImportError:
+    from imageio import imread as imageio_imread, imsave
 
 
 @wraps(imageio_imread)


### PR DESCRIPTION
## Description

closes #6341 

This PR imports `imread`, `imsave` directly from `imageio.v2` when available to avoid a warning that has been causing recent CI failures. This also ensures there will not be an unexpected change in behavior to existing code once imagio's default changes to the v3 API. We can migrate to that API version at a later time.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
