### PR TITLE
backport of gh-6405: In newer PIL, palette may contain <256 entries

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,7 +1,7 @@
 numpy>=1.17.0
 scipy>=1.4.1
 networkx>=2.2
-pillow>=6.1.0,!=7.1.0,!=7.1.1,!=8.3.0,<9.1
+pillow>=6.1.0,!=7.1.0,!=7.1.1,!=8.3.0
 imageio>=2.4.1
 tifffile>=2019.7.26
 PyWavelets>=1.1.1

--- a/skimage/io/_plugins/pil_plugin.py
+++ b/skimage/io/_plugins/pil_plugin.py
@@ -153,7 +153,7 @@ def _palette_is_grayscale(pil_image):
     if pil_image.mode != 'P':
         raise ValueError('pil_image.mode must be equal to "P".')
     # get palette as an array with R, G, B columns
-    palette = np.asarray(pil_image.getpalette()).reshape((256, 3))
+    palette = np.asarray(pil_image.getpalette()).reshape((-1, 3))
     # Not all palette colors are used; unused colors have junk values.
     start, stop = pil_image.getextrema()
     valid_palette = palette[start:stop + 1]


### PR DESCRIPTION
## Description

This is a manual backport of gh-6405. In main we require a recent pillow, but I wasn't sure we should bump the requirement in this branch on a point release. I did remove the upper bound, though since that should not be necessary with this fix.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
