### PR TITLE
Allow a very small floating point tolerance for pearson test

### DIFF
--- a/skimage/measure/_colocalization.py
+++ b/skimage/measure/_colocalization.py
@@ -94,7 +94,7 @@ def pearson_corr_coeff(image0, image1, mask=None):
         image0 = image0.reshape(-1)
         image1 = image1.reshape(-1)
 
-    return pearsonr(image0, image1)
+    return tuple(float(v) for v in pearsonr(image0, image1))
 
 
 def manders_coloc_coeff(image0, image1_mask, mask=None):

--- a/skimage/measure/tests/test_colocalization.py
+++ b/skimage/measure/tests/test_colocalization.py
@@ -52,7 +52,9 @@ def test_invalid_input():
 def test_pcc():
     # simple example
     img1 = np.array([[i + j for j in range(4)] for i in range(4)])
-    assert pearson_corr_coeff(img1, img1) == (1.0, 0.0)
+    np.testing.assert_almost_equal(
+        pearson_corr_coeff(img1, img1), (1.0, 0.0), decimal=14
+    )
 
     img2 = np.where(img1 <= 2, 0, img1)
     np.testing.assert_almost_equal(


### PR DESCRIPTION
Also, ensure that `pearsonr` returns a tuple of two floats, as per the docstring.

Should address the CI failure we've been seeing with pre-release SciPy.