### PR TITLE
Temporarily exclude Dask 2024.8.0 to fix CI

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -11,6 +11,8 @@ Version 0.25
 * In `skimage/util/compare.py`, remove deprecated parameter `image2` as
   well as `test_compare_images_replaced_param` in `skimage/util/tests/test_compare.py`
   (and all `pytest.warns(FutureWarning)` context managers there).
+* Resolve temporary exclusion of Dask 2024.8.0 in optional dependencies, see
+  https://github.com/scikit-image/scikit-image/issues/7491 for details.
 
 Version 0.26
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ optional = [
     'SimpleITK',
     'astropy>=5.0',
     'cloudpickle>=0.2.1',  # necessary to provide the 'processes' scheduler for dask
-    'dask[array]>=2021.1.0',
+    'dask[array]>=2021.1.0,!=2024.8.0',
     'matplotlib>=3.6',
     'pooch>=1.6.0',
     'pyamg',

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -3,7 +3,7 @@
 SimpleITK
 astropy>=5.0
 cloudpickle>=0.2.1
-dask[array]>=2021.1.0
+dask[array]>=2021.1.0,!=2024.8.0
 matplotlib>=3.6
 pooch>=1.6.0
 pyamg


### PR DESCRIPTION
## Description

while investigation is ongoing. See https://github.com/scikit-image/scikit-image/issues/7491 for more details and context.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
