### PR TITLE
Add upper bound to setuptools in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools<65",
+    "setuptools<=65.3,!=65.0,!=65.1",
     "packaging",
     "Cython>=0.29.24,<3.0",
     "pythran",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools",
+    "setuptools<65",
     "packaging",
     "Cython>=0.29.24,<3.0",
     "pythran",

--- a/tools/github/before_install.sh
+++ b/tools/github/before_install.sh
@@ -29,7 +29,7 @@ if [[ $MINIMUM_REQUIREMENTS == 1 ]]; then
     done
 fi
 
-python -m pip install --upgrade "pip<22.1" wheel setuptools
+python -m pip install --upgrade "pip<22.1" wheel "setuptools<65"
 
 # Install build time requirements
 python -m pip install $PIP_FLAGS -r requirements/build.txt

--- a/tools/github/before_install.sh
+++ b/tools/github/before_install.sh
@@ -29,7 +29,7 @@ if [[ $MINIMUM_REQUIREMENTS == 1 ]]; then
     done
 fi
 
-python -m pip install --upgrade "pip<22.1" wheel "setuptools<65"
+python -m pip install --upgrade pip wheel "setuptools<65"
 
 # Install build time requirements
 python -m pip install $PIP_FLAGS -r requirements/build.txt

--- a/tools/github/before_install.sh
+++ b/tools/github/before_install.sh
@@ -29,7 +29,7 @@ if [[ $MINIMUM_REQUIREMENTS == 1 ]]; then
     done
 fi
 
-python -m pip install --upgrade pip wheel "setuptools<65"
+python -m pip install --upgrade pip wheel "setuptools<65.4"
 
 # Install build time requirements
 python -m pip install $PIP_FLAGS -r requirements/build.txt


### PR DESCRIPTION

## Description

This pinning is for robustness against potential future breaking changes of the type reported here:
https://discuss.scientific-python.org/t/developer-builds-using-pip-now-fails/500

and also recently reported in dependencies like PyWavelets
https://github.com/PyWavelets/pywt/issues/645

I think the specific issue seen in PyWavelets with 65.0 was resolved in 65.2, but I still think it is preferable to pin to a known working upper version in `pyproject.toml` given that `setuptools` is making quite a few changes nowadays.

@stefanv, does this resolve the issue you encountered?

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
