### PR TITLE
Gray-scale Hough Line Transform

### DIFF
--- a/skimage/transform/__init__.pyi
+++ b/skimage/transform/__init__.pyi
@@ -6,6 +6,7 @@ __all__ = [
     'hough_circle',
     'hough_ellipse',
     'hough_line',
+    'gray_scale_hough_line',
     'probabilistic_hough_line',
     'hough_circle_peaks',
     'hough_line_peaks',
@@ -46,6 +47,7 @@ __all__ = [
 from .hough_transform import (
     hough_line,
     hough_line_peaks,
+    gray_scale_hough_line,
     probabilistic_hough_line,
     hough_circle,
     hough_circle_peaks,

--- a/skimage/transform/_hough_transform.pyx
+++ b/skimage/transform/_hough_transform.pyx
@@ -542,17 +542,19 @@ def _probabilistic_hough_line(cnp.ndarray img, Py_ssize_t threshold,
             for line in lines[:nlines]]
 
 
-def _gray_scale_hough_line(cnp.ndarray[ndim=2, dtype=cnp.uint8_t] img,
-                cnp.ndarray[ndim=1, dtype=cnp.float64_t] theta):
+def _gray_scale_hough_line(cnp.ndarray img,
+                cnp.ndarray[ndim=1, dtype=cnp.float64_t] theta,
+                cnp.ndarray[ndim=1, dtype=cnp.float64_t] intensity):
     """Perform a gray-scale straight line Hough transform.
 
     Parameters
     ----------
     img : (M, N) ndarray of unit8
-        Input image with in intensity values in the range [0, 255]. 
-        Currently only 8-bit unsigned integer are supported.
+        Input image with gra-scale intensity values 
     theta : 1D ndarray of float64
         Angles at which to compute the transform, in radians.
+    intensity : 1D ndarray of float64
+        Intensities at which to compute the transform, in the range [0, 1]
 
     Returns
     -------
@@ -562,6 +564,8 @@ def _gray_scale_hough_line(cnp.ndarray[ndim=2, dtype=cnp.uint8_t] img,
         Angles at which the transform was computed, in radians.
     distances : ndarray
         Distance values.
+    intensity: ndarray 
+        intensities at which the transform was computed, in the range [0, 1].
 
     Notes
     -----
@@ -572,8 +576,8 @@ def _gray_scale_hough_line(cnp.ndarray[ndim=2, dtype=cnp.uint8_t] img,
 
     References
     ----------
-    .. [1] R. Lo, W. Tsa, "Gray-Scale Hough Transform For Thick Line Detection In Gray-Scale Images", in IEEE Computer Society
-           Pattern Recognition Vol. 28, No. 5, pp. 647-661, 1995.
+    .. [1] R. Lo, W. Tsa, "Gray-Scale Hough Transform For Thick Line Detection In Gray-Scale Images",
+           in Pattern Recognition Vol. 28, No. 5, pp. 647-661, 1995.
 
     """
     # Compute the array of angles and their sine and cosine
@@ -583,6 +587,10 @@ def _gray_scale_hough_line(cnp.ndarray[ndim=2, dtype=cnp.uint8_t] img,
     ctheta = np.cos(theta)
     stheta = np.sin(theta)
 
+    # convert intensity and img to c objects
+    cdef cnp.ndarray[ndim=1, dtype=cnp.float64_t] cintensity = intensity
+    cdef cnp.ndarray[ndim=2, dtype=cnp.float64_t] cimg = img
+
     # compute the bins and allocate the accumulator array
     cdef cnp.ndarray[ndim=3, dtype=cnp.uint64_t] accum
     cdef cnp.ndarray[ndim=1, dtype=cnp.float64_t] bins
@@ -591,7 +599,7 @@ def _gray_scale_hough_line(cnp.ndarray[ndim=2, dtype=cnp.uint8_t] img,
     offset = <Py_ssize_t>ceil(sqrt(img.shape[0] * img.shape[0] +
                                    img.shape[1] * img.shape[1]))
     max_distance = 2 * offset + 1
-    accum = np.zeros((max_distance, theta.shape[0], 256), dtype=np.uint64)  # 256 correspond to intensity values of 8bit unsignde integer
+    accum = np.zeros((max_distance, theta.shape[0], intensity.shape[0]), dtype=np.uint64)
     bins = np.linspace(-offset, offset, max_distance)
 
     # compute the nonzero indexes
@@ -599,16 +607,24 @@ def _gray_scale_hough_line(cnp.ndarray[ndim=2, dtype=cnp.uint8_t] img,
     y_idxs, x_idxs = np.nonzero(img)
 
     # finally, run the transform
-    cdef Py_ssize_t nidxs, nthetas, i, j, x, y, accum_idx
+    cdef Py_ssize_t nidxs, nthetas, i, j, x, y, acc_idx, intensity_idx
+    cdef cnp.float64_t pixel_intensity
 
     nidxs = y_idxs.shape[0]  # x and y are the same shape
     nthetas = theta.shape[0]
+    nintensities = intensity.shape[0]
+    intensity_idx = 0  # without this line a warning is raised saying that intensity_idx is not initialized 
     with nogil:
         for i in range(nidxs):
             x = x_idxs[i]
             y = y_idxs[i]
+            pixel_intensity = cimg[x, y]
+            for intensity_idx in range(nintensities):
+                if  pixel_intensity < cintensity[intensity_idx]:
+                    break 
             for j in range(nthetas):
-                accum_idx = round((ctheta[j] * x + stheta[j] * y)) + offset
-                accum[accum_idx, j, img[x, y]] += 1
+                acc_idx = round((ctheta[j] * x + stheta[j] * y)) + offset
 
-    return accum, theta, bins
+                accum[acc_idx, j, intensity_idx] += 1
+
+    return accum, theta, bins, intensity

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -487,7 +487,11 @@ def gray_scale_hough_line(image, theta=None, intensity=None):
         Angles at which to compute the transform, in radians.
         Defaults to a vector of 180 angles evenly spaced in the
         range [-pi/2, pi/2).
-
+    intensity : ndarray of double, shape (K,) and value range [0, 1], optional
+        intensity values for a float image at which the transform is computed.
+        Defaults to a vector of 256 intensity values equally spaced in the 
+        range [0, 1].
+ 
     Returns
     -------
     hspace : ndarray of uint64, shape (P, Q, G)

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -1,8 +1,11 @@
 import numpy as np
 from scipy.spatial import cKDTree
+from scipy.ndimage import rotate
+
 
 from ._hough_transform import _hough_circle, _hough_ellipse, _hough_line
 from ._hough_transform import _probabilistic_hough_line as _prob_hough_line
+from ._hough_transform import _gray_scale_hough_line
 
 
 def hough_line_peaks(
@@ -471,3 +474,43 @@ def label_distant_points(xs, ys, min_xdistance, min_ydistance, max_points):
             n_pts += 1
     should_keep = ~is_neighbor
     return should_keep
+
+
+def gray_scale_hough_line(image, theta=None):
+    """Perform a straight line Hough transform using gray-scale images.
+
+    Parameters
+    ----------
+    image : (M, N) ndarray of type uint8
+        Input image with intensity values in the range [0, 255] 
+    theta : ndarray of double, shape (K,), optional
+        Angles at which to compute the transform, in radians.
+        Defaults to a vector of 180 angles evenly spaced in the
+        range [-pi/2, pi/2).
+
+    Returns
+    -------
+    hspace : ndarray of uint64, shape (P, Q, G)
+        Gray-Scale Hough transform accumulator where G is the intensity in the range [0, 255].
+    angles : ndarray
+        Angles at which the transform is computed, in radians.
+    distances : ndarray
+        Distance values.
+
+    Notes
+    -----
+    The origin is the top left corner of the original image.
+    X and Y axis are horizontal and vertical edges respectively.
+    The distance is the minimal algebraic distance from the origin
+    to the detected line.
+    The angle accuracy can be improved by decreasing the step size in
+    the `theta` array.
+    """
+    if image.ndim != 2:
+        raise ValueError('The input image `image` must be 2D.')
+
+    if theta is None:
+        # These values are approximations of pi/2
+        theta = np.linspace(-np.pi / 2, np.pi / 2, 180, endpoint=False)
+
+    return _gray_scale_hough_line(image, theta=theta)

--- a/skimage/transform/hough_transform.py
+++ b/skimage/transform/hough_transform.py
@@ -6,7 +6,7 @@ from scipy.ndimage import rotate
 from ._hough_transform import _hough_circle, _hough_ellipse, _hough_line
 from ._hough_transform import _probabilistic_hough_line as _prob_hough_line
 from ._hough_transform import _gray_scale_hough_line
-
+from ..util import img_as_float
 
 def hough_line_peaks(
     hspace,
@@ -476,7 +476,7 @@ def label_distant_points(xs, ys, min_xdistance, min_ydistance, max_points):
     return should_keep
 
 
-def gray_scale_hough_line(image, theta=None):
+def gray_scale_hough_line(image, theta=None, intensity=None):
     """Perform a straight line Hough transform using gray-scale images.
 
     Parameters
@@ -496,6 +496,8 @@ def gray_scale_hough_line(image, theta=None):
         Angles at which the transform is computed, in radians.
     distances : ndarray
         Distance values.
+    intensities: ndarray
+        Intensities at which the transform is computed, in the range [0, 1].
 
     Notes
     -----
@@ -513,4 +515,7 @@ def gray_scale_hough_line(image, theta=None):
         # These values are approximations of pi/2
         theta = np.linspace(-np.pi / 2, np.pi / 2, 180, endpoint=False)
 
-    return _gray_scale_hough_line(image, theta=theta)
+    if intensity is None:
+        intensity = np.linspace(0, 1, 256)
+
+    return _gray_scale_hough_line(img_as_float(image), theta=theta, intensity=intensity)


### PR DESCRIPTION
## Description

In a recent project I stumbled on the problem of detecting thick lines in images. In a 1995 paper of [Lo and Tsai "Gray-scale hough transform for thick line detection in gray-scale images"](https://doi.org/10.1016/j.jvcir.2013.09.007) they introduce the concept of gray-scale hough transform (GHT).  Instead of removing gray scale information by binarization and edge detection they consider the image intensity in the accumulator. I implemented GHT based on their pseudo code and the existing Hough Line implementation in scikit-image. I made some minor adjustment to the original definition to work with float intensity values and a arbitrary number of intensity bins instead of expecting uint8 as input.

I did not yet implemented the processing of the accumulator array. Here multiple possibility exists:
  - searching for plateaus along the distance axis with same angle and intensity to find bands of same intensity
  - searching for regions with similar slopes in intensity and same angle and similar distance to identify lines with slow change in intensity, e.g. blurry edges ([Zhu et al 2014 "A rectilinear Gaussian model for estimating straight-line parameters"](https://doi.org/10.1016/0031-3203(94)00127-8))

With this pull-request I would first like to clarify whether there is any interest at all in the project to implement this algorithm. In case of positive feedback I would also look after the implementation of the accumulator processing and write tests for the test-suite.

## Example 

This example shows how the implementation currently works. However, the processing of the accumulator array is not very complex here, as it only searches for the maximum in the summed Hough space for the intensity range >250. But this can be made much more advanced as described above.

```python
import sys
from PIL import Image
import numpy as np
import matplotlib.pyplot as plt

# append build path of skimage to PATH
sys.path.append("./scikit-image/build-install/usr/lib64/python3.11/site-packages/")
import skimage as ski

# load an image
image = np.array(Image.open("./example-image.png").convert("L"))
image = ski.transform.rotate(image, angle=35, resize=False)
# perform gray scale hough line transform
acc, theta, bins, ints = ski.transform.gray_scale_hough_line(image)

fig, axs = plt.subplots(1, 2, layout="constrained")

axs[0].set_title("raw image + detected line")
axs[0].imshow(image, cmap="gray")
axs[1].set_title("3D projection of 4D accumulator")
# plot the accumulator for high intensity (>225) pixel
axs[1].contourf(np.rad2deg(theta), bins, acc[..., 225:250].sum(axis=-1))
axs[1].set_ylabel("distance in px")
axs[1].set_xlabel("angle in deg")

axs[0].axhline(image.shape[0] / 2, c="green", ls="--", alpha=0.5)
axs[0].axvline(image.shape[1] / 2, c="green", ls="--", alpha=0.5)

# find the maximum matching the line
max_idx = np.unravel_index(np.argmax(acc[..., 250:].sum(axis=-1)), acc[:, :, 0].shape)

dist = bins[max_idx[0]]
angle = theta[max_idx[1]]
x0 = np.sin(angle) * dist, np.cos(angle) * dist
axs[0].scatter(*x0, c="r")
dx = np.array([np.cos(angle), -np.sin(angle)])
x1 = np.add(x0, dx)
axs[0].scatter(*x1, c="b")

print(f"dist: {dist}, angle: {np.rad2deg(angle)}")
axs[0].axline(x0, slope=-np.tan(angle), c="r", ls="--");
```

![image](https://github.com/user-attachments/assets/b961b7e1-b4fb-4bc8-9f45-8f7ea81445c3)


