### PR TITLE
Use before install script for releases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -176,7 +176,6 @@ jobs:
         run: |
           set -ex
           source tools/github/before_install.sh
-          pip install -U pip setuptools<=65.5 wheel
           python setup.py sdist
           pip install -vv --no-build-isolation .;
 

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -248,8 +248,6 @@ jobs:
 
       - name: Install Twine
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements/build.txt
           pip install twine
 
       - uses: actions/download-artifact@v3
@@ -261,6 +259,7 @@ jobs:
       - name: Publish the source distribution on PyPI
         run: |
           SK_VERSION=$(git describe --tags)
+          source tools/github/before_install.sh
           python setup.py sdist
           ls -la ${{ github.workspace }}/dist
           # We prefer to release wheels before source because otherwise there is a


### PR DESCRIPTION
The release failed https://github.com/scikit-image/scikit-image/actions/runs/4061600040/jobs/6993288214 with the error
```
  File "/home/runner/work/scikit-image/scikit-image/skimage/__init__.py", line 73, in <module>
    import lazy_loader as lazy
ModuleNotFoundError: No module named 'lazy_loader'
Error: Process completed with exit code 1.
```

This adds
```
source tools/github/before_install.sh
```
and `tools/github/before_install.sh` includes
```
python -m pip install --upgrade pip wheel "setuptools<=65.5"
python -m pip install $PIP_FLAGS -r requirements/build.txt
python -m pip install $PIP_FLAGS -r requirements/default.txt
```
