### PR TITLE
Add more test cases to test_downsize

### DIFF
--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -519,6 +519,20 @@ def test_downsize(dtype):
     assert scaled[2:, :].sum() == 0
     assert scaled[:, 2:].sum() == 0
 
+    x = np.zeros((10, 10), dtype=dtype)
+    x[1:3, 1:3] = 1
+    scaled = resize(x, (5, 5), order=0, anti_aliasing=False, mode='constant')
+    expected_dtype = np.float32 if dtype == np.float16 else dtype
+    assert scaled.dtype == expected_dtype
+    assert scaled.shape == (5, 5)
+    assert scaled[0, 0] == 1
+    assert scaled[1:, :].sum() == 0
+    assert scaled[:, 1:].sum() == 0
+
+    x = np.eye(10, dtype=dtype)
+    scaled = resize(x, (5, 5), order=0, anti_aliasing=False, mode='constant')
+    np.testing.assert_array_equal(scaled, np.eye(5))
+
 
 def test_downsize_anti_aliasing():
     x = np.zeros((10, 10), dtype=np.float64)


### PR DESCRIPTION
## Description

We recently ran into an issue where skimage.transform.resize returned different results after upgrading from 0.18 to 0.19. Running these test cases convinced us it was more correct after the version upgrade. It is interesting to get this result though:
```
Original:
[[0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
 [0. 1. 1. 0. 0. 0. 0. 0. 0. 0.]
 [0. 1. 1. 0. 0. 0. 0. 0. 0. 0.]
 [0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
 [0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
 [0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
 [0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
 [0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
 [0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
 [0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]]

Old resize:
[[0. 0. 0. 0. 0.]
 [1. 0. 0. 0. 0.]
 [0. 0. 0. 0. 0.]
 [0. 0. 0. 0. 0.]
 [0. 0. 0. 0. 0.]]

New resize:
[[1. 0. 0. 0. 0.]
 [0. 0. 0. 0. 0.]
 [0. 0. 0. 0. 0.]
 [0. 0. 0. 0. 0.]
 [0. 0. 0. 0. 0.]]
```

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
