### PR TITLE
add TYPE_CHECKING hints for lazy imports in data and filters

### DIFF
--- a/skimage/data/__init__.py
+++ b/skimage/data/__init__.py
@@ -1,4 +1,20 @@
+from typing import TYPE_CHECKING
 from .._shared import lazy
+
+if TYPE_CHECKING:
+    from ._binary_blobs import binary_blobs
+    from ._fetchers import (create_image_fetcher, data_dir, download_all,
+                            file_hash, image_fetcher, astronaut,
+                            brain, brick, camera, cat,
+                            cell, cells3d, checkerboard, chelsea, clock,
+                            coffee, coins, colorwheel, eagle, grass,
+                            gravel, horse, hubble_deep_field, human_mitosis,
+                            immunohistochemistry, kidney,
+                            lbp_frontal_face_cascade_filename, lfw_subset,
+                            lily, logo, microaneurysms, moon,
+                            nickel_solidification, page, protein_transport,
+                            retina, rocket, shepp_logan_phantom,
+                            skin, stereo_motorcycle, text, vortex)
 
 __getattr__, __dir__, __all__ = lazy.attach(
     __name__,

--- a/skimage/filters/__init__.py
+++ b/skimage/filters/__init__.py
@@ -1,4 +1,31 @@
+from typing import TYPE_CHECKING
+
 from .._shared import lazy
+
+if TYPE_CHECKING:
+    from .lpi_filter import inverse, wiener, LPIFilter2D
+    from ._gaussian import gaussian, difference_of_gaussians
+    from .edges import (sobel, sobel_h, sobel_v,
+                        scharr, scharr_h, scharr_v,
+                        prewitt, prewitt_h, prewitt_v,
+                        roberts, roberts_pos_diag, roberts_neg_diag,
+                        laplace,
+                        farid, farid_h, farid_v)
+    from ._rank_order import rank_order
+    from ._gabor import gabor_kernel, gabor
+    from .thresholding import (threshold_local, threshold_otsu, threshold_yen,
+                               threshold_isodata, threshold_li, threshold_minimum,
+                               threshold_mean, threshold_triangle,
+                               threshold_niblack, threshold_sauvola,
+                               threshold_multiotsu, try_all_threshold,
+                               apply_hysteresis_threshold)
+    from .ridges import meijering, sato, frangi, hessian
+    from ._median import median
+    from ._sparse import correlate_sparse
+    from ._unsharp_mask import unsharp_mask
+    from ._window import window
+    from ._fft_based import butterworth
+
 
 __getattr__, __dir__, __all__ = lazy.attach(
     __name__,


### PR DESCRIPTION
## Description
#5101 made all imports from data and filters lazy, which is great for import times, but terrible for IDEs.

This PR adds a TYPE_CHECKING clause to each of those modules so linters and IDEs can find the functions again:

current release:
![Screen Shot 2022-07-05 at 1 50 39 PM](https://user-images.githubusercontent.com/1609449/177386950-1e035c5a-c0e9-4e8b-87eb-afbef6f9bc78.png)

with this PR:
![Screen Shot 2022-07-05 at 1 51 28 PM](https://user-images.githubusercontent.com/1609449/177386983-463343ff-06fb-4baa-a762-471594c5bdc8.png)


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
