### PR TITLE
allow masks to be computed with arbitrary offsets relative to polygons

### DIFF
--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -243,8 +243,8 @@ def _polygon(r, c, shape, offset):
     cdef Py_ssize_t minr_image = max(offset[0], minr)
     cdef Py_ssize_t minc_image = max(offset[1], minc)
     # max extent is determined by shape if supplied, otherwise determined by polygon vertices
-    cdef Py_ssize_t maxr_image = offset[0] + shape[0] - 1 is shape is not None else maxr
-    cdef Py_ssize_t maxc_image = offset[1] + shape[1] - 1 is shape is not None else maxr
+    cdef Py_ssize_t maxr_image = offset[0] + shape[0] - 1 if shape is not None else maxr
+    cdef Py_ssize_t maxc_image = offset[1] + shape[1] - 1 if shape is not None else maxr
     # image max cant be less than min
     maxr_image = max(maxr_image, minr_image)
     maxc_image = max(maxc_image, minc_image)

--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -227,8 +227,7 @@ def _polygon(r, c, shape, offset):
 
     if offset is not None:
         # enforce offsets >= 0
-        offset[0] = max(0, offset[0])
-        offset[1] = max(0, offset[1])
+        offset = (max(0, offset[0]), max(0, offset[1]))
 
     cdef Py_ssize_t nr_verts = c.shape[0]
     cdef Py_ssize_t minr = int(max(offset[0] if offset is not None else 0, max(0, r.min())))

--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -230,9 +230,9 @@ def _polygon(r, c, shape, offset):
         offset = (max(0, offset[0]), max(0, offset[1]))
 
     cdef Py_ssize_t nr_verts = c.shape[0]
-    cdef Py_ssize_t minr = int(max(offset[0] if offset is not None else 0, max(0, r.min())))
+    cdef Py_ssize_t minr = int(max(offset[0], max(0, r.min())))
     cdef Py_ssize_t maxr = int(ceil(r.max()))
-    cdef Py_ssize_t minc = int(max(offset[1] if offset is not None else 0, max(0, c.min())))
+    cdef Py_ssize_t minc = int(max(offset[1], max(0, c.min())))
     cdef Py_ssize_t maxc = int(ceil(c.max()))
 
     # make sure output coordinates do not exceed image size

--- a/skimage/draw/_polygon2mask.py
+++ b/skimage/draw/_polygon2mask.py
@@ -38,6 +38,9 @@ def polygon2mask(image_shape, polygon, offset=None):
     vertex_row_coords, vertex_col_coords = polygon.T
     fill_row_coords, fill_col_coords = draw.polygon(
         vertex_row_coords, vertex_col_coords, image_shape, offset)
+    if offset is not None:
+        image_shape = (image_shape[0] - max(offset[0], 0),
+                       image_shape[1] - max(offset[1], 0))
     mask = np.zeros(image_shape, dtype=bool)
     mask[fill_row_coords, fill_col_coords] = True
     return mask

--- a/skimage/draw/_polygon2mask.py
+++ b/skimage/draw/_polygon2mask.py
@@ -3,7 +3,7 @@ import numpy as np
 from . import draw
 
 
