### PR TITLE
Avoid error when using conda.

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -337,7 +337,7 @@ before you get started.
   # Install main development and runtime dependencies
   conda install -c conda-forge --file requirements/default.txt
   conda install -c conda-forge --file requirements/test.txt
-  conda install -c conda-forge --file requirements/developer.txt
+  conda install -c conda-forge pre-commit
   # Install build dependencies of scikit-image
   conda install -c conda-forge --file requirements/build.txt
   # Build scikit-image from source


### PR DESCRIPTION
## Description

This is a short-term fix following #6781 (sorry I missed it yesterday!). There are only two dependencies listed in `requirements/developer.txt`, i.e., `pre-commit` and `rtoml`, which is only available from PyPI (see hMarianne Corvellec: It looks like rtoml is only available from PyPI indeed (https://github.com/samuelcolvin/rtoml#install).

In practice, removing this dependency for the conda user won't be blocking, since it's only used for `pyproject.toml`, and the import failure is already handled: https://github.com/scikit-image/scikit-image/blob/44da98e0a61f9382b0d96ad3973a1b83b2db1b5f/tools/generate_pyproject.toml.py#L6-L9

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
