### PR TITLE
Support float input to skimage.draw.rectangle() [#4283]

### DIFF
--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -925,6 +925,9 @@ def _rectangle_slice(start, end=None, extent=None):
     top_left = np.minimum(start, end)
     bottom_right = np.maximum(start, end)
 
+    top_left = np.round(top_left).astype(int)
+    bottom_right = np.round(bottom_right).astype(int)
+
     if extent is None:
         bottom_right += 1
 

--- a/skimage/draw/tests/test_draw.py
+++ b/skimage/draw/tests/test_draw.py
@@ -929,6 +929,37 @@ def test_rectangle_end():
     assert_array_equal(img, expected)
 
 
+def test_rectangle_float_input():
+    expected = np.array([[0, 1, 1, 1, 0],
+                         [0, 1, 1, 1, 0],
+                         [0, 1, 1, 1, 0],
+                         [0, 1, 1, 1, 0],
+                         [0, 0, 0, 0, 0]], dtype=np.uint8)
+    start = (0.2, 0.8)
+    end = (3.1, 2.9)
+    img = np.zeros((5, 5), dtype=np.uint8)
+    rr, cc = rectangle(start, end=end, shape=img.shape)
+    img[rr, cc] = 1
+    assert_array_equal(img, expected)
+
+    # Swap start and end
+    img = np.zeros((5, 5), dtype=np.uint8)
+    rr, cc = rectangle(end=start, start=end, shape=img.shape)
+    img[rr, cc] = 1
+    assert_array_equal(img, expected)
+
+    # Bottom left and top right
+    img = np.zeros((5, 5), dtype=np.uint8)
+    rr, cc = rectangle(start=(3.1, 0.8), end=(0.2, 2.9), shape=img.shape)
+    img[rr, cc] = 1
+    assert_array_equal(img, expected)
+
+    img = np.zeros((5, 5), dtype=np.uint8)
+    rr, cc = rectangle(end=(3.1, 0.8), start=(0.2, 2.9), shape=img.shape)
+    img[rr, cc] = 1
+    assert_array_equal(img, expected)
+
+
 def test_rectangle_extent():
     expected = np.array([[0, 0, 0, 0, 0],
                          [0, 1, 1, 1, 0],


### PR DESCRIPTION
Fixes #4283 

skimage.draw.rectangle(start,end) with float input produces float output
that cannot be used to index which is unexpected behavior compared to
the other skimage.draw.* functions. See discussion at issue #4283

This patch implements np.round(...).astype(int) as suggested by @jni.
Users who desire different behavior for float input can explicitly
convert start, end to int as they desire before calling
skimage.draw.rectangle(). np.round(...).astype(int) seems a reasonable
default that behaves similarly to the other draw functions.