### PR TITLE
Ignore arch specific cast warnings originating from `astype` in tests

### DIFF
--- a/skimage/transform/tests/test_pyramids.py
+++ b/skimage/transform/tests/test_pyramids.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 
 import pytest
 import numpy as np
@@ -194,8 +195,16 @@ def test_check_factor():
     'pyramid_func', [pyramids.pyramid_gaussian, pyramids.pyramid_laplacian]
 )
 def test_pyramid_dtype_support(pyramid_func, dtype):
-    img = np.random.randn(32, 8).astype(dtype)
-    pyramid = pyramid_func(img)
+    with warnings.catch_warnings():
+        # Ignore arch specific warning on arm64, armhf, ppc64el, riscv64, s390x
+        # https://github.com/scikit-image/scikit-image/issues/7391
+        warnings.filterwarnings(
+            action="ignore",
+            category=RuntimeWarning,
+            message="invalid value encountered in cast",
+        )
+        img = np.random.randn(32, 8).astype(dtype)
 
+    pyramid = pyramid_func(img)
     float_dtype = _supported_float_type(dtype)
     assert np.all([im.dtype == float_dtype for im in pyramid])


### PR DESCRIPTION
## Description

Closes #7391.

Apparently `astype(...)` raises a warning on some platforms despite `casting="unsafe"` being the default. I couldn't reproduce this as I don't have access to the architectures this fails for [1]. Ideally, we could adapt the tests in a way that doesn't raise these warnings but I don't really care for debugging these remotely when these warnings are hopefully harmless to ignore. :crossed_fingers: 

[1] https://buildd.debian.org/status/logs.php?pkg=skimage&ver=0.23.1-1&suite=sid

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

We use [changelist](https://github.com/scientific-python/changelist) to compile each pull request into an item of the release notes. Please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) and [past release notes](https://scikit-image.org/docs/stable/release_notes/index.html) for guidance and examples.

```release-note
...
```
