### PR TITLE
Add a docstring to `skimage.measure`

### DIFF
--- a/skimage/measure/__init__.py
+++ b/skimage/measure/__init__.py
@@ -1,42 +1,5 @@
 """
-Image measurement tools. A collection of functions for image measurement.
-
-Functions
----------
-find_contours : Find iso-valued contours in a 2D array for a given level value.
-regionprops : Calculate various properties of labeled image regions.
-regionprops_table: Return measurements for image region properties in tabular form.
-perimeter : Calculate perimeter of objects in the label image.
-perimeter_crofton : Approximate perimeter of objects in the label image using Crofton formula.
-euler_number : Calculate Euler characteristic of labeled image regions.
-approximate_polygon : Approximate a polygonal curve(s) for a given contour or binary image.
-subdivide_polygon : Subdivide a polygon into smaller chunks.
-LineModelND : A class to fit a straight n-dimensional line to a set of data points.
-CircleModel : A class to fit a circular model to a set of data points.
-EllipseModel : A class to fit an elliptical model to a set of data points.
-ransac : An implementation of the RANSAC algorithm for robust linear estimation.
-block_reduce : Reduce the image size by block averaging.
-moments : Calculate raw (uncentered) moments of the distribution.
-moments_central : Calculate central moments of the distribution.
-moments_coords : Calculate moments about the origin of the image.
-moments_coords_central : Calculate central moments about the center of mass of the image.
-moments_normalized : Calculate normalized central moments of the distribution.
-moments_hu : Calculate Hu moments of the distribution.
-inertia_tensor : Calculate inertia tensor of the input image.
-inertia_tensor_eigvals : Calculate eigenvalues of the inertia tensor.
-marching_cubes : Generate a triangular mesh for a given isosurface using the marching cubes algorithm.
-mesh_surface_area : Compute total surface area of the triangular mesh.
-profile_line : Profile intensity along a directed line segment inside the image.
-label : Label connected regions of an integer array.
-points_in_poly : Check if points fall within a polygon.
-grid_points_in_poly : Find grid points falling within a polygon.
-shannon_entropy : Calculate the Shannon entropy of an array-like sequence.
-blur_effect : Apply a blur effect to an image.
-pearson_corr_coeff : Compute Pearson's correlation coefficient between two channels.
-manders_coloc_coeff : Compute Mander's coefficients for colocalization analysis.
-manders_overlap_coeff : Compute Mander's overlap coefficients for colocalization analysis.
-intersection_coeff : Compute intersection coefficient for colocalization analysis.
-
+Image measurement tool is collection of functions for image measurement.
 """
 
 

--- a/skimage/measure/__init__.py
+++ b/skimage/measure/__init__.py
@@ -1,3 +1,45 @@
+"""
+Image measurement tools. A collection of functions for image measurement.
+
+Functions
+---------
+find_contours : Find iso-valued contours in a 2D array for a given level value.
+regionprops : Calculate various properties of labeled image regions.
+regionprops_table: Return measurements for image region properties in tabular form.
+perimeter : Calculate perimeter of objects in the label image.
+perimeter_crofton : Approximate perimeter of objects in the label image using Crofton formula.
+euler_number : Calculate Euler characteristic of labeled image regions.
+approximate_polygon : Approximate a polygonal curve(s) for a given contour or binary image.
+subdivide_polygon : Subdivide a polygon into smaller chunks.
+LineModelND : A class to fit a straight n-dimensional line to a set of data points.
+CircleModel : A class to fit a circular model to a set of data points.
+EllipseModel : A class to fit an elliptical model to a set of data points.
+ransac : An implementation of the RANSAC algorithm for robust linear estimation.
+block_reduce : Reduce the image size by block averaging.
+moments : Calculate raw (uncentered) moments of the distribution.
+moments_central : Calculate central moments of the distribution.
+moments_coords : Calculate moments about the origin of the image.
+moments_coords_central : Calculate central moments about the center of mass of the image.
+moments_normalized : Calculate normalized central moments of the distribution.
+moments_hu : Calculate Hu moments of the distribution.
+inertia_tensor : Calculate inertia tensor of the input image.
+inertia_tensor_eigvals : Calculate eigenvalues of the inertia tensor.
+marching_cubes : Generate a triangular mesh for a given isosurface using the marching cubes algorithm.
+mesh_surface_area : Compute total surface area of the triangular mesh.
+profile_line : Profile intensity along a directed line segment inside the image.
+label : Label connected regions of an integer array.
+points_in_poly : Check if points fall within a polygon.
+grid_points_in_poly : Find grid points falling within a polygon.
+shannon_entropy : Calculate the Shannon entropy of an array-like sequence.
+blur_effect : Apply a blur effect to an image.
+pearson_corr_coeff : Compute Pearson's correlation coefficient between two channels.
+manders_coloc_coeff : Compute Mander's coefficients for colocalization analysis.
+manders_overlap_coeff : Compute Mander's overlap coefficients for colocalization analysis.
+intersection_coeff : Compute intersection coefficient for colocalization analysis.
+
+"""
+
+
 from ._find_contours import find_contours
 from ._marching_cubes_lewiner import marching_cubes, mesh_surface_area
 from ._regionprops import (regionprops, perimeter,

--- a/skimage/measure/__init__.py
+++ b/skimage/measure/__init__.py
@@ -1,5 +1,5 @@
 """
-Image measurement tool is collection of functions for image measurement.
+Tools to measure image metrics and features.
 """
 
 


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description
Added a docstring to skimage.measure. This updates the issue #6761 
<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
