### PR TITLE
Handle pip-only dependencies when using conda.

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -339,7 +339,7 @@ before you get started.
   conda install -c conda-forge --file requirements/test.txt
   conda install -c conda-forge pre-commit
   # Install build dependencies of scikit-image
-  conda install -c conda-forge --file requirements/build.txt
+  pip install -r requirements/build.txt
   # Build scikit-image from source
   ./dev.py build
   # Test your installation


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

Sorry for shipping these in dribs and drabs! This should be backported in the wake of #6781 and #6792: @lagru could you please update #6803 with this last fix?

With this PR, the conda instructions run successfully. So at least nothing is broken, even though it's not perfect (until we address #6794).

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
