### PR TITLE
Add explicit `noexcept` to address Cython 3.0 warnings

### DIFF
--- a/skimage/_shared/fast_exp.pxd
+++ b/skimage/_shared/fast_exp.pxd
@@ -6,11 +6,11 @@ cimport numpy as cnp
 from .fused_numerics cimport np_floats
 
 cdef extern from "fast_exp.h":
-    cnp.float64_t _fast_exp(cnp.float64_t y) nogil
-    cnp.float32_t _fast_expf(cnp.float32_t y) nogil
+    cnp.float64_t _fast_exp(cnp.float64_t y) noexcept nogil
+    cnp.float32_t _fast_expf(cnp.float32_t y) noexcept nogil
 
 
-cdef inline np_floats _fast_exp_floats(np_floats x) nogil:
+cdef inline np_floats _fast_exp_floats(np_floats x) noexcept nogil:
     if np_floats is cnp.float32_t:
         return _fast_expf(x)
     else:

--- a/skimage/_shared/geometry.pxd
+++ b/skimage/_shared/geometry.pxd
@@ -9,7 +9,7 @@ cdef enum:
 
 
 cdef unsigned char point_in_polygon(np_floats[::1] xp, np_floats[::1] yp,
-                                    np_floats x, np_floats y) nogil
+                                    np_floats x, np_floats y) noexcept nogil
 
 cdef void points_in_polygon(np_floats[::1] xp, np_floats[::1] yp,
                             np_floats[::1] x, np_floats[::1] y,

--- a/skimage/_shared/geometry.pyx
+++ b/skimage/_shared/geometry.pyx
@@ -8,7 +8,7 @@ cnp.import_array()
 
 
 cdef unsigned char point_in_polygon(np_floats[::1] xp, np_floats[::1] yp,
-                                    np_floats x, np_floats y) nogil:
+                                    np_floats x, np_floats y) noexcept nogil:
     """Test relative point position to a polygon.
 
     Parameters

--- a/skimage/_shared/transform.pxd
+++ b/skimage/_shared/transform.pxd
@@ -2,4 +2,4 @@ from .fused_numerics cimport np_real_numeric
 
 cdef np_real_numeric integrate(np_real_numeric[:, ::1] sat,
                                Py_ssize_t r0, Py_ssize_t c0,
-                               Py_ssize_t r1, Py_ssize_t c1) nogil
+                               Py_ssize_t r1, Py_ssize_t c1) noexcept nogil

--- a/skimage/_shared/transform.pyx
+++ b/skimage/_shared/transform.pyx
@@ -6,7 +6,7 @@
 
 cdef np_real_numeric integrate(np_real_numeric[:, ::1] sat,
                                Py_ssize_t r0, Py_ssize_t c0,
-                               Py_ssize_t r1, Py_ssize_t c1) nogil:
+                               Py_ssize_t r1, Py_ssize_t c1) noexcept nogil:
     """
     Using a summed area table / integral image, calculate the sum
     over a given window.

