### PR TITLE
Analytical 2D and 3D eigenvalues and determinant

### DIFF
--- a/benchmarks/benchmark_feature.py
+++ b/benchmarks/benchmark_feature.py
@@ -1,7 +1,6 @@
 # See "Writing benchmarks" in the asv docs for more information.
 # https://asv.readthedocs.io/en/latest/writing_benchmarks.html
 import numpy as np
-from scipy import ndimage as ndi
 from skimage import color, data, feature, util
 
 
@@ -17,16 +16,75 @@ class FeatureSuite:
                 )
 
     def time_canny(self):
-        result = feature.canny(self.image)
+        feature.canny(self.image)
 
     def time_glcm(self):
         pi = np.pi
-        result = feature.greycomatrix(self.image_ubyte, distances=[1, 2],
-                                      angles=[0, pi/4, pi/2, 3*pi/4])
+        feature.greycomatrix(self.image_ubyte, distances=[1, 2],
+                             angles=[0, pi/4, pi/2, 3*pi/4])
 
     def time_brief(self):
         extractor = feature.BRIEF()
         extractor.extract(self.image, self.keypoints)
 
     def time_hessian_matrix_det(self):
-        result = feature.hessian_matrix_det(self.image, 4)
+        feature.hessian_matrix_det(self.image, 4)
+
+
+class HessianSuite:
+    """Benchmark for feature routines in scikit-image."""
+    param_names = ['ndim']
+    params = [2, 3]
+
+    def setup(self, ndim):
+        # Use a real-world image for more realistic features, but tile it to
+        # get a larger size for the benchmark.
+        rng = np.random.default_rng(5)
+        if ndim == 2:
+            self.image = rng.standard_normal((3840, 2160), dtype=np.float32)
+        else:
+            self.image = rng.standard_normal((128, 96, 64), dtype=np.float32)
+        self.sigma = 3.0
+        self.H = feature.hessian_matrix(
+            self.image, sigma=self.sigma, use_gaussian_derivatives=False
+        )
+
+    def time_hessian_matrix(self, ndim):
+        feature.hessian_matrix(
+            self.image, self.sigma, use_gaussian_derivatives=False
+        )
+
+    def time_hessian_matrix_det(self, ndim):
+        feature.hessian_matrix_det(
+            self.image, self.sigma, approximate=False
+        )
+
+    def time_hessian_matrix_eigvals(self, ndim):
+        feature.hessian_matrix_eigvals(self.H)
+
+    def peakmem_reference(self, *args):
+        """Provide reference for memory measurement with empty benchmark.
+
+        Peakmem benchmarks measure the maximum amount of RAM used by a
+        function. However, this maximum also includes the memory used
+        during the setup routine (as of asv 0.2.1; see [1]_).
+        Measuring an empty peakmem function might allow us to disambiguate
+        between the memory used by setup and the memory used by target (see
+        other ``peakmem_`` functions below).
+
+        References
+        ----------
+        .. [1]: https://asv.readthedocs.io/en/stable/writing_benchmarks.html#peak-memory
+        """  # noqa
+        pass
+
+    def peakmem_hessian_matrix(self, ndim):
+        feature.hessian_matrix(
+            self.image, self.sigma, use_gaussian_derivatives=False
+        )
+
+    def peakmem_hessian_matrix_det(self, ndim):
+        feature.hessian_matrix_det(self.image, self.sigma, approximate=False)
+
+    def peakmem_hessian_matrix_eigvals(self, ndim):
+        feature.hessian_matrix_eigvals(self.H)

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -442,7 +442,7 @@ def _symmetric_compute_eigenvalues(S_elems, sort='descending', abs_sort=False):
         leading_axes = tuple(range(eigs.ndim - 1))
         eigs = np.transpose(eigs, (eigs.ndim - 1,) + leading_axes)
         if abs_sort:
-            eigs = cp.take_along_axis(eigs, cp.abs(eigs).argsort(0), 0)
+            eigs = np.take_along_axis(eigs, np.abs(eigs).argsort(0), 0)
         if sort == 'descending':
             eigs = eigs[::-1, ...]
         return eigs

