### PR TITLE
Added docstring to skimage.registration submodule.

### DIFF
--- a/skimage/registration/__init__.py
+++ b/skimage/registration/__init__.py
@@ -1,4 +1,35 @@
 """Image registration module.
+This module provides a set of functions to register (align two images into single coordinate system) based on various transformation models. Implemented algorithms include phase_cross_correlation and optical flow estimator.
+
+Functions
+---------
+phase_cross_correlation: function
+Perform the phase correlation to determine the shift between two images using DFT upsampling.
+
+optical_flow_tvl1: function
+Estimates the optical flow components for each axis between two images using TV-L1 solver.
+
+optical_flow_ilk: function
+Estimates the optical flow between two images using iterative Lucas-Kanade(iLK) solver.
+
+See Also
+--------
+See the documentation for each function for details.
+
+Notes
+-----
+Color images are not supported for optical flow estimators.
+
+Examples
+--------
+>>> from skimage import data
+>>> from skimage.data import stereo_motorcycle
+>>> from skimage.registration import optical_flow_tvl1
+>>> image0, image1, disp =stereo_motorcycle()
+>>> image0=rgb2gray(image0)
+>>> image1=rgb2gray(image1)
+>>> flow= optical_flow_tvl1(image1,image0)
+
 """
 from ._optical_flow import optical_flow_tvl1, optical_flow_ilk
 from ._phase_cross_correlation import phase_cross_correlation
@@ -7,4 +38,4 @@ __all__ = [
     'optical_flow_ilk',
     'optical_flow_tvl1',
     'phase_cross_correlation'
-    ]
+]

--- a/skimage/registration/__init__.py
+++ b/skimage/registration/__init__.py
@@ -1,3 +1,39 @@
+"""
+Image registration module
+
+This module provides a set of functions to register (align two images into single coordinate system) based on various transformation models. Implemented algorithms include phase_cross_correlation and optical flow estimator.
+
+Functions
+---------
+phase_cross_correlation: function
+Perform the phase correlation to determine the shift between two images using DFT upsampling.
+
+optical_flow_tvl1: function
+Estimates the optical flow components for each axis between two images using TV-L1 solver.
+
+optical_flow_ilk: function
+Estimates the optical flow between two images using iterative Lucas-Kanade(iLK) solver.
+
+See Also
+--------
+See the documentation for each function for details.
+
+Notes
+-----
+Color images are not supported for optical flow estimators.
+
+Examples
+--------
+>>> from skimage import data
+>>> from skimage.data import stereo_motorcycle
+>>> from skimage.registration import optical_flow_tvl1
+>>> image0, image1, disp =stereo_motorcycle()
+>>> image0=rgb2gray(image0)
+>>> image1=rgb2gray(image1)
+>>> flow= optical_flow_tvl1(image1,image0)
+
+"""
+
 from ._optical_flow import optical_flow_tvl1, optical_flow_ilk
 from ._phase_cross_correlation import phase_cross_correlation
 

--- a/skimage/registration/__init__.py
+++ b/skimage/registration/__init__.py
@@ -7,4 +7,4 @@ __all__ = [
     'optical_flow_ilk',
     'optical_flow_tvl1',
     'phase_cross_correlation'
-    ]
+]

--- a/skimage/registration/__init__.py
+++ b/skimage/registration/__init__.py
@@ -1,3 +1,5 @@
+"""Image registration module.
+"""
 from ._optical_flow import optical_flow_tvl1, optical_flow_ilk
 from ._phase_cross_correlation import phase_cross_correlation
 

--- a/skimage/registration/__init__.py
+++ b/skimage/registration/__init__.py
@@ -7,4 +7,4 @@ __all__ = [
     'optical_flow_ilk',
     'optical_flow_tvl1',
     'phase_cross_correlation'
-]
+    ]


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
