### PR TITLE
Speed up doctest of `calibrate_denoiser` by ~30 s

### DIFF
--- a/skimage/restoration/j_invariant.py
+++ b/skimage/restoration/j_invariant.py
@@ -143,10 +143,14 @@ def denoise_invariant(image, denoise_function, *, stride=4,
     Examples
     --------
     >>> import skimage
-    >>> from skimage.restoration import denoise_invariant, denoise_tv_chambolle
+    >>> from skimage.restoration import denoise_invariant, denoise_wavelet
     >>> image = skimage.util.img_as_float(skimage.data.chelsea())
     >>> noisy = skimage.util.random_noise(image, var=0.2 ** 2)
-    >>> denoised = denoise_invariant(noisy, denoise_function=denoise_tv_chambolle)
+
+    In this case, `denoise_wavelet` requires the optional dependency PyWavelets.
+
+    >>> import pytest; _ = pytest.importorskip("pywt")
+    >>> denoised = denoise_invariant(noisy, denoise_function=denoise_wavelet)
     """
     image = img_as_float(image)
 


### PR DESCRIPTION
## Description

denoise_tv_chambolle (34.01 s) is a lot slower than denoise_wavelet (2.14 s). denoise_wavelet, was previously replaced because PyWavelets got turned into an optional dependency and handling this in doctests is awkward. So let's revert this change.

denoise_tv_bregman would be another faster option (5.23 s) but I am not sure if using something different from denoise_wavelet actually makes sense from an algorithm standpoint.

Other top slowest tests in our suite (use `--duration=X` with pytest to get X slowest tests):
```
========================================== slowest durations ==========================================
34.01s call     restoration/j_invariant.py::skimage.restoration.j_invariant.denoise_invariant
32.39s call     data/tests/test_data.py::test_download_all_with_pooch
16.65s call     registration/tests/test_tvl1.py::test_3d_motion
15.12s call     restoration/tests/test_rolling_ball.py::test_ndim
12.85s call     graph/tests/test_rag.py::test_reproducibility
7.16s call     restoration/_rolling_ball.py::skimage.restoration._rolling_ball.rolling_ball
4.00s call     filters/tests/test_ridges.py::test_3d_cropped_camera_image
3.95s call     registration/_optical_flow.py::skimage.registration._optical_flow.optical_flow_tvl1
3.31s call     registration/tests/test_ilk.py::test_3d_motion[True-True]
3.10s call     registration/tests/test_ilk.py::test_3d_motion[True-False]
2.84s call     measure/tests/test_blur_effect.py::test_blur_effect_3d
2.65s call     segmentation/tests/test_random_walker.py::test_spacing_1
2.60s call     morphology/tests/test_footprints.py::test_nsphere_series_approximation[100-ball]
2.58s call     feature/sift.py::skimage.feature.sift.SIFT
...
```


## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
