### PR TITLE
Enable testing against nightly upstream wheels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,8 +46,9 @@ jobs:
           - platform_id: manylinux_x86_64
             python-version: 3.11
             PIP_FLAGS: >-
-              -i https://pypi.org/simple
-              -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+              --extra-index-url
+              https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+              --upgrade
               --pre
             SKIMAGE_TEST_STRICT_WARNINGS_GLOBAL: 1
             # test nightly wheels

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,11 +44,14 @@ jobs:
             BUILD_DOCS: 0
             OPTIONS_NAME: "mini-req-optional-deps"
           - platform_id: manylinux_x86_64
-            python-version: 3.9
-            PIP_FLAGS: "--pre"
+            python-version: 3.11
+            PIP_FLAGS: >-
+              -i https://pypi.org/simple
+              -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+              --pre
             SKIMAGE_TEST_STRICT_WARNINGS_GLOBAL: 1
-            # test pre-releases
-            OPTIONS_NAME: "pre"
+            # test nightly wheels
+            OPTIONS_NAME: "nightly"
           - platform_id: manylinux_x86_64
             python-version: 3.9
             BUILD_DOCS: 1

--- a/skimage/io/tests/test_histograms.py
+++ b/skimage/io/tests/test_histograms.py
@@ -1,16 +1,14 @@
 import numpy as np
+
 from skimage.io._plugins._histograms import histograms
 
-from skimage._shared.testing import assert_array_equal, assert_equal, TestCase
 
-
-class TestHistogram(TestCase):
+class TestHistogram:
     def test_basic(self):
         img = np.ones((50, 50, 3), dtype=np.uint8)
-        r, g, b, v = histograms(img, 255)
-
-        for band in (r, g, b, v):
-            yield assert_equal, band.sum(), 50 * 50
+        bands = histograms(img, 255)
+        for band in bands:
+            np.testing.assert_equal(band.sum(), 50**2)
 
     def test_counts(self):
         channel = np.arange(255).reshape(51, 5)
@@ -19,7 +17,7 @@ class TestHistogram(TestCase):
         img[:, :, 1] = channel
         img[:, :, 2] = channel
         r, g, b, v = histograms(img, 255)
-        assert_array_equal(r, g)
-        assert_array_equal(r, b)
-        assert_array_equal(r, v)
-        assert_array_equal(r, np.ones(255))
+        np.testing.assert_array_equal(r, g)
+        np.testing.assert_array_equal(r, b)
+        np.testing.assert_array_equal(r, v)
+        np.testing.assert_array_equal(r, np.ones(255))

--- a/skimage/io/tests/test_imageio.py
+++ b/skimage/io/tests/test_imageio.py
@@ -1,20 +1,21 @@
 from tempfile import NamedTemporaryFile
 
 import numpy as np
-from skimage.io import imread, imsave, use_plugin, reset_plugins
+from skimage.io import imread, imsave,plugin_order
 
 from skimage._shared import testing
-from skimage._shared.testing import assert_array_almost_equal, TestCase, fetch
+from skimage._shared.testing import fetch
 
 import pytest
 
 
-def setup():
-    use_plugin('imageio')
-
-
-def teardown():
-    reset_plugins()
+def test_prefered_plugin():
+    # Don't call use_plugin("imageio") before, this way we test that imageio is used
+    # by default
+    order = plugin_order()
+    assert order["imread"][0] == "imageio"
+    assert order["imsave"][0] == "imageio"
+    assert order["imread_collection"][0] == "imageio"
 
 
 def test_imageio_as_gray():
@@ -41,28 +42,37 @@ def test_imageio_truncated_jpg():
         imread(fetch('data/truncated.jpg'))
 
 
-class TestSave(TestCase):
+class TestSave:
 
-    def roundtrip(self, x, scaling=1):
-        with NamedTemporaryFile(suffix='.png') as f:
-            fname = f.name
-
-        imsave(fname, x)
-        y = imread(fname)
-
-        assert_array_almost_equal((x * scaling).astype(np.int32), y)
-
-    def test_imsave_roundtrip(self):
-        dtype = np.uint8
-        np.random.seed(0)
-        for shape in [(10, 10), (10, 10, 3), (10, 10, 4)]:
-            x = np.ones(shape, dtype=dtype) * np.random.rand(*shape)
-
-            if np.issubdtype(dtype, np.floating):
-                yield self.roundtrip, x, 255
-            else:
-                x = (x * 255).astype(dtype)
-                yield self.roundtrip, x
+    @pytest.mark.parametrize(
+        "shape,dtype", [
+            # float32, float64 can't be saved as PNG and raise
+            # uint32 is not roundtripping properly
+            ((10, 10), np.uint8),
+            ((10, 10), np.uint16),
+            ((10, 10, 2), np.uint8),
+            ((10, 10, 3), np.uint8),
+            ((10, 10, 4), np.uint8),
+        ]
+    )
+    def test_imsave_roundtrip(self, shape, dtype, tmp_path):
+        if np.issubdtype(dtype, np.floating):
+            min_ = 0
+            max_ = 1
+        else:
+            min_ = 0
+            max_ = np.iinfo(dtype).max
+        expected = np.linspace(
+            min_, max_,
+            endpoint=True,
+            num=np.prod(shape),
+            dtype=dtype
+        )
+        expected = expected.reshape(shape)
+        file_path = tmp_path / "roundtrip.png"
+        imsave(file_path, expected)
+        actual = imread(file_path)
+        np.testing.assert_array_almost_equal(actual, expected)
 
     def test_bool_array_save(self):
         with NamedTemporaryFile(suffix='.png') as f:

--- a/skimage/io/tests/test_pil.py
+++ b/skimage/io/tests/test_pil.py
@@ -16,27 +16,24 @@ from skimage.metrics import structural_similarity
 
 from ... import img_as_float
 from ...color import rgb2lab
-from .. import imread, imsave, reset_plugins, use_plugin
+from .. import imread, imsave, reset_plugins, use_plugin, plugin_order
 from .._plugins.pil_plugin import (_palette_is_grayscale, ndarray_to_pil,
                                    pil_to_ndarray)
 
 
-def setup():
+@pytest.fixture(autouse=True)
+def use_pil_plugin():
+    """Ensure that PIL plugin is used in tests here."""
     use_plugin('pil')
-
-
-def teardown():
+    yield
     reset_plugins()
 
 
-def setup_module(self):
-    """The effect of the `plugin.use` call may be overridden by later imports.
-    Call `use_plugin` directly before the tests to ensure that PIL is used.
-    """
-    try:
-        use_plugin('pil')
-    except ImportError:
-        pass
+def test_prefered_plugin():
+    order = plugin_order()
+    assert order["imread"][0] == "pil"
+    assert order["imsave"][0] == "pil"
+    assert order["imread_collection"][0] == "pil"
 
 
 def test_png_round_trip():


### PR DESCRIPTION
## Description

See https://github.com/scientific-python/upload-nightly-action#using-nightly-builds-in-ci

Somewhat related https://github.com/scikit-image/scikit-image/issues/6514.

cc @bsipocz, @jarrodmillman  

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
