### PR TITLE
MAINT: remove llvm manual install from chocolatey

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,11 +101,6 @@ jobs:
               export CXXFLAGS="-m32"
           fi
 
-          # Install llvm 16 manually, remove after
-          # https://github.com/actions/runner-images/issues/8125 is resolved and that
-          # version is included in the image by default
-          choco upgrade llvm
-
           ## To list all installed packages:
           # choco list --localonly
 


### PR DESCRIPTION
This should probably fix the chocolatey issue @jarrodmillman, and also closes https://github.com/scikit-image/scikit-image/issues/7108

