### PR TITLE
Add CI to release nightly free-threaded wheels

### DIFF
--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -101,7 +101,7 @@ jobs:
           # CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
           CIBW_BEFORE_BUILD: "pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy scipy pywavelets"
           CIBW_BEFORE_TEST: "pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy scipy pywavelets"
-          CIBW_TEST_COMMAND: "PYTHON_GIL=0 $CIBW_TEST_COMMAND"
+          CIBW_TEST_COMMAND: "PYTHON_GIL=0 pytest --pyargs skimage"
       - uses: actions/upload-artifact@v3
         with:
           name: wheels

--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -64,6 +64,49 @@ jobs:
           name: wheels
           path: ./dist/*.whl
 
+  build_linux_free_threaded_wheels:
+    name: Build python ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        cibw_python: ["cp313t-*"]
+        cibw_manylinux: [manylinux2014]
+        cibw_arch: ["x86_64"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: "3.12"
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel
+      # TODO: Remove nightly wheel installation once the corresponding
+      # free-threaded dependencies wheels are available on PyPi
+      - name: Build the wheel
+        run: python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_PRERELEASE_PYTHONS: True
+          CIBW_FREE_THREADED_SUPPORT: True
+          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
+          CIBW_SKIP: "*-musllinux_*"
+          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
+          CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
+          CIBW_ENVIRONMENT_PASS_LINUX: SKIMAGE_LINK_FLAGS
+          SKIMAGE_LINK_FLAGS: "-Wl,--strip-debug"
+          CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+          CIBW_BEFORE_BUILD: "pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy scipy pywavelets"
+          CIBW_BEFORE_TEST: "pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy scipy pywavelets"
+          CIBW_TEST_COMMAND: "PYTHON_GIL=0 $CIBW_TEST_COMMAND"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: ./dist/*.whl
+
   build_linux_aarch64_wheels:
     name: Build python ${{ matrix.cibw_python }} aarch64 wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -98,7 +98,7 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_ENVIRONMENT_PASS_LINUX: SKIMAGE_LINK_FLAGS
           SKIMAGE_LINK_FLAGS: "-Wl,--strip-debug"
-          CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+          # CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
           CIBW_BEFORE_BUILD: "pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy scipy pywavelets"
           CIBW_BEFORE_TEST: "pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy scipy pywavelets"
           CIBW_TEST_COMMAND: "PYTHON_GIL=0 $CIBW_TEST_COMMAND"

--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cibw_python: ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
+        cibw_python: ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313t-*"]
         cibw_manylinux: [manylinux2014]
         cibw_arch: ["x86_64"]
     steps:
@@ -49,6 +49,17 @@ jobs:
           python-version: "3.12"
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
+      - name: Setup free-threaded environment
+        if: endsWith(matrix.cibw_python, 't-*')
+        run: |
+          ANACONDA_URL="https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
+          NIGHTLY_INSTALL="pip install --pre -i $ANACONDA_URL cython numpy scipy pywavelets"
+          TEST_COMMAND="PYTHON_GIL=0 pytest --pyargs skimage"
+          echo "CIBW_PRERELEASE_PYTHONS=1" >> "$GITHUB_ENV"
+          echo "CIBW_FREE_THREADED_SUPPORT=1" >> "$GITHUB_ENV"
+          echo "CIBW_BEFORE_BUILD=$NIGHTLY_INSTALL" >> "$GITHUB_ENV"
+          echo "CIBW_BEFORE_TEST=$NIGHTLY_INSTALL" >> "$GITHUB_ENV"
+          echo "CIBW_TEST_COMMAND=$TEST_COMMAND" >> "$GITHUB_ENV"
       - name: Build the wheel
         run: python -m cibuildwheel --output-dir dist
         env:
@@ -59,49 +70,6 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
           CIBW_ENVIRONMENT_PASS_LINUX: SKIMAGE_LINK_FLAGS
           SKIMAGE_LINK_FLAGS: "-Wl,--strip-debug"
-      - uses: actions/upload-artifact@v3
-        with:
-          name: wheels
-          path: ./dist/*.whl
-
-  build_linux_free_threaded_wheels:
-    name: Build python ${{ matrix.cibw_python }} ${{ matrix.cibw_arch }} wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        cibw_python: ["cp313t-*"]
-        cibw_manylinux: [manylinux2014]
-        cibw_arch: ["x86_64"]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v5
-        name: Install Python
-        with:
-          python-version: "3.12"
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel
-      # TODO: Remove nightly wheel installation once the corresponding
-      # free-threaded dependencies wheels are available on PyPi
-      - name: Build the wheel
-        run: python -m cibuildwheel --output-dir dist
-        env:
-          CIBW_PRERELEASE_PYTHONS: True
-          CIBW_FREE_THREADED_SUPPORT: True
-          CIBW_BUILD: ${{ matrix.cibw_python }}
-          CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
-          CIBW_SKIP: "*-musllinux_*"
-          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
-          CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
-          CIBW_ENVIRONMENT_PASS_LINUX: SKIMAGE_LINK_FLAGS
-          SKIMAGE_LINK_FLAGS: "-Wl,--strip-debug"
-          # CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
-          CIBW_BEFORE_BUILD: "pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy scipy pywavelets"
-          CIBW_BEFORE_TEST: "pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy scipy pywavelets"
-          CIBW_TEST_COMMAND: "PYTHON_GIL=0 pytest --pyargs skimage"
       - uses: actions/upload-artifact@v3
         with:
           name: wheels

--- a/skimage/segmentation/tests/test_clear_border.py
+++ b/skimage/segmentation/tests/test_clear_border.py
@@ -147,7 +147,7 @@ def test_clear_border_non_binary_out():
     image = np.array(
         [[1, 2, 3, 1, 2], [3, 3, 5, 4, 2], [3, 4, 5, 4, 2], [3, 3, 2, 1, 2]]
     )
-    out = np.empty_like(image)
+    out = image.copy()
     result = clear_border(image, out=out)
     expected = np.array(
         [[0, 0, 0, 0, 0], [0, 0, 5, 4, 0], [0, 4, 5, 4, 0], [0, 0, 0, 0, 0]]
@@ -165,7 +165,7 @@ def test_clear_border_non_binary_out_3d():
             [[1, 2, 3, 1, 2], [3, 3, 3, 4, 2], [3, 4, 3, 4, 2], [3, 3, 2, 1, 2]],
         ]
     )
-    out = np.empty_like(image3d)
+    out = image3d.copy()
 
     result = clear_border(image3d, out=out)
     expected = np.array(


### PR DESCRIPTION
## Description
See #7464

This PR serves as a followup to #7463, adding a separate workflow to produce, test and upload nightly wheels to the Scientific Python Anaconda channel. 

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