--- a/skimage/feature/corner_cy.pyx
+++ b/skimage/feature/corner_cy.pyx
@@ -29,7 +29,7 @@ def _real_symmetric_2x2_evs(
     else:
         dtype = np.float64
 
-    cdef np_floats[:, :, ::1] evals = np.zeros((2, rows, cols), dtype=dtype)
+    cdef np_floats[:, :, ::1] evals = np.empty((2, rows, cols), dtype=dtype)
 
     with nogil:
         for r in range(rows):
@@ -107,7 +107,7 @@ def _real_symmetric_3x3_evs(
     else:
         dtype = np.float64
 
-    cdef np_floats[:, :, :, ::1] evals = np.zeros((3, planes, rows, cols),
+    cdef np_floats[:, :, :, ::1] evals = np.empty((3, planes, rows, cols),
                                                   dtype=dtype)
 
     with nogil:
@@ -134,6 +134,7 @@ def _real_symmetric_3x3_evs(
                     x2 += 9 * (tmpc * d_sq + tmpb * f_sq + tmpa * e_sq)
                     x2 -= 54 * d * e * f
                     x1 = a*a + b*b + c*c - a*b - a*c - b*c + 3 * (d_sq + e_sq + f_sq)
+                    x1 = fmax(x1, 0.0)
 
                     if x2 == 0.0:
                         phi = M_PI / 2.0

--- a/skimage/feature/corner_cy.pyx
+++ b/skimage/feature/corner_cy.pyx
@@ -5,12 +5,256 @@
 import numpy as np
 cimport numpy as cnp
 from libc.float cimport DBL_MAX
-from libc.math cimport atan2, fabs
+from libc.math cimport M_PI, atan, atan2, cos, fabs, fmax, sqrt
 
 from .._shared.fused_numerics cimport np_floats
 from ..util import img_as_float64
 
 cnp.import_array()
+
+def _real_symmetric_2x2_evs(
+    np_floats[:, ::1] M00, np_floats[:, ::1] M01, np_floats[:, ::1] M11,
+    bint ascending=False, bint abs_sort=False,
+):
+    """Analytical eigenvalues of a symmetric 2 x 2 matrix."""
+    # use double-precision intermediate variables for accuracy
+    cdef:
+        cnp.float64_t m00, m01, m11, tmp1, tmp2, lam1, lam2, stmp;
+        Py_ssize_t rows = M00.shape[0];
+        Py_ssize_t cols = M00.shape[1];
+        Py_ssize_t r, c;
+
+    if np_floats is cnp.float32_t:
+        dtype = np.float32
+    else:
+        dtype = np.float64
+
+    cdef np_floats[:, :, ::1] evals = np.zeros((2, rows, cols), dtype=dtype)
+
+    with nogil:
+        for r in range(rows):
+            for c in range(cols):
+                m00 = <cnp.float64_t>(M00[r, c])
+                m01 = <cnp.float64_t>(M01[r, c])
+                m11 = <cnp.float64_t>(M11[r, c])
+                tmp1 = 4 * m01 * m01
+
+                tmp2 = m00 - m11
+                tmp2 *= tmp2
+                tmp2 += tmp1
+                tmp2 = sqrt(tmp2) / 2
+
+                tmp1 = (m00 + m11) / 2
+                if ascending:
+                    lam1 = tmp1 - tmp2
+                    lam2 = tmp1 + tmp2
+                    if abs_sort and (fabs(lam1) > fabs(lam2)):
+                        stmp = lam1
+                        lam1 = lam2
+                        lam2 = stmp
+                else:
+                    lam1 = tmp1 + tmp2
+                    lam2 = tmp1 - tmp2
+                    if abs_sort and (fabs(lam1) < fabs(lam2)):
+                        stmp = lam1
+                        lam1 = lam2
+                        lam2 = stmp
+                evals[0, r, c] = lam1
+                evals[1, r, c] = lam2
+    return np.asarray(evals)
+
+
+def _real_symmetric_3x3_evs(
+    np_floats[:, :, ::1] M00, np_floats[:, :, ::1] M01, np_floats[:, :, ::1] M02,
+    np_floats[:, :, ::1] M11, np_floats[:, :, ::1] M12, np_floats[:, :, ::1] M22,
+    bint ascending=False, bint abs_sort=False,
+):
+    """Analytical eigenvalues of a symmetric 3 x 3 matrix.
+
+    Follows the expressions given for hermitian symmetric 3 x 3 matrices in
+    [1]_, but simplified to handle real-valued matrices only.
+
+    Parameters
+    ----------
+    a, d, f, b, e, c : cp.ndarray
+        Images corresponding to the individual components of the matrix, `M`,
+        shown above. For example, ``d = M[0, 1]``.
+    sort : {"ascending", "descending"}, optional
+        Eigenvalues should be sorted in the specified order.
+    abs_sort : boolean, optional
+        If ``True``, sort based on the absolute values.
+
+    References
+    ----------
+    .. [1] C. Deledalle, L. Denis, S. Tabti, F. Tupin. Closed-form expressions
+        of the eigen decomposition of 2 x 2 and 3 x 3 Hermitian matrices.
+        [Research Report] Université de Lyon. 2017.
+        https://hal.archives-ouvertes.fr/hal-01501221/file/matrix_exp_and_log_formula.pdf
+    """  # noqa
+    cdef:
+        # use double-precision intermediate variables for accuracy
+        cnp.float64_t a, b, c, d, e, f, d_sq, e_sq, f_sq;
+        cnp.float64_t x1, x2, phi, tmpa, tmpb, tmpc, arg, x1_term, abc;
+        cnp.float64_t lam1, lam2, lam3, stmp;
+        cnp.float64_t abs_lam1, abs_lam2, abs_lam3;
+        Py_ssize_t planes = M00.shape[0];
+        Py_ssize_t rows = M00.shape[1];
+        Py_ssize_t cols = M00.shape[2];
+        Py_ssize_t pln, row, col;
+
+    if np_floats is cnp.float32_t:
+        dtype = np.float32
+    else:
+        dtype = np.float64
+
+    cdef np_floats[:, :, :, ::1] evals = np.zeros((3, planes, rows, cols),
+                                                  dtype=dtype)
+
+    with nogil:
+        for pln in range(planes):
+            for row in range(rows):
+                for col in range(cols):
+                    # M = [[a, d, f],
+                    #      [d, b, e],
+                    #      [f, e, c]]
+                    # so d = M01, etc.
+                    a = <cnp.float64_t>(M00[pln, row, col])
+                    b = <cnp.float64_t>(M11[pln, row, col])
+                    c = <cnp.float64_t>(M22[pln, row, col])
+                    d = <cnp.float64_t>(M01[pln, row, col])
+                    e = <cnp.float64_t>(M12[pln, row, col])
+                    f = <cnp.float64_t>(M02[pln, row, col])
+                    d_sq = d * d
+                    e_sq = e * e
+                    f_sq = f * f
+                    tmpa = 2 * a - b - c
+                    tmpb = 2 * b - a - c
+                    tmpc = 2 * c - a - b
+                    x2 = - tmpa * tmpb * tmpc
+                    x2 += 9 * (tmpc * d_sq + tmpb * f_sq + tmpa * e_sq)
+                    x2 -= 54 * d * e * f
+                    x1 = a*a + b*b + c*c - a*b - a*c - b*c + 3 * (d_sq + e_sq + f_sq)
+
+                    if x2 == 0.0:
+                        phi = M_PI / 2.0
+                    else:
+                        # added max() here for numerical stability
+                        # (avoid NaN values in test_hessian_matrix_eigvals_3d)
+                        arg = fmax(4*x1*x1*x1 - x2*x2, 0.0)
+                        phi = atan(sqrt(arg)/x2)
+                        if x2 < 0:
+                            phi += M_PI
+                    x1_term = (2.0 / 3.0) * sqrt(x1)
+                    abc = (a + b + c) / 3.0
+                    lam1 = abc - x1_term * cos(phi/3.0)
+                    lam2 = abc + x1_term * cos((phi - M_PI)/3.0)
+                    lam3 = abc + x1_term * cos((phi + M_PI)/3.0)
+                    if abs_sort:
+                        abs_lam1 = fabs(lam1)
+                        abs_lam2 = fabs(lam2)
+                        abs_lam3 = fabs(lam3)
+                    else:
+                        # reuse abs_lam variables without abs to avoid
+                        # duplicate code below
+                        abs_lam1 = lam1
+                        abs_lam2 = lam2
+                        abs_lam3 = lam3
+
+                    if ascending:
+                        if (abs_lam1 > abs_lam2):
+                            stmp = lam1
+                            lam1 = lam2
+                            lam2 = stmp
+                        if (abs_lam1 > abs_lam3):
+                            stmp = lam3
+                            lam3 = lam1
+                            lam1 = stmp
+                        if (abs_lam2 > abs_lam3):
+                            stmp = lam3
+                            lam3 = lam2
+                            lam2 = stmp
+                    else:
+                        if (abs_lam3 > abs_lam2):
+                            stmp = lam3
+                            lam3 = lam2
+                            lam2 = stmp
+                        if (abs_lam3 > abs_lam1):
+                            stmp = lam1
+                            lam1 = lam3
+                            lam3 = stmp
+                        if (abs_lam2 > abs_lam1):
+                            stmp = lam1
+                            lam1 = lam2
+                            lam2 = stmp
+                    evals[0, pln, row, col] = lam1
+                    evals[1, pln, row, col] = lam2
+                    evals[2, pln, row, col] = lam3
+    return np.asarray(evals)
+
+
+def _real_symmetric_2x2_det(
+    np_floats[:, ::1] M00, np_floats[:, ::1] M01, np_floats[:, ::1] M11
+):
+    """Determinant for real, symmetric 2 x 2 matrices."""
+    cdef:
+        cnp.float64_t m00, m01, m11;
+        Py_ssize_t rows = M00.shape[0];
+        Py_ssize_t cols = M00.shape[1];
+        Py_ssize_t r, c;
+
+    if np_floats is cnp.float32_t:
+        dtype = np.float32
+    else:
+        dtype = np.float64
+
+    cdef np_floats[:, ::1] det = np.zeros((rows, cols), dtype=dtype)
+
+    with nogil:
+        for r in range(rows):
+            for c in range(cols):
+                m00 = <cnp.float64_t>(M00[r, c])
+                m01 = <cnp.float64_t>(M01[r, c])
+                m11 = <cnp.float64_t>(M11[r, c])
+                det[r, c] = m00 * m11 - m01 * m01;
+    return np.asarray(det)
+
+
+def _real_symmetric_3x3_det(
+    np_floats[:, :, ::1] M00, np_floats[:, :, ::1] M01, np_floats[:, :, ::1] M02,
+    np_floats[:, :, ::1] M11, np_floats[:, :, ::1] M12, np_floats[:, :, ::1] M22,
+):
+    """Determinant for real, symmetric 3 x 3 matrices."""
+    cdef:
+        cnp.float64_t m00, m01, m02, m11, m12, m22;
+        Py_ssize_t planes = M00.shape[0];
+        Py_ssize_t rows = M00.shape[1];
+        Py_ssize_t cols = M00.shape[2];
+        Py_ssize_t pln, row, col;
+
+    if np_floats is cnp.float32_t:
+        dtype = np.float32
+    else:
+        dtype = np.float64
+
+    cdef np_floats[:, :, ::1] det = np.zeros((planes, rows, cols), dtype=dtype)
+
+    with nogil:
+
+        for pln in range(planes):
+            for row in range(rows):
+                for col in range(cols):
+                    m00 = <cnp.float64_t>(M00[pln, row, col])
+                    m01 = <cnp.float64_t>(M01[pln, row, col])
+                    m02 = <cnp.float64_t>(M02[pln, row, col])
+                    m11 = <cnp.float64_t>(M11[pln, row, col])
+                    m12 = <cnp.float64_t>(M12[pln, row, col])
+                    m22 = <cnp.float64_t>(M22[pln, row, col])
+                    det[pln, row, col] = (
+                        m00 * (m11 * m22 - m12 * m12)
+                        - m01 * (m01 * m22 - m12 * m02)
+                        + m02 * (m01 * m12 - m11 * m02)
+                    )
+    return np.asarray(det)
 
 
 def _corner_moravec(np_floats[:, ::1] cimage, Py_ssize_t window_size=1):

--- a/skimage/feature/corner_cy.pyx
+++ b/skimage/feature/corner_cy.pyx
@@ -76,9 +76,10 @@ def _real_symmetric_3x3_evs(
 
     Parameters
     ----------
-    a, d, f, b, e, c : cp.ndarray
-        Images corresponding to the individual components of the matrix, `M`,
-        shown above. For example, ``d = M[0, 1]``.
+    M00, M01, M02, M11, M12, M22 : cp.ndarray
+        Images corresponding to the individual components of the symmteric,
+        real-valued matrix M. `M01`, for instance, represents entry ``M[0, 1]``
+        (equivalent to ``M[1, 0]`` by symmetry).
     sort : {"ascending", "descending"}, optional
         Eigenvalues should be sorted in the specified order.
     abs_sort : boolean, optional

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -250,7 +250,7 @@ def _reference_eigvals_computation(S_elems):
 def test_hessian_eigvals_analytical(shape, dtype):
     rng = np.random.default_rng(seed=5)
     img = rng.integers(0, 256, shape)
-    H = hessian_matrix(img)
+    H = hessian_matrix(img, use_gaussian_derivatives=False)
     H = tuple(h.astype(dtype, copy=False) for h in H)
     evs1 = _reference_eigvals_computation(H)
     evs2 = hessian_matrix_eigvals(H)

--- a/skimage/filters/tests/test_ridges.py
+++ b/skimage/filters/tests/test_ridges.py
@@ -175,7 +175,6 @@ def test_2d_cropped_camera_image():
     a_black = crop(camera(), ((200, 212), (100, 312)))
     a_white = invert(a_black)
 
-    zeros = np.zeros((100, 100))
     ones = np.ones((100, 100))
 
     assert_allclose(meijering(a_black, black_ridges=True),
@@ -218,7 +217,6 @@ def test_3d_cropped_camera_image(uniform_stack):
         tol = 1e-10
     a_white = invert(a_black)
 
-    zeros = np.zeros(a_black.shape)
     ones = np.ones(a_black.shape)
 
     assert_allclose(meijering(a_black, black_ridges=True),

--- a/skimage/filters/tests/test_ridges.py
+++ b/skimage/filters/tests/test_ridges.py
@@ -200,23 +200,36 @@ def test_ridge_output_dtype(func, dtype):
     assert func(img).dtype == _supported_float_type(img.dtype)
 
 
-def test_3d_cropped_camera_image():
+@pytest.mark.parametrize('uniform_stack', [False, True])
+def test_3d_cropped_camera_image(uniform_stack):
 
     a_black = crop(camera(), ((200, 212), (100, 312)))
-    a_black = np.stack([a_black] * 5, axis=-1)
+    if uniform_stack:
+        # Hessian along last axis will be 0 due to identical image content
+        a_black = np.stack([a_black] * 5, axis=-1)
+        # in this uniform_stack case, numerical error seems to be higher
+        tol = 1e-5
+    else:
+        # stack using shift to give a non-zero Hessian on the last axis
+        a_black = np.stack(
+            [np.roll(a_black, shift=n, axis=0) for n in range(5)],
+            axis=-1
+        )
+        tol = 1e-10
     a_white = invert(a_black)
 
     zeros = np.zeros(a_black.shape)
     ones = np.ones(a_black.shape)
 
     assert_allclose(meijering(a_black, black_ridges=True),
-                    meijering(a_white, black_ridges=False))
+                    meijering(a_white, black_ridges=False), atol=tol, rtol=tol)
 
     assert_allclose(sato(a_black, black_ridges=True, mode='reflect'),
-                    sato(a_white, black_ridges=False, mode='reflect'))
+                    sato(a_white, black_ridges=False, mode='reflect'),
+                    atol=tol, rtol=tol)
 
     assert_allclose(frangi(a_black, black_ridges=True),
-                    frangi(a_white, black_ridges=False))
+                    frangi(a_white, black_ridges=False), atol=tol, rtol=tol)
 
     assert_allclose(hessian(a_black, black_ridges=True, mode='reflect'),
                     ones, atol=1 - 1e-7)


### PR DESCRIPTION
closes #6635.  Should also give further improvement for issue #6507.

Faster and more memory efficient eigenvalue and determinant computations as used by several feature and filter functions. This is a port of downstream PR rapidsai/cucim#434. Details of the functions benefiting from this are listed in #6635

There are no changes to the public API. Behavior is the same aside from possible numeric precision / floating point rounding differences. New test functions were added to verify a close match to the prior implementation.

The private `_symmetric_compute_eigenvalues` helper gets a couple of optional kwargs to control how the eigenvalues are sorted. Values other than the default are currently only used to avoid additional sorting steps for the `frangi` ridge filter.

The old implementation involved formation of a large `_symmetric_image` intermediate array of shape `(rows, cols, 2, 2)` in 2D or `(planes, rows, cols, 3, 3)` in 3D and then passes that to a `numpy.linalg` function. The new implementation does not form this intermediate array at all, so the large memory overhead is avoided. Using an analytical solution rather than a generic solver is also more performant.

Benchmark results for `hessian_matrix_det` and `hessian_matrix_eigvals` are shown below. The reference `peakmem` is mainly due to computation of the hessian matrix itself. It can be seen that the old implementation substantially increased peak memory usage above that for just computing the hessian itself, while the new one does not. Performance is also substantially better than previously (30-40x for 2D eigenvalues and ~10x for 3D eigenvalues). It is also 4-5x better for the determinant even though the time for this function also involves computation of the hessian matrix itself.

### hessian_matrix_det

shape           | duration (old) | duration (new) | peakmem (old) | peakmem (new) | peakmem (reference)
----------------|----------------|----------------|---------------|---------------|--------------------
(512, 512)      | 0.0555 s       | 0.0100 s       | 98.9 M        | 86.3 M        | 86.3 M
(3840, 2160)    | 1.4400 s       | 0.2530 s       | 837 M         | 528 M         | 528 M
(64, 48, 32)    | 0.0298 s       | 0.0073 s       | 91.7 M        | 81.2 M        | 80.7 M
(128, 96, 64)   | 0.2300 s       | 0.0452 s       | 216 M         | 132 M         | 131 M
(256, 192, 128) | 1.8000 s       | 0.3510 s       | 1210 M        | 528 M         | 528 M

### hessian_matrix_eigvals

shape           | duration (old) | duration (new) | peakmem (old) | peakmem (new) | peakmem (reference)
----------------|----------------|----------------|---------------|---------------|--------------------
(512, 512)      | 0.0650 s       | 0.0018 s       | 101 M         | 83.1 M        | 83.1 M
(3840, 2160)    | 1.8500 s       | 0.0457 s       | 772 M         | 340 M         | 340 M
(64, 48, 32)    | 0.1170 s       | 0.0177 s       | 93 M          | 78.7 M        | 78.7
(128, 96, 64)   | 0.6280 s       | 0.0593 s       | 208 M         | 113 M         | 113 M
(256, 192, 128) | 4.5400 s       | 0.4680 s       | 1110 M        | 376 M         | 376 M