### PR TITLE
Use trusted publisher

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -20,12 +20,14 @@ jobs:
     uses: ./.github/workflows/wheels_recipe.yml
 
   deploy:
-    permissions:
-      contents: write # for softprops/action-gh-release to create GitHub release
     name: Release
     needs: call-workflow-build-wheels
     if: github.repository_owner == 'scikit-image' && startsWith(github.ref, 'refs/tags/v') && always()
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write # for softprops/action-gh-release to create GitHub release
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - uses: actions/checkout@v3
         with:
@@ -33,7 +35,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Install Twine
         run: |
@@ -45,19 +47,17 @@ jobs:
           name: wheels
           path: ./dist
 
-      - name: Publish the source distribution on PyPI
+      - name: Build the source distribution
         run: |
           SK_VERSION=$(git describe --tags)
           source tools/github/before_install.sh
           python -m build --no-isolation --skip-dependency-check --sdist .
           ls -la ${{ github.workspace }}/dist
-          # We prefer to release wheels before source because otherwise there is a
-          # small window during which users who pip install scikit-image will require compilation.
-          twine upload ${{ github.workspace }}/dist/*.whl
-          twine upload ${{ github.workspace }}/dist/scikit_image-${SK_VERSION:1}.tar.gz
-        env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+
+      # We prefer to release wheels before source because otherwise there is a
+      # small window during which users who pip install scikit-image will require compilation.
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Github release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Description

The 0.22.0rc0 wheels and source tarball didn't get uploaded to PyPI because
```
WARNING  Error during upload. Retry with the --verbose option for more details. 
ERROR    HTTPError: 401 Unauthorized from https://upload.pypi.org/legacy/       
         User *** has two factor auth enabled, an API Token or Trusted      
         Publisher must be used to upload in place of password.                 
Error: Process completed with exit code 1.
```

I enabled GH as a trusted publisher for PyPI:
![2023-09-30T10:11:34,362619152-07:00](https://github.com/scikit-image/scikit-image/assets/123428/fc31e400-84c6-4b35-931d-a98b7c644556)

I tested this approach with devstats:
https://github.com/scientific-python/devstats/pull/39

It seemed to work except that I ran into this issue:
```
$ twine check dist/*
Checking dist/devstats-0.1rc4-py3-none-any.whl: PASSED
Checking dist/devstats-0.1rc4.tar.gz: PASSED with warnings
WARNING  `long_description` missing.     
```

But I believe `long_description`  from setup.py was replaced with `readme` in pyproject.toml:
https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#readme

It doesn't cause an error and everything got uploaded to PyPI, but I thought that the readme from pyproject.toml would populate the `Project description` here:
https://pypi.org/project/devstats/

I will test this out with 0.22.0rc1.

