### PR TITLE
Update minimum sklearn (SPEC 0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ docs = [
     'ipykernel',  # needed until https://github.com/jupyter-widgets/ipywidgets/issues/3731 is resolved
     'plotly>=5.10',
     'kaleido',
-    'scikit-learn>=0.24.0',
+    'scikit-learn>=1.1',
     'sphinx_design>=0.3',
     'pydata-sphinx-theme>=0.13',
 ]
@@ -92,7 +92,7 @@ optional = [
     'matplotlib>=3.5',
     'pooch>=1.6.0',
     'pyamg',
-    'scikit-learn>=1.0',
+    'scikit-learn>=1.1',
 ]
 test = [
     'asv',

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -16,6 +16,6 @@ ipywidgets
 ipykernel
 plotly>=5.10
 kaleido
-scikit-learn>=0.24.0
+scikit-learn>=1.1
 sphinx_design>=0.3
 pydata-sphinx-theme>=0.13

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -7,4 +7,4 @@ dask[array]>=2021.1.0
 matplotlib>=3.5
 pooch>=1.6.0
 pyamg
-scikit-learn>=1.0
+scikit-learn>=1.1


### PR DESCRIPTION
Per https://scientific-python.org/specs/spec-0000/
```
24 Sep 2023: drop scikit-learn 1.0 (initially released on Sep 24, 2021)
```

Since we need at least one release candidate, I think it is safe to assume Sept. 25th is about as early as we could release 0.22. I would like to get 0.22 out soon now that we seem to have things working on NumPy 1.26. I am tentatively thinking of aiming for a 0.22rc0 next week.