### PR TITLE
Radon/iradon: rotation center re-definition & user definition support

### DIFF
--- a/skimage/transform/_radon_transform.pyx
+++ b/skimage/transform/_radon_transform.pyx
@@ -33,9 +33,9 @@ cdef bilinear_ray_sum(np_floats[:, :] image, np_floats theta,
         A measure of how long the ray's path through the reconstruction circle was.
     """
     theta = theta / 180. * M_PI
-    cdef np_floats radius = image.shape[0] // 2 - 1
-    cdef np_floats projection_center = image.shape[0] // 2
-    cdef np_floats rotation_center = image.shape[0] // 2
+    cdef np_floats radius = image.shape[0] / 2.0 - 1.5
+    cdef np_floats projection_center = image.shape[0] / 2.0 - 0.5
+    cdef np_floats rotation_center = image.shape[0] / 2.0 - 0.5
     # (s, t) is the (x, y) system rotated by theta
     cdef np_floats t = ray_position - projection_center
     # s0 is the half-length of the ray's path in the reconstruction circle
@@ -43,6 +43,7 @@ cdef bilinear_ray_sum(np_floats[:, :] image, np_floats theta,
     s0 = sqrt(radius * radius - t * t) if radius*radius >= t*t else 0.
     cdef Py_ssize_t Ns = 2 * (<Py_ssize_t>ceil(2 * s0))  # number of steps
                                                          # along the ray
+
     cdef np_floats ray_sum = 0.
     cdef np_floats weight_norm = 0.
     cdef np_floats ds, dx, dy, x0, y0, x, y, di, dj,
@@ -120,9 +121,9 @@ cdef bilinear_ray_update(np_floats[:, :] image,
     else:
         deviation = 0.
     theta = theta / 180. * M_PI
-    cdef np_floats radius = image.shape[0] // 2 - 1
-    cdef np_floats projection_center = image.shape[0] // 2
-    cdef np_floats rotation_center = image.shape[0] // 2
+    cdef np_floats radius = image.shape[0] / 2.0 - 1.5
+    cdef np_floats projection_center = image.shape[0] / 2.0 - 0.5
+    cdef np_floats rotation_center = image.shape[0] / 2.0 - 0.5
     # (s, t) is the (x, y) system rotated by theta
     cdef np_floats t = ray_position - projection_center
     # s0 is the half-length of the ray's path in the reconstruction circle

--- a/skimage/transform/_radon_transform.pyx
+++ b/skimage/transform/_radon_transform.pyx
@@ -11,6 +11,12 @@ from .._shared.fused_numerics cimport np_floats
 
 cnp.import_array()
 
+cdef _get_default_center(Py_ssize_t image_shape, bint legacy=True):
+    if legacy:
+        return image_shape // 2
+    else:
+        return image_shape / 2.0 - 0.5
+
 cdef bilinear_ray_sum(np_floats[:, :] image, np_floats theta,
                       np_floats ray_position):
     """
@@ -33,9 +39,9 @@ cdef bilinear_ray_sum(np_floats[:, :] image, np_floats theta,
         A measure of how long the ray's path through the reconstruction circle was.
     """
     theta = theta / 180. * M_PI
-    cdef np_floats radius = image.shape[0] / 2.0 - 1.5
-    cdef np_floats projection_center = image.shape[0] / 2.0 - 0.5
-    cdef np_floats rotation_center = image.shape[0] / 2.0 - 0.5
+    cdef np_floats radius = _get_default_center(image.shape[0]) - 1.0
+    cdef np_floats projection_center = _get_default_center(image.shape[0])
+    cdef np_floats rotation_center = _get_default_center(image.shape[0])
     # (s, t) is the (x, y) system rotated by theta
     cdef np_floats t = ray_position - projection_center
     # s0 is the half-length of the ray's path in the reconstruction circle
@@ -121,9 +127,9 @@ cdef bilinear_ray_update(np_floats[:, :] image,
     else:
         deviation = 0.
     theta = theta / 180. * M_PI
-    cdef np_floats radius = image.shape[0] / 2.0 - 1.5
-    cdef np_floats projection_center = image.shape[0] / 2.0 - 0.5
-    cdef np_floats rotation_center = image.shape[0] / 2.0 - 0.5
+    cdef np_floats radius = _get_default_center(image.shape[0]) - 1.0
+    cdef np_floats projection_center = _get_default_center(image.shape[0])
+    cdef np_floats rotation_center = _get_default_center(image.shape[0])
     # (s, t) is the (x, y) system rotated by theta
     cdef np_floats t = ray_position - projection_center
     # s0 is the half-length of the ray's path in the reconstruction circle

--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -90,9 +90,11 @@ def radon(image, theta=None, circle=True, *, preserve_range=False, center=None):
 
         # Crop image to make it square
         slices = tuple(
-            slice(int(np.ceil(excess / 2)), -int(np.ceil(excess / 2)))
-            if excess > 0
-            else slice(None)
+            (
+                slice(int(np.ceil(excess / 2)), -int(np.ceil(excess / 2)))
+                if excess > 0
+                else slice(None)
+            )
             for excess in (img_shape - shape_min)
         )
         padded_image = image[slices]

--- a/skimage/transform/radon_transform.py
+++ b/skimage/transform/radon_transform.py
@@ -34,9 +34,9 @@ def radon(image, theta=None, circle=True, *, preserve_range=False, center=None):
         image is converted according to the conventions of `img_as_float`.
         Also see https://scikit-image.org/docs/dev/user_guide/data_types.html
     center : array_like, optional
-        It specifies the rotation center of the image. By default, the rotation
-        axis will be located in the position:
-        ``((image.shape[0] - 1) / 2, (image.shape[1] - 1) / 2)``
+        Coordinates of the rotation axis. If None, the rotation axis will be
+        located in the pixel with coordinates:
+        ``(image.shape[0] // 2, image.shape[1] // 2)``
 
     Returns
     -------

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -320,8 +320,9 @@ def _random_circle(shape):
     np.random.seed(98312871)
     image = np.random.rand(*shape)
     c0, c1 = np.ogrid[0 : shape[0], 0 : shape[1]]
-    r = np.sqrt((c0 - shape[0] // 2) ** 2 + (c1 - shape[1] // 2) ** 2)
-    radius = min(shape) // 2
+    center = np.array(shape) / 2 - 0.5
+    r = np.sqrt((c0 - center[0]) ** 2 + (c1 - center[1]) ** 2)
+    radius = min(shape) / 2 - 0.5
     image[r > radius] = 0.0
     return image
 
@@ -334,8 +335,9 @@ def test_radon_circle():
     # Synthetic data, circular symmetry
     shape = (61, 79)
     c0, c1 = np.ogrid[0 : shape[0], 0 : shape[1]]
-    r = np.sqrt((c0 - shape[0] // 2) ** 2 + (c1 - shape[1] // 2) ** 2)
-    radius = min(shape) // 2
+    center = np.array(shape) / 2 - 0.5
+    r = np.sqrt((c0 - center[0]) ** 2 + (c1 - center[1]) ** 2)
+    radius = min(shape)  / 2 - 0.5
     image = np.clip(radius - r, 0, np.inf)
     image = _rescale_intensity(image)
     angles = np.linspace(0, 180, min(shape), endpoint=False)

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -337,7 +337,7 @@ def test_radon_circle():
     c0, c1 = np.ogrid[0 : shape[0], 0 : shape[1]]
     center = np.array(shape) / 2 - 0.5
     r = np.sqrt((c0 - center[0]) ** 2 + (c1 - center[1]) ** 2)
-    radius = min(shape)  / 2 - 0.5
+    radius = min(shape) / 2 - 0.5
     image = np.clip(radius - r, 0, np.inf)
     image = _rescale_intensity(image)
     angles = np.linspace(0, 180, min(shape), endpoint=False)


### PR DESCRIPTION
## Description

The current center definition in `radon`, `iradon`, and `iradon_sart` changes, depending on the image shape, and it is not coherent with the function `rotate`. The current definition is `image.shape // 2`, which always aligns with an integer pixel position. The function `rotate` and various tomography libraries use the definition `(image.shape - 1) / 2`, which always puts the rotation axis in the center of the image.

This PR changes the definition of the rotation center to `(image.shape - 1) / 2`, and it add support for specifying the center as an argument to those functions. This way, they users can either specify off-center rotation axes, or fall back to the previous behavior.

This closes #6425.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Gallery example in `./doc/examples` (new features only)
<!-- - Benchmark in `./benchmarks`, if your changes aren't covered by an existing benchmark -->
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
