### PR TITLE
Drop Numpy 1.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,7 @@ requires = [
 
     # We follow scipy for much of these pinnings
     # https://github.com/scipy/scipy/blob/master/pyproject.toml
-    # numpy 1.19 was the first minor release to provide aarch64 wheels, but
-    # wheels require fixes contained in numpy 1.19.2
-    "numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64'",
+    "numpy==1.20.0; python_version=='3.8' and platform_machine=='aarch64'",
     # aarch64 for py39 and py310 are covered by the default requirement below
 
     # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.20.0
@@ -19,8 +17,8 @@ requires = [
     # arm64 for py310 is covered by the default requirement below
 
     # default numpy requirements
-    "numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
-    "numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
+    "numpy==1.20.0; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
+    "numpy==1.20.0; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
     "numpy==1.21.4; python_version=='3.10' and platform_python_implementation != 'PyPy'",
 
     # For Python versions which aren't yet officially supported,

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -2,4 +2,4 @@ Cython>=0.29.21,!=0.29.18
 packaging>=20.0
 pythran
 wheel
-numpy>=1.19.0
+numpy>=1.20

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,4 +1,4 @@
-numpy>=1.19
+numpy>=1.20
 scipy>=1.5
 networkx>=2.5
 pillow>=9.0.1


### PR DESCRIPTION
See NEP 29: https://numpy.org/neps/nep-0029-deprecation_policy.html