### PR TITLE
Prepare CI configuration for merge queue

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request]
+on: [push, pull_request, merge_group]
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 # Workflow to build and test wheels
 name: Test
 
-on: [push, pull_request]
+on: [push, pull_request, merge_group]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

As proposed on our [dev forum](https://discuss.scientific-python.org/t/enable-merge-queues-on-scikit-image-github-repo/660), we plan to enable merge queues for our pull requests. With this GitHub feature enabled, pull requests can be added to a merge queue. GitHub then creates a temporary branch between pull request and target branch (main) and runs the checks. This might offer some convenience for the “I’ll merge once the CI is green” cases.

GitHub sends a different event when a pull request is added to a merge queue, so we need to update our CI configuration to trigger on "merge_group" events:

- [x] For our GitHub action workflows we can do so by simply adding `merge_group` to the trigger `on` list ([see docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions)).
- [x] For CircleCI, the event "Merge groups" needs to be enabled under Repo settings » Webhooks. I already did so.
- [ ] For Azure Pipelines, I'm not sure yet. Because we don't have a `trigger` field in our configuration file I'm assuming that we use ["classic" CI triggers](https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=classic#ci-triggers) which need to be updated to trigger on the branch specification `gh-readonly-queue/{base_branch}`. @stefanv can you do that or give me access to do it?
- [x] I think we don't need to update the webhook to Codecov, as the [scikit-image repo is deactivated on Codecov](https://app.codecov.io/gh/scikit-image).
- [x] All other workflows don't trigger on pull requests (use `pull_request` event).

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
