### PR TITLE
Issue 7313 dt comment + copyediting grayscale

### DIFF
--- a/skimage/registration/_optical_flow.py
+++ b/skimage/registration/_optical_flow.py
@@ -67,7 +67,7 @@ def _tvl1(
         sparse=True,
     )
 
-    # dt corresponds to tau in [1]_, i.e. the time step
+    # dt corresponds to tau in [3]_, i.e. the time step
     dt = 0.5 / reference_image.ndim
     reg_num_iter = 2
     f0 = attachment * tightness

--- a/skimage/registration/_optical_flow.py
+++ b/skimage/registration/_optical_flow.py
@@ -67,9 +67,8 @@ def _tvl1(
         sparse=True,
     )
 
-    dt = (
-        0.5 / reference_image.ndim
-    )  # dt corresponds to :math:`\tau` in [1]_, i.e. the time step
+    # dt corresponds to tau in [1]_, i.e. the time step
+    dt = 0.5 / reference_image.ndim
     reg_num_iter = 2
     f0 = attachment * tightness
     f1 = dt / tightness

--- a/skimage/registration/_optical_flow.py
+++ b/skimage/registration/_optical_flow.py
@@ -30,9 +30,9 @@ def _tvl1(
     Parameters
     ----------
     reference_image : ndarray, shape (M, N[, P[, ...]])
-        The first gray scale image of the sequence.
+        The first grayscale image of the sequence.
     moving_image : ndarray, shape (M, N[, P[, ...]])
-        The second gray scale image of the sequence.
+        The second grayscale image of the sequence.
     flow0 : ndarray, shape (image0.ndim, M, N[, P[, ...]])
         Initialization for the vector field.
     attachment : float
@@ -67,7 +67,9 @@ def _tvl1(
         sparse=True,
     )
 
-    dt = 0.5 / reference_image.ndim
+    dt = (
+        0.5 / reference_image.ndim
+    )  # dt corresponds to :math:`\tau` in [1]_, i.e. the time step
     reg_num_iter = 2
     f0 = attachment * tightness
     f1 = dt / tightness
@@ -185,9 +187,9 @@ def optical_flow_tvl1(
     Parameters
     ----------
     reference_image : ndarray, shape (M, N[, P[, ...]])
-        The first gray scale image of the sequence.
+        The first grayscale image of the sequence.
     moving_image : ndarray, shape (M, N[, P[, ...]])
-        The second gray scale image of the sequence.
+        The second grayscale image of the sequence.
     attachment : float, optional
         Attachment parameter (:math:`\lambda` in [1]_). The smaller
         this parameter is, the smoother the returned result will be.
@@ -272,9 +274,9 @@ def _ilk(reference_image, moving_image, flow0, radius, num_warp, gaussian, prefi
     Parameters
     ----------
     reference_image : ndarray, shape (M, N[, P[, ...]])
-        The first gray scale image of the sequence.
+        The first grayscale image of the sequence.
     moving_image : ndarray, shape (M, N[, P[, ...]])
-        The second gray scale image of the sequence.
+        The second grayscale image of the sequence.
     flow0 : ndarray, shape (reference_image.ndim, M, N[, P[, ...]])
         Initialization for the vector field.
     radius : int
@@ -363,9 +365,9 @@ def optical_flow_ilk(
     Parameters
     ----------
     reference_image : ndarray, shape (M, N[, P[, ...]])
-        The first gray scale image of the sequence.
+        The first grayscale image of the sequence.
     moving_image : ndarray, shape (M, N[, P[, ...]])
-        The second gray scale image of the sequence.
+        The second grayscale image of the sequence.
     radius : int, optional
         Radius of the window considered around each pixel.
     num_warp : int, optional

--- a/skimage/registration/_optical_flow_utils.py
+++ b/skimage/registration/_optical_flow_utils.py
@@ -71,7 +71,7 @@ def get_pyramid(I, downscale=2.0, nlevel=10, min_size=16):
     Parameters
     ----------
     I : ndarray
-        The image to be preprocessed (Gray scale or RGB).
+        The image to be preprocessed (Grayscale or RGB).
     downscale : float
         The pyramid downscale factor.
     nlevel : int
@@ -107,9 +107,9 @@ def coarse_to_fine(
     Parameters
     ----------
     I0 : ndarray
-        The first gray scale image of the sequence.
+        The first grayscale image of the sequence.
     I1 : ndarray
-        The second gray scale image of the sequence.
+        The second grayscale image of the sequence.
     solver : callable
         The solver applied at each pyramid level.
     downscale : float


### PR DESCRIPTION
## Description

Added comment about dt (issue #7313 Part 2).
Changed gray scale in grayscale in the registration module.

Closes #7313

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Added comment to clarify that dt corresponds to tau, i.e. the time step. Changed gray scale in grayscale in the entire registration module. 
```
