### PR TITLE
ENH Add JupyterLite button to gallery examples

### DIFF
--- a/doc/examples/applications/plot_3d_image_processing.py
+++ b/doc/examples/applications/plot_3d_image_processing.py
@@ -335,3 +335,9 @@ fig['layout'].pop('updatemenus')
 plotly.io.show(fig)
 
 plt.show()
+
+# %%
+# .. warning::
+#
+#   This example does not run in JupterLite, due to a limitation
+#   when downloading large datasets.

--- a/doc/examples/applications/plot_3d_interaction.py
+++ b/doc/examples/applications/plot_3d_interaction.py
@@ -148,3 +148,9 @@ plotly.io.show(fig)
 # .. [2] https://en.wikipedia.org/wiki/Glomerulus_(kidney)
 
 plt.show()
+
+# %%
+# .. warning::
+#
+#   This example does not run in JupterLite, due to a limitation
+#   when downloading large datasets.

--- a/doc/examples/applications/plot_3d_structure_tensor.py
+++ b/doc/examples/applications/plot_3d_structure_tensor.py
@@ -228,3 +228,9 @@ plotly.io.show(fig5)
 # we would get the pancake situation.
 #
 # .. [2] https://en.wikipedia.org/wiki/Structure_tensor#Interpretation_2
+
+# %%
+# .. warning::
+#
+#   This example does not run in JupterLite, due to a limitation
+#   when downloading large datasets.

--- a/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
+++ b/doc/examples/color_exposure/plot_adapt_hist_eq_3d.py
@@ -242,3 +242,9 @@ cbar_ax.set_xticklabels([])
 cbar_ax.set_yticklabels([1., 0.])
 
 plt.show()
+
+# %%
+# .. warning::
+#
+#   This example does not run in JupterLite, due to a limitation
+#   when downloading large datasets.

--- a/doc/examples/data/plot_3d.py
+++ b/doc/examples/data/plot_3d.py
@@ -37,3 +37,9 @@ fig = px.imshow(
 fig.layout.annotations[0]["text"] = "Cell membranes"
 fig.layout.annotations[1]["text"] = "Nuclei"
 plotly.io.show(fig)
+
+# %%
+# .. warning::
+#
+#   This example does not run in JupterLite, due to a limitation
+#   when downloading large datasets.

--- a/doc/examples/data/plot_scientific.py
+++ b/doc/examples/data/plot_scientific.py
@@ -61,3 +61,9 @@ for xpos in [100, 150, 200]:
     further_img[150 - 10 : 150 + 10, xpos - 10 : xpos + 10] = 0
 axs[2, 2].imshow(further_img, cmap=plt.cm.gray)
 plt.subplots_adjust(wspace=-0.3, hspace=0.1)
+
+# %%
+# .. warning::
+#
+#   This example does not run in JupterLite, due to a limitation
+#   when downloading large datasets.

--- a/doc/examples/segmentation/plot_rolling_ball.py
+++ b/doc/examples/segmentation/plot_rolling_ball.py
@@ -314,3 +314,9 @@ plt.plot(x - background, label='radius=80')
 plt.plot(x - background2, label='radius=10')
 plt.legend()
 plt.show()
+
+# %%
+# .. warning::
+#
+#   This example does not run in JupterLite, due to a limitation
+#   when downloading large datasets.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -212,8 +212,8 @@ sphinx_gallery_conf = {
     # Remove sphinx_gallery_thumbnail_number from generated files
     "remove_config_comments": True,
     "jupyterlite": {"notebook_modification_function": notebook_modification_function},
-    # TODO temporary to speed the build by not running the example
-    "plot_gallery": False
+    # Can be disabled during development to accelerate build
+    "plot_gallery": True
 }
 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -89,14 +89,7 @@ v = parse(release)
 if v.release is None:
     raise ValueError(f"Ill-formed version: {version!r}. Version should follow PEP440")
 
