### PR TITLE
Fix reference formatting for nitpicky sphinx

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -559,7 +559,7 @@ Here, the creation of the image is completed in the ``setup`` method, and not
 included in the reported time of the benchmark.
 
 It is also possible to benchmark features such as peak memory usage. To learn
-more about the features of `asv`, please refer to the official
+more about the features of ``asv``, please refer to the official
 `airpseed velocity documentation <https://asv.readthedocs.io/en/latest/writing_benchmarks.html>`_.
 
 Also, the benchmark files need to be importable when benchmarking old versions

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -559,7 +559,7 @@ Here, the creation of the image is completed in the ``setup`` method, and not
 included in the reported time of the benchmark.
 
 It is also possible to benchmark features such as peak memory usage. To learn
-more about the features of ``asv``, please refer to the official
+more about the features, please refer to the official
 `airpseed velocity documentation <https://asv.readthedocs.io/en/latest/writing_benchmarks.html>`_.
 
 Also, the benchmark files need to be importable when benchmarking old versions

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -560,7 +560,7 @@ included in the reported time of the benchmark.
 
 It is also possible to benchmark features such as peak memory usage. To learn
 more about the features, please refer to the official
-`airpseed velocity documentation <https://asv.readthedocs.io/en/latest/writing_benchmarks.html>`_.
+`airspeed velocity documentation <https://asv.readthedocs.io/en/latest/writing_benchmarks.html>`_.
 
 Also, the benchmark files need to be importable when benchmarking old versions
 of scikit-image. So if anything from scikit-image is imported at the top level,

--- a/doc/examples/applications/plot_3d_interaction.py
+++ b/doc/examples/applications/plot_3d_interaction.py
@@ -59,7 +59,7 @@ vmin, vmax = data.min(), data.max()
 print(f'range: ({vmin}, {vmax})')
 
 #####################################################################
-# We turn to ``plotly``'s implementation of the `imshow` function, for it
+# We turn to Plotly's implementation of the :func:`plotly.express.imshow` function, for it
 # supports `value ranges
 # <https://plotly.com/python/imshow/#defining-the-data-range-covered-by-the-color-range-with-zmin-and-zmax>`_
 # beyond ``(0.0, 1.0)`` for floats and ``(0, 255)`` for integers.

--- a/doc/examples/applications/plot_3d_interaction.py
+++ b/doc/examples/applications/plot_3d_interaction.py
@@ -59,7 +59,7 @@ vmin, vmax = data.min(), data.max()
 print(f'range: ({vmin}, {vmax})')
 
 #####################################################################
-# We turn to `plotly`'s implementation of the `imshow` function, for it
+# We turn to ``plotly``'s implementation of the `imshow` function, for it
 # supports `value ranges
 # <https://plotly.com/python/imshow/#defining-the-data-range-covered-by-the-color-range-with-zmin-and-zmax>`_
 # beyond ``(0.0, 1.0)`` for floats and ``(0, 255)`` for integers.

--- a/doc/examples/segmentation/plot_compact_watershed.py
+++ b/doc/examples/segmentation/plot_compact_watershed.py
@@ -11,7 +11,7 @@ in downstream analyses.
 The *compact* watershed transform remedies this by favoring seeds that are
 close to the pixel being considered.
 
-Both algorithms are implemented in the :py:func:`skimage.morphology.watershed`
+Both algorithms are implemented in the :py:func:`skimage.segmentation.watershed`
 function. To use the compact form, simply pass a ``compactness`` value greater
 than 0.
 """

--- a/doc/examples/segmentation/plot_compact_watershed.py
+++ b/doc/examples/segmentation/plot_compact_watershed.py
@@ -11,7 +11,7 @@ in downstream analyses.
 The *compact* watershed transform remedies this by favoring seeds that are
 close to the pixel being considered.
 
-Both algorithms are implemented in the :py:func:`skimage.segmentation.watershed`
+Both algorithms are implemented in the :func:`skimage.segmentation.watershed`
 function. To use the compact form, simply pass a ``compactness`` value greater
 than 0.
 """

--- a/doc/examples/segmentation/plot_metrics.py
+++ b/doc/examples/segmentation/plot_metrics.py
@@ -7,7 +7,7 @@ When trying out different segmentation methods, how do you know which one is
 best? If you have a *ground truth* or *gold standard* segmentation, you can use
 various metrics to check how close each automated method comes to the truth.
 In this example we use an easy-to-segment image as an example of how to
-interpret various segmentation metrics. We will use the the adapted Rand error
+interpret various segmentation metrics. We will use the adapted Rand error
 and the variation of information as example metrics, and see how
 *oversegmentation* (splitting of true segments into too many sub-segments) and
 *undersegmentation* (merging of different true segments into a single segment)
@@ -58,7 +58,7 @@ edges = sobel(image)
 im_test1 = watershed(edges, markers=468, compactness=0.001)
 
 ###############################################################################
-# The next approach uses the Canny edge filter, :func:`skimage.filters.canny`.
+# The next approach uses the Canny edge filter, :func:`skimage.feature.canny`.
 # This is a very good edge finder, and gives balanced results.
 
 edges = canny(image)

--- a/doc/examples/segmentation/plot_rag.py
+++ b/doc/examples/segmentation/plot_rag.py
@@ -4,8 +4,8 @@ Region Adjacency Graphs (RAGs)
 ==============================
 
 This example demonstrates the use of the `merge_nodes` function of a Region
-Adjacency Graph (RAG). The `RAG` class represents a undirected weighted graph
-which inherits from `networkx.graph` class. When a new node is formed by
+Adjacency Graph (RAG). The `RAG` class represents an undirected weighted graph
+which inherits from :obj:`networkx.Graph` class. When a new node is formed by
 merging two nodes, the edge weight of all the edges incident on the resulting
 node can be updated by a user defined function `weight_func`.
 

--- a/doc/examples/segmentation/plot_regionprops_table.py
+++ b/doc/examples/segmentation/plot_regionprops_table.py
@@ -66,7 +66,7 @@ plt.show()
 # To get a better sense of the distribution, we may want to add some 'jitter'
 # to the visualization. To this end, we use :obj:`seaborn.stripplot` (from
 # `seaborn library <https://seaborn.pydata.org/>`_ for statistical data visualization)
-# with argument `jitter=True`.
+# with argument ``jitter=True``.
 
 fig, ax = plt.subplots()
 sns.stripplot(x='volume fraction', y='area', data=areas, jitter=True, ax=ax)

--- a/doc/examples/segmentation/plot_regionprops_table.py
+++ b/doc/examples/segmentation/plot_regionprops_table.py
@@ -64,7 +64,7 @@ plt.show()
 #####################################################################
 # In the scatterplot, many points seem to be overlapping at low area values.
 # To get a better sense of the distribution, we may want to add some 'jitter'
-# to the visualization. To this end, we use `stripplot` (from `seaborn`, the
+# to the visualization. To this end, we use `stripplot` (from ``seaborn``, the
 # Python library dedicated to statistical data visualization) with argument
 # `jitter=True`.
 

--- a/doc/examples/segmentation/plot_regionprops_table.py
+++ b/doc/examples/segmentation/plot_regionprops_table.py
@@ -64,9 +64,9 @@ plt.show()
 #####################################################################
 # In the scatterplot, many points seem to be overlapping at low area values.
 # To get a better sense of the distribution, we may want to add some 'jitter'
