### PR TITLE
Remove parallelism in face detection gallery example

### DIFF
--- a/doc/examples/applications/plot_haar_extraction_selection_classification.py
+++ b/doc/examples/applications/plot_haar_extraction_selection_classification.py
@@ -29,8 +29,6 @@ from time import time
 import numpy as np
 import matplotlib.pyplot as plt
 
-from dask import delayed
-
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import roc_auc_score
@@ -48,7 +46,6 @@ from skimage.feature import draw_haar_like_feature
 # integral image within this ROI is computed. Finally, the integral image is
 # used to extract the features.
 
-@delayed
 def extract_feature_image(img, feature_type, feature_coord=None):
     """Extract the haar feature for the current image"""
     ii = integral_image(img)
@@ -67,12 +64,10 @@ images = lfw_subset()
 # To speed up the example, extract the two types of features only
 feature_types = ['type-2-x', 'type-2-y']
 
-# Build a computation graph using Dask. This allows the use of multiple
-# CPU cores later during the actual computation
-X = delayed(extract_feature_image(img, feature_types) for img in images)
 # Compute the result
 t_start = time()
-X = np.array(X.compute(scheduler='single-threaded'))
+X = [extract_feature_image(img, feature_types) for img in images]
+X = np.stack(X)
 time_full_feature_comp = time() - t_start
 
 # Label images (100 faces and 100 non-faces)
@@ -139,12 +134,13 @@ feature_type_sel = feature_type[idx_sorted[:sig_feature_count]]
 # but we would like to emphasize the usage of `feature_coord` and `feature_type`
 # to recompute a subset of desired features.
 
-# Build the computational graph using Dask
-X = delayed(extract_feature_image(img, feature_type_sel, feature_coord_sel)
-            for img in images)
 # Compute the result
 t_start = time()
-X = np.array(X.compute(scheduler='single-threaded'))
+X = [
+    extract_feature_image(img, feature_type_sel, feature_coord_sel)
+    for img in images
+]
+X = np.stack(X)
 time_subs_feature_comp = time() - t_start
 
 y = np.array([1] * 100 + [0] * 100)


### PR DESCRIPTION
## Description

This is meant to be a temporary hotfix while https://github.com/scikit-image/scikit-image/pull/7140 is being investigated. It naturally has a similar performance compared to the single-threaded dask solution.

cc @mkcor

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Remove single-threaded dask usage in face detection gallery example which fixes issues
with running the example on Windows and CI. 
```
