### PR TITLE
Set `check: true` for `run_command`

### DIFF
--- a/skimage/meson.build
+++ b/skimage/meson.build
@@ -11,7 +11,10 @@ if is_windows
   add_global_arguments('-D__USE_MINGW_ANSI_STDIO=1', language: ['c', 'cpp'])
   # Manual add of MS_WIN64 macro when not using MSVC.
   # https://bugs.python.org/issue28267
-  bitness = run_command('_build_utils/gcc_build_bitness.py').stdout().strip()
+  bitness = run_command(
+    '_build_utils/gcc_build_bitness.py',
+    check: true
+  ).stdout().strip()
   if bitness == '64'
     add_global_arguments('-DMS_WIN64', language: ['c', 'cpp'])
   endif


### PR DESCRIPTION
In response to a Meson warning:

> You should add the boolean check kwarg to the run_command call.
>       It currently defaults to false,
>       but it will default to true in future releases of meson.
>       See also: https://github.com/mesonbuild/meson/issues/9300
