### PR TITLE
Make Python 3.12 default CI Python

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Setup some dependencies
         shell: bash -l {0}

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           sudo apt install optipng

--- a/.github/workflows/test_nightlies_on_main.yml
+++ b/.github/workflows/test_nightlies_on_main.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Build package
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         EAGER_IMPORT: [0]
         include:
           - platform_id: manylinux_x86_64
-            python-version: "3.10"
+            python-version: "3.12"
             MINIMUM_REQUIREMENTS: 1
             BUILD_DOCS: 0
             OPTIONAL_DEPS: 0
@@ -38,30 +38,30 @@ jobs:
             # with dask and astropy)
             OPTIONS_NAME: "mini-req-eager-import"
           - platform_id: manylinux_x86_64
-            python-version: "3.10"
+            python-version: "3.12"
             MINIMUM_REQUIREMENTS: 1
             OPTIONAL_DEPS: 1
             BUILD_DOCS: 0
             OPTIONS_NAME: "mini-req-optional-deps"
           - platform_id: manylinux_x86_64
-            python-version: "3.11"
+            python-version: "3.12"
             PIP_FLAGS: "--pre"
             SKIMAGE_TEST_STRICT_WARNINGS_GLOBAL: 1
             # test prereleases
             OPTIONS_NAME: "pre"
           - platform_id: manylinux_x86_64
-            python-version: "3.10"
+            python-version: "3.12"
             BUILD_DOCS: 1
             OPTIONAL_DEPS: 1
             OPTIONS_NAME: "optional-deps"
           - platform_id: manylinux_x86_64
-            python-version: "3.10"
+            python-version: "3.12"
             PYTHONOPTIMIZE: 2
             WITHOUT_POOCH: 1
             BUILD_DOCS: 0
             OPTIONS_NAME: "optimize and no pooch"
           - platform_id: manylinux_x86_64
-            python-version: "3.10"
+            python-version: "3.12"
             INSTALL_FROM_SDIST: 1
             OPTIONS_NAME: "install-from-sdist"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,16 +29,14 @@ jobs:
         EAGER_IMPORT: [0]
         include:
           - platform_id: manylinux_x86_64
-            python-version: "3.12"
+            python-version: "3.10"
             MINIMUM_REQUIREMENTS: 1
             BUILD_DOCS: 0
             OPTIONAL_DEPS: 0
             EAGER_IMPORT: 1
-            # Test minimum requirements (don't build docs there is a problem
-            # with dask and astropy)
             OPTIONS_NAME: "mini-req-eager-import"
           - platform_id: manylinux_x86_64
-            python-version: "3.12"
+            python-version: "3.10"
             MINIMUM_REQUIREMENTS: 1
             OPTIONAL_DEPS: 1
             BUILD_DOCS: 0
@@ -47,7 +45,6 @@ jobs:
             python-version: "3.12"
             PIP_FLAGS: "--pre"
             SKIMAGE_TEST_STRICT_WARNINGS_GLOBAL: 1
-            # test prereleases
             OPTIONS_NAME: "pre"
           - platform_id: manylinux_x86_64
             python-version: "3.12"

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install Twine
         run: |

--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
       - name: Build the wheel
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install cibuildwheel
         run: |
@@ -183,7 +183,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install cibuildwheel and add clang-cl to path
         run: |


### PR DESCRIPTION
This is a follow-up to #7173. That PR was to enable tests we were skipping because pywavelets didn't support Python 3.12.  PyWavelets 1.5 (with Python 3.12 support) was released on Friday:
https://pypi.org/project/PyWavelets/1.5.0/

I missed a question on that PR from @lagru asking if we should use Python 3.12 for `build_docs.yml` and `test_nightlies_on_main.yml`. We could have used Python 3.12 for testing nightlies wheels already, but building the docs needed pywavelet 1.5.

At any rate, that got me thinking of whether we should target Python 3.12 as the "default" Python version for cases when we aren't using multiple Python versions. This PR updates all the GH actions only using one version of Python to 3.12. Thoughts?