### PR TITLE
Use `numpy.inf` instead of deprecated `numpy.infty`

### DIFF
--- a/doc/examples/features_detection/plot_windowed_histogram.py
+++ b/doc/examples/features_detection/plot_windowed_histogram.py
@@ -63,7 +63,7 @@ def windowed_histogram_similarity(image, footprint, reference_hist, n_bins):
 
     num = (X - Y) ** 2
     denom = X + Y
-    denom[denom == 0] = np.infty
+    denom[denom == 0] = np.inf
     frac = num / denom
 
     chi_sqr = 0.5 * np.sum(frac, axis=2)

--- a/tools/mailmap.py
+++ b/tools/mailmap.py
@@ -40,7 +40,7 @@ for name, email in (author.split('::') for author in authors if author.strip()):
         emails.append(email)
 
 N = len(names)
-D = np.zeros((N, N)) + np.infty
+D = np.zeros((N, N)) + np.inf
 
 for i in range(1, N):
     for j in range(i):


### PR DESCRIPTION
## Description

Prerequisite to https://github.com/scikit-image/scikit-image/pull/7384.

We didn't pick this up earlier in our NumPy 2 preparation, because NumPy 2.0 wasn't yet used while building our documentation. Lucky, that we didn't have more things we missed in our gallery.

See also:
- https://github.com/scikit-image/scikit-image/pull/7384#issuecomment-2049571755
- [NumPy 2.0 migration guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#main-namespace)

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

We use [changelist](https://github.com/scientific-python/changelist) to compile each pull request into an item of the release notes. Please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) and [past release notes](https://scikit-image.org/docs/stable/release_notes/index.html) for guidance and examples.

```release-note
...
```
