### PR TITLE
Make Canny more consistent across different data types

### DIFF
--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -56,12 +56,10 @@ def _preprocess(image, mask, sigma, mode, cval):
     pixels.
     """
     gaussian_kwargs = dict(sigma=sigma, mode=mode, cval=cval,
-                           preserve_range=False)
-    compute_bleedover = (mode == 'constant' or mask is not None)
+                           preserve_range=True)
+    compute_bleedover = mask is not None
     float_type = _supported_float_type(image.dtype)
     if mask is None:
-        if compute_bleedover:
-            mask = np.ones(image.shape, dtype=float_type)
         masked_image = image
 
         eroded_mask = np.ones(image.shape, dtype=bool)

--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -83,7 +83,7 @@ def _preprocess(image, mask, sigma, mode, cval):
         # the function to the mask (which gets you the fraction of the
         # pixel data that's due to significant points)
         bleed_over = gaussian(mask.astype(float_type, copy=False),
-                              **gaussian_kwargs) + np.finfo(float_type).eps
+                              sigma=1, mode='nearest') + np.finfo(float_type).eps
 
     # Smooth the masked image
     smoothed_image = gaussian(masked_image, **gaussian_kwargs)


### PR DESCRIPTION
- When a mask is not provided, do not do bleed-over calculation; bleed-over normalization does affect the outcome a tiny bit.
- Do not use `preserve_range=True` in the Gaussian filter, since it rescales the smoothed image unnecessarily.

Closes #6871 