### PR TITLE
Add dev container config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+# Can sub out for any other docker image with necessary python version
+FROM mcr.microsoft.com/devcontainers/python
+
+# [Optional] Uncomment this section to install additional OS packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends build-essential

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+	"name": "scikit-image devcontainer",
+	"build": {
+		"context": "..",
+		"dockerfile": "Dockerfile"
+	},
+	"features": {
+		"ghcr.io/devcontainers-contrib/features/pre-commit:2": {}
+	},
+	"postCreateCommand": "pre-commit install && bash ./.devcontainer/postBuild",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"ms-toolsai.jupyter",
+				"donjayamanne.python-environment-manager"
+			],
+			"settings": {
+				"python.defaultInterpreterPath": "/home/vscode/envs/skimage-dev/bin"
+			}
+		}
+	}
+}

--- a/.devcontainer/postBuild
+++ b/.devcontainer/postBuild
@@ -1,0 +1,17 @@
+# Create a virtualenv named ``skimage-dev`` that lives outside of the repository.
+# One common convention is to place it inside an ``envs`` directory under your home directory:
+mkdir ~/envs
+python -m venv ~/envs/skimage-dev
+# Activate it
+source ~/envs/skimage-dev/bin/activate
+# Install main development and runtime dependencies
+pip install -r requirements.txt
+# Install build dependencies of scikit-image
+pip install -r requirements/build.txt
+pip install -r requirements/docs.txt
+# Build scikit-image from source
+spin build
+# Test your installation
+spin test
+# Build docs
+spin docs


### PR DESCRIPTION
## Adding config for scikit-image for the open spec, [Development Containers](https://containers.dev/), which allows tools like [VS Code](https://containers.dev/supporting#visual-studio-code), [Codespaces](https://github.com/features/codespaces), [JetBrains tools](https://plugins.jetbrains.com/plugin/21962-dev-containers), DevPod, and hopefully more soon ([GitPod?]())

_initially drafted this at SciPy 2023 sprints with @lagru <3_

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

✅ A descriptive but concise pull request title
✅ [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
✅ [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
✅ A gallery example in `./doc/examples` for new features
✅ [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Added configuration files for tools that support the [Dev Container spec](https://containers.dev/). Makes it easier for contributors and maintainers to ensure reproducable workspaces.
```
