### PR TITLE
Fix CI tests with minimal dependencies and make dependency resolution more robust

### DIFF
--- a/tools/github/before_install.sh
+++ b/tools/github/before_install.sh
@@ -33,9 +33,6 @@ python -m pip install --upgrade pip
 
 # Install build time requirements
 python -m pip install $PIP_FLAGS -r requirements/build.txt
-# Default requirements are necessary to build because of lazy importing
-# They can be moved after the build step if #3158 is accepted
-python -m pip install $PIP_FLAGS -r requirements/default.txt
 
 # Show what's installed
 python -m pip list

--- a/tools/github/before_install.sh
+++ b/tools/github/before_install.sh
@@ -5,7 +5,7 @@ export PIP_DEFAULT_TIMEOUT=60
 
 if [[ $MINIMUM_REQUIREMENTS == 1 ]]; then
     for filename in requirements/*.txt; do
-        sed -i 's/>=/==/g' $filename
+        sed -i 's/>=/==/g' "$filename"
     done
 fi
 

--- a/tools/github/before_install.sh
+++ b/tools/github/before_install.sh
@@ -3,26 +3,6 @@ set -ex
 
 export PIP_DEFAULT_TIMEOUT=60
 
-# This causes way too many internal warnings within python.
-# export PYTHONWARNINGS="d,all:::skimage"
-
-retry () {
-    # https://gist.github.com/fungusakafungus/1026804
-    local retry_max=3
-    local count=$retry_max
-    while [ $count -gt 0 ]; do
-        "$@" && break
-        count=$(($count - 1))
-        sleep 1
-    done
-
-    [ $count -eq 0 ] && {
-        echo "Retry failed [$retry_max]: $@" >&2
-        return 1
-    }
-    return 0
-}
-
 if [[ $MINIMUM_REQUIREMENTS == 1 ]]; then
     for filename in requirements/*.txt; do
         sed -i 's/>=/==/g' $filename
@@ -36,12 +16,5 @@ python -m pip install $PIP_FLAGS -r requirements/build.txt
 
 # Show what's installed
 python -m pip list
-
-section () {
-    tools/header.py $1
-}
-
-export -f section
-export -f retry
 
 set +ex

--- a/tools/github/script.sh
+++ b/tools/github/script.sh
@@ -2,8 +2,7 @@
 # Fail on non-zero exit and echo the commands
 set -evx
 
-python -m pip install $PIP_FLAGS -r requirements/test.txt
-
+python -m pip install $PIP_FLAGS -r requirements/default.txt -r requirements/test.txt
 
 
 TEST_ARGS="--doctest-plus --cov=skimage --showlocals"

--- a/tools/github/script.sh
+++ b/tools/github/script.sh
@@ -2,27 +2,36 @@
 # Fail on non-zero exit and echo the commands
 set -evx
 
-python -m pip install $PIP_FLAGS -r requirements/default.txt -r requirements/test.txt
-
-
 TEST_ARGS="--doctest-plus --cov=skimage --showlocals"
+
+
+# Combine requirement files for a more robust pip solve
+# installing successively may update previously constraint dependencies
+REQUIREMENT_FILES="-r requirements/default.txt -r requirements/test.txt"
+if [[ "${OPTIONAL_DEPS}" == "1" ]]; then
+    REQUIREMENT_FILES="-${REQUIREMENT_FILES} -r requirements/optional.txt"
+fi
+
+python -m pip install $PIP_FLAGS $REQUIREMENT_FILES
 
 if [[ ${WITHOUT_POOCH} == "1" ]]; then
   # remove pooch (previously installed via requirements/test.txt)
   python -m pip uninstall pooch -y
 fi
-if [[ "${OPTIONAL_DEPS}" == "1" ]]; then
-    python -m pip install $PIP_FLAGS -r ./requirements/optional.txt
-fi
 
 python -m pip list
 
+
+# Run the tests
 (cd .. && pytest $TEST_ARGS --pyargs skimage)
 
 
+# Optionally, prepare building the docs (and test examples)
 if [[ "${BUILD_DOCS}" == "1" ]] || [[ "${TEST_EXAMPLES}" == "1" ]]; then
-  echo Build or run examples
-  python -m pip install $PIP_FLAGS -r ./requirements/docs.txt
+  echo "Build or run examples"
+  # Use previous installed requirements as well, otherwise installing
+  # successively may update previously constraint dependencies
+  python -m pip install $PIP_FLAGS $REQUIREMENT_FILES -r ./requirements/docs.txt
   python -m pip list
 
   export MPL_DIR
@@ -34,6 +43,7 @@ if [[ "${BUILD_DOCS}" == "1" ]] || [[ "${TEST_EXAMPLES}" == "1" ]]; then
   fi
 fi
 
+# Optionally, build the docs or test examples
 if [[ "${BUILD_DOCS}" == "1" ]]; then
   echo Build docs
   export SPHINXCACHE=${HOME}/.cache/sphinx; make -C doc html

--- a/tools/github/script.sh
+++ b/tools/github/script.sh
@@ -9,7 +9,7 @@ TEST_ARGS="--doctest-plus --cov=skimage --showlocals"
 # installing successively may update previously constraint dependencies
 REQUIREMENT_FILES="-r requirements/default.txt -r requirements/test.txt"
 if [[ "${OPTIONAL_DEPS}" == "1" ]]; then
-    REQUIREMENT_FILES="-${REQUIREMENT_FILES} -r requirements/optional.txt"
+    REQUIREMENT_FILES="${REQUIREMENT_FILES} -r requirements/optional.txt"
 fi
 
 python -m pip install $PIP_FLAGS $REQUIREMENT_FILES

--- a/tools/github/script.sh
+++ b/tools/github/script.sh
@@ -6,7 +6,7 @@ TEST_ARGS="--doctest-plus --cov=skimage --showlocals"
 
 
 # Combine requirement files for a more robust pip solve
-# installing successively may update previously constraint dependencies
+# installing successively may update previously constrained dependencies
 REQUIREMENT_FILES="-r requirements/default.txt -r requirements/test.txt"
 if [[ "${OPTIONAL_DEPS}" == "1" ]]; then
     REQUIREMENT_FILES="${REQUIREMENT_FILES} -r requirements/optional.txt"


### PR DESCRIPTION
## Description

NumPy 2 is minimal dep for build but not for default. So installing defaults before building actually downgrades NumPy for the build step. This becomes a problem later when testing.

Still investigating how best to solve this.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
