### PR TITLE
Remove unused and deprecated dependency pytest-runner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ docs = [
     'sphinx-gallery>=0.14',
     'numpydoc>=1.7',
     'sphinx-copybutton',
-    'pytest-runner',
     'matplotlib>=3.6',
     'dask[array]>=2022.9.2',
     'pandas>=1.5',

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,7 +4,6 @@ sphinx>=7.3
 sphinx-gallery>=0.14
 numpydoc>=1.7
 sphinx-copybutton
-pytest-runner
 matplotlib>=3.6
 dask[array]>=2022.9.2
 pandas>=1.5


### PR DESCRIPTION
## Description

Closes https://github.com/scikit-image/scikit-image/issues/7494.

Tidelift let us know that the project is archived / deprecated. From the project description it seems related to setup.py and setuptools shenanigans, both of which we no longer use. I'm guessing that it's safe to remove now.


## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