--- a/skimage/feature/_cascade.pyx
+++ b/skimage/feature/_cascade.pyx
@@ -491,7 +491,7 @@ cdef class Cascade:
         self._load_xml(xml_file, eps)
 
     cdef bint classify(self, cnp.float32_t[:, ::1] int_img, Py_ssize_t row,
-                       Py_ssize_t col, cnp.float32_t scale) nogil:
+                       Py_ssize_t col, cnp.float32_t scale) noexcept nogil:
         """Classify the provided image patch i.e. check if the classifier
         detects an object in the given image patch.
 

--- a/skimage/feature/_haar.pxd
+++ b/skimage/feature/_haar.pxd
@@ -12,7 +12,7 @@ cdef inline void set_rectangle_feature(Rectangle* rectangle,
                                        Py_ssize_t top_y,
                                        Py_ssize_t top_x,
                                        Py_ssize_t bottom_y,
-                                       Py_ssize_t bottom_x) nogil:
+                                       Py_ssize_t bottom_x) noexcept nogil:
     rectangle[0].top_left.row = top_y
     rectangle[0].top_left.col = top_x
     rectangle[0].bottom_right.row = bottom_y

--- a/skimage/feature/_haar.pyx
+++ b/skimage/feature/_haar.pyx
@@ -23,7 +23,7 @@ N_RECTANGLE = {'type-2-x': 2, 'type-2-y': 2,
 cdef vector[vector[Rectangle]] _haar_like_feature_coord(
     Py_ssize_t width,
     Py_ssize_t height,
-    unsigned int feature_type) nogil:
+    unsigned int feature_type) noexcept nogil:
     """Private function to compute the coordinates of all Haar-like features.
     """
     cdef:

--- a/skimage/feature/_hoghistogram.pyx
+++ b/skimage/feature/_hoghistogram.pyx
@@ -16,7 +16,7 @@ cdef np_floats cell_hog(np_floats[:, ::1] magnitude,
                         int column_index, int row_index,
                         int size_columns, int size_rows,
                         int range_rows_start, int range_rows_stop,
-                        int range_columns_start, int range_columns_stop) nogil:
+                        int range_columns_start, int range_columns_stop) noexcept nogil:
     """Calculation of the cell's HOG value
 
     Parameters

--- a/skimage/feature/_texture.pxd
+++ b/skimage/feature/_texture.pxd
@@ -4,4 +4,4 @@ cpdef int _multiblock_lbp(np_floats[:, ::1] int_image,
                           Py_ssize_t r,
                           Py_ssize_t c,
                           Py_ssize_t width,
-                          Py_ssize_t height) nogil
+                          Py_ssize_t height) noexcept nogil

--- a/skimage/feature/_texture.pyx
+++ b/skimage/feature/_texture.pyx
@@ -70,7 +70,7 @@ def _glcm_loop(any_int[:, ::1] image, cnp.float64_t[:] distances,
                             out[i, j, d_idx, a_idx] += 1
 
 
-cdef inline int _bit_rotate_right(int value, int length) nogil:
+cdef inline int _bit_rotate_right(int value, int length) noexcept nogil:
     """Cyclic bit shift to the right.
 
     Parameters
@@ -284,7 +284,7 @@ cpdef int _multiblock_lbp(np_floats[:, ::1] int_image,
                           Py_ssize_t r,
                           Py_ssize_t c,
                           Py_ssize_t width,
-                          Py_ssize_t height) nogil:
+                          Py_ssize_t height) noexcept nogil:
     """Multi-block local binary pattern (MB-LBP) [1]_.
 
     Parameters

--- a/skimage/feature/corner_cy.pyx
+++ b/skimage/feature/corner_cy.pyx
@@ -93,7 +93,7 @@ def _corner_moravec(np_floats[:, ::1] cimage, Py_ssize_t window_size=1):
 cdef inline np_floats _corner_fast_response(np_floats curr_pixel,
                                             np_floats* circle_intensities,
                                             signed char* bins, signed char
-                                            state, char n) nogil:
+                                            state, char n) noexcept nogil:
     cdef char consecutive_count = 0
     cdef np_floats curr_response
     cdef Py_ssize_t l, m

--- a/skimage/feature/safe_openmp.pxd
+++ b/skimage/feature/safe_openmp.pxd
@@ -1,9 +1,9 @@
 cdef extern from "conditional_omp.h":
     ctypedef struct omp_lock_t:
         pass
-    extern void omp_init_lock(omp_lock_t *) nogil
-    extern void omp_destroy_lock(omp_lock_t *) nogil
-    extern void omp_set_lock(omp_lock_t *) nogil
-    extern void omp_unset_lock(omp_lock_t *) nogil
-    extern int omp_test_lock(omp_lock_t *) nogil
+    extern void omp_init_lock(omp_lock_t *) noexcept nogil
+    extern void omp_destroy_lock(omp_lock_t *) noexcept nogil
+    extern void omp_set_lock(omp_lock_t *) noexcept nogil
+    extern void omp_unset_lock(omp_lock_t *) noexcept nogil
+    extern int omp_test_lock(omp_lock_t *) noexcept nogil
     cdef int have_openmp

