### PR TITLE
Add missing backticks to DOI role in docstring of `area_opening`

### DIFF
--- a/doc/examples/README.txt
+++ b/doc/examples/README.txt
@@ -9,5 +9,5 @@ applications in tutorial form.
 
 .. hint::
 
-    Check out our :ref:`user_guide` for a good narrative
+    Check out our :ref:`user_guide` for a narrative
     introduction to key library conventions and basic image manipulation.

--- a/skimage/morphology/max_tree.py
+++ b/skimage/morphology/max_tree.py
@@ -21,20 +21,20 @@ References:
     .. [1] Salembier, P., Oliveras, A., & Garrido, L. (1998). Antiextensive
            Connected Operators for Image and Sequence Processing.
            IEEE Transactions on Image Processing, 7(4), 555-570.
-           :DOI:10.1109/83.663500
+           :DOI:`10.1109/83.663500`
     .. [2] Berger, C., Geraud, T., Levillain, R., Widynski, N., Baillard, A.,
            Bertin, E. (2007). Effective Component Tree Computation with
            Application to Pattern Recognition in Astronomical Imaging.
            In International Conference on Image Processing (ICIP) (pp. 41-44).
-           :DOI:10.1109/ICIP.2007.4379949
+           :DOI:`10.1109/ICIP.2007.4379949`
     .. [3] Najman, L., & Couprie, M. (2006). Building the component tree in
            quasi-linear time. IEEE Transactions on Image Processing, 15(11),
            3531-3539.
-           :DOI:10.1109/TIP.2006.877518
+           :DOI:`10.1109/TIP.2006.877518`
     .. [4] Carlinet, E., & Geraud, T. (2014). A Comparative Review of
            Component Tree Computation Algorithms. IEEE Transactions on Image
            Processing, 23(9), 3885-3895.
-           :DOI:10.1109/TIP.2014.2336551
+           :DOI:`10.1109/TIP.2014.2336551`
 """
 
 import numpy as np
@@ -206,19 +206,19 @@ def area_opening(image, area_threshold=64, connectivity=1,
            May 1993.
     .. [2] Soille, P., "Morphological Image Analysis: Principles and
            Applications" (Chapter 6), 2nd edition (2003), ISBN 3540429883.
-           :DOI:10.1007/978-3-662-05088-0
+           :DOI:`10.1007/978-3-662-05088-0`
     .. [3] Salembier, P., Oliveras, A., & Garrido, L. (1998). Antiextensive
            Connected Operators for Image and Sequence Processing.
            IEEE Transactions on Image Processing, 7(4), 555-570.
-           :DOI:10.1109/83.663500
+           :DOI:`10.1109/83.663500`
     .. [4] Najman, L., & Couprie, M. (2006). Building the component tree in
            quasi-linear time. IEEE Transactions on Image Processing, 15(11),
            3531-3539.
-           :DOI:10.1109/TIP.2006.877518
+           :DOI:`10.1109/TIP.2006.877518`
     .. [5] Carlinet, E., & Geraud, T. (2014). A Comparative Review of
            Component Tree Computation Algorithms. IEEE Transactions on Image
            Processing, 23(9), 3885-3895.
-           :DOI:10.1109/TIP.2014.2336551
+           :DOI:`10.1109/TIP.2014.2336551`
 
     Examples
     --------


### PR DESCRIPTION
## Description

It was pointed out in https://github.com/scikit-image/scikit-image/pull/6714#issuecomment-1503966967, that these were not rendering properly. Also tweak the text on the Gallery landing page as pointed out in https://github.com/scikit-image/scikit-image/pull/6714#issuecomment-1502235530.

cc @stefanv 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
