### PR TITLE
in check_dtype let masks be different sizes

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -194,20 +194,17 @@ def _infer_regionprop_dtype(func, *, intensity, ndim):
     dtype : NumPy data type
         The data type of the returned property.
     """
-    labels = [1, 2]
-    sample = np.zeros((3,) * ndim, dtype=np.intp)
-
-    regions = [(slice(0,),) * ndim, (slice(1, None),) * ndim]
-    sample[regions[0]] = labels[0]
-    sample[regions[1]] = labels[1]
-
-    propmasks = [(sample[region] == label) for (label, region) in zip(labels, regions)]
+    mask_1 = np.ones((1,) * ndim, dtype=bool)
+    mask_1 = np.pad(mask_1, (0, 1), constant_values=False)
+    mask_2 = np.ones((2,) * ndim, dtype=bool)
+    mask_2 = np.pad(mask_2, (1, 0), constant_values=False)
+    propmasks = [mask_1, mask_2]
 
     rng = np.random.default_rng()
 
     if intensity and _infer_number_of_required_args(func) == 2:
         def _func(mask):
-            return func(mask, rng.random(sample.shape))
+            return func(mask, rng.random(mask.shape))
     else:
         _func = func
     props1, props2 = map(_func, propmasks)

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -196,9 +196,12 @@ def _infer_regionprop_dtype(func, *, intensity, ndim):
     """
     labels = [1, 2]
     sample = np.zeros((3,) * ndim, dtype=np.intp)
-    sample[(0,) * ndim] = labels[0]
-    sample[(slice(1, None),) * ndim] = labels[1]
-    propmasks = [(sample == n) for n in labels]
+
+    regions = [(slice(0,),) * ndim, (slice(1, None),) * ndim]
+    sample[regions[0]] = labels[0]
+    sample[regions[1]] = labels[1]
+
+    propmasks = [(sample[region] == label) for (label, region) in zip(labels, regions)]
 
     rng = np.random.default_rng()
 

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -1280,6 +1280,11 @@ def intensity_median(regionmask, image_intensity):
     return np.median(image_intensity[regionmask])
 
 
+def bbox_list(regionmask):
+    """Extra property who's output shape is dependent on mask shape."""
+    return [1] * regionmask.shape[1]
+
+
 def too_many_args(regionmask, image_intensity, superfluous):
     return 1
 
@@ -1337,13 +1342,18 @@ def test_extra_properties_mixed():
 
 
 def test_extra_properties_table():
-    out = regionprops_table(SAMPLE_MULTIPLE,
-                            intensity_image=INTENSITY_SAMPLE_MULTIPLE,
-                            properties=('label',),
-                            extra_properties=(intensity_median, pixelcount)
-                            )
+    out = regionprops_table(
+        SAMPLE_MULTIPLE,
+        intensity_image=INTENSITY_SAMPLE_MULTIPLE,
+        properties=('label',),
+        extra_properties=(intensity_median, pixelcount, bbox_list)
+    )
     assert_array_almost_equal(out['intensity_median'], np.array([2., 4.]))
     assert_array_equal(out['pixelcount'], np.array([10, 2]))
+
+    assert out["bbox_list"].dtype == np.object_
+    assert out["bbox_list"][0] == [1] * 10
+    assert out["bbox_list"][1] == [1] * 1
 
 
 def test_multichannel():

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -1281,7 +1281,7 @@ def intensity_median(regionmask, image_intensity):
 
 
 def bbox_list(regionmask):
-    """Extra property who's output shape is dependent on mask shape."""
+    """Extra property whose output shape is dependent on mask shape."""
     return [1] * regionmask.shape[1]
 
 
@@ -1351,7 +1351,7 @@ def test_extra_properties_table():
     assert_array_almost_equal(out['intensity_median'], np.array([2., 4.]))
     assert_array_equal(out['pixelcount'], np.array([10, 2]))
 
-    assert out["bbox_list"].dtype == np.object_
+    assert out['bbox_list'].dtype == np.object_
     assert out["bbox_list"][0] == [1] * 10
     assert out["bbox_list"][1] == [1] * 1
 


### PR DESCRIPTION
## Description

Attempt to fix #7129 By using regions of different sizes to do the dtype check.


## Checklist

 - [x] A descriptive but concise pull request title
 - [x] [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing) I would love to do but for the life of me [cannot get `scikit-image` to build correctly on this system](https://discuss.scientific-python.org/t/spin-test-fails-on-windows/830)
- [x] [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Allow `extra_properties` of non equal lengths to be passed correctly to `regionprops_table`
```
