### PR TITLE
Make titles in RAG gallery examples more explicit

### DIFF
--- a/doc/examples/segmentation/plot_rag.py
+++ b/doc/examples/segmentation/plot_rag.py
@@ -1,7 +1,7 @@
 """
-=======================
-Region Adjacency Graphs
-=======================
+=============================
+Region Adjacency Graphs (RAGs)
+=============================
 
 This example demonstrates the use of the `merge_nodes` function of a Region
 Adjacency Graph (RAG). The `RAG` class represents a undirected weighted graph

--- a/doc/examples/segmentation/plot_rag.py
+++ b/doc/examples/segmentation/plot_rag.py
@@ -1,7 +1,7 @@
 """
-=============================
+==============================
 Region Adjacency Graphs (RAGs)
-=============================
+==============================
 
 This example demonstrates the use of the `merge_nodes` function of a Region
 Adjacency Graph (RAG). The `RAG` class represents a undirected weighted graph

--- a/doc/examples/segmentation/plot_rag_boundary.py
+++ b/doc/examples/segmentation/plot_rag_boundary.py
@@ -1,7 +1,7 @@
 """
-==========================
-Region Boundary based RAGs
-==========================
+====================================================
+Region Boundary based Region adjacency graphs (RAGs)
+====================================================
 
 Construct a region boundary RAG with the ``rag_boundary`` function. The
 function  :py:func:`skimage.graph.rag_boundary` takes an

--- a/doc/examples/segmentation/plot_rag_mean_color.py
+++ b/doc/examples/segmentation/plot_rag_mean_color.py
@@ -1,7 +1,7 @@
 """
-================
-RAG Thresholding
-================
+=========================================
+Region adjacency graph (RAG) Thresholding
+=========================================
 
 This example constructs a Region Adjacency Graph (RAG) and merges regions
 which are similar in color. We construct a RAG and define edges as the

--- a/doc/examples/segmentation/plot_rag_merge.py
+++ b/doc/examples/segmentation/plot_rag_merge.py
@@ -1,7 +1,7 @@
 """
-===========
-RAG Merging
-===========
+====================================
+Region adjacency graph (RAG) Merging
+====================================
 
 This example constructs a Region Adjacency Graph (RAG) and progressively merges
 regions that are similar in color. Merging two adjacent regions produces


### PR DESCRIPTION
fixes #2589 

This PR changes the title and adds the keywords "adjacency" and "graph" to the title.