### PR TITLE
FIX Use python3 in Meson version script shebang

### DIFF
--- a/skimage/_build_utils/version.py
+++ b/skimage/_build_utils/version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ Extract version number from __init__.py
 """
 


### PR DESCRIPTION
## Description

We did a similar change in scikit-learn recently, there are some environments where `python` does not exist and `python3` always seems to exist, numpy use `python3` in its Meson version script as well.

See https://github.com/scikit-learn/scikit-learn/pull/29415 for more details with some examples where `python` does not exist and some bug reports we had about this.

Context: I drew some inspiration from many projects meson.build files when I started to work on using Meson in scikit-learn and scikit-image was one of them. This was actually super helpful to have a project whose meson.build files were slightly easier to understand than numpy and scipy :pray:.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
