### PR TITLE
Use mask during rescaling in segmentation.slic and improve handling of error cases

### DIFF
--- a/benchmarks/benchmark_segmentation.py
+++ b/benchmarks/benchmark_segmentation.py
@@ -72,7 +72,9 @@ class MaskSlicSegmentation(SlicSegmentation):
         try:
             mask = np.zeros((64, 64)) > 0
             mask[10:-10, 10:-10] = 1
-            segmentation.slic(np.ones_like(mask), mask=mask)
+            segmentation.slic(
+                np.ones_like(mask), mask=mask, **_channel_kwarg(False)
+            )
         except TypeError:
             raise NotImplementedError("masked slic unavailable")
 

--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -270,18 +270,19 @@ def slic(image, n_segments=100, compactness=10., max_num_iter=10, sigma=0,
     if mask is not None:
         # Create masked_image to rescale while ignoring masked values
         mask = np.ascontiguousarray(mask, dtype=bool)
-        inverted_mask = ~mask
         if channel_axis is not None:
-            inverted_mask = np.expand_dims(inverted_mask, axis=channel_axis)
-            inverted_mask = np.broadcast_to(inverted_mask, image.shape)
-        masked_image = np.ma.masked_array(image, mask=inverted_mask)
+            mask_ = np.expand_dims(mask, axis=channel_axis)
+            mask_ = np.broadcast_to(mask_, image.shape)
+        else:
+            mask_ = mask
+        image_values = image[mask_]
     else:
-        masked_image = image
+        image_values = image
 
     # Rescale image to [0, 1] to make choice of compactness insensitive to
     # input image scale.
-    imin = masked_image.min()
-    imax = masked_image.max()
+    imin = image_values.min()
+    imax = image_values.max()
     image -= imin
     if imax != 0:
         image /= (imax - imin)

--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -283,13 +283,13 @@ def slic(image, n_segments=100, compactness=10., max_num_iter=10, sigma=0,
     # input image scale.
     imin = image_values.min()
     imax = image_values.max()
-    image -= imin
-    if imax != 0:
-        image /= (imax - imin)
     if np.isnan(imin):
         raise ValueError("unmasked NaN values in image are not supported")
     if np.isinf(imin) or np.isinf(imax):
         raise ValueError("unmasked infinite values in image are not supported")
+    image -= imin
+    if imax != imin:
+        image /= (imax - imin)
 
     use_mask = mask is not None
     dtype = image.dtype

--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -203,6 +203,10 @@ def slic(image, n_segments=100, compactness=10., max_num_iter=10, sigma=0,
         dimension is not of length 3.
     ValueError
         If ``start_label`` is not 0 or 1.
+    ValueError
+        If ``image`` contains unmasked NaN values.
+    ValueError
+        If ``image`` contains unmasked infinite values.
 
     Notes
     -----
@@ -214,7 +218,8 @@ def slic(image, n_segments=100, compactness=10., max_num_iter=10, sigma=0,
       and ``spacing=[5, 1, 1]``, the effective `sigma` is ``[0.2, 1, 1]``. This
       ensures sensible smoothing for anisotropic images.
 
-    * The image is rescaled to be in [0, 1] prior to processing.
+    * The image is rescaled to be in [0, 1] prior to processing (masked
+      values are ignored).
 
     * Images of shape (M, N, 3) are interpreted as 2D RGB images by default. To
       interpret them as 3D with the last dimension having length 3, use
@@ -254,12 +259,28 @@ def slic(image, n_segments=100, compactness=10., max_num_iter=10, sigma=0,
     # function input
     image = image.astype(float_dtype, copy=True)
 
+    if mask is not None:
+        # Create masked_image to rescale while ignoring masked values
+        mask = np.ascontiguousarray(mask, dtype=bool)
+        inverted_mask = ~mask
+        if channel_axis is not None:
+            inverted_mask = np.expand_dims(inverted_mask, axis=channel_axis)
+            inverted_mask = np.broadcast_to(inverted_mask, image.shape)
+        masked_image = np.ma.masked_array(image, mask=inverted_mask)
+    else:
+        masked_image = image
+
     # Rescale image to [0, 1] to make choice of compactness insensitive to
     # input image scale.
-    image -= image.min()
-    imax = image.max()
+    imin = masked_image.min()
+    imax = masked_image.max()
+    image -= imin
     if imax != 0:
-        image /= imax
+        image /= (imax - imin)
+    if np.isnan(imin):
+        raise ValueError("unmasked NaN values in image are not supported")
+    if np.isinf(imin) or np.isinf(imax):
+        raise ValueError("unmasked infinite values in image are not supported")
 
     use_mask = mask is not None
     dtype = image.dtype
@@ -291,7 +312,7 @@ def slic(image, n_segments=100, compactness=10., max_num_iter=10, sigma=0,
     # initialize cluster centroids for desired number of segments
     update_centroids = False
     if use_mask:
-        mask = np.ascontiguousarray(mask, dtype=bool).view('uint8')
+        mask = mask.view('uint8')
         if mask.ndim == 2:
             mask = np.ascontiguousarray(mask[np.newaxis, ...])
         if mask.shape != image.shape[:3]:

--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -207,6 +207,8 @@ def slic(image, n_segments=100, compactness=10., max_num_iter=10, sigma=0,
         If ``image`` contains unmasked NaN values.
     ValueError
         If ``image`` contains unmasked infinite values.
+    ValueError
+        If ``image`` is 2D but ``channel_axis`` is -1 (the default).
 
     Notes
     -----
@@ -252,6 +254,12 @@ def slic(image, n_segments=100, compactness=10., max_num_iter=10, sigma=0,
     >>> segments = slic(img, n_segments=100, compactness=20)
 
     """
+    if image.ndim == 2 and channel_axis is not None:
+        raise ValueError(
+            f"channel_axis={channel_axis} indicates a multichannel for a two-"
+            "dimensional image which is not supported, use channel_axis=None if"
+            "the image is grayscale"
+        )
 
     image = img_as_float(image)
     float_dtype = utils._supported_float_type(image.dtype)

--- a/skimage/segmentation/slic_superpixels.py
+++ b/skimage/segmentation/slic_superpixels.py
@@ -256,8 +256,8 @@ def slic(image, n_segments=100, compactness=10., max_num_iter=10, sigma=0,
     """
     if image.ndim == 2 and channel_axis is not None:
         raise ValueError(
-            f"channel_axis={channel_axis} indicates a multichannel for a two-"
-            "dimensional image which is not supported, use channel_axis=None if"
+            f"channel_axis={channel_axis} indicates multichannel, which is not "
+            "supported for a two-dimensional image; use channel_axis=None if "
             "the image is grayscale"
         )
 

--- a/skimage/segmentation/tests/test_slic.py
+++ b/skimage/segmentation/tests/test_slic.py
@@ -102,6 +102,14 @@ def test_gray_2d_deprecated_multichannel():
                    start_label=0)
 
 
+def test_gray2d_default_channel_axis():
+    img = np.zeros((20, 21))
+    img[:10, :10] = 0.33
+    with pytest.raises(ValueError, match="channel_axis=-1 indicates a multichannel"):
+        slic(img)
+    slic(img, channel_axis=None)
+
+
 def _check_segment_labels(seg1, seg2, allowed_mismatch_ratio=0.1):
     size = seg1.size
     ndiff = np.sum(seg1 != seg2)
@@ -224,10 +232,12 @@ def test_enforce_connectivity():
 
     segments_connected = slic(img, 2, compactness=0.0001,
                               enforce_connectivity=True,
-                              convert2lab=False, start_label=0)
+                              convert2lab=False, start_label=0,
+                              channel_axis=None)
     segments_disconnected = slic(img, 2, compactness=0.0001,
                                  enforce_connectivity=False,
-                                 convert2lab=False, start_label=0)
+                                 convert2lab=False, start_label=0,
+                                 channel_axis=None)
 
     # Make sure nothing fatal occurs (e.g. buffer overflow) at low values of
     # max_size_factor
@@ -235,7 +245,8 @@ def test_enforce_connectivity():
                                       enforce_connectivity=True,
                                       convert2lab=False,
                                       max_size_factor=0.8,
-                                      start_label=0)
+                                      start_label=0,
+                                      channel_axis=None)
 
     result_connected = np.array([[0, 0, 0, 1, 1, 1],
                                  [0, 0, 0, 1, 1, 1],
@@ -411,17 +422,18 @@ def test_enforce_connectivity_mask():
 
     segments_connected = slic(img, 2, compactness=0.0001,
                               enforce_connectivity=True,
-                              convert2lab=False, mask=msk)
+                              convert2lab=False, mask=msk, channel_axis=None)
     segments_disconnected = slic(img, 2, compactness=0.0001,
                                  enforce_connectivity=False,
-                                 convert2lab=False, mask=msk)
+                                 convert2lab=False, mask=msk, channel_axis=None)
 
     # Make sure nothing fatal occurs (e.g. buffer overflow) at low values of
     # max_size_factor
     segments_connected_low_max = slic(img, 2, compactness=0.0001,
                                       enforce_connectivity=True,
                                       convert2lab=False,
-                                      max_size_factor=0.8, mask=msk)
+                                      max_size_factor=0.8, mask=msk,
+                                      channel_axis=None)
 
     result_connected = np.array([[0, 1, 1, 2, 2, 0],
                                  [0, 1, 1, 2, 2, 0],
@@ -541,7 +553,7 @@ def test_dtype_support(dtype):
     img = np.random.rand(28, 28).astype(dtype)
 
     # Simply run the function to assert that it runs without error
-    slic(img, start_label=1)
+    slic(img, start_label=1, channel_axis=None)
 
 
 def test_start_label_fix():

--- a/skimage/segmentation/tests/test_slic.py
+++ b/skimage/segmentation/tests/test_slic.py
@@ -105,7 +105,9 @@ def test_gray_2d_deprecated_multichannel():
 def test_gray2d_default_channel_axis():
     img = np.zeros((20, 21))
     img[:10, :10] = 0.33
-    with pytest.raises(ValueError, match="channel_axis=-1 indicates a multichannel"):
+    with pytest.raises(
+            ValueError, match="channel_axis=-1 indicates multichannel"
+    ):
         slic(img)
     slic(img, channel_axis=None)
 

--- a/skimage/segmentation/tests/test_slic.py
+++ b/skimage/segmentation/tests/test_slic.py
@@ -558,3 +558,24 @@ def test_start_label_fix():
                   n_segments=6, compactness=0.01, enforce_connectivity=True,
                   max_num_iter=10)
     assert superp.min() == start_label
+
+
+def test_raises_ValueError_if_input_has_NaN():
+    img = np.zeros((4,5), dtype=float)
+    img[2, 3] = np.NaN
+    with pytest.raises(ValueError):
+        slic(img, channel_axis=None)
+
+    mask = ~np.isnan(img)
+    slic(img, mask=mask, channel_axis=None)
+
+
+@pytest.mark.parametrize("inf", [-np.inf, np.inf])
+def test_raises_ValueError_if_input_has_inf(inf):
+    img = np.zeros((4,5), dtype=float)
+    img[2, 3] = inf
+    with pytest.raises(ValueError):
+        slic(img, channel_axis=None)
+
+    mask = np.isfinite(img)
+    slic(img, mask=mask, channel_axis=None)

--- a/skimage/segmentation/tests/test_slic.py
+++ b/skimage/segmentation/tests/test_slic.py
@@ -115,14 +115,18 @@ def test_slic_consistency_across_image_magnitude():
     img_uint16 = 256 * img_uint8.astype(np.uint16)
     img_float32 = img_as_float(img_uint8)
     img_float32_norm = img_float32 / img_float32.max()
+    img_float32_offset = img_float32 + 1000
 
     seg1 = slic(img_uint8)
     seg2 = slic(img_uint16)
     seg3 = slic(img_float32)
     seg4 = slic(img_float32_norm)
+    seg5 = slic(img_float32_offset)
 
     np.testing.assert_array_equal(seg1, seg2)
     np.testing.assert_array_equal(seg1, seg3)
+    # Assert that offset has no impact on result
+    np.testing.assert_array_equal(seg4, seg5)
     # Floating point cases can have mismatch due to floating point error
     # exact match was observed on x86_64, but mismatches seen no i686.
     # For now just verify that a similar number of superpixels are present in


### PR DESCRIPTION
## Description

Addresses several (related) things.

- Fixes #4883. Use mask during rescaling in slic. Previously, the mask was ignored when rescaling the image to make choice of compactness insensitive to the image values. So contrary to the docsting, NaN's (and infinite values) couldn't actually be masked. Therefore, we use a masked array to compute the max and min value forrescaling. Additionally these intermediate results are checked for NaN and infinite which would give wrong rescaling results. This solution needs to invert the mask, because NumPy's masked array and this function interpret True & False the opposite way. Not sure if that is the solution with the best performance. The following changes are a consequence of this point.
- Add's a test that explicitly checks that an offset to the input image does not affect the the output (see rescaling and compactness).
- Raise ValueError for 2D multichannel input to slic. The way I understand the docstring, an image must be at least 2D.
channel_axis=-1 (the default) indicates that the last dimension is a multichannel / color channel which would make the image 1D. Therefore, this parameter constellation should raise a ValueError. This change adds a guard for this case, an appropriate test and fixes several unit tests which relied on the fact that the implementation ignored channel_axis for 2D images. 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
