### PR TITLE
Simplified code in _euler_rotation

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1100,16 +1100,16 @@ def _euler_rotation(axis, angle):
     Ri : array of float, shape (3, 3)
         The rotation matrix along axis `axis`.
     """
-    R = np.eye(3)
+    Ri = np.eye(3)
     # We need the row and column other than the rotation axis,
     # in the right order:
-    i = (axis + 2) % 3
-    j = (axis - 2) % 3
+    row = (axis + 2) % 3
+    col = (axis - 2) % 3
     # We then embed the 2-axis rotation matrix into the full matrix.
-    R[i, i] = R[j, j] = np.cos(angle)
-    R[i, j] = np.sin(angle)
-    R[j, i] = -R[i, j]
-    return R
+    Ri[row, row] = Ri[col, col] = np.cos(angle)
+    Ri[row, col] = np.sin(angle)
+    Ri[col, row]
+    return Ri
 
 
 def _euler_rotation_matrix(angles, axes=None):

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1108,7 +1108,7 @@ def _euler_rotation(axis, angle):
     # We then embed the 2-axis rotation matrix into the full matrix.
     Ri[row, row] = Ri[col, col] = np.cos(angle)
     Ri[row, col] = np.sin(angle)
-    Ri[col, row]
+    Ri[col, row] = -Ri[row, col]
     return Ri
 
 

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1100,16 +1100,15 @@ def _euler_rotation(axis, angle):
     Ri : array of float, shape (3, 3)
         The rotation matrix along axis `axis`.
     """
-    Ri = np.eye(3)
-    # We need the row and column other than the rotation axis,
-    # in the right order:
-    row = (axis + 2) % 3
-    col = (axis - 2) % 3
+    R = np.eye(3)
+    # We need the axes other than the rotation axis, in the right order:
+    i = (axis + 2) % 3
+    j = (axis - 2) % 3
     # We then embed the 2-axis rotation matrix into the full matrix.
-    Ri[row, row] = Ri[col, col] = np.cos(angle)
-    Ri[row, col] = np.sin(angle)
-    Ri[col, row] = -Ri[row, col]
-    return Ri
+    R[i, i] = R[j, j] = np.cos(angle)
+    R[i, j] = np.sin(angle)
+    R[j, i] = -R[i, j]
+    return R
 
 
 def _euler_rotation_matrix(angles, axes=None):

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1100,20 +1100,16 @@ def _euler_rotation(axis, angle):
     Ri : array of float, shape (3, 3)
         The rotation matrix along axis `axis`.
     """
-    i = axis
-    s = (-1)**i * np.sin(angle)
-    c = np.cos(angle)
-    R2 = np.array([[c, -s],
-                   [s,  c]])
-    Ri = np.eye(3)
-    # We need the axes other than the rotation axis, in the right order:
-    # 0 -> (1, 2); 1 -> (0, 2); 2 -> (0, 1).
-    axes = sorted({0, 1, 2} - {axis})
+    R = np.eye(3)
+    # We need the row and column other than the rotation axis,
+    # in the right order:
+    i = (axis + 2) % 3
+    j = (axis - 2) % 3
     # We then embed the 2-axis rotation matrix into the full matrix.
-    # (1, 2) -> R[1:3:1, 1:3:1] = R2, (0, 2) -> R[0:3:2, 0:3:2] = R2, etc.
-    sl = slice(axes[0], axes[1] + 1, axes[1] - axes[0])
-    Ri[sl, sl] = R2
-    return Ri
+    R[i, i] = R[j, j] = np.cos(angle)
+    R[i, j] = np.sin(angle)
+    R[j, i] = -R[i, j]
+    return R
 
 
 def _euler_rotation_matrix(angles, axes=None):

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1097,7 +1097,7 @@ def _euler_rotation(axis, angle):
 
     Returns
     -------
-    Ri : array of float, shape (3, 3)
+    R : array of float, shape (3, 3)
         The rotation matrix along axis `axis`.
     """
     R = np.eye(3)


### PR DESCRIPTION
## Description
Slightly simplified the code from `_euler_rotation` from `Transform/_geometric`.

Does not change much, but this version is a bit shorter and, arguably, a bit easier to understand.

## Checklist
Nothing new was implemented.

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