-def polygon2mask(image_shape, polygon):
+def polygon2mask(image_shape, polygon, offset=None):
     """Compute a mask from polygon.
 
     Parameters
@@ -13,6 +13,8 @@ def polygon2mask(image_shape, polygon):
     polygon : array_like.
         The polygon coordinates of shape (N, 2) where N is
         the number of points.
+    offset : tuple of size 2.
+        The pixel offset of the mask.
 
     Returns
     -------
@@ -35,7 +37,7 @@ def polygon2mask(image_shape, polygon):
     polygon = np.asarray(polygon)
     vertex_row_coords, vertex_col_coords = polygon.T
     fill_row_coords, fill_col_coords = draw.polygon(
-        vertex_row_coords, vertex_col_coords, image_shape)
+        vertex_row_coords, vertex_col_coords, image_shape, offset)
     mask = np.zeros(image_shape, dtype=bool)
     mask[fill_row_coords, fill_col_coords] = True
     return mask

--- a/skimage/draw/_polygon2mask.py
+++ b/skimage/draw/_polygon2mask.py
@@ -13,7 +13,7 @@ def polygon2mask(image_shape, polygon, offset=None):
     polygon : array_like.
         The polygon coordinates of shape (N, 2) where N is
         the number of points.
-    offset : tuple of size 2.
+    offset : tuple  of ints of size 2.
         The pixel offset of the mask.
 
     Returns

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -449,12 +449,14 @@ def polygon(r, c, shape=None, offset=None):
         size. If None, the full extent of the polygon is used.  Must be at
         least length 2. Only the first two values are used to determine the
         extent of the input image.
-    offset: tuple
+    offset: tuple of int, optional
         Pixel offset of that returned coordinates will exceed. This is
         useful for polygons that span a very large number of pixels,
         when getting all pixels at once would use too much memory.
         If None, default to using larger of 0 and the minimum vertex
-        coordinate of the polygon
+        coordinate of the polygon. Must be at least length 2. Only
+        the first two values are used to determine the extent of the input
+        image.
 
     Returns
     -------
@@ -483,6 +485,17 @@ def polygon(r, c, shape=None, offset=None):
            [0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=uint8)
 
+    >>> from skimage.draw import polygon
+    >>> img = np.zeros((10, 10), dtype=np.uint8)
+    >>> r = np.array([1, 2, 8])
+    >>> c = np.array([1, 7, 4])
+    >>> rr, cc = polygon(r, c, shape=(4,4), offset=(2,2))
+    >>> img[rr, cc] = 1
+    >>> img
+    array([[1, 1, 1, 1],
+           [1, 1, 1, 1],
+           [0, 1, 1, 1],
+           [0, 1, 1, 1]], dtype=uint8)
     """
     return _polygon(r, c, shape, offset)
 

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -486,10 +486,11 @@ def polygon(r, c, shape=None, offset=None):
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=uint8)
 
     >>> from skimage.draw import polygon
-    >>> img = np.zeros((10, 10), dtype=np.uint8)
+    >>> shape = (4, 4)
+    >>> img = np.zeros(shape, dtype=np.uint8)
     >>> r = np.array([1, 2, 8])
     >>> c = np.array([1, 7, 4])
