### PR TITLE
Raise error when source_range is not correct

### DIFF
--- a/skimage/exposure/_adapthist.py
+++ b/skimage/exposure/_adapthist.py
@@ -82,7 +82,7 @@ def equalize_adapthist(image, kernel_size=None,
     elif isinstance(kernel_size, numbers.Number):
         kernel_size = (kernel_size,) * image.ndim
     elif len(kernel_size) != image.ndim:
-        ValueError(f'Incorrect value of `kernel_size`: {kernel_size}')
+        raise ValueError(f'Incorrect value of `kernel_size`: {kernel_size}')
 
     kernel_size = [int(k) for k in kernel_size]
 

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -178,7 +178,7 @@ def _get_numpy_hist_range(image, source_range):
     elif source_range == 'dtype':
         hist_range = dtype_limits(image, clip_negative=False)
     else:
-        ValueError('Wrong value for the `source_range` argument')
+        raise ValueError('Wrong value for the `source_range` argument')
     return hist_range
 
 

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -178,7 +178,7 @@ def _get_numpy_hist_range(image, source_range):
     elif source_range == 'dtype':
         hist_range = dtype_limits(image, clip_negative=False)
     else:
-        raise ValueError('Wrong value for the `source_range` argument')
+        raise ValueError(f'Incorrect value for `source_range` argument: {source_range}')
     return hist_range
 
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -21,8 +21,9 @@ from skimage._shared.utils import _supported_float_type
 # Test integer histograms
 # =======================
 
-def test_wrong_source_range():
-    im = np.array([-1, 100], dtype=np.int8)
+@pytest.mark.parametrize('dtype', [np.int8, np.float32])
+def test_wrong_source_range(dtype):
+    im = np.array([-1, 100], dtype=dtype)
     with pytest.raises(ValueError):
         frequencies, bin_centers = exposure.histogram(im,
                                                       source_range='foobar')

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -24,7 +24,7 @@ from skimage._shared.utils import _supported_float_type
 @pytest.mark.parametrize('dtype', [np.int8, np.float32])
 def test_wrong_source_range(dtype):
     im = np.array([-1, 100], dtype=dtype)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Incorrect value for `source_range` argument"):
         frequencies, bin_centers = exposure.histogram(im,
                                                       source_range='foobar')
 
@@ -593,6 +593,12 @@ def norm_brightness_err(img1, img2):
     ambe = np.abs(img1.mean() - img2.mean())
     nbe = ambe / dtype_range[img1.dtype.type][1]
     return nbe
+
+
+def test_adapthist_incorrect_kernel_size():
+    img = np.ones((8, 8), dtype=float)
+    with pytest.raises(ValueError, match="Incorrect value of `kernel_size`"):
+        exposure.equalize_adapthist(img, (3, 3, 3))
 
 
 # Test Gamma Correction

--- a/skimage/segmentation/_quickshift.py
+++ b/skimage/segmentation/_quickshift.py
@@ -74,7 +74,7 @@ def quickshift(image, ratio=1.0, kernel_size=5, max_dist=10,
 
     if convert2lab:
         if image.shape[-1] != 3:
-            ValueError("Only RGB images can be converted to Lab space.")
+            raise ValueError("Only RGB images can be converted to Lab space.")
         image = rgb2lab(image)
 
     if kernel_size < 1:

--- a/skimage/segmentation/tests/test_quickshift.py
+++ b/skimage/segmentation/tests/test_quickshift.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from skimage.segmentation import quickshift
 
 from skimage._shared import testing
@@ -59,3 +60,11 @@ def test_color(dtype, channel_axis):
     # still don't cross lines
     assert (seg2[9, :] != seg2[10, :]).all()
     assert (seg2[:, 9] != seg2[:, 10]).all()
+
+
+def test_convert2lab_not_rgb():
+    img = np.zeros((20, 21, 2))
+    with pytest.raises(
+            ValueError, match="Only RGB images can be converted to Lab space"
+    ):
+        quickshift(img, convert2lab=True)


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

`ValueError` was not raised in the histogram generation when the input dtype is floating point.
So, I fixed this issue and covered this case in the unit test.


## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
