### PR TITLE
[MINOR] colour -> color in doc/examples/applications/plot_3d_interaction.py

### DIFF
--- a/doc/examples/applications/plot_3d_interaction.py
+++ b/doc/examples/applications/plot_3d_interaction.py
@@ -4,7 +4,7 @@ Interact with 3D images (of kidney tissue)
 ==========================================
 
 In this tutorial, we explore interactively a biomedical image which has three
-spatial dimensions and three colour dimensions (channels).
+spatial dimensions and three color dimensions (channels).
 For a general introduction to 3D image processing, please refer to
 :ref:`sphx_glr_auto_examples_applications_plot_3d_image_processing.py`.
 The data we use here correspond to kidney tissue which was
@@ -54,7 +54,7 @@ ax.imshow(data[n_plane // 2])
 
 #####################################################################
 # According to the warning message, the range of values is unexpected. The
-# image rendering is clearly not satisfactory colour-wise.
+# image rendering is clearly not satisfactory color-wise.
 
 vmin, vmax = data.min(), data.max()
 print(f'range: ({vmin}, {vmax})')
@@ -89,7 +89,7 @@ fig = px.imshow(
 plotly.io.show(fig)
 
 #####################################################################
-# What is the range of values for each colour channel?
+# What is the range of values for each color channel?
 # We check by taking the min and max across all non-channel
 # axes.
 


### PR DESCRIPTION
## Description

Minor change in docs: `colour` -> `color` in `doc/examples/applications/plot_3d_interaction.py`.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
