### PR TITLE
Stabilize EllipseModel fitting parameters

### DIFF
--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -527,10 +527,21 @@ class EllipseModel(BaseModel):
         if a > c:
             phi += 0.5 * np.pi
 
+
+        # stabilize parameters:
+        # sometimes small fluctuations in data can cause
+        # height and width to swap
+        if width < height:
+            width, height = height, width
+            phi += np.pi / 2
+
+        phi %= np.pi
+
         # revert normalization and set params
         params = np.nan_to_num([x0, y0, width, height, phi]).real
         params[:4] *= scale
         params[:2] += origin
+
         self.params = tuple(float(p) for p in params)
 
         return True

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -407,12 +407,12 @@ class EllipseModel(BaseModel):
     --------
 
     >>> xy = EllipseModel().predict_xy(np.linspace(0, 2 * np.pi, 25),
-    ...                                params=(10, 15, 4, 8, np.deg2rad(30)))
+    ...                                params=(10, 15, 8, 4, np.deg2rad(30)))
     >>> ellipse = EllipseModel()
     >>> ellipse.estimate(xy)
     True
     >>> np.round(ellipse.params, 2)
-    array([10.  , 15.  ,  4.  ,  8.  ,  0.52])
+    array([10.  , 15.  ,  8.  ,  4.  ,  0.52])
     >>> np.round(abs(ellipse.residuals(xy)), 5)
     array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
            0., 0., 0., 0., 0., 0., 0., 0.])

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -218,6 +218,37 @@ def test_ellipse_model_estimate():
         assert_array_less(res, np.ones(res.shape))
 
 
+def test_ellipse_parameter_stability():
+    """The fit should be modified so that a > b
+    """
+
+    for angle in np.arange(0, 180 + 1, 1):
+        # generate rotation matrix
+        theta = np.deg2rad(angle)
+        c = np.cos(theta)
+        s = np.sin(theta)
+        R = np.array([
+            [c, -s],
+            [s, c]]
+        )
+
+        # generate points on ellipse
+        t = np.linspace(0, 2 * np.pi, 20)
+        a = 100
+        b = 50
+        points = np.array([a * np.cos(t), b * np.sin(t)])
+        points = R @ points
+
+        # fit model to points
+        ellipse_model = EllipseModel()
+        ellipse_model.estimate(points.T)
+        _, _, a_prime, b_prime, theta_prime = ellipse_model.params
+
+        assert_almost_equal(theta_prime, theta)
+        assert_almost_equal(a_prime, a)
+        assert_almost_equal(b_prime, b)
+
+
 def test_ellipse_model_estimate_from_data():
     data = np.array([
         [264, 854], [265, 875], [268, 863], [270, 857], [275, 905], [285, 915],


### PR DESCRIPTION
Ensure a > b, or swap them around and adjust the angle accordingly if not.

Addresses https://github.com/scikit-image/scikit-image/issues/2646#issuecomment-1171635398
