### PR TITLE
Use `num_workers` instead of alternate parameter names

### DIFF
--- a/benchmarks/benchmark_restoration.py
+++ b/benchmarks/benchmark_restoration.py
@@ -221,11 +221,11 @@ class RollingBall:
 
     time_rollingball_ndim.setup = _skip_slow
 
-    def time_rollingball_threads(self, threads):
-        restoration.rolling_ball(data.coins(), radius=100, num_threads=threads)
+    def time_rollingball_parallel(self, num_workers):
+        restoration.rolling_ball(data.coins(), radius=100, num_workers=num_workers)
 
-    time_rollingball_threads.params = (0, 2, 4, 8)
-    time_rollingball_threads.param_names = ["threads"]
+    time_rollingball_parallel.params = (0, 2, 4, 8)
+    time_rollingball_parallel.param_names = ["num_workers"]
 
 
 class Inpaint:

--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -321,7 +321,7 @@ def fetch(data_filename):
         pytest.skip(f'Unable to download {data_filename}', allow_module_level=True)
 
 
-def run_in_parallel(num_threads=2, warnings_matching=None):
+def run_in_parallel(num_workers=2, warnings_matching=None):
     """Decorator to run the same function multiple times in parallel.
 
     This decorator is useful to ensure that separate threads execute
@@ -329,7 +329,7 @@ def run_in_parallel(num_threads=2, warnings_matching=None):
 
     Parameters
     ----------
-    num_threads : int, optional
+    num_workers : int, optional
         The number of times the function is run in parallel.
 
     warnings_matching: list or None
@@ -340,14 +340,14 @@ def run_in_parallel(num_threads=2, warnings_matching=None):
 
     """
 
-    assert num_threads > 0
+    assert num_workers > 0
 
     def wrapper(func):
         @functools.wraps(func)
         def inner(*args, **kwargs):
             with expected_warnings(warnings_matching):
                 threads = []
-                for i in range(num_threads - 1):
+                for i in range(num_workers - 1):
                     thread = threading.Thread(target=func, args=args, kwargs=kwargs)
                     threads.append(thread)
                 for thread in threads:

--- a/skimage/_shared/tests/test_testing.py
+++ b/skimage/_shared/tests/test_testing.py
@@ -83,14 +83,14 @@ def test_run_in_parallel():
     change_state1()
     assert len(state) == 2
 
-    @run_in_parallel(num_threads=1)
+    @run_in_parallel(num_workers=1)
     def change_state2():
         state.append(None)
 
     change_state2()
     assert len(state) == 3
 
-    @run_in_parallel(num_threads=3)
+    @run_in_parallel(num_workers=3)
     def change_state3():
         state.append(None)
 

--- a/skimage/restoration/_rolling_ball_cy.pyx
+++ b/skimage/restoration/_rolling_ball_cy.pyx
@@ -78,7 +78,7 @@ def apply_kernel_nan(DTYPE_FLOAT[::1] img not None,
                      Py_ssize_t[::1] img_shape not None,
                      Py_ssize_t[::1] padded_img_shape not None,
                      Py_ssize_t[::1] kernel_shape not None,
-                     Py_ssize_t num_threads=0):
+                     Py_ssize_t num_workers=0):
     """Apply a ND kernel to an ND image.
 
     This function is the critical piece of code for
@@ -103,7 +103,7 @@ def apply_kernel_nan(DTYPE_FLOAT[::1] img not None,
         The shape of the unflattened, padded image.
     kernel_shape : (N) ndarray
         The shape of the unflattened kernel.
-    num_threads : int, optional
+    num_workers : int, optional
         The number of threads used to compute the result. If no value is
         provided (0, default) fall back to the number of threads that openMP
         is currently configured to use.
@@ -131,7 +131,7 @@ def apply_kernel_nan(DTYPE_FLOAT[::1] img not None,
 
     for offset_idx in prange(
             out_data_size,
-            num_threads=num_threads,
+            num_threads=num_workers,
             nogil=True):
         offset = ind2ind(offset_idx, 0, img_shape, padded_img_shape)
         min_value = INFINITY
@@ -162,7 +162,7 @@ def apply_kernel(DTYPE_FLOAT[::1] img not None,
                  Py_ssize_t[::1] img_shape not None,
                  Py_ssize_t[::1] padded_img_shape not None,
                  Py_ssize_t[::1] kernel_shape not None,
-                 Py_ssize_t num_threads=0):
+                 Py_ssize_t num_workers=0):
     """Apply a ND kernel to an ND image.
 
     This function is the critical piece of code for
@@ -187,7 +187,7 @@ def apply_kernel(DTYPE_FLOAT[::1] img not None,
         The shape of the unflattened, padded image.
     kernel_shape : (N) ndarray
         The shape of the unflattened kernel.
-    num_threads : int, optional
+    num_workers : int, optional
         The number of threads used to compute the result. If no value is
         provided (0, default) fall back to the number of threads that openMP
         is currently configured to use.
@@ -220,7 +220,7 @@ def apply_kernel(DTYPE_FLOAT[::1] img not None,
 
     for offset_idx in prange(
             out_data_size,
-            num_threads=num_threads,
+            num_threads=num_workers,
             nogil=True):
         offset = ind2ind(offset_idx, 0, img_shape, padded_img_shape)
         min_value = INFINITY

--- a/skimage/restoration/tests/test_rolling_ball.py
+++ b/skimage/restoration/tests/test_rolling_ball.py
@@ -3,6 +3,8 @@ Tests for Rolling Ball Filter
 (skimage.restoration.rolling_ball)
 """
 
+import inspect
+
 import numpy as np
 import pytest
 
@@ -81,16 +83,27 @@ def test_preserve_peaks(radius):
     assert np.allclose(img - background, expected_img)
 
 
-@pytest.mark.parametrize("num_threads", [None, 1, 2])
-def test_threads(num_threads):
+@pytest.mark.parametrize("num_workers", [None, 1, 2])
+def test_workers(num_workers):
     # not testing if we use multiple threads
     # just checking if the API throws an exception
     img = 23 * np.ones((100, 100), dtype=np.uint8)
-    rolling_ball(img, radius=10, num_threads=num_threads)
-    rolling_ball(img, radius=10, nansafe=True, num_threads=num_threads)
+    rolling_ball(img, radius=10, num_workers=num_workers)
+    rolling_ball(img, radius=10, nansafe=True, num_workers=num_workers)
 
 
 def test_ndim():
     image = data.cells3d()[:5, 1, ...]
     kernel = ellipsoid_kernel((3, 100, 100), 100)
     rolling_ball(image, kernel=kernel)
+
+
+@pytest.mark.parametrize("num_threads", [None, 1, 2])
+def test_deprecated_num_threads(num_threads):
+    img = 23 * np.ones((100, 100), dtype=np.uint8)
+    with pytest.warns(FutureWarning, match=".*`num_threads` is deprecated") as record:
+        rolling_ball(img, radius=10, num_threads=num_threads)
+        lineno = inspect.currentframe().f_lineno - 1
+    assert len(record) == 1
+    assert record[0].filename == __file__
+    assert record[0].lineno == lineno


### PR DESCRIPTION
## Description

Closes #4876. Refer to the closed issue for the original discussion, which settled on `workers` or `num_workers` as the consistent name to use. I opted for the latter here, as it seemed more explicit.

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Deprecated parameter `num_threads` in `skimage.restoration.rolling_ball`; 
use `num_workers` instead.
```
