### PR TITLE
Handle NaNs when clipping in `transform.resize`

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -162,9 +162,6 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
     if order > 0:
         image = convert_to_float(image, preserve_range)
 
-    # Save input value range for clip
-    img_bounds = np.array([image.min(), image.max()]) if clip else None
-
     # Translate modes used by np.pad to those used by scipy.ndimage
     ndi_mode = _to_ndimage_mode(mode)
     if anti_aliasing:
@@ -179,14 +176,16 @@ def resize(image, output_shape, order=None, mode='reflect', cval=0, clip=True,
             elif np.any((anti_aliasing_sigma > 0) & (factors <= 1)):
                 warn("Anti-aliasing standard deviation greater than zero but "
                      "not down-sampling along all axes")
-        image = ndi.gaussian_filter(image, anti_aliasing_sigma,
-                                    cval=cval, mode=ndi_mode)
+        filtered = ndi.gaussian_filter(image, anti_aliasing_sigma,
+                                       cval=cval, mode=ndi_mode)
+    else:
+        filtered = image
 
     zoom_factors = [1 / f for f in factors]
-    out = ndi.zoom(image, zoom_factors, order=order, mode=ndi_mode,
+    out = ndi.zoom(filtered, zoom_factors, order=order, mode=ndi_mode,
                    cval=cval, grid_mode=True)
 
-    _clip_warp_output(img_bounds, out, mode, cval, clip)
+    _clip_warp_output(image, out, mode, cval, clip)
 
     return out
 

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -447,7 +447,7 @@ def test_resize_clip(order, preserve_range, anti_aliasing, dtype):
     if dtype == np.uint8:
         x *= 255
     else:
-        x[0,0] = np.NaN
+        x[0, 0] = np.NaN
     resized = resize(x, (3, 3), order=order, preserve_range=preserve_range,
                      anti_aliasing=anti_aliasing)
 

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -446,10 +446,12 @@ def test_resize_clip(order, preserve_range, anti_aliasing, dtype):
     x = np.ones((5, 5), dtype=dtype)
     if dtype == np.uint8:
         x *= 255
+    else:
+        x[0,0] = np.NaN
     resized = resize(x, (3, 3), order=order, preserve_range=preserve_range,
                      anti_aliasing=anti_aliasing)
 
-    assert resized.max() == expected_max
+    assert np.nanmax(resized) == expected_max
 
 
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->

Fixes #6850. I included this test in the existing test_resize_clip test, but if you think it should be its own test I can break it out. 

<!-- If this is a new feature, reference what paper it implements. -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
