### PR TITLE
Fix User Guide watershed usage

### DIFF
--- a/doc/source/user_guide/numpy_images.rst
+++ b/doc/source/user_guide/numpy_images.rst
@@ -202,7 +202,7 @@ Many functions in ``scikit-image`` can operate on 3D images directly::
     >>> rng = np.random.default_rng()
     >>> im3d = rng.random((100, 1000, 1000))
     >>> seeds = sp.ndimage.label(im3d < 0.1)[0]
-    >>> ws = ski.morphology.watershed(im3d, seeds)
+    >>> ws = ski.segmentation.watershed(im3d, seeds)
 
 In many cases, however, the third spatial dimension has lower resolution
 than the other two. Some ``scikit-image`` functions provide a ``spacing``


### PR DESCRIPTION
## Description
the `watershed` function was under the wrong module (probably just outdated).

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Fixed "A crash course on NumPy for images" user guide watershed usage.
```
