### PR TITLE
Use supported circleci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   doc:
     docker:
-      - image: circleci/python:3.8.2
+      - image: cimg/python:3.8
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Use new docker images (instead of legacy images that are no longer supported):
https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034