-if v.is_devrelease:
-    binder_branch = "main"
-else:
-    major, minor = v.release[:2]
-    binder_branch = f"v{major}.{minor}.x"
-
 # set plotly renderer to capture _repr_html_ for sphinx-gallery
-
 pio.renderers.default = "sphinx_gallery_png"
 
 
@@ -199,16 +192,6 @@ sphinx_gallery_conf = {
             "../examples/developers",
         ]
     ),
-    "binder": {
-        # Required keys
-        "org": "scikit-image",
-        "repo": "scikit-image",
-        "branch": binder_branch,  # Can be any branch, tag, or commit hash
-        "binderhub_url": "https://mybinder.org",  # Any URL of a binderhub.
-        "dependencies": ["../../.binder/requirements.txt", "../../.binder/runtime.txt"],
-        # Optional keys
-        "use_jupyter_lab": False,
-    },
     # Remove sphinx_gallery_thumbnail_number from generated files
     "remove_config_comments": True,
     "jupyterlite": {"notebook_modification_function": notebook_modification_function},

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -8,6 +8,7 @@ import inspect
 import os
 import sys
 from warnings import filterwarnings
+import warnings
 
 import plotly.io as pio
 import skimage

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -166,9 +166,6 @@ new_registry_urls = {
 skimage.data._registry.registry_urls = new_registry_urls
     """.splitlines()
         )
-    # always import matplotlib and pandas to avoid Pyodide limitation with
-    # imports inside functions. TODO not sure this is needed for scikit-image ...
-    code_lines.extend(["import matplotlib", "import pandas"])
 
     if code_lines:
         code_lines = ["# JupyterLite-specific code"] + code_lines

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,8 @@ docs = [
     'scikit-learn>=0.24.0',
     'sphinx_design>=0.3',
     'pydata-sphinx-theme>=0.13',
+    'jupyterlite-sphinx',
+    'jupyterlite-pyodide-kernel',
 ]
 optional = [
     'SimpleITK',

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -18,3 +18,5 @@ kaleido
 scikit-learn>=0.24.0
 sphinx_design>=0.3
 pydata-sphinx-theme>=0.13
+jupyterlite-sphinx
+jupyterlite-pyodide-kernel


### PR DESCRIPTION
## Description

close #6903 

This is a draft PR (for now) that uses sphinx-gallery JupyterLite integration (new in sphinx-gallery 0.13).

Because of a CircleCI artifacts limitation, JupyterLite does not work inside CircleCI (seehttps://github.com/sphinx-gallery/sphinx-gallery/pull/977#issuecomment-1330438821 for more details), so I have built the scikit-image doc locally (without running the examples to save time) and put it on https://lesteve.github.io/scikit-image-jupyterlite/.

You can see the JupyterLite button in an example for example this one:
https://lesteve.github.io/scikit-image-jupyterlite/auto_examples/numpy_operations/plot_camera_numpy.html

Here is a [direct link](https://lesteve.github.io/scikit-image-jupyterlite/lite/lab/?path=auto_examples/numpy_operations/plot_camera_numpy.ipynb) to this notebook inside JupyterLite.

Feel free to try any example you like in the [gallery](https://lesteve.github.io/scikit-image-jupyterlite/auto_examples/) and report issues.

One issue I noticed (there may well be others) is loading the data in:
https://lesteve.github.io/scikit-image-jupyterlite/auto_examples/data/plot_3d.html

Long story short, there is no socket inside Pyodide (browser limitation) so `pyodide-http` replace all the fetch by js `XMLHTTPRequest`. This causes CORS issue because generally the server does not include CORS headers in the response. In scikit-learn examples, most of the datasets are on OpenML which has the necessary CORS headers. Besides finding (or running) a CORS proxy, I don't really know what would be a good solution for this issue ...

More details about JupyterLite sphinx-gallery integration may be available in https://github.com/scikit-learn/scikit-learn/pull/25887 that added this functionality for scikit-learn.

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
