### PR TITLE
Add new flag to convex_hull_image and grid_points_in_poly

### DIFF
--- a/skimage/measure/__init__.py
+++ b/skimage/measure/__init__.py
@@ -3,8 +3,7 @@ from ._marching_cubes_lewiner import marching_cubes, mesh_surface_area
 from ._regionprops import (regionprops, perimeter,
                            perimeter_crofton, euler_number, regionprops_table)
 from ._polygon import approximate_polygon, subdivide_polygon
-from .pnpoly import (points_in_poly, grid_points_in_poly,
-                     grid_points_in_poly_label)
+from .pnpoly import (points_in_poly, grid_points_in_poly)
 from ._moments import (moments, moments_central, moments_coords,
                        moments_coords_central, moments_normalized, centroid,
                        moments_hu, inertia_tensor, inertia_tensor_eigvals)
@@ -43,7 +42,6 @@ __all__ = ['find_contours',
            'label',
            'points_in_poly',
            'grid_points_in_poly',
-           'grid_points_in_poly_label',
            'shannon_entropy',
            'blur_effect',
            ]

--- a/skimage/measure/__init__.py
+++ b/skimage/measure/__init__.py
@@ -3,7 +3,8 @@ from ._marching_cubes_lewiner import marching_cubes, mesh_surface_area
 from ._regionprops import (regionprops, perimeter,
                            perimeter_crofton, euler_number, regionprops_table)
 from ._polygon import approximate_polygon, subdivide_polygon
-from .pnpoly import points_in_poly, grid_points_in_poly, grid_points_in_poly_label
+from .pnpoly import (points_in_poly, grid_points_in_poly,
+                     grid_points_in_poly_label)
 from ._moments import (moments, moments_central, moments_coords,
                        moments_coords_central, moments_normalized, centroid,
                        moments_hu, inertia_tensor, inertia_tensor_eigvals)

--- a/skimage/measure/__init__.py
+++ b/skimage/measure/__init__.py
@@ -3,7 +3,7 @@ from ._marching_cubes_lewiner import marching_cubes, mesh_surface_area
 from ._regionprops import (regionprops, perimeter,
                            perimeter_crofton, euler_number, regionprops_table)
 from ._polygon import approximate_polygon, subdivide_polygon
-from .pnpoly import points_in_poly, grid_points_in_poly
+from .pnpoly import points_in_poly, grid_points_in_poly, grid_points_in_poly_label
 from ._moments import (moments, moments_central, moments_coords,
                        moments_coords_central, moments_normalized, centroid,
                        moments_hu, inertia_tensor, inertia_tensor_eigvals)
@@ -42,6 +42,7 @@ __all__ = ['find_contours',
            'label',
            'points_in_poly',
            'grid_points_in_poly',
+           'grid_points_in_poly_label',
            'shannon_entropy',
            'blur_effect',
            ]

--- a/skimage/measure/_pnpoly.pyx
+++ b/skimage/measure/_pnpoly.pyx
@@ -10,7 +10,7 @@ from .._shared.geometry cimport point_in_polygon, points_in_polygon
 cnp.import_array()
 
 
-def _grid_points_in_poly(shape, verts):
+def _grid_points_in_poly(shape, verts, return_labels=False):
     """Test whether points on a specified grid are inside a polygon.
 
     For each ``(r, c)`` coordinate on a grid, i.e. ``(0, 0)``, ``(0, 1)`` etc.,
@@ -51,6 +51,11 @@ def _grid_points_in_poly(shape, verts):
         for m in range(M):
             for n in range(N):
                 out[m, n] = point_in_polygon(vx, vy, m, n)
+
+    # In case the consumer of this function would like to transform
+    # the labels array into a mask manually, we shall return the raw labels.
+    if return_labels:
+        return out.view(bool), out
 
     return out.view(bool)
 

--- a/skimage/measure/_pnpoly.pyx
+++ b/skimage/measure/_pnpoly.pyx
@@ -10,7 +10,7 @@ from .._shared.geometry cimport point_in_polygon, points_in_polygon
 cnp.import_array()
 
 
-def _grid_points_in_poly(shape, verts, return_labels=False):
+def _grid_points_in_poly(shape, verts):
     """Test whether points on a specified grid are inside a polygon.
 
     For each ``(r, c)`` coordinate on a grid, i.e. ``(0, 0)``, ``(0, 1)`` etc.,

