### PR TITLE
CI: Pin scientific-python/upload-nightly-action to release sha

### DIFF
--- a/.github/workflows/nightly_wheel_build.yml
+++ b/.github/workflows/nightly_wheel_build.yml
@@ -31,7 +31,7 @@ jobs:
           path: ./dist
 
       - name: Upload wheel
-        uses: scientific-python/upload-nightly-action@main
+        uses: scientific-python/upload-nightly-action@6e9304f7a3a5501c6f98351537493ec898728299 # 0.3.0
         with:
           artifacts_path: dist
           anaconda_nightly_upload_token: ${{secrets.UPLOAD_TOKEN}}


### PR DESCRIPTION
## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

For security best practices, use the action from known commit shas that correspond to tagged releases. These can be updated via Dependabot as demonstrated in https://github.com/dependabot/dependabot-core/issues/4691.
   - Amends PR https://github.com/scikit-image/scikit-image/pull/6957

c.f. https://github.com/scientific-python/upload-nightly-action/pull/13 for additional context.

At the moment scikit-image doesn't use Dependabot to manage GitHub Actions releases, so if this would be something that the team isn't interested in the future, a slightly less secure workflow would be to use version tags like `@0.3.0`.

Given his review on PR #6957 tagging @stefanv for review here.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- [x] A descriptive but concise pull request title
- [N/A] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [N/A] [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- [N/A] A gallery example in `./doc/examples` for new features
- [x] [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
For security best practices, use the scientific-python/upload-nightly-action GitHub Action from known commit shas that correspond to tagged releases. These can be updated automatically via Dependabot.
```
