### PR TITLE
Fix missing warnings import in `phase_cross_correlation`

### DIFF
--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -4,6 +4,7 @@ http://www.mathworks.com/matlabcentral/fileexchange/18401-efficient-subpixel-ima
 """
 
 import itertools
+import warnings
 
 import numpy as np
 from scipy.fft import fftn, ifftn, fftfreq

--- a/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_phase_cross_correlation.py
@@ -1,4 +1,5 @@
 import itertools
+import warnings
 
 import numpy as np
 import pytest
@@ -204,6 +205,17 @@ def test_disambiguate_2d(shift0, shift1):
             reference, moving, disambiguate=True,
             )
     np.testing.assert_equal(shift, computed_shift)
+
+
+def test_invalid_value_in_division_warnings():
+    """Regression test for https://github.com/scikit-image/scikit-image/issues/7146."""
+    im1 = np.zeros((100, 100))
+    im1[50, 50] = 1
+    im2 = np.zeros((100, 100))
+    im2[60, 60] = 1
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        phase_cross_correlation(im1, im2, disambiguate=True)
 
 
 @pytest.mark.parametrize('disambiguate', [True, False])


### PR DESCRIPTION
## Description

Fixes our broken `main`.

https://github.com/scikit-image/scikit-image/commit/05e84c292e13ed2dc2137a64b0af20a97ab43ee7 removed the import of warnings thus breaking the merge
result after merging https://github.com/scikit-image/scikit-image/pull/7147!

Also adds a unit test for the change in #7147. 

@jarrodmillman, sorry for the timing. I'll refrain from merging until you are done with the release candidate. :pray: 

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
