### PR TITLE
Update _multiotsu.pyx; initialize first moment with 0

### DIFF
--- a/skimage/filters/_multiotsu.pyx
+++ b/skimage/filters/_multiotsu.pyx
@@ -110,7 +110,7 @@ cdef void _set_var_btwcls_lut(cnp.float32_t [::1] prob,
     cdef cnp.float32_t zeroth_moment_ij, first_moment_ij
 
     zeroth_moment[0] = prob[0]
-    first_moment[0] = prob[0]
+    first_moment[0] = 0
     for i in range(1, nbins):
         zeroth_moment[i] = zeroth_moment[i - 1] + prob[i]
         first_moment[i] = first_moment[i - 1] + i * prob[i]
@@ -310,7 +310,7 @@ cdef void _set_moments_lut_first_row(cnp.float32_t [::1] prob,
     cdef cnp.intp_t i
 
     zeroth_moment[0] = prob[0]
-    first_moment[0] = prob[0]
+    first_moment[0] = 0
     for i in range(1, nbins):
         zeroth_moment[i] = zeroth_moment[i - 1] + prob[i]
         first_moment[i] = first_moment[i - 1] + i * prob[i]


### PR DESCRIPTION
The zeroth entry of the first moment should be 0.

<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

The first moment is initialized as first_moment[0] = prob[0]. 
As the first moment is given by 
$$\text{first moment}\_j = \sum_{i=0}^{j} \text{prob}\_i \times i,$$
 it should be initialized as first_moment[0]= 0.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
