### PR TITLE
Improve robustness of _dynamic_max_trials used for ransac

### DIFF
--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -662,8 +662,8 @@ def _dynamic_max_trials(n_inliers, n_samples, min_samples, probability):
     if n_inliers == 0:
         return np.inf
     inlier_ratio = n_inliers / n_samples
-    nom = max(_EPSILON, 1 - probability)
-    denom = max(_EPSILON, 1 - inlier_ratio**min_samples)
+    nom = np.clip(1 - probability, _EPSILON, 1 - _EPSILON)
+    denom = np.clip(1 - inlier_ratio**min_samples, _EPSILON, 1 - _EPSILON)
     return np.ceil(np.log(nom) / np.log(denom))
 
 

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -599,6 +599,11 @@ def test_ransac_dynamic_max_trials():
     assert_equal(_dynamic_max_trials(1, 100, 5, 0), 0)
     assert_equal(_dynamic_max_trials(1, 100, 5, 1), 360436504051)
 
+    # Due to rounding errors, we can not properly compute the exact maximum number of trials for large number
+    # of minimum samples. It will be smaller than the actual value. From a practical point of view it does not
+    # matter because the number of trials are huge nevertheless.
+    assert_equal(_dynamic_max_trials(1, 100, 20, 1), 162326183972299296)
+
 
 def test_ransac_invalid_input():
     # `residual_threshold` must be greater than zero


### PR DESCRIPTION
## Description

The merge request https://github.com/scikit-image/scikit-image/pull/6046 changed the behavior of `_dynamic_max_trials` to give an actual estimate of the number of maximum trials for ransac instead of returning `np.inf`. For a larger number of `min_samples`, `ransac` only does two iterations because `_dynamic_max_trials` returns `-np.inf` due to rounding errors.

With an upgrade of scikit-image in an environment which is used by legacy code, one might not realize that regression right away because only a division by zero warning is giving but the fit is not as good as it is supposed to be.

## Code change in `_dynamic_max_trials`:

For a larger number of minimum samples the denominator is equal to one due to rounding errors which gives a logarithm of zero. Since the logarithm of the nominator is negative, we get as a return value -np.inf.

To prevent the rounding errors, limit the nominator to a number slightly smaller than one.

As a robustness measure, the nominator is also being clipped to make sure we always get a positive number for the maximum number of trials.
