### PR TITLE
Update Ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,16 @@ skip-string-normalization = 1
 [tool.ruff]
 line-length = 88
 target-version = 'py310'
+exclude = [
+    '.git',
+    '.ruff_cache',
+    'build',
+    'build-install',
+    'dist',
+    'doc/source/auto_examples',
+]
+
+[tool.ruff.lint]
 select = [
     'F',
     'E',
@@ -165,16 +175,8 @@ ignore = [
     'E741',
     'E712',
 ]
-exclude = [
-    '.git',
-    '.ruff_cache',
-    'build',
-    'build-install',
-    'dist',
-    'doc/source/auto_examples',
-]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "**/__init__.py" = [
     'E402',
     'F401',
@@ -190,7 +192,7 @@ exclude = [
 "skimage/_shared/testing.py" = ['F401']
 "doc/examples/**/*.py" = ['E402']
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = 'numpy'
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,7 @@ select = [
     'E',
     'W',
     'UP',
+    'NPY201',
 ]
 ignore = [
     'E501',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,6 @@ skip-string-normalization = 1
 
 [tool.ruff]
 line-length = 88
-target-version = 'py310'
 exclude = [
     '.git',
     '.ruff_cache',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,17 +151,6 @@ Metrics = [
 target-version = ['py310', 'py311', 'py312']
 skip-string-normalization = 1
 
-[tool.ruff]
-line-length = 88
-exclude = [
-    '.git',
-    '.ruff_cache',
-    'build',
-    'build-install',
-    'dist',
-    'doc/source/auto_examples',
-]
-
 [tool.ruff.lint]
 select = [
     'F',


### PR DESCRIPTION
## Description

1. Update pyproject.toml to use ruff's new linter settings (the old way has been deprecated).
2. Use project.requires-python  instead of tool.ruff.target-version as recommended by ruff.
3. Use NPY201 linter rule (hopefully this would have caught things like #7386.
4. Remove `line-length` and `exclude`.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

We use [changelist](https://github.com/scientific-python/changelist) to
compile each pull request into an item of the release notes. Please refer to
the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes)
and [past release notes](https://scikit-image.org/docs/stable/release_notes/index.html)
for guidance and examples.

```release-note
...
```
