### PR TITLE
make non-functional change to build.txt to fix cache issue on CircleCI

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -2,4 +2,4 @@ Cython>=0.29.21,!=0.29.18
 packaging>=20.0
 pythran
 wheel
-numpy>=1.19
+numpy>=1.19.0


### PR DESCRIPTION
## Description

closes #6527 

This is somewhat of a hack in order to get CircleCI not to reuse some apparently bad cached data. I just changed the NumPy pin from `1.19` to `1.19.0` so the checksum used by CircleCI would no longer match and packages would be redownloaded instead of using the cached ones:

https://github.com/scikit-image/scikit-image/blob/5e3370157c289f3e4bbb3ed943ac6f58e98083bb/.circleci/config.yml#L10-L17


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
