### PR TITLE
Don't use boolean shift as default in `skimage.filters.rank` functions

### DIFF
--- a/skimage/filters/rank/_percentile.py
+++ b/skimage/filters/rank/_percentile.py
@@ -41,7 +41,13 @@ __all__ = [
 def _apply(func, image, footprint, out, mask, shift_x, shift_y, p0, p1, out_dtype=None):
     check_nD(image, 2)
     image, footprint, out, mask, n_bins = _preprocess_input(
-        image, footprint, out, mask, out_dtype
+        image,
+        footprint,
+        out,
+        mask,
+        out_dtype,
+        shift_x=shift_x,
+        shift_y=shift_y,
     )
 
     func(

--- a/skimage/filters/rank/_percentile.py
+++ b/skimage/filters/rank/_percentile.py
@@ -60,7 +60,7 @@ def _apply(func, image, footprint, out, mask, shift_x, shift_y, p0, p1, out_dtyp
 
 
 def autolevel_percentile(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, p0=0, p1=1
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, p0=0, p1=1
 ):
     """Return grayscale local autolevel of an image.
 
@@ -108,7 +108,7 @@ def autolevel_percentile(
 
 
 def gradient_percentile(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, p0=0, p1=1
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, p0=0, p1=1
 ):
     """Return local gradient of an image (i.e. local maximum - local minimum).
 
@@ -153,7 +153,7 @@ def gradient_percentile(
 
 
 def mean_percentile(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, p0=0, p1=1
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, p0=0, p1=1
 ):
     """Return local mean of an image.
 
@@ -198,7 +198,7 @@ def mean_percentile(
 
 
 def subtract_mean_percentile(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, p0=0, p1=1
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, p0=0, p1=1
 ):
     """Return image subtracted from its local mean.
 
@@ -243,7 +243,7 @@ def subtract_mean_percentile(
 
 
 def enhance_contrast_percentile(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, p0=0, p1=1
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, p0=0, p1=1
 ):
     """Enhance contrast of an image.
 
@@ -291,9 +291,7 @@ def enhance_contrast_percentile(
     )
 
 
-def percentile(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, p0=0
-):
+def percentile(image, footprint, out=None, mask=None, shift_x=0, shift_y=0, p0=0):
     """Return local percentile of an image.
 
     Returns the value of the p0 lower percentile of the local grayvalue
@@ -339,7 +337,7 @@ def percentile(
 
 
 def pop_percentile(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, p0=0, p1=1
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, p0=0, p1=1
 ):
     """Return the local number (population) of pixels.
 
@@ -387,7 +385,7 @@ def pop_percentile(
 
 
 def sum_percentile(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, p0=0, p1=1
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, p0=0, p1=1
 ):
     """Return the local sum of pixels.
 
@@ -435,7 +433,7 @@ def sum_percentile(
 
 
 def threshold_percentile(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, p0=0
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, p0=0
 ):
     """Local threshold of an image.
 

--- a/skimage/filters/rank/bilateral.py
+++ b/skimage/filters/rank/bilateral.py
@@ -33,7 +33,13 @@ __all__ = ['mean_bilateral', 'pop_bilateral', 'sum_bilateral']
 def _apply(func, image, footprint, out, mask, shift_x, shift_y, s0, s1, out_dtype=None):
     check_nD(image, 2)
     image, footprint, out, mask, n_bins = _preprocess_input(
-        image, footprint, out, mask, out_dtype
+        image,
+        footprint,
+        out,
+        mask,
+        out_dtype,
+        shift_x=shift_x,
+        shift_y=shift_y,
     )
 
     func(

--- a/skimage/filters/rank/bilateral.py
+++ b/skimage/filters/rank/bilateral.py
@@ -52,7 +52,7 @@ def _apply(func, image, footprint, out, mask, shift_x, shift_y, s0, s1, out_dtyp
 
 
 def mean_bilateral(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, s0=10, s1=10
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, s0=10, s1=10
 ):
     """Apply a flat kernel bilateral filter.
 
@@ -120,7 +120,7 @@ def mean_bilateral(
 
 
 def pop_bilateral(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, s0=10, s1=10
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, s0=10, s1=10
 ):
     """Return the local number (population) of pixels.
 
@@ -186,7 +186,7 @@ def pop_bilateral(
 
 
 def sum_bilateral(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, s0=10, s1=10
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, s0=10, s1=10
 ):
     """Apply a flat kernel bilateral filter.
 

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -108,7 +108,7 @@ def _preprocess_input(
         Dimension of each pixel. Default value is 1.
     shift_x, shift_y : int, optional
         Offset added to the footprint center point. Shift is bounded to the
-        footprint sizes (center must be inside the given footprint).
+        footprint size (center must be inside of the given footprint).
 
     Returns
     -------

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -223,7 +223,7 @@ def _handle_input_3D(
         Dimension of each pixel. Default value is 1.
     shift_x, shift_y, shift_z : int, optional
         Offset added to the footprint center point. Shift is bounded to the
-        footprint sizes (center must be inside the given footprint).
+        footprint size (center must be inside of the given footprint).
 
     Returns
     -------

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -384,9 +384,7 @@ def _apply_vector_per_pixel(
     return out
 
 
-def autolevel(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
-):
+def autolevel(image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0):
     """Auto-level image using local histogram.
 
     This filter locally stretches the histogram of gray values to cover the
@@ -451,9 +449,7 @@ def autolevel(
     raise ValueError(f'`image` must have 2 or 3 dimensions, got {np_image.ndim}.')
 
 
-def equalize(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
-):
+def equalize(image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0):
     """Equalize image using local histogram.
 
     Parameters
@@ -515,9 +511,7 @@ def equalize(
     raise ValueError(f'`image` must have 2 or 3 dimensions, got {np_image.ndim}.')
 
 
-def gradient(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
-):
+def gradient(image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0):
     """Return local gradient of an image (i.e. local maximum - local minimum).
 
     Parameters
@@ -579,9 +573,7 @@ def gradient(
     raise ValueError(f'`image` must have 2 or 3 dimensions, got {np_image.ndim}.')
 
 
-def maximum(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
-):
+def maximum(image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0):
     """Return local maximum of an image.
 
     Parameters
@@ -652,9 +644,7 @@ def maximum(
     raise ValueError(f'`image` must have 2 or 3 dimensions, got {np_image.ndim}.')
 
 
-def mean(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
-):
+def mean(image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0):
     """Return local mean of an image.
 
     Parameters
@@ -717,7 +707,7 @@ def mean(
 
 
 def geometric_mean(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Return local geometric mean of an image.
 
@@ -786,7 +776,7 @@ def geometric_mean(
 
 
 def subtract_mean(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Return image subtracted from its local mean.
 
@@ -862,9 +852,9 @@ def median(
     footprint=None,
     out=None,
     mask=None,
-    shift_x=False,
-    shift_y=False,
-    shift_z=False,
+    shift_x=0,
+    shift_y=0,
+    shift_z=0,
 ):
     """Return local median of an image.
 
@@ -935,9 +925,7 @@ def median(
     raise ValueError(f'`image` must have 2 or 3 dimensions, got {np_image.ndim}.')
 
 
-def minimum(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
-):
+def minimum(image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0):
     """Return local minimum of an image.
 
     Parameters
@@ -1008,9 +996,7 @@ def minimum(
     raise ValueError(f'`image` must have 2 or 3 dimensions, got {np_image.ndim}.')
 
 
-def modal(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
-):
+def modal(image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0):
     """Return local mode of an image.
 
     The mode is the value that appears most often in the local histogram.
@@ -1075,7 +1061,7 @@ def modal(
 
 
 def enhance_contrast(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Enhance contrast of an image.
 
@@ -1142,9 +1128,7 @@ def enhance_contrast(
     raise ValueError(f'`image` must have 2 or 3 dimensions, got {np_image.ndim}.')
 
 
-def pop(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
-):
+def pop(image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0):
     """Return the local number (population) of pixels.
 
     The number of pixels is defined as the number of pixels which are included
@@ -1213,9 +1197,7 @@ def pop(
     raise ValueError(f'`image` must have 2 or 3 dimensions, got {np_image.ndim}.')
 
 
-def sum(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
-):
+def sum(image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0):
     """Return the local sum of pixels.
 
     Note that the sum may overflow depending on the data type of the input
@@ -1284,9 +1266,7 @@ def sum(
     raise ValueError(f'`image` must have 2 or 3 dimensions, got {np_image.ndim}.')
 
 
-def threshold(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
-):
+def threshold(image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0):
     """Local threshold of an image.
 
     The resulting binary mask is True if the gray value of the center pixel is
@@ -1356,7 +1336,7 @@ def threshold(
 
 
 def noise_filter(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0
 ):
     """Noise feature.
 
@@ -1444,9 +1424,7 @@ def noise_filter(
     raise ValueError(f'`image` must have 2 or 3 dimensions, got {np_image.ndim}.')
 
 
-def entropy(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
-):
+def entropy(image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0):
     """Local entropy.
 
     The entropy is computed using base 2 logarithm i.e. the filter returns the
@@ -1518,9 +1496,7 @@ def entropy(
     raise ValueError(f'`image` must have 2 or 3 dimensions, got {np_image.ndim}.')
 
 
-def otsu(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, shift_z=False
-):
+def otsu(image, footprint, out=None, mask=None, shift_x=0, shift_y=0, shift_z=0):
     """Local Otsu's threshold value for each pixel.
 
     Parameters
@@ -1589,7 +1565,7 @@ def otsu(
 
 
 def windowed_histogram(
-    image, footprint, out=None, mask=None, shift_x=False, shift_y=False, n_bins=None
+    image, footprint, out=None, mask=None, shift_x=0, shift_y=0, n_bins=None
 ):
     """Normalized sliding window histogram
 
@@ -1656,9 +1632,9 @@ def majority(
     *,
     out=None,
     mask=None,
-    shift_x=False,
-    shift_y=False,
-    shift_z=False,
+    shift_x=0,
+    shift_y=0,
+    shift_z=0,
 ):
     """Assign to each pixel the most common value within its neighborhood.
 

--- a/skimage/filters/rank/generic.py
+++ b/skimage/filters/rank/generic.py
@@ -48,6 +48,7 @@ References
 
 """
 
+
 import numpy as np
 from scipy import ndimage as ndi
 
@@ -78,7 +79,14 @@ __all__ = [
 
 
 def _preprocess_input(
-    image, footprint=None, out=None, mask=None, out_dtype=None, pixel_size=1
+    image,
+    footprint=None,
+    out=None,
+    mask=None,
+    out_dtype=None,
+    pixel_size=1,
+    shift_x=None,
+    shift_y=None,
 ):
     """Preprocess and verify input for filters.rank methods.
 
@@ -98,6 +106,9 @@ def _preprocess_input(
         in input dtype.
     pixel_size : int, optional
         Dimension of each pixel. Default value is 1.
+    shift_x, shift_y : int, optional
+        Offset added to the footprint center point. Shift is bounded to the
+        footprint sizes (center must be inside the given footprint).
 
     Returns
     -------
@@ -169,11 +180,28 @@ def _preprocess_input(
             stacklevel=2,
         )
 
+    for name, value in zip(("shift_x", "shift_y"), (shift_x, shift_y)):
+        if np.dtype(type(value)) == bool:
+            warn(
+                f"Paramter `{name}` is boolean and will be interpreted as int. "
+                "This is not officially supported, use int instead.",
+                category=UserWarning,
+                stacklevel=4,
+            )
+
     return image, footprint, out, mask, n_bins
 
 
 def _handle_input_3D(
-    image, footprint=None, out=None, mask=None, out_dtype=None, pixel_size=1
+    image,
+    footprint=None,
+    out=None,
+    mask=None,
+    out_dtype=None,
+    pixel_size=1,
+    shift_x=None,
+    shift_y=None,
+    shift_z=None,
 ):
     """Preprocess and verify input for filters.rank methods.
 
@@ -193,6 +221,9 @@ def _handle_input_3D(
         in input dtype.
     pixel_size : int, optional
         Dimension of each pixel. Default value is 1.
+    shift_x, shift_y, shift_z : int, optional
+        Offset added to the footprint center point. Shift is bounded to the
+        footprint sizes (center must be inside the given footprint).
 
     Returns
     -------
@@ -258,6 +289,17 @@ def _handle_input_3D(
             stacklevel=2,
         )
 
+    for name, value in zip(
+        ("shift_x", "shift_y", "shift_z"), (shift_x, shift_y, shift_z)
+    ):
+        if np.dtype(type(value)) == bool:
+            warn(
+                f"Parameter `{name}` is boolean and will be interpreted as int. "
+                "This is not officially supported, use int instead.",
+                category=UserWarning,
+                stacklevel=4,
+            )
+
     return image, footprint, out, mask, n_bins
 
 
@@ -289,7 +331,7 @@ def _apply_scalar_per_pixel(
     """
     # preprocess and verify the input
     image, footprint, out, mask, n_bins = _preprocess_input(
-        image, footprint, out, mask, out_dtype
+        image, footprint, out, mask, out_dtype, shift_x=shift_x, shift_y=shift_y
     )
 
     # apply cython function
@@ -310,7 +352,14 @@ def _apply_scalar_per_pixel_3D(
     func, image, footprint, out, mask, shift_x, shift_y, shift_z, out_dtype=None
 ):
     image, footprint, out, mask, n_bins = _handle_input_3D(
-        image, footprint, out, mask, out_dtype
+        image,
+        footprint,
+        out,
+        mask,
+        out_dtype,
+        shift_x=shift_x,
+        shift_y=shift_y,
+        shift_z=shift_z,
     )
 
     func(
@@ -367,7 +416,14 @@ def _apply_vector_per_pixel(
     """
     # preprocess and verify the input
     image, footprint, out, mask, n_bins = _preprocess_input(
-        image, footprint, out, mask, out_dtype, pixel_size
+        image,
+        footprint,
+        out,
+        mask,
+        out_dtype,
+        pixel_size,
+        shift_x=shift_x,
+        shift_y=shift_y,
     )
 
     # apply cython function


### PR DESCRIPTION
## Description

fix for [#7246](https://github.com/scikit-image/scikit-image/issues/7246)

I changed the default values of shift_x, shift_y and shift_z in the skimage.filters.rank functions from False to 0 (zero), to correctly reflect their intended use as integers specifying the offset for the footprint center.

I closed the pull request https://github.com/scikit-image/scikit-image/pull/7316 and fixed here that black is complaining.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Change the default value of the parameters `shift_x`, `shift_y` and `shift_z` from
`False` to `0` in the `skimage.filters.rank` functions. This has not impact on the 
results. Warn in case boolean shifts are provided from now on.
```