### PR TITLE
set random seed for np.random.default_rng

### DIFF
--- a/doc/examples/applications/plot_colocalization_metrics.py
+++ b/doc/examples/applications/plot_colocalization_metrics.py
@@ -33,7 +33,7 @@ from matplotlib.colors import LinearSegmentedColormap
 from scipy import ndimage as ndi
 from skimage import data, filters, measure, segmentation
 
-rng = np.random.default_rng()
+rng = np.random.default_rng(123)
 
 # segment nucleus
 nucleus = data.protein_transport()[0, 0, :, :180]

--- a/doc/examples/applications/plot_rank_filters.py
+++ b/doc/examples/applications/plot_rank_filters.py
@@ -66,7 +66,7 @@ plt.tight_layout()
 from skimage.filters.rank import median
 from skimage.morphology import disk, ball
 
-rng = np.random.default_rng()
+rng = np.random.default_rng(123)
 noise = rng.random(noisy_image.shape)
 noisy_image = img_as_ubyte(data.camera())
 noisy_image[noise > 0.99] = 255

--- a/doc/examples/features_detection/plot_shape_index.py
+++ b/doc/examples/features_detection/plot_shape_index.py
@@ -51,7 +51,7 @@ def create_test_image(
     """
     Generate a test image with random noise, uneven illumination and spots.
     """
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(123)
     image = rng.normal(
         loc=0.25,
         scale=0.25,

--- a/doc/examples/filters/plot_deconvolution.py
+++ b/doc/examples/filters/plot_deconvolution.py
@@ -23,7 +23,7 @@ from scipy.signal import convolve2d as conv2
 
 from skimage import color, data, restoration
 
-rng = np.random.default_rng()
+rng = np.random.default_rng(123)
 
 astro = color.rgb2gray(data.astronaut())
 

--- a/doc/examples/filters/plot_entropy.py
+++ b/doc/examples/filters/plot_entropy.py
@@ -33,7 +33,7 @@ from skimage.util import img_as_ubyte
 from skimage.filters.rank import entropy
 from skimage.morphology import disk
 
-rng = np.random.default_rng()
+rng = np.random.default_rng(123)
 
 noise_mask = np.full((128, 128), 28, dtype=np.uint8)
 noise_mask[32:-32, 32:-32] = 30

--- a/doc/examples/filters/plot_restoration.py
+++ b/doc/examples/filters/plot_restoration.py
@@ -35,7 +35,7 @@ import matplotlib.pyplot as plt
 
 from skimage import color, data, restoration
 
-rng = np.random.default_rng()
+rng = np.random.default_rng(123)
 
 astro = color.rgb2gray(data.astronaut())
 from scipy.signal import convolve2d as conv2

--- a/doc/examples/registration/plot_masked_register_translation.py
+++ b/doc/examples/registration/plot_masked_register_translation.py
@@ -37,7 +37,7 @@ from scipy import ndimage as ndi
 image = data.camera()
 shift = (-22, 13)
 
-rng = np.random.default_rng()
+rng = np.random.default_rng(123)
 corrupted_pixels = rng.choice([False, True], size=image.shape, p=[0.25, 0.75])
 
 # The shift corresponds to the pixel offset relative to the reference image

--- a/doc/examples/segmentation/plot_random_walker_segmentation.py
+++ b/doc/examples/segmentation/plot_random_walker_segmentation.py
@@ -28,7 +28,7 @@ from skimage.data import binary_blobs
 from skimage.exposure import rescale_intensity
 import skimage
 
-rng = np.random.default_rng()
+rng = np.random.default_rng(123)
 
 # Generate noisy synthetic data
 data = skimage.img_as_float(binary_blobs(length=128, rng=1))

--- a/doc/examples/transform/plot_ransac.py
+++ b/doc/examples/transform/plot_ransac.py
@@ -36,7 +36,7 @@ from matplotlib import pyplot as plt
 
 from skimage.measure import LineModelND, ransac
 
-rng = np.random.default_rng()
+rng = np.random.default_rng(123)
 
 # generate coordinates of line
 x = np.arange(-200, 200)

--- a/doc/examples/transform/plot_ssim.py
+++ b/doc/examples/transform/plot_ssim.py
@@ -33,7 +33,7 @@ img = img_as_float(data.camera())
 rows, cols = img.shape
 
 noise = np.ones_like(img) * 0.2 * (img.max() - img.min())
-rng = np.random.default_rng()
+rng = np.random.default_rng(123)
 noise[rng.random(size=noise.shape) > 0.5] *= -1
 
 img_noise = img + noise

--- a/doc/source/user_guide/numpy_images.rst
+++ b/doc/source/user_guide/numpy_images.rst
@@ -184,7 +184,7 @@ argument.
 
 Many functions in ``scikit-image`` can operate on 3D images directly::
 
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> im3d = rng.random((100, 1000, 1000))
     >>> from skimage import morphology
     >>> from scipy import ndimage as ndi
@@ -229,7 +229,7 @@ is the same::
     ...         arr[:, :, plane] *= scalar
     ...
     >>> import time
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> im3d = rng.random((100, 1024, 1024))
     >>> t0 = time.time(); x = in_order_multiply(im3d, 5); t1 = time.time()
     >>> print("%.2f seconds" % (t1 - t0))  # doctest: +SKIP

--- a/skimage/_shared/_warnings.py
+++ b/skimage/_shared/_warnings.py
@@ -83,7 +83,7 @@ def expected_warnings(matching):
     Examples
     --------
     >>> import numpy as np
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> image = rng.integers(0, 2**16, size=(100, 100), dtype=np.uint16)
     >>> # rank filters are slow when bit-depth exceeds 10 bits
     >>> from skimage import filters

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -549,7 +549,7 @@ def reshape_nd(arr, ndim, dim):
 
     Examples
     --------
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> arr = rng.random(7)
     >>> reshape_nd(arr, 2, 0).shape
     (7, 1)

--- a/skimage/feature/_canny.py
+++ b/skimage/feature/_canny.py
@@ -175,7 +175,7 @@ def canny(image, sigma=1., low_threshold=None, high_threshold=None,
     Examples
     --------
     >>> from skimage import feature
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> # Generate noisy image of a square
     >>> im = np.zeros((256, 256))
     >>> im[64:-64, 64:-64] = 1

--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -42,7 +42,7 @@ class DescriptorExtractor:
 
 def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
                  keypoints_color='k', matches_color=None, only_matches=False,
-                 alignment='horizontal'):
+                 alignment='horizontal', seed=123):
     """Plot matched features.
 
     Parameters
@@ -71,6 +71,8 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
     alignment : {'horizontal', 'vertical'}, optional
         Whether to show images side by side, ``'horizontal'``, or one above
         the other, ``'vertical'``.
+    seed :  {None, int, array_like[ints], SeedSequence, BitGenerator, Generator}, optional
+        Random seed of numpy's random number generator.
 
     """
     image1 = img_as_float(image1)
@@ -122,7 +124,7 @@ def plot_matches(ax, image1, image2, keypoints1, keypoints2, matches,
     ax.imshow(image, cmap='gray')
     ax.axis((0, image1.shape[1] + offset[1], image1.shape[0] + offset[0], 0))
 
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(seed)
 
     for i in range(matches.shape[0]):
         idx1 = matches[i, 0]

--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -107,7 +107,7 @@ def _reshape_nd(arr, ndim, dim):
 
     Examples
     --------
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> arr = rng.random(7)
     >>> _reshape_nd(arr, 2, 0).shape
     (7, 1)

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -373,7 +373,7 @@ def autolevel(image, footprint, out=None, mask=None,
     >>> from skimage.filters.rank import autolevel
     >>> import numpy as np
     >>> img = data.camera()
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> volume = rng.integers(0, 255, size=(10,10,10), dtype=np.uint8)
     >>> auto = autolevel(img, disk(5))
     >>> auto_vol = autolevel(volume, ball(5))
@@ -426,7 +426,7 @@ def equalize(image, footprint, out=None, mask=None,
     >>> from skimage.filters.rank import equalize
     >>> import numpy as np
     >>> img = data.camera()
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> volume = rng.integers(0, 255, size=(10,10,10), dtype=np.uint8)
     >>> equ = equalize(img, disk(5))
     >>> equ_vol = equalize(volume, ball(5))
@@ -479,7 +479,7 @@ def gradient(image, footprint, out=None, mask=None,
     >>> from skimage.filters.rank import gradient
     >>> import numpy as np
     >>> img = data.camera()
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> volume = rng.integers(0, 255, size=(10,10,10), dtype=np.uint8)
     >>> out = gradient(img, disk(5))
     >>> out_vol = gradient(volume, ball(5))
@@ -541,7 +541,7 @@ def maximum(image, footprint, out=None, mask=None,
     >>> from skimage.filters.rank import maximum
     >>> import numpy as np
     >>> img = data.camera()
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> volume = rng.integers(0, 255, size=(10,10,10), dtype=np.uint8)
     >>> out = maximum(img, disk(5))
     >>> out_vol = maximum(volume, ball(5))
@@ -594,7 +594,7 @@ def mean(image, footprint, out=None, mask=None,
     >>> from skimage.filters.rank import mean
     >>> import numpy as np
     >>> img = data.camera()
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> volume = rng.integers(0, 255, size=(10,10,10), dtype=np.uint8)
     >>> avg = mean(img, disk(5))
     >>> avg_vol = mean(volume, ball(5))
@@ -647,7 +647,7 @@ def geometric_mean(image, footprint, out=None, mask=None,
     >>> from skimage.filters.rank import mean
     >>> import numpy as np
     >>> img = data.camera()
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> volume = rng.integers(0, 255, size=(10,10,10), dtype=np.uint8)
     >>> avg = geometric_mean(img, disk(5))
     >>> avg_vol = geometric_mean(volume, ball(5))
@@ -713,7 +713,7 @@ def subtract_mean(image, footprint, out=None, mask=None,
     >>> from skimage.filters.rank import subtract_mean
     >>> import numpy as np
     >>> img = data.camera()
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> volume = rng.integers(0, 255, size=(10,10,10), dtype=np.uint8)
     >>> out = subtract_mean(img, disk(5))
     >>> out_vol = subtract_mean(volume, ball(5))
@@ -772,7 +772,7 @@ def median(image, footprint=None, out=None, mask=None,
     >>> from skimage.filters.rank import median
     >>> import numpy as np
     >>> img = data.camera()
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> volume = rng.integers(0, 255, size=(10,10,10), dtype=np.uint8)
     >>> med = median(img, disk(5))
     >>> med_vol = median(volume, ball(5))
@@ -836,7 +836,7 @@ def minimum(image, footprint, out=None, mask=None,
     >>> from skimage.filters.rank import minimum
     >>> import numpy as np
     >>> img = data.camera()
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> volume = rng.integers(0, 255, size=(10,10,10), dtype=np.uint8)
     >>> out = minimum(img, disk(5))
     >>> out_vol = minimum(volume, ball(5))
@@ -891,7 +891,7 @@ def modal(image, footprint, out=None, mask=None,
     >>> from skimage.filters.rank import modal
     >>> import numpy as np
     >>> img = data.camera()
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> volume = rng.integers(0, 255, size=(10,10,10), dtype=np.uint8)
     >>> out = modal(img, disk(5))
     >>> out_vol = modal(volume, ball(5))
@@ -948,7 +948,7 @@ def enhance_contrast(image, footprint, out=None, mask=None,
     >>> from skimage.filters.rank import enhance_contrast
     >>> import numpy as np
     >>> img = data.camera()
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> volume = rng.integers(0, 255, size=(10,10,10), dtype=np.uint8)
     >>> out = enhance_contrast(img, disk(5))
     >>> out_vol = enhance_contrast(volume, ball(5))
@@ -1186,7 +1186,7 @@ def noise_filter(image, footprint, out=None, mask=None,
     >>> from skimage.filters.rank import noise_filter
     >>> import numpy as np
     >>> img = data.camera()
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> volume = rng.integers(0, 255, size=(10,10,10), dtype=np.uint8)
     >>> out = noise_filter(img, disk(5))
     >>> out_vol = noise_filter(volume, ball(5))
@@ -1267,7 +1267,7 @@ def entropy(image, footprint, out=None, mask=None,
     >>> from skimage.morphology import disk, ball
     >>> import numpy as np
     >>> img = data.camera()
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> volume = rng.integers(0, 255, size=(10,10,10), dtype=np.uint8)
     >>> ent = entropy(img, disk(5))
     >>> ent_vol = entropy(volume, ball(5))
@@ -1326,7 +1326,7 @@ def otsu(image, footprint, out=None, mask=None,
     >>> from skimage.morphology import disk, ball
     >>> import numpy as np
     >>> img = data.camera()
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> volume = rng.integers(0, 255, size=(10,10,10), dtype=np.uint8)
     >>> local_otsu = otsu(img, disk(5))
     >>> thresh_image = img >= local_otsu
@@ -1389,7 +1389,7 @@ def windowed_histogram(image, footprint, out=None, mask=None,
     >>> from skimage.morphology import disk, ball
     >>> import numpy as np
     >>> img = data.camera()
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> volume = rng.integers(0, 255, size=(10,10,10), dtype=np.uint8)
     >>> hist_img = windowed_histogram(img, disk(5))
 
@@ -1436,7 +1436,7 @@ def majority(image, footprint, *, out=None, mask=None,
     >>> from skimage.morphology import disk, ball
     >>> import numpy as np
     >>> img = data.camera()
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> volume = rng.integers(0, 255, size=(10,10,10), dtype=np.uint8)
     >>> maj_img = majority(img, disk(5))
     >>> maj_img_vol = majority(volume, ball(5))

--- a/skimage/graph/tests/test_pixel_graph.py
+++ b/skimage/graph/tests/test_pixel_graph.py
@@ -2,7 +2,7 @@ import numpy as np
 from skimage.graph._graph import pixel_graph, central_pixel
 
 mask = np.array([[1, 0, 0], [0, 1, 1], [0, 1, 0]], dtype=bool)
-image = np.random.default_rng().random(mask.shape)
+image = np.random.default_rng(123).random(mask.shape)
 
 
 def test_small_graph():

--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -200,7 +200,7 @@ def show():
     --------
     >>> import skimage.io as io
 
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> for i in range(4):
     ...     ax_im = io.imshow(rng.random((50, 50)))
     >>> io.show() # doctest: +SKIP

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -198,7 +198,7 @@ def _infer_regionprop_dtype(func, *, intensity, ndim):
     sample[(slice(1, None),) * ndim] = labels[1]
     propmasks = [(sample == n) for n in labels]
 
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(123)
 
     if intensity and _infer_number_of_required_args(func) == 2:
         def _func(mask):

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -807,7 +807,7 @@ def ransac(data, model_class, min_samples, residual_threshold,
     proportion of the total samples, rather than an absolute number.
 
     >>> from skimage.transform import SimilarityTransform
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> src = 100 * rng.random((50, 2))
     >>> model0 = SimilarityTransform(scale=0.5, rotation=1,
     ...                              translation=(10, 20))

--- a/skimage/metrics/tests/test_simple_metrics.py
+++ b/skimage/metrics/tests/test_simple_metrics.py
@@ -122,7 +122,7 @@ def test_nmi_different_sizes():
 
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_nmi_random(dtype):
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(123)
     random1 = rng.random((100, 100)).astype(dtype)
     random2 = rng.random((100, 100)).astype(dtype)
     nmi = normalized_mutual_information(random1, random2, bins=10)

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -168,7 +168,7 @@ def denoise_bilateral(image, win_size=None, sigma_color=None, sigma_spatial=1,
     >>> from skimage import data, img_as_float
     >>> astro = img_as_float(data.astronaut())
     >>> astro = astro[220:300, 220:320]
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> noisy = astro + 0.6 * astro.std() * rng.random(astro.shape)
     >>> noisy = np.clip(noisy, 0, 1)
     >>> denoised = denoise_bilateral(noisy, sigma_color=0.05, sigma_spatial=15,
@@ -528,7 +528,7 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
 
     >>> from skimage import color, data
     >>> img = color.rgb2gray(data.astronaut())[:50, :50]
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> img += 0.5 * img.std() * rng.standard_normal(img.shape)
     >>> denoised_img = denoise_tv_chambolle(img, weight=60)
 
@@ -537,7 +537,7 @@ def denoise_tv_chambolle(image, weight=0.1, eps=2.e-4, max_num_iter=200,
     >>> x, y, z = np.ogrid[0:20, 0:20, 0:20]
     >>> mask = (x - 22)**2 + (y - 20)**2 + (z - 17)**2 < 8**2
     >>> mask = mask.astype(float)
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> mask += 0.2 * rng.standard_normal(mask.shape)
     >>> res = denoise_tv_chambolle(mask, weight=100)
 
@@ -888,7 +888,7 @@ def denoise_wavelet(image, sigma=None, wavelet='db1', mode='soft',
     >>> from skimage import color, data
     >>> img = img_as_float(data.astronaut())
     >>> img = color.rgb2gray(img)
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> img += 0.1 * rng.standard_normal(img.shape)
     >>> img = np.clip(img, 0, 1)
     >>> denoised_img = denoise_wavelet(img, sigma=0.1, rescale_sigma=True)
@@ -1002,7 +1002,7 @@ def estimate_sigma(image, average_sigmas=False, *,
     >>> from skimage import img_as_float
     >>> img = img_as_float(skimage.data.camera())
     >>> sigma = 0.1
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> img = img + sigma * rng.standard_normal(img.shape)
     >>> sigma_hat = estimate_sigma(img, channel_axis=None)
     """

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -57,7 +57,7 @@ def wiener(image, psf, balance, reg=None, is_real=True, clip=True):
     >>> from scipy.signal import convolve2d
     >>> psf = np.ones((5, 5)) / 25
     >>> img = convolve2d(img, psf, 'same')
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> img += 0.1 * img.std() * rng.standard_normal(img.shape)
     >>> deconvolved_img = restoration.wiener(img, psf, 0.1)
 
@@ -212,7 +212,7 @@ def unsupervised_wiener(image, psf, reg=None, user_params=None, is_real=True,
     >>> from scipy.signal import convolve2d
     >>> psf = np.ones((5, 5)) / 25
     >>> img = convolve2d(img, psf, 'same')
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> img += 0.1 * img.std() * rng.standard_normal(img.shape)
     >>> deconvolved_img = restoration.unsupervised_wiener(img, psf)
 
@@ -383,7 +383,7 @@ def richardson_lucy(image, psf, num_iter=50, clip=True, filter_epsilon=None):
     >>> from scipy.signal import convolve2d
     >>> psf = np.ones((5, 5)) / 25
     >>> camera = convolve2d(camera, psf, 'same')
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> camera += 0.1 * camera.std() * rng.standard_normal(camera.shape)
     >>> deconvolved = restoration.richardson_lucy(camera, psf, 5)
 

--- a/skimage/restoration/j_invariant.py
+++ b/skimage/restoration/j_invariant.py
@@ -263,7 +263,7 @@ def calibrate_denoiser(image, denoise_function, denoise_parameters, *,
     >>> from skimage.restoration import denoise_wavelet
     >>> import numpy as np
     >>> img = color.rgb2gray(data.astronaut()[:50, :50])
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> noisy = img + 0.5 * img.std() * rng.standard_normal(img.shape)
     >>> parameters = {'sigma': np.arange(0.1, 0.4, 0.02)}
     >>> denoising_function = calibrate_denoiser(noisy, denoise_wavelet,

--- a/skimage/restoration/non_local_means.py
+++ b/skimage/restoration/non_local_means.py
@@ -135,7 +135,7 @@ def denoise_nl_means(image, patch_size=7, patch_distance=11, h=0.1,
     --------
     >>> a = np.zeros((40, 40))
     >>> a[10:-10, 10:-10] = 1.
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> a += 0.3 * rng.standard_normal(a.shape)
     >>> denoised_a = denoise_nl_means(a, 7, 5, 0.1)
     """

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -404,7 +404,7 @@ def random_walker(data, labels, beta=130, mode='cg_j', tol=1.e-3, copy=True,
 
     Examples
     --------
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> a = np.zeros((10, 10)) + 0.2 * rng.random((10, 10))
     >>> a[5:8, 5:8] += 1
     >>> b = np.zeros_like(a, dtype=np.int32)

--- a/skimage/segmentation/tests/test_watershed.py
+++ b/skimage/segmentation/tests/test_watershed.py
@@ -394,7 +394,7 @@ class TestWatershed(unittest.TestCase):
 
     def test_watershed_input_not_modified(self):
         """Test to ensure input markers are not modified."""
-        image = np.random.default_rng().random(size=(21, 21))
+        image = np.random.default_rng(123).random(size=(21, 21))
         markers = np.zeros((21, 21), dtype=np.uint8)
         markers[[5, 5, 15, 15], [5, 15, 5, 15]] = [1, 2, 3, 4]
         original_markers = np.copy(markers)

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -281,7 +281,7 @@ def _hough_line(cnp.ndarray img,
     >>> img[35:45, 35:50] = 1
     >>> for i in range(90):
     ...     img[i, i] = 1
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> img += rng.random(img.shape) > 0.95
 
     Apply the Hough transform:

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -815,7 +815,7 @@ def warp(image, inverse_map, map_args=None, output_shape=None, order=None,
     if you want to rescale a 3-D cube, you can do:
 
     >>> cube_shape = np.array([30, 30, 30])
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> cube = rng.random(cube_shape)
 
     Setup the coordinate array, that defines the scaling:

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -205,7 +205,7 @@ def hough_line(image, theta=None):
     >>> img[35:45, 35:50] = 1
     >>> for i in range(90):
     ...     img[i, i] = 1
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(123)
     >>> img += rng.random(img.shape) > 0.95
 
     Apply the Hough transform:

--- a/skimage/util/tests/test_slice_along_axes.py
+++ b/skimage/util/tests/test_slice_along_axes.py
@@ -4,7 +4,7 @@ import pytest
 from skimage.util import slice_along_axes
 
 
-rng = np.random.default_rng()
+rng = np.random.default_rng(123)
 
 
 def test_2d_crop_0():


### PR DESCRIPTION
## Description
This commit fixes the issue of random seed, which I reported in #6862. As the random seed is not set at many of unit tests, the CI sometimes fails due to the randomness.

I also recognized that there are many unit tests which use `np.random.rand`, `np.random.random` and `np.random.randn`.  I think it should also set the random seed by `np.random.seed` or replace everything with `np.random.default_rng`, but I wasn't sure what strategy the maintainers prefer so that I didn't touch them.

I also fixed some randomness in two functions which are not in unit tests. I also couldn't figure out what's the preferred behavior, so please advise me what to do with them.


## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
