### PR TITLE
Remove np.bool8 support (deprecated)

### DIFF
--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -24,7 +24,6 @@ _integer_ranges = {t: (np.iinfo(t).min, np.iinfo(t).max)
                    for t in _integer_types}
 dtype_range = {bool: (False, True),
                np.bool_: (False, True),
-               np.bool8: (False, True),
                float: (-1, 1),
                np.float_: (-1, 1),
                np.float16: (-1, 1),

--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -109,17 +109,13 @@ def test_copy():
 
 def test_bool():
     img_ = np.zeros((10, 10), bool)
-    img8 = np.zeros((10, 10), np.bool8)
     img_[1, 1] = True
-    img8[1, 1] = True
     for (func, dt) in [(img_as_int, np.int16),
                        (img_as_float, np.float64),
                        (img_as_uint, np.uint16),
                        (img_as_ubyte, np.ubyte)]:
         converted_ = func(img_)
         assert np.sum(converted_) == dtype_range[dt][1]
-        converted8 = func(img8)
-        assert np.sum(converted8) == dtype_range[dt][1]
 
 
 def test_clobber():


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

numpy/numpy#22607 deprecated use of the `np.bool8` dtype. This PR simply removes the relevant bits of skimage that concern that dtype, so deprecation warnings don't cause downstream packages to run into deprecation warnings/errors.

This was discovered in [dev-dependency test logs](https://github.com/spacetelescope/jdaviz/actions/runs/3550655505/jobs/5964421579#step:5:274) while working on spacetelescope/jdaviz#1834.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
