### PR TITLE
Fix typo in docstring of `skimage.measure.regionprops`

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -1188,7 +1188,7 @@ def regionprops(
         Centroid coordinate tuple ``(row, col)``, relative to region bounding
         box, weighted with intensity image.
     **coords_scaled** : (K, 2) ndarray
-        Coordinate list ``(row, col)``of the region scaled by ``spacing``.
+        Coordinate list ``(row, col)`` of the region scaled by ``spacing``.
     **coords** : (K, 2) ndarray
         Coordinate list ``(row, col)`` of the region.
     **eccentricity** : float


### PR DESCRIPTION
…nprops.py

## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

Fixed the typo in the doc string of the arg `coords_scaled`

Current version:

![image](https://github.com/scikit-image/scikit-image/assets/26847524/311cae94-7b6e-416f-a272-eaef80449a08)

An extra space needs to be added here, which is exactly what the current commit does.

