### PR TITLE
Change geometric transform inverse to property

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1436,12 +1436,6 @@ class SimilarityTransform(EuclideanTransform):
                 'Scale is only implemented for 2D and 3D.')
 
 
-class ParamsUndetermined:
-    """Signal that a transforms `params` are undetermined
-    """
-    ...
-
-
 class PolynomialTransform(GeometricTransform):
     """2D polynomial transformation.
 
@@ -1469,14 +1463,13 @@ class PolynomialTransform(GeometricTransform):
             raise NotImplementedError(
                 'Polynomial transforms are only implemented for 2D.'
             )
-        if params is not ParamsUndetermined:
-            if params is None:
-                # default to transformation which preserves original coordinates
-                params = np.array([[0, 1, 0], [0, 0, 1]])
-            else:
-                params = np.asarray(params)
-            if params.shape[0] != 2:
-                raise ValueError("invalid shape of transformation parameters")
+        if params is None:
+            # default to transformation which preserves original coordinates
+            params = np.array([[0, 1, 0], [0, 0, 1]])
+        else:
+            params = np.asarray(params)
+        if params.shape[0] != 2:
+            raise ValueError("invalid shape of transformation parameters")
         self.params = params
 
     def estimate(self, src, dst, order=2, weights=None):
@@ -1591,13 +1584,6 @@ class PolynomialTransform(GeometricTransform):
             Transformed coordinates.
 
         """
-        if self.params is ParamsUndetermined:
-            raise NotImplementedError(
-                'There is no explicit way to do the inverse polynomial '
-                'transformation. Instead, estimate the inverse transformation '
-                'parameters by exchanging source and destination coordinates,'
-                'then apply the forward transformation.'
-            )
         coords = np.asarray(coords)
         x = coords[:, 0]
         y = coords[:, 1]
@@ -1617,7 +1603,11 @@ class PolynomialTransform(GeometricTransform):
 
     @property
     def inverse(self):
-        return PolynomialTransform(params=ParamsUndetermined)
+        raise NotImplementedError(
+            'There is no explicit way to do the inverse polynomial '
+            'transformation. Instead, estimate the inverse transformation '
+            'parameters by exchanging source and destination coordinates,'
+            'then apply the forward transformation.')
 
 
 TRANSFORMS = {

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -284,7 +284,11 @@ class FundamentalMatrixTransform(GeometricTransform):
 
     @property
     def inverse(self):
-        """Return a transform object representing the inverse."""
+        """Return a transform object representing the inverse.
+
+        See Hartley & Zisserman, Ch. 8: Epipolar Geometry and the Fundamental
+        Matrix, for an explanation of why F.T gives the inverse.
+        """
         return type(self)(matrix=self.params.T)
 
     def _setup_constraint_matrix(self, src, dst):

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1436,6 +1436,12 @@ class SimilarityTransform(EuclideanTransform):
                 'Scale is only implemented for 2D and 3D.')
 
 
+class ParamsUndetermined:
+    """Signal that a transforms `params` are undetermined
+    """
+    ...
+
+
 class PolynomialTransform(GeometricTransform):
     """2D polynomial transformation.
 
@@ -1463,13 +1469,14 @@ class PolynomialTransform(GeometricTransform):
             raise NotImplementedError(
                 'Polynomial transforms are only implemented for 2D.'
             )
-        if params is None:
-            # default to transformation which preserves original coordinates
-            params = np.array([[0, 1, 0], [0, 0, 1]])
-        else:
-            params = np.asarray(params)
-        if params.shape[0] != 2:
-            raise ValueError("invalid shape of transformation parameters")
+        if params is not ParamsUndetermined:
+            if params is None:
+                # default to transformation which preserves original coordinates
+                params = np.array([[0, 1, 0], [0, 0, 1]])
+            else:
+                params = np.asarray(params)
+            if params.shape[0] != 2:
+                raise ValueError("invalid shape of transformation parameters")
         self.params = params
 
     def estimate(self, src, dst, order=2, weights=None):
@@ -1584,6 +1591,13 @@ class PolynomialTransform(GeometricTransform):
             Transformed coordinates.
 
         """
+        if self.params is ParamsUndetermined:
+            raise NotImplementedError(
+                'There is no explicit way to do the inverse polynomial '
+                'transformation. Instead, estimate the inverse transformation '
+                'parameters by exchanging source and destination coordinates,'
+                'then apply the forward transformation.'
+            )
         coords = np.asarray(coords)
         x = coords[:, 0]
         y = coords[:, 1]
