### PR TITLE
Add 3D rotation and translation for EuclideanTransform object, and 3D scale for SimilarityTransform

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1267,7 +1267,7 @@ class EuclideanTransform(ProjectiveTransform):
 class SimilarityTransform(EuclideanTransform):
     """Similarity transformation.
 
-    2D Has the following form::
+    Has the following form in 2D::
 
         X = a0 * x - b0 * y + a1 =
           = s * x * cos(rotation) - s * y * sin(rotation) + a1
@@ -1355,9 +1355,9 @@ class SimilarityTransform(EuclideanTransform):
 
         Parameters
         ----------
-        src : (N, dim) array
+        src : (N, ndim) array
             Source coordinates.
-        dst : (N, dim) array
+        dst : (N, ndim) array
             Destination coordinates.
 
         Returns

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1408,7 +1408,8 @@ class SimilarityTransform(EuclideanTransform):
         elif self.dimensionality == 3:
             return np.cbrt(np.linalg.det(self.params))
         else:
-            raise NotImplementedError('Scale is only implemented for 2D and 3D.')
+            raise NotImplementedError(
+                'Scale is only implemented for 2D and 3D.')
 
 
 class PolynomialTransform(GeometricTransform):

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -163,35 +163,6 @@ def _umeyama(src, dst, estimate_scale):
     return T
 
 
-def _rotation_matrix_to_euler_angles(R):
-    """
-    Converts rotation matrix to euler angles.
-
-    Parameters
-    ----------
-    R: (3, 3) array
-        Rotation matrix
-
-    Returns
-    -------
-    euler_angles: (roll, pitch, yaw)
-        Euler angles in radians
-
-    """
-    sy = math.sqrt(R[0, 0] * R[0, 0] + R[1, 0] * R[1, 0])
-    singular = sy < 1e-6
-    if not singular:
-        x = math.atan2(R[2, 1], R[2, 2])
-        y = math.atan2(-R[2, 0], sy)
-        z = math.atan2(R[1, 0], R[0, 0])
-    else:
-        x = math.atan2(-R[1, 2], R[1, 1])
-        y = math.atan2(-R[2, 0], sy)
-        z = 0
-
-    return np.array([x, y, z])
-
-
 class GeometricTransform(object):
     """Base class for geometric transformations.
 
@@ -1281,7 +1252,8 @@ class EuclideanTransform(ProjectiveTransform):
         if self.dimensionality == 2:
             return math.atan2(self.params[1, 0], self.params[1, 1])
         elif self.dimensionality == 3:
-            return _rotation_matrix_to_euler_angles(self.params[:3, :3])
+            # Returning 3D Euler rotation matrix
+            return self.params[:3, :3]
         else:
             raise NotImplementedError(
                 'Rotation only implemented for 2D and 3D transforms.'

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -163,7 +163,7 @@ def _umeyama(src, dst, estimate_scale):
     return T
 
 
-def rotation_matrix_to_euler_angles(R):
+def _rotation_matrix_to_euler_angles(R):
     """
     Converts rotation matrix to euler angles.
     
@@ -1281,7 +1281,7 @@ class EuclideanTransform(ProjectiveTransform):
         if self.dimensionality == 2:
             return math.atan2(self.params[1, 0], self.params[1, 1])
         elif self.dimensionality == 3:
-            return rotation_matrix_to_euler_angles(self.params[:3, :3])
+            return _rotation_matrix_to_euler_angles(self.params[:3, :3])
         else:
             raise NotImplementedError(
                 'The rotation property is only implemented for 2D and 3D transforms.'

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -166,12 +166,12 @@ def _umeyama(src, dst, estimate_scale):
 def _rotation_matrix_to_euler_angles(R):
     """
     Converts rotation matrix to euler angles.
-    
+
     Parameters
     ----------
     R: (3, 3) array
         Rotation matrix
-    
+
     Returns
     -------
     euler_angles: (roll, pitch, yaw)
@@ -1284,7 +1284,7 @@ class EuclideanTransform(ProjectiveTransform):
             return _rotation_matrix_to_euler_angles(self.params[:3, :3])
         else:
             raise NotImplementedError(
-                'The rotation property is only implemented for 2D and 3D transforms.'
+                'Rotation only implemented for 2D and 3D transforms.'
             )
 
     @property

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -71,6 +71,31 @@ def test_euclidean_estimation():
     assert_almost_equal(tform3.params, tform2.params)
 
 
+def test_3d_euclidean_estimation():
+    src_points = np.random.rand(1000, 3)
+
+    # Random transformation for testing
+    angles = np.random.random((3,)) * 2 * np.pi - np.pi
+    rotation_matrix = _euler_rotation_matrix(angles)
+    translation_vector = np.random.random((3,))
+    dst_points = []
+    for pt in src_points:
+        pt_r = pt.reshape(3, 1)
+        dst = np.matmul(rotation_matrix, pt_r) + \
+            translation_vector.reshape(3, 1)
+        dst = dst.reshape(3)
+        dst_points.append(dst)
+
+    dst_points = np.array(dst_points)
+    # estimating the transformation
+    tform = EuclideanTransform(dimensionality=3)
+    assert tform.estimate(src_points, dst_points)
+    estimated_rotation = tform.rotation
+    estimated_translation = tform.translation
+    assert_almost_equal(estimated_rotation, rotation_matrix)
+    assert_almost_equal(estimated_translation, translation_vector)
+
+
 def test_euclidean_init():
     # init with implicit parameters
     rotation = 1
@@ -116,6 +141,34 @@ def test_similarity_estimation():
     tform3 = SimilarityTransform()
     assert tform3.estimate(SRC, DST)
     assert_almost_equal(tform3.params, tform2.params)
+
+
+def test_3d_similarity_estimation():
+    src_points = np.random.rand(1000, 3)
+
+    # Random transformation for testing
+    angles = np.random.random((3,)) * 2 * np.pi - np.pi
+    scale = np.random.randint(0, 20)
+    rotation_matrix = _euler_rotation_matrix(angles)*scale
+    translation_vector = np.random.random((3,))
+    dst_points = []
+    for pt in src_points:
+        pt_r = pt.reshape(3, 1)
+        dst = np.matmul(rotation_matrix, pt_r) + \
+            translation_vector.reshape(3, 1)
+        dst = dst.reshape(3)
+        dst_points.append(dst)
+
+    dst_points = np.array(dst_points)
+    # estimating the transformation
+    tform = SimilarityTransform(dimensionality=3)
+    assert tform.estimate(src_points, dst_points)
+    estimated_rotation = tform.rotation
+    estimated_translation = tform.translation
+    estimated_scale = tform.scale
+    assert_almost_equal(estimated_translation, translation_vector)
+    assert_almost_equal(estimated_scale, scale)
+    assert_almost_equal(estimated_rotation, rotation_matrix)
 
 
 def test_similarity_init():

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -149,7 +149,7 @@ def test_3d_similarity_estimation():
     # Random transformation for testing
     angles = np.random.random((3,)) * 2 * np.pi - np.pi
     scale = np.random.randint(0, 20)
-    rotation_matrix = _euler_rotation_matrix(angles)*scale
+    rotation_matrix = _euler_rotation_matrix(angles) * scale
     translation_vector = np.random.random((3,))
     dst_points = []
     for pt in src_points:


### PR DESCRIPTION
## Description
1. Added 3D rotation and translation object for EuclideanTransform
2. Added 3D scale data for SimilarityTransform
<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
Closes #6365
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
