### PR TITLE
Transition user guide to `import skimage as ski`

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -36,8 +36,8 @@ worked, run the following in a Python shell or Jupyter notebook:
 
 .. code-block:: python
 
-  import skimage
-  print(skimage.__version__)
+  import skimage as ski
+  print(ski.__version__)
 
 or, from the command line:
 
@@ -151,7 +151,7 @@ is installed and then run this command:
 
 .. code-block:: sh
 
-    python -c 'from skimage.data import download_all; download_all()'
+    python -c 'import skimage; skimage.data.download_all()'
 
 or call ``download_all()`` in your favourite interactive Python environment
 (IPython, Jupyter notebook, ...).

--- a/doc/source/user_guide/data_types.rst
+++ b/doc/source/user_guide/data_types.rst
@@ -33,11 +33,12 @@ functions that convert dtypes and properly rescale image intensities (see
 `Input types`_). You should **never use** ``astype`` on an image, because it
 violates these assumptions about the dtype range::
 
-   >>> from skimage.util import img_as_float
+   >>> import numpy as np
+   >>> import skimage as ski
    >>> image = np.arange(0, 50, 10, dtype=np.uint8)
    >>> print(image.astype(float)) # These float values are out of range.
    [  0.  10.  20.  30.  40.]
-   >>> print(img_as_float(image))
+   >>> print(ski.util.img_as_float(image))
    [ 0.          0.03921569  0.07843137  0.11764706  0.15686275]
 
 
@@ -65,25 +66,25 @@ img_as_int     Convert to 16-bit int.
 These functions convert images to the desired dtype and *properly rescale their
 values*::
 
-   >>> from skimage.util import img_as_ubyte
+   >>> import skimage as ski
    >>> image = np.array([0, 0.5, 1], dtype=float)
-   >>> img_as_ubyte(image)
+   >>> ski.util.img_as_ubyte(image)
    array([  0, 128, 255], dtype=uint8)
 
 Be careful! These conversions can result in a loss of precision, since 8 bits
 cannot hold the same amount of information as 64 bits::
 
    >>> image = np.array([0, 0.5, 0.503, 1], dtype=float)
-   >>> image_as_ubyte(image)
+   >>> ski.util.image_as_ubyte(image)
    array([  0, 128, 128, 255], dtype=uint8)
 
-Note that ``img_as_float`` will preserve the precision of floating point types
-and does not automatically rescale the range of floating point inputs.
+Note that :func:`ski.util.img_as_float` will preserve the precision of floating point
+types and does not automatically rescale the range of floating point inputs.
 
 Additionally, some functions take a ``preserve_range`` argument where a range
 conversion is convenient but not necessary. For example, interpolation in
-``transform.warp`` requires an image of type float, which should have a range
-in [0, 1]. So, by default, input images will be rescaled to this range.
+:func:`skimage.transform.warp` requires an image of type float, which should have a
+range in [0, 1]. So, by default, input images will be rescaled to this range.
 However, in some cases, the image values represent physical measurements, such
 as temperature or rainfall values, that the user does not want rescaled.
 With ``preserve_range=True``, the original range of the data will be
@@ -94,16 +95,14 @@ may expect an image in [0, 1]. In general, unless a function has a
 be automatically rescaled.
 
 
-    >>> from skimage import data
-    >>> from skimage.transform import rescale
-    >>> image = data.coins()
+    >>> image = ski.data.coins()
     >>> image.dtype, image.min(), image.max(), image.shape
     (dtype('uint8'), 1, 252, (303, 384))
-    >>> rescaled = rescale(image, 0.5)
+    >>> rescaled = ski.transform.rescale(image, 0.5)
     >>> (rescaled.dtype, np.round(rescaled.min(), 4),
     ...  np.round(rescaled.max(), 4), rescaled.shape)
     (dtype('float64'), 0.0147, 0.9456, (152, 192))
