### PR TITLE
CI Set MACOSX_DEPLOYMENT_TARGET=10.9 for Wheels

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -151,8 +151,8 @@ jobs:
               export MACOS_DEPLOYMENT_TARGET=12.0
               OPENMP_URL="https://anaconda.org/conda-forge/llvm-openmp/11.1.0/download/osx-arm64/llvm-openmp-11.1.0-hf3c4609_1.tar.bz2"
           else
-              export MACOSX_DEPLOYMENT_TARGET=10.13
-              export MACOS_DEPLOYMENT_TARGET=10.13
+              export MACOSX_DEPLOYMENT_TARGET=10.9
+              export MACOS_DEPLOYMENT_TARGET=10.9
               OPENMP_URL="https://anaconda.org/conda-forge/llvm-openmp/11.1.0/download/osx-64/llvm-openmp-11.1.0-hda6cdc1_1.tar.bz2"
           fi
           echo MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}


### PR DESCRIPTION
Change CI MACOSX_DEPLOYMENT_TARGET from 10.13 to 10.9 to allow for continued compatibility with earlier MacOS versions given that associated projects also have wheels available which meet the dependency version requirements.


## Description

Would close issue #6461

Hopefully this is what @stefanv meant - I'd like to make a useful contribution but don't really know if I've got this right. 

A wheel build of scikit-image 0.20rc5 on OS X 10.11 under Python 3.10 succeeds _locally_ via Meson and passes the test suite with:

numpy 1.24.2
SciPy 1.9.3
networkx 3.0
pillow 9.2.0
imageio 2.25.0
tifffile 2023.2.3
PyWavelets 1.4.1
packaging 21.3
lazy_loader 0.1




## Checklist

```
=============================== warnings summary ===============================
segmentation/tests/test_watershed.py::TestWatershed::test_watershed09
  /Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/scipy/ndimage/_measurements.py:1527: DeprecationWarning: `np.int0` is a deprecated alias for `np.intp`.  (Deprecated NumPy 1.24)
    integral_types = [numpy.int0,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========== 8024 passed, 25 skipped, 1 warning in 365.35s (0:06:05) ============
Premature end of JPEG file
Bogus Huffman table definition
```

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
