### PR TITLE
Fix for Unexpected Output Channel Reduction in skimage.transform.rescale without Explicit channel_axis

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -562,7 +562,7 @@ def swirl(
         the range 0-5. See `skimage.transform.warp` for detail.
     mode : {'constant', 'edge', 'symmetric', 'reflect', 'wrap'}, optional
         Points outside the boundaries of the input are filled according
-        to the given mode, with 'constant' used as the default. Modes match
+        to the given mode, with 'reflect' used as the default. Modes match
         the behaviour of `numpy.pad`.
     cval : float, optional
         Used in conjunction with mode 'constant', the value outside

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -301,6 +301,8 @@ def rescale(
 
     """
     scale = np.atleast_1d(scale)
+    if channel_axis is None and image.ndim == 3 and image.shape[-1] in [3, 4]:
+        channel_axis = -1  # Assuming channel-last format for RGB/RGBA images
     multichannel = channel_axis is not None
     if len(scale) > 1:
         if (not multichannel and len(scale) != image.ndim) or (


### PR DESCRIPTION
## Description

fix for https://github.com/scikit-image/scikit-image/issues/7242
