### PR TITLE
Emit warning for proper stacklevel in lab2rgb.

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1073,7 +1073,7 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
 
 def _lab2xyz(lab, illuminant, observer, *, channel_axis=-1):
     """
-    Like lab2xyz, but return the invalid pixels in the z channel
+    Like lab2xyz, but return the invalid pixels in the Z channel
     as a separate array for correct warning propagation.
     """
     arr = _prepare_colorarray(lab, channel_axis=-1).copy()
@@ -1194,8 +1194,8 @@ def lab2rgb(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     xyz, n_invalid = _lab2xyz(lab, illuminant, observer)
     if n_invalid != 0:
         warn(
-            "Color conversion from LAB to RGB via negative Z values. "
-            "{n_invalid} z-values have been clipped to zero.",
+            "Color conversion from CIE-LAB to sRGB with negative Z values. "
+            "{n_invalid} Z-values have been clipped to zero.",
             stacklevel=3,
         )
 

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -641,9 +641,13 @@ class TestColorconv():
         a, b = np.meshgrid(np.arange(-100, 100), np.arange(-100, 100))
         L = np.ones(a.shape)
         lab = np.dstack((L, a, b))
+        regex = (
+            "Conversion from CIE-LAB to XYZ color space resulted in "
+            "\\d+ negative Z values that have been clipped to zero"
+        )
         for value in [0, 10, 20]:
             lab[:, :, 0] = value
-            with expected_warnings(['Color data out of range']):
+            with pytest.warns(UserWarning, match=regex):
                 lab2xyz(lab)
 
     @pytest.mark.parametrize("channel_axis", [0, 1, -1, -2])
@@ -759,6 +763,17 @@ class TestColorconv():
                        for pt in rgb.reshape(-1, 3)]
                       )
         assert_almost_equal(yiq, gt, decimal=2)
+
+    @pytest.mark.parametrize("func", [lab2rgb, lab2xyz])
+    def test_warning_stacklevel(self, func):
+        regex = (
+            "Conversion from CIE-LAB.* XYZ.*color space resulted in "
+            "1 negative Z values that have been clipped to zero"
+        )
+        with pytest.warns(UserWarning, match=regex) as messages:
+            func(lab=[[[0, 0, 300.]]])
+        assert len(messages) == 1
+        assert messages[0].filename == __file__, "warning points at wrong file"
 
 
 def test_gray2rgb():


### PR DESCRIPTION
`lab2rgb` uses `lab2xyz`, which itself emit a UserWarning (stacklevel=3) if one of the given colors get a negative Z. When calling `lab2rgb` the warning point inside the lab2rgb function, which is not as useful as it could be.

This reemits a warning with the right stack level to make it easier to track usage of lab2rgb that go through a clipped Z value, thus making it easier to point the caller of lab2rgb instead of having the warning pointing inside the lab2rgb function.


<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->
<!--
## Checklist

<!-- It's fine to submit PRs which are a work in progress! 
<!-- But before they are merged, all PRs should provide: 

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
