### PR TITLE
Add missing directories to `spin docs --clean` command

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -34,10 +34,16 @@ def docs(ctx, clean, install_deps, build):
 
     """
     if clean:
-        doc_dir = "./doc/build"
-        if os.path.isdir(doc_dir):
-            print(f"Removing `{doc_dir}`")
-            shutil.rmtree(doc_dir)
+        doc_dirs = [
+            "./doc/build/",
+            "./doc/source/api/",
+            "./doc/source/auto_examples/",
+            "./doc/source/jupyterlite_contents/",
+        ]
+        for doc_dir in doc_dirs:
+            if os.path.isdir(doc_dir):
+                print(f"Removing {doc_dir!r}")
+                shutil.rmtree(doc_dir)
 
     if build:
         click.secho(


### PR DESCRIPTION
## Description

If the "--clean" option is given, truly everything including the API and gallery examples should be removed.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed
