### PR TITLE
Fix formatting of mode parameter in util.random_noise

### DIFF
--- a/skimage/util/noise.py
+++ b/skimage/util/noise.py
@@ -47,18 +47,24 @@ def random_noise(image, mode='gaussian', seed=None, clip=True, **kwargs):
     mode : str, optional
         One of the following strings, selecting the type of noise to add:
 
-        - 'gaussian'  Gaussian-distributed additive noise.
-        - 'localvar'  Gaussian-distributed additive noise, with specified
-                      local variance at each point of `image`.
-        - 'poisson'   Poisson-distributed noise generated from the data.
-        - 'salt'      Replaces random pixels with 1.
-        - 'pepper'    Replaces random pixels with 0 (for unsigned images) or
-                      -1 (for signed images).
-        - 's&p'       Replaces random pixels with either 1 or `low_val`, where
-                      `low_val` is 0 for unsigned images or -1 for signed
-                      images.
-        - 'speckle'   Multiplicative noise using out = image + n*image, where
-                      n is Gaussian noise with specified mean & variance.
+        'gaussian' (default)
+            Gaussian-distributed additive noise.
+        'localvar'
+            Gaussian-distributed additive noise, with specified local variance
+            at each point of `image`.
+        'poisson'
+            Poisson-distributed noise generated from the data.
+        'salt'
+            Replaces random pixels with 1.
+        'pepper'
+            Replaces random pixels with 0 (for unsigned images) or -1 (for
+            signed images).
+        's&p'
+            Replaces random pixels with either 1 or `low_val`, where `low_val`
+            is 0 for unsigned images or -1 for signed images.
+        'speckle'
+            Multiplicative noise using ``out = image + n * image``, where ``n``
+            is Gaussian noise with specified mean & variance.
     seed : {None, int, `numpy.random.Generator`}, optional
         If `seed` is None the `numpy.random.Generator` singleton is
         used.


### PR DESCRIPTION
## Description

Bullet points with an indent following in the next line were [rendered bold while the ones without were not](https://scikit-image.org/docs/dev/api/skimage.util.html#skimage.util.random_noise). This makes the rendering more consistent similar to the mode parameter in NumPy's pad.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
