### PR TITLE
Don't use mutable types as default values for arguments

### DIFF
--- a/doc/ext/doi_role.py
+++ b/doc/ext/doi_role.py
@@ -19,7 +19,7 @@ from docutils import nodes, utils
 from sphinx.util.nodes import split_explicit_title
 
 
-def doi_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
+def doi_role(typ, rawtext, text, lineno, inliner, options=None, content=None):
     text = utils.unescape(text)
     has_explicit_title, title, part = split_explicit_title(text)
     full_url = 'https://doi.org/' + part
@@ -29,7 +29,7 @@ def doi_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
     return [pnode], []
 
 
-def arxiv_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
+def arxiv_role(typ, rawtext, text, lineno, inliner, options=None, content=None):
     text = utils.unescape(text)
     has_explicit_title, title, part = split_explicit_title(text)
     full_url = 'https://arxiv.org/abs/' + part

--- a/skimage/filters/lpi_filter.py
+++ b/skimage/filters/lpi_filter.py
@@ -177,7 +177,7 @@ def inverse(data, impulse_response=None, filter_params=None, max_gain=2,
                           max_gain, predefined_filter)
 
 
-def filter_inverse(data, impulse_response, filter_params=None, max_gain=2,
+def filter_inverse(data, impulse_response=None, filter_params=None, max_gain=2,
                    predefined_filter=None):
     """Apply the filter in reverse to the given data.
 
@@ -186,7 +186,8 @@ def filter_inverse(data, impulse_response, filter_params=None, max_gain=2,
     data : (M,N) ndarray
         Input data.
     impulse_response : callable `f(r, c, **filter_params)`
-        Impulse response of the filter.  See :class:`~.LPIFilter2D`.
+        Impulse response of the filter.  See :class:`~.LPIFilter2D`. This is a required
+        argument unless a `predifined_filter` is provided.
     filter_params : dict, optional
         Additional keyword parameters to the impulse_response function.
     max_gain : float, optional
@@ -196,7 +197,7 @@ def filter_inverse(data, impulse_response, filter_params=None, max_gain=2,
 
     Other Parameters
     ----------------
-    predefined_filter : LPIFilter2D
+    predefined_filter : LPIFilter2D, optional
         If you need to apply the same filter multiple times over different
         images, construct the LPIFilter2D and specify it here.
 

--- a/skimage/filters/lpi_filter.py
+++ b/skimage/filters/lpi_filter.py
@@ -130,7 +130,7 @@ class LPIFilter2D:
         return out
 
 
-def filter_forward(data, impulse_response=None, filter_params={},
+def filter_forward(data, impulse_response=None, filter_params=None,
                    predefined_filter=None):
     """Apply the given filter to data.
 
@@ -140,7 +140,7 @@ def filter_forward(data, impulse_response=None, filter_params={},
         Input data.
     impulse_response : callable `f(r, c, **filter_params)`
         Impulse response of the filter.  See LPIFilter2D.__init__.
-    filter_params : dict
+    filter_params : dict, optional
         Additional keyword parameters to the impulse_response function.
 
     Other Parameters
@@ -161,6 +161,8 @@ def filter_forward(data, impulse_response=None, filter_params={},
     >>> filtered = filter_forward(data.coins(), filt_func)
 
     """
+    if filter_params is None:
+        filter_params = {}
     check_nD(data, 2, 'data')
     if predefined_filter is None:
         predefined_filter = LPIFilter2D(impulse_response, **filter_params)
@@ -169,13 +171,13 @@ def filter_forward(data, impulse_response=None, filter_params={},
 
 @deprecated(alt_func='skimage.filters.lpi_filter.filter_inverse',
             removed_version='0.22')
-def inverse(data, impulse_response=None, filter_params={}, max_gain=2,
+def inverse(data, impulse_response=None, filter_params=None, max_gain=2,
             predefined_filter=None):
     return filter_inverse(data, impulse_response, filter_params,
                           max_gain, predefined_filter)
 
 
-def filter_inverse(data, impulse_response=None, filter_params={}, max_gain=2,
+def filter_inverse(data, impulse_response, filter_params=None, max_gain=2,
                    predefined_filter=None):
     """Apply the filter in reverse to the given data.
 
@@ -184,10 +186,10 @@ def filter_inverse(data, impulse_response=None, filter_params={}, max_gain=2,
     data : (M,N) ndarray
         Input data.
     impulse_response : callable `f(r, c, **filter_params)`
-        Impulse response of the filter.  See LPIFilter2D.__init__.
-    filter_params : dict
+        Impulse response of the filter.  See :class:`~.LPIFilter2D`.
+    filter_params : dict, optional
         Additional keyword parameters to the impulse_response function.
-    max_gain : float
+    max_gain : float, optional
         Limit the filter gain.  Often, the filter contains zeros, which would
         cause the inverse filter to have infinite gain.  High gain causes
         amplification of artefacts, so a conservative limit is recommended.
@@ -199,6 +201,9 @@ def filter_inverse(data, impulse_response=None, filter_params={}, max_gain=2,
         images, construct the LPIFilter2D and specify it here.
 
     """
+    if filter_params is None:
+        filter_params = {}
+
     check_nD(data, 2, 'data')
     if predefined_filter is None:
         filt = LPIFilter2D(impulse_response, **filter_params)
@@ -215,7 +220,7 @@ def filter_inverse(data, impulse_response=None, filter_params={}, max_gain=2,
     return _center(np.abs(fft.ifftshift(fft.ifftn(G * F))), data.shape)
 
 
-def wiener(data, impulse_response=None, filter_params={}, K=0.25,
+def wiener(data, impulse_response=None, filter_params=None, K=0.25,
            predefined_filter=None):
     """Minimum Mean Square Error (Wiener) inverse filter.
 
@@ -228,7 +233,7 @@ def wiener(data, impulse_response=None, filter_params={}, K=0.25,
         image.
     impulse_response : callable `f(r, c, **filter_params)`
         Impulse response of the filter.  See LPIFilter2D.__init__.
-    filter_params : dict
+    filter_params : dict, optional
         Additional keyword parameters to the impulse_response function.
 
     Other Parameters
@@ -238,6 +243,9 @@ def wiener(data, impulse_response=None, filter_params={}, K=0.25,
         images, construct the LPIFilter2D and specify it here.
 
     """
+    if filter_params is None:
+        filter_params = {}
+
     check_nD(data, 2, 'data')
 
     if not isinstance(K, float):

--- a/skimage/graph/_rag.py
+++ b/skimage/graph/_rag.py
@@ -159,7 +159,7 @@ class RAG(nx.Graph):
                 extra_arguments=(self,))
 
     def merge_nodes(self, src, dst, weight_func=min_weight, in_place=True,
-                    extra_arguments=[], extra_keywords={}):
+                    extra_arguments=None, extra_keywords=None):
         """Merge node `src` and `dst`.
 
         The new combined node is adjacent to all the neighbors of `src`
@@ -196,6 +196,11 @@ class RAG(nx.Graph):
         If `in_place` is `False` the resulting node has a new id, rather than
         `dst`.
         """
+        if extra_arguments is None:
+            extra_arguments = []
+        if extra_keywords is None:
+            extra_keywords = {}
+
         src_nbrs = set(self.neighbors(src))
         dst_nbrs = set(self.neighbors(dst))
         neighbors = (src_nbrs | dst_nbrs) - {src, dst}

--- a/skimage/restoration/_cycle_spin.py
+++ b/skimage/restoration/_cycle_spin.py
@@ -49,7 +49,7 @@ def _generate_shifts(ndim, multichannel, max_shifts, shift_steps=1):
 
 @utils.channel_as_last_axis()
 def cycle_spin(x, func, max_shifts, shift_steps=1, num_workers=None,
-               func_kw={}, *, channel_axis=None):
+               func_kw=None, *, channel_axis=None):
     """Cycle spinning (repeatedly apply func to shifted versions of x).
 
     Parameters
@@ -118,6 +118,9 @@ def cycle_spin(x, func, max_shifts, shift_steps=1, num_workers=None,
     ...                       max_shifts=3)
 
     """
+    if func_kw is None:
+        func_kw = {}
+
     x = np.asanyarray(x)
     multichannel = channel_axis is not None
     all_shifts = _generate_shifts(x.ndim, multichannel, max_shifts,

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -692,7 +692,7 @@ def _clip_warp_output(input_image, output_image, mode, cval, clip):
         np.clip(output_image, min_val, max_val, out=output_image)
 
 
-def warp(image, inverse_map, map_args={}, output_shape=None, order=None,
+def warp(image, inverse_map, map_args=None, output_shape=None, order=None,
          mode='constant', cval=0., clip=True, preserve_range=False):
     """Warp an image according to a given coordinate transformation.
 
@@ -834,6 +834,8 @@ def warp(image, inverse_map, map_args={}, output_shape=None, order=None,
     >>> warped = warp(cube, coords)
 
     """
+    if map_args is None:
+        map_args = {}
 
     if image.size == 0:
         raise ValueError("Cannot warp empty image with dimensions",

--- a/skimage/util/apply_parallel.py
+++ b/skimage/util/apply_parallel.py
@@ -55,7 +55,7 @@ def _ensure_dask_array(array, chunks=None):
 
 
 def apply_parallel(function, array, chunks=None, depth=0, mode=None,
-                   extra_arguments=(), extra_keywords={}, *, dtype=None,
+                   extra_arguments=(), extra_keywords=None, *, dtype=None,
                    compute=None, channel_axis=None):
     """Map a function in parallel across an array.
 
@@ -133,6 +133,9 @@ def apply_parallel(function, array, chunks=None, depth=0, mode=None,
     except ImportError:
         raise RuntimeError("Could not import 'dask'.  Please install "
                            "using 'pip install dask'")
+
+    if extra_keywords is None:
+        extra_arguments = {}
 
     if compute is None:
         compute = not isinstance(array, da.Array)


### PR DESCRIPTION
See https://pylint.pycqa.org/en/latest/user_guide/messages/warning/dangerous-default-value.html

<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
