### PR TITLE
Remove thumbnail_size in config since sphinx-gallery>=0.9.0.

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -41,5 +41,3 @@ Other
   on macOS. See https://github.com/scikit-image/scikit-image/pull/3898
 * When sphinx-gallery>=0.9.0, remove the thumbnail_size in
   doc/source/conf.py as the default value will be comparable (#4801).
-* When ``scipy`` is set to >= 1.8.0, remove conditional import of QhullError in
-  ``skimage/morphology/convex_hull.py``.

--- a/TODO.txt
+++ b/TODO.txt
@@ -39,7 +39,5 @@ Other
 -----
 * Check whether imread wheels are available, then re-enable testing imread
   on macOS. See https://github.com/scikit-image/scikit-image/pull/3898
-* When sphinx-gallery>=0.9.0, remove the thumbnail_size in
-  doc/source/conf.py as the default value will be comparable (#4801).
 * When ``scipy`` is set to >= 1.8.0, remove conditional import of QhullError in
   ``skimage/morphology/convex_hull.py``.

--- a/TODO.txt
+++ b/TODO.txt
@@ -41,3 +41,5 @@ Other
   on macOS. See https://github.com/scikit-image/scikit-image/pull/3898
 * When sphinx-gallery>=0.9.0, remove the thumbnail_size in
   doc/source/conf.py as the default value will be comparable (#4801).
+* When ``scipy`` is set to >= 1.8.0, remove conditional import of QhullError in
+  ``skimage/morphology/convex_hull.py``.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -89,7 +89,6 @@ sphinx_gallery_conf = {
     "backreferences_dir": "api",
     "reference_url": {"skimage": None},
     "image_scrapers": ("matplotlib", plotly_sg_scraper),
-    "thumbnail_size": (280, 196),
     "subsection_order": ExplicitOrder(
         [
             "../examples/data",


### PR DESCRIPTION
## Description

I was reading through https://github.com/scikit-image/scikit-image/blob/main/RELEASE.txt and saw:
https://github.com/scikit-image/scikit-image/blob/26d7c3905b95244784a2bef32e06dd3878fb50b1/RELEASE.txt#L17

I have simply addressed an old item under 'other' in the TODO list, since we are at
https://github.com/scikit-image/scikit-image/blob/26d7c3905b95244784a2bef32e06dd3878fb50b1/requirements/docs.txt#L2

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
