### PR TITLE
Temporarily pin Cython to <3.0.3 until CI is fixed, take 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ requires = [
     'wheel',
     'setuptools>=67',
     'packaging>=21',
-    'Cython>=0.29.32',
+    'Cython>=0.29.32,<3.0.3',
     'pythran',
     'lazy_loader>=0.3',
     "numpy==1.22.4; python_version=='3.9' and platform_python_implementation != 'PyPy'",


### PR DESCRIPTION
Follow-up to #7189. (Cython appears twice.)