### PR TITLE
Remove FUNDING.yml in preference of org version

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-custom: https://numfocus.org/donate-to-scikit-image


### PR DESCRIPTION
The org FUNDING.yml lives at https://github.com/scikit-image/.github
