### PR TITLE
Document boundary behavior of `draw.polygon` and `draw.polygon2mask`

### DIFF
--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -193,18 +193,20 @@ def _line_aa(Py_ssize_t r0, Py_ssize_t c0, Py_ssize_t r1, Py_ssize_t c1):
 
 
 def _polygon(r, c, shape):
-    """Generate coordinates of pixels within polygon.
+    """Generate coordinates of pixels inside a polygon.
 
     Parameters
     ----------
-    r : (N,) ndarray
-        Row coordinates of vertices of polygon.
-    c : (N,) ndarray
-        Column coordinates of vertices of polygon.
-    shape : tuple
+    r : (N,) array_like
+        Row coordinates of the polygon's vertices.
+    c : (N,) array_like
+        Column coordinates of the polygon's vertices.
+    shape : tuple, optional
         Image shape which is used to determine the maximum extent of output
         pixel coordinates. This is useful for polygons that exceed the image
-        size. If None, the full extent of the polygon is used.
+        size. If None, the full extent of the polygon is used.  Must be at
+        least length 2. Only the first two values are used to determine the
+        extent of the input image.
 
     Returns
     -------
@@ -212,6 +214,11 @@ def _polygon(r, c, shape):
         Pixel coordinates of polygon.
         May be used to directly index into an array, e.g.
         ``img[rr, cc] = 1``.
+
+    Notes
+    -----
+    This function ensures that `rr` and `cc` don't contain negative values.
+    Pixels of the polygon that whose coordinates are smaller 0, are not drawn.
     """
     r = np.atleast_1d(r)
     c = np.atleast_1d(c)

--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -218,7 +218,7 @@ def _polygon(r, c, shape):
     Notes
     -----
     This function ensures that `rr` and `cc` don't contain negative values.
-    Pixels of the polygon that whose coordinates are smaller 0, are not drawn.
+    Pixels in the polygon with coordinates smaller than 0 are not drawn.
     """
     r = np.atleast_1d(r)
     c = np.atleast_1d(c)

--- a/skimage/draw/_polygon2mask.py
+++ b/skimage/draw/_polygon2mask.py
@@ -4,33 +4,65 @@ from . import draw
 
 
 def polygon2mask(image_shape, polygon):
-    """Compute a mask from polygon.
+    """Create a binary mask from a polygon.
 
     Parameters
     ----------
-    image_shape : tuple of size 2.
+    image_shape : tuple of size 2
         The shape of the mask.
-    polygon : array_like.
+    polygon : (N, 2) array_like
         The polygon coordinates of shape (N, 2) where N is
         the number of points.
 
     Returns
     -------
-    mask : 2-D ndarray of type 'bool'.
-        The mask that corresponds to the input polygon.
+    mask : 2-D ndarray of type 'bool'
+        The binary mask that corresponds to the input polygon.
+
+    See Also
+    --------
+    polygon:
+        Generate coordinates of pixels inside a polygon.
 
     Notes
     -----
-    This function does not do any border checking, so that all
-    the vertices need to be within the given shape.
+    This function does not do any border checking. Parts of the polygon that
+    are outside the coordinate space defined by `image_shape` are not drawn.
 
     Examples
     --------
