### PR TITLE
Caution about rolling ball performance

### DIFF
--- a/skimage/restoration/_rolling_ball.py
+++ b/skimage/restoration/_rolling_ball.py
@@ -53,8 +53,9 @@ def rolling_ball(image, *, radius=100, kernel=None, nansafe=False, num_threads=N
     noise). If this is a problem in your image, you can apply mild
     gaussian smoothing before passing the image to this function.
 
-    This algorithm is polynomial in the radius, with exponent = image.ndim,
-    meaning it can take a long time as the radius grows beyond 30 or so [2]_ [3]_.
+    This algorithm's complexity is polynomial in the radius, with degree equal
+    to the image dimensionality (a 2D image is N^2, 3D image is N^3 etc.),
+    so it can take a long time as the radius grows beyond 30 or so [2]_ [3]_.
     It is an exact N-dimensional calculation; if all you need is an
     approximation, faster options to consider are top-hat filtering [4]_ or
     downscaling-then-upscaling to reduce the size of the input processed.

--- a/skimage/restoration/_rolling_ball.py
+++ b/skimage/restoration/_rolling_ball.py
@@ -56,7 +56,7 @@ def rolling_ball(image, *, radius=100, kernel=None, nansafe=False, num_threads=N
     This algorithm is polynomial in the radius, with exponent = image.ndim,
     meaning it can take a long time as the radius grows beyond 30 or so [2]_ [3]_.
     It is an exact N-dimensional calculation; if all you need is an
-    approximation, faster options to consider are top-hat filtering [4] or
+    approximation, faster options to consider are top-hat filtering [4]_ or
     downscaling-then-upscaling to reduce the size of the input processed.
 
     References

--- a/skimage/restoration/_rolling_ball.py
+++ b/skimage/restoration/_rolling_ball.py
@@ -55,7 +55,7 @@ def rolling_ball(image, *, radius=100, kernel=None, nansafe=False, num_threads=N
 
     This algorithm's complexity is polynomial in the radius, with degree equal
     to the image dimensionality (a 2D image is N^2, a 3D image is N^3, etc.),
-    so it can take a long time as the radius grows beyond 30 or so [2]_ [3]_.
+    so it can take a long time as the radius grows beyond 30 or so ([2]_, [3]_).
     It is an exact N-dimensional calculation; if all you need is an
     approximation, faster options to consider are top-hat filtering [4]_ or
     downscaling-then-upscaling to reduce the size of the input processed.

--- a/skimage/restoration/_rolling_ball.py
+++ b/skimage/restoration/_rolling_ball.py
@@ -54,7 +54,7 @@ def rolling_ball(image, *, radius=100, kernel=None, nansafe=False, num_threads=N
     gaussian smoothing before passing the image to this function.
 
     This algorithm is polynomial in the radius, with exponent = image.ndim,
-    meaning it can take a long time as the radius grows beyond 30 or so [2, 3].
+    meaning it can take a long time as the radius grows beyond 30 or so [2]_ [3]_.
     It is an exact N-dimensional calculation; if all you need is an
     approximation, faster options to consider are top-hat filtering [4] or
     downscaling-then-upscaling to reduce the size of the input processed.

--- a/skimage/restoration/_rolling_ball.py
+++ b/skimage/restoration/_rolling_ball.py
@@ -53,10 +53,19 @@ def rolling_ball(image, *, radius=100, kernel=None, nansafe=False, num_threads=N
     noise). If this is a problem in your image, you can apply mild
     gaussian smoothing before passing the image to this function.
 
+    This algorithm is polynomial in the radius, with exponent = image.ndim,
+    meaning it can take a long time as the radius grows beyond 30 or so [2, 3].
+    It is an exact N-dimensional calculation; if all you need is an
+    approximation, faster options to consider are top-hat filtering [4] or
+    downscaling-then-upscaling to reduce the size of the input processed.
+
     References
     ----------
     .. [1] Sternberg, Stanley R. "Biomedical image processing." Computer 1
            (1983): 22-34. :DOI:`10.1109/MC.1983.1654163`
+    .. [2] https://github.com/scikit-image/scikit-image/issues/5193
+    .. [3] https://github.com/scikit-image/scikit-image/issues/7423
+    .. [4] https://forum.image.sc/t/59267/7
 
     Examples
     --------

--- a/skimage/restoration/_rolling_ball.py
+++ b/skimage/restoration/_rolling_ball.py
@@ -54,7 +54,7 @@ def rolling_ball(image, *, radius=100, kernel=None, nansafe=False, num_threads=N
     gaussian smoothing before passing the image to this function.
 
     This algorithm's complexity is polynomial in the radius, with degree equal
-    to the image dimensionality (a 2D image is N^2, 3D image is N^3 etc.),
+    to the image dimensionality (a 2D image is N^2, a 3D image is N^3, etc.),
     so it can take a long time as the radius grows beyond 30 or so [2]_ [3]_.
     It is an exact N-dimensional calculation; if all you need is an
     approximation, faster options to consider are top-hat filtering [4]_ or


### PR DESCRIPTION
## Description

This patch adds detail to the `skimage.restoration.rolling_ball` docstring, cautioning about the algorithm performance and suggesting alternatives for when something faster is desired.

As discussed in #7423, the rolling ball algorithm complexity is such that larger radii and/or images with higher dimensionality can take quite some time to compute. Let's give the user some guidance about this so they can make informed decisions about how to proceed with their image processing.

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Add algorithmic complexity description + suggested alternatives to `skimage.restoration.rolling_ball` docstring.
```
