### PR TITLE
Add example to ProjectiveTransform class

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -575,26 +575,24 @@ class ProjectiveTransform(GeometricTransform):
     >>> import numpy as np
     >>> from skimage import data
     >>> from skimage.transform import ProjectiveTransform
-    >>> img_src = data.rocket()
-    >>> height, width, dim = img_src.shape
-    >>> img_dst = np.zeros((height, width, dim))
+    >>> img = data.rocket()
+    >>> height, width, dim = img.shape
 
     Provide four pairs of matching points between the source and
     destination images to estimate the homography matrix, H,
     automatically for you.
 
-    >>> src = np.array([[ 41., 74.],
-    ...                [ 228., 72.],
-    ...                [ 192., 272.],
-    ...                [ 96., 272.]])
+    >>> src = np.array([[41., 74.],
+    ...                 [width, 72.],
+    ...                 [height, width],
+    ...                 [96., height]])
     >>> dst = np.array([[0., 0.],
-    ...                [height-1, 0.],
-    ...                [height-1, width-1],
-    ...                [0., width-1]])
+    ...                 [0., height],
+    ...                 [height-50, width*0.75],
+    ...                 [width*0.75, 80]])
     >>> pt = ProjectiveTransform()
     >>> pt.estimate(src, dst)
     True
-
     """
     def __init__(self, matrix=None, *, dimensionality=2):
         if matrix is None:

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -570,8 +570,32 @@ class ProjectiveTransform(GeometricTransform):
     params : (D+1, D+1) array
         Homogeneous transformation matrix.
 
-    """
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skimage.transform import ProjectiveTransform
+    >>> from skimage import data
+    >>> img_src = data.rocket()
+    >>> height, width, dim = img_src.shape
+    >>> img_dst = np.zeros((height, width, dim))
 
+    Provide four pairs of matching points between the source and
+    destination images to estimate the homography matrix, H,
+    automatically for you.
+
+    >>> src = np.array([[ 41., 74.],
+    ...                [ 228., 72.],
+    ...                [ 192., 272.],
+    ...                [ 96., 272.]])
+    >>> dst = np.array([[0., 0.],
+    ...                [height-1, 0.],
+    ...                [height-1, width-1],
+    ...                [0., width-1]])
+    >>> pt = ProjectiveTransform()
+    >>> pt.estimate(src, dst)
+    True
+
+    """
     def __init__(self, matrix=None, *, dimensionality=2):
         if matrix is None:
             # default to an identity transform

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -579,8 +579,7 @@ class ProjectiveTransform(GeometricTransform):
     >>> height, width, dim = img.shape
 
     Provide four pairs of matching points between the source and
-    destination images to estimate the homography matrix, H,
-    automatically for you.
+    destination images to estimate the homography matrix H:
 
     >>> src = np.array([[41., 74.],
     ...                 [width, 72.],

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -574,24 +574,29 @@ class ProjectiveTransform(GeometricTransform):
     --------
     >>> import numpy as np
     >>> from skimage import data
-    >>> from skimage.transform import ProjectiveTransform
+    >>> from skimage.transform import warp, ProjectiveTransform
     >>> img = data.rocket()
     >>> height, width, dim = img.shape
 
     Provide four pairs of matching points between the source and
     destination images to estimate the homography matrix H:
 
-    >>> src = np.array([[41., 74.],
-    ...                 [width, 72.],
+    >>> src_points = np.array([[0, 0],
+    ...                 [height, 0.],
     ...                 [height, width],
-    ...                 [96., height]])
-    >>> dst = np.array([[0., 0.],
-    ...                 [0., height],
-    ...                 [height-50, width*0.75],
-    ...                 [width*0.75, 80]])
+    ...                 [0., width]])
+    >>> dst_points = np.array([[height*0.5, 0.],
+    ...                 [height, 0.],
+    ...                 [height, width],
+    ...                 [0., width]])
     >>> pt = ProjectiveTransform()
-    >>> pt.estimate(src, dst)
+    >>> pt.estimate(src_points, dst_points)
     True
+
+    Apply the transformation to the image
+
+    >>> warped_img = warp(img, pt.inverse)
+
     """
     def __init__(self, matrix=None, *, dimensionality=2):
         if matrix is None:

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -573,8 +573,8 @@ class ProjectiveTransform(GeometricTransform):
     Examples
     --------
     >>> import numpy as np
-    >>> from skimage.transform import ProjectiveTransform
     >>> from skimage import data
+    >>> from skimage.transform import ProjectiveTransform
     >>> img_src = data.rocket()
     >>> height, width, dim = img_src.shape
     >>> img_dst = np.zeros((height, width, dim))


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description
Add example docstring to `ProjectiveTransform` class

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
