### PR TITLE
Use context manager to ensure urlopen buffer is closed

### DIFF
--- a/skimage/io/tests/test_io.py
+++ b/skimage/io/tests/test_io.py
@@ -62,10 +62,10 @@ def test_imread_pathlib_tiff():
     """Tests reading from Path object (issue gh-5545)."""
 
     # read via fetch
-    expected = io.imread(fetch('data/multipage.tif'))
+    fname = fetch('data/multipage.tif')
+    expected = io.imread(fname)
 
     # read by passing in a pathlib.Path object
-    fname = os.path.join(data_dir, 'multipage.tif')
     path = pathlib.Path(fname)
     img = io.imread(path)
 

--- a/skimage/io/util.py
+++ b/skimage/io/util.py
@@ -25,8 +25,8 @@ def file_or_url_context(resource_name):
         _, ext = os.path.splitext(url_components.path)
         try:
             with tempfile.NamedTemporaryFile(delete=False, suffix=ext) as f:
-                u = urllib.request.urlopen(resource_name)
-                f.write(u.read())
+                with urllib.request.urlopen(resource_name) as u:
+                    f.write(u.read())
             # f must be closed before yielding
             yield f.name
         except (URLError, HTTPError):


### PR DESCRIPTION
Thanks to @FirefoxMetzger for identifying the urlopen problem.

This patch also:

- Handles unclosed `imageio.get_reader` calls
- Updates ImageCollection examples to use `imageio.v3`
- Fixes the test suite to use `fetch(...)` to grab filenames of test data (since `data_dir + '/fn.png'` is no longer reliable).

Closes #6939