--- a/skimage/measure/_pnpoly.pyx
+++ b/skimage/measure/_pnpoly.pyx
@@ -24,6 +24,10 @@ def _grid_points_in_poly(shape, verts, return_labels=False):
         Specify the V vertices of the polygon, sorted either clockwise
         or anti-clockwise.  The first point may (but does not need to be)
         duplicated.
+    return_labels: bool, optional
+        If ``True``, a label mask will also be returned along with the default
+        boolean mask. The possible labels are: O - outside, 1 - inside,
+        2 - vertex, 3 - edge.
 
     See Also
     --------
@@ -33,6 +37,9 @@ def _grid_points_in_poly(shape, verts, return_labels=False):
     -------
     mask : (M, N) ndarray of bool
         True where the grid falls inside the polygon.
+    labels: (M, N) ndarray of labels (integers)
+        Labels array, with pixels having a label between 0 and 3.
+        This is only returned if `return_labels` is set to True.
 
     """
     verts = np.asarray(verts)

--- a/skimage/measure/_pnpoly.pyx
+++ b/skimage/measure/_pnpoly.pyx
@@ -24,10 +24,6 @@ def _grid_points_in_poly(shape, verts, return_labels=False):
         Specify the V vertices of the polygon, sorted either clockwise
         or anti-clockwise.  The first point may (but does not need to be)
         duplicated.
-    return_labels: bool, optional
-        If ``True``, a label mask will also be returned along with the default
-        boolean mask. The possible labels are: O - outside, 1 - inside,
-        2 - vertex, 3 - edge.
 
     See Also
     --------
@@ -37,9 +33,6 @@ def _grid_points_in_poly(shape, verts, return_labels=False):
     -------
     mask : (M, N) ndarray of bool
         True where the grid falls inside the polygon.
-    labels: (M, N) ndarray of labels (integers)
-        Labels array, with pixels having a label between 0 and 3.
-        This is only returned if `return_labels` is set to True.
 
     """
     verts = np.asarray(verts)
@@ -59,12 +52,7 @@ def _grid_points_in_poly(shape, verts, return_labels=False):
             for n in range(N):
                 out[m, n] = point_in_polygon(vx, vy, m, n)
 
-    # In case the consumer of this function would like to transform
-    # the labels array into a mask manually, we shall return the raw labels.
-    if return_labels:
-        return out.view(bool), out
-
-    return out.view(bool)
+    return out
 
 
 def _points_in_poly(points, verts):

--- a/skimage/measure/pnpoly.py
+++ b/skimage/measure/pnpoly.py
@@ -1,7 +1,7 @@
 from ._pnpoly import _grid_points_in_poly, _points_in_poly
 
 
-def grid_points_in_poly(shape, verts):
+def grid_points_in_poly(shape, verts, return_labels=False):
     """Test whether points on a specified grid are inside a polygon.
 
     For each ``(r, c)`` coordinate on a grid, i.e. ``(0, 0)``, ``(0, 1)`` etc.,
@@ -26,7 +26,7 @@ def grid_points_in_poly(shape, verts):
         True where the grid falls inside the polygon.
 
     """
-    return _grid_points_in_poly(shape, verts)
+    return _grid_points_in_poly(shape, verts, return_labels=return_labels)
 
 
 def points_in_poly(points, verts):

--- a/skimage/measure/pnpoly.py
+++ b/skimage/measure/pnpoly.py
@@ -1,39 +1,7 @@
 from ._pnpoly import _grid_points_in_poly, _points_in_poly
 
 
-def grid_points_in_poly_label(shape, verts):
-    """Test whether points on a specified grid are inside a polygon.
-
-    For each ``(r, c)`` coordinate on a grid, i.e. ``(0, 0)``, ``(0, 1)`` etc.,
-    check what is the relative location to the polygon. For each pixel, it
-    assigns one of these values: O - outside, 1 - inside, 2 - vertex, 3 - edge.
-
-    Parameters
-    ----------
-    shape : tuple (M, N)
-        Shape of the grid.
-    verts : (V, 2) array
-        Specify the V vertices of the polygon, sorted either clockwise
-        or anti-clockwise. The first point may (but does not need to be)
-        duplicated.
-
-    See Also
-    --------
-    points_in_poly
-    grid_points_in_poly
-
-    Returns
-    -------
-    labels: (M, N) ndarray of int
-        Labels array, with pixels having a label between 0 and 3.
-        The meaning of the values is: O - outside, 1 - inside,
-        2 - vertex, 3 - edge.
-
-    """
-    return _grid_points_in_poly(shape, verts)
-
-
-def grid_points_in_poly(shape, verts):
+def grid_points_in_poly(shape, verts, binarize=True):
     """Test whether points on a specified grid are inside a polygon.
 
     For each ``(r, c)`` coordinate on a grid, i.e. ``(0, 0)``, ``(0, 1)`` etc.,
@@ -50,20 +18,29 @@ def grid_points_in_poly(shape, verts):
         Specify the V vertices of the polygon, sorted either clockwise
         or anti-clockwise. The first point may (but does not need to be)
         duplicated.
+    binarize: bool
+        If `True`, the output of the function is a boolean mask.
+        Otherwise, it is a labels array. The labels are:
+        O - outside, 1 - inside, 2 - vertex, 3 - edge.
 
     See Also
     --------
     points_in_poly
-    grid_points_in_poly_label
 
     Returns
     -------
     mask : (M, N) ndarray of bool
-        True where the grid falls inside the polygon.
+        If `binarize` is True, the output is a boolean mask. True means the
+        corresponding pixel falls inside the polygon.
+        If `binarize` is False, the output is a label array, with pixels
+        having a label between 0 and 3. The meaning of the values is:
+        O - outside, 1 - inside, 2 - vertex, 3 - edge.
 
     """
     output = _grid_points_in_poly(shape, verts)
