### PR TITLE
Fixup conda development installation instructions

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -279,7 +279,7 @@ before you get started.
   conda install -c conda-forge --file requirements/test.txt
   conda install -c conda-forge pre-commit
   # Install build dependencies of scikit-image
-  pip install -r requirements/build.txt
+  conda install -c conda-forge --file requirements/build.txt
   # Build scikit-image from source
   spin build
   # The new version lives under `${PWD}/build-install/.../site-packages`.

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -7,4 +7,4 @@ pillow>=9.1
 imageio>=2.33
 tifffile>=2022.8.12
 packaging>=21
-lazy-loader>=0.4
+lazy_loader>=0.4

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -7,4 +7,4 @@ pillow>=9.1
 imageio>=2.33
 tifffile>=2022.8.12
 packaging>=21
-lazy_loader>=0.4
+lazy-loader>=0.4


### PR DESCRIPTION
I believe that these two minor fixes should be worth our effort in order to maintain compatibility with conda.

The first seems to be a quirk of pip and pypi which alias underscores and dashes. This isn't true in conda(-forge) which requires two separate packages. We are attempting to address this at the conda-forge level: https://github.com/conda-forge/lazy_loader-feedstock/pull/11

The second one line change simply updates the command to use conda-forge for all build packages since they are now available there.

xref: https://github.com/scikit-image/scikit-image/pull/7373/files