### PR TITLE
Document L*a*b* range in two colorspace conversion functions.

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1027,7 +1027,7 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     ----------
     lab : (..., 3, ...) array_like
         The input image in CIE-LAB color space.
-        By default, the final dimension denotes channels.
+        Unless `channel_axis` is set, the final dimension denotes the LAB channels.
         The range of L* values is 0 to 100;
         the range of a* values and b* values is -128 to 127.
     illuminant : {"A", "B", "C", "D50", "D55", "D65", "D75", "E"}, optional
@@ -1058,7 +1058,7 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
 
     Notes
     -----
-    By default, observer="2", illuminant="D65". CIE XYZ tristimulus values x_ref
+    By default, ``observer="2"``, ``illuminant="D65"``. CIE XYZ tristimulus values x_ref
     = 95.047, y_ref = 100., z_ref = 108.883. See function `get_xyz_coords` for
     a list of supported illuminants.
 

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1027,7 +1027,8 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     ----------
     lab : (..., 3, ...) array_like
         The input image in CIE-LAB color space.
-        Unless `channel_axis` is set, the final dimension denotes the LAB channels.
+        Unless `channel_axis` is set, the final dimension denotes the CIE-LAB
+        channels.
         The range of L* values is 0 to 100;
         the range of a* values and b* values is -128 to 127.
     illuminant : {"A", "B", "C", "D50", "D55", "D65", "D75", "E"}, optional