-    return output.astype(bool)
+    if binarize:
+        output = output.astype(bool)
+    return output
 
 
 def points_in_poly(points, verts):

--- a/skimage/measure/pnpoly.py
+++ b/skimage/measure/pnpoly.py
@@ -15,6 +15,10 @@ def grid_points_in_poly(shape, verts, return_labels=False):
         Specify the V vertices of the polygon, sorted either clockwise
         or anti-clockwise. The first point may (but does not need to be)
         duplicated.
+    return_labels: bool, optional
+        If ``True``, a label mask will also be returned along with the default
+        boolean mask. The possible labels are: O - outside, 1 - inside,
+        2 - vertex, 3 - edge.
 
     See Also
     --------
@@ -24,6 +28,9 @@ def grid_points_in_poly(shape, verts, return_labels=False):
     -------
     mask : (M, N) ndarray of bool
         True where the grid falls inside the polygon.
+    labels: (M, N) ndarray of labels (integers)
+        Labels array, with pixels having a label between 0 and 3.
+        This is only returned if `return_labels` is set to True.
 
     """
     return _grid_points_in_poly(shape, verts, return_labels=return_labels)

--- a/skimage/measure/pnpoly.py
+++ b/skimage/measure/pnpoly.py
@@ -29,7 +29,7 @@ def grid_points_in_poly(shape, verts, binarize=True):
 
     Returns
     -------
-    mask : (M, N) ndarray of bool
+    mask : (M, N) ndarray
         If `binarize` is True, the output is a boolean mask. True means the
         corresponding pixel falls inside the polygon.
         If `binarize` is False, the output is a label array, with pixels

--- a/skimage/measure/pnpoly.py
+++ b/skimage/measure/pnpoly.py
@@ -5,8 +5,8 @@ def grid_points_in_poly_label(shape, verts):
     """Test whether points on a specified grid are inside a polygon.
 
     For each ``(r, c)`` coordinate on a grid, i.e. ``(0, 0)``, ``(0, 1)`` etc.,
-    check what is the relative location to the polygon. For each pixel, it assigns
-    one of these values: O - outside, 1 - inside, 2 - vertex, 3 - edge.
+    check what is the relative location to the polygon. For each pixel, it
+    assigns one of these values: O - outside, 1 - inside, 2 - vertex, 3 - edge.
 
     Parameters
     ----------
@@ -26,7 +26,8 @@ def grid_points_in_poly_label(shape, verts):
     -------
     labels: (M, N) ndarray of int
         Labels array, with pixels having a label between 0 and 3.
