### PR TITLE
cval description modified in int or float

### DIFF
--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -127,7 +127,7 @@ def denoise_bilateral(
     mode : {'constant', 'edge', 'symmetric', 'reflect', 'wrap'}
         How to handle values outside the image borders. See
         `numpy.pad` for detail.
-    cval : string
+    cval : int or float
         Used in conjunction with mode 'constant', the value outside
         the image boundaries.
     channel_axis : int or None, optional


### PR DESCRIPTION
## Description
Documentation issue in _denoise.py (#7247)


## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
The description of the parameter cval is modified in "int or float". cval is a numerical value not a string.
```
