### PR TITLE
Fix `graph.RAG.merge_nodes` for in-place merging

### DIFF
--- a/skimage/graph/_rag.py
+++ b/skimage/graph/_rag.py
@@ -207,7 +207,7 @@ class RAG(nx.Graph):
             self.add_node(new)
 
         for neighbor in neighbors:
-            data = weight_func(self, src, new, neighbor, *extra_arguments,
+            data = weight_func(self, src, dst, neighbor, *extra_arguments,
                                **extra_keywords)
             self.add_edge(neighbor, new, attr_dict=data)
 

--- a/skimage/graph/tests/test_rag.py
+++ b/skimage/graph/tests/test_rag.py
@@ -1,3 +1,4 @@
+import pytest
 from numpy.testing import assert_array_equal
 import numpy as np
 from skimage import graph
@@ -46,7 +47,10 @@ def test_rag_merge():
     assert list(g.edges()) == []
 
 
-def test_rag_merge_gh5360():
+@pytest.mark.parametrize(
+    "in_place", [True, False],
+)
+def test_rag_merge_gh5360(in_place):
     # Add another test case covering the gallery example plot_rag.py.
     # See bug report at gh-5360.
     g = graph.RAG()
@@ -59,13 +63,16 @@ def test_rag_merge_gh5360():
         g.nodes[n]['labels'] = [n]
     gc = g.copy()
 
-    g.merge_nodes(1, 3)
-    assert g.adj[3][2]['weight'] == 10
-    assert g.adj[3][4]['weight'] == 30
+    # New node ID is chosen if in_place=False
+    merged_id = 3 if in_place is True else 5
 
-    gc.merge_nodes(1, 3, weight_func=max_edge, in_place=False)
-    assert gc.adj[5][2]['weight'] == 20
-    assert gc.adj[5][4]['weight'] == 40
+    g.merge_nodes(1, 3, in_place=in_place)
+    assert g.adj[merged_id][2]['weight'] == 10
+    assert g.adj[merged_id][4]['weight'] == 30
+
+    gc.merge_nodes(1, 3, weight_func=max_edge, in_place=in_place)
+    assert gc.adj[merged_id][2]['weight'] == 20
+    assert gc.adj[merged_id][4]['weight'] == 40
 
 
 def test_threshold_cut():

--- a/skimage/graph/tests/test_rag.py
+++ b/skimage/graph/tests/test_rag.py
@@ -46,6 +46,28 @@ def test_rag_merge():
     assert list(g.edges()) == []
 
 
+def test_rag_merge_gh5360():
+    # Add another test case covering the gallery example plot_rag.py.
+    # See bug report at gh-5360.
+    g = graph.RAG()
+    g.add_edge(1, 2, weight=10)
+    g.add_edge(2, 3, weight=20)
+    g.add_edge(3, 4, weight=30)
+    g.add_edge(4, 1, weight=40)
+    g.add_edge(1, 3, weight=50)
+    for n in g.nodes():
+        g.nodes[n]['labels'] = [n]
+    gc = g.copy()
+
+    g.merge_nodes(1, 3)
+    assert g.adj[3][2]['weight'] == 10
+    assert g.adj[3][4]['weight'] == 30
+
+    gc.merge_nodes(1, 3, weight_func=max_edge, in_place=False)
+    assert gc.adj[5][2]['weight'] == 20
+    assert gc.adj[5][4]['weight'] == 40
+
+
 def test_threshold_cut():
 
     img = np.zeros((100, 100, 3), dtype='uint8')


### PR DESCRIPTION
## Description

Fixes #5360. See old code https://github.com/scikit-image/scikit-image/blob/23711dc749f750880c08fdfee93329e4d320231f/skimage/graph/_rag.py#L203-L211

When `in_place=False`, `new` is assigned a new node ID that doesn't yet have any edges to pre-existing nodes. So the `wheight_func` can only ever identify the existing edge `neighbor`-`src`; the edge `neighbor`-`new` doesn't exist yet. 

That it worked for the `in_place=True` was because `new` was set to `dst`.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
