### PR TITLE
segmentation.watershed returns wrong data type bug fix

### DIFF
--- a/skimage/segmentation/_watershed.py
+++ b/skimage/segmentation/_watershed.py
@@ -26,7 +26,7 @@ from ..util import crop, regular_seeds
 
 
 def _validate_inputs(image, markers, mask, connectivity):
-    """Ensure that all inputs to watershed have matching shapes and types.
+    """Ensures that all inputs to watershed have matching shapes and types.
 
     Parameters
     ----------
@@ -119,7 +119,7 @@ def watershed(image, markers=None, connectivity=1, offset=None, mask=None,
     Returns
     -------
     out : ndarray
-        A labeled matrix of the same type and shape as markers
+        A labeled matrix of dtype `int32` and the shape as markers
 
     See Also
     --------

--- a/skimage/segmentation/_watershed.py
+++ b/skimage/segmentation/_watershed.py
@@ -26,7 +26,7 @@ from ..util import crop, regular_seeds
 
 
 def _validate_inputs(image, markers, mask, connectivity):
-    """Ensures that all inputs to watershed have matching shapes and types.
+    """Ensure that all inputs to watershed have matching shapes and types.
 
     Parameters
     ----------

--- a/skimage/segmentation/_watershed.py
+++ b/skimage/segmentation/_watershed.py
@@ -79,7 +79,7 @@ def _validate_inputs(image, markers, mask, connectivity):
                        f'shape as `image` (shape {image.shape})')
             raise ValueError(message)
     return (image.astype(np.float64),
-            markers.astype(f'{markers.dtype}'),
+            markers,
             mask.astype(np.int8))
 
 

--- a/skimage/segmentation/_watershed.py
+++ b/skimage/segmentation/_watershed.py
@@ -26,7 +26,7 @@ from ..util import crop, regular_seeds
 
 
 def _validate_inputs(image, markers, mask, connectivity):
-    """Ensure that all inputs to watershed have matching shapes and types.
+    """Ensures that all inputs to watershed have matching shapes and types.
 
     Parameters
     ----------

--- a/skimage/segmentation/_watershed.py
+++ b/skimage/segmentation/_watershed.py
@@ -79,7 +79,7 @@ def _validate_inputs(image, markers, mask, connectivity):
                        f'shape as `image` (shape {image.shape})')
             raise ValueError(message)
     return (image.astype(np.float64),
-            markers.astype(np.int32),
+            markers.astype(f'{markers.dtype}'),
             mask.astype(np.int8))
 
 

--- a/skimage/segmentation/_watershed.py
+++ b/skimage/segmentation/_watershed.py
@@ -26,7 +26,7 @@ from ..util import crop, regular_seeds
 
 
 def _validate_inputs(image, markers, mask, connectivity):
-    """Ensures that all inputs to watershed have matching shapes and types.
+    """Ensure that all inputs to watershed have matching shapes and types.
 
     Parameters
     ----------
