### PR TITLE
Merge duplicate instructions for setting up build environment.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -45,49 +45,7 @@ Here's the long and short of it:
      - ``origin``, which refers to your personal fork
 
    * Next, you need to set up your build environment.
-     Here are instructions for two popular environment managers:
-
-     * ``venv`` (pip based)
-
-       ::
-
-         # Create a virtualenv named ``skimage-dev`` that lives outside of the repository.
-         # One common convention is to place it inside an ``envs`` directory under your home directory:
-         mkdir ~/envs
-         python -m venv ~/envs/skimage-dev
-         # Activate it
-         source ~/envs/skimage-dev/bin/activate
-         # Install main development and runtime dependencies
-         pip install -r requirements.txt
-         # Install build dependencies of scikit-image
-         pip install -r requirements/build.txt
-         # Build scikit-image from source
-         ./dev.py build
-         # Test your installation
-         ./dev.py test
-         # Try the new version in IPython
-         ./dev.py ipython
-
-     * ``conda`` (Anaconda or Miniconda)
-
-       ::
-
-         # Create a conda environment named ``skimage-dev``
-         conda create --name skimage-dev
-         # Activate it
-         conda activate skimage-dev
-         # Install main development and runtime dependencies
-         conda install -c conda-forge --file requirements.txt
-         # Install build dependencies of scikit-image
-         conda install -c conda-forge --file requirements/build.txt
-         # Build scikit-image from source
-         ./dev.py build
-         # Test your installation
-         ./dev.py test
-         # Try the new version in IPython
-         ./dev.py ipython
-
-   * For more information about building and using the dev.py package, see ``meson.md``.
+     Please refer to :ref:`build-env-setup` for instructions.
 
    * Finally, we recommend you use a pre-commit hook, which runs some auto-formatters
      when you do a ``git commit``::
@@ -222,12 +180,6 @@ Once you've fixed all merge conflicts, do::
    Advanced Git users are encouraged to `rebase instead of merge
    <https://scikit-image.org/docs/dev/gitwash/development_workflow.html#rebasing-on-trunk>`__,
    but we squash and merge most PRs either way.
-
-Build environment setup
------------------------
-
-Please refer to :ref:`installing-scikit-image` for development installation
-instructions.
 
 Guidelines
 ----------

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -256,24 +256,26 @@ This directory contains the following files:
     scikit-image
     ├── asv.conf.json
     ├── azure-pipelines.yml
-    ├── benchmarks
+    ├── benchmarks/
+    ├── CITATION.bib
     ├── CODE_OF_CONDUCT.md
     ├── CONTRIBUTING.rst
     ├── CONTRIBUTORS.txt
-    ├── doc
+    ├── dev.py
+    ├── doc/
     ├── INSTALL.rst
     ├── LICENSE.txt
-    ├── Makefile
     ├── MANIFEST.in
+    ├── meson.build
+    ├── meson.md
+    ├── pyproject.toml
     ├── README.md
     ├── RELEASE.txt
-    ├── requirements
+    ├── requirements/
     ├── requirements.txt
-    ├── setup.cfg
-    ├── setup.py
-    ├── skimage
+    ├── skimage/
     ├── TODO.txt
-    ├── tools
+    └── tools/
 
 All commands below are assumed to be running from the ``scikit-image``
 directory containing the files above.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -312,8 +312,8 @@ venv
   ./dev.py build
   # Test your installation
   ./dev.py test
-  # Install docs dependencies of scikit-image
-  pip install -r requirements/docs.txt
+  # Build docs
+  ./dev.py docs
   # Try the new version in IPython
   ./dev.py ipython
 
@@ -342,8 +342,8 @@ before you get started.
   ./dev.py build
   # Test your installation
   ./dev.py test
-  # Install docs dependencies of scikit-image
-  conda install -c conda-forge --file requirements/docs.txt
+  # Build docs
+  ./dev.py docs
   # Try the new version in IPython
   ./dev.py ipython
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -312,6 +312,8 @@ venv
   ./dev.py build
   # Test your installation
   ./dev.py test
+  # Install docs dependencies of scikit-image
+  pip install -r requirements/docs.txt
   # Try the new version in IPython
   ./dev.py ipython
 
@@ -340,6 +342,8 @@ before you get started.
   ./dev.py build
   # Test your installation
   ./dev.py test
+  # Install docs dependencies of scikit-image
+  conda install -c conda-forge --file requirements/docs.txt
   # Try the new version in IPython
   ./dev.py ipython
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -281,6 +281,8 @@ All commands below are assumed to be running from the ``scikit-image``
 directory containing the files above.
 
 
+.. _build-env-setup:
+
 Build environment setup
 ------------------------------------------------------------------------------
 
@@ -293,24 +295,25 @@ Here we provide instructions for two popular environment managers:
 venv
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When using ``venv``, you may find the following bash commands useful:
-
 .. code-block:: sh
 
-  # Create a virtualenv named ``skimage-dev``
-  python -m venv skimage-dev
-  # Activate it. On Linux and MacOS:
-  source skimage-dev/bin/activate
-  # Make sure that pip is up to date
-  pip install --upgrade pip
-  # Install all development and runtime dependencies of scikit-image
+  # Create a virtualenv named ``skimage-dev`` that lives outside of the repository.
+  # One common convention is to place it inside an ``envs`` directory under your home directory:
+  mkdir ~/envs
+  python -m venv ~/envs/skimage-dev
+  # Activate it
+  # (On Windows, please use ``skimage-dev\Scripts\activate``)
+  source ~/envs/skimage-dev/bin/activate
+  # Install main development and runtime dependencies
   pip install -r requirements.txt
-  # Build and install scikit-image from source
-  pip install -e . -vv  ## TODO: to be updated for meson (see meson.md)
+  # Install build dependencies of scikit-image
+  pip install -r requirements/build.txt
+  # Build scikit-image from source
+  ./dev.py build
   # Test your installation
-  pytest --pyargs skimage
-
-On Windows, please use ``skimage-dev\Scripts\activate`` on the activation step.
+  ./dev.py test
+  # Try the new version in IPython
+  ./dev.py ipython
 
 conda
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -329,12 +332,18 @@ before you get started.
   conda create --name skimage-dev
   # Activate it
   conda activate skimage-dev
-  # Install major development and runtime dependencies of scikit-image
-  conda install --file requirements/default.txt --file requirements/build.txt --file requirements/test.txt
-  # Install scikit-image from source
-  pip install -e . -vv  ## TODO: to be updated for meson (see meson.md)
+  # Install main development and runtime dependencies
+  conda install -c conda-forge --file requirements.txt
+  # Install build dependencies of scikit-image
+  conda install -c conda-forge --file requirements/build.txt
+  # Build scikit-image from source
+  ./dev.py build
   # Test your installation
-  pytest --pyargs skimage
+  ./dev.py test
+  # Try the new version in IPython
+  ./dev.py ipython
+
+For more information about building and using the dev.py package, see ``meson.md``.
 
 Updating the installation
 ------------------------------------------------------------------------------

--- a/meson.md
+++ b/meson.md
@@ -1,5 +1,8 @@
 # Building with Meson
 
+We are assuming that you have a default Python environment already configured on
+your computer and that you intend to install `scikit-image` inside of it.
+
 ### Developer build
 
 Install the `dev.py` tool:


### PR DESCRIPTION
## Description

I'm following up on my https://github.com/scikit-image/scikit-image/issues/6748#issuecomment-1429280343. With this PR, there is now a single place for the build env setup instructions (so we don't need to maintain two versions in parallel). I've kept the version that worked for me, anticipating in particular the application period for Outreachy projects.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
