### PR TITLE
Document L*a*b* range in lab2lch function.

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1662,7 +1662,7 @@ def combine_stains(stains, conv_matrix, *, channel_axis=-1):
 def lab2lch(lab, *, channel_axis=-1):
     """Convert image in CIE-LAB to CIE-LCh color space.
 
-    CIE-LCh is the cylindrical representation of CIE-LAB (Cartesian).
+    CIE-LCh is the cylindrical representation of the CIE-LAB (Cartesian) color space.
 
     Parameters
     ----------

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1662,7 +1662,8 @@ def combine_stains(stains, conv_matrix, *, channel_axis=-1):
 def lab2lch(lab, *, channel_axis=-1):
     """Convert image in CIE-LAB to CIE-LCh color space.
 
-    CIE-LCh is the cylindrical representation of the CIE-LAB (Cartesian) color space.
+    CIE-LCh is the cylindrical representation of the CIE-LAB (Cartesian) color
+    space.
 
     Parameters
     ----------

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -986,8 +986,8 @@ def xyz2lab(xyz, illuminant="D65", observer="2", *, channel_axis=-1):
 
     References
     ----------
-    .. [1] http://www.easyrgb.com/index.php?X=MATH&H=07
-    .. [2] https://en.wikipedia.org/wiki/Lab_color_space
+    .. [1] http://www.easyrgb.com/en/math.php
+    .. [2] https://en.wikipedia.org/wiki/CIELAB_color_space
 
     Examples
     --------
@@ -1065,7 +1065,7 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
 
     References
     ----------
-    .. [1] http://www.easyrgb.com/index.php?X=MATH&H=07
+    .. [1] http://www.easyrgb.com/en/math.php
     .. [2] https://en.wikipedia.org/wiki/CIELAB_color_space
     """
     arr = _prepare_colorarray(lab, channel_axis=-1).copy()
@@ -1232,7 +1232,7 @@ def xyz2luv(xyz, illuminant="D65", observer="2", *, channel_axis=-1):
 
     References
     ----------
-    .. [1] http://www.easyrgb.com/index.php?X=MATH&H=16#text16
+    .. [1] http://www.easyrgb.com/en/math.php
     .. [2] https://en.wikipedia.org/wiki/CIELUV
 
     Examples
@@ -1324,7 +1324,7 @@ def luv2xyz(luv, illuminant="D65", observer="2", *, channel_axis=-1):
 
     References
     ----------
-    .. [1] http://www.easyrgb.com/index.php?X=MATH&H=16#text16
+    .. [1] http://www.easyrgb.com/en/math.php
     .. [2] https://en.wikipedia.org/wiki/CIELUV
     """
     arr = _prepare_colorarray(luv, channel_axis=-1).copy()
@@ -1390,9 +1390,8 @@ def rgb2luv(rgb, *, channel_axis=-1):
 
     References
     ----------
