### PR TITLE
Add back support for python 3.9 for numpy 2 compatibility woes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         PIP_FLAGS: [""]
         MINIMUM_REQUIREMENTS: [0]
         BUILD_DOCS: [1]
@@ -115,7 +115,7 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         OPTIONAL_DEPS: [1]
         BUILD_DOCS: [1]
         OPTIONS_NAME: ["default"]

--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cibw_python: ["cp310-*", "cp311-*", "cp312-*"]
+        cibw_python: ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
         cibw_manylinux: [manylinux2014]
         cibw_arch: ["x86_64"]
     steps:
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cibw_python: ["cp310-*", "cp311-*", "cp312-*"]
+        cibw_python: ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
         cibw_manylinux: [manylinux2014]
     steps:
       - uses: actions/checkout@v4
@@ -111,7 +111,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-12]
-        cibw_python: ["cp310-*", "cp311-*", "cp312-*"]
+        cibw_python: ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
         # TODO: add "universal2" once a universal2 libomp is available
         cibw_arch: ["x86_64", "arm64"]
 
@@ -190,7 +190,7 @@ jobs:
       matrix:
         os: [windows-latest]
         cibw_arch: ["AMD64"]
-        cibw_python: ["cp310-*", "cp311-*", "cp312-*"]
+        cibw_python: ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
 
     steps:
       - uses: actions/checkout@v4

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,9 @@ jobs:
         Python310-x64:
           PYTHON_VERSION: "3.10"
           ARCH: "x64"
+        Python39-x64:
+          PYTHON_VERSION: "3.9"
+          ARCH: "x64"
     continueOnError: false
     timeoutInMinutes: 60
 

--- a/doc/tools/apigen.py
+++ b/doc/tools/apigen.py
@@ -218,7 +218,7 @@ class ApiDocWriter:
                 continue
 
             # figure out if obj is a function or class
-            if isinstance(obj, FunctionType | BuiltinFunctionType):
+            if isinstance(obj, (FunctionType, BuiltinFunctionType)):
                 functions.append(obj_str)
             elif isinstance(obj, ModuleType) and 'skimage' in mod.__name__:
                 submodules.append(obj_str)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = 'scikit-image'
 description = 'Image processing in Python'
-requires-python = '>=3.10'
+requires-python = '>=3.9'
 readme = 'README.md'
 classifiers = [
     'Development Status :: 4 - Beta',
@@ -12,6 +12,7 @@ classifiers = [
     'Programming Language :: C',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',

--- a/skimage/feature/_fisher_vector.py
+++ b/skimage/feature/_fisher_vector.py
@@ -101,7 +101,7 @@ def learn_gmm(descriptors, *, n_modes=32, gm_args=None):
 
     if not isinstance(descriptors, (list, np.ndarray)):
         raise DescriptorException(
-            'Please ensure descriptors are either a NumPY array, '
+            'Please ensure descriptors are either a NumPy array, '
             'or a list of NumPy arrays.'
         )
 

--- a/skimage/feature/_fisher_vector.py
+++ b/skimage/feature/_fisher_vector.py
@@ -99,7 +99,7 @@ def learn_gmm(descriptors, *, n_modes=32, gm_args=None):
             'order to use the Fisher vector functionality.'
         )
 
-    if not isinstance(descriptors, list | np.ndarray):
+    if not isinstance(descriptors, (list, np.ndarray)):
         raise DescriptorException(
             'Please ensure descriptors are either a NumPY array, '
             'or a list of NumPy arrays.'

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -313,7 +313,7 @@ def _validate_image_histogram(image, hist, nbins=None, normalize=False):
         raise Exception("Either image or hist must be provided.")
 
     if hist is not None:
-        if isinstance(hist, tuple | list):
+        if isinstance(hist, (tuple, list)):
             counts, bin_centers = hist
         else:
             counts = hist

--- a/skimage/io/collection.py
+++ b/skimage/io/collection.py
@@ -299,7 +299,7 @@ class ImageCollection:
         if hasattr(n, '__index__'):
             n = n.__index__()
 
-        if not isinstance(n, int | slice):
+        if not isinstance(n, (int, slice)):
             raise TypeError('slicing must be with an int or slice object')
 
         if isinstance(n, int):

--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -857,7 +857,7 @@ def ransac(
     rng = np.random.default_rng(rng)
 
     # in case data is not pair of input and output, male it like it
-    if not isinstance(data, tuple | list):
+    if not isinstance(data, (tuple, list)):
         data = (data,)
     num_samples = len(data[0])
 

--- a/skimage/segmentation/_watershed.py
+++ b/skimage/segmentation/_watershed.py
@@ -67,7 +67,7 @@ def _validate_inputs(image, markers, mask, connectivity):
         markers_bool = local_minima(image, connectivity=connectivity) * mask
         footprint = ndi.generate_binary_structure(markers_bool.ndim, connectivity)
         markers = ndi.label(markers_bool, structure=footprint)[0]
-    elif not isinstance(markers, np.ndarray | list | tuple):
+    elif not isinstance(markers, (np.ndarray, list, tuple)):
         # not array-like, assume int
         # given int, assume that number of markers *within mask*.
         markers = regular_seeds(image.shape, int(markers / (n_pixels / image.size)))

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -748,9 +748,11 @@ def test_inverse_all_transforms(tform):
     # Test addition with inverse, not implemented for all
     if not isinstance(
         tform,
-        EssentialMatrixTransform
-        | FundamentalMatrixTransform
-        | PiecewiseAffineTransform,
+        (
+            EssentialMatrixTransform,
+            FundamentalMatrixTransform,
+            PiecewiseAffineTransform,
+        ),
     ):
         assert_almost_equal((tform + tform.inverse)(SRC), SRC)
         assert_almost_equal((tform.inverse + tform)(SRC), SRC)


### PR DESCRIPTION
It seems highly probable that numpy 2 will release a build for Python 3.9
@rgommers had asked us to add an upper bound to our releases in Jan but it seems that we didn't take action (understanding how pip solves packages is unclear to me even).

Instead of releasing 0.22.1 for python 3.9 with metadata updates, i'm curious to see if we can release a new version with python 3.9.

The headache of getting CIs working is what I'm hoping to avoid with this startegy

xref: https://mail.python.org/archives/list/numpy-discussion@python.org/thread/AHTATJKGUEOILBNUI5IGGZPXJ5FXIRAU/
xref: https://github.com/scikit-image/scikit-image/issues/7282#issuecomment-1885659412

- [ ] Make a PR to scikit-image-build

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Add support back for Python 3.9 to enhance compatibility with Numpy 2.
```
