### PR TITLE
Add short examples to PiecewiseAffineTransform class #6808 

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -971,8 +971,8 @@ class PiecewiseAffineTransform(GeometricTransform):
     >>> tform = PiecewiseAffineTransform()
     >>> tform.estimate(src, dst)
     True
-    """
 
+    """
     def __init__(self):
         self._tesselation = None
         self._inverse_tesselation = None

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -959,6 +959,18 @@ class PiecewiseAffineTransform(GeometricTransform):
     inverse_affines : list of AffineTransform objects
         Inverse affine transformations for each triangle in the mesh.
 
+    Examples
+    --------
+    >>> from numpy import np
+    >>> from skimage.transform import PiecewiseAffineTransform
+    >>> frim skimage import data
+
+    >>> img = data.camera()
+    >>> rows, cols = img.shape[0], img.shape[1]
+    >>> src_cols = np.linspace(0, cols, 30)
+    >>> src_rows = np.linspace(0, rows, 15)
+    >>> src_rows, src_cols = np.meshgrid(src_rows, src_cols)
+    >>> src = np.dstack([src_cols.flat, src_rows.flat])[0]
     """
 
     def __init__(self):

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -963,14 +963,14 @@ class PiecewiseAffineTransform(GeometricTransform):
     --------
     >>> from numpy import np
     >>> from skimage.transform import PiecewiseAffineTransform
-    >>> frim skimage import data
-
+    >>> from skimage import data
     >>> img = data.camera()
-    >>> rows, cols = img.shape[0], img.shape[1]
-    >>> src_cols = np.linspace(0, cols, 30)
-    >>> src_rows = np.linspace(0, rows, 15)
-    >>> src_rows, src_cols = np.meshgrid(src_rows, src_cols)
-    >>> src = np.dstack([src_cols.flat, src_rows.flat])[0]
+    >>> rows, cols = img.shape[:2]
+    >>> src_points = np.float32([[0,0], [0,rows-1], [cols/2,0], [cols/2,rows-1]])
+    >>> dst_points = np.float32([[0,100], [0,rows-101], [cols/2,0], [cols/2,rows-1]])
+    >>> tform = PiecewiseAffineTransform()
+    >>> tform.estimate(src, dst)
+    True
     """
 
     def __init__(self):


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description
Added example docstring to `PiecewiseAffineTransform` class 

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
