### PR TITLE
Backport "Fix conda instructions for dev env setup" to v0.20.x

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -327,10 +327,14 @@ before you get started.
   conda create --name skimage-dev
   # Activate it
   conda activate skimage-dev
-  # Install major development and runtime dependencies of scikit-image
-  conda install --file requirements/default.txt --file requirements/build.txt --file requirements/test.txt
-  # Install scikit-image from source
-  pip install -e . -vv  ## TODO: to be updated for meson (see meson.md)
+  # Install main development and runtime dependencies
+  conda install -c conda-forge --file requirements/default.txt
+  conda install -c conda-forge --file requirements/test.txt
+  conda install -c conda-forge --file requirements/developer.txt
+  # Install build dependencies of scikit-image
+  conda install -c conda-forge --file requirements/build.txt
+  # Build scikit-image from source
+  ./dev.py build
   # Test your installation
   pytest --pyargs skimage
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -330,7 +330,7 @@ before you get started.
   # Install main development and runtime dependencies
   conda install -c conda-forge --file requirements/default.txt
   conda install -c conda-forge --file requirements/test.txt
-  conda install -c conda-forge --file requirements/developer.txt
+  conda install -c conda-forge pre-commit
   # Install build dependencies of scikit-image
   conda install -c conda-forge --file requirements/build.txt
   # Build scikit-image from source

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -332,7 +332,7 @@ before you get started.
   conda install -c conda-forge --file requirements/test.txt
   conda install -c conda-forge pre-commit
   # Install build dependencies of scikit-image
-  conda install -c conda-forge --file requirements/build.txt
+  pip install -r requirements/build.txt
   # Build scikit-image from source
   ./dev.py build
   # Test your installation


### PR DESCRIPTION
## Description

Backports #6781, #6792 and #6806 to v0.20.x.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