-        The meaning of the values is: O - outside, 1 - inside, 2 - vertex, 3 - edge.
+        The meaning of the values is: O - outside, 1 - inside,
+        2 - vertex, 3 - edge.
 
     """
     return _grid_points_in_poly(shape, verts)
@@ -37,7 +38,7 @@ def grid_points_in_poly(shape, verts):
 
     For each ``(r, c)`` coordinate on a grid, i.e. ``(0, 0)``, ``(0, 1)`` etc.,
     test whether that point lies inside a polygon.
-    
+
     Note that this function explicitly includes vertices/edges inside the poly.
     For a better control on this behaviour, use ``grid_points_in_poly_label``.
 

--- a/skimage/measure/pnpoly.py
+++ b/skimage/measure/pnpoly.py
@@ -20,7 +20,7 @@ def grid_points_in_poly(shape, verts, binarize=True):
         duplicated.
     binarize: bool
         If `True`, the output of the function is a boolean mask.
-        Otherwise, it is a labels array. The labels are:
+        Otherwise, it is a labeled array. The labels are:
         O - outside, 1 - inside, 2 - vertex, 3 - edge.
 
     See Also

--- a/skimage/measure/pnpoly.py
+++ b/skimage/measure/pnpoly.py
@@ -32,7 +32,7 @@ def grid_points_in_poly(shape, verts, binarize=True):
     mask : (M, N) ndarray
         If `binarize` is True, the output is a boolean mask. True means the
         corresponding pixel falls inside the polygon.
-        If `binarize` is False, the output is a label array, with pixels
+        If `binarize` is False, the output is a labeled array, with pixels
         having a label between 0 and 3. The meaning of the values is:
         O - outside, 1 - inside, 2 - vertex, 3 - edge.
 

--- a/skimage/measure/pnpoly.py
+++ b/skimage/measure/pnpoly.py
@@ -7,8 +7,8 @@ def grid_points_in_poly(shape, verts, binarize=True):
     For each ``(r, c)`` coordinate on a grid, i.e. ``(0, 0)``, ``(0, 1)`` etc.,
     test whether that point lies inside a polygon.
 
-    Note that this function explicitly includes vertices/edges inside the poly.
-    For a better control on this behaviour, use ``grid_points_in_poly_label``.
+    You can control the output type with the `binarize` flag. Please refer to its
+    documentation for further details.
 
     Parameters
     ----------

--- a/skimage/measure/pnpoly.py
+++ b/skimage/measure/pnpoly.py
@@ -1,11 +1,12 @@
 from ._pnpoly import _grid_points_in_poly, _points_in_poly
 
 
-def grid_points_in_poly(shape, verts, return_labels=False):
+def grid_points_in_poly_label(shape, verts):
     """Test whether points on a specified grid are inside a polygon.
 
     For each ``(r, c)`` coordinate on a grid, i.e. ``(0, 0)``, ``(0, 1)`` etc.,
-    test whether that point lies inside a polygon.
+    check what is the relative location to the polygon. For each pixel, it assigns
+    one of these values: O - outside, 1 - inside, 2 - vertex, 3 - edge.
 
     Parameters
     ----------
@@ -15,25 +16,53 @@ def grid_points_in_poly(shape, verts, return_labels=False):
         Specify the V vertices of the polygon, sorted either clockwise
         or anti-clockwise. The first point may (but does not need to be)
         duplicated.
-    return_labels: bool, optional
-        If ``True``, a label mask will also be returned along with the default
-        boolean mask. The possible labels are: O - outside, 1 - inside,
-        2 - vertex, 3 - edge.
 
     See Also
     --------
     points_in_poly
+    grid_points_in_poly
+
+    Returns
+    -------
+    labels: (M, N) ndarray of int
+        Labels array, with pixels having a label between 0 and 3.
+        The meaning of the values is: O - outside, 1 - inside, 2 - vertex, 3 - edge.
+
+    """
+    return _grid_points_in_poly(shape, verts)
+
+
+def grid_points_in_poly(shape, verts):
+    """Test whether points on a specified grid are inside a polygon.
+
+    For each ``(r, c)`` coordinate on a grid, i.e. ``(0, 0)``, ``(0, 1)`` etc.,
+    test whether that point lies inside a polygon.
+    
+    Note that this function explicitly includes vertices/edges inside the poly.
+    For a better control on this behaviour, use ``grid_points_in_poly_label``.
+
+    Parameters
+    ----------
+    shape : tuple (M, N)
+        Shape of the grid.
+    verts : (V, 2) array
+        Specify the V vertices of the polygon, sorted either clockwise
+        or anti-clockwise. The first point may (but does not need to be)
+        duplicated.
+
+    See Also
+    --------
+    points_in_poly
+    grid_points_in_poly_label
 
     Returns
     -------
     mask : (M, N) ndarray of bool
         True where the grid falls inside the polygon.
