### PR TITLE
Fix morphology.thin from modifying input array

### DIFF
--- a/skimage/morphology/_skeletonize.py
+++ b/skimage/morphology/_skeletonize.py
@@ -321,7 +321,7 @@ def thin(image, max_num_iter=None):
     check_nD(image, 2)
 
     # convert image to uint8 with values in {0, 1}
-    skel = np.asanyarray(image, dtype=bool).view(np.uint8)
+    skel = np.asanyarray(image, dtype=bool).copy().view(np.uint8)
 
     # neighborhood mask
     mask = np.array([[8, 4, 2], [16, 0, 1], [32, 64, 128]], dtype=np.uint8)

--- a/skimage/morphology/tests/test_skeletonize.py
+++ b/skimage/morphology/tests/test_skeletonize.py
@@ -146,6 +146,14 @@ class TestThin:
         assert np.all(thin(image) == False)
 
     @pytest.mark.parametrize("dtype", [bool, float, int])
+    def test_thin_copies_input(self, dtype):
+        """Thin mustn't modify the original input image."""
+        image = self.input_image.astype(dtype)
+        original = image.copy()
+        thin(image)
+        np.testing.assert_array_equal(image, original)
+
+    @pytest.mark.parametrize("dtype", [bool, float, int])
     def test_iter_1(self, dtype):
         image = self.input_image.astype(dtype)
         result = thin(image, 1).astype(bool)

--- a/skimage/morphology/tests/test_skeletonize.py
+++ b/skimage/morphology/tests/test_skeletonize.py
@@ -147,7 +147,7 @@ class TestThin:
 
     @pytest.mark.parametrize("dtype", [bool, float, int])
     def test_thin_copies_input(self, dtype):
-        """Thin mustn't modify the original input image."""
+        """Ensure thinning does not modify the input image."""
         image = self.input_image.astype(dtype)
         original = image.copy()
         thin(image)


### PR DESCRIPTION
## Description
Ensure `morphology.thin` doesn't change the original input array.
Bug fix: [7457](https://github.com/scikit-image/scikit-image/issues/7457).
<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
