### PR TITLE
Add missing option stale-pr-label for "Mark dormant issues" workflow

### DIFF
--- a/.github/workflows/dormant-issues-prs.yml
+++ b/.github/workflows/dormant-issues-prs.yml
@@ -18,10 +18,11 @@ jobs:
           days-before-stale: 180
           days-before-close: -1  # never close
           stale-issue-label: ":sleeping: Dormant"
+          stale-pr-label: ":sleeping: Dormant"
           remove-stale-when-updated: true
           stale-issue-message: >
-            Hey, there hasn't been any activity on this for more than 180
-            days, so we have marked it as "dormant" for now until there is some
+            Hey, there hasn't been any activity on this issue for more than 180
+            days. So for now, we have marked it as "dormant" until there is some
             new activity. You are welcome to reach out to people by
             mentioning them here or on our
             [forum](https://discuss.scientific-python.org/c/contributor/skimage/22)
@@ -30,10 +31,10 @@ jobs:
             some point (either way, it will be done manually).
             In any case, thank you for your contributions so far!
           stale-pr-message: >
-            Hey, there hasn't been any activity on this for more than 180
-            days, so we have marked it as "dormant" for now until there is some
-            new activity. You are welcome to reach out to people by
-            mentioning them here or on our
+            Hey, there hasn't been any activity on this pull request for more 
+            than 180 days. So for now, we have marked it as "dormant" until
+            there is some new activity. You are welcome to reach out to people
+            by mentioning them here or on our
             [forum](https://discuss.scientific-python.org/c/contributor/skimage/22)
             if you need more feedback! Otherwise, we would be thankful for a 
             short update, for example if you would like to continue or if you

--- a/.github/workflows/dormant-issues-prs.yml
+++ b/.github/workflows/dormant-issues-prs.yml
@@ -22,7 +22,7 @@ jobs:
           remove-stale-when-updated: true
           stale-issue-message: >
             Hey, there hasn't been any activity on this issue for more than 180
-            days. So for now, we have marked it as "dormant" until there is some
+            days. For now, we have marked it as "dormant" until there is some
             new activity. You are welcome to reach out to people by
             mentioning them here or on our
             [forum](https://discuss.scientific-python.org/c/contributor/skimage/22)
@@ -32,7 +32,7 @@ jobs:
             In any case, thank you for your contributions so far!
           stale-pr-message: >
             Hey, there hasn't been any activity on this pull request for more 
-            than 180 days. So for now, we have marked it as "dormant" until
+            than 180 days. For now, we have marked it as "dormant" until
             there is some new activity. You are welcome to reach out to people
             by mentioning them here or on our
             [forum](https://discuss.scientific-python.org/c/contributor/skimage/22)


### PR DESCRIPTION
## Description

Without this option [1], the action was using the default label name "Stale" which we don't want!

I also tweaked the bot messages. I think the shorter sentences and other tweaks make it easier to read.

[1] https://github.com/actions/stale#stale-pr-label


Closes #6551.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
