### PR TITLE
Fix compliation warning about struct initialization in `Cascade.detect_multi_scale`

### DIFF
--- a/skimage/feature/_cascade.pyx
+++ b/skimage/feature/_cascade.pyx
@@ -750,7 +750,6 @@ cdef class Cascade:
 
                     if result:
 
-                        new_detection = Detection()
                         new_detection.r = current_row
                         new_detection.c = current_col
                         new_detection.width = current_width


### PR DESCRIPTION
## Description

Fixes the compilation warnings:
```
warning: skimage/feature/_cascade.pyx:753:49: Not all members given for struct 'Detection' warning: skimage/feature/_cascade.pyx:753:49: Not all members given for struct 'Detection'
```
Context: https://github.com/scikit-image/scikit-image/pull/6725#issuecomment-1415812410

The memory for the Detection struct was already allocated on the stack of this function, so we can just directly assign to its members. I also tried the syntax
```python
new_detection = Detection(
    r=current_row
    c=current_col
    width=current_width
    height=current_height
)
```
with and without parameter names. However, that leads to the following compilation error:
```
/home/lg/Res/scikit-image/skimage/feature/_cascade.pyx:753:50: Operation not allowed without gil
```

I'm not sure where the GIL comes into play (or the `nogil` statement is) and the [Cython docs on structs](https://cython.readthedocs.io/en/latest/src/userguide/language_basics.html#structs-unions-enums) don't really help here but I'm think it should be safe to reuse the member variables of the struct this way. It's used in [`mean_detection_from_cluster`](https://github.com/scikit-image/scikit-image/blob/f9be3bd15900324d09de905ec81c46ce8afda77e/skimage/feature/_cascade.pyx#L227-L232) the same way.

cc @stefanv 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
