### PR TITLE
BUG: Fix heap growing memory error and silence compiler warning

### DIFF
--- a/skimage/morphology/_queue_with_history.pxi
+++ b/skimage/morphology/_queue_with_history.pxi
@@ -115,7 +115,7 @@ cdef inline void queue_exit(QueueWithHistory* self) nogil:
     free(self._buffer_ptr)
 
 
-cdef inline void _queue_grow_buffer(QueueWithHistory* self) nogil:
+cdef inline int _queue_grow_buffer(QueueWithHistory* self) nogil except -1:
     """Double the memory used for the buffer."""
     cdef QueueItem* new_buffer
     self._buffer_size *= 2
@@ -127,3 +127,5 @@ cdef inline void _queue_grow_buffer(QueueWithHistory* self) nogil:
         with gil:
             raise MemoryError("couldn't reallocate buffer")
     self._buffer_ptr = new_buffer_ptr
+
+    return 0

--- a/skimage/segmentation/heap_general.pxi
+++ b/skimage/segmentation/heap_general.pxi
@@ -106,7 +106,8 @@ cdef inline void heappush(Heap *heap, Heapitem *new_elem) nogil:
         new_data = <Heapitem *>realloc(<void *>heap.data,
                         <Py_ssize_t>(heap.space * sizeof(Heapitem)))
         if not new_data:
-            raise MemoryError()
+            with gil:
+                raise MemoryError()
         heap.data = new_data
 
         # If necessary, correct all stored pointers:
@@ -117,7 +118,8 @@ cdef inline void heappush(Heap *heap, Heapitem *new_elem) nogil:
         new_ptrs = <Heapitem **>realloc(<void *>heap.ptrs,
                     <Py_ssize_t>(heap.space * sizeof(Heapitem *)))
         if not new_ptrs:
-            raise MemoryError()
+            with gil:
+                raise MemoryError()
         heap.ptrs = new_ptrs
 
         # Initialize newly allocated pointer storage:

--- a/skimage/segmentation/heap_general.pxi
+++ b/skimage/segmentation/heap_general.pxi
@@ -93,20 +93,36 @@ cdef inline void heappush(Heap *heap, Heapitem *new_elem) nogil:
     cdef Py_ssize_t child = heap.items
     cdef Py_ssize_t parent
     cdef Py_ssize_t k
+    cdef Heapitem *original_data_ptr
     cdef Heapitem *new_data
+    cdef Heapitem **new_ptr
 
     # grow if necessary
     if heap.items == heap.space:
-      heap.space = heap.space * 2
-      new_data = <Heapitem*>realloc(<void*>heap.data,
-                    <Py_ssize_t>(heap.space * sizeof(Heapitem)))
-      heap.ptrs = <Heapitem**>realloc(<void*>heap.ptrs,
+        heap.space = heap.space * 2
+
+        # Original pointer to silence compiler warnings about use-after-free:
+        original_data_ptr = heap.data
+        new_data = <Heapitem *>realloc(<void *>heap.data,
+                        <Py_ssize_t>(heap.space * sizeof(Heapitem)))
+        if not new_data:
+            raise MemoryError()
+        heap.data = new_data
+
+        # If necessary, correct all stored pointers:
+        if original_data_ptr != heap.data:
+            for k in range(heap.items):
+                heap.ptrs[k] = heap.data + (heap.ptrs[k] - original_data_ptr)
+
+        new_ptrs = <Heapitem **>realloc(<void *>heap.ptrs,
                     <Py_ssize_t>(heap.space * sizeof(Heapitem *)))
-      for k in range(heap.items):
-          heap.ptrs[k] = new_data + (heap.ptrs[k] - heap.data)
-      for k in range(heap.items, heap.space):
-          heap.ptrs[k] = new_data + k
-      heap.data = new_data
+        if not new_ptrs:
+            raise MemoryError()
+        heap.ptrs = new_ptrs
+
+        # Initialize newly allocated pointer storage:
+        for k in range(heap.items, heap.space):
+            heap.ptrs[k] = new_data + k
 
     # insert new data at child
     heap.ptrs[child][0] = new_elem[0]

--- a/skimage/segmentation/heap_general.pxi
+++ b/skimage/segmentation/heap_general.pxi
@@ -88,7 +88,7 @@ cdef inline void heappop(Heap *heap, Heapitem *dest) nogil:
 #
 # Note: heap ordering is the same as python heapq, i.e., smallest first.
 ##################################################
-cdef inline void heappush(Heap *heap, Heapitem *new_elem) nogil:
+cdef inline int heappush(Heap *heap, Heapitem *new_elem) nogil except -1:
 
     cdef Py_ssize_t child = heap.items
     cdef Py_ssize_t parent
@@ -139,3 +139,5 @@ cdef inline void heappush(Heap *heap, Heapitem *new_elem) nogil:
             child = parent
         else:
             break
+
+    return 0


### PR DESCRIPTION
I am not 100% sure how certain the fix is here.  The code seemed always fine (although I am not quite sure that pointer arithmetic on dead pointers is technically valid).

The current logic seemed to be broken for realloc failures, so I fixed that which is the larger diff...

(I have not added tests since trigger memory error in the right place is often hard, but could have a try...)

xref gh-6725


EDIT: Just as a note.  This didn't warn locally, if it does I guess the truly clean thing would be to do the offset calculations in `uintptr_t`, but it also feels like it needs a lot of pretty ugly casts.