### PR TITLE
Minor doc fix: add missing print statement in the `plot_segmentations.py` example

### DIFF
--- a/doc/examples/segmentation/plot_segmentations.py
+++ b/doc/examples/segmentation/plot_segmentations.py
@@ -105,6 +105,7 @@ segments_watershed = watershed(gradient, markers=250, compactness=0.001)
 print(f'Felzenszwalb number of segments: {len(np.unique(segments_fz))}')
 print(f'SLIC number of segments: {len(np.unique(segments_slic))}')
 print(f'Quickshift number of segments: {len(np.unique(segments_quick))}')
+print(f'Watershed number of segments: {len(np.unique(segments_watershed))}')
 
 fig, ax = plt.subplots(2, 2, figsize=(10, 10), sharex=True, sharey=True)
 


### PR DESCRIPTION
## Description

The example prints out the number of generated segments for each of the four segmentation algorithms in the example except for Watershed. This PR fixes that oversight.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
