### PR TITLE
pin setuptools in GHA MacOS workflow and azure-pipelines.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -181,7 +181,7 @@ jobs:
         run: |
           set -ex
           source tools/github/before_install.sh
-          pip install -U pip setuptools wheel
+          pip install -U pip setuptools<=65.5 wheel
           python setup.py sdist
           pip install -vv --no-build-isolation .;
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,7 @@ jobs:
           PYTHON="$(python.pythonLocation)\\python.exe"
 
           # Update pip
-          $PYTHON -m pip install -U pip setuptools<=65.5 wheel
+          $PYTHON -m pip install -U pip "setuptools<=65.5" wheel
 
           # print out the pip cache dir followed by the variable defined above
           # to confirm that they match

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,7 @@ jobs:
           PYTHON="$(python.pythonLocation)\\python.exe"
 
           # Update pip
-          $PYTHON -m pip install -U pip setuptools wheel
+          $PYTHON -m pip install -U pip setuptools<=65.5 wheel
 
           # print out the pip cache dir followed by the variable defined above
           # to confirm that they match


### PR DESCRIPTION
closes #6625

`numpy.distutils` cannot be imported when using setuptools 65.6