### PR TITLE
Fix failing regionprop_table for multichannel properties

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -854,15 +854,10 @@ def _props_to_dict(regions, properties=('label', 'bbox'), separator='-'):
                 column_buffer[i] = regions[i][prop]
             out[orig_prop] = np.copy(column_buffer)
         else:
-            if isinstance(rp, np.ndarray):
-                shape = rp.shape
-            else:
-                shape = (len(rp),)
-
             # precompute property column names and locations
             modified_props = []
             locs = []
-            for ind in np.ndindex(shape):
+            for ind in np.ndindex(np.shape(rp)):
                 modified_props.append(
                     separator.join(map(str, (orig_prop,) + ind))
                 )
@@ -872,7 +867,9 @@ def _props_to_dict(regions, properties=('label', 'bbox'), separator='-'):
             n_columns = len(locs)
             column_data = np.empty((n, n_columns), dtype=dtype)
             for k in range(n):
-                rp = regions[k][prop]
+                # we coerce to a numpy array to ensure structures like
+                # tuple-of-arrays expand correctly into columns
+                rp = np.asarray(regions[k][prop])
                 for i, loc in enumerate(locs):
                     column_data[k, i] = rp[loc]
 

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -733,7 +733,8 @@ def test_multichannel_centroid_weighted_table():
 
     table = regionprops_table(SAMPLE, intensity_image=intensity_image,
                               properties=('centroid_weighted',))
-    assert table.shape[1] == np.size(rpm.centroid_weighted)
+    # check the number of returned columns is correct
+    assert len(table) == np.size(rpm.centroid_weighted)
 
 
 def test_moments_weighted_central():

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -727,6 +727,7 @@ def test_multichannel_centroid_weighted_table():
                                    np.squeeze(rp1.centroid_weighted))
     np.testing.assert_almost_equal(rp0.centroid_weighted,
                                    np.array(rpm.centroid_weighted)[:, 0])
+    assert np.shape(rp0.centroid_weighted) == (SAMPLE.ndim,)
     assert np.shape(rp1.centroid_weighted) == (SAMPLE.ndim, 1)
     assert np.shape(rpm.centroid_weighted) == (SAMPLE.ndim,
                                                intensity_image.shape[-1])


### PR DESCRIPTION
## Description

Closes #6860

Use `np.shape()` to determine a non-object regionprop's shape, so that the
raveling of the array to columns works even for array-likes, such as
tuple-of-arrays. We also coerce the property to a NumPy array when it comes
time to add the data to the columns.

## Checklist

- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- ~~Gallery example in `./doc/examples` (new features only)~~
- ~~Benchmark in `./benchmarks`, if your changes aren't covered by an existing benchmark~~
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] Descriptive commit messages (see below)

## For reviewers

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
