### PR TITLE
[dev-tps-warping] Replace `_interpoint_distances` with SciPy's `cdist`

### DIFF
--- a/skimage/transform/_thin_plate_splines.py
+++ b/skimage/transform/_thin_plate_splines.py
@@ -1,5 +1,4 @@
 import numpy as np
-from scipy import ndimage
 import scipy as sp
 
 
@@ -52,7 +51,7 @@ def warp_images(
     """
     transform = _make_inverse_warp(from_points, to_points,
                                    output_region, approximate_grid)
-    return [ndimage.map_coordinates(np.asarray(image), transform, order=interpolation_order) for image in images]
+    return [sp.ndimage.map_coordinates(np.asarray(image), transform, order=interpolation_order) for image in images]
 
 
 def _make_inverse_warp(
@@ -107,7 +106,7 @@ def _U(x):
 def _make_L_matrix(points):
     n = len(points)
     P = np.hstack([np.ones((n, 1)), points])
-    K = _U(distance.cdist(points, points, metric='euclidean'))
+    K = _U(sp.spatial.distance.cdist(points, points, metric='euclidean'))
     O = np.zeros((3, 3))
     L = np.asarray(np.bmat([[K, P], [P.transpose(), O]]))
     return L
@@ -137,4 +136,5 @@ def _make_warp(from_points, to_points, x_vals, y_vals):
     x_warp = _calculate_f(coeffs[:, 0], from_points, x_vals, y_vals)
     y_warp = _calculate_f(coeffs[:, 1], from_points, x_vals, y_vals)
     np.seterr(**err)
+    return [x_warp, y_warp]
     return [x_warp, y_warp]

--- a/skimage/transform/_thin_plate_splines.py
+++ b/skimage/transform/_thin_plate_splines.py
@@ -97,11 +97,21 @@ def _make_inverse_warp(
     return transform
 
 
-
 def _U(x):
-    _small = 1e-100 # A small value to avoid division by zero
-    return (x**2) * np.where(x < _small, 0, np.log(x))
+    """Compute basis kernel function for thine-plate splines.
 
+    Parameters
+    ----------
+    x: ndarray
+        Input array representing the norm distance between points.
+        The norm is the Euclidean distance.
+    Returns
+    -------
+    ndarray
+        Calculated U values.
+    """
+    _small = 1e-8  # Small value to avoid divide-by-zero
+    return np.where(x == 0.0, 0.0, (x**2) * np.log((x**2) + _small))
 
 def _make_L_matrix(points):
     n = len(points)
@@ -136,5 +146,4 @@ def _make_warp(from_points, to_points, x_vals, y_vals):
     x_warp = _calculate_f(coeffs[:, 0], from_points, x_vals, y_vals)
     y_warp = _calculate_f(coeffs[:, 1], from_points, x_vals, y_vals)
     np.seterr(**err)
-    return [x_warp, y_warp]
     return [x_warp, y_warp]

--- a/skimage/transform/_thin_plate_splines.py
+++ b/skimage/transform/_thin_plate_splines.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy import ndimage
-from scipy.spatial import distance
+import scipy as sp
 
 
 def warp_images(

--- a/skimage/transform/_thin_plate_splines.py
+++ b/skimage/transform/_thin_plate_splines.py
@@ -210,12 +210,9 @@ def _calculate_f(coeffs, points, x, y):
 def _make_warp(from_points, to_points, x_vals, y_vals):
     from_points = np.asarray(from_points)
     to_points = np.asarray(to_points)
-    err = np.seterr(divide='ignore')
-    L = _make_L_matrix(from_points)
-    V = np.resize(to_points, (len(to_points)+3, 2))
-    V[-3:, :] = 0
-    coeffs = np.dot(np.linalg.pinv(L), V)
+    # err = np.seterr(divide='ignore')
+    coeffs = _coeffs(from_points, to_points)
     x_warp = _calculate_f(coeffs[:, 0], from_points, x_vals, y_vals)
     y_warp = _calculate_f(coeffs[:, 1], from_points, x_vals, y_vals)
-    np.seterr(**err)
+    # np.seterr(**err)
     return [x_warp, y_warp]

--- a/skimage/transform/_thin_plate_splines.py
+++ b/skimage/transform/_thin_plate_splines.py
@@ -121,7 +121,7 @@ def _make_L_matrix(points):
 
     Parameters
     ----------
-    points: (N, 2) shaped array_like
+    points : (N, 2) shaped array_like
         A (N, D) array of N landmarks in D=2 dimensions.
 
     Returns
@@ -164,15 +164,46 @@ def _coeffs(from_points, to_points):
 
 
 def _calculate_f(coeffs, points, x, y):
+    """Compute the thin-plate spline function at given coordinates (x, y).
+
+    Parameters:
+    ----------
+    coeffs : ndarray
+        Array of shape (N+3, 2) containing the thin-plate spline coefficients.
+    points : ndarray
+        Array of shape (N, 2) representing the source landmarks.
+    x : ndarray
+        Array representing the x-coordinates of the evaluation points.
+    y : ndarray
+        Array representing the y-coordinates of the evaluation points.
+
+    Returns:
+    -------
+    ndarray :
+        Array containing the computed thin-plate spline function values.
+
+    Notes:
+    -----
+    This function calculates the thin-plate spline function values at each
+    coordinate (x, y) everywhere in the plane.
+
+    The function is calculated as:
+
+    .. math::
+
+        f(x, y) = a1 + ax * x + ay * y + Σ(wi * U(|Pi - (x, y)|))
+
+        where:
+        - a1, ax, and ay are the last three coefficients in `coeffs`.
+        - wi represents the weights corresponding to each point Pi in `points`.
+        - U(r) is the basis kernel function.
+
+    """
     w = coeffs[:-3]
     a1, ax, ay = coeffs[-3:]
-    # The following uses too much RAM:
-    # distances = _U(np.sqrt((points[:,0]-x[...,np.newaxis])**2
-    # + (points[:,1]-y[...,np.newaxis])**2))
-    # summation = (w * distances).sum(axis=-1)
     summation = np.zeros(x.shape)
     for wi, Pi in zip(w, points):
-        summation += wi * _U(np.sqrt((x-Pi[0])**2 + (y-Pi[1])**2))
+        summation += wi * _U(np.sqrt((Pi[0]-x)**2 + (Pi[1]-y)**2))
     return a1 + ax*x + ay*y + summation
 
 

--- a/skimage/transform/_thin_plate_splines.py
+++ b/skimage/transform/_thin_plate_splines.py
@@ -138,6 +138,30 @@ def _make_L_matrix(points):
     L = np.asarray(np.bmat([[K, P], [P.transpose(), O]]))
     return L
 
+def _coeffs(from_points, to_points):
+    """Find the thin-plate spline coefficients.
+
+    Parameters
+    ----------
+    from_points : (N, 2) array_like
+        An array of N points representing the source landmark.
+
+    to_points : (N,2) array_like
+        An array of N points representing the target landmark.
+        `to_points` must have the same shape as `from_points`.
+
+    Returns
+    -------
+    coeffs : ndarray
+        Array of shape (N+3, 2) containing the calculated coefficients.
+
+    """
+    n_coords = from_points.shape[1]
+    Y = np.row_stack((to_points, np.zeros((n_coords+1, n_coords))))
+    L = _make_L_matrix(from_points)
+    coeffs = np.dot(np.linalg.pinv(L), Y)
+    return coeffs
+
 
 def _calculate_f(coeffs, points, x, y):
     w = coeffs[:-3]

--- a/skimage/transform/_thin_plate_splines.py
+++ b/skimage/transform/_thin_plate_splines.py
@@ -70,7 +70,7 @@ def _make_inverse_warp(
 
     if approximate_grid != 1:
         # linearly interpolate the zoomed transform grid
-        new_x, new_y = np.mgrid[x_min:x_max+1, y_min:y_max+1]
+        new_x, new_y = np.mgrid[x_min:x_max, y_min:y_max]
         x_fracs, x_indices = np.modf(
             (x_steps-1)*(new_x-x_min)/float(x_max-x_min))
         y_fracs, y_indices = np.modf(

--- a/skimage/transform/_thin_plate_splines.py
+++ b/skimage/transform/_thin_plate_splines.py
@@ -114,8 +114,25 @@ def _U(x):
     return np.where(x == 0.0, 0.0, (x**2) * np.log((x**2) + _small))
 
 def _make_L_matrix(points):
-    n = len(points)
-    P = np.hstack([np.ones((n, 1)), points])
+    """Define the L matrix based on the given points.
+
+    A (N+P+1, N+P+1)-shaped L matrix that gets inverted when calculating
+    the thin-plate spline from `points`.
+
+    Parameters
+    ----------
+    points: (N, 2) shaped array_like
+        A (N, D) array of N landmarks in D=2 dimensions.
+
+    Returns
+    -------
+    L : ndarray
+        A (N+D+1, N+D+1) shaped array of the form [[K | P][P.T | 0]].
+    """
+    if points.ndim != 2:
+        raise ValueError("The input `points` must be a 2-D tensor")
+    n_pts = points.shape[0]
+    P = np.hstack([np.ones((n_pts, 1)), points])
     K = _U(sp.spatial.distance.cdist(points, points, metric='euclidean'))
     O = np.zeros((3, 3))
     L = np.asarray(np.bmat([[K, P], [P.transpose(), O]]))

--- a/skimage/transform/_thin_plate_splines.py
+++ b/skimage/transform/_thin_plate_splines.py
@@ -120,28 +120,6 @@ def _make_inverse_warp(
         y_indices = np.clip(y_indices, 0, y_steps - 1)
 
 
-        # x_fracs, x_indices = np.modf(
-        #     (x_steps-1)*(new_x-x_min)/float(x_max-x_min))
-        # y_fracs, y_indices = np.modf(
-        #     (y_steps-1)*(new_y-y_min)/float(y_max-y_min))
-        # x_indices = x_indices.astype(int)
-        # y_indices = y_indices.astype(int)
-        # x1 = 1 - x_fracs
-        # y1 = 1 - y_fracs
-        # ix1 = (x_indices+1).clip(0, x_steps-1)
-        # iy1 = (y_indices+1).clip(0, y_steps-1)
-        # t00 = transform[0][(x_indices, y_indices)]
-        # t01 = transform[0][(x_indices, iy1)]
-        # t10 = transform[0][(ix1, y_indices)]
-        # t11 = transform[0][(ix1, iy1)]
-        # transform_x = (t00*x1*y1 + t01*x1*y_fracs
-        #                + t10*x_fracs*y1 + t11*x_fracs*y_fracs)
-        # t00 = transform[1][(x_indices, y_indices)]
-        # t01 = transform[1][(x_indices, iy1)]
-        # t10 = transform[1][(ix1, y_indices)]
-        # t11 = transform[1][(ix1, iy1)]
-        # transform_y = (t00*x1*y1 + t01*x1*y_fracs
-        #                + t10*x_fracs*y1 + t11*x_fracs*y_fracs)
 
         transform_x = sp.ndimage.map_coordinates(transform[0], [x_indices, y_indices])
         transform_y = sp.ndimage.map_coordinates(transform[1], [x_indices, y_indices])


### PR DESCRIPTION
## Description
Replace `_interpoint_distances` function with built in `distance.cdist` function from Scipy spatial module.

@ana42742 @lagru  Please review this improvements??
<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed
