### PR TITLE
Build wheels on CI via branch rather than tag

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -2,8 +2,10 @@ name: Build Wheels and Release
 on:
   push:
     tags:
-      - "v*"
-      - "buildwheels*"
+      - v*
+    branches:
+      - maintenance/**
+
 env:
   CIBW_BUILD_VERBOSITY: 2
   CIBW_TEST_REQUIRES: "-r requirements/default.txt -r requirements/test.txt"

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -73,24 +73,10 @@ the appropriate point in main and the following instructions are still apt.
   `NumpyVersion <https://github.com/scikit-image/scikit-image/pull/4947>`_
   correctly interprets the version number.
 
+- To debug building and testing wheels via CI, push to a branch named
+  `maintenance/anything`.
 
-- If you wish, you can iterate with the following steps until the building
-  and testing of the wheels by CI is to your satisfaction.
-
-
-  1. Add a tag in git that starts with the string "buildwheels"::
-
-    git tag -m <github_release_message> buildwheels_<major>.<minor>.0test
-
-  2. Push the new tag to GitHub (you can delete these after if you wish)::
-
-    git push upstream buildwheels_<major>.<minor>.0test
-
-        (where ``upstream`` is the name of the
-        ``github.com:scikit-image/scikit-image`` repository.)
-
-  Once you are happy with the above (making changes/fixes as required), you can
-  proceed with the following steps.
+  Once everything works as intended, remove those branches and proceed.
 
 - Edit ``doc/source/_static/docversions.js`` in order to
   add the release, e.g., `0.15.x`, and commit.


### PR DESCRIPTION
Branches tend to be easier to work with than tags, and you can push to them multiple times.

