### PR TITLE
Make Wiener restoration N-d

### DIFF
--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -23,7 +23,7 @@ def wiener(image, psf, balance, reg=None, is_real=True, clip=True):
        response (input image space) if the data-type is real, or the
        transfer function (Fourier space) if the data-type is
        complex. There is no constraints on the shape of the impulse
-       response. The transfer function must be of shape 
+       response. The transfer function must be of shape
        `(N1, N2, ..., ND)` if `is_real is True`,
        `(N1, N2, ..., ND // 2 + 1)` otherwise (see `np.fft.rfftn`).
     balance : float

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -128,10 +128,13 @@ def wiener(image, psf, balance, reg=None, is_real=True, clip=True):
     wiener_filter = np.conj(trans_func) / (np.abs(trans_func) ** 2 +
                                            balance * np.abs(reg) ** 2)
     if is_real:
-        deconv = uft.uirfft2(wiener_filter * uft.urfft2(image),
+        # deconv = uft.uirfft2(wiener_filter * uft.urfft2(image),
+        #                      shape=image.shape)
+        deconv = uft.uirfftn(wiener_filter * uft.urfftn(image),
                              shape=image.shape)
     else:
-        deconv = uft.uifft2(wiener_filter * uft.ufft2(image))
+        # deconv = uft.uifft2(wiener_filter * uft.ufft2(image))
+        deconv = uft.uifftn(wiener_filter * uft.ufftn(image))
 
     if clip:
         deconv[deconv > 1] = 1

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -16,16 +16,16 @@ def wiener(image, psf, balance, reg=None, is_real=True, clip=True):
 
     Parameters
     ----------
-    image : (M, N) ndarray
-       Input degraded image
+    image : ndarray
+       Input degraded image (can be N dimensional).
     psf : ndarray
        Point Spread Function. This is assumed to be the impulse
        response (input image space) if the data-type is real, or the
        transfer function (Fourier space) if the data-type is
        complex. There is no constraints on the shape of the impulse
-       response. The transfer function must be of shape `(M, N)` if
-       `is_real is True`, `(M, N // 2 + 1)` otherwise (see
-       `np.fft.rfftn`).
+       response. The transfer function must be of shape 
+       `(N1, N2, ..., ND)` if `is_real is True`,
+       `(N1, N2, ..., ND // 2 + 1)` otherwise (see `np.fft.rfftn`).
     balance : float
        The regularisation parameter value that tunes the balance
        between the data adequacy that improve frequency restoration

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -17,7 +17,7 @@ def wiener(image, psf, balance, reg=None, is_real=True, clip=True):
     Parameters
     ----------
     image : ndarray
-       Input degraded image (can be N dimensional).
+       Input degraded image (can be n-dimensional).
     psf : ndarray
        Point Spread Function. This is assumed to be the impulse
        response (input image space) if the data-type is real, or the
@@ -128,12 +128,9 @@ def wiener(image, psf, balance, reg=None, is_real=True, clip=True):
     wiener_filter = np.conj(trans_func) / (np.abs(trans_func) ** 2 +
                                            balance * np.abs(reg) ** 2)
     if is_real:
-        # deconv = uft.uirfft2(wiener_filter * uft.urfft2(image),
-        #                      shape=image.shape)
         deconv = uft.uirfftn(wiener_filter * uft.urfftn(image),
                              shape=image.shape)
     else:
-        # deconv = uft.uifft2(wiener_filter * uft.ufft2(image))
         deconv = uft.uifftn(wiener_filter * uft.ufftn(image))
 
     if clip:
@@ -377,7 +374,7 @@ def richardson_lucy(image, psf, num_iter=50, clip=True, filter_epsilon=None):
     Parameters
     ----------
     image : ndarray
-       Input degraded image (can be N dimensional).
+       Input degraded image (can be n-dimensional).
     psf : ndarray
        The point spread function.
     num_iter : int, optional

--- a/skimage/restoration/tests/test_restoration.py
+++ b/skimage/restoration/tests/test_restoration.py
@@ -26,33 +26,6 @@ def _get_rtol_atol(dtype):
     return rtol, atol
 
 
-# @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
-# def test_wiener(dtype):
-#     psf = np.ones((5, 5), dtype=dtype) / 25
-#     data = convolve2d(test_img, psf, 'same')
-#     np.random.seed(0)
-#     data += 0.1 * data.std() * np.random.standard_normal(data.shape)
-#     data = data.astype(dtype, copy=False)
-#     deconvolved = restoration.wiener(data, psf, 0.05)
-#     assert deconvolved.dtype == _supported_float_type(dtype)
-
-#     rtol, atol = _get_rtol_atol(dtype)
-#     path = fetch('restoration/tests/camera_wiener.npy')
-#     np.testing.assert_allclose(deconvolved, np.load(path), rtol=rtol,
-#                                atol=atol)
-
-#     _, laplacian = uft.laplacian(2, data.shape)
-#     otf = uft.ir2tf(psf, data.shape, is_real=False)
-#     assert otf.real.dtype == _supported_float_type(dtype)
-#     deconvolved = restoration.wiener(data, otf, 0.05,
-#                                      reg=laplacian,
-#                                      is_real=False)
-#     assert deconvolved.real.dtype == _supported_float_type(dtype)
-#     np.testing.assert_allclose(np.real(deconvolved),
-#                                np.load(path),
-#                                rtol=rtol, atol=atol)
-
-
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
 @pytest.mark.parametrize('ndim', [1, 2, 3])
 def test_wiener(dtype, ndim):

--- a/skimage/restoration/tests/test_restoration.py
+++ b/skimage/restoration/tests/test_restoration.py
@@ -66,7 +66,8 @@ def test_wiener(dtype, ndim):
     # for ndim == 2 use camera (to compare to presaved result)
     if ndim != 2:
         test_img = np.random.randint(0, 100, [50] * ndim)
-    else: test_img = util.img_as_float(camera())
+    else:
+        test_img = util.img_as_float(camera())
 
     data = convolve(test_img, psf, 'same')
     data += 0.1 * data.std() * np.random.standard_normal(data.shape)
@@ -77,8 +78,8 @@ def test_wiener(dtype, ndim):
     if ndim == 2:
         rtol, atol = _get_rtol_atol(dtype)
         path = fetch('restoration/tests/camera_wiener.npy')
-        np.testing.assert_allclose(deconvolved, np.load(path), rtol=rtol,
-                                atol=atol)
+        np.testing.assert_allclose(deconvolved, np.load(path),
+                                   rtol=rtol, atol=atol)
 
     _, laplacian = uft.laplacian(ndim, data.shape)
     otf = uft.ir2tf(psf, data.shape, is_real=False)
@@ -89,8 +90,8 @@ def test_wiener(dtype, ndim):
     assert deconvolved.real.dtype == _supported_float_type(dtype)
     if ndim == 2:
         np.testing.assert_allclose(np.real(deconvolved),
-                                np.load(path),
-                                rtol=rtol, atol=atol)
+                                   np.load(path),
+                                   rtol=rtol, atol=atol)
 
 
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
@@ -166,12 +167,14 @@ def test_image_shape():
     np.testing.assert_array_less(np.median(sup_relative_error), 0.1)
     np.testing.assert_array_less(np.median(un_relative_error), 0.1)
 
