### PR TITLE
Fix Cython errors/warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,16 +29,10 @@ elif cc.get_id() == 'msvc'
   endif
 endif
 
-# TODO: the below -Wno flags are all needed to silence warnings in
-# f2py-generated code. This should be fixed in f2py itself.
 _global_c_args = cc.get_supported_arguments(
-  '-Wno-unused-but-set-variable',
   '-Wno-unused-function',
-  '-Wno-conversion',
-  '-Wno-misleading-indentation',
-  '-Wno-incompatible-pointer-types',
 )
-add_project_arguments(_global_c_args, language : 'c')
+add_project_arguments(_global_c_args, language: ['c', 'cpp'])
 
 # We need -lm for all C code (assuming it uses math functions, which is safe to
 # assume for scikit-image). For C++ it isn't needed, because libstdc++/libc++ is

--- a/skimage/_shared/fast_exp.pyx
+++ b/skimage/_shared/fast_exp.pyx
@@ -1,4 +1,3 @@
-import numpy as np
 cimport numpy as cnp
 from .fused_numerics cimport np_floats
 from .fast_exp cimport _fast_exp_floats

--- a/skimage/_shared/geometry.pyx
+++ b/skimage/_shared/geometry.pyx
@@ -2,7 +2,6 @@
 #cython: boundscheck=False
 #cython: nonecheck=False
 #cython: wraparound=False
-import numpy as np
 
 cimport numpy as cnp
 cnp.import_array()

--- a/skimage/draw/_draw.pyx
+++ b/skimage/draw/_draw.pyx
@@ -2,7 +2,6 @@
 #cython: boundscheck=False
 #cython: nonecheck=False
 #cython: wraparound=False
-import math
 import numpy as np
 
 cimport numpy as cnp
@@ -134,7 +133,6 @@ def _line_aa(Py_ssize_t r0, Py_ssize_t c0, Py_ssize_t r1, Py_ssize_t c1):
     cdef list val = list()
 
     cdef int dc = abs(c0 - c1)
-    cdef int dc_prime
 
     cdef int dr = abs(r0 - r1)
     cdef cnp.float64_t err = dc - dr
@@ -216,7 +214,6 @@ def _polygon(r, c, shape):
     r = np.atleast_1d(r)
     c = np.atleast_1d(c)
 
-    cdef Py_ssize_t nr_verts = c.shape[0]
     cdef Py_ssize_t minr = int(max(0, r.min()))
     cdef Py_ssize_t maxr = int(ceil(r.max()))
     cdef Py_ssize_t minc = int(max(0, c.min()))
