### PR TITLE
Expose `GeometricTransform.residuals` in HTML doc

### DIFF
--- a/doc/tools/apigen.py
+++ b/doc/tools/apigen.py
@@ -303,6 +303,7 @@ class ApiDocWriter:
             ad += '\n.. autoclass:: ' + c + '\n'
             # must NOT exclude from index to keep cross-refs working
             ad += '  :members:\n' \
+                  '  :inherited-members:\n' \
                   '  :undoc-members:\n' \
                   '  :show-inheritance:\n' \
                   '\n' \

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1,7 +1,9 @@
 import math
+import textwrap
+from abc import ABC, abstractmethod
+
 import numpy as np
 from scipy import spatial
-import textwrap
 
 from .._shared.utils import safe_as_int
 
@@ -165,10 +167,10 @@ def _umeyama(src, dst, estimate_scale):
     return T
 
 
-class GeometricTransform:
-    """Base class for geometric transformations.
+class _GeometricTransform(ABC):
+    """Abstract base class for geometric transformations."""
 
-    """
+    @abstractmethod
     def __call__(self, coords):
         """Apply forward transformation.
 
@@ -183,17 +185,16 @@ class GeometricTransform:
             Destination coordinates.
 
         """
-        raise NotImplementedError()
 
     @property
+    @abstractmethod
     def inverse(self):
         """Return a transform object representing the inverse."""
-        raise NotImplementedError()
 
     def residuals(self, src, dst):
         """Determine residuals of transformed destination coordinates.
 
-        For each transformed source coordinate the euclidean distance to the
+        For each transformed source coordinate the Euclidean distance to the
         respective destination coordinate is determined.
 
         Parameters
@@ -211,14 +212,8 @@ class GeometricTransform:
         """
         return np.sqrt(np.sum((self(src) - dst)**2, axis=1))
 
-    def __add__(self, other):
-        """Combine this transformation with another.
 
-        """
-        raise NotImplementedError()
-
-
-class FundamentalMatrixTransform(GeometricTransform):
+class FundamentalMatrixTransform(_GeometricTransform):
     """Fundamental matrix transformation.
 
     The fundamental matrix relates corresponding points between a pair of
@@ -546,7 +541,7 @@ class EssentialMatrixTransform(FundamentalMatrixTransform):
         return True
 
 
-class ProjectiveTransform(GeometricTransform):
+class ProjectiveTransform(_GeometricTransform):
     r"""Projective transformation.
 
     Apply a projective transformation (homography) on coordinates.
@@ -1009,7 +1004,7 @@ class AffineTransform(ProjectiveTransform):
         return self.params[0:self.dimensionality, self.dimensionality]
 
 
-class PiecewiseAffineTransform(GeometricTransform):
+class PiecewiseAffineTransform(_GeometricTransform):
     """Piecewise affine transformation.
 
     Control points are used to define the mapping. The transform is based on
@@ -1440,7 +1435,7 @@ class SimilarityTransform(EuclideanTransform):
                 'Scale is only implemented for 2D and 3D.')
 
 
-class PolynomialTransform(GeometricTransform):
+class PolynomialTransform(_GeometricTransform):
     """2D polynomial transformation.
 
     Has the following form::
@@ -1655,7 +1650,7 @@ def estimate_transform(ttype, src, dst, *args, **kwargs):
 
     Returns
     -------
-    tform : :class:`GeometricTransform`
+    tform : :class:`_GeometricTransform`
         Transform object containing the transformation parameters and providing
         access to forward and inverse transformation functions.
 

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -11,7 +11,7 @@ from skimage.transform import (AffineTransform, EssentialMatrixTransform,
                                PiecewiseAffineTransform, PolynomialTransform,
                                ProjectiveTransform, SimilarityTransform,
                                estimate_transform, matrix_transform)
-from skimage.transform._geometric import (GeometricTransform,
+from skimage.transform._geometric import (_GeometricTransform,
                                           _affine_matrix_from_vector,
                                           _center_and_normalize_points,
                                           _euler_rotation_matrix)
@@ -620,13 +620,8 @@ def test_inverse_all_transforms(tform):
 
 
 def test_geometric_tform():
-    tform = GeometricTransform()
-    with pytest.raises(NotImplementedError):
-        tform(0)
-    with pytest.raises(NotImplementedError):
-        tform.inverse(0)
-    with pytest.raises(NotImplementedError):
-        tform.__add__(0)
+    with pytest.raises(TypeError, match="Can't instantiate abstract class"):
+        _GeometricTransform()
 
     # See gh-3926 for discussion details
     for i in range(20):


### PR DESCRIPTION
## Description

`GeometricTransform` as a class itself is not part of the official API and documentation. So let's make that apparent by prefixing with "_" and making it a proper abstract base class so that it can't be instantiated and subclasses raise an error if they don't implement an abstract method.

Using the `:inherited-members:` directive makes sure that the method `_GeometricTransform.residuals` and its docstring show up in our HTML doc and makes the interface of each class clearer without having to jump around.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
