### PR TITLE
derive OBJECT_COLUMNS from COL_DTYPES in regionprops

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -89,11 +89,6 @@ PROPS = {
     'weighted_moments_normalized': 'moments_weighted_normalized',
 }
 
-OBJECT_COLUMNS = {
-    'image', 'coords', 'image_convex', 'slice',
-    'image_filled', 'image_intensity'
-}
-
 COL_DTYPES = {
     'area': float,
     'area_bbox': float,
@@ -136,6 +131,8 @@ COL_DTYPES = {
     'slice': object,
     'solidity': float,
 }
+
+OBJECT_COLUMNS = [col for col, dtype in COL_DTYPES.items() if dtype == object]
 
 PROP_VALS = set(PROPS.values())
 


### PR DESCRIPTION
## Description

Derives a list of region properties that return objects `OBJECT_COLUMNS` from a dict of all props and their types `COL_DTYPES` to make adding new props easier and less error prone.
See discussion of the same change in cuCIM: https://github.com/rapidsai/cucim/pull/272#discussion_r879949925


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
