### PR TITLE
add recently merged PR to the v0.19.3 release notes

### DIFF
--- a/doc/release/release_0.19.rst
+++ b/doc/release/release_0.19.rst
@@ -32,12 +32,14 @@ Pull Requests Included
 - Backport PR #6355 on branch v0.19.x (remove use of deprecated kwargs from `test_tifffile_kwarg_passthrough`) (#6357)
 - Backport PR #6352 on branch v0.19.x (Fix channel_axis default for cycle_spin) (#6358)
 - Backport PR #6348 on branch v0.19.x (Fix smoothed image computation when mask is None in canny) (#6359)
+- Backport PR #6361 on branch v0.19.x (Document support for Path objects in io functions) #6363
 
-5 authors added to this release [alphabetical by first name or login]
+6 authors added to this release [alphabetical by first name or login]
 ---------------------------------------------------------------------
 - Bartłomiej Śmietanka
 - Dave Mellert
 - Gregory Lee
+- johnthagen (johnthagen)
 - Mark Harfouche
 - Riadh Fezzani
 

--- a/doc/release/release_0.19.rst
+++ b/doc/release/release_0.19.rst
@@ -39,7 +39,7 @@ Pull Requests Included
 - Bartłomiej Śmietanka
 - Dave Mellert
 - Gregory Lee
-- johnthagen (johnthagen)
+John Hagen
 - Mark Harfouche
 - Riadh Fezzani
 

--- a/doc/release/release_0.19.rst
+++ b/doc/release/release_0.19.rst
@@ -39,7 +39,7 @@ Pull Requests Included
 - Bartłomiej Śmietanka
 - Dave Mellert
 - Gregory Lee
-John Hagen
+- John Hagen
 - Mark Harfouche
 - Riadh Fezzani
 


### PR DESCRIPTION
## Description

small update to the release notes

@johnthagen, please provide your name if you would like it to be listed here instead of your GitHub id


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
