### PR TITLE
Add num_pixels and coords_scaled to regionprops_table

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ optional = [
 test = [
     'asv',
     'matplotlib>=3.5',
+    'numpydoc>=1.5',
     'pooch>=1.6.0',
     'pytest>=7.0',
     'pytest-cov>=2.11.0',

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,6 @@
 asv
 matplotlib>=3.5
+numpydoc>=1.5
 pooch>=1.6.0
 pytest>=7.0
 pytest-cov>=2.11.0

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -1097,8 +1097,6 @@ def regionprops(label_image, intensity_image=None, cache=True,
     -----
     The following properties can be accessed as attributes or keys:
 
-    **num_pixels** : int
-        Number of foreground pixels.
     **area** : float
         Area of the region i.e. number of pixels of the region scaled by pixel-area.
     **area_bbox** : float
@@ -1220,6 +1218,8 @@ def regionprops(label_image, intensity_image=None, cache=True,
             wnu_ij = wmu_ij / wm_00^[(i+j)/2 + 1]
 
         where ``wm_00`` is the zeroth spatial moment (intensity-weighted area).
+    **num_pixels** : int
+        Number of foreground pixels.
     **orientation** : float
         Angle between the 0th axis (rows) and the major
         axis of the ellipse that has the same second moments as the region,

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -125,6 +125,7 @@ COL_DTYPES = {
     'moments_weighted_central': float,
     'moments_weighted_hu': float,
     'moments_weighted_normalized': float,
+    'num_pixels': int,
     'orientation': float,
     'perimeter': float,
     'perimeter_crofton': float,

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -102,6 +102,7 @@ COL_DTYPES = {
     'centroid_weighted': float,
     'centroid_weighted_local': float,
     'coords': object,
+    'coords_scaled': object,
     'eccentricity': float,
     'equivalent_diameter_area': float,
     'euler_number': int,

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -1234,10 +1234,6 @@ def test_regionprops_table_no_regions():
     assert len(out['bbox+3']) == 0
 
 
-def test_column_dtypes_complete():
-    assert set(COL_DTYPES.keys()).union(OBJECT_COLUMNS) == set(PROPS.values())
-
-
 def test_column_dtypes_correct():
     msg = 'mismatch with expected type,'
     region = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE)[0]

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -1,8 +1,10 @@
 import math
 
+import re
 import numpy as np
 import pytest
 import scipy.ndimage as ndi
+import numpydoc
 from numpy.testing import (assert_allclose, assert_almost_equal,
                            assert_array_almost_equal, assert_array_equal,
                            assert_equal)
@@ -1260,6 +1262,17 @@ def test_column_dtypes_correct():
             assert False, (
                 f'{col} dtype {t} {msg} {COL_DTYPES[col]}'
             )
+
+
+def test_all_documented_items_in_col_dtypes():
+    docstring = numpydoc.docscrape.FunctionDoc(regionprops)
+    notes_lines = docstring['Notes']
+    property_lines = filter(lambda line: line.startswith('**'), notes_lines)
+    pattern = r'\*\*(?P<property_name>[a-z_]+)\*\*.*'
+    property_names = {re.search(pattern, property_line).group('property_name')
+                      for property_line in property_lines}
+    column_keys = set(COL_DTYPES.keys())
+    assert column_keys == property_names
 
 
 def pixelcount(regionmask):


### PR DESCRIPTION
Fixes #7038

This PR makes the following changes:
- Add num_pixels to COL_DTYPES list
- Move num_pixels documentation to maintain alphabetical order
- Add test checking all documented regionprops are compatible with regionprops_table
- Add missing feature coords_scaled in regionprops_table
- Remove outdated test for complete COL_DTYPES

The last test was outdated because it checked against the PROPS
dictionary. This is not a good check because only deprecated properties
go in that dictionary. Newly-added properties don't need to be added
to the dictionary, which means that they had to be added only to pass
that test, which isn't great. The new test checks against the
documented properties, which will ensure at least that *if* a property
is documented, it is actually usable by regionprops_table.
