### PR TITLE
Match pep8speaks and ruff line lengths to 88

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -2,7 +2,7 @@ scanner:
   diff_only: True # Errors caused by only the patch are shown, not the whole file
 
 pycodestyle:
-  max-line-length: 88  # Same as in pyproject.toml > tool.ruff
+  max-line-length: 88 # Same as in pyproject.toml > tool.ruff
   ignore: # Errors and warnings to ignore
     - W391 # blank line at the end of file
     - E203 # whitespace before ,;:

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -2,6 +2,7 @@ scanner:
   diff_only: True # Errors caused by only the patch are shown, not the whole file
 
 pycodestyle:
+  max-line-length: 88  # Same as in pyproject.toml > tool.ruff
   ignore: # Errors and warnings to ignore
     - W391 # blank line at the end of file
     - E203 # whitespace before ,;:


### PR DESCRIPTION
## Description

Probably an oversight. Make both tools use the same line length. I am opting for 88 which has been properly enforced by our pre-commit and linting job for some time now. 

I didn't notice this before because pep8speaks seemed suspiciously quiet before and only got noisy again the last few days. At least that's my impression. Was it broken or disabled before? :thinking: 

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
