### PR TITLE
Fix minor typo in sato() implemntation.

### DIFF
--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -346,11 +346,11 @@ def sato(image, sigmas=range(1, 10, 2), black_ridges=True,
     for i, sigma in enumerate(sigmas):
 
         # Calculate (sorted) eigenvalues
-        lamba1, *lambdas = compute_hessian_eigenvalues(image, sigma,
-                                                       sorting='val',
-                                                       mode=mode, cval=cval)
+        lambda1, *lambdas = compute_hessian_eigenvalues(image, sigma,
+                                                        sorting='val',
+                                                        mode=mode, cval=cval)
 
-        # Compute tubeness, see  equation (9) in reference [1]_.
+        # Compute tubeness, see equation (9) in reference [1]_.
         # np.abs(lambda2) in 2D, np.sqrt(np.abs(lambda2 * lambda3)) in 3D
         filtered = np.abs(np.multiply.reduce(lambdas)) ** (1/len(lambdas))
 


### PR DESCRIPTION
## Description

`lamba1` is never actually used, but the name is a bit jarring.
Likewise for the double space just below.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
