### PR TITLE
Simplify sort-by-absolute-value in ridge filters.

### DIFF
--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -50,37 +50,6 @@ def _divide_nonzero(array1, array2, cval=1e-10):
     return np.divide(array1, denominator)
 
 
-def _sortbyabs(array, axis=0):
-    """
-    Sort array along a given axis by absolute values.
-
-    Parameters
-    ----------
-    array : (N, ..., M) ndarray
-        Array with input image data.
-    axis : int
-        Axis along which to sort.
-
-    Returns
-    -------
-    array : (N, ..., M) ndarray
-        Array sorted along a given axis by absolute values.
-
-    Notes
-    -----
-    Modified from: http://stackoverflow.com/a/11253931/4067734
-    """
-
-    # Create auxiliary array for indexing
-    index = list(np.ix_(*[np.arange(i) for i in array.shape]))
-
-    # Get indices of abs sorted array
-    index[axis] = np.abs(array).argsort(axis)
-
-    # Return abs sorted array
-    return array[tuple(index)]
-
-
 def _check_sigmas(sigmas):
     """Check sigma values for ridges filters.
 
@@ -164,7 +133,8 @@ def compute_hessian_eigenvalues(image, sigma, sorting='none',
     if sorting == 'abs':
 
         # Sort eigenvalues by absolute values in ascending order
-        hessian_eigenvalues = _sortbyabs(hessian_eigenvalues, axis=0)
+        hessian_eigenvalues = np.take_along_axis(
+            hessian_eigenvalues, abs(hessian_eigenvalues).argsort(0), 0)
 
     elif sorting == 'val':
 


### PR DESCRIPTION
Using np.take_along_axis is explicitly mentioned in the docstring of
np.argsort, so let's use that rather than a hand-rolled version (which
predates np.take_along_axis).

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
