### PR TITLE
Use test that can fail for sdist

### DIFF
--- a/tools/github/script.sh
+++ b/tools/github/script.sh
@@ -16,14 +16,7 @@ if [[ ${WITHOUT_POOCH} == "1" ]]; then
   pip uninstall pooch -y
 fi
 
-# When installing from sdist
-# We can't run it in the git directory since there is a folder called `skimage`
-# in there. pytest will crawl that instead of the module we installed and want to test
-if [[ ${INSTALL_FROM_SDIST} == "1" ]]; then
-  (cd .. && python -c "import skimage; skimage.test()")
-else
-  (cd .. && pytest $TEST_ARGS --pyargs skimage)
-fi
+(cd .. && pytest $TEST_ARGS --pyargs skimage)
 
 if [[ "${BUILD_DOCS}" == "1" ]] || [[ "${TEST_EXAMPLES}" == "1" ]]; then
   echo Build or run examples


### PR DESCRIPTION
As it was, the testing for sdist couldn't fail. I noticed the issue in PR #6729 here
https://github.com/scikit-image/scikit-image/actions/runs/4089407973/jobs/7052056287

It shows that test pass, but if you check you can see they fail. I am not sure why you were using `skimage.test()`, but it doesn't seem to work how it was intended. Since it hasn't worked since it was introduced in #5909, I suspect no one uses it.

I would vote to remove it. If we want to keep it, we should figure out how it should behave and fix it. Out of curiosity, why wouldn't users who want to install skimage and run the tests just do this:
```
pip install skimage
pytest --pyargs skimage
```

That seems more standard and is more widely used and tested. Is there something I am missing?