### PR TITLE
improved speed of fast corner detect

### DIFF
--- a/skimage/feature/corner_cy.pyx
+++ b/skimage/feature/corner_cy.pyx
@@ -123,7 +123,7 @@ def _corner_fast(np_floats[:, ::1] image, signed char n, np_floats threshold):
     cdef Py_ssize_t i, j, k
 
     cdef signed char speed_sum_b, speed_sum_d
-    cdef np_floats curr_pixel
+    cdef np_floats curr_pixel, ring_pixel
     cdef np_floats lower_threshold, upper_threshold
     cdef np_floats[:, ::1] corner_response = np.zeros((rows, cols),
                                                       dtype=dtype)
@@ -145,6 +145,19 @@ def _corner_fast(np_floats[:, ::1] image, signed char n, np_floats threshold):
                 lower_threshold = curr_pixel - threshold
                 upper_threshold = curr_pixel + threshold
 
+                # High speed test for n >= 12
+                if n >= 12:
+                    speed_sum_b = 0
+                    speed_sum_d = 0
+                    for k in range(0, 16, 4):
+                        ring_pixel = image[i + rp[k], j + cp[k]]
+                        if ring_pixel > upper_threshold:
+                            speed_sum_b += 1
+                        elif ring_pixel < lower_threshold:
+                            speed_sum_d += 1
+                    if speed_sum_d < 3 and speed_sum_b < 3:
+                        continue
+
                 for k in range(16):
                     circle_intensities[k] = image[i + rp[k], j + cp[k]]
                     if circle_intensities[k] > upper_threshold:
@@ -156,18 +169,6 @@ def _corner_fast(np_floats[:, ::1] image, signed char n, np_floats threshold):
                     else:
                         # Similar pixel
                         bins[k] = b's'
-
-                # High speed test for n >= 12
-                if n >= 12:
-                    speed_sum_b = 0
-                    speed_sum_d = 0
-                    for k in range(0, 16, 4):
-                        if bins[k] == b'b':
-                            speed_sum_b += 1
-                        elif bins[k] == b'd':
-                            speed_sum_d += 1
-                    if speed_sum_d < 3 and speed_sum_b < 3:
-                        continue
 
                 # Test for bright pixels
                 curr_response = _corner_fast_response[np_floats](curr_pixel,


### PR DESCRIPTION
Closes #7388. 

The correct implementation of Fast corner detection involves moving the fast check when n_fast >= 12 to the beginning of calculating the pixel values around the entire circle, which can significantly reduce the time spent on non-corner detection.

recreate of pr #7379