### PR TITLE
Increase tolerance for moments test for 32 bit floats

### DIFF
--- a/skimage/measure/tests/test_moments.py
+++ b/skimage/measure/tests/test_moments.py
@@ -234,7 +234,7 @@ def test_analytical_moments_calculation(dtype, order, ndim):
     m2 = moments_central(x, center=centroid(x), order=order)
     # ensure numeric and analytical central moments are close
     # TODO: np 2 failed w/ thresh = 1e-4
-    thresh = 1.2e-4 if x.dtype == np.float32 else 1e-9
+    thresh = 1.5e-4 if x.dtype == np.float32 else 1e-9
     compare_moments(m1, m2, thresh=thresh)
 
 


### PR DESCRIPTION
## Description

On our [Debian buildds](https://buildd.debian.org/status/logs.php?pkg=skimage&ver=0.22.0-1&suite=sid), the observed deviation is

* 0.00012985113 on [riscv64](https://buildd.debian.org/status/fetch.php?pkg=skimage&arch=riscv64&ver=0.22.0-1&stamp=1696439331&raw=0)
* 0.00012848839 on [s390x](https://buildd.debian.org/status/fetch.php?pkg=skimage&arch=s390x&ver=0.22.0-1&stamp=1696427491&raw=0)
* 0.0001250156 on [ppc64](https://buildd.debian.org/status/fetch.php?pkg=skimage&arch=ppc64&ver=0.22.0-1&stamp=1696428622&raw=0) (big endian)

and this is probably all still acceptable. Without increasing, the  test_analytical_moments_calculation test would fail on these platforms. To be a bit robust here, the tolerance is increased to 0.00015.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- [x] A descriptive but concise pull request title
- [ ] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- [ ] A gallery example in `./doc/examples` for new features
- [x] [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Increase tolerance for moments test for 32 bit floats
```
