### PR TITLE
Fix LPI filter for data with even dimensions

### DIFF
--- a/skimage/filters/__init__.pyi
+++ b/skimage/filters/__init__.pyi
@@ -13,6 +13,7 @@ __all__ = [
     "farid_h",
     "farid_v",
     "filter_inverse",
+    "filter_forward",
     "frangi",
     "gabor",
     "gabor_kernel",
@@ -84,6 +85,7 @@ from .edges import (
 from .lpi_filter import (
     LPIFilter2D,
     filter_inverse,
+    filter_forward,
     inverse,
     wiener,
 )

--- a/skimage/filters/tests/test_lpi_filter.py
+++ b/skimage/filters/tests/test_lpi_filter.py
@@ -1,10 +1,38 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_, assert_equal
+from numpy.testing import assert_, assert_equal, assert_array_almost_equal
 
 from skimage._shared.utils import _supported_float_type
-from skimage.data import camera
-from skimage.filters.lpi_filter import LPIFilter2D, filter_inverse, wiener
+from skimage.data import camera, coins
+from skimage.filters import (
+    LPIFilter2D, filter_inverse, filter_forward, wiener, gaussian
+)
+
+
+def test_filter_forward():
+    def filt_func(r, c, sigma=2):
+        return (1 / (2 * np.pi * sigma**2)) *  np.exp(-(r**2 + c**2) / (2 * sigma ** 2))
+
+    gaussian_args = {
+        'sigma': 2,
+        'preserve_range': True,
+        'mode': 'constant',
+        'truncate': 20  # LPI filtering is more precise than the truncated
+                        # Gaussian, so don't truncate at the default of 4 sigma
+    }
+
+    # Odd image size
+    image = coins()[:303, :383]
+    filtered = filter_forward(image, filt_func)
+    filtered_gaussian = gaussian(image, **gaussian_args)
+    assert_array_almost_equal(filtered, filtered_gaussian)
+
+    # Even image size
+    image = coins()
+    filtered = filter_forward(image, filt_func)
+    filtered_gaussian = gaussian(image, **gaussian_args)
+    assert_array_almost_equal(filtered, filtered_gaussian)
+
 
 
 class TestLPIFilter2D:
@@ -12,7 +40,7 @@ class TestLPIFilter2D:
     img = camera()[:50, :50]
 
     def filt_func(self, r, c):
-        return np.exp(-np.hypot(r, c) / 1)
+        return np.exp(-(r**2 + c**2) / 1)
 
     def setup_method(self):
         self.f = LPIFilter2D(self.filt_func)


### PR DESCRIPTION
Also add `filter_forward` to public API: this is the functional interface to the LPIFilter2D class.

A stringest test is added that compares filter output with that of `skimage.filters.gaussian`.
