### PR TITLE
Fix channel_axis default for cycle_spin

### DIFF
--- a/skimage/restoration/_cycle_spin.py
+++ b/skimage/restoration/_cycle_spin.py
@@ -50,7 +50,7 @@ def _generate_shifts(ndim, multichannel, max_shifts, shift_steps=1):
 @utils.channel_as_last_axis()
 @utils.deprecate_multichannel_kwarg(multichannel_position=5)
 def cycle_spin(x, func, max_shifts, shift_steps=1, num_workers=None,
-               multichannel=False, func_kw={}, *, channel_axis=-1):
+               multichannel=False, func_kw={}, *, channel_axis=None):
     """Cycle spinning (repeatedly apply func to shifted versions of x).
 
     Parameters

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -1178,6 +1178,13 @@ def test_cycle_spinning_num_workers():
     dn_cc1 = restoration.cycle_spin(noisy, denoise_func, max_shifts=1,
                                     func_kw=func_kw, channel_axis=None,
                                     num_workers=1)
+
+    # Repeat dn_cc1 computation, but without channel_axis specified to
+    # verify that the default behavior is channel_axis=None
+    dn_cc1_ = restoration.cycle_spin(noisy, denoise_func, max_shifts=1,
+                                    func_kw=func_kw, num_workers=1)
+    assert_array_equal(dn_cc1, dn_cc1_)
+
     with expected_warnings([DASK_NOT_INSTALLED_WARNING]):
         dn_cc2 = restoration.cycle_spin(noisy, denoise_func, max_shifts=1,
                                         func_kw=func_kw, channel_axis=None,

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -1090,78 +1090,79 @@ def test_denoise_wavelet_biorthogonal(rescale_sigma):
                  rescale_sigma=rescale_sigma)
 
 
+
+@pytest.mark.parametrize('channel_axis', [-1, None])
 @pytest.mark.parametrize('rescale_sigma', [True, False])
-def test_cycle_spinning_multichannel(rescale_sigma):
+def test_cycle_spinning_multichannel(rescale_sigma, channel_axis):
     sigma = 0.1
     rstate = np.random.default_rng(1234)
 
-    for channel_axis in -1, None:
-        if channel_axis is not None:
-            img = astro
-            # can either omit or be 0 along the channels axis
-            valid_shifts = [1, (0, 1), (1, 0), (1, 1), (1, 1, 0)]
-            # can either omit or be 1 on channels axis.
-            valid_steps = [1, 2, (1, 2), (1, 2, 1)]
-            # too few or too many shifts or non-zero shift on channels
-            invalid_shifts = [(1, 1, 2), (1, ), (1, 1, 0, 1)]
-            # too few or too many shifts or any shifts <= 0
-            invalid_steps = [(1, ), (1, 1, 1, 1), (0, 1), (-1, -1)]
-        else:
-            img = astro_gray
-            valid_shifts = [1, (0, 1), (1, 0), (1, 1)]
-            valid_steps = [1, 2, (1, 2)]
-            invalid_shifts = [(1, 1, 2), (1, )]
-            invalid_steps = [(1, ), (1, 1, 1), (0, 1), (-1, -1)]
+    if channel_axis is not None:
+        img = astro
+        # can either omit or be 0 along the channels axis
+        valid_shifts = [1, (0, 1), (1, 0), (1, 1), (1, 1, 0)]
+        # can either omit or be 1 on channels axis.
+        valid_steps = [1, 2, (1, 2), (1, 2, 1)]
+        # too few or too many shifts or non-zero shift on channels
+        invalid_shifts = [(1, 1, 2), (1, ), (1, 1, 0, 1)]
+        # too few or too many shifts or any shifts <= 0
+        invalid_steps = [(1, ), (1, 1, 1, 1), (0, 1), (-1, -1)]
+    else:
+        img = astro_gray
+        valid_shifts = [1, (0, 1), (1, 0), (1, 1)]
+        valid_steps = [1, 2, (1, 2)]
+        invalid_shifts = [(1, 1, 2), (1, )]
+        invalid_steps = [(1, ), (1, 1, 1), (0, 1), (-1, -1)]
 
-        noisy = img.copy() + 0.1 * rstate.standard_normal(img.shape)
+    noisy = img.copy() + 0.1 * rstate.standard_normal(img.shape)
 
-        denoise_func = restoration.denoise_wavelet
-        func_kw = dict(sigma=sigma, channel_axis=channel_axis,
-                       rescale_sigma=rescale_sigma)
+    denoise_func = restoration.denoise_wavelet
+    func_kw = dict(sigma=sigma, channel_axis=channel_axis,
+                   rescale_sigma=rescale_sigma)
 
-        # max_shifts=0 is equivalent to just calling denoise_func
+    # max_shifts=0 is equivalent to just calling denoise_func
+    with expected_warnings([DASK_NOT_INSTALLED_WARNING]):
+        dn_cc = restoration.cycle_spin(noisy, denoise_func, max_shifts=0,
+                                       func_kw=func_kw,
+                                       channel_axis=channel_axis)
+        dn = denoise_func(noisy, **func_kw)
+    assert_array_equal(dn, dn_cc)
+
+    # denoising with cycle spinning will give better PSNR than without
+    for max_shifts in valid_shifts:
         with expected_warnings([DASK_NOT_INSTALLED_WARNING]):
-            dn_cc = restoration.cycle_spin(noisy, denoise_func, max_shifts=0,
+            dn_cc = restoration.cycle_spin(noisy, denoise_func,
+                                           max_shifts=max_shifts,
                                            func_kw=func_kw,
                                            channel_axis=channel_axis)
-            dn = denoise_func(noisy, **func_kw)
-        assert_array_equal(dn, dn_cc)
+        psnr = peak_signal_noise_ratio(img, dn)
+        psnr_cc = peak_signal_noise_ratio(img, dn_cc)
+        assert psnr_cc > psnr
 
-        # denoising with cycle spinning will give better PSNR than without
-        for max_shifts in valid_shifts:
-            with expected_warnings([DASK_NOT_INSTALLED_WARNING]):
-                dn_cc = restoration.cycle_spin(noisy, denoise_func,
-                                               max_shifts=max_shifts,
-                                               func_kw=func_kw,
-                                               channel_axis=channel_axis)
-            psnr = peak_signal_noise_ratio(img, dn)
-            psnr_cc = peak_signal_noise_ratio(img, dn_cc)
-            assert psnr_cc > psnr
+    for shift_steps in valid_steps:
+        with expected_warnings([DASK_NOT_INSTALLED_WARNING]):
+            dn_cc = restoration.cycle_spin(noisy, denoise_func,
+                                           max_shifts=2,
+                                           shift_steps=shift_steps,
+                                           func_kw=func_kw,
+                                           channel_axis=channel_axis)
+        psnr = peak_signal_noise_ratio(img, dn)
+        psnr_cc = peak_signal_noise_ratio(img, dn_cc)
+        assert psnr_cc > psnr
 
-        for shift_steps in valid_steps:
-            with expected_warnings([DASK_NOT_INSTALLED_WARNING]):
-                dn_cc = restoration.cycle_spin(noisy, denoise_func,
-                                               max_shifts=2,
-                                               shift_steps=shift_steps,
-                                               func_kw=func_kw,
-                                               channel_axis=channel_axis)
-            psnr = peak_signal_noise_ratio(img, dn)
-            psnr_cc = peak_signal_noise_ratio(img, dn_cc)
-            assert psnr_cc > psnr
-
-        for max_shifts in invalid_shifts:
-            with pytest.raises(ValueError):
-                dn_cc = restoration.cycle_spin(noisy, denoise_func,
-                                               max_shifts=max_shifts,
-                                               func_kw=func_kw,
-                                               channel_axis=channel_axis)
-        for shift_steps in invalid_steps:
-            with pytest.raises(ValueError):
-                dn_cc = restoration.cycle_spin(noisy, denoise_func,
-                                               max_shifts=2,
-                                               shift_steps=shift_steps,
-                                               func_kw=func_kw,
-                                               channel_axis=channel_axis)
+    for max_shifts in invalid_shifts:
+        with pytest.raises(ValueError):
+            dn_cc = restoration.cycle_spin(noisy, denoise_func,
+                                           max_shifts=max_shifts,
+                                           func_kw=func_kw,
+                                           channel_axis=channel_axis)
+    for shift_steps in invalid_steps:
+        with pytest.raises(ValueError):
+            dn_cc = restoration.cycle_spin(noisy, denoise_func,
+                                           max_shifts=2,
+                                           shift_steps=shift_steps,
+                                           func_kw=func_kw,
+                                           channel_axis=channel_axis)
 
 
 def test_cycle_spinning_num_workers():

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -16,7 +16,9 @@ from skimage.restoration._denoise import _wavelet_threshold
 try:
     import dask  # noqa
 except ImportError:
-    DASK_NOT_INSTALLED_WARNING = 'The optional dask dependency is not installed'
+    DASK_NOT_INSTALLED_WARNING = (
+        'The optional dask dependency is not installed'
+    )
 else:
     DASK_NOT_INSTALLED_WARNING = None
 
@@ -1090,7 +1092,6 @@ def test_denoise_wavelet_biorthogonal(rescale_sigma):
                  rescale_sigma=rescale_sigma)
 
 
-
 @pytest.mark.parametrize('channel_axis', [-1, None])
 @pytest.mark.parametrize('rescale_sigma', [True, False])
 def test_cycle_spinning_multichannel(rescale_sigma, channel_axis):
@@ -1182,7 +1183,7 @@ def test_cycle_spinning_num_workers():
     # Repeat dn_cc1 computation, but without channel_axis specified to
     # verify that the default behavior is channel_axis=None
     dn_cc1_ = restoration.cycle_spin(noisy, denoise_func, max_shifts=1,
-                                    func_kw=func_kw, num_workers=1)
+                                     func_kw=func_kw, num_workers=1)
     assert_array_equal(dn_cc1, dn_cc1_)
 
     with expected_warnings([DASK_NOT_INSTALLED_WARNING]):


### PR DESCRIPTION
## Description

For `cycle_spin`, the default should be `channel_axis=None`. This was a bug introduced in v0.19.0 when introducing the `channel_axis` argument. The default should match the prior default of `multichannel=False`.

The second commit here just refactors an existing `cycle_spin` test case to use `parametrize` instead of an internal for loop.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
