### PR TITLE
Relax reproduce section in bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -30,21 +30,14 @@ body:
       label: "Way to reproduce:"
       description: >
         Provide a short, self-contained code example that reproduces the issue,
-        i.e., can be copy-pasted into the Python interpreter.
+        i.e., can be copy-pasted into the Python interpreter. Please also
+        include the full error message, traceback or output, if any.
       placeholder: |
+        ```python
         import numpy as np
-        import skimage
+        import skimage as ski
         # Your code here...
-      render: Python
-
-  - type: textarea
-    attributes:
-      label: "Traceback or output:"
-      description: >
-        Include the full error message, traceback or output, if any.
-      placeholder: |
-        Full error (starting from Traceback) or output..
-      render: Shell
+        ```
 
   - type: textarea
     attributes:


### PR DESCRIPTION
## Description

The previous formatting forced the "Way to reproduce:" and "Traceback or output:" sections to use simple text fields without rich Markdown formatting. I noticed a few times that users tend to just use the description field instead.

I think we should allow contributors some degree of freedom in describing how to reproduce the bug. Sometimes it might not be enough to post a simple code snippet and more complex behavior needs to be described. Or the  contributor wants to compare correct and faulty behavior next to each other.

This also makes it unnecessary to have a separate field for the output.
## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
