### PR TITLE
Fix PEP 8 issues in `test_phase_cross_correlation.py`

### DIFF
--- a/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_phase_cross_correlation.py
@@ -265,6 +265,6 @@ def test_disambiguate_zero_shift(disambiguate):
     image = camera()
     computed_shift, _, _ = phase_cross_correlation(
         image, image, disambiguate=disambiguate, return_error='always'
-        )
+    )
     assert isinstance(computed_shift, np.ndarray)
     np.testing.assert_array_equal(computed_shift, np.array((0., 0.)))

--- a/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_phase_cross_correlation.py
@@ -253,6 +253,7 @@ def test_disambiguate_2d(shift0, shift1):
             )
     np.testing.assert_equal(shift, computed_shift)
 
+
 @pytest.mark.parametrize('disambiguate', [True, False])
 def test_disambiguate_zero_shift(disambiguate):
     """When the shift is 0, disambiguation becomes degenerate.
@@ -263,7 +264,7 @@ def test_disambiguate_zero_shift(disambiguate):
     """
     image = camera()
     computed_shift, _, _ = phase_cross_correlation(
-            image, image, disambiguate=disambiguate, return_error='always'
-            )
+        image, image, disambiguate=disambiguate, return_error='always'
+        )
     assert isinstance(computed_shift, np.ndarray)
     np.testing.assert_array_equal(computed_shift, np.array((0., 0.)))


### PR DESCRIPTION
## Description

This is a follow-up on #7112. I just addressed https://github.com/scikit-image/scikit-image/pull/7112#issuecomment-1725213770, @decorouz @lagru.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Fix PEP 8 issues.
```
