### PR TITLE
[MINOR] centre -> center in doc/examples/applications/plot_morphology.py

### DIFF
--- a/doc/examples/applications/plot_morphology.py
+++ b/doc/examples/applications/plot_morphology.py
@@ -87,7 +87,7 @@ plot_comparison(orig_phantom, dilated, 'dilation')
 ######################################################################
 # Notice how the white boundary of the image thickens, or gets dilated, as we
 # increase the size of the disk. Also notice the decrease in size of the two
-# black ellipses in the centre, and the thickening of the light gray circle
+# black ellipses in the center, and the thickening of the light gray circle
 # in the center and the 3 patches in the lower part of the image.
 #
 # Opening


### PR DESCRIPTION
## Description

Minor change in docs: `centre` -> `center` in `doc/examples/applications/plot_morphology.py`.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
