### PR TITLE
Ensure only a single label is present

### DIFF
--- a/.github/workflows/label-check.yaml
+++ b/.github/workflows/label-check.yaml
@@ -4,18 +4,22 @@ on:
   pull_request:
     types:
       - opened
-      - repoened
+      - reopened
       - labeled
       - unlabeled
       - synchronize
 
 env:
-  LABELS: ${{ join( github.event.pull_request.labels.*.name, ' ' ) }}
+  LABELS: ${{ toJSON(github.event.pull_request.labels) }}
 
 jobs:
   check-type-label:
     name: ensure type label
     runs-on: ubuntu-latest
     steps:
-      - if: "contains( env.LABELS, 'type: ' ) == false"
-        run: exit 1
+      - name: Ensure single label
+        run: |
+          N=$(echo $LABELS | jq 'map( select (.name | contains("type:"))) | length')
+          if [[ $N != 1 ]]; then
+            exit 1
+          fi


### PR DESCRIPTION
Having multiple `type: *` labels on a PR make its changes appear under multiple changelist categories. This updates the label check to ensure that exactly one label is specified.

If multiple entries are desired, changelist still allows for that, by editing the PR description:

````
```release-note {label="Bug fix"}
Make `is_odd()` work for negative numbers.
```

```release-note {label="Maintenance"}
Deprecate `ìs_odd`; use `not (x % 2)` instead! {label="API, Highlight"}
```
````