### PR TITLE
Remove references to api_changes

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -117,7 +117,7 @@ For a more detailed discussion, read these :doc:`detailed documents
 5. Document changes
 
    If your change introduces any API modifications, please update
-   ``doc/source/api_changes.txt``.
+   ``doc/release/release_dev.rst``.
 
    If your change introduces a deprecation, add a reminder to ``TODO.txt``
    for the team to remove the deprecated functionality in the future.

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,4 +1,4 @@
-Remember to list any API changes below in `doc/source/api_changes.txt`.
+Remember to list any API changes below in `doc/release/release_dev.rst`.
 
 Version 0.17
 ------------

--- a/doc/source/api_changes.md
+++ b/doc/source/api_changes.md
@@ -1,3 +1,5 @@
+:orphan:
+
 # Version 0.16
 
 - The following functions are deprecated and will be removed in 0.18:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -453,6 +453,7 @@ def linkcode_resolve(domain, info):
         return ("https://github.com/scikit-image/scikit-image/blob/"
                 "v%s/skimage/%s%s" % (skimage.__version__, fn, linespec))
 
+
 # ----------------------------------------------------------------------------
 # MyST
 # ----------------------------------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -459,6 +459,6 @@ def linkcode_resolve(domain, info):
 # ----------------------------------------------------------------------------
 
 myst_enable_extensions = [
-    # Enable fieldlist to allow for Field Lists like in rST (e.g. :orphan:)
+    # Enable fieldlist to allow for Field Lists like in rST (e.g., :orphan:)
     "fieldlist",
 ]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -452,3 +452,12 @@ def linkcode_resolve(domain, info):
     else:
         return ("https://github.com/scikit-image/scikit-image/blob/"
                 "v%s/skimage/%s%s" % (skimage.__version__, fn, linespec))
+
+# ----------------------------------------------------------------------------
+# MyST
+# ----------------------------------------------------------------------------
+
+myst_enable_extensions = [
+    # Enable fieldlist to allow for Field Lists like in rST (e.g. :orphan:)
+    "fieldlist",
+]

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -16,7 +16,6 @@ Sections
 
    overview
    api/api
-   api_changes
    install
    user_guide
    glossary
@@ -36,7 +35,7 @@ Sections
 
        Introduction to scikit-image.
 
-     - `API Reference <api/api.html>`_ (`changes <api_changes.html>`_)
+     - `API Reference <api/api.html>`_
 
        Documentation for the functions included in scikit-image.
 


### PR DESCRIPTION


## Description

Remove references to api_changes.
Closes #6450.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