--- a/skimage/filters/_multiotsu.pyx
+++ b/skimage/filters/_multiotsu.pyx
@@ -129,7 +129,7 @@ cdef void _set_var_btwcls_lut(cnp.float32_t [::1] prob,
 
 cdef cnp.float32_t _get_var_btwclas_lut(cnp.float32_t [::1] var_btwcls,
                                         Py_ssize_t i, Py_ssize_t j,
-                                        Py_ssize_t nbins) nogil:
+                                        Py_ssize_t nbins) noexcept nogil:
     """Returns the variance between classes stored in compressed upper
     triangular matrix form at the desired 2D indices.
 
@@ -156,7 +156,7 @@ cdef cnp.float32_t _set_thresh_indices_lut(
         cnp.float32_t[::1] var_btwcls, Py_ssize_t hist_idx,
         Py_ssize_t thresh_idx, Py_ssize_t nbins, Py_ssize_t thresh_count,
         cnp.float32_t sigma_max, Py_ssize_t[::1] current_indices,
-        Py_ssize_t[::1] thresh_indices) nogil:
+        Py_ssize_t[::1] thresh_indices) noexcept nogil:
     """Recursive function for finding the indices of the thresholds
     maximizing the  variance between classes sigma.
 
@@ -317,7 +317,7 @@ cdef void _set_moments_lut_first_row(cnp.float32_t [::1] prob,
 
 cdef cnp.float32_t _get_var_btwclas(cnp.float32_t [::1] zeroth_moment,
                                     cnp.float32_t [::1] first_moment,
-                                    Py_ssize_t i, Py_ssize_t j) nogil:
+                                    Py_ssize_t i, Py_ssize_t j) noexcept nogil:
     """Computes the variance between two classes.
 
     Parameters
@@ -357,7 +357,7 @@ cdef cnp.float32_t _set_thresh_indices(cnp.float32_t[::1] zeroth_moment,
                                        Py_ssize_t thresh_count,
                                        cnp.float32_t sigma_max,
                                        Py_ssize_t[::1] current_indices,
-                                       Py_ssize_t[::1] thresh_indices) nogil:
+                                       Py_ssize_t[::1] thresh_indices) noexcept nogil:
     """Recursive function for finding the indices of the thresholds
     maximizing the  variance between classes sigma.
 

--- a/skimage/graph/heap.pxd
+++ b/skimage/graph/heap.pxd
@@ -25,8 +25,8 @@ cdef class BinaryHeap:
     cdef void _update_one(self, INDEX_T i) noexcept nogil
     cdef void _remove(self, INDEX_T i) noexcept nogil
 
-    cdef INDEX_T push_fast(self, VALUE_T value, REFERENCE_T reference) nogil
-    cdef VALUE_T pop_fast(self) nogil
+    cdef INDEX_T push_fast(self, VALUE_T value, REFERENCE_T reference) noexcept nogil
+    cdef VALUE_T pop_fast(self) noexcept nogil
 
 cdef class FastUpdateBinaryHeap(BinaryHeap):
     cdef readonly REFERENCE_T max_reference
@@ -36,4 +36,4 @@ cdef class FastUpdateBinaryHeap(BinaryHeap):
 
     cdef VALUE_T value_of_fast(self, REFERENCE_T reference)
     cdef INDEX_T push_if_lower_fast(self, VALUE_T value,
-                                    REFERENCE_T reference) nogil
+                                    REFERENCE_T reference) noexcept nogil

--- a/skimage/graph/heap.pyx
+++ b/skimage/graph/heap.pyx
@@ -286,7 +286,7 @@ cdef class BinaryHeap:
 
     ## C Public methods
 
-    cdef INDEX_T push_fast(self, VALUE_T value, REFERENCE_T reference) nogil:
+    cdef INDEX_T push_fast(self, VALUE_T value, REFERENCE_T reference) noexcept nogil:
         """The c-method for fast pushing.
 
         Returns the index relative to the start of the last level in the heap.
@@ -311,7 +311,7 @@ cdef class BinaryHeap:
         # return
         return count
 
-    cdef VALUE_T pop_fast(self) nogil:
+    cdef VALUE_T pop_fast(self) noexcept nogil:
         """The c-method for fast popping.
 
         Returns the minimum value. The reference is put in self._popped_ref.