-    >>> rescaled = rescale(image, 0.5, preserve_range=True)
+    >>> rescaled = ski.transform.rescale(image, 0.5, preserve_range=True)
     >>> (rescaled.dtype, np.round(rescaled.min()),
     ...  np.round(rescaled.max()), rescaled.shape
     (dtype('float64'), 4.0, 241.0, (152, 192))
@@ -120,8 +119,7 @@ unnecessary data copies take place.
 A user that requires a specific type of output (e.g., for display purposes),
 may write::
 
-   >>> from skimage.util import img_as_uint
-   >>> out = img_as_uint(sobel(image))
+   >>> out = ski.util.img_as_uint(sobel(image))
    >>> plt.imshow(out)
 
 
@@ -154,19 +152,19 @@ Using an image from OpenCV with ``skimage``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If cv_image is an array of unsigned bytes, ``skimage`` will understand it by
-default. If you prefer working with floating point images, :func:`img_as_float`
+default. If you prefer working with floating point images, :func:`~.img_as_float`
 can be used to convert the image::
 
-    >>> from skimage.util import img_as_float
-    >>> image = img_as_float(any_opencv_image)
+    >>> import skimage as ski
+    >>> image = ski.util.img_as_float(any_opencv_image)
 
 Using an image from ``skimage`` with OpenCV
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The reverse can be achieved with :func:`img_as_ubyte`::
+The reverse can be achieved with :func:`~.img_as_ubyte`::
 
-    >>> from skimage.util import img_as_ubyte
-    >>> cv_image = img_as_ubyte(any_skimage_image)
+    >>> import skimage as ski
+    >>> cv_image = ski.util.img_as_ubyte(any_skimage_image)
 
 
 Image processing pipeline
@@ -178,15 +176,15 @@ a custom function that requires a particular dtype, you should call one of the
 dtype conversion functions (here, ``func1`` and ``func2`` are ``skimage``
 functions)::
 
-   >>> from skimage.util import img_as_float
-   >>> image = img_as_float(func1(func2(image)))
+   >>> import skimage as ski
+   >>> image = ski.util.img_as_float(func1(func2(image)))
    >>> processed_image = custom_func(image)
 
 Better yet, you can convert the image internally and use a simplified
 processing pipeline::
 
    >>> def custom_func(image):
-   ...     image = img_as_float(image)
+   ...     image = ski.util.img_as_float(image)
    ...     # do something
    ...
    >>> processed_image = custom_func(func1(func2(image)))
@@ -207,19 +205,19 @@ range but do not. For example, some cameras store images with 10-, 12-, or
 14-bit depth per pixel. If these images are stored in an array with dtype
 uint16, then the image won't extend over the full intensity range, and thus,
 would appear dimmer than it should. To correct for this, you can use the
-``rescale_intensity`` function to rescale the image so that it uses the full
+:func:`~.rescale_intensity` function to rescale the image so that it uses the full
 dtype range::
 
-   >>> from skimage import exposure
-   >>> image = exposure.rescale_intensity(img10bit, in_range=(0, 2**10 - 1))
+   >>> import skimage as ski
+   >>> image = ski.exposure.rescale_intensity(img10bit, in_range=(0, 2**10 - 1))
 
 Here, the ``in_range`` argument is set to the maximum range for a 10-bit image.
-By default, ``rescale_intensity`` stretches the values of ``in_range`` to match
-the range of the dtype. ``rescale_intensity`` also accepts strings as inputs
+By default, :func:`~.rescale_intensity` stretches the values of ``in_range`` to match
+the range of the dtype. :func:`~.rescale_intensity` also accepts strings as inputs
 to ``in_range`` and ``out_range``, so the example above could also be written
 as::
 
-   >>> image = exposure.rescale_intensity(img10bit, in_range='uint10')
+   >>> image = ski.exposure.rescale_intensity(img10bit, in_range='uint10')
 
 
 Note about negative values
@@ -233,8 +231,8 @@ negative values are clipped to 0 when converting from signed to unsigned
 dtypes. (Negative values are preserved when converting between signed dtypes.)
 To prevent this clipping behavior, you should rescale your image beforehand::
 
-   >>> image = exposure.rescale_intensity(img_int32, out_range=(0, 2**31 - 1))
-   >>> img_uint8 = img_as_ubyte(image)
+   >>> image = ski.exposure.rescale_intensity(img_int32, out_range=(0, 2**31 - 1))
+   >>> img_uint8 = ski.util.img_as_ubyte(image)
 
 This behavior is symmetric: The values in an unsigned dtype are spread over
 just the positive range of a signed dtype.

--- a/doc/source/user_guide/geometrical_transform.rst
+++ b/doc/source/user_guide/geometrical_transform.rst
@@ -13,8 +13,8 @@ square corresponding to the top-left corner of the astronaut image. Note that
 this operation is done for all color channels (the color dimension is the last,
 third dimension)::
 
-   >>> from skimage import data
-   >>> img = data.astronaut()
+   >>> import skimage as ski
+   >>> img = ski.data.astronaut()
    >>> top_left = img[:100, :100]
 
 In order to change the shape of the image, :mod:`skimage.color` provides several
@@ -46,25 +46,20 @@ of homographies available in scikit-image are presented in
 Projective transformations can either be created using the explicit
 parameters (e.g. scale, shear, rotation and translation)::
 
-   from skimage import data
-   from skimage import transform
-   from skimage import img_as_float
+   import numpy as np
+   import skimage as ski
 
-   tform = transform.EuclideanTransform(
+   tform = ski.transform.EuclideanTransform(
       rotation=np.pi / 12.,
       translation = (100, -20)
       )
 
 or the full transformation matrix::
 
-   from skimage import data
-   from skimage import transform
-   from skimage import img_as_float
-
    matrix = np.array([[np.cos(np.pi/12), -np.sin(np.pi/12), 100],
                       [np.sin(np.pi/12), np.cos(np.pi/12), -20],
                       [0, 0, 1]])
-   tform = transform.EuclideanTransform(matrix)
+   tform = ski.transform.EuclideanTransform(matrix)
 
 The transformation matrix of a transform is available as its ``tform.params``
 attribute. Transformations can be composed by multiplying matrices with the
@@ -78,8 +73,8 @@ represented with finite coordinates.
 
 Transformations can be applied to images using :func:`skimage.transform.warp`::
 
-   img = img_as_float(data.chelsea())
-   tf_img = transform.warp(img, tform.inverse)
+   img = ski.util.img_as_float(ski.data.chelsea())
+   tf_img = ski.util.transform.warp(img, tform.inverse)
 
 .. image:: ../auto_examples/transform/images/sphx_glr_plot_transform_types_001.png
    :target: ../auto_examples/transform/plot_transform_types.html
@@ -91,14 +86,14 @@ method in order to estimate the parameters of the transformation from two sets
 of points (the source and the destination), as explained in the
 :ref:`sphx_glr_auto_examples_transform_plot_geometric.py` tutorial::
 
-   text = data.text()
+   text = ski.data.text()
 
    src = np.array([[0, 0], [0, 50], [300, 50], [300, 0]])
    dst = np.array([[155, 15], [65, 40], [260, 130], [360, 95]])
 
-   tform3 = transform.ProjectiveTransform()
+   tform3 = ski.transform.ProjectiveTransform()
    tform3.estimate(src, dst)
-   warped = transform.warp(text, tform3, output_shape=(50, 300))
+   warped = ski.transform.warp(text, tform3, output_shape=(50, 300))
 
 
 .. image:: ../auto_examples/transform/images/sphx_glr_plot_geometric_002.png

--- a/doc/source/user_guide/getting_started.rst
+++ b/doc/source/user_guide/getting_started.rst
@@ -4,12 +4,11 @@ Getting started
 ``scikit-image`` is an image processing Python package that works with
 :mod:`numpy` arrays. The package is imported as ``skimage``: ::
 
-    >>> import skimage
+    >>> import skimage as ski
 
 Most functions of ``skimage`` are found within submodules: ::
 
-    >>> from skimage import data
-    >>> camera = data.camera()
+    >>> camera = ski.data.camera()
 
 A list of submodules and functions is found on the `API reference
 <https://scikit-image.org/docs/stable/api/api.html>`_ webpage.
@@ -27,9 +26,8 @@ The :mod:`skimage.data` submodule provides a set of functions returning
 example images, that can be used to get started quickly on using
 scikit-image's functions: ::
 
-    >>> coins = data.coins()
-    >>> from skimage import filters
-    >>> threshold_value = filters.threshold_otsu(coins)
+    >>> coins = ski.data.coins()
+    >>> threshold_value = ski.filters.threshold_otsu(coins)
     >>> threshold_value
     107
 
@@ -38,14 +36,12 @@ from image files, using :func:`skimage.io.imread`: ::
 
     >>> import os
     >>> filename = os.path.join(skimage.data_dir, 'moon.png')
-    >>> from skimage import io
-    >>> moon = io.imread(filename)
+    >>> moon = ski.io.imread(filename)
 
 Use `natsort <https://pypi.org/project/natsort/>`_ to load multiple images ::
 
     >>> import os
     >>> from natsort import natsorted, ns
-    >>> from skimage import io
     >>> list_files = os.listdir('.')
     >>> list_files
     ['01.png', '010.png', '0101.png', '0190.png', '02.png']
@@ -54,4 +50,4 @@ Use `natsort <https://pypi.org/project/natsort/>`_ to load multiple images ::
     ['01.png', '02.png', '010.png', '0101.png', '0190.png']
     >>> image_list = []
     >>> for filename in list_files:
-    ...   image_list.append(io.imread(filename))
+    ...   image_list.append(ski.io.imread(filename))

--- a/doc/source/user_guide/numpy_images.rst
+++ b/doc/source/user_guide/numpy_images.rst
@@ -8,8 +8,8 @@ Images in ``scikit-image`` are represented by NumPy ndarrays. Hence, many
 common operations can be achieved using standard NumPy methods for
 manipulating arrays::
 
-    >>> from skimage import data
-    >>> camera = data.camera()
+    >>> import skimage as ski
+    >>> camera = ski.data.camera()
     >>> type(camera)
     <type 'numpy.ndarray'>
 
@@ -67,6 +67,7 @@ Masking (indexing with masks of booleans)::
 
 Fancy indexing (indexing with sets of indices)::
 
+    >>> import numpy as np
     >>> inds_r = np.arange(len(camera))
     >>> inds_c = 4 * inds_r % len(camera)
     >>> camera[inds_r, inds_c] = 0
@@ -101,7 +102,7 @@ Color images
 All of the above remains true for color images. A color image is a
 NumPy array with an additional trailing dimension for the channels::
 
-    >>> cat = data.chelsea()
+    >>> cat = ski.data.chelsea()
     >>> type(cat)
     <type 'numpy.ndarray'>
     >>> cat.shape
@@ -121,16 +122,15 @@ We can also use 2D boolean masks for 2D multichannel images, as we did with
 the grayscale image above:
 
 .. plot::
+   :caption: Using a 2D mask on a 2D color image
 
-    Using a 2D mask on a 2D color image
+   import skimage as ski
+   cat = ski.data.chelsea()
+   reddish = cat[:, :, 0] > 160
+   cat[reddish] = [0, 255, 0]
+   plt.imshow(cat)
 
-    >>> from skimage import data
-    >>> cat = data.chelsea()
-    >>> reddish = cat[:, :, 0] > 160
-    >>> cat[reddish] = [0, 255, 0]
-    >>> plt.imshow(cat)
-
-The example color images included in ``skimage.data`` have channels stored
+The example color images included in :mod:`skimage.data` have channels stored
 along the last axis, although other software may follow different conventions.
 The scikit-image library functions supporting color images have a
 ``channel_axis`` argument that can be used to specify which axis of an array
@@ -143,7 +143,7 @@ Coordinate conventions
 
 Because ``scikit-image`` represents images using NumPy arrays, the
 coordinate conventions must match. Two-dimensional (2D) grayscale images
-(such as `camera` above) are indexed by rows and columns (abbreviated to
+(such as ``camera`` above) are indexed by rows and columns (abbreviated to
 either ``(row, col)`` or ``(r, c)``), with the lowest element ``(0, 0)``
 at the top-left corner. In various parts of the library, you will
 also see ``rr`` and ``cc`` refer to lists of row and column
@@ -184,29 +184,28 @@ argument.
 
 Many functions in ``scikit-image`` can operate on 3D images directly::
 
+    >>> import numpy as np
+    >>> import scipy as sp
+    >>> import skimage as ski
     >>> rng = np.random.default_rng()
     >>> im3d = rng.random((100, 1000, 1000))
-    >>> from skimage import morphology
-    >>> from scipy import ndimage as ndi
-    >>> seeds = ndi.label(im3d < 0.1)[0]
-    >>> ws = morphology.watershed(im3d, seeds)
+    >>> seeds = sp.ndimage.label(im3d < 0.1)[0]
+    >>> ws = ski.morphology.watershed(im3d, seeds)
 
 In many cases, however, the third spatial dimension has lower resolution
 than the other two. Some ``scikit-image`` functions provide a ``spacing``
 keyword argument to help handle this kind of data::
 
-    >>> from skimage import segmentation
-    >>> slics = segmentation.slic(im3d, spacing=[5, 1, 1], channel_axis=None)
+    >>> slics = ski.segmentation.slic(im3d, spacing=[5, 1, 1], channel_axis=None)
 
 Other times, the processing must be done plane-wise. When planes are stacked
 along the leading dimension (in agreement with our convention), the following
 syntax can be used::
 
-    >>> from skimage import filters
     >>> edges = np.empty_like(im3d)
     >>> for pln, image in enumerate(im3d):
     ...     # Iterate over the leading dimension
-    ...     edges[pln] = filters.sobel(image)
+    ...     edges[pln] = ski.filters.sobel(image)
 
 
 Notes on the order of array dimensions

--- a/doc/source/user_guide/plugins.rst
+++ b/doc/source/user_guide/plugins.rst
@@ -48,8 +48,8 @@ Any plugin in the ``_plugins`` directory is automatically examined by
 ``skimage.io`` upon import.  You may list all the plugins on your
 system::
 
-  >>> import skimage.io as io
-  >>> io.find_available_plugins()
+  >>> import skimage as ski
+  >>> ski.io.find_available_plugins()
   {'gtk': ['imshow'],
    'matplotlib': ['imshow', 'imread', 'imread_collection'],
    'pil': ['imread', 'imsave', 'imread_collection'],
@@ -57,27 +57,26 @@ system::
 
 or only those already loaded::
 
-  >>> io.find_available_plugins(loaded=True)
+  >>> ski.io.find_available_plugins(loaded=True)
   {'matplotlib': ['imshow', 'imread', 'imread_collection'],
    'pil': ['imread', 'imsave', 'imread_collection']}
 
 A plugin is loaded using the ``use_plugin`` command::
 
-  >>> import skimage.io as io
-  >>> io.use_plugin('pil') # Use all capabilities provided by PIL
+  >>> ski.io.use_plugin('pil') # Use all capabilities provided by PIL
 
 or
 
 ::
 
-  >>> io.use_plugin('pil', 'imread') # Use only the imread capability of PIL
+  >>> ski.io.use_plugin('pil', 'imread') # Use only the imread capability of PIL
 
 Note that, if more than one plugin provides certain functionality, the
 last plugin loaded is used.
 
 To query a plugin's capabilities, use ``plugin_info``::
 
-  >>> io.plugin_info('pil')
+  >>> ski.io.plugin_info('pil')
   >>>
   {'description': 'Image reading via the Python Imaging Library',
    'provides': 'imread, imsave'}

--- a/doc/source/user_guide/transforming_image_data.rst
+++ b/doc/source/user_guide/transforming_image_data.rst
@@ -48,10 +48,9 @@ Conversion from RGBA to RGB - Removing alpha channel through alpha blending
 Converting an RGBA image to an RGB image by alpha blending it with a
 background is realized with :func:`rgba2rgb` ::
 
-    >>> from skimage.color import rgba2rgb
-    >>> from skimage import data
-    >>> img_rgba = data.logo()
-    >>> img_rgb = rgba2rgb(img_rgba)
+    >>> import skimage as ski
+    >>> img_rgba = ski.data.logo()
+    >>> img_rgb = ski.color.rgba2rgb(img_rgba)
 
 Conversion between color and gray values
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -59,10 +58,8 @@ Conversion between color and gray values
 Converting an RGB image to a grayscale image is realized with
 :func:`rgb2gray` ::
 
-    >>> from skimage.color import rgb2gray
-    >>> from skimage import data
-    >>> img = data.astronaut()
-    >>> img_gray = rgb2gray(img)
+    >>> img = ski.data.astronaut()
+    >>> img_gray = ski.color.rgb2gray(img)
 
 :func:`rgb2gray` uses a non-uniform weighting of color channels, because of the
 different sensitivity of the human eye to different colors. Therefore,
@@ -71,10 +68,10 @@ such a weighting ensures `luminance preservation
 from RGB to grayscale::
 
     >>> red_pixel = np.array([[[255, 0, 0]]], dtype=np.uint8)
-    >>> color.rgb2gray(red_pixel)
+    >>> ski.color.rgb2gray(red_pixel)
     array([[ 0.2125]])
     >>> green_pixel = np.array([[[0, 255, 0]]], dtype=np.uint8)
-    >>> color.rgb2gray(green_pixel)
+    >>> ski.color.rgb2gray(green_pixel)
     array([[ 0.7154]])
 
 
@@ -90,9 +87,9 @@ difference of the maximum value of the data type and the actual value. For RGB
 images, the same operation is done for each channel. This operation can be achieved
 with :py:func:`skimage.util.invert`::
 
-    >>> from skimage import util
-    >>> img = data.camera()
-    >>> inverted_img = util.invert(img)
+    >>> import skimage as ski
+    >>> img = ski.data.camera()
+    >>> inverted_img = ski.util.invert(img)
 
 Painting images with labels
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -142,8 +139,10 @@ Other methods re-distribute pixel values according to the *histogram* of
 the image. The histogram of pixel values is computed with
 :func:`skimage.exposure.histogram`::
 
+    >>> import numpy as np
+    >>> import skimage as ski
     >>> image = np.array([[1, 3], [1, 1]])
-    >>> exposure.histogram(image)
+    >>> ski.exposure.histogram(image)
     (array([3, 0, 1]), array([1, 2, 3]))
 
 :func:`histogram` returns the number of pixels for each value bin, and
@@ -155,11 +154,11 @@ The simplest contrast enhancement :func:`rescale_intensity` consists in
 stretching pixel values to the whole allowed range, using a linear
 transformation::
 
-    >>> from skimage import exposure
-    >>> text = data.text()
+    >>> import skimage as ski
+    >>> text = ski.data.text()
     >>> text.min(), text.max()
     (10, 197)
-    >>> better_contrast = exposure.rescale_intensity(text)
+    >>> better_contrast = ski.exposure.rescale_intensity(text)
     >>> better_contrast.min(), better_contrast.max()
     (0, 255)
 
@@ -169,12 +168,11 @@ pixel values using percentiles of the image improves the contrast (at the
 expense of some loss of information, because some pixels are saturated by
 this operation)::
 
-    >>> moon = data.moon()
+    >>> moon = ski.data.moon()
     >>> v_min, v_max = np.percentile(moon, (0.2, 99.8))
     >>> v_min, v_max
     (10.0, 186.0)
-    >>> better_contrast = exposure.rescale_intensity(
-    ...                                     moon, in_range=(v_min, v_max))
+    >>> better_contrast = ski.exposure.rescale_intensity(moon, in_range=(v_min, v_max))
 
 The function :func:`equalize_hist` maps the cumulative distribution
 function (cdf) of pixel values onto a linear cdf, ensuring that all parts

--- a/doc/source/user_guide/tutorial_parallelization.rst
+++ b/doc/source/user_guide/tutorial_parallelization.rst
@@ -9,25 +9,31 @@ loops. Here is an example of such repetitive tasks:
 
 .. code-block:: python
 
-    from skimage import data, color, util
-    from skimage.restoration import denoise_tv_chambolle
-    from skimage.feature import hog
+    import skimage as ski
 
     def task(image):
         """
         Apply some functions and return an image.
         """
-        image = denoise_tv_chambolle(image[0][0], weight=0.1, channel_axis=-1)
-        fd, hog_image = hog(color.rgb2gray(image), orientations=8,
-                            pixels_per_cell=(16, 16), cells_per_block=(1, 1),
-                            visualize=True)
+        image = ski.restoration.denoise_tv_chambolle(
+            image[0][0], weight=0.1, channel_axis=-1
+        )
+        fd, hog_image = ski.feature.hog(
+            ski.color.rgb2gray(image),
+            orientations=8,
+            pixels_per_cell=(16, 16),
+            cells_per_block=(1, 1),
+            visualize=True
+        )
         return hog_image
 
 
     # Prepare images
-    hubble = data.hubble_deep_field()
+    hubble = ski.data.hubble_deep_field()
     width = 10
-    pics = util.view_as_windows(hubble, (width, hubble.shape[1], hubble.shape[2]), step=width)
+    pics = ski.util.view_as_windows(
+        hubble, (width, hubble.shape[1], hubble.shape[2]), step=width
+    )
 
 To call the function ``task`` on each element of the list ``pics``, it is
 usual to write a for loop. To measure the execution time of this loop, you can

--- a/doc/source/user_guide/tutorial_segmentation.rst
+++ b/doc/source/user_guide/tutorial_segmentation.rst
@@ -5,7 +5,7 @@ Image segmentation is the task of labeling the pixels of objects of
 interest in an image.
 
 In this tutorial, we will see how to segment objects from a background.
-We use the ``coins`` image from ``skimage.data``. This image shows
+We use the image from :func:`skimage.data.coins`. This image shows
 several coins outlined against a darker background. The segmentation of
 the coins cannot be done directly from the histogram of gray values,
 because the background shares enough gray levels with the coins that a
@@ -17,10 +17,9 @@ thresholding segmentation is not sufficient.
 
 ::
 
-    >>> from skimage import data
     >>> from skimage.exposure import histogram
-    >>> coins = data.coins()
-    >>> hist, hist_centers = histogram(coins)
+    >>> coins = ski.data.coins()
+    >>> hist, hist_centers = ski.exposure.histogram(coins)
 
 Simply thresholding the image leads either to missing significant parts
 of the coins, or to merging parts of the background with the
@@ -38,20 +37,19 @@ Edge-based segmentation
 
 Let us first try to detect edges that enclose the coins. For edge
 detection, we use the `Canny detector
-<https://en.wikipedia.org/wiki/Canny_edge_detector>`_ of ``skimage.feature.canny``
+<https://en.wikipedia.org/wiki/Canny_edge_detector>`_ of :func:`skimage.feature.canny`
 
 ::
 
-    >>> from skimage.feature import canny
-    >>> edges = canny(coins/255.)
+    >>> edges = ski.feature.canny(coins / 255.)
 
 As the background is very smooth, almost all edges are found at the
 boundary of the coins, or inside the coins.
 
 ::
 
-    >>> from scipy import ndimage as ndi
-    >>> fill_coins = ndi.binary_fill_holes(edges)
+    >>> import scipy as sp
+    >>> fill_coins = sp.ndimage.binary_fill_holes(edges)
 
 .. image:: ../auto_examples/applications/images/sphx_glr_plot_coins_segmentation_003.png
    :target: ../auto_examples/applications/plot_coins_segmentation.html
@@ -59,7 +57,7 @@ boundary of the coins, or inside the coins.
 
 Now that we have contours that delineate the outer boundary of the coins,
 we fill the inner part of the coins using the
-``ndi.binary_fill_holes`` function, which uses mathematical morphology
+:func:`scipy.ndimage.binary_fill_holes` function, which uses mathematical morphology
 to fill the holes.
 
 .. image:: ../auto_examples/applications/images/sphx_glr_plot_coins_segmentation_004.png
@@ -72,7 +70,7 @@ function to remove objects smaller than a small threshold.
 
 ::
 
-    >>> label_objects, nb_labels = ndi.label(fill_coins)
+    >>> label_objects, nb_labels = sp.ndimage..label(fill_coins)
     >>> sizes = np.bincount(label_objects.ravel())
     >>> mask_sizes = sizes > 20
     >>> mask_sizes[0] = 0
@@ -117,8 +115,7 @@ The choice of the elevation map is critical for good segmentation.
 Here, the amplitude of the gradient provides a good elevation map. We
 use the Sobel operator for computing the amplitude of the gradient::
 
-    >>> from skimage.filters import sobel
-    >>> elevation_map = sobel(coins)
+    >>> elevation_map = ski.filters.sobel(coins)
 
 From the 3-D surface plot shown below, we see that high barriers effectively
 separate the coins from the background.
@@ -145,8 +142,7 @@ extreme parts of the histogram of gray values::
 
 Let us now compute the watershed transform::
 
-    >>> from skimage.segmentation import watershed
-    >>> segmentation = watershed(elevation_map, markers)
+    >>> segmentation = ski.segmentation.watershed(elevation_map, markers)
 
 .. image:: ../auto_examples/applications/images/sphx_glr_plot_coins_segmentation_008.png
    :target: ../auto_examples/applications/plot_coins_segmentation.html
@@ -159,11 +155,11 @@ background.
 
 We remove a few small holes with mathematical morphology::
 
-    >>> segmentation = ndi.binary_fill_holes(segmentation - 1)
+    >>> segmentation = sp.ndimage.binary_fill_holes(segmentation - 1)
 
 We can now label all the coins one by one using ``ndi.label``::
 
-    >>> labeled_coins, _ = ndi.label(segmentation)
+    >>> labeled_coins, _ = sp.ndimage.label(segmentation)
 
 .. image:: ../auto_examples/applications/images/sphx_glr_plot_coins_segmentation_009.png
    :target: ../auto_examples/applications/plot_coins_segmentation.html

--- a/doc/source/user_guide/video.rst
+++ b/doc/source/user_guide/video.rst
@@ -62,6 +62,7 @@ PyAV's API reflects the way frames are stored in a video file.
 
 .. code-block:: python
 
+   import numpy as np
    for packet in container.demux():
        for frame in packet.decode():
            if frame.type == 'video':


### PR DESCRIPTION
## Description

As far as I'm aware the old approach was a limitation of our old import mechanism and namespace hierarchy. With the lazy loading added we no longer have do that and there are big advantages to the new way that make it worth it in my opinion:

- It makes the origin of a function, class, etc. very clear at the place where it is actually used.
- It doesn't pollute the current namespace with often generic and ambiguous terms as "data", "filters", "io", ... which are also prone to naming conflicts with similar libraries. E.g. label, is it from scikit-image or SciPy?
- For me it's also a nicer experience when developing or reading code, no need to jump between imports and code as I am adding new functionality from scikit-image.

See also the discussion in https://github.com/scikit-image/scikit-image/pull/6853#discussion_r1225260544

cc @mkcor  

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed
