### PR TITLE
Enable use of `rescale_intensity` with dask array

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -595,7 +595,7 @@ def rescale_intensity(image, in_range='image', out_range='dtype'):
 
     if imin != imax:
         image = (image - imin) / (imax - imin)
-        return np.asarray(image * (omax - omin) + omin, dtype=out_dtype)
+        return (image * (omax - omin) + omin).astype(out_dtype)
     else:
         return np.clip(image, omin, omax).astype(out_dtype)
 

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -894,6 +894,7 @@ def test_dask_histogram():
     expected_hist = [1, 2, 1]
     assert np.allclose(expected_bins, output_bins)
     assert np.allclose(expected_hist, output_hist)
+    assert isinstance(output_hist, da.Array)
 
 
 def test_dask_rescale():

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -894,3 +894,13 @@ def test_dask_histogram():
     expected_hist = [1, 2, 1]
     assert np.allclose(expected_bins, output_bins)
     assert np.allclose(expected_hist, output_hist)
+
+
+def test_dask_rescale():
+    pytest.importorskip('dask', reason="dask python library is not installed")
+    import dask.array as da
+    image = da.array([51, 102, 153], dtype=np.uint8)
+    out = exposure.rescale_intensity(image)
+    assert out.dtype == np.uint8
+    assert_array_almost_equal(out, [0, 127, 255])
+    assert isinstance(out, da.Array)


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

Avoid calling `np.asarray` to enable use of `skimage.exposure.rescale_intensity` with dask array:

```python
import dask.array as da
import numpy as np
from skimage.exposure import rescale_intensity


image = da.array([51, 102, 153], dtype=np.uint8)
a = rescale_intensity(image)
a.compute()
```

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
