### PR TITLE
Build macosx/py38 wheel natively

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -116,6 +116,16 @@ jobs:
         with:
           python-version: "3.9"
 
+      # See:
+      # https://cibuildwheel.readthedocs.io/en/stable/faq/#macos-building-cpython-38-wheels-on-arm64
+      # https://github.com/pypa/cibuildwheel/issues/1414
+      - name: Install experimental MacOSX Py38
+        if: startsWith(matrix.cibw_python, 'cp38') && (matrix.cibw_arch == 'arm64')
+        run: |
+          curl -o /tmp/Python38.pkg https://www.python.org/ftp/python/3.8.10/python-3.8.10-macos11.pkg
+          sudo installer -pkg /tmp/Python38.pkg -target /
+          sh "/Applications/Python 3.8/Install Certificates.command"
+
       - name: Install cibuildwheel
         run: |
           python -m pip install cibuildwheel


### PR DESCRIPTION
This speeds up the build, and also ensures that the correct wheel tag is applied.

- https://github.com/pypa/cibuildwheel/issues/1414
- https://cibuildwheel.readthedocs.io/en/stable/faq/#macos-building-cpython-38-wheels-on-arm64
