### PR TITLE
Fix matrix calculation for shear angle in `AffineTransform`

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -852,7 +852,6 @@ class AffineTransform(ProjectiveTransform):
         X = a0*x + a1*y + a2 =
           = sx*x*cos(rotation) - sy*y*(tan(shear) * sin(rotation) + sin(rotation)) + a2
 
-
         Y = b0*x + b1*y + b2 =
           = sx*x*sin(rotation) - sy*y*(tan(shear) * sin(rotation) - cos(rotation)) + b2
 

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -895,8 +895,9 @@ class AffineTransform(ProjectiveTransform):
         Rotation angle in counter-clockwise direction as radians. Only
         available for 2D.
     shear : float, optional
-        Shear angle in counter-clockwise direction as radians. Only available
-        for 2D.
+        Shear angle is the counter-clockwise radians between the former verticals and the y-axis.
+        See the reference [2] for detail about the shear mapping.
+        Only available for 2D.
     translation : (tx, ty) as array, list or tuple, optional
         Translation parameters. Only available for 2D.
     dimensionality : int, optional
@@ -942,6 +943,15 @@ class AffineTransform(ProjectiveTransform):
     ----------
     .. [1] Wikipedia, "Image transformation" section of "Affine transformation":
            <https://en.wikipedia.org/wiki/Affine_transformation>
