### PR TITLE
possibly skip pythran include_directories during build

### DIFF
--- a/skimage/meson.build
+++ b/skimage/meson.build
@@ -61,7 +61,7 @@ if use_pythran
   ).stdout().strip()
   inc_pythran = include_directories(incdir_pythran)
 else
-  incdir_pythran = ""
+  incdir_pythran = ''
 endif
 
 cpp_args_pythran = [


### PR DESCRIPTION
## Description

During build via meson pythran is used if possible. I tried to build scikit-image without pythran when I had a problem (which I resolved later), but I still got an error because for `include_directories` it was still expected that pythran is installed. This PR disables the pythran-specific `include_directories` when `use_pythran == False` (e.g. via `SCIPY_USE_PYTHRAN=0`).

## For reviewers

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.