### PR TITLE
Fix computation of histogram bins for multichannel integer-valued images

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -74,7 +74,9 @@ def _bincount_histogram(image, source_range, bin_centers=None):
         bin_centers = _bincount_histogram_centers(image, source_range)
     image_min, image_max = bin_centers[0], bin_centers[-1]
     image = _offset_array(image, image_min, image_max)
-    hist = np.bincount(image.ravel(), minlength=image_max - min(image_min, 0) + 1)
+    hist = np.bincount(
+        image.ravel(), minlength=image_max - min(image_min, 0) + 1
+    )
     if source_range == 'image':
         idx = max(image_min, 0)
         hist = hist[idx:]

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -29,9 +29,7 @@ def _offset_array(arr, low_boundary, high_boundary):
             # prevent overflow errors when offsetting
             arr = arr.astype(offset_dtype)
         arr = arr - offset
-    else:
-        offset = 0
-    return arr, offset
+    return arr
 
 
 def _bincount_histogram_centers(image, source_range):
@@ -75,8 +73,8 @@ def _bincount_histogram(image, source_range, bin_centers=None):
     if bin_centers is None:
         bin_centers = _bincount_histogram_centers(image, source_range)
     image_min, image_max = bin_centers[0], bin_centers[-1]
-    image, offset = _offset_array(image, image_min, image_max)
-    hist = np.bincount(image.ravel(), minlength=image_max - image_min + 1)
+    image = _offset_array(image, image_min, image_max)
+    hist = np.bincount(image.ravel(), minlength=image_max - min(image_min, 0) + 1)
     if source_range == 'image':
         idx = max(image_min, 0)
         hist = hist[idx:]

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -54,6 +54,15 @@ def test_int_range_image():
     assert_equal(bin_centers[-1], 100)
 
 
+def test_multichannel_int_range_image():
+    im = np.array([[10, 5], [100, 102]], dtype=np.int8)
+    frequencies, bin_centers = exposure.histogram(im, channel_axis=-1)
+    for ch in range(im.shape[-1]):
+        assert_equal(len(frequencies[ch]), len(bin_centers))
+    assert_equal(bin_centers[0], 5)
+    assert_equal(bin_centers[-1], 102)
+
+
 def test_peak_uint_range_dtype():
     im = np.array([10, 100], dtype=np.uint8)
     frequencies, bin_centers = exposure.histogram(im, source_range='dtype')


### PR DESCRIPTION
## Description

closes #6412

When calling `np.bincount`, we need to make sure the minimum bin is always zero, otherwise there can be a size mismatch across channels as encountered in #6412. A small test case for this was added to verify the fix.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
