### PR TITLE
Fix dynamic max trials of RANSAC (follow up)

### DIFF
--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -662,9 +662,12 @@ def _dynamic_max_trials(n_inliers, n_samples, min_samples, probability):
     if n_inliers == 0:
         return np.inf
     inlier_ratio = n_inliers / n_samples
-    nom = max(_EPSILON, 1 - probability)
+    nom = 1 - probability
     denom = 1 - inlier_ratio**min_samples
-    # Avoid log(1) below turning into -inf
+    # Keep (de-)nominator in the range of [_EPSILON, 1 - _EPSILON] so that
+    # it is always guaranteed that the logarithm is negative and we return
+    # a positive number of trials.
+    nom = np.clip(nom, a_min=_EPSILON, a_max=1 - _EPSILON)
     denom = np.clip(denom, a_min=_EPSILON, a_max=1 - _EPSILON)
     return np.ceil(np.log(nom) / np.log(denom))
 

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -600,8 +600,8 @@ def test_ransac_dynamic_max_trials():
     assert_equal(_dynamic_max_trials(1, 100, 5, 1), 360436504051)
 
 
-def test_ransac_dynamic_max_trials_denom_nearly_1():
-    """Test that the function behaves well when `denom` becomes almost 1.0."""
+def test_ransac_dynamic_max_trials_clipping():
+    """Test that the function behaves well when `nom` or `denom` become almost 1.0."""
     # e = 0%, min_samples = 10
     # Ensure that (1 - inlier_ratio ** min_samples) approx 1 does not fail.
     assert_equal(_dynamic_max_trials(1, 100, 10, 0), 0)
@@ -610,6 +610,10 @@ def test_ransac_dynamic_max_trials_denom_nearly_1():
     desired = np.ceil(np.log(EPSILON) / np.log(1 - EPSILON))
     assert desired > 0
     assert_equal(_dynamic_max_trials(1, 100, 1000, 1), desired)
+
+    # Ensure that (1 - probability) approx 1 does not fail.
+    assert_equal(_dynamic_max_trials(1, 100, 10, 1e-40), 1)
+    assert_equal(_dynamic_max_trials(1, 100, 1000, 1e-40), 1)
 
 
 def test_ransac_invalid_input():


### PR DESCRIPTION
Follow up of https://github.com/scikit-image/scikit-image/pull/7065, to limit the nominator for extremely small probabilities for `_dynamic_max_trials`.

## Release note
```
Fix numerical precision error in RANSAC. Very small probabilities lead to -0 number of max trials.
```