### PR TITLE
Remove circleci url check

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -16,6 +16,3 @@ jobs:
           artifact-path: 0/doc/build/html/index.html
           circleci-jobs: doc
           job-title: Check the rendered docs here!
-      - name: Check the URL
-        run: |
-          curl --fail ${{ steps.step1.outputs.url }} | grep $GITHUB_SHA


### PR DESCRIPTION
This check always fails:
https://github.com/scikit-image/scikit-image/actions/workflows/circleci.yml

I think it was put there for debugging when the redirect URL changed. Matplotlib also removed it:
https://github.com/matplotlib/matplotlib/commit/383819527a81419939af0e5fac6a5e17e3c120a5
