### PR TITLE
Use pytest-doctestplus instead of classic pytest-doctest

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -264,7 +264,7 @@ Run:
 - Run tests with **arbitrary ``pytest`` options**:
   ``spin test -- any pytest args you want``.
 - Run all tests and **doctests**:
-  ``spin test -- --doctest-modules skimage``
+  ``spin test -- --doctest-plus skimage``
 
 Warnings during testing phase
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -168,7 +168,7 @@ jobs:
           export MATPLOTLIBRC=${AGENT_BUILDDIRECTORY}
 
           # Run unit tests with pytest
-          # We don't test docstring examples (--doctest-modules) on
+          # We don't test docstring examples (--doctest-plus) on
           # Windows due to inconsistent ndarray formatting in `numpy`.
           # For more details, see https://github.com/numpy/numpy/issues/13468
           export TEST_ARGS="-v --cov=skimage"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -55,6 +55,7 @@ extensions = [
     "sphinx_design",
     "matplotlib.sphinxext.plot_directive",
     "myst_parser",
+    "pytest_doctestplus.sphinx.doctestplus",
     "skimage_extensions",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ docs = [
     'sphinx_design>=0.5',
     'pydata-sphinx-theme>=0.14.1',
     'PyWavelets>=1.1.1',
+    'pytest-doctestplus',
 ]
 optional = [
     'SimpleITK',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ test = [
     'pytest-cov>=2.11.0',
     'pytest-localserver',
     'pytest-faulthandler',
+    'pytest-doctestplus',
 ]
 
 [project.urls]

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -20,3 +20,4 @@ scikit-learn>=1.1
 sphinx_design>=0.5
 pydata-sphinx-theme>=0.14.1
 PyWavelets>=1.1.1
+pytest-doctestplus

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,3 +8,4 @@ pytest>=7.0
 pytest-cov>=2.11.0
 pytest-localserver
 pytest-faulthandler
+pytest-doctestplus

--- a/skimage/feature/_fisher_vector.py
+++ b/skimage/feature/_fisher_vector.py
@@ -79,8 +79,9 @@ def learn_gmm(descriptors, *, n_modes=32, gm_args=None):
 
     Examples
     --------
-    >>> import pytest
-    >>> _ = pytest.importorskip('sklearn')
+    .. testsetup::
+        >>> import pytest; _ = pytest.importorskip('sklearn')
+
     >>> from skimage.feature import fisher_vector
     >>> rng = np.random.Generator(np.random.PCG64())
     >>> sift_for_images = [rng.standard_normal((10, 128)) for _ in range(10)]
@@ -191,8 +192,9 @@ def fisher_vector(descriptors, gmm, *, improved=False, alpha=0.5):
 
     Examples
     --------
-    >>> import pytest
-    >>> _ = pytest.importorskip('sklearn')
+    .. testsetup::
+        >>> import pytest; _ = pytest.importorskip('sklearn')
+
     >>> from skimage.feature import fisher_vector, learn_gmm
     >>> sift_for_images = [np.random.random((10, 128)) for _ in range(10)]
     >>> num_modes = 16

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -959,8 +959,9 @@ def denoise_wavelet(
 
     Examples
     --------
-    >>> import pytest
-    >>> _ = pytest.importorskip('pywt')
+    .. testsetup::
+        >>> import pytest; _ = pytest.importorskip('pywt')
+
     >>> from skimage import color, data
     >>> img = img_as_float(data.astronaut())
     >>> img = color.rgb2gray(img)
@@ -1084,8 +1085,9 @@ def estimate_sigma(image, average_sigmas=False, *, channel_axis=None):
 
     Examples
     --------
-    >>> import pytest
-    >>> _ = pytest.importorskip('pywt')
+    .. testsetup::
+        >>> import pytest; _ = pytest.importorskip('pywt')
+
     >>> import skimage.data
     >>> from skimage import img_as_float
     >>> img = img_as_float(skimage.data.camera())

--- a/tools/github/script.sh
+++ b/tools/github/script.sh
@@ -7,7 +7,7 @@ export MPL_DIR=`python -c 'import matplotlib; print(matplotlib.get_configdir())'
 mkdir -p $MPL_DIR
 touch $MPL_DIR/matplotlibrc
 
-TEST_ARGS="--doctest-modules --cov=skimage --showlocals"
+TEST_ARGS="--doctest-plus --cov=skimage --showlocals"
 
 if [[ ${WITHOUT_POOCH} == "1" ]]; then
   # remove pooch (previously installed via requirements/test.txt)


### PR DESCRIPTION
## Description

This has the advantage of being able to hide custom test setup from the rendered HTML docstrings and many more perks we might use in the future. E.g. in the past I've wished for access to `# doctest: +FLOAT_CMP`, `# doctest: +IGNORE_WARNINGS` or `.. testsetup::`.

See also https://github.com/scientific-python/pytest-doctestplus.

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
