### PR TITLE
Ignore new matplotlib warning

### DIFF
--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -281,6 +281,13 @@ def setup_test():
         )
 
 
+        warnings.filterwarnings(
+            "default",
+            message=("The figure layout has changed to tight"),
+            category=UserWarning,
+        )
+
+
 def teardown_test():
     """Default package level teardown routine for skimage tests.
 


### PR DESCRIPTION
mpl 3.7.2 (Jul 5, 2023) added this warning and now main and new PRs fail with `--pre`.

For example, https://github.com/scikit-image/scikit-image/actions/runs/5485938621/jobs/9995373989

## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
