### PR TITLE
apply spacing rescaling when computing centroid_weighted

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -631,8 +631,8 @@ class RegionProperties:
     @property
     def centroid_weighted(self):
         ctr = self.centroid_weighted_local
-        return tuple(idx + slc.start
-                     for idx, slc in zip(ctr, self.slice))
+        return tuple(idx + slc.start * spc
+                     for idx, slc, spc in zip(ctr, self.slice, self._spacing))
 
     @property
     def centroid_weighted_local(self):

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -797,6 +797,15 @@ def test_moments_weighted_central():
 
 
 def test_centroid_weighted():
+    sample_for_spacing = np.array(
+        [[0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 0, 0, 0],
+         [0, 0, 0, 1, 1, 1],
+         [0, 0, 0, 1, 1, 1],
+         [0, 0, 0, 1, 1, 1],]
+        )
+    target_centroid_wspacing = (4.0, 4.0)
     centroid = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE
                            )[0].centroid_weighted
     target_centroid = (5.540540540540, 9.445945945945)
@@ -816,6 +825,8 @@ def test_centroid_weighted():
     centroid = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE, spacing=spacing)[0].centroid_weighted
     assert_almost_equal(centroid, (cX, cY))
     assert_almost_equal(centroid, 2 * np.array(target_centroid))
+    centroid = regionprops(sample_for_spacing, intensity_image=sample_for_spacing, spacing=spacing)[0].centroid_weighted
+    assert_almost_equal(centroid, 2 * np.array(target_centroid_wspacing))
 
     spacing = (1.3, 0.7)
     Mpq = get_moment_function(INTENSITY_SAMPLE, spacing=spacing)
@@ -823,6 +834,8 @@ def test_centroid_weighted():
     cX = Mpq(1, 0) / Mpq(0, 0)
     centroid = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE, spacing=spacing)[0].centroid_weighted
     assert_almost_equal(centroid, (cX, cY))
+    centroid = regionprops(sample_for_spacing, intensity_image=sample_for_spacing, spacing=spacing)[0].centroid_weighted
+    assert_almost_equal(centroid, spacing * np.array(target_centroid_wspacing))
 
 
 def test_moments_weighted_hu():


### PR DESCRIPTION
## Description

We noticed the numbers for the _centroid_weighted_ returned by _regionprops_, when using anisotropic spacing (e.g. 2, 1 1), where not correct. Upon investigation it looks like the slice.start coordinates are not rescaled before adding to the, correctly rescaled, centroid_weighted_local. This commit fixes the issue and should now return the correct coordinates.

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
