### PR TITLE
Address autosummary.import_cycle warning

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -74,7 +74,7 @@ suppress_warnings = [
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 exclude_trees = []
-default_role = "autolink"
+default_role = "py:obj"
 pygments_style = "sphinx"
 
 # -- Sphinx-gallery configuration --------------------------------------------

--- a/doc/tools/apigen.py
+++ b/doc/tools/apigen.py
@@ -282,24 +282,23 @@ class ApiDocWriter:
         ad += title + '\n' + self.rst_section_levels[1] * len(title) + '\n\n'
 
         ad += '.. automodule:: ' + uri + '\n\n'
-        ad += '.. currentmodule:: ' + uri + '\n\n'
+        # ad += '.. currentmodule:: ' + uri + '\n\n'
         ad += '.. autosummary::\n   :nosignatures:\n\n'
         for f in functions:
-            ad += '   ' + uri + '.' + f + '\n'
+            ad += '   ' + f + '\n'
         ad += '\n'
         for c in classes:
-            ad += '   ' + uri + '.' + c + '\n'
+            ad += '   ' + c + '\n'
         ad += '\n'
         for m in submodules:
-            ad += '   ' + uri + '.' + m + '\n'
+            ad += '   ' + m + '\n'
         ad += '\n'
 
         for f in functions:
             ad += "------------\n\n"
             # must NOT exclude from index to keep cross-refs working
-            full_f = uri + '.' + f
-            ad += '\n.. autofunction:: ' + full_f + '\n\n'
-            ad += f'    .. minigallery:: {full_f}\n\n'
+            ad += '\n.. autofunction:: ' + f + '\n\n'
+            ad += f'    .. minigallery:: {f}\n\n'
         for c in classes:
             ad += '\n.. autoclass:: ' + c + '\n'
             # must NOT exclude from index to keep cross-refs working
@@ -311,8 +310,7 @@ class ApiDocWriter:
                 '\n'
                 '  .. automethod:: __init__\n\n'
             )
-            full_c = uri + '.' + c
-            ad += f'    .. minigallery:: {full_c}\n\n'
+            ad += f'    .. minigallery:: {c}\n\n'
         return ad
 
     def _survives_exclude(self, matchstr, match_type):


### PR DESCRIPTION
## Description

Tries to address https://github.com/scikit-image/scikit-image/issues/7485, at least temporarily. Will have to monitor https://github.com/sphinx-doc/sphinx/issues/12589 to judge how to properly fix this. In the meantime let's get our CI green again. 

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