-    labels: (M, N) ndarray of labels (integers)
-        Labels array, with pixels having a label between 0 and 3.
-        This is only returned if `return_labels` is set to True.
 
     """
-    return _grid_points_in_poly(shape, verts, return_labels=return_labels)
+    output = _grid_points_in_poly(shape, verts)
+    return output.astype(bool)
 
 
 def points_in_poly(points, verts):

--- a/skimage/measure/tests/test_pnpoly.py
+++ b/skimage/measure/tests/test_pnpoly.py
@@ -1,5 +1,6 @@
 import numpy as np
-from skimage.measure import points_in_poly, grid_points_in_poly, grid_points_in_poly_label
+from skimage.measure import (points_in_poly, grid_points_in_poly,
+                             grid_points_in_poly_label)
 
 from skimage._shared.testing import assert_array_equal
 

--- a/skimage/measure/tests/test_pnpoly.py
+++ b/skimage/measure/tests/test_pnpoly.py
@@ -33,3 +33,18 @@ def test_grid_points_in_poly():
     expected = np.tril(np.ones((5, 5), dtype=bool))
 
     assert_array_equal(grid_points_in_poly((5, 5), v), expected)
+
+
+def test_grid_points_in_poly_with_labels():
+    v = np.array([[0, 0],
+                  [5, 0],
+                  [5, 5]])
+
+    expected = np.array([[2, 0, 0, 0, 0],
+                        [3, 3, 0, 0, 0],
+                        [3, 1, 3, 0, 0],
+                        [3, 1, 1, 3, 0],
+                        [3, 1, 1, 1, 3]])
+    _, labels = grid_points_in_poly((5, 5), v, return_labels=True)
+
+    assert_array_equal(labels, expected)

--- a/skimage/measure/tests/test_pnpoly.py
+++ b/skimage/measure/tests/test_pnpoly.py
@@ -1,5 +1,5 @@
 import numpy as np
-from skimage.measure import points_in_poly, grid_points_in_poly
+from skimage.measure import points_in_poly, grid_points_in_poly, grid_points_in_poly_label
 
 from skimage._shared.testing import assert_array_equal
 
@@ -35,7 +35,7 @@ def test_grid_points_in_poly():
     assert_array_equal(grid_points_in_poly((5, 5), v), expected)
 
 
-def test_grid_points_in_poly_with_labels():
+def test_grid_points_in_poly_label():
     v = np.array([[0, 0],
                   [5, 0],
                   [5, 5]])
@@ -45,6 +45,5 @@ def test_grid_points_in_poly_with_labels():
                         [3, 1, 3, 0, 0],
                         [3, 1, 1, 3, 0],
                         [3, 1, 1, 1, 3]])
-    _, labels = grid_points_in_poly((5, 5), v, return_labels=True)
 
-    assert_array_equal(labels, expected)
+    assert_array_equal(grid_points_in_poly_label((5, 5), v), expected)

--- a/skimage/measure/tests/test_pnpoly.py
+++ b/skimage/measure/tests/test_pnpoly.py
@@ -36,7 +36,7 @@ def test_grid_points_in_poly():
     assert_array_equal(grid_points_in_poly((5, 5), v), expected)
 
 
-def test_grid_points_in_poly_label():
+def test_grid_points_in_poly_binarize():
     v = np.array([[0, 0],
                   [5, 0],
                   [5, 5]])
@@ -47,4 +47,4 @@ def test_grid_points_in_poly_label():
                         [3, 1, 1, 3, 0],
                         [3, 1, 1, 1, 3]])
 
-    assert_array_equal(grid_points_in_poly_label((5, 5), v), expected)
+    assert_array_equal(grid_points_in_poly((5, 5), v, binarize=False), expected)

--- a/skimage/measure/tests/test_pnpoly.py
+++ b/skimage/measure/tests/test_pnpoly.py
@@ -1,6 +1,5 @@
 import numpy as np
-from skimage.measure import (points_in_poly, grid_points_in_poly,
-                             grid_points_in_poly_label)
+from skimage.measure import points_in_poly, grid_points_in_poly
 
 from skimage._shared.testing import assert_array_equal
 

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -2,7 +2,7 @@
 from itertools import product
 import numpy as np
 from scipy.spatial import ConvexHull
-from ..measure.pnpoly import grid_points_in_poly, grid_points_in_poly_label
+from ..measure.pnpoly import grid_points_in_poly
 from ._convex_hull import possible_hull
 from ..measure._label import label
 from ..util import unique_rows

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -158,7 +158,7 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10,
         # If include_borders is False, we exclude vertices and edge points
         # from the hull mask
         included_labels = [1, 2, 3] if include_borders else [1]
-        labels = grid_points_in_poly_label(image.shape, vertices)
+        labels = grid_points_in_poly(image.shape, vertices, binarize=False)
 
         mask = np.isin(labels, included_labels)
     else:

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -155,7 +155,8 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10,
 
     # If 2D, use fast Cython function to locate convex hull pixels
     if ndim == 2:
-        # If include_borders is True, we do an intersection
+        # If include_borders is False, we exclude vertices and edge points
+        # from the hull mask
         included_labels = [1, 2, 3] if include_borders else [1]
         labels = grid_points_in_poly_label(image.shape, vertices)
 

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -77,7 +77,7 @@ def _check_coords_in_hull(gridcoords, hull_equations, tolerance):
     return coords_in_hull
 
 
-def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10):
+def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10, return_labels=False):
     """Compute the convex hull image of a binary image.
 
     The convex hull is the set of pixels included in the smallest convex
