### PR TITLE
Sign error fix in measure.regionprops for orientations of 45 degrees

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -604,9 +604,9 @@ class RegionProperties:
         a, b, b, c = self.inertia_tensor.flat
         if a - c == 0:
             if b < 0:
-                return -PI / 4.
-            else:
                 return PI / 4.
+            else:
+                return -PI / 4.
         else:
             return 0.5 * atan2(-2 * b, c - a)
 

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -645,21 +645,36 @@ def test_orientation():
     # test diagonal regions
     diag = np.eye(10, dtype=int)
     orient_diag = regionprops(diag)[0].orientation
-    assert_almost_equal(orient_diag, -math.pi / 4)
+    assert_almost_equal(orient_diag, math.pi / 4)
     orient_diag = regionprops(diag, spacing=(1, 2))[0].orientation
     assert_almost_equal(orient_diag, np.arccos(0.5 / np.sqrt(1 + 0.5 ** 2)))
     orient_diag = regionprops(np.flipud(diag))[0].orientation
-    assert_almost_equal(orient_diag, math.pi / 4)
+    assert_almost_equal(orient_diag, -math.pi / 4)
     orient_diag = regionprops(np.flipud(diag), spacing=(1, 2))[0].orientation
     assert_almost_equal(orient_diag, -np.arccos(0.5 / np.sqrt(1 + 0.5 ** 2)))
     orient_diag = regionprops(np.fliplr(diag))[0].orientation
-    assert_almost_equal(orient_diag, math.pi / 4)
+    assert_almost_equal(orient_diag, -math.pi / 4)
     orient_diag = regionprops(np.fliplr(diag), spacing=(1, 2))[0].orientation
     assert_almost_equal(orient_diag, -np.arccos(0.5 / np.sqrt(1 + 0.5 ** 2)))
     orient_diag = regionprops(np.fliplr(np.flipud(diag)))[0].orientation
-    assert_almost_equal(orient_diag, -math.pi / 4)
+    assert_almost_equal(orient_diag, math.pi / 4)
     orient_diag = regionprops(np.fliplr(np.flipud(diag)), spacing=(1, 2))[0].orientation
     assert_almost_equal(orient_diag, np.arccos(0.5 / np.sqrt(1 + 0.5 ** 2)))
+
+def test_orientation_continuity():
+    # nearly diagonal array
+    arr1 = np.array([[0, 0, 1, 1],[0, 0, 1, 0],[0, 1, 0, 0],[1, 0, 0, 0]])
+    # diagonal array
+    arr2 = np.array([[0, 0, 0, 2],[0, 0, 2, 0],[0, 2, 0, 0],[2, 0, 0, 0]])
+    # nearly diagonal array
+    arr3 = np.array([[0, 0, 0, 3],[0, 0, 3, 3],[0, 3, 0, 0],[3, 0, 0, 0]])
+    image = np.hstack((arr1,arr2,arr3))
+    props = regionprops(image)
+    orientations = [prop.orientation for prop in props]
+    np.testing.assert_allclose(orientations, orientations[1], rtol=0, atol=0.08)
+    assert_almost_equal(orientations[0], -0.7144496360953664)
+    assert_almost_equal(orientations[1], -0.7853981633974483)
+    assert_almost_equal(orientations[2], -0.8563466906995303)
 
 
 def test_perimeter():


### PR DESCRIPTION
## Description

Fixed a sign error in the orientation property in measure.regionprops. The preset values for the orientations PI/4 and -PI/4 needed to be switched. This probably dates from switching regionprops over from xy coordinates to rc coordinates.

Closes #6815

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
