### PR TITLE
Add date to 0.23.1 release notes

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -69,6 +69,8 @@ Example `version number`
   - Check for duplicate names in the automatically generated list of
     contributors and reviewers.
 
+  - Append the release date to the title similar to previous iterations.
+
 - If this is a release:
 
   - update the file ``skimage/data/_fetchers.py`` to point the pooch

--- a/doc/source/release_notes/release_0.23.1.rst
+++ b/doc/source/release_notes/release_0.23.1.rst
@@ -1,5 +1,5 @@
-scikit-image 0.23.1
-===================
+scikit-image 0.23.1 (2024-04-10)
+================================
 
 We're happy to announce the release of scikit-image 0.23.1!
 


### PR DESCRIPTION
## Description

Just making it consistent with the other notes and adding a note of the task to our release instructions.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

We use [changelist](https://github.com/scientific-python/changelist) to
compile each pull request into an item of the release notes. Please refer to
the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes)
and [past release notes](https://scikit-image.org/docs/stable/release_notes/index.html)
for guidance and examples.

```release-note
...
```
