### PR TITLE
Add bin splitting to `filters.rank.percentile_mean`

### DIFF
--- a/skimage/filters/rank/_percentile.py
+++ b/skimage/filters/rank/_percentile.py
@@ -122,7 +122,7 @@ def gradient_percentile(image, footprint, out=None, mask=None, shift_x=False,
 
 def mean_percentile(image, footprint, out=None, mask=None, shift_x=False,
                     shift_y=False, p0=0, p1=1):
-    """Return local mean of an image.
+    """Return local mean of an image exlcuding outer percentiles in kernel.
 
     Only grayvalues between percentiles [p0, p1] are considered in the filter.
 
@@ -154,7 +154,9 @@ def mean_percentile(image, footprint, out=None, mask=None, shift_x=False,
     The algorithm is defined as follows:
 
     1. Determine the local neighborhood and sort by value.
-    2. Drop values below percentile given by p0 and above percentile given by p1.
+    2. Drop values below percentile given by p0 and above percentile given by p1. The
+       interval is inclusive, e.g. ``p0=0`` and ``p0=0.1`` behave the same for a kernel
+       size of 10.
     3. Calculate the arithmetic mean and drop the remainder (for backwards compability).
 
     Note that the actual implementation differs for performance reasons.

--- a/skimage/filters/rank/_percentile.py
+++ b/skimage/filters/rank/_percentile.py
@@ -149,8 +149,33 @@ def mean_percentile(image, footprint, out=None, mask=None, shift_x=False,
     out : 2-D array (same dtype as input image)
         Output image.
 
-    """
+    Notes
+    -----
+    The algorithm is defined as follows:
 
+    1. Determine the local neighborhood and sort by value.
+    2. Drop values below percentile given by p0 and above percentile given by p1.
+    3. Calculate the arithmetic mean and drop the remainder (for backwards compability).
+
+    Note that the actual implementation differs for performance reasons.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import skimage as ski
+    >>> image = np.array([[0, 1, 2],
+    ...                   [3, 4, 5],
+    ...                   [6, 7, 8]], dtype=np.uint8)
+    >>> fp = np.ones((3, 3), dtype=bool)
+    >>> ski.filters.rank.mean_percentile(image, footprint=fp, p0=0.25, p1=0.75)
+    array([[2, 2, 3],
+           [3, 4, 4],
+           [5, 5, 6]], dtype=uint8)
+    """
+    if not 0. <= p0 < p1 <= 1.:
+        raise ValueError(
+            f"Percentile interval doesn't satisfy 0 <= p0 < p1 <= 1, was [{p0}, {p1}]"
+        )
     return _apply(percentile_cy._mean,
                   image, footprint, out=out, mask=mask, shift_x=shift_x,
                   shift_y=shift_y, p0=p0, p1=p1)

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -887,3 +887,34 @@ class TestRank:
         elem = np.ones((3, 3), dtype=bool)
         with pytest.raises(ValueError):
             rank.maximum(image=image, footprint=elem)
+
+    @pytest.mark.parametrize("p0,p1", [(0.5, 0.5), (0.6, 0.4), (-1, 1), (0, 2)])
+    def test_percentile_mean_invalid(self, p0, p1):
+        image = np.ones((9, 9), dtype=np.uint8)
+        fp = np.ones((3, 3), dtype=bool)
+        with pytest.raises(ValueError, match="Percentile interval doesn't satisfy"):
+            rank.mean_percentile(image, footprint=fp, p0=p0, p1=p1)
+
+    @pytest.mark.parametrize("dtype", [np.uint8, np.uint16])
+    def test_percentile_mean_handcrafted(self, dtype):
+        image = np.array([[0, 1, 2],
+                          [3, 4, 5],
+                          [6, 7, 8]], dtype=dtype)
+        fp = np.ones((3, 3), dtype=bool)
+        result = rank.mean_percentile(image, footprint=fp, p0=0.25, p1=0.75)
+        desired = np.array([[2, 2, 3],
+                            [3, 4, 4],
+                            [5, 5, 6]], dtype=dtype)
+        np.testing.assert_equal(result, desired)
+
+    @pytest.mark.parametrize("dtype", [np.uint8, np.uint16])
+    def test_percentile_mean_pr7096(self, dtype):
+        image = np.array([[0, 0, 0],
+                          [0, 1, 1],
+                          [1, 1, 1]], dtype=dtype)
+        fp = np.ones((3, 3), dtype=bool)
+        result = rank.mean_percentile(image, footprint=fp, p0=0.25, p1=0.75)
+        desired = np.array([[0, 0, 0],
+                            [0, 0, 0],
+                            [1, 1, 1]], dtype=dtype)
+        np.testing.assert_equal(result, desired)


### PR DESCRIPTION
## Description

Fixes #7096.

The algorithm works by summing bins of a histogram of the surrounding neighborhood together while skipping bins outside the defined percentile. However, the previous implementation would only deal with complete bins leading to unexpected behavior when according to the given percentile, a part of a bin should factor into the mean. The new implementation fixes this problem, while increasing performance such that it is on par with `rank.mean` for most tested scenarios.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
