### PR TITLE
fix for #7246: change shift_x, shift_y and shift_z in the skimage.filters.rank functions from False to 0 (zero)

### DIFF
--- a/skimage/filters/rank/_percentile.py
+++ b/skimage/filters/rank/_percentile.py
@@ -60,7 +60,7 @@ def _apply(func, image, footprint, out, mask, shift_x, shift_y, p0, p1, out_dtyp
 
 
 def autolevel_percentile(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, p0=0, p1=1
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, p0=0, p1=1
 ):
     """Return grayscale local autolevel of an image.
 
@@ -108,7 +108,7 @@ def autolevel_percentile(
 
 
 def gradient_percentile(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, p0=0, p1=1
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, p0=0, p1=1
 ):
     """Return local gradient of an image (i.e. local maximum - local minimum).
 
@@ -153,7 +153,7 @@ def gradient_percentile(
 
 
 def mean_percentile(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, p0=0, p1=1
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, p0=0, p1=1
 ):
     """Return local mean of an image.
 
@@ -198,7 +198,7 @@ def mean_percentile(
 
 
 def subtract_mean_percentile(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, p0=0, p1=1
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, p0=0, p1=1
 ):
     """Return image subtracted from its local mean.
 
@@ -243,7 +243,7 @@ def subtract_mean_percentile(
 
 
 def enhance_contrast_percentile(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, p0=0, p1=1
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, p0=0, p1=1
 ):
     """Enhance contrast of an image.
 
@@ -292,7 +292,7 @@ def enhance_contrast_percentile(
 
 
 def percentile(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, p0=0
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, p0=0
 ):
     """Return local percentile of an image.
 
@@ -339,7 +339,7 @@ def percentile(
 
 
 def pop_percentile(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, p0=0, p1=1
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, p0=0, p1=1
 ):
     """Return the local number (population) of pixels.
 
@@ -387,7 +387,7 @@ def pop_percentile(
 
 
 def sum_percentile(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, p0=0, p1=1
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, p0=0, p1=1
 ):
     """Return the local sum of pixels.
 
@@ -435,7 +435,7 @@ def sum_percentile(
 
 
 def threshold_percentile(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, p0=0
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, p0=0
 ):
     """Local threshold of an image.
 

--- a/skimage/filters/rank/bilateral.py
+++ b/skimage/filters/rank/bilateral.py
@@ -52,7 +52,7 @@ def _apply(func, image, footprint, out, mask, shift_x, shift_y, s0, s1, out_dtyp
 
 
 def mean_bilateral(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, s0=10, s1=10
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, s0=10, s1=10
 ):
     """Apply a flat kernel bilateral filter.
 
@@ -120,7 +120,7 @@ def mean_bilateral(
 
 
 def pop_bilateral(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, s0=10, s1=10
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, s0=10, s1=10
 ):
     """Return the local number (population) of pixels.
 
@@ -186,7 +186,7 @@ def pop_bilateral(
 
 
 def sum_bilateral(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, s0=10, s1=10
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, s0=10, s1=10
 ):
     """Apply a flat kernel bilateral filter.
 

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -385,7 +385,7 @@ def _apply_vector_per_pixel(
 
 
 def autolevel(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Auto-level image using local histogram.
 
@@ -452,7 +452,7 @@ def autolevel(
 
 
 def equalize(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Equalize image using local histogram.
 
@@ -516,7 +516,7 @@ def equalize(
 
 
 def gradient(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Return local gradient of an image (i.e. local maximum - local minimum).
 
@@ -580,7 +580,7 @@ def gradient(
 
 
 def maximum(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Return local maximum of an image.
 
@@ -653,7 +653,7 @@ def maximum(
 
 
 def mean(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Return local mean of an image.
 
@@ -717,7 +717,7 @@ def mean(
 
 
 def geometric_mean(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Return local geometric mean of an image.
 
@@ -786,7 +786,7 @@ def geometric_mean(
 
 
 def subtract_mean(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Return image subtracted from its local mean.
 
@@ -862,9 +862,9 @@ def median(
     footprint=None,
     out=None,
     mask=None,
-    shift_x=False,
-    shift_y=False,
-    shift_z=False,
+    shift_x=0,
+    shift_y=0,
+    shift_z=0,
 ):
     """Return local median of an image.
 
@@ -936,7 +936,7 @@ def median(
 
 
 def minimum(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Return local minimum of an image.
 
@@ -1009,7 +1009,7 @@ def minimum(
 
 
 def modal(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Return local mode of an image.
 
@@ -1075,7 +1075,7 @@ def modal(
 
 
 def enhance_contrast(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Enhance contrast of an image.
 
@@ -1143,7 +1143,7 @@ def enhance_contrast(
 
 
 def pop(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Return the local number (population) of pixels.
 
@@ -1214,7 +1214,7 @@ def pop(
 
 
 def sum(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Return the local sum of pixels.
 
@@ -1285,7 +1285,7 @@ def sum(
 
 
 def threshold(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Local threshold of an image.
 
@@ -1356,7 +1356,7 @@ def threshold(
 
 
 def noise_filter(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Noise feature.
 
@@ -1445,7 +1445,7 @@ def noise_filter(
 
 
 def entropy(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Local entropy.
 
@@ -1519,7 +1519,7 @@ def entropy(
 
 
 def otsu(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Local Otsu's threshold value for each pixel.
 
@@ -1589,7 +1589,7 @@ def otsu(
 
 
 def windowed_histogram(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, n_bins=None
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, n_bins=None
 ):
     """Normalized sliding window histogram
 
@@ -1656,9 +1656,9 @@ def majority(
     *,
     out=None,
     mask=None,
-    shift_x=False,
-    shift_y=False,
-    shift_z=False,
+    shift_x=0,
+    shift_y=0,
+    shift_z=0,
 ):
     """Assign to each pixel the most common value within its neighborhood.
 


### PR DESCRIPTION
## Description

fix for [#7246](https://github.com/scikit-image/scikit-image/issues/7246)

I changed the default values of shift_x, shift_y and shift_z in the skimage.filters.rank functions from False to 0 (zero), to correctly reflect their intended use as integers specifying the offset for the footprint center.
