### PR TITLE
Replace deprecated nose style setup/teardown with autouse fixtures

### DIFF
--- a/skimage/filters/rank/tests/__init__.py
+++ b/skimage/filters/rank/tests/__init__.py
@@ -1,9 +1,0 @@
-from ...._shared.testing import setup_test, teardown_test
-
-
-def setup():
-    setup_test()
-
-
-def teardown():
-    teardown_test()

--- a/skimage/io/tests/test_imread.py
+++ b/skimage/io/tests/test_imread.py
@@ -12,16 +12,16 @@ from skimage._shared.testing import (
     fetch,
 )
 
-from pytest import importorskip
+import pytest
 
-importorskip('imread')
+pytest.importorskip('imread')
 
 
-def setup():
+@pytest.fixture(autouse=True)
+def _use_imread_plugin():
+    """Ensure that PIL plugin is used in tests here."""
     use_plugin('imread')
-
-
-def teardown():
+    yield
     reset_plugins()
 
 

--- a/skimage/io/tests/test_mpl_imshow.py
+++ b/skimage/io/tests/test_mpl_imshow.py
@@ -7,7 +7,8 @@ from skimage._shared._warnings import expected_warnings
 plt = pytest.importorskip("matplotlib.pyplot")
 
 
-def setup():
+@pytest.fixture(autouse=True)
+def _reset_plugins():
     io.reset_plugins()
 
 

--- a/skimage/io/tests/test_plugin.py
+++ b/skimage/io/tests/test_plugin.py
@@ -10,11 +10,10 @@ from skimage.io import manage_plugins
 priority_plugin = 'pil'
 
 
-def setup():
+@pytest.fixture(autouse=True)
+def _use_pil_plugin():
     io.use_plugin('pil')
-
-
-def teardown_module():
+    yield
     io.reset_plugins()
 
 

--- a/skimage/io/tests/test_tifffile.py
+++ b/skimage/io/tests/test_tifffile.py
@@ -8,12 +8,12 @@ from skimage._shared.testing import fetch
 from skimage.io import imread, imsave, reset_plugins, use_plugin
 
 
-def setup():
+@pytest.fixture(autouse=True)
+def _use_tifffile_plugin():
+    """Ensure that PIL plugin is used in tests here."""
     use_plugin('tifffile')
     np.random.seed(0)
-
-
-def teardown():
+    yield
     reset_plugins()
 
 


### PR DESCRIPTION
## Description

Follow-up to https://github.com/scikit-image/scikit-image/pull/7340. 

Pytest has deprecated nose style setup and teardown since 7.2. 

https://docs.pytest.org/en/latest/deprecations.html#nose-deprecation


## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

We use [changelist](https://github.com/scientific-python/changelist) to
compile each pull request into an item of the release notes. Please refer to
the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes)
and [past release notes](https://scikit-image.org/docs/stable/release_notes/index.html)
for guidance and examples.

```release-note
...
```
