### PR TITLE
Render paragraphs in dormant message

### DIFF
--- a/.github/workflows/dormant_issues_prs.yml
+++ b/.github/workflows/dormant_issues_prs.yml
@@ -20,16 +20,20 @@ jobs:
           stale-issue-label: ":sleeping: Dormant"
           stale-pr-label: ":sleeping: Dormant"
           remove-stale-when-updated: true
+          # Keep paragraphs rendered properly in GitHub's UI
+          # by using two blank lines to delimit paragraphs
           stale-issue-message: >
             Hello scikit-image core devs! There hasn't been any activity on
             this issue for more than 180 days. I have marked it as "dormant" to
             make it easy to find.
+
 
             To our contributors, thank you for your contribution and apologies
             if this issue fell through the cracks! Hopefully this ping will
             help bring some fresh attention to the issue. If you need help, you
             can always reach out on our
             [forum](https://discuss.scientific-python.org/c/contributor/skimage/22)
+
 
             If you think that this issue is no longer relevant, you may close
             it, or we may do it at some point (either way, it will be done
@@ -40,11 +44,13 @@ jobs:
             this PR for more than 180 days. I have marked it as "dormant" to
             make it easy to find.
 
+
             To our contributors, thank you for your contribution and apologies
             if this contribution fell through the cracks! Hopefully this ping
             will help bring some fresh attention to the review. If you need
             help, you can always reach out on our
             [forum](https://discuss.scientific-python.org/c/contributor/skimage/22)
+
 
             If you think that this PR is no longer relevant, you may close
             it, or we may do it at some point (either way, it will be done


### PR DESCRIPTION
## Description

Minor annoyance fix. By using two blank lines to delimit paragraphs, the paragraphs should stay preserved.

```python
import yaml  # pyyaml

raw = """
stale-issue-message: >
  First paragraph
  over two lines.


  Second paragraph
  over two lines
"""
yaml.safe_load(raw)
```
```
{'stale-issue-message': 'First paragraph over two lines.\n\nSecond paragraph over two lines\n'}
```
Compare with how the [bots current comments ](https://github.com/scikit-image/scikit-image/pull/6929).

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