@@ -549,7 +549,7 @@ cdef class FastUpdateBinaryHeap(BinaryHeap):
             self._update_one(i1)
             self._update_one(i2)
 
-    cdef INDEX_T push_fast(self, VALUE_T value, REFERENCE_T reference) nogil:
+    cdef INDEX_T push_fast(self, VALUE_T value, REFERENCE_T reference) noexcept nogil:
         """The c method for fast pushing.
 
         If the reference is already present, will update its value, otherwise
@@ -582,7 +582,7 @@ cdef class FastUpdateBinaryHeap(BinaryHeap):
         return ir
 
     cdef INDEX_T push_if_lower_fast(self, VALUE_T value,
-                                    REFERENCE_T reference) nogil:
+                                    REFERENCE_T reference) noexcept nogil:
         """If the reference is already present, will update its value ONLY if
         the new value is lower than the old one. If the reference is not
         present, this append it. If a value was appended, self._pushed is

--- a/skimage/measure/_ccomp.pxd
+++ b/skimage/measure/_ccomp.pxd
@@ -3,6 +3,6 @@ cimport numpy as cnp
 
 ctypedef cnp.intp_t DTYPE_t
 
-cdef DTYPE_t find_root(DTYPE_t *forest, DTYPE_t n) nogil
+cdef DTYPE_t find_root(DTYPE_t *forest, DTYPE_t n) noexcept nogil
 cdef void set_root(DTYPE_t *forest, DTYPE_t n, DTYPE_t root) noexcept nogil
 cdef void join_trees(DTYPE_t *forest, DTYPE_t n, DTYPE_t m) noexcept nogil

--- a/skimage/measure/_ccomp.pyx
+++ b/skimage/measure/_ccomp.pyx
@@ -14,7 +14,7 @@ cdef DTYPE_t BG_NODE_NULL = -999
 cdef struct s_shpinfo
 
 ctypedef s_shpinfo shape_info
-ctypedef size_t (* fun_ravel)(size_t, size_t, size_t, shape_info *) nogil
+ctypedef size_t (* fun_ravel)(size_t, size_t, size_t, shape_info *) noexcept nogil
 
 
 # For having stuff concerning background in one place
@@ -167,7 +167,7 @@ cdef inline void join_trees_wrapper(DTYPE_t *data_p, DTYPE_t *forest_p,
 
 
 cdef size_t ravel_index1D(size_t x, size_t y, size_t z,
-                          shape_info *shapeinfo) nogil:
+                          shape_info *shapeinfo) noexcept nogil:
     """
     Ravel index of a 1D array - trivial. y and z are ignored.
     """
@@ -175,7 +175,7 @@ cdef size_t ravel_index1D(size_t x, size_t y, size_t z,
 
 
 cdef size_t ravel_index2D(size_t x, size_t y, size_t z,
-                          shape_info *shapeinfo) nogil:
+                          shape_info *shapeinfo) noexcept nogil:
     """
     Ravel index of a 2D array. z is ignored
     """
@@ -184,7 +184,7 @@ cdef size_t ravel_index2D(size_t x, size_t y, size_t z,
 
 
 cdef size_t ravel_index3D(size_t x, size_t y, size_t z,
-                          shape_info *shapeinfo) nogil:
+                          shape_info *shapeinfo) noexcept nogil:
     """
     Ravel index of a 3D array
     """
