### PR TITLE
Use pytest.warn instead of custom context manager

### DIFF
--- a/skimage/io/tests/test_imageio.py
+++ b/skimage/io/tests/test_imageio.py
@@ -5,7 +5,8 @@ from skimage.io import imread, imsave, use_plugin, reset_plugins
 
 from skimage._shared import testing
 from skimage._shared.testing import assert_array_almost_equal, TestCase, fetch
-from skimage._shared._warnings import expected_warnings
+
+import pytest
 
 
 def setup():
@@ -67,7 +68,7 @@ class TestSave(TestCase):
         with NamedTemporaryFile(suffix='.png') as f:
             fname = f.name
 
-        with expected_warnings(['.* is a boolean image']):
+        with pytest.warns(UserWarning, match=r'.* is a boolean image'):
             a = np.zeros((5, 5), bool)
             a[2, 2] = True
             imsave(fname, a)


### PR DESCRIPTION
Not sure this is the best fix, but I think it makes the CI pass.

I noticed the errors started showing up yesterday when Stefan was working on #6764. Here is the error:
```
FAILED io/tests/test_imageio.py::TestSave::test_bool_array_save - ValueError: Unexpected warning: unclosed file <_io.BufferedReader name='/home/runner/.cache/scikit-image/main/data/no_time_for_that_tiny.gif'>
```

But I don't think it is related to those changes. The error occurs in `io/tests/test_imageio.py::TestSave::test_bool_array_save`, but the warning that is reported isn't related to those tests. I was also able to get the same error on a branch without the imageio PR #6930.

I wasn't sure why the test was using a custom context manager for handling expected warnings. I decided to try just using pytest.warns, which I am more familiar with.