### PR TITLE
change the max value of poisson noise input from 2 ** n to 2 ** n - 1

### DIFF
--- a/skimage/util/noise.py
+++ b/skimage/util/noise.py
@@ -189,6 +189,8 @@ def random_noise(image, mode='gaussian', seed=None, clip=True, **kwargs):
             image = (image + 1.) / (old_max + 1.)
 
         # Generating noise for each unique value in image.
+        # the max value of 2**n unique integer values is 2 ** n - 1, so I think the following code is more precise: 
+        vals -= 1
         out = rng.poisson(image * vals) / float(vals)
 
         # Return image to original range if input was signed

--- a/skimage/util/tests/test_random_noise.py
+++ b/skimage/util/tests/test_random_noise.py
@@ -150,7 +150,7 @@ def test_poisson():
     cam_noisy2 = random_noise(data, mode='poisson', seed=seed, clip=False)
 
     rng = np.random.default_rng(seed)
-    expected = rng.poisson(img_as_float(data) * 256) / 256.
+    expected = rng.poisson(img_as_float(data) * 255) / 255.
     assert_allclose(cam_noisy, np.clip(expected, 0., 1.))
     assert_allclose(cam_noisy2, expected)
 


### PR DESCRIPTION
## Description

This PR changes the implementation of poisson noise in skimage.util.random_noise. 

As the max value of an unsigned n-bit integer is 2 ** n - 1 and the min value is 0, the scaling operation should be image * (2 ** n - 1). For example, when we take an image of type uint8 as input, it will be calculated as image / 255 * 256, which is weird.

https://github.com/scikit-image/scikit-image/blob/5e3370157c289f3e4bbb3ed943ac6f58e98083bb/skimage/util/noise.py#L181-L196