### PR TITLE
shift and normalize data before fitting circle or ellipse

### DIFF
--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -287,9 +287,8 @@ class CircleModel(BaseModel):
         origin = data.mean(axis=0)
         data = data - origin
         scale = data.std()
-        # take care of too low scale values
         if scale < np.finfo(float_type).tiny:
-            # data is a cluster not a circle
+            warn("Cannot resolve circle in data.")
             return False
         data /= scale
 
@@ -447,9 +446,8 @@ class EllipseModel(BaseModel):
         origin = data.mean(axis=0)
         data = data - origin
         scale = data.std()
-        # take care of too low scale values
         if scale < np.finfo(float_type).tiny:
-            # data is a cluster not an ellipse
+            warn("Cannot resolve ellipse in data.")
             return False
         data /= scale
 

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -288,7 +288,10 @@ class CircleModel(BaseModel):
         data = data - origin
         scale = data.std()
         if scale < np.finfo(float_type).tiny:
-            warn("Cannot resolve circle in data.")
+            warn(
+                "Standard deviation of data is too small to estimate "
+                "circle with meaningfull precision."
+            )
             return False
         data /= scale
 
@@ -412,7 +415,7 @@ class EllipseModel(BaseModel):
     """
 
     def estimate(self, data):
-        """Estimate circle model from data using total least squares.
+        """Estimate ellipse model from data using total least squares.
 
         Parameters
         ----------
@@ -447,7 +450,10 @@ class EllipseModel(BaseModel):
         data = data - origin
         scale = data.std()
         if scale < np.finfo(float_type).tiny:
-            warn("Cannot resolve ellipse in data.")
+            warn(
+                "Standard deviation of data is too small to estimate "
+                "ellipse with meaningfull precision."
+            )
             return False
         data /= scale
 

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -290,7 +290,9 @@ class CircleModel(BaseModel):
         if scale < np.finfo(float_type).tiny:
             warn(
                 "Standard deviation of data is too small to estimate "
-                "circle with meaningful precision."
+                "circle with meaningful precision.",
+                category=RuntimeWarning,
+                stacklevel=2,
             )
             return False
         data /= scale
@@ -452,7 +454,9 @@ class EllipseModel(BaseModel):
         if scale < np.finfo(float_type).tiny:
             warn(
                 "Standard deviation of data is too small to estimate "
-                "ellipse with meaningful precision."
+                "ellipse with meaningful precision.",
+                category=RuntimeWarning,
+                stacklevel=2,
             )
             return False
         data /= scale

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -290,7 +290,7 @@ class CircleModel(BaseModel):
         if scale < np.finfo(float_type).tiny:
             warn(
                 "Standard deviation of data is too small to estimate "
-                "circle with meaningfull precision."
+                "circle with meaningful precision."
             )
             return False
         data /= scale
@@ -452,7 +452,7 @@ class EllipseModel(BaseModel):
         if scale < np.finfo(float_type).tiny:
             warn(
                 "Standard deviation of data is too small to estimate "
-                "ellipse with meaningfull precision."
+                "ellipse with meaningful precision."
             )
             return False
         data /= scale

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -291,6 +291,7 @@ class CircleModel(BaseModel):
         if scale < np.finfo(float_type).tiny:
             # data is a cluster not a circle
             return False
+        data /= scale
 
         # Adapted from a spherical estimator covered in a blog post by Charles
         # Jeckel (see also reference 1 above):

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -433,6 +433,13 @@ class EllipseModel(BaseModel):
         origin = data.mean(axis=0)
         data = data - origin
         scale = data.std()
+        # take care of too low scale values
+        fmin = np.nextafter(0, 1, dtype=float_type)
+        eps = np.spacing(1, dtype=float_type)
+        delta = fmin / eps
+        if scale < delta:
+            # data is a cluster not an ellipse
+            return False
         data /= scale
 
         x = data[:, 0]

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -520,7 +520,7 @@ class EllipseModel(BaseModel):
         params = np.nan_to_num([x0, y0, width, height, phi]).real
         params[:4] *= scale
         params[:2] += origin
-        self.params = [float(x) for x in params]
+        self.params = tuple(float(p) for p in params)
 
         return True
 

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -428,6 +428,10 @@ class EllipseModel(BaseModel):
         float_type = np.promote_types(data.dtype, np.float32)
         data = data.astype(float_type, copy=False)
 
+        # shift data
+        origin = data.mean(axis=0)
+        data = data - origin
+
         x = data[:, 0]
         y = data[:, 1]
 
@@ -494,6 +498,10 @@ class EllipseModel(BaseModel):
 
         self.params = np.nan_to_num([x0, y0, width, height, phi]).tolist()
         self.params = [float(np.real(x)) for x in self.params]
+
+        # shift back the result
+        self.params[0] += origin[0]
+        self.params[1] += origin[1]
         return True
 
     def residuals(self, data):

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -155,7 +155,10 @@ def test_circle_model_insufficient_data():
     with expected_warnings(warning_message):
         model.estimate(np.array([[0, 0], [1, 1], [2, 2]]))
 
-    warning_message = ["Cannot resolve circle in data."]
+    warning_message = [
+        "Standard deviation of data is too small to estimate "
+        "circle with meaningfull precision."
+    ]
     with expected_warnings(warning_message):
         model.estimate(np.ones((6, 2)))
 
@@ -273,7 +276,10 @@ def test_ellipse_model_estimate_from_far_shifted_data():
 def test_ellipse_model_estimate_failers():
     # estimate parameters of real data
     model = EllipseModel()
-    warning_message = ["Cannot resolve ellipse in data."]
+    warning_message = [
+        "Standard deviation of data is too small to estimate "
+        "ellipse with meaningfull precision."
+    ]
     with expected_warnings(warning_message):
         assert not model.estimate(np.ones((6, 2)))
     assert not model.estimate(np.array([[50, 80], [51, 81], [52, 80]]))

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from skimage._shared import testing
 from skimage._shared._warnings import expected_warnings
@@ -155,12 +156,15 @@ def test_circle_model_insufficient_data():
     with expected_warnings(warning_message):
         model.estimate(np.array([[0, 0], [1, 1], [2, 2]]))
 
-    warning_message = [
+    warning_message = (
         "Standard deviation of data is too small to estimate "
         "circle with meaningful precision."
-    ]
-    with expected_warnings(warning_message):
-        model.estimate(np.ones((6, 2)))
+    )
+    with pytest.warns(RuntimeWarning, match=warning_message) as _warnings:
+        assert not model.estimate(np.ones((6, 2)))
+    # Check that stacklevel is correct
+    assert len(_warnings) == 1
+    assert _warnings[0].filename == __file__
 
 
 def test_circle_model_estimate_from_small_scale_data():
@@ -274,12 +278,16 @@ def test_ellipse_model_estimate_from_far_shifted_data():
 def test_ellipse_model_estimate_failers():
     # estimate parameters of real data
     model = EllipseModel()
-    warning_message = [
+    warning_message = (
         "Standard deviation of data is too small to estimate "
         "ellipse with meaningful precision."
-    ]
-    with expected_warnings(warning_message):
+    )
+    with pytest.warns(RuntimeWarning, match=warning_message) as _warnings:
         assert not model.estimate(np.ones((6, 2)))
+    # Check that stacklevel is correct
+    assert len(_warnings) == 1
+    assert _warnings[0].filename == __file__
+
     assert not model.estimate(np.array([[50, 80], [51, 81], [52, 80]]))
 
 

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -234,6 +234,20 @@ def test_ellipse_model_estimate_from_data():
     assert_array_less(np.zeros(4), np.abs(model.params[:4]))
 
 
+def test_ellipse_model_estimate_from_far_shifted_data():
+    data = np.array([
+        [1541.221, 1254.780], [1541.848, 1255.290], [1543.009, 1255.535],
+        [1544.150, 1255.395], [1544.962, 1254.945], [1545.777, 1253.922],
+        [1545.943, 1253.000], [1545.786, 1252.063], [1545.103, 1250.892],
+        [1543.986, 1250.374], [1543.140, 1250.401], [1541.968, 1250.959],
+        [1541.094, 1252.049], [1540.765, 1252.968], [1540.799, 1254.069],
+        [1541.221, 1254.780]
+    ])
+    # estimate parameters of far shifted data
+    model = EllipseModel()
+    assert model.estimate(data)
+
+
 @xfail(condition=arch32,
        reason=('Known test failure on 32-bit platforms. See links for '
                'details: '

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from skimage._shared import testing
 from skimage._shared._warnings import expected_warnings
-from skimage._shared.testing import (arch32, assert_almost_equal,
+from skimage._shared.testing import (arch32, assert_almost_equal, skipif,
                                      assert_array_less, assert_equal, xfail)
 from skimage.measure import LineModelND, CircleModel, EllipseModel, ransac
 from skimage.measure.fit import _dynamic_max_trials
@@ -160,6 +160,7 @@ def test_circle_model_insufficient_data():
         model.estimate(np.ones((6, 2)))
 
 
+@skipif(not hasattr(np, "float128"), reason="no quad precision available")
 def test_circle_model_estimate_from_small_scale_data():
     params = np.array([1.23e-90, 2.34e-90, 3.45e-100], dtype=np.float128)
     angles = np.array([
@@ -249,6 +250,7 @@ def test_ellipse_model_estimate_from_data():
     assert_array_less(np.zeros(4), np.abs(model.params[:4]))
 
 
+@skipif(not hasattr(np, "float128"), reason="no quad precision available")
 def test_ellipse_model_estimate_from_far_shifted_data():
     params = np.array([1e6, 2e6, 0.5, 0.1, 0.5], dtype=np.float128)
     angles = np.array([

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from skimage._shared import testing
 from skimage._shared._warnings import expected_warnings
-from skimage._shared.testing import (arch32, assert_almost_equal, skipif,
+from skimage._shared.testing import (arch32, assert_almost_equal,
                                      assert_array_less, assert_equal, xfail)
 from skimage.measure import LineModelND, CircleModel, EllipseModel, ransac
 from skimage.measure.fit import _dynamic_max_trials
@@ -163,13 +163,12 @@ def test_circle_model_insufficient_data():
         model.estimate(np.ones((6, 2)))
 
 
-@skipif(not hasattr(np, "float128"), reason="no quad precision available")
 def test_circle_model_estimate_from_small_scale_data():
-    params = np.array([1.23e-90, 2.34e-90, 3.45e-100], dtype=np.float128)
+    params = np.array([1.23e-90, 2.34e-90, 3.45e-100], dtype=np.float64)
     angles = np.array([
         0.107, 0.407, 1.108, 1.489, 2.216, 2.768,
         3.183, 3.969, 4.840, 5.387, 5.792, 6.139
-    ], dtype=np.float128)
+    ], dtype=np.float64)
     data = CircleModel().predict_xy(angles, params=params)
     model = CircleModel()
     # assert that far small scale data can be estimated
@@ -253,13 +252,12 @@ def test_ellipse_model_estimate_from_data():
     assert_array_less(np.zeros(4), np.abs(model.params[:4]))
 
 
-@skipif(not hasattr(np, "float128"), reason="no quad precision available")
 def test_ellipse_model_estimate_from_far_shifted_data():
-    params = np.array([1e6, 2e6, 0.5, 0.1, 0.5], dtype=np.float128)
+    params = np.array([1e6, 2e6, 0.5, 0.1, 0.5], dtype=np.float64)
     angles = np.array([
         0.107, 0.407, 1.108, 1.489, 2.216, 2.768,
         3.183, 3.969, 4.840, 5.387, 5.792, 6.139
-    ], dtype=np.float128)
+    ], dtype=np.float64)
     data = EllipseModel().predict_xy(angles, params=params)
     model = EllipseModel()
     # assert that far shifted data can be estimated

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -235,17 +235,17 @@ def test_ellipse_model_estimate_from_data():
 
 
 def test_ellipse_model_estimate_from_far_shifted_data():
-    data = np.array([
-        [1541.221, 1254.780], [1541.848, 1255.290], [1543.009, 1255.535],
-        [1544.150, 1255.395], [1544.962, 1254.945], [1545.777, 1253.922],
-        [1545.943, 1253.000], [1545.786, 1252.063], [1545.103, 1250.892],
-        [1543.986, 1250.374], [1543.140, 1250.401], [1541.968, 1250.959],
-        [1541.094, 1252.049], [1540.765, 1252.968], [1540.799, 1254.069],
-        [1541.221, 1254.780]
+    params = np.array([1e6, 2e6, 0.5, 0.1, 0.5])
+    angles = np.array([
+        0.107, 0.407, 1.108, 1.489, 2.216, 2.768,
+        3.183, 3.969, 4.840, 5.387, 5.792, 6.139
     ])
-    # estimate parameters of far shifted data
+    data = EllipseModel().predict_xy(angles, params=params)
     model = EllipseModel()
+    # assert that far shifted data can be estimated
     assert model.estimate(data)
+    # test whether the predicted parameters are close to the original ones
+    assert_almost_equal(params, model.params)
 
 
 @xfail(condition=arch32,

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -153,10 +153,11 @@ def test_circle_model_insufficient_data():
         model.estimate(np.array([[1, 2], [3, 4]]))
 
     with expected_warnings(warning_message):
-        model.estimate(np.ones((6, 2)))
-
-    with expected_warnings(warning_message):
         model.estimate(np.array([[0, 0], [1, 1], [2, 2]]))
+
+    warning_message = ["Cannot resolve circle in data."]
+    with expected_warnings(warning_message):
+        model.estimate(np.ones((6, 2)))
 
 
 def test_circle_model_estimate_from_small_scale_data():
@@ -166,7 +167,6 @@ def test_circle_model_estimate_from_small_scale_data():
         3.183, 3.969, 4.840, 5.387, 5.792, 6.139
     ], dtype=np.float128)
     data = CircleModel().predict_xy(angles, params=params)
-
     model = CircleModel()
     # assert that far small scale data can be estimated
     assert model.estimate(data.astype(np.float64))
@@ -271,7 +271,9 @@ def test_ellipse_model_estimate_from_far_shifted_data():
 def test_ellipse_model_estimate_failers():
     # estimate parameters of real data
     model = EllipseModel()
-    assert not model.estimate(np.ones((5, 2)))
+    warning_message = ["Cannot resolve ellipse in data."]
+    with expected_warnings(warning_message):
+        assert not model.estimate(np.ones((6, 2)))
     assert not model.estimate(np.array([[50, 80], [51, 81], [52, 80]]))
 
 

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -159,6 +159,21 @@ def test_circle_model_insufficient_data():
         model.estimate(np.array([[0, 0], [1, 1], [2, 2]]))
 
 
+def test_circle_model_estimate_from_small_scale_data():
+    params = np.array([1.23e-90, 2.34e-90, 3.45e-100], dtype=np.float128)
+    angles = np.array([
+        0.107, 0.407, 1.108, 1.489, 2.216, 2.768,
+        3.183, 3.969, 4.840, 5.387, 5.792, 6.139
+    ], dtype=np.float128)
+    data = CircleModel().predict_xy(angles, params=params)
+
+    model = CircleModel()
+    # assert that far small scale data can be estimated
+    assert model.estimate(data.astype(np.float64))
+    # test whether the predicted parameters are close to the original ones
+    assert_almost_equal(params, model.params)
+
+
 def test_ellipse_model_invalid_input():
     with testing.raises(ValueError):
         EllipseModel().estimate(np.empty((5, 3)))
@@ -235,15 +250,15 @@ def test_ellipse_model_estimate_from_data():
 
 
 def test_ellipse_model_estimate_from_far_shifted_data():
-    params = np.array([1e6, 2e6, 0.5, 0.1, 0.5])
+    params = np.array([1e6, 2e6, 0.5, 0.1, 0.5], dtype=np.float128)
     angles = np.array([
         0.107, 0.407, 1.108, 1.489, 2.216, 2.768,
         3.183, 3.969, 4.840, 5.387, 5.792, 6.139
-    ])
+    ], dtype=np.float128)
     data = EllipseModel().predict_xy(angles, params=params)
     model = EllipseModel()
     # assert that far shifted data can be estimated
-    assert model.estimate(data)
+    assert model.estimate(data.astype(np.float64))
     # test whether the predicted parameters are close to the original ones
     assert_almost_equal(params, model.params)
 

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -157,7 +157,7 @@ def test_circle_model_insufficient_data():
 
     warning_message = [
         "Standard deviation of data is too small to estimate "
-        "circle with meaningfull precision."
+        "circle with meaningful precision."
     ]
     with expected_warnings(warning_message):
         model.estimate(np.ones((6, 2)))
@@ -278,7 +278,7 @@ def test_ellipse_model_estimate_failers():
     model = EllipseModel()
     warning_message = [
         "Standard deviation of data is too small to estimate "
-        "ellipse with meaningfull precision."
+        "ellipse with meaningful precision."
     ]
     with expected_warnings(warning_message):
         assert not model.estimate(np.ones((6, 2)))


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

This PR closes #6699. The idea is to shift the input data towards the origin before fitting the ellipse.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