@@ -294,9 +291,6 @@ def _circle_perimeter(Py_ssize_t r_o, Py_ssize_t c_o, Py_ssize_t radius,
     cdef Py_ssize_t r = radius
     cdef Py_ssize_t d = 0
 
-    cdef cnp.float64_t dceil = 0
-    cdef cnp.float64_t dceil_prev = 0
-
     cdef char cmethod
     if method == 'bresenham':
         d = 3 - 2 * radius
@@ -372,7 +366,6 @@ def _circle_perimeter_aa(Py_ssize_t r_o, Py_ssize_t c_o,
 
     cdef Py_ssize_t c = 0
     cdef Py_ssize_t r = radius
-    cdef Py_ssize_t d = 0
 
     cdef cnp.float64_t dceil = 0
     cdef cnp.float64_t dceil_prev = 0

--- a/skimage/feature/_cascade.pyx
+++ b/skimage/feature/_cascade.pyx
@@ -11,7 +11,6 @@ from . cimport safe_openmp as openmp
 from .safe_openmp cimport have_openmp
 from libc.stdlib cimport malloc, free
 from libcpp.vector cimport vector
-from skimage._shared.transform cimport integrate
 
 from skimage._shared.interpolation cimport round, fmax, fmin
 
@@ -124,7 +123,6 @@ cdef vector[Detection] _group_detections(vector[Detection] detections,
     cdef:
         Detection mean_detection
         vector[DetectionsCluster] clusters
-        vector[int] clusters_scores
         Py_ssize_t nr_of_clusters
         Py_ssize_t current_detection_nr
         Py_ssize_t current_cluster_nr
@@ -382,7 +380,6 @@ cdef cnp.float32_t rect_intersection_score(Detection rect_a, Detection rect_b):
 
     cdef:
         cnp.float32_t intersection_area
-        cnp.float32_t union_area
         cnp.float32_t smaller_area
         cnp.float32_t area_a = rect_a.height * rect_a.width
         cnp.float32_t area_b = rect_b.height * rect_b.width
@@ -525,19 +522,14 @@ cdef class Cascade:
         """
 
         cdef:
-            cnp.float32_t stage_threshold
             cnp.float32_t stage_points
             int lbp_code
             int bit
             Py_ssize_t stage_number
             Py_ssize_t weak_classifier_number
-            Py_ssize_t feature_number
-            Py_ssize_t features_number
-            Py_ssize_t stumps_number
             Py_ssize_t first_stump_idx
             Py_ssize_t lut_idx
             Py_ssize_t r, c, width, height
-            cnp.uint32_t[::1] current_lut
             Stage current_stage
             MBLBPStump current_stump
             MBLBP current_feature

--- a/skimage/feature/_haar.pyx
+++ b/skimage/feature/_haar.pyx
@@ -28,7 +28,6 @@ cdef vector[vector[Rectangle]] _haar_like_feature_coord(
     """Private function to compute the coordinates of all Haar-like features.
     """
     cdef:
-        Py_ssize_t max_feature = height * height * width * width
         vector[vector[Rectangle]] rect_feat
         Rectangle single_rect
         Py_ssize_t n_rectangle

--- a/skimage/feature/_hoghistogram.pyx
+++ b/skimage/feature/_hoghistogram.pyx
@@ -114,7 +114,7 @@ def hog_histograms(np_floats[:, ::1] gradient_columns,
                                                 gradient_rows)
     cdef np_floats[:, ::1] orientation = \
         np.rad2deg(np.arctan2(gradient_rows, gradient_columns)) % 180
-    cdef int i, c, r, o, r_i, c_i, cc, cr, c_0, r_0, \
+    cdef int i, c, r, r_i, c_i, cc, cr, c_0, r_0, \
         range_rows_start, range_rows_stop, \
         range_columns_start, range_columns_stop
     cdef np_floats orientation_start, orientation_end, \

--- a/skimage/feature/_sift.pyx
+++ b/skimage/feature/_sift.pyx
@@ -5,7 +5,7 @@
 
 import numpy as np
 cimport numpy as cnp
-from libc.math cimport M_PI, floor
+from libc.math cimport M_PI
 
 from .._shared.fused_numerics cimport np_floats
 
@@ -31,7 +31,7 @@ cpdef _ori_distances(np_floats[::1] ori_bins,
     cdef:
         Py_ssize_t n_theta = theta.size
         Py_ssize_t n_ori = ori_bins.size
-        Py_ssize_t i, j, idx_min
+        Py_ssize_t i, j, idx_min = 0
         np_floats th, dist, dist_min
         np_floats two_pi = 2 * M_PI
         Py_ssize_t[::1] near_t = np.empty((n_theta, ), dtype=np.intp)
@@ -91,7 +91,7 @@ cpdef _update_histogram(np_floats[:, :, ::1] histograms,
 
     """
     cdef:
-        Py_ssize_t i, p, r, c, k_index, k_index2
+        Py_ssize_t p, r, c, k_index, k_index2
         Py_ssize_t n_patch = len(magnitude)
         Py_ssize_t n_hist = histograms.shape[0]
         Py_ssize_t n_ori = histograms.shape[2]

--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -4,7 +4,7 @@
 #cython: wraparound=False
 import numpy as np
 cimport numpy as cnp
-from libc.math cimport sin, cos, abs
+from libc.math cimport sin, cos
 from .._shared.interpolation cimport bilinear_interpolation, round
 from .._shared.transform cimport integrate
 
@@ -12,7 +12,6 @@ cdef extern from "numpy/npy_math.h":
     cnp.float64_t NAN "NPY_NAN"
 
 from .._shared.fused_numerics cimport np_anyint as any_int
-from .._shared.fused_numerics cimport np_real_numeric
 
 cnp.import_array()
 
@@ -326,7 +325,7 @@ cpdef int _multiblock_lbp(np_floats[:, ::1] int_image,
         Py_ssize_t c_shift = width - 1
 
         Py_ssize_t current_rect_r, current_rect_c
-        Py_ssize_t element_num, i
+        Py_ssize_t element_num
         np_floats current_rect_val
         int has_greater_value
         int lbp_code = 0

--- a/skimage/feature/corner_cy.pyx
+++ b/skimage/feature/corner_cy.pyx
@@ -8,7 +8,6 @@ from libc.float cimport DBL_MAX
 from libc.math cimport atan2, fabs
 
 from .._shared.fused_numerics cimport np_floats
-from ..util import img_as_float64
 
 cnp.import_array()
 
@@ -70,7 +69,7 @@ def _corner_moravec(np_floats[:, ::1] cimage, Py_ssize_t window_size=1):
     cdef np_floats[:, ::1] out = np.zeros((rows, cols), dtype=dtype)
 
     cdef np_floats msum, min_msum, t
-    cdef Py_ssize_t r, c, br, bc, mr, mc, a, b
+    cdef Py_ssize_t r, c, br, bc, mr, mc
 
     with nogil:
         for r in range(2 * window_size, rows - 2 * window_size):

--- a/skimage/feature/meson.build
+++ b/skimage/feature/meson.build
@@ -21,12 +21,6 @@ foreach pyx_file: pyx_files
   )
 endforeach
 
-if cc.has_argument('-Wno-unused-but-set-variable')
-  Wno_unused_but_set = ['-Wno-unused-but-set-variable']
-else
-  Wno_unused_but_set = []
-endif
-
 _brief_pythran = custom_target('_brief_pythran',
   output: ['brief_cy.cpp'],
   input: 'brief_pythran.py',
@@ -35,12 +29,7 @@ _brief_pythran = custom_target('_brief_pythran',
 
 py3.extension_module('brief_cy',
   [_brief_pythran],
-  cpp_args: [
-    '-Wno-unused-function', '-Wno-unused-variable',
-    '-Wno-deprecated-declarations',
-    '-Wno-cpp', '-Wno-int-in-bool-context',
-    Wno_unused_but_set
-  ] + cpp_args_pythran,
+  cpp_args: cpp_args_pythran,
   include_directories: [incdir_pythran, incdir_numpy],
   dependencies: [py3_dep],
   install: true,
@@ -55,12 +44,7 @@ _hessian_det_appx_pythran = custom_target('_hessian_det_appx_pythran',
 
 py3.extension_module('_hessian_det_appx',
   [_hessian_det_appx_pythran],
-  cpp_args: [
-    '-Wno-unused-function', '-Wno-unused-variable',
-    '-Wno-deprecated-declarations',
-    '-Wno-cpp', '-Wno-int-in-bool-context',
-    Wno_unused_but_set
-  ] + cpp_args_pythran,
+  cpp_args: cpp_args_pythran,
   include_directories: [incdir_pythran, incdir_numpy],
   dependencies: [py3_dep],
   install: true,

--- a/skimage/feature/orb_cy.pyx
+++ b/skimage/feature/orb_cy.pyx
@@ -16,7 +16,7 @@ from ._orb_descriptor_positions import POS, POS0, POS1
 def _orb_loop(np_floats[:, ::1] image, Py_ssize_t[:, ::1] keypoints,
               np_floats[:] orientations):
 
-    cdef Py_ssize_t i, d, kr, kc, pr0, pr1, pc0, pc1, spr0, spc0, spr1, spc1
+    cdef Py_ssize_t i, kr, kc, pr0, pr1, pc0, pc1, spr0, spc0, spr1, spc1
     cdef np_floats angle, sin_a, cos_a
     cdef unsigned char[:, ::1] descriptors = np.zeros(
         (keypoints.shape[0], POS.shape[0]), dtype=np.uint8)

--- a/skimage/filters/_multiotsu.pyx
+++ b/skimage/filters/_multiotsu.pyx
@@ -5,7 +5,6 @@
 import numpy as np
 
 cimport numpy as cnp
-cimport cython
 cnp.import_array()
 
 def _get_multiotsu_thresh_indices_lut(cnp.float32_t [::1] prob,

--- a/skimage/filters/rank/bilateral_cy.pyx
+++ b/skimage/filters/rank/bilateral_cy.pyx
@@ -4,7 +4,6 @@
 #cython: wraparound=False
 
 cimport numpy as cnp
-from libc.math cimport log
 
 from .core_cy cimport dtype_t, dtype_t_out, _core
 

--- a/skimage/filters/rank/core_cy.pyx
+++ b/skimage/filters/rank/core_cy.pyx
@@ -4,11 +4,10 @@
 #cython: wraparound=False
 
 import numpy as np
-
 cimport numpy as cnp
-from libc.stdlib cimport malloc, free
 
 cnp.import_array()
+
 
 cdef inline dtype_t _max(dtype_t a, dtype_t b) nogil:
     return a if a >= b else b
@@ -83,7 +82,7 @@ cdef void _core(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t[::1], cnp.float
         mask_data = &mask[0, 0]
 
     # define local variable types
-    cdef Py_ssize_t r, c, rr, cc, s, value, local_max, i, even_row
+    cdef Py_ssize_t r, c, rr, cc, s, even_row
 
     # number of pixels actually inside the neighborhood (cnp.float64_t)
     cdef cnp.float64_t pop = 0

--- a/skimage/filters/rank/core_cy_3d.pyx
+++ b/skimage/filters/rank/core_cy_3d.pyx
@@ -4,9 +4,7 @@
 #cython: wraparound=False
 
 import numpy as np
-
 cimport numpy as cnp
-from libc.stdlib cimport malloc, free
 
 cnp.import_array()
 
@@ -207,7 +205,7 @@ cdef void _core_3D(void kernel(dtype_t_out*, Py_ssize_t, Py_ssize_t[::1], cnp.fl
     cdef char* mask_data = &mask[0, 0, 0]
 
     # define local variable types
-    cdef Py_ssize_t p, r, c, rr, cc, pp, value, local_max, i, even_row
+    cdef Py_ssize_t p, r, c, even_row
 
     # number of pixels actually inside the neighborhood (cnp.float64_t)
     cdef cnp.float64_t pop = 0

--- a/skimage/filters/rank/generic_cy.pyx
+++ b/skimage/filters/rank/generic_cy.pyx
@@ -21,7 +21,7 @@ cdef inline void _kernel_autolevel(dtype_t_out* out, Py_ssize_t odepth,
                                    cnp.float64_t p0, cnp.float64_t p1,
                                    Py_ssize_t s0, Py_ssize_t s1) nogil:
 
-    cdef Py_ssize_t i, imin, imax, delta
+    cdef Py_ssize_t i, imin = 0, imax = 0, delta
 
     if pop:
         for i in range(n_bins - 1, -1, -1):
@@ -68,7 +68,7 @@ cdef inline void _kernel_gradient(dtype_t_out* out, Py_ssize_t odepth,
                                   cnp.float64_t p0, cnp.float64_t p1,
                                   Py_ssize_t s0, Py_ssize_t s1) nogil:
 
-    cdef Py_ssize_t i, imin, imax
+    cdef Py_ssize_t i, imin = 0, imax = 0
 
     if pop:
         for i in range(n_bins - 1, -1, -1):
@@ -225,7 +225,7 @@ cdef inline void _kernel_enhance_contrast(dtype_t_out* out,
                                           cnp.float64_t p1, Py_ssize_t s0,
                                           Py_ssize_t s1) nogil:
 
-    cdef Py_ssize_t i, imin, imax
+    cdef Py_ssize_t i, imin = 0, imax = 0
 
     if pop:
         for i in range(n_bins - 1, -1, -1):
@@ -391,7 +391,6 @@ cdef inline void _kernel_win_hist(dtype_t_out* out, Py_ssize_t odepth,
                                   cnp.float64_t p0, cnp.float64_t p1,
                                   Py_ssize_t s0, Py_ssize_t s1) nogil:
     cdef Py_ssize_t i
-    cdef Py_ssize_t max_i
     cdef cnp.float64_t scale
     if pop:
         scale = 1.0 / pop

--- a/skimage/filters/rank/percentile_cy.pyx
+++ b/skimage/filters/rank/percentile_cy.pyx
@@ -14,7 +14,7 @@ cdef inline void _kernel_autolevel(dtype_t_out* out, Py_ssize_t odepth,
                                    cnp.float64_t p0, cnp.float64_t p1,
                                    Py_ssize_t s0, Py_ssize_t s1) nogil:
 
-    cdef Py_ssize_t i, imin, imax, sum, delta
+    cdef Py_ssize_t i = 0, imin = 0, imax = 0, sum, delta
 
     if pop:
         sum = 0
@@ -48,7 +48,7 @@ cdef inline void _kernel_gradient(dtype_t_out* out, Py_ssize_t odepth,
                                   cnp.float64_t p0, cnp.float64_t p1,
                                   Py_ssize_t s0, Py_ssize_t s1) nogil:
 
-    cdef Py_ssize_t i, imin, imax, sum, delta
+    cdef Py_ssize_t i, imin = 0, imax = 0, sum
 
     if pop:
         sum = 0
@@ -158,7 +158,7 @@ cdef inline void _kernel_enhance_contrast(dtype_t_out* out,
                                           cnp.float64_t p1, Py_ssize_t s0,
                                           Py_ssize_t s1) nogil:
 
-    cdef Py_ssize_t i, imin, imax, sum, delta
+    cdef Py_ssize_t i, imin = 0, imax = 0, sum
 
     if pop:
         sum = 0
@@ -193,7 +193,7 @@ cdef inline void _kernel_percentile(dtype_t_out* out, Py_ssize_t odepth,
                                     cnp.float64_t p0, cnp.float64_t p1,
                                     Py_ssize_t s0, Py_ssize_t s1) nogil:
 
-    cdef Py_ssize_t i
+    cdef Py_ssize_t i = 0
     cdef Py_ssize_t sum = 0
 
     if pop:
@@ -218,7 +218,7 @@ cdef inline void _kernel_pop(dtype_t_out* out, Py_ssize_t odepth,
                              cnp.float64_t p0, cnp.float64_t p1,
                              Py_ssize_t s0, Py_ssize_t s1) nogil:
 
-    cdef Py_ssize_t i, sum, n
+    cdef Py_ssize_t i = 0, sum, n
 
     if pop:
         sum = 0
@@ -239,7 +239,7 @@ cdef inline void _kernel_threshold(dtype_t_out* out, Py_ssize_t odepth,
                                    cnp.float64_t p0, cnp.float64_t p1,
                                    Py_ssize_t s0, Py_ssize_t s1) nogil:
 
-    cdef int i
+    cdef int i = 0
     cdef Py_ssize_t sum = 0
 
     if pop:

--- a/skimage/graph/_mcp.pyx
+++ b/skimage/graph/_mcp.pyx
@@ -439,7 +439,7 @@ cdef class MCP:
         # basic variables to use for end-finding; also fix up the start and end
         # lists
         cdef BOOL_T use_ends = 0
-        cdef INDEX_T num_ends
+        cdef INDEX_T num_ends = 0
         cdef BOOL_T all_ends = find_all_ends
         cdef INDEX_T[:] flat_ends
         starts = _normalize_indices(starts, self.costs_shape)

--- a/skimage/graph/_ncut_cy.pyx
+++ b/skimage/graph/_ncut_cy.pyx
@@ -59,7 +59,7 @@ def cut_cost(cut, W):
         The total weight of crossing edges.
     """
     cdef cnp.ndarray[cnp.uint8_t, cast = True] cut_mask = np.array(cut)
-    cdef Py_ssize_t num_rows, num_cols
+    cdef Py_ssize_t num_cols
     cdef cnp.int32_t row, col
     cdef cnp.int32_t[:] indices = W.indices
     cdef cnp.int32_t[:] indptr = W.indptr
@@ -67,7 +67,6 @@ def cut_cost(cut, W):
     cdef cnp.int32_t row_index
     cdef cnp.float64_t cost = 0
 
-    num_rows = W.shape[0]
     num_cols = W.shape[1]
 
     for col in range(num_cols):

--- a/skimage/graph/heap.pyx
+++ b/skimage/graph/heap.pyx
@@ -4,7 +4,6 @@
 Cython implementation of a binary min heap.
 """
 # cython specific imports
-import cython
 from libc.stdlib cimport malloc, free
 
 cdef extern from "pyport.h":

--- a/skimage/io/_plugins/_histograms.pyx
+++ b/skimage/io/_plugins/_histograms.pyx
@@ -50,7 +50,7 @@ def histograms(cnp.ndarray[cnp.uint8_t, ndim=3] img, int nbins):
     b = np.zeros((nbins,), dtype=np.int32)
     v = np.zeros((nbins,), dtype=np.int32)
 
-    cdef int i, j, k, rbin, gbin, bbin, vbin
+    cdef int i, j, rbin, gbin, bbin, vbin
     cdef cnp.float32_t bin_width = 255./ nbins
     cdef cnp.float32_t R, G, B, V
 

--- a/skimage/measure/_ccomp.pyx
+++ b/skimage/measure/_ccomp.pyx
@@ -4,7 +4,6 @@
 #cython: wraparound=False
 
 import numpy as np
-from warnings import warn
 
 cimport numpy as cnp
 cnp.import_array()

--- a/skimage/measure/_find_contours_cy.pyx
+++ b/skimage/measure/_find_contours_cy.pyx
@@ -2,7 +2,6 @@
 #cython: boundscheck=False
 #cython: nonecheck=False
 #cython: wraparound=False
-import numpy as np
 cimport numpy as cnp
 cnp.import_array()
 

--- a/skimage/measure/_marching_cubes_lewiner_cy.pyx
+++ b/skimage/measure/_marching_cubes_lewiner_cy.pyx
@@ -22,7 +22,6 @@ by Almar Klein in 2012. Adapted for scikit-image in 2016.
 # Cython specific imports
 import numpy as np
 cimport numpy as cnp
-import cython
 cnp.import_array()
 
 # Enable low level memory management
@@ -379,7 +378,7 @@ cdef class Cell:
     def get_faces(self):
         faces = np.empty((self._faceCount,), np.int32)
         cdef int [:] faces_ = faces
-        cdef int i, j
+        cdef int i
         for i in range(self._faceCount):
             faces_[i] = self._faces[i]
         return faces
@@ -387,7 +386,7 @@ cdef class Cell:
     def get_values(self):
         values = np.empty((self._vertexCount,), np.float32)
         cdef cnp.float32_t [:] values_ = values
-        cdef int i, j
+        cdef int i
         for i in range(self._vertexCount):
             values_[i] = self._values[i]
         return values
@@ -611,7 +610,6 @@ cdef class Cell:
         # Init indices, both are corrected below
         cdef int i = self.nx * self.y + self.x  # Index of cube to get vertex at
         cdef int j = 0 # Vertex number for that cell
-        cdef int vi_ = vi
 
         cdef int *faceLayer
 
@@ -956,7 +954,7 @@ def marching_cubes(cnp.float32_t[:, :, :] im not None, cnp.float64_t isovalue,
     # Typedef variables
     cdef int x, y, z, x_st, y_st, z_st
     cdef int nt
-    cdef int case, config, subconfig
+    cdef int case, config
     cdef bint no_mask = mask is None
     # Unfortunately specifying a step in range() significantly degrades
     # performance. Therefore we use a while loop.
@@ -1288,7 +1286,7 @@ cdef int test_face(Cell cell, int face):
         absFace *= -1
 
     # Get values of corners A B C D
-    cdef cnp.float64_t A, B, C, D
+    cdef cnp.float64_t A=0, B=0, C=0, D=0
     if absFace == 1:
         A, B, C, D = cell.v0, cell.v4, cell.v5, cell.v1
     elif absFace == 2:

--- a/skimage/morphology/_max_tree.pyx
+++ b/skimage/morphology/_max_tree.pyx
@@ -15,7 +15,6 @@ functions to characterize the tree components.
 
 import numpy as np
 cimport numpy as np
-cimport cython
 from .._shared.fused_numerics cimport np_real_numeric
 
 np.import_array()
@@ -132,7 +131,7 @@ cdef np.ndarray[DTYPE_INT32_t, ndim = 2] unravel_offsets(
                                                         dtype=np.int32)
     cdef DTYPE_INT32_t neg_shift = np.ravel_multi_index(center_point, shape)
 
-    cdef DTYPE_INT32_t i, offset, curr_index, coord
+    cdef DTYPE_INT32_t i, offset
 
     for i, offset in enumerate(offsets):
         current_point = np.unravel_index(offset + neg_shift, shape)
@@ -268,7 +267,6 @@ cpdef void _max_tree_local_maxima(np_real_numeric[::1] image,
 
     cdef DTYPE_INT64_t p_root = sorted_indices[0]
     cdef DTYPE_INT64_t p, q
-    cdef DTYPE_UINT64_t number_of_pixels = len(image)
     cdef DTYPE_UINT64_t label = 1
 
     for p in sorted_indices[::-1]:
@@ -346,7 +344,6 @@ cpdef void _direct_filter(np_real_numeric[::1] image,
 
     cdef DTYPE_INT64_t p_root = sorted_indices[0]
     cdef DTYPE_INT64_t p, q
-    cdef DTYPE_UINT64_t number_of_pixels = len(image)
 
     if attribute[p_root] < attribute_threshold:
         output[p_root] = 0
@@ -415,7 +412,6 @@ cpdef void _max_tree(np_real_numeric[::1] image,
     """
 
     cdef DTYPE_UINT64_t number_of_pixels = len(image)
-    cdef DTYPE_UINT64_t number_of_dimensions = len(shape)
 
     cdef DTYPE_INT64_t i = 0
     cdef DTYPE_INT64_t p = 0

--- a/skimage/restoration/_denoise_cy.pyx
+++ b/skimage/restoration/_denoise_cy.pyx
@@ -5,7 +5,7 @@
 
 cimport numpy as cnp
 import numpy as np
-from libc.math cimport exp, fabs, sqrt
+from libc.math cimport sqrt
 from libc.float cimport DBL_MAX
 from .._shared.interpolation cimport get_pixel3d
 from .._shared.fused_numerics cimport np_floats
@@ -32,7 +32,7 @@ def _denoise_bilateral(np_floats[:, :, ::1] image, cnp.float64_t max_value,
         Py_ssize_t window_ext = (win_size - 1) / 2
         Py_ssize_t max_color_lut_bin = bins - 1
 
-        Py_ssize_t r, c, d, wr, wc, kr, kc, rr, cc, pixel_addr, color_lut_bin
+        Py_ssize_t r, c, d, wr, wc, kr, kc, rr, cc, color_lut_bin
         np_floats value, weight, dist, total_weight, csigma_color, color_weight, \
                range_weight, t
         np_floats dist_scale
@@ -103,13 +103,9 @@ def _denoise_tv_bregman(np_floats[:, :, ::1] image, np_floats weight,
         Py_ssize_t rows = image.shape[0]
         Py_ssize_t cols = image.shape[1]
         Py_ssize_t dims = image.shape[2]
-        Py_ssize_t rows2 = rows + 2
-        Py_ssize_t cols2 = cols + 2
         Py_ssize_t r, c, k
 
         Py_ssize_t total = rows * cols * dims
-
-    shape_ext = (rows2, cols2, dims)
 
     cdef:
         np_floats[:, :, ::1] dx = out.copy()

--- a/skimage/restoration/_inpaint.pyx
+++ b/skimage/restoration/_inpaint.pyx
@@ -1,7 +1,5 @@
-import numpy as np
 import cython
 
-cimport numpy as cnp
 from .._shared.fused_numerics cimport np_floats
 
 

--- a/skimage/restoration/_nl_means_denoising.pyx
+++ b/skimage/restoration/_nl_means_denoising.pyx
@@ -159,7 +159,6 @@ def _nl_means_denoising_2d(cnp.ndarray[np_floats, ndim=3] image, Py_ssize_t s,
         np.pad(image, ((offset, offset), (offset, offset), (0, 0)),
                mode='reflect'))
     cdef np_floats [:, :, ::1] result = np.empty_like(image)
-    cdef np_floats new_value
     cdef np_floats weight_sum, weight
 
     cdef np_floats A = ((s - 1.) / 4.)
@@ -1008,7 +1007,6 @@ def _fast_nl_means_denoising_4d(cnp.ndarray[np_floats, ndim=5] image,
              pln, row, col, channel, n_channels, t_time, n_time, time
     cdef Py_ssize_t time_dist_min, time_dist_max, pln_dist_min, pln_dist_max, \
              row_dist_min, row_dist_max, col_dist_min, col_dist_max,
-    cdef Py_ssize_t d_row, d_col, d_pln, d_time
     cdef cnp.float64_t weight, distance, alpha
     n_time, n_pln, n_row, n_col, n_channels = padded.shape[0], padded.shape[1], padded.shape[2], padded.shape[3], padded.shape[4]
     cdef cnp.float64_t s4_h_square = n_channels * h * h * s * s * s * s

--- a/skimage/restoration/_rolling_ball_cy.pyx
+++ b/skimage/restoration/_rolling_ball_cy.pyx
@@ -1,6 +1,5 @@
 import math
 
-import numpy as np
 cimport cython
 from libc.math cimport isnan, INFINITY
 from cython.parallel cimport prange

--- a/skimage/restoration/unwrap_2d_ljmu.c
+++ b/skimage/restoration/unwrap_2d_ljmu.c
@@ -644,11 +644,6 @@ void unwrapImage(PIXELM *pixel, int image_width, int image_height) {
 // set the masked pixels (mask = 0) to the minimum of the unwrapper phase
 void maskImage(PIXELM *pixel, unsigned char *input_mask, int image_width,
                int image_height) {
-  int image_width_plus_one = image_width + 1;
-  int image_height_plus_one = image_height + 1;
-  int image_width_minus_one = image_width - 1;
-  int image_height_minus_one = image_height - 1;
-
   PIXELM *pointer_pixel = pixel;
   unsigned char *IMP = input_mask;  // input mask pointer
   double min = DBL_MAX;

--- a/skimage/restoration/unwrap_3d_ljmu.c
+++ b/skimage/restoration/unwrap_3d_ljmu.c
@@ -230,7 +230,7 @@ void extend_mask(unsigned char *input_mask, unsigned char *extended_mask,
                  int volume_width, int volume_height, int volume_depth,
                  params_t *params) {
   int n, i, j;
-  int vw = volume_width, vh = volume_height, vd = volume_depth;
+  int vw = volume_width;
   int fs = volume_width * volume_height;  // frame size
   int frame_size = volume_width * volume_height;
   int volume_size = volume_width * volume_height * volume_depth;  // volume size
@@ -1058,15 +1058,10 @@ void unwrapVolume(VOXELM *voxel, int volume_width, int volume_height,
 // set the masked voxels (mask = 0) to the minimum of the unwrapper phase
 void maskVolume(VOXELM *voxel, unsigned char *input_mask, int volume_width,
                 int volume_height, int volume_depth) {
-  int volume_width_plus_one = volume_width + 1;
-  int volume_height_plus_one = volume_height + 1;
-  int volume_width_minus_one = volume_width - 1;
-  int volume_height_minus_one = volume_height - 1;
-
   VOXELM *pointer_voxel = voxel;
   unsigned char *IMP = input_mask;  // input mask pointer
   double min = DBL_MAX;
-  int i, j;
+  int i;
   int volume_size = volume_width * volume_height * volume_depth;
 
   // find the minimum of the unwrapped phase

--- a/skimage/segmentation/_felzenszwalb_cy.pyx
+++ b/skimage/segmentation/_felzenszwalb_cy.pyx
@@ -95,7 +95,7 @@ def _felzenszwalb_cython(image, cnp.float64_t scale=1, sigma=0.8,
     # inner cost of segments
     cdef cnp.ndarray[cnp.float64_t, ndim=1] cint = np.zeros(width * height)
     cdef cnp.intp_t seg0, seg1, seg_new, e
-    cdef cnp.float32_t cost, inner_cost0, inner_cost1
+    cdef cnp.float32_t inner_cost0, inner_cost1
     cdef Py_ssize_t num_costs = costs.size
 
     with nogil:

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -1,9 +1,9 @@
-#cython: cdivision=True
-#cython: boundscheck=False
-#cython: nonecheck=False
-#cython: wraparound=False
-import numpy as np
+# cython: cdivision=True
+# cython: boundscheck=False
+# cython: nonecheck=False
+# cython: wraparound=False
 
+import numpy as np
 cimport numpy as cnp
 
 from cpython.mem cimport PyMem_Malloc, PyMem_Free
@@ -15,6 +15,7 @@ from ..draw import circle_perimeter
 from .._shared.interpolation cimport round
 
 cnp.import_array()
+
 
 def _hough_circle(cnp.ndarray img,
                   cnp.ndarray[ndim=1, dtype=cnp.intp_t] radius,
@@ -229,7 +230,7 @@ def _hough_ellipse(cnp.ndarray img, Py_ssize_t threshold=4,
                             if orientation > M_PI:
                                 orientation = orientation - M_PI / 2.
                                 a, b = b, a
-                        results.append((hist_max, # Accumulator
+                        results.append((hist_max,  # Accumulator
                                         yc, xc,
                                         a, b,
                                         orientation))
@@ -379,9 +380,9 @@ def _probabilistic_hough_line(cnp.ndarray img, Py_ssize_t threshold,
         <Py_ssize_t *>PyMem_Malloc(4 * sizeof(Py_ssize_t))
     if not line_end:
         raise MemoryError('could not allocate line_end')
-    cdef Py_ssize_t max_distance, offset, num_indexes, index
+    cdef Py_ssize_t max_distance, offset, index
     cdef cnp.float64_t a, b
-    cdef Py_ssize_t nidxs, i, j, k, x, y, px, py, accum_idx, max_theta
+    cdef Py_ssize_t j, k, x, y, px, py, accum_idx, max_theta
     cdef Py_ssize_t xflag, x0, y0, dx0, dy0, dx, dy, gap, x1, y1, count
     cdef cnp.int64_t value, max_value,
     cdef int shift = 16

--- a/skimage/transform/_radon_transform.pyx
+++ b/skimage/transform/_radon_transform.pyx
@@ -6,7 +6,7 @@ import numpy as np
 
 cimport numpy as cnp
 cimport cython
-from libc.math cimport cos, sin, floor, ceil, sqrt, abs, M_PI
+from libc.math cimport cos, sin, floor, ceil, sqrt, M_PI
 from .._shared.fused_numerics cimport np_floats
 
 cnp.import_array()


### PR DESCRIPTION
Most of these were discovered using `cython-lint --no-pycodestyle` The rest are from fixing compiler warnings, after I [removed most of the suppressing flags](https://github.com/scikit-image/scikit-image/pull/6725/files#diff-245864c5faafafde9e1ae393add6cdc2b4049d1bf969e5cf7efaa759abeef117L58).

For Pythran-related warnings, see https://github.com/serge-sans-paille/pythran/issues/2076

Remaining warnings that I cannot fix:

```
skimage/feature/_cascade.cpython-310-x86_64-linux-gnu.so.p/_cascade.cpp: In function ‘PyObject* __pyx_convert_vector_to_py_struct____pyx_t_7skimage_7feature_8_cascade_Detection(const std::vector<__pyx_t_7skimage_7feature_8_cascade_Detection>&)’:
skimage/feature/_cascade.cpython-310-x86_64-linux-gnu.so.p/_cascade.cpp:96126:33: warning: comparison of integer expressions of different signedness: ‘Py_ssize_t’ {aka ‘long int’} and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
96126 |   for (__pyx_t_5 = 0; __pyx_t_5 < __pyx_t_4; __pyx_t_5+=1) {
      |                       ~~~~~~~~~~^~~~~~~~~~~

In function ‘__pyx_f_7skimage_12segmentation_13_watershed_cy_heappush’,
    inlined from ‘__pyx_pf_7skimage_12segmentation_13_watershed_cy_watershed_raveled’ at skimage/segmentation/_watershed_cy.cpython-310-x86_64-linux-gnu.so.p/_watershed_cy.c:5637:11,
    inlined from ‘__pyx_pw_7skimage_12segmentation_13_watershed_cy_1watershed_raveled’ at skimage/segmentation/_watershed_cy.cpython-310-x86_64-linux-gnu.so.p/_watershed_cy.c:5457:13:
skimage/segmentation/_watershed_cy.cpython-310-x86_64-linux-gnu.so.p/_watershed_cy.c:4804:94: warning: pointer may be used after ‘realloc’ [-Wuse-after-free]
 4804 |       (__pyx_v_heap->ptrs[__pyx_v_k]) = (__pyx_v_new_data + ((__pyx_v_heap->ptrs[__pyx_v_k]) - __pyx_v_heap->data));
      |                                                                                              ^
skimage/segmentation/_watershed_cy.cpython-310-x86_64-linux-gnu.so.p/_watershed_cy.c:4774:92: note: call to ‘realloc’ here
 4774 |     __pyx_v_new_data = ((struct __pyx_t_7skimage_12segmentation_13_watershed_cy_Heapitem *)realloc(((void *)__pyx_v_heap->data), ((Py_ssize_t)(__pyx_v_heap->space * (sizeof(struct __pyx_t_7skimage_12segmentation_13_watershed_cy_Heapitem))))));
      |                                                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘__pyx_f_7skimage_12segmentation_13_watershed_cy_heappush’,
    inlined from ‘__pyx_pf_7skimage_12segmentation_13_watershed_cy_watershed_raveled’ at skimage/segmentation/_watershed_cy.cpython-310-x86_64-linux-gnu.so.p/_watershed_cy.c:5976:13,
    inlined from ‘__pyx_pw_7skimage_12segmentation_13_watershed_cy_1watershed_raveled’ at skimage/segmentation/_watershed_cy.cpython-310-x86_64-linux-gnu.so.p/_watershed_cy.c:5457:13:
skimage/segmentation/_watershed_cy.cpython-310-x86_64-linux-gnu.so.p/_watershed_cy.c:4804:94: warning: pointer may be used after ‘realloc’ [-Wuse-after-free]
 4804 |       (__pyx_v_heap->ptrs[__pyx_v_k]) = (__pyx_v_new_data + ((__pyx_v_heap->ptrs[__pyx_v_k]) - __pyx_v_heap->data));
      |                                                                                              ^
skimage/segmentation/_watershed_cy.cpython-310-x86_64-linux-gnu.so.p/_watershed_cy.c:4774:92: note: call to ‘realloc’ here
 4774 |     __pyx_v_new_data = ((struct __pyx_t_7skimage_12segmentation_13_watershed_cy_Heapitem *)realloc(((void *)__pyx_v_heap->data), ((Py_ssize_t)(__pyx_v_heap->space * (sizeof(struct __pyx_t_7skimage_12segmentation_13_watershed_cy_Heapitem))))));
      |                                                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The first should be trivial, the second is this piece of code:

https://github.com/scikit-image/scikit-image/blob/main/skimage/segmentation/heap_general.pxi#L101

And is presumably triggered by using `heap.data` after calling re-alloc on it.

Perhaps @lagru, @grlee, or @seberg has the chops to fix these?