@@ -1601,12 +1615,9 @@ class PolynomialTransform(GeometricTransform):
 
         return dst
 
-    def inverse(self, coords):
-        raise Exception(
-            'There is no explicit way to do the inverse polynomial '
-            'transformation. Instead, estimate the inverse transformation '
-            'parameters by exchanging source and destination coordinates,'
-            'then apply the forward transformation.')
+    @property
+    def inverse(self):
+        return PolynomialTransform(params=ParamsUndetermined)
 
 
 TRANSFORMS = {

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -3,7 +3,7 @@ import numpy as np
 from scipy import spatial
 import textwrap
 
-from .._shared.utils import get_bound_method_class, safe_as_int
+from .._shared.utils import safe_as_int
 
 
 def _affine_matrix_from_vector(v):
@@ -185,20 +185,9 @@ class GeometricTransform:
         """
         raise NotImplementedError()
 
-    def inverse(self, coords):
-        """Apply inverse transformation.
-
-        Parameters
-        ----------
-        coords : (N, 2) array_like
-            Destination coordinates.
-
-        Returns
-        -------
-        coords : (N, 2) array
-            Source coordinates.
-
-        """
+    @property
+    def inverse(self):
+        """Return a transform object representing the inverse."""
         raise NotImplementedError()
 
     def residuals(self, src, dst):
@@ -293,23 +282,10 @@ class FundamentalMatrixTransform(GeometricTransform):
         coords_homogeneous = np.column_stack([coords, np.ones(coords.shape[0])])
         return coords_homogeneous @ self.params.T
 
-    def inverse(self, coords):
-        """Apply inverse transformation.
-
-        Parameters
-        ----------
-        coords : (N, 2) array_like
-            Destination coordinates.
-
-        Returns
-        -------
-        coords : (N, 3) array
-            Epipolar lines in the source image.
-
-        """
-        coords = np.asarray(coords)
-        coords_homogeneous = np.column_stack([coords, np.ones(coords.shape[0])])
-        return coords_homogeneous @ self.params
+    @property
+    def inverse(self):
+        """Return a transform object representing the inverse."""
+        return type(self)(matrix=self.params.T)
 
     def _setup_constraint_matrix(self, src, dst):
         """Setup and solve the homogeneous epipolar constraint matrix::
@@ -660,21 +636,10 @@ class ProjectiveTransform(GeometricTransform):
         """
         return self._apply_mat(coords, self.params)
 
-    def inverse(self, coords):
-        """Apply inverse transformation.
-
-        Parameters
-        ----------
-        coords : (N, D) array_like
-            Destination coordinates.
-
-        Returns
-        -------
-        coords_out : (N, D) array
-            Source coordinates.
-
-        """
-        return self._apply_mat(coords, self._inv_matrix)
+    @property
+    def inverse(self):
+        """Return a transform object representing the inverse."""
+        return type(self)(matrix=self._inv_matrix)
 
     def estimate(self, src, dst, weights=None):
         """Estimate the transformation from a set of corresponding points.
@@ -810,10 +775,6 @@ class ProjectiveTransform(GeometricTransform):
             else:
                 tform = ProjectiveTransform
             return tform(other.params @ self.params)
-        elif (hasattr(other, '__name__')
-                and other.__name__ == 'inverse'
-                and hasattr(get_bound_method_class(other), '_inv_matrix')):
-            return ProjectiveTransform(other.__self__._inv_matrix @ self.params)
         else:
             raise TypeError("Cannot combine transformations of differing "
                             "types.")
@@ -1148,40 +1109,15 @@ class PiecewiseAffineTransform(GeometricTransform):
 
         return out
 
-    def inverse(self, coords):
-        """Apply inverse transformation.
-
-        Coordinates outside of the mesh will be set to `- 1`.
-
-        Parameters
-        ----------
-        coords : (N, D) array_like
-            Source coordinates.
-
-        Returns
-        -------
-        coords : (N, D) array
-            Transformed coordinates.
-
-        """
-        coords = np.asarray(coords)
-        out = np.empty_like(coords, np.float64)
-
-        # determine triangle index for each coordinate
-        simplex = self._inverse_tesselation.find_simplex(coords)
-
-        # coordinates outside of mesh
-        out[simplex == -1, :] = -1
-
-        for index in range(len(self._inverse_tesselation.simplices)):
-            # affine transform for triangle
-            affine = self.inverse_affines[index]
-            # all coordinates within triangle
-            index_mask = simplex == index
-
-            out[index_mask, :] = affine(coords[index_mask, :])
-
-        return out
+    @property
+    def inverse(self):
+        """Return a transform object representing the inverse."""
+        tform = type(self)()
+        tform._tesselation = self._inverse_tesselation
+        tform._inverse_tesselation = self._tesselation
+        tform.affines = self.inverse_affines
+        tform.inverse_affines = self.affines
+        return tform
 
 
 def _euler_rotation(axis, angle):

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -285,7 +285,7 @@ class FundamentalMatrixTransform(GeometricTransform):
     @property
     def inverse(self):
         """Return a transform object representing the inverse."""
-        return type(self)(matrix=self.params.T)
+        return FundamentalMatrixTransform(matrix=self.params.T)
 
     def _setup_constraint_matrix(self, src, dst):
         """Setup and solve the homogeneous epipolar constraint matrix::
@@ -639,7 +639,7 @@ class ProjectiveTransform(GeometricTransform):
     @property
     def inverse(self):
         """Return a transform object representing the inverse."""
-        return type(self)(matrix=self._inv_matrix)
+        return ProjectiveTransform(matrix=self._inv_matrix)
 
     def estimate(self, src, dst, weights=None):
         """Estimate the transformation from a set of corresponding points.
@@ -1112,7 +1112,7 @@ class PiecewiseAffineTransform(GeometricTransform):
     @property
     def inverse(self):
         """Return a transform object representing the inverse."""
-        tform = type(self)()
+        tform = PiecewiseAffineTransform()
         tform._tesselation = self._inverse_tesselation
         tform._inverse_tesselation = self._tesselation
         tform.affines = self.inverse_affines

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -285,7 +285,7 @@ class FundamentalMatrixTransform(GeometricTransform):
     @property
     def inverse(self):
         """Return a transform object representing the inverse."""
-        return FundamentalMatrixTransform(matrix=self.params.T)
+        return type(self)(matrix=self.params.T)
 
     def _setup_constraint_matrix(self, src, dst):
         """Setup and solve the homogeneous epipolar constraint matrix::
@@ -639,7 +639,7 @@ class ProjectiveTransform(GeometricTransform):
     @property
     def inverse(self):
         """Return a transform object representing the inverse."""
-        return ProjectiveTransform(matrix=self._inv_matrix)
+        return type(self)(matrix=self._inv_matrix)
 
     def estimate(self, src, dst, weights=None):
         """Estimate the transformation from a set of corresponding points.
@@ -1112,7 +1112,7 @@ class PiecewiseAffineTransform(GeometricTransform):
     @property
     def inverse(self):
         """Return a transform object representing the inverse."""
-        tform = PiecewiseAffineTransform()
+        tform = type(self)()
         tform._tesselation = self._inverse_tesselation
         tform._inverse_tesselation = self._tesselation
         tform.affines = self.inverse_affines

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -354,7 +354,26 @@ def test_fundamental_matrix_inverse():
                         [[0, 1, 0], [0, 1, -1], [0, 1, -1]])
 
 
