### PR TITLE
Fix typo in photo description.

### DIFF
--- a/skimage/data/_fetchers.py
+++ b/skimage/data/_fetchers.py
@@ -936,7 +936,7 @@ def coffee():
 
     This photograph is courtesy of Pikolo Espresso Bar.
     It contains several elliptical shapes as well as varying texture (smooth
-    porcelain to course wood grain).
+    porcelain to coarse wood grain).
 
     Notes
     -----


### PR DESCRIPTION
## Description

I was looking up the description for this picture after I noticed it was now a 'standard image' in [imageio](https://imageio.readthedocs.io/en/stable/user_guide/standardimages.html). I was [responsible](https://github.com/scikit-image/scikit-image/pull/689/commits/5afb53a1260bb33611270db65ce8eae098bef2b0) for [propagating](https://github.com/scikit-image/scikit-image/pull/689#discussion_r5768530) the typo in the first place.

/cc @stefanv :wink: 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
