### PR TITLE
FIX: pre-commit hook config for generating requirements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
         name: generate_requirements.py
         language: system
         entry: python tools/generate_requirements.py
-        files: "pyproject.toml|requirements/.*\\.txt|tools/generate_requirements.py"
+        files: "pyproject.toml|requirements/.*.txt|tools/generate_requirements.py"
 
 ci:
   autofix_prs: false


### PR DESCRIPTION
the hook now triggers when a .txt file is modified inside the requirements folder

## Description

The regex seem broken on my computer. This new version works for me.

Solves https://github.com/scikit-image/scikit-image/issues/7460

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
- fix `generate_requirements` trigger condition to trigger on changes on .txt files inside the requirements folder. Please run `pre-commit install`.
```
