### PR TITLE
Refactoring LPI filter API

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -32,6 +32,8 @@ Version 1.0
   function in `skimage/measure/_label.py`
 * Change the warning about poorly conditioned data to a ValueError within
   `skimage.measure.CircleModel.estimate` and update the tests in `test_circle_model_insufficient_data` accordingly.
+* In ``skimage/filters/lpi_filter.py``, remove the deprecated function
+  inverse().
 
 Other (2022)
 ------------

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -39,8 +39,7 @@ Bugfixes
 Deprecations
 ------------
 
-- The function ``filters.lpi_filter.inverse`` was deprecated. Please use
-``filters.lpi_filter.filter_inverse`` instead.
+- The function ``filters.lpi_filter.inverse`` was deprecated.
 
 
 Contributors to this release

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -39,6 +39,8 @@ Bugfixes
 Deprecations
 ------------
 
+- The function ``filters.lpi_filter.inverse`` was deprecated. Please use
+``filters.lpi_filter.filter_inverse`` instead.
 
 
 Contributors to this release

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -39,7 +39,8 @@ Bugfixes
 Deprecations
 ------------
 
-- The function ``filters.lpi_filter.inverse`` was deprecated.
+- The function ``filters.inverse`` was deprecated. Please use
+  ``filters.filter_inverse``.
 
 
 Contributors to this release

