### PR TITLE
Schedule nightly wheel builds at uncommon time

### DIFF
--- a/.github/workflows/nightly_wheel_build.yml
+++ b/.github/workflows/nightly_wheel_build.yml
@@ -2,8 +2,7 @@ name: Nightly Wheel builder
 on:
   workflow_dispatch:
   schedule:
-    # this cron is ran every Sunday at midnight UTC
-    - cron: "0 0 * * 0"
+    - cron: "27 11 * * SUN" # every Sunday at 11:27 UTC
 env:
   CIBW_BUILD_VERBOSITY: 2
   CIBW_TEST_REQUIRES: "-r requirements/default.txt -r requirements/test.txt"


### PR DESCRIPTION
## Description

... and after nightlies of important dependencies should have been uploaded: SciPy ([everyday at 9:09](https://github.com/scipy/scipy/blob/main/.github/workflows/wheels.yml#L19)), NumPy ([SUN,WED at 2:42](https://github.com/numpy/numpy/blob/main/.github/workflows/wheels.yml#L24)) and networkx ([everyday at 0:00](https://github.com/networkx/networkx/blob/main/.github/workflows/nightly.yml#L5)). 

Prompted by https://github.com/scikit-image/scikit-image/pull/7251#discussion_r1404203549.

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
