### PR TITLE
Added error handling in regionprops_table with fill_value

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -1,5 +1,4 @@
 import inspect
-import re
 from functools import wraps
 from math import atan2
 from math import pi as PI

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -498,8 +498,6 @@ class RegionProperties:
     @property
     @_cached
     def inertia_tensor_eigvals(self):
-        if self.label == 1:
-            raise FileExistsError('dummy')
         return _moments.inertia_tensor_eigvals(self.image,
                                                T=self.inertia_tensor)
 
@@ -764,10 +762,10 @@ def _props_to_dict(regions, properties=('label', 'bbox'), separator='-',
         number of columns would change depending on the object. For example,
         ``image`` and ``coords``.
     errors: {'ignore', 'raise'}, optional
-        If 'ignore' suppress error when computing property and return 
+        If 'ignore' suppress error when computing property and return
         `fill_value` for that property. Default is 'raise'.
     fill_value: float or None, optional
-        If `errors='ignore'` return `fill_value` if computing a property raises 
+        If `errors='ignore'` return `fill_value` if computing a property raises
         an error.
 
     Returns
@@ -855,8 +853,8 @@ def _props_to_dict(regions, properties=('label', 'bbox'), separator='-',
 
         if rp is None:
             # Error was raised on all the objects -->
-            # rp is None and `errors='ignore'` --> we do not add the property 
-            # now since we don't know if it would have been a scalar, array or 
+            # rp is None and `errors='ignore'` --> we do not add the property
+            # now since we don't know if it would have been a scalar, array or
             # tuple property
             for i in range(n):
                 region = regions[i]
@@ -924,14 +922,14 @@ def _props_to_dict(regions, properties=('label', 'bbox'), separator='-',
             # add the columns to the output dictionary
             for i, modified_prop in enumerate(modified_props):
                 out[modified_prop] = column_data[:, i]
-    
+
     if errors == 'ignore':
         out = _props_to_dict_fill_value_errors(
             out, fill_value, missing_props_info, separator)
     return out
 
 def _props_to_dict_fill_value_errors(out, fill_value, missing_props_info, separator):
-    """Insert `fill_value` where the property was missing because it raised an 
+    """Insert `fill_value` where the property was missing because it raised an
     error.
 
     Parameters
@@ -945,7 +943,7 @@ def _props_to_dict_fill_value_errors(out, fill_value, missing_props_info, separa
         Value used to fill properties that raised an error (`errors = 'ignore'`)
         in `regionprops_table`.
     missing_props_info : dict
-        Dictionary mapping the labels to a list of the property names that 
+        Dictionary mapping the labels to a list of the property names that
         raised an error
     separator : str, optional
         For non-scalar properties not listed in OBJECT_COLUMNS, each element
@@ -968,14 +966,14 @@ def _props_to_dict_fill_value_errors(out, fill_value, missing_props_info, separa
         regions to rows.
 
         The array of values where the property was missing contains the `fill_value`
-    
+
     Notes
     -----
-    This function is needed only when all objects in `label_image` raised 
+    This function is needed only when all objects in `label_image` raised
     an error. Since we don't know whether the property is a scalar, a tuple, or
     an array, the property is missing entirely and we need to insert it with the
     requested `fill_value`.
-    """    
+    """
     labels = list(out['label'])
     for label, missing_props in missing_props_info.items():
         try:
@@ -988,7 +986,7 @@ def _props_to_dict_fill_value_errors(out, fill_value, missing_props_info, separa
         for missing_prop in missing_props:
             norm_missing_prop = _normalize_prop(missing_prop, separator)
             found_props = [
-                prop for prop in out 
+                prop for prop in out
                 if _normalize_prop(prop, separator) == norm_missing_prop
             ]
             if found_props:
@@ -1021,9 +1019,9 @@ def _normalize_prop(prop, separator):
     Returns
     -------
     str
-        Normalised property name with integers and separators replaced 
+        Normalised property name with integers and separators replaced
         by empty charachter
-    """    
+    """
     prop = prop.replace(separator, '')
     prop = re.sub(r'(\d+)', '', prop)
     return prop
@@ -1031,7 +1029,7 @@ def _normalize_prop(prop, separator):
 def regionprops_table(label_image, intensity_image=None,
                       properties=('label', 'bbox'),
                       *,
-                      cache=True, separator='-', extra_properties=None, 
+                      cache=True, separator='-', extra_properties=None,
                       spacing=None, errors='raise', fill_value=None):
     """Compute image properties and return them as a pandas-compatible table.
 
@@ -1084,10 +1082,10 @@ def regionprops_table(label_image, intensity_image=None,
     spacing: tuple of float, shape (ndim, )
         The pixel spacing along each axis of the image.
     errors: {'ignore', 'raise'}, optional
-        If 'ignore' suppress error when computing property and return 
+        If 'ignore' suppress error when computing property and return
         `fill_value` for that property. Default is 'raise'.
     fill_value: float or None, optional
-        If `errors='ignore'` return `fill_value` if computing a property raises 
+        If `errors='ignore'` return `fill_value` if computing a property raises
         an error.
 
     Returns

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -852,8 +852,8 @@ def _props_to_dict(regions, properties=('label', 'bbox'), separator='-',
                 rp = None
 
         if rp is None:
-            # Error was raised on all the objects so we add the property 
-            # without modified name --> we cannot modify the name because 
+            # Error was raised on all the objects so we add the property
+            # without modified name --> we cannot modify the name because
             # we do not know the type of the property
             out[prop] = np.full(n, fill_value, dtype=float)
             continue

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -826,8 +826,6 @@ def _props_to_dict(regions, properties=('label', 'bbox'), separator='-',
 
     out = {}
     n = len(regions)
-    # Keep info about missing properties due to ignored errors (`errors='ignore'`)
-    missing_props_info = {}
     for prop in properties:
         r = regions[0]
         # Copy the original property name so the output will have the


### PR DESCRIPTION
The user can now set `errors='ignore'` to `skimage.measure.regionprops_table` and, optionally, a `fill_value` to replace region properties that raised an error with `fill_value` (default `fill_value` is `None`). This allows getting a table with all of the properties that did not raise any exception, instead of raising an exception for the entire table.

<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

Implementation of the feature that I requested in #6603. Note that if an error is raised on a specific property of all the regions and this property was a tuple or array, then the property will appear in the table with its non-modified name. This is because it was never computed, so it was never possible to determine if it was a scalar, tuple or array.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
