### PR TITLE
Add docstring to skimage.draw module

### DIFF
--- a/skimage/draw/__init__.py
+++ b/skimage/draw/__init__.py
@@ -1,3 +1,9 @@
+"""Utilities for generating coordinates of a bezier curve, circle, ellipse, rectangle, 
+generating ellipsoid, 
+calculating surface-area and volume of ellipsoid, 
+drawing lines, 
+setting pixel color at a coordinate.
+"""
 from .draw import (ellipse, set_color, polygon_perimeter,
                    line, line_aa, polygon, ellipse_perimeter,
                    circle_perimeter, circle_perimeter_aa,

--- a/skimage/draw/__init__.py
+++ b/skimage/draw/__init__.py
@@ -1,4 +1,4 @@
-"""Utilities for generating coordinates of different shapes and curves.
+"""Functionality for generating coordinates of different shapes and curves.
 """
 from .draw import (ellipse, set_color, polygon_perimeter,
                    line, line_aa, polygon, ellipse_perimeter,

--- a/skimage/draw/__init__.py
+++ b/skimage/draw/__init__.py
@@ -1,8 +1,4 @@
-"""Utilities for generating coordinates of a bezier curve, circle, ellipse, rectangle, 
-generating ellipsoid, 
-calculating surface-area and volume of ellipsoid, 
-drawing lines, 
-setting pixel color at a coordinate.
+"""Utilities for generating coordinates of different shapes and curves.
 """
 from .draw import (ellipse, set_color, polygon_perimeter,
                    line, line_aa, polygon, ellipse_perimeter,


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->
Added docstrings to skimage.draw .This updates the issue https://github.com/scikit-image/scikit-image/issues/6761

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
