### PR TITLE
Add warning when browsing developer docs

### DIFF
--- a/doc/source/_static/theme_overrides.css
+++ b/doc/source/_static/theme_overrides.css
@@ -1,5 +1,9 @@
 /* Additional styling for the PyData Sphinx theme. */
 
+html {
+  --pst-header-article-height: auto;
+}
+
 /* Use hyperlink color for grid-item-cards.
 TODO find a way to only apply this to grid-item-cards that link somewhere */
 .sd-card-title {
@@ -16,4 +20,8 @@ div.highlight a {
 /* Stack components in footer vertically. */
 .bd-footer .footer-items__end, .bd-footer .footer-items__start {
   flex-direction: row;
+}
+
+.version-switcher__button[data-active-version-name*="dev"] {
+  background-color: var(--pst-color-secondary);
 }

--- a/doc/source/_templates/doc-version-warning.html
+++ b/doc/source/_templates/doc-version-warning.html
@@ -1,0 +1,9 @@
+{% if 'dev' in version %}
+<div class="admonition warning">
+  <p class="admonition-title">You are browsing documentation for an unreleased version.</p>
+  <p>
+    Some of the functionality you see here may not yet be available.
+    Perhaps you are looking for the <a href="https://scikit-image.org/docs/stable">latest release documentation</a> instead?
+  </p>
+</div>
+{% endif %}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -159,6 +159,7 @@ html_theme_options = {
             "icon": "fa-solid fa-box",
         },
     ],
+    "article_header_start": ["doc-version-warning", "breadcrumbs"],
     "navbar_end": ["version-switcher", "navbar-icon-links"],
     "switcher": {
         "json_url": "https://scikit-image.org/docs/dev/_static/version_switcher.json",


### PR DESCRIPTION
This adds a warning banner to the top of the current "article" when the dev docs are being browsed (perhaps you want to look at stable docs?).

Unfortunately, I cannot figure out how to coax pydata-sphinx-theme into rendering the breadcrums either underneath or above the block.

Any ideas?

/cc @lagru