### PR TITLE
Update minimum pillow dependency

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,7 +1,7 @@
 numpy>=1.19
 scipy>=1.5
 networkx>=2.5
-pillow>=6.2.0,!=7.1.0,!=7.1.1,!=8.3.0,!=9.1.0,!=9.1.1
+pillow>=9.0.1,!=9.1.0,!=9.1.1
 imageio>=2.4.1
 tifffile>=2019.7.26
 PyWavelets>=1.1.1


### PR DESCRIPTION
There are a number of security issues (many marked `high` or `critical`) with `pillow<9.0.1`:
https://github.com/scikit-image/scikit-image/security/dependabot