### PR TITLE
Use prange in map_array implementation for speedup

### DIFF
--- a/skimage/util/_map_array.py
+++ b/skimage/util/_map_array.py
@@ -44,7 +44,7 @@ def map_array(input_arr, input_vals, output_vals, out=None):
     # arr.reshape(-1) may be preferable."
     input_arr = input_arr.reshape(-1)
     if out is None:
-        out = np.zeros(orig_shape, dtype=output_vals.dtype)
+        out = np.empty(orig_shape, dtype=output_vals.dtype)
     elif out.shape != orig_shape:
         raise ValueError(
             'If out array is provided, it should have the same shape as '

--- a/skimage/util/_map_array.py
+++ b/skimage/util/_map_array.py
@@ -20,6 +20,18 @@ def map_array(input_arr, input_vals, output_vals, out=None):
     -------
     out : array, same shape as `input_arr`
         The array of mapped values.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import skimage as ski
+    >>> ski.util.map_array(
+    ...    input_arr=np.array([[0, 2, 2, 0], [3, 4, 5, 0]]),
+    ...    input_vals=np.array([1, 2, 3, 4, 6]),
+    ...    output_vals=np.array([6, 7, 8, 9, 10]),
+    ... )
+    array([[0, 7, 7, 0],
+           [8, 9, 0, 0]])
     """
     from ._remap import _map_array
 

--- a/skimage/util/_map_array.py
+++ b/skimage/util/_map_array.py
@@ -21,6 +21,11 @@ def map_array(input_arr, input_vals, output_vals, out=None):
     out : array, same shape as `input_arr`
         The array of mapped values.
 
+    Notes
+    -----
+    If `input_arr` contains values that aren't covered by `input_vals`, they
+    are set to 0.
+
     Examples
     --------
     >>> import numpy as np

--- a/skimage/util/_map_array.py
+++ b/skimage/util/_map_array.py
@@ -32,7 +32,7 @@ def map_array(input_arr, input_vals, output_vals, out=None):
     # arr.reshape(-1) may be preferable."
     input_arr = input_arr.reshape(-1)
     if out is None:
-        out = np.empty(orig_shape, dtype=output_vals.dtype)
+        out = np.zeros(orig_shape, dtype=output_vals.dtype)
     elif out.shape != orig_shape:
         raise ValueError(
             'If out array is provided, it should have the same shape as '

--- a/skimage/util/_remap.pyx
+++ b/skimage/util/_remap.pyx
@@ -22,4 +22,4 @@ def _map_array(np_anyint[:] inarr, np_numeric[:] outarr,
     for i in prange(n_array):
         it = lut.find(inarr[i])
         if it != lut.end():
-            outarr[i] = dereference(it).second 
+            outarr[i] = dereference(it).second

--- a/skimage/util/_remap.pyx
+++ b/skimage/util/_remap.pyx
@@ -9,6 +9,7 @@ def _map_array(np_anyint[:] inarr, np_numeric[:] outarr,
     # build the map from the input and output vectors
     cdef size_t i, n_map, n_array
     cdef unordered_map[np_anyint, np_numeric] lut
+    cdef unordered_map[np_anyint, np_numeric].iterator it
     n_map = inval.shape[0]
     for i in range(n_map):
         lut[inval[i]] = outval[i]
@@ -18,5 +19,7 @@ def _map_array(np_anyint[:] inarr, np_numeric[:] outarr,
     #  "Unsigned index type not allowed before OpenMP 3.0"
     # and didn't seem to be any faster
     # for i in prange(n_array, nogil=True): #
-    for i in range(n_array):
-        outarr[i] = lut[inarr[i]]
+    for i in prange(n_array):
+        it = lut.find(inarr[i])
+        if it != lut.end():
+            outarr[i] = dereference(it).second 

--- a/skimage/util/_remap.pyx
+++ b/skimage/util/_remap.pyx
@@ -1,5 +1,8 @@
 from libcpp.unordered_map cimport unordered_map
 cimport cython
+from cython.operator import dereference
+from cython.parallel import prange
+
 from .._shared.fused_numerics cimport np_numeric, np_anyint
 
 @cython.boundscheck(False)  # Deactivate bounds checking
@@ -18,8 +21,7 @@ def _map_array(np_anyint[:] inarr, np_numeric[:] outarr,
     # The prange option gave some compilation warnings
     #  "Unsigned index type not allowed before OpenMP 3.0"
     # and didn't seem to be any faster
-    # for i in prange(n_array, nogil=True): #
-    for i in prange(n_array):
+    for i in prange(n_array, nogil=True): #
         it = lut.find(inarr[i])
         if it != lut.end():
             outarr[i] = dereference(it).second

--- a/skimage/util/_remap.pyx
+++ b/skimage/util/_remap.pyx
@@ -22,3 +22,5 @@ def _map_array(np_anyint[:] inarr, np_numeric[:] outarr,
         it = lut.find(inarr[i])
         if it != lut.end():
             outarr[i] = dereference(it).second
+        else:
+            outarr[i] = 0

--- a/skimage/util/_remap.pyx
+++ b/skimage/util/_remap.pyx
@@ -18,9 +18,6 @@ def _map_array(np_anyint[:] inarr, np_numeric[:] outarr,
         lut[inval[i]] = outval[i]
     # apply the map to the array
     n_array = inarr.shape[0]
-    # The prange option gave some compilation warnings
-    #  "Unsigned index type not allowed before OpenMP 3.0"
-    # and didn't seem to be any faster
     for i in prange(n_array, nogil=True): #
         it = lut.find(inarr[i])
         if it != lut.end():

--- a/skimage/util/tests/test_map_array.py
+++ b/skimage/util/tests/test_map_array.py
@@ -1,7 +1,24 @@
 import numpy as np
+import pytest
 from skimage.util._map_array import map_array, ArrayMap
 
 from skimage._shared import testing
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [np.uint8, np.uint16, np.uint32, np.uint64, np.int8, np.int16, np.int32, np.int64],
+)
+def test_map_array_simple(dtype):
+    input_arr = np.array([0, 2, 0, 3, 4, 5, 0], dtype=dtype)
+    input_vals = np.array([1, 2, 3, 4, 6], dtype=dtype)[::-1]
+    output_vals = np.array([6, 7, 8, 9, 10], dtype=dtype)[::-1]
+    desired = np.array([0, 7, 0, 8, 9, 0, 0], dtype=dtype)
+    result = map_array(
+        input_arr=input_arr, input_vals=input_vals, output_vals=output_vals
+    )
+    np.testing.assert_array_equal(result, desired)
+    assert result.dtype == dtype
 
 
 def test_map_array_incorrect_output_shape():

--- a/skimage/util/tests/test_map_array.py
+++ b/skimage/util/tests/test_map_array.py
@@ -29,7 +29,7 @@ def test_map_array_simple(dtype_in, dtype_out, out_array):
     desired = np.array([0, 7, 0, 8, 9, 0, 0], dtype=dtype_out)
     out = None
     if out_array:
-        out = np.random.randint(2**23, size=desired.shape).astype(dtype_out)
+        out = np.full(desired.shape, 11, dtype=dtype_out)
     result = map_array(
         input_arr=input_arr, input_vals=input_vals, output_vals=output_vals, out=out
     )

--- a/skimage/util/tests/test_map_array.py
+++ b/skimage/util/tests/test_map_array.py
@@ -36,7 +36,6 @@ def test_map_array_simple(dtype_in, dtype_out, out_array):
     np.testing.assert_array_equal(result, desired)
     assert result.dtype == dtype_out
     if out_array:
-        np.testing.assert_array_equal(out, desired)
         assert out is result
 
 

--- a/skimage/util/tests/test_map_array.py
+++ b/skimage/util/tests/test_map_array.py
@@ -5,20 +5,32 @@ from skimage.util._map_array import map_array, ArrayMap
 from skimage._shared import testing
 
 
-@pytest.mark.parametrize(
-    "dtype",
-    [np.uint8, np.uint16, np.uint32, np.uint64, np.int8, np.int16, np.int32, np.int64],
-)
-def test_map_array_simple(dtype):
-    input_arr = np.array([0, 2, 0, 3, 4, 5, 0], dtype=dtype)
-    input_vals = np.array([1, 2, 3, 4, 6], dtype=dtype)[::-1]
-    output_vals = np.array([6, 7, 8, 9, 10], dtype=dtype)[::-1]
-    desired = np.array([0, 7, 0, 8, 9, 0, 0], dtype=dtype)
+_map_array_dtypes_in = [
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+]
+
+_map_array_dtypes_out = _map_array_dtypes_in + [np.float32, np.float64]
+
+
+@pytest.mark.parametrize("dtype_in", _map_array_dtypes_in)
+@pytest.mark.parametrize("dtype_out", _map_array_dtypes_out)
+def test_map_array_simple(dtype_in, dtype_out):
+    input_arr = np.array([0, 2, 0, 3, 4, 5, 0], dtype=dtype_in)
+    input_vals = np.array([1, 2, 3, 4, 6], dtype=dtype_in)[::-1]
+    output_vals = np.array([6, 7, 8, 9, 10], dtype=dtype_out)[::-1]
+    desired = np.array([0, 7, 0, 8, 9, 0, 0], dtype=dtype_out)
     result = map_array(
         input_arr=input_arr, input_vals=input_vals, output_vals=output_vals
     )
     np.testing.assert_array_equal(result, desired)
-    assert result.dtype == dtype
+    assert result.dtype == dtype_out
 
 
 def test_map_array_incorrect_output_shape():

--- a/skimage/util/tests/test_map_array.py
+++ b/skimage/util/tests/test_map_array.py
@@ -21,13 +21,17 @@ _map_array_dtypes_out = _map_array_dtypes_in + [np.float32, np.float64]
 
 @pytest.mark.parametrize("dtype_in", _map_array_dtypes_in)
 @pytest.mark.parametrize("dtype_out", _map_array_dtypes_out)
-def test_map_array_simple(dtype_in, dtype_out):
+@pytest.mark.parametrize("out_array", [True, False])
+def test_map_array_simple(dtype_in, dtype_out, out_array):
     input_arr = np.array([0, 2, 0, 3, 4, 5, 0], dtype=dtype_in)
     input_vals = np.array([1, 2, 3, 4, 6], dtype=dtype_in)[::-1]
     output_vals = np.array([6, 7, 8, 9, 10], dtype=dtype_out)[::-1]
     desired = np.array([0, 7, 0, 8, 9, 0, 0], dtype=dtype_out)
+    out = None
+    if out_array:
+        out = np.random.randint(2**23, size=desired.shape).astype(dtype_out)
     result = map_array(
-        input_arr=input_arr, input_vals=input_vals, output_vals=output_vals
+        input_arr=input_arr, input_vals=input_vals, output_vals=output_vals, out=out
     )
     np.testing.assert_array_equal(result, desired)
     assert result.dtype == dtype_out

--- a/skimage/util/tests/test_map_array.py
+++ b/skimage/util/tests/test_map_array.py
@@ -37,6 +37,7 @@ def test_map_array_simple(dtype_in, dtype_out, out_array):
     assert result.dtype == dtype_out
     if out_array:
         np.testing.assert_array_equal(out, desired)
+        assert out is result
 
 
 def test_map_array_incorrect_output_shape():

--- a/skimage/util/tests/test_map_array.py
+++ b/skimage/util/tests/test_map_array.py
@@ -35,6 +35,8 @@ def test_map_array_simple(dtype_in, dtype_out, out_array):
     )
     np.testing.assert_array_equal(result, desired)
     assert result.dtype == dtype_out
+    if out_array:
+        np.testing.assert_array_equal(out, desired)
 
 
 def test_map_array_incorrect_output_shape():


### PR DESCRIPTION
## Description

Close #7262

## Checklist

This PR uses prange instead of range in `_map_array` implementation
To not modify unordered map (by inserting an element using `[]` operator) I have changed to using the`find()` method.

Based on my knowledge this PR require proper setup openMP for compilation, but jni convinced me that it should be already setup in scikit image. 

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Speedup `skimage.util.map_array` by parallelization with Cython's `prange`.
```
