### PR TITLE
Add and update docstring to submodule in skimage

### DIFF
--- a/skimage/feature/brief.py
+++ b/skimage/feature/brief.py
@@ -137,7 +137,7 @@ class BRIEF(DescriptorExtractor):
         self.mask = None
 
     def extract(self, image, keypoints):
-        """Extract BRIEF binary descriptors for given keypoints in image.
+        """Compute binary descriptors corresponding to given keypoints in image.
 
         Parameters
         ----------

--- a/skimage/morphology/__init__.py
+++ b/skimage/morphology/__init__.py
@@ -1,3 +1,11 @@
+"""Collection of utilities to carryout nonlinear operations
+related to the shape or morphology of features in images.
+
+This operations are particularly suited of binary images
+(where pixels are represented as 0 oe 1), although it can
+be extend to grayscale images.
+"""
+
 from .binary import (binary_closing, binary_dilation, binary_erosion,
                      binary_opening)
 from .gray import (black_tophat, closing, dilation, erosion, opening,


### PR DESCRIPTION
Contributed to a task in #6761

## Description
1. Update docstring for extract() method in BRIEF class of skimage.
2. Add docstring to skimage.morphology module




<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
