### PR TITLE
Rewrite docstring for denoise_tv_chambolle

### DIFF
--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -289,7 +289,7 @@ def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
     Parameters
     ----------
     image : ndarray
-        Input image to be denoised (converted using ``img_as_float``).
+        Input image to be denoised (converted using :ref:`~.img_as_float`).
     weight : float, optional
         Denoising weight. It is equal to :math:`\frac{\lambda}{2}`. Therefore,
         the smaller the `weight`, the more denoising (at
@@ -339,7 +339,7 @@ def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
     ----------
     .. [1] Tom Goldstein and Stanley Osher, "The Split Bregman Method For L1
            Regularized Problems",
-           ftp://ftp.math.ucla.edu/pub/camreport/cam08-29.pdf
+           https://ww3.math.ucla.edu/camreport/cam08-29.pdf
     .. [2] Pascal Getreuer, "Rudin–Osher–Fatemi Total Variation Denoising
            using Split Bregman" in Image Processing On Line on 2012–05–19,
            https://www.ipol.im/pub/art/2012/g-tvd/article_lr.pdf
@@ -491,7 +491,7 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
     ----------
     image : ndarray
         Input image to be denoised. If its dtype is not float, it gets
-        converted with ``img_as_float``.
+        converted with :ref:`~.img_as_float`.
     weight : float, optional
         Denoising weight. It is equal to :math:`\frac{1}{\lambda}`. Therefore,
         the greater the `weight`, the more denoising (at the expense of

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -441,7 +441,11 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
 
     This function is an implementation of the algorithm proposed by Chambolle
     in [1]_ to solve the Rudin--Osher--Fatemi minimization problem:
-    :math:`\min_{u} \sum_{i=0}^{N-1} \left( \left| \nabla{u_i} \right| + \frac{\lambda}{2}(f_i - u_i)^2 \right)`
+
+    .. math::
+
+        \min_{u} \sum_{i=0}^{N-1} \left( \left| \nabla{u_i} \right| + \frac{\lambda}{2}(f_i - u_i)^2 \right)
+
     where :math:`f` denotes the input data (noisy image) and :math:`\lambda`
     is a positive parameter. The first term of this cost function is the total
     variation; the second term represents data fidelity. As :math:`\lambda \to 0`,
@@ -459,9 +463,8 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
         the expense of fidelity to `image`).
     eps : float, optional
         Absolute value of relative difference of the cost function that
-        determines the stop criterion. The algorithm stops when:
-
-            E_(n-1) - E_n < eps * E_0
+        determines the stop criterion. The algorithm stops when
+        :math:`|E_{n-1} - E_n| < eps * E_0`.
 
     max_num_iter : int, optional
         Maximal number of iterations used for the optimization.

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -310,7 +310,7 @@ def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
            ``channel_axis`` was added in 0.19.
     multichannel : bool, optional
         Whether to apply total variation denoising separately to each channel.
-        Should be True for color images, otherwise the denoising is
+        Should be ``True`` for color images, otherwise the denoising is
         also applied in the channels dimension. This argument is deprecated:
         specify `channel_axis` instead.
 
@@ -497,14 +497,14 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
         the greater the `weight`, the more denoising (at the expense of
         fidelity to `image`).
     eps : float, optional
-        Absolute value of relative difference of the cost function :math:`E`
-        that determines the stop criterion. The algorithm stops when
-        :math:`|E_{n-1} - E_n| < eps * E_0`.
+        Stop criterion :math:`\varepsilon > 0` (absolute value of relative
+        difference of the cost function :math:`E`).
+        The algorithm stops when :math:`|E_{n-1} - E_n| < \varepsilon * E_0`.
     max_num_iter : int, optional
         Maximal number of iterations used for the optimization.
     multichannel : bool, optional
         Whether to apply total variation denoising separately to each channel.
-        Should be True for color images, otherwise the denoising is
+        Should be ``True`` for color images, otherwise the denoising is
         also applied in the channels dimension. This argument is deprecated:
         specify `channel_axis` instead.
     channel_axis : int or None, optional

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -309,8 +309,8 @@ def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
         .. versionadded:: 0.19
            ``channel_axis`` was added in 0.19.
     multichannel : bool, optional
-        Whether to apply total variation denoising separately to each channel.
-        Should be ``True`` for color images, otherwise the denoising is
+        Whether or not to apply denoising separately to each channel.
+        Should always be set to ``True`` for color images, otherwise the denoising is
         also applied in the channels dimension. This argument is deprecated:
         specify `channel_axis` instead.
 
@@ -321,7 +321,7 @@ def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
 
     Notes
     -----
-    Make sure to set the `channel_axis` parameter appropriately for color
+    Ensure that `channel_axis` parameter is set appropriately for color
     images.
 
     The principle of total variation denoising is explained in [4]_.
@@ -508,7 +508,7 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
         also applied in the channels dimension. This argument is deprecated:
         specify `channel_axis` instead.
     channel_axis : int or None, optional
-        If None, the image is assumed to be grayscale (single-channel).
+        If ``None``, the image is assumed to be grayscale (single-channel).
         Otherwise, this parameter indicates which axis of the array corresponds
         to channels.
 

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -289,7 +289,7 @@ def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
     Parameters
     ----------
     image : ndarray
-        Input image to be denoised (converted using :ref:`~.img_as_float`).
+        Input image to be denoised (converted using :func:`~.img_as_float`).
     weight : float, optional
         Denoising weight. It is equal to :math:`\frac{\lambda}{2}`. Therefore,
         the smaller the `weight`, the more denoising (at
@@ -491,7 +491,7 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
     ----------
     image : ndarray
         Input image to be denoised. If its dtype is not float, it gets
-        converted with :ref:`~.img_as_float`.
+        converted with :func:`~.img_as_float`.
     weight : float, optional
         Denoising weight. It is equal to :math:`\frac{1}{\lambda}`. Therefore,
         the greater the `weight`, the more denoising (at the expense of

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -461,7 +461,7 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
         Absolute value of relative difference of the cost function that
         determines the stop criterion. The algorithm stops when:
 
-            |E_(n-1) - E_n| < eps * |E_0|
+            E_(n-1) - E_n < eps * E_0
 
     max_num_iter : int, optional
         Maximal number of iterations used for the optimization.

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -462,10 +462,9 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
         the greater `weight`, the more denoising (at
         the expense of fidelity to `image`).
     eps : float, optional
-        Absolute value of relative difference of the cost function that
-        determines the stop criterion. The algorithm stops when
+        Absolute value of relative difference of the cost function :math:`E`
+        that determines the stop criterion. The algorithm stops when
         :math:`|E_{n-1} - E_n| < eps * E_0`.
-
     max_num_iter : int, optional
         Maximal number of iterations used for the optimization.
     multichannel : bool, optional
@@ -483,7 +482,7 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
 
     Returns
     -------
-    out : ndarray
+    u : ndarray
         Denoised image.
 
     Notes

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -302,7 +302,7 @@ def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
     isotropic : boolean, optional
         Switch between isotropic and anisotropic TV denoising.
     channel_axis : int or None, optional
-        If None, the image is assumed to be grayscale (single-channel).
+        If ``None``, the image is assumed to be grayscale (single-channel).
         Otherwise, this parameter indicates which axis of the array corresponds
         to channels.
 

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -295,8 +295,8 @@ def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
         the smaller the `weight`, the more denoising (at
         the expense of less similarity to `image`).
     eps : float, optional
-        Stop criterion. The algorithm stops when
-        :math:`\sqrt{(u_n - u_{n-1})^2} < eps`.
+        Stop criterion :math:`\varepsilon > 0`. The algorithm stops when
+        :math:`\|u_n - u_{n-1}\|_2 < \varepsilon`.
     max_num_iter : int, optional
         Maximal number of iterations used for the optimization.
     isotropic : boolean, optional

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -129,7 +129,7 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
         channels or another spatial dimension. This argument is deprecated:
         specify `channel_axis` instead.
     channel_axis : int or None, optional
-        If None, the image is assumed to be a grayscale (single channel) image.
+        If ``None``, the image is assumed to be grayscale (single-channel).
         Otherwise, this parameter indicates which axis of the array corresponds
         to channels.
 
@@ -848,7 +848,7 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
         .. versionadded:: 0.16
            ``rescale_sigma`` was introduced in 0.16
     channel_axis : int or None, optional
-        If None, the image is assumed to be a grayscale (single channel) image.
+        If ``None``, the image is assumed to be grayscale (single-channel).
         Otherwise, this parameter indicates which axis of the array corresponds
         to channels.
 
@@ -1000,7 +1000,7 @@ def estimate_sigma(image, average_sigmas=False, multichannel=False, *,
         Estimate sigma separately for each channel. This argument is
         deprecated: specify `channel_axis` instead.
     channel_axis : int or None, optional
-        If None, the image is assumed to be a grayscale (single channel) image.
+        If ``None``, the image is assumed to be grayscale (single-channel).
         Otherwise, this parameter indicates which axis of the array corresponds
         to channels.
 

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -310,9 +310,9 @@ def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
            ``channel_axis`` was added in 0.19.
     multichannel : bool, optional
         Whether or not to apply denoising separately to each channel.
-        Should always be set to ``True`` for color images, otherwise the denoising is
-        also applied in the channels dimension. This argument is deprecated:
-        specify `channel_axis` instead.
+        Should always be set to ``True`` for color images, otherwise the
+        denoising is also applied in the channels dimension.
+        This argument is deprecated: specify `channel_axis` instead.
 
     Returns
     -------
@@ -503,10 +503,10 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
     max_num_iter : int, optional
         Maximal number of iterations used for the optimization.
     multichannel : bool, optional
-        Whether to apply total variation denoising separately to each channel.
-        Should be ``True`` for color images, otherwise the denoising is
-        also applied in the channels dimension. This argument is deprecated:
-        specify `channel_axis` instead.
+        Whether or not to apply denoising separately to each channel.
+        Should always be set to ``True`` for color images, otherwise the
+        denoising is also applied in the channels dimension.
+        This argument is deprecated: specify `channel_axis` instead.
     channel_axis : int or None, optional
         If ``None``, the image is assumed to be grayscale (single-channel).
         Otherwise, this parameter indicates which axis of the array corresponds

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -437,32 +437,41 @@ def _denoise_tv_chambolle_nd(image, weight=0.1, eps=2.e-4, max_num_iter=200):
 @utils.deprecate_multichannel_kwarg(multichannel_position=4)
 def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
                          multichannel=False, *, channel_axis=None):
-    """Perform total-variation denoising on n-dimensional images.
+    r"""Perform total variation denoising in nD.
+
+    This function is an implementation of the algorithm proposed by Chambolle
+    in [1]_ to solve the Rudin--Osher--Fatemi minimization problem:
+    :math:`\min_{u} \sum_{i=0}^{N-1} \left( \left| \nabla{u_i} \right| + \frac{\lambda}{2}(f_i - u_i)^2 \right)`
+    where :math:`f` denotes the input data (noisy image) and :math:`\lambda`
+    is a positive parameter. The first term of this cost function is the total
+    variation; the second term represents data fidelity. As :math:`\lambda \to 0`,
+    the total variation term dominates, forcing the solution to have smaller
+    total variation, at the expense of looking less like the input data.
 
     Parameters
     ----------
-    image : ndarray of ints, uints or floats
-        Input data to be denoised. `image` can be of any numeric type,
-        but it is cast into an ndarray of floats for the computation
-        of the denoised image.
+    image : ndarray
+        Input image to be denoised. If its dtype is not float, it gets
+        converted with ``img_as_float``.
     weight : float, optional
-        Denoising weight. The greater `weight`, the more denoising (at
-        the expense of fidelity to `input`).
+        Denoising weight. It is equal to :math:`\frac{1}{\lambda}`. Therefore,
+        the greater `weight`, the more denoising (at
+        the expense of fidelity to `image`).
     eps : float, optional
-        Relative difference of the value of the cost function that
+        Absolute value of relative difference of the cost function that
         determines the stop criterion. The algorithm stops when:
 
-            (E_(n-1) - E_n) < eps * E_0
+            |E_(n-1) - E_n| < eps * |E_0|
 
     max_num_iter : int, optional
         Maximal number of iterations used for the optimization.
     multichannel : bool, optional
-        Apply total-variation denoising separately for each channel. This
-        option should be true for color images, otherwise the denoising is
+        Whether to apply total-variation denoising separately to each channel.
+        Should be True for color images, otherwise the denoising is
         also applied in the channels dimension. This argument is deprecated:
         specify `channel_axis` instead.
     channel_axis : int or None, optional
-        If None, the image is assumed to be a grayscale (single channel) image.
+        If None, the image is assumed to be grayscale (single-channel).
         Otherwise, this parameter indicates which axis of the array corresponds
         to channels.
 
@@ -476,25 +485,22 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
 
     Notes
     -----
-    Make sure to set the multichannel parameter appropriately for color images.
+    Make sure to set the `channel_axis` parameter appropriately for color
+    images.
 
-    The principle of total variation denoising is explained in
-    https://en.wikipedia.org/wiki/Total_variation_denoising
-
-    The principle of total variation denoising is to minimize the
-    total variation of the image, which can be roughly described as
-    the integral of the norm of the image gradient. Total variation
-    denoising tends to produce "cartoon-like" images, that is,
+    The principle of total-variation denoising is explained in [2]_.
+    It is about minimizing the total variation of an image,
+    which can be roughly described as
+    the integral of the norm of the image gradient. Total-variation
+    denoising tends to produce cartoon-like images, that is,
     piecewise-constant images.
-
-    This code is an implementation of the algorithm of Rudin, Fatemi and Osher
-    that was proposed by Chambolle in [1]_.
 
     References
     ----------
     .. [1] A. Chambolle, An algorithm for total variation minimization and
            applications, Journal of Mathematical Imaging and Vision,
            Springer, 2004, 20, 89-97.
+    .. [2] https://en.wikipedia.org/wiki/Total_variation_denoising
 
     Examples
     --------

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -266,7 +266,7 @@ def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
                        multichannel=False):
     r"""Perform total variation denoising using split-Bregman optimization.
 
-    Given :math:`f` a noisy image (input data),
+    Given :math:`f`, a noisy image (input data),
     total variation denoising (also known as total variation regularization)
     aims to find an image :math:`u` with less total variation than :math:`f`,
     under the constraint that :math:`u` remain similar to :math:`f`.
@@ -467,7 +467,7 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
                          multichannel=False, *, channel_axis=None):
     r"""Perform total variation denoising in nD.
 
-    Given :math:`f` a noisy image (input data),
+    Given :math:`f`, a noisy image (input data),
     total variation denoising (also known as total variation regularization)
     aims to find an image :math:`u` with less total variation than :math:`f`,
     under the constraint that :math:`u` remain similar to :math:`f`.

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -295,7 +295,7 @@ def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
         the smaller the `weight`, the more denoising (at
         the expense of less similarity to `image`).
     eps : float, optional
-        Parameter :math:`\varepsilon > 0` for the stop criterion:
+        Tolerance :math:`\varepsilon > 0` for the stop criterion:
         The algorithm stops when :math:`\|u_n - u_{n-1}\|_2 < \varepsilon`.
     max_num_iter : int, optional
         Maximal number of iterations used for the optimization.
@@ -497,7 +497,7 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
         the greater the `weight`, the more denoising (at the expense of
         fidelity to `image`).
     eps : float, optional
-        Parameter :math:`\varepsilon > 0` for the stop criterion (compares to
+        Tolerance :math:`\varepsilon > 0` for the stop criterion (compares to
         absolute value of relative difference of the cost function :math:`E`):
         The algorithm stops when :math:`|E_{n-1} - E_n| < \varepsilon * E_0`.
     max_num_iter : int, optional

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -295,8 +295,8 @@ def denoise_tv_bregman(image, weight=5.0, max_num_iter=100, eps=1e-3,
         the smaller the `weight`, the more denoising (at
         the expense of less similarity to `image`).
     eps : float, optional
-        Stop criterion :math:`\varepsilon > 0`. The algorithm stops when
-        :math:`\|u_n - u_{n-1}\|_2 < \varepsilon`.
+        Parameter :math:`\varepsilon > 0` for the stop criterion:
+        The algorithm stops when :math:`\|u_n - u_{n-1}\|_2 < \varepsilon`.
     max_num_iter : int, optional
         Maximal number of iterations used for the optimization.
     isotropic : boolean, optional
@@ -497,8 +497,8 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
         the greater the `weight`, the more denoising (at the expense of
         fidelity to `image`).
     eps : float, optional
-        Stop criterion :math:`\varepsilon > 0` (absolute value of relative
-        difference of the cost function :math:`E`).
+        Parameter :math:`\varepsilon > 0` for the stop criterion (compares to
+        absolute value of relative difference of the cost function :math:`E`):
         The algorithm stops when :math:`|E_{n-1} - E_n| < \varepsilon * E_0`.
     max_num_iter : int, optional
         Maximal number of iterations used for the optimization.


### PR DESCRIPTION
## Description

Closes #5379 by defining the `weight` parameter explicitly. 

I have reworked the docstrings for both `denoise_tv_chambolle` and `denoise_tv_bregman`; they now share this entire paragraph:
![paragraph](https://user-images.githubusercontent.com/2227806/192880909-c79a5660-1219-4b73-95c5-5f857849918d.png)
and some parameter descriptions as well; they also refer to each other (with the "see also" subsection).

@grlee77 regarding the expression of the cost function, I have decided to go for the Getreuer convention because it is so standard in math (see also https://en.wikipedia.org/wiki/Total_variation_denoising#Rudin%E2%80%93Osher%E2%80%93Fatemi_PDE in spite of the other sections where lambda has a different meaning).

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
