### PR TITLE
Add dosctrings to `test_adapt_rgb.py`

### DIFF
--- a/skimage/color/tests/test_adapt_rgb.py
+++ b/skimage/color/tests/test_adapt_rgb.py
@@ -60,7 +60,7 @@ def smooth_each(image, sigma):
 
 @adapt_rgb(each_channel)
 def mask_each(image, mask):
-        """
+    """
     Applies a binary mask to an RGB image, with each color channel processed
     independently.
 

--- a/skimage/color/tests/test_adapt_rgb.py
+++ b/skimage/color/tests/test_adapt_rgb.py
@@ -155,7 +155,7 @@ def test_gray_scale_image():
 
 
 def test_each_channel():
-     """Test that edges are correctly detected in each color channel of an RGB image."""
+    """Test that edges are correctly detected in each color channel of an RGB image."""
         
     filtered = edges_each(COLOR_IMAGE)
     for i, channel in enumerate(np.rollaxis(filtered, axis=-1)):
@@ -179,7 +179,7 @@ def test_each_channel_with_asymmetric_kernel():
 
 
 def test_hsv_value():
-     """Test that edges are correctly detected in the value component of the HSV representation of an RGB image."""
+    """Test that edges are correctly detected in the value component of the HSV representation of an RGB image."""
         
     filtered = edges_hsv(COLOR_IMAGE)
     value = color.rgb2hsv(COLOR_IMAGE)[:, :, 2]

--- a/skimage/color/tests/test_adapt_rgb.py
+++ b/skimage/color/tests/test_adapt_rgb.py
@@ -1,4 +1,3 @@
-# Importing necessary libraries
 from functools import partial
 
 import numpy as np
@@ -19,7 +18,7 @@ assert_allclose = partial(np.testing.assert_allclose, atol=1e-8)
 @adapt_rgb(each_channel)
 def edges_each(image):
     """
-    Applies Sobel edge detection to an RGB image, using each color channel
+    Apply Sobel edge detection to an RGB image, using each color channel
     independently.
 
     Parameters
@@ -39,7 +38,7 @@ def edges_each(image):
 @adapt_rgb(each_channel)
 def smooth_each(image, sigma):
     """
-    Applies Gaussian smoothing to an RGB image, using each color channel
+    Apply Gaussian smoothing to an RGB image, using each color channel
     independently.
 
     Parameters
@@ -52,8 +51,6 @@ def smooth_each(image, sigma):
     Returns
     -------
     result : ndarray
-        Smoothed version of the input image, with each color channel processed
-        independently.
     """
     return filters.gaussian(image, sigma)
 
@@ -61,22 +58,20 @@ def smooth_each(image, sigma):
 @adapt_rgb(each_channel)
 def mask_each(image, mask):
     """
-    Applies a binary mask to an RGB image, with each color channel processed
-    independently.
-
-    Pixels where `mask` is True will be set to zero.
+    Apply a binary mask to an RGB image, setting pixels where the mask
+    is True to zero in each color channel.
 
     Parameters
     ----------
     image : ndarray
         Input RGB image.
-    mask : ndarray, bool
+    mask : ndarray
         Boolean mask to apply to the image.
 
     Returns
     -------
     result : ndarray
-        Copy of the input image with masked pixels set to zero.
+    
     """
     result = image.copy()
     result[mask] = 0
@@ -86,7 +81,7 @@ def mask_each(image, mask):
 @adapt_rgb(hsv_value)
 def edges_hsv(image):
     """
-    Applies Sobel edge detection to an RGB image, after converting to HSV and
+    Apply Sobel edge detection to an RGB image, after converting to HSV and
     using the value channel.
 
     Parameters
@@ -97,8 +92,7 @@ def edges_hsv(image):
     Returns
     -------
     result : ndarray
