### PR TITLE
CI: Use full length commit SHA for PyPI publishing

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -68,7 +68,7 @@ jobs:
       # We prefer to release wheels before source because otherwise there is a
       # small window during which users who pip install scikit-image will require compilation.
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # v1.8.14
 
       - name: Github release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
* Related to SPEC 08 discussions at the 2024 Scientific Python Developer Summit, for publishing actions use the full length commit. Dependabot will update these and the version number automatically.
   - c.f. https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.8.14

## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- [x] A descriptive but concise pull request title
- [N/A] [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [N/A] [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- [N/A] A gallery example in `./doc/examples` for new features
- [x] [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
For publishing actions use the full length commit SHA.
```
