### PR TITLE
Avoid deprecated auto-removal of overlapping axes in thresholding example

### DIFF
--- a/doc/examples/applications/plot_thresholding_guide.py
+++ b/doc/examples/applications/plot_thresholding_guide.py
@@ -113,16 +113,12 @@ plt.show()
 
 from skimage.filters import threshold_otsu
 
-
 image = data.camera()
 thresh = threshold_otsu(image)
 binary = image > thresh
 
-fig, axes = plt.subplots(ncols=3, figsize=(8, 2.5))
-ax = axes.ravel()
-ax[0] = plt.subplot(1, 3, 1)
-ax[1] = plt.subplot(1, 3, 2)
-ax[2] = plt.subplot(1, 3, 3, sharex=ax[0], sharey=ax[0])
+fig, ax = plt.subplots(ncols=3, figsize=(8, 2.5))
+
 
 ax[0].imshow(image, cmap=plt.cm.gray)
 ax[0].set_title('Original')


### PR DESCRIPTION
## Description

Closes https://github.com/scikit-image/scikit-image/issues/6640.

This avoids the following warning. I think forcing a shared x and y axis explicitly is not really necessary as `image` and `binary` have the same shape anyway.
```
MatplotlibDeprecationWarning:

Auto-removal of overlapping axes is deprecated since 3.6 and will be removed two minor releases later; explicitly call ax.remove() as needed.
```
## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed
