### PR TITLE
added aspect_ratio to regionprops

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -34,6 +34,7 @@ PROPS = {
     'ConvexImage': 'image_convex',
     'convex_image': 'image_convex',
     'Coordinates': 'coords',
+    'Aspect_ratio': 'aspect_ratio',
     'Eccentricity': 'eccentricity',
     'EquivDiameter': 'equivalent_diameter_area',
     'equivalent_diameter': 'equivalent_diameter_area',

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -94,6 +94,7 @@ COL_DTYPES = {
     'area_bbox': float,
     'area_convex': float,
     'area_filled': float,
+    'aspect_ratio': float,
     'axis_major_length': float,
     'axis_minor_length': float,
     'bbox': int,
@@ -547,6 +548,10 @@ class RegionProperties:
     def intensity_min(self):
         vals = self.image_intensity[self.image]
         return np.min(vals, axis=0).astype(np.float64, copy=False)
+
+    @property
+    def aspect_ratio(self):
+        return self.axis_major_length / self.axis_minor_length
 
     @property
     def axis_major_length(self):
@@ -1117,6 +1122,9 @@ def regionprops(label_image, intensity_image=None, cache=True,
     **axis_minor_length** : float
         The length of the minor axis of the ellipse that has the same
         normalized second central moments as the region.
+    **aspect_ratio** : float
+        The length of the major axis of the ellipse that has the same
+        normalized second central moments as the region divided by the minor axis.
     **bbox** : tuple
         Bounding box ``(min_row, min_col, max_row, max_col)``.
         Pixels belonging to the bounding box are in the half-open interval

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -545,6 +545,11 @@ def test_intensity_min():
     assert_almost_equal(intensity, 1)
 
 
+def test_aspect_ratio():
+    val = regionprops(SAMPLE)[0].aspect_ratio
+    assert_almost_equal(val, 1.7241915393999292)
+
+
 def test_axis_minor_length():
     length = regionprops(SAMPLE)[0].axis_minor_length
     # MATLAB has different interpretation of ellipse than found in literature,


### PR DESCRIPTION

<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

This adds aspect_ratio as defined in ImageJ to scikit-image. See #6698 for discussion.

I could not fully test it because of #6710 and hope github CI does the job well.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
