### PR TITLE
SSIM Modifications - Documentation Transparency and Return Consistency

### DIFF
--- a/skimage/metrics/_structural_similarity.py
+++ b/skimage/metrics/_structural_similarity.py
@@ -268,11 +268,8 @@ def structural_similarity(
     D = B1 * B2
     S = (A1 * A2) / D
 
-    # to avoid edge effects will ignore filter radius strip around edges
-    pad = (win_size - 1) // 2
-
     # compute (weighted) mean of ssim. Use float64 for accuracy.
-    mssim = crop(S, pad).mean(dtype=np.float64)
+    mssim = S.mean(dtype=np.float64)
 
     if gradient:
         # The following is Eqs. 7-8 of Avanaki 2009.

--- a/skimage/metrics/_structural_similarity.py
+++ b/skimage/metrics/_structural_similarity.py
@@ -27,8 +27,6 @@ def structural_similarity(
 ):
     """
     Compute the mean structural similarity index between two images.
-    Images are reflection-padded, with size dependent on the window size, such that
-    the resulting SSIM image is the same shape as the input images.
     Please pay attention to the `data_range` parameter with floating-point images.
 
     Parameters

--- a/skimage/metrics/_structural_similarity.py
+++ b/skimage/metrics/_structural_similarity.py
@@ -26,6 +26,8 @@ def structural_similarity(
 ):
     """
     Compute the mean structural similarity index between two images.
+    Images are reflection-padded, with size dependent on the window size, such that
+    the resulting SSIM image is the same shape as the input images.
     Please pay attention to the `data_range` parameter with floating-point images.
 
     Parameters
@@ -72,7 +74,7 @@ def structural_similarity(
     Returns
     -------
     mssim : float
-        The mean structural similarity index over the image.
+        The mean structural similarity index over the SSIM image.
     grad : ndarray
         The gradient of the structural similarity between im1 and im2 [2]_.
         This is only returned if `gradient` is set to True.

--- a/skimage/metrics/tests/test_structural_similarity.py
+++ b/skimage/metrics/tests/test_structural_similarity.py
@@ -39,9 +39,9 @@ def test_structural_similarity_image():
     S2 = structural_similarity(X, Y, win_size=11, gaussian_weights=True)
     assert S2 < 0.3
 
-    mssim0, S3 = structural_similarity(X, Y, full=True)
+    mssim0, S3 = structural_similarity(X, Y, padding_mode='reflect', full=True)
     assert_equal(S3.shape, X.shape)
-    mssim = structural_similarity(X, Y)
+    mssim = structural_similarity(X, Y, padding_mode='reflect')
     assert_equal(mssim0, mssim)
 
     # structural_similarity of image with itself should be 1.0
@@ -121,16 +121,25 @@ def test_structural_similarity_multichannel(channel_axis):
     assert_almost_equal(S1, S2)
 
     # full case should return an image as well
-    m, S3 = structural_similarity(Xc, Yc, channel_axis=channel_axis, full=True)
+    m, S3 = structural_similarity(
+        Xc, Yc, padding_mode='reflect', channel_axis=channel_axis, full=True
+    )
     assert_equal(S3.shape, Xc.shape)
 
     # gradient case
-    m, grad = structural_similarity(Xc, Yc, channel_axis=channel_axis, gradient=True)
+    m, grad = structural_similarity(
+        Xc, Yc, padding_mode='reflect', channel_axis=channel_axis, gradient=True
+    )
     assert_equal(grad.shape, Xc.shape)
 
     # full and gradient case
     m, grad, S3 = structural_similarity(
-        Xc, Yc, channel_axis=channel_axis, full=True, gradient=True
+        Xc,
+        Yc,
+        padding_mode='reflect',
+        channel_axis=channel_axis,
+        full=True,
+        gradient=True,
     )
     assert_equal(grad.shape, Xc.shape)
     assert_equal(S3.shape, Xc.shape)

--- a/skimage/metrics/tests/test_structural_similarity.py
+++ b/skimage/metrics/tests/test_structural_similarity.py
@@ -39,9 +39,9 @@ def test_structural_similarity_image():
     S2 = structural_similarity(X, Y, win_size=11, gaussian_weights=True)
     assert S2 < 0.3
 
-    mssim0, S3 = structural_similarity(X, Y, padding_mode='reflect', full=True)
+    mssim0, S3 = structural_similarity(X, Y, full=True)
     assert_equal(S3.shape, X.shape)
-    mssim = structural_similarity(X, Y, padding_mode='reflect')
+    mssim = structural_similarity(X, Y)
     assert_equal(mssim0, mssim)
 
     # structural_similarity of image with itself should be 1.0
@@ -121,25 +121,16 @@ def test_structural_similarity_multichannel(channel_axis):
     assert_almost_equal(S1, S2)
 
     # full case should return an image as well
-    m, S3 = structural_similarity(
-        Xc, Yc, padding_mode='reflect', channel_axis=channel_axis, full=True
-    )
+    m, S3 = structural_similarity(Xc, Yc, channel_axis=channel_axis, full=True)
     assert_equal(S3.shape, Xc.shape)
 
     # gradient case
-    m, grad = structural_similarity(
-        Xc, Yc, padding_mode='reflect', channel_axis=channel_axis, gradient=True
-    )
+    m, grad = structural_similarity(Xc, Yc, channel_axis=channel_axis, gradient=True)
     assert_equal(grad.shape, Xc.shape)
 
     # full and gradient case
     m, grad, S3 = structural_similarity(
-        Xc,
-        Yc,
-        padding_mode='reflect',
-        channel_axis=channel_axis,
-        full=True,
-        gradient=True,
+        Xc, Yc, channel_axis=channel_axis, full=True, gradient=True
     )
     assert_equal(grad.shape, Xc.shape)
     assert_equal(S3.shape, Xc.shape)


### PR DESCRIPTION
## Description

Currently there is implicit internal reflection padding applied to images in computation of the full SSIM matrix, which is ignored via cropping in the computation of the returned mean. This PR addresses these issues by adding transparency about the padding in the docstring, and ensuring the mean returned is that of the full SSIM image.