### PR TITLE
Make it possible to run tests without numpydoc

### DIFF
--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -248,6 +248,7 @@ def _func_replace_params(
 
 
 class Test_deprecate_parameter:
+    @pytest.mark.skipif(not have_numpydoc, reason="requires numpydoc")
     def test_docstring_removed_param(self):
         # function name and doc are preserved
         assert _func_deprecated_params.__name__ == "_func_deprecated_params"
@@ -278,6 +279,7 @@ class Test_deprecate_parameter:
 """
             )
 
+    @pytest.mark.skipif(not have_numpydoc, reason="requires numpydoc")
     def test_docstring_replaced_param(self):
         assert _func_replace_params.__name__ == "_func_replace_params"
         if sys.flags.optimize < 2:

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -4,7 +4,6 @@ import re
 import numpy as np
 import pytest
 import scipy.ndimage as ndi
-import numpydoc
 from numpy.testing import (
     assert_allclose,
     assert_almost_equal,
@@ -1369,6 +1368,7 @@ def test_column_dtypes_correct():
 
 
 def test_all_documented_items_in_col_dtypes():
+    numpydoc = pytest.importorskip("numpydoc")
     docstring = numpydoc.docscrape.FunctionDoc(regionprops)
     notes_lines = docstring['Notes']
     property_lines = filter(lambda line: line.startswith('**'), notes_lines)

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -1368,8 +1368,8 @@ def test_column_dtypes_correct():
 
 
 def test_all_documented_items_in_col_dtypes():
-    numpydoc = pytest.importorskip("numpydoc")
-    docstring = numpydoc.docscrape.FunctionDoc(regionprops)
+    numpydoc_docscrape = pytest.importorskip("numpydoc.docscrape")
+    docstring = numpydoc_docscrape.FunctionDoc(regionprops)
     notes_lines = docstring['Notes']
     property_lines = filter(lambda line: line.startswith('**'), notes_lines)
     pattern = r'\*\*(?P<property_name>[a-z_]+)\*\*.*'


### PR DESCRIPTION
## Description

Skip the three tests requiring numpydoc when it is not installed. For `skimage/_shared/tests/test_utils.py`, use the existing `have_numpydoc` constant.
For `skimage/measure/tests/test_regionprops.py`, use the standard `pytest.importorskip()` function.

This makes it possible to successfully run the test suite when `numpydoc` is not installed.  This would be convenient for Gentoo since numpydoc is facing neverending test regressions (in its own test suite).

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
The test suite can now be run without `numpydoc` installed.
```
