### PR TITLE
Improved docstring in skeletonize

### DIFF
--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -19,8 +19,8 @@ def skeletonize(image, *, method=None):
     image : (M, N[, P]) ndarray of bool or int
         The image containing the objects to be skeletonized. Each connected component
         in the image is reduced to a single-pixel wide skeleton. The image is binarized
-        prior to thinning; thus, several adjacent objects of different intensities are
-        considered as one. Zeros or ``False`` values represent the background, nonzero
+        prior to thinning; thus, adjacent objects of different intensities are
+        considered as one. Zero or ``False`` values represent the background, nonzero
         values or ``True`` -- foreground.
     method : {'zhang', 'lee'}, optional
         Which algorithm to use. Zhang's algorithm [Zha84]_ only works for

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -21,7 +21,7 @@ def skeletonize(image, *, method=None):
         in the image is reduced to a single-pixel wide skeleton. The image is binarized
         prior to thinning; thus, adjacent objects of different intensities are
         considered as one. Zero or ``False`` values represent the background, nonzero
-        values or ``True`` -- foreground.
+        or ``True`` values -- foreground.
     method : {'zhang', 'lee'}, optional
         Which algorithm to use. Zhang's algorithm [Zha84]_ only works for
         2D images, and is the default for 2D. Lee's algorithm [Lee94]_

--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -12,16 +12,16 @@ from ._skeletonize_cy import _fast_skeletonize, _skeletonize_loop, _table_lookup
 
 
 def skeletonize(image, *, method=None):
-    """Compute the skeleton of a binary image.
-
-    Thinning is used to reduce each connected component in a binary image
-    to a single-pixel wide skeleton.
+    """Compute the skeleton of the input image via thinning.
 
     Parameters
     ----------
-    image : ndarray, 2D or 3D
-        An image containing the objects to be skeletonized. Zeros or ``False``
-        represent background, nonzero values or ``True`` are foreground.
+    image : (M, N[, P]) ndarray of bool or int
+        The image containing the objects to be skeletonized. Each connected component
+        in the image is reduced to a single-pixel wide skeleton. The image is binarized
+        prior to thinning; thus, several adjacent objects of different intensities are
+        considered as one. Zeros or ``False`` values represent the background, nonzero
+        values or ``True`` -- foreground.
     method : {'zhang', 'lee'}, optional
         Which algorithm to use. Zhang's algorithm [Zha84]_ only works for
         2D images, and is the default for 2D. Lee's algorithm [Lee94]_
@@ -29,7 +29,7 @@ def skeletonize(image, *, method=None):
 
     Returns
     -------
-    skeleton : ndarray of bool
+    skeleton : (M, N[, P]) ndarray of bool
         The thinned image.
 
     See Also


### PR DESCRIPTION
## Description

Clarified the expected image dtypes and how objects of different intensities are handled.
Fixes #7133.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
