### PR TITLE
Update "Mark dormant issues" workflow

### DIFF
--- a/.github/workflows/dormant-issues-prs.yml
+++ b/.github/workflows/dormant-issues-prs.yml
@@ -5,6 +5,7 @@ name: Mark dormant issues
 on:
   schedule:
     - cron: "15 2 * * *"  # trigger every day at 2:15
+  workflow_dispatch:  # or run manually
 permissions:
   issues: write
   pull-requests: write
@@ -14,7 +15,6 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          debug-only: true
           days-before-stale: 180
           days-before-close: -1  # never close
           stale-issue-label: ":sleeping: Dormant"

--- a/.github/workflows/dormant-issues-prs.yml
+++ b/.github/workflows/dormant-issues-prs.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@3de2653986ebd134983c79fe2be5d45cc3d9f4e1  # v6.0.0
         with:
           days-before-stale: 180
           days-before-close: -1  # never close


### PR DESCRIPTION
## Description

- Remove debugging option in dormant workflow to make the action's changes have an effect [1]. And make it possible to
execute the workflow manually via workflow_dispatch [2], might be useful not having to wait for the schedule.

- Pin to actions/stale@v6 via commit SHA: "Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload." [3]

[1] https://github.com/actions/stale#debug-only
[2] https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
[3] https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Updates #6506.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
