### PR TITLE
Remove old scipy cruft

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -28,13 +28,6 @@ Other (2022)
 * Remove custom code for ignored warning in `skimage/_shared/testing.py` relating
   to (sparse) matricies (instead of arrays).
 
-Other (2023)
-------------
-* When ``scipy`` is set to >= 1.6.0, remove legacy (i.e. non-zoom) code paths in
-  ``skimage.transform.resize``.
-* When ``scipy`` is set to >= 1.6.0, remove SciPy version checks from
-  ``skimage._shared.utils._fix_ndimage_mode``
-
 Other
 -----
 * Check whether imread wheels are available, then re-enable testing imread

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -6,7 +6,6 @@ from collections.abc import Iterable
 
 import numpy as np
 import scipy
-from numpy.lib import NumpyVersion
 
 from ._warnings import all_warnings, warn
 
@@ -688,9 +687,7 @@ def _fix_ndimage_mode(mode):
     # SciPy 1.6.0 introduced grid variants of constant and wrap which
     # have less surprising behavior for images. Use these when available
     grid_modes = {'constant': 'grid-constant', 'wrap': 'grid-wrap'}
-    if NumpyVersion(scipy.__version__) >= '1.6.0':
-        mode = grid_modes.get(mode, mode)
-    return mode
+    return grid_modes.get(mode, mode)
 
 
 new_float_type = {


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
