### PR TITLE
Fix warningfilter for deprecation in SciPy 1.12.0rc1

### DIFF
--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -290,8 +290,8 @@ def setup_test():
         warnings.filterwarnings(
             "default",
             message=(
-                "'scipy.sparse.linalg.cg' keyword argument 'tol' is deprecated in "
-                "favor of 'rtol' and will be removed in SciPy v.1.14.0."
+                "'scipy.sparse.linalg.cg' keyword argument `tol` is deprecated in "
+                "favor of `rtol`"
             ),
             category=DeprecationWarning,
         )


### PR DESCRIPTION
## Description

@scikit-image/core, we may want to get this small fix in so that we can fix PRs that are failing for SciPy 1.12.0rc1.

Not sure if the filters regex was wrong previously or if SciPy changed the message of the warning slightly. In any case, it began tripping up our test workflow using the `--pre` flag and SciPy 1.12.0rc1. E.g. see https://github.com/scikit-image/scikit-image/actions/runs/7299807113/job/19893319329

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
