### PR TITLE
Add Github actions/stale to label "dormant" issues and PRs

### DIFF
--- a/.github/workflows/dormant-issues-prs.yml
+++ b/.github/workflows/dormant-issues-prs.yml
@@ -1,4 +1,4 @@
-# Mark issues without activity as dormant
+# Mark issues and pull requests without activity as dormant
 # See https://github.com/actions/stale for documentation and configuration
 
 name: Mark dormant issues
@@ -17,7 +17,7 @@ jobs:
           debug-only: true
           days-before-stale: 180
           days-before-close: -1  # never close
-          stale-issue-label: ":zzz: Dormant"
+          stale-issue-label: ":sleeping: Dormant"
           remove-stale-when-updated: true
           stale-issue-message: >
             Hey, there hasn't been any activity on this for more than 180

--- a/.github/workflows/dormant.yml
+++ b/.github/workflows/dormant.yml
@@ -17,7 +17,7 @@ jobs:
           debug-only: true
           days-before-stale: 180
           days-before-close: -1  # never close
-          stale-issue-label: ":zzz: dormant"
+          stale-issue-label: ":zzz: Dormant"
           remove-stale-when-updated: true
           stale-issue-message: >
             Hey, there hasn't been any activity on this for more than 180

--- a/.github/workflows/dormant.yml
+++ b/.github/workflows/dormant.yml
@@ -22,7 +22,7 @@ jobs:
           stale-issue-message: >
             Hey, there hasn't been any activity on this for more than 180
             days, so we have marked it as "dormant" for now until there is some
