### PR TITLE
Mark NaN-related deprecation warning from `np.clip` as optional in tests

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -39,3 +39,6 @@ Other (2022)
 * Remove warningsfilter for imageio and Pillow once
   https://github.com/python-pillow/Pillow/pull/7125 is shipped in the minimal required
   version of pillow (probably the release after Pillow 9.5.0).
+* NumPy 1.25.0 is minimal required version:
+    * Remove optional test for a NaN-related deprecation warning from numpy.clip in
+      skimage/exposure/tests/test_exposure.py::test_rescale_nan_warning

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -368,19 +368,16 @@ def test_rescale_nan_warning(in_range, out_range):
     )
 
     # 2019/11/10 Passing NaN to np.clip raises a DeprecationWarning for
-    # versions above 1.17
-    # TODO: Remove once NumPy removes this DeprecationWarning
+    # versions above 1.17, "|\A\Z" marks as optional warning
+    # TODO: Remove once NumPy 1.25.0 is minimal dependency
     numpy_warning_1_17_plus = (
-        "Passing `np.nan` to mean no clipping in np.clip"
+        "|\\A\\ZPassing `np.nan` to mean no clipping in np.clip"
     )
 
-    if in_range == "image":
-        exp_warn = [msg, numpy_warning_1_17_plus]
-    else:
-        exp_warn = [msg]
+    with expected_warnings([msg, numpy_warning_1_17_plus]):
+        result = exposure.rescale_intensity(image, in_range, out_range)
 
-    with expected_warnings(exp_warn):
-        exposure.rescale_intensity(image, in_range, out_range)
+    assert np.all(np.isnan(result))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Should address one of the failures in https://github.com/scikit-image/scikit-image/issues/7042.

We already have our own warning that informs users and this deprecation didn't really effect the behavior of rescale_intensity. So, mark the warning as optional until we can remove it. No need for matching the NumPy version number here.

@jarrodmillman, there doesn't seem to be a way yet to trigger the nightly wheel builder workflow for pull requests. True?

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
