### PR TITLE
Ensure existing target directory for `random.js`

### DIFF
--- a/doc/ext/skimage_extensions.py
+++ b/doc/ext/skimage_extensions.py
@@ -122,6 +122,7 @@ def write_random_js(app, exception):
     content = content.replace('{{LINKS}}', str(tutorial_urls))
     content = content.replace('{{GALLERY_DIV}}', ''.join(GALLERY_DIV.split('\n')))
 
+    random_js_path.parent.mkdir(parents=True, exist_ok=True)
     with open(random_js_path, 'w') as file:
         file.write(content)
     logger.info(


### PR DESCRIPTION
## Description

@ana42742  reported an issue on Zulip when running `spin docs` which resulted in the following error:
```
Extension error (skimage_extensions):
Handler <function write_random_js at 0x120763f70> for event 'build-finished' threw an exception (exception: [Errno 2] No such file or directory: '~/scikit-image/doc/build/html/_static/random.js')
make: *** [html] Error 2
```
A cause might be the missing target directory `~/scikit-image/doc/build/html/_static`, though it's curious that this
hasn't come up for us or in our CI.

This should make the function a bit more robust and independent of sphinx creating the target directory in time. Might save us some future pain if we ever update or change how this extension works.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed
