### PR TITLE
Silence PyData theme warning about new default for "navigation_with_keys"

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -23,6 +23,9 @@ Other (2022)
 * NumPy 1.25.0 is minimal required version:
     * Remove optional test for a NaN-related deprecation warning from numpy.clip in
       skimage/exposure/tests/test_exposure.py::test_rescale_nan_warning
+* pydata-sphinx-theme 0.15.0 is minimal version: remove obsolete config option
+  ``"navigation_with_keys": False,`` in doc/source/conf.py::html_theme_options.
+
 
 Post numpy 2
 ------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -184,6 +184,9 @@ html_theme_options = {
         "plausible_analytics_domain": "scikit-image.org",
         "plausible_analytics_url": ("https://views.scientific-python.org/js/script.js"),
     },
+    # Silence warning in pydata-sphinx-theme v0.14.2
+    # can be removed after >=0.15 is released and pinned
+    "navigation_with_keys": False,
 }
 
 # Custom sidebar templates, maps document names to template names.


### PR DESCRIPTION
## Description

Hopefully addresses our [failing Windows CI](https://dev.azure.com/scikit-image/scikit-image/_build/results?buildId=10593&view=logs&j=feb0b66f-d63c-5533-bf34-a72e08b12053&t=26b7b1f7-60f2-5676-21d5-45b533330524). The new default (`False`) apparently has the nice benefit of improving keyboard navigation (see https://github.com/pydata/pydata-sphinx-theme/issues/1492).

With PyData theme v0.14.2 [a warning is raised](https://github.com/pydata/pydata-sphinx-theme/blob/fe02751fa10a9487d38d65e817cb007d6d413d2f/src/pydata_sphinx_theme/__init__.py#L53-L63) about a changing default config option. As it is treated as an error by our Windows CI mute it by setting it explicitly to the new default.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Stop HTML documentation from intercepting left and right-arrow keys
to improve keyboard accessibility.
```
