### PR TITLE
Document refactoring from grey* to graymatrix and graycoprops in 0.19 with versionchanged directive

### DIFF
--- a/doc/examples/features_detection/plot_glcm.py
+++ b/doc/examples/features_detection/plot_glcm.py
@@ -17,6 +17,11 @@ In a typical classification problem, the final step (not included in
 this example) would be to train a classifier, such as logistic
 regression, to label image patches from new images.
 
+.. versionchanged:: 0.19
+           `greymatrix` was renamed to `graymatrix` in 0.19.
+.. versionchanged:: 0.19
+           `greycoprops` was renamed to `graycoprops` in 0.19.
+
 References
 ----------
 .. [1] Haralick, RM.; Shanmugam, K.,

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -19,6 +19,9 @@ def graycomatrix(image, distances, angles, levels=None, symmetric=False,
     A gray level co-occurrence matrix is a histogram of co-occurring
     grayscale values at a given offset over an image.
 
+    .. versionchanged:: 0.19
+               `greymatrix` was renamed to `graymatrix` in 0.19.
+
     Parameters
     ----------
     image : array_like
@@ -174,6 +177,9 @@ def graycoprops(P, prop='contrast'):
 
     Each GLCM is normalized to have a sum of 1 before the computation of
     texture properties.
+
+    .. versionchanged:: 0.19
+           `greycoprops` was renamed to `graycoprops` in 0.19.
 
     Parameters
     ----------


### PR DESCRIPTION
https://github.com/scikit-image/scikit-image/issues/6390#issue-1250559865

## Description
Fixes https://github.com/scikit-image/scikit-image/issues/6390.

Create a box/flag for `grey`-> `gray` change in docs of relevant functions (`graycoprops`, `graymatrix`) and GLCM example to help users and prevent confusion.


## Checklist
I leave this untouched since I'm not sure if we do any changes to anything important. Only the [documentation about GLCM](https://scikit-image.org/docs/dev/auto_examples/features_detection/plot_glcm.html) could possibly change and fail render (I'm not sure how to test that, I'd be happy for tips).

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
