### PR TITLE
In registration.phase_cross_correlation: catch expected runtime warning when disambiguate=True

### DIFF
--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -163,10 +163,8 @@ def _disambiguate_shift(reference_image, moving_image, shift):
         moving_tile = np.reshape(shifted[test_slice], -1)
         corr = -1.0
         if reference_tile.size > 2:
-            # In the case of zero std, np.corrcoef returns nan and warns
-            # about zero division. This is expected and handled below.
-            # To avoid performing a computationally expensive check for
-            # zero std, we catch the warning.
+            # In the case of zero std, np.corrcoef returns NaN and warns
+            # about division by zero. This is expected and handled below.
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=RuntimeWarning)
                 corr = np.corrcoef(reference_tile, moving_tile)[0, 1]

--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -163,7 +163,13 @@ def _disambiguate_shift(reference_image, moving_image, shift):
         moving_tile = np.reshape(shifted[test_slice], -1)
         corr = -1.0
         if reference_tile.size > 2:
-            corr = np.corrcoef(reference_tile, moving_tile)[0, 1]
+            # In the case of zero std, np.corrcoef returns nan and warns
+            # about zero division. This is expected and handled below.
+            # To avoid performing a computationally expensive check for
+            # zero std, we catch the warning.
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=RuntimeWarning)
+                corr = np.corrcoef(reference_tile, moving_tile)[0, 1]
         if corr > max_corr:
             max_corr = corr
             max_slice = test_slice


### PR DESCRIPTION
## Description

This PR addresses https://github.com/scikit-image/scikit-image/issues/7146.

To fix this while keeping `np.corrcoef` as a metric (see https://github.com/scikit-image/scikit-image/pull/6617#issuecomment-1341978858), basically I'd see these two options:
1) check for non zero std in the input tiles
2) catch the warning since it is expected.

While 1) might be cleaner, it requires additional computations of the stds of potentially large images for every candidate shift. Therefore, I propose 2) here. 

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title [check]
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py) [no new function]
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing) [not added test for absence of warning]
- A gallery example in `./doc/examples` for new features [doesn't apply]
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed [check]

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Filter out expected runtime warnings in registation.phase_cross_correlation when disambiguate=True
```