### PR TITLE
Fix NumPy 1.25 deprecation warnings

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -336,7 +336,7 @@ def cumulative_distribution(image, nbins=256):
     >>> image = img_as_float(data.camera())
     >>> hi = exposure.histogram(image)
     >>> cdf = exposure.cumulative_distribution(image)
-    >>> np.all(cdf[0] == np.cumsum(hi[0])/float(image.size))
+    >>> all(cdf[0] == np.cumsum(hi[0])/float(image.size))
     True
     """
     hist, bin_centers = histogram(image, nbins)

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -336,7 +336,7 @@ def cumulative_distribution(image, nbins=256):
     >>> image = img_as_float(data.camera())
     >>> hi = exposure.histogram(image)
     >>> cdf = exposure.cumulative_distribution(image)
-    >>> np.alltrue(cdf[0] == np.cumsum(hi[0])/float(image.size))
+    >>> np.all(cdf[0] == np.cumsum(hi[0])/float(image.size))
     True
     """
     hist, bin_centers = histogram(image, nbins)

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -320,7 +320,7 @@ class RegionProperties:
         if spacing is None:
             spacing = np.full(self._ndim, 1.)
         self._spacing = _normalize_spacing(spacing, self._ndim)
-        self._pixel_area = np.product(self._spacing)
+        self._pixel_area = np.prod(self._spacing)
 
         self._extra_properties = {}
         if extra_properties is not None:

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -748,7 +748,7 @@ def test_linear_warp_polar(dtype):
     assert warped.dtype == _supported_float_type(dtype)
     profile = warped.mean(axis=0)
     peaks = peak_local_max(profile)
-    assert np.all([peak in radii for peak in peaks])
+    assert all(peak in radii for peak in peaks)
 
 
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
@@ -767,7 +767,7 @@ def test_log_warp_polar(dtype):
     peaks_coord = peak_local_max(profile)
     peaks_coord.sort(axis=0)
     gaps = peaks_coord[1:] - peaks_coord[:-1]
-    assert np.all([x >= 38 and x <= 40 for x in gaps])
+    assert all(x >= 38 and x <= 40 for x in gaps)
 
 
 def test_invalid_scaling_polar():

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -748,7 +748,7 @@ def test_linear_warp_polar(dtype):
     assert warped.dtype == _supported_float_type(dtype)
     profile = warped.mean(axis=0)
     peaks = peak_local_max(profile)
-    assert np.alltrue([peak in radii for peak in peaks])
+    assert np.all([peak in radii for peak in peaks])
 
 
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
@@ -767,7 +767,7 @@ def test_log_warp_polar(dtype):
     peaks_coord = peak_local_max(profile)
     peaks_coord.sort(axis=0)
     gaps = peaks_coord[1:] - peaks_coord[:-1]
-    assert np.alltrue([x >= 38 and x <= 40 for x in gaps])
+    assert np.all([x >= 38 and x <= 40 for x in gaps])
 
 
 def test_invalid_scaling_polar():

--- a/tools/github/before_install.sh
+++ b/tools/github/before_install.sh
@@ -29,6 +29,10 @@ if [[ $MINIMUM_REQUIREMENTS == 1 ]]; then
     done
 fi
 
+
+perl -pi -e 's/numpy>=1.21.1/numpy>=1.21.1,<1.25/g' requirements/default.txt
+perl -pi -e 's/numpy>=1.21.1/numpy>=1.21.1,<1.25/g' requirements/build.txt
+
 python -m pip install --upgrade pip wheel "setuptools<=65.5"
 
 # Install build time requirements


### PR DESCRIPTION
This PR fixes `np.alltrue` and `np.product` deprecation warnings for NumPy 1.25. It also disables testing on NumPy 1.25 due to changes that need to be more closely examined. If merged, I will create a new PR removing the NumPy upper pin for testing so we can sort through the issue without making the main branch and every new PR fail due to this known issue.