### PR TITLE
Deprecate `return_error`  in `phase_cross_correlation` only in 0.23

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -10,6 +10,8 @@ Version 0.23
 * Remove deprecated `random_seed`, `random_state`, and `sample_seed`
   arguments in favor of `rng`.
 * Remove deprecated function ``skimage.color.colorconv.get_xyz_coords()``.
+* Remove deprecated ``return_error`` in
+  ``skimage.registration.phase_cross_correlation``.
 
 Other (2022)
 ------------

--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -9,6 +9,7 @@ import numpy as np
 from scipy.fft import fftn, ifftn, fftfreq
 from scipy import ndimage as ndi
 
+from skimage._shared.utils import remove_arg
 from ._masked_phase_cross_correlation import _masked_phase_cross_correlation
 
 
@@ -175,9 +176,11 @@ def _disambiguate_shift(reference_image, moving_image, shift):
     return np.array(real_shift_acc)
 
 
+@remove_arg('return_error', changed_version='0.23')
 def phase_cross_correlation(reference_image, moving_image, *,
                             upsample_factor=1, space="real",
                             disambiguate=False,
+                            return_error=True,
                             reference_mask=None,
                             moving_mask=None, overlap_ratio=0.3,
                             normalization="phase"):

--- a/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_phase_cross_correlation.py
@@ -220,3 +220,15 @@ def test_disambiguate_zero_shift(disambiguate):
     )
     assert isinstance(computed_shift, np.ndarray)
     np.testing.assert_array_equal(computed_shift, np.array((0., 0.)))
+
+
+@pytest.mark.parametrize(
+    "return_error", [False, True, "always"]
+)
+def test_deprecated_return_error(return_error):
+    img = np.ones((10, 10))
+    with pytest.warns() as record:
+        phase_cross_correlation(img, img, return_error=return_error)
+    assert len(record) == 1
+    assert "return_error argument is deprecated" in record[0].message.args[0]
+    assert record[0].filename == __file__


### PR DESCRIPTION
## Description

Until 0.22 we told users to pass return_error='always' to this function to silence the warning. Starting with 0.22 this will immediately return an error without any explanation.

I kind of feel like removing the parameter completely requires another deprecation? It get that this is totally annoying but that's how I would interpret our deprecation guide lines and the user experience.

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Deprecate `return_error` in `skimage.registration.phase_cross_correlation`.
```