-def test_fundamental_matrix_inverse2():
+def test_fundamental_matrix_inverse_estimation():
+    src = np.array([1.839035, 1.924743, 0.543582,  0.375221,
+                    0.473240, 0.142522, 0.964910,  0.598376,
+                    0.102388, 0.140092, 15.994343, 9.622164,
+                    0.285901, 0.430055, 0.091150,  0.254594]).reshape(-1, 2)
+
+    dst = np.array([1.002114, 1.129644, 1.521742, 1.846002,
+                    1.084332, 0.275134, 0.293328, 0.588992,
+                    0.839509, 0.087290, 1.779735, 1.116857,
+                    0.878616, 0.602447, 0.642616, 1.028681]).reshape(-1, 2)
+
+    # Inverse of (src -> dst) transform should be equivalent to
+    # (dst -> src) transformation
+    tform = estimate_transform('fundamental', src, dst)
+    tform_inv = estimate_transform('fundamental', dst, src)
+
+    np.testing.assert_array_almost_equal(tform.inverse.params, tform_inv.params)
+
+
+def test_fundamental_matrix_epipolar_projection():
     src = np.array([1.839035, 1.924743, 0.543582,  0.375221,
                     0.473240, 0.142522, 0.964910,  0.598376,
                     0.102388, 0.140092, 15.994343, 9.622164,

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -509,8 +509,12 @@ def test_polynomial_default_order():
 
 
 def test_polynomial_inverse():
-    with pytest.raises(Exception):
-        PolynomialTransform().inverse(0)
+    # Instantiation of an inverse transform should not raise
+    inv_transform = PolynomialTransform().inverse
+    assert isinstance(inv_transform, PolynomialTransform)
+    # Applying the transform should raise
+    with pytest.raises(NotImplementedError):
+        inv_transform(0)
 
 
 def test_union():

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -562,7 +562,7 @@ def test_union_differing_types():
         ((t := PiecewiseAffineTransform()).estimate(SRC, DST) and t),
     ],
 )
