### PR TITLE
For uniform intensity images, return intensity value as threshold

### DIFF
--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -570,6 +570,8 @@ def test_mean():
 
 
 def test_triangle_uint_images():
+    assert(threshold_triangle(np.zeros((10, 10), dtype='uint8')) == 0)
+    assert(threshold_triangle(np.zeros((10, 10))) == 0.0)
     assert(threshold_triangle(np.invert(data.text())) == 151)
     assert(threshold_triangle(data.text()) == 104)
     assert(threshold_triangle(data.coins()) == 80)

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -570,9 +570,9 @@ def test_mean():
 
 @pytest.mark.parametrize("dtype", [np.uint8, np.int16, np.float16, np.float32])
 def test_traingle_uniform_images(dtype):
-    assert(threshold_triangle(np.zeros((10, 10), dtype=dtype)) == 0)
-    assert(threshold_triangle(np.ones((10, 10), dtype=dtype)) == 1)
-    assert(threshold_triangle(np.full((10, 10), 2, dtype=dtype)) == 2)
+    assert threshold_triangle(np.zeros((10, 10), dtype=dtype)) == 0
+    assert threshold_triangle(np.ones((10, 10), dtype=dtype)) == 1
+    assert threshold_triangle(np.full((10, 10), 2, dtype=dtype)) == 2
 
 def test_triangle_uint_images():
     assert(threshold_triangle(np.invert(data.text())) == 151)

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -569,7 +569,7 @@ def test_mean():
     assert(threshold_mean(img) == 1.)
 
 @pytest.mark.parametrize("dtype", [np.uint8, np.int16, np.float16, np.float32])
-def test_traingle_uniform_images(dtype):
+def test_triangle_uniform_images(dtype):
     assert threshold_triangle(np.zeros((10, 10), dtype=dtype)) == 0
     assert threshold_triangle(np.ones((10, 10), dtype=dtype)) == 1
     assert threshold_triangle(np.full((10, 10), 2, dtype=dtype)) == 2

--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -568,10 +568,13 @@ def test_mean():
     img[:, 4:] = 2
     assert(threshold_mean(img) == 1.)
 
+@pytest.mark.parametrize("dtype", [np.uint8, np.int16, np.float16, np.float32])
+def test_traingle_uniform_images(dtype):
+    assert(threshold_triangle(np.zeros((10, 10), dtype=dtype)) == 0)
+    assert(threshold_triangle(np.ones((10, 10), dtype=dtype)) == 1)
+    assert(threshold_triangle(np.full((10, 10), 2, dtype=dtype)) == 2)
 
 def test_triangle_uint_images():
-    assert(threshold_triangle(np.zeros((10, 10), dtype='uint8')) == 0)
-    assert(threshold_triangle(np.zeros((10, 10))) == 0.0)
     assert(threshold_triangle(np.invert(data.text())) == 151)
     assert(threshold_triangle(data.text()) == 104)
     assert(threshold_triangle(data.coins()) == 80)

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -927,22 +927,20 @@ def threshold_triangle(image, nbins=256):
     >>> thresh = threshold_triangle(image)
     >>> binary = image > thresh
     """
-    # Check if the image has more than one intensity value; if not, return that
-    # value
-    if image is not None:
-        first_pixel = image.reshape(-1)[0]
-        if np.all(image == first_pixel):
-            return first_pixel
-    # nbins is ignored for integer arrays
-    # so, we recalculate the effective nbins.
     hist, bin_centers = histogram(image.reshape(-1), nbins,
                                   source_range='image')
+    # nbins is ignored for integer arrays
+    # so, we recalculate the effective nbins.
     nbins = len(hist)
 
     # Find peak, lowest and highest gray levels.
     arg_peak_height = np.argmax(hist)
     peak_height = hist[arg_peak_height]
     arg_low_level, arg_high_level = np.flatnonzero(hist)[[0, -1]]
+
+    if arg_low_level == arg_high_level:
+        # Image has constant intensity.
+        return image.ravel()[0]
 
     # Flip is True if left tail is shorter.
     flip = arg_peak_height - arg_low_level < arg_high_level - arg_peak_height

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -927,6 +927,12 @@ def threshold_triangle(image, nbins=256):
     >>> thresh = threshold_triangle(image)
     >>> binary = image > thresh
     """
+    # Check if the image has more than one intensity value; if not, return that
+    # value
+    if image is not None:
+        first_pixel = image.reshape(-1)[0]
+        if np.all(image == first_pixel):
+            return first_pixel
     # nbins is ignored for integer arrays
     # so, we recalculate the effective nbins.
     hist, bin_centers = histogram(image.reshape(-1), nbins,

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -927,10 +927,10 @@ def threshold_triangle(image, nbins=256):
     >>> thresh = threshold_triangle(image)
     >>> binary = image > thresh
     """
-    hist, bin_centers = histogram(image.reshape(-1), nbins,
-                                  source_range='image')
     # nbins is ignored for integer arrays
     # so, we recalculate the effective nbins.
+    hist, bin_centers = histogram(image.reshape(-1), nbins,
+                                  source_range='image')
     nbins = len(hist)
 
     # Find peak, lowest and highest gray levels.


### PR DESCRIPTION
## Description
When uniform intensity/pixel images are passed to the `skimage.filters.threshold_triangle` it raises an exception with an unclear error message.

This PR adds a check; if the image has more than one intensity value; if not, return that value as the threshold.

Closes #7091

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
