### PR TITLE
Remove outdated & duplicate "preferred" field in `version_switcher.json`

### DIFF
--- a/doc/source/_static/version_switcher.json
+++ b/doc/source/_static/version_switcher.json
@@ -13,8 +13,7 @@
     {
         "name": "0.21",
         "version":"0.21.0",
-        "url": "https://scikit-image.org/docs/0.21.x//",
-        "preferred": true
+        "url": "https://scikit-image.org/docs/0.21.x//"
     },
     {
         "name": "0.20",


### PR DESCRIPTION
## Description

From [PyData Theme's docs](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/version-dropdown.html#add-a-json-file-to-define-your-switcher-s-versions):

> preferred: an optional field that should occur on at most one entry in the JSON file. It specifies which version is considered “latest stable”, and is used to customize the message used on Version warning banners (if they are enabled).

Luckily, the version switcher looks for [`version_switcher.json` in our dev docs](https://github.com/scikit-image/scikit-image/blob/b318e93e1e4db7fcd583c5d5a6edcf4cf44d78d4/doc/source/conf.py#L173-L175), so this file only needs to be up-to-date and correct on `main`. No need to backport to the already backported v0.22 (I think).

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
