### PR TITLE
Temporary work-around for NEP 51 numpy scalar reprs + doctests

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -42,3 +42,12 @@ Other (2022)
 * NumPy 1.25.0 is minimal required version:
     * Remove optional test for a NaN-related deprecation warning from numpy.clip in
       skimage/exposure/tests/test_exposure.py::test_rescale_nan_warning
+
+Post numpy 2
+------------
+
+- Remove try except blocks following comment starting
+  `# TODO: when minimum numpy`
+  in `skimage/color/colorconv.py`, `skimage/color/tests/test_colorconv.py`,
+  `skimage/measure/_blur_effect.py`, and `skimage/util/tests/test_montage.py`
+- Remove `handle_np2` from `skimage/conftest.py`

--- a/skimage/conftest.py
+++ b/skimage/conftest.py
@@ -1,3 +1,4 @@
+import pytest
 from skimage._shared.testing import setup_test, teardown_test
 
 # List of files that pytest should ignore
@@ -12,3 +13,13 @@ def pytest_runtest_setup(item):
 
 def pytest_runtest_teardown(item):
     teardown_test()
+
+@pytest.fixture(autouse=True)
+def handle_np2():
+    # TODO: remove when we require numpy >= 2
+    try:
+        import numpy as np
+
+        np.set_printoptions(legacy="1.21")
+    except ImportError:
+        pass


### PR DESCRIPTION
This should finally fix the nightly wheels test. For  #7122, I was testing locally with
```
spin test
```
Now I am correctly testing locally with
```
spin test -- --doctest-modules skimage
```

This PR is following the same approach as NetworkX https://github.com/networkx/networkx/pull/6856.

### Errors

This suppresses errors like
```
Expected:
    13
Got:
    np.int64(13)
```
and
```
Expected:
    True
Got:
    np.True_
```
in the doctests.