### PR TITLE
Preserve value of deprecated parameters without replacement

### DIFF
--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -321,13 +321,13 @@ class Test_deprecate_parameter:
             r"in 0\.12.* see the documentation of .*_func_deprecated_params`."
         )
         with pytest.warns(FutureWarning, match=match):
-            assert _func_deprecated_params(1, 2) == (1, DEPRECATED, DEPRECATED, None)
+            assert _func_deprecated_params(1, 2) == (1, 2, DEPRECATED, None)
         with pytest.warns(FutureWarning, match=match):
-            assert _func_deprecated_params(1, 2, 3) == (1, DEPRECATED, DEPRECATED, None)
+            assert _func_deprecated_params(1, 2, 3) == (1, 2, 3, None)
         with pytest.warns(FutureWarning, match=match):
             assert _func_deprecated_params(1, old0=2) == (
                 1,
-                DEPRECATED,
+                2,
                 DEPRECATED,
                 None,
             )
@@ -335,7 +335,7 @@ class Test_deprecate_parameter:
             assert _func_deprecated_params(1, old1=2) == (
                 1,
                 DEPRECATED,
-                DEPRECATED,
+                2,
                 None,
             )
 

--- a/skimage/_shared/utils.py
+++ b/skimage/_shared/utils.py
@@ -286,12 +286,19 @@ class deprecate_parameter:
             # Extract value of deprecated parameter
             if len(args) > deprecated_idx:
                 deprecated_value = args[deprecated_idx]
-                args = (
-                    args[:deprecated_idx] + (DEPRECATED,) + args[deprecated_idx + 1 :]
-                )
+                # Overwrite old with DEPRECATED if replacement exists
+                if self.new_name is not None:
+                    args = (
+                        args[:deprecated_idx]
+                        + (DEPRECATED,)
+                        + args[deprecated_idx + 1 :]
+                    )
             if self.deprecated_name in kwargs.keys():
                 deprecated_value = kwargs[self.deprecated_name]
-                kwargs[self.deprecated_name] = DEPRECATED
+                # Overwrite old with DEPRECATED if replacement exists
+                if self.new_name is not None:
+                    kwargs[self.deprecated_name] = DEPRECATED
+
             # Extract value of new parameter (if present)
             if new_idx is not False and len(args) > new_idx:
                 new_value = args[new_idx]


### PR DESCRIPTION
## Description

Even if a parameter is deprecated, a value passed to it must be preserved during the deprecation cycle! Othwerwise, we effectively remove the deprecated behavior before the cycle is complete.

This is only relevant if there's no replacement for the deprecated parameter. In that case, the given value preserved and passed to the replacing parameter, and the deprecated one can be overwritten with `DEPRECATED`.

E.g.
```python
from skimage._shared.utils import deprecate_parameter, DEPRECATED

@deprecate_parameter("a", start_version="X", stop_version="X+2")
def foo(a=DEPRECATED):
    if a is True:
        print("Can still use deprecated behavior!")

foo(True)
```
should warn **and** print but only warns on `main` because it silently replaces with `DEPRECATED`.

Thankfully, it doesn't look like we are currently using the decorator in a way that is affected by this bug. Discovered while preparing #7353.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
During deprecation cycles, preserve the value of deprecated parameters
that don't have a new parameter as a replacement.
```
