### PR TITLE
Do not allow 64-bit integer inputs; add test to ensure masked and unmasked modes are aligned

### DIFF
--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -55,8 +55,12 @@ def _preprocess(image, mask, sigma, mode, cval):
     on the mask to recover the effect of smoothing from just the significant
     pixels.
     """
-    gaussian_kwargs = dict(sigma=sigma, mode=mode, cval=cval,
-                           preserve_range=False)
+    gaussian_kwargs = dict(
+        sigma=sigma,
+        mode=mode,
+        cval=cval,
+        preserve_range=False
+    )
     compute_bleedover = (mode == 'constant' or mask is not None)
     float_type = _supported_float_type(image.dtype)
     if mask is None:
@@ -187,6 +191,9 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None,
     # that is "infected" by the masked point, so it's enough to erode the
     # mask by one and then mask the output. We also mask out the border points
     # because who knows what lies beyond the edge of the image?
+
+    if np.issubdtype(image.dtype, np.int64) or np.issubdtype(image.dtype, np.uint64):
+        raise ValueError("skimage does not support 64-bit integer images")
 
     check_nD(image, 2)
     dtype_max = dtype_limits(image, clip_negative=False)[1]

--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -193,7 +193,7 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None,
     # because who knows what lies beyond the edge of the image?
 
     if np.issubdtype(image.dtype, np.int64) or np.issubdtype(image.dtype, np.uint64):
-        raise ValueError("skimage does not support 64-bit integer images")
+        raise ValueError("64-bit integer images are not supported")
 
     check_nD(image, 2)
     dtype_max = dtype_limits(image, clip_negative=False)[1]

--- a/skimage/feature/tests/test_canny.py
+++ b/skimage/feature/tests/test_canny.py
@@ -1,5 +1,6 @@
 import unittest
 import numpy as np
+import pytest
 from skimage._shared.testing import assert_equal
 from scipy.ndimage import binary_dilation, binary_erosion
 from skimage import data, feature
@@ -141,3 +142,12 @@ class TestCanny(unittest.TestCase):
                 feature.canny(image, mode=mode),
                 feature.canny(image, mode=mode, mask=np.ones_like(image, dtype=bool))
         )
+
+    def test_unsupported_int64(self):
+        for dtype in (np.int64, np.uint64):
+            image = np.zeros((10, 10), dtype=dtype)
+            image[3, 3] = np.iinfo(dtype).max
+            with pytest.raises(
+                    ValueError, match="64-bit integer images are not supported"
+            ):
+                feature.canny(image)

--- a/skimage/feature/tests/test_canny.py
+++ b/skimage/feature/tests/test_canny.py
@@ -129,3 +129,15 @@ class TestCanny(unittest.TestCase):
 
         assert_equal(feature.canny(image_float, 1.0, low, high),
                      feature.canny(image_uint8, 1.0, 255 * low, 255 * high))
+
+    def test_full_mask_matches_no_mask(self):
+        """The masked and unmasked algorithms should return the same result.
+
+        """
+        image = data.camera()
+
+        for mode in ('constant', 'nearest', 'reflect'):
+            assert_equal(
+                feature.canny(image, mode=mode),
+                feature.canny(image, mode=mode, mask=np.ones_like(image, dtype=bool))
+        )


### PR DESCRIPTION
@rfezzani A less intrusive patch, and a test to ensure that masked and unmasked modes remain aligned.

Closes #6871

Follow-up to #6874