### PR TITLE
Rewrite the meijering, sato, and frangi ridge filters.

### DIFF
--- a/doc/examples/edges/plot_ridge_filter.py
+++ b/doc/examples/edges/plot_ridge_filter.py
@@ -13,9 +13,6 @@ The present class of ridge filters relies on the eigenvalues of
 the Hessian matrix of image intensities to detect ridge structures where the
 intensity changes perpendicular but not along the structure.
 
-Note that, due to edge effects, results for Meijering and Frangi filters
-are cropped by 4 pixels on each edge to get a proper rendering.
-
 References
 ----------
 
@@ -49,7 +46,7 @@ from skimage.filters import meijering, sato, frangi, hessian
 import matplotlib.pyplot as plt
 
 
-def identity(image, **kwargs):
+def original(image, **kwargs):
     """Return the original image, ignoring any kwargs."""
     return image
 
@@ -57,20 +54,29 @@ def identity(image, **kwargs):
 image = color.rgb2gray(data.retina())[300:700, 700:900]
 cmap = plt.cm.gray
 
-kwargs = {'sigmas': [1], 'mode': 'reflect'}
-
-fig, axes = plt.subplots(2, 5)
-for i, black_ridges in enumerate([1, 0]):
-    for j, func in enumerate([identity, meijering, sato, frangi, hessian]):
-        kwargs['black_ridges'] = black_ridges
-        result = func(image, **kwargs)
-        axes[i, j].imshow(result, cmap=cmap, aspect='auto')
+plt.rcParams["axes.titlesize"] = "medium"
+axes = plt.figure(figsize=(10, 4)).subplots(2, 9)
+for i, black_ridges in enumerate([True, False]):
+    for j, (func, sigmas) in enumerate([
+            (original, None),
+            (meijering, [1]),
+            (meijering, range(1, 5)),
+            (sato, [1]),
+            (sato, range(1, 5)),
+            (frangi, [1]),
+            (frangi, range(1, 5)),
+            (hessian, [1]),
+            (hessian, range(1, 5)),
+    ]):
+        result = func(image, black_ridges=black_ridges, sigmas=sigmas)
+        axes[i, j].imshow(result, cmap=cmap)
         if i == 0:
-            axes[i, j].set_title(['Original\nimage', 'Meijering\nneuriteness',
-                                  'Sato\ntubeness', 'Frangi\nvesselness',
-                                  'Hessian\nvesselness'][j])
+            title = func.__name__
+            if sigmas:
+                title += f"\n\N{GREEK SMALL LETTER SIGMA} = {list(sigmas)}"
+            axes[i, j].set_title(title)
         if j == 0:
-            axes[i, j].set_ylabel('black_ridges = ' + str(bool(black_ridges)))
+            axes[i, j].set_ylabel(f'{black_ridges = }')
         axes[i, j].set_xticks([])
         axes[i, j].set_yticks([])
 

--- a/doc/release/release_dev.rst
+++ b/doc/release/release_dev.rst
@@ -28,8 +28,22 @@ API Changes
 
 - All references to EN-GB spelling for the word ``neighbour`` and others—e.g.,
   ``neigbourhood``, ``neighboring``, were changed to their EN-US spelling,
