### PR TITLE
Fix intensity autoscaling in animated imshow.

### DIFF
--- a/doc/examples/applications/plot_fluorescence_nuclear_envelope.py
+++ b/doc/examples/applications/plot_fluorescence_nuclear_envelope.py
@@ -59,6 +59,7 @@ fig = px.imshow(
     animation_frame=0,
     zmin=vmin,
     zmax=vmax,
+    binary_string=True,
     labels={'animation_frame': 'time point', 'facet_col': 'channel'}
 )
 plotly.io.show(fig)

--- a/doc/examples/applications/plot_fluorescence_nuclear_envelope.py
+++ b/doc/examples/applications/plot_fluorescence_nuclear_envelope.py
@@ -51,10 +51,14 @@ print(f'shape: {image_sequence.shape}')
 #####################################################################
 # The dataset is a 2D image stack with 15 frames (time points) and 2 channels.
 
+vmin, vmax = 0, image_sequence.max()
+
 fig = px.imshow(
     image_sequence,
     facet_col=1,
     animation_frame=0,
+    zmin=vmin,
+    zmax=vmax,
     labels={'animation_frame': 'time point', 'facet_col': 'channel'}
 )
 plotly.io.show(fig)


### PR DESCRIPTION
## Description

While preparing for my webinar at Data Umbrella [1], I noticed that the intensity scale was changing from frame to frame! This does not make sense when visualizing the image time sequence as a movie. 

[1] https://www.youtube.com/playlist?list=PLBKcU7Ik-ir9Fi_hM_A6_U2UTpm7ACUtl

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
