### PR TITLE
Apply black to `_hog.py` after previous merge lacking black

### DIFF
--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -311,10 +311,12 @@ def hog(
     if n_blocks_col <= 0 or n_blocks_row <= 0:
         min_row = b_row * c_row
         min_col = b_col * c_col
-        raise ValueError('The input image is too small given the values of '
-                         'pixels_per_cell and cells_per_block. '
-                         'It should have at least: '
-                         f'{min_row} rows and {min_col} cols.')
+        raise ValueError(
+            'The input image is too small given the values of '
+            'pixels_per_cell and cells_per_block. '
+            'It should have at least: '
+            f'{min_row} rows and {min_col} cols.'
+        )
     normalized_blocks = np.zeros(
         (n_blocks_row, n_blocks_col, b_row, b_col, orientations), dtype=float_dtype
     )

--- a/skimage/feature/tests/test_hog.py
+++ b/skimage/feature/tests/test_hog.py
@@ -353,4 +353,8 @@ def test_hog_small_image():
 
     img = np.zeros((23, 23))
     with pytest.raises(ValueError, match=".*image is too small given"):
-        feature.hog(img, pixels_per_cell=(8, 8), cells_per_block=(3, 3),)
+        feature.hog(
+            img,
+            pixels_per_cell=(8, 8),
+            cells_per_block=(3, 3),
+        )


### PR DESCRIPTION
## Description

#7153 was merged previously and didn't yet include the most recent changes from main yet which introduced the black pre-commit hook. So for a while we'll need to make sure that we merge `main` before merging.

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
