### PR TITLE
Address new copy semantics & broadcasting in `np.solve` in NumPy 2

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -36,3 +36,5 @@ Post numpy 2
   dependencies. Also remove temporary assert for NumPy 2.0 in
   `nightly_wheel_build.yml`.
 - Remove references to `numpy.bool8` once NumPy 2.0 is minimal required version.
+- Remove `skimage._shared.compat.NP_COPY_IF_NEEDED` and all usages of it
+  once NumPy 2.0.0 is minimal required version.

--- a/skimage/_shared/compat.py
+++ b/skimage/_shared/compat.py
@@ -1,0 +1,22 @@
+"""Compatibility helpers for dependencies."""
+
+from packaging.version import parse
+
+import numpy as np
+
+
+__all__ = [
+    "NUMPY_LT_2_0_0",
+    "NP_COPY_IF_NEEDED",
+]
+
+
+NUMPY_LT_2_0_0 = parse(np.__version__) < parse('2.0.0.dev0')
+
+# With NumPy 2.0.0, `copy=False` now raises a ValueError if the copy cannot be
+# made. The previous behavior to only copy if needed is provided with `copy=None`.
+# During the transition period, use this symbol instead.
+# Remove once NumPy 2.0.0 is the minimal required version.
+# https://numpy.org/devdocs/release/2.0.0-notes.html#new-copy-keyword-meaning-for-array-and-asarray-constructors
+# https://github.com/numpy/numpy/pull/25168
+NP_COPY_IF_NEEDED = False if NUMPY_LT_2_0_0 else None

--- a/skimage/_shared/meson.build
+++ b/skimage/_shared/meson.build
@@ -36,6 +36,7 @@ python_sources = [
   '_geometry.py',
   '_tempfile.py',
   '_warnings.py',
+  'compat.py',
   'coord.py',
   'dtype.py',
   'filters.py',

--- a/skimage/draw/draw.py
+++ b/skimage/draw/draw.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from .._shared._geometry import polygon_clip
 from .._shared.version_requirements import require
+from .._shared.compat import NP_COPY_IF_NEEDED
 from ._draw import (
     _coords_inside_image,
     _line,
@@ -336,7 +337,7 @@ def set_color(image, coords, color, alpha=1):
     if image.ndim == 2:
         image = image[..., np.newaxis]
 
-    color = np.array(color, ndmin=1, copy=False)
+    color = np.array(color, ndmin=1, copy=NP_COPY_IF_NEEDED)
 
     if image.shape[-1] != color.shape[-1]:
         raise ValueError(

--- a/skimage/feature/orb.py
+++ b/skimage/feature/orb.py
@@ -10,6 +10,7 @@ from ..feature.util import (
 from .corner import corner_fast, corner_orientations, corner_peaks, corner_harris
 from ..transform import pyramid_gaussian
 from .._shared.utils import check_nD
+from .._shared.compat import NP_COPY_IF_NEEDED
 
 from .orb_cy import _orb_loop
 
@@ -226,7 +227,9 @@ class ORB(FeatureDetector, DescriptorExtractor):
 
     def _extract_octave(self, octave_image, keypoints, orientations):
         mask = _mask_border_keypoints(octave_image.shape, keypoints, distance=20)
-        keypoints = np.array(keypoints[mask], dtype=np.intp, order='C', copy=False)
+        keypoints = np.array(
+            keypoints[mask], dtype=np.intp, order='C', copy=NP_COPY_IF_NEEDED
+        )
         orientations = np.array(orientations[mask], order='C', copy=False)
 
         descriptors = _orb_loop(octave_image, keypoints, orientations)

--- a/skimage/registration/_optical_flow.py
+++ b/skimage/registration/_optical_flow.py
@@ -310,7 +310,7 @@ def _ilk(reference_image, moving_image, flow0, radius, num_warp, gaussian, prefi
     # is the solution of the ndim x ndim linear system
     # A[i, j] * X = b[i, j]
     A = np.zeros(reference_image.shape + (ndim, ndim), dtype=dtype)
-    b = np.zeros(reference_image.shape + (ndim,), dtype=dtype)
+    b = np.zeros(reference_image.shape + (ndim, 1), dtype=dtype)
 
     grid = np.meshgrid(
         *[np.arange(n, dtype=dtype) for n in reference_image.shape],
@@ -333,7 +333,7 @@ def _ilk(reference_image, moving_image, flow0, radius, num_warp, gaussian, prefi
             A[..., i, j] = A[..., j, i] = filter_func(grad[i] * grad[j])
 
         for i in range(ndim):
-            b[..., i] = filter_func(grad[i] * error_image)
+            b[..., i, 0] = filter_func(grad[i] * error_image)
 
         # Don't consider badly conditioned linear systems
         idx = abs(np.linalg.det(A)) < 1e-14
@@ -341,7 +341,7 @@ def _ilk(reference_image, moving_image, flow0, radius, num_warp, gaussian, prefi
         b[idx] = 0
 
         # Solve the local linear systems
-        flow = np.moveaxis(np.linalg.solve(A, b), ndim, 0)
+        flow = np.moveaxis(np.linalg.solve(A, b)[..., 0], ndim, 0)
 
     return flow
 

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -6,6 +6,7 @@ import numpy as np
 from scipy import spatial
 
 from .._shared.utils import safe_as_int
+from .._shared.compat import NP_COPY_IF_NEEDED
 
 
 def _affine_matrix_from_vector(v):
@@ -672,7 +673,7 @@ class ProjectiveTransform(_GeometricTransform):
 
     def _apply_mat(self, coords, matrix):
         ndim = matrix.shape[0] - 1
-        coords = np.array(coords, copy=False, ndmin=2)
+        coords = np.array(coords, copy=NP_COPY_IF_NEEDED, ndmin=2)
 
         src = np.concatenate([coords, np.ones((coords.shape[0], 1))], axis=1)
         dst = src @ matrix.T


### PR DESCRIPTION
## Description

With NumPy 2.0.0, `copy=False` now raises a ValueError if the copy cannot be made in `numpy.asarray` and `numpy.array`, see the [release notes](https://numpy.org/devdocs/release/2.0.0-notes.html#new-copy-keyword-meaning-for-array-and-asarray-constructors) for details. I'm using an [approach by astropy](https://github.com/astropy/astropy/blob/2390bf8f8f2a1c5b6beffbd87db9af5aa6538df1/astropy/utils/compat/numpycompat.py#L29) to address this.

Additionally, broadcasting in `np.linalg.solve` is now handled differently in a backwards-incompatible way, see [release notes](https://numpy.org/devdocs/release/2.0.0-notes.html#removed-ambiguity-when-broadcasting-in-np-solve) on the recommended fix.

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

We use [changelist](https://github.com/scientific-python/changelist) to
compile each pull request into an item of the release notes. Please refer to
the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes)
and [past release notes](https://scikit-image.org/docs/stable/release_notes/index.html)
for guidance and examples.

```release-note
...
```
