### PR TITLE
Document support for Path objects in io functions

### DIFF
--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -18,7 +18,7 @@ def imread(fname, as_gray=False, plugin=None, **plugin_args):
 
     Parameters
     ----------
-    fname : string
+    fname : str or pathlib.Path
         Image file name, e.g. ``test.jpg`` or URL.
     as_gray : bool, optional
         If True, convert color images to gray-scale (64-bit floats).
@@ -103,7 +103,7 @@ def imsave(fname, arr, plugin=None, check_contrast=True, **plugin_args):
 
     Parameters
     ----------
-    fname : str
+    fname : str or pathlib.Path
         Target filename.
     arr : ndarray of shape (M,N) or (M,N,3) or (M,N,4)
         Image data.


### PR DESCRIPTION
## Description

Closes #6360 

This PR has been tested on PyCharm 2022.1 to fix type warnings when passing `Path` objects into `imread` and `imshow`.

Prefer to use `or` as the type separator to match the conventions used nearby. PyCharm still understands the type as a union.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
