### PR TITLE
Add lazy loading to graph submodule

### DIFF
--- a/skimage/graph/__init__.py
+++ b/skimage/graph/__init__.py
@@ -1,26 +1,3 @@
-from ._graph import pixel_graph, central_pixel
-from ._graph_cut import cut_threshold, cut_normalized
-from ._graph_merge import merge_hierarchical
-from ._rag import rag_mean_color, RAG, show_rag, rag_boundary
-from .spath import shortest_path
-from .mcp import (
-    MCP, MCP_Geometric, MCP_Connect, MCP_Flexible, route_through_array
-)
+import lazy_loader as lazy
 
-
-__all__ = [
-    'pixel_graph',
-    'central_pixel',
-    'shortest_path',
-    'MCP',
-    'MCP_Geometric',
-    'MCP_Connect',
-    'MCP_Flexible',
-    'route_through_array',
-    'rag_mean_color',
-    'rag_boundary',
-    'cut_threshold',
-    'cut_normalized',
-    'merge_hierarchical',
-    'RAG',
-]
+__getattr__, __dir__, __all__ = lazy.attach_stub(__name__, __file__)

--- a/skimage/graph/__init__.pyi
+++ b/skimage/graph/__init__.pyi
@@ -1,0 +1,32 @@
+# Explicitly setting `__all__` is necessary for type inference engines
+# to know which symbols are exported. See
+# https://peps.python.org/pep-0484/#stub-files
+
+__all__ = [
+    'pixel_graph',
+    'central_pixel',
+    'shortest_path',
+    'MCP',
+    'MCP_Geometric',
+    'MCP_Connect',
+    'MCP_Flexible',
+    'route_through_array',
+    'rag_mean_color',
+    'rag_boundary',
+    'cut_threshold',
+    'cut_normalized',
+    'merge_hierarchical',
+    'RAG',
+]
+
+from ._graph import pixel_graph, central_pixel
+from ._graph_cut import cut_threshold, cut_normalized
+from ._graph_merge import merge_hierarchical
+from ._rag import rag_mean_color, RAG, show_rag, rag_boundary
+from .spath import shortest_path
+from .mcp import (
+    MCP, MCP_Geometric,
+    MCP_Connect,
+    MCP_Flexible,
+    route_through_array
+)

--- a/skimage/graph/meson.build
+++ b/skimage/graph/meson.build
@@ -17,6 +17,7 @@ endforeach
 
 python_sources = [
   '__init__.py',
+  '__init__.pyi',
   '_graph.py',
   '_graph_cut.py',
   '_graph_merge.py',


### PR DESCRIPTION
<!--
Please use `pre-commit` to format code.

```
pip install pre-commit  # install the package
pre-commit install  # install git commit hook
```

Now, formatting checks will be run on each commit.
You can also run `pre-commit` manually:

```
pre-commit run -a
```
-->

## Description
Add lazy loading to `skimage.graph` submodule. #6964

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what paper it implements. -->

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