-    >>> image_shape = (128, 128)
-    >>> polygon = np.array([[60, 100], [100, 40], [40, 40]])
-    >>> mask = polygon2mask(image_shape, polygon)
-    >>> mask.shape
-    (128, 128)
+    >>> import skimage as ski
+    >>> image_shape = (10, 10)
+    >>> polygon = np.array([[1, 1], [2, 7], [8, 4]])
+    >>> mask = ski.draw.polygon2mask(image_shape, polygon)
+    >>> mask.astype(int)
+    array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+           [0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+           [0, 0, 1, 1, 1, 1, 1, 1, 0, 0],
+           [0, 0, 1, 1, 1, 1, 1, 0, 0, 0],
+           [0, 0, 0, 1, 1, 1, 1, 0, 0, 0],
+           [0, 0, 0, 1, 1, 1, 0, 0, 0, 0],
+           [0, 0, 0, 0, 1, 1, 0, 0, 0, 0],
+           [0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
+
+    If vertices / points of the `polygon` are outside the coordinate space
+    defined by `image_shape`, only a part (or none at all) of the polygon is
+    drawn in the mask.
+
+    >>> offset = np.array([[2, -4]])
+    >>> ski.draw.polygon2mask(image_shape, polygon - offset).astype(int)
+    array([[0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
+           [0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
+           [0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
+           [0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
+           [0, 0, 0, 0, 0, 0, 0, 0, 1, 1],
+           [0, 0, 0, 0, 0, 0, 0, 0, 1, 0],
+           [0, 0, 0, 0, 0, 0, 0, 0, 1, 0],
+           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
     """
     polygon = np.asarray(polygon)
     vertex_row_coords, vertex_col_coords = polygon.T

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -435,14 +435,14 @@ def line_aa(r0, c0, r1, c1):
 
 
 def polygon(r, c, shape=None):
-    """Generate coordinates of pixels within polygon.
+    """Generate coordinates of pixels inside a polygon.
 
     Parameters
     ----------
-    r : (N,) ndarray
-        Row coordinates of vertices of polygon.
-    c : (N,) ndarray
-        Column coordinates of vertices of polygon.
+    r : (N,) array_like
+        Row coordinates of the polygon's vertices.
+    c : (N,) array_like
+        Column coordinates of the polygon's vertices.
     shape : tuple, optional
         Image shape which is used to determine the maximum extent of output
         pixel coordinates. This is useful for polygons that exceed the image
@@ -457,13 +457,23 @@ def polygon(r, c, shape=None):
         May be used to directly index into an array, e.g.
         ``img[rr, cc] = 1``.
 
+    See Also
+    --------
+    polygon2mask:
+        Create a binary mask from a polygon.
+
+    Notes
+    -----
+    This function ensures that `rr` and `cc` don't contain negative values.
+    Pixels of the polygon that whose coordinates are smaller 0, are not drawn.
+
     Examples
     --------
-    >>> from skimage.draw import polygon
-    >>> img = np.zeros((10, 10), dtype=np.uint8)
+    >>> import skimage as ski
     >>> r = np.array([1, 2, 8])
     >>> c = np.array([1, 7, 4])
-    >>> rr, cc = polygon(r, c)
+    >>> rr, cc = ski.draw.polygon(r, c)
+    >>> img = np.zeros((10, 10), dtype=int)
     >>> img[rr, cc] = 1
     >>> img
     array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -475,8 +485,27 @@ def polygon(r, c, shape=None):
            [0, 0, 0, 0, 1, 1, 0, 0, 0, 0],
            [0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
            [0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
-           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], dtype=uint8)
+           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
 
+    If the image `shape` is defined and vertices / points of the `polygon` are
+    outside this coordinate space, only a part (or none at all) of the polygon's
+    pixels is returned.
+
+    >>> offset = (2, -4)
+    >>> rr, cc = ski.draw.polygon(r - offset[0], c - offset[1], shape=img.shape)
+    >>> img = np.zeros((10, 10), dtype=int)
+    >>> img[rr, cc] = 1
+    >>> img
+    array([[0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
+           [0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
+           [0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
+           [0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
+           [0, 0, 0, 0, 0, 0, 0, 0, 1, 1],
+           [0, 0, 0, 0, 0, 0, 0, 0, 1, 0],
+           [0, 0, 0, 0, 0, 0, 0, 0, 1, 0],
+           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+           [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]])
     """
     return _polygon(r, c, shape)
 

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -489,7 +489,9 @@ def polygon(r, c, shape=None):
 
     If the image `shape` is defined and vertices / points of the `polygon` are
     outside this coordinate space, only a part (or none at all) of the polygon's
-    pixels is returned.
+    pixels is returned. Shifting the polygon's vertices by an offset can be used
+    to move the polygon around and potentially draw an arbitrary sub-region of
+    the polygon.
 
     >>> offset = (2, -4)
     >>> rr, cc = ski.draw.polygon(r - offset[0], c - offset[1], shape=img.shape)


### PR DESCRIPTION
## Description

Replaces #6649.

The extended example section and other improvements hopefully make it clear how these functions behave, if polygon vertices are outside a defined coordinate range.

While playing around with this and testing the behavior, I noticed that the coordinate values returned by `polygon` always have a lower bound of 0 https://github.com/scikit-image/scikit-image/blob/23711dc749f750880c08fdfee93329e4d320231f/skimage/draw/_draw.pyx#L220-L222
How do you feel about (optionally) removing this constraint? That would make it possible to get fun "wrap-around" behavior...

I was gonna suggest removing the thin wrapper of `polygon` around `_polgyon`. That could remove quite some duplication but it seems we'd need [pytest-cython](https://pypi.org/project/pytest-cython/) for doctest support in Cython. And I don't think that testing dependency is worth it. 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
