### PR TITLE
CI: Add GitHub artifact attestations to package distribution

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: write # for softprops/action-gh-release to create GitHub release
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+      attestations: write # for GitHub attestations
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,10 +31,6 @@ jobs:
         name: Install Python
         with:
           python-version: "3.12"
-
-      - name: Install Twine
-        run: |
-          pip install twine
 
       - uses: actions/download-artifact@v3
         id: download
@@ -47,6 +44,14 @@ jobs:
           source tools/github/before_install.sh
           python -m build --no-isolation --skip-dependency-check --sdist .
           ls -la ${{ github.workspace }}/dist
+
+      - name: Verify the distribution
+        run: pipx run twine check --strict dist/*
+
+      - name: Generate artifact attestation for sdist and wheels
+        uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+        with:
+          subject-path: "dist/scikit_image-*"
 
       # We prefer to release wheels before source because otherwise there is a
       # small window during which users who pip install scikit-image will require compilation.

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -45,13 +45,25 @@ jobs:
           python -m build --no-isolation --skip-dependency-check --sdist .
           ls -la ${{ github.workspace }}/dist
 
-      - name: Verify the distribution
-        run: pipx run twine check --strict dist/*
-
       - name: Generate artifact attestation for sdist and wheels
         uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
         with:
           subject-path: "dist/scikit_image-*"
+
+      - name: Verify the distribution
+        run: pipx run twine check --strict dist/*
+
+      # Ensure that a compromised twine couldn't have altered the distributions
+      # Required to resolve sdist and wheels separately
+      - name: Verify sdist artifact attestation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh attestation verify dist/scikit_image-*.tar.gz --repo ${{ github.repository }}
+
+      - name: Verify wheel artifact attestation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh attestation verify dist/scikit_image-*.whl --repo ${{ github.repository }}
 
       # We prefer to release wheels before source because otherwise there is a
       # small window during which users who pip install scikit-image will require compilation.


### PR DESCRIPTION
## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Do not use AI to help write your contribution.
- Use `pre-commit` to check and format code.
-->

* Add generation of GitHub artifact attestations to built sdist and wheels before upload to PyPI. c.f.:
   - https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/
   - https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds

This PR is related to https://github.com/scientific-python/summit-2024/issues/9.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- [x] A descriptive but concise pull request title
- [N/A] [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [N/A] [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- [N/A] A gallery example in `./doc/examples` for new features
- [x] [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Add generation of GitHub artifact attestations to built sdist and wheels before upload to PyPI.
```
