### PR TITLE
Uncomment `currentmodule` directive again

### DIFF
--- a/doc/tools/apigen.py
+++ b/doc/tools/apigen.py
@@ -282,7 +282,7 @@ class ApiDocWriter:
         ad += title + '\n' + self.rst_section_levels[1] * len(title) + '\n\n'
 
         ad += '.. automodule:: ' + uri + '\n\n'
-        # ad += '.. currentmodule:: ' + uri + '\n\n'
+        ad += '.. currentmodule:: ' + uri + '\n\n'
         ad += '.. autosummary::\n   :nosignatures:\n\n'
         for f in functions:
             ad += '   ' + f + '\n'


### PR DESCRIPTION
## Description

This line was left commented as an oversight from debugging https://github.com/scikit-image/scikit-image/issues/7485 and https://github.com/scikit-image/scikit-image/pull/7486.

It didn't seem to cause any problems but let's put it back in to be safe. I'm a bit fuzzy on this because I can't find a good answer in Sphinx docs to how those two directives interact and why it seems to work with and without.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