@@ -119,7 +119,7 @@ def watershed(image, markers=None, connectivity=1, offset=None, mask=None,
     Returns
     -------
     out : ndarray
-        A labeled matrix of dtype `int32` and the shape as markers
+        A labeled matrix of the same type and shape as markers
 
     See Also
     --------

--- a/skimage/segmentation/_watershed_cy.pyx
+++ b/skimage/segmentation/_watershed_cy.pyx
@@ -1,12 +1,12 @@
 """watershed.pyx - cython implementation of guts of watershed
 """
 from libc.math cimport sqrt
+from .._shared.fused_numerics cimport np_anyint
 
 cimport numpy as cnp
 cimport cython
 cnp.import_array()
 
-ctypedef cnp.int32_t DTYPE_INT32_t
 ctypedef cnp.int8_t DTYPE_BOOL_t
 
 
@@ -35,7 +35,7 @@ cdef inline cnp.float64_t _euclid_dist(Py_ssize_t pt0, Py_ssize_t pt1,
 @cython.boundscheck(False)
 @cython.cdivision(True)
 @cython.unraisable_tracebacks(False)
-cdef inline DTYPE_BOOL_t _diff_neighbors(DTYPE_INT32_t[::1] output,
+cdef inline DTYPE_BOOL_t _diff_neighbors(np_anyint[::1] output,
                                          cnp.intp_t[::1] structure,
                                          DTYPE_BOOL_t[::1] mask,
                                          Py_ssize_t index) nogil:
@@ -46,7 +46,7 @@ cdef inline DTYPE_BOOL_t _diff_neighbors(DTYPE_INT32_t[::1] output,
     """
     cdef:
         Py_ssize_t i, neighbor_index
-        DTYPE_INT32_t neighbor_label0, neighbor_label1
+        np_anyint neighbor_label0, neighbor_label1
         Py_ssize_t nneighbors = structure.shape[0]
 
     if not mask[index]:
@@ -73,7 +73,7 @@ def watershed_raveled(cnp.float64_t[::1] image,
                       DTYPE_BOOL_t[::1] mask,
                       cnp.intp_t[::1] strides,
                       cnp.float64_t compactness,
-                      DTYPE_INT32_t[::1] output,
+                      np_anyint[::1] output,
                       DTYPE_BOOL_t wsl):
     """Perform watershed algorithm using a raveled image and neighborhood.
 

--- a/skimage/segmentation/tests/test_watershed.py
+++ b/skimage/segmentation/tests/test_watershed.py
@@ -443,7 +443,7 @@ def test_watershed_output_dtype(dtype):
     image = np.zeros((100, 100))
     markers = np.zeros((100, 100), dtype)
     out = watershed(image, markers)
-    np.testing.assert_equal(out.dtype, markers.dtype)
+    assert out.dtype == markers.dtype
 
 
 def test_incorrect_markers_shape():

--- a/skimage/segmentation/tests/test_watershed.py
+++ b/skimage/segmentation/tests/test_watershed.py
@@ -393,10 +393,7 @@ class TestWatershed(unittest.TestCase):
             self.assertTrue(np.sum(ws == lab) == area)
 
     def test_watershed_input_not_modified(self):
-        """Test on markers
-
-        This is here to ensure input markers is not modified
-        """
+        """Test to ensure input markers are not modified."""
         image = np.random.default_rng().random(size=(21, 21))
         markers = np.zeros((21, 21), dtype=np.uint8)
         markers[[5, 5, 15, 15], [5, 15, 5, 15]] = [1, 2, 3, 4]
@@ -439,8 +436,8 @@ def test_numeric_seed_watershed():
 
 
 @pytest.mark.parametrize(
-    'dtype', [np.uint8, np.int8, np.uint16,
-              np.int16, np.int32, np.uint64, np.int64]
+    'dtype', [np.uint8, np.int8, np.uint16, np.int16,
+              np.uint32, np.int32, np.uint64, np.int64]
 )
 def test_watershed_output_dtype(dtype):
     image = np.zeros((100, 100))

--- a/skimage/segmentation/tests/test_watershed.py
+++ b/skimage/segmentation/tests/test_watershed.py
@@ -392,16 +392,19 @@ class TestWatershed(unittest.TestCase):
         for lab, area in zip(range(4), [34,74,74,74]):
             self.assertTrue(np.sum(ws == lab) == area)
 
-    def test_watershed13(self):
+    def test_watershed_input_not_modified(self):
         """Test on markers
 
         This is here to ensure input markers is not modified
         """
-        image = np.zeros((21, 21))
-        markers = np.zeros((21, 21), int)
+        image = np.random.default_rng().random(size=(21, 21))
+        markers = np.zeros((21, 21), dtype=np.uint8)
+        markers[[5, 5, 15, 15], [5, 15, 5, 15]] = [1, 2, 3, 4]
         original_markers = np.copy(markers)
-        watershed(image, markers)
+        result = watershed(image, markers)
         np.testing.assert_equal(original_markers, markers)
+        assert not np.all(result == markers)
+
 
 def test_compact_watershed():
     image = np.zeros((5, 6))

--- a/skimage/segmentation/tests/test_watershed.py
+++ b/skimage/segmentation/tests/test_watershed.py
@@ -392,7 +392,16 @@ class TestWatershed(unittest.TestCase):
         for lab, area in zip(range(4), [34,74,74,74]):
             self.assertTrue(np.sum(ws == lab) == area)
 
+    def test_watershed13(self):
+        """Test on markers
 
+        This is here to ensure input markers is not modified
+        """
+        image = np.zeros((21, 21))
+        markers = np.zeros((21, 21), int)
+        original_markers = np.copy(markers)
+        watershed(image, markers)
+        np.testing.assert_equal(original_markers, markers)
 
 def test_compact_watershed():
     image = np.zeros((5, 6))
@@ -424,6 +433,17 @@ def test_numeric_seed_watershed():
                          [1, 1, 1, 1, 2, 2],
                          [1, 1, 1, 1, 2, 2]], dtype=np.int32)
     np.testing.assert_equal(compact, expected)
+
+
+@pytest.mark.parametrize(
+    'dtype', [np.uint8, np.int8, np.uint16,
+              np.int16, np.int32, np.uint64, np.int64]
+)
+def test_watershed_output_dtype(dtype):
+    image = np.zeros((100, 100))
+    markers = np.zeros((100, 100), dtype)
+    out = watershed(image, markers)
+    np.testing.assert_equal(out.dtype, markers.dtype)
 
 
 def test_incorrect_markers_shape():


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description
Bug fix: segmentation.watershed returns wrong data type #6587

(Fixes #6587)

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
