### PR TITLE
Fix download-artifact@v4 error 

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -98,7 +98,7 @@ jobs:
         if: always()
         run: cp benchmarks/README_CI.md benchmarks.log .asv/results/
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: asv-benchmark-results-${{ runner.os }}

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -52,7 +52,7 @@ jobs:
           DEPLOY_KEY: ${{ secrets.DOC_DEPLOY_KEY_PRIVATE }}
           GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
       - name: Store docs as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: doc/build/html

--- a/.github/workflows/nightly_wheel_build.yml
+++ b/.github/workflows/nightly_wheel_build.yml
@@ -33,8 +33,9 @@ jobs:
       - uses: actions/download-artifact@v4
         id: download
         with:
-          name: wheels
+          name: skimage-wheels-*
           path: ./dist
+          merge-multiple: true
 
       - name: Upload wheel
         uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc # 0.5.0

--- a/.github/workflows/nightly_wheel_build.yml
+++ b/.github/workflows/nightly_wheel_build.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.repository_owner == 'scikit-image' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         id: download
         with:
           name: wheels

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -38,8 +38,9 @@ jobs:
       - uses: actions/download-artifact@v4
         id: download
         with:
-          name: wheels
+          name: skimage-wheels-*
           path: ./dist
+          merge-multiple: true
 
       - name: Build the source distribution
         run: |

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           pip install twine
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         id: download
         with:
           name: wheels

--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -59,7 +59,7 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_ENVIRONMENT_PASS_LINUX: SKIMAGE_LINK_FLAGS
           SKIMAGE_LINK_FLAGS: "-Wl,--strip-debug"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: ./dist/*.whl
@@ -99,7 +99,7 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_ENVIRONMENT_PASS_LINUX: SKIMAGE_LINK_FLAGS
           SKIMAGE_LINK_FLAGS: "-Wl,--strip-debug"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: ./dist/*.whl
@@ -177,7 +177,7 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
           CIBW_TEST_SKIP: "*-macosx_arm64"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: ./dist/*.whl
@@ -235,7 +235,7 @@ jobs:
           # -Wl,-S equivalent to gcc's -Wl,--strip-debug
           LDFLAGS: "-Wl,-S"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: ./dist/*.whl

--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -61,7 +61,7 @@ jobs:
           SKIMAGE_LINK_FLAGS: "-Wl,--strip-debug"
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: skimage-wheels-${{ matrix.os }}-${{ matrix.cibw_arch }}-${{ strategy.job-index }}
           path: ./dist/*.whl
 
   build_linux_aarch64_wheels:
@@ -101,7 +101,7 @@ jobs:
           SKIMAGE_LINK_FLAGS: "-Wl,--strip-debug"
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: skimage-wheels-${{ matrix.os }}-${{ matrix.cibw_arch }}-${{ strategy.job-index }}
           path: ./dist/*.whl
 
   build_macos_wheels:
@@ -179,7 +179,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: skimage-wheels-${{ matrix.os }}-${{ matrix.cibw_arch }}-${{ strategy.job-index }}
           path: ./dist/*.whl
 
   build_windows_wheels:
@@ -237,5 +237,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: skimage-wheels-${{ matrix.os }}-${{ matrix.cibw_arch }}-${{ strategy.job-index }}
           path: ./dist/*.whl


### PR DESCRIPTION
## Description

In https://github.com/scikit-image/scikit-image/actions/runs/8677013598/job/23792109693 all the uploads seemed to work fine. For example, [call-workflow-build-wheels / Build python cp310-* x86_64 wheels on ubuntu-latest](https://github.com/scikit-image/scikit-image/actions/runs/8677013598/job/23792109693#logs)
```
Run actions/upload-artifact@v4
  with:
    name: skimage-wheels-ubuntu-latest-x86_64-0
    path: ./dist/*.whl
    if-no-files-found: warn
    compression-level: 6
    overwrite: false
  env:
    CIBW_BUILD_VERBOSITY: 2
    CIBW_TEST_REQUIRES: -r requirements/default.txt -r requirements/test.txt
    CIBW_ENVIRONMENT: PIP_PREFER_BINARY=1
    CIBW_BUILD_FRONTEND: 
    CIBW_TEST_COMMAND: pytest --pyargs skimage
    pythonLocation: /opt/hostedtoolcache/Python/3.12.2/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.12.2/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.2/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.2/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.2/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.12.2/x64/lib
With the provided path, there will be 1 file uploaded
Artifact name is valid!
Root directory input is valid!
Beginning upload of artifact content to blob storage
Uploaded bytes 8388608
Uploaded bytes 14599789
Finished uploading artifact content to blob storage!
SHA256 hash of uploaded artifact zip is 1332b6872a06b227d2b9e88692879d50f62440761123238d2f9ec4fa77e1d7f2
Finalizing artifact upload
Artifact skimage-wheels-ubuntu-latest-x86_64-0.zip successfully finalized. Artifact ID 1411579588
Artifact skimage-wheels-ubuntu-latest-x86_64-0 has been successfully uploaded! Final size is 14599789 bytes. Artifact ID is 1411579588
Artifact download URL: https://github.com/scikit-image/scikit-image/actions/runs/8677013598/artifacts/1411579588
```
But the downloader failed with
```
Run actions/download-artifact@v4
  with:
    name: skimage-wheels-*
    path: ./dist
    merge-multiple: true
    repository: scikit-image/scikit-image
    run-id: 8677013598
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.12.2/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.12.2/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.2/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.2/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.12.2/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.12.2/x64/lib
Downloading single artifact
Error: Unable to download artifact(s): Artifact not found for name: skimage-wheels-*
        Please ensure that your artifact is not expired and the artifact was uploaded using a compatible version of toolkit/upload-artifact.
        For more information, visit the GitHub Artifacts FAQ: https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md
```
![2024-04-13T18:52:38,501500433-07:00](https://github.com/scikit-image/scikit-image/assets/123428/7143f5d0-7299-40a1-a65a-f62dd008ae1e)
