### PR TITLE
add informative error message for region properties requiring `intensity_image`

### DIFF
--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -13,6 +13,7 @@ from skimage._shared._warnings import expected_warnings
 from skimage.measure._regionprops import (COL_DTYPES, OBJECT_COLUMNS, PROPS,
                                           _inertia_eigvals_to_axes_lengths_3D,
                                           _parse_docs, _props_to_dict,
+                                          _require_intensity_image,
                                           euler_number, perimeter,
                                           perimeter_crofton, regionprops,
                                           regionprops_table)
@@ -1120,6 +1121,18 @@ def test_extra_properties_intensity():
                          extra_properties=(intensity_median,)
                          )[0]
     assert region.intensity_median == np.median(INTENSITY_SAMPLE[SAMPLE == 1])
+
+
+@pytest.mark.parametrize('intensity_prop', _require_intensity_image)
+def test_intensity_image_required(intensity_prop):
+    region = regionprops(SAMPLE)[0]
+    with pytest.raises(AttributeError) as e:
+        getattr(region, intensity_prop)
+    expected_error = (
+        f"Attribute '{intensity_prop}' unavailable when `intensity_image` has "
+        f"not been specified."
+    )
+    assert expected_error == str(e.value)
 
 
 def test_extra_properties_no_intensity_provided():


### PR DESCRIPTION


<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

closes #6574

There is no change in behavior here aside from providing a more helpful error message when a property that requires an intensity image is called without one.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
