### PR TITLE
Add two new GLCM properties derived from correlation property: mean and variance.

### DIFF
--- a/skimage/feature/tests/test_texture.py
+++ b/skimage/feature/tests/test_texture.py
@@ -216,6 +216,12 @@ class TestGLCM():
         mean = graycoprops(result, 'mean')
         np.testing.assert_almost_equal(mean[0, 0], 1.2916666)
 
+    def test_variance(self):
+        result = graycomatrix(self.image, [1, 2], [0], 4, normed=True,
+                              symmetric=True)
+        mean = graycoprops(result, 'variance')
+        np.testing.assert_almost_equal(mean[0, 0], 1.03993055)
+
     def test_uniform_properties(self):
         im = np.ones((4, 4), dtype=np.uint8)
         result = graycomatrix(im, [1, 2, 8], [0, np.pi / 2], 4, normed=True,

--- a/skimage/feature/tests/test_texture.py
+++ b/skimage/feature/tests/test_texture.py
@@ -210,6 +210,12 @@ class TestGLCM():
         np.testing.assert_almost_equal(energy[0, 0], 0.71953255)
         np.testing.assert_almost_equal(energy[1, 0], 0.41176470)
 
+    def test_mean(self):
+        result = graycomatrix(self.image, [1, 2], [0], 4, normed=True,
+                              symmetric=True)
+        mean = graycoprops(result, 'mean')
+        np.testing.assert_almost_equal(mean[0, 0], 1.2916666)
+
     def test_uniform_properties(self):
         im = np.ones((4, 4), dtype=np.uint8)
         result = graycomatrix(im, [1, 2, 8], [0, np.pi / 2], 4, normed=True,

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -169,10 +169,12 @@ def graycoprops(P, prop='contrast'):
     - 'dissimilarity': :math:`\\sum_{i,j=0}^{levels-1}P_{i,j}|i-j|`
     - 'homogeneity': :math:`\\sum_{i,j=0}^{levels-1}\\frac{P_{i,j}}{1+(i-j)^2}`
     - 'ASM': :math:`\\sum_{i,j=0}^{levels-1} P_{i,j}^2`
+    - 'mean': :math:`\\sum_{i,j=0}^{levels-1}P_{i,j}i`
     - 'energy': :math:`\\sqrt{ASM}`
     - 'correlation':
         .. math:: \\sum_{i,j=0}^{levels-1} P_{i,j}\\left[\\frac{(i-\\mu_i) \\
                   (j-\\mu_j)}{\\sqrt{(\\sigma_i^2)(\\sigma_j^2)}}\\right]
+
 
     Each GLCM is normalized to have a sum of 1 before the computation of
     texture properties.
@@ -189,7 +191,7 @@ def graycoprops(P, prop='contrast'):
         occurs at a distance d and at an angle theta from
         gray-level i.
     prop : {'contrast', 'dissimilarity', 'homogeneity', 'energy', \
-            'correlation', 'ASM'}, optional
+            'correlation', 'ASM', 'mean'}, optional
         The property of the GLCM to compute. The default is 'contrast'.
 
     Returns
@@ -246,7 +248,7 @@ def graycoprops(P, prop='contrast'):
         weights = np.abs(I - J)
     elif prop == 'homogeneity':
         weights = 1. / (1. + (I - J) ** 2)
-    elif prop in ['ASM', 'energy', 'correlation']:
+    elif prop in ['ASM', 'energy', 'correlation', 'mean']:
         pass
     else:
         raise ValueError('%s is an invalid property' % (prop))
@@ -257,12 +259,18 @@ def graycoprops(P, prop='contrast'):
         results = np.sqrt(asm)
     elif prop == 'ASM':
         results = np.sum(P ** 2, axis=(0, 1))
-    elif prop == 'correlation':
+    elif prop in ['correlation', 'mean']:
         results = np.zeros((num_dist, num_angle), dtype=np.float64)
         I = np.array(range(num_level)).reshape((num_level, 1, 1, 1))
         J = np.array(range(num_level)).reshape((1, num_level, 1, 1))
-        diff_i = I - np.sum(I * P, axis=(0, 1))
-        diff_j = J - np.sum(J * P, axis=(0, 1))
+
+        mean_i = np.sum(I * P, axis=(0, 1))
+        if prop == 'mean':
+            return mean_i
+
+        mean_j = np.sum(J * P, axis=(0, 1))
+        diff_i = I - mean_i
+        diff_j = J - mean_j
 
         std_i = np.sqrt(np.sum(P * (diff_i) ** 2, axis=(0, 1)))
         std_j = np.sqrt(np.sum(P * (diff_j) ** 2, axis=(0, 1)))


### PR DESCRIPTION
## Description

This PR just add two new properties to GLCM that are part of correlation calculation: mean and variance.
According the papers, they just need to be executed in some axis: i or j. For this case, we are considering just i (see the doc equations).

Now you should be able to access other properties like:

```python
mean = graycoprops(glcm, 'mean')
,,,
var = graycoprops(glcm, 'variance')
```


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py) (updated the existing one).
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
