### PR TITLE
Assign next milestone only for PRs targeting `main` branch

### DIFF
--- a/.github/workflows/milestone-merged-prs.yaml
+++ b/.github/workflows/milestone-merged-prs.yaml
@@ -4,6 +4,8 @@ on:
   pull_request_target:
     types:
       - closed
+    branches:
+      - "main"
 
 jobs:
   milestone_pr:


### PR DESCRIPTION
## Description

Avoids assigning milestones to PRs that are merged into feature branches instead of `main`, e.g. https://github.com/scikit-image/scikit-image/pull/7017. [Source for the syntax is here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request_target-workflow-based-on-the-head-or-base-branch-of-a-pull-request).

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed
