### PR TITLE
Update OpenBLAS to v0.3.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.8"
 dependencies = [
     # TODO: update to "pin-compatible" once possible, see
     # https://github.com/FFY00/meson-python/issues/29
-    "numpy>=1.20",
+    "numpy>=1.21.1,
 ]
 readme = "README.md"
 classifiers = [
@@ -57,13 +57,6 @@ requires = [
 
     # We follow scipy for much of these pinnings
     # https://github.com/scipy/scipy/blob/master/pyproject.toml
-    "numpy==1.20.0; python_version=='3.8' and platform_machine=='aarch64'",
-    # aarch64 for py39 and py310 are covered by the default requirement below
-
-    # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.20.0
-    "numpy==1.20.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'",
-    "numpy==1.20.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'",
-    # arm64 for py310 is covered by the default requirement below
 
     # On Windows we need to avoid 1.21.6, 1.22.0 and 1.22.1 because they were
     # built with vc142. 1.22.3 is the first version that has 32-bit Windows
@@ -71,8 +64,8 @@ requires = [
     "numpy==1.22.3; python_version=='3.10' and platform_system=='Windows' and platform_python_implementation != 'PyPy'",
 
     # default numpy requirements
-    "numpy==1.20.0; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'",
-    "numpy==1.20.0; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'",
+    "numpy==1.21.1; python_version=='3.8' and platform_python_implementation != 'PyPy'",
+    "numpy==1.21.1; python_version=='3.9' and platform_python_implementation != 'PyPy'",
     "numpy==1.21.4; python_version=='3.10' and platform_python_implementation != 'PyPy'",
     "numpy==1.23.3; python_version=='3.11' and platform_python_implementation != 'PyPy'",
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.8"
 dependencies = [
     # TODO: update to "pin-compatible" once possible, see
     # https://github.com/FFY00/meson-python/issues/29
-    "numpy>=1.21.1,
+    "numpy>=1.21.1",
 ]
 readme = "README.md"
 classifiers = [


### PR DESCRIPTION
We were getting regular CI failures particularly related to multiprocessing. Stefan suspected it might be fixed by an updated OpenBLAS. I've rerun the CI on this PR mulitple times and it passed everytime, so I think this may solve the annoying CI failures.

This involves dropping NumPy 1.20 (https://github.com/numpy/numpy/pull/19495). According to NEP 29, we should drop 1.20 by January 2023. Given the current status of main, I suspect we will be lucky to get a scikit 0.20 final release out this month. So we will only be a month of so early on dropping NumPy 1.20 according to NEP 29. Moreover, we already require more recent versions of NumPy for some of our wheels.