### PR TITLE
DOC: add original plot in examples/segmentation/plot_expand_labels.py

### DIFF
--- a/doc/examples/segmentation/plot_expand_labels.py
+++ b/doc/examples/segmentation/plot_expand_labels.py
@@ -36,7 +36,13 @@ seg1 = label(ws == foreground)
 expanded = expand_labels(seg1, distance=10)
 
 # Show the segmentations.
-fig, axes = plt.subplots(nrows=1, ncols=3, figsize=(9, 5), sharex=True, sharey=True)
+fig, axes = plt.subplots(
+    nrows=1,
+    ncols=3,
+    figsize=(9, 5),
+    sharex=True,
+    sharey=True,
+)
 
 axes[0].imshow(coins, cmap="Greys_r")
 axes[0].set_title("Original")

--- a/doc/examples/segmentation/plot_expand_labels.py
+++ b/doc/examples/segmentation/plot_expand_labels.py
@@ -10,14 +10,13 @@ In contrast to :py:func:`skimage.morphology.dilation` this method will
 not let connected components expand into neighboring connected components
 with lower label number.
 """
-import numpy as np
 import matplotlib.pyplot as plt
-
+import numpy as np
+from skimage import data
+from skimage.color import label2rgb
 from skimage.filters import sobel
 from skimage.measure import label
-from skimage.segmentation import watershed, expand_labels
-from skimage.color import label2rgb
-from skimage import data
+from skimage.segmentation import expand_labels, watershed
 
 coins = data.coins()
 
@@ -37,18 +36,20 @@ seg1 = label(ws == foreground)
 expanded = expand_labels(seg1, distance=10)
 
 # Show the segmentations.
-fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(9, 5),
-                         sharex=True, sharey=True)
+fig, axes = plt.subplots(nrows=1, ncols=3, figsize=(9, 5), sharex=True, sharey=True)
+
+axes[0].imshow(coins, cmap="Greys_r")
+axes[0].set_title("Original")
 
 color1 = label2rgb(seg1, image=coins, bg_label=0)
-axes[0].imshow(color1)
-axes[0].set_title('Sobel+Watershed')
+axes[1].imshow(color1)
+axes[1].set_title("Sobel+Watershed")
 
 color2 = label2rgb(expanded, image=coins, bg_label=0)
-axes[1].imshow(color2)
-axes[1].set_title('Expanded labels')
+axes[2].imshow(color2)
+axes[2].set_title("Expanded labels")
 
 for a in axes:
-    a.axis('off')
+    a.axis("off")
 fig.tight_layout()
 plt.show()


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

I have made a small modification to the `plot_expand_labels` example by adding the original plot as well. I found this beneficial to understand what the two other images were showing. I thought other users would also find it beneficial so I made my first PR here. I have also used black formatting on the code.

You can test the code outside of there PR here: https://github.com/raybellwaves/scikit-image/blob/plot-orginal-in-plot-expand-labels/doc/examples/segmentation/plot_expand_labels.py

It will make the following plot:

![Screen Shot 2022-06-01 at 10 12 34 PM](https://user-images.githubusercontent.com/17162724/171533888-e3519b6b-3232-4b3f-b3f0-b88507164784.png)


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
