### PR TITLE
meson: extract version info from __init__.py

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
   # Note that the git commit hash cannot be added dynamically here
   # That only happens when importing from a git repository.
   # See `skimage/__init__.py`
-  version: '0.20.0.dev0',
+  version: run_command('skimage/_build_utils/version.py', check: true).stdout().strip(),
   license: 'BSD-3',
   meson_version: '>= 0.63.0',
   default_options: [

--- a/skimage/_build_utils/copyfiles.py
+++ b/skimage/_build_utils/copyfiles.py
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python
 """ Platform independent file copier script
 """
 

--- a/skimage/_build_utils/cythoner.py
+++ b/skimage/_build_utils/cythoner.py
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python
 """ Scipy variant of Cython command
 
 Cython, as applied to single pyx file.

--- a/skimage/_build_utils/gcc_build_bitness.py
+++ b/skimage/_build_utils/gcc_build_bitness.py
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python
 """ Detect bitness (32 or 64) of Mingw-w64 gcc build target on Windows.
 """
 

--- a/skimage/_build_utils/tempita.py
+++ b/skimage/_build_utils/tempita.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import sys
 import os
 import argparse

--- a/skimage/_build_utils/version.py
+++ b/skimage/_build_utils/version.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+""" Extract version number from __init__.py
+"""
+
+import os
+
+
+ski_init = os.path.join(os.path.dirname(__file__), '../__init__.py')
+
+data = open(ski_init).readlines()
+version_line = next(line for line in data if line.startswith('__version__'))
+
+version = version_line.strip().split(' = ')[1].replace('"', '').replace("'", '')
+
+print(version)


### PR DESCRIPTION
Fix #6721.

Waiting on https://github.com/mesonbuild/meson/issues/11356 and on the CI build results to see what to do about the `#!python` lines in the scripts.