### PR TITLE
 Corrected energy calculation in chan vese

### DIFF
--- a/skimage/segmentation/_chan_vese.py
+++ b/skimage/segmentation/_chan_vese.py
@@ -98,7 +98,7 @@ def _cv_edge_length_term(phi, mu):
     P = np.pad(phi, 1, mode='edge')
     fy = (P[2:, 1:-1] - P[:-2, 1:-1]) / 2.0
     fx = (P[1:-1, 2:] - P[1:-1, :-2]) / 2.0
-    return mu * _cv_delta(phi) * np.sqrt(fx * fx + fy * fy)
+    return mu * _cv_delta(phi) * np.sqrt(fx ** 2 + fy ** 2)
 
 
 def _cv_energy(image, phi, mu, lambda1, lambda2):

--- a/skimage/segmentation/_chan_vese.py
+++ b/skimage/segmentation/_chan_vese.py
@@ -4,21 +4,6 @@ from scipy.ndimage import distance_transform_edt as distance
 from .._shared.utils import _supported_float_type
 
 
-def _cv_curvature(phi):
-    """Returns the 'curvature' of a level set 'phi'.
-    """
-    P = np.pad(phi, 1, mode='edge')
-    fy = (P[2:, 1:-1] - P[:-2, 1:-1]) / 2.0
-    fx = (P[1:-1, 2:] - P[1:-1, :-2]) / 2.0
-    fyy = P[2:, 1:-1] + P[:-2, 1:-1] - 2*phi
-    fxx = P[1:-1, 2:] + P[1:-1, :-2] - 2*phi
-    fxy = .25 * (P[2:, 2:] + P[:-2, :-2] - P[:-2, 2:] - P[2:, :-2])
-    grad2 = fx**2 + fy**2
-    K = ((fxx*fy**2 - 2*fxy*fx*fy + fyy*fx**2) /
-         (grad2*np.sqrt(grad2) + 1e-8))
-    return K
-
-
 def _cv_calculate_variation(image, phi, mu, lambda1, lambda2, dt):
     """Returns the variation of level set 'phi' based on algorithm parameters.
     """

--- a/skimage/segmentation/_chan_vese.py
+++ b/skimage/segmentation/_chan_vese.py
@@ -6,6 +6,21 @@ from .._shared.utils import _supported_float_type
 
 def _cv_calculate_variation(image, phi, mu, lambda1, lambda2, dt):
     """Returns the variation of level set 'phi' based on algorithm parameters.
+
+    This corresponds to equation (22) of the paper by Pascal Getreuer,
+    which computes the next iteration of the level set based on a current
+    level set.
+
+    A full explanation regarding all the terms is beyond the scope of the
+    present description, but there is one difference of particular import.
+    In the original algorithm, convergence is accelerated, and required
+    memory is reduced, by using a single array. This array, therefore, is a
+    combination of non-updated and updated values. If this were to be
+    implemented in python, this would require a double loop, where the
+    benefits of having fewer iterations would be outweided by massively
+    increasing the time required to perform each individual iteration. A
+    similar approach is used by Rami Cohen, and it is from there that the
+    C1-4 notation is taken.
     """
     eta = 1e-16
     P = np.pad(phi, 1, mode='edge')
@@ -88,6 +103,18 @@ def _cv_edge_length_term(phi, mu):
 
 def _cv_energy(image, phi, mu, lambda1, lambda2):
     """Returns the total 'energy' of the current level set function.
+
+    This corresponds to equation (7) of the paper by Pascal Getreuer,
+    which is the weighted sum of the following:
+    (A) the length of the contour produced by the zero values of the
+    level set,
+    (B) the area of the "foreground" (area of the image where the
+    level set is positive),
+    (C) the variance of the image inside the foreground,
+    (D) the variance of the image outside of the foreground
+
+    Each value is computed for each pixel, and then summed. The weight
+    of (B) is set to 0 in this implementation.
     """
     H = _cv_heavyside(phi)
     avgenergy = _cv_difference_from_average_term(image, H, lambda1, lambda2)

--- a/skimage/segmentation/_chan_vese.py
+++ b/skimage/segmentation/_chan_vese.py
@@ -95,8 +95,10 @@ def _cv_edge_length_term(phi, mu):
     """Returns the 'energy' contribution due to the length of the
     edge between regions at each point, multiplied by a factor 'mu'.
     """
-    toret = _cv_curvature(phi)
-    return mu * toret
+    P = np.pad(phi, 1, mode='edge')
+    fy = (P[2:, 1:-1] - P[:-2, 1:-1]) / 2.0
+    fx = (P[1:-1, 2:] - P[1:-1, :-2]) / 2.0
+    return mu * _cv_delta(phi) * np.sqrt(fx * fx + fy * fy)
 
 
 def _cv_energy(image, phi, mu, lambda1, lambda2):


### PR DESCRIPTION
## Description

Closes #6889

The previous implementation used an integral over curvature instead of an integral over length. The present change intends to remedy this. While integrating over absolute curvature would also give a useful indication, the current implementation fits more closely to the function that needs to be minimized.

The new length-term energy is now computed as μ·δ(Φ)·|∇Φ| instead of μ·κ(Φ). Only the reported "energy" is impacted by this change, as the level set calculation appears to have been implemented by closely following the code in [the paper by P. Getreuer](http://dx.doi.org/10.5201/ipol.2012.g-cv). As such the behavior of the algorithm should not be severely affected.

## Checklist

- ~~[Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)~~
- ~~Gallery example in `./doc/examples` (new features only)~~
- ~~Benchmark in `./benchmarks`, if your changes aren't covered by an  existing benchmark~~
- ~~Unit tests~~
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