--- a/skimage/filters/__init__.py
+++ b/skimage/filters/__init__.py
@@ -4,7 +4,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
     submodules={'rank'},
     submod_attrs={
-        'lpi_filter': ['inverse', 'wiener', 'LPIFilter2D'],
+        'lpi_filter': ['apply_filter_inverse', 'wiener', 'LPIFilter2D'],
         '_gaussian': ['gaussian', 'difference_of_gaussians'],
         'edges': ['sobel', 'sobel_h', 'sobel_v',
                   'scharr', 'scharr_h', 'scharr_v',

--- a/skimage/filters/__init__.py
+++ b/skimage/filters/__init__.py
@@ -4,7 +4,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
     __name__,
     submodules={'rank'},
     submod_attrs={
-        'lpi_filter': ['apply_filter_inverse', 'wiener', 'LPIFilter2D'],
+        'lpi_filter': ['filter_inverse', 'wiener', 'LPIFilter2D'],
         '_gaussian': ['gaussian', 'difference_of_gaussians'],
         'edges': ['sobel', 'sobel_h', 'sobel_v',
                   'scharr', 'scharr_h', 'scharr_v',

--- a/skimage/filters/lpi_filter.py
+++ b/skimage/filters/lpi_filter.py
@@ -168,7 +168,7 @@ def filter_forward(data, impulse_response=None, filter_params={},
 
 
 @deprecated(alt_func='skimage.filters.lpi_filter.filter_inverse',
-            removed_version='1.0')
+            removed_version='0.21')
 def inverse(data, impulse_response=None, filter_params={}, max_gain=2,
             predefined_filter=None):
     return filter_inverse(data, impulse_response, filter_params,

--- a/skimage/filters/lpi_filter.py
+++ b/skimage/filters/lpi_filter.py
@@ -247,8 +247,3 @@ def wiener(data, impulse_response=None, filter_params={}, K=0.25,
     F = 1 / F * H_mag_sqr / (H_mag_sqr + K)
 
     return _centre(np.abs(fft.ifftshift(fft.ifftn(G * F))), data.shape)
-
-
-def constrained_least_squares(data, lam, impulse_response=None,
-                              filter_params={}):
-    raise NotImplementedError

--- a/skimage/filters/lpi_filter.py
+++ b/skimage/filters/lpi_filter.py
@@ -158,7 +158,7 @@ def apply_filter_forward(data, impulse_response=None, filter_params={},
     ...     return np.exp(-np.hypot(r, c)/1)
     >>>
     >>> from skimage import data
-    >>> filtered = forward(data.coins(), filt_func)
+    >>> filtered = apply_filter_forward(data.coins(), filt_func)
 
     """
     check_nD(data, 2, 'data')

--- a/skimage/filters/lpi_filter.py
+++ b/skimage/filters/lpi_filter.py
@@ -130,8 +130,8 @@ class LPIFilter2D(object):
         return out
 
 
-def forward(data, impulse_response=None, filter_params={},
-            predefined_filter=None):
+def apply_filter_forward(data, impulse_response=None, filter_params={},
+                         predefined_filter=None):
     """Apply the given filter to data.
 
     Parameters
@@ -167,8 +167,8 @@ def forward(data, impulse_response=None, filter_params={},
     return predefined_filter(data)
 
 
-def inverse(data, impulse_response=None, filter_params={}, max_gain=2,
-            predefined_filter=None):
+def apply_filter_inverse(data, impulse_response=None, filter_params={}, max_gain=2,
+                         predefined_filter=None):
     """Apply the filter in reverse to the given data.
 
     Parameters

--- a/skimage/filters/lpi_filter.py
+++ b/skimage/filters/lpi_filter.py
@@ -6,7 +6,7 @@
 import numpy as np
 import scipy.fft as fft
 
-from .._shared.utils import _supported_float_type, check_nD
+from .._shared.utils import _supported_float_type, check_nD, deprecated
 
 
 def _min_limit(x, val=np.finfo(float).eps):
@@ -165,6 +165,14 @@ def filter_forward(data, impulse_response=None, filter_params={},
     if predefined_filter is None:
         predefined_filter = LPIFilter2D(impulse_response, **filter_params)
     return predefined_filter(data)
+
+
+@deprecated(alt_func='skimage.filters.lpi_filter.filter_inverse',
+            removed_version='1.0')
+def inverse(data, impulse_response=None, filter_params={}, max_gain=2,
+            predefined_filter=None):
+    return filter_inverse(data, impulse_response, filter_params,
+                          max_gain, predefined_filter)
 
 
 def filter_inverse(data, impulse_response=None, filter_params={}, max_gain=2,

--- a/skimage/filters/lpi_filter.py
+++ b/skimage/filters/lpi_filter.py
@@ -14,8 +14,8 @@ def _min_limit(x, val=np.finfo(float).eps):
     x[mask] = np.sign(x[mask]) * val
 
 
-def _centre(x, oshape):
-    """Return an array of oshape from the centre of x.
+def _center(x, oshape):
+    """Return an array of oshape from the center of x.
 
     """
     start = (np.array(x.shape) - np.array(oshape)) // 2 + 1
@@ -126,7 +126,7 @@ class LPIFilter2D(object):
         check_nD(data, 2, 'data')
         F, G = self._prepare(data)
         out = fft.ifftn(F * G)
-        out = np.abs(_centre(out, data.shape))
+        out = np.abs(_center(out, data.shape))
         return out
 
 
@@ -204,7 +204,7 @@ def inverse(data, impulse_response=None, filter_params={}, max_gain=2,
     mask = np.abs(F) > max_gain
     F[mask] = np.sign(F[mask]) * max_gain
 
-    return _centre(np.abs(fft.ifftshift(fft.ifftn(G * F))), data.shape)
+    return _center(np.abs(fft.ifftshift(fft.ifftn(G * F))), data.shape)
 
 
 def wiener(data, impulse_response=None, filter_params={}, K=0.25,
@@ -246,4 +246,4 @@ def wiener(data, impulse_response=None, filter_params={}, K=0.25,
     H_mag_sqr = np.abs(F) ** 2
     F = 1 / F * H_mag_sqr / (H_mag_sqr + K)
 
-    return _centre(np.abs(fft.ifftshift(fft.ifftn(G * F))), data.shape)
+    return _center(np.abs(fft.ifftshift(fft.ifftn(G * F))), data.shape)

--- a/skimage/filters/lpi_filter.py
+++ b/skimage/filters/lpi_filter.py
@@ -15,7 +15,7 @@ def _min_limit(x, val=np.finfo(float).eps):
 
 
 def _center(x, oshape):
-    """Return an array of oshape from the center of x.
+    """Return an array of shape ``oshape`` from the center of array ``x``.
 
     """
     start = (np.array(x.shape) - np.array(oshape)) // 2 + 1

--- a/skimage/filters/lpi_filter.py
+++ b/skimage/filters/lpi_filter.py
@@ -130,8 +130,8 @@ class LPIFilter2D(object):
         return out
 
 
-def apply_filter_forward(data, impulse_response=None, filter_params={},
-                         predefined_filter=None):
+def filter_forward(data, impulse_response=None, filter_params={},
+                   predefined_filter=None):
     """Apply the given filter to data.
 
     Parameters
@@ -158,7 +158,7 @@ def apply_filter_forward(data, impulse_response=None, filter_params={},
     ...     return np.exp(-np.hypot(r, c)/1)
     >>>
     >>> from skimage import data
-    >>> filtered = apply_filter_forward(data.coins(), filt_func)
+    >>> filtered = filter_forward(data.coins(), filt_func)
 
     """
     check_nD(data, 2, 'data')
@@ -167,8 +167,8 @@ def apply_filter_forward(data, impulse_response=None, filter_params={},
     return predefined_filter(data)
 
 
-def apply_filter_inverse(data, impulse_response=None, filter_params={}, max_gain=2,
-                         predefined_filter=None):
+def filter_inverse(data, impulse_response=None, filter_params={}, max_gain=2,
+                   predefined_filter=None):
     """Apply the filter in reverse to the given data.
 
     Parameters

--- a/skimage/filters/lpi_filter.py
+++ b/skimage/filters/lpi_filter.py
@@ -120,7 +120,7 @@ class LPIFilter2D(object):
 
         Parameters
         ----------
-        data : (M,N) ndarray
+        data : (M, N) ndarray
 
         """
         check_nD(data, 2, 'data')
@@ -136,7 +136,7 @@ def forward(data, impulse_response=None, filter_params={},
 
     Parameters
     ----------
-    data : (M,N) ndarray
+    data : (M, N) ndarray
         Input data.
     impulse_response : callable `f(r, c, **filter_params)`
         Impulse response of the filter.  See LPIFilter2D.__init__.

--- a/skimage/filters/tests/test_lpi_filter.py
+++ b/skimage/filters/tests/test_lpi_filter.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_, assert_equal
 
 from skimage._shared.utils import _supported_float_type
 from skimage.data import camera
-from skimage.filters.lpi_filter import LPIFilter2D, apply_filter_inverse, wiener
+from skimage.filters.lpi_filter import LPIFilter2D, filter_inverse, wiener
 
 have_scipy_fft = np.lib.NumpyVersion(scipy.__version__) >= '1.4.0'
 
@@ -30,7 +30,7 @@ class TestLPIFilter2D:
     @pytest.mark.parametrize(
         'dtype', [np.uint8, np.float16, np.float32, np.float64]
     )
-    def test_apply_filter_inverse(self, dtype):
+    def test_filter_inverse(self, dtype):
         img = self.img.astype(dtype, copy=False)
 
         if have_scipy_fft:
@@ -43,18 +43,18 @@ class TestLPIFilter2D:
         F = self.f(img)
         assert F.dtype == expected_dtype
 
-        g = apply_filter_inverse(F, predefined_filter=self.f)
+        g = filter_inverse(F, predefined_filter=self.f)
         assert g.dtype == expected_dtype
         assert_equal(g.shape, self.img.shape)
 
-        g1 = apply_filter_inverse(F[::-1, ::-1], predefined_filter=self.f)
+        g1 = filter_inverse(F[::-1, ::-1], predefined_filter=self.f)
         assert_((g - g1[::-1, ::-1]).sum() < 55)
 
         # test cache
-        g1 = apply_filter_inverse(F[::-1, ::-1], predefined_filter=self.f)
+        g1 = filter_inverse(F[::-1, ::-1], predefined_filter=self.f)
         assert_((g - g1[::-1, ::-1]).sum() < 55)
 
-        g1 = apply_filter_inverse(F[::-1, ::-1], self.filt_func)
+        g1 = filter_inverse(F[::-1, ::-1], self.filt_func)
         assert_((g - g1[::-1, ::-1]).sum() < 55)
 
     @pytest.mark.parametrize(

--- a/skimage/filters/tests/test_lpi_filter.py
+++ b/skimage/filters/tests/test_lpi_filter.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_, assert_equal
 
 from skimage._shared.utils import _supported_float_type
 from skimage.data import camera
-from skimage.filters.lpi_filter import LPIFilter2D, inverse, wiener
+from skimage.filters.lpi_filter import LPIFilter2D, apply_filter_inverse, wiener
 
 have_scipy_fft = np.lib.NumpyVersion(scipy.__version__) >= '1.4.0'
 
@@ -30,7 +30,7 @@ class TestLPIFilter2D:
     @pytest.mark.parametrize(
         'dtype', [np.uint8, np.float16, np.float32, np.float64]
     )
-    def test_inverse(self, dtype):
+    def test_apply_filter_inverse(self, dtype):
         img = self.img.astype(dtype, copy=False)
 
         if have_scipy_fft:
@@ -43,18 +43,18 @@ class TestLPIFilter2D:
         F = self.f(img)
         assert F.dtype == expected_dtype
 
-        g = inverse(F, predefined_filter=self.f)
+        g = apply_filter_inverse(F, predefined_filter=self.f)
         assert g.dtype == expected_dtype
         assert_equal(g.shape, self.img.shape)
 
-        g1 = inverse(F[::-1, ::-1], predefined_filter=self.f)
+        g1 = apply_filter_inverse(F[::-1, ::-1], predefined_filter=self.f)
         assert_((g - g1[::-1, ::-1]).sum() < 55)
 
         # test cache
-        g1 = inverse(F[::-1, ::-1], predefined_filter=self.f)
+        g1 = apply_filter_inverse(F[::-1, ::-1], predefined_filter=self.f)
         assert_((g - g1[::-1, ::-1]).sum() < 55)
 
-        g1 = inverse(F[::-1, ::-1], self.filt_func)
+        g1 = apply_filter_inverse(F[::-1, ::-1], self.filt_func)
         assert_((g - g1[::-1, ::-1]).sum() < 55)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

First steps to improve/refactor our LPI filters. Solves #350.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
