### PR TITLE
Say `spin test --coverage`, not `spin coverage`

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -296,9 +296,9 @@ i.e., statement coverage should be at 100%.
 
 To measure test coverage run::
 
-  $ spin coverage
+  $ spin test --coverage
 
-This will print a report with one line for each file in `skimage`,
+This will run tests and print a report with one line for each file in `skimage`,
 detailing the test coverage::
 
   Name                                             Stmts   Exec  Cover   Missing


### PR DESCRIPTION
## Description

The contributor guide still said `spin coverage`, which was remove in #7168, which recommends `spin test --coverage` instead.

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