-        Edge map of the input image, with the value channel of the HSV image
-        processed.
+    
     """
     return filters.sobel(image)
 
@@ -106,7 +100,7 @@ def edges_hsv(image):
 @adapt_rgb(hsv_value)
 def smooth_hsv(image, sigma):
     """
-    Applies Gaussian smoothing to an RGB image, after converting to HSV and
+    Apply Gaussian smoothing to an RGB image, after converting to HSV and
     using the value channel.
 
     Parameters
@@ -119,8 +113,7 @@ def smooth_hsv(image, sigma):
     Returns
     -------
     result : ndarray
-        Smoothed version of the input image, with the value channel of the HSV
-        image processed.
+       
     """
     return filters.gaussian(image, sigma)
 
@@ -128,9 +121,8 @@ def smooth_hsv(image, sigma):
 @adapt_rgb(hsv_value)
 def edges_hsv_uint(image):
     """
-    Applies Sobel edge detection to an RGB image, after converting to HSV and
-    using the value channel. The output is converted to unsigned 16-bit integer
-    format.
+    Applies Sobel edge detection to the value channel of an HSV converted RGB 
+    image and output it in 16-bit integer format.
 
     Parameters
     ----------
@@ -139,9 +131,8 @@ def edges_hsv_uint(image):
 
     Returns
     -------
