### PR TITLE
Replaced git checkout in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -58,13 +58,13 @@ can be contributed to scikit-image.
 
    * Pull the latest changes from upstream::
 
-      git checkout main
+      git switch main
       git pull upstream main
 
    * Create a branch for the feature you want to work on. Use a sensible name,
      such as 'transform-speedups'::
 
-      git checkout -b transform-speedups
+      git switch -c transform-speedups
 
    * Commit locally as you progress (with ``git add`` and ``git commit``).
      Please write `good commit messages


### PR DESCRIPTION
Addresses Issue #7213

This Pull Request replaces the command "git-checkout" with "git-switch" in the documentation.