-    .. [1] http://www.easyrgb.com/index.php?X=MATH&H=16#text16
-    .. [2] http://www.easyrgb.com/index.php?X=MATH&H=02#text2
-    .. [3] https://en.wikipedia.org/wiki/CIELUV
+    .. [1] http://www.easyrgb.com/en/math.php
+    .. [2] https://en.wikipedia.org/wiki/CIELUV
     """
     return xyz2luv(rgb2xyz(rgb))
 
@@ -1696,7 +1695,7 @@ def lab2lch(lab, *, channel_axis=-1):
 
     References
     ----------
-    .. [1] http://www.easyrgb.com/index.php?X=MATH&H=07
+    .. [1] http://www.easyrgb.com/en/math.php
     .. [2] https://en.wikipedia.org/wiki/HCL_color_space
 
     Examples

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1063,6 +1063,10 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     z_ref = 108.883. See function :func:`~.get_xyz_coords` for a list of
     supported illuminants.
 
+    See Also
+    --------
+    xyz2lab
+
     References
     ----------
     .. [1] http://www.easyrgb.com/en/math.php
@@ -1181,6 +1185,10 @@ def lab2rgb(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     The CIE XYZ tristimulus values are x_ref = 95.047, y_ref = 100., and
     z_ref = 108.883. See function :func:`~.get_xyz_coords` for a list of
     supported illuminants.
+
+    See Also
+    --------
+    rgb2lab
 
     References
     ----------
@@ -1693,6 +1701,10 @@ def lab2lch(lab, *, channel_axis=-1):
     Notes
     -----
     The h channel (i.e., hue) is expressed as an angle in range ``(0, 2*pi)``.
+
+    See Also
+    --------
+    lch2lab
 
     References
     ----------

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1045,7 +1045,7 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     Returns
     -------
     out : (..., 3, ...) ndarray
-        The image in XYZ color space. Same dimensions as input.
+        The image in XYZ color space, of same shape as input.
 
     Raises
     ------
@@ -1168,7 +1168,7 @@ def lab2rgb(lab, illuminant="D65", observer="2", *, channel_axis=-1):
     Returns
     -------
     out : (..., 3, ...) ndarray
-        The image in RGB format. Same dimensions as input.
+        The image in sRGB color space, of same shape as input.
 
     Raises
     ------
@@ -1177,7 +1177,7 @@ def lab2rgb(lab, illuminant="D65", observer="2", *, channel_axis=-1):
 
     Notes
     -----
-    This function uses lab2xyz and xyz2rgb.
+    This function uses :func:`~.lab2xyz` and :func:`~.xyz2rgb`.
     The CIE XYZ tristimulus values are x_ref = 95.047, y_ref = 100., and
     z_ref = 108.883. See function :func:`~.get_xyz_coords` for a list of
     supported illuminants.

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1710,6 +1710,7 @@ def lab2lch(lab, *, channel_axis=-1):
     ----------
     .. [1] http://www.easyrgb.com/en/math.php
     .. [2] https://en.wikipedia.org/wiki/HCL_color_space
+    .. [3] https://en.wikipedia.org/wiki/CIELAB_color_space
 
     Examples
     --------

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1709,8 +1709,8 @@ def lab2lch(lab, *, channel_axis=-1):
     References
     ----------
     .. [1] http://www.easyrgb.com/en/math.php
-    .. [2] https://en.wikipedia.org/wiki/HCL_color_space
-    .. [3] https://en.wikipedia.org/wiki/CIELAB_color_space
+    .. [2] https://en.wikipedia.org/wiki/CIELAB_color_space
+    .. [3] https://en.wikipedia.org/wiki/HCL_color_space
 
     Examples
     --------

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1770,15 +1770,15 @@ def lch2lab(lch, *, channel_axis=-1):
 
 
 def _prepare_lab_array(arr, force_copy=True):
-    """Ensure input for lab2lch, lch2lab are well-posed.
+    """Ensure input for lab2lch and lch2lab is well-formed.
 
-    Arrays must be in floating point and have at least 3 elements in
-    last dimension.  Return a new array.
+    Input array must be in floating point and have at least 3 elements in the
+    last dimension. Returns a new array by default.
     """
     arr = np.asarray(arr)
     shape = arr.shape
     if shape[-1] < 3:
-        raise ValueError('Input array has less than 3 color channels')
+        raise ValueError('Input image has less than 3 channels.')
     float_dtype = _supported_float_type(arr.dtype)
     if float_dtype == np.float32:
         _func = dtype.img_as_float32

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1661,16 +1661,18 @@ def combine_stains(stains, conv_matrix, *, channel_axis=-1):
 
 @channel_as_last_axis()
 def lab2lch(lab, *, channel_axis=-1):
-    """CIE-LAB to CIE-LCH color space conversion.
+    """Convert image in CIE-LAB to CIE-LCh color space.
 
-    LCH is the cylindrical representation of the LAB (Cartesian) colorspace
+    CIE-LCh is the cylindrical representation of CIE-LAB (Cartesian).
 
     Parameters
     ----------
     lab : (..., 3, ...) array_like
-        The N-D image in CIE-LAB format. The last (``N+1``-th) dimension must
-        have at least 3 elements, corresponding to the ``L``, ``a``, and ``b``
-        color channels. Subsequent elements are copied.
+        The input image in CIE-LAB color space.
+        Unless `channel_axis` is set, the final dimension denotes the CIE-LAB
+        channels.
+        The L* values range from 0 to 100;
+        the a* and b* values range from -128 to 127.
     channel_axis : int, optional
         This parameter indicates which axis of the array corresponds to
         channels.
@@ -1681,16 +1683,21 @@ def lab2lch(lab, *, channel_axis=-1):
     Returns
     -------
     out : (..., 3, ...) ndarray
-        The image in LCH format, in a N-D array with same shape as input `lab`.
+        The image in CIE-LCh color space, of same shape as input.
 
     Raises
     ------
     ValueError
-        If `lch` does not have at least 3 color channels (i.e. l, a, b).
+        If `lab` does not have at least 3 channels (i.e., L*, a*, and b*).
 
     Notes
     -----
-    The Hue is expressed as an angle between ``(0, 2*pi)``
+    The h channel (i.e., hue) is expressed as an angle in range ``(0, 2*pi)``.
+
+    References
+    ----------
+    .. [1] http://www.easyrgb.com/index.php?X=MATH&H=07
+    .. [2] https://en.wikipedia.org/wiki/HCL_color_space
 
     Examples
     --------


### PR DESCRIPTION
## Description

Follows up on #6688.

Note that channels are not necessarily *color* channels (e.g., L* = luminance).

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
