### PR TITLE
MAINT: Add +1 to warning stacklevel of decorated function.

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1075,7 +1075,7 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     if np.any(z < 0):
         invalid = np.nonzero(z < 0)
         warn(f'Color data out of range: Z < 0 in {invalid[0].size} pixels',
-             stacklevel=2)
+             stacklevel=3)
         z[invalid] = 0
 
     out = np.stack([x, y, z], axis=-1)


### PR DESCRIPTION
`lab2xyz` is decorated by `channel_as_last_axis`, therefore any warning emitted from inside the function likely need a stacklevel of at least 3, to not show up from within the decorator.

Found in napari benchmark test suite with the warning message:

    .../path/to/skimage/_shared/utils.py:394: UserWarning:Color data out of range: Z < 0 in 20 pixels
    return func(*args, **kwargs)

Which could be more useful.

This can be tested in IPython, which now print the current cell where the warning appear:

    In [1]: from skimage.color.colorconv import lab2xyz
       ...: import numpy as np
       ...: lab2xyz(np.array([[ 0., 99., 99.]]))
    <ipython-input-1-1e2be3413572>:3: UserWarning: Color data out of range: Z < 0 in 1 pixels

Instead of `.../_shared/utils.py` as a path.


## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
