### PR TITLE
Deal with parallel write warning from Pydata theme

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -26,7 +26,7 @@ from spin import util
     default=True,
     help="Sphinx gallery: enable/disable plots",
 )
-@click.option("--jobs", "-j", default="auto", help="Number of parallel build jobs")
+@click.option("--jobs", "-j", default="1", help="Number of parallel build jobs")
 @click.option(
     "--install-deps/--no-install-deps",
     default=False,

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 PYTHON        ?= python
-SPHINXOPTS    ?= -j auto
+SPHINXOPTS    ?= -j1
 SPHINXBUILD   ?= $(PYTHON) -m sphinx
 SPHINXCACHE   ?= build/doctrees
 PAPER         ?=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ docs = [
     'kaleido',
     'scikit-learn>=1.1',
     'sphinx_design>=0.5',
-    'pydata-sphinx-theme>=0.15.1',
+    'pydata-sphinx-theme>=0.15.2',
     'PyWavelets>=1.1.1',
     'pytest-doctestplus',
 ]

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -18,6 +18,6 @@ plotly>=5.10
 kaleido
 scikit-learn>=1.1
 sphinx_design>=0.5
-pydata-sphinx-theme>=0.15.1
+pydata-sphinx-theme>=0.15.2
 PyWavelets>=1.1.1
 pytest-doctestplus


### PR DESCRIPTION
## Description

Starting with 0.15.2, the PyData Sphinx theme was marked as unsafe for parallel writing (see https://github.com/pydata/pydata-sphinx-theme/pull/1642). So let's default to 1 job for now. Our CI wasn't acting up because it either already builds with `-j 1` or doesn't treat sphinx warnings as errors.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
