### PR TITLE
[WIP]: Use `cibuildwheel` to build WASM/Pyodide wheels for `scikit-image`, push nightlies to Anaconda.org

### DIFF
--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -266,4 +266,6 @@ jobs:
           CIBW_PLATFORM: pyodide
           CIBW_ENVIRONMENT_PYODIDE: ""
           CIBW_TEST_REQUIRES_PYODIDE: "" # The Node.js runner installs the test requirements
-          CIBW_TEST_COMMAND_PYODIDE: "node {project}/tools/emscripten/pytest_scikit_image_pyodide.js --pyargs skimage"
+          CIBW_TEST_COMMAND_PYODIDE: |
+            npm install pyodide --global
+            node {project}/tools/emscripten/pytest_scikit_image_pyodide.js --pyargs skimage

--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -17,6 +17,7 @@ on:
         required: false
         type: string
         default: "pytest --pyargs skimage"
+  workflow_dispatch: # temporarily added for debugging
 
 env:
   CIBW_BUILD_VERBOSITY: 2
@@ -239,3 +240,30 @@ jobs:
         with:
           name: wheels
           path: ./dist/*.whl
+
+  build_pyodide_wheel:
+    name: Build python cp312-* pyodide_wasm32 wheels on ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # For adjusting the Python version, please refer to:
+      # https://github.com/pyodide/pyodide/blob/main/Makefile.envs#L2
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: "3.12"
+
+      - name: Build and test scikit-image for Pyodide
+        run: |
+          python -m pip install cibuildwheel>=2.19.0
+          python -m cibuildwheel --output-dir dist --platform pyodide
+        env:
+          # Override CIBW_ENVIRONMENT, CIBW_TEST_REQUIRES, and CIBW_TEST_COMMAND
+          # for Pyodide-related settings.
+          CIBW_PLATFORM: pyodide
+          CIBW_ENVIRONMENT_PYODIDE: ""
+          CIBW_TEST_REQUIRES_PYODIDE: "" # The Node.js runner installs the test requirements
+          CIBW_TEST_COMMAND_PYODIDE: "node {project}/tools/emscripten/pytest_scikit_image_pyodide.js --pyargs skimage"

--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -267,5 +267,5 @@ jobs:
           CIBW_ENVIRONMENT_PYODIDE: ""
           CIBW_TEST_REQUIRES_PYODIDE: "" # The Node.js runner installs the test requirements
           CIBW_TEST_COMMAND_PYODIDE: |
-            npm install pyodide --global
+            npm install pyodide@0.26.1
             node {project}/tools/emscripten/pytest_scikit_image_pyodide.js --pyargs skimage

--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -267,5 +267,5 @@ jobs:
           CIBW_ENVIRONMENT_PYODIDE: ""
           CIBW_TEST_REQUIRES_PYODIDE: "" # The Node.js runner installs the test requirements
           CIBW_TEST_COMMAND_PYODIDE: |
-            npm install pyodide@0.26.1
+            npm install pyodide@0.26.1 --verbose
             node {project}/tools/emscripten/pytest_scikit_image_pyodide.js --pyargs skimage


### PR DESCRIPTION
## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

This PR is a follow-up to #7350 based on https://github.com/scikit-image/scikit-image/pull/7350#discussion_r1568713998. It modifies the wheel recipe workflow in `wheels_recipe.yml` to additionally build and test Pyodide wheels through `cibuildwheel` version 2.19.0, which added experimental support for building to a WebAssembly target. Since the workflow is triggered using the `workflow_call:` event in `nightly_wheel_build.yml`, this enables pushing the wheels to the Anaconda.org index, which is hosted at https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- [x] A descriptive but concise pull request title
- [ ] [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [ ] [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- [ ] A gallery example in `./doc/examples` for new features
- [ ] [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
