### PR TITLE
Removed missing (previously deprecated) arg from docstring example for active_contour

### DIFF
--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -94,7 +94,7 @@ def active_contour(
 
     Fit spline to image:
 
-    >>> snake = active_contour(img, init, w_edge=0, w_line=1, coordinates='rc')  # doctest: +SKIP
+    >>> snake = active_contour(img, init, w_edge=0, w_line=1)  # doctest: +SKIP
     >>> dist = np.sqrt((45-snake[:, 0])**2 + (35-snake[:, 1])**2)  # doctest: +SKIP
     >>> int(np.mean(dist))  # doctest: +SKIP
     25


### PR DESCRIPTION
## Description

Removed missing (previously deprecated) arg: `coordinates='rc'` from docstring example for `segmentation.active_contour`

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

Summarize the introduced changes in the code block below in one or a few sentences. The
summary will be included in the next release notes automatically:

```release-note
- fixed failing docstring example for active_contour
```