+
 @pytest.mark.parametrize('ndim', [1, 2, 3])
 def test_richardson_lucy(ndim):
     psf = np.ones([5] * ndim, dtype=float) / 5 ** ndim
     if ndim != 2:
         test_img = np.random.randint(0, 100, [30] * ndim)
-    else: test_img = util.img_as_float(camera())
+    else:
+        test_img = util.img_as_float(camera())
     data = convolve2d(test_img, psf, 'same')
     np.random.seed(0)
     data += 0.1 * data.std() * np.random.standard_normal(data.shape)

--- a/skimage/restoration/tests/test_restoration.py
+++ b/skimage/restoration/tests/test_restoration.py
@@ -66,7 +66,6 @@ def test_wiener(dtype, ndim):
     # for ndim == 2 use camera (to compare to presaved result)
     if ndim != 2:
         test_img = np.random.randint(0, 100, [50] * ndim)
-        test_img = ndi.gaussian_filter(test_img, sigma=5)
     else: test_img = util.img_as_float(camera())
 
     data = convolve(test_img, psf, 'same')
@@ -172,7 +171,6 @@ def test_richardson_lucy(ndim):
     psf = np.ones([5] * ndim, dtype=float) / 5 ** ndim
     if ndim != 2:
         test_img = np.random.randint(0, 100, [30] * ndim)
-        test_img = ndi.gaussian_filter(test_img, sigma=5)
     else: test_img = util.img_as_float(camera())
     data = convolve2d(test_img, psf, 'same')
     np.random.seed(0)

--- a/skimage/restoration/tests/test_restoration.py
+++ b/skimage/restoration/tests/test_restoration.py
@@ -175,7 +175,7 @@ def test_richardson_lucy(ndim):
         test_img = np.random.randint(0, 100, [30] * ndim)
     else:
         test_img = util.img_as_float(camera())
-    data = convolve2d(test_img, psf, 'same')
+    data = convolve(test_img, psf, 'same')
     np.random.seed(0)
     data += 0.1 * data.std() * np.random.standard_normal(data.shape)
     deconvolved = restoration.richardson_lucy(data, psf, num_iter=5)


### PR DESCRIPTION
## Description

I was trying out `skimage.restoration.wiener` and realised that it's currently limited to the 2d case only (as opposed to RL deconvolution, which is N-d). As far as I can tell, this is solely because `uft.ufft2` is used instead of it's N-d equivalent `uft.ufftn`, which is readily available in the `skimage.restoration.uft` module.

This PR makes the existing `skimage.restoration.wiener` available to the N-d case by replacing the use of `uft.ufft2` to its N-d equivalent `uft.ufftn` (as well as for the inverse) within the existing implementation.

To reflect this in the tests, one of the existing test functions is parametrized over `dims=[1,2,3]`. The same is done for a test of `skimage.restoration.richardson_lucy`, which so far hadn't tested for N-d capability. It should be noted that in the current test adaptations numerical comparisons to precomputed results are only performed in the 2d case.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
