### PR TITLE
Avoid unnecessary padding in `skimage.measure.block_resize`

### DIFF
--- a/skimage/measure/block.py
+++ b/skimage/measure/block.py
@@ -81,8 +81,9 @@ def block_reduce(image, block_size=2, func=np.sum, cval=0, func_kwargs=None):
             after_width = 0
         pad_width.append((0, after_width))
 
-    image = np.pad(image, pad_width=pad_width, mode='constant',
-                   constant_values=cval)
+    if np.any(np.asarray(pad_width)):
+        image = np.pad(image, pad_width=pad_width, mode='constant',
+                       constant_values=cval)
 
     blocked = view_as_blocks(image, block_size)
 


### PR DESCRIPTION
## Description

`skimage.measure.block_resize()` is very useful for reducing large arrays.
In many cases, the original array and the reduced array are even (ex: 1024x1024 -> 512x512) which not requires any padding.
However, padding is systematically done regardless the values of `pad_width`.
Since `numpy.pad()` returns a new array, CPU time and RAM are required for this, which can be (very) penalizing when working with big arrays.
this PR aims at reducing this cost when padding is not necessary (pad_width = 0).
The present PR does not affect the tests.


## Discussion

Personally I would be for not doing padding by default. 
Padding should be in my opinion a voluntary choice for the user by setting the padding conditions (cval) in conscience and being ready to pay the price for this :)
This could be obtained by replacing `cval=0` into `cval=None` in the kwargs function, changing the current PR to:
`if np.any(np.asarray(pad_width)) and cval is not None:`
and commenting out the assertion [here](https://github.com/scikit-image/scikit-image/tree/main/skimage/util/shape.py#L85)
Such a change would affect the tests .. and certainly more !
 
