### PR TITLE
Handle 2D labels in 3D images for convex hull calculation

### DIFF
--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -43,6 +43,12 @@ SAMPLE_3D[1:3, 1:3, 1:3] = 1
 SAMPLE_3D[3, 2, 2] = 1
 INTENSITY_SAMPLE_3D = SAMPLE_3D.copy()
 
+SAMPLE_3D_LABEL_2D = np.zeros((5, 4, 5), dtype=np.uint8)
+SAMPLE_3D_LABEL_2D[1:4, 1, 1:4] = 1
+SAMPLE_3D_LABEL_2D[3, 1, 2] = 0
+SAMPLE_3D_LABEL_1D = np.zeros((5, 4, 5), dtype=np.uint8)
+SAMPLE_3D_LABEL_1D[1:4, 1, 2] = 1
+
 
 def get_moment_function(img, spacing=(1, 1)):
     rows, cols = img.shape
@@ -331,6 +337,27 @@ def test_image_convex():
     )
     assert_array_equal(img, ref)
 
+def test_image_convex_3D_label_2D():
+    img = regionprops(SAMPLE_3D_LABEL_2D())[0].image_convex
+    ref = np.array(
+        [
+            [[True, True, True]],
+            [[True, True, True]],
+            [[True, True, True]]
+        ]
+    )
+    assert_array_equal(img, ref)
+    
+def test_image_convex_3D_label_1D():
+    img = regionprops(SAMPLE_3D_LABEL_1D())[0].image_convex
+    ref = np.array(
+        [
+            [[True, ]],
+            [[True, ]],
+            [[True, ]]
+        ]
+    )
+    assert_array_equal(img, ref)
 
 def test_coordinates():
     sample = np.zeros((10, 10), dtype=np.int8)

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -106,6 +106,13 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10):
     .. [1] https://blogs.mathworks.com/steve/2011/10/04/binary-image-convex-hull-algorithm-notes/
 
     """
+    image_shape = np.array(image.shape)
+    # Look for 1D axes
+    axes_1D = np.where(image_shape == 1)[0]
+    label_is_2D = (axes_1D.size != 0) and (len(image_shape) == 3)
+    if label_is_2D:
+        # If there is at least one axis 1D and image is 3D, treat it as 2D
+        image = np.squeeze(image, axis=axes_1D[0])
     ndim = image.ndim
     if np.count_nonzero(image) == 0:
         warn("Input image is entirely zero, no valid convex hull. "
@@ -160,6 +167,10 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10):
         coords_in_hull = _check_coords_in_hull(gridcoords,
                                                hull.equations, tolerance)
         mask = np.reshape(coords_in_hull, image.shape)
+
+    if label_is_2D:
+        # If image was 3D with 1D axis, restore mask to original 3D shape
+        mask = mask.reshape(image_shape)
 
     return mask
 


### PR DESCRIPTION
Hi scikit-image developers,

So I finally got some time to work around #6432 . I am basically providing an exception for the convex hull image calculation when there are 2D labels in 3D images. I drop one unitary axis and put it back by the end, so calculation is done as if it were a 2D image label.

Let me know if this solution seems reasonable to you and if there is anything missing. 😃 
I also added two tests.

## Description

This PR fixes #6432 .


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
