### PR TITLE
Add lazy loading to skimage.future module

### DIFF
--- a/skimage/future/__init__.py
+++ b/skimage/future/__init__.py
@@ -8,15 +8,6 @@
     in production code that will depend on updated skimage versions.
 """
 
-from .manual_segmentation import manual_polygon_segmentation
-from .manual_segmentation import manual_lasso_segmentation
-from .trainable_segmentation import fit_segmenter, predict_segmenter, TrainableSegmenter
+import lazy_loader as lazy
 
-
-__all__ = [
-    "manual_lasso_segmentation",
-    "manual_polygon_segmentation",
-    "fit_segmenter",
-    "predict_segmenter",
-    "TrainableSegmenter",
-]
+__getattr__, __dir__, __all__ = lazy.attach_stub(__name__, __file__)

--- a/skimage/future/__init__.pyi
+++ b/skimage/future/__init__.pyi
@@ -1,0 +1,15 @@
+# Explicitly setting `__all__` is necessary for type inference engines
+# to know which symbols are exported. See
+# https://peps.python.org/pep-0484/#stub-files
+
+__all__ = [
+    "manual_lasso_segmentation",
+    "manual_polygon_segmentation",
+    "fit_segmenter",
+    "predict_segmenter",
+    "TrainableSegmenter",
+]
+
+from .manual_segmentation import manual_polygon_segmentation
+from .manual_segmentation import manual_lasso_segmentation
+from .trainable_segmentation import fit_segmenter, predict_segmenter, TrainableSegmenter

--- a/skimage/future/__init__.pyi
+++ b/skimage/future/__init__.pyi
@@ -10,6 +10,5 @@ __all__ = [
     "TrainableSegmenter",
 ]
 
-from .manual_segmentation import manual_polygon_segmentation
-from .manual_segmentation import manual_lasso_segmentation
+from .manual_segmentation import manual_lasso_segmentation, manual_polygon_segmentation
 from .trainable_segmentation import fit_segmenter, predict_segmenter, TrainableSegmenter

--- a/skimage/future/meson.build
+++ b/skimage/future/meson.build
@@ -1,5 +1,6 @@
 python_sources = [
   '__init__.py',
+  '__init__.pyi',
   'manual_segmentation.py',
   'trainable_segmentation.py'
 ]


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description
Resolves a task in #6964
<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
