### PR TITLE
Fix NumPy2 dtype promotion issues in pywt dependent code

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -27,6 +27,10 @@ Other
       skimage/exposure/tests/test_exposure.py::test_rescale_nan_warning
 * Finalize ``skimage.future.manual_segmentation`` API,
   see https://github.com/scikit-image/scikit-image/issues/2624
+* Remove ``except AttributeError`` block in
+  ``skimage/segmentation/random_walker_segmentation.py`` as well as the warning filter
+  in ``pyproject.toml``, once pyamg supports NumPy 2
+  (see https://github.com/pyamg/pyamg/issues/406).
 
 Post numpy 2
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,6 +195,7 @@ python_classes = ["Test*", "*Suite"]
 python_functions = ["time_*", "test_*", "peakmem_*"]
 filterwarnings = [
     "error",
+    'default:.*pyamg, which cannot \(yet\) be imported with NumPy >=2:RuntimeWarning'
 ]
 
 [tool.coverage.run]

--- a/skimage/metrics/simple_metrics.py
+++ b/skimage/metrics/simple_metrics.py
@@ -164,6 +164,7 @@ def peak_signal_noise_ratio(image_true, image_test, *, data_range=None):
     image_true, image_test = _as_floats(image_true, image_test)
 
     err = mean_squared_error(image_true, image_test)
+    data_range = float(data_range)  # prevent overflow for small integer types
     return 10 * np.log10((data_range**2) / err)
 
 

--- a/skimage/metrics/simple_metrics.py
+++ b/skimage/metrics/simple_metrics.py
@@ -164,7 +164,8 @@ def peak_signal_noise_ratio(image_true, image_test, *, data_range=None):
     image_true, image_test = _as_floats(image_true, image_test)
 
     err = mean_squared_error(image_true, image_test)
-    return 20 * np.log10(data_range / err)
+    data_range = float(data_range)  # prevent overflow for small integer types
+    return 10 * np.log10((data_range**2) / err)
 
 
 def _pad_to(arr, shape):

--- a/skimage/metrics/simple_metrics.py
+++ b/skimage/metrics/simple_metrics.py
@@ -164,8 +164,7 @@ def peak_signal_noise_ratio(image_true, image_test, *, data_range=None):
     image_true, image_test = _as_floats(image_true, image_test)
 
     err = mean_squared_error(image_true, image_test)
-    data_range = float(data_range)  # prevent overflow for small integer types
-    return 10 * np.log10((data_range**2) / err)
+    return 20 * np.log10(data_range / err)
 
 
 def _pad_to(arr, shape):

--- a/skimage/restoration/_denoise.py
+++ b/skimage/restoration/_denoise.py
@@ -788,7 +788,9 @@ def _wavelet_threshold(
             for thresh, level in zip(threshold, dcoeffs)
         ]
     denoised_coeffs = [coeffs[0]] + denoised_detail
-    return pywt.waverecn(denoised_coeffs, wavelet)[original_extent]
+    out = pywt.waverecn(denoised_coeffs, wavelet)[original_extent]
+    out = out.astype(image.dtype)
+    return out
 
 
 def _scale_sigma_and_image_consistently(image, sigma, multichannel, rescale_sigma):

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -43,6 +43,16 @@ try:
     amg_loaded = True
 except ImportError:
     amg_loaded = False
+except AttributeError as e:
+    if "`np.deprecate` was removed" not in e.args[0]:
+        raise e
+    warn(
+        "found optional dependency pyamg, which cannot (yet) be imported with "
+        "NumPy >=2 and will be treated as if not available",
+        RuntimeWarning,
+    )
+    amg_loaded = False
+
 
 from ..util import img_as_float
 

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -43,15 +43,16 @@ try:
     amg_loaded = True
 except ImportError:
     amg_loaded = False
-except AttributeError as e:
-    if "`np.deprecate` was removed" not in e.args[0]:
-        raise e
-    warn(
-        "found optional dependency pyamg, which cannot (yet) be imported with "
-        "NumPy >=2 and will be treated as if not available",
-        RuntimeWarning,
-    )
-    amg_loaded = False
+except AttributeError as error:
+    if "`np.deprecate` was removed" in error.args[0]:
+        warn(
+            "found optional dependency pyamg, which cannot (yet) be imported with "
+            "NumPy >=2 and will be treated as if not available",
+            RuntimeWarning,
+        )
+        amg_loaded = False
+    else:
+        raise error
 
 
 from ..util import img_as_float


### PR DESCRIPTION
## Description

See failures described in https://github.com/scikit-image/scikit-image/issues/7282#issuecomment-2094861211.

Additionally, turn the error raised by pyamg lacking support for NumPy 2 (see https://github.com/pyamg/pyamg/issues/406) into a warning for now.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
