### PR TITLE
Fix duplicate gray morphology test case

### DIFF
--- a/skimage/morphology/tests/test_gray.py
+++ b/skimage/morphology/tests/test_gray.py
@@ -333,14 +333,14 @@ def test_rectangle_decomposition(cam_image, function, nrows, ncols,
                  "black_tophat"],
 )
 @pytest.mark.parametrize("radius", (2, 3))
-@pytest.mark.parametrize("decomposition", ['separable', 'sequence'])
+@pytest.mark.parametrize("decomposition", ['sequence'])
 def test_diamond_decomposition(cam_image, function, radius, decomposition):
     """Validate footprint decomposition for various shapes.
 
     comparison is made to the case without decomposition.
     """
-    footprint_ndarray = footprints.square(radius, decomposition=None)
-    footprint = footprints.square(radius, decomposition=decomposition)
+    footprint_ndarray = footprints.diamond(radius, decomposition=None)
+    footprint = footprints.diamond(radius, decomposition=decomposition)
     func = getattr(gray, function)
     expected = func(cam_image, footprint=footprint_ndarray)
     out = func(cam_image, footprint=footprint)


### PR DESCRIPTION
This MR fixes what appears to be a copy/paste error in the morphology tests.  Diamond footprint test cases were actually not using the diamond footprint at all and were just duplicating the square footprint tests! 