### PR TITLE
Unpin scipy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 dynamic = ['version']
 dependencies = [
     'numpy>=1.21.1',
-    "scipy>=1.8",
+    'scipy>=1.8',
     'networkx>=2.8',
     'pillow>=9.0.1',
     'imageio>=2.4.1',
@@ -69,7 +69,7 @@ build = [
 data = ['pooch>=1.3.0']
 default = [
     'numpy>=1.21.1',
-    "scipy>=1.8",
+    'scipy>=1.8',
     'networkx>=2.8',
     'pillow>=9.0.1',
     'imageio>=2.4.1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,7 @@ classifiers = [
 dynamic = ['version']
 dependencies = [
     'numpy>=1.21.1',
-    "scipy>=1.8,<1.9.2; python_version<='3.9'",
-    "scipy>=1.8; python_version>'3.9'",
+    "scipy>=1.8",
     'networkx>=2.8',
     'pillow>=9.0.1',
     'imageio>=2.4.1',
@@ -70,8 +69,7 @@ build = [
 data = ['pooch>=1.3.0']
 default = [
     'numpy>=1.21.1',
-    "scipy>=1.8,<1.9.2; python_version<='3.9'",
-    "scipy>=1.8; python_version>'3.9'",
+    "scipy>=1.8",
     'networkx>=2.8',
     'pillow>=9.0.1',
     'imageio>=2.4.1',

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,6 +1,5 @@
 numpy>=1.21.1
-scipy>=1.8,<1.9.2; python_version<='3.9'
-scipy>=1.8; python_version>'3.9'
+scipy>=1.8
 networkx>=2.8
 pillow>=9.0.1
 imageio>=2.4.1


### PR DESCRIPTION
## Description

Re-enables the use of new scipy on old python. See https://github.com/scikit-image/scikit-image/pull/6567#issuecomment-1450878366 for context.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.

@jarrodmillman @stefanv 