-    >>> rr, cc = polygon(r, c, shape=(4,4), offset=(2,2))
+    >>> rr, cc = polygon(r, c, shape=shape, offset=(2, 2))
     >>> img[rr, cc] = 1
     >>> img
     array([[1, 1, 1, 1],

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -434,7 +434,7 @@ def line_aa(r0, c0, r1, c1):
     return _line_aa(r0, c0, r1, c1)
 
 
-def polygon(r, c, shape=None):
+def polygon(r, c, shape=None, offset=None):
     """Generate coordinates of pixels within polygon.
 
     Parameters
@@ -449,6 +449,12 @@ def polygon(r, c, shape=None):
         size. If None, the full extent of the polygon is used.  Must be at
         least length 2. Only the first two values are used to determine the
         extent of the input image.
+    offset: tuple
+        Pixel offset of that returned coordinates will exceed. This is
+        useful for polygons that span a very large number of pixels,
+        when getting all pixels at once would use too much memory.
+        If None, default to using larger of 0 and the minimum vertex
+        coordinate of the polygon
 
     Returns
     -------
@@ -478,7 +484,7 @@ def polygon(r, c, shape=None):
            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=uint8)
 
     """
-    return _polygon(r, c, shape)
+    return _polygon(r, c, shape, offset)
 
 
 def circle_perimeter(r, c, radius, method='bresenham', shape=None):

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -498,7 +498,12 @@ def polygon(r, c, shape=None, offset=None):
            [0, 1, 1, 1],
            [0, 1, 1, 1]], dtype=uint8)
     """
-    return _polygon(r, c, shape, offset)
+    r = np.atleast_1d(r)
+    c = np.atleast_1d(c)
+    if offset is not None:
+        r -= offset[0]
+        c -= offset[1]
+    return _polygon(r, c, shape)
 
 
 def circle_perimeter(r, c, radius, method='bresenham', shape=None):

--- a/skimage/draw/tests/test_draw.py
+++ b/skimage/draw/tests/test_draw.py
@@ -177,6 +177,40 @@ def test_polygon_rectangle_angular():
 
     assert_array_equal(img, img_)
 
+def test_polygon_rectangle_angular_offset_no_shape():
+    img = np.zeros((10, 10), 'uint8')
+    poly = np.array(((0, 3), (4, 7), (7, 4), (3, 0), (0, 3)))
+
+    rr, cc = polygon(poly[:, 0], poly[:, 1], offset=(2, 2))
+    img[rr, cc] = 1
+
+    img_ = np.array(
+        [[1, 1, 1, 1, 0, 0, 0, 0],
+         [1, 1, 1, 1, 1, 0, 0, 0],
+         [1, 1, 1, 1, 1, 1, 0, 0],
+         [1, 1, 1, 1, 1, 0, 0, 0],
+         [0, 1, 1, 1, 0, 0, 0, 0],
+         [0, 0, 1, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0, 0, 0, 0]], 'uint8'
+    )
+
+    assert_array_equal(img, img_)
+
+def test_polygon_rectangle_angular_offset_and_shape():
+    img = np.zeros((10, 10), 'uint8')
+    poly = np.array(((0, 3), (4, 7), (7, 4), (3, 0), (0, 3)))
+
+    rr, cc = polygon(poly[:, 0], poly[:, 1], shape=(3, 3), offset=(2, 2))
+    img[rr, cc] = 1
+
+    img_ = np.array(
+        [[1, 1, 1],
+         [1, 1, 1],
+         [1, 1, 1]], 'uint8'
+    )
+
+    assert_array_equal(img, img_)
 
 def test_polygon_parallelogram():
     img = np.zeros((10, 10), 'uint8')

--- a/skimage/draw/tests/test_draw.py
+++ b/skimage/draw/tests/test_draw.py
@@ -198,16 +198,16 @@ def test_polygon_rectangle_angular_offset_no_shape():
     assert_array_equal(img, img_)
 
 def test_polygon_rectangle_angular_offset_and_shape():
-    img = np.zeros((3, 3), 'uint8')
+    img = np.zeros((3, 4), 'uint8')
     poly = np.array(((0, 3), (4, 7), (7, 4), (3, 0), (0, 3)))
 
-    rr, cc = polygon(poly[:, 0], poly[:, 1], shape=img.shape, offset=(2, 2))
+    rr, cc = polygon(poly[:, 0], poly[:, 1], shape=img.shape, offset=(3, 2))
     img[rr, cc] = 1
 
     img_ = np.array(
-        [[1, 1, 1],
-         [1, 1, 1],
-         [1, 1, 1]], 'uint8'
+        [[1, 1, 1, 1],
+         [1, 1, 1, 1],
+         [1, 1, 1, 1]], 'uint8'
     )
 
     assert_array_equal(img, img_)

--- a/skimage/draw/tests/test_draw.py
+++ b/skimage/draw/tests/test_draw.py
@@ -178,7 +178,7 @@ def test_polygon_rectangle_angular():
     assert_array_equal(img, img_)
 
 def test_polygon_rectangle_angular_offset_no_shape():
-    img = np.zeros((10, 10), 'uint8')
+    img = np.zeros((8, 8), 'uint8')
     poly = np.array(((0, 3), (4, 7), (7, 4), (3, 0), (0, 3)))
 
     rr, cc = polygon(poly[:, 0], poly[:, 1], offset=(2, 2))
@@ -198,10 +198,10 @@ def test_polygon_rectangle_angular_offset_no_shape():
     assert_array_equal(img, img_)
 
 def test_polygon_rectangle_angular_offset_and_shape():
-    img = np.zeros((10, 10), 'uint8')
+    img = np.zeros((3, 3), 'uint8')
     poly = np.array(((0, 3), (4, 7), (7, 4), (3, 0), (0, 3)))
 
-    rr, cc = polygon(poly[:, 0], poly[:, 1], shape=(3, 3), offset=(2, 2))
+    rr, cc = polygon(poly[:, 0], poly[:, 1], shape=img.shape, offset=(2, 2))
     img[rr, cc] = 1
 
     img_ = np.array(


### PR DESCRIPTION
## Description

I'm trying to use Napari to generate a mask based on a user drawn polygon over a very large (multi-resolution) image. The image is big enough that I don't want to generate the whole thing at once and overload memory. The existing polygon drawing functionality allows the specification of an arbitrary image shape, but this always seems to be anchored to the top left corner of the polygon. So this PR adds an `offset` parameter that allows a mask to be computed at an arbitrary location and shape relative to the polygon.

The changes seem pretty straightforward, though I haven't tested them because I'm unsure how to compile and use these .pyx files (any help appreciated!).

@jni , since I know you work on both napari and skimage


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
