### PR TITLE
Find peaks at border with `peak_local_max with `exclude_border=0`

### DIFF
--- a/skimage/feature/peak.py
+++ b/skimage/feature/peak.py
@@ -40,7 +40,7 @@ def _get_peak_mask(image, footprint, threshold, mask=None):
         return image > threshold
 
     image_max = ndi.maximum_filter(image, footprint=footprint,
-                                   mode='constant')
+                                   mode='nearest')
 
     out = image == image_max
 

--- a/skimage/feature/tests/test_peak.py
+++ b/skimage/feature/tests/test_peak.py
@@ -400,6 +400,19 @@ class TestPeakLocalMax():
             assert len(peak.peak_local_max(image,
                                            min_distance=0)) == image.size - 1
 
+    def test_peak_at_border(self):
+        image = np.full((10, 10), -2)
+        image[2, 4] = -1
+        image[3, 0] = -1
+
+        peaks = peak.peak_local_max(image, min_distance=3)
+        assert not peaks
+
+        peaks = peak.peak_local_max(image, min_distance=3, exclude_border=0)
+        assert len(peaks) == 2
+        assert [2, 4] in peaks
+        assert [3, 0] in peaks
+
 
 @pytest.mark.parametrize(
     ["indices"],

--- a/skimage/feature/tests/test_peak.py
+++ b/skimage/feature/tests/test_peak.py
@@ -406,7 +406,7 @@ class TestPeakLocalMax():
         image[3, 0] = -1
 
         peaks = peak.peak_local_max(image, min_distance=3)
-        assert not peaks
+        assert peaks.size == 0
 
         peaks = peak.peak_local_max(image, min_distance=3, exclude_border=0)
         assert len(peaks) == 2


### PR DESCRIPTION
## Description

Fixes #6391
Uses `mode='nearest'` instead of `'mirror'` because it seems a bit clearer and I did not see a performance difference.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
