### PR TITLE
Upgrade to spin 0.7

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -92,13 +92,10 @@ def ipython(ctx, ipython_args):
     env = os.environ
     env['PYTHONWARNINGS'] = env.get('PYTHONWARNINGS', 'all')
 
-    ctx.invoke(meson.build)
+    preimport = (
+        r"import skimage as ski; "
+        r"print(f'\nPreimported scikit-image {ski.__version__} as ski')"
+    )
+    ctx.params['ipython_args'] = (f"--TerminalIPythonApp.exec_lines={preimport}",) + ipython_args
 
-    ppath = meson._set_pythonpath()
-
-    print(f'💻 Launching IPython with PYTHONPATH="{ppath}"')
-    preimport = (r"import skimage as ski; "
-                 r"print(f'\nPreimported scikit-image {ski.__version__} as ski')")
-    util.run(["ipython", "--ignore-cwd",
-              f"--TerminalIPythonApp.exec_lines={preimport}"] +
-             list(ipython_args))
+    ctx.forward(meson.ipython)

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -41,6 +41,11 @@ def docs(ctx, sphinx_target, clean, first_build, jobs, sphinx_gallery_plot, inst
 
       SPHINXOPTS="" spin docs
 
+    The command is roughly equivalent to `cd doc && make SPHINX_TARGET`.
+    To get a list of viable `SPHINX_TARGET`:
+
+      spin docs help
+
     """
     if install_deps:
         util.run(['pip', 'install', '-q', '-r', 'requirements/docs.txt'])

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import sys
 
 import click
@@ -8,23 +7,33 @@ from spin import util
 
 
 @click.command()
+@click.argument("sphinx_target", default="html")
 @click.option(
-    "--clean", is_flag=True,
+    "--clean",
+    is_flag=True,
     default=False,
-    help="Clean previously built docs before building"
+    help="Clean previously built docs before building",
 )
+@click.option(
+    "--build/--no-build",
+    "first_build",
+    default=True,
+    help="Build project before generating docs",
+)
+@click.option(
+    "--plot/--no-plot",
+    "sphinx_gallery_plot",
+    default=True,
+    help="Sphinx gallery: enable/disable plots",
+)
+@click.option("--jobs", "-j", default="auto", help="Number of parallel build jobs")
 @click.option(
     "--install-deps/--no-install-deps",
-    default=True,
+    default=False,
     help="Install dependencies before building"
 )
-@click.option(
-    '--build/--no-build',
-    default=True,
-    help="Build skimage before generating docs"
-)
 @click.pass_context
-def docs(ctx, clean, install_deps, build):
+def docs(ctx, sphinx_target, clean, first_build, jobs, sphinx_gallery_plot, install_deps):
     """📖 Build documentation
 
     By default, SPHINXOPTS="-W", raising errors on warnings.
@@ -33,37 +42,12 @@ def docs(ctx, clean, install_deps, build):
       SPHINXOPTS="" spin docs
 
     """
-    if clean:
-        doc_dirs = [
-            "./doc/build/",
-            "./doc/source/api/",
-            "./doc/source/auto_examples/",
-            "./doc/source/jupyterlite_contents/",
-        ]
-        for doc_dir in doc_dirs:
-            if os.path.isdir(doc_dir):
-                print(f"Removing {doc_dir!r}")
-                shutil.rmtree(doc_dir)
-
-    if build:
-        click.secho(
-            "Invoking `build` prior to running tests:", bold=True, fg="bright_green"
-        )
-        ctx.invoke(meson.build)
-
-    try:
-        site_path = meson._get_site_packages()
-    except FileNotFoundError:
-        print("No built scikit-image found; run `spin build` first.")
-        sys.exit(1)
-
     if install_deps:
         util.run(['pip', 'install', '-q', '-r', 'requirements/docs.txt'])
 
-    os.environ['SPHINXOPTS'] = os.environ.get('SPHINXOPTS', "-W")
-
-    os.environ['PYTHONPATH'] = f'{site_path}{os.sep}:{os.environ.get("PYTHONPATH", "")}'
-    util.run(['make', '-C', 'doc', 'html'], replace=True)
+    for extra_param in ('install_deps',):
+        del ctx.params[extra_param]
+    ctx.forward(meson.docs)
 
 
 @click.command()
@@ -87,14 +71,34 @@ def asv(asv_args):
 
 
 @click.command()
-def coverage():
-    """📊 Generate coverage report
-    """
-    util.run(['python', '-m', 'spin', 'test', '--', '-o', 'python_functions=test_*', 'skimage', '--cov=skimage'], replace=True)
-
-
-@click.command()
 def sdist():
     """📦 Build a source distribution in `dist/`.
     """
     util.run(['python', '-m', 'build', '.', '--sdist'])
+
+
+@click.command(context_settings={
+    'ignore_unknown_options': True
+})
+@click.argument("ipython_args", metavar='', nargs=-1)
+@click.pass_context
+def ipython(ctx, ipython_args):
+    """💻 Launch IPython shell with PYTHONPATH set
+
+    OPTIONS are passed through directly to IPython, e.g.:
+
+    spin ipython -i myscript.py
+    """
+    env = os.environ
+    env['PYTHONWARNINGS'] = env.get('PYTHONWARNINGS', 'all')
+
+    ctx.invoke(meson.build)
+
+    ppath = meson._set_pythonpath()
+
+    print(f'💻 Launching IPython with PYTHONPATH="{ppath}"')
+    preimport = (r"import skimage as ski; "
+                 r"print(f'\nPreimported scikit-image {ski.__version__} as ski')")
+    util.run(["ipython", "--ignore-cwd",
+              f"--TerminalIPythonApp.exec_lines={preimport}"] +
+             list(ipython_args))

--- a/doc/ext/skimage_extensions.py
+++ b/doc/ext/skimage_extensions.py
@@ -135,3 +135,6 @@ def write_random_js(app, exception):
 def setup(app):
     app.add_directive('naturalsortedtoctree', NaturalSortedTocTree)
     app.connect('build-finished', write_random_js)
+    return {
+        'parallel_read_safe': True
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ build = [
     'pythran',
     'numpy>=1.22',
     # Developer UI
-    'spin==0.6',
+    'spin==0.7',
     'build',
 ]
 data = ['pooch>=1.6.0']
@@ -137,19 +137,18 @@ package = 'skimage'
 
 [tool.spin.commands]
 Build = [
-    'spin.build',
-    'spin.test',
-    '.spin/cmds.py:sdist',
+    'spin.cmds.meson.build',
+    'spin.cmds.meson.test',
+    'spin.cmds.build.sdist',
 ]
 Environments = [
-    'spin.shell',
-    'spin.ipython',
-    'spin.python',
+    'spin.cmds.meson.run',
+    '.spin/cmds.py:ipython',
+    'spin.cmds.meson.python',
 ]
 Documentation = ['.spin/cmds.py:docs']
 Metrics = [
-    '.spin/cmds.py:asv',
-    '.spin/cmds.py:coverage',
+    '.spin/cmds.py:asv'
 ]
 
 [tool.ruff]

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -8,5 +8,5 @@ ninja
 Cython>=0.29.32
 pythran
 numpy>=1.22
-spin==0.6
+spin==0.7
 build

--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -4,6 +4,7 @@ http://www.mathworks.com/matlabcentral/fileexchange/18401-efficient-subpixel-ima
 """
 
 import itertools
+import warnings
 
 import numpy as np
 from scipy.fft import fftn, ifftn, fftfreq


### PR DESCRIPTION
Notable changes:

- No longer auto-installs dependencies on docs build (speed things up a bit, and doesn't annoy conda users)
- No longer provide `coverage` command; use `spin test --coverage ...` instead
- Auto import `skimage as ski` in IPython terminal

I cannot figure out how to make the coverage report *not* include `*/tests/*`. It *is* configured in `pyproject.toml`, but `pytest-cov` / `coverage` doesn't seem to listen.