### PR TITLE
Replace ignored teardown with autouse fixture in `test_fits.py`

### DIFF
--- a/skimage/io/tests/test_fits.py
+++ b/skimage/io/tests/test_fits.py
@@ -2,10 +2,17 @@ import numpy as np
 import skimage.io as io
 from skimage._shared import testing
 
+
 testing.pytest.importorskip('astropy')
 
 
-def test_fits_plugin_import():
+@testing.pytest.fixture(autouse=True)
+def _reset_plugin():
+    yield
+    io.reset_plugins()
+
+
+def test_imread():
     # Make sure we get an import exception if Astropy isn't there
     # (not sure how useful this is, but it ensures there isn't some other
     # error when trying to load the plugin)
@@ -13,10 +20,6 @@ def test_fits_plugin_import():
         io.use_plugin('fits')
     except ImportError:
         raise ()
-
-
-def teardown():
-    io.reset_plugins()
 
 
 def _same_ImageCollection(collection1, collection2):


### PR DESCRIPTION
thereby making sure that follow-up tests are not affected by this test. Fixes https://github.com/scikit-image/scikit-image/issues/7339.

Pytest has deprecated nose style `setup` and `teardown` [1]. It seems those functions have been broken for some time now and we are slowly seeing problems with it now.

[1] https://docs.pytest.org/en/latest/changelog.html#id179

## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

We use [changelist](https://github.com/scientific-python/changelist) to
compile each pull request into an item of the release notes. Please refer to
the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes)
and [past release notes](https://scikit-image.org/docs/stable/release_notes/index.html)
for guidance and examples.

```release-note
...
```
