### PR TITLE
Update references to outdated dev.py with spin

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -260,9 +260,9 @@ i.e., statement coverage should be at 100%.
 
 To measure the test coverage, install
 `pytest-cov <https://pytest-cov.readthedocs.io/en/latest/>`__
-(using ``pip install pytest-cov``) and then run::
+(using ``pip install -r requirements/test.txt``) and then run::
 
-  $ ./dev.py coverage
+  $ spin coverage
 
 This will print a report with one line for each file in `skimage`,
 detailing the test coverage::
@@ -281,14 +281,14 @@ To build the HTML documentation, you can run:
 
 .. code:: sh
 
-    ./dev.py docs
+    spin docs
 
 Then, all the HTML files will be generated in ``scikit-image/doc/build/html/``.
 To rebuild a full clean documentation, run:
 
 .. code:: sh
 
-    ./dev.py docs --clean
+    spin docs --clean
 
 Requirements
 ~~~~~~~~~~~~
@@ -458,8 +458,8 @@ optimized for. A historical view of our snapshots can be found on
 at the following `website <https://pandas.pydata.org/speed/scikit-image/>`_.
 
 In this section we will review how to setup the benchmarks,
-and three commands ``./dev.py asv -- dev``, ``./dev.py asv -- run`` and
-``./dev.py asv -- continuous``.
+and three commands ``spin asv -- dev``, ``spin asv -- run`` and
+``spin asv -- continuous``.
 
 Prerequisites
 ~~~~~~~~~~~~~
@@ -477,7 +477,7 @@ If you are using conda, then the command::
 
 is more appropriate. Once installed, it is useful to run the command::
 
-  ./dev.py asv -- machine
+  spin asv -- machine
 
 To let airspeed velocity know more information about your machine.
 
@@ -548,7 +548,7 @@ Testing the benchmarks locally
 Prior to running the true benchmark, it is often worthwhile to test that the
 code is free of typos. To do so, you may use the command::
 
-  ./dev.py asv -- dev -b TransformSuite
+  spin asv -- dev -b TransformSuite
 
 Where the ``TransformSuite`` above will be run once in your current environment
 to test that everything is in order.
@@ -563,7 +563,7 @@ features. The command ``asv run -E existing`` will specify that you wish to run
 the benchmark in your existing environment. This will save a significant amount
 of time since building scikit-image can be a time consuming task::
 
-  ./dev.py asv -- run -E existing -b TransformSuite
+  spin asv -- run -E existing -b TransformSuite
 
 Comparing results to main
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -572,7 +572,7 @@ Often, the goal of a PR is to compare the results of the modifications in terms
 speed to a snapshot of the code that is in the main branch of the
 ``scikit-image`` repository. The command ``asv continuous`` is of help here::
 
-  ./dev.py asv -- continuous main -b TransformSuite
+  spin asv -- continuous main -b TransformSuite
 
 This call will build out the environments specified in the ``asv.conf.json``
 file and compare the performance of the benchmark between your current commit
@@ -580,7 +580,7 @@ and the code in the main branch.
 
 The output may look something like::
 
-  $ ./dev.py asv -- continuous main -b TransformSuite
+  $ spin asv -- continuous main -b TransformSuite
   · Creating environments
   · Discovering benchmarks
   ·· Uninstalling from conda-py3.7-cython-numpy1.15-scipy
@@ -599,10 +599,10 @@ It is also possible to get a comparison of results for two specific revisions
 for which benchmark results have previously been run via the `asv compare`
 command::
 
-    ./dev.py asv -- compare v0.14.5 v0.17.2
+    spin asv -- compare v0.14.5 v0.17.2
 
 Finally, one can also run ASV benchmarks only for a specific commit hash or
 release tag by appending ``^!`` to the commit or tag name. For example to run
 the skimage.filter module benchmarks on release v0.17.2::
 
-    ./dev.py asv -- run -b Filter v0.17.2^!
+    spin asv -- run -b Filter v0.17.2^!

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -243,7 +243,7 @@ We also make a few more assumptions about your system:
 - You have a C compiler set up.
 - You have a C++ compiler set up.
 - You are running a version of Python compatible with our system as listed
-  in our `setup.py file <https://github.com/scikit-image/scikit-image/blob/main/setup.py#L212>`_.
+  in our `pyproject.toml <https://github.com/scikit-image/scikit-image/blob/main/pyproject.toml#L14>`_.
 - You've cloned the git repository into a directory called ``scikit-image``.
   You have set up the `upstream` remote to point to our repository and `origin`
   to point to your fork.
@@ -261,7 +261,6 @@ This directory contains the following files:
     ├── CODE_OF_CONDUCT.md
     ├── CONTRIBUTING.rst
     ├── CONTRIBUTORS.txt
-    ├── dev.py
     ├── doc/
     ├── INSTALL.rst
     ├── LICENSE.txt
@@ -309,13 +308,13 @@ venv
   # Install build dependencies of scikit-image
   pip install -r requirements/build.txt
   # Build scikit-image from source
-  ./dev.py build
+  spin build
   # Test your installation
-  ./dev.py test
+  spin test
   # Build docs
-  ./dev.py docs
+  spin docs
   # Try the new version in IPython
-  ./dev.py ipython
+  spin ipython
 
 conda
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -341,15 +340,15 @@ before you get started.
   # Install build dependencies of scikit-image
   pip install -r requirements/build.txt
   # Build scikit-image from source
-  ./dev.py build
+  spin build
   # Test your installation
-  ./dev.py test
+  spin test
   # Build docs
-  ./dev.py docs
-  # Try the new version in IPython
-  ./dev.py ipython
+  spin docs
+  # Try the new version
+  spin python
 
-For more information about building and using the dev.py package, see ``meson.md``.
+For more information about building and using the ``spin`` package, see ``meson.md``.
 
 Updating the installation
 ------------------------------------------------------------------------------

--- a/meson.md
+++ b/meson.md
@@ -5,32 +5,34 @@ your computer and that you intend to install `scikit-image` inside of it.
 
 ### Developer build
 
-Install the `dev.py` tool:
+Install the required dependencies:
 
 ```
-pip install -r requirements/developer.txt
+pip install -r requirements.txt
+pip install -r requirements/build.txt
 ```
 
 Then build `skimage`:
 
 ```
-./dev.py build
-./dev.py test
+spin build
+spin test
 ```
 
 To run a specific test:
 
 ```
-./dev.py test -- skimage/io/tests/test_imageio.py
+spin test -- skimage/io/tests/test_imageio.py
 ```
 
 Or to try the new version in IPython:
 
 ```
-./dev.py ipython
+pip install ipython
+spin ipython
 ```
 
-Run `./dev.py --help` for more commands.
+Run `spin --help` for more commands.
 
 ### Developer build (explicit)
 
@@ -42,7 +44,8 @@ Run `./dev.py --help` for more commands.
 
 **Install:** `meson install -C build`
 
-The install step copies the necessary Python files into the build dir to form a complete package.
+The installation step copies the necessary Python files into the build dir to form a
+complete package.
 Do not skip this step, or the package won't work.
 
 To use the package, add it to your PYTHONPATH:


### PR DESCRIPTION
## Description

Update some missed references to `dev.py` in our documentation that we missed in #6842.

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
