### PR TITLE
Add CircleCI API token; fixes status link to built docs

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -13,6 +13,7 @@ jobs:
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.CIRCLECI_TOKEN }}
           artifact-path: 0/doc/build/html/index.html
           circleci-jobs: doc
           job-title: Check the rendered docs here!


### PR DESCRIPTION
As per instructions provided by @larsoner at
https://github.com/larsoner/circleci-artifacts-redirector-action/issues/40#issuecomment-1505543564
