### PR TITLE
ORB: Break early if octave image is too small

### DIFF
--- a/skimage/feature/orb.py
+++ b/skimage/feature/orb.py
@@ -182,6 +182,10 @@ class ORB(FeatureDetector, DescriptorExtractor):
 
             octave_image = np.ascontiguousarray(pyramid[octave])
 
+            if np.squeeze(octave_image).ndim < 2:
+                # No further keypoints can be detected if the image is not really 2d
+                break
+
             keypoints, orientations, responses = self._detect_octave(
                 octave_image)
 
@@ -300,6 +304,10 @@ class ORB(FeatureDetector, DescriptorExtractor):
         for octave in range(len(pyramid)):
 
             octave_image = np.ascontiguousarray(pyramid[octave])
+
+            if np.squeeze(octave_image).ndim < 2:
+                # No further keypoints can be detected if the image is not really 2d
+                break
 
             keypoints, orientations, responses = self._detect_octave(
                 octave_image)

--- a/skimage/feature/tests/test_orb.py
+++ b/skimage/feature/tests/test_orb.py
@@ -139,3 +139,9 @@ def test_no_descriptors_extracted_orb():
     detector_extractor = ORB()
     with pytest.raises(RuntimeError):
         detector_extractor.detect_and_extract(img)
+
+def test_img_too_small_orb():
+    img = data.brick()[:64,:64]
+    detector_extractor = ORB(downscale=2, n_scales=8)
+    detector_extractor.detect(img)
+    detector_extractor.detect_and_extract(img)


### PR DESCRIPTION
## Description

Avoids the search for keypoints in octave images that contain 1s in their shape.

Closes #6589.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
