### PR TITLE
CI: Update scientific-python/upload-nightly-action to 0.5.0

### DIFF
--- a/.github/workflows/nightly_wheel_build.yml
+++ b/.github/workflows/nightly_wheel_build.yml
@@ -37,7 +37,7 @@ jobs:
           path: ./dist
 
       - name: Upload wheel
-        uses: scientific-python/upload-nightly-action@6e9304f7a3a5501c6f98351537493ec898728299 # 0.3.0
+        uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc # 0.5.0
         with:
           artifacts_path: dist
           anaconda_nightly_upload_token: ${{secrets.UPLOAD_TOKEN}}


### PR DESCRIPTION
## Description

Update the scientific-python/upload-nightly-action to v0.5.0 for dependency stability and to take advantage of Anaconda Cloud upload bug fixes.
   - c.f. https://github.com/scientific-python/upload-nightly-action/releases/tag/0.5.0

This PR does not add Dependabot support (c.f. https://github.com/scikit-image/scikit-image/pull/7306#issuecomment-1910566912) given that there wasn't previous confirmation on this and that this would trigger a very large update PR after merge (probably worth updating the CI manually one last time and then turning it over to Dependabot).

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- [x] A descriptive but concise pull request title
- [N/A] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [N/A] [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- [N/A] A gallery example in `./doc/examples` for new features
- [x] [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
Update the scientific-python/upload-nightly-action to v0.5.0 for dependency stability and to take advantage of Anaconda Cloud upload bug fixes.
```
