### PR TITLE
Enable version warning banners for docs

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -82,8 +82,8 @@ the appropriate point in main and the following instructions are still apt.
   Once everything works as intended, remove those branches and proceed.
 
 - Edit ``doc/source/_static/docversions.js`` and
-  ``doc/source/_static/version_switcher.json`` in order to
-  add the release, e.g., `0.15.x`, and commit.
+  ``doc/source/_static/version_switcher.json`` in order to add the release, move the
+  key value pair `"preferred": true` to the most recent stable version, and commit.
 
 - Update the version number to stable in ``skimage/__init__.py``, and commit.
 

--- a/doc/source/_static/version_switcher.json
+++ b/doc/source/_static/version_switcher.json
@@ -7,7 +7,8 @@
     {
         "name": "0.21 (stable)",
         "version":"0.21.0",
-        "url": "https://scikit-image.org/docs/stable/"
+        "url": "https://scikit-image.org/docs/stable/",
+        "preferred": true
     },
     {
         "name": "0.20",

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -156,18 +156,24 @@ html_theme_options = {
     "header_links_before_dropdown": 6,
     "icon_links": [
         {
+            "name": "GitHub",
+            "url": "https://github.com/scikit-image/scikit-image",
+            "icon": "fa-brands fa-github",
+        },
+        {
             "name": "PyPI",
             "url": "https://pypi.org/project/scikit-image/",
             "icon": "fa-solid fa-box",
         },
     ],
+    "navbar_align": "left",
     "navbar_end": ["version-switcher", "navbar-icon-links"],
     "show_prev_next": False,
     "switcher": {
-        "json_url": "https://scikit-image.org/docs/dev/_static/version_switcher.json",
+        "json_url": "https://gist.githubusercontent.com/lagru/8bce79c510b9026dab455c0a96a2c0b3/raw/d7d6159090de17cf54b55b457b198284c4078da0/version_switcher.json",
         "version_match": "dev" if "dev" in version else version,
     },
-    "github_url": "https://github.com/scikit-image/scikit-image",
+    "show_version_warning_banner": True,
     # Footer
     "footer_start": ["copyright"],
     "footer_end": ["sphinx-version", "theme-version"],

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -170,7 +170,9 @@ html_theme_options = {
     "navbar_end": ["version-switcher", "navbar-icon-links"],
     "show_prev_next": False,
     "switcher": {
-        "json_url": "https://gist.githubusercontent.com/lagru/8bce79c510b9026dab455c0a96a2c0b3/raw/d7d6159090de17cf54b55b457b198284c4078da0/version_switcher.json",
+        "json_url": (
+            "https://scikit-image.org/docs/dev/_static/version_switcher.json"
+        ),
         "version_match": "dev" if "dev" in version else version,
     },
     "show_version_warning_banner": True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ docs = [
     'kaleido',
     'scikit-learn>=1.1',
     'sphinx_design>=0.3',
-    'pydata-sphinx-theme>=0.14',
+    'pydata-sphinx-theme>=0.14.1',
 ]
 optional = [
     'SimpleITK',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ docs = [
     'kaleido',
     'scikit-learn>=1.1',
     'sphinx_design>=0.3',
-    'pydata-sphinx-theme>=0.13',
+    'pydata-sphinx-theme>=0.14',
 ]
 optional = [
     'SimpleITK',

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -18,4 +18,4 @@ plotly>=5.10
 kaleido
 scikit-learn>=1.1
 sphinx_design>=0.3
-pydata-sphinx-theme>=0.14
+pydata-sphinx-theme>=0.14.1

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -18,4 +18,4 @@ plotly>=5.10
 kaleido
 scikit-learn>=1.1
 sphinx_design>=0.3
-pydata-sphinx-theme>=0.13
+pydata-sphinx-theme>=0.14


### PR DESCRIPTION
## Description

If the doc version isn't the preferred one, a warning banner is shown at the top. This also accounts for dev builds.

Blocked until ~~https://github.com/pydata/pydata-sphinx-theme/pull/1450~~ https://github.com/pydata/pydata-sphinx-theme/pull/1446 is resolved and merged.

Partially addresses https://github.com/scikit-image/scikit-image/issues/7138.

## Checklist

For reviewers: see https://github.com/scikit-image/scikit-image/pull/7139#issuecomment-1731156018

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
