### PR TITLE
Replace API break in `hessian_matrix` with deprecation

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -25,6 +25,11 @@ Version 0.21
   ``docwriter.package_skip_patterns`` in
   ``doc/tools/build_modref_templates.py``.
 
+Version 0.22
+------------
+* Turn deprecation warning in skimage.feature.hessian_matrix` about only
+  supporting ``order="xy"`` for 2D images into error.
+
 Other (2022)
 ------------
 * Remove custom code for ignored warning in `skimage/_shared/testing.py` relating

--- a/skimage/feature/corner.py
+++ b/skimage/feature/corner.py
@@ -175,8 +175,6 @@ def _hessian_matrix_with_gaussian(image, sigma=1, mode='reflect', cval=0,
     image = img_as_float(image)
     float_dtype = _supported_float_type(image.dtype)
     image = image.astype(float_dtype, copy=False)
-    if image.ndim > 2 and order == "xy":
-        raise ValueError("order='xy' is only supported for 2D images.")
     if order not in ["rc", "xy"]:
         raise ValueError(f"unrecognized order: {order}")
 
@@ -303,7 +301,13 @@ def hessian_matrix(image, sigma=1, mode='constant', cval=0, order='rc',
     float_dtype = _supported_float_type(image.dtype)
     image = image.astype(float_dtype, copy=False)
     if image.ndim > 2 and order == "xy":
-        raise ValueError("order='xy' is only supported for 2D images.")
+        warn(
+            "Using order='xy' for images with more than 2 dimensions is "
+            "deprecated since v0.20 and will raise an error in a future "
+            "version.",
+            category=FutureWarning,
+            stacklevel=2
+        )
     if order not in ["rc", "xy"]:
         raise ValueError(f"unrecognized order: {order}")
 

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -185,10 +185,16 @@ def test_hessian_matrix_3d_xy(use_gaussian_derivatives):
 
     img = np.ones((5, 5, 5))
 
-    # order="xy" is only permitted for 2D
-    with pytest.raises(ValueError):
-        hessian_matrix(img, sigma=0.1, order="xy",
-                       use_gaussian_derivatives=use_gaussian_derivatives)
+    # order="xy" is deprecated for images with more than 2 dimensions
+    msg = "order='xy' for images with more than 2 dimensions is deprecated"
+    with pytest.warns(FutureWarning, match=msg) as record:
+        hessian_matrix(
+            img,
+            sigma=0.1,
+            order="xy",
+            use_gaussian_derivatives=use_gaussian_derivatives
+        )
+    assert record[0].filename == __file__, "wrong stacklevel"
 
     with pytest.raises(ValueError):
         hessian_matrix(img, sigma=0.1, order='nonexistant',


### PR DESCRIPTION
## Description

I'm unsure whether this is actually critical and should block the release, but I thought to err on the side of caution.

82331508becbca6a0735e4c1459eea2fb355b8ab (#6624) raises an new exception for images with more than 2 dimensions if `order="xy"` is requested. While this makes it consistent with `structure_tensor`, I think it also breaks the API without a deprecation because the following worked previously:

```python
import numpy as np
import skimage as ski

img = np.ones((5, 5, 5))
H_elems_xy = ski.feature.hessian_matrix(
    img, sigma=0.1, order="xy", use_gaussian_derivatives=False
)
H_elems_rc = ski.feature.hessian_matrix(
    img, sigma=0.1, order="rc", use_gaussian_derivatives=False
)
for a, b in zip(H_elems_xy, reversed(H_elems_rc)):
    np.testing.assert_array_equal(a, b)
```

In case of `use_gaussian_derivatives=True` this fails with assert errors because array are different for both orders. Not sure how to interpret that but I guess it doesn't hurt to raise a warning in that case also. If this is actually a sign of a bug, then we with that justification we could probably keep raising an error for `use_gaussian_derivatives=True`. @grlee77, maybe you know what's up?

<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
