### PR TITLE
Remove last reference to distutils in `_build_utils/tempita.py`

### DIFF
--- a/skimage/_build_utils/tempita.py
+++ b/skimage/_build_utils/tempita.py
@@ -17,10 +17,6 @@ def process_tempita(fromfile, outfile=None):
     E.g. processing `template.c.in` generates `template.c`.
 
     """
-    if outfile is None:
-        # We're dealing with a distutils build here, write in-place
-        outfile = os.path.splitext(fromfile)[0]
-
     from_filename = tempita.Template.from_filename
     template = from_filename(fromfile, encoding=sys.getdefaultencoding())
 

--- a/skimage/_build_utils/tempita.py
+++ b/skimage/_build_utils/tempita.py
@@ -10,7 +10,7 @@ from Cython import Tempita as tempita
 # cython.tempita or numpy/npy_tempita.
 
 
-def process_tempita(fromfile, outfile=None):
+def process_tempita(fromfile, outfile):
     """Process tempita templated file and write out the result.
 
     The template file is expected to end in `.c.in` or `.pyx.in`:
@@ -42,7 +42,11 @@ def main():
     if not args.infile.endswith('.in'):
         raise ValueError(f"Unexpected extension: {args.infile}")
 
+    if os.path.isabs(args.outdir):
+        raise ValueError("outdir must relative to the current directory")
     outdir_abs = os.path.join(os.getcwd(), args.outdir)
+    if not os.path.exists(outdir_abs):
+        raise ValueError("outdir doesn't exist")
     outfile = os.path.join(
         outdir_abs, os.path.splitext(os.path.split(args.infile)[1])[0]
     )


### PR DESCRIPTION
## Description

It seems like tempita is still required by our meson-based build system, but the build seems to work without the if clause. So maybe it's no longer needed?

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
