### PR TITLE
Require setuptools 67+

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,7 @@ jobs:
           PYTHON="$(python.pythonLocation)\\python.exe"
 
           # Update pip
-          $PYTHON -m pip install -U pip "setuptools>=65.6" wheel
+          $PYTHON -m pip install -U pip "setuptools>=67" wheel
 
           # print out the pip cache dir followed by the variable defined above
           # to confirm that they match

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,8 +131,8 @@ build-backend = 'mesonpy'
 requires = [
     'meson-python>=0.13.0rc0',
     'wheel',
-    'setuptools>=65.6',
-    'packaging>=20.0',
+    'setuptools>=67',
+    'packaging>=20',
     'Cython>=0.29.24',
     'pythran',
     'lazy_loader>=0.1',

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,8 +1,8 @@
 # Also update `tools/pyproject.toml.in`, [build-system] -> requires
 meson-python>=0.13.0rc0
 wheel
-setuptools<=65.5
-packaging>=20.0
+setuptools>=67
+packaging>=20
 ninja
 Cython>=0.29.24
 pythran

--- a/tools/pyproject.toml.in
+++ b/tools/pyproject.toml.in
@@ -51,8 +51,8 @@ requires = [
     # doesn't list it as a runtime requirement (at least in 0.10.0)
     # See https://github.com/FFY00/meson-python/blob/main/pyproject.toml#L4
     "wheel",
-    "setuptools>=65.6",
-    "packaging>=20.0",
+    "setuptools>=67",
+    "packaging>=20",
     "Cython>=0.29.24",
     "pythran",
     "lazy_loader>=0.1",


### PR DESCRIPTION
I missed one of the places we specify setuptools. So I decided to just update our setuptools dependency. Since it is mainly for developers and packagers and we don't test old versions, I think it makes sense to require a recent version.