### PR TITLE
Add multiscale structural similarity

### DIFF
--- a/skimage/metrics/__init__.py
+++ b/skimage/metrics/__init__.py
@@ -1,10 +1,17 @@
 from ._adapted_rand_error import adapted_rand_error
 from ._contingency_table import contingency_table
-from ._structural_similarity import structural_similarity, muliscale_structural_similarity
+from ._structural_similarity import (
+    structural_similarity,
+    muliscale_structural_similarity
+)
 from ._variation_of_information import variation_of_information
 from .set_metrics import hausdorff_distance, hausdorff_pair
-from .simple_metrics import (mean_squared_error, normalized_mutual_information,
-                             normalized_root_mse, peak_signal_noise_ratio)
+from .simple_metrics import (
+    mean_squared_error,
+    normalized_mutual_information,
+    normalized_root_mse,
+    peak_signal_noise_ratio
+)
 
 __all__ = [
     "adapted_rand_error",

--- a/skimage/metrics/__init__.py
+++ b/skimage/metrics/__init__.py
@@ -1,6 +1,6 @@
 from ._adapted_rand_error import adapted_rand_error
 from ._contingency_table import contingency_table
-from ._structural_similarity import structural_similarity
+from ._structural_similarity import structural_similarity, muliscale_structural_similarity
 from ._variation_of_information import variation_of_information
 from .set_metrics import hausdorff_distance, hausdorff_pair
 from .simple_metrics import (mean_squared_error, normalized_mutual_information,
@@ -15,6 +15,7 @@ __all__ = [
     "normalized_root_mse",
     "peak_signal_noise_ratio",
     "structural_similarity",
+    "muliscale_structural_similarity",
     "hausdorff_distance",
     "hausdorff_pair",
 ]

--- a/skimage/metrics/__init__.py
+++ b/skimage/metrics/__init__.py
@@ -1,9 +1,6 @@
 from ._adapted_rand_error import adapted_rand_error
 from ._contingency_table import contingency_table
-from ._structural_similarity import (
-    structural_similarity,
-    muliscale_structural_similarity
-)
+from ._structural_similarity import structural_similarity, multiscale_structural_similarity
 from ._variation_of_information import variation_of_information
 from .set_metrics import hausdorff_distance, hausdorff_pair
 from .simple_metrics import (
@@ -22,7 +19,7 @@ __all__ = [
     "normalized_root_mse",
     "peak_signal_noise_ratio",
     "structural_similarity",
-    "muliscale_structural_similarity",
+    "multiscale_structural_similarity",
     "hausdorff_distance",
     "hausdorff_pair",
 ]

--- a/skimage/metrics/_structural_similarity.py
+++ b/skimage/metrics/_structural_similarity.py
@@ -9,7 +9,7 @@ from .._shared.utils import _supported_float_type, check_shape_equality, warn
 from ..util.arraycrop import crop
 from ..util.dtype import dtype_range
 
-__all__ = ["structural_similarity", "multiscale_structural_similarity"]
+__all__ = ['structural_similarity', 'multiscale_structural_similarity']
 
 
 @utils.deprecate_multichannel_kwarg()
@@ -273,14 +273,10 @@ def structural_similarity(
 
 
 @utils.deprecate_multichannel_kwarg()
-def muliscale_structural_similarity(
-    im1,
-    im2,
-    *,
-    win_size=11,
-    multiscale_weights=[0.0448, 0.2856, 0.3001, 0.2363, 0.1333],
-    **kwargs,
-):
+def multiscale_structural_similarity(im1, im2,
+                          *,
+                          win_size=11,
+                          multiscale_weights=[0.0448, 0.2856, 0.3001, 0.2363, 0.1333], **kwargs):
     """
     Compute the multiscale structural similarity index between two images.
 
@@ -290,7 +286,7 @@ def muliscale_structural_similarity(
         Images. Any dimensionality with same shape.
     win_size : int, optional
         The side-length of the sliding window used in comparison. Must be an
-        odd value.
+        odd value. 
     multiscale_weights : list, optional
         The weights that needs to applied to the ssim at each scale
 
@@ -298,11 +294,11 @@ def muliscale_structural_similarity(
     -------
     ms_ssim : float
         The multiscale structural similarity index over the image.
-
+    
     Notes
     -----
     - kwargs can be used to pass arguments for the ssim metric at each scale see metrics.ssim for details
-    - Code adapted version of the pytorch implementation of the msssim from `pytorch-mssim` by @jorge-pessoa
+    - Code adapted version of the pytorch implementation of the msssim from `pytorch-mssim` by @jorge-pessoa       
 
     """
 
@@ -310,19 +306,15 @@ def muliscale_structural_similarity(
     min_size_img = 2 ** len(multiscale_weights)
 
     # assuming 3rd dim is the channel
-    assert min(
-        im1.shape[0], im1.shape[1]
-    ), f"min required image size is {min_size_img}, multiscale_weights of length {len(multiscale_weights)} is being used"
-
+    assert min(im1.shape[0], im1.shape[1]), f"min required image size is {min_size_img}, multiscale_weights of length {len(multiscale_weights)} is being used"
+    
     mssim = []
     mcs = []
-
+    
     for i in range(len(multiscale_weights)):
         # calculate ssim at scale i
-        sim, cs = structural_similarity(
-            im1=im1, im2=im2, win_size=win_size, full=True, **kwargs
-        )
-
+        sim, cs = structural_similarity(im1=im1, im2=im2, win_size=win_size, full=True, **kwargs)
+        
         # multiply the weights for the scale i
         mssim.append(sim ** multiscale_weights[i])
         mcs.append(cs.mean() ** multiscale_weights[i])

--- a/skimage/metrics/_structural_similarity.py
+++ b/skimage/metrics/_structural_similarity.py
@@ -277,7 +277,7 @@ def multiscale_structural_similarity(im1, im2,
                           win_size=11,
                           multiscale_weights=(0.0448, 0.2856, 0.3001, 0.2363, 0.1333),
                           # \alpha, \beta values from https://ece.uwaterloo.ca/~z70wang/publications/msssim.pdf
-                          channel_axis = 2,
+                          channel_axis=None,
                           **kwargs):
     """
     Compute the multiscale structural similarity index between two images.
@@ -328,9 +328,11 @@ def multiscale_structural_similarity(im1, im2,
             im2 = zoom(im2, zoom=0.5)
         else:
             warn(
-                f"Running truncated mssim. To run full ms-ssim expected minimum img spatial dim {2 ** len(multiscale_weights)}",
+                f"Running truncated mssim. To run full ms-ssim expected 
+                f"minimum image size {2 ** len(multiscale_weights)}",
                 stacklevel=2,
             )
+            break
 
 
     mssim = np.stack(mssim)

--- a/skimage/metrics/_structural_similarity.py
+++ b/skimage/metrics/_structural_similarity.py
@@ -276,6 +276,7 @@ def multiscale_structural_similarity(im1, im2,
                           *,
                           win_size=11,
                           multiscale_weights=(0.0448, 0.2856, 0.3001, 0.2363, 0.1333),
+                          channel_axis = 2,
                           **kwargs):
     """
     Compute the multiscale structural similarity index between two images.
@@ -286,7 +287,10 @@ def multiscale_structural_similarity(im1, im2,
         Images. Any dimensionality with same shape.
     win_size : int, optional
         The side-length of the sliding window used in comparison. Must be an
-        odd value. 
+        odd value.
+    channel_axis : int
+        This parameter indicates which axis of the array corresponds
+        to channels.
     multiscale_weights : list, optional
         The weights that needs to applied to the ssim at each scale
 
@@ -304,17 +308,18 @@ def multiscale_structural_similarity(im1, im2,
 
     check_shape_equality(im1, im2)
     min_size_img = 2 ** len(multiscale_weights)
+    n_dims = list(im1.shape)
+    n_dims.pop(channel_axis)
+    smallest_spatial_dim = min(n_dims)
 
-    # assuming 3rd dim is the channel
-    assert min(im1.shape[0], im1.shape[1]), f"min required image size is {min_size_img}, multiscale_weights of length {len(multiscale_weights)} is being used"
+    assert smallest_spatial_dim >= min_size_img, f"min required image size is {min_size_img}, multiscale_weights of length {len(multiscale_weights)} is being used"
     
     mssim = []
     mcs = []
     
     for weight in multiscale_weights:
         # calculate ssim at current scale
-        sim, cs = structural_similarity(im1, im2, win_size=win_size, full=True,
-                                        **kwargs)
+        sim, cs = structural_similarity(im1, im2, win_size=win_size, channel_axis=channel_axis, full=True, **kwargs)
         
         # multiply the weights for current scale
         mssim.append(sim ** weight)

--- a/skimage/metrics/_structural_similarity.py
+++ b/skimage/metrics/_structural_similarity.py
@@ -272,7 +272,6 @@ def structural_similarity(
             return mssim
 
 
-@utils.deprecate_multichannel_kwarg()
 def multiscale_structural_similarity(im1, im2,
                           *,
                           win_size=11,

--- a/skimage/metrics/_structural_similarity.py
+++ b/skimage/metrics/_structural_similarity.py
@@ -276,7 +276,8 @@ def structural_similarity(
 def multiscale_structural_similarity(im1, im2,
                           *,
                           win_size=11,
-                          multiscale_weights=[0.0448, 0.2856, 0.3001, 0.2363, 0.1333], **kwargs):
+                          multiscale_weights=(0.0448, 0.2856, 0.3001, 0.2363, 0.1333),
+                          **kwargs):
     """
     Compute the multiscale structural similarity index between two images.
 
@@ -311,13 +312,14 @@ def multiscale_structural_similarity(im1, im2,
     mssim = []
     mcs = []
     
-    for i in range(len(multiscale_weights)):
-        # calculate ssim at scale i
-        sim, cs = structural_similarity(im1=im1, im2=im2, win_size=win_size, full=True, **kwargs)
+    for weight in multiscale_weights:
+        # calculate ssim at current scale
+        sim, cs = structural_similarity(im1, im2, win_size=win_size, full=True,
+                                        **kwargs)
         
-        # multiply the weights for the scale i
-        mssim.append(sim ** multiscale_weights[i])
-        mcs.append(cs.mean() ** multiscale_weights[i])
+        # multiply the weights for current scale
+        mssim.append(sim ** weight)
+        mcs.append(cs.mean() ** weight)
 
         # rescale the images for scale i+1
         im1 = zoom(im1, zoom=0.5)

--- a/skimage/metrics/_structural_similarity.py
+++ b/skimage/metrics/_structural_similarity.py
@@ -130,7 +130,9 @@ def structural_similarity(
         channel_axis = channel_axis % im1.ndim
         _at = functools.partial(utils.slice_at_axis, axis=channel_axis)
         for ch in range(nch):
-            ch_result = structural_similarity(im1[_at(ch)], im2[_at(ch)], **args)
+            ch_result = structural_similarity(
+                im1[_at(ch)], im2[_at(ch)], **args
+            )
             if gradient and full:
                 mssim[ch], G[_at(ch)], S[_at(ch)] = ch_result
             elif gradient:
@@ -254,7 +256,9 @@ def structural_similarity(
         # The following is Eqs. 7-8 of Avanaki 2009.
         grad = filter_func(A1 / D, **filter_args) * im1
         grad += filter_func(-S / B2, **filter_args) * im2
-        grad += filter_func((ux * (A2 - A1) - uy * (B2 - B1) * S) / D, **filter_args)
+        grad += filter_func(
+            (ux * (A2 - A1) - uy * (B2 - B1) * S) / D, **filter_args
+        )
         grad *= 2 / im1.size
 
         if full:

--- a/skimage/metrics/tests/test_simple_metrics.py
+++ b/skimage/metrics/tests/test_simple_metrics.py
@@ -4,8 +4,12 @@ from numpy.testing import assert_equal, assert_almost_equal
 
 from skimage import data
 from skimage._shared._warnings import expected_warnings
-from skimage.metrics import (peak_signal_noise_ratio, normalized_root_mse,
-                             mean_squared_error, normalized_mutual_information)
+from skimage.metrics import (
+    peak_signal_noise_ratio,
+    normalized_root_mse,
+    mean_squared_error,
+    normalized_mutual_information,
+)
 
 
 np.random.seed(5)
@@ -16,7 +20,7 @@ cam_noisy = cam_noisy.astype(cam.dtype)
 
 
 def test_PSNR_vs_IPOL():
-    """ Tests vs. imdiff result from the following IPOL article and code:
+    """Tests vs. imdiff result from the following IPOL article and code:
     https://www.ipol.im/pub/art/2011/g_lmii/.
 
     Notes
@@ -38,32 +42,35 @@ def test_PSNR_vs_IPOL():
     assert_almost_equal(p, p_IPOL, decimal=4)
 
 
-@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
 def test_PSNR_float(dtype):
     p_uint8 = peak_signal_noise_ratio(cam, cam_noisy)
-    camf = (cam / 255.).astype(dtype, copy=False)
-    camf_noisy = (cam_noisy / 255.).astype(dtype, copy=False)
+    camf = (cam / 255.0).astype(dtype, copy=False)
+    camf_noisy = (cam_noisy / 255.0).astype(dtype, copy=False)
     p_float64 = peak_signal_noise_ratio(camf, camf_noisy, data_range=1)
     assert p_float64.dtype == np.float64
     decimal = 3 if dtype == np.float16 else 5
     assert_almost_equal(p_uint8, p_float64, decimal=decimal)
 
     # mixed precision inputs
-    p_mixed = peak_signal_noise_ratio(cam / 255., np.float32(cam_noisy / 255.),
-                                      data_range=1)
+    p_mixed = peak_signal_noise_ratio(
+        cam / 255.0, np.float32(cam_noisy / 255.0), data_range=1
+    )
 
     assert_almost_equal(p_mixed, p_float64, decimal=decimal)
 
     # mismatched dtype results in a warning if data_range is unspecified
-    with expected_warnings(['Inputs have mismatched dtype']):
-        p_mixed = peak_signal_noise_ratio(cam / 255.,
-                                          np.float32(cam_noisy / 255.))
+    with expected_warnings(["Inputs have mismatched dtype"]):
+        p_mixed = peak_signal_noise_ratio(
+            cam / 255.0, np.float32(cam_noisy / 255.0)
+        )
     assert_almost_equal(p_mixed, p_float64, decimal=decimal)
 
     # mismatched dtype results in a warning if data_range is unspecified
-    with expected_warnings(['Inputs have mismatched dtype']):
-        p_mixed = peak_signal_noise_ratio(cam / 255.,
-                                          np.float32(cam_noisy / 255.))
+    with expected_warnings(["Inputs have mismatched dtype"]):
+        p_mixed = peak_signal_noise_ratio(
+            cam / 255.0, np.float32(cam_noisy / 255.0)
+        )
     assert_almost_equal(p_mixed, p_float64, decimal=decimal)
 
 
@@ -73,31 +80,39 @@ def test_PSNR_errors():
         peak_signal_noise_ratio(cam, cam[:-1, :])
 
 
-@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
 def test_NRMSE(dtype):
     x = np.ones(4, dtype=dtype)
-    y = np.asarray([0., 2., 2., 2.], dtype=dtype)
-    nrmse = normalized_root_mse(y, x, normalization='mean')
+    y = np.asarray([0.0, 2.0, 2.0, 2.0], dtype=dtype)
+    nrmse = normalized_root_mse(y, x, normalization="mean")
     assert nrmse.dtype == np.float64
     assert_equal(nrmse, 1 / np.mean(y))
-    assert_equal(normalized_root_mse(y, x, normalization='euclidean'),
-                 1 / np.sqrt(3))
-    assert_equal(normalized_root_mse(y, x, normalization='min-max'),
-                 1 / (y.max() - y.min()))
+    assert_equal(
+        normalized_root_mse(y, x, normalization="euclidean"), 1 / np.sqrt(3)
+    )
+    assert_equal(
+        normalized_root_mse(y, x, normalization="min-max"),
+        1 / (y.max() - y.min()),
+    )
 
     # mixed precision inputs are allowed
-    assert_almost_equal(normalized_root_mse(y, np.float32(x),
-                                            normalization='min-max'),
-                        1 / (y.max() - y.min()))
+    assert_almost_equal(
+        normalized_root_mse(y, np.float32(x), normalization="min-max"),
+        1 / (y.max() - y.min()),
+    )
 
 
 def test_NRMSE_no_int_overflow():
     camf = cam.astype(np.float32)
     cam_noisyf = cam_noisy.astype(np.float32)
-    assert_almost_equal(mean_squared_error(cam, cam_noisy),
-                        mean_squared_error(camf, cam_noisyf))
-    assert_almost_equal(normalized_root_mse(cam, cam_noisy),
-                        normalized_root_mse(camf, cam_noisyf))
+    assert_almost_equal(
+        mean_squared_error(cam, cam_noisy),
+        mean_squared_error(camf, cam_noisyf),
+    )
+    assert_almost_equal(
+        normalized_root_mse(cam, cam_noisy),
+        normalized_root_mse(camf, cam_noisyf),
+    )
 
 
 def test_NRMSE_errors():
@@ -107,20 +122,21 @@ def test_NRMSE_errors():
         normalized_root_mse(x[:-1], x)
     # invalid normalization name
     with pytest.raises(ValueError):
-        normalized_root_mse(x, x, normalization='foo')
+        normalized_root_mse(x, x, normalization="foo")
 
 
 def test_nmi():
     assert_almost_equal(normalized_mutual_information(cam, cam), 2)
-    assert (normalized_mutual_information(cam, cam_noisy)
-            < normalized_mutual_information(cam, cam))
+    assert normalized_mutual_information(
+        cam, cam_noisy
+    ) < normalized_mutual_information(cam, cam)
 
 
 def test_nmi_different_sizes():
     assert normalized_mutual_information(cam[:, :400], cam[:400, :]) > 1
 
 
-@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
 def test_nmi_random(dtype):
     rng = np.random.default_rng()
     random1 = rng.random((100, 100)).astype(dtype)

--- a/skimage/metrics/tests/test_structural_similarity.py
+++ b/skimage/metrics/tests/test_structural_similarity.py
@@ -282,5 +282,5 @@ def test_ms_structural_similarity():
     # test small image
 
     X = np.ones((5, 5))
-    with pytest.raises(AssertionError):
+    with expected_warnings(["Running truncated mssim. To run full ms-ssim expected minimum img spatial dim 16"]):
         multiscale_structural_similarity(X, X)

--- a/skimage/metrics/tests/test_structural_similarity.py
+++ b/skimage/metrics/tests/test_structural_similarity.py
@@ -21,7 +21,7 @@ def test_structural_similarity_patch_range():
     X = (np.random.rand(N, N) * 255).astype(np.uint8)
     Y = (np.random.rand(N, N) * 255).astype(np.uint8)
 
-    assert(structural_similarity(X, Y, win_size=N) < 0.1)
+    assert structural_similarity(X, Y, win_size=N) < 0.1
     assert_equal(structural_similarity(X, X, win_size=N), 1)
 
 
@@ -34,10 +34,10 @@ def test_structural_similarity_image():
     assert_equal(S0, 1)
 
     S1 = structural_similarity(X, Y, win_size=3)
-    assert(S1 < 0.3)
+    assert S1 < 0.3
 
     S2 = structural_similarity(X, Y, win_size=11, gaussian_weights=True)
-    assert(S2 < 0.3)
+    assert S2 < 0.3
 
     mssim0, S3 = structural_similarity(X, Y, full=True)
     assert_equal(S3.shape, X.shape)
@@ -50,8 +50,8 @@ def test_structural_similarity_image():
 
 # Because we are forcing a random seed state, it is probably good to test
 # against a few seeds in case on seed gives a particularly bad example
-@pytest.mark.parametrize('seed', [1, 2, 3, 5, 8, 13])
-@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
+@pytest.mark.parametrize("seed", [1, 2, 3, 5, 8, 13])
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
 def test_structural_similarity_grad(seed, dtype):
     N = 60
     # NOTE: This test is known to randomly fail on some systems (Mac OS X 10.6)
@@ -73,20 +73,21 @@ def test_structural_similarity_grad(seed, dtype):
     assert np.all(g[1] < 0.05)
 
     mssim, grad, s = structural_similarity(
-        X, Y, data_range=255, gradient=True, full=True)
+        X, Y, data_range=255, gradient=True, full=True
+    )
     assert s.dtype == _supported_float_type(dtype)
     assert grad.dtype == _supported_float_type(dtype)
     assert np.all(grad < 0.05)
 
 
 @pytest.mark.parametrize(
-    'dtype', [np.uint8, np.int32, np.float16, np.float32, np.float64]
+    "dtype", [np.uint8, np.int32, np.float16, np.float32, np.float64]
 )
 def test_structural_similarity_dtype(dtype):
     N = 30
     X = np.random.rand(N, N)
     Y = np.random.rand(N, N)
-    if np.dtype(dtype).kind in 'iub':
+    if np.dtype(dtype).kind in "iub":
         X = (X * 255).astype(np.uint8)
         Y = (X * 255).astype(np.uint8)
     else:
@@ -99,7 +100,7 @@ def test_structural_similarity_dtype(dtype):
     assert S1 < 0.1
 
 
-@pytest.mark.parametrize('channel_axis', [0, 1, 2, -1])
+@pytest.mark.parametrize("channel_axis", [0, 1, 2, -1])
 def test_structural_similarity_multichannel(channel_axis):
     N = 100
     X = (np.random.rand(N, N) * 255).astype(np.uint8)
@@ -122,15 +123,13 @@ def test_structural_similarity_multichannel(channel_axis):
     assert_equal(S3.shape, Xc.shape)
 
     # gradient case
-    m, grad = structural_similarity(Xc, Yc, channel_axis=channel_axis,
-                                    gradient=True)
+    m, grad = structural_similarity(Xc, Yc, channel_axis=channel_axis, gradient=True)
     assert_equal(grad.shape, Xc.shape)
 
     # full and gradient case
-    m, grad, S3 = structural_similarity(Xc, Yc,
-                                        channel_axis=channel_axis,
-                                        full=True,
-                                        gradient=True)
+    m, grad, S3 = structural_similarity(
+        Xc, Yc, channel_axis=channel_axis, full=True, gradient=True
+    )
     assert_equal(grad.shape, Xc.shape)
     assert_equal(S3.shape, Xc.shape)
 
@@ -154,12 +153,14 @@ def test_structural_similarity_multichannel_deprecated():
     assert_almost_equal(S1, S2)
 
 
-@pytest.mark.parametrize('dtype', [np.uint8, np.float32, np.float64])
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32, np.float64])
 def test_structural_similarity_nD(dtype):
     # test 1D through 4D on small random arrays
     N = 10
     for ndim in range(1, 5):
-        xsize = [N, ] * 5
+        xsize = [
+            N,
+        ] * 5
         X = (np.random.rand(*xsize) * 255).astype(dtype)
         Y = (np.random.rand(*xsize) * 255).astype(dtype)
 
@@ -177,8 +178,9 @@ def test_structural_similarity_multichannel_chelsea():
 
     # multichannel result should be mean of the individual channel results
     mssim = structural_similarity(Xc, Yc, channel_axis=-1)
-    mssim_sep = [structural_similarity(
-        Yc[..., c], Xc[..., c]) for c in range(Xc.shape[-1])]
+    mssim_sep = [
+        structural_similarity(Yc[..., c], Xc[..., c]) for c in range(Xc.shape[-1])
+    ]
     assert_almost_equal(mssim, np.mean(mssim_sep))
 
     # structural_similarity of image with itself should be 1.0
@@ -186,7 +188,7 @@ def test_structural_similarity_multichannel_chelsea():
 
 
 def test_gaussian_structural_similarity_vs_IPOL():
-    """ Tests vs. imdiff result from the following IPOL article and code:
+    """Tests vs. imdiff result from the following IPOL article and code:
     https://www.ipol.im/pub/art/2011/g_lmii/.
 
     Notes
@@ -204,8 +206,9 @@ def test_gaussian_structural_similarity_vs_IPOL():
     https://github.com/scikit-image/scikit-image/pull/4913#issuecomment-700653165
     """
     mssim_IPOL = 0.357959091663361
-    mssim = structural_similarity(cam, cam_noisy, gaussian_weights=True,
-                                  use_sample_covariance=False)
+    mssim = structural_similarity(
+        cam, cam_noisy, gaussian_weights=True, use_sample_covariance=False
+    )
     assert_almost_equal(mssim, mssim_IPOL, decimal=3)
 
 
@@ -218,17 +221,18 @@ def test_mssim_vs_legacy():
 
 def test_mssim_mixed_dtype():
     mssim = structural_similarity(cam, cam_noisy)
-    with expected_warnings(['Inputs have mismatched dtype']):
+    with expected_warnings(["Inputs have mismatched dtype"]):
         mssim_mixed = structural_similarity(cam, cam_noisy.astype(np.float32))
     assert_almost_equal(mssim, mssim_mixed)
 
     # no warning when user supplies data_range
     mssim_mixed = structural_similarity(
-        cam, cam_noisy.astype(np.float32), data_range=255)
+        cam, cam_noisy.astype(np.float32), data_range=255
+    )
     assert_almost_equal(mssim, mssim_mixed)
 
 
-@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
+@pytest.mark.parametrize("dtype", [np.float16, np.float32, np.float64])
 def test_structural_similarity_small_image(dtype):
     X = np.zeros((5, 5), dtype=dtype)
     # structural_similarity can be computed for small images if win_size is
@@ -258,6 +262,7 @@ def test_invalid_input():
     with pytest.raises(ValueError):
         structural_similarity(X, X, sigma=-1.0)
 
+
 def test_ms_structural_similarity():
     # color image example
     Xc = data.chelsea()
@@ -267,8 +272,10 @@ def test_ms_structural_similarity():
 
     # multichannel result should be mean of the individual channel results
     mssim = muliscale_structural_similarity(Xc, Yc, channel_axis=-1)
-    mssim_sep = [muliscale_structural_similarity(
-        Yc[..., c], Xc[..., c]) for c in range(Xc.shape[-1])]
+    mssim_sep = [
+        muliscale_structural_similarity(Yc[..., c], Xc[..., c])
+        for c in range(Xc.shape[-1])
+    ]
     assert_almost_equal(mssim, np.mean(mssim_sep))
 
     # structural_similarity of image with itself should be 1.0

--- a/skimage/metrics/tests/test_structural_similarity.py
+++ b/skimage/metrics/tests/test_structural_similarity.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_equal, assert_almost_equal
 from skimage import data
 from skimage._shared._warnings import expected_warnings
 from skimage._shared.utils import _supported_float_type
-from skimage.metrics import structural_similarity, muliscale_structural_similarity
+from skimage.metrics import structural_similarity, multiscale_structural_similarity
 
 np.random.seed(5)
 cam = data.camera()
@@ -271,18 +271,16 @@ def test_ms_structural_similarity():
     Yc = Yc.astype(Xc.dtype)
 
     # multichannel result should be mean of the individual channel results
-    mssim = muliscale_structural_similarity(Xc, Yc, channel_axis=-1)
-    mssim_sep = [
-        muliscale_structural_similarity(Yc[..., c], Xc[..., c])
-        for c in range(Xc.shape[-1])
-    ]
+    mssim = multiscale_structural_similarity(Xc, Yc, channel_axis=-1)
+    mssim_sep = [multiscale_structural_similarity(
+        Yc[..., c], Xc[..., c]) for c in range(Xc.shape[-1])]
     assert_almost_equal(mssim, np.mean(mssim_sep))
 
     # structural_similarity of image with itself should be 1.0
-    assert_equal(muliscale_structural_similarity(Xc, Xc, channel_axis=-1), 1.0)
+    assert_equal(multiscale_structural_similarity(Xc, Xc, channel_axis=-1), 1.0)
 
     # test small image
 
-    X = np.zeros((5, 5))
+    X = np.ones((5, 5))
     with pytest.raises(AssertionError):
-        muliscale_structural_similarity(X, X)
+        multiscale_structural_similarity(X, X)


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
Duplicate PR of  #6470  Closes #5194
Adding `multiscale_structural_similarity` to `skimage.metrics`

<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
