### PR TITLE
Add CI to test scikit-image against free-threaded Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,7 +123,7 @@ jobs:
       # TODO: replace with setup-python when there is support
       - uses: deadsnakes/action@e704e592227156e253e24c7f7ccf2bfe62ef58d4 # v3.1.0
         with:
-          python-version: "3.13.0b3"
+          python-version: "3.13"
           nogil: true
 
       - name: Install nightly dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,7 +121,7 @@ jobs:
         uses: actions/checkout@v4
 
       # TODO: replace with setup-python when there is support
-      - uses: deadsnakes/action@e704e592227156e253e24c7f7ccf2bfe62ef58d4 # v3.1.0
+      - uses: deadsnakes/action@6c8b9b82fe0b4344f4b98f2775fcc395df45e494 # v3.1.0
         with:
           python-version: "3.13"
           nogil: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,6 +112,32 @@ jobs:
         run: |
           asv check -v -E existing
 
+  test_skimage_linux_free_threaded:
+    name: linux-cp313t-default
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout scikit-image
+        uses: actions/checkout@v4
+
+      # TODO: replace with setup-python when there is support
+      - uses: deadsnakes/action@e704e592227156e253e24c7f7ccf2bfe62ef58d4 # v3.1.0
+        with:
+          python-version: "3.13.0b3"
+          nogil: true
+
+      - name: Install nightly dependencies
+        run: |
+          set -ex
+          source tools/github/before_install.sh
+          pip install -vv --no-build-isolation .
+
+      - name: Run tests
+        env:
+          PYTHON_GIL: 0
+        run: |
+          source tools/github/script.sh
+
   test_skimage_macos:
     name: macos-cp${{ matrix.python-version }}
     runs-on: macos-12

--- a/TODO.txt
+++ b/TODO.txt
@@ -34,6 +34,8 @@ Other
   ``skimage/segmentation/random_walker_segmentation.py`` as well as the warning filter
   in ``pyproject.toml``, once pyamg supports NumPy 2
   (see https://github.com/pyamg/pyamg/issues/406).
+* Delete FREE_THREADED_BUILD block in tools/github/before_install.sh once free-threaded
+  wheels for scipy, numpy, cython and pywavelets, ... are available on PyPi
 
 Post numpy 2
 ------------

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
   'scikit-image',
-  'c', 'cpp',
+  'c', 'cpp', 'cython',
   # Note that the git commit hash cannot be added dynamically here
   # That only happens when importing from a git repository.
   # See `skimage/__init__.py`

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -1,4 +1,5 @@
 import inspect
+import sys
 from functools import wraps
 from math import atan2
 from math import pi as PI
@@ -1406,9 +1407,11 @@ def _parse_docs():
     import textwrap
 
     doc = regionprops.__doc__ or ''
-    matches = re.finditer(
-        r'\*\*(\w+)\*\* \:.*?\n(.*?)(?=\n    [\*\S]+)', doc, flags=re.DOTALL
-    )
+    arg_regex = r'\*\*(\w+)\*\* \:.*?\n(.*?)(?=\n    [\*\S]+)'
+    if sys.version_info >= (3, 13):
+        arg_regex = r'\*\*(\w+)\*\* \:.*?\n(.*?)(?=\n[\*\S]+)'
+
+    matches = re.finditer(arg_regex, doc, flags=re.DOTALL)
     prop_doc = {m.group(1): textwrap.dedent(m.group(2)) for m in matches}
 
     return prop_doc

--- a/skimage/meson.build
+++ b/skimage/meson.build
@@ -123,9 +123,17 @@ py3.install_sources(
 )
 
 cython_cli = find_program('_build_utils/cythoner.py')
+cy = meson.get_compiler('cython')
+
+cython_args = ['@INPUT@', '@OUTPUT@']
+if cy.version().version_compare('>=3.1.0')
+  cython_args += ['-Xfreethreading_compatible=True']
+endif
+
+cython_cpp_args = cython_args + ['--cplus']
 
 cython_gen = generator(cython_cli,
-  arguments : ['@INPUT@', '@OUTPUT@'],
+  arguments : cython_args,
   output : '@BASENAME@.c')
 
 cython_gen_cpp = generator(cython_cli,

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -687,7 +687,7 @@ class ProjectiveTransform(_GeometricTransform):
 
         return dst[:, :ndim]
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=False):
         if dtype is None:
             return self.params
         else:

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -687,7 +687,7 @@ class ProjectiveTransform(_GeometricTransform):
 
         return dst[:, :ndim]
 
-    def __array__(self, dtype=None, copy=False):
+    def __array__(self, dtype=None, copy=None):
         if dtype is None:
             return self.params
         else:

--- a/skimage/util/_map_array.py
+++ b/skimage/util/_map_array.py
@@ -129,7 +129,7 @@ class ArrayMap:
         """Return one more than the maximum label value being remapped."""
         return np.max(self.in_values) + 1
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=False):
         """Return an array that behaves like the arraymap when indexed.
 
         This array can be very large: it is the size of the largest value

--- a/skimage/util/_map_array.py
+++ b/skimage/util/_map_array.py
@@ -129,7 +129,7 @@ class ArrayMap:
         """Return one more than the maximum label value being remapped."""
         return np.max(self.in_values) + 1
 
-    def __array__(self, dtype=None, copy=False):
+    def __array__(self, dtype=None, copy=None):
         """Return an array that behaves like the arraymap when indexed.
 
         This array can be very large: it is the size of the largest value

--- a/tools/github/before_install.sh
+++ b/tools/github/before_install.sh
@@ -31,7 +31,7 @@ fi
 
 python -m pip install --upgrade pip
 
-# TODO: delete when scipy, numpy, cython and pywavelets wheels are available on PyPi
+# TODO: delete when scipy, numpy, cython and pywavelets free-threaded wheels are available on PyPi
 FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
 if [[ $FREE_THREADED_BUILD == "True" ]]; then
     pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy scipy pywavelets

--- a/tools/github/before_install.sh
+++ b/tools/github/before_install.sh
@@ -34,7 +34,7 @@ python -m pip install --upgrade pip
 # TODO: delete when scipy, numpy, cython and pywavelets wheels are available on PyPi
 FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
 if [[ $FREE_THREADED_BUILD == "True" ]]; then
-    pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy scipy pywavelets
+    pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy scipy pywavelets
 fi
 
 # Install build time requirements

--- a/tools/github/before_install.sh
+++ b/tools/github/before_install.sh
@@ -31,6 +31,12 @@ fi
 
 python -m pip install --upgrade pip
 
+# TODO: delete when scipy, numpy, cython and pywavelets wheels are available on PyPi
+FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
+if [[ $FREE_THREADED_BUILD == "True" ]]; then
+    pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy scipy pywavelets
+fi
+
 # Install build time requirements
 python -m pip install $PIP_FLAGS -r requirements/build.txt
 # Default requirements are necessary to build because of lazy importing


### PR DESCRIPTION
## Description

See https://github.com/scikit-image/scikit-image/issues/7464

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

This PR enables testing scikit-image against free-threaded Python, this is part of the ongoing effort to test projects against the changes proposed in [PEP703](https://peps.python.org/pep-0703/)

For more information see the following related PRs in other projects:
* NumPy https://github.com/numpy/numpy/pull/26512
* SciPy https://github.com/scipy/scipy/pull/20822
* PyWavelets https://github.com/PyWavelets/pywt/pull/753
* Pandas: https://github.com/pandas-dev/pandas/pull/59058
* Pillow: https://github.com/python-pillow/Pillow/pull/8200

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
