### PR TITLE
Fix venv instructions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -52,10 +52,11 @@ Here's the long and short of it:
        ::
 
          # Create a virtualenv named ``skimage-dev`` that lives in the directory of
-         # the same name
-         python -m venv skimage-dev
+         # the same name. Note that ./dev.py breaks when the virtualenv is in the
+         # source tree, so we create it one level up.
+         python -m venv ../skimage-dev
          # Activate it
-         source skimage-dev/bin/activate
+         source ../skimage-dev/bin/activate
          # Install main development and runtime dependencies
          pip install -r requirements.txt
          # Install build dependencies of scikit-image

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -52,8 +52,8 @@ Here's the long and short of it:
        ::
 
          # Create a virtualenv named ``skimage-dev`` that lives outside of the repository.
-         # One convention is to use an ``envs`` directory under the home directory:
-         mkdir -p ~/envs
+         # One common convention is to place it inside an ``envs`` directory under your home directory:
+         mkdir ~/envs
          python -m venv ~/envs/skimage-dev
          # Activate it
          source ~/envs/skimage-dev/bin/activate

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -51,12 +51,12 @@ Here's the long and short of it:
 
        ::
 
-         # Create a virtualenv named ``skimage-dev`` that lives in the directory of
-         # the same name. Note that ./dev.py breaks when the virtualenv is in the
-         # source tree, so we create it one level up.
-         python -m venv ../skimage-dev
+         # Create a virtualenv named ``skimage-dev`` that lives in a dedicated directory outside
+         # the source tree. One suggestion below is to create an ~/envs folder:
+         mkdir -p ~/envs
+         python -m venv ~/envs/skimage-dev
          # Activate it
-         source ../skimage-dev/bin/activate
+         source ~/envs/skimage-dev/bin/activate
          # Install main development and runtime dependencies
          pip install -r requirements.txt
          # Install build dependencies of scikit-image

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -51,8 +51,8 @@ Here's the long and short of it:
 
        ::
 
-         # Create a virtualenv named ``skimage-dev`` that lives in a dedicated directory outside
-         # the source tree. One suggestion below is to create an ~/envs folder:
+         # Create a virtualenv named ``skimage-dev`` that lives outside of the repository.
+         # One convention is to use an ``envs`` directory under the home directory:
          mkdir -p ~/envs
          python -m venv ~/envs/skimage-dev
          # Activate it


### PR DESCRIPTION
## Description

Fixes issue identified in https://discuss.scientific-python.org/t/encountering-errors-following-start-of-development-process-in-scikit-image-contributing-rst/632/2. Updates the instructions for using venv+pip to ensure virtualenv created and run outside the source tree.

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
