### PR TITLE
Handle deprecation warning by updating to_scipy_sparse_array function

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,6 @@
 numpy>=1.19
 scipy>=1.5
-networkx>=2.5
+networkx>=2.8
 pillow>=9.0.1
 imageio>=2.4.1
 tifffile>=2019.7.26

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,5 @@
 numpy>=1.19
-scipy>=1.5
+scipy>=1.8
 networkx>=2.8
 pillow>=9.0.1
 imageio>=2.4.1

--- a/skimage/future/graph/_ncut.py
+++ b/skimage/future/graph/_ncut.py
@@ -22,7 +22,7 @@ def DW_matrices(graph):
         joining `i` to `j`.
     """
     # sparse.eighsh is most efficient with CSC-formatted input
-    W = nx.to_scipy_sparse_matrix(graph, format='csc')
+    W = nx.to_scipy_sparse_array(graph, format='csc')
     entries = W.sum(axis=0)
     D = sparse.dia_matrix((entries, 0), shape=W.shape).tocsc()
 


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->
This PR is handles the deprecation warning described in #6559. The `to_scipy_sparse_matrix` function is updated to `to_scipy_sparse_array` function to remove the deprecation warning.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
