### PR TITLE
Sync numpy minimum version

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -2,6 +2,4 @@ Cython>=0.29.21,!=0.29.18
 packaging>=20.0
 pythran
 wheel
-# numpy 1.18.0 breaks builds on MacOSX
-# https://github.com/numpy/numpy/pull/15194
-numpy>=1.17.3,!=1.18.0
+numpy>=1.19


### PR DESCRIPTION
Use the same numpy version dependencies for building as used by default.