### PR TITLE
Complete deprecations and TODOs for 0.23

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -480,7 +480,7 @@ Deprecating Keywords and Functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When removing keywords or entire functions, the
-``skimage._shared.utils.deprecate_kwarg`` and
+``skimage._shared.utils.deprecate_parameter`` and
 ``skimage._shared.utils.deprecate_func`` utility functions can be used
 to perform the above procedure.
 

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,18 +1,13 @@
 Remember to list any API changes below in `doc/release/release_dev.rst`.
 
-Version 0.17
-------------
-
-* Finalize ``skimage.future.manual_segmentation`` API.
-
 Version 0.26
 ------------
 * In ``skimage/morphology/gray.py``, remove deprecated parameters ``shift_x``
   and ``shift_y`` from ``erosion`` and ``dilation``, along with associated
   function ``_shift_footprint``.
 
-Other (2022)
-------------
+Other
+-----
 * Remove custom code for ignored warning in `skimage/_shared/testing.py` relating
   to (sparse) matricies (instead of arrays).
 * Remove warningsfilter for imageio and Pillow once
@@ -21,10 +16,11 @@ Other (2022)
 * NumPy 1.25.0 is minimal required version:
     * Remove optional test for a NaN-related deprecation warning from numpy.clip in
       skimage/exposure/tests/test_exposure.py::test_rescale_nan_warning
+* Finalize ``skimage.future.manual_segmentation`` API,
+  see https://github.com/scikit-image/scikit-image/issues/2624
 
 Post numpy 2
 ------------
-
 - Remove try except blocks following comment starting
   `# TODO: when minimum numpy`
   in `skimage/color/colorconv.py`, `skimage/color/tests/test_colorconv.py`,

--- a/TODO.txt
+++ b/TODO.txt
@@ -7,8 +7,6 @@ Version 0.17
 
 Version 0.23
 ------------
-* Remove deprecated `random_seed`, `random_state`, and `sample_seed`
-  arguments in favor of `rng`.
 * Remove deprecated function ``skimage.color.colorconv.get_xyz_coords()``.
 * Remove deprecated ``return_error`` in
   ``skimage.registration.phase_cross_correlation``.

--- a/TODO.txt
+++ b/TODO.txt
@@ -7,7 +7,6 @@ Version 0.17
 
 Version 0.23
 ------------
-* Remove deprecated function ``skimage.color.colorconv.get_xyz_coords()``.
 * Remove deprecated ``return_error`` in
   ``skimage.registration.phase_cross_correlation``.
 

--- a/TODO.txt
+++ b/TODO.txt
@@ -21,9 +21,6 @@ Other (2022)
 * NumPy 1.25.0 is minimal required version:
     * Remove optional test for a NaN-related deprecation warning from numpy.clip in
       skimage/exposure/tests/test_exposure.py::test_rescale_nan_warning
-* pydata-sphinx-theme 0.15.0 is minimal version: remove obsolete config option
-  ``"navigation_with_keys": False,`` in doc/source/conf.py::html_theme_options.
-
 
 Post numpy 2
 ------------

--- a/TODO.txt
+++ b/TODO.txt
@@ -5,11 +5,6 @@ Version 0.17
 
 * Finalize ``skimage.future.manual_segmentation`` API.
 
-Version 0.23
-------------
-* Remove deprecated ``return_error`` in
-  ``skimage.registration.phase_cross_correlation``.
-
 Version 0.26
 ------------
 * In ``skimage/morphology/gray.py``, remove deprecated parameters ``shift_x``

--- a/doc/examples/features_detection/plot_haar.py
+++ b/doc/examples/features_detection/plot_haar.py
@@ -48,7 +48,7 @@ fig, axs = plt.subplots(3, 2)
 for ax, img, feat_t in zip(np.ravel(axs), images, feature_types):
     coord, _ = haar_like_feature_coord(img.shape[0], img.shape[1], feat_t)
     haar_feature = draw_haar_like_feature(
-        img, 0, 0, img.shape[0], img.shape[1], coord, max_n_features=1, random_state=0
+        img, 0, 0, img.shape[0], img.shape[1], coord, max_n_features=1, rng=0
     )
     ax.imshow(haar_feature)
     ax.set_title(feat_t)

