### PR TITLE
relax label name comparison in benchmarks.yaml

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   benchmark:
-     if: ${{ contains(github.event.label.name, 'benchmark') || github.event_name == 'workflow_dispatch' }}
+     if: (contains(github.event.label.name, 'benchmark') || github.event_name == 'workflow_dispatch')
     name: Linux
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   benchmark:
-    if: contains(github.event.label.name, 'run-benchmark')
+    if: contains(github.event.label.name, 'benchmark') || github.event_name == 'workflow_dispatch'
     name: Linux
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,6 +5,9 @@ on:
     types: [labeled]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     if: contains(github.event.label.name, 'benchmark') || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   benchmark:
-    # if: ${{ github.event.label.name == 'run-benchmark' || github.event_name == 'workflow_dispatch' }}
+     if: ${{ contains(github.event.label.name, 'benchmark') || github.event_name == 'workflow_dispatch' }}
     name: Linux
     runs-on: ubuntu-latest
     env:
@@ -66,9 +66,6 @@ jobs:
           ASV_SKIP_SLOW: 1
         run: |
           set -x
-
-          echo "github.event.label.name: ${{ github.event.label.name }}"
-          echo "github.event_name: ${{ github.event_name }}"
 
           python -m pip install virtualenv
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   benchmark:
-     if: (contains(github.event.label.name, 'benchmark') || github.event_name == 'workflow_dispatch')
+    if: contains(github.event.label.name, 'run-benchmark')
     name: Linux
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,9 +5,6 @@ on:
     types: [labeled]
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   benchmark:
     if: ${{ github.event.label.name == 'run-benchmark' && github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   benchmark:
-    if: ${{ github.event.label.name == 'run-benchmark' && github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event.label.name == 'run-benchmark' || github.event_name == 'workflow_dispatch' }}
     name: Linux
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -67,6 +67,9 @@ jobs:
         run: |
           set -x
 
+          echo "github.event.label.name: ${{ github.event.label.name }}"
+          echo "github.event_name: ${{ github.event_name }}"
+
           python -m pip install virtualenv
 
           # ID this runner

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   benchmark:
-    if: ${{ github.event.label.name == 'run-benchmark' || github.event_name == 'workflow_dispatch' }}
+    # if: ${{ github.event.label.name == 'run-benchmark' || github.event_name == 'workflow_dispatch' }}
     name: Linux
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-python@v3
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Setup some dependencies
         shell: bash -l {0}


### PR DESCRIPTION
## Description

closes #6518

~This change from https://github.com/scikit-image/scikit-image/pull/6426 seems to prevent running the benchmarks via the run-benchmark label in PRs.~

~Will try adding the label here to verify...~

**update**: The problem was not permissions, but a change which included an emoji in the benchmark tag. The string comparison is relaxed in this PR to allow the workflow to run in this case as well.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