-            new activity. Feel free to reach out to people directly by
+            new activity. You are welcome to reach out to people directly by
             mentioning them here or on our
             [forum](https://discuss.scientific-python.org/c/contributor/skimage/22)
             if more feedback is needed! If you feel that this issue is no longer
@@ -32,10 +32,10 @@ jobs:
           stale-pr-message: >
             Hey, there hasn't been any activity on this for more than 180
             days, so we have marked it as "dormant" for now until there is some
-            new activity. Feel free to reach out to people directly by
+            new activity. You are welcome to reach out to people directly by
             mentioning them here or on our
             [forum](https://discuss.scientific-python.org/c/contributor/skimage/22)
-            if more feedback is needed! Otherwise, we would appreciate a short
-            update if you plan to continue this or if you are okay with someone
-            else taking over.
+            if more feedback is needed! Otherwise, we would be thankful for a 
+            short update, for example if you would like to continue or if you
+            are okay with someone else doing so.
             In any case, thank you for your contributions so far!

--- a/.github/workflows/dormant.yml
+++ b/.github/workflows/dormant.yml
@@ -22,20 +22,20 @@ jobs:
           stale-issue-message: >
             Hey, there hasn't been any activity on this for more than 180
             days, so we have marked it as "dormant" for now until there is some
-            new activity. You are welcome to reach out to people directly by
+            new activity. You are welcome to reach out to people by
             mentioning them here or on our
             [forum](https://discuss.scientific-python.org/c/contributor/skimage/22)
-            if more feedback is needed! If you feel that this issue is no longer
-            relevant you may close it by yourself; otherwise, we may do it at
+            if you need more feedback! If you think that this issue is no longer
+            relevant, you may close it by yourself; otherwise, we may do it at
             some point (either way, it will be done manually).
             In any case, thank you for your contributions so far!
           stale-pr-message: >
             Hey, there hasn't been any activity on this for more than 180
             days, so we have marked it as "dormant" for now until there is some
-            new activity. You are welcome to reach out to people directly by
+            new activity. You are welcome to reach out to people by
             mentioning them here or on our
             [forum](https://discuss.scientific-python.org/c/contributor/skimage/22)
-            if more feedback is needed! Otherwise, we would be thankful for a 
+            if you need more feedback! Otherwise, we would be thankful for a 
             short update, for example if you would like to continue or if you
             are okay with someone else doing so.
             In any case, thank you for your contributions so far!

--- a/.github/workflows/dormant.yml
+++ b/.github/workflows/dormant.yml
@@ -4,7 +4,7 @@
 name: Mark dormant issues
 on:
   schedule:
-    - cron: "15 2 * * *"  # trigger everyday at 2:15
+    - cron: "15 2 * * *"  # trigger every day at 2:15
 permissions:
   issues: write
   pull-requests: write
@@ -20,21 +20,22 @@ jobs:
           stale-issue-label: ":zzz: dormant"
           remove-stale-when-updated: true
           stale-issue-message: >
-            Hey, there hasn't been any recent activity on this for more than 180
+            Hey, there hasn't been any activity on this for more than 180
             days, so we have marked it as "dormant" for now until there is some
-            new activity. Please, feel free to reach out to people directly by
+            new activity. Feel free to reach out to people directly by
             mentioning them here or on our
             [forum](https://discuss.scientific-python.org/c/contributor/skimage/22)
             if more feedback is needed! If you feel that this issue is no longer
-            relevant you may close this or we may do it at some point manually.
+            relevant you may close it by yourself; otherwise, we may do it at
+            some point (either way, it will be done manually).
             In any case, thank you for your contributions so far!
           stale-pr-message: >
-            Hey, there hasn't been any recent activity on this for more than 180
+            Hey, there hasn't been any activity on this for more than 180
             days, so we have marked it as "dormant" for now until there is some
-            new activity. Please, feel free to reach out to people directly by
+            new activity. Feel free to reach out to people directly by
             mentioning them here or on our
             [forum](https://discuss.scientific-python.org/c/contributor/skimage/22)
-            if more feedback is needed! Otherwise, we would be thankful for a
-            brief update on whether you are planning to continue this or if you
-            are happy for someone to take over.
+            if more feedback is needed! Otherwise, we would appreciate a short
+            update if you plan to continue this or if you are okay with someone
+            else taking over.
             In any case, thank you for your contributions so far!

--- a/.github/workflows/dormant.yml
+++ b/.github/workflows/dormant.yml
@@ -1,0 +1,40 @@
+# Mark issues without activity as dormant
+# See https://github.com/actions/stale for documentation and configuration
+
+name: Mark dormant issues
+on:
+  schedule:
+    - cron: "15 2 * * *"  # trigger everyday at 2:15
+permissions:
+  issues: write
+  pull-requests: write
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          debug-only: true
+          days-before-stale: 180
+          days-before-close: -1  # never close
+          stale-issue-label: ":zzz: dormant"
+          remove-stale-when-updated: true
+          stale-issue-message: >
+            Hey, there hasn't been any recent activity on this for more than 180
+            days, so we have marked it as "dormant" for now until there is some
+            new activity. Please, feel free to reach out to people directly by
+            mentioning them here or on our
+            [forum](https://discuss.scientific-python.org/c/contributor/skimage/22)
+            if more feedback is needed! If you feel that this issue is no longer
+            relevant you may close this or we may do it at some point manually.
+            In any case, thank you for your contributions so far!
+          stale-pr-message: >
+            Hey, there hasn't been any recent activity on this for more than 180
+            days, so we have marked it as "dormant" for now until there is some
+            new activity. Please, feel free to reach out to people directly by
+            mentioning them here or on our
+            [forum](https://discuss.scientific-python.org/c/contributor/skimage/22)
+            if more feedback is needed! Otherwise, we would be thankful for a
+            brief update on whether you are planning to continue this or if you
+            are happy for someone to take over.
+            In any case, thank you for your contributions so far!


### PR DESCRIPTION
## Description

Configures a GitHub action [1] to mark issues and pull requests with the label ":zzz: dormant" (which I just added) after a period of inactivity. "dormant" issues and PRs are never closed automatically. See also discussion in [2]. This is intended to help us keeping track of older contributions and hopefully help us in keeping them before they are truly out of date, memory is lost and participants are no longer around.

Debugging (dry-run) is enabled for now to test this.

[1] https://github.com/actions/stale
[2] https://discuss.scientific-python.org/t/442

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
