### PR TITLE
List only the two primary methods of installing skimage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@
 
 ## Installation from binaries
 
-- **Debian/Ubuntu:** ``sudo apt-get install python-skimage``
-- **OSX:** ``pip install scikit-image``
-- **Anaconda:** ``conda install -c conda-forge scikit-image``
+- **All platforms:** ``pip install scikit-image``
+- **Conda:** ``conda install -c conda-forge scikit-image``
 
 Also see [installing ``scikit-image``](INSTALL.rst).
 


### PR DESCRIPTION
If we consistently wanted to specify installation instructions for each distro / OS, the list will get very long.

