### PR TITLE
Unpin Cython after release of Cython 3.0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ build = [
     'setuptools>=67',
     'packaging>=21',
     'ninja',
-    'Cython>=0.29.32,<3.0.3',
+    'Cython>=0.29.32,!=3.0.3',
     'pythran',
     'numpy>=1.22',
     # Developer UI
@@ -122,7 +122,7 @@ requires = [
     'wheel',
     'setuptools>=67',
     'packaging>=21',
-    'Cython>=0.29.32,<3.0.3',
+    'Cython>=0.29.32,!=3.0.3',
     'pythran',
     'lazy_loader>=0.3',
     "numpy==1.22.4; python_version=='3.9' and platform_python_implementation != 'PyPy'",

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -5,7 +5,7 @@ wheel
 setuptools>=67
 packaging>=21
 ninja
-Cython>=0.29.32,<3.0.3
+Cython>=0.29.32,!=3.0.3
 pythran
 numpy>=1.22
 spin==0.7


### PR DESCRIPTION
## Description

With Cython 3.0.4 [1] released, the issues from 3.0.3 [2] are hopefully addressed.

[1] https://github.com/cython/cython/blob/master/CHANGES.rst#304-2023-10-17
[2] https://github.com/scikit-image/scikit-image/pull/7189

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
