### PR TITLE
Improve histogram matching performance on unsigned integer data (resume #6209)

### DIFF
--- a/benchmarks/benchmark_exposure.py
+++ b/benchmarks/benchmark_exposure.py
@@ -85,7 +85,7 @@ class MatchHistogramsSuite:
 
         References
         ----------
-        .. [1]: https://asv.readthedocs.io/en/stable/writing_benchmarks.html#peak-memory
+        .. [1]: https://asv.readthedocs.io/en/stable/writing_benchmarks.html#peak-memory  # noqa
         """
         pass
 

--- a/benchmarks/benchmark_exposure.py
+++ b/benchmarks/benchmark_exposure.py
@@ -1,5 +1,7 @@
 # See "Writing benchmarks" in the asv docs for more information.
 # https://asv.readthedocs.io/en/latest/writing_benchmarks.html
+import math
+
 import numpy as np
 
 from skimage import data, img_as_float
@@ -37,3 +39,55 @@ class ExposureSuite:
     def time_gamma_adjust_u8(self):
         for i in range(10):
             _ = exposure.adjust_gamma(self.image_u8)
+
+
+class MatchHistogramsSuite:
+
+    param_names = ["shape", "dtype", "multichannel"]
+    params = [
+        ((64, 64), (256, 256), (1024, 1024)),
+        (np.uint8, np.float32, np.float64),
+        (False, True),
+    ]
+
+    def _tile_to_shape(self, image, shape, multichannel):
+        n_tile = tuple(math.ceil(s / n) for s, n in zip(shape, image.shape))
+        if multichannel:
+            image = image[..., np.newaxis]
+            n_tile = n_tile + (3,)
+        image = np.tile(image, n_tile)
+        sl = tuple(slice(s) for s in shape)
+        return image[sl]
+
+    """Benchmark for exposure routines in scikit-image."""
+    def setup(self, shape, dtype, multichannel):
+        self.image = data.moon().astype(dtype, copy=False)
+        self.reference = data.camera().astype(dtype, copy=False)
+
+        self.image = self._tile_to_shape(self.image, shape, multichannel)
+        self.reference = self._tile_to_shape(self.reference, shape,
+                                             multichannel)
+        channel_axis = -1 if multichannel else None
+        self.kwargs = {'channel_axis': channel_axis}
+
+    def time_match_histogram(self, *args):
+        exposure.match_histograms(self.image, self.reference, **self.kwargs)
+
+    def peakmem_reference(self, *args):
+        """Provide reference for memory measurement with empty benchmark.
+
+        Peakmem benchmarks measure the maximum amount of RAM used by a
+        function. However, this maximum also includes the memory used
+        during the setup routine (as of asv 0.2.1; see [1]_).
+        Measuring an empty peakmem function might allow us to disambiguate
+        between the memory used by setup and the memory used by target (see
+        other ``peakmem_`` functions below).
+
+        References
+        ----------
+        .. [1]: https://asv.readthedocs.io/en/stable/writing_benchmarks.html#peak-memory
+        """
+        pass
+
+    def peakmem_match_histogram(self, *args):
+        exposure.match_histograms(self.image, self.reference, **self.kwargs)

--- a/benchmarks/benchmark_exposure.py
+++ b/benchmarks/benchmark_exposure.py
@@ -46,7 +46,7 @@ class MatchHistogramsSuite:
     param_names = ["shape", "dtype", "multichannel"]
     params = [
         ((64, 64), (256, 256), (1024, 1024)),
-        (np.uint8, np.float32, np.float64),
+        (np.uint8, np.uint32, np.float32, np.float64),
         (False, True),
     ]
 

--- a/skimage/exposure/histogram_matching.py
+++ b/skimage/exposure/histogram_matching.py
@@ -19,8 +19,8 @@ def _match_cumulative_cdf(source, template):
         tmpl_values = tmpl_values[tmpl_values_exist]
     else:
         src_values, src_lookup, src_counts = np.unique(source.ravel(),
-                                                           return_inverse=True,
-                                                           return_counts=True)
+                                                       return_inverse=True,
+                                                       return_counts=True)
         tmpl_values, tmpl_counts = np.unique(template.ravel(), return_counts=True)
 
     # calculate normalized quantiles for each array

--- a/skimage/exposure/histogram_matching.py
+++ b/skimage/exposure/histogram_matching.py
@@ -9,19 +9,20 @@ def _match_cumulative_cdf(source, template):
     its values matches the cumulative density function of the template.
     """
     if source.dtype.kind == 'u':
-        src_lookup = source.ravel()
+        src_lookup = source.reshape(-1)
         src_counts = np.bincount(src_lookup)
-        tmpl_counts = np.bincount(template.ravel())
+        tmpl_counts = np.bincount(template.reshape(-1))
         tmpl_values = np.arange(len(tmpl_counts))
-        
+
         tmpl_values_exist = tmpl_counts > 0
         tmpl_counts = tmpl_counts[tmpl_values_exist]
         tmpl_values = tmpl_values[tmpl_values_exist]
     else:
-        src_values, src_lookup, src_counts = np.unique(source.ravel(),
+        src_values, src_lookup, src_counts = np.unique(source.reshape(-1),
                                                        return_inverse=True,
                                                        return_counts=True)
-        tmpl_values, tmpl_counts = np.unique(template.ravel(), return_counts=True)
+        tmpl_values, tmpl_counts = np.unique(template.reshape(-1),
+                                             return_counts=True)
 
     # calculate normalized quantiles for each array
     src_quantiles = np.cumsum(src_counts) / source.size

--- a/skimage/exposure/histogram_matching.py
+++ b/skimage/exposure/histogram_matching.py
@@ -8,17 +8,27 @@ def _match_cumulative_cdf(source, template):
     Return modified source array so that the cumulative density function of
     its values matches the cumulative density function of the template.
     """
-    src_values, src_unique_indices, src_counts = np.unique(source.ravel(),
+    if source.dtype.kind == 'u':
+        src_lookup = source.ravel()
+        src_counts = np.bincount(src_lookup)
+        tmpl_counts = np.bincount(template.ravel())
+        tmpl_values = np.arange(len(tmpl_counts))
+        
+        tmpl_values_exist = tmpl_counts > 0
+        tmpl_counts = tmpl_counts[tmpl_values_exist]
+        tmpl_values = tmpl_values[tmpl_values_exist]
+    else:
+        src_values, src_lookup, src_counts = np.unique(source.ravel(),
                                                            return_inverse=True,
                                                            return_counts=True)
-    tmpl_values, tmpl_counts = np.unique(template.ravel(), return_counts=True)
+        tmpl_values, tmpl_counts = np.unique(template.ravel(), return_counts=True)
 
     # calculate normalized quantiles for each array
     src_quantiles = np.cumsum(src_counts) / source.size
     tmpl_quantiles = np.cumsum(tmpl_counts) / template.size
 
     interp_a_values = np.interp(src_quantiles, tmpl_quantiles, tmpl_values)
-    return interp_a_values[src_unique_indices].reshape(source.shape)
+    return interp_a_values[src_lookup].reshape(source.shape)
 
 
 @utils.channel_as_last_axis(channel_arg_positions=(0, 1))

--- a/skimage/exposure/histogram_matching.py
+++ b/skimage/exposure/histogram_matching.py
@@ -12,11 +12,10 @@ def _match_cumulative_cdf(source, template):
         src_lookup = source.reshape(-1)
         src_counts = np.bincount(src_lookup)
         tmpl_counts = np.bincount(template.reshape(-1))
-        tmpl_values = np.arange(len(tmpl_counts))
 
-        tmpl_values_exist = tmpl_counts > 0
-        tmpl_counts = tmpl_counts[tmpl_values_exist]
-        tmpl_values = tmpl_values[tmpl_values_exist]
+        # omit values where the count was 0
+        tmpl_values = np.nonzero(tmpl_counts)[0]
+        tmpl_counts = tmpl_counts[tmpl_values]
     else:
         src_values, src_lookup, src_counts = np.unique(source.reshape(-1),
                                                        return_inverse=True,

--- a/skimage/exposure/tests/test_histogram_matching.py
+++ b/skimage/exposure/tests/test_histogram_matching.py
@@ -114,3 +114,13 @@ class TestMatchHistogram:
             channels_pdf.append((channel_values, channel_quantiles))
 
         return np.asarray(channels_pdf, dtype=object)
+
+    def test_match_histograms_consistency(self):
+        """ensure equivalent results for float and integer-based code paths"""
+        image_u8 = self.image_rgb
+        reference_u8 = self.template_rgb
+        image_f64 = self.image_rgb.astype(np.float64)
+        reference_f64 = self.template_rgb.astype(np.float64, copy=False)
+        matched_u8 = exposure.match_histograms(image_u8, reference_u8)
+        matched_f64 = exposure.match_histograms(image_f64, reference_f64)
+        assert_array_almost_equal(matched_u8.astype(np.float64), matched_f64)


### PR DESCRIPTION
## Description

This PR adds the suggestions from #6209. Benchmark results show a large improvement for unsigned integer types as compared to floating point types. The improvement is > 10x at larger sizes.

```

[100.00%] ··· benchmark_exposure.MatchHistogramsSuite.time_match_histogram 
[100.00%] ··· ============== =============== ============= =============
              --                                     multichannel       
              ------------------------------ ---------------------------
                  shape           dtype          False          True    
              ============== =============== ============= =============
                 (64, 64)      numpy.uint8     54.8±0.4μs     149±2μs   
                 (64, 64)      numpy.uint32    56.0±0.9μs     154±1μs   
                 (64, 64)     numpy.float32     287±1μs       843±7μs   
                 (64, 64)     numpy.float64    285±0.8μs      827±20μs  
                (256, 256)     numpy.uint8      354±7μs     1.30±0.02ms 
                (256, 256)     numpy.uint32     411±5μs     1.64±0.01ms 
                (256, 256)    numpy.float32   4.25±0.03ms   13.2±0.04ms 
                (256, 256)    numpy.float64    4.40±0.1ms    13.4±0.1ms 
               (1024, 1024)    numpy.uint8    5.33±0.04ms    23.2±0.5ms 
               (1024, 1024)    numpy.uint32   6.35±0.05ms    31.3±0.6ms 
               (1024, 1024)   numpy.float32    87.0±0.2ms     268±3ms   
               (1024, 1024)   numpy.float64    96.2±0.8ms     288±7ms   
              ============== =============== ============= =============
```


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
