### PR TITLE
example to render text onto an image

### DIFF
--- a/doc/examples/applications/plot_text.py
+++ b/doc/examples/applications/plot_text.py
@@ -1,0 +1,37 @@
+"""
+=========================
+Render text onto an image
+=========================
+
+Scikit-image currently doesn't feature a function that allows you to plot/render
+text onto an image. However, there is a fairly easy workaround using the
+`matplotlib <https://matplotlib.org/>`_ library.
+
+"""
+
+import numpy as np
+import imageio.v3 as iio
+import matplotlib.pyplot as plt
+from matplotlib.figure import figaspect
+
+img = iio.imread("imageio:chelsea.png")
+
+fig, ax = plt.subplots(figsize=figaspect(img), dpi=75)
+ax.imshow(img)
+ax.text(5, 5, "I am stefan's cat.", fontsize=32, va="top")
+ax.set_axis_off()
+ax.set_position([0, 0, 1, 1])
+fig.canvas.draw()
+annotated_img = np.asarray(fig.canvas.renderer.buffer_rgba())
+plt.close(fig)
+
+
+################################################################################
+# For the purpose of this example, we can also show the image; however, if one
+# just wants to render the image on top of the text, this step is not necessary.
+
+fig, ax = plt.subplots()
+ax.imshow(annotated_img)
+ax.set_axis_off()
+ax.set_position([0, 0, 1, 1])
+plt.show()

--- a/doc/examples/applications/plot_text.py
+++ b/doc/examples/applications/plot_text.py
@@ -17,10 +17,7 @@ import matplotlib.pyplot as plt
 img = iio.imread("imageio:chelsea.png")
 
 fig = plt.figure()
-fig.figimage(
-    img,
-    resize=True,  # Resize the figure to the image to avoid any interpolation.
-)
+fig.figimage(img, resize=True)
 fig.text(0, 0.99, "I am stefan's cat.", fontsize=32, va="top")
 fig.canvas.draw()
 annotated_img = np.asarray(fig.canvas.renderer.buffer_rgba())

--- a/doc/examples/applications/plot_text.py
+++ b/doc/examples/applications/plot_text.py
@@ -12,15 +12,15 @@ using the `matplotlib <https://matplotlib.org/>`_ library.
 import numpy as np
 import imageio.v3 as iio
 import matplotlib.pyplot as plt
-from matplotlib.figure import figaspect
 
 img = iio.imread("imageio:chelsea.png")
 
-fig, ax = plt.subplots(figsize=figaspect(img), dpi=75)
-ax.imshow(img)
-ax.text(5, 5, "I am stefan's cat.", fontsize=32, va="top")
-ax.set_axis_off()
-ax.set_position([0, 0, 1, 1])
+fig = plt.figure()
+fig.figimage(
+    img,
+    resize=True,  # Resize the figure to the image to avoid any interpolation.
+)
+fig.text(0, .99, "I am stefan's cat.", fontsize=32, va="top")
 fig.canvas.draw()
 annotated_img = np.asarray(fig.canvas.renderer.buffer_rgba())
 plt.close(fig)

--- a/doc/examples/applications/plot_text.py
+++ b/doc/examples/applications/plot_text.py
@@ -10,11 +10,11 @@ using scikit-image's optional dependency `matplotlib
 
 """
 
-import numpy as np
-import imageio.v3 as iio
 import matplotlib.pyplot as plt
+import numpy as np
+from skimage import data
 
-img = iio.imread("imageio:chelsea.png")
+img = data.cat()
 
 fig = plt.figure()
 fig.figimage(img, resize=True)

--- a/doc/examples/applications/plot_text.py
+++ b/doc/examples/applications/plot_text.py
@@ -4,8 +4,9 @@ Render text onto an image
 =========================
 
 Scikit-image currently doesn't feature a function that allows you to
-plot/render text onto an image. However, there is a fairly easy workaround
-using scikit-image's optional dependency `matplotlib <https://matplotlib.org/>`_.
+write text onto an image. However, there is a fairly easy workaround
+using scikit-image's optional dependency `matplotlib
+<https://matplotlib.org/>`_.
 
 """
 
@@ -20,7 +21,7 @@ fig.figimage(
     img,
     resize=True,  # Resize the figure to the image to avoid any interpolation.
 )
-fig.text(0, .99, "I am stefan's cat.", fontsize=32, va="top")
+fig.text(0, 0.99, "I am stefan's cat.", fontsize=32, va="top")
 fig.canvas.draw()
 annotated_img = np.asarray(fig.canvas.renderer.buffer_rgba())
 plt.close(fig)

--- a/doc/examples/applications/plot_text.py
+++ b/doc/examples/applications/plot_text.py
@@ -26,8 +26,7 @@ plt.close(fig)
 
 ###############################################################################
 # For the purpose of this example, we can also show the image; however, if one
-# just wants to render the image on top of the text, this step is not
-# necessary.
+# just wants to write onto the image, this step is not necessary.
 
 fig, ax = plt.subplots()
 ax.imshow(annotated_img)

--- a/doc/examples/applications/plot_text.py
+++ b/doc/examples/applications/plot_text.py
@@ -3,9 +3,9 @@
 Render text onto an image
 =========================
 
-Scikit-image currently doesn't feature a function that allows you to plot/render
-text onto an image. However, there is a fairly easy workaround using the
-`matplotlib <https://matplotlib.org/>`_ library.
+Scikit-image currently doesn't feature a function that allows you to
+plot/render text onto an image. However, there is a fairly easy workaround
+using the `matplotlib <https://matplotlib.org/>`_ library.
 
 """
 
@@ -26,9 +26,10 @@ annotated_img = np.asarray(fig.canvas.renderer.buffer_rgba())
 plt.close(fig)
 
 
-################################################################################
+###############################################################################
 # For the purpose of this example, we can also show the image; however, if one
-# just wants to render the image on top of the text, this step is not necessary.
+# just wants to render the image on top of the text, this step is not
+# necessary.
 
 fig, ax = plt.subplots()
 ax.imshow(annotated_img)


### PR DESCRIPTION
Closes: #877 

As discussed in #877 this PR adds a gallery example of how to use `matplotlib` to render a text on top of an image.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
