### PR TITLE
Use upload- and download-artifact v4

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -98,7 +98,7 @@ jobs:
         if: always()
         run: cp benchmarks/README_CI.md benchmarks.log .asv/results/
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: asv-benchmark-results-${{ runner.os }}

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -52,7 +52,7 @@ jobs:
           DEPLOY_KEY: ${{ secrets.DOC_DEPLOY_KEY_PRIVATE }}
           GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
       - name: Store docs as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: doc/build/html

--- a/.github/workflows/nightly_wheel_build.yml
+++ b/.github/workflows/nightly_wheel_build.yml
@@ -33,8 +33,9 @@ jobs:
       - uses: actions/download-artifact@v4
         id: download
         with:
-          name: wheels
+          name: skimage-wheels-*
           path: ./dist
+          merge-multiple: true
 
       - name: Upload wheel
         uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc # 0.5.0

--- a/.github/workflows/nightly_wheel_build.yml
+++ b/.github/workflows/nightly_wheel_build.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.repository_owner == 'scikit-image' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         id: download
         with:
           name: wheels

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -38,8 +38,9 @@ jobs:
       - uses: actions/download-artifact@v4
         id: download
         with:
-          name: wheels
+          name: skimage-wheels-*
           path: ./dist
+          merge-multiple: true
 
       - name: Build the source distribution
         run: |

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           pip install twine
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         id: download
         with:
           name: wheels

--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -59,7 +59,7 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_ENVIRONMENT_PASS_LINUX: SKIMAGE_LINK_FLAGS
           SKIMAGE_LINK_FLAGS: "-Wl,--strip-debug"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: ./dist/*.whl
@@ -99,7 +99,7 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_ENVIRONMENT_PASS_LINUX: SKIMAGE_LINK_FLAGS
           SKIMAGE_LINK_FLAGS: "-Wl,--strip-debug"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: ./dist/*.whl
@@ -177,7 +177,7 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
           CIBW_TEST_SKIP: "*-macosx_arm64"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: ./dist/*.whl
@@ -235,7 +235,7 @@ jobs:
           # -Wl,-S equivalent to gcc's -Wl,--strip-debug
           LDFLAGS: "-Wl,-S"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: ./dist/*.whl

--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -61,7 +61,7 @@ jobs:
           SKIMAGE_LINK_FLAGS: "-Wl,--strip-debug"
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: skimage-wheels-${{ matrix.os }}-${{ matrix.cibw_arch }}-${{ strategy.job-index }}
           path: ./dist/*.whl
 
   build_linux_aarch64_wheels:
@@ -101,7 +101,7 @@ jobs:
           SKIMAGE_LINK_FLAGS: "-Wl,--strip-debug"
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: skimage-wheels-${{ matrix.os }}-${{ matrix.cibw_arch }}-${{ strategy.job-index }}
           path: ./dist/*.whl
 
   build_macos_wheels:
@@ -179,7 +179,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: skimage-wheels-${{ matrix.os }}-${{ matrix.cibw_arch }}-${{ strategy.job-index }}
           path: ./dist/*.whl
 
   build_windows_wheels:
@@ -237,5 +237,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: skimage-wheels-${{ matrix.os }}-${{ matrix.cibw_arch }}-${{ strategy.job-index }}
           path: ./dist/*.whl


### PR DESCRIPTION
## Description

Close #7383. This handles the following breaking change in [actions/upload-artifact@v4](https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new):
```
Uploading to the same named Artifact multiple times.

Due to how Artifacts are created in this new version, it is no longer possible to upload
to the same named Artifact multiple times. You must either split the uploads into multiple
Artifacts with different names, or only upload once. Otherwise you will encounter an error.
```
by using different names via
```
      - uses: actions/upload-artifact@v4
        with:
          name: skimage-wheels-${{ matrix.os }}-${{ matrix.cibw_arch }}-${{ strategy.job-index }}
          path: ./dist/*.whl
```
and merging them with
```
      - uses: actions/download-artifact@v4
        id: download
        with:
          name: skimage-wheels-*
          path: ./dist
          merge-multiple: true
```
@Czaki Thanks for sharing the fix!