### PR TITLE
Exclude submodules of doc from package install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -245,7 +245,8 @@ if __name__ == "__main__":
         install_requires=INSTALL_REQUIRES,
         extras_require=extras_require,
         python_requires='>=3.8',
-        packages=setuptools.find_packages(exclude=['doc', 'doc.*', 'benchmarks']),
+        packages=setuptools.find_packages(
+            exclude=['doc', 'doc.*', 'benchmarks']),
         package_data={
             # distribute Cython source files in the wheel
             "": ["*.pyx", "*.pxd", "*.pxi", ""],

--- a/setup.py
+++ b/setup.py
@@ -245,7 +245,7 @@ if __name__ == "__main__":
         install_requires=INSTALL_REQUIRES,
         extras_require=extras_require,
         python_requires='>=3.8',
-        packages=setuptools.find_packages(exclude=['doc', 'benchmarks']),
+        packages=setuptools.find_packages(exclude=['doc', 'doc.*', 'benchmarks']),
         package_data={
             # distribute Cython source files in the wheel
             "": ["*.pyx", "*.pxd", "*.pxi", ""],


### PR DESCRIPTION
## Description

The currently published wheels contain a stray `doc.ext` module installed into the root of the platlib. Exclude them.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
