### PR TITLE
meson: allow proper selection of NumPy, Pythran in cross builds

### DIFF
--- a/skimage/meson.build
+++ b/skimage/meson.build
@@ -29,37 +29,61 @@ if is_windows
   endif
 endif
 
-# NumPy include directory - needed in all submodules
-incdir_numpy = run_command(py3,
-  [
-    '-c',
-    'import os; os.chdir(".."); import numpy; print(numpy.get_include())'
-  ],
-  check: true
-).stdout().strip()
+# When cross-compiling skimage, the compiler needs access to NumPy and Pythran
+# headers for the host platform (where the package will actually run). These
+# headers may be incompatible with any corresponding headers that might be
+# installed on the build system (where the compilation is performed). To make
+# sure that the compiler finds the right headers, paths can be configured in
+# the 'properties' section of a Meson cross file:
+#
+#   [properties]
+#   numpy-include-dir = '/path/to/host/numpy/includes'
+#   pythran-include-dir = '/path/to/host/pythran/includes'
+#
+# If a cross file is not provided or does not specify either of these
+# properties, fall back to running Python on the build system to query NumPy or
+# Pythran directly for the appropriate paths. This will detect appropriate
+# paths for native builds. (This might even work for certain build/host cross
+# combinations, but don't rely on that.)
+#
+# For more information about cross compilation in Meson, including a definition
+# of "build" and "host" in this context, refer to
+#
+#     https://mesonbuild.com/Cross-compilation.html
+
+# NumPy include directory
+incdir_numpy = meson.get_external_property('numpy-include-dir', 'not-given')
+if incdir_numpy == 'not-given'
+  # If not specified, try to query NumPy from the build python
+  incdir_numpy = run_command(py3,
+    [
+      '-c',
+      'import os; os.chdir(".."); import numpy; print(numpy.get_include())'
+    ],
+    check: true
+  ).stdout().strip()
+endif
 
 inc_np = include_directories(incdir_numpy)
 
 cc = meson.get_compiler('c')
 
-# Pythran include directory and build flags
-use_pythran = run_command(py3,
-  [
-    '-c',
-    'import os; print(os.environ.get("SCIPY_USE_PYTHRAN", 1))'
-  ],
-  check: true
-).stdout().strip() == '1'
+# Pythran include directory
+incdir_pythran = meson.get_external_property('pythran-include-dir', 'not-given')
+if incdir_pythran == 'not-given'
+  # If not specified, try to query Pythran from the build python
+  incdir_pythran = run_command(py3,
+    [
+      '-c',
+      'import os; os.chdir(".."); import pythran; print(os.path.dirname(pythran.__file__));'
+    ],
+    check: true
+  ).stdout().strip()
+endif
 
-incdir_pythran = run_command(py3,
-  [
-    '-c',
-    'import os; os.chdir(".."); import pythran; print(os.path.dirname(pythran.__file__));'
-  ],
-  check: true
-).stdout().strip()
 inc_pythran = include_directories(incdir_pythran)
 
+# Pythran build flags
 cpp_args_pythran = [
   '-DENABLE_PYTHON_MODULE',
   '-D__PYTHRAN__=3',


### PR DESCRIPTION
## Description

When cross-building this package with Meson, it is not appropriate to run the build Python looking for NumPy and Pythran includes. Instead, these files must come from the intended host. The simplest way to make sure we pick the right includes is to allow specification of the paths via a Meson cross file.

The changes in this PR were adapted from [scipy](https://github.com/scipy/scipy/blob/main/scipy/meson.build#L30-L72).

Also, while I was at it, I removed the `use_pythran` logic, because it wasn't actually used to gate the use of Pythran.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->

- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->

- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
  `doc/release/release_dev.rst`.
- There is a bot to help automate backporting a PR to an older branch. For
  example, to backport to v0.19.x after merging, add the following in a PR
  comment: `@meeseeksdev backport to v0.19.x`
- To run benchmarks on a PR, add the `run-benchmark` label. To rerun, the label
  can be removed and then added again. The benchmark output can be checked in
  the "Actions" tab.