-# to the visualization. To this end, we use `stripplot` (from ``seaborn``, the
-# Python library dedicated to statistical data visualization) with argument
-# `jitter=True`.
+# to the visualization. To this end, we use :obj:`seaborn.stripplot` (from
+# `seaborn library <https://seaborn.pydata.org/>`_ for statistical data visualization)
+# with argument `jitter=True`.
 
 fig, ax = plt.subplots()
 sns.stripplot(x='volume fraction', y='area', data=areas, jitter=True, ax=ax)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -255,23 +255,36 @@ intersphinx_mapping = {
 
 nitpicky = True
 nitpick_ignore = [
-    ("py:obj", "color_dict"),
     ("py:class", "skimage.transform._geometric._GeometricTransform"),
-    ("py:class", "skimage.transform._geometric.ProjectiveTransform"),
-    ("py:class", "skimage.feature.util.DescriptorExtractor"),
-    ("py:class", "skimage.feature.util.FeatureDetector"),
-    ("py:class", "skimage.measure.fit.BaseModel"),
-    ("py:exc", "NetworkXError"),
-    ("py:obj", "Graph"),
-    ("py:obj", "Graph.__iter__"),
-    ("py:obj", "__len__"),
-    ("py:class", "_GeometricTransform"),
-    ("py:obj", "convert"),
-    ("py:obj", "available_plugins"),
-    ("py:obj", "skimage.io.collection"),
-    ("py:obj", "skimage.io.manage_plugins"),
-    ("py:obj", "skimage.io.sift"),
-    ("py:obj", "skimage.io.util"),
+    # ^ skimage.transform._geometric.{FundamentalMatrixTransform,PiecewiseAffineTransform,PolynomialTransform,ProjectiveTransform}
+    (
+        "py:class",
+        "skimage.feature.util.DescriptorExtractor",
+    ),  # skimage.feature.{censure.CENSURE/orb.ORB/sift.SIFT}
+    (
+        "py:class",
+        "skimage.feature.util.FeatureDetector",
+    ),  # skimage.feature.{censure.CENSURE/orb.ORB/sift.SIFT}
+    (
+        "py:class",
+        "skimage.measure.fit.BaseModel",
+    ),  # skimage.measure.fit.{CircleModel/EllipseModel/LineModelND}
+    ("py:exc", "NetworkXError"),  # networkx.classes.graph.Graph.nbunch_iter
+    ("py:obj", "Graph"),  # networkx.classes.graph.Graph.to_undirected
+    ("py:obj", "Graph.__iter__"),  # networkx.classes.graph.Graph.nbunch_iter
+    ("py:obj", "__len__"),  # networkx.classes.graph.Graph.{number_of_nodes/order}
+    (
+        "py:class",
+        "_GeometricTransform",
+    ),  # skimage.transform._geometric.estimate_transform
+    ("py:obj", "convert"),  # skimage.graph._rag.RAG.__init__
+    ("py:obj", "skimage.io.collection"),  # (generated) doc/source/api/skimage.io.rst
+    (
+        "py:obj",
+        "skimage.io.manage_plugins",
+    ),  # (generated) doc/source/api/skimage.io.rst
+    ("py:obj", "skimage.io.sift"),  # (generated) doc/source/api/skimage.io.rst
+    ("py:obj", "skimage.io.util"),  # (generated) doc/source/api/skimage.io.rst
 ]
 # -- Source code links -------------------------------------------------------
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -248,6 +248,7 @@ intersphinx_mapping = {
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "sklearn": ("https://scikit-learn.org/stable/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
+    "networkx": ("https://networkx.org/documentation/stable/", None),
 }
 
 # -- Source code links -------------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -249,8 +249,30 @@ intersphinx_mapping = {
     "sklearn": ("https://scikit-learn.org/stable/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "networkx": ("https://networkx.org/documentation/stable/", None),
+    "plotly": ("https://plotly.com/python-api-reference/", None),
+    "seaborn": ("https://seaborn.pydata.org/", None),
 }
 
+nitpicky = True
+nitpick_ignore = [
+    ("py:obj", "color_dict"),
+    ("py:class", "skimage.transform._geometric._GeometricTransform"),
+    ("py:class", "skimage.transform._geometric.ProjectiveTransform"),
+    ("py:class", "skimage.feature.util.DescriptorExtractor"),
+    ("py:class", "skimage.feature.util.FeatureDetector"),
+    ("py:class", "skimage.measure.fit.BaseModel"),
+    ("py:exc", "NetworkXError"),
+    ("py:obj", "Graph"),
+    ("py:obj", "Graph.__iter__"),
+    ("py:obj", "__len__"),
+    ("py:class", "_GeometricTransform"),
+    ("py:obj", "convert"),
+    ("py:obj", "available_plugins"),
+    ("py:obj", "skimage.io.collection"),
+    ("py:obj", "skimage.io.manage_plugins"),
+    ("py:obj", "skimage.io.sift"),
+    ("py:obj", "skimage.io.util"),
+]
 # -- Source code links -------------------------------------------------------
 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -253,7 +253,9 @@ intersphinx_mapping = {
     "seaborn": ("https://seaborn.pydata.org/", None),
 }
 
-nitpicky = True
+# Do not (yet) use nitpicky mode for checking cross-references
+nitpicky = False
+# nitpick_ignore is only considered when nitpicky=True
 nitpick_ignore = [
     (
         "py:class",

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -255,8 +255,10 @@ intersphinx_mapping = {
 
 nitpicky = True
 nitpick_ignore = [
-    ("py:class", "skimage.transform._geometric._GeometricTransform"),
-    # ^ skimage.transform._geometric.{FundamentalMatrixTransform,PiecewiseAffineTransform,PolynomialTransform,ProjectiveTransform}
+    (
+        "py:class",
+        "skimage.transform._geometric._GeometricTransform",
+    ),  # skimage.transform._geometric.{FundamentalMatrixTransform,PiecewiseAffineTransform,PolynomialTransform,ProjectiveTransform}
     (
         "py:class",
         "skimage.feature.util.DescriptorExtractor",

--- a/doc/source/release_notes/release_0.14.rst
+++ b/doc/source/release_notes/release_0.14.rst
@@ -548,7 +548,7 @@ It contains the following 186 merged pull requests by 67 committers:
 - Deprecate `visualise` in favor of `visualize` in `skimage.feature.hog` (#2705)
 - Remove alpha channel when saving to jpg format (#2706)
 - Tweak in-place installation instructions (#2712)
-- Add `skimage.lookfor` function (#2713)
+- Add ``skimage.lookfor`` function (#2713)
 - Speedup image dtype conversion by switching to `asarray` (#2715)
 - MAINT reorganizing CI-related scripts (#2718)
 - added rect function to draw module (#2719)

--- a/doc/source/release_notes/release_0.16.rst
+++ b/doc/source/release_notes/release_0.16.rst
@@ -119,14 +119,14 @@ API Changes
   `skimage.morphology.remove_small_holes`. Use ``area_threshold`` instead.
 - Deprecated ``correct_mesh_orientation`` in `skimage.measure` has been
   removed.
-- `skimage.measure._regionprops` has been completely switched to using
+- ``skimage.measure._regionprops`` has been completely switched to using
   row-column coordinates. Old x-y interface is not longer available.
 - Default value of ``behavior`` parameter has been set to ``ndimage`` in
   `skimage.filters.median`.
 - Parameter ``flatten`` in `skimage.io.imread` has been removed in
   favor of ``as_gray``.
 - Parameters ``Hxx, Hxy, Hyy`` have been removed from
-  `skimage.feature.corner.hessian_matrix_eigvals` in favor of ``H_elems``.
+  ``skimage.feature.corner.hessian_matrix_eigvals`` in favor of ``H_elems``.
 - Default value of ``order`` parameter has been set to ``rc`` in
   `skimage.feature.hessian_matrix`.
 - ``skimage.util.img_as_*`` functions no longer raise precision and/or loss warnings.

--- a/doc/source/release_notes/release_0.17.rst
+++ b/doc/source/release_notes/release_0.17.rst
@@ -76,7 +76,7 @@ New Features
   (#3850)
 - Pooch -- on the fly download of datasets from github: we introduced the
   possibility to include larger datasets in the `data` submodule, thanks to the
-  `pooch` library. `data.download_all` fetches all datasets. (#3945)
+  ``pooch`` library. `data.download_all` fetches all datasets. (#3945)
 - Starting with this version, our gallery examples now have links to run the
   example notebook on a binder instance. (#4543)
 

--- a/doc/source/release_notes/release_0.20.rst
+++ b/doc/source/release_notes/release_0.20.rst
@@ -24,7 +24,7 @@ This release completes the transition to a more flexible
 includes several other deprecations that make the API more consistent and
 expressive.
 
-Finally, in preparation for the removal of `distutils` in the upcoming
+Finally, in preparation for the removal of ``distutils`` in the upcoming
 Python 3.12 release, we replaced our build system with `meson` and a
 static `pyproject.toml` specification.
 

--- a/doc/source/release_notes/release_0.21.rst
+++ b/doc/source/release_notes/release_0.21.rst
@@ -35,9 +35,9 @@ seeds and NumPy Generators. Please see the related `SciPy discussion`_, as well 
 
 - Unify API on seed keyword for random seeds / generator
   (`#6258 <https://github.com/scikit-image/scikit-image/pull/6258>`_).
-- Refactor `_invariant_denoise` to `denoise_invariant`
+- Refactor ``_invariant_denoise`` to ``denoise_invariant``
   (`#6660 <https://github.com/scikit-image/scikit-image/pull/6660>`_).
-- Expose `color.get_xyz_coords` in public API
+- Expose ``color.get_xyz_coords`` in public API
   (`#6696 <https://github.com/scikit-image/scikit-image/pull/6696>`_).
 - Make join_segmentations return array maps from output to input labels
   (`#6786 <https://github.com/scikit-image/scikit-image/pull/6786>`_).
@@ -54,9 +54,9 @@ Enhancements
   (`#6752 <https://github.com/scikit-image/scikit-image/pull/6752>`_).
 - Make join_segmentations return array maps from output to input labels
   (`#6786 <https://github.com/scikit-image/scikit-image/pull/6786>`_).
-- Check if `spacing` parameter is tuple in `regionprops`
+- Check if ``spacing`` parameter is tuple in ``regionprops``
   (`#6907 <https://github.com/scikit-image/scikit-image/pull/6907>`_).
-- Enable use of `rescale_intensity` with dask array
+- Enable use of ``rescale_intensity`` with dask array
   (`#6910 <https://github.com/scikit-image/scikit-image/pull/6910>`_).
 
 Performance
@@ -72,21 +72,21 @@ Performance
 
 Bug Fixes
 ---------
-- Fix and refactor `deprecated` decorator to `deprecate_func`
+- Fix and refactor ``deprecated`` decorator to ``deprecate_func``
   (`#6594 <https://github.com/scikit-image/scikit-image/pull/6594>`_).
-- Refactor `_invariant_denoise` to `denoise_invariant`
+- Refactor ``_invariant_denoise`` to ``denoise_invariant``
   (`#6660 <https://github.com/scikit-image/scikit-image/pull/6660>`_).
-- Expose `color.get_xyz_coords` in public API
+- Expose ``color.get_xyz_coords`` in public API
   (`#6696 <https://github.com/scikit-image/scikit-image/pull/6696>`_).
 - shift and normalize data before fitting circle or ellipse
   (`#6703 <https://github.com/scikit-image/scikit-image/pull/6703>`_).
 - Showcase pydata-sphinx-theme
   (`#6714 <https://github.com/scikit-image/scikit-image/pull/6714>`_).
-- Fix matrix calculation for shear angle in `AffineTransform`
+- Fix matrix calculation for shear angle in ``AffineTransform``
   (`#6717 <https://github.com/scikit-image/scikit-image/pull/6717>`_).
 - Fix threshold_li(): prevent log(0) on single-value background.
   (`#6745 <https://github.com/scikit-image/scikit-image/pull/6745>`_).
-- Fix copy-paste error in `footprints.diamond` test case
+- Fix copy-paste error in ``footprints.diamond`` test case
   (`#6756 <https://github.com/scikit-image/scikit-image/pull/6756>`_).
 - Update .devpy/cmds.py to match latest devpy
   (`#6789 <https://github.com/scikit-image/scikit-image/pull/6789>`_).
@@ -96,9 +96,9 @@ Bug Fixes
   (`#6805 <https://github.com/scikit-image/scikit-image/pull/6805>`_).
 - Sign error fix in measure.regionprops for orientations of 45 degrees
   (`#6836 <https://github.com/scikit-image/scikit-image/pull/6836>`_).
-- Fix returned data type in `segmentation.watershed`
+- Fix returned data type in ``segmentation.watershed``
   (`#6839 <https://github.com/scikit-image/scikit-image/pull/6839>`_).
-- Handle NaNs when clipping in `transform.resize`
+- Handle NaNs when clipping in ``transform.resize``
   (`#6852 <https://github.com/scikit-image/scikit-image/pull/6852>`_).
 - Fix failing regionprop_table for multichannel properties
   (`#6861 <https://github.com/scikit-image/scikit-image/pull/6861>`_).
@@ -108,7 +108,7 @@ Bug Fixes
   (`#6881 <https://github.com/scikit-image/scikit-image/pull/6881>`_).
 - Fix LPI filter for data with even dimensions
   (`#6883 <https://github.com/scikit-image/scikit-image/pull/6883>`_).
-- Use legacy datasets without creating a `data_dir`
+- Use legacy datasets without creating a ``data_dir``
   (`#6886 <https://github.com/scikit-image/scikit-image/pull/6886>`_).
 - Raise error when source_range is not correct
   (`#6898 <https://github.com/scikit-image/scikit-image/pull/6898>`_).
@@ -116,9 +116,9 @@ Bug Fixes
   (`#6900 <https://github.com/scikit-image/scikit-image/pull/6900>`_).
 - Corrected energy calculation in Chan Vese
   (`#6902 <https://github.com/scikit-image/scikit-image/pull/6902>`_).
-- Add missing backticks to DOI role in docstring of `area_opening`
+- Add missing backticks to DOI role in docstring of ``area_opening``
   (`#6913 <https://github.com/scikit-image/scikit-image/pull/6913>`_).
-- Fix inclusion of `random.js` in HTML output
+- Fix inclusion of ``random.js`` in HTML output
   (`#6935 <https://github.com/scikit-image/scikit-image/pull/6935>`_).
 - Fix URL of random gallery links
   (`#6937 <https://github.com/scikit-image/scikit-image/pull/6937>`_).
@@ -129,11 +129,11 @@ Bug Fixes
 
 Maintenance
 -----------
-- Fix and refactor `deprecated` decorator to `deprecate_func`
+- Fix and refactor ``deprecated`` decorator to ``deprecate_func``
   (`#6594 <https://github.com/scikit-image/scikit-image/pull/6594>`_).
 - allow trivial ransac call
   (`#6755 <https://github.com/scikit-image/scikit-image/pull/6755>`_).
-- Fix copy-paste error in `footprints.diamond` test case
+- Fix copy-paste error in ``footprints.diamond`` test case
   (`#6756 <https://github.com/scikit-image/scikit-image/pull/6756>`_).
 - Use imageio v3 API
   (`#6764 <https://github.com/scikit-image/scikit-image/pull/6764>`_).
@@ -151,7 +151,7 @@ Maintenance
   (`#6847 <https://github.com/scikit-image/scikit-image/pull/6847>`_).
 - Specify kernel for ipywidgets
   (`#6849 <https://github.com/scikit-image/scikit-image/pull/6849>`_).
-- Make `image_fetcher` and `create_image_fetcher` in `data` private
+- Make ``image_fetcher`` and ``create_image_fetcher`` in ``data`` private
   (`#6855 <https://github.com/scikit-image/scikit-image/pull/6855>`_).
 - Update references to outdated dev.py with spin
   (`#6856 <https://github.com/scikit-image/scikit-image/pull/6856>`_).
@@ -167,11 +167,11 @@ Maintenance
   (`#6875 <https://github.com/scikit-image/scikit-image/pull/6875>`_).
 - Don't use mutable types as default values for arguments
   (`#6876 <https://github.com/scikit-image/scikit-image/pull/6876>`_).
-- Point `version_switcher.json` URL at dev docs
+- Point ``version_switcher.json`` URL at dev docs
   (`#6882 <https://github.com/scikit-image/scikit-image/pull/6882>`_).
 - Add back parallel tests that were removed as part of Meson build
   (`#6884 <https://github.com/scikit-image/scikit-image/pull/6884>`_).
-- Use legacy datasets without creating a `data_dir`
+- Use legacy datasets without creating a ``data_dir``
   (`#6886 <https://github.com/scikit-image/scikit-image/pull/6886>`_).
 - Remove old doc cruft
   (`#6901 <https://github.com/scikit-image/scikit-image/pull/6901>`_).
@@ -183,9 +183,9 @@ Maintenance
   (`#6931 <https://github.com/scikit-image/scikit-image/pull/6931>`_).
 - Follow-up to move to pydata-sphinx-theme
   (`#6933 <https://github.com/scikit-image/scikit-image/pull/6933>`_).
-- Mark functions as `noexcept` to support Cython 3
+- Mark functions as ``noexcept`` to support Cython 3
   (`#6936 <https://github.com/scikit-image/scikit-image/pull/6936>`_).
-- Skip unstable test in `ransac`'s docstring
+- Skip unstable test in ``ransac``'s docstring
   (`#6938 <https://github.com/scikit-image/scikit-image/pull/6938>`_).
 - Stabilize EllipseModel fitting parameters
   (`#6943 <https://github.com/scikit-image/scikit-image/pull/6943>`_).
@@ -195,7 +195,7 @@ Maintenance
   (`#6948 <https://github.com/scikit-image/scikit-image/pull/6948>`_).
 - Skip ransac doctest
   (`#6953 <https://github.com/scikit-image/scikit-image/pull/6953>`_).
-- Expose `GeometricTransform.residuals` in HTML doc
+- Expose ``GeometricTransform.residuals`` in HTML doc
   (`#6968 <https://github.com/scikit-image/scikit-image/pull/6968>`_).
 - Fix NumPy 1.25 deprecation warnings
   (`#6969 <https://github.com/scikit-image/scikit-image/pull/6969>`_).
@@ -210,15 +210,15 @@ Maintenance
 
 Documentation
 -------------
-- Document boundary behavior of `draw.polygon` and `draw.polygon2mask`
+- Document boundary behavior of ``draw.polygon`` and ``draw.polygon2mask``
   (`#6690 <https://github.com/scikit-image/scikit-image/pull/6690>`_).
 - Showcase pydata-sphinx-theme
   (`#6714 <https://github.com/scikit-image/scikit-image/pull/6714>`_).
 - Merge duplicate instructions for setting up build environment.
   (`#6770 <https://github.com/scikit-image/scikit-image/pull/6770>`_).
-- Add docstring to `skimage.color` module
+- Add docstring to ``skimage.color`` module
   (`#6777 <https://github.com/scikit-image/scikit-image/pull/6777>`_).
-- DOC: Fix underline length in `docstring_add_deprecated`
+- DOC: Fix underline length in ``docstring_add_deprecated``
   (`#6778 <https://github.com/scikit-image/scikit-image/pull/6778>`_).
 - Link full license to README
   (`#6779 <https://github.com/scikit-image/scikit-image/pull/6779>`_).
@@ -228,13 +228,13 @@ Documentation
   (`#6782 <https://github.com/scikit-image/scikit-image/pull/6782>`_).
 - Remove outdated build instructions from README
   (`#6788 <https://github.com/scikit-image/scikit-image/pull/6788>`_).
-- Add docstring to the `transform` module
+- Add docstring to the ``transform`` module
   (`#6797 <https://github.com/scikit-image/scikit-image/pull/6797>`_).
 - Handle pip-only dependencies when using conda.
   (`#6806 <https://github.com/scikit-image/scikit-image/pull/6806>`_).
 - Added examples to the EssentialMatrixTransform class and its estimation function
   (`#6832 <https://github.com/scikit-image/scikit-image/pull/6832>`_).
-- Fix returned data type in `segmentation.watershed`
+- Fix returned data type in ``segmentation.watershed``
   (`#6839 <https://github.com/scikit-image/scikit-image/pull/6839>`_).
 - Update references to outdated dev.py with spin
   (`#6856 <https://github.com/scikit-image/scikit-image/pull/6856>`_).
@@ -242,13 +242,13 @@ Documentation
   (`#6859 <https://github.com/scikit-image/scikit-image/pull/6859>`_).
 - Update _warps_cy.pyx
   (`#6867 <https://github.com/scikit-image/scikit-image/pull/6867>`_).
-- Point `version_switcher.json` URL at dev docs
+- Point ``version_switcher.json`` URL at dev docs
   (`#6882 <https://github.com/scikit-image/scikit-image/pull/6882>`_).
 - Fix docstring underline lengths
   (`#6895 <https://github.com/scikit-image/scikit-image/pull/6895>`_).
 - ENH Add JupyterLite button to gallery examples
   (`#6911 <https://github.com/scikit-image/scikit-image/pull/6911>`_).
-- Add missing backticks to DOI role in docstring of `area_opening`
+- Add missing backticks to DOI role in docstring of ``area_opening``
   (`#6913 <https://github.com/scikit-image/scikit-image/pull/6913>`_).
 - Add 0.21 release notes
   (`#6925 <https://github.com/scikit-image/scikit-image/pull/6925>`_).
@@ -266,7 +266,7 @@ Documentation
   (`#6949 <https://github.com/scikit-image/scikit-image/pull/6949>`_).
 - fix bad link in CODE_OF_CONDUCT.md
   (`#6952 <https://github.com/scikit-image/scikit-image/pull/6952>`_).
-- Expose `GeometricTransform.residuals` in HTML doc
+- Expose ``GeometricTransform.residuals`` in HTML doc
   (`#6968 <https://github.com/scikit-image/scikit-image/pull/6968>`_).
 
 Infrastructure
@@ -287,7 +287,7 @@ Infrastructure
   (`#6846 <https://github.com/scikit-image/scikit-image/pull/6846>`_).
 - Update pre-commits
   (`#6870 <https://github.com/scikit-image/scikit-image/pull/6870>`_).
-- Remove `codecov` dependency which disappeared from PyPI
+- Remove ``codecov`` dependency which disappeared from PyPI
   (`#6887 <https://github.com/scikit-image/scikit-image/pull/6887>`_).
 - Add CircleCI API token; fixes status link to built docs
   (`#6894 <https://github.com/scikit-image/scikit-image/pull/6894>`_).
@@ -297,11 +297,11 @@ Infrastructure
   (`#6917 <https://github.com/scikit-image/scikit-image/pull/6917>`_).
 - Use official meson-python release
   (`#6928 <https://github.com/scikit-image/scikit-image/pull/6928>`_).
-- Fix inclusion of `random.js` in HTML output
+- Fix inclusion of ``random.js`` in HTML output
   (`#6935 <https://github.com/scikit-image/scikit-image/pull/6935>`_).
 - Fix URL of random gallery links
   (`#6937 <https://github.com/scikit-image/scikit-image/pull/6937>`_).
-- Respect SPHINXOPTS and add --install-deps flags to `spin docs`
+- Respect SPHINXOPTS and add --install-deps flags to ``spin docs``
   (`#6940 <https://github.com/scikit-image/scikit-image/pull/6940>`_).
 - Build skimage before generating docs
   (`#6946 <https://github.com/scikit-image/scikit-image/pull/6946>`_).

--- a/doc/source/skips/3-transition-to-v1.rst
+++ b/doc/source/skips/3-transition-to-v1.rst
@@ -115,7 +115,7 @@ correctly, in sync with scikit-image.
 Related Work
 ------------
 
-`pandas` released 1.0.0 in January 2020, including many backwards-incompatible
+``pandas`` released 1.0.0 in January 2020, including many backwards-incompatible
 API changes [3]_. `scipy` released version 1.0 in 2017, but, given its stage of
 maturity and position at the base of the scientific Python ecosystem, opted not
 to make major breaking changes [4]_. However, SciPy has adopted a policy of

--- a/doc/source/skips/4-transition-to-v2.rst
+++ b/doc/source/skips/4-transition-to-v2.rst
@@ -131,7 +131,7 @@ allowing users to migrate their code progressively.
 Related Work
 ------------
 
-`pandas` released 1.0.0 in January 2020, including many backwards-incompatible
+``pandas`` released 1.0.0 in January 2020, including many backwards-incompatible
 API changes [3]_. `scipy` released version 1.0 in 2017, but, given its stage of
 maturity and position at the base of the scientific Python ecosystem, opted not
 to make major breaking changes [4]_. However, SciPy has adopted a policy of

--- a/doc/source/user_guide/geometrical_transform.rst
+++ b/doc/source/user_guide/geometrical_transform.rst
@@ -7,7 +7,7 @@ Cropping, resizing and rescaling images
 
 .. currentmodule:: skimage.transform
 
-Images being NumPy arrays (as described in the :ref:`numpy` section), cropping
+Images being NumPy arrays (as described in the :ref:`numpy_images` section), cropping
 an image can be done with simple slicing operations. Below we crop a 100x100
 square corresponding to the top-left corner of the astronaut image. Note that
 this operation is done for all color channels (the color dimension is the last,

--- a/doc/source/user_guide/geometrical_transform.rst
+++ b/doc/source/user_guide/geometrical_transform.rst
@@ -134,7 +134,7 @@ The ``estimate`` method is point-based, that is, it uses only a set of points
 from the source and destination images. For estimating translations (shifts),
 it is also possible to use a *full-field* method using all pixels, based on
 Fourier-space cross-correlation. This method is implemented by
-:func:`skimage.registration.register_translation` and explained in the
+:func:`skimage.registration.phase_cross_correlation` and explained in the
 :ref:`sphx_glr_auto_examples_registration_plot_register_translation.py`
 tutorial.
 

--- a/doc/source/user_guide/glossary.md
+++ b/doc/source/user_guide/glossary.md
@@ -32,7 +32,7 @@ contour
 contrast
     Differences of intensity or color in an image, which make objects
     distinguishable. Several functions to manipulate the contrast of an
-    image are available in {mod}`skimage.exposure`.
+    image are available in {mod}`skimage.exposure`. See {ref}`exposure`.
 
 disk
     A filled-in {term}`circle`.
@@ -41,7 +41,7 @@ float
     Representation of real numbers, for example as {obj}`numpy.float32` or
     {obj}`numpy.float64`. See {ref}`data_types`. Some operations on images
     need a float datatype (such as multiplying image values with
-    exponential prefactors in {func}`skimage.filters.gaussian`, so that
+    exponential prefactors in {func}`skimage.filters.gaussian`), so that
     images of integer type are often converted to float type internally. Also
     see {term}`int` values.
 

--- a/doc/source/user_guide/glossary.md
+++ b/doc/source/user_guide/glossary.md
@@ -5,10 +5,10 @@ Work in progress
 ```{glossary}
 
 array
-    Numerical array, provided by the {class}`numpy.ndarray` object. In
+    Numerical array, provided by the :py:obj:`numpy.ndarray` object. In
     ``scikit-image``, images are NumPy arrays with dimensions that
     correspond to spatial dimensions of the image, and color channels for
-    color images. See {ref}`numpy`.
+    color images. See :ref:`numpy`.
 
 channel
     Typically used to refer to a single color channel in a color image. RGBA
@@ -22,7 +22,7 @@ channel
     dimension over which to operate.
 
 circle
-    The perimeter of a {term}`disk`.
+    The perimeter of a :term:`disk`.
 
 contour
     Curve along which a 2-D image has a constant value. The interior
@@ -32,71 +32,71 @@ contour
 contrast
     Differences of intensity or color in an image, which make objects
     distinguishable. Several functions to manipulate the contrast of an
-    image are available in {mod}`skimage.exposure`. See {ref}`exposure`.
+    image are available in :py:mod:`skimage.exposure`.
 
 disk
-    A filled-in {term}`circle`.
+    A filled-in :term:`circle`.
 
 float
-    Representation of real numbers, for example as {obj}`np.float32` or
-    {obj}`np.float64`. See {ref}`data_types`. Some operations on images
+    Representation of real numbers, for example as :py:obj:`numpy.float32` or
+    :py:obj:`numpy.float64`. See :ref:`data_types`. Some operations on images
     need a float datatype (such as multiplying image values with
-    exponential prefactors in {func}`filters.gaussian`), so that
+    exponential prefactors in :py:func:`filters.gaussian`), so that
     images of integer type are often converted to float type internally. Also
-    see {term}`int` values.
+    see :term:`int` values.
 
 float values
-    See {term}`float`.
+    See :term:`float`.
 
 histogram
     For an image, histogram of intensity values, where the range of
     intensity values is divided into bins and the histogram counts how
     many pixel values fall in each bin. See
-    {func}`exposure.histogram`.
+    :func:`exposure.histogram`.
 
 int
     Representation of integer numbers, which can be signed or not, and
     encoded on one, two, four or eight bytes according to the maximum value
     which needs to be represented. In ``scikit-image``, the most common
-    integer types are {obj}`np.int64` (for large integer values) and
-    {obj}`np.uint8` (for small integer values, typically images of labels
-    with less than 255 labels). See {ref}`data_types`.
+    integer types are :obj:`numpy.int64` (for large integer values) and
+    :obj:`numpy.uint8` (for small integer values, typically images of labels
+    with less than 255 labels). See :ref:`data_types`.
 
 int values
-    See {term}`int`.
+    See :term:`int`.
 
 iso-valued contour
-    See {term}`contour`.
+    See :term:`contour`.
 
 labels
     An image of labels is of integer type, where pixels with the same
     integer value belong to the same object. For example, the result of a
-    segmentation is an image of labels. {func}`measure.label` labels
+    segmentation is an image of labels. :py:func:`measure.label` labels
     connected components of a binary image and returns an image of
     labels. Labels are usually contiguous integers, and
-    {func}`segmentation.relabel_sequential` can be used to relabel
+    :py:func:`segmentation.relabel_sequential` can be used to relabel
     arbitrary labels to sequential (contiguous) ones.
 
 label image
-    See {term}`labels`.
+    See :term:`labels`.
 
 pixel
     Smallest element of an image. An image is a grid of pixels, and the
     intensity of each pixel is variable. A pixel can have a single
     intensity value in grayscale images, or several channels for color
     images. In ``scikit-image``, pixels are the individual elements of
-    ``numpy arrays`` (see {ref}`numpy`).
-    Also see {term}`voxel`.
+    ``numpy arrays`` (see :ref:`numpy`).
+    Also see :term:`voxel`.
 
 segmentation
     Partitioning an image into multiple objects (segments), for
     example an object of interest and its background. The output of a
-    segmentation is typically an image of {term}`labels`, where
+    segmentation is typically an image of :term:`labels`, where
     the pixels of different objects have been attributed different
     integer labels. Several segmentation algorithms are available in
-    {mod}`skimage.segmentation`.
+    :mod:`skimage.segmentation`.
 
 voxel
-    {term}`pixel` (smallest element of an image) of a
+    :term:`pixel` (smallest element of an image) of a
     three-dimensional image.
 ```

--- a/doc/source/user_guide/glossary.md
+++ b/doc/source/user_guide/glossary.md
@@ -5,10 +5,10 @@ Work in progress
 ```{glossary}
 
 array
-    Numerical array, provided by the :py:obj:`numpy.ndarray` object. In
+    Numerical array, provided by the {obj}`numpy.ndarray` object. In
     ``scikit-image``, images are NumPy arrays with dimensions that
     correspond to spatial dimensions of the image, and color channels for
-    color images. See :ref:`numpy`.
+    color images. See {ref}`numpy_images`.
 
 channel
     Typically used to refer to a single color channel in a color image. RGBA
@@ -22,7 +22,7 @@ channel
     dimension over which to operate.
 
 circle
-    The perimeter of a :term:`disk`.
+    The perimeter of a {term}`disk`.
 
 contour
     Curve along which a 2-D image has a constant value. The interior
@@ -32,71 +32,71 @@ contour
 contrast
     Differences of intensity or color in an image, which make objects
     distinguishable. Several functions to manipulate the contrast of an
-    image are available in :py:mod:`skimage.exposure`.
+    image are available in {mod}`skimage.exposure`.
 
 disk
-    A filled-in :term:`circle`.
+    A filled-in {term}`circle`.
 
 float
-    Representation of real numbers, for example as :py:obj:`numpy.float32` or
-    :py:obj:`numpy.float64`. See :ref:`data_types`. Some operations on images
+    Representation of real numbers, for example as {obj}`numpy.float32` or
+    {obj}`numpy.float64`. See {ref}`data_types`. Some operations on images
     need a float datatype (such as multiplying image values with
-    exponential prefactors in :py:func:`filters.gaussian`), so that
+    exponential prefactors in {func}`skimage.filters.gaussian`, so that
     images of integer type are often converted to float type internally. Also
-    see :term:`int` values.
+    see {term}`int` values.
 
 float values
-    See :term:`float`.
+    See {term}`float`.
 
 histogram
     For an image, histogram of intensity values, where the range of
     intensity values is divided into bins and the histogram counts how
     many pixel values fall in each bin. See
-    :func:`exposure.histogram`.
+    {func}`skimage.exposure.histogram`.
 
 int
     Representation of integer numbers, which can be signed or not, and
     encoded on one, two, four or eight bytes according to the maximum value
     which needs to be represented. In ``scikit-image``, the most common
-    integer types are :obj:`numpy.int64` (for large integer values) and
-    :obj:`numpy.uint8` (for small integer values, typically images of labels
-    with less than 255 labels). See :ref:`data_types`.
+    integer types are {obj}`numpy.int64` (for large integer values) and
+    {obj}`numpy.uint8` (for small integer values, typically images of labels
+    with less than 255 labels). See {ref}`data_types`.
 
 int values
-    See :term:`int`.
+    See {term}`int`.
 
 iso-valued contour
-    See :term:`contour`.
+    See {term}`contour`.
 
 labels
     An image of labels is of integer type, where pixels with the same
     integer value belong to the same object. For example, the result of a
-    segmentation is an image of labels. :py:func:`measure.label` labels
+    segmentation is an image of labels. {func}`skimage.measure.label` labels
     connected components of a binary image and returns an image of
     labels. Labels are usually contiguous integers, and
-    :py:func:`segmentation.relabel_sequential` can be used to relabel
+    {func}`skimage.segmentation.relabel_sequential` can be used to relabel
     arbitrary labels to sequential (contiguous) ones.
 
 label image
-    See :term:`labels`.
+    See {term}`labels`.
 
 pixel
     Smallest element of an image. An image is a grid of pixels, and the
     intensity of each pixel is variable. A pixel can have a single
     intensity value in grayscale images, or several channels for color
     images. In ``scikit-image``, pixels are the individual elements of
-    ``numpy arrays`` (see :ref:`numpy`).
-    Also see :term:`voxel`.
+    ``numpy arrays`` (see {ref}`numpy_images`).
+    Also see {term}`voxel`.
 
 segmentation
     Partitioning an image into multiple objects (segments), for
     example an object of interest and its background. The output of a
-    segmentation is typically an image of :term:`labels`, where
+    segmentation is typically an image of {term}`labels`, where
     the pixels of different objects have been attributed different
     integer labels. Several segmentation algorithms are available in
-    :mod:`skimage.segmentation`.
+    {mod}`skimage.segmentation`.
 
 voxel
-    :term:`pixel` (smallest element of an image) of a
+    {term}`pixel` (smallest element of an image) of a
     three-dimensional image.
 ```

--- a/doc/source/user_guide/numpy_images.rst
+++ b/doc/source/user_guide/numpy_images.rst
@@ -1,4 +1,4 @@
-.. _numpy:
+.. _numpy_images:
 
 ==================================
 A crash course on NumPy for images

--- a/doc/tools/apigen.py
+++ b/doc/tools/apigen.py
@@ -55,14 +55,14 @@ class ApiDocWriter:
             first dot in the package path, after *package_name* - so,
             if *package_name* is ``sphinx``, then ``sphinx.util`` will
             result in ``.util`` being passed for searching by these
-            regexps.  If is None, gives default. Default is ['\.tests$'].
+            regexps.  If is None, gives default. Default is ``['\.tests$']``.
         module_skip_patterns : None or sequence
             Sequence of strings giving URIs of modules to be excluded
             Operates on the module name including preceding URI path,
             back to the first dot after *package_name*.  For example
             ``sphinx.util.console`` results in the string to search of
             ``.util.console``.
-            If is None, gives default. Default is ['\.setup$', '\._'].
+            If is None, gives default. Default is ``['\.setup$', '\._']``.
         """
         if package_skip_patterns is None:
             package_skip_patterns = ['\\.tests$']

--- a/doc/tools/apigen.py
+++ b/doc/tools/apigen.py
@@ -1,5 +1,5 @@
 """
-Attempt to generate templates for module reference with Sphinx
+Attempt to generate templates for module reference with Sphinx.
 
 To include extension modules, first identify them as valid in the
 ``_uri2path`` method, then handle them in the ``_parse_module_with_import``
@@ -28,8 +28,7 @@ DEBUG = True
 
 
 class ApiDocWriter:
-    '''Class for automatic detection and parsing of API docs
-    to Sphinx-parsable reST format'''
+    """Automatic detection and parsing of API docs to Sphinx-parsable reST format."""
 
     # only separating first two levels
     rst_section_levels = ['*', '=', '-', '~', '^']
@@ -41,32 +40,30 @@ class ApiDocWriter:
         package_skip_patterns=None,
         module_skip_patterns=None,
     ):
-        r'''Initialize package for parsing
+        r"""Initialize package for parsing
 
         Parameters
         ----------
         package_name : string
-            Name of the top-level package.  *package_name* must be the
-            name of an importable package
+            Name of the top-level package. *package_name* must be the
+            name of an importable package.
         rst_extension : string, optional
-            Extension for reST files, default '.rst'
+            Extension for reST files, default '.rst'.
         package_skip_patterns : None or sequence of {strings, regexps}
             Sequence of strings giving URIs of packages to be excluded
             Operates on the package path, starting at (including) the
             first dot in the package path, after *package_name* - so,
             if *package_name* is ``sphinx``, then ``sphinx.util`` will
-            result in ``.util`` being passed for earching by these
-            regexps.  If is None, gives default. Default is:
-            ['\.tests$']
+            result in ``.util`` being passed for searching by these
+            regexps.  If is None, gives default. Default is ['\.tests$'].
         module_skip_patterns : None or sequence
             Sequence of strings giving URIs of modules to be excluded
             Operates on the module name including preceding URI path,
             back to the first dot after *package_name*.  For example
             ``sphinx.util.console`` results in the string to search of
-            ``.util.console``
-            If is None, gives default. Default is:
-            ['\.setup$', '\._']
-        '''
+            ``.util.console``.
+            If is None, gives default. Default is ['\.setup$', '\._'].
+        """
         if package_skip_patterns is None:
             package_skip_patterns = ['\\.tests$']
         if module_skip_patterns is None:
@@ -80,7 +77,7 @@ class ApiDocWriter:
         return self._package_name
 
     def set_package_name(self, package_name):
-        '''Set package_name
+        """Set package_name
 
         >>> docwriter = ApiDocWriter('sphinx')
         >>> import sphinx
@@ -90,7 +87,7 @@ class ApiDocWriter:
         >>> import docutils
         >>> docwriter.root_path == docutils.__path__[0]
         True
-        '''
+        """
         # It's also possible to imagine caching the module parsing here
         self._package_name = package_name
         root_module = self._import(package_name)
@@ -102,7 +99,7 @@ class ApiDocWriter:
     )
 
     def _import(self, name):
-        '''Import namespace package'''
+        """Import namespace package."""
         mod = __import__(name)
         components = name.split('.')
         for comp in components[1:]:
@@ -110,7 +107,8 @@ class ApiDocWriter:
         return mod
 
     def _get_object_name(self, line):
-        '''Get second token in line
+        """Get second token in line.
+
         >>> docwriter = ApiDocWriter('sphinx')
         >>> docwriter._get_object_name("  def func():  ")
         'func'
@@ -118,14 +116,14 @@ class ApiDocWriter:
         'Klass'
         >>> docwriter._get_object_name("  class Klass:  ")
         'Klass'
-        '''
+        """
         name = line.split()[1].split('(')[0].strip()
         # in case we have classes which are not derived from object
         # ie. old style classes
         return name.rstrip(':')
 
     def _uri2path(self, uri):
-        '''Convert uri to absolute filepath
+        """Convert uri to absolute filepath.
 
         Parameters
         ----------
@@ -151,7 +149,7 @@ class ApiDocWriter:
         True
         >>> docwriter._uri2path('sphinx.does_not_exist')
 
-        '''
+        """
         if uri == self.package_name:
             return os.path.join(self.root_path, '__init__.py')
         path = uri.replace(self.package_name + '.', '')
@@ -167,7 +165,7 @@ class ApiDocWriter:
         return path
 
     def _path2uri(self, dirpath):
-        '''Convert directory path to uri'''
+        """Convert directory path to uri."""
         package_dir = self.package_name.replace('.', os.path.sep)
         relpath = dirpath.replace(self.root_path, package_dir)
         if relpath.startswith(os.path.sep):
@@ -175,7 +173,7 @@ class ApiDocWriter:
         return relpath.replace(os.path.sep, '.')
 
     def _parse_module(self, uri):
-        '''Parse module defined in *uri*'''
+        """Parse module defined in uri."""
         filename = self._uri2path(uri)
         if filename is None:
             print(filename, 'erk')
@@ -187,7 +185,7 @@ class ApiDocWriter:
         return functions, classes
 
     def _parse_module_with_import(self, uri):
-        """Look for functions and classes in an importable module.
+        """Look for functions and classes in the importable module.
 
         Parameters
         ----------
@@ -234,7 +232,7 @@ class ApiDocWriter:
         return functions, classes, submodules
 
     def _parse_lines(self, linesource):
-        '''Parse lines of text for functions and classes'''
+        """Parse lines of text for functions and classes."""
         functions = []
         classes = []
         for line in linesource:
@@ -255,18 +253,18 @@ class ApiDocWriter:
         return functions, classes
 
     def generate_api_doc(self, uri):
-        '''Make autodoc documentation template string for a module
+        """Make autodoc documentation template string for a module.
 
         Parameters
         ----------
         uri : string
-            python location of module - e.g 'sphinx.builder'
+            Python location of module - e.g 'sphinx.builder'.
 
         Returns
         -------
         S : string
-            Contents of API doc
-        '''
+            Contents of API doc.
+        """
         # get the names of all classes and functions
         functions, classes, submodules = self._parse_module_with_import(uri)
         if not (len(functions) or len(classes) or len(submodules)) and DEBUG:
@@ -293,7 +291,7 @@ class ApiDocWriter:
             ad += '   ' + uri + '.' + c + '\n'
         ad += '\n'
         for m in submodules:
-            ad += '    ' + uri + '.' + m + '\n'
+            ad += '   ' + uri + '.' + m + '\n'
         ad += '\n'
 
         for f in functions:
@@ -318,9 +316,9 @@ class ApiDocWriter:
         return ad
 
     def _survives_exclude(self, matchstr, match_type):
-        '''Returns True if *matchstr* does not match patterns
+        """Return True if matchstr does not match patterns.
 
-        ``self.package_name`` removed from front of string if present
+        Removes ``self.package_name`` from the beginning of the string if present.
 
         Examples
         --------
@@ -337,7 +335,7 @@ class ApiDocWriter:
         >>> dw.module_skip_patterns.append('^\\.badmod$')
         >>> dw._survives_exclude('sphinx.badmod', 'module')
         False
-        '''
+        """
         if match_type == 'module':
             patterns = self.module_skip_patterns
         elif match_type == 'package':
@@ -358,17 +356,12 @@ class ApiDocWriter:
         return True
 
     def discover_modules(self):
-        r'''Return module sequence discovered from ``self.package_name``
-
-
-        Parameters
-        ----------
-        None
+        r"""Return module sequence discovered from ``self.package_name``.
 
         Returns
         -------
         mods : sequence
-            Sequence of module names within ``self.package_name``
+            Sequence of module names within ``self.package_name``.
 
         Examples
         --------
@@ -380,7 +373,7 @@ class ApiDocWriter:
         >>> 'sphinx.util' in dw.discover_modules()
         False
         >>>
-        '''
+        """
         modules = [self.package_name]
         # raw directory parsing
         for dirpath, dirnames, filenames in os.walk(self.root_path):
@@ -417,16 +410,12 @@ class ApiDocWriter:
         Parameters
         ----------
         outdir : string
-            Directory name in which to store files
-            We create automatic filenames for each module
-
-        Returns
-        -------
-        None
+            Directory name in which to store the files. Filenames for each module
+            are automatically created.
 
         Notes
         -----
-        Sets self.written_modules to list of written modules
+        Sets self.written_modules to list of written modules.
         """
         if not os.path.exists(outdir):
             os.mkdir(outdir)
@@ -435,19 +424,19 @@ class ApiDocWriter:
         self.write_modules_api(modules, outdir)
 
     def write_index(self, outdir, froot='gen', relative_to=None):
-        """Make a reST API index file from written files
+        """Make a reST API index file from the written files.
 
         Parameters
         ----------
         outdir : string
-            Directory to which to write generated index file
+            Directory to which to write generated index file.
         froot : string, optional
-            root (filename without extension) of filename to write to
-            Defaults to 'gen'.  We add ``self.rst_extension``.
+            Root (filename without extension) of filename to write to
+            Defaults to 'gen'. We add ``self.rst_extension``.
         relative_to : string
-            path to which written filenames are relative.  This
+            Path to which written filenames are relative. This
             component of the written file path will be removed from
-            outdir, in the generated index.  Default is None, meaning,
+            outdir, in the generated index. Default is None, meaning,
             leave path as it is.
         """
         if self.written_modules is None:

--- a/skimage/_shared/filters.py
+++ b/skimage/_shared/filters.py
@@ -79,7 +79,7 @@ def gaussian(
 
     Notes
     -----
-    This function is a wrapper around :func:`scipy.ndi.gaussian_filter`.
+    This function is a wrapper around :func:`scipy.ndimage.gaussian_filter`.
 
     Integer arrays are converted to float.
 

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -113,7 +113,7 @@ def label2rgb(
         `bg_color` is `None`, and `kind` is `overlay`,
         background is not painted by any colors.
     bg_color : str or array, optional
-        Background color. Must be a name in 'color_dict' or RGB float values
+        Background color. Must be a name in `color_dict` or RGB float values
         between [0, 1].
     image_alpha : float [0, 1], optional
         Opacity of the image.
@@ -133,7 +133,7 @@ def label2rgb(
         `image` that corresponds to channels.
 
         .. versionadded:: 0.19
-           ``channel_axis`` was added in 0.19.
+            ``channel_axis`` was added in 0.19.
 
     Returns
     -------

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -37,7 +37,7 @@ def _rgb_vector(color):
     Parameters
     ----------
     color : str or array
-        Color name in `color_dict` or RGB float values between [0, 1].
+        Color name in ``skimage.color.color_dict`` or RGB float values between [0, 1].
     """
     if isinstance(color, str):
         color = color_dict[color]
@@ -113,8 +113,8 @@ def label2rgb(
         `bg_color` is `None`, and `kind` is `overlay`,
         background is not painted by any colors.
     bg_color : str or array, optional
-        Background color. Must be a name in `color_dict` or RGB float values
-        between [0, 1].
+        Background color. Must be a name in ``skimage.color.color_dict`` or RGB float
+        values between [0, 1].
     image_alpha : float [0, 1], optional
         Opacity of the image.
     kind : string, one of {'overlay', 'avg'}
@@ -183,8 +183,8 @@ def _label2rgb_overlay(
         Label that's treated as the background. If `bg_label` is specified and
         `bg_color` is `None`, background is not painted by any colors.
     bg_color : str or array, optional
-        Background color. Must be a name in `color_dict` or RGB float values
-        between [0, 1].
+        Background color. Must be a name in ``skimage.color.color_dict`` or RGB float
+        values between [0, 1].
     image_alpha : float [0, 1], optional
         Opacity of the image.
     saturation : float [0, 1], optional

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -113,7 +113,7 @@ def label2rgb(
         `bg_color` is `None`, and `kind` is `overlay`,
         background is not painted by any colors.
     bg_color : str or array, optional
-        Background color. Must be a name in `color_dict` or RGB float values
+        Background color. Must be a name in 'color_dict' or RGB float values
         between [0, 1].
     image_alpha : float [0, 1], optional
         Opacity of the image.

--- a/skimage/data/_fetchers.py
+++ b/skimage/data/_fetchers.py
@@ -268,7 +268,7 @@ def download_all(directory=None):
     scikit-image will only search for images stored in the default directory.
     Only specify the directory if you wish to download the images to your own
     folder for a particular reason. You can access the location of the default
-    data directory by inspecting the variable `skimage.data.data_dir`.
+    data directory by inspecting the variable ``skimage.data.data_dir``.
     """
 
     if _image_fetcher is None:

--- a/skimage/feature/_fisher_vector.py
+++ b/skimage/feature/_fisher_vector.py
@@ -38,7 +38,7 @@ def learn_gmm(descriptors, *, n_modes=32, gm_args=None):
     """Estimate a Gaussian mixture model (GMM) given a set of descriptors and
     number of modes (i.e. Gaussians). This function is essentially a wrapper
     around the scikit-learn implementation of GMM, namely the
-    :func:`sklearn.mixture.GaussianMixture` class.
+    :py:obj:`sklearn.mixture.GaussianMixture` class.
 
     Due to the nature of the Fisher vector, the only enforced parameter of the
     underlying scikit-learn class is the covariance_type, which must be 'diag'.
@@ -65,11 +65,11 @@ def learn_gmm(descriptors, *, n_modes=32, gm_args=None):
         The number of modes/Gaussians to estimate during the GMM estimate.
     gm_args : dict
         Keyword arguments that can be passed into the underlying scikit-learn
-        :func:`sklearn.mixture.GaussianMixture` class.
+        :py:obj:`sklearn.mixture.GaussianMixture` class.
 
     Returns
     -------
-    gmm : :func:`sklearn.mixture.GaussianMixture`
+    gmm : :py:obj:`sklearn.mixture.GaussianMixture`
         The estimated GMM object, which contains the necessary parameters
         needed to compute the Fisher vector.
 

--- a/skimage/feature/_fisher_vector.py
+++ b/skimage/feature/_fisher_vector.py
@@ -38,7 +38,7 @@ def learn_gmm(descriptors, *, n_modes=32, gm_args=None):
     """Estimate a Gaussian mixture model (GMM) given a set of descriptors and
     number of modes (i.e. Gaussians). This function is essentially a wrapper
     around the scikit-learn implementation of GMM, namely the
-    :py:obj:`sklearn.mixture.GaussianMixture` class.
+    :class:`sklearn.mixture.GaussianMixture` class.
 
     Due to the nature of the Fisher vector, the only enforced parameter of the
     underlying scikit-learn class is the covariance_type, which must be 'diag'.
@@ -65,11 +65,11 @@ def learn_gmm(descriptors, *, n_modes=32, gm_args=None):
         The number of modes/Gaussians to estimate during the GMM estimate.
     gm_args : dict
         Keyword arguments that can be passed into the underlying scikit-learn
-        :py:obj:`sklearn.mixture.GaussianMixture` class.
+        :class:`sklearn.mixture.GaussianMixture` class.
 
     Returns
     -------
-    gmm : :py:obj:`sklearn.mixture.GaussianMixture`
+    gmm : :class:`sklearn.mixture.GaussianMixture`
         The estimated GMM object, which contains the necessary parameters
         needed to compute the Fisher vector.
 
@@ -159,7 +159,7 @@ def fisher_vector(descriptors, gmm, *, improved=False, alpha=0.5):
     descriptors : np.ndarray, shape=(n_descriptors, descriptor_length)
         NumPy array of the descriptors for which the Fisher vector
         representation is to be computed.
-    gmm : sklearn.mixture.GaussianMixture
+    gmm : :class:`sklearn.mixture.GaussianMixture`
         An estimated GMM object, which contains the necessary parameters needed
         to compute the Fisher vector.
     improved : bool, default=False

--- a/skimage/feature/_hog.py
+++ b/skimage/feature/_hog.py
@@ -123,7 +123,7 @@ def hog(
         A visualisation of the HOG image. Only provided if `visualize` is True.
 
     Raises
-    -------
+    ------
     ValueError
         If the image is too small given the values of pixels_per_cell and
         cells_per_block.

--- a/skimage/feature/orb.py
+++ b/skimage/feature/orb.py
@@ -22,7 +22,6 @@ for i in range(-15, 16):
 
 
 class ORB(FeatureDetector, DescriptorExtractor):
-
     """Oriented FAST and rotated BRIEF feature detector and binary descriptor
     extractor.
 

--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -21,6 +21,8 @@ class FeatureDetector:
 
 
 class DescriptorExtractor:
+    """"""
+
     def __init__(self):
         self.descriptors_ = np.array([])
 

--- a/skimage/feature/util.py
+++ b/skimage/feature/util.py
@@ -21,8 +21,6 @@ class FeatureDetector:
 
 
 class DescriptorExtractor:
-    """"""
-
     def __init__(self):
         self.descriptors_ = np.array([])
 

--- a/skimage/filters/rank/bilateral.py
+++ b/skimage/filters/rank/bilateral.py
@@ -93,7 +93,7 @@ def mean_bilateral(
 
     See also
     --------
-    denoise_bilateral
+    :func:`skimage.restoration.denoise_bilateral`
 
     Examples
     --------
@@ -230,7 +230,7 @@ def sum_bilateral(
 
     See also
     --------
-    denoise_bilateral
+    :func:`skimage.restoration.denoise_bilateral`
 
     Examples
     --------

--- a/skimage/filters/rank/bilateral.py
+++ b/skimage/filters/rank/bilateral.py
@@ -93,7 +93,7 @@ def mean_bilateral(
 
     See also
     --------
-    :func:`skimage.restoration.denoise_bilateral`
+    skimage.restoration.denoise_bilateral
 
     Examples
     --------
@@ -230,7 +230,7 @@ def sum_bilateral(
 
     See also
     --------
-    :func:`skimage.restoration.denoise_bilateral`
+    skimage.restoration.denoise_bilateral
 
     Examples
     --------

--- a/skimage/future/trainable_segmentation.py
+++ b/skimage/future/trainable_segmentation.py
@@ -133,7 +133,7 @@ def predict_segmenter(features, clf):
         scikit-learn's API, for example an instance of
         ``RandomForestClassifier`` or ``LogisticRegression`` classifier. The
         classifier must be already trained, for example with
-        :func:`skimage.segmentation.fit_segmenter`.
+        :func:`skimage.future.fit_segmenter`.
 
     Returns
     -------

--- a/skimage/graph/_rag.py
+++ b/skimage/graph/_rag.py
@@ -106,9 +106,7 @@ def _add_edge_filter(values, graph):
 
 
 class RAG(nx.Graph):
-
-    """
-    The Region Adjacency Graph (RAG) of an image, subclasses :obj:`networkx.Graph`.
+    """The Region Adjacency Graph (RAG) of an image, subclasses :obj:`networkx.Graph`.
 
     Parameters
     ----------
@@ -121,11 +119,10 @@ class RAG(nx.Graph):
         a connectivity of 1 corresponds to immediate neighbors up, down,
         left, and right, while a connectivity of 2 also includes diagonal
         neighbors. See :func:`scipy.ndimage.generate_binary_structure`.
-    data : networkx Graph specification, optional
-        Initial or additional edges to pass to the NetworkX Graph
-        constructor. See :obj:`networkx.Graph`. Valid edge specifications
-        include edge list (list of tuples), NumPy arrays, and SciPy
-        sparse matrices.
+    data : :obj:`networkx.Graph` specification, optional
+        Initial or additional edges to pass to :obj:`networkx.Graph`
+        constructor. Valid edge specifications include edge list (list of tuples),
+        NumPy arrays, and SciPy sparse matrices.
     **attr : keyword arguments, optional
         Additional attributes to add to the graph.
     """

--- a/skimage/graph/_rag.py
+++ b/skimage/graph/_rag.py
@@ -108,8 +108,7 @@ def _add_edge_filter(values, graph):
 class RAG(nx.Graph):
 
     """
-    The Region Adjacency Graph (RAG) of an image, subclasses
-    `networx.Graph <http://networkx.github.io/documentation/latest/reference/classes/graph.html>`_
+    The Region Adjacency Graph (RAG) of an image, subclasses :obj:`networkx.Graph`.
 
     Parameters
     ----------
@@ -121,10 +120,10 @@ class RAG(nx.Graph):
         The connectivity between pixels in ``label_image``. For a 2D image,
         a connectivity of 1 corresponds to immediate neighbors up, down,
         left, and right, while a connectivity of 2 also includes diagonal
-        neighbors. See `scipy.ndimage.generate_binary_structure`.
+        neighbors. See :func:`scipy.ndimage.generate_binary_structure`.
     data : networkx Graph specification, optional
         Initial or additional edges to pass to the NetworkX Graph
-        constructor. See `networkx.Graph`. Valid edge specifications
+        constructor. See :obj:`networkx.Graph`. Valid edge specifications
         include edge list (list of tuples), NumPy arrays, and SciPy
         sparse matrices.
     **attr : keyword arguments, optional
@@ -182,7 +181,7 @@ class RAG(nx.Graph):
             node. For each neighbor `n` for `src` and `dst`, `weight_func` will
             be called as follows: `weight_func(src, dst, n, *extra_arguments,
             **extra_keywords)`. `src`, `dst` and `n` are IDs of vertices in the
-            RAG object which is in turn a subclass of `networkx.Graph`. It is
+            RAG object which is in turn a subclass of :obj:`networkx.Graph`. It is
             expected to return a dict of attributes of the resulting edge.
         in_place : bool, optional
             If set to `True`, the merged node has the id `dst`, else merged
@@ -237,7 +236,7 @@ class RAG(nx.Graph):
     def add_node(self, n, attr_dict=None, **attr):
         """Add node `n` while updating the maximum node id.
 
-        .. seealso:: :func:`networkx.Graph.add_node`."""
+        .. seealso:: :obj:`networkx.Graph.add_node`."""
         if attr_dict is None:  # compatibility with old networkx
             attr_dict = attr
         else:
@@ -248,7 +247,7 @@ class RAG(nx.Graph):
     def add_edge(self, u, v, attr_dict=None, **attr):
         """Add an edge between `u` and `v` while updating max node id.
 
-        .. seealso:: :func:`networkx.Graph.add_edge`."""
+        .. seealso:: :obj:`networkx.Graph.add_edge`."""
         if attr_dict is None:  # compatibility with old networkx
             attr_dict = attr
         else:
@@ -259,7 +258,7 @@ class RAG(nx.Graph):
     def copy(self):
         """Copy the graph with its max node id.
 
-        .. seealso:: :func:`networkx.Graph.copy`."""
+        .. seealso:: :obj:`networkx.Graph.copy`."""
         g = super().copy()
         g.max_id = self.max_id
         return g
@@ -303,7 +302,7 @@ class RAG(nx.Graph):
 
         This is a convenience method used internally.
 
-        .. seealso:: :func:`networkx.Graph.add_node`."""
+        .. seealso:: :obj:`networkx.Graph.add_node`."""
         super().add_node(n)
 
 

--- a/skimage/io/_io.py
+++ b/skimage/io/_io.py
@@ -82,15 +82,15 @@ def imread_collection(load_pattern, conserve_memory=True, plugin=None, **plugin_
     ----------
     load_pattern : str or list
         List of objects to load. These are usually filenames, but may
-        vary depending on the currently active plugin.  See the docstring
-        for ``ImageCollection`` for the default behaviour of this parameter.
+        vary depending on the currently active plugin. See :class:`ImageCollection`
+        for the default behaviour of this parameter.
     conserve_memory : bool, optional
         If True, never keep more than one in memory at a specific
         time.  Otherwise, images will be cached once they are loaded.
 
     Returns
     -------
-    ic : ImageCollection
+    ic : :class:`ImageCollection`
         Collection of images.
 
     Other Parameters
@@ -129,9 +129,9 @@ def imsave(fname, arr, plugin=None, check_contrast=True, **plugin_args):
     Notes
     -----
     When saving a JPEG, the compression ratio may be controlled using the
-    ``quality`` keyword argument which is an integer with values in [1, 100]
-    where 1 is worst quality and smallest file size, and 100 is best quality
-    and largest file size (default 75).  This is only available when using
+    ``quality`` keyword argument which is an integer with values in [1, 100],
+    where 1 is worst quality and smallest file size, and 100 is the best quality
+    and largest file size (default 75). This is only available when using
     the PIL and imageio plugins.
     """
     if isinstance(fname, pathlib.Path):
@@ -161,8 +161,7 @@ def imshow(arr, plugin=None, **plugin_args):
         Image data or name of image file.
     plugin : str
         Name of plugin to use.  By default, the different plugins are
-        tried (starting with imageio) until a suitable
-        candidate is found.
+        tried (starting with imageio) until a suitable candidate is found.
 
     Other Parameters
     ----------------
@@ -180,7 +179,7 @@ def imshow_collection(ic, plugin=None, **plugin_args):
 
     Parameters
     ----------
-    ic : ImageCollection
+    ic : :class:`ImageCollection`
         Collection to display.
     plugin : str
         Name of plugin to use.  By default, the different plugins are
@@ -196,9 +195,9 @@ def imshow_collection(ic, plugin=None, **plugin_args):
 
 
 def show():
-    '''Display pending images.
+    """Display pending images.
 
-    Launch the event loop of the current gui plugin, and display all
+    Launch the event loop of the current GUI plugin, and display all
     pending images, queued via `imshow`. This is required when using
     `imshow` from non-interactive scripts.
 
@@ -214,5 +213,5 @@ def show():
     ...     ax_im = io.imshow(rng.random((50, 50)))
     >>> io.show() # doctest: +SKIP
 
-    '''
+    """
     return call_plugin('_app_show')

--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -36,7 +36,8 @@ def concatenate_images(ic):
 
     See Also
     --------
-    ImageCollection.concatenate, MultiImage.concatenate
+    ImageCollection.concatenate
+    MultiImage.concatenate
 
     Raises
     ------
@@ -106,13 +107,13 @@ class ImageCollection:
         Pattern string or list of strings to load. The filename path can be
         absolute or relative.
     conserve_memory : bool, optional
-        If True, `ImageCollection` does not keep more than one in memory at a
-        specific time. Otherwise, images will be cached once they are loaded.
+        If True, :class:`skimage.io.ImageCollection` does not keep more than one in
+        memory at a specific time. Otherwise, images will be cached once they are loaded.
 
     Other parameters
     ----------------
     load_func : callable
-        ``imread`` by default. See notes below.
+        ``imread`` by default. See Notes below.
     **load_func_kwargs : dict
         Any other keyword arguments are passed to `load_func`.
 
@@ -125,8 +126,8 @@ class ImageCollection:
 
     Notes
     -----
-    Note that files are always returned in alphanumerical order. Also note
-    that slicing returns a new ImageCollection, *not* a view into the data.
+    Note that files are always returned in alphanumerical order. Also note that slicing
+    returns a new :class:`skimage.io.ImageCollection`, *not* a view into the data.
 
     ImageCollection image loading can be customized through
     `load_func`. For an ImageCollection ``ic``, ``ic[5]`` calls
@@ -151,11 +152,11 @@ class ImageCollection:
       x[5]  # the 10th frame of the first video
 
     Alternatively, if `load_func` is provided and `load_pattern` is a
-    sequence, an `ImageCollection` of corresponding length will be created,
-    and the individual images will be loaded by calling `load_func` with the
+    sequence, an :class:`skimage.io.ImageCollection` of corresponding length will
+    be created, and the individual images will be loaded by calling `load_func` with the
     matching element of the `load_pattern` as its first argument. In this
     case, the elements of the sequence do not need to be names of existing
-    files (or strings at all). For example, to create an `ImageCollection`
+    files (or strings at all). For example, to create an :class:`skimage.io.ImageCollection`
     containing 500 images from a video::
 
       class FrameReader:
@@ -292,7 +293,7 @@ class ImageCollection:
 
         Returns
         -------
-        img : ndarray or ImageCollection.
+        img : ndarray or :class:`skimage.io.ImageCollection`
             The `n`-th image in the collection, or a new ImageCollection with
             the selected images.
         """
@@ -395,12 +396,13 @@ class ImageCollection:
 
         See Also
         --------
-        concatenate_images
+        skimage.io.concatenate_images
 
         Raises
         ------
         ValueError
-            If images in the `ImageCollection` don't have identical shapes.
+            If images in the :class:`skimage.io.ImageCollection` do not have identical
+            shapes.
         """
         return concatenate_images(self)
 

--- a/skimage/io/manage_plugins.py
+++ b/skimage/io/manage_plugins.py
@@ -230,7 +230,8 @@ def use_plugin(name, kind=None):
 
     See Also
     --------
-    available_plugins : List of available plugins
+    available_plugins
+        List of available plugins.
 
     Examples
     --------
@@ -239,8 +240,8 @@ def use_plugin(name, kind=None):
     >>> from skimage import io
     >>> io.use_plugin('matplotlib', 'imread')
 
-    To see a list of available plugins run ``io.available_plugins``. Note that
-    this lists plugins that are defined, but the full list may not be usable
+    To see a list of available plugins run `available_plugins`. Note
+    that this lists plugins that are defined, but the full list may not be usable
     if your system does not have the required libraries installed.
 
     """

--- a/skimage/io/manage_plugins.py
+++ b/skimage/io/manage_plugins.py
@@ -3,11 +3,11 @@
 To improve performance, plugins are only loaded as needed. As a result, there
 can be multiple states for a given plugin:
 
-    available: Defined in an *ini file located in `skimage.io._plugins`.
-        See also `skimage.io.available_plugins`.
+    available: Defined in an *ini file located in ``skimage.io._plugins``.
+        See also :func:`skimage.io.available_plugins`.
     partial definition: Specified in an *ini file, but not defined in the
         corresponding plugin module. This will raise an error when loaded.
-    available but not on this system: Defined in `skimage.io._plugins`, but
+    available but not on this system: Defined in ``skimage.io._plugins``, but
         a dependent library (e.g. Qt, PIL) is not available on your system.
         This will raise an error when loaded.
     loaded: The real availability is determined when it's explicitly loaded,

--- a/skimage/io/manage_plugins.py
+++ b/skimage/io/manage_plugins.py
@@ -223,15 +223,11 @@ def use_plugin(name, kind=None):
     Parameters
     ----------
     name : str
-        Name of plugin.
+        Name of plugin. See ``skimage.io.available_plugins`` for a list of available
+        plugins.
     kind : {'imsave', 'imread', 'imshow', 'imread_collection', 'imshow_collection'}, optional
         Set the plugin for this function.  By default,
         the plugin is set for all functions.
-
-    See Also
-    --------
-    available_plugins
-        List of available plugins.
 
     Examples
     --------
@@ -240,7 +236,7 @@ def use_plugin(name, kind=None):
     >>> from skimage import io
     >>> io.use_plugin('matplotlib', 'imread')
 
-    To see a list of available plugins run `available_plugins`. Note
+    To see a list of available plugins run ``skimage.io.available_plugins``. Note
     that this lists plugins that are defined, but the full list may not be usable
     if your system does not have the required libraries installed.
 

--- a/skimage/io/sift.py
+++ b/skimage/io/sift.py
@@ -10,8 +10,8 @@ def _sift_read(filelike, mode='SIFT'):
     http://people.cs.ubc.ca/~lowe/keypoints/ and
     http://www.vision.ee.ethz.ch/~surf/.
 
-    This routine *does not* generate SIFT/SURF features from an image.  These
-    algorithms are patent encumbered.  Please use :obj:`skimage.feature.CENSURE`
+    This routine *does not* generate SIFT/SURF features from an image. These
+    algorithms are patent encumbered. Please use :obj:`skimage.feature.CENSURE`
     instead.
 
     Parameters

--- a/skimage/io/sift.py
+++ b/skimage/io/sift.py
@@ -11,7 +11,7 @@ def _sift_read(filelike, mode='SIFT'):
     http://www.vision.ee.ethz.ch/~surf/.
 
     This routine *does not* generate SIFT/SURF features from an image.  These
-    algorithms are patent encumbered.  Please use `skimage.feature.CENSURE`
+    algorithms are patent encumbered.  Please use :obj:`skimage.feature.CENSURE`
     instead.
 
     Parameters

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -73,8 +73,8 @@ def label(label_image, background=None, return_num=False, connectivity=None):
 
     See Also
     --------
-    regionprops
-    regionprops_table
+    :func:`skimage.measure.regionprops`
+    :func:`skimage.measure.regionprops_table`
 
     References
     ----------

--- a/skimage/measure/_label.py
+++ b/skimage/measure/_label.py
@@ -73,8 +73,8 @@ def label(label_image, background=None, return_num=False, connectivity=None):
 
     See Also
     --------
-    :func:`skimage.measure.regionprops`
-    :func:`skimage.measure.regionprops_table`
+    skimage.measure.regionprops
+    skimage.measure.regionprops_table
 
     References
     ----------

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -81,9 +81,9 @@ def h_maxima(image, h, footprint=None):
 
     See Also
     --------
-    :func:`skimage.morphology.h_minima`
-    :func:`skimage.morphology.local_maxima`
-    :func:`skimage.morphology.local_minima`
+    skimage.morphology.h_minima
+    skimage.morphology.local_maxima
+    skimage.morphology.local_minima
 
     References
     ----------
@@ -210,9 +210,9 @@ def h_minima(image, h, footprint=None):
 
     See Also
     --------
-    :func:`skimage.morphology.h_maxima`
-    :func:`skimage.morphology.local_maxima`
-    :func:`skimage.morphology.local_minima`
+    skimage.morphology.h_maxima
+    skimage.morphology.local_maxima
+    skimage.morphology.local_minima
 
     References
     ----------
@@ -318,9 +318,9 @@ def local_maxima(
 
     See Also
     --------
-    :func:`skimage.morphology.local_minima`
-    :func:`skimage.morphology.h_maxima`
-    :func:`skimage.morphology.h_minima`
+    skimage.morphology.local_minima
+    skimage.morphology.h_maxima
+    skimage.morphology.h_minima
 
     Notes
     -----

--- a/skimage/morphology/extrema.py
+++ b/skimage/morphology/extrema.py
@@ -81,9 +81,9 @@ def h_maxima(image, h, footprint=None):
 
     See Also
     --------
-    skimage.morphology.extrema.h_minima
-    skimage.morphology.extrema.local_maxima
-    skimage.morphology.extrema.local_minima
+    :func:`skimage.morphology.h_minima`
+    :func:`skimage.morphology.local_maxima`
+    :func:`skimage.morphology.local_minima`
 
     References
     ----------
@@ -210,9 +210,9 @@ def h_minima(image, h, footprint=None):
 
     See Also
     --------
-    skimage.morphology.extrema.h_maxima
-    skimage.morphology.extrema.local_maxima
-    skimage.morphology.extrema.local_minima
+    :func:`skimage.morphology.h_maxima`
+    :func:`skimage.morphology.local_maxima`
+    :func:`skimage.morphology.local_minima`
 
     References
     ----------
@@ -318,9 +318,9 @@ def local_maxima(
 
     See Also
     --------
-    skimage.morphology.local_minima
-    skimage.morphology.h_maxima
-    skimage.morphology.h_minima
+    :func:`skimage.morphology.local_minima`
+    :func:`skimage.morphology.h_maxima`
+    :func:`skimage.morphology.h_minima`
 
     Notes
     -----

--- a/skimage/morphology/footprints.py
+++ b/skimage/morphology/footprints.py
@@ -79,13 +79,13 @@ def footprint_from_sequence(footprints):
     footprints : tuple of 2-tuples
         A sequence of footprint tuples where the first element of each tuple
         is an array corresponding to a footprint and the second element is the
-        number of times it is to be applied. Currently all footprints should
+        number of times it is to be applied. Currently, all footprints should
         have odd size.
 
     Returns
     -------
     footprint : ndarray
-        An single array equivalent to applying the sequence of `footprints`.
+        An single array equivalent to applying the sequence of ``footprints``.
     """
 
     # Create a single pixel image of sufficient size and apply binary dilation.
@@ -113,10 +113,10 @@ def square(width, dtype=np.uint8, *, decomposition=None):
     decomposition : {None, 'separable', 'sequence'}, optional
         If None, a single array is returned. For 'sequence', a tuple of smaller
         footprints is returned. Applying this series of smaller footprints will
-        given an identical result to a single, larger footprint, but often with
+        give an identical result to a single, larger footprint, but often with
         better computational performance. See Notes for more details.
         With 'separable', this function uses separable 1D footprints for each
-        axis. Whether 'seqeunce' or 'separable' is computationally faster may
+        axis. Whether 'sequence' or 'separable' is computationally faster may
         be architecture-dependent.
 
     Returns

--- a/skimage/segmentation/morphsnakes.py
+++ b/skimage/segmentation/morphsnakes.py
@@ -341,11 +341,11 @@ def morphological_geodesic_active_contour(
         original image. Instead, this is usually a preprocessed version of the
         original image that enhances and highlights the borders (or other
         structures) of the object to segment.
-        `morphological_geodesic_active_contour` will try to stop the contour
+        :func:`morphological_geodesic_active_contour` will try to stop the contour
         evolution in areas where `gimage` is small. See
-        `morphsnakes.inverse_gaussian_gradient` as an example function to
+        :func:`inverse_gaussian_gradient` as an example function to
         perform this preprocessing. Note that the quality of
-        `morphological_geodesic_active_contour` might greatly depend on this
+        :func:`morphological_geodesic_active_contour` might greatly depend on this
         preprocessing.
     num_iter : uint
         Number of num_iter to run.
@@ -362,7 +362,7 @@ def morphological_geodesic_active_contour(
         segmentations.
     threshold : float, optional
         Areas of the image with a value smaller than this threshold will be
-        considered borders. The evolution of the contour will stop in this
+        considered borders. The evolution of the contour will stop in these
         areas.
     balloon : float, optional
         Balloon force to guide the contour in non-informative areas of the

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -388,7 +388,7 @@ def random_walker(
 
     See Also
     --------
-    :func:`skimage.segmentation.watershed` :
+    skimage.segmentation.watershed
         A segmentation algorithm based on mathematical morphology
         and "flooding" of regions from markers.
 

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -388,7 +388,7 @@ def random_walker(
 
     See Also
     --------
-    skimage.morphology.watershed : watershed segmentation
+    :func:`skimage.segmentation.watershed` :
         A segmentation algorithm based on mathematical morphology
         and "flooding" of regions from markers.
 


### PR DESCRIPTION
## Description
An attempt to fix #6824. 

<details>
<summary>Before, 74 warnings</summary>
/Users/epanfilo/Software/miniconda3/envs/skimage_dev/lib/python3.11/site-packages/numpydoc/docscrape.py:455: UserWarning:

potentially wrong underline length...
Raises
------- in
Extract Histogram of Oriented Gradients (HOG) for a given image.
... in the docstring of hog in /Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/_shared/utils.py.

reading sources... [100%] user_guide/index .. user_guide/visualization
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying downloadable files... [100%] auto_examples/applications/plot_haar_extraction_selection_classification.ipynb
copying static files... done
copying extra files... done
done
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/color/colorlabel.py:docstring of skimage.color.colorlabel.label2rgb:28: WARNING: py:obj reference target not found: color_dict
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/data/_fetchers.py:docstring of skimage.data._fetchers.download_all:35: WARNING: py:obj reference target not found: skimage.data.data_dir
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/feature/_fisher_vector.py:docstring of skimage.feature._fisher_vector.learn_gmm:2: WARNING: py:func reference target not found: sklearn.mixture.GaussianMixture
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/feature/_fisher_vector.py:docstring of skimage.feature._fisher_vector.learn_gmm:33: WARNING: py:func reference target not found: sklearn.mixture.GaussianMixture
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/feature/_fisher_vector.py:docstring of skimage.feature._fisher_vector.learn_gmm:48: WARNING: py:func reference target not found: sklearn.mixture.GaussianMixture
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/feature/brief.py:docstring of skimage.feature.brief.BRIEF:1: WARNING: py:class reference target not found: skimage.feature.util.DescriptorExtractor
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/feature/censure.py:docstring of skimage.feature.censure.CENSURE:1: WARNING: py:class reference target not found: skimage.feature.util.FeatureDetector
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/feature/orb.py:docstring of skimage.feature.orb.ORB:1: WARNING: py:class reference target not found: skimage.feature.util.FeatureDetector
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/feature/orb.py:docstring of skimage.feature.orb.ORB:1: WARNING: py:class reference target not found: skimage.feature.util.DescriptorExtractor
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/feature/sift.py:docstring of skimage.feature.sift.SIFT:1: WARNING: py:class reference target not found: skimage.feature.util.FeatureDetector
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/feature/sift.py:docstring of skimage.feature.sift.SIFT:1: WARNING: py:class reference target not found: skimage.feature.util.DescriptorExtractor
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/_shared/filters.py:docstring of skimage._shared.filters.gaussian:73: WARNING: py:func reference target not found: scipy.ndi.gaussian_filter
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/filters/rank/bilateral.py:docstring of skimage.filters.rank.bilateral.mean_bilateral:53: WARNING: py:obj reference target not found: denoise_bilateral
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/filters/rank/bilateral.py:docstring of skimage.filters.rank.bilateral.sum_bilateral:56: WARNING: py:obj reference target not found: denoise_bilateral
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/future/trainable_segmentation.py:docstring of skimage.future.trainable_segmentation.predict_segmenter:13: WARNING: py:func reference target not found: skimage.segmentation.fit_segmenter
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of skimage.graph._rag.RAG:1: WARNING: py:class reference target not found: networkx.classes.graph.Graph
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of skimage.graph._rag.RAG:20: WARNING: py:obj reference target not found: networkx.Graph
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of skimage.graph._rag.RAG.__init__:27: WARNING: py:obj reference target not found: convert
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of skimage.graph._rag.RAG.add_edge:4: WARNING: py:func reference target not found: networkx.Graph.add_edge
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of skimage.graph._rag.RAG.add_node:4: WARNING: py:func reference target not found: networkx.Graph.add_node
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of skimage.graph._rag.RAG.copy:4: WARNING: py:func reference target not found: networkx.Graph.copy
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of skimage.graph._rag.RAG.merge_nodes:14: WARNING: py:obj reference target not found: networkx.Graph
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of networkx.classes.graph.Graph.nbunch_iter:33: WARNING: py:obj reference target not found: Graph.__iter__
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of networkx.classes.graph.Graph.nbunch_iter:44: WARNING: py:exc reference target not found: NetworkXError
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of networkx.classes.graph.Graph.nbunch_iter:44: WARNING: py:exc reference target not found: NetworkXError
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of networkx.classes.graph.Graph.number_of_nodes:22: WARNING: py:obj reference target not found: __len__
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of networkx.classes.graph.Graph.order:22: WARNING: py:obj reference target not found: __len__
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of networkx.classes.graph.Graph.to_undirected:24: WARNING: py:obj reference target not found: Graph
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/api/skimage.io.rst:39:<autosummary>:1: WARNING: py:obj reference target not found: skimage.io.collection
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/api/skimage.io.rst:39:<autosummary>:1: WARNING: py:obj reference target not found: skimage.io.manage_plugins
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/api/skimage.io.rst:39:<autosummary>:1: WARNING: py:obj reference target not found: skimage.io.sift
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/api/skimage.io.rst:39:<autosummary>:1: WARNING: py:obj reference target not found: skimage.io.util
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/io/manage_plugins.py:docstring of skimage.io.manage_plugins.use_plugin:25: WARNING: py:obj reference target not found: available_plugins
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/measure/fit.py:docstring of skimage.measure.fit.CircleModel:1: WARNING: py:class reference target not found: skimage.measure.fit.BaseModel
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/measure/fit.py:docstring of skimage.measure.fit.EllipseModel:1: WARNING: py:class reference target not found: skimage.measure.fit.BaseModel
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/measure/fit.py:docstring of skimage.measure.fit.LineModelND:1: WARNING: py:class reference target not found: skimage.measure.fit.BaseModel
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/morphology/footprints.py:docstring of skimage.morphology.footprints.footprint_from_sequence:16: WARNING: py:obj reference target not found: footprints
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/morphology/extrema.py:docstring of skimage.morphology.extrema.h_maxima:46: WARNING: py:obj reference target not found: skimage.morphology.extrema.h_minima
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/morphology/extrema.py:docstring of skimage.morphology.extrema.h_maxima:48: WARNING: py:obj reference target not found: skimage.morphology.extrema.local_maxima
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/morphology/extrema.py:docstring of skimage.morphology.extrema.h_maxima:50: WARNING: py:obj reference target not found: skimage.morphology.extrema.local_minima
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/morphology/extrema.py:docstring of skimage.morphology.extrema.h_minima:46: WARNING: py:obj reference target not found: skimage.morphology.extrema.h_maxima
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/morphology/extrema.py:docstring of skimage.morphology.extrema.h_minima:48: WARNING: py:obj reference target not found: skimage.morphology.extrema.local_maxima
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/morphology/extrema.py:docstring of skimage.morphology.extrema.h_minima:50: WARNING: py:obj reference target not found: skimage.morphology.extrema.local_minima
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/measure/_label.py:docstring of skimage.measure._label.label:55: WARNING: py:obj reference target not found: regionprops
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/measure/_label.py:docstring of skimage.measure._label.label:57: WARNING: py:obj reference target not found: regionprops_table
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/segmentation/morphsnakes.py:docstring of skimage.segmentation.morphsnakes.morphological_geodesic_active_contour:11: WARNING: py:obj reference target not found: morphsnakes.inverse_gaussian_gradient
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/segmentation/random_walker_segmentation.py:docstring of skimage.segmentation.random_walker_segmentation.random_walker:100: WARNING: py:obj reference target not found: skimage.morphology.watershed
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/transform/_geometric.py:docstring of skimage.transform._geometric.estimate_transform:41: WARNING: py:class reference target not found: _GeometricTransform
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/transform/_geometric.py:docstring of skimage.transform._geometric.FundamentalMatrixTransform:1: WARNING: py:class reference target not found: skimage.transform._geometric._GeometricTransform
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/transform/_geometric.py:docstring of skimage.transform._geometric.PiecewiseAffineTransform:1: WARNING: py:class reference target not found: skimage.transform._geometric._GeometricTransform
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/transform/_geometric.py:docstring of skimage.transform._geometric.PolynomialTransform:1: WARNING: py:class reference target not found: skimage.transform._geometric._GeometricTransform
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/transform/_geometric.py:docstring of skimage.transform._geometric.ProjectiveTransform:1: WARNING: py:class reference target not found: skimage.transform._geometric._GeometricTransform
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/auto_examples/applications/plot_3d_interaction.rst:183: WARNING: py:obj reference target not found: plotly
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/auto_examples/segmentation/plot_compact_watershed.rst:33: WARNING: py:func reference target not found: skimage.morphology.watershed
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/auto_examples/segmentation/plot_metrics.rst:118: WARNING: py:func reference target not found: skimage.filters.canny
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/auto_examples/segmentation/plot_rag.rst:25: WARNING: py:obj reference target not found: networkx.graph
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/auto_examples/segmentation/plot_regionprops_table.rst:113: WARNING: py:obj reference target not found: seaborn
/Users/epanfilo/Workspace/_contrib/scikit-image/CONTRIBUTING.rst:561: WARNING: py:obj reference target not found: asv
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/release_notes/release_0.14.rst:551: WARNING: py:obj reference target not found: skimage.lookfor
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/release_notes/release_0.16.rst:122: WARNING: py:obj reference target not found: skimage.measure._regionprops
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/release_notes/release_0.16.rst:128: WARNING: py:obj reference target not found: skimage.feature.corner.hessian_matrix_eigvals
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/release_notes/release_0.17.rst:77: WARNING: py:obj reference target not found: pooch
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/release_notes/release_0.20.rst:27: WARNING: py:obj reference target not found: distutils
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/skips/3-transition-to-v1.rst:118: WARNING: py:obj reference target not found: pandas
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/skips/4-transition-to-v2.rst:134: WARNING: py:obj reference target not found: pandas
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/user_guide/geometrical_transform.rst:133: WARNING: py:func reference target not found: skimage.registration.register_translation
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/user_guide/glossary.md:40: WARNING: py:obj reference target not found: np.float32
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/user_guide/glossary.md:40: WARNING: py:obj reference target not found: np.float64
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/user_guide/glossary.md:40: WARNING: py:func reference target not found: filters.gaussian
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/user_guide/glossary.md:51: WARNING: py:func reference target not found: exposure.histogram
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/user_guide/glossary.md:57: WARNING: py:obj reference target not found: np.int64
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/user_guide/glossary.md:57: WARNING: py:obj reference target not found: np.uint8
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/user_guide/glossary.md:71: WARNING: py:func reference target not found: measure.label
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/user_guide/glossary.md:71: WARNING: py:func reference target not found: segmentation.relabel_sequential
writing output... [100%] user_guide/getting_help .. user_guide/visualization
generating indices... genindex py-modindex done
writing additional pages... search done
copying images... [100%] auto_examples/applications/images/sphx_glr_plot_coins_segmentation_009.png
dumping search index in English (code: en)... done
dumping object inventory... done
copying binder requirements...
copying binder notebooks...[100%] auto_examples

Sphinx-Gallery successfully executed 5 out of 5 files subselected by:

    gallery_conf["filename_pattern"] = '/plot'
    gallery_conf["ignore_pattern"]   = '__init__\\.py'

after excluding 134 files that had previously been run (based on MD5).

embedding documentation hyperlinks...
embedding documentation hyperlinks for auto_examples... [100%] index.html
[skimage_extensions] created /Users/epanfilo/Workspace/_contrib/scikit-image/doc/build/html/_static/random.js with 133 possible targets
build succeeded, 74 warnings.
</details>

<details>
<summary>After, 27 warnings left</summary>
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/feature/brief.py:docstring of skimage.feature.brief.BRIEF:1: WARNING: py:class reference target not found: skimage.feature.util.DescriptorExtractor
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/feature/censure.py:docstring of skimage.feature.censure.CENSURE:1: WARNING: py:class reference target not found: skimage.feature.util.FeatureDetector
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/feature/orb.py:docstring of skimage.feature.orb.ORB:1: WARNING: py:class reference target not found: skimage.feature.util.FeatureDetector
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/feature/orb.py:docstring of skimage.feature.orb.ORB:1: WARNING: py:class reference target not found: skimage.feature.util.DescriptorExtractor
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/feature/sift.py:docstring of skimage.feature.sift.SIFT:1: WARNING: py:class reference target not found: skimage.feature.util.FeatureDetector
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/feature/sift.py:docstring of skimage.feature.sift.SIFT:1: WARNING: py:class reference target not found: skimage.feature.util.DescriptorExtractor
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of skimage.graph._rag.RAG.__init__:27: WARNING: py:obj reference target not found: convert
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of networkx.classes.graph.Graph.nbunch_iter:33: WARNING: py:obj reference target not found: Graph.__iter__
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of networkx.classes.graph.Graph.nbunch_iter:44: WARNING: py:exc reference target not found: NetworkXError
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of networkx.classes.graph.Graph.nbunch_iter:44: WARNING: py:exc reference target not found: NetworkXError
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of networkx.classes.graph.Graph.number_of_nodes:22: WARNING: py:obj reference target not found: __len__
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of networkx.classes.graph.Graph.order:22: WARNING: py:obj reference target not found: __len__
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/graph/_rag.py:docstring of networkx.classes.graph.Graph.to_undirected:24: WARNING: py:obj reference target not found: Graph
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/api/skimage.io.rst:39:<autosummary>:1: WARNING: py:obj reference target not found: skimage.io.collection
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/api/skimage.io.rst:39:<autosummary>:1: WARNING: py:obj reference target not found: skimage.io.manage_plugins
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/api/skimage.io.rst:39:<autosummary>:1: WARNING: py:obj reference target not found: skimage.io.sift
/Users/epanfilo/Workspace/_contrib/scikit-image/doc/source/api/skimage.io.rst:39:<autosummary>:1: WARNING: py:obj reference target not found: skimage.io.util
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/io/manage_plugins.py:docstring of skimage.io.manage_plugins.use_plugin:25: WARNING: py:obj reference target not found: available_plugins
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/measure/fit.py:docstring of skimage.measure.fit.CircleModel:1: WARNING: py:class reference target not found: skimage.measure.fit.BaseModel
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/measure/fit.py:docstring of skimage.measure.fit.EllipseModel:1: WARNING: py:class reference target not found: skimage.measure.fit.BaseModel
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/measure/fit.py:docstring of skimage.measure.fit.LineModelND:1: WARNING: py:class reference target not found: skimage.measure.fit.BaseModel
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/morphology/footprints.py:docstring of skimage.morphology.footprints.footprint_from_sequence:16: WARNING: py:obj reference target not found: footprints
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/transform/_geometric.py:docstring of skimage.transform._geometric.estimate_transform:41: WARNING: py:class reference target not found: _GeometricTransform
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/transform/_geometric.py:docstring of skimage.transform._geometric.FundamentalMatrixTransform:1: WARNING: py:class reference target not found: skimage.transform._geometric._GeometricTransform
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/transform/_geometric.py:docstring of skimage.transform._geometric.PiecewiseAffineTransform:1: WARNING: py:class reference target not found: skimage.transform._geometric._GeometricTransform
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/transform/_geometric.py:docstring of skimage.transform._geometric.PolynomialTransform:1: WARNING: py:class reference target not found: skimage.transform._geometric._GeometricTransform
/Users/epanfilo/Workspace/_contrib/scikit-image/build-install/usr/lib/python3.11/site-packages/skimage/transform/_geometric.py:docstring of skimage.transform._geometric.ProjectiveTransform:1: WARNING: py:class reference target not found: skimage.transform._geometric._GeometricTransform
writing output... [100%] user_guide/getting_help .. user_guide/visualization
generating indices... genindex py-modindex done
writing additional pages... search done
copying images... [100%] auto_examples/applications/images/sphx_glr_plot_coins_segmentation_009.png
dumping search index in English (code: en)... done
dumping object inventory... done
copying binder requirements...
copying binder notebooks...[100%] auto_examples

Sphinx-Gallery successfully executed 0 out of 0 files subselected by:

    gallery_conf["filename_pattern"] = '/plot'
    gallery_conf["ignore_pattern"]   = '__init__\\.py'

after excluding 139 files that had previously been run (based on MD5).

embedding documentation hyperlinks...
embedding documentation hyperlinks for auto_examples... [100%] index.html
[skimage_extensions] created /Users/epanfilo/Workspace/_contrib/scikit-image/doc/build/html/_static/random.js with 133 possible targets
build succeeded, 27 warnings.
</details>

Most of the remaining warnings come from the base classes. I have not gotten a clear picture of how Sphinx handles those yet, but it seems there is no easy way to mark the base classes for exclusion. And this is not something we want for `RAG` anyway.

Perhaps, the PR can be merged as it is, and the final cases are looked at separately in a different PR.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
