### PR TITLE
Handle floating point warning for empty images in `skimage.registration.phase_cross_correlation`

### DIFF
--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -120,8 +120,9 @@ def _compute_error(cross_correlation_max, src_amp, target_amp):
     amp = src_amp * target_amp
     if amp == 0:
         warnings.warn(
-            "Could not determine RMS error for normalized average image intensity "
-            f"of {amp}, either the reference or moving image may be empty",
+            "Could not determine RMS error between images with the normalized "
+            f"average intensities {src_amp!r} and {target_amp!r}. Either the "
+            "reference or moving image may be empty.",
             UserWarning,
             stacklevel=4,
         )

--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -117,9 +117,16 @@ def _compute_error(cross_correlation_max, src_amp, target_amp):
     target_amp : float
         The normalized average image intensity of the target image
     """
-    error = 1.0 - cross_correlation_max * cross_correlation_max.conj() / (
-        src_amp * target_amp
-    )
+    amp = src_amp * target_amp
+    if amp == 0:
+        warnings.warn(
+            "Could not determine RMS error for normalized average image intensity "
+            f"of {amp}, either the reference or moving image may be empty",
+            UserWarning,
+            stacklevel=4,
+        )
+    with np.errstate(invalid="ignore"):
+        error = 1.0 - cross_correlation_max * cross_correlation_max.conj() / amp
     return np.sqrt(np.abs(error))
 
 

--- a/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_phase_cross_correlation.py
@@ -232,21 +232,27 @@ def test_disambiguate_zero_shift(disambiguate):
     np.testing.assert_array_equal(computed_shift, np.array((0.0, 0.0)))
 
 
-def test_disambiguate_empty_image():
+@pytest.mark.parametrize('null_images', [(1, 0), (0, 1), (0, 0)])
+def test_disambiguate_empty_image(null_images):
     """When the image is empty, disambiguation becomes degenerate."""
     image = camera()
-    regex = "Could not determine real-space shift"
-    with pytest.warns(UserWarning, match=regex) as record:
+    with pytest.warns(UserWarning) as records:
         shift, error, phasediff = phase_cross_correlation(
-            image, image * 0, disambiguate=True
+            image * null_images[0], image * null_images[1], disambiguate=True
         )
         expected_lineno = inspect.currentframe().f_lineno - 3
     np.testing.assert_array_equal(shift, np.array([0.0, 0.0]))
     assert np.isnan(error)
     assert phasediff == 0.0
+
+    # Check warnings
+    assert len(records) == 2
+    assert "Could not determine real-space shift" in records[0].message.args[0]
+    assert "RMS error for normalized average image" in records[1].message.args[0]
     # Assert correct stacklevel
-    assert record[0].filename == __file__
-    assert record[0].lineno == expected_lineno
+    for record in records:
+        assert record.filename == __file__
+        assert record.lineno == expected_lineno
 
 
 @pytest.mark.parametrize("return_error", [False, True, "always"])

--- a/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_phase_cross_correlation.py
@@ -248,7 +248,7 @@ def test_disambiguate_empty_image(null_images):
     # Check warnings
     assert len(records) == 2
     assert "Could not determine real-space shift" in records[0].message.args[0]
-    assert "RMS error for normalized average image" in records[1].message.args[0]
+    assert "Could not determine RMS error between images" in records[1].message.args[0]
     # Assert correct stacklevel
     for record in records:
         assert record.filename == __file__


### PR DESCRIPTION
## Description

Should fix our failing py3.12-pre job across the board. 

Starting with [pytest 8.0.0rc1](https://docs.pytest.org/en/latest/changelog.html) (search for \#9288), the following warning triggered the test in question to fail:

```
RuntimeWarning: invalid value encountered in scalar divide
```

For earlier pytest versions, this warning was silently consumed by `pytest.warns` (bad!). Now, it's actually showing. 

I wasn't completely sure how to handle this case, so I opted to just replace it with a more useful warning and test for it.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
