### PR TITLE
Fix color conversion error

### DIFF
--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -1179,7 +1179,10 @@ def _lab2xyz(lab, illuminant, observer):
     n_invalid = invalid[0].size
     if n_invalid != 0:
         # Warning should be emitted by caller
-        z[invalid] = 0
+        if z.ndim > 0:
+            z[invalid] = 0
+        else:
+            z = 0
 
     out = np.stack([x, y, z], axis=-1)
 


### PR DESCRIPTION
## Description
```py
ski.color.lab2rgb([0, 0,  28.0])
```

raises a `TypeError: 'numpy.float64' object does not support item assignment` 
while 
```py
ski.color.lab2rgb([0, 0,  27.0])
# and
ski.color.lab2rgb([[0, 0,  28.0]])
```
doesn't. 
This inconsistent behaviour was reported as a bug #7105.

This PR insures that `z` is always an array that can be assigned to.

Closes #7105

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
