### PR TITLE
DOC: fix ridge detection docstrings.

### DIFF
--- a/skimage/filters/ridges.py
+++ b/skimage/filters/ridges.py
@@ -104,7 +104,7 @@ def meijering(image, sigmas=range(1, 10, 2), alpha=None,
     wrinkles, rivers. It can be used to calculate the fraction of the
     whole image containing such objects.
 
-    Calculates the eigenvectors of the Hessian to compute the similarity of
+    Calculates the eigenvalues of the Hessian to compute the similarity of
     an image region to neurites, according to the method described in [1]_.
 
     Parameters
@@ -185,7 +185,7 @@ def sato(image, sigmas=range(1, 10, 2), black_ridges=True,
     wrinkles, rivers. It can be used to calculate the fraction of the
     whole image containing such objects.
 
-    Defined only for 2-D and 3-D images. Calculates the eigenvectors of the
+    Defined only for 2-D and 3-D images. Calculates the eigenvalues of the
     Hessian to compute the similarity of an image region to tubes, according to
     the method described in [1]_.
 
@@ -256,7 +256,7 @@ def frangi(image, sigmas=range(1, 10, 2), scale_range=None,
     wrinkles, rivers. It can be used to calculate the fraction of the
     whole image containing such objects.
 
-    Defined only for 2-D and 3-D images. Calculates the eigenvectors of the
+    Defined only for 2-D and 3-D images. Calculates the eigenvalues of the
     Hessian to compute the similarity of an image region to vessels, according
     to the method described in [1]_.
 


### PR DESCRIPTION
The ridge detectors use the hessian eigenvalues, not the eigenvectors.

## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed
