### PR TITLE
Substitute vertices with simplices in `transform/_geometric.py`

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -997,7 +997,7 @@ class PiecewiseAffineTransform(GeometricTransform):
 
         # find affine mapping from source positions to destination
         self.affines = []
-        for tri in self._tesselation.vertices:
+        for tri in self._tesselation.simplices:
             affine = AffineTransform(dimensionality=ndim)
             success &= affine.estimate(src[tri, :], dst[tri, :])
             self.affines.append(affine)
@@ -1007,7 +1007,7 @@ class PiecewiseAffineTransform(GeometricTransform):
         self._inverse_tesselation = spatial.Delaunay(dst)
         # find affine mapping from source positions to destination
         self.inverse_affines = []
-        for tri in self._inverse_tesselation.vertices:
+        for tri in self._inverse_tesselation.simplices:
             affine = AffineTransform(dimensionality=ndim)
             success &= affine.estimate(dst[tri, :], src[tri, :])
             self.inverse_affines.append(affine)
@@ -1039,7 +1039,7 @@ class PiecewiseAffineTransform(GeometricTransform):
         # coordinates outside of mesh
         out[simplex == -1, :] = -1
 
-        for index in range(len(self._tesselation.vertices)):
+        for index in range(len(self._tesselation.simplices)):
             # affine transform for triangle
             affine = self.affines[index]
             # all coordinates within triangle
@@ -1074,7 +1074,7 @@ class PiecewiseAffineTransform(GeometricTransform):
         # coordinates outside of mesh
         out[simplex == -1, :] = -1
 
-        for index in range(len(self._inverse_tesselation.vertices)):
+        for index in range(len(self._inverse_tesselation.simplices)):
             # affine transform for triangle
             affine = self.inverse_affines[index]
             # all coordinates within triangle


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

Our current tesselation calls in `_geometric.py` are using `vertices`, an attribute deprecated in favor of `simplices`. 
This is breaking our CI:

```
E   DeprecationWarning: Delaunay attribute 'vertices' is deprecated in favour of 'simplices'
and will be removed in Scipy 1.11.0.
```

This PR should fix it.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
