### PR TITLE
Advise users about removal of `future.graph.ncut`

### DIFF
--- a/skimage/future/graph/__init__.py
+++ b/skimage/future/graph/__init__.py
@@ -2,5 +2,6 @@
 
 raise ModuleNotFoundError(
     "The `skimage.future.graph` submodule was moved to `skimage.graph` in "
-    "v0.20. Please update your import paths accordingly."
+    "v0.20. `ncut` was removed in favor of the identical function "
+    "`cut_normalized`. Please update your import paths accordingly."
 )

--- a/skimage/future/tests/test_graph.py
+++ b/skimage/future/tests/test_graph.py
@@ -6,7 +6,8 @@ import pytest
 def test_future_graph_import_error():
     error_msg = (
         "The `skimage.future.graph` submodule was moved to `skimage.graph` in "
-        "v0.20. Please update your import paths accordingly."
+        "v0.20. `ncut` was removed in favor of the identical function "
+        "`cut_normalized`. Please update your import paths accordingly."
     )
     with pytest.raises(ModuleNotFoundError, match=error_msg):
         import skimage.future.graph


### PR DESCRIPTION
## Description

Just a small patch and addendum to #6674.

Before bf3cd84c8d86d30e3bd3a5ded21ec176e2a5f461 `skimage.future.graph.ncut` was a duplicate of `skimage.future.graph.cut_normalized` ([ref](https://github.com/scikit-image/scikit-image/blob/82331508becbca6a0735e4c1459eea2fb355b8ab/skimage/future/graph/__init__.py#L4)). In case someone tries to use it, the error message is a good place to point them to `cut_normalized`.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