@@ -152,6 +152,9 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10):
 
     # If 2D, use fast Cython function to locate convex hull pixels
     if ndim == 2:
+        if return_labels:
+            mask, labels = grid_points_in_poly(image.shape, vertices, return_labels=True)
+            return mask, labels
         mask = grid_points_in_poly(image.shape, vertices)
     else:
         gridcoords = np.reshape(np.mgrid[tuple(map(slice, image.shape))],
@@ -160,7 +163,7 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10):
         coords_in_hull = _check_coords_in_hull(gridcoords,
                                                hull.equations, tolerance)
         mask = np.reshape(coords_in_hull, image.shape)
-
+    
     return mask
 
 

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -96,17 +96,17 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10, return_la
         to numerical floating point errors, a tolerance of 0 can result in
         some points erroneously being classified as being outside the hull.
     return_labels: bool, optional
-        If ``True``, a label mask will also be returned along with the default
-        boolean mask. The possible labels are: O - outside, 1 - inside,
-        2 - vertex, 3 - edge.
+        If ``True``, a mask of integers will be returned. The possible labels are:
+        O - outside, 1 - inside, 2 - vertex, 3 - edge.
 
     Returns
     -------
-    hull : (M, N) array of bool
-        Binary image with pixels in convex hull set to True.
-    labels: (M, N) array of labels (integers)
-        Labels array, with pixels having a label between 0 and 3.
-        This is only returned if `return_labels` is set to True.
+    hull : (M, N) array of bool or int
+        If ``return_labels`` is True, the return type is a binary image with pixels
+        in convex hull set to True (edges/vertices are included by default).
+
+        If ``return_labels`` is False, the return type is a raw labels array, with pixels
+        assigned to labels between 0 and 3. The values are: O - outside, 1 - inside, 2 - vertex, 3 - edge.
 
     References
     ----------

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -95,11 +95,18 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10, return_la
         Tolerance when determining whether a point is inside the hull. Due
         to numerical floating point errors, a tolerance of 0 can result in
         some points erroneously being classified as being outside the hull.
+    return_labels: bool, optional
+        If ``True``, a label mask will also be returned along with the default
+        boolean mask. The possible labels are: O - outside, 1 - inside,
+        2 - vertex, 3 - edge.
 
     Returns
     -------
     hull : (M, N) array of bool
         Binary image with pixels in convex hull set to True.
+    labels: (M, N) array of labels (integers)
+        Labels array, with pixels having a label between 0 and 3.
+        This is only returned if `return_labels` is set to True.
 
     References
     ----------

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -96,20 +96,13 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10,
         Tolerance when determining whether a point is inside the hull. Due
         to numerical floating point errors, a tolerance of 0 can result in
         some points erroneously being classified as being outside the hull.
-    return_labels: bool, optional
-        If ``True``, a mask of integers will be returned. The possible
-        labels are: O - outside, 1 - inside, 2 - vertex, 3 - edge.
+    include_borders: bool, optional
+        If ``False``, vertices/edges are excluded from the final hull mask.
 
     Returns
     -------
     hull : (M, N) array of bool or int
-        If ``return_labels`` is True, the return type is a binary image
-        with pixels in convex hull set to True (edges/vertices are 
-        included by default).
-
-        If ``return_labels`` is False, the return type is a raw labels array,
-        with pixels assigned to labels between 0 and 3. The values are: 
-        O - outside, 1 - inside, 2 - vertex, 3 - edge.
+        Binary image with pixels in convex hull set to True.
 
     References
     ----------

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -77,7 +77,8 @@ def _check_coords_in_hull(gridcoords, hull_equations, tolerance):
     return coords_in_hull
 
 
