### PR TITLE
MNT: Remove np.float_ alias; it is removed in NumPy 2.0

### DIFF
--- a/skimage/util/dtype.py
+++ b/skimage/util/dtype.py
@@ -27,7 +27,6 @@ _integer_ranges = {t: (np.iinfo(t).min, np.iinfo(t).max)
 dtype_range = {bool: (False, True),
                np.bool_: (False, True),
                float: (-1, 1),
-               np.float_: (-1, 1),
                np.float16: (-1, 1),
                np.float32: (-1, 1),
                np.float64: (-1, 1)}


### PR DESCRIPTION
## Description

Importing `scikit-image` in an environment with `numpy 2.0dev` gives an `AttributeError`:

```
AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.. Did you mean: 'float16'?
```

xref: https://github.com/numpy/numpy/pull/24376

This PR removes the usage of the `np.float_` alias.  It's the same as `np.float64`.
```python
>>> np.float_ is np.float64
True
```


<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
