### PR TITLE
Fix chocolatey

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,7 +107,7 @@ jobs:
           choco upgrade llvm
 
           ## To list all installed packages:
-          # choco list --localonly
+          choco list
 
           # Remove other gcc compilers
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,11 +101,6 @@ jobs:
               export CXXFLAGS="-m32"
           fi
 
-          # Install llvm 16 manually, remove after
-          # https://github.com/actions/runner-images/issues/8125 is resolved and that
-          # version is included in the image by default
-          choco upgrade llvm
-
           ## To list all installed packages:
           choco list
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,9 +115,9 @@ jobs:
           # choco uninstall llvm mingw rtools strawberryperl -x
 
           # Remove mingw gcc
-          rm /c/ProgramData/Chocolatey/bin/gcc
-          rm /c/ProgramData/Chocolatey/bin/g++
-          rm /c/ProgramData/Chocolatey/bin/c++
+          #rm /c/ProgramData/Chocolatey/bin/gcc
+          #rm /c/ProgramData/Chocolatey/bin/g++
+          #rm /c/ProgramData/Chocolatey/bin/c++
           # Remove perl gcc
           rm -rf /c/Strawberry
 


### PR DESCRIPTION
We are getting to following error on the CI:
```
2023-10-11T16:39:19.4420906Z Installing llvm...
2023-10-11T16:40:36.6639955Z llvm has been installed.
2023-10-11T16:40:38.3602675Z   llvm may be able to be automatically uninstalled.
2023-10-11T16:40:38.4387515Z  The upgrade of llvm was successful.
2023-10-11T16:40:38.4394075Z   Software installed as 'EXE', install location is likely default.
2023-10-11T16:40:38.5133832Z 
2023-10-11T16:40:38.5141032Z Chocolatey upgraded 1/1 packages. 
2023-10-11T16:40:38.5142307Z  See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
2023-10-11T16:40:38.5808494Z + rm /c/ProgramData/Chocolatey/bin/gcc
2023-10-11T16:40:38.7116516Z rm: cannot remove '/c/ProgramData/Chocolatey/bin/gcc': No such file or directory
2023-10-11T16:40:38.7450939Z ##[error]Bash exited with code '1'.
2023-10-11T16:40:38.7762484Z ##[section]Finishing: Installation
```

I am using this PR to look into it.