-def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10, return_labels=False):
+def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10,
+                      return_labels=False):
     """Compute the convex hull image of a binary image.
 
     The convex hull is the set of pixels included in the smallest convex
@@ -96,17 +97,19 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10, return_la
         to numerical floating point errors, a tolerance of 0 can result in
         some points erroneously being classified as being outside the hull.
     return_labels: bool, optional
-        If ``True``, a mask of integers will be returned. The possible labels are:
-        O - outside, 1 - inside, 2 - vertex, 3 - edge.
+        If ``True``, a mask of integers will be returned. The possible
+        labels are: O - outside, 1 - inside, 2 - vertex, 3 - edge.
 
     Returns
     -------
     hull : (M, N) array of bool or int
-        If ``return_labels`` is True, the return type is a binary image with pixels
-        in convex hull set to True (edges/vertices are included by default).
+        If ``return_labels`` is True, the return type is a binary image
+        with pixels in convex hull set to True (edges/vertices are 
+        included by default).
 
-        If ``return_labels`` is False, the return type is a raw labels array, with pixels
-        assigned to labels between 0 and 3. The values are: O - outside, 1 - inside, 2 - vertex, 3 - edge.
+        If ``return_labels`` is False, the return type is a raw labels array,
+        with pixels assigned to labels between 0 and 3. The values are: 
+        O - outside, 1 - inside, 2 - vertex, 3 - edge.
 
     References
     ----------
@@ -170,7 +173,7 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10, return_la
         coords_in_hull = _check_coords_in_hull(gridcoords,
                                                hull.equations, tolerance)
         mask = np.reshape(coords_in_hull, image.shape)
-    
+
     return mask
 
 

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -78,7 +78,7 @@ def _check_coords_in_hull(gridcoords, hull_equations, tolerance):
 
 
 def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10,
-                      return_labels=False):
+                      include_borders=True):
     """Compute the convex hull image of a binary image.
 
     The convex hull is the set of pixels included in the smallest convex
@@ -162,10 +162,11 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10,
 
     # If 2D, use fast Cython function to locate convex hull pixels
     if ndim == 2:
-        if return_labels:
-            mask = grid_points_in_poly_label(image.shape, vertices)
-        else:
-            mask = grid_points_in_poly(image.shape, vertices)
+        # If include_borders is True, we do an intersection
+        included_labels = [1, 2, 3] if include_borders else [1]
+        labels = grid_points_in_poly_label(image.shape, vertices)
+
+        mask = np.isin(labels, included_labels)
     else:
         gridcoords = np.reshape(np.mgrid[tuple(map(slice, image.shape))],
                                 (ndim, -1))

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -2,7 +2,7 @@
 from itertools import product
 import numpy as np
 from scipy.spatial import ConvexHull
-from ..measure.pnpoly import grid_points_in_poly
+from ..measure.pnpoly import grid_points_in_poly, grid_points_in_poly_label
 from ._convex_hull import possible_hull
 from ..measure._label import label
 from ..util import unique_rows
@@ -160,9 +160,9 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10, return_la
     # If 2D, use fast Cython function to locate convex hull pixels
     if ndim == 2:
         if return_labels:
-            mask, labels = grid_points_in_poly(image.shape, vertices, return_labels=True)
-            return mask, labels
-        mask = grid_points_in_poly(image.shape, vertices)
+            mask = grid_points_in_poly_label(image.shape, vertices)
+        else:
+            mask = grid_points_in_poly(image.shape, vertices)
     else:
         gridcoords = np.reshape(np.mgrid[tuple(map(slice, image.shape))],
                                 (ndim, -1))

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -101,7 +101,7 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10,
 
     Returns
     -------
-    hull : (M, N) array of bool or int
+    hull : (M, N) array of bool
         Binary image with pixels in convex hull set to True.
 
     References

--- a/skimage/morphology/convex_hull.py
+++ b/skimage/morphology/convex_hull.py
@@ -155,12 +155,10 @@ def convex_hull_image(image, offset_coordinates=True, tolerance=1e-10,
 
     # If 2D, use fast Cython function to locate convex hull pixels
     if ndim == 2:
-        # If include_borders is False, we exclude vertices and edge points
-        # from the hull mask
-        included_labels = [1, 2, 3] if include_borders else [1]
         labels = grid_points_in_poly(image.shape, vertices, binarize=False)
-
-        mask = np.isin(labels, included_labels)
+        # If include_borders is True, we include vertices (2) and edge
+        # points (3) in the mask, otherwise only the inside of the hull (1)
+        mask = labels >= 1 if include_borders else labels == 1
     else:
         gridcoords = np.reshape(np.mgrid[tuple(map(slice, image.shape))],
                                 (ndim, -1))

--- a/skimage/morphology/tests/test_convex_hull.py
+++ b/skimage/morphology/tests/test_convex_hull.py
@@ -62,6 +62,18 @@ def test_pathological_qhull_example():
                  [1, 1, 1, 1, 1, 0, 0]], dtype=bool)
     assert_array_equal(convex_hull_image(image), expected)
 
