### PR TITLE
Make join_segmentations return array maps from output to input labels

### DIFF
--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -53,11 +53,11 @@ def join_segmentations(s1, s2, return_mapping: bool = False):
     # Create joined label image
     factor = s2.max() + 1
     j_initial = factor * s1_relabeled + s2_relabeled
-    labels_j = np.unique(j_initial)
     j, _, map_j_to_j_initial = relabel_sequential(j_initial)
     if not return_mapping:
         return j
     # Determine label mapping
+    labels_j = np.unique(j_initial)
     labels_s1_relabeled, labels_s2_relabeled = np.divmod(labels_j, factor)
     map_j_to_s1 = ArrayMap(map_j_to_j_initial.in_values, backward_map1[labels_s1_relabeled])
     map_j_to_s2 = ArrayMap(map_j_to_j_initial.in_values, backward_map2[labels_s2_relabeled])

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -58,7 +58,6 @@ def join_segmentations(s1, s2, return_mapping: bool = False):
     if not return_mapping:
         return j
     # Determine label mapping
-    assert np.all(backward_map_joined.out_values == labels_joined)
     labels1_reindexed, labels2_reindexed = np.divmod(labels_joined, factor)
     labels1_map = ArrayMap(backward_map_joined.in_values, backward_map1[labels1_reindexed])
     labels2_map = ArrayMap(backward_map_joined.in_values, backward_map2[labels2_reindexed])

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -21,9 +21,9 @@ def join_segmentations(s1, s2, return_mapping: bool = False):
     -------
     j : numpy array
         The join segmentation of s1 and s2.
-    labels1_map : ArrayMap, optional
+    map_j_to_s1 : ArrayMap, optional
         Mapping from labels of the joined segmentation j to labels of s1.
-    labels2_map : ArrayMap, optional
+    map_j_to_s2 : ArrayMap, optional
         Mapping from labels of the joined segmentation j to labels of s2.
 
     Examples
@@ -48,20 +48,20 @@ def join_segmentations(s1, s2, return_mapping: bool = False):
         raise ValueError("Cannot join segmentations of different shape. "
                          f"s1.shape: {s1.shape}, s2.shape: {s2.shape}")
     # Reindex input label images
-    s1, _, backward_map1 = relabel_sequential(s1)
-    s2, _, backward_map2 = relabel_sequential(s2)
+    s1_relabeled, _, backward_map1 = relabel_sequential(s1)
+    s2_relabeled, _, backward_map2 = relabel_sequential(s2)
     # Create joined label image
     factor = s2.max() + 1
-    j = factor * s1 + s2
-    labels_joined = np.unique(j)
-    j, _, backward_map_joined = relabel_sequential(j)
+    j_initial = factor * s1_relabeled + s2_relabeled
+    labels_j = np.unique(j_initial)
+    j, _, map_j_to_j_initial = relabel_sequential(j_initial)
     if not return_mapping:
         return j
     # Determine label mapping
-    labels1_reindexed, labels2_reindexed = np.divmod(labels_joined, factor)
-    labels1_map = ArrayMap(backward_map_joined.in_values, backward_map1[labels1_reindexed])
-    labels2_map = ArrayMap(backward_map_joined.in_values, backward_map2[labels2_reindexed])
-    return j, labels1_map, labels2_map
+    labels_s1_relabeled, labels_s2_relabeled = np.divmod(labels_j, factor)
+    map_j_to_s1 = ArrayMap(map_j_to_j_initial.in_values, backward_map1[labels_s1_relabeled])
+    map_j_to_s2 = ArrayMap(map_j_to_j_initial.in_values, backward_map2[labels_s2_relabeled])
+    return j, map_j_to_s1, map_j_to_s2
 
 
 def relabel_sequential(label_field, offset=1):

--- a/skimage/segmentation/_join.py
+++ b/skimage/segmentation/_join.py
@@ -39,10 +39,13 @@ def join_segmentations(s1, s2, return_mapping: bool = False):
     array([[0, 1, 3, 2],
            [0, 5, 3, 2],
            [4, 5, 5, 3]])
-    >>> join_segmentations(s1, s2, return_mapping=True)
-    (array([[0, 1, 3, 2],
-           [0, 5, 3, 2],
-           [4, 5, 5, 3]]), ArrayMap(array([0, 1, 2, 3, 4, 5]), array([0, 0, 1, 1, 2, 2])), ArrayMap(array([0, 1, 2, 3, 4, 5]), array([0, 1, 0, 1, 0, 1])))
+    >>> j, m1, m2 = join_segmentations(s1, s2, return_mapping=True)
+    >>> m1
+    ArrayMap(array([0, 1, 2, 3, 4, 5]), array([0, 0, 1, 1, 2, 2]))
+    >>> np.all(m1[j] == s1)
+    True
+    >>> np.all(m2[j] == s2)
+    True
     """
     if s1.shape != s2.shape:
         raise ValueError("Cannot join segmentations of different shape. "

--- a/skimage/segmentation/tests/test_join.py
+++ b/skimage/segmentation/tests/test_join.py
@@ -24,6 +24,11 @@ def test_join_segmentations():
                       [4, 5, 5, 3]])
     assert_array_equal(j, j_ref)
 
+    # test correct mapping
+    j, m1, m2 = join_segmentations(s1, s2, return_mapping=True)
+    assert_array_equal(m1[j], s1)
+    assert_array_equal(m2[j], s2)
+
     # test correct exception when arrays are different shapes
     s3 = np.array([[0, 0, 1, 1], [0, 2, 2, 1]])
     with testing.raises(ValueError):


### PR DESCRIPTION
## Description

This is an implementation for https://github.com/scikit-image/scikit-image/issues/6785.

It adds as optional return value two ArrayMaps which allow tracing the labels of the returned segmentation back to the labels of the two input segmentations.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