-  ``neighbor``. With that, ``skimage.measure.perimeter` parameter ``neighbourhood``
+  ``neighbor``. With that, ``skimage.measure.perimeter`` parameter ``neighbourhood``
   was deprecated in favor of ``neighborhood`` in 0.19.2.
+
+
+Backward Incompatible Changes
+-----------------------------
+
+- ``skimage.filters.meijering``, ``skimage.filters.sato``,
+  ``skimage.filters.frangi``, and ``skimage.filters.hessian`` have all been
+  rewritten to match more closely the published algorithms; the output values
+  will be different from previously.  The Hessian matrix calculation is now
+  done more accurately.  The filters will now correctly be set to zero whenever
+  one of the hessian eigenvalues has a sign incompatible with a ridge of the
+  desired polarity.  The gamma constant of the Frangi filter is now set
+  adaptively based on the maximum Hessian norm.
+
 
 Bugfixes
 --------

--- a/doc/source/api_changes.md
+++ b/doc/source/api_changes.md
@@ -1,5 +1,16 @@
 :orphan:
 
+# Version 0.20
+
+- ``skimage.filters.meijering``, ``skimage.filters.sato``,
+  ``skimage.filters.frangi``, and ``skimage.filters.hessian`` have all been
+  rewritten to match more closely the published algorithms; the output values
+  will be different from previously.  The Hessian matrix calculation is now
+  done more accurately.  The filters will now correctly be set to zero whenever
+  one of the hessian eigenvalues has a sign incompatible with a ridge of the
+  desired polarity.  The gamma constant of the Frangi filter is now set
+  adaptively based on the maximum Hessian norm.
+
 # Version 0.16
 
 - The following functions are deprecated and will be removed in 0.18:

--- a/doc/source/api_changes.md
+++ b/doc/source/api_changes.md
@@ -1,16 +1,5 @@
 :orphan:
 
-# Version 0.20
-
-- ``skimage.filters.meijering``, ``skimage.filters.sato``,
-  ``skimage.filters.frangi``, and ``skimage.filters.hessian`` have all been
-  rewritten to match more closely the published algorithms; the output values
-  will be different from previously.  The Hessian matrix calculation is now
-  done more accurately.  The filters will now correctly be set to zero whenever
-  one of the hessian eigenvalues has a sign incompatible with a ridge of the
-  desired polarity.  The gamma constant of the Frangi filter is now set
-  adaptively based on the maximum Hessian norm.
-
 # Version 0.16
 
 - The following functions are deprecated and will be removed in 0.18:

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -12,69 +12,14 @@ perpendicular but not along the structure.
 from warnings import warn
 
 import numpy as np
+from scipy import linalg
 
-from .._shared.utils import _supported_float_type, check_nD
+from .._shared.utils import _supported_float_type, check_nD, deprecated
 from ..feature.corner import hessian_matrix, hessian_matrix_eigvals
-from ..util import img_as_float, invert
+from ..util import img_as_float
 
 
-def _divide_nonzero(array1, array2, cval=1e-10):
-    """
-    Divides two arrays.
-
-    Denominator is set to small value where zero to avoid ZeroDivisionError and
-    return finite float array.
-
-    Parameters
-    ----------
-    array1 : (N, ..., M) ndarray
-        Array 1 in the enumerator.
-    array2 : (N, ..., M) ndarray
-        Array 2 in the denominator.
-    cval : float, optional
-        Value used to replace zero entries in the denominator.
-
-    Returns
-    -------
-    array : (N, ..., M) ndarray
-        Quotient of the array division.
-    """
-
-    # Copy denominator
-    denominator = np.copy(array2)
-
-    # Set zero entries of denominator to small value
-    denominator[denominator == 0] = cval
-
-    # Return quotient
-    return np.divide(array1, denominator)
-
-
-def _check_sigmas(sigmas):
-    """Check sigma values for ridges filters.
-
-    Parameters
-    ----------
-    sigmas : iterable of floats
-        Sigmas argument to be checked
-
-    Returns
-    -------
-    sigmas : ndarray
-        input iterable converted to ndarray
-
-    Raises
-    ------
-    ValueError if any input value is negative
-
-    """
-    sigmas = np.asarray(sigmas).ravel()
-    if np.any(sigmas < 0.0):
-        raise ValueError('Sigma values should be equal to or greater '
-                         'than zero.')
-    return sigmas
-
-
+@deprecated(removed_version="1.0")
 def compute_hessian_eigenvalues(image, sigma, sorting='none',
                                 mode='constant', cval=0,
                                 use_gaussian_derivatives=False):
@@ -145,9 +90,8 @@ def compute_hessian_eigenvalues(image, sigma, sorting='none',
     return hessian_eigenvalues
 
 
-def meijering(image, sigmas=range(1, 10, 2), alpha=-1 / 3,
-              black_ridges=True, mode='reflect', cval=0,
-              use_gaussian_derivatives=True):
+def meijering(image, sigmas=range(1, 10, 2), alpha=None,
+              black_ridges=True, mode='reflect', cval=0):
     """
     Filter an image with the Meijering neuriteness filter.
 
@@ -166,7 +110,7 @@ def meijering(image, sigmas=range(1, 10, 2), alpha=-1 / 3,
         Sigmas used as scales of filter
     alpha : float, optional
         Shaping filter constant, that selects maximally flat elongated
-        features. Optimal value should be -1/3.
+        features.  The default, None, selects the optimal value -1/(ndim+1).
     black_ridges : boolean, optional
         When True (the default), the filter detects black ridges; when
         False, it detects white ridges.
@@ -196,56 +140,32 @@ def meijering(image, sigmas=range(1, 10, 2), alpha=-1 / 3,
         :DOI:`10.1002/cyto.a.20022`
     """
 
-    # Check (sigma) scales
-    sigmas = _check_sigmas(sigmas)
+    image = image.astype(_supported_float_type(image.dtype), copy=False)
+    if not black_ridges:  # Normalize to black ridges.
+        image = -image
 
-    # Get image dimensions
-    ndim = image.ndim
+    if alpha is None:
+        alpha = 1 / (image.ndim + 1)
+    mtx = linalg.circulant(
+        [1, *[alpha] * (image.ndim - 1)]).astype(image.dtype)
 
-    float_dtype = _supported_float_type(image.dtype)
-    image = image.astype(float_dtype, copy=False)
-
-    # Invert image to detect dark ridges on bright background
-    if black_ridges:
-        image = invert(image)
-
-    # Generate empty (n+1)D arrays for storing auxiliary images filtered at
-    # different (sigma) scales
-    filtered_array = np.zeros(sigmas.shape + image.shape, float_dtype)
-
-    # Filtering for all (sigma) scales
-    for i, sigma in enumerate(sigmas):
-
-        # Calculate (sorted) eigenvalues
-        eigenvalues = compute_hessian_eigenvalues(
-            image, sigma, sorting='abs', mode=mode, cval=cval,
-            use_gaussian_derivatives=use_gaussian_derivatives
-        )
-
-        if ndim > 1:
-
-            # Set coefficients for scaling eigenvalues
-            coefficients = [alpha] * ndim
-            coefficients[0] = 1
-
-            # Compute normalized eigenvalues l_i = e_i + sum_{j!=i} alpha * e_j
-            auxiliary = [np.sum([eigenvalues[i] * np.roll(coefficients, j)[i]
-                         for j in range(ndim)], axis=0) for i in range(ndim)]
-
-            # Get maximum eigenvalues by magnitude
-            auxiliary = auxiliary[-1]
-
-            # Rescale image intensity and avoid ZeroDivisionError
-            filtered = _divide_nonzero(auxiliary, np.min(auxiliary))
-
-            # Remove background
-            filtered = np.where(auxiliary < 0, filtered, 0)
-
-            # Store results in (n+1)D matrices
-            filtered_array[i] = filtered
-
-    # Return for every pixel the maximum value over all (sigma) scales
-    return np.max(filtered_array, axis=0)
+    filtered = []
+    for sigma in sigmas:  # Filter for all sigmas.
+        eigvals = hessian_matrix_eigvals(hessian_matrix(
+            image, sigma, mode=mode, cval=cval, use_gaussian_derivatives=True))
+        # Compute normalized eigenvalues l_i = e_i + sum_{j!=i} alpha * e_j.
+        vals = np.tensordot(mtx, eigvals, 1)
+        # Get largest normalized eigenvalue (by magnitude) at each pixel.
+        vals = np.take_along_axis(
+            vals, abs(vals).argmax(0)[None], 0).squeeze(0)
+        # Remove negative values.
+        vals = np.maximum(vals, 0)
+        # Normalize to max = 1 (unless everything is already zero).
+        max_val = vals.max()
+        if max_val > 0:
+            vals /= max_val
+        filtered.append(vals)
+    return np.max(filtered, axis=0)  # Return pixel-wise max over all sigmas.
 
 
 def sato(image, sigmas=range(1, 10, 2), black_ridges=True,
@@ -296,43 +216,28 @@ def sato(image, sigmas=range(1, 10, 2), black_ridges=True,
         :DOI:`10.1016/S1361-8415(98)80009-1`
     """
 
-    # Check image dimensions
-    check_nD(image, [2, 3])
+    check_nD(image, [2, 3])  # Check image dimensions.
+    image = image.astype(_supported_float_type(image.dtype), copy=False)
+    if not black_ridges:  # Normalize to black ridges.
+        image = -image
 
-    # Check (sigma) scales
-    sigmas = _check_sigmas(sigmas)
-
-    # Invert image to detect bright ridges on dark background
-    if not black_ridges:
-        image = invert(image)
-
-    float_dtype = _supported_float_type(image.dtype)
-
-    # Generate empty (n+1)D arrays for storing auxiliary images filtered
-    # at different (sigma) scales
-    filtered_array = np.zeros(sigmas.shape + image.shape, dtype=float_dtype)
-
-    # Filtering for all (sigma) scales
-    for i, sigma in enumerate(sigmas):
-
-        # Calculate (sorted) eigenvalues
-        lambda1, *lambdas = compute_hessian_eigenvalues(image, sigma,
-                                                        sorting='val',
-                                                        mode=mode, cval=cval)
-
-        # Compute tubeness, see equation (9) in reference [1]_.
-        # np.abs(lambda2) in 2D, np.sqrt(np.abs(lambda2 * lambda3)) in 3D
-        filtered = np.abs(np.multiply.reduce(lambdas)) ** (1/len(lambdas))
-
-        # Remove background and store results in (n+1)D matrices
-        filtered_array[i] = np.where(lambdas[-1] > 0, filtered, 0)
-
-    # Return for every pixel the maximum value over all (sigma) scales
-    return np.max(filtered_array, axis=0)
+    filtered = []
+    for sigma in sigmas:  # Filter for all sigmas.
+        eigvals = hessian_matrix_eigvals(hessian_matrix(
+            image, sigma, mode=mode, cval=cval, use_gaussian_derivatives=True))
+        # Compute normalized tubeness (eqs. (9) and (22), ref. [1]_) as the
+        # geometric mean of eigvals other than the lowest one
+        # (hessian_matrix_eigvals returns eigvals in decreasing order), clipped
+        # to 0, multiplied by sigma^2.
+        eigvals = eigvals[:-1]
+        vals = (sigma ** 2
+                * np.prod(np.maximum(eigvals, 0), 0) ** (1 / len(eigvals)))
+        filtered.append(vals)
+    return np.max(filtered, axis=0)  # Return pixel-wise max over all sigmas.
 
 
 def frangi(image, sigmas=range(1, 10, 2), scale_range=None,
-           scale_step=None, alpha=0.5, beta=0.5, gamma=15,
+           scale_step=None, alpha=0.5, beta=0.5, gamma=None,
            black_ridges=True, mode='reflect', cval=0):
     """
     Filter an image with the Frangi vesselness filter.
@@ -365,6 +270,7 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None,
     gamma : float, optional
         Frangi correction constant that adjusts the filter's
         sensitivity to areas of high variance/texture/structure.
+        The default, None, uses half of the maximum Hessian norm.
     black_ridges : boolean, optional
         When True (the default), the filter detects black ridges; when
         False, it detects white ridges.
@@ -381,9 +287,9 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None,
 
     Notes
     -----
-    Written by Marc Schrijver, November 2001
-    Re-Written by D. J. Kroon, University of Twente, May 2009, [2]_
-    Adoption of 3D version from D. G. Ellis, Januar 20017, [3]_
+    Earlier versions of this filter were implemented by Marc Schrijver,
+    (November 2001), D. J. Kroon, University of Twente (May 2009) [2]_, and
+    D. G. Ellis (January 2017) [3]_.
 
     See also
     --------
@@ -407,66 +313,40 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None,
              stacklevel=2)
         sigmas = np.arange(scale_range[0], scale_range[1], scale_step)
 
-    # Check image dimensions
-    check_nD(image, [2, 3])
+    check_nD(image, [2, 3])  # Check image dimensions.
+    image = image.astype(_supported_float_type(image.dtype), copy=False)
+    if not black_ridges:  # Normalize to black ridges.
+        image = -image
 
-    # Check (sigma) scales
-    sigmas = _check_sigmas(sigmas)
-
-    # Rescale filter parameters
-    alpha_sq = 2 * alpha ** 2
-    beta_sq = 2 * beta ** 2
-    gamma_sq = 2 * gamma ** 2
-
-    # Get image dimensions
-    ndim = image.ndim
-
-    # Invert image to detect dark ridges on light background
-    if black_ridges:
-        image = invert(image)
-
-    float_dtype = _supported_float_type(image.dtype)
-
-    # Generate empty (n+1)D arrays for storing auxiliary images filtered
-    # at different (sigma) scales
-    filtered_array = np.zeros(sigmas.shape + image.shape, dtype=float_dtype)
-    lambdas_array = np.zeros_like(filtered_array, dtype=float_dtype)
-
-    # Filtering for all (sigma) scales
-    for i, sigma in enumerate(sigmas):
-
-        # Calculate (abs sorted) eigenvalues
-        lambda1, *lambdas = compute_hessian_eigenvalues(image, sigma,
-                                                        sorting='abs',
-                                                        mode=mode, cval=cval)
-
-        # Compute sensitivity to deviation from a plate-like
-        # structure see equations (11) and (15) in reference [1]_
-        r_a = np.inf if ndim == 2 else _divide_nonzero(*lambdas) ** 2
-
-        # Compute sensitivity to deviation from a blob-like structure,
-        # see equations (10) and (15) in reference [1]_,
-        # np.abs(lambda2) in 2D, np.sqrt(np.abs(lambda2 * lambda3)) in 3D
-        filtered_raw = np.abs(np.multiply.reduce(lambdas)) ** (1/len(lambdas))
-        r_b = _divide_nonzero(lambda1, filtered_raw) ** 2
-
-        # Compute sensitivity to areas of high variance/texture/structure,
-        # see equation (12)in reference [1]_
-        r_g = sum([lambda1 ** 2] + [lambdai ** 2 for lambdai in lambdas])
-
-        # Compute output image for given (sigma) scale and store results in
-        # (n+1)D matrices, see equations (13) and (15) in reference [1]_
-        filtered_array[i] = ((1 - np.exp(-r_a / alpha_sq))
-                             * np.exp(-r_b / beta_sq)
-                             * (1 - np.exp(-r_g / gamma_sq)))
-
-        lambdas_array[i] = np.max(lambdas, axis=0)
-
-    # Remove background
-    filtered_array[lambdas_array > 0] = 0
-
-    # Return for every pixel the maximum value over all (sigma) scales
-    return np.max(filtered_array, axis=0)
+    filtered = []
+    for sigma in sigmas:  # Filter for all sigmas.
+        eigvals = hessian_matrix_eigvals(hessian_matrix(
+            image, sigma, mode=mode, cval=cval, use_gaussian_derivatives=True))
+        # Sort eigenvalues by magnitude.
+        eigvals = np.take_along_axis(eigvals, abs(eigvals).argsort(0), 0)
+        lambda1 = eigvals[0]
+        if image.ndim == 2:
+            lambda2, = np.maximum(eigvals[1:], 1e-10)
+            r_a = np.inf  # implied by eq. (15).
+            r_b = abs(lambda1) / lambda2  # eq. (15).
+        else:  # ndim == 3
+            lambda2, lambda3 = np.maximum(eigvals[1:], 1e-10)
+            r_a = lambda2 / lambda3  # eq. (11).
+            r_b = abs(lambda1) / np.sqrt(lambda2 * lambda3)  # eq. (10).
+        s = np.sqrt((eigvals ** 2).sum(0))  # eq. (12).
+        if gamma is None:
+            gamma = s.max() / 2
+            if gamma == 0:
+                gamma = 1  # If s == 0 everywhere, gamma doesn't matter.
+        # Filtered image, eq. (13) and (15).  Our implementation relies on the
+        # blobness exponential factor underflowing to zero whenever the second
+        # or third eigenvalues are negative (we clip them to 1e-10, to make r_b
+        # very large).
+        vals = 1.0 - np.exp(-r_a**2 / (2 * alpha**2))  # plate sensitivity
+        vals *= np.exp(-r_b**2 / (2 * beta**2))  # blobness
+        vals *= 1.0 - np.exp(-s**2 / (2 * gamma**2))  # structuredness
+        filtered.append(vals)
+    return np.max(filtered, axis=0)  # Return pixel-wise max over all sigmas.
 
 
 def hessian(image, sigmas=range(1, 10, 2), scale_range=None, scale_step=None,

--- a/skimage/filters/tests/test_ridges.py
+++ b/skimage/filters/tests/test_ridges.py
@@ -184,8 +184,8 @@ def test_2d_cropped_camera_image():
     assert_allclose(sato(a_black, black_ridges=True, mode='reflect'),
                     sato(a_white, black_ridges=False, mode='reflect'))
 
-    assert_allclose(frangi(a_black, black_ridges=True), zeros, atol=1e-3)
-    assert_allclose(frangi(a_white, black_ridges=False), zeros, atol=1e-3)
+    assert_allclose(frangi(a_black, black_ridges=True),
+                    frangi(a_white, black_ridges=False))
 
     assert_allclose(hessian(a_black, black_ridges=True, mode='reflect'),
                     ones, atol=1 - 1e-7)
@@ -215,8 +215,8 @@ def test_3d_cropped_camera_image():
     assert_allclose(sato(a_black, black_ridges=True, mode='reflect'),
                     sato(a_white, black_ridges=False, mode='reflect'))
 
-    assert_allclose(frangi(a_black, black_ridges=True), zeros, atol=1e-3)
-    assert_allclose(frangi(a_white, black_ridges=False), zeros, atol=1e-3)
+    assert_allclose(frangi(a_black, black_ridges=True),
+                    frangi(a_white, black_ridges=False))
 
     assert_allclose(hessian(a_black, black_ridges=True, mode='reflect'),
                     ones, atol=1 - 1e-7)
@@ -224,9 +224,9 @@ def test_3d_cropped_camera_image():
                     ones, atol=1 - 1e-7)
 
 
-@pytest.mark.parametrize('func, tol', [(frangi, 1e-7),
+@pytest.mark.parametrize('func, tol', [(frangi, 1e-2),
                                        (meijering, 1e-2),
-                                       (sato, 1e-3),
+                                       (sato, 2e-3),
                                        (hessian, 2e-2)])
 def test_border_management(func, tol):
     img = rgb2gray(retina()[300:500, 700:900])


### PR DESCRIPTION
See discussion at #6436.  I took full advantage of the allowance given at https://github.com/scikit-image/scikit-image/issues/6436#issuecomment-1186134297 to **change the outputs**, as I believe the current implementations are all incorrect in a way or another...  (However, I would very much appreciate if a reviewer could double check my understanding of the equations, as a breaking change that mis-implements the equations would be very bad :/)

I did not change the `hessian()` filter, though, as (as noted in #6436) if my understanding of it is correct it should just be (deprecated and) removed.

-----

Meijering filter:  Fix default alpha.  Apply alpha correction before
sorting eigenvalues.  Simplify normalization code.

Sato filter:  In 3D, also force tubeness to zero if the middle
eigenvalue has the "wrong" sign.

Frangi filter:  Don't use absolute values in the denominator of r_b, but
rather make that denominator zero (which makes the whole filtered value
zero) whenever an eigenvalue has the "wrong" sign.  Fix the default
gamma value (to match Frangi's "half maximum hessian norm").  Edit
attribution notes, as the implementation has been nearly entirely
rewritten.

In all cases:

- Shorten dtype casting.
- Make all implementations focus on the black (lambda>0) case, where the
  signs are easier to follow.
- Remove unneeded compute_hessian_eigenvalues (casting to float is
  already done earlier, the sorting code is different for all filters
  anyways, and all that's left is calling hessian_matrix_eigvals over
  the result of hessian_matrix).
- Force use_gaussian_derivatives=True everywhere (it's not really
  something that most users can/should meaningfully tweak, and this
  patch already changes the values everywhere anyways, so even switching
  it back to False won't help with restoring the old values).
- Remove unneeded _divide_nonzero (it's clearer to handle that
  explicitly whereever needed rather than having to guess what happens
  for 0/0...).
- Remove repeated checks for sigma positivity (if anything, this check
  belongs to `hessian_matrix`, however, right now negative sigmas are
  just fine as we only ever use `sigma**2` anyways).

Test changes:  Border handling slightly changed, but that's not too
surprising and the tolerances for frangi and sato remain lower than for
meijering.  Also the large increase in tolerance for frangi is likely(?)
related to the fact that the gamma (c) factor is now adaptively set,
which avoids going into degenerate regimes where everything is very
close to zero.  Likewise, this explains why the cropped camera tests
don't yield zero values anymore; the tests have now been adjusted to
match meijering() and sato().

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
