### PR TITLE
Fix CI for Scipy1.9.2

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,5 +1,6 @@
 numpy>=1.19
-scipy>=1.8
+scipy>=1.8,<1.9.2; python_version<="3.9"
+scipy>=1.8; python_version>"3.9"
 networkx>=2.8
 pillow>=9.0.1
 imageio>=2.4.1


### PR DESCRIPTION
SciPy 1.9.2 doesn't provide win32 wheels: https://pypi.org/project/scipy/#files

You are only testing win32 with Python 3.8 and 3.9.

See https://github.com/scipy/scipy/issues/15836