-def test_inverse(tform):
+def test_inverse_all_transforms(tform):
     assert isinstance(tform.inverse, type(tform))
     assert_almost_equal(tform.inverse.inverse(SRC), tform(SRC))
     # Test addition with inverse, not implemented for all

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -354,6 +354,24 @@ def test_fundamental_matrix_inverse():
                         [[0, 1, 0], [0, 1, -1], [0, 1, -1]])
 
 
+def test_fundamental_matrix_inverse2():
+    src = np.array([1.839035, 1.924743, 0.543582,  0.375221,
+                    0.473240, 0.142522, 0.964910,  0.598376,
+                    0.102388, 0.140092, 15.994343, 9.622164,
+                    0.285901, 0.430055, 0.091150,  0.254594]).reshape(-1, 2)
+
+    dst = np.array([1.002114, 1.129644, 1.521742, 1.846002,
+                    1.084332, 0.275134, 0.293328, 0.588992,
+                    0.839509, 0.087290, 1.779735, 1.116857,
+                    0.878616, 0.602447, 0.642616, 1.028681]).reshape(-1, 2)
+
+    tform = estimate_transform('fundamental', src, dst)
+
+    # calculate x' F x for each coordinate; should be close to zero
+    p = np.abs(np.sum(np.column_stack((dst, np.ones(len(dst)))) * tform(src), axis=1))
+    assert np.all(p < 0.01)
+
+
 def test_essential_matrix_init():
     tform = EssentialMatrixTransform(rotation=np.eye(3),
                                      translation=np.array([0, 0, 1]))
@@ -753,7 +771,6 @@ def test_projective_str():
     # compatibility with different numpy versions.
     want = want.replace('0\\.', ' *0\\.')
     want = want.replace('1\\.', ' *1\\.')
-    print(want)
     assert re.match(want, str(tform))
 
 

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -509,12 +509,8 @@ def test_polynomial_default_order():
 
 
 def test_polynomial_inverse():
-    # Instantiation of an inverse transform should not raise
-    inv_transform = PolynomialTransform().inverse
-    assert isinstance(inv_transform, PolynomialTransform)
-    # Applying the transform should raise
     with pytest.raises(NotImplementedError):
-        inv_transform(0)
+        PolynomialTransform().inverse(0)
 
 
 def test_union():

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -565,6 +565,7 @@ def test_union_differing_types():
 def test_inverse(tform):
     assert isinstance(tform.inverse, type(tform))
     assert_almost_equal(tform.inverse.inverse(SRC), tform(SRC))
+    # Test addition with inverse, not implemented for all
     if not isinstance(
         tform,
         (

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -564,6 +564,10 @@ def test_union_differing_types():
 )
 def test_inverse_all_transforms(tform):
     assert isinstance(tform.inverse, type(tform))
+    try:
+        assert_almost_equal(tform.inverse.inverse.params, tform.params)
+    except AttributeError:
+        assert isinstance(tform, PiecewiseAffineTransform)
     assert_almost_equal(tform.inverse.inverse(SRC), tform(SRC))
     # Test addition with inverse, not implemented for all
     if not isinstance(


### PR DESCRIPTION
## Description

This PR changes the signature of `inverse` for all transform classes to a property returning a new instance of the same type with the inverse transform. When called with coordinates, the new transform replicates the behavior of the former `inverse(coords)` method.

This enables:
- accessing parameters of an inverse, e.g. `tform.inverse.params`
- composing transforms with the inverse first, e.g. `tform1.inverse + tform2`
- inverting an inverse, e.g. `tform.inverse.inverse`

Closes issue #6921.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [ ] Gallery example in `./doc/examples` (new features only)
- [ ] Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- [x] Unit tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- [ ] Descriptive commit messages (see below)

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
