### PR TITLE
Procedure to enable editable mode using conda+pip+meson

### DIFF
--- a/meson.md
+++ b/meson.md
@@ -102,6 +102,20 @@ using a combination of `conda`, `pip` and `meson` command lines:
 
 and you are done!
 
+#### Testing with pytest
+
+Testing in the above settings can be achieved using
+
+- Activate the previously created development environment and install `pytest`
+  ```
+  conda activate skimage-dev
+  conda install pytest
+  ```
+- use the `importlib` import mode when you run the tests:
+  ```
+  pytest --import-mode=importlib skimage/
+  ```
+
 ## Notes
 
 ### Templated Cython files

--- a/meson.md
+++ b/meson.md
@@ -75,6 +75,33 @@ produce an sdist and a wheel:
 python -m build --no-isolation
 ```
 
+### Conda (Experimental)
+
+.. warning::
+   Combining `conda` and `pip` is not recommanded. Use with caution!
+
+The recommanded versions of `scikit-image` dependencies are
+unfortunatly not available in the main Conda channel. But you still
+can get `scikit-image` installed in editable mode for development
+using a combination of `conda`, `pip` and `meson` command lines:
+
+- First, create a conda environment with available build and run dependencies
+  ```
+  conda create -n skimage-dev python=3.10 scipy networkx pywavelets pillow imageiomeson-python cython pythran
+  conda activate skimage-dev
+  ```
+- then install skimage in editable mode
+  ```
+  cd SKIMAGE_SRC_PATH
+  pip install -e . --config-settings editable-verbose=true
+  ```
+- reconfigure meson
+  ```
+  meson setup .mesonpy/editable/build --wipe
+  ```
+
+and you are done!
+
 ## Notes
 
 ### Templated Cython files


### PR DESCRIPTION
It took me some time to find a way for hacking in editable mode with the new build system using `conda`. I hope it can help!

<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
