### PR TITLE
Keep deprecated functions available in `skimage.filters`

### DIFF
--- a/skimage/filters/__init__.pyi
+++ b/skimage/filters/__init__.pyi
@@ -6,6 +6,7 @@ __all__ = [
     "LPIFilter2D",
     "apply_hysteresis_threshold",
     "butterworth",
+    "compute_hessian_eigenvalues",
     "correlate_sparse",
     "difference_of_gaussians",
     "farid",
@@ -17,6 +18,7 @@ __all__ = [
     "gabor_kernel",
     "gaussian",
     "hessian",
+    "inverse",
     "laplace",
     "median",
     "meijering",
@@ -79,8 +81,19 @@ from .edges import (
     sobel_h,
     sobel_v,
 )
-from .lpi_filter import LPIFilter2D, filter_inverse, wiener
-from .ridges import frangi, hessian, meijering, sato
+from .lpi_filter import (
+    LPIFilter2D,
+    filter_inverse,
+    inverse,
+    wiener,
+)
+from .ridges import (
+    compute_hessian_eigenvalues,
+    frangi,
+    hessian,
+    meijering,
+    sato,
+)
 from .thresholding import (
     apply_hysteresis_threshold,
     threshold_isodata,

--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -19,7 +19,7 @@ from ..feature.corner import hessian_matrix, hessian_matrix_eigvals
 from ..util import img_as_float
 
 
-@deprecated(removed_version="0.21")
+@deprecated(alt_func='skimage.feature.hessian_matrix', removed_version="0.21")
 def compute_hessian_eigenvalues(image, sigma, sorting='none',
                                 mode='constant', cval=0,
                                 use_gaussian_derivatives=False):


### PR DESCRIPTION
## Description

While `compute_hessian_eigenvalues` and `inverse` are deprecated, removing them from the module level would break code for users who use the import path `skimage.filters.DEPRECATED_FUNC`. The whole purpose of a deprecation cycle is to give users the chance to avoid broken code!

Drawn out of #6700 in the hope that this can be quickly merged into 0.20.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
