### PR TITLE
Update how to document changes in contribution guide & PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,8 +19,10 @@
 ## Release note
 
 We use [changelist](https://github.com/scientific-python/changelist) to
-compile each pull request into an item in our release notes. Please refer to
-[documenting changes](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) and past [release notes](https://scikit-image.org/docs/stable/release_notes/index.html) for guidance and examples.
+compile each pull request into an item of the release notes. Please refer to
+the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes)
+and [past release notes](https://scikit-image.org/docs/stable/release_notes/index.html)
+for guidance and examples.
 
 ```release-note
 ...

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,8 +18,9 @@
 
 ## Release note
 
-Summarize the introduced changes in the code block below in one or a few sentences. The
-summary will be included in the next release notes automatically:
+We use [changelist](https://github.com/scientific-python/changelist) to
+compile each pull request into an item in our release notes. Please refer to
+[documenting changes](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) and past [release notes](https://scikit-image.org/docs/stable/release_notes/index.html) for guidance and examples.
 
 ```release-note
 ...

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -122,21 +122,21 @@ For a more detailed discussion, read these :doc:`detailed documents
    If your change introduces a deprecation, add a reminder to ``TODO.txt``
    for the team to remove the deprecated functionality in the future.
 
-   If your change introduces any API modifications, or impacts users directly
-   (e.g. bug fixes, performance improvements) please describe the change inside
-   the pull request description inside a code block which is compiled by
-   `changelist <https://github.com/scientific-python/changelist>`_ into the
-   release notes::
+   scikit-image uses `changelist <https://github.com/scientific-python/changelist>`_
+   to generate a list of release notes automatically from pull requests. By
+   default, changelist will use the title of a pull request and its GitHub
+   labels to sort it into the appropriate section. However, for more complex
+   changes we encourage you to describe the change inside the pull request
+   description inside a more detailed code block like::
 
        ```release-note
-       One or two sentences describing the change in imperative mood.
+       Remove the deprecated function `skimage.color.blue`. Blend
+       `skimage.color.cyan` and `skimage.color.magenta` instead.
        ```
 
-   For trivial changes that are adequately summarized by the PR title, this
-   block can be left empty (``...``). If a public function, class or parameter
-   is referenced the the full import path should be used to do so, e.g.
-   ``skimage.submodule.function``. Refer to :doc:`/release_notes/index` for
-   examples.
+   You can refer to :doc:`/release_notes/index` for examples and to
+   `changelist's documentation <https://github.com/scientific-python/changelist>`_
+   for more details.
 
 .. note::
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -115,19 +115,33 @@ For a more detailed discussion, read these :doc:`detailed documents
 
    * A pull request must be approved by two core team members before merging.
 
-5. Document changes
+.. _documenting-changes:
 
-   If your change introduces any API modifications, please update
-   ``doc/release/release_dev.rst``.
+5. Document changes
 
    If your change introduces a deprecation, add a reminder to ``TODO.txt``
    for the team to remove the deprecated functionality in the future.
 
+   If your change introduces any API modifications, or impacts users directly
+   (e.g. bug fixes, performance improvements) please describe the change inside
+   the pull request description inside a code block which is compiled by
+   `changelist <https://github.com/scientific-python/changelist>`_ into the
+   release notes::
+
+       ```release-note
+       One or two sentences describing the change in imperative mood.
+       ```
+
+   For trivial changes that are adequately summarized by the PR title, this
+   block can be left empty (``...``). If a public function, class or parameter
+   is referenced the the full import path should be used to do so, e.g.
+   ``skimage.submodule.function``. Refer to :doc:`/release_notes/index` for
+   examples.
+
 .. note::
 
-   To reviewers: if it is not obvious from the PR description, add a short
-   explanation of what a branch did to the merge message and, if closing a
-   bug, also add "Closes #123" where 123 is the issue number.
+   To reviewers: if it is not obvious from the PR description, make sure that
+   the reason and context for a change are described in the merge message.
 
 
 Divergence between ``upstream main`` and your feature branch

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -126,8 +126,8 @@ For a more detailed discussion, read these :doc:`detailed documents
    to generate a list of release notes automatically from pull requests. By
    default, changelist will use the title of a pull request and its GitHub
    labels to sort it into the appropriate section. However, for more complex
-   changes we encourage you to describe the change inside the pull request
-   description inside a more detailed code block like::
+   changes, we encourage you to describe them in more detail using the
+   `release-note` code block within the pull request description; e.g.::
 
        ```release-note
        Remove the deprecated function `skimage.color.blue`. Blend


### PR DESCRIPTION
## Description

In the past I noticed some confusion around how to use [changelist](https://github.com/scientific-python/changelist) and the `release-notes` block in our PRs. This updates the outdated section in our contribution guide and gives a few helpful pointers.

I am open to discuss if this is the best way to address this. Alternatively, we might update our core developer guide to document our usage in more detail and just link to that. 

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Update description of how to document pull requests
for inclusion in the release notes.
```
