### PR TITLE
Improve multi_otsu error messgae and maintance of threshold.py

### DIFF
--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -1287,8 +1287,10 @@ def threshold_multiotsu(image=None, classes=3, nbins=256, *, hist=None):
 
     nvalues = np.count_nonzero(prob)
     if nvalues < classes:
-        msg = (f'The input image has only {nvalues} different values. '
-               f'It cannot be thresholded in {classes} classes.')
+        msg = (f'After discretization into bins, the input image has '
+               f'only {nvalues} different values. It cannot be thresholded '
+               f'in {classes} classes. If there are more unique values '
+               f'before discretization, try increasing the number of bins.')
         raise ValueError(msg)
     elif nvalues == classes:
         thresh_idx = np.flatnonzero(prob)[:-1]

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -930,7 +930,7 @@ def threshold_triangle(image, nbins=256):
     # Find peak, lowest and highest gray levels.
     arg_peak_height = np.argmax(hist)
     peak_height = hist[arg_peak_height]
-    arg_low_level, arg_high_level = np.where(hist > 0)[0][[0, -1]]
+    arg_low_level, arg_high_level = np.flatnonzero(hist)[[0, -1]]
 
     # Flip is True if left tail is shorter.
     flip = arg_peak_height - arg_low_level < arg_high_level - arg_peak_height
@@ -1291,7 +1291,7 @@ def threshold_multiotsu(image=None, classes=3, nbins=256, *, hist=None):
                f'It cannot be thresholded in {classes} classes.')
         raise ValueError(msg)
     elif nvalues == classes:
-        thresh_idx = np.where(prob > 0)[0][:-1]
+        thresh_idx = np.flatnonzero(prob)[:-1]
     else:
         # Get threshold indices
         try:

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -58,7 +58,7 @@ def _try_all(image, methods=None, figsize=None, num_cols=2, verbose=True):
 
     # Compute the image histogram for better performances
     nbins = 256  # Default in threshold functions
-    hist = histogram(image.ravel(), nbins, source_range='image')
+    hist = histogram(image.reshape(-1), nbins, source_range='image')
 
     # Handle default value
     methods = methods or {}
@@ -66,7 +66,7 @@ def _try_all(image, methods=None, figsize=None, num_cols=2, verbose=True):
     num_rows = math.ceil((len(methods) + 1.) / num_cols)
     fig, ax = plt.subplots(num_rows, num_cols, figsize=figsize,
                            sharex=True, sharey=True)
-    ax = ax.ravel()
+    ax = ax.reshape(-1)
 
     ax[0].imshow(image, cmap=plt.cm.gray)
     ax[0].set_title('Original')
@@ -304,7 +304,7 @@ def _validate_image_histogram(image, hist, nbins=None, normalize=False):
             counts, bin_centers = counts[start:end], bin_centers[start:end]
     else:
         counts, bin_centers = histogram(
-                image.ravel(), nbins, source_range='image', normalize=normalize
+            image.reshape(-1), nbins, source_range='image', normalize=normalize
             )
     return counts.astype('float32', copy=False), bin_centers
 
@@ -357,7 +357,7 @@ def threshold_otsu(image=None, nbins=256, *, hist=None):
     # Check if the image has more than one intensity value; if not, return that
     # value
     if image is not None:
-        first_pixel = image.ravel()[0]
+        first_pixel = image.reshape(-1)[0]
         if np.all(image == first_pixel):
             return first_pixel
 
@@ -923,7 +923,8 @@ def threshold_triangle(image, nbins=256):
     """
     # nbins is ignored for integer arrays
     # so, we recalculate the effective nbins.
-    hist, bin_centers = histogram(image.ravel(), nbins, source_range='image')
+    hist, bin_centers = histogram(image.reshape(-1), nbins,
+                                  source_range='image')
     nbins = len(hist)
 
     # Find peak, lowest and highest gray levels.

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -306,7 +306,7 @@ def _validate_image_histogram(image, hist, nbins=None, normalize=False):
         counts, bin_centers = histogram(
                 image.ravel(), nbins, source_range='image', normalize=normalize
             )
-    return counts.astype(float), bin_centers
+    return counts.astype('float32', copy=False), bin_centers
 
 
 def threshold_otsu(image=None, nbins=256, *, hist=None):
@@ -1282,7 +1282,7 @@ def threshold_multiotsu(image=None, classes=3, nbins=256, *, hist=None):
     # calculating the histogram and the probability of each gray level.
     prob, bin_centers = _validate_image_histogram(image, hist, nbins,
                                                   normalize=True)
-    prob = prob.astype('float32')
+    prob = prob.astype('float32', copy=False)
 
     nvalues = np.count_nonzero(prob)
     if nvalues < classes:

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -430,7 +430,7 @@ def threshold_yen(image=None, nbins=256, *, hist=None):
         return bin_centers[0]
 
     # Calculate probability mass function
-    pmf = counts.astype(np.float32) / counts.sum()
+    pmf = counts.astype(np.float32, copy=False) / counts.sum()
     P1 = np.cumsum(pmf)  # Cumulative normalized histogram
     P1_sq = np.cumsum(pmf ** 2)
     # Get cumsum calculated from end of squared array:
@@ -511,7 +511,7 @@ def threshold_isodata(image=None, nbins=256, return_all=False, *, hist=None):
         else:
             return bin_centers[0]
 
-    counts = counts.astype(np.float32)
+    counts = counts.astype(np.float32, copy=False)
 
     # csuml and csumh contain the count of pixels in that bin or lower, and
     # in all bins strictly higher than that bin, respectively
@@ -729,7 +729,7 @@ def threshold_li(image, *, tolerance=None, initial_guess=None,
     if image.dtype.kind in 'iu':
         hist, bin_centers = histogram(image.reshape(-1),
                                       source_range='image')
-        hist = hist.astype(float)
+        hist = hist.astype(float, copy=False)
         while abs(t_next - t_curr) > tolerance:
             t_curr = t_next
             foreground = bin_centers > t_curr


### PR DESCRIPTION
## Description

Fixes #6324 and implements some code maintenance:
- `ravel` -> `reshape(-1)`,
- `copy=False` in astype
- use single precision when possible (`float` -> `float32`)
- call `np.flatnonzero(arr)` instead of `np.where(arr >0)[0]`

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
