### PR TITLE
added circularity to regionprops + test + docstring

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -102,6 +102,7 @@ COL_DTYPES = {
     'centroid_weighted': float,
     'centroid_weighted_local': float,
     'coords': object,
+    'circularity': float,
     'eccentricity': float,
     'equivalent_diameter_area': float,
     'euler_number': int,
@@ -444,6 +445,11 @@ class RegionProperties:
                 self.slice[i].start for i in range(self._ndim)
                 ])
         return object_offset + indices + self._offset
+
+    @property
+    @only2d
+    def circularity(self):
+        return 4 * np.pi * self.area / pow(self.perimeter, 2)
 
     @property
     @only2d
@@ -1136,6 +1142,10 @@ def regionprops(label_image, intensity_image=None, cache=True,
         Coordinate list ``(row, col)``of the region scaled by ``spacing``.
     **coords** : (N, 2) ndarray
         Coordinate list ``(row, col)`` of the region.
+    **circularity** : float
+        Ratio of the circumference of the region to the circumference of a
+        circle with the same area. A value of 1.0 indicates a perfect circle.
+        Values lower than 1.0 indicate an extended perimeter.
     **eccentricity** : float
         Eccentricity of the ellipse that has the same second-moments as the
         region. The eccentricity is the ratio of the focal distance

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -379,6 +379,11 @@ def test_slice():
     assert_equal(result, expected)
 
 
+def test_circularity():
+    val = regionprops(SAMPLE)[0].circularity
+    assert_almost_equal(val, 0.29641327260486866)
+
+
 def test_eccentricity():
     eps = regionprops(SAMPLE)[0].eccentricity
     assert_almost_equal(eps, 0.814629313427)


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

This adds circularity as defined in ImageJ to scikit-image. See https://github.com/scikit-image/scikit-image/issues/6698 for discussion.

I could not fully test it because of https://github.com/scikit-image/scikit-image/issues/6710 and hope github CI does the job well.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
