### PR TITLE
Fix NumPy deprecation warning

### DIFF
--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -298,7 +298,8 @@ def test_ransac_geometric():
 
     # test whether estimated parameters equal original parameters
     assert_almost_equal(model0.params, model_est.params)
-    assert np.all(np.nonzero(inliers == False)[0] == outliers)
+    assert tuple(np.nonzero(np.atleast_1d(inliers == False))[0]) == outliers
+
 
 
 def test_ransac_is_data_valid():


### PR DESCRIPTION
Should fix these warnings:
```
measure/tests/test_fit.py::test_ransac_geometric
  /home/jarrod/.venv/sktest/lib64/python3.9/site-packages/numpy/core/fromnumeric.py:43: DeprecationWarning: Calling nonzero on 0d arrays is deprecated, as it behaves surprisingly. Use `atleast_1d(cond).nonzero()` if the old behavior was intended. If the context of this warning is of the form `arr[nonzero(cond)]`, just use `arr[cond]`.
    result = getattr(asarray(obj), method)(*args, **kwds)

measure/tests/test_fit.py::test_ransac_geometric
  /home/jarrod/.venv/sktest/lib64/python3.9/site-packages/skimage/measure/tests/test_fit.py:301: DeprecationWarning: elementwise comparison failed; this will raise an error in the future.
    assert np.all(np.nonzero(inliers is False)[0] == outliers)
```