### PR TITLE
Update _polygon2mask.py

### DIFF
--- a/skimage/draw/_polygon2mask.py
+++ b/skimage/draw/_polygon2mask.py
@@ -12,7 +12,7 @@ def polygon2mask(image_shape, polygon):
         The shape of the mask.
     polygon : (N, 2) array_like
         The polygon coordinates of shape (N, 2) where N is
-        the number of points.
+        the number of points, and the column order is y, x.
 
     Returns
     -------

--- a/skimage/draw/_polygon2mask.py
+++ b/skimage/draw/_polygon2mask.py
@@ -12,7 +12,7 @@ def polygon2mask(image_shape, polygon):
         The shape of the mask.
     polygon : (N, 2) array_like
         The polygon coordinates of shape (N, 2) where N is
-        the number of points, and the column order is y, x.
+        the number of points. The coordinates are (row, column).
 
     Returns
     -------


### PR DESCRIPTION
Clarified column order in documentation. This is a useful clarification particularly because the following have the opposite order:
- [`matplotlib.patches.Polygon`](https://matplotlib.org/stable/api/_as_gen/matplotlib.patches.Polygon.html)
- [`shapely.Geometry.Polygon`](https://shapely.readthedocs.io/en/stable/reference/shapely.Polygon.html#shapely.Polygon)

An alternative is naming the inputs "r, c", as in `skimage.draw.polygon`.

## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Specify coordinate convention in `skimage.draw.polygon2mask`.
```
