### PR TITLE
Fix doc build on CircleCI and add ccache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,16 +7,27 @@ jobs:
     steps:
       - checkout
       - run:
-          name: concatenate requirement files
+          name: Install apt packages
+          command: |
+            sudo apt-get update
+            sudo apt-get install ccache
+      - run:
+          name: Concatenate requirement files
           command: cat requirements/*.txt > requirements/all_requirements
       - restore_cache:
+          name: restore cached data files
           keys:
             - data-v1-{{ checksum "skimage/data/_registry.py" }}
       - restore_cache:
+          name: Restore cached pip dependencies
           keys:
             - packages-v1-{{ checksum "requirements/all_requirements" }}
+      - restore_cache:
+          name: Restore cached build files (ccache)
+          keys:
+            - ccache-v2-{{ .Branch }}
       - run:
-          name: install dependencies and package
+          name: Install dependencies and build package
           command: |
             python3 -m pip install --upgrade pip
             python3 -m pip install -r requirements/build.txt
@@ -25,17 +36,24 @@ jobs:
             python3 -m pip install -r requirements/default.txt
             python3 -m pip install -r requirements/docs.txt
       - save_cache:
+          name: Cache pip dependencies
           key: packages-v1-{{ checksum "requirements/all_requirements" }}
           paths:
-            - skimage_venv
+            - ~/.cache/pip
+      - save_cache:
+          name: Cache build files (ccache)
+          key: ccache-v2-{{ .Branch }}
+          paths:
+            - ~/.cache/ccache
       - run:
-          name: build doc
+          name: Build doc
           no_output_timeout: 50m
           command: |
             cd doc
             PYTHON=python3 make clean
             PYTHON=python3 SPHINXOPTS="-j 1" make html
       - save_cache:
+          name: Cache data files
           key: data-v1-{{ checksum "skimage/data/_registry.py" }}
           paths:
             - /home/circleci/.cache/scikit-image/master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   doc:
     machine:
-      image: ubuntu-2204
+      image: ubuntu-2204:current
     steps:
       - checkout
       - run:
@@ -18,14 +18,12 @@ jobs:
       - run:
           name: install dependencies and package
           command: |
-            python -m venv skimage_venv
-            source skimage_venv/bin/activate
-            python -m pip install --upgrade pip
-            python -m pip install -r requirements/build.txt
-            python -m pip install -vv --no-build-isolation .
-            python -m pip install -r requirements/default.txt
-            python -m pip install -r requirements/docs.txt
-            export
+            python3 -m pip install --upgrade pip
+            python3 -m pip install -r requirements/build.txt
+            python3 -m pip install -vv --no-build-isolation .
+            # Ensure build succeeds without runtime requirements
+            python3 -m pip install -r requirements/default.txt
+            python3 -m pip install -r requirements/docs.txt
       - save_cache:
           key: packages-v1-{{ checksum "requirements/all_requirements" }}
           paths:
@@ -34,10 +32,9 @@ jobs:
           name: build doc
           no_output_timeout: 50m
           command: |
-            source skimage_venv/bin/activate
             cd doc
-            make clean
-            SPHINXOPTS="-j 1" make html
+            PYTHON=python3 make clean
+            PYTHON=python3 SPHINXOPTS="-j 1" make html
       - save_cache:
           key: data-v1-{{ checksum "skimage/data/_registry.py" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,10 @@ jobs:
             # Ensure build succeeds without runtime requirements
             python3 -m pip install -r requirements/default.txt
             python3 -m pip install -r requirements/docs.txt
+      - run:
+          name: Print ccache performance
+          command: |
+            ccache -s
       - save_cache:
           name: Cache pip dependencies
           key: packages-v1-{{ checksum "requirements/all_requirements" }}


### PR DESCRIPTION
## Description

Try to debug and fix #6645.

Link for convenience: https://app.circleci.com/pipelines/github/scikit-image/scikit-image

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