--- a/doc/examples/transform/plot_fundamental_matrix.py
+++ b/doc/examples/transform/plot_fundamental_matrix.py
@@ -56,7 +56,7 @@ model, inliers = ransac(
     min_samples=8,
     residual_threshold=1,
     max_trials=5000,
-    random_state=rng,
+    rng=rng,
 )
 
 inlier_keypoints_left = keypoints_left[matches[inliers, 0]]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -183,9 +183,6 @@ html_theme_options = {
         "plausible_analytics_domain": "scikit-image.org",
         "plausible_analytics_url": ("https://views.scientific-python.org/js/script.js"),
     },
-    # Silence warning in pydata-sphinx-theme v0.14.2
-    # can be removed after >=0.15 is released and pinned
-    "navigation_with_keys": False,
 }
 
 # Custom sidebar templates, maps document names to template names.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ docs = [
     'kaleido',
     'scikit-learn>=1.1',
     'sphinx_design>=0.5',
-    'pydata-sphinx-theme>=0.14.1',
+    'pydata-sphinx-theme>=0.15.1',
     'PyWavelets>=1.1.1',
 ]
 optional = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ build = [
     'ninja',
     'Cython>=3.0.4',
     'pythran',
-    'numpy>=1.23',
+    'numpy>=1.25',
     # Developer UI
     'spin==0.7',
     'build',

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -7,6 +7,6 @@ packaging>=21
 ninja
 Cython>=3.0.4
 pythran
-numpy>=1.23
+numpy>=1.25
 spin==0.7
 build

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -18,5 +18,5 @@ plotly>=5.10
 kaleido
 scikit-learn>=1.1
 sphinx_design>=0.5
-pydata-sphinx-theme>=0.14.1
+pydata-sphinx-theme>=0.15.1
 PyWavelets>=1.1.1

--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -13,8 +13,6 @@ from skimage._shared.utils import (
     channel_as_last_axis,
     check_nD,
     deprecate_func,
-    deprecate_kwarg,
-    remove_arg,
     deprecate_parameter,
     DEPRECATED,
 )
@@ -30,68 +28,6 @@ try:
     have_numpydoc = True
 except ImportError:
     pass
-
-
-def test_remove_argument():
-    @remove_arg('arg1', changed_version='0.12')
-    def foo(arg0, arg1=0, arg2=1):
-        """Expected docstring"""
-        return arg0, arg1, arg2
-
-    @remove_arg(
-        'arg1', changed_version='0.12', help_msg="Some indication on future behavior"
-    )
-    def bar(arg0, arg1=0, arg2=1):
-        """Expected docstring"""
-        return arg0, arg1, arg2
-
-    # Assert warning messages
-    expected_msg = (
-        "arg1 argument is deprecated and will be removed "
-        "in version 0.12. To avoid this warning, "
-        "please do not use the arg1 argument. Please see "
-        "foo documentation for more details."
-    )
-
-    with pytest.warns(FutureWarning) as record:
-        assert foo(0, 1) == (0, 1, 1)
-
-    assert str(record[0].message) == expected_msg
-
-    with pytest.warns(FutureWarning) as record:
-        assert foo(0, arg1=1) == (0, 1, 1)
-
-    assert str(record[0].message) == expected_msg
-
-    expected_msg = (
-        "arg1 argument is deprecated and will be removed "
-        "in version 0.12. To avoid this warning, "
-        "please do not use the arg1 argument. Please see "
-        "bar documentation for more details."
-        " Some indication on future behavior"
-    )
-
-    with pytest.warns(FutureWarning) as record:
-        assert bar(0, 1) == (0, 1, 1)
-
-    assert str(record[0].message) == expected_msg
-
-    with pytest.warns(FutureWarning) as record:
-        assert bar(0, arg1=1) == (0, 1, 1)
-
-    assert str(record[0].message) == expected_msg
-    with warnings.catch_warnings(record=True) as recorded:
-        # No kwargs
-        assert foo(0) == (0, 0, 1)
-        assert foo(0, arg2=0) == (0, 0, 0)
-
-        # Function name and doc is preserved
-        assert foo.__name__ == 'foo'
-        if sys.flags.optimize < 2:
-            # if PYTHONOPTIMIZE is set to 2, docstrings are stripped
-            assert foo.__doc__ == 'Expected docstring'
-    # Assert no warnings were raised
-    assert len(recorded) == 0
 
 
 def test_change_default_value():
@@ -137,70 +73,6 @@ def test_change_default_value():
             # if PYTHONOPTIMIZE is set to 2, docstrings are stripped
             assert foo.__doc__ == 'Expected docstring'
     # Assert no warnings were raised
-    assert len(recorded) == 0
-
-
-def test_deprecate_kwarg():
-    @deprecate_kwarg({'old_arg1': 'new_arg1'}, '0.19')
-    def foo(arg0, new_arg1=1, arg2=None):
-        """Expected docstring"""
-        return arg0, new_arg1, arg2
-
-    @deprecate_kwarg(
-        {'old_arg1': 'new_arg1'},
-        deprecated_version='0.19',
-        warning_msg="Custom warning message",
-    )
-    def bar(arg0, new_arg1=1, arg2=None):
-        """Expected docstring"""
-        return arg0, new_arg1, arg2
-
-    # Assert that the DeprecationWarning is raised when the deprecated
-    # argument name is used and that the reasult is valid
-    with pytest.warns(FutureWarning) as record:
-        assert foo(0, old_arg1=1) == (0, 1, None)
-        assert bar(0, old_arg1=1) == (0, 1, None)
-
-    msg = (
-        "`old_arg1` is a deprecated argument name "
-        "for `foo`. Please use `new_arg1` instead."
-    )
-    assert str(record[0].message) == msg
-    assert str(record[1].message) == "Custom warning message"
-
-    # Assert that nothing happens when the function is called with the
-    # new API
-    with warnings.catch_warnings(record=True) as recorded:
-        # No kwargs
-        assert foo(0) == (0, 1, None)
-        assert foo(0, 2) == (0, 2, None)
-        assert foo(0, 1, 2) == (0, 1, 2)
-        # Kwargs without deprecated argument
-        assert foo(0, new_arg1=1, arg2=2) == (0, 1, 2)
-        assert foo(0, new_arg1=2) == (0, 2, None)
-        assert foo(0, arg2=2) == (0, 1, 2)
-        assert foo(0, 1, arg2=2) == (0, 1, 2)
-        # Function name and doc is preserved
-        assert foo.__name__ == 'foo'
-        if sys.flags.optimize < 2:
-            # if PYTHONOPTIMIZE is set to 2, docstrings are stripped
-            if not have_numpydoc:
-                assert foo.__doc__ == """Expected docstring"""
-            else:
-                assert (
-                    foo.__doc__
-                    == """Expected docstring
-
-
-    Other Parameters
-    ----------------
-    old_arg1 : DEPRECATED
-        Deprecated in favor of `new_arg1`.
-
-        .. deprecated:: 0.19
-"""
-                )
-
     assert len(recorded) == 0
 
 
@@ -309,22 +181,6 @@ def test_decorated_channel_axis_shape(channel_axis):
         assert size is None
     else:
         assert size == x.shape[channel_axis]
-
-
-@deprecate_kwarg({"old_kwarg": "new_kwarg"}, deprecated_version="x.y.z")
-def _function_with_deprecated_kwarg(*, new_kwarg):
-    pass
-
-
-def test_deprecate_kwarg_location():
-    """Assert that warning message issued by deprecate_kwarg points to
-    file and line number where decorated function is called.
-    """
-    with pytest.warns(FutureWarning) as record:
-        _function_with_deprecated_kwarg(old_kwarg=True)
-        expected_lineno = inspect.currentframe().f_lineno - 1
-    assert record[0].lineno == expected_lineno
-    assert record[0].filename == __file__
 
 
 @deprecate_func(

--- a/skimage/color/colorconv.py
+++ b/skimage/color/colorconv.py
@@ -61,7 +61,6 @@ from .._shared.utils import (
     identity,
     reshape_nd,
     slice_at_axis,
-    deprecate_func,
 )
 from ..util import dtype, dtype_limits
 
@@ -628,43 +627,6 @@ def xyz_tristimulus_values(*, illuminant, observer, dtype=float):
             f'Unknown illuminant/observer combination '
             f'(`{illuminant}`, `{observer}`)'
         )
-
-
-@deprecate_func(
-    hint="Use `skimage.color.xyz_tristimulus_values` instead.",
-    deprecated_version="0.21",
-    removed_version="0.23",
-)
-def get_xyz_coords(illuminant, observer, dtype=float):
-    """Get the XYZ coordinates of the given illuminant and observer [1]_.
-
-    Parameters
-    ----------
-    illuminant : {"A", "B", "C", "D50", "D55", "D65", "D75", "E"}, optional
-        The name of the illuminant (the function is NOT case sensitive).
-    observer : {"2", "10", "R"}, optional
-        One of: 2-degree observer, 10-degree observer, or 'R' observer as in
-        R function grDevices::convertColor.
-    dtype: dtype, optional
-        Output data type.
-
-    Returns
-    -------
-    out : array
-        Array with 3 elements containing the XYZ coordinates of the given
-        illuminant.
-
-    Raises
-    ------
-    ValueError
-        If either the illuminant or the observer angle are not supported or
-        unknown.
-
-    References
-    ----------
-    .. [1] https://en.wikipedia.org/wiki/Standard_illuminant
-    """
-    return xyz_tristimulus_values(illuminant=illuminant, observer=observer, dtype=dtype)
 
 
 # Haematoxylin-Eosin-DAB colorspace

--- a/skimage/data/_binary_blobs.py
+++ b/skimage/data/_binary_blobs.py
@@ -1,10 +1,8 @@
 import numpy as np
 
-from .._shared.utils import deprecate_kwarg
 from .._shared.filters import gaussian
 
 
-@deprecate_kwarg({'seed': 'rng'}, deprecated_version='0.21', removed_version='0.23')
 def binary_blobs(
     length=512, blob_size_fraction=0.1, n_dim=2, volume_fraction=0.5, rng=None
 ):

--- a/skimage/draw/_random_shapes.py
+++ b/skimage/draw/_random_shapes.py
@@ -3,7 +3,7 @@ import math
 import numpy as np
 
 from .draw import polygon as draw_polygon, disk as draw_disk, ellipse as draw_ellipse
-from .._shared.utils import deprecate_kwarg, warn
+from .._shared.utils import warn
 
 
 def _generate_rectangle_mask(point, image, shape, random):
@@ -301,9 +301,6 @@ def _generate_random_colors(num_colors, num_channels, intensity_range, random):
     return np.transpose(colors)
 
 
-@deprecate_kwarg(
-    {'random_seed': 'rng'}, deprecated_version='0.21', removed_version='0.23'
-)
 def random_shapes(
     image_shape,
     max_shapes,

--- a/skimage/draw/tests/test_random_shapes.py
+++ b/skimage/draw/tests/test_random_shapes.py
@@ -63,11 +63,6 @@ def test_generates_correct_bounding_boxes_for_rectangles():
     assert (image == 255).all()
 
 
-def test_random_seed_deprecation():
-    with expected_warnings(['`random_seed` is a deprecated argument']):
-        random_shapes((128, 128), max_shapes=1, shape='rectangle', random_seed=42)
-
-
 def test_generates_correct_bounding_boxes_for_triangles():
     image, labels = random_shapes((128, 128), max_shapes=1, shape='triangle', rng=42)
     assert len(labels) == 1

--- a/skimage/feature/brief.py
+++ b/skimage/feature/brief.py
@@ -3,7 +3,7 @@ import copy
 import numpy as np
 
 from .._shared.filters import gaussian
-from .._shared.utils import check_nD, deprecate_kwarg
+from .._shared.utils import check_nD
 from .brief_cy import _brief_loop
 from .util import (
     DescriptorExtractor,
@@ -123,9 +123,6 @@ class BRIEF(DescriptorExtractor):
 
     """
 
-    @deprecate_kwarg(
-        {'sample_seed': 'rng'}, deprecated_version='0.21', removed_version='0.23'
-    )
     def __init__(
         self, descriptor_size=256, patch_size=49, mode='normal', sigma=1, rng=1
     ):

--- a/skimage/feature/haar.py
+++ b/skimage/feature/haar.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from ._haar import haar_like_feature_coord_wrapper
 from ._haar import haar_like_feature_wrapper
-from .._shared.utils import deprecate_kwarg
 from ..color import gray2rgb
 from ..draw import rectangle
 from ..util import img_as_float
@@ -233,9 +232,6 @@ def haar_like_feature(
         return haar_feature
 
 
-@deprecate_kwarg(
-    {'random_state': 'rng'}, deprecated_version='0.21', removed_version='0.23'
-)
 def draw_haar_like_feature(
     image,
     r,

--- a/skimage/feature/tests/test_brief.py
+++ b/skimage/feature/tests/test_brief.py
@@ -57,8 +57,7 @@ def test_uniform_mode(dtype):
     )
 
     extractor = BRIEF(descriptor_size=8, sigma=2, mode='uniform', rng=1)
-    with testing.expected_warnings(['`sample_seed` is a deprecated argument']):
-        BRIEF(descriptor_size=8, sigma=2, mode='uniform', sample_seed=1)
+    BRIEF(descriptor_size=8, sigma=2, mode='uniform', rng=1)
 
     extractor.extract(img, keypoints[:8])
 

--- a/skimage/feature/tests/test_haar.py
+++ b/skimage/feature/tests/test_haar.py
@@ -6,7 +6,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 from numpy.testing import assert_array_equal
 
-from skimage._shared._warnings import expected_warnings
 from skimage.transform import integral_image
 from skimage.feature import haar_like_feature
 from skimage.feature import haar_like_feature_coord
@@ -178,9 +177,6 @@ def test_draw_haar_like_feature(max_n_features, nnz_values):
     image = draw_haar_like_feature(
         img, 0, 0, 5, 5, coord, max_n_features=max_n_features, rng=0
     )
-    with expected_warnings(['`random_state` is a deprecated argument']):
-        draw_haar_like_feature(
-            img, 0, 0, 5, 5, coord, max_n_features=max_n_features, random_state=0
-        )
+    draw_haar_like_feature(img, 0, 0, 5, 5, coord, max_n_features=max_n_features, rng=0)
     assert image.shape == (5, 5, 3)
     assert np.count_nonzero(image) == nnz_values

--- a/skimage/graph/_graph_cut.py
+++ b/skimage/graph/_graph_cut.py
@@ -2,7 +2,6 @@ import networkx as nx
 import numpy as np
 from scipy.sparse import linalg
 
-from .._shared.utils import deprecate_kwarg
 from . import _ncut, _ncut_cy
 
 
@@ -68,9 +67,6 @@ def cut_threshold(labels, rag, thresh, in_place=True):
     return map_array[labels]
 
 
-@deprecate_kwarg(
-    {'random_state': 'rng'}, deprecated_version='0.21', removed_version='0.23'
-)
 def cut_normalized(
     labels,
     rag,

--- a/skimage/graph/tests/test_rag.py
+++ b/skimage/graph/tests/test_rag.py
@@ -4,7 +4,6 @@ import numpy as np
 from skimage import graph
 from skimage import segmentation, data
 from skimage._shared import testing
-from skimage._shared._warnings import expected_warnings
 
 
 def max_edge(g, src, dst, n):
@@ -219,8 +218,7 @@ def test_reproducibility():
         results[i] = graph.cut_normalized(
             labels1, g, in_place=False, thresh=1e-3, rng=1234
         )
-    with expected_warnings(['`random_state` is a deprecated argument']):
-        graph.cut_normalized(labels1, g, in_place=False, thresh=1e-3, random_state=1234)
+    graph.cut_normalized(labels1, g, in_place=False, thresh=1e-3, rng=1234)
 
     for i in range(len(results) - 1):
         assert_array_equal(results[i], results[i + 1])

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -5,7 +5,6 @@ import numpy as np
 from numpy.linalg import inv
 from scipy import optimize, spatial
 
-from .._shared.utils import deprecate_kwarg
 
 _EPSILON = np.spacing(1)
 
@@ -669,9 +668,6 @@ def _dynamic_max_trials(n_inliers, n_samples, min_samples, probability):
     return np.ceil(np.log(nom) / np.log(denom))
 
 
-@deprecate_kwarg(
-    {'random_state': 'rng'}, deprecated_version='0.21', removed_version='0.23'
-)
 def ransac(
     data,
     model_class,

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -498,8 +498,7 @@ def test_ransac_shape():
 
     # estimate parameters of corrupted data
     model_est, inliers = ransac(data0, CircleModel, 3, 5, rng=1)
-    with expected_warnings(['`random_state` is a deprecated argument']):
-        ransac(data0, CircleModel, 3, 5, random_state=1)
+    ransac(data0, CircleModel, 3, 5, rng=1)
 
     # test whether estimated parameters equal original parameters
     assert_almost_equal(model0.params, model_est.params)

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -4,7 +4,7 @@ Algorithms for computing the skeleton of a binary image
 import numpy as np
 from scipy import ndimage as ndi
 
-from .._shared.utils import check_nD, deprecate_kwarg
+from .._shared.utils import check_nD
 from ..util import crop
 from ._skeletonize_3d_cy import _compute_thin_image
 from ._skeletonize_cy import _fast_skeletonize, _skeletonize_loop, _table_lookup_index
@@ -355,9 +355,6 @@ def thin(image, max_num_iter=None):
 _eight_connect = ndi.generate_binary_structure(2, 2)
 
 
-@deprecate_kwarg(
-    {'random_state': 'rng'}, deprecated_version='0.21', removed_version='0.23'
-)
 def medial_axis(image, mask=None, return_distance=False, *, rng=None):
     """Compute the medial axis transform of a binary image.
 

--- a/skimage/morphology/tests/test_skeletonize.py
+++ b/skimage/morphology/tests/test_skeletonize.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_array_equal
 from scipy.ndimage import correlate
 
 from skimage import draw
-from skimage._shared.testing import expected_warnings, fetch
+from skimage._shared.testing import fetch
 from skimage.io import imread
 from skimage.morphology import medial_axis, skeletonize, thin
 from skimage.morphology._skeletonize import G123_LUT, G123P_LUT, _generate_thin_luts
@@ -264,8 +264,3 @@ class TestMedialAxis:
         image[:, 1:-1] = True
         result = medial_axis(image)
         assert np.all(result == image)
-
-    def test_deprecated_random_state(self):
-        """Test medial_axis on an array of all zeros."""
-        with expected_warnings(['`random_state` is a deprecated argument']):
-            medial_axis(np.zeros((10, 10), bool), random_state=None)

--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -10,7 +10,6 @@ import numpy as np
 from scipy.fft import fftn, ifftn, fftfreq
 from scipy import ndimage as ndi
 
-from skimage._shared.utils import remove_arg
 from ._masked_phase_cross_correlation import _masked_phase_cross_correlation
 
 
@@ -192,7 +191,6 @@ def _disambiguate_shift(reference_image, moving_image, shift):
     return np.array(real_shift_acc)
 
 
-@remove_arg('return_error', changed_version='0.23')
 def phase_cross_correlation(
     reference_image,
     moving_image,
@@ -200,7 +198,6 @@ def phase_cross_correlation(
     upsample_factor=1,
     space="real",
     disambiguate=False,
-    return_error=True,
     reference_mask=None,
     moving_mask=None,
     overlap_ratio=0.3,

--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -123,7 +123,7 @@ def _compute_error(cross_correlation_max, src_amp, target_amp):
             f"average intensities {src_amp!r} and {target_amp!r}. Either the "
             "reference or moving image may be empty.",
             UserWarning,
-            stacklevel=4,
+            stacklevel=3,
         )
     with np.errstate(invalid="ignore"):
         error = 1.0 - cross_correlation_max * cross_correlation_max.conj() / amp

--- a/skimage/registration/_phase_cross_correlation.py
+++ b/skimage/registration/_phase_cross_correlation.py
@@ -181,7 +181,7 @@ def _disambiguate_shift(reference_image, moving_image, shift):
         warnings.warn(
             f"Could not determine real-space shift for periodic shift {shift!r} "
             f"as requested by `disambiguate=True` (disambiguation is degenerate).",
-            stacklevel=4,
+            stacklevel=3,
         )
         return shift
     real_shift_acc = []

--- a/skimage/registration/tests/test_phase_cross_correlation.py
+++ b/skimage/registration/tests/test_phase_cross_correlation.py
@@ -247,13 +247,3 @@ def test_disambiguate_empty_image():
     # Assert correct stacklevel
     assert record[0].filename == __file__
     assert record[0].lineno == expected_lineno
-
-
-@pytest.mark.parametrize("return_error", [False, True, "always"])
-def test_deprecated_return_error(return_error):
-    img = np.ones((10, 10))
-    with pytest.warns() as record:
-        phase_cross_correlation(img, img, return_error=return_error)
-    assert len(record) == 1
-    assert "return_error argument is deprecated" in record[0].message.args[0]
-    assert record[0].filename == __file__

--- a/skimage/restoration/deconvolution.py
+++ b/skimage/restoration/deconvolution.py
@@ -3,7 +3,7 @@
 import numpy as np
 from scipy.signal import convolve
 
-from .._shared.utils import _supported_float_type, deprecate_kwarg
+from .._shared.utils import _supported_float_type
 from . import uft
 
 
@@ -139,9 +139,6 @@ def wiener(image, psf, balance, reg=None, is_real=True, clip=True):
     return deconv
 
 
-@deprecate_kwarg(
-    {'random_state': 'rng'}, deprecated_version='0.21', removed_version='0.23'
-)
 def unsupervised_wiener(
     image, psf, reg=None, user_params=None, is_real=True, clip=True, *, rng=None
 ):

--- a/skimage/restoration/tests/test_restoration.py
+++ b/skimage/restoration/tests/test_restoration.py
@@ -10,7 +10,6 @@ from skimage._shared.utils import _supported_float_type
 from skimage.color import rgb2gray
 from skimage.data import astronaut, camera
 from skimage.restoration import uft
-from skimage._shared._warnings import expected_warnings
 
 
 test_img = util.img_as_float(camera())
@@ -77,8 +76,7 @@ def test_unsupervised_wiener(dtype):
     data += 0.1 * data.std() * rng.standard_normal(data.shape)
     data = data.astype(dtype, copy=False)
     deconvolved, _ = restoration.unsupervised_wiener(data, psf, rng=seed)
-    with expected_warnings(['`random_state` is a deprecated argument']):
-        restoration.unsupervised_wiener(data, psf, random_state=seed)
+    restoration.unsupervised_wiener(data, psf, rng=seed)
     float_type = _supported_float_type(dtype)
     assert deconvolved.dtype == float_type
 

--- a/skimage/restoration/unwrap.py
+++ b/skimage/restoration/unwrap.py
@@ -1,14 +1,12 @@
 import numpy as np
 
 from .._shared.utils import warn
-from .._shared.utils import deprecate_kwarg
 
 from ._unwrap_1d import unwrap_1d
 from ._unwrap_2d import unwrap_2d
 from ._unwrap_3d import unwrap_3d
 
 
-@deprecate_kwarg({'seed': 'rng'}, deprecated_version='0.21', removed_version='0.23')
 def unwrap_phase(image, wrap_around=False, rng=None):
     '''Recover the original from a wrapped phase image.
 

--- a/skimage/segmentation/_quickshift.py
+++ b/skimage/segmentation/_quickshift.py
@@ -1,15 +1,12 @@
 import numpy as np
 
 from .._shared.filters import gaussian
-from .._shared.utils import _supported_float_type, deprecate_kwarg
+from .._shared.utils import _supported_float_type
 from ..color import rgb2lab
 from ..util import img_as_float
 from ._quickshift_cy import _quickshift_cython
 
 
-@deprecate_kwarg(
-    {'random_seed': 'rng'}, deprecated_version='0.21', removed_version='0.23'
-)
 def quickshift(
     image,
     ratio=1.0,

--- a/skimage/segmentation/tests/test_quickshift.py
+++ b/skimage/segmentation/tests/test_quickshift.py
@@ -22,10 +22,7 @@ def test_grey(dtype):
     img += 0.05 * rng.normal(size=img.shape)
     img = img.astype(dtype, copy=False)
     seg = quickshift(img, kernel_size=2, max_dist=3, rng=0, convert2lab=False, sigma=0)
-    with testing.expected_warnings(['`random_seed` is a deprecated argument']):
-        quickshift(
-            img, kernel_size=2, max_dist=3, random_seed=0, convert2lab=False, sigma=0
-        )
+    quickshift(img, kernel_size=2, max_dist=3, rng=0, convert2lab=False, sigma=0)
     # we expect 4 segments:
     assert_equal(len(np.unique(seg)), 4)
     # that mostly respect the 4 regions:

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -3,7 +3,6 @@ from scipy.spatial import cKDTree
 
 from ._hough_transform import _hough_circle, _hough_ellipse, _hough_line
 from ._hough_transform import _probabilistic_hough_line as _prob_hough_line
-from .._shared.utils import deprecate_kwarg
 
 
 def hough_line_peaks(
@@ -248,7 +247,6 @@ def hough_line(image, theta=None):
     return _hough_line(image, theta=theta)
 
 
-@deprecate_kwarg({'seed': 'rng'}, deprecated_version='0.21', removed_version='0.23')
 def probabilistic_hough_line(
     image, threshold=10, line_length=50, line_gap=10, theta=None, rng=None
 ):

--- a/skimage/util/noise.py
+++ b/skimage/util/noise.py
@@ -3,7 +3,6 @@ __all__ = ['random_noise']
 
 import numpy as np
 from .dtype import img_as_float
-from .._shared.utils import deprecate_kwarg
 
 
 def _bernoulli(p, shape, *, rng):
@@ -37,7 +36,6 @@ def _bernoulli(p, shape, *, rng):
     return rng.random(shape) <= p
 
 
-@deprecate_kwarg({'seed': 'rng'}, deprecated_version='0.21', removed_version='0.23')
 def random_noise(image, mode='gaussian', rng=None, clip=True, **kwargs):
     """
     Function to add random noise of various types to a floating-point image.


### PR DESCRIPTION
## Description

- Complete deprecations that were scheduled for our 0.23 release.
- Remove now unused `deprecate_kwarg` and `remove_arg`; they are entirely succeeded by `deprecate_parameter`.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
