### PR TITLE
Update to LLVM 16 with choco temporarily

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,6 +103,11 @@ jobs:
               export CXXFLAGS="-m32"
           fi
 
+          # Install llvm 16 manually, remove after
+          # https://github.com/actions/runner-images/issues/8125 is resolved and that
+          # version is included in the image by default
+          choco install llvm
+
           ## To list all installed packages:
           # choco list --localonly
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,7 +106,7 @@ jobs:
           # Install llvm 16 manually, remove after
           # https://github.com/actions/runner-images/issues/8125 is resolved and that
           # version is included in the image by default
-          choco install llvm
+          choco upgrade llvm
 
           ## To list all installed packages:
           # choco list --localonly


### PR DESCRIPTION
## Description

This is a "manual" and temporary fix until version 16 is included in the image "windows-latest" by default. For more see
https://github.com/scikit-image/scikit-image/issues/7108 and https://github.com/actions/runner-images/issues/8125.


<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
