### PR TITLE
Include py.typed file in distribution (PEP 561)

### DIFF
--- a/skimage/meson.build
+++ b/skimage/meson.build
@@ -112,7 +112,8 @@ numpy_nodepr_api = '-DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION'
 python_sources = [
   '__init__.py',
   '__init__.pyi',
-  'conftest.py'
+  'conftest.py',
+  'py.typed'
 ]
 
 py3.install_sources(


### PR DESCRIPTION
## Description

In order for the `.pyi` files to be useful,  scikit-image needs to include a `py.typed` file in top level module of the distribution.

See [PEP 561](https://peps.python.org/pep-0561/) and the [mypy documentation](https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages) for more information.

currently, when using scikit-image in an IDE, you get:
<img width="389" alt="Screen Shot 2023-07-21 at 7 48 08 PM" src="https://github.com/tlambert03/scikit-image/assets/1609449/32ac72f7-56b8-401b-9439-37ebeab98d04">

if you drop `py.typed` file in the skimage folder of site-packages you get:

<img width="702" alt="Screen Shot 2023-07-21 at 7 48 44 PM" src="https://github.com/tlambert03/scikit-image/assets/1609449/8797bbad-27bc-4f97-a112-dfdae6aa87e1">
