### PR TITLE
Include Plausible analytics from Scientific Python in our HTML docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -174,6 +174,10 @@ html_theme_options = {
     # Other
     "pygment_light_style": "default",
     "pygment_dark_style": "github-dark",
+    "analytics": {
+        "plausible_analytics_domain": "scikit-image.org",
+        "plausible_analytics_url": "https://views.scientific-python.org/js/script.js"
+    }
 }
 
 # Custom sidebar templates, maps document names to template names.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -176,8 +176,10 @@ html_theme_options = {
     "pygment_dark_style": "github-dark",
     "analytics": {
         "plausible_analytics_domain": "scikit-image.org",
-        "plausible_analytics_url": "https://views.scientific-python.org/js/script.js"
-    }
+        "plausible_analytics_url": (
+            "https://views.scientific-python.org/js/script.js"
+        ),
+    },
 }
 
 # Custom sidebar templates, maps document names to template names.


### PR DESCRIPTION
## Description

Scientific Python offered us to use their plausible instance for our website analytics. [Plausible](https://plausible.io) self-describes as

> No cookies and fully compliant with GDPR, CCPA and PECR

and should hopefully gain us some insights into our users in a privacy-friendly manner.

Documentation for the inclusion in our theme can be found here: https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/analytics.html

I am not yet sure how and who will be able to access the reports at https://views.scientific-python.org but @stefanv would know more.

After adding this we could also think about adding it to our main page and possibly shoehorn into our old HTML docs. Not sure if the latter is worth it though. I am mainly interested in which part of our documentation get accessed most or least.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```