### PR TITLE
Fix docstring for connectivity parameter in watershed function.

### DIFF
--- a/skimage/segmentation/_watershed.py
+++ b/skimage/segmentation/_watershed.py
@@ -107,13 +107,14 @@ def watershed(
         :func:`skimage.measure.label` onto the result (with the same given
         `connectivity`). Generally speaking, users are encouraged to pass
         markers explicitly.
-    connectivity : ndarray, optional
-        An array with the same number of dimensions as `image` whose
-        non-zero elements indicate neighbors for connection.
-        Following the scipy convention, default is a one-connected array of
-        the dimension of the image.
+    connectivity : int or ndarray, optional
+        The neighborhood connectivity. An integer is interpreted as in
+        ``scipy.ndimage.generate_binary_structure``, as the maximum number
+        of orthogonal steps to reach a neighbor. An array is directly
+        interpreted as a footprint (structuring element). Default value is 1.
+        In 2D, 1 gives a 4-neighborhood while 2 gives an 8-neighborhood.
     offset : array_like of shape image.ndim, optional
-        offset of the connectivity (one offset per dimension)
+        The coordinates of the center of the footprint.
     mask : (M, N[, ...]) ndarray of bools or 0's and 1's, optional
         Array of same shape as `image`. Only points at which mask == True
         will be labeled.
@@ -206,7 +207,7 @@ def watershed(
 
     >>> labels = watershed(-distance, markers, mask=image)
 
-    The algorithm works also for 3-D images, and can be used for example to
+    The algorithm works also for 3D images, and can be used for example to
     separate overlapping spheres.
     """
     image, markers, mask = _validate_inputs(image, markers, mask, connectivity)


### PR DESCRIPTION
## Description

While investigating the watershed implementation these days, I noticed that the docstring for `connectivity` was a bit off: In the function signature, we have `connectivity=1` and then `connectivity : ndarray, optional`...

It turns out we use a `connectivity` parameter in many functions across the library, many of which use
https://github.com/scikit-image/scikit-image/blob/9e8bf6805fde48126008480920f02d316ebbbd98/skimage/morphology/_util.py#L8
internally, which itself relies on scipy's [generate_binary_sctructure](https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.generate_binary_structure.html). There's definitely room for standardization here, but I'll start with just the instance in `watershed`.

I've drawn from the docstring in `_validate_connectivity` (above).

@stefanv since this PR is docs-only, maybe it could go into v0.23?

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

We use [changelist](https://github.com/scientific-python/changelist) to
compile each pull request into an item of the release notes. Please refer to
the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes)
and [past release notes](https://scikit-image.org/docs/stable/release_notes/index.html)
for guidance and examples.

```release-note
...
```
