### PR TITLE
removed array in-place deprecated warning,  decorators.  updated test.

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -11,9 +11,6 @@ Version 1.0
 
 * consider removing the argument `coordinates` in
   `skimage.segmentation.active_contour`, which has not effect.
-* In ``skimage/morphology/misc.py`` remove the deprecated parameter
-  ``in_place`` in remove_small_holes(), remove_small_objects() and
-  clear_border(), and update the tests.
 * Remove the deprecation warning for `input` kwarg of the `label`
   function in `skimage/measure/_label.py`
 * Change the warning about poorly conditioned data to a ValueError within

--- a/skimage/morphology/misc.py
+++ b/skimage/morphology/misc.py
@@ -2,7 +2,7 @@
 import numpy as np
 import functools
 from scipy import ndimage as ndi
-from .._shared.utils import warn, remove_arg
+from .._shared.utils import warn
 
 # Our function names don't exactly correspond to ndimages.
 # This dictionary translates from our names to scipy's.
@@ -47,8 +47,6 @@ def _check_dtype_supported(ar):
                         "Got %s." % ar.dtype)
 
 
-@remove_arg("in_place", changed_version="1.0",
-            help_msg="Please use out argument instead.")
 def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False,
                          *, out=None):
     """Remove objects smaller than the specified size.
@@ -151,8 +149,6 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False,
     return out
 
 
-@remove_arg("in_place", changed_version="1.0",
-            help_msg="Please use out argument instead.")
 def remove_small_holes(ar, area_threshold=64, connectivity=1, in_place=False,
                        *, out=None):
     """Remove contiguous holes smaller than the specified size.

--- a/skimage/morphology/misc.py
+++ b/skimage/morphology/misc.py
@@ -47,8 +47,7 @@ def _check_dtype_supported(ar):
                         "Got %s." % ar.dtype)
 
 
-def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False,
-                         *, out=None):
+def remove_small_objects(ar, min_size=64, connectivity=1, *, out=None):
     """Remove objects smaller than the specified size.
 
     Expects ar to be an array with labeled objects, and removes objects
@@ -66,10 +65,6 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False,
     connectivity : int, {1, 2, ..., ar.ndim}, optional (default: 1)
         The connectivity defining the neighborhood of a pixel. Used during
         labelling if `ar` is bool.
-    in_place : bool, optional (default: False)
-        If ``True``, remove the objects in the input array itself.
-        Otherwise, make a copy. Deprecated since version 0.19. Please
-        use `out` instead.
     out : ndarray
         Array of the same shape as `ar`, into which the output is
         placed. By default, a new array is created.
@@ -110,16 +105,10 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False,
     # Raising type error if not int or bool
     _check_dtype_supported(ar)
 
-    if out is not None:
-        in_place = False
-
-    if in_place:
-        out = ar
+    if out is None:
+        out = ar.copy()
     else:
-        if out is None:
-            out = ar.copy()
-        else:
-            out[:] = ar
+        out[:] = ar
 
     if min_size == 0:  # shortcut for efficiency
         return out
@@ -149,8 +138,7 @@ def remove_small_objects(ar, min_size=64, connectivity=1, in_place=False,
     return out
 
 
-def remove_small_holes(ar, area_threshold=64, connectivity=1, in_place=False,
-                       *, out=None):
+def remove_small_holes(ar, area_threshold=64, connectivity=1, *, out=None):
     """Remove contiguous holes smaller than the specified size.
 
     Parameters
@@ -162,10 +150,6 @@ def remove_small_holes(ar, area_threshold=64, connectivity=1, in_place=False,
         Replaces `min_size`.
     connectivity : int, {1, 2, ..., ar.ndim}, optional (default: 1)
         The connectivity defining the neighborhood of a pixel.
-    in_place : bool, optional (default: False)
-        If `True`, remove the connected components in the input array
-        itself. Otherwise, make a copy. Deprecated since version 0.19.
-        Please use `out` instead.
     out : ndarray
         Array of the same shape as `ar` and bool dtype, into which the
         output is placed. By default, a new array is created.
@@ -223,11 +207,7 @@ def remove_small_holes(ar, area_threshold=64, connectivity=1, in_place=False,
     if out is not None:
         if out.dtype != bool:
             raise TypeError("out dtype must be bool")
-        in_place = False
-
-    if in_place:
-        out = ar
-    elif out is None:
+    else:
         out = ar.astype(bool, copy=True)
 
     # Creating the inverse of ar

--- a/skimage/morphology/tests/test_misc.py
+++ b/skimage/morphology/tests/test_misc.py
@@ -28,14 +28,6 @@ def test_two_connectivity():
     assert_array_equal(observed, expected)
 
 
-def test_in_place():
-    image = test_image.copy()
-    with expected_warnings(["in_place argument is deprecated"]):
-        observed = remove_small_objects(image, min_size=6, in_place=True)
-    assert_equal(observed is image, True,
-                 "remove_small_objects in_place argument failed.")
-
-
 @pytest.mark.parametrize("in_dtype", [bool, int, np.int32])
 @pytest.mark.parametrize("out_dtype", [bool, int, np.int32])
 def test_out(in_dtype, out_dtype):
@@ -135,14 +127,6 @@ def test_two_connectivity_holes():
     observed = remove_small_holes(test_holes_image, area_threshold=3,
                                   connectivity=2)
     assert_array_equal(observed, expected)
-
-
-def test_in_place_holes():
-    image = test_holes_image.copy()
-    with expected_warnings(["in_place argument is deprecated"]):
-        observed = remove_small_holes(image, area_threshold=3, in_place=True)
-    assert_equal(observed is image, True,
-                 "remove_small_holes in_place argument failed.")
 
 
 def test_out_remove_small_holes():


### PR DESCRIPTION
update for TODO for version 2.0: 

* In ``skimage/morphology/misc.py`` remove the deprecated parameter
  ``in_place`` in remove_small_holes(), remove_small_objects() and
  clear_border(), and update the tests.


## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
