### PR TITLE
Update wording on stalebot to assume core devs dropped the ball

### DIFF
--- a/.github/workflows/dormant_issues_prs.yml
+++ b/.github/workflows/dormant_issues_prs.yml
@@ -23,7 +23,7 @@ jobs:
           stale-issue-message: >
             Hello scikit-image core devs! There hasn't been any activity on
             this issue for more than 180 days. I have marked it as "dormant" to
-            make it easy to find. You can remove the dormant tag by adding some
+            make it easy to find. You can remove the dormant label by adding some
             new activity.
 
             To our contributors, thank you for your contribution and apologies
@@ -39,7 +39,7 @@ jobs:
           stale-pr-message: >
             Hello scikit-image core devs! There hasn't been any activity on
             this PR for more than 180 days. I have marked it as "dormant" to
-            make it easy to find. You can remove the dormant tag by adding some
+            make it easy to find. You can remove the dormant label by adding some
             new activity.
 
             To our contributors, thank you for your contribution and apologies

--- a/.github/workflows/dormant_issues_prs.yml
+++ b/.github/workflows/dormant_issues_prs.yml
@@ -21,22 +21,35 @@ jobs:
           stale-pr-label: ":sleeping: Dormant"
           remove-stale-when-updated: true
           stale-issue-message: >
-            Hey, there hasn't been any activity on this issue for more than 180
-            days. For now, we have marked it as "dormant" until there is some
-            new activity. You are welcome to reach out to people by
-            mentioning them here or on our
+            Hello scikit-image core devs! There hasn't been any activity on
+            this issue for more than 180 days. I have marked it as "dormant" to
+            make it easy to find. You can remove the dormant tag by adding some
+            new activity.
+
+            To our contributors, thank you for your contribution and apologies
+            if this issue fell through the cracks! Hopefully this ping will
+            help bring some fresh attention to the issue. If you need help, you
+            can always reach out on our
             [forum](https://discuss.scientific-python.org/c/contributor/skimage/22)
-            if you need more feedback! If you think that this issue is no longer
-            relevant, you may close it by yourself; otherwise, we may do it at
-            some point (either way, it will be done manually).
-            In any case, thank you for your contributions so far!
+
+            If you think that this issue is no longer relevant, you may close
+            it, or we may do it at some point (either way, it will be done
+            manually).
+
           stale-pr-message: >
-            Hey, there hasn't been any activity on this pull request for more
-            than 180 days. For now, we have marked it as "dormant" until
-            there is some new activity. You are welcome to reach out to people
-            by mentioning them here or on our
+            Hello scikit-image core devs! There hasn't been any activity on
+            this PR for more than 180 days. I have marked it as "dormant" to
+            make it easy to find. You can remove the dormant tag by adding some
+            new activity.
+
+            To our contributors, thank you for your contribution and apologies
+            if this contribution fell through the cracks! Hopefully this ping
+            will help bring some fresh attention to the review. If you need
+            help, you can always reach out on our
             [forum](https://discuss.scientific-python.org/c/contributor/skimage/22)
-            if you need more feedback! Otherwise, we would be thankful for a
-            short update, for example if you would like to continue or if you
-            are okay with someone else doing so.
-            In any case, thank you for your contributions so far!
+
+            If you think that this PR is no longer relevant, you may close
+            it, or we may do it at some point (either way, it will be done
+            manually). If you think the PR is valuable but you no longer have
+            the bandwidth to update it, please let us know, so that someone can
+            take it over. 🙏

--- a/.github/workflows/dormant_issues_prs.yml
+++ b/.github/workflows/dormant_issues_prs.yml
@@ -23,8 +23,7 @@ jobs:
           stale-issue-message: >
             Hello scikit-image core devs! There hasn't been any activity on
             this issue for more than 180 days. I have marked it as "dormant" to
-            make it easy to find. You can remove the dormant label by adding some
-            new activity.
+            make it easy to find.
 
             To our contributors, thank you for your contribution and apologies
             if this issue fell through the cracks! Hopefully this ping will
@@ -39,8 +38,7 @@ jobs:
           stale-pr-message: >
             Hello scikit-image core devs! There hasn't been any activity on
             this PR for more than 180 days. I have marked it as "dormant" to
-            make it easy to find. You can remove the dormant label by adding some
-            new activity.
+            make it easy to find.
 
             To our contributors, thank you for your contribution and apologies
             if this contribution fell through the cracks! Hopefully this ping


### PR DESCRIPTION
## Description

We've had a few cases of issues and PRs where contributors were waiting for a
response and then the bot comes in and says "hey we haven't heard from you so
we're labeling this as dormant." Even as a bystander I find it infuriating!

I've also noticed that the bot commenting usually jolts us and reminds us to
look at old issues and PRs that are still very much relevant.

Therefore, I propose here to update the wording to make the stale bot ping
*us*, the core devs, into action, and only gently suggest action from the
contributor. I think even in the rare cases where we *are* waiting for
contributor input, we can take it. 😜

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Update wording on the stale bot to assume the core team dropped the ball.
```
