### PR TITLE
Fix zero division error in SIFT

### DIFF
--- a/skimage/feature/sift.py
+++ b/skimage/feature/sift.py
@@ -429,7 +429,7 @@ class SIFT(FeatureDetector, DescriptorExtractor):
 
     def _fit(self, h):
         """Refine the position of the peak by fitting it to a parabola"""
-        return (h[0] - h[2]) / (2 * (h[0] + h[2] - 2 * h[1]))
+        return (h[0] - h[2]) / (2 * ((h[0] - h[1]) + (h[2] - h[1])))
 
     def _compute_orientation(self, positions_oct, scales_oct, sigmas_oct,
                              octaves, gaussian_scalespace):
@@ -519,6 +519,8 @@ class SIFT(FeatureDetector, DescriptorExtractor):
                     # result
                     ori = ((m + self._fit(hist[neigh]) + 0.5)
                            * 2 * np.pi / self.n_bins)
+                    if not np.isfinite(ori):
+                        continue
                     if ori > np.pi:
                         ori -= 2 * np.pi
                     if c == 0:


### PR DESCRIPTION
## Description

I encountered a zero division error in SIFT computation due to numerical precision.
```
(h[0] - h[2]) / (2 * (h[0] + h[2] - 2 * h[1]))
```
I encountered a case where `h[0]` is slightly smaller than `h[1]` but `h[1]` and `h[2]` is exactly the same. Arithmetically, the divisor should not become zero, but it became exactly zero due to numerical precision. 

From the perspective of the algorithm, `h[1]` and `h[2]` should not become exactly the same, but I didn't resolve it here because it wouldn't affect the performance of algorithm.

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Release note
```release-note
Fix zero division error in SIFT.
```
