### PR TITLE
Fix docstring for local_binary_pattern.

### DIFF
--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -286,7 +286,7 @@ def graycoprops(P, prop='contrast'):
 def local_binary_pattern(image, P, R, method='default'):
     """Compute the local binary patterns (LBP) of an image.
 
-    LBP is typically used for texture classification.
+    LBP is a visual descriptor often used in texture classification.
 
     Parameters
     ----------

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -299,6 +299,7 @@ def local_binary_pattern(image, P, R, method='default'):
         Radius of circle (spatial resolution of the operator).
     method : str {'default', 'ror', 'uniform', 'nri_uniform', 'var'}, optional
         Method to determine the pattern:
+
         ``default``
             Original local binary pattern which is grayscale invariant but not
             rotation invariant.

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -284,22 +284,21 @@ def graycoprops(P, prop='contrast'):
 
 
 def local_binary_pattern(image, P, R, method='default'):
-    """Gray scale and rotation invariant LBP (Local Binary Patterns).
+    """Compute the local binary patterns (LBP) of an image.
 
-    LBP is an invariant descriptor that can be used for texture classification.
+    LBP is typically used for texture classification.
 
     Parameters
     ----------
-    image : (N, M) array
-        Graylevel image.
+    image : (M, N) array
+        2D grayscale image.
     P : int
         Number of circularly symmetric neighbor set points (quantization of
         the angular space).
     R : float
         Radius of circle (spatial resolution of the operator).
-    method : {'default', 'ror', 'uniform', 'var'}
-        Method to determine the pattern.
-
+    method : {'default', 'ror', 'uniform', 'nri_uniform', 'var'}
+        Method to determine the pattern:
         * 'default': original local binary pattern which is gray scale but not
             rotation invariant.
         * 'ror': extension of default implementation which is gray scale and
@@ -314,7 +313,7 @@ def local_binary_pattern(image, P, R, method='default'):
 
     Returns
     -------
-    output : (N, M) array
+    output : (M, N) array
         LBP image.
 
     References

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -297,19 +297,24 @@ def local_binary_pattern(image, P, R, method='default'):
         the angular space).
     R : float
         Radius of circle (spatial resolution of the operator).
-    method : {'default', 'ror', 'uniform', 'nri_uniform', 'var'}
+    method : str {'default', 'ror', 'uniform', 'nri_uniform', 'var'}, optional
         Method to determine the pattern:
-        * 'default': original local binary pattern which is gray scale but not
+        ``default``
+            Original local binary pattern which is grayscale invariant but not
             rotation invariant.
-        * 'ror': extension of default implementation which is gray scale and
+        ``ror``
+            Extension of default pattern which is grayscale invariant and
             rotation invariant.
-        * 'uniform': improved rotation invariance with uniform patterns and
-            finer quantization of the angular space which is gray scale and
-            rotation invariant.
-        * 'nri_uniform': non rotation-invariant uniform patterns variant
-            which is only gray scale invariant [2]_, [3]_.
-        * 'var': rotation invariant variance measures of the contrast of local
-            image texture which is rotation but not gray scale invariant.
+        ``uniform``
+            Uniform pattern which is grayscale invariant and rotation
+            invariant, offering finer quantization of the angular space.
+            For details, see [1]_.
+        ``nri_uniform``
+            Variant of uniform pattern which is grayscale invariant but not
+            rotation invariant. For details, see [2]_ and [3]_.
+        ``var``
+            Variance of local image texture (related to contrast)
+            which is rotation invariant but not grayscale invariant.
 
     Returns
     -------

--- a/skimage/feature/texture.py
+++ b/skimage/feature/texture.py
@@ -333,7 +333,7 @@ def local_binary_pattern(image, P, R, method='default'):
            Local Binary Patterns: Application to Face Recognition",
            IEEE Transactions on Pattern Analysis and Machine Intelligence,
            vol. 28, no. 12, pp. 2037-2041, Dec. 2006
-           :DOI:`10.1109/TPAMI.2006.244.`
+           :DOI:`10.1109/TPAMI.2006.244`
     """
     check_nD(image, 2)
 


### PR DESCRIPTION
## Description

Supersedes #5144 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
