### PR TITLE
allow specifying channel axis when comparing multi-channel images using the checkerboard method

### DIFF
--- a/skimage/util/compare.py
+++ b/skimage/util/compare.py
@@ -44,7 +44,7 @@ def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
     elif method == 'blend':
         comparison = 0.5 * (img2 + img1)
     elif method == 'checkerboard':
-        shapex, shapey = img1.shape
+        shapex, shapey = img1.shape[:2]
         mask = np.full((shapex, shapey), False)
         stepx = int(shapex / n_tiles[0])
         stepy = int(shapey / n_tiles[1])

--- a/skimage/util/compare.py
+++ b/skimage/util/compare.py
@@ -3,7 +3,9 @@ from ..util import img_as_float
 from itertools import product
 
 
-def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
+def compare_images(
+    image1, image2, method="diff", *, n_tiles=(8, 8), channel_axis: int = -1
+):
     """
     Return an image showing the differences between two images.
 
@@ -20,6 +22,9 @@ def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
     n_tiles : tuple, optional
         Used only for the `checkerboard` method. Specifies the number
         of tiles (row, column) to divide the image.
+    channel_axis : int, optional
+        Defines the channel axis of the input images. By default, the last
+        axis is considered as the channel axis.
 
     Returns
     -------
@@ -34,27 +39,42 @@ def compare_images(image1, image2, method='diff', *, n_tiles=(8, 8)):
     alternatively the first and the second image.
     """
     if image1.shape != image2.shape:
-        raise ValueError('Images must have the same shape.')
+        raise ValueError("Images must have the same shape.")
+    if image1.ndim < 2 or image1.ndim > 3:
+        raise ValueError(
+            "Images must be 2-D with a single channel or 3-D with a channel dimension. Ndarrays are currently not supported."
+        )
+    if not isinstance(channel_axis, int):
+        raise TypeError("channel_axis must be an integer")
+    if channel_axis < -image1.ndim or channel_axis >= image1.ndim:
+        raise np.AxisError("channel_axis exceeds image dimensions")
 
-    img1 = img_as_float(image1)
-    img2 = img_as_float(image2)
+    img1 = img_as_float(np.moveaxis(image1, source=channel_axis, destination=-1))
+    img2 = img_as_float(np.moveaxis(image2, source=channel_axis, destination=-1))
 
-    if method == 'diff':
+    if method == "diff":
         comparison = np.abs(img2 - img1)
-    elif method == 'blend':
+    elif method == "blend":
         comparison = 0.5 * (img2 + img1)
-    elif method == 'checkerboard':
+    elif method == "checkerboard":
         shapex, shapey = img1.shape[:2]
+
         mask = np.full((shapex, shapey), False)
         stepx = int(shapex / n_tiles[0])
         stepy = int(shapey / n_tiles[1])
         for i, j in product(range(n_tiles[0]), range(n_tiles[1])):
             if (i + j) % 2 == 0:
-                mask[i * stepx:(i + 1)*stepx, j * stepy:(j + 1) * stepy] = True
+                mask[i * stepx : (i + 1) * stepx, j * stepy : (j + 1) * stepy] = True
         comparison = np.zeros_like(img1)
         comparison[mask] = img1[mask]
         comparison[~mask] = img2[~mask]
     else:
-        raise ValueError('Wrong value for `method`. '
-                         'Must be either "diff", "blend" or "checkerboard".')
+        raise ValueError(
+            "Wrong value for `method`. "
+            'Must be either "diff", "blend" or "checkerboard".'
+        )
+
+    # restore change to channel axis
+    comparison = np.moveaxis(comparison, source=-1, destination=channel_axis)
+
     return comparison

--- a/skimage/util/tests/test_compare.py
+++ b/skimage/util/tests/test_compare.py
@@ -62,3 +62,27 @@ def test_compare_images_checkerboard_tuple():
         assert_array_equal(res[i, :], exp_row1)
     for i in (4, 5, 6, 7, 12, 13, 14, 15):
         assert_array_equal(res[i, :], exp_row2)
+
+def test_compare_mutlichannel_images_checkerboard_channel_axis_unspecified():
+    img1 = np.zeros((2**4, 2**4, 3), dtype=np.uint8)
+    img2 = np.full(img1.shape, fill_value=255, dtype=np.uint8)
+    res = compare_images(img1, img2, method='checkerboard')
+    exp_row1 = np.array([[i]*3 for i in [0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1.]])
+    exp_row2 = np.array([[i]*3 for i in [1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0.]])
+    for i in (0, 1, 4, 5, 8, 9, 12, 13):
+        assert_array_equal(res[i, :], exp_row1)
+    for i in (2, 3, 6, 7, 10, 11, 14, 15):
+        assert_array_equal(res[i, :], exp_row2)
+
+def test_compare_multichannel_images_checkerboard_channel_axis_specified():
+    img1 = np.zeros((3, 2**4, 2**4), dtype=np.uint8)
+    img2 = np.full(img1.shape, fill_value=255, dtype=np.uint8)
+    res = compare_images(img1, img2, method='checkerboard', channel_axis=0)
+    assert res.shape[0] == 3, "result image should have same channel axis as input image"
+    exp_row1 = np.array([0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1.])
+    exp_row2 = np.array([1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0., 1., 1., 0., 0.])
+    for c in range(3):
+        for i in (0, 1, 4, 5, 8, 9, 12, 13):
+            assert_array_equal(res[c, i, :], exp_row1)
+        for i in (2, 3, 6, 7, 10, 11, 14, 15):
+            assert_array_equal(res[c, i, :], exp_row2)


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

A 4 character fix in `skimage.util.compare` that allows passing images with more than 1 channel to `compare_images` for the "checkerboard" method. The "diff" and "blend" methods already work fine with multi-channeled images and with this fix checkerboard does as well. 

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

N/A

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
