### PR TITLE
Use theta for tightness in the docstring of optical_flow_tvl1

### DIFF
--- a/skimage/registration/_optical_flow.py
+++ b/skimage/registration/_optical_flow.py
@@ -192,7 +192,7 @@ def optical_flow_tvl1(
         Attachment parameter (:math:`\lambda` in [1]_). The smaller
         this parameter is, the smoother the returned result will be.
     tightness : float, optional
-        Tightness parameter (:math:`\tau` in [1]_). It should have
+        Tightness parameter (:math:`\theta` in [1]_). It should have
         a small value in order to maintain attachment and
         regularization parts in correspondence.
     num_warp : int, optional


### PR DESCRIPTION
## Description
Issue #7313 [](https://github.com/scikit-image/scikit-image/issues/7313)
<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Function docstring was changed to follow the conventions adopted in the original paper. τ was replaced with θ. 
```
