### PR TITLE
CI: Verify each artifact attestation in a loop

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -59,18 +59,15 @@ jobs:
         run: pipx run twine check --strict dist/*
 
       # Ensure that a compromised twine couldn't have altered the distributions
-      # Required to resolve sdist and wheels separately
-      - name: Verify sdist artifact attestation
+      - name: Verify artifact attestation
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh attestation verify dist/scikit_image-*.tar.gz --repo ${{ github.repository }}
-
-      # This needs to be fixed, see
-      # https://github.com/scikit-image/scikit-image/issues/7443
-      # - name: Verify wheel artifact attestation
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: gh attestation verify dist/scikit_image-*.whl --repo ${{ github.repository }}
+        shell: bash
+        run: |
+          for artifact in dist/*; do
+              echo "# ${artifact}"
+              gh attestation verify "${artifact}" --repo ${{ github.repository }}
+          done
 
       # We prefer to release wheels before source because otherwise there is a
       # small window during which users who pip install scikit-image will require compilation.


### PR DESCRIPTION
## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

Resolves https://github.com/scikit-image/scikit-image/issues/7443

As `gh attestation verify` of `gh` CLI `v2.51.0` is only able to operate on a single filepath, then to verify all artifacts that have been attested, loop over all the files under `dist/` and run `gh attestation verify` on each.

This is slightly clunky IMO, but until there is feedback on https://github.com/cli/cli/issues/9215 this is the most clear path forward.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- [x] A descriptive but concise pull request title
- [N/A] [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [N/A] [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- [N/A] A gallery example in `./doc/examples` for new features
- [x] [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Verify all artifacts that have been attested by looping over them in CI.
```
