### PR TITLE
allow trivial ransac call

### DIFF
--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -805,8 +805,8 @@ def ransac(data, model_class, min_samples, residual_threshold,
         data = (data, )
     num_samples = len(data[0])
 
-    if not (0 < min_samples < num_samples):
-        raise ValueError(f"`min_samples` must be in range (0, {num_samples})")
+    if not (0 < min_samples <= num_samples):
+        raise ValueError(f"`min_samples` must be in range (0, {num_samples}]")
 
     if residual_threshold < 0:
         raise ValueError("`residual_threshold` must be greater than zero")

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -383,9 +383,9 @@ def test_ransac_invalid_input():
     with testing.raises(ValueError):
         ransac(np.zeros((10, 2)), None, min_samples=0,
                residual_threshold=0)
-    # `min_samples` as ratio must be in range (0, nb)
+    # `min_samples` as ratio must be in range (0, nb]
     with testing.raises(ValueError):
-        ransac(np.zeros((10, 2)), None, min_samples=10,
+        ransac(np.zeros((10, 2)), None, min_samples=11,
                residual_threshold=0)
     # `min_samples` must be greater than zero
     with testing.raises(ValueError):


### PR DESCRIPTION

## Description

the code is perfectly fine with having exactly as many samples as minimally required (i.e. fitting the unique model hypothesis) and the check is too restrictive.

This avoids having to add another code path in user code for this one case.

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
