### PR TITLE
Fix sparse index type casting in `skimage.graph._ncut`

### DIFF
--- a/skimage/graph/_ncut.py
+++ b/skimage/graph/_ncut.py
@@ -54,7 +54,7 @@ def ncut_cost(cut, D, W):
            Intelligence, Page 889, Equation 2.
     """
     cut = np.array(cut)
-    cut_cost = _ncut_cy.cut_cost(cut, W)
+    cut_cost = _ncut_cy.cut_cost(cut, W, W.indices, W.indptr)
 
     # D has elements only along the diagonal, one per node, so we can directly
     # index the data attribute with cut.

--- a/skimage/graph/_ncut_cy.pyx
+++ b/skimage/graph/_ncut_cy.pyx
@@ -50,9 +50,9 @@ def argmin2(cnp.float64_t[:] array):
 
 def cut_cost(
     cut,
-    const floating[:] W_data,
-    const index_t[:] W_indices,
-    const index_t[:] W_indptr,
+    floating[:] W_data,
+    index_t[:] W_indices,
+    index_t[:] W_indptr,
     int num_cols,
 ):
     """Return the total weight of crossing edges in a bi-partition.

--- a/skimage/graph/_ncut_cy.pyx
+++ b/skimage/graph/_ncut_cy.pyx
@@ -7,6 +7,11 @@ import numpy as np
 cnp.import_array()
 
 
+ctypedef fused index_t:
+    cnp.int32_t
+    cnp.int64_t
+
+
 def argmin2(cnp.float64_t[:] array):
     """Return the index of the 2nd smallest value in an array.
 
@@ -42,7 +47,7 @@ def argmin2(cnp.float64_t[:] array):
     return min_idx2
 
 
-def cut_cost(cut, W):
+def cut_cost(cut, W, index_t[:] W_indices, index_t[:] W_indptr):
     """Return the total weight of crossing edges in a bi-partition.
 
     Parameters
@@ -51,7 +56,11 @@ def cut_cost(cut, W):
         A array of booleans. Elements set to `True` belong to one
         set.
     W : array
-        The weight matrix of the graph.
+        The sparse weight matrix.
+    W_indices : array
+        The indices of the sparse weight matrix of the graph.
+    W_indptr : array
+        The index pointers of the sparse weight matrix of the graph.
 
     Returns
     -------
@@ -61,8 +70,6 @@ def cut_cost(cut, W):
     cdef cnp.ndarray[cnp.uint8_t, cast = True] cut_mask = np.array(cut)
     cdef Py_ssize_t num_cols
     cdef cnp.int64_t row, col
-    cdef cnp.int64_t[:] indices = W.indices.astype(np.int64)
-    cdef cnp.int64_t[:] indptr = W.indptr.astype(np.int64)
     cdef cnp.float64_t[:] data = W.data.astype(np.float64)
     cdef cnp.int64_t row_index
     cdef cnp.float64_t cost = 0
@@ -70,8 +77,8 @@ def cut_cost(cut, W):
     num_cols = W.shape[1]
 
     for col in range(num_cols):
-        for row_index in range(indptr[col], indptr[col + 1]):
-            row = indices[row_index]
+        for row_index in range(W_indptr[col], W_indptr[col + 1]):
+            row = W_indices[row_index]
             if cut_mask[row] != cut_mask[col]:
                 cost += data[row_index]
 

--- a/skimage/graph/_ncut_cy.pyx
+++ b/skimage/graph/_ncut_cy.pyx
@@ -60,11 +60,11 @@ def cut_cost(cut, W):
     """
     cdef cnp.ndarray[cnp.uint8_t, cast = True] cut_mask = np.array(cut)
     cdef Py_ssize_t num_cols
-    cdef cnp.int32_t row, col
-    cdef cnp.int32_t[:] indices = W.indices
-    cdef cnp.int32_t[:] indptr = W.indptr
+    cdef cnp.int64_t row, col
+    cdef cnp.int64_t[:] indices = W.indices.astype(np.int64)
+    cdef cnp.int64_t[:] indptr = W.indptr.astype(np.int64)
     cdef cnp.float64_t[:] data = W.data.astype(np.float64)
-    cdef cnp.int32_t row_index
+    cdef cnp.int64_t row_index
     cdef cnp.float64_t cost = 0
 
     num_cols = W.shape[1]


### PR DESCRIPTION
In SciPy 0.12, we are no longer guaranteed that indices will be 32-bit in most situation. In fact, that was never a valid assumption, but one that often worked out in practice.

The approach taken here is not ideal: all indices are cast to 64-bit, because we don't *know* whether 32 or 64-bit indices are being used.

The issue was exposed by https://github.com/scipy/scipy/pull/18509, which no longer down-casts indices, once they've been upcast.

