### PR TITLE
Handle new warnings introduced in NumPy 1.24

### DIFF
--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -256,6 +256,14 @@ def setup_test():
             category=DeprecationWarning
         )
 
+        # ignore dtype deprecation warning from NumPy arising from use of SciPy
+        # as a reference in test_watershed09
+        warnings.filterwarnings(
+            'default',
+            message=('`np.int0` is a deprecated alias for `np.intp`'),
+            category=DeprecationWarning
+        )
+
 
 def teardown_test():
     """Default package level teardown routine for skimage tests.

--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -257,7 +257,8 @@ def setup_test():
         )
 
         # ignore dtype deprecation warning from NumPy arising from use of SciPy
-        # as a reference in test_watershed09
+        # as a reference in test_watershed09. Should be fixed in scipy>=1.9.4
+        # https://github.com/scipy/scipy/commit/da3ff893b9ac161938e11f9bcd5380e09cf03150
         warnings.filterwarnings(
             'default',
             message=('`np.int0` is a deprecated alias for `np.intp`'),

--- a/skimage/color/tests/test_delta_e.py
+++ b/skimage/color/tests/test_delta_e.py
@@ -30,8 +30,7 @@ def test_ciede2000_dE(dtype, channel_axis):
     dE2 = deltaE_ciede2000(lab1, lab2, channel_axis=channel_axis)
     assert dE2.dtype == _supported_float_type(dtype)
 
-    rtol = 1e-2 if dtype == np.float32 else 1e-4
-    assert_allclose(dE2, data['dE'], rtol=rtol)
+    assert_allclose(dE2, data['dE'], rtol=1e-2)
 
 
 def load_ciede2000_data():

--- a/skimage/feature/_cascade.pyx
+++ b/skimage/feature/_cascade.pyx
@@ -909,7 +909,9 @@ cdef class Cascade:
                 feature_number = int(internal_nodes[0])
                 # list() is for Python3 fix here
                 lut_array = list(map(lambda x: int(x), internal_nodes[1:]))
-                lut = np.asarray(lut_array, dtype='uint32')
+                # Cast via astype to avoid warning about integer wraparound.
+                # see: https://github.com/scikit-image/scikit-image/issues/6638
+                lut = np.asarray(lut_array).astype(np.uint32)
 
                 # Copy array to the main LUT array
                 for i in range(8):

--- a/skimage/feature/tests/test_cascade.py
+++ b/skimage/feature/tests/test_cascade.py
@@ -1,5 +1,8 @@
+import warnings
+
 import skimage.data as data
 from skimage.feature import Cascade
+
 
 
 def test_detector_astronaut():
@@ -8,7 +11,13 @@ def test_detector_astronaut():
     trained_file = data.lbp_frontal_face_cascade_filename()
 
     # Initialize the detector cascade.
-    detector = Cascade(trained_file)
+    with warnings.catch_warnings():
+        # TODO: Ignore warning on overflow of negative values to positive in
+        #       cast to uint32. Should determine the cause of negative values
+        #       in trained_file
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+        detector = Cascade(trained_file)
 
     img = data.astronaut()
 

--- a/skimage/feature/tests/test_cascade.py
+++ b/skimage/feature/tests/test_cascade.py
@@ -1,5 +1,3 @@
-import warnings
-
 import skimage.data as data
 from skimage.feature import Cascade
 
@@ -11,13 +9,7 @@ def test_detector_astronaut():
     trained_file = data.lbp_frontal_face_cascade_filename()
 
     # Initialize the detector cascade.
-    with warnings.catch_warnings():
-        # TODO: Ignore warning on overflow of negative values to positive in
-        #       cast to uint32. Should determine the cause of negative values
-        #       in trained_file
-        warnings.filterwarnings("ignore", category=DeprecationWarning)
-
-        detector = Cascade(trained_file)
+    detector = Cascade(trained_file)
 
     img = data.astronaut()
 

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -142,10 +142,15 @@ def relabel_sequential(label_field, offset=1):
     if input_type.itemsize < required_type.itemsize:
         output_type = required_type
     else:
-        if input_type.type(out_vals[-1]) == out_vals[-1]:
-            output_type = input_type
-        else:
-            output_type = required_type
+        with warnings.catch_warnings():
+            # Ignore RuntimeWarning from NumPy>=1.24 on the potentially invalid
+            # cast we are checking for here.
+            warnings.filterwarnings('ignore', category=RuntimeWarning)
+
+            if input_type.type(out_vals[-1]) == out_vals[-1]:
+                output_type = input_type
+            else:
+                output_type = required_type
     out_array = np.empty(label_field.shape, dtype=output_type)
     out_vals = out_vals.astype(output_type)
     map_array(label_field, in_vals, out_vals, out=out_array)

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -1,4 +1,7 @@
+import warnings
+
 import numpy as np
+
 from ..util._map_array import map_array, ArrayMap
 
 

--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -1,5 +1,7 @@
-import numpy as np
+import warnings
 from warnings import warn
+
+import numpy as np
 
 
 __all__ = ['img_as_float32', 'img_as_float64', 'img_as_float',
@@ -24,12 +26,19 @@ _integer_ranges = {t: (np.iinfo(t).min, np.iinfo(t).max)
                    for t in _integer_types}
 dtype_range = {bool: (False, True),
                np.bool_: (False, True),
-               np.bool8: (False, True),
                float: (-1, 1),
                np.float_: (-1, 1),
                np.float16: (-1, 1),
                np.float32: (-1, 1),
                np.float64: (-1, 1)}
+
+with warnings.catch_warnings():
+    warnings.filterwarnings('ignore', category=DeprecationWarning)
+
+    # np.bool8 is a deprecated alias of np.bool_
+    if hasattr(np, 'bool8'):
+        dtype_range[np.bool8] = (False, True)
+
 dtype_range.update(_integer_ranges)
 
 _supported_types = list(dtype_range.keys())

--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -109,7 +109,7 @@ def test_copy():
 
 def test_bool():
     img_ = np.zeros((10, 10), bool)
-    img8 = np.zeros((10, 10), np.bool8)
+    img8 = np.zeros((10, 10), np.bool_)
     img_[1, 1] = True
     img8[1, 1] = True
     for (func, dt) in [(img_as_int, np.int16),


### PR DESCRIPTION
The pre-release test case on CI fails due to a few new warnings introduced in NumPy 1.24 ([example of a recent test log](https://github.com/scikit-image/scikit-image/actions/runs/3561205333/jobs/5981908484)). (Our pre-release test CI job treats warnings as errors via env var `SKIMAGE_TEST_STRICT_WARNINGS_GLOBAL=1`)

The changes here should resolve these failures.