### PR TITLE
Fix resize anti_aliazing default value when input dtype is integer and order == 0

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -150,8 +150,10 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
         image = image.astype(np.float32)
 
     if anti_aliasing is None:
-        anti_aliasing = (not input_type == bool and
-                         any(x < y for x, y in zip(output_shape, input_shape)))
+        anti_aliasing = (
+            not input_type == bool and
+            not (np.issubdtype(input_type, np.integer) and order == 0) and
+            any(x < y for x, y in zip(output_shape, input_shape)))
 
     if input_type == bool and anti_aliasing:
         raise ValueError("anti_aliasing must be False for boolean images")

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -986,6 +986,17 @@ def test_resize_local_mean_dtype():
                              preserve_range=True).dtype == x_f32.dtype
 
 
+def test_nn_resize_int_img():
+    """Issue #6467"""
+    img = np.zeros((12, 12), dtype=np.int16)
+    img[4:8, 1:4] = 5
+    img[4:8, 7:10] = 7
+
+    resized = resize(img, (8, 8), order=0)
+
+    assert np.array_equal(np.unique(resized), [0, 5, 7])
+
+
 @pytest.mark.parametrize("_type", [tuple, np.asarray, list])
 def test_output_shape_arg_type(_type):
     img = np.random.rand(3, 3)

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -994,7 +994,7 @@ def test_nn_resize_int_img():
 
     resized = resize(img, (8, 8), order=0)
 
-    assert np.array_equal(np.unique(resized), [0, 5, 7])
+    assert np.array_equal(np.unique(resized), np.unique(img))
 
 
 @pytest.mark.parametrize("_type", [tuple, np.asarray, list])


### PR DESCRIPTION
## Description

Fixes #6467.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
