### PR TITLE
Speed up threshold_local function by fixing call to _supported_float_type

### DIFF
--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -247,8 +247,8 @@ def test_supported_float_dtype_input_kinds(dtype):
     'dtypes, expected',
     [
         ((np.float16, np.float64), np.float64),
-        ([np.float32, np.uint16, np.int8], np.float64),
-        ({np.float32, np.float16}, np.float32),
+        ((np.float32, np.uint16, np.int8), np.float64),
+        ((np.float32, np.float16), np.float32),
     ]
 )
 def test_supported_float_dtype_sequence(dtypes, expected):

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -2,7 +2,6 @@ import inspect
 import functools
 import sys
 import warnings
-from collections.abc import Iterable
 
 import numpy as np
 
@@ -713,8 +712,8 @@ def _supported_float_type(input_dtype, allow_complex=False):
 
     Parameters
     ----------
-    input_dtype : np.dtype or Iterable of np.dtype
-        The input dtype. If a sequence of multiple dtypes is provided, each
+    input_dtype : np.dtype or tuple of np.dtype
+        The input dtype. If a tuple of multiple dtypes is provided, each
         dtype is first converted to a supported floating point type and the
         final dtype is then determined by applying `np.result_type` on the
         sequence of supported floating point types.
@@ -726,7 +725,7 @@ def _supported_float_type(input_dtype, allow_complex=False):
     float_type : dtype
         Floating-point dtype for the image.
     """
-    if isinstance(input_dtype, Iterable) and not isinstance(input_dtype, str):
+    if isinstance(input_dtype, tuple):
         return np.result_type(*(_supported_float_type(d) for d in input_dtype))
     input_dtype = np.dtype(input_dtype)
     if not allow_complex and input_dtype.kind == 'c':

--- a/skimage/color/delta_e.py
+++ b/skimage/color/delta_e.py
@@ -28,7 +28,7 @@ def _float_inputs(lab1, lab2, allow_float32=True):
     lab1 = np.asarray(lab1)
     lab2 = np.asarray(lab2)
     if allow_float32:
-        float_dtype = _supported_float_type([lab1.dtype, lab2.dtype])
+        float_dtype = _supported_float_type((lab1.dtype, lab2.dtype))
     else:
         float_dtype = np.float64
     lab1 = lab1.astype(float_dtype, copy=False)
@@ -374,7 +374,8 @@ def get_dH2(lab1, lab2, *, channel_axis=-1):
         2*|ab1|*|ab2| - 2*dot(ab1, ab2)
     """
     # This function needs double precision internally for accuracy
-    input_is_float_32 = _supported_float_type([lab1, lab2]) == np.float32
+    input_is_float_32 = _supported_float_type((lab1.dtype, lab2.dtype)) == \
+        np.float32
     lab1, lab2 = _float_inputs(lab1, lab2, allow_float32=False)
 
     a1, b1 = np.moveaxis(lab1, source=channel_axis, destination=0)[1:3]

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -227,7 +227,7 @@ def threshold_local(image, block_size=3, method='gaussian', offset=0,
     if any(b % 2 == 0 for b in block_size):
         raise ValueError(f'block_size must be odd! Given block_size '
                          f'{block_size} contains even values.')
-    float_dtype = _supported_float_type(image)
+    float_dtype = _supported_float_type(image.dtype)
     image = image.astype(float_dtype, copy=False)
     thresh_image = np.zeros(image.shape, dtype=float_dtype)
     if method == 'generic':

--- a/skimage/metrics/simple_metrics.py
+++ b/skimage/metrics/simple_metrics.py
@@ -15,7 +15,7 @@ def _as_floats(image0, image1):
     """
     Promote im1, im2 to nearest appropriate floating point precision.
     """
-    float_type = _supported_float_type([image0.dtype, image1.dtype])
+    float_type = _supported_float_type((image0.dtype, image1.dtype))
     image0 = np.asarray(image0, dtype=float_type)
     image1 = np.asarray(image1, dtype=float_type)
     return image0, image1

--- a/skimage/registration/_masked_phase_cross_correlation.py
+++ b/skimage/registration/_masked_phase_cross_correlation.py
@@ -157,7 +157,7 @@ def cross_correlate_masked(arr1, arr2, m1, m2, mode='full', axes=(-2, -1),
     fixed_image = np.asarray(arr1)
     moving_image = np.asarray(arr2)
     float_dtype = _supported_float_type(
-        [fixed_image.dtype, moving_image.dtype]
+        (fixed_image.dtype, moving_image.dtype)
     )
     if float_dtype.kind == 'c':
         raise ValueError("complex-valued arr1, arr2 are not supported")

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -57,12 +57,12 @@ def test_denoise_tv_chambolle_2d(dtype):
     img = np.clip(img, 0, 1)
     # denoise
     denoised_astro = restoration.denoise_tv_chambolle(img, weight=0.1)
-    assert denoised_astro.dtype == _supported_float_type(img)
+    assert denoised_astro.dtype == _supported_float_type(img.dtype)
 
     from scipy import ndimage as ndi
 
     # Convert to a floating point type supported by scipy.ndimage
-    float_dtype = _supported_float_type(img)
+    float_dtype = _supported_float_type(img.dtype)
     img = img.astype(float_dtype, copy=False)
 
     grad = ndi.morphological_gradient(img, size=((3, 3)))
@@ -743,7 +743,7 @@ def test_wavelet_denoising_scaling(case, dtype, convert2ycbcr,
                                            channel_axis=channel_axis,
                                            convert2ycbcr=convert2ycbcr,
                                            rescale_sigma=True)
-    assert denoised.dtype == _supported_float_type(noisy)
+    assert denoised.dtype == _supported_float_type(noisy.dtype)
 
     data_range = x.max() - x.min()
     psnr_noisy = peak_signal_noise_ratio(x, noisy, data_range=data_range)

--- a/skimage/restoration/tests/test_inpaint.py
+++ b/skimage/restoration/tests/test_inpaint.py
@@ -21,7 +21,7 @@ def test_inpaint_biharmonic_2d(dtype, split_into_regions):
     img[np.where(mask)] = 0
     out = inpaint.inpaint_biharmonic(img, mask,
                                      split_into_regions=split_into_regions)
-    assert out.dtype == _supported_float_type(img)
+    assert out.dtype == _supported_float_type(img.dtype)
 
     ref = np.array(
         [[0., 0.0625, 0.25000000, 0.5625000, 0.73925058],

--- a/skimage/restoration/uft.py
+++ b/skimage/restoration/uft.py
@@ -391,7 +391,7 @@ def ir2tf(imp_resp, shape, dim=None, is_real=True):
     if not dim:
         dim = imp_resp.ndim
     # Zero padding and fill
-    irpadded_dtype = _supported_float_type(imp_resp)
+    irpadded_dtype = _supported_float_type(imp_resp.dtype)
     irpadded = np.zeros(shape, dtype=irpadded_dtype)
     irpadded[tuple([slice(0, s) for s in imp_resp.shape])] = imp_resp
     # Roll for zero convention of the fft to avoid the phase


### PR DESCRIPTION
Fix call to _supported_float_type(dtype) in threshold_local() function.

We currently pass the image itself instead of its dtype to the _supported_float_type function, forcing it to iterate over the entire image to get its dtype.

Passing the image's dtype directly leads to a much faster execution time of the threshold_local() function

In my case, for (2480, 3508) images, the execution time goes down from 20s on average to 2s on average with this fix.