### PR TITLE
update EuclideanTransform documentation to clarify order of dimensions

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1197,6 +1197,12 @@ class EuclideanTransform(ProjectiveTransform):
     translation parameters. The similarity transformation extends the Euclidean
     transformation with a single scaling factor.
 
+    In 2D and 3D, the transformation parameters can be given as the homogeneous
+    transformation matrix, above, or as the implicit parameters, rotation and
+    translation in x (a1) and y (b1). Beyond 3D, translation can be specified
+    using the implicit parameter (again, in x (a1), y (b1), etc.), otherwise,
+    only the matrix form is allowed.
+
     Parameters
     ----------
     matrix : (D+1, D+1) array_like, optional
@@ -1208,7 +1214,7 @@ class EuclideanTransform(ProjectiveTransform):
         higher dimensions, you must provide or estimate the transformation
         matrix.
     translation : sequence of float, length D, optional
-        Translation parameters for each axis.
+        x, y[, z, ...] translation parameters.
     dimensionality : int, optional
         The dimensionality of the transform.
 


### PR DESCRIPTION
## Description

I find the current [documentation](https://github.com/scikit-image/scikit-image/blob/481e8b8dd676c3f0adbd31aa14f7348466f1201d/skimage/transform/_geometric.py#L1179) for the implicit translation parameter of skimage.transform.EuclideanTransform to be confusing with respect to the order of the dimensions. It currently says, "Translation parameters for each axis", but that to me suggests row, col, etc. a la numpy matrix ordering. Additionally, skimage typically uses y,x order (e.g., [skimage.transform.rotate](https://github.com/scikit-image/scikit-image/blob/481e8b8dd676c3f0adbd31aa14f7348466f1201d/skimage/transform/_warps.py#L312)). Finally, AffineTransform and SimilarityTransform are clearer about the order of the dimensions. Based on that, I updated the EuclideanTranform documentation.


## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
update EuclideanTransform documentation to clarify order of dimensions
```
