### PR TITLE
Update link to numpydoc example.py

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@
 <!-- Before pull requests can be merged, they should provide: -->
 
 - A descriptive but concise pull request title
-- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
+- [Docstrings for all functions](https://github.com/numpy/numpy/blob/maintenance/1.3.x/doc/example.py)
 - [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
 - A gallery example in `./doc/examples` for new features
 - [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@
 <!-- Before pull requests can be merged, they should provide: -->
 
 - A descriptive but concise pull request title
-- [Docstrings for all functions](https://github.com/numpy/numpy/blob/maintenance/1.3.x/doc/example.py)
+- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
 - [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
 - A gallery example in `./doc/examples` for new features
 - [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed


### PR DESCRIPTION
## Description
Dear All. This PR fixes one of the links in PULL_REQUEST_TEMPLATE.md. The original link to example.py no longer exists because it has been removed from Numpy's master branch. I replaced the link to an older version of Numpy where the file still exists.
<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

We use [changelist](https://github.com/scientific-python/changelist) to
compile each pull request into an item of the release notes. Please refer to
the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes)
and [past release notes](https://scikit-image.org/docs/stable/release_notes/index.html)
for guidance and examples.

```release-note
...
```