+def test_pathological_qhull_labels():
+    image = np.array(
+                [[0, 0, 0, 0, 1, 0, 0],
+                 [0, 0, 1, 1, 1, 1, 1],
+                 [1, 1, 1, 0, 0, 0, 0]], dtype=bool)
+    
+    expected = np.array([[0, 0, 0, 3, 1, 3, 0],
+                         [0, 3, 1, 1, 1, 1, 1],
+                         [1, 1, 1, 1, 3, 0, 0]])
+    
+    assert_array_equal(convex_hull_image(image, return_labels=True)[1], expected)
+
 
 def test_possible_hull():
     image = np.array(

--- a/skimage/morphology/tests/test_convex_hull.py
+++ b/skimage/morphology/tests/test_convex_hull.py
@@ -62,16 +62,16 @@ def test_pathological_qhull_example():
                  [1, 1, 1, 1, 1, 0, 0]], dtype=bool)
     assert_array_equal(convex_hull_image(image), expected)
 
+
 def test_pathological_qhull_labels():
-    image = np.array(
-                [[0, 0, 0, 0, 1, 0, 0],
-                 [0, 0, 1, 1, 1, 1, 1],
-                 [1, 1, 1, 0, 0, 0, 0]], dtype=bool)
-    
+    image = np.array([[0, 0, 0, 0, 1, 0, 0],
+                      [0, 0, 1, 1, 1, 1, 1],
+                      [1, 1, 1, 0, 0, 0, 0]], dtype=bool)
+
     expected = np.array([[0, 0, 0, 3, 1, 3, 0],
                          [0, 3, 1, 1, 1, 1, 1],
                          [1, 1, 1, 1, 3, 0, 0]])
-    
+
     assert_array_equal(convex_hull_image(image, return_labels=True), expected)
 
 

--- a/skimage/morphology/tests/test_convex_hull.py
+++ b/skimage/morphology/tests/test_convex_hull.py
@@ -72,7 +72,8 @@ def test_pathological_qhull_labels():
                          [0, 0, 1, 1, 1, 1, 1],
                          [1, 1, 1, 1, 0, 0, 0]], dtype=bool)
 
-    assert_array_equal(convex_hull_image(image, include_borders=False), expected)
+    actual = convex_hull_image(image, include_borders=False)
+    assert_array_equal(actual, expected)
 
 
 def test_possible_hull():

--- a/skimage/morphology/tests/test_convex_hull.py
+++ b/skimage/morphology/tests/test_convex_hull.py
@@ -68,11 +68,11 @@ def test_pathological_qhull_labels():
                       [0, 0, 1, 1, 1, 1, 1],
                       [1, 1, 1, 0, 0, 0, 0]], dtype=bool)
 
-    expected = np.array([[0, 0, 0, 3, 1, 3, 0],
-                         [0, 3, 1, 1, 1, 1, 1],
-                         [1, 1, 1, 1, 3, 0, 0]])
+    expected = np.array([[0, 0, 0, 0, 1, 0, 0],
+                         [0, 0, 1, 1, 1, 1, 1],
+                         [1, 1, 1, 1, 0, 0, 0]], dtype=bool)
 
-    assert_array_equal(convex_hull_image(image, return_labels=True), expected)
+    assert_array_equal(convex_hull_image(image, include_borders=False), expected)
 
 
 def test_possible_hull():

--- a/skimage/morphology/tests/test_convex_hull.py
+++ b/skimage/morphology/tests/test_convex_hull.py
@@ -72,7 +72,7 @@ def test_pathological_qhull_labels():
                          [0, 3, 1, 1, 1, 1, 1],
                          [1, 1, 1, 1, 3, 0, 0]])
     
-    assert_array_equal(convex_hull_image(image, return_labels=True)[1], expected)
+    assert_array_equal(convex_hull_image(image, return_labels=True), expected)
 
 
 def test_possible_hull():


### PR DESCRIPTION
## Description

Closes #6510 

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->
This PR addresses the problem described in [#6510](https://github.com/scikit-image/scikit-image/issues/6510). The cause for this problem was also discussed in [#3892](https://github.com/scikit-image/scikit-image/issues/3892), which was later addressed in [this PR](https://github.com/scikit-image/scikit-image/pull/5029).

The solution that this PR offers is to add a flag to `convex_hull_image`, `grid_points_in_poly` and `_grid_points_in_poly`, offering to return the raw labels as well. This will allow the users of these functions to transform the raw labels array into  a boolean array themselves.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
