### PR TITLE
changed image1 to moving_image in tvl1 parameter docs

### DIFF
--- a/skimage/registration/_optical_flow.py
+++ b/skimage/registration/_optical_flow.py
@@ -35,7 +35,7 @@ def _tvl1(reference_image, moving_image, flow0, attachment, tightness,
         maintain attachement and regularization parts in
         correspondence.
     num_warp : int
-        Number of times image1 is warped.
+        Number of times moving_image is warped.
     num_iter : int
         Number of fixed point iteration.
     tol : float
@@ -165,7 +165,7 @@ def optical_flow_tvl1(reference_image, moving_image,
         a small value in order to maintain attachement and
         regularization parts in correspondence.
     num_warp : int, optional
-        Number of times image1 is warped.
+        Number of times moving_image is warped.
     num_iter : int, optional
         Number of fixed point iteration.
     tol : float, optional


### PR DESCRIPTION
## Description

The docstrings in skimage.registration._optical_flow.py for optical_flow_tvl1 and _tvl1 both have the parameter num_warp described as `Number of times image1 is warped.` This is confusing since image1 could be either the reference_image or the moving_image. The  _ilk docstrings have moving_image rather than image1, so this change would make it consistent.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
