### PR TITLE
Fix URLs that lead to 404 page

### DIFF
--- a/doc/source/development/core_developer.md
+++ b/doc/source/development/core_developer.md
@@ -92,7 +92,7 @@ When reviewing, focus on the following:
    new contributions should be consistent with {doc}`our mission <../about/values>`.
 
 [wiki_functional]: https://en.wikipedia.org/wiki/Functional_programming
-[dep_pol]: https://scikit-image.org/docs/dev/contribute.html#deprecation-cycle
+[dep_pol]: https://scikit-image.org/docs/dev/development/contribute.html#deprecation-cycle
 [mit_license]: https://spdx.org/licenses/MIT.html
 [apache_2-2]: https://spdx.org/licenses/Apache-2.0.html
 

--- a/doc/source/release_notes/release_0.18.rst
+++ b/doc/source/release_notes/release_0.18.rst
@@ -171,11 +171,11 @@ Documentation
   <https://scikit-image.org/docs/dev/auto_examples/segmentation/plot_regionprops.html>`_
   (#5010).
 - Documentation has been added to explain
-  `how to download example datasets <https://scikit-image.org/docs/dev/install.html#downloading-all-demo-datasets>`_
+  `how to download example datasets <https://scikit-image.org/docs/dev/user_guide/install.html#downloading-all-demo-datasets>`_
   which are not installed with scikit-image (#4984). Similarly, the contributor
   guide has been updated to mention how to host new datasets in a gitlab
   repository (#4892).
-- The `benchmarking section of the developer documentation <https://scikit-image.org/docs/dev/contribute.html#benchmarks>`_
+- The `benchmarking section of the developer documentation <https://scikit-image.org/docs/dev/development/contribute.html#benchmarks>`_
   has been expanded (#4905).
 - Added links to the image.sc forum in example pages (#5094, #5096)
 - Added missing datasets to gallery examples (#5116, #5118)


### PR DESCRIPTION
## Description

Some URLs were not correct anymore and lead to a 404 page.
I checked all https://scikit-image.org/... URLs and they should all work now.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed
