### PR TITLE
Ignore table of execution times by Sphinx gallery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ skimage/version.py
 .coverage
 doc/source/auto_examples/**/*
 doc/source/_static/random.js
-doc/source/sg_execution_times.rst
+sg_execution_times.rst
 .idea/
 *.log
 doc/release/_release_notes_for_docs.rst

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ skimage/version.py
 .coverage
 doc/source/auto_examples/**/*
 doc/source/_static/random.js
+doc/source/sg_execution_times.rst
 .idea/
 *.log
 doc/release/_release_notes_for_docs.rst


### PR DESCRIPTION
## Description

This table is a result of creating the gallery, unique to each machine and doesn't need to / shouldn't be versioned.

See also
https://sphinx-gallery.github.io/stable/getting_started.html#configure-and-use-sphinx-gallery

It's been annoying me long enough. :sweat_smile: 

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
