### PR TITLE
Temporarily pin Cython to <3.0.3 until CI is fixed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ build = [
     'setuptools>=67',
     'packaging>=21',
     'ninja',
-    'Cython>=0.29.32',
+    'Cython>=0.29.32,<3.0.3',
     'pythran',
     'numpy>=1.22',
     # Developer UI

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -5,7 +5,7 @@ wheel
 setuptools>=67
 packaging>=21
 ninja
-Cython>=0.29.32
+Cython>=0.29.32,<3.0.3
 pythran
 numpy>=1.22
 spin==0.6


### PR DESCRIPTION
## Description

Our CI is currently failing with the recent minor release of [Cython 3.0.3](https://github.com/cython/cython/blob/master/CHANGES.rst#303-2023-10-05), e.g https://github.com/scikit-image/scikit-image/actions/runs/6431361218. I am not really sure what's happening yet but ignoring the new `noexcept` related warnings it seems to originate in
https://github.com/scikit-image/scikit-image/blob/73ae3096a82c66d409b96f84d9923174d2b5e39e/skimage/_shared/interpolation.pxd#L42-L69

(and possibly elsewhere). In the meantime, pin to <3.0.3 so our CI continues being useful.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
