### PR TITLE
Remove `codecov` dependency which disappeared from PyPI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,4 +40,4 @@ repos:
         name: pyproject.toml
         language: system
         entry: python tools/generate_pyproject.toml.py
-        files: pyproject.toml
+        files: "pyproject.toml|requirements/.*\\.txt|tools/.*pyproject.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,6 @@ optional = [
 ]
 test = [
     'asv',
-    'codecov',
     'matplotlib>=3.5',
     'pooch>=1.6.0',
     'pytest>=7.0',

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,4 @@
 asv
-codecov
 matplotlib>=3.5
 pooch>=1.6.0
 pytest>=7.0


### PR DESCRIPTION
## Description

It seems like this package disappeared entirely from PyPI (a few minutes ago for me), see https://pypi.org/project/codecov/. This breaks installing our test dependencies.

It seems that we are no-longer using it, so removing it should be fine? Anyone know something more? Maybe it's related to [PyPIs recent migration of its object storage](https://status.python.org/incidents/y52td1f7pyy1).

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
