### PR TITLE
Removing reference to `marching_cubes_lewiner` from `plot_marching_cubes.py` 

### DIFF
--- a/doc/examples/edges/plot_marching_cubes.py
+++ b/doc/examples/edges/plot_marching_cubes.py
@@ -37,7 +37,7 @@ ellip_double = np.concatenate((ellip_base[:-1, ...],
 verts, faces, normals, values = measure.marching_cubes(ellip_double, 0)
 
 # Display resulting triangular mesh using Matplotlib. This can also be done
-# with mayavi (see skimage.measure.marching_cubes_lewiner docstring).
+# with mayavi (see skimage.measure.marching_cubes docstring).
 fig = plt.figure(figsize=(10, 10))
 ax = fig.add_subplot(111, projection='3d')
 


### PR DESCRIPTION
## Description

We removed `marching_cubes_lewiner` in favor of `marching_cubes`, but a sentence of our documentation still referred to it. Fixing.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
