### PR TITLE
Make it clear that funcs in `_optical_flow_utils` are private

### DIFF
--- a/skimage/registration/_optical_flow.py
+++ b/skimage/registration/_optical_flow.py
@@ -11,7 +11,7 @@ from scipy import ndimage as ndi
 from .._shared.filters import gaussian as gaussian_filter
 from .._shared.utils import _supported_float_type
 from ..transform import warp
-from ._optical_flow_utils import coarse_to_fine, get_warp_points
+from ._optical_flow_utils import _coarse_to_fine, _get_warp_points
 
 
 def _tvl1(
@@ -103,7 +103,7 @@ def _tvl1(
             )
 
         image1_warp = warp(
-            moving_image, get_warp_points(grid, flow_current), mode='edge'
+            moving_image, _get_warp_points(grid, flow_current), mode='edge'
         )
         grad = np.array(np.gradient(image1_warp))
         NI = (grad * grad).sum(0)
@@ -264,7 +264,7 @@ def optical_flow_tvl1(
         msg = f"dtype={dtype} is not supported. Try 'float32' or 'float64.'"
         raise ValueError(msg)
 
-    return coarse_to_fine(reference_image, moving_image, solver, dtype=dtype)
+    return _coarse_to_fine(reference_image, moving_image, solver, dtype=dtype)
 
 
 def _ilk(reference_image, moving_image, flow0, radius, num_warp, gaussian, prefilter):
@@ -322,7 +322,9 @@ def _ilk(reference_image, moving_image, flow0, radius, num_warp, gaussian, prefi
         if prefilter:
             flow = ndi.median_filter(flow, (1,) + ndim * (3,))
 
-        moving_image_warp = warp(moving_image, get_warp_points(grid, flow), mode='edge')
+        moving_image_warp = warp(
+            moving_image, _get_warp_points(grid, flow), mode='edge'
+        )
         grad = np.stack(np.gradient(moving_image_warp), axis=0)
         error_image = (grad * flow).sum(axis=0) + reference_image - moving_image_warp
 
@@ -426,4 +428,4 @@ def optical_flow_ilk(
         msg = f"dtype={dtype} is not supported. Try 'float32' or 'float64.'"
         raise ValueError(msg)
 
-    return coarse_to_fine(reference_image, moving_image, solver, dtype=dtype)
+    return _coarse_to_fine(reference_image, moving_image, solver, dtype=dtype)

--- a/skimage/registration/_optical_flow_utils.py
+++ b/skimage/registration/_optical_flow_utils.py
@@ -9,7 +9,7 @@ from ..transform import pyramid_reduce
 from ..util.dtype import _convert
 
 
-def get_warp_points(grid, flow):
+def _get_warp_points(grid, flow):
     """Compute warp point coordinates.
 
     Parameters
@@ -32,7 +32,7 @@ def get_warp_points(grid, flow):
     return out
 
 
-def resize_flow(flow, shape):
+def _resize_flow(flow, shape):
     """Rescale the values of the vector field (u, v) to the desired shape.
 
     The values of the output vector field are scaled to the new
@@ -65,7 +65,7 @@ def resize_flow(flow, shape):
     return rflow
 
 
-def get_pyramid(I, downscale=2.0, nlevel=10, min_size=16):
+def _get_pyramid(I, downscale=2.0, nlevel=10, min_size=16):
     """Construct image pyramid.
 
     Parameters
@@ -99,7 +99,7 @@ def get_pyramid(I, downscale=2.0, nlevel=10, min_size=16):
     return pyramid[::-1]
 
 
-def coarse_to_fine(
+def _coarse_to_fine(
     I0, I1, solver, downscale=2, nlevel=10, min_size=16, dtype=np.float32
 ):
     """Generic coarse to fine solver.
@@ -136,8 +136,8 @@ def coarse_to_fine(
 
     pyramid = list(
         zip(
-            get_pyramid(_convert(I0, dtype), downscale, nlevel, min_size),
-            get_pyramid(_convert(I1, dtype), downscale, nlevel, min_size),
+            _get_pyramid(_convert(I0, dtype), downscale, nlevel, min_size),
+            _get_pyramid(_convert(I1, dtype), downscale, nlevel, min_size),
         )
     )
 
@@ -147,6 +147,6 @@ def coarse_to_fine(
     flow = solver(pyramid[0][0], pyramid[0][1], flow)
 
     for J0, J1 in pyramid[1:]:
-        flow = solver(J0, J1, resize_flow(flow, J0.shape))
+        flow = solver(J0, J1, _resize_flow(flow, J0.shape))
 
     return flow


### PR DESCRIPTION
## Description

These helper functions aren't exposed in one of our public submodule namespaces and they can't be found in our HTML API documentation.

Usually we prefix these kind of functions with `_`. This makes their API status clear without having to look up if they appear in some `__all__` in some `__init__.py` somewhere.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
...
```
