### PR TITLE
Add footprint_from_sequence to public API in skimage.morphology

### DIFF
--- a/skimage/morphology/__init__.py
+++ b/skimage/morphology/__init__.py
@@ -1,62 +1,62 @@
-from .binary import (binary_erosion, binary_dilation, binary_opening,
-                     binary_closing)
-from .gray import (erosion, dilation, opening, closing, white_tophat,
-                   black_tophat)
+from .binary import (binary_closing, binary_dilation, binary_erosion,
+                     binary_opening)
+from .gray import (black_tophat, closing, dilation, erosion, opening,
+                   white_tophat)
 from .footprints import (ball, cube, diamond, disk, ellipse,
-                         octagon, octahedron, rectangle, square, star,
-                         footprint_from_sequence)
+                         footprint_from_sequence, octagon, octahedron,
+                         rectangle, square, star)
 from ..measure._label import label
-from ._skeletonize import skeletonize, medial_axis, thin, skeletonize_3d
+from ._skeletonize import medial_axis, skeletonize, skeletonize_3d, thin
 from .convex_hull import convex_hull_image, convex_hull_object
 from .grayreconstruct import reconstruction
-from .misc import remove_small_objects, remove_small_holes
-from .extrema import h_minima, h_maxima, local_maxima, local_minima
+from .misc import remove_small_holes, remove_small_objects
+from .extrema import h_maxima, h_minima, local_minima, local_maxima
 from ._flood_fill import flood, flood_fill
-from .max_tree import (max_tree, area_opening, area_closing,
-                       diameter_opening, diameter_closing,
+from .max_tree import (area_opening, area_closing, diameter_closing,
+                       diameter_opening, max_tree,
                        max_tree_local_maxima)
 
-__all__ = ['binary_erosion',
-           'binary_dilation',
-           'binary_opening',
-           'binary_closing',
-           'erosion',
-           'dilation',
-           'opening',
-           'closing',
-           'white_tophat',
-           'black_tophat',
-           'square',
-           'rectangle',
-           'diamond',
-           'disk',
-           'ellipse',
-           'cube',
-           'octahedron',
+__all__ = ['area_closing',
+           'area_opening',
            'ball',
-           'octagon',
-           'star',
-           'label',
-           'skeletonize',
-           'skeletonize_3d',
-           'thin',
-           'medial_axis',
+           'binary_closing',
+           'binary_dilation',
+           'binary_erosion',
+           'binary_opening',
+           'black_tophat',
+           'closing',
            'convex_hull_image',
            'convex_hull_object',
-           'reconstruction',
-           'remove_small_objects',
-           'remove_small_holes',
-           'h_minima',
-           'h_maxima',
-           'local_maxima',
-           'local_minima',
+           'cube',
+           'diameter_closing',
+           'diameter_opening',
+           'diamond',
+           'dilation',
+           'disk',
+           'ellipse',
+           'erosion',
            'flood',
            'flood_fill',
+           'footprint_from_sequence',
+           'h_maxima',
+           'h_minima',
+           'label',
+           'local_maxima',
+           'local_minima',
            'max_tree',
-           'area_opening',
-           'area_closing',
-           'diameter_opening',
-           'diameter_closing',
            'max_tree_local_maxima',
-           'footprint_from_sequence'
-           ]
+           'medial_axis',
+           'octagon',
+           'octahedron',
+           'opening',
+           'reconstruction',
+           'rectangle',
+           'remove_small_holes',
+           'remove_small_objects',
+           'skeletonize',
+           'skeletonize_3d',
+           'square',
+           'star',
+           'thin',
+           'white_tophat'
+]

--- a/skimage/morphology/__init__.py
+++ b/skimage/morphology/__init__.py
@@ -3,7 +3,8 @@ from .binary import (binary_erosion, binary_dilation, binary_opening,
 from .gray import (erosion, dilation, opening, closing, white_tophat,
                    black_tophat)
 from .footprints import (ball, cube, diamond, disk, ellipse,
-                         octagon, octahedron, rectangle, square, star)
+                         octagon, octahedron, rectangle, square, star,
+                         footprint_from_sequence)
 from ..measure._label import label
 from ._skeletonize import skeletonize, medial_axis, thin, skeletonize_3d
 from .convex_hull import convex_hull_image, convex_hull_object
@@ -57,4 +58,5 @@ __all__ = ['binary_erosion',
            'diameter_opening',
            'diameter_closing',
            'max_tree_local_maxima',
+           'footprint_from_sequence'
            ]


### PR DESCRIPTION
## Description

[`footprint_from_sequence` does not show up in our current API documentation](https://scikit-image.org/docs/dev/search.html?q=footprint_from_sequence&check_keywords=yes&area=default) but nevertheless seems to be part of our public API ([see this gallery example](https://scikit-image.org/docs/dev/auto_examples/numpy_operations/plot_footprint_decompositions.html))? I think this was simply forgotten in 852e9daccf6c394a96fd662ae1f1c5488f1b6596 (#5482).

Discovered while preparing the release notes for v0.20.

cc @grlee77

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
