### PR TITLE
Fix parent module in an example in NumPy for images

### DIFF
--- a/doc/source/user_guide/numpy_images.rst
+++ b/doc/source/user_guide/numpy_images.rst
@@ -202,7 +202,7 @@ Many functions in ``scikit-image`` can operate on 3D images directly::
     >>> rng = np.random.default_rng()
     >>> im3d = rng.random((100, 1000, 1000))
     >>> seeds = sp.ndimage.label(im3d < 0.1)[0]
-    >>> ws = ski.morphology.watershed(im3d, seeds)
+    >>> ws = ski.segmentation.watershed(im3d, seeds)
 
 In many cases, however, the third spatial dimension has lower resolution
 than the other two. Some ``scikit-image`` functions provide a ``spacing``


### PR DESCRIPTION
## Description

An example in [A crash course on NumPy for images](https://scikit-image.org/docs/stable/user_guide/numpy_images.html#coordinate-conventions) suggests that the watershed function is a part of the `morphology` module instead of the `segmentation` module. As is, running the example raises an attribute error: module 'skimage.morphology' has no attribute 'watershed'. Changing the parent module to `segmentation` makes the example run.

## Checklist

- Tried to make the PR title as descriptive and concise as I can.
- No code changes, so not running tests and writing docstrings.

## Release note

```release-note
 Fixed incorrect parent module for the watershed function in an example in the documentation.
```