@@ -1149,7 +1150,8 @@ def lab2rgb(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     ----------
     lab : (..., 3, ...) array_like
         The input image in CIE-LAB color space.
-        By default, the final dimension denotes channels.
+        Unless `channel_axis` is set, the final dimension denotes the CIE-LAB
+        channels.
         The range of L* values is 0 to 100;
         the range of a* values and b* values is -128 to 127.
     illuminant : {"A", "B", "C", "D50", "D55", "D65", "D75", "E"}, optional
@@ -1176,7 +1178,7 @@ def lab2rgb(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     Notes
     -----
     This function uses lab2xyz and xyz2rgb.
-    By default, observer="2", illuminant="D65". CIE XYZ tristimulus values
+    By default, ``observer="2"``, ``illuminant="D65"``. CIE XYZ tristimulus values
     x_ref=95.047, y_ref=100., z_ref=108.883. See function `get_xyz_coords` for
     a list of supported illuminants.
 

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1062,7 +1062,6 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     The CIE XYZ tristimulus values are x_ref = 95.047, y_ref = 100., and
     z_ref = 108.883. See function :func:`~.get_xyz_coords` for a list of
     supported illuminants.
-    a list of supported illuminants.
 
     References
     ----------

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1143,13 +1143,15 @@ def rgb2lab(rgb, illuminant="D65", observer="2", *, channel_axis=-1):
 
 @channel_as_last_axis()
 def lab2rgb(lab, illuminant="D65", observer="2", *, channel_axis=-1):
-    """Lab to RGB color space conversion.
+    """Convert image in CIE-LAB to sRGB color space.
 
     Parameters
     ----------
     lab : (..., 3, ...) array_like
-        The image in Lab format. By default, the final dimension denotes
-        channels.
+        The input image in CIE-LAB color space.
+        By default, the final dimension denotes channels.
+        The range of L* values is 0 to 100;
+        the range of a* values and b* values is -128 to 127.
     illuminant : {"A", "B", "C", "D50", "D55", "D65", "D75", "E"}, optional
         The name of the illuminant (the function is NOT case sensitive).
     observer : {"2", "10", "R"}, optional
@@ -1174,7 +1176,7 @@ def lab2rgb(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     Notes
     -----
     This function uses lab2xyz and xyz2rgb.
-    By default Observer="2", Illuminant="D65". CIE XYZ tristimulus values
+    By default, observer="2", illuminant="D65". CIE XYZ tristimulus values
     x_ref=95.047, y_ref=100., z_ref=108.883. See function `get_xyz_coords` for
     a list of supported illuminants.
 

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1059,8 +1059,9 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
 
     Notes
     -----
-    By default, ``observer="2"``, ``illuminant="D65"``. CIE XYZ tristimulus values x_ref
-    = 95.047, y_ref = 100., z_ref = 108.883. See function `get_xyz_coords` for
+    The CIE XYZ tristimulus values are x_ref = 95.047, y_ref = 100., and
+    z_ref = 108.883. See function :func:`~.get_xyz_coords` for a list of
+    supported illuminants.
     a list of supported illuminants.
 
     References
@@ -1178,9 +1179,9 @@ def lab2rgb(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     Notes
     -----
     This function uses lab2xyz and xyz2rgb.
-    By default, ``observer="2"``, ``illuminant="D65"``. CIE XYZ tristimulus values
-    x_ref=95.047, y_ref=100., z_ref=108.883. See function `get_xyz_coords` for
-    a list of supported illuminants.
+    The CIE XYZ tristimulus values are x_ref = 95.047, y_ref = 100., and
+    z_ref = 108.883. See function :func:`~.get_xyz_coords` for a list of
+    supported illuminants.
 
     References
     ----------

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1065,7 +1065,7 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     References
     ----------
     .. [1] http://www.easyrgb.com/index.php?X=MATH&H=07
-    .. [2] https://en.wikipedia.org/wiki/Lab_color_space
+    .. [2] https://en.wikipedia.org/wiki/CIELAB_color_space
     """
     arr = _prepare_colorarray(lab, channel_axis=-1).copy()
 

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1029,8 +1029,8 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
         The input image in CIE-LAB color space.
         Unless `channel_axis` is set, the final dimension denotes the CIE-LAB
         channels.
-        The range of L* values is 0 to 100;
-        the range of a* values and b* values is -128 to 127.
+        The L* values range from 0 to 100;
+        the a* and b* values range from -128 to 127.
     illuminant : {"A", "B", "C", "D50", "D55", "D65", "D75", "E"}, optional
         The name of the illuminant (the function is NOT case sensitive).
     observer : {"2", "10", "R"}, optional
@@ -1152,8 +1152,8 @@ def lab2rgb(lab, illuminant="D65", observer="2", *, channel_axis=-1):
         The input image in CIE-LAB color space.
         Unless `channel_axis` is set, the final dimension denotes the CIE-LAB
         channels.
-        The range of L* values is 0 to 100;
-        the range of a* values and b* values is -128 to 127.
+        The L* values range from 0 to 100;
+        the a* and b* values range from -128 to 127.
     illuminant : {"A", "B", "C", "D50", "D55", "D65", "D75", "E"}, optional
         The name of the illuminant (the function is NOT case sensitive).
     observer : {"2", "10", "R"}, optional

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1186,6 +1186,7 @@ def lab2rgb(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Standard_illuminant
+    .. [2] https://en.wikipedia.org/wiki/CIELAB_color_space
     """
     return xyz2rgb(lab2xyz(lab, illuminant, observer))
 

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1058,7 +1058,7 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
 
     Notes
     -----
-    By default, Observer="2", Illuminant="D65". CIE XYZ tristimulus values x_ref
+    By default, observer="2", illuminant="D65". CIE XYZ tristimulus values x_ref
     = 95.047, y_ref = 100., z_ref = 108.883. See function `get_xyz_coords` for
     a list of supported illuminants.
 

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1021,13 +1021,15 @@ def xyz2lab(xyz, illuminant="D65", observer="2", *, channel_axis=-1):
 
 @channel_as_last_axis()
 def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
-    """CIE-LAB to XYZcolor space conversion.
+    """Convert image in CIE-LAB to XYZ color space.
 
     Parameters
     ----------
     lab : (..., 3, ...) array_like
-        The image in Lab format. By default, the final dimension denotes
-        channels.
+        The input image in CIE-LAB color space.
+        By default, the final dimension denotes channels.
+        The range of L* values is 0 to 100;
+        the range of a* values and b* values is -128 to 127.
     illuminant : {"A", "B", "C", "D50", "D55", "D65", "D75", "E"}, optional
         The name of the illuminant (the function is NOT case sensitive).
     observer : {"2", "10", "R"}, optional
@@ -1042,7 +1044,7 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     Returns
     -------
     out : (..., 3, ...) ndarray
-        The image in XYZ format. Same dimensions as input.
+        The image in XYZ color space. Same dimensions as input.
 
     Raises
     ------
@@ -1056,8 +1058,8 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
 
     Notes
     -----
-    By default Observer="2", Illuminant="D65". CIE XYZ tristimulus values x_ref
-    = 95.047, y_ref = 100., z_ref = 108.883. See function 'get_xyz_coords' for
+    By default, Observer="2", Illuminant="D65". CIE XYZ tristimulus values x_ref
+    = 95.047, y_ref = 100., z_ref = 108.883. See function `get_xyz_coords` for
     a list of supported illuminants.
 
     References


### PR DESCRIPTION
## Description

I'm tackling #1185 since it's part of the [0.20 milestone](https://github.com/scikit-image/scikit-image/milestone/22). This is just a start (see @hmaarrfk's https://github.com/scikit-image/scikit-image/issues/1185#issuecomment-522335391).

I have taken into account the parenthesis "(Referring to CIELAB as "Lab" without asterisks should be avoided to prevent confusion with [Hunter Lab](https://en.wikipedia.org/wiki/Hunter_Lab))" from reference https://en.wikipedia.org/wiki/CIELAB_color_space. 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
