### PR TITLE
Exclude `pre-commit[bot]` from changelist's contributor list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,3 +206,9 @@ filterwarnings = []
 
 [tool.coverage.run]
 omit = ['*/tests/*']
+
+[tool.changelist]
+ignored_user_logins = [
+    "web-flow",
+    "pre-commit-ci[bot]"
+]


### PR DESCRIPTION
## Description

Pretty self-explanatory. See also the reference for [changelist's configuration](https://github.com/scientific-python/changelist?tab=readme-ov-file#configuration).

Can be verified with
```sh
changelist scikit-image/scikit-image --config "path/to/PRs/pyproject.toml" v0.22.0 v0.23.0rc0
```

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

We use [changelist](https://github.com/scientific-python/changelist) to
compile each pull request into an item of the release notes. Please refer to
the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes)
and [past release notes](https://scikit-image.org/docs/stable/release_notes/index.html)
for guidance and examples.

```release-note
...
```
