### PR TITLE
Bump spin version to 0.11

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -8,5 +8,5 @@ ninja
 Cython>=3.0.4
 pythran
 numpy>=2.0.0
-spin==0.10
+spin==0.11
 build

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -8,5 +8,5 @@ ninja
 Cython>=3.0.4
 pythran
 numpy>=2.0.0
-spin==0.8
+spin==0.10
 build


### PR DESCRIPTION
## Description

@stefanv ok, we want to pin a specific version so we don't run into any surprise. The latest version is 0.11 (https://pypi.org/project/spin/#history) so pinning 0.10 seems conservative enough.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
