### PR TITLE
Remove rng parameter of binary_blobs() function in plot_random_walker_segmentation.py

### DIFF
--- a/doc/examples/segmentation/plot_random_walker_segmentation.py
+++ b/doc/examples/segmentation/plot_random_walker_segmentation.py
@@ -31,7 +31,7 @@ import skimage
 rng = np.random.default_rng()
 
 # Generate noisy synthetic data
-data = skimage.img_as_float(binary_blobs(length=128, rng=1))
+data = skimage.img_as_float(binary_blobs(length=128))
 sigma = 0.35
 data += rng.normal(loc=0, scale=sigma, size=data.shape)
 data = rescale_intensity(data, in_range=(-sigma, 1 + sigma), out_range=(-1, 1))


### PR DESCRIPTION
Using the rng parameter throws the following TypeError:

TypeError: binary_blobs() got an unexpected keyword argument 'rng' 

## Description

Parameter rng removal in line:

`data = skimage.img_as_float(binary_blobs(length=128, rng=1))`

of Random walker segmentation Example.

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

```release-note
## Removed rng parameter.
data = skimage.img_as_float(binary_blobs(length=128))
```

To reproduce error and fix: https://colab.research.google.com/drive/1iy8InDNAoadAaNkn0WuyND6S0a3VFmEx?usp=sharing

Removing it does not make any change to the aim of the tutorial; which is showing the segmentation capabilities.