### PR TITLE
Update Ubuntu LTS version on Actions workflows

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,7 +12,7 @@ jobs:
   benchmark:
     if: ${{ github.event.label.name == 'run-benchmark' && github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     name: Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CCACHE_BASEDIR: "${{ github.workspace }}"
       CCACHE_DIR: "${{ github.workspace }}/.ccache"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,7 +12,7 @@ jobs:
   benchmark:
     if: ${{ github.event.label.name == 'run-benchmark' && github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     name: Linux
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       CCACHE_BASEDIR: "${{ github.workspace }}"
       CCACHE_DIR: "${{ github.workspace }}/.ccache"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write  # for Git to git push
     name: Build docs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write  # for Git to git push
     name: Build docs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,7 +1,7 @@
 on: [status]
 jobs:
   circleci_artifacts_redirector_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,7 +1,7 @@
 on: [status]
 jobs:
   circleci_artifacts_redirector_job:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
   test_skimage_linux:
     name: linux-cp${{ matrix.python-version }}-${{ matrix.OPTIONS_NAME }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       # Ensure that a wheel builder finishes even if another fails

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
   test_skimage_linux:
     name: linux-cp${{ matrix.python-version }}-${{ matrix.OPTIONS_NAME }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       # Ensure that a wheel builder finishes even if another fails

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -21,12 +21,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest]
         cibw_python: [ "cp38-*", "cp39-*"]
         cibw_manylinux: [ manylinux2014 ]
         cibw_arch: [ "x86_64", "i686" ]
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             cibw_python: "cp310-*"
             cibw_manylinux: manylinux2014
             cibw_arch: x86_64
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest]
         cibw_python: [ "cp38-*" , "cp39-*" , "cp310-*" ]
         cibw_manylinux: [ manylinux2014 ]
     steps:
@@ -281,7 +281,7 @@ jobs:
     name: Release
     needs: [build_linux_37_and_above_wheels, build_linux_aarch64_wheels, build_macos_wheels, build_windows_wheels]
     if: github.repository_owner == 'scikit-image' && startsWith(github.ref, 'refs/tags/v') && always()
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -21,12 +21,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-22.04]
         cibw_python: [ "cp38-*", "cp39-*"]
         cibw_manylinux: [ manylinux2014 ]
         cibw_arch: [ "x86_64", "i686" ]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-22.04
             cibw_python: "cp310-*"
             cibw_manylinux: manylinux2014
             cibw_arch: x86_64
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-22.04]
         cibw_python: [ "cp38-*" , "cp39-*" , "cp310-*" ]
         cibw_manylinux: [ manylinux2014 ]
     steps:
@@ -281,7 +281,7 @@ jobs:
     name: Release
     needs: [build_linux_37_and_above_wheels, build_linux_aarch64_wheels, build_macos_wheels, build_windows_wheels]
     if: github.repository_owner == 'scikit-image' && startsWith(github.ref, 'refs/tags/v') && always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Description

Updating Ubuntu LTS version on the GitHub Actions workflows to the most recent one — from 18.04/20.04 to 22.04, currently.