### PR TITLE
Fix threshold_li(): prevent log(0) on single-value background.

### DIFF
--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -388,20 +388,26 @@ def test_li_negative_inital_guess():
         threshold_li(coins, initial_guess=-5)
 
 
-def test_li_pathological_arrays():
-    # See https://github.com/scikit-image/scikit-image/issues/4140
-    a = np.array([0, 0, 1, 0, 0, 1, 0, 1])
-    b = np.array([0, 0, 0.1, 0, 0, 0.1, 0, 0.1])
-    c = np.array([0, 0, 0.1, 0, 0, 0.1, 0.01, 0.1])
-    d = np.array([0, 0, 1, 0, 0, 1, 0.5, 1])
-    e = np.array([1, 1])
-    f = np.array([1, 2])
-    f = np.array([0, 254, 255], dtype='uint8')
-    f = np.array([0, 1, 255], dtype='uint8')
-    f = np.array([0.1, 0.8, 0.9])
-    arrays = [a, b, c, d, e, f]
-    thresholds = [threshold_li(arr) for arr in arrays]
-    assert np.all(np.isfinite(thresholds))
+@pytest.mark.parametrize(
+    "image",
+    [
+        # See https://github.com/scikit-image/scikit-image/issues/4140
+        [0, 0, 1, 0, 0, 1, 0, 1],
+        [0, 0, 0.1, 0, 0, 0.1, 0, 0.1],
+        [0, 0, 0.1, 0, 0, 0.1, 0.01, 0.1],
+        [0, 0, 1, 0, 0, 1, 0.5, 1],
+        [1, 1],
+        [1, 2],
+        # See https://github.com/scikit-image/scikit-image/issues/6744
+        [0, 254, 255],
+        [0, 1, 255],
+        [0.1, 0.8, 0.9]
+    ]
+)
+def test_li_pathological(image):
+    image = np.array(image)
+    threshold = threshold_li(image)
+    assert np.isfinite(threshold)
 
 
 def test_yen_camera_image():

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -396,10 +396,11 @@ def test_li_pathological_arrays():
     d = np.array([0, 0, 1, 0, 0, 1, 0.5, 1])
     e = np.array([1, 1])
     f = np.array([1, 2])
+    f = np.array([0, 254, 255], dtype='uint8')
+    f = np.array([0, 1, 255], dtype='uint8')
+    f = np.array([0.1, 0.8, 0.9])
     arrays = [a, b, c, d, e, f]
-    with np.errstate(divide='ignore'):
-        # ignoring "divide by zero encountered in log" error from np.log(0)
-        thresholds = [threshold_li(arr) for arr in arrays]
+    thresholds = [threshold_li(arr) for arr in arrays]
     assert np.all(np.isfinite(thresholds))
 
 

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -725,6 +725,8 @@ def threshold_li(image, *, tolerance=None, initial_guess=None,
 
     # Stop the iterations when the difference between the
     # new and old threshold values is less than the tolerance
+    # or if the background mode has only one value left,
+    # since log(0) is not defined.
 
     if image.dtype.kind in 'iu':
         hist, bin_centers = histogram(image.reshape(-1),
@@ -740,6 +742,9 @@ def threshold_li(image, *, tolerance=None, initial_guess=None,
             mean_back = np.average(bin_centers[background],
                                    weights=hist[background])
 
+            if mean_back == 0:
+                break
+
             t_next = ((mean_back - mean_fore)
                       / (np.log(mean_back) - np.log(mean_fore)))
 
@@ -752,6 +757,9 @@ def threshold_li(image, *, tolerance=None, initial_guess=None,
             foreground = (image > t_curr)
             mean_fore = np.mean(image[foreground])
             mean_back = np.mean(image[~foreground])
+
+            if mean_back == 0.0:
+                break
 
             t_next = ((mean_back - mean_fore)
                       / (np.log(mean_back) - np.log(mean_fore)))


### PR DESCRIPTION
When background mode has only a single value (normalized to 0), its logarithm is not defined and produces a warning or exception and the resulting threshold was the same as the background. Instead we can stop the iteration and take the last threshold which is between the two modes.

A few examples of bi-modal arrays with single-value background are provided to the existing unit test (both for byte or float images). Ignoring the numpy warning is no longer needed.

<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description


Fixes #6744.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
