### PR TITLE
Added detailed description docstrings to skimage.draw module

### DIFF
--- a/skimage/draw/__init__.py
+++ b/skimage/draw/__init__.py
@@ -1,3 +1,9 @@
+"""Utilities for generating coordinates of a bezier curve, circle, ellipse, rectangle, 
+generating ellipsoid, 
+calculating surface-area and volume of ellipsoid, 
+drawing lines, 
+setting pixel color at a coordinate.
+"""
 from .draw import (ellipse, set_color, polygon_perimeter,
                    line, line_aa, polygon, ellipse_perimeter,
                    circle_perimeter, circle_perimeter_aa,

--- a/skimage/draw/__init__.py
+++ b/skimage/draw/__init__.py
@@ -1,4 +1,50 @@
-"""Functionality for generating coordinates of different shapes and curves.
+"""Utilities for generating coordinates of different shapes and curves.
+
+Use this module for generating coordinates of a bezier curve, circle, ellipse, rectangle, 
+generating ellipsoid, calculating surface-area and volume of ellipsoid, 
+drawing lines, setting pixel color at a coordinate.
+
+...
+
+Using this module following functionalities can be accessed
+
+
+bezier_curve(r0, c0, r1, c1, ...)     Generate Bezier curve coordinates.
+
+circle_perimeter(r, c, radius)        Generate circle perimeter coordinates.
+
+circle_perimeter_aa(r, c, radius)     Generate anti-aliased circle perimeter coordinates.
+
+disk(center, radius, *[, shape])      Generate coordinates of pixels within circle.
+
+ellipse(r, c, r_radius, c_radius)     Generate coordinates of pixels within ellipse.
+
+ellipse_perimeter(r, c, ...[, ...])   Generate ellipse perimeter coordinates.
+
+ellipsoid(a, b, c[, spacing, ...])    Generates ellipsoid with semimajor axes aligned with grid dimensions on grid with specified spacing.
+
+ellipsoid_stats(a, b, c)              Calculates analytical surface area and volume for ellipsoid with semimajor axes aligned with grid dimensions of specified spacing.
+
+line(r0, c0, r1, c1)                  Generate line pixel coordinates.
+
+line_aa(r0, c0, r1, c1)               Generate anti-aliased line pixel coordinates.
+
+line_nd(start, stop, *[, ...])        Draw a single-pixel thick line in n dimensions.
+
+polygon(r, c[, shape])                Generate coordinates of pixels within polygon.
+
+polygon2mask(image_shape, polygon)    Compute a mask from polygon.
+
+polygon_perimeter(r, c[, ...])        Generate polygon perimeter coordinates.
+
+random_shapes(image_shape, ...)       Generate an image with random shapes, labeled with bounding boxes.
+
+rectangle(start[, end, extent, ...])  Generate coordinates of pixels within a rectangle.
+
+rectangle_perimeter(start[, ...])     Generate coordinates of pixels that are exactly around a rectangle.
+
+set_color(image, coords, color)       Set pixel color in the image at the given coordinates.
+
 """
 from .draw import (ellipse, set_color, polygon_perimeter,
                    line, line_aa, polygon, ellipse_perimeter,

--- a/skimage/draw/__init__.py
+++ b/skimage/draw/__init__.py
@@ -1,50 +1,10 @@
 """Utilities for generating coordinates of different shapes and curves.
 
-Use this module for generating coordinates of a bezier curve, circle, ellipse, rectangle, 
-generating ellipsoid, calculating surface-area and volume of ellipsoid, 
-drawing lines, setting pixel color at a coordinate.
+Use the tools in this module to generate coordinates of basic geometric shapes
+curves such as ellipses or bezier curves. Additional tools allow the creation
+of masks from polygons or setting the color of manipulation.
 
 ...
-
-Using this module following functionalities can be accessed
-
-
-bezier_curve(r0, c0, r1, c1, ...)     Generate Bezier curve coordinates.
-
-circle_perimeter(r, c, radius)        Generate circle perimeter coordinates.
-
-circle_perimeter_aa(r, c, radius)     Generate anti-aliased circle perimeter coordinates.
-
-disk(center, radius, *[, shape])      Generate coordinates of pixels within circle.
-
-ellipse(r, c, r_radius, c_radius)     Generate coordinates of pixels within ellipse.
-
-ellipse_perimeter(r, c, ...[, ...])   Generate ellipse perimeter coordinates.
-
-ellipsoid(a, b, c[, spacing, ...])    Generates ellipsoid with semimajor axes aligned with grid dimensions on grid with specified spacing.
-
-ellipsoid_stats(a, b, c)              Calculates analytical surface area and volume for ellipsoid with semimajor axes aligned with grid dimensions of specified spacing.
-
-line(r0, c0, r1, c1)                  Generate line pixel coordinates.
-
-line_aa(r0, c0, r1, c1)               Generate anti-aliased line pixel coordinates.
-
-line_nd(start, stop, *[, ...])        Draw a single-pixel thick line in n dimensions.
-
-polygon(r, c[, shape])                Generate coordinates of pixels within polygon.
-
-polygon2mask(image_shape, polygon)    Compute a mask from polygon.
-
-polygon_perimeter(r, c[, ...])        Generate polygon perimeter coordinates.
-
-random_shapes(image_shape, ...)       Generate an image with random shapes, labeled with bounding boxes.
-
-rectangle(start[, end, extent, ...])  Generate coordinates of pixels within a rectangle.
-
-rectangle_perimeter(start[, ...])     Generate coordinates of pixels that are exactly around a rectangle.
-
-set_color(image, coords, color)       Set pixel color in the image at the given coordinates.
-
 """
 from .draw import (ellipse, set_color, polygon_perimeter,
                    line, line_aa, polygon, ellipse_perimeter,

--- a/skimage/draw/__init__.py
+++ b/skimage/draw/__init__.py
@@ -1,4 +1,4 @@
-"""Utilities for generating coordinates of different shapes and curves.
+"""Functionality for generating coordinates of different shapes and curves.
 """
 from .draw import (ellipse, set_color, polygon_perimeter,
                    line, line_aa, polygon, ellipse_perimeter,

--- a/skimage/draw/__init__.py
+++ b/skimage/draw/__init__.py
@@ -1,8 +1,4 @@
-"""Utilities for generating coordinates of a bezier curve, circle, ellipse, rectangle, 
-generating ellipsoid, 
-calculating surface-area and volume of ellipsoid, 
-drawing lines, 
-setting pixel color at a coordinate.
+"""Utilities for generating coordinates of different shapes and curves.
 """
 from .draw import (ellipse, set_color, polygon_perimeter,
                    line, line_aa, polygon, ellipse_perimeter,


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->
Added detailed description docstrings to skimage.draw module. This updates the issue https://github.com/scikit-image/scikit-image/issues/6761

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
