### PR TITLE
Added fset validator to `keypoints` in `skimage.feature.SIFT`

### DIFF
--- a/skimage/feature/sift.py
+++ b/skimage/feature/sift.py
@@ -701,6 +701,16 @@ class SIFT(FeatureDetector, DescriptorExtractor):
         self._set_number_of_octaves(image.shape)
         return image
 
+    @property
+    def keypoints(self):
+        return self.keypoints
+
+    @keypoints.setter
+    def keypoints(self, value):
+        if not (isinstance(value, np.ndarray) and value.ndim == 2 and value.shape[1] == 2):
+            raise ValueError("Keypoints must be a numpy array of int64 type with shape Nx2.")
+        self.keypoints = value
+
     def detect(self, image):
         """Detect the keypoints.
 


### PR DESCRIPTION
## Description

Closes #7526 

As discussed in the issue, I’ve implemented an fset validator for `keypoints` with correctness checks for robustness.

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
