### PR TITLE
Bump 0.21 removals to 0.22

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -5,7 +5,7 @@ Version 0.17
 
 * Finalize ``skimage.future.manual_segmentation`` API.
 
-Version 0.21
+Version 0.22
 ------------
 * In ``skimage/filters/lpi_filter.py``, remove the deprecated function
   inverse().

--- a/skimage/_shared/filters.py
+++ b/skimage/_shared/filters.py
@@ -28,7 +28,7 @@ class ChannelAxisNotSet(metaclass=_PatchClassRepr):
     image is grayscale.
 
     This automatic behavior was broken in v0.19, recovered but deprecated in
-    v0.20 and will be removed in v0.21.
+    v0.20 and will be removed in v0.22.
     """
 
 
@@ -81,7 +81,7 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
             behavior is fixed. The last axis of an `image` with dimensions
             (M, N, 3) is interpreted as a color channel if `channel_axis` is not
             set by the user (signaled by the default proxy value
-            `ChannelAxisNotSet`). Starting with 0.21, `channel_axis=None` will
+            `ChannelAxisNotSet`). Starting with 0.22, `channel_axis=None` will
             be used as the new default value.
 
     Returns
@@ -139,7 +139,7 @@ def gaussian(image, sigma=1, output=None, mode='nearest', cval=0,
             warn(
                 "Automatic detection of the color channel was deprecated in "
                 "v0.19, and `channel_axis=None` will be the new default in "
-                "v0.21. Set `channel_axis=-1` explicitly to silence this "
+                "v0.22. Set `channel_axis=-1` explicitly to silence this "
                 "warning.",
                 FutureWarning,
                 stacklevel=2,

--- a/skimage/filters/lpi_filter.py
+++ b/skimage/filters/lpi_filter.py
@@ -168,7 +168,7 @@ def filter_forward(data, impulse_response=None, filter_params={},
 
 
 @deprecated(alt_func='skimage.filters.lpi_filter.filter_inverse',
-            removed_version='0.21')
+            removed_version='0.22')
 def inverse(data, impulse_response=None, filter_params={}, max_gain=2,
             predefined_filter=None):
     return filter_inverse(data, impulse_response, filter_params,

--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -298,7 +298,7 @@ def phase_cross_correlation(reference_image, moving_image, *,
     """
     def warn_return_error():
         warnings.warn(
-            "In scikit-image 0.21, phase_cross_correlation will start "
+            "In scikit-image 0.22, phase_cross_correlation will start "
             "returning a tuple or 3 items (shift, error, phasediff) always. "
             "To enable the new return behavior and silence this warning, use "
             "return_error='always'.",

--- a/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_phase_cross_correlation.py
@@ -175,7 +175,7 @@ def test_4d_input_subpixel():
 @pytest.mark.parametrize("reference_mask", [None, True])
 def test_phase_cross_correlation_deprecation(return_error, reference_mask):
     # For now, assert that phase_cross_correlation raises a warning that
-    # returning only shifts is deprecated. In skimage 0.21, this test should be
+    # returning only shifts is deprecated. In skimage 0.22, this test should be
     # updated for the deprecation of the return_error parameter.
     should_warn = (
         return_error is False
@@ -191,7 +191,7 @@ def test_phase_cross_correlation_deprecation(return_error, reference_mask):
 
     if should_warn:
         msg = (
-            "In scikit-image 0.21, phase_cross_correlation will start "
+            "In scikit-image 0.22, phase_cross_correlation will start "
             "returning a tuple or 3 items (shift, error, phasediff) always. "
             "To enable the new return behavior and silence this warning, use "
             "return_error='always'."


### PR DESCRIPTION
Since 0.21 is being released so soon after 0.20, we decided on a developer call to postpone 0.21 planned removals to 0.22.