### PR TITLE
DOC: Get rid of numpy dep warning in plot_log_gamma.py

### DIFF
--- a/doc/examples/color_exposure/plot_log_gamma.py
+++ b/doc/examples/color_exposure/plot_log_gamma.py
@@ -55,7 +55,7 @@ logarithmic_corrected = exposure.adjust_log(img, 1)
 
 # Display results
 fig = plt.figure(figsize=(8, 5))
-axes = np.zeros((2, 3), dtype=np.object)
+axes = np.zeros((2, 3), dtype=object)
 axes[0, 0] = plt.subplot(2, 3, 1)
 axes[0, 1] = plt.subplot(2, 3, 2, sharex=axes[0, 0], sharey=axes[0, 0])
 axes[0, 2] = plt.subplot(2, 3, 3, sharex=axes[0, 0], sharey=axes[0, 0])


### PR DESCRIPTION
A tiny change to remove warning: "DeprecationWarning: np.object is a deprecated alias for the builtin object. To silence this warning, use object by itself. Doing this will not modify any behavior and is safe. Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations np.object".

https://scikit-image.org/docs/stable/auto_examples/color_exposure/plot_log_gamma.html?highlight=log_gamma
![image](https://user-images.githubusercontent.com/3051351/208248936-9db9bdbe-97c2-4d35-80b8-81655a13f3b4.png)


Similar to #6650

<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
