### PR TITLE
Use pyplot.get_cmap for compatiblity with matplotlib 3.3 to 3.6 in in show_rag

### DIFF
--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -498,7 +498,7 @@ def show_rag(labels, rag, image, border_color='black', edge_width=1.5,
     >>> lc = graph.show_rag(labels, g, img)
     >>> cbar = plt.colorbar(lc)
     """
-    from matplotlib import colors, pyplot
+    from matplotlib import colors
     from matplotlib import pyplot as plt
     from matplotlib.collections import LineCollection
 
@@ -516,12 +516,12 @@ def show_rag(labels, rag, image, border_color='black', edge_width=1.5,
         # Ignore the alpha channel
         out = image[:, :, :3]
     else:
-        img_cmap = pyplot.get_cmap(img_cmap)
+        img_cmap = plt.get_cmap(img_cmap)
         out = color.rgb2gray(image)
         # Ignore the alpha channel
         out = img_cmap(out)[:, :, :3]
 
-    edge_cmap = pyplot.get_cmap(edge_cmap)
+    edge_cmap = plt.get_cmap(edge_cmap)
 
     # Handling the case where one node has multiple labels
     # offset is 1 so that regionprops does not ignore 0

--- a/skimage/future/graph/rag.py
+++ b/skimage/future/graph/rag.py
@@ -446,7 +446,7 @@ def rag_boundary(labels, edge_map, connectivity=2):
     return rag
 
 
-@require("matplotlib", ">=3.5")
+@require("matplotlib", ">=3.3")
 def show_rag(labels, rag, image, border_color='black', edge_width=1.5,
              edge_cmap='magma', img_cmap='bone', in_place=True, ax=None):
     """Show a Region Adjacency Graph on an image.
@@ -498,7 +498,7 @@ def show_rag(labels, rag, image, border_color='black', edge_width=1.5,
     >>> lc = graph.show_rag(labels, g, img)
     >>> cbar = plt.colorbar(lc)
     """
-    from matplotlib import colors, colormaps
+    from matplotlib import colors, pyplot
     from matplotlib import pyplot as plt
     from matplotlib.collections import LineCollection
 
@@ -516,12 +516,12 @@ def show_rag(labels, rag, image, border_color='black', edge_width=1.5,
         # Ignore the alpha channel
         out = image[:, :, :3]
     else:
-        img_cmap = colormaps[img_cmap]
+        img_cmap = pyplot.get_cmap(img_cmap)
         out = color.rgb2gray(image)
         # Ignore the alpha channel
         out = img_cmap(out)[:, :, :3]
 
-    edge_cmap = colormaps[edge_cmap]
+    edge_cmap = pyplot.get_cmap(edge_cmap)
 
     # Handling the case where one node has multiple labels
     # offset is 1 so that regionprops does not ignore 0


### PR DESCRIPTION
## Description

Updates the solution from 514c08923cbbdbcb6f8e8165806f4728a3ad7112 (#6483) to one that is compatible with all currently supported matplotlib versions and will work with 3.6 also. This allows us to not update our matplotlib dependency to 3.5 yet, which might be a bit early.

Marking as draft because I want to get this merged before the CI is green. ;)

Closes #6486

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