+    .. [2] Wikipedia, :"Shear mapping"
+           <https://en.wikipedia.org/wiki/Shear_mapping>
+
+    Notes
+    -----
+    The shear angle definition is different from the angle defined in [2].
+    The skimage's version is defined as the angle between the former verticals
+    and the y-axis instead of the angle between the former verticals and the x-axis,
+    and the direction is counter-clockwise.
     """
 
     def __init__(self, matrix=None, scale=None, rotation=None, shear=None,

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -941,10 +941,10 @@ class AffineTransform(ProjectiveTransform):
 
     References
     ----------
-    .. [1] Wikipedia, "Image transformation" section of "Affine transformation":
-           <https://en.wikipedia.org/wiki/Affine_transformation>
-    .. [2] Wikipedia, :"Shear mapping"
-           <https://en.wikipedia.org/wiki/Shear_mapping>
+    .. [1] Wikipedia, "Affine transformation",
+           https://en.wikipedia.org/wiki/Affine_transformation#Image_transformation
+    .. [2] Wikipedia, "Shear mapping",
+           https://en.wikipedia.org/wiki/Shear_mapping
 
     Notes
     -----

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -855,8 +855,16 @@ class AffineTransform(ProjectiveTransform):
         Y = b0*x + b1*y + b2 =
           = sx*x*sin(rotation) - sy*y*(tan(shear) * sin(rotation) - cos(rotation)) + b2
 
-    where ``sx`` and ``sy`` are scale factors in the x and y directions,
-    and the homogeneous transformation matrix is::
+    where ``sx`` and ``sy`` are scale factors in the x and y directions.
+
+    This is equivalent to applying the operations in the following order:
+
+    1. Scale
+    2. Shear(x-dimension)
+    3. Rotate
+    4. Translate
+
+    The homogeneous transformation matrix is::
 
         [[a0  a1  a2]
          [b0  b1  b2]
@@ -930,6 +938,10 @@ class AffineTransform(ProjectiveTransform):
 
     >>> warped = ski.transform.warp(img, inverse_map=tform.inverse)
 
+    References
+    ----------
+    .. [1] Wikipedia, "Image transformation" section of "Affine transformation":
+           <https://en.wikipedia.org/wiki/Affine_transformation>
     """
 
     def __init__(self, matrix=None, scale=None, rotation=None, shear=None,
@@ -969,12 +981,17 @@ class AffineTransform(ProjectiveTransform):
             else:
                 sx, sy = scale
 
-            self.params = np.array([
-                [sx * math.cos(rotation), -sy * (math.tan(shear) * math.cos(rotation) + math.sin(rotation)), 0],
-                [sx * math.sin(rotation), -sy * (math.tan(shear) * math.sin(rotation) - math.cos(rotation)), 0],
-                [                      0,                                                                 0, 1]
-            ])
-            self.params[0:2, 2] = translation
+            a0 = sx * math.cos(rotation)
+            a1 = -sy * (
+                math.tan(shear) * math.cos(rotation) + math.sin(rotation)
+            )
+            a2 = translation[0]
+            b0 = sx * math.sin(rotation)
+            b1 = -sy * (
+                math.tan(shear) * math.sin(rotation) - math.cos(rotation)
+            )
+            b2 = translation[1]
+            self.params = np.array([[a0, a1, a2], [b0, b1, b2], [0, 0, 1]])
         else:
             # default to an identity transform
             self.params = np.eye(dimensionality + 1)
@@ -984,9 +1001,9 @@ class AffineTransform(ProjectiveTransform):
         if self.dimensionality != 2:
             return np.sqrt(np.sum(self.params ** 2, axis=0))[:self.dimensionality]
         else:
-            ss = np.sum(self.params ** 2, axis=0)[:self.dimensionality]
+            ss = np.sum(self.params ** 2, axis=0)
             ss[1] = ss[1] / (math.tan(self.shear)**2 + 1)
-            return np.sqrt(ss)
+            return np.sqrt(ss)[:self.dimensionality]
 
     @property
     def rotation(self):

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -892,10 +892,9 @@ class AffineTransform(ProjectiveTransform):
         .. versionadded:: 0.17
            Added support for supplying a single scalar value.
     rotation : float, optional
-        Rotation angle in counter-clockwise direction as radians. Only
-        available for 2D.
+        Rotation angle, clockwise, as radians. Only available for 2D.
     shear : float, optional
-        The shear angle is the counter-clockwise radians by which the y-axis is
+        The shear angle, clockwise, by which the y-axis is
         rotated around the origin [2]. Only available in 2D.
     translation : (tx, ty) as array, list or tuple, optional
         Translation parameters. Only available for 2D.
@@ -944,12 +943,6 @@ class AffineTransform(ProjectiveTransform):
            https://en.wikipedia.org/wiki/Affine_transformation#Image_transformation
     .. [2] Wikipedia, "Shear mapping",
            https://en.wikipedia.org/wiki/Shear_mapping
-
-    Notes
-    -----
-    The shear angle is defined differently from [2]:
-    here, it is the angle that the transformed y-axis makes with the y-axis,
-    measured counter-clockwise.
     """
 
     def __init__(self, matrix=None, scale=None, rotation=None, shear=None,
@@ -1258,7 +1251,7 @@ class EuclideanTransform(ProjectiveTransform):
     matrix : (D+1, D+1) array_like, optional
         Homogeneous transformation matrix.
     rotation : float or sequence of float, optional
-        Rotation angle in counter-clockwise direction as radians. If given as
+        Rotation angle, clockwise, as radians. If given as
         a vector, it is interpreted as Euler rotation angles [1]_. Only 2D
         (single rotation) and 3D (Euler rotations) values are supported. For
         higher dimensions, you must provide or estimate the transformation
@@ -1398,7 +1391,7 @@ class SimilarityTransform(EuclideanTransform):
     scale : float, optional
         Scale factor. Implemented only for 2D and 3D.
     rotation : float, optional
-        Rotation angle in counter-clockwise direction as radians.
+        Rotation angle, clockwise, as radians.
         Implemented only for 2D and 3D. For 3D, this is given in ZYX Euler
         angles.
     translation : (dim,) array_like, optional

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -895,9 +895,8 @@ class AffineTransform(ProjectiveTransform):
         Rotation angle in counter-clockwise direction as radians. Only
         available for 2D.
     shear : float, optional
-        Shear angle is the counter-clockwise radians between the former verticals and the y-axis.
-        See the reference [2] for detail about the shear mapping.
-        Only available for 2D.
+        The shear angle is the counter-clockwise radians by which the former y-axis is
+        rotated around the origin [2]. Only available for 2D.
     translation : (tx, ty) as array, list or tuple, optional
         Translation parameters. Only available for 2D.
     dimensionality : int, optional

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -850,10 +850,10 @@ class AffineTransform(ProjectiveTransform):
     Has the following form::
 
         X = a0*x + a1*y + a2 =
-          = sx*x*cos(rotation) - sy*y*(tan(shear) * sin(rotation) + sin(rotation)) + a2
+          = sx*x*cos(rotation) - sy*y*(tan(shear) * cos(rotation) + sin(rotation)) + translation_x
 
         Y = b0*x + b1*y + b2 =
-          = sx*x*sin(rotation) - sy*y*(tan(shear) * sin(rotation) - cos(rotation)) + b2
+          = sx*x*sin(rotation) - sy*y*(tan(shear) * sin(rotation) - cos(rotation)) + translation_y
 
     where ``sx`` and ``sy`` are scale factors in the x and y directions.
 

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -895,8 +895,8 @@ class AffineTransform(ProjectiveTransform):
         Rotation angle in counter-clockwise direction as radians. Only
         available for 2D.
     shear : float, optional
-        The shear angle is the counter-clockwise radians by which the former y-axis is
-        rotated around the origin [2]. Only available for 2D.
+        The shear angle is the counter-clockwise radians by which the y-axis is
+        rotated around the origin [2]. Only available in 2D.
     translation : (tx, ty) as array, list or tuple, optional
         Translation parameters. Only available for 2D.
     dimensionality : int, optional
@@ -947,10 +947,9 @@ class AffineTransform(ProjectiveTransform):
 
     Notes
     -----
-    The shear angle definition is different from the angle defined in [2].
-    The skimage's version is defined as the angle between the former verticals
-    and the y-axis instead of the angle between the former verticals and the x-axis,
-    and the direction is counter-clockwise.
+    The shear angle is defined differently from [2]:
+    here, it is the angle that the transformed y-axis makes with the y-axis,
+    measured counter-clockwise.
     """
 
     def __init__(self, matrix=None, scale=None, rotation=None, shear=None,

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -850,10 +850,11 @@ class AffineTransform(ProjectiveTransform):
     Has the following form::
 
         X = a0*x + a1*y + a2 =
-          = sx*x*cos(rotation) - sy*y*sin(rotation + shear) + a2
+          = sx*x*cos(rotation) - sy*y*(tan(shear) * sin(rotation) + sin(rotation)) + a2
+
 
         Y = b0*x + b1*y + b2 =
-          = sx*x*sin(rotation) + sy*y*cos(rotation + shear) + b2
+          = sx*x*sin(rotation) - sy*y*(tan(shear) * sin(rotation) - cos(rotation)) + b2
 
     where ``sx`` and ``sy`` are scale factors in the x and y directions,
     and the homogeneous transformation matrix is::
@@ -970,9 +971,9 @@ class AffineTransform(ProjectiveTransform):
                 sx, sy = scale
 
             self.params = np.array([
-                [sx * math.cos(rotation), -sy * math.sin(rotation + shear), 0],
-                [sx * math.sin(rotation),  sy * math.cos(rotation + shear), 0],
-                [                      0,                                0, 1]
+                [sx * math.cos(rotation), -sy * (math.tan(shear) * math.cos(rotation) + math.sin(rotation)), 0],
+                [sx * math.sin(rotation), -sy * (math.tan(shear) * math.sin(rotation) - math.cos(rotation)), 0],
+                [                      0,                                                                 0, 1]
             ])
             self.params[0:2, 2] = translation
         else:
@@ -981,7 +982,12 @@ class AffineTransform(ProjectiveTransform):
 
     @property
     def scale(self):
-        return np.sqrt(np.sum(self.params ** 2, axis=0))[:self.dimensionality]
+        if self.dimensionality != 2:
+            return np.sqrt(np.sum(self.params ** 2, axis=0))[:self.dimensionality]
+        else:
+            ss = np.sum(self.params ** 2, axis=0)[:self.dimensionality]
+            ss[1] = ss[1] / (math.tan(self.shear)**2 + 1)
+            return np.sqrt(ss)
 
     @property
     def rotation(self):

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -261,6 +261,19 @@ def test_affine_init():
                         AffineTransform(scale=(0.5, 0.5)).scale)
 
 
+def test_affine_shear():
+    shear = 0.1
+    # expected horizontal shear transform
+    expected = np.array([
+        [1, -np.tan(shear), 0],
+        [0,                1, 0],
+        [0,                0, 1]
+    ])
+
+    tform = AffineTransform(shear=shear)
+    assert_almost_equal(tform.params, expected)
+
+
 def test_piecewise_affine():
     tform = PiecewiseAffineTransform()
     assert tform.estimate(SRC, DST)

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -266,8 +266,8 @@ def test_affine_shear():
     # expected horizontal shear transform
     expected = np.array([
         [1, -np.tan(shear), 0],
-        [0,                1, 0],
-        [0,                0, 1]
+        [0,              1, 0],
+        [0,              0, 1]
     ])
 
     tform = AffineTransform(shear=shear)


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->
In this PR, I would like to fix #3239.

I think the following document is not correct for the shear parameter.

https://github.com/scikit-image/scikit-image/blob/d3b8b6c296bd40ec15c23f38894156133745c6d9/skimage/transform/_geometric.py#L717-L724

I rewrote the code with the following fixed equations:

```
X = sx * x * cos(rotation) - sy * y * (tan(shear) * sin(rotation) + sin(rotation)) + a2
Y = sx * x * sin(rotation) - sy * y * (tan(shear) * sin(rotation) - cos(rotation)) + b2
```

I would appreciate if you review this PR.

## Derivation

For simplicity, ignoring the scale and translation, we can rewrite the original equations:

```
X = x * cos(rotation) - y * sin(rotation + shear)
Y = x * sin(rotation) + y * cos(rotation + shear)
```

However, the transformation matrix of rotation and shear should be the followings:

```
X = x * cos(rotation) - y * (tan(shear) * sin(rotation) + sin(rotation))
Y = x * sin(rotation) - y * (tan(shear) * sin(rotation) - cos(rotation)
```

Here is a derivation:

```math
R_{\theta} S_{\phi_x}
\begin{pmatrix}
x \\
y
\end{pmatrix}
 = 
\begin{pmatrix}
\cos\theta & -\sin\theta\\
\sin\theta & \cos\theta
\end{pmatrix}
\begin{pmatrix}
1 & -\tan\phi_{x} \\
0 & 1
\end{pmatrix}
\begin{pmatrix}
x \\
y
\end{pmatrix}\\
=
\begin{pmatrix}
\cos\theta & -(\tan\phi_x \cos\theta + \sin\theta)\\
\sin\theta & -(\tan\phi_x \sin\theta - \cos\theta)
\end{pmatrix}
\begin{pmatrix}
x \\
y
\end{pmatrix}
\\
=
\begin{pmatrix}
x \cos\theta - y \left( \tan\phi_x \cos\theta + \sin\theta \right) \\
x \sin\theta - y \left( \tan\phi_x \sin\theta - \cos\theta \right) 
\end{pmatrix},
```

where the $\theta$ and $\phi_x$ correspond to `rotation` and `shear`, and $R_\theta$ and $S_{\phi_x}$ depict rotation and shear matrices.

So, the full expressions that include scale and translation will be:

```
X = sx * x * cos(rotation) - sy * y * (tan(shear) * sin(rotation) + sin(rotation)) + a2
Y = sx * x * sin(rotation) - sy * y * (tan(shear) * sin(rotation) - cos(rotation)) + b2
```

In this PR, I rewrote the code by using the above equations.

## Example

This is an example of a comparison between current and fixed shear transform.

![affine_shear](https://user-images.githubusercontent.com/9190086/215761789-493b283a-3ca6-4abb-be1f-6654ccbb892b.jpg)

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
