### PR TITLE
Ignore SciPy 1.12.dev0 deprecation warning

### DIFF
--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -280,6 +280,17 @@ def setup_test():
             category=UserWarning,
         )
 
+        # Temporary warning raised by scipy. May be removed when scipy 1.12 is
+        # minimum supported version and we replace tol with rtol
+        warnings.filterwarnings(
+            "default",
+            message=(
+                "'scipy.sparse.linalg.cg' keyword argument 'tol' is deprecated in "
+                "favor of 'rtol' and will be removed in SciPy v.1.14.0."
+            ),
+            category=DeprecationWarning,
+        )
+
 
         warnings.filterwarnings(
             "default",


### PR DESCRIPTION
Close #7053 .

See
- https://github.com/scipy/scipy/pull/18488
- https://github.com/scipy/scipy/pull/18723