### PR TITLE
Generate table of scikit-image's entire runtime API

### DIFF
--- a/tools/api_table.py
+++ b/tools/api_table.py
@@ -1,0 +1,135 @@
+"""Create an API table for a given Python package."""
+
+import logging
+import importlib
+import inspect
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import click
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class Entry:
+    source_path: str
+    discovery_paths: list
+    obj: object
+
+    def __str__(self):
+        return f"{self.sorted_discovery_paths[0]} ({self.type_name})"
+
+    @property
+    def is_public(self):
+        return len(self.public_discovery_paths) > 0
+
+    @property
+    def sorted_discovery_paths(self):
+        paths = sorted(self.discovery_paths, key=lambda x: x.count("."))
+        return paths
+
+    @property
+    def public_discovery_paths(self):
+        paths = [path for path in self.sorted_discovery_paths if "._" not in path]
+        if len(paths) > 1:
+            logger.warning(
+                "object at %r with more than 1 public discovery path: %r",
+                self.source_path,
+                paths,
+            )
+        return paths
+
+    @property
+    def type_name(self):
+        return type(self.obj).__name__
+
+
+def visit_api(table, *, discovery_path, obj):
+    obj_module = inspect.getmodule(obj)
+
+    source_path = f"{obj_module.__name__}."
+    try:
+        source_path += obj.__qualname__
+    except AttributeError:
+        try:
+            source_path += obj.__name__
+        except AttributeError:
+            logger.warning(
+                "stopping API discovery at %r, cannot determine source path, "
+                "no __qualname__ or __name__ attributes",
+                discovery_path,
+            )
+            pass
+
+    if source_path in table:
+        logger.info(
+            "stopping API discovery at %r, already know %r", discovery_path, source_path
+        )
+        table[source_path].discovery_paths.append(discovery_path)
+        return  # Already visited, avoids endless recursion
+
+    table[source_path] = Entry(
+        source_path=source_path, discovery_paths=[discovery_path], obj=obj
+    )
+
+    for member_name, member in inspect.getmembers(obj):
+        member_discovery_path = f"{discovery_path}.{member_name}"
+
+        if inspect.iscode(member):
+            logger.debug(
+                "stopping API discovery at %r, is code object", member_discovery_path
+            )
+            continue  # Skip code objects
+
+        member_module = inspect.getmodule(member)
+        if member_module is None:
+            # logger.debug(
+            #     "stopping API discovery at %r, cannot find its module, "
+            #     "probably a builtin",
+            #     member_discovery_path,
+            # )
+            continue  # Skip built-ins
+        if obj_module.__name__ not in member_module.__name__:
+            logger.debug(
+                "stopping API discovery at %r, in external package %r",
+                member_discovery_path,
+                member_module.__name__,
+            )
+            continue  # Skip members defined outside inspected package
+
+        visit_api(table, obj=member, discovery_path=member_discovery_path)
+
+
+def print_public_api(table):
+    public_entries = [entry for entry in table.values() if entry.is_public]
+
+    for entry in sorted(public_entries, key=lambda e: e.public_discovery_paths[0]):
+        print(entry)
+
+    print(f"{len(public_entries)} objects in public API")
+
+
+@click.command()
+@click.argument("module")
+def main(module):
+    """Create an API table for a given Python package."""
+    log_file = Path(tempfile.gettempdir()) / (Path(__file__).name + ".log")
+    print(f"logging to {log_file}")
+    logging.basicConfig(
+        filename=log_file,
+        filemode="w",
+        level=logging.DEBUG,
+    )
+
+    table = {}
+    api_root = importlib.import_module(module)
+    visit_api(table, obj=api_root, discovery_path=module)
+
+    print_public_api(table)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

In previous discussions, it was suggested to create a resource that spells out scikit-image's complete Python API. This is meant as a first step in identifying common patterns in our API to help with the skimage2 transition and also with typing our API (see the proposal at https://github.com/scikit-image/skimage-archive/pull/29). @jni suggested to aggregate this information in a spreadsheet and pointed to similar work in https://github.com/scikit-image/boilerplate-utils/pull/5. Depending on how this shakes out, I think this could be a very useful tool in general to inspect and measure our API.

While still work in progress, I'm already happy to share the current state. Some notes on the current behavior:

- The script assumes that there is exactly one unique source path for each object, but multiple discovery paths are possible. E.g. `skimage.util.unique.unique_rows` is the source path, while `skimage.util.unique_rows` and `skimage.util.unique.unique_rows` are discovery paths.
- Methods that aren't overwritten in inherited classes, are considered additional discovery paths. Currently the script just uses the first discovered path as the source path here.
- Decorated function (having a `__wrapped__` attribute) are treated as an additional discovery path.
- Variable declarations are detected and listed as well, e.g. `ski.color.ahx_from_rgb`. This was tricky to do. 
- `lazy.attach_stub` overwrites the the `__dir__` function of modules. Because this function is used under the hood to crawl the object tree, things that are actually reachable but not discover-able at runtime are hidden from the script! E.g. `img_as_float64` is available in the current [`skimage/__init__.py` ](https://github.com/scikit-image/scikit-image/blob/f03a55fe4b63ae494586cfbe39143528902747b0/skimage/__init__.py) but not discover-able because it's not included in the matching PYI file. I'm slightly in favor of arguing that the script should only list objects that are part of the object tree as defined `__dir__`. So this is actually working as intended. 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
