### PR TITLE
DOC: minor numpydoc syntax update

### DIFF
--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -20,8 +20,8 @@ def match_locations(img0, img1, coords0, coords1, radius=5, sigma=3):
     are defined as patches located around pixels with Gaussian
     weights.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     img0, img1 : 2D array
         Input images.
     coords0 : (2, m) array_like
@@ -33,8 +33,8 @@ def match_locations(img0, img1, coords0, coords1, radius=5, sigma=3):
     sigma : float
         Standard deviation of the Gaussian kernel centered over the patches.
 
-    Returns:
-    --------
+    Returns
+    -------
     match_coords: (2, m) array
         The points in `coords1` that are the closest corresponding matches to
         those in `coords0` as determined by the (Gaussian weighted) sum of

--- a/skimage/registration/tests/test_tvl1.py
+++ b/skimage/registration/tests/test_tvl1.py
@@ -10,8 +10,8 @@ def _sin_flow_gen(image0, max_motion=4.5, npics=5):
     """Generate a synthetic ground truth optical flow with a sinusoid as
       first component.
 
-    Parameters:
-    ----
+    Parameters
+    ----------
     image0: ndarray
         The base image to be warped.
     max_motion: float

--- a/skimage/restoration/inpaint.py
+++ b/skimage/restoration/inpaint.py
@@ -42,7 +42,7 @@ def _inpaint_biharmonic_single_region(image, mask, out, neigh_coef_full,
     boundary constraints and ``u`` is the vector of inpainted values to be
     (uniquely) determined by solving the linear system.
 
-    ``A`` is a sparse matrix of shape (n_mask, n_mask) where `n_mask``
+    ``A`` is a sparse matrix of shape (n_mask, n_mask) where ``n_mask``
     corresponds to the number of non-zero values in ``mask`` (i.e. the number
     of pixels to be inpainted). Each row in A will have a number of non-zero
     values equal to the number of non-zero values in the biharmonic kernel,


### PR DESCRIPTION
- There is no `:` in the spec, and it's the only places using a `:` and numpydoc in the codebase.

- The shorter underline have numpydoc emit a warning.

- A missing backtick


```release-note
```
