### PR TITLE
DOC: Get rid of numpy dep warning in plot_equalize.

### DIFF
--- a/doc/examples/color_exposure/plot_equalize.py
+++ b/doc/examples/color_exposure/plot_equalize.py
@@ -71,7 +71,7 @@ img_adapteq = exposure.equalize_adapthist(img, clip_limit=0.03)
 
 # Display results
 fig = plt.figure(figsize=(8, 5))
-axes = np.zeros((2, 4), dtype=np.object)
+axes = np.zeros((2, 4), dtype=object)
 axes[0, 0] = fig.add_subplot(2, 4, 1)
 for i in range(1, 4):
     axes[0, i] = fig.add_subplot(2, 4, 1+i, sharex=axes[0,0], sharey=axes[0,0])


### PR DESCRIPTION
A cosmetic change to remove [the warning from the plot_equalize example](https://scikit-image.org/docs/dev/auto_examples/color_exposure/plot_equalize.html#sphx-glr-auto-examples-color-exposure-plot-equalize-py).