### PR TITLE
Speedup ~2x hessian_matrix_eigvals and 2D structure_tensor_eigenvalues.

### DIFF
--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -371,12 +371,6 @@ def hessian_matrix_det(image, sigma=1, approximate=True):
         return np.linalg.det(hessian_mat_array)
 
 
-def _image_orthogonal_matrix22_eigvals(M00, M01, M11):
-    l1 = (M00 + M11) / 2 + np.sqrt(4 * M01 ** 2 + (M00 - M11) ** 2) / 2
-    l2 = (M00 + M11) / 2 - np.sqrt(4 * M01 ** 2 + (M00 - M11) ** 2) / 2
-    return l1, l2
-
-
 def _symmetric_compute_eigenvalues(S_elems):
     """Compute eigenvalues from the upperdiagonal entries of a symmetric matrix
 
@@ -394,15 +388,20 @@ def _symmetric_compute_eigenvalues(S_elems):
         ith-largest eigenvalue at position (j, k).
     """
 
-    if len(S_elems) == 3:  # Use fast Cython code for 2D
-        eigs = np.stack(_image_orthogonal_matrix22_eigvals(*S_elems))
+    if len(S_elems) == 3:  # Fast explicit formulas for 2D.
+        M00, M01, M11 = S_elems
+        eigs = np.empty((2, *M00.shape), M00.dtype)
+        eigs[:] = (M00 + M11) / 2
+        hsqrtdet = np.sqrt(M01 ** 2 + ((M00 - M11) / 2) ** 2)
+        eigs[0] += hsqrtdet
+        eigs[1] -= hsqrtdet
+        return eigs
     else:
         matrices = _symmetric_image(S_elems)
         # eigvalsh returns eigenvalues in increasing order. We want decreasing
         eigs = np.linalg.eigvalsh(matrices)[..., ::-1]
         leading_axes = tuple(range(eigs.ndim - 1))
-        eigs = np.transpose(eigs, (eigs.ndim - 1,) + leading_axes)
-    return eigs
+        return np.transpose(eigs, (eigs.ndim - 1,) + leading_axes)
 
 
 def _symmetric_image(S_elems):

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -372,7 +372,8 @@ def hessian_matrix_det(image, sigma=1, approximate=True):
 
 
 def _symmetric_compute_eigenvalues(S_elems):
-    """Compute eigenvalues from the upperdiagonal entries of a symmetric matrix
+    """Compute eigenvalues from the upper-diagonal entries of a symmetric
+    matrix.
 
     Parameters
     ----------


### PR DESCRIPTION
Both functions call _symmetric_compute_eigenvalues.  One can consider
various improvements to it (all listed and timed below); in this PR, I
avoid computing the sqrt twice and fill the preallocated final array
with in-place operations, yielding a nearly 2x speedup.

```
import numpy as np
from skimage.feature import hessian_matrix

h = hessian_matrix(np.random.rand(512, 512), use_gaussian_derivatives=True)

def _image_orthogonal_matrix22_eigvals(M00, M01, M11):  # original implementation.
    l1 = (M00 + M11) / 2 + np.sqrt(4 * M01 ** 2 + (M00 - M11) ** 2) / 2
    l2 = (M00 + M11) / 2 - np.sqrt(4 * M01 ** 2 + (M00 - M11) ** 2) / 2
    return l1, l2
def _symmetric_compute_eigenvalues(S_elems):
    return np.stack(_image_orthogonal_matrix22_eigvals(*S_elems))

def reuse_and_stack(M00, M01, M11):  # Don't compute sqrt twice.
    mean = (M00 + M11) / 2
    hsqrtdet = np.sqrt(M01 ** 2 + ((M00 - M11) / 2) ** 2)
    return np.stack((mean + hsqrtdet, mean - hsqrtdet))

def reuse_and_broadcast(M00, M01, M11):  # Directly create final array by broadcasting.
    mean = (M00 + M11) / 2
    hsqrtdet = np.sqrt(M01 ** 2 + ((M00 - M11) / 2) ** 2)
    return mean + np.multiply.outer([+1, -1], hsqrtdet)

def reuse_and_prealloc(M00, M01, M11):  # Preallocate the final array.
    mean = (M00 + M11) / 2
    hsqrtdet = np.sqrt(M01 ** 2 + ((M00 - M11) / 2) ** 2)
    eigs = np.empty((2, *M00.shape))
    eigs[0] = mean + hsqrtdet
    eigs[1] = mean - hsqrtdet
    return eigs

def reuse_and_inplace(M00, M01, M11):  # Preallocate final array, fill it by in-place ops.
    mean = (M00 + M11) / 2
    hsqrtdet = np.sqrt(M01 ** 2 + ((M00 - M11) / 2) ** 2)
    eigs = np.empty((2, *M00.shape))
    np.add(mean, hsqrtdet, eigs[0])
    np.subtract(mean, hsqrtdet, eigs[1])
    return eigs

def reuse_and_inplace2(M00, M01, M11):  # Preallocate final array, fill it by in-place ops.
    eigs = np.empty((2, *M00.shape))
    eigs[:] = (M00 + M11) / 2
    hsqrtdet = np.sqrt(M01 ** 2 + ((M00 - M11) / 2) ** 2)
    eigs[0] += hsqrtdet
    eigs[1] -= hsqrtdet
    return eigs

def reuse_and_many_inplace(M00, M01, M11):  # Use as many in-place ops as possible.
    mean = M00 + M11
    mean /= 2
    det = M01 ** 2
    delta = M00 - M11
    delta /= 2
    delta **= 2
    det += delta
    np.sqrt(det, det)
    eigs = np.empty((2, *M00.shape))
    np.add(mean, det, eigs[0])
    np.subtract(mean, det, eigs[1])
    return eigs

assert (reuse_and_stack(*h) == _symmetric_compute_eigenvalues(h)).all()
assert (reuse_and_broadcast(*h) == _symmetric_compute_eigenvalues(h)).all()
assert (reuse_and_prealloc(*h) == _symmetric_compute_eigenvalues(h)).all()
assert (reuse_and_inplace(*h) == _symmetric_compute_eigenvalues(h)).all()
assert (reuse_and_inplace2(*h) == _symmetric_compute_eigenvalues(h)).all()
assert (reuse_and_many_inplace(*h) == _symmetric_compute_eigenvalues(h)).all()

%timeit _symmetric_compute_eigenvalues(h)
%timeit reuse_and_stack(*h)
%timeit reuse_and_broadcast(*h)
%timeit reuse_and_prealloc(*h)
%timeit reuse_and_inplace(*h)
%timeit reuse_and_inplace2(*h)
%timeit reuse_and_many_inplace(*h)
```
Results:
```
9.13 ms ± 56.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
5.44 ms ± 142 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
6.4 ms ± 3.96 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
5.22 ms ± 2.32 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
4.81 ms ± 1.91 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
4.58 ms ± 5.43 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
4.99 ms ± 246 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