-    result : ndarray, uint16
-        Edge map of the input image, with the value channel of the HSV image
-        processed and converted to unsigned 16-bit integer format.
+    result : ndarray
+
     """
     return img_as_uint(filters.sobel(image))
 

--- a/skimage/color/tests/test_adapt_rgb.py
+++ b/skimage/color/tests/test_adapt_rgb.py
@@ -1,3 +1,4 @@
+# Importing necessary libraries
 from functools import partial
 
 import numpy as np
@@ -17,16 +18,66 @@ assert_allclose = partial(np.testing.assert_allclose, atol=1e-8)
 
 @adapt_rgb(each_channel)
 def edges_each(image):
+    """
+    Applies Sobel edge detection to an RGB image, using each color channel
+    independently.
+
+    Parameters
+    ----------
+    image : ndarray
+        Input RGB image.
+
+    Returns
+    -------
+    result : ndarray
+        Edge map of the input image, with each color channel processed
+        independently.
+    """
     return filters.sobel(image)
 
 
 @adapt_rgb(each_channel)
 def smooth_each(image, sigma):
+    """
+    Applies Gaussian smoothing to an RGB image, using each color channel
+    independently.
+
+    Parameters
+    ----------
+    image : ndarray
+        Input RGB image.
+    sigma : float
+        Standard deviation of the Gaussian kernel.
+
+    Returns
+    -------
+    result : ndarray
+        Smoothed version of the input image, with each color channel processed
+        independently.
+    """
     return filters.gaussian(image, sigma)
 
 
 @adapt_rgb(each_channel)
 def mask_each(image, mask):
+        """
+    Applies a binary mask to an RGB image, with each color channel processed
+    independently.
+
+    Pixels where `mask` is True will be set to zero.
+
+    Parameters
+    ----------
+    image : ndarray
+        Input RGB image.
+    mask : ndarray, bool
+        Boolean mask to apply to the image.
+
+    Returns
+    -------
+    result : ndarray
+        Copy of the input image with masked pixels set to zero.
+    """
     result = image.copy()
     result[mask] = 0
     return result
@@ -34,26 +85,78 @@ def mask_each(image, mask):
 
 @adapt_rgb(hsv_value)
 def edges_hsv(image):
+    """
+    Applies Sobel edge detection to an RGB image, after converting to HSV and
+    using the value channel.
+
+    Parameters
+    ----------
+    image : ndarray
+        Input RGB image.
+
+    Returns
+    -------
+    result : ndarray
+        Edge map of the input image, with the value channel of the HSV image
+        processed.
+    """
     return filters.sobel(image)
 
 
 @adapt_rgb(hsv_value)
 def smooth_hsv(image, sigma):
+    """
+    Applies Gaussian smoothing to an RGB image, after converting to HSV and
+    using the value channel.
+
+    Parameters
+    ----------
+    image : ndarray
+        Input RGB image.
+    sigma : float
+        Standard deviation of the Gaussian kernel.
+
+    Returns
+    -------
+    result : ndarray
+        Smoothed version of the input image, with the value channel of the HSV
+        image processed.
+    """
     return filters.gaussian(image, sigma)
 
 
 @adapt_rgb(hsv_value)
 def edges_hsv_uint(image):
+    """
+    Applies Sobel edge detection to an RGB image, after converting to HSV and
+    using the value channel. The output is converted to unsigned 16-bit integer
+    format.
+
+    Parameters
+    ----------
+    image : ndarray
+        Input RGB image.
+
+    Returns
+    -------
+    result : ndarray, uint16
+        Edge map of the input image, with the value channel of the HSV image
+        processed and converted to unsigned 16-bit integer format.
+    """
     return img_as_uint(filters.sobel(image))
 
 
 def test_gray_scale_image():
+    """Test that edges are correctly detected in a gray-scale image."""
+    
     # We don't need to test both `hsv_value` and `each_channel` since
     # `adapt_rgb` is handling gray-scale inputs.
     assert_allclose(edges_each(GRAY_IMAGE), filters.sobel(GRAY_IMAGE))
 
 
 def test_each_channel():
+     """Test that edges are correctly detected in each color channel of an RGB image."""
+        
     filtered = edges_each(COLOR_IMAGE)
     for i, channel in enumerate(np.rollaxis(filtered, axis=-1)):
         expected = img_as_float(filters.sobel(COLOR_IMAGE[:, :, i]))
@@ -61,32 +164,44 @@ def test_each_channel():
 
 
 def test_each_channel_with_filter_argument():
+    """Test that an input image with each color channel filtered with a Gaussian kernel."""
+    
     filtered = smooth_each(COLOR_IMAGE, SIGMA)
     for i, channel in enumerate(np.rollaxis(filtered, axis=-1)):
         assert_allclose(channel, smooth(COLOR_IMAGE[:, :, i]))
 
 
 def test_each_channel_with_asymmetric_kernel():
+    """Test that an input image with each color channel masked by an upper triangular mask."""
+    
     mask = np.triu(np.ones(COLOR_IMAGE.shape[:2], dtype=bool))
     mask_each(COLOR_IMAGE, mask)
 
 
 def test_hsv_value():
+     """Test that edges are correctly detected in the value component of the HSV representation of an RGB image."""
+        
     filtered = edges_hsv(COLOR_IMAGE)
     value = color.rgb2hsv(COLOR_IMAGE)[:, :, 2]
     assert_allclose(color.rgb2hsv(filtered)[:, :, 2], filters.sobel(value))
 
 
 def test_hsv_value_with_filter_argument():
+    """Test that an input image with its value component filtered with a Gaussian kernel in the HSV representation."""
+    
     filtered = smooth_hsv(COLOR_IMAGE, SIGMA)
     value = color.rgb2hsv(COLOR_IMAGE)[:, :, 2]
     assert_allclose(color.rgb2hsv(filtered)[:, :, 2], smooth(value))
 
 
 def test_hsv_value_with_non_float_output():
+    """Test that an input image with edges detected in the value component of the HSV representation,
+    and the output has a dtype that matches the input dtype."""
+    
     # Since `rgb2hsv` returns a float image and the result of the filtered
     # result is inserted into the HSV image, we want to make sure there isn't
     # a dtype mismatch.
+    
     filtered = edges_hsv_uint(COLOR_IMAGE)
     filtered_value = color.rgb2hsv(filtered)[:, :, 2]
     value = color.rgb2hsv(COLOR_IMAGE)[:, :, 2]


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description
Updates the test_adapt_rgb.py file. This updates issue #6761 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