@@ -216,7 +216,7 @@ cdef size_t ravel_index3D(size_t x, size_t y, size_t z,
 # discovered and trees begin to surface.
 # When we found out that label 5 and 3 are the same, we assign array[5] = 3.
 
-cdef DTYPE_t find_root(DTYPE_t *forest, DTYPE_t n) nogil:
+cdef DTYPE_t find_root(DTYPE_t *forest, DTYPE_t n) noexcept nogil:
     """Find the root of node n.
     Given the example above, for any integer from 1 to 9, 1 is always returned
     """
@@ -403,7 +403,7 @@ def label_cython(input_, background=None, return_num=False,
 
 
 cdef DTYPE_t resolve_labels(DTYPE_t *data_p, DTYPE_t *forest_p,
-                            shape_info *shapeinfo, bginfo *bg) nogil:
+                            shape_info *shapeinfo, bginfo *bg) noexcept nogil:
     """
     We iterate through the provisional labels and assign final labels based on
     our knowledge of prov. labels relationship.

--- a/skimage/morphology/_extrema_cy.pyx
+++ b/skimage/morphology/_extrema_cy.pyx
@@ -96,7 +96,7 @@ def _local_maxima(dtype_t[::1] image not None,
 
 
 cdef inline void _mark_candidates_in_last_dimension(
-        dtype_t[::1] image, unsigned char[::1] flags) nogil:
+        dtype_t[::1] image, unsigned char[::1] flags) noexcept nogil:
     """Mark local maxima in last dimension.
 
     This function considers only the last dimension of the image and marks
@@ -143,7 +143,7 @@ cdef inline void _mark_candidates_in_last_dimension(
             i += 1
 
 
-cdef inline void _mark_candidates_all(unsigned char[::1] flags) nogil:
+cdef inline void _mark_candidates_all(unsigned char[::1] flags) noexcept nogil:
     """Mark all pixels as potential maxima, exclude border pixels.
 
     This function marks pixels with the "CANDIDATE" flag if they aren't the
@@ -165,7 +165,7 @@ cdef inline void _mark_candidates_all(unsigned char[::1] flags) nogil:
 cdef inline void _fill_plateau(
         dtype_t[::1] image, unsigned char[::1] flags,
         Py_ssize_t[::1] neighbor_offsets, QueueWithHistory* queue_ptr,
-        Py_ssize_t start_index) nogil:
+        Py_ssize_t start_index) noexcept nogil:
     """Fill with 1 if plateau is local maximum else with 0.
 
     Parameters

--- a/skimage/morphology/_queue_with_history.pxi
+++ b/skimage/morphology/_queue_with_history.pxi
@@ -50,7 +50,7 @@ cdef struct QueueWithHistory:
     Py_ssize_t _index_consumed  # Index to most recently consumed item
 
 
-cdef inline void queue_init(QueueWithHistory* self, Py_ssize_t buffer_size) nogil:
+cdef inline void queue_init(QueueWithHistory* self, Py_ssize_t buffer_size) noexcept nogil:
     """Initialize the queue and its buffer size.
 
     The size is defined as the number of queue items to fit into the initial
@@ -67,7 +67,7 @@ cdef inline void queue_init(QueueWithHistory* self, Py_ssize_t buffer_size) nogi
     self._index_valid = -1
 
 
-cdef inline void queue_push(QueueWithHistory* self, QueueItem* item_ptr) nogil:
+cdef inline void queue_push(QueueWithHistory* self, QueueItem* item_ptr) noexcept nogil:
     """Enqueue a new item."""
     self._index_valid += 1
     if self._buffer_size <= self._index_valid:
@@ -76,7 +76,7 @@ cdef inline void queue_push(QueueWithHistory* self, QueueItem* item_ptr) nogil:
 
 
 cdef inline unsigned char queue_pop(QueueWithHistory* self,
-                                    QueueItem* item_ptr) nogil:
+                                    QueueItem* item_ptr) noexcept nogil:
     """If not empty pop an item and return 1 otherwise return 0.
 
     The item is still preserved in the internal buffer and can be restored with
@@ -89,7 +89,7 @@ cdef inline unsigned char queue_pop(QueueWithHistory* self,
     return 0
 
 
-cdef inline void queue_restore(QueueWithHistory* self) nogil:
+cdef inline void queue_restore(QueueWithHistory* self) noexcept nogil:
     """Restore all consumed items to the queue.
 
     The order of the restored queue is the same as previous one, meaning older
@@ -98,7 +98,7 @@ cdef inline void queue_restore(QueueWithHistory* self) nogil:
     self._index_consumed = -1
 
 
-cdef inline void queue_clear(QueueWithHistory* self) nogil:#
+cdef inline void queue_clear(QueueWithHistory* self) noexcept nogil:#
     """Remove all consumable items.
 
     After this the old items can't be restored with `queue_restore`.
@@ -107,7 +107,7 @@ cdef inline void queue_clear(QueueWithHistory* self) nogil:#
     self._index_valid = -1
 
 
-cdef inline void queue_exit(QueueWithHistory* self) nogil:
+cdef inline void queue_exit(QueueWithHistory* self) noexcept nogil:
     """Free the buffer of the queue.
 
     Don't use the queue after this command unless `queue_init` is called again.
@@ -115,7 +115,7 @@ cdef inline void queue_exit(QueueWithHistory* self) nogil:
     free(self._buffer_ptr)
 
 
-cdef inline int _queue_grow_buffer(QueueWithHistory* self) nogil except -1:
+cdef inline int _queue_grow_buffer(QueueWithHistory* self) except -1 nogil:
     """Double the memory used for the buffer."""
     cdef QueueItem* new_buffer
     self._buffer_size *= 2

--- a/skimage/morphology/_skeletonize_3d_cy.pyx.in
+++ b/skimage/morphology/_skeletonize_3d_cy.pyx.in
@@ -275,7 +275,7 @@ _neighb_idx = [[2, 1, 11, 10, 5, 4, 14],      # NEB
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cdef bint is_Euler_invariant(pixel_type neighbors[],
-                             int[::1] lut) nogil:
+                             int[::1] lut) noexcept nogil:
     """Check if a point is Euler invariant.
 
     Calculate Euler characteristic for each octant and sum up.
@@ -318,7 +318,7 @@ cdef inline bint is_endpoint(pixel_type neighbors[]) noexcept nogil:
     return s == 2
 
 
-cdef bint is_simple_point(pixel_type neighbors[]) nogil:
+cdef bint is_simple_point(pixel_type neighbors[]) noexcept nogil:
     """Check is a point is a Simple Point.
 
     A point is simple iff its deletion does not change connectivity in

--- a/skimage/restoration/_unwrap_2d.pyx
+++ b/skimage/restoration/_unwrap_2d.pyx
@@ -14,7 +14,7 @@ cdef extern from "unwrap_2d_ljmu.h":
             int image_width, int image_height,
             int wrap_around_x, int wrap_around_y,
             char use_seed, unsigned int seed
-            ) nogil
+            ) noexcept nogil
 
 
 def unwrap_2d(cnp.float64_t[:, ::1] image,

--- a/skimage/restoration/_unwrap_3d.pyx
+++ b/skimage/restoration/_unwrap_3d.pyx
@@ -14,7 +14,7 @@ cdef extern from "unwrap_3d_ljmu.h":
             int volume_width, int volume_height, int volume_depth,
             int wrap_around_x, int wrap_around_y, int wrap_around_z,
             char use_seed, unsigned int seed
-            ) nogil
+            ) noexcept nogil
 
 
 

--- a/skimage/segmentation/heap_general.pxi
+++ b/skimage/segmentation/heap_general.pxi
@@ -89,7 +89,7 @@ cdef inline void heappop(Heap *heap, Heapitem *dest) noexcept nogil:
 #
 # Note: heap ordering is the same as python heapq, i.e., smallest first.
 ##################################################
-cdef inline int heappush(Heap *heap, Heapitem *new_elem) nogil except -1:
+cdef inline int heappush(Heap *heap, Heapitem *new_elem) except -1 nogil:
 
     cdef Py_ssize_t child = heap.items
     cdef Py_ssize_t parent


### PR DESCRIPTION
## Description

The implicit `noexcept` for functions marked as `nogil` is deprecated in Cython 3.0 [1]. So we need to replace

`nogil` with `noexcept nogil` and
`nogil except -1` with `except -1 nogil`

[1] https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html#exception-values-and-noexcept

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
