### PR TITLE
Fix fstring

### DIFF
--- a/skimage/_shared/_warnings.py
+++ b/skimage/_shared/_warnings.py
@@ -142,5 +142,6 @@ def expected_warnings(matching):
             if strict_warnings and not found:
                 raise ValueError(f'Unexpected warning: {str(warn.message)}')
         if strict_warnings and (len(remaining) > 0):
-            msg = f"No warning raised matching:\n{{'\n'.join(remaining)}}"
+            newline = "\n"
+            msg = f"No warning raised matching:{newline}{newline.join(remaining)}"
             raise ValueError(msg)


### PR DESCRIPTION
Fix #6730

Before
```
$ python
Python 3.9.9 (main, Nov 19 2021, 00:00:00)
[GCC 10.3.1 20210422 (Red Hat 10.3.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> remaining = ["t", "s"]
>>> msg = f"No warning raised matching:\n{{'\n'.join(remaining)}}"
>>> print(msg)
No warning raised matching:
{'
'.join(remaining)}
```

After
```
$ python
Python 3.9.9 (main, Nov 19 2021, 00:00:00)
[GCC 10.3.1 20210422 (Red Hat 10.3.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> remaining = ["t", "s"]
>>> newline = "\n"
>>> msg = f"No warning raised matching:{newline}{newline.join(remaining)}"
>>> print(msg)
No warning raised matching:
t
s
```