### PR TITLE
Use matplotlib.colormaps instead of deprecated cm.get_cmap in show_rag

### DIFF
--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -448,7 +448,7 @@ def rag_boundary(labels, edge_map, connectivity=2):
     return rag
 
 
-@require("matplotlib", ">=3.3")
+@require("matplotlib", ">=3.5")
 def show_rag(labels, rag, image, border_color='black', edge_width=1.5,
              edge_cmap='magma', img_cmap='bone', in_place=True, ax=None):
     """Show a Region Adjacency Graph on an image.
@@ -500,7 +500,7 @@ def show_rag(labels, rag, image, border_color='black', edge_width=1.5,
     >>> lc = graph.show_rag(labels, g, img)
     >>> cbar = plt.colorbar(lc)
     """
-    from matplotlib import colors, cm
+    from matplotlib import colors, colormaps
     from matplotlib import pyplot as plt
     from matplotlib.collections import LineCollection
 
@@ -518,12 +518,12 @@ def show_rag(labels, rag, image, border_color='black', edge_width=1.5,
         # Ignore the alpha channel
         out = image[:, :, :3]
     else:
-        img_cmap = cm.get_cmap(img_cmap)
+        img_cmap = colormaps[img_cmap]
         out = color.rgb2gray(image)
         # Ignore the alpha channel
         out = img_cmap(out)[:, :, :3]
 
-    edge_cmap = cm.get_cmap(edge_cmap)
+    edge_cmap = colormaps[edge_cmap]
 
     # Handling the case where one node has multiple labels
     # offset is 1 so that regionprops does not ignore 0


### PR DESCRIPTION
## Description

Top-level functions in `mpl.cm` are deprecated since maptlotlib version 3.6. The replacement `.ColormapRegistry` class is exposed in `matplotlib.colormaps` since version 3.5 [1].

[1] https://github.com/matplotlib/matplotlib/blob/main/doc/api/next_api_changes/deprecations/23668-TC.rst

Closes #6482.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
