### PR TITLE
Use meson-python main branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ tracker = "https://github.com/scikit-image/scikit-image/issues"
 [build-system]
 build-backend = "mesonpy"
 requires = [
-    "meson-python>=0.11.0",
+    "git+https://github.com/mesonbuild/meson-python",
     # `wheel` is needed for non-isolated builds, given that `meson-python`
     # doesn't list it as a runtime requirement (at least in 0.10.0)
     # See https://github.com/FFY00/meson-python/blob/main/pyproject.toml#L4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ tracker = "https://github.com/scikit-image/scikit-image/issues"
 [build-system]
 build-backend = "mesonpy"
 requires = [
-    "git+https://github.com/mesonbuild/meson-python",
+    "meson-python @ git+https://github.com/mesonbuild/meson-python@babdf709618fbeeaf59634bc2b4331ca5f7924ce",
     # `wheel` is needed for non-isolated builds, given that `meson-python`
     # doesn't list it as a runtime requirement (at least in 0.10.0)
     # See https://github.com/FFY00/meson-python/blob/main/pyproject.toml#L4

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,4 +1,4 @@
-meson-python>=0.11.0
+git+https://github.com/mesonbuild/meson-python
 ninja
 Cython>=0.29.21
 packaging>=20.0


### PR DESCRIPTION
See https://github.com/scikit-image/scikit-image/issues/6667

<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
