### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,6 +5,9 @@ on:
     types: [labeled]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     if: ${{ github.event.label.name == 'run-benchmark' && github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -5,8 +5,13 @@ on:
 
 name: Build docs
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: write  # for Git to git push
     name: Build docs
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,9 @@ name: Test
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   test_skimage_linux:

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -11,6 +11,9 @@ env:
   CIBW_ENVIRONMENT: PIP_PREFER_BINARY=1
 
 
+permissions:
+  contents: read
+
 jobs:
   build_linux_37_and_above_wheels:
     name: Build python ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
@@ -273,6 +276,8 @@ jobs:
           path: ./dist/*.whl
 
   deploy:
+    permissions:
+      contents: write  # for softprops/action-gh-release to create GitHub release
     name: Release
     needs: [build_linux_37_and_above_wheels, build_linux_aarch64_wheels, build_macos_wheels, build_windows_wheels]
     if: github.repository_owner == 'scikit-image' && startsWith(github.ref, 'refs/tags/v') && always()


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
