### PR TITLE
Remove ensure_python_version function

### DIFF
--- a/skimage/__init__.py
+++ b/skimage/__init__.py
@@ -67,10 +67,6 @@ dtype_limits
 
 __version__ = '0.23.0rc3.dev0'
 
-from ._shared.version_requirements import ensure_python_version
-
-ensure_python_version((3, 8))
-
 import lazy_loader as lazy
 
 __getattr__, __lazy_dir__, _ = lazy.attach_stub(__name__, __file__)

--- a/skimage/_shared/version_requirements.py
+++ b/skimage/_shared/version_requirements.py
@@ -3,39 +3,6 @@ import sys
 from packaging import version as _version
 
 
-def ensure_python_version(min_version):
-    if not isinstance(min_version, tuple):
-        min_version = (min_version,)
-    if sys.version_info < min_version:
-        # since ensure_python_version is in the critical import path,
-        # we lazy import it.
-        from platform import python_version
-
-        raise ImportError(
-            """
-
-You are running scikit-image on an unsupported version of Python.
-
-Unfortunately, scikit-image 0.15 and above no longer work with your installed
-version of Python ({}).  You therefore have two options: either upgrade to
-Python {}, or install an older version of scikit-image.
-
-For Python 2.7 or Python 3.4, use
-
- $ pip install 'scikit-image<0.15'
-
-Please also consider updating `pip` and `setuptools`:
-
- $ pip install pip setuptools --upgrade
-
-Newer versions of these tools avoid installing packages incompatible
-with your version of Python.
-""".format(
-                python_version(), '.'.join([str(v) for v in min_version])
-            )
-        )
-
-
 def _check_version(actver, version, cmp_op):
     """
     Check version string of an active module against a required version.


### PR DESCRIPTION
This is handled by requires-python in pyproject.toml and we hadn't been updating it for awhile.

## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

We use [changelist](https://github.com/scientific-python/changelist) to
compile each pull request into an item of the release notes. Please refer to
the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes)
and [past release notes](https://scikit-image.org/docs/stable/release_notes/index.html)
for guidance and examples.

```release-note
...
```
