### PR TITLE
Fix URLs to the install page

### DIFF
--- a/doc/examples/filters/plot_inpaint.py
+++ b/doc/examples/filters/plot_inpaint.py
@@ -1,15 +1,16 @@
 """
-===========
-Inpainting
-===========
+===============================
+Fill in defects with inpainting
+===============================
+
 Inpainting [1]_ is the process of reconstructing lost or deteriorated
 parts of images and videos.
 
-The reconstruction is supposed to be performed in fully automatic way by
-exploiting the information presented in non-damaged regions.
+The reconstruction (restoration) is performed in an automatic way by
+exploiting the information present in non-damaged regions.
 
-In this example, we show how the masked pixels get inpainted by
-inpainting algorithm based on 'biharmonic equation'-assumption [2]_ [3]_ [4]_.
+In this example, we show how the masked pixels get inpainted using an
+inpainting algorithm based on the biharmonic equation [2]_ [3]_ [4]_.
 
 .. [1]  Wikipedia. Inpainting
         https://en.wikipedia.org/wiki/Inpainting
@@ -44,12 +45,12 @@ mask[-60:-30, 170:195] = 1
 mask[-180:-160, 70:155] = 1
 mask[-60:-20, 0:20] = 1
 
-# add a few long, narrow defects
+# Add a few long, narrow defects
 mask[200:205, -200:] = 1
 mask[150:255, 20:23] = 1
 mask[365:368, 60:130] = 1
 
-# add randomly positioned small point-like defects
+# Add randomly positioned small point-like defects
 rstate = np.random.default_rng(0)
 for radius in [0, 2, 4]:
     # larger defects are less common

--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -87,7 +87,7 @@ directory and you need to try from another location."""
 _STANDARD_MSG = """
 Your install of scikit-image appears to be broken.
 Try re-installing the package following the instructions at:
-https://scikit-image.org/docs/stable/install.html """
+https://scikit-image.org/docs/stable/user_guide/install.html"""
 
 
 def _raise_build_error(e):

--- a/skimage/data/_fetchers.py
+++ b/skimage/data/_fetchers.py
@@ -219,7 +219,7 @@ def _fetch(data_filename):
             "but requires the installation of an optional dependency, pooch. "
             "To install pooch, use your preferred python package manager. "
             "Follow installation instruction found at "
-            "https://scikit-image.org/docs/stable/install.html"
+            "https://scikit-image.org/docs/stable/user_guide/install.html"
         )
     # Download the data with pooch which caches it automatically
     _ensure_cache_dir(target_dir=cache_dir)
@@ -248,7 +248,7 @@ def download_all(directory=None):
     This function requires the installation of an optional dependency, pooch,
     to download the full dataset. Follow installation instruction found at
 
-        https://scikit-image.org/docs/stable/install.html
+        https://scikit-image.org/docs/stable/user_guide/install.html
 
     Call this function to download all sample images making them available
     offline on your machine.
@@ -276,7 +276,7 @@ def download_all(directory=None):
             "To download all package data, scikit-image needs an optional "
             "dependency, pooch."
             "To install pooch, follow our installation instructions found at "
-            "https://scikit-image.org/docs/stable/install.html"
+            "https://scikit-image.org/docs/stable/user_guide/install.html"
         )
     # Consider moving this kind of logic to Pooch
     old_dir = _image_fetcher.path


### PR DESCRIPTION


## Description

Just a small fix of four URLs which should lead to the install page but resulted in a 404 error.

"https://scikit-image.org/docs/stable/install.html"

changed to 

"https://scikit-image.org/docs/stable/user_guide/install.html"


## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
