### PR TITLE
Remove repeated import in canny_py

### DIFF
--- a/doc/source/skips/3-transition-to-v1.rst
+++ b/doc/source/skips/3-transition-to-v1.rst
@@ -285,10 +285,10 @@ license [1]_, as in `Copyright`, below, with attribution encouraged with CC0+BY
    https://creativecommons.org/publicdomain/zero/1.0/
 .. [2] https://dancohen.org/2013/11/26/cc0-by/
 .. [3] https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.0.0.html#backwards-incompatible-api-changes
-.. [4] https://docs.scipy.org/doc/scipy/reference/release.1.0.0.html
+.. [4] https://docs.scipy.org/doc/scipy/release.1.0.0.html
 .. [5] https://github.com/scipy/scipy/pull/12862
 .. [6] https://semver.org/
-.. [7] https://github.com/scikit-image/scikit-image/discussions/5651
+.. [7] https://github.com/scikit-image/scikit-image/issues/5439
 .. [8] https://github.com/scikit-image/scikit-image/milestones/1.0
 .. [9] https://github.com/scikit-image/meeting-notes/blob/main/2021/july-api-meetings.md
 .. [10] https://forum.image.sc/tag/scikit-image

--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -11,7 +11,6 @@ import scipy.ndimage as ndi
 from ..util.dtype import dtype_limits
 from .._shared.filters import gaussian
 from .._shared.utils import _supported_float_type, check_nD
-from ..filters._gaussian import gaussian
 from ._canny_cy import _nonmaximum_suppression_bilinear
 
 


### PR DESCRIPTION
## Description

Remove duplicate import. Please see Issue #6455.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
