### PR TITLE
Make `unwrap_phase` fail for 2D input containing NaNs

### DIFF
--- a/skimage/restoration/tests/test_unwrap.py
+++ b/skimage/restoration/tests/test_unwrap.py
@@ -2,6 +2,8 @@ import numpy as np
 from skimage.restoration import unwrap_phase
 import sys
 
+import pytest
+
 from skimage._shared import testing
 from skimage._shared.testing import (assert_array_almost_equal_nulp,
                                      assert_almost_equal, assert_array_equal,
@@ -215,3 +217,16 @@ def test_unwrap_3d_all_masked():
     assert_(np.ma.isMaskedArray(unwrap))
     assert_(np.sum(unwrap.mask) == 999)   # all but one masked
     assert_(unwrap[0, 0, 0] == 0)
+
+
+def test_unwrap_2d_raise_on_nan():
+    """Check that unwrap_phase fails for NaN input.
+
+    Regression test for
+    https://github.com/scikit-image/scikit-image/issues/3831.
+    """
+    x = np.linspace(1, 100)
+    x[1] = np.nan
+    xx, yy = np.meshgrid(x, x)
+    with pytest.raises(RuntimeError, match="NaN encountered while sorting edges"):
+        unwrap_phase(xx)

--- a/skimage/restoration/unwrap.py
+++ b/skimage/restoration/unwrap.py
@@ -49,6 +49,9 @@ def unwrap_phase(image, wrap_around=False, rng=None):
     ValueError
         If called with a masked 1D array or called with a 1D array and
         ``wrap_around=True``.
+    RuntimeError
+        If a NaN is encountered while sorting edges (abrupt phase steps). This
+        may happen if `image` contains unmasked NaNs.
 
     Examples
     --------

--- a/skimage/restoration/unwrap_2d_ljmu.h
+++ b/skimage/restoration/unwrap_2d_ljmu.h
@@ -1,4 +1,4 @@
-void unwrap2D(
+short unwrap2D(
         double *wrapped_image,
         double *UnwrappedImage,
         unsigned char *input_mask,


### PR DESCRIPTION
## Description

Closes https://github.com/scikit-image/scikit-image/issues/3831.

After some stone-age debugging with print statements, it seems to me that the infinite loop happens inside 
https://github.com/scikit-image/scikit-image/blob/97b3ecb19e83c743b272d898f24e5b9c563cc72e/skimage/restoration/unwrap_2d_ljmu.c#L128-L139

which never exits due to `pivot` being NaN. Current solution is to check `pivot` before passing it to that function and return error codes up the call stack until we can raise a proper Python exception.



<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Raise a `RuntimeError` in `skimage.restoration.unwrap_phase` If a NaN is encountered 
while sorting edges. This may happen if the input `image` contains unmasked NaNs.
```
