### PR TITLE
In newer PIL, palette may contain <256 entries

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,7 +1,7 @@
 numpy>=1.19
 scipy>=1.5
 networkx>=2.5
-pillow>=9.0.1,!=9.1.0,!=9.1.1
+pillow>=9.0.1
 imageio>=2.4.1
 tifffile>=2019.7.26
 PyWavelets>=1.1.1

--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -153,7 +153,8 @@ def _palette_is_grayscale(pil_image):
     if pil_image.mode != 'P':
         raise ValueError('pil_image.mode must be equal to "P".')
     # get palette as an array with R, G, B columns
-    palette = np.asarray(pil_image.getpalette()).reshape((256, 3))
+    # Starting in pillow 9.1 palettes may have less than 256 entries
+    palette = np.asarray(pil_image.getpalette()).reshape((-1, 3))
     # Not all palette colors are used; unused colors have junk values.
     start, stop = pil_image.getextrema()
     valid_palette = palette[start:stop + 1]


### PR DESCRIPTION
`Co-authored-by: Graham Inggs <ginggs@debian.org>`

See https://github.com/scikit-image/scikit-image/issues/6314