### PR TITLE
Use broadcast_to instead of as_strided to generate broadcasted arrays.

### DIFF
--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -1,6 +1,5 @@
 import networkx as nx
 import numpy as np
-from numpy.lib.stride_tricks import as_strided
 from scipy import ndimage as ndi
 from scipy import sparse
 import math
@@ -149,14 +148,14 @@ class RAG(nx.Graph):
             # output, without this, a float array of the same shape as the
             # input image will be created and that could be expensive in
             # memory consumption.
+            output = np.broadcast_to(1., label_image.shape)
+            output.setflags(write=True)
             ndi.generic_filter(
                 label_image,
                 function=_add_edge_filter,
                 footprint=fp,
                 mode='nearest',
-                output=as_strided(np.empty((1,), dtype=float),
-                                  shape=label_image.shape,
-                                  strides=((0,) * label_image.ndim)),
+                output=output,
                 extra_arguments=(self,))
 
     def merge_nodes(self, src, dst, weight_func=min_weight, in_place=True,
@@ -426,8 +425,7 @@ def rag_boundary(labels, edge_map, connectivity=2):
     n = np.max(labels_large) + 1
 
     # use a dummy broadcast array as data for RAG
-    ones = as_strided(np.ones((1,), dtype=float), shape=labels_small.shape,
-                      strides=(0,))
+    ones = np.broadcast_to(1., labels_small.shape)
     count_matrix = sparse.coo_matrix((ones, (labels_small, labels_large)),
                                      dtype=int, shape=(n, n)).tocsr()
     data = np.concatenate((edge_map[boundaries0], edge_map[boundaries1]))


### PR DESCRIPTION
broadcast_to is both shorter to use and safer in general.

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
