### PR TITLE
Use NumPy 2.0 now that it is out

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ build = [
     'ninja',
     'Cython>=3.0.4',
     'pythran',
-    'numpy>=2.0.0rc1',
+    'numpy>=2.0.0',
     # Developer UI
     'spin==0.8',
     'build',

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -7,6 +7,6 @@ packaging>=21
 ninja
 Cython>=3.0.4
 pythran
-numpy>=2.0.0rc1
+numpy>=2.0.0
 spin==0.8
 build


### PR DESCRIPTION
## Description

When building with NumPy 2, use the stable version now that the release is complete

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Use NumPy 2.0 stable to build packages
```
