### PR TITLE
Fix windows wheels: use `vsdevcmd.bat` to make sure `rc.exe` is on the path

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -184,13 +184,18 @@ jobs:
           path: ./dist/*.whl
 
   build_windows_wheels:
-    name: Build ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
+    name: Build ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [windows-latest]
         cibw_arch: ["AMD64", "x86"]
+        cibw_python: ["cp37-*", "cp38-*", "cp39-*", "cp310-*"]
+        exclude:
+          - os: windows-latest
+            cibw_python: "cp310-*"
+            cibw_arch: x86
 
     steps:
       - uses: actions/checkout@v2
@@ -214,8 +219,7 @@ jobs:
         run: |
           choco install --force --x86 llvm
 
-      # install clang-cl (needed for Pythran)
-      - name: Install clang-cl
+      - name: Install x64 clang-cl
         if: matrix.cibw_arch == 'AMD64'
         run: |
           choco install --force llvm
@@ -226,23 +230,54 @@ jobs:
           SET PATH="C:\\Program Files\\LLVM\\bin;%PATH%"
           SET PATH="C:\\Program Files (x86)\\LLVM\\bin;%PATH%"
 
-      - name: Build Windows wheels for CPython 3.10
-        # NumPy dropped x86 wheels for Python 3.10
-        if: matrix.cibw_arch == 'AMD64'
+      - name: Build x86 Windows wheels for CPython
+        if: matrix.cibw_arch == 'x86'
+        # To avoid "LINK : fatal error LNK1158: cannot run 'rc.exe'"
+        # we explicitly add rc.exe to path using the method from:
+        # https://github.com/actions/virtual-environments/issues/294#issuecomment-588090582
+        # with additional -arch=x86 flag to vsdevcmd.bat
         run: |
+          function Invoke-VSDevEnvironment {
+            $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+              $installationPath = & $vswhere -prerelease -legacy -latest -property installationPath
+              $Command = Join-Path $installationPath "Common7\Tools\vsdevcmd.bat"
+            & "${env:COMSPEC}" /s /c "`"$Command`" -arch=x86 -no_logo && set" | Foreach-Object {
+                  if ($_ -match '^([^=]+)=(.*)') {
+                      [System.Environment]::SetEnvironmentVariable($matches[1], $matches[2])
+                  }
+              }
+          }
+          Invoke-VSDevEnvironment
+          Get-Command rc.exe | Format-Table -AutoSize
           python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp310-*"
+          CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
           # -Wl,-S equivalent to gcc's -Wl,--strip-debug
           LDFLAGS: "-Wl,-S"
 
-      - name: Build Windows wheels for CPython
+      - name: Build x64 Windows wheels for CPython
+        if: matrix.cibw_arch == 'AMD64'
+        # To avoid "LINK : fatal error LNK1158: cannot run 'rc.exe'"
+        # we explicitly add rc.exe to path using the method from:
+        # https://github.com/actions/virtual-environments/issues/294#issuecomment-588090582
+        # with additional -arch=x86 flag to vsdevcmd.bat
         run: |
+          function Invoke-VSDevEnvironment {
+            $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+              $installationPath = & $vswhere -prerelease -legacy -latest -property installationPath
+              $Command = Join-Path $installationPath "Common7\Tools\vsdevcmd.bat"
+            & "${env:COMSPEC}" /s /c "`"$Command`" -arch=amd64 -no_logo && set" | Foreach-Object {
+                  if ($_ -match '^([^=]+)=(.*)') {
+                      [System.Environment]::SetEnvironmentVariable($matches[1], $matches[2])
+                  }
+              }
+          }
+          Invoke-VSDevEnvironment
+          Get-Command rc.exe | Format-Table -AutoSize
           python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp3?-*"
-          CIBW_SKIP: "cp36-*"
+          CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
           # -Wl,-S equivalent to gcc's -Wl,--strip-debug
           LDFLAGS: "-Wl,-S"


### PR DESCRIPTION
## Description

This PR is to resolve wheel build failures @alexdesiqueira and I observed on Wed. when trying to build v0.19.3 wheels. 

The script for finding the path of `rc.exe` is adapted from: https://github.com/actions/virtual-environments/issues/294#issuecomment-588090582, but with an additional `-arch=arm64` or `-arch=x86` flag to make sure we get the paths for the correct architecture. Someone with better Powershell skills can probably merge the: `name: Build x86 Windows wheels for CPython` and `name: Build x64 Windows wheels for CPython` code paths that are mostly duplicated (it is just the `-arch=` flag that is different between the two).

Aside from the `rc.exe` path fix, I moved the Python architectures to the matrix so all of the builds occur in parallel.

Here is a log of a successful run with the settings as here (non-Windows wheels were commented out): https://github.com/grlee77/scikit-image/runs/6241317513?check_suite_focus=true


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
