### PR TITLE
If user provides RNG, spawn it before deepcopying

### DIFF
--- a/skimage/feature/tests/test_brief.py
+++ b/skimage/feature/tests/test_brief.py
@@ -1,4 +1,6 @@
 import pytest
+import copy
+
 import numpy as np
 
 from skimage._shared.testing import assert_array_equal
@@ -80,3 +82,18 @@ def test_border(dtype):
 
     assert extractor.descriptors.shape[0] == 3
     assert_array_equal(extractor.mask, (False, True, True, True))
+
+
+def test_independent_rng():
+    img = np.zeros((100, 100), dtype=int)
+    keypoints = np.array([[1, 1], [20, 20], [50, 50], [80, 80]])
+
+    rng = np.random.default_rng()
+    extractor = BRIEF(patch_size=41, rng=rng)
+
+    x = copy.deepcopy(extractor.rng).random()
+    rng.random()
+    extractor.extract(img, keypoints)
+    z = copy.deepcopy(extractor.rng).random()
+
+    assert x == z


### PR DESCRIPTION
Otherwise, the user can still draw values from the RNG and change its state.

See https://github.com/scikit-learn/scikit-learn/issues/16988#issuecomment-1518037853

Custom seeding BRIEF will probably be deprecated in the future; there's not much of a point to it. But, for now, we need to handle the `rng` correctly.
