### PR TITLE
Account for empty arrays when counting segments per contour level.

### DIFF
--- a/doc/examples/applications/plot_human_mitosis.py
+++ b/doc/examples/applications/plot_human_mitosis.py
@@ -53,7 +53,7 @@ qcs.levels
 #####################################################################
 # Each level has, respectively, the following number of segments:
 
-[len(seg) for seg in qcs.allsegs]
+[len(seg) if seg[0].shape[0] > 1 else 0 for seg in qcs.allsegs]
 
 #####################################################################
 # Estimate the mitotic index

--- a/doc/examples/applications/plot_human_mitosis.py
+++ b/doc/examples/applications/plot_human_mitosis.py
@@ -53,7 +53,8 @@ qcs.levels
 #####################################################################
 # Each level has, respectively, the following number of segments:
 
-[len(seg) if seg[0].shape[0] > 1 else 0 for seg in qcs.allsegs]
+# Levels without segments still contain one empty array, account for that
+[len(seg) if seg[0].size else 0 for seg in qcs.allsegs]
 
 #####################################################################
 # Estimate the mitotic index


### PR DESCRIPTION
## Description

Closes #7361

```py
qcs.allsegs[0][0].shape
# (0, 2)
```

As can be seen above and at https://github.com/scikit-image/scikit-image/issues/7361#issuecomment-2373537797, even when there is no segment, the current behaviour of `qcs.allsegs` is to populate a list of length 1 with an empty array. With this change, we just check for this, and overwrite length 1 with 0.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
