### PR TITLE
Don't use deprecated `io.show` and `io.imshow`

### DIFF
--- a/doc/examples/segmentation/plot_rag_boundary.py
+++ b/doc/examples/segmentation/plot_rag_boundary.py
@@ -13,7 +13,7 @@ between two regions is the average value of the corresponding pixels in
 """
 
 from skimage import graph
-from skimage import data, segmentation, color, filters, io
+from skimage import data, segmentation, color, filters
 from matplotlib import pyplot as plt
 
 
@@ -30,4 +30,4 @@ lc = graph.show_rag(
 )
 
 plt.colorbar(lc, fraction=0.03)
-io.show()
+plt.show()

--- a/doc/examples/segmentation/plot_rag_merge.py
+++ b/doc/examples/segmentation/plot_rag_merge.py
@@ -10,9 +10,10 @@ until no highly similar region pairs remain.
 
 """
 
-from skimage import data, io, segmentation, color
+from skimage import data, segmentation, color
 from skimage import graph
 import numpy as np
+import matplotlib.pyplot as plt
 
 
 def _weight_mean_color(graph, src, dst, n):
@@ -76,5 +77,8 @@ labels2 = graph.merge_hierarchical(
 
 out = color.label2rgb(labels2, img, kind='avg', bg_label=0)
 out = segmentation.mark_boundaries(out, labels2, (0, 0, 0))
-io.imshow(out)
-io.show()
+
+fig, ax = plt.subplots()
+ax.imshow(out)
+plt.tight_layout()
+plt.show()

--- a/skimage/filters/_gabor.py
+++ b/skimage/filters/_gabor.py
@@ -69,20 +69,19 @@ def gabor_kernel(
     Examples
     --------
     >>> from skimage.filters import gabor_kernel
-    >>> from skimage import io
     >>> from matplotlib import pyplot as plt  # doctest: +SKIP
 
     >>> gk = gabor_kernel(frequency=0.2)
-    >>> plt.figure()        # doctest: +SKIP
-    >>> io.imshow(gk.real)  # doctest: +SKIP
-    >>> io.show()           # doctest: +SKIP
+    >>> fig, ax = plt.subplots()  # doctest: +SKIP
+    >>> ax.imshow(gk.real)        # doctest: +SKIP
+    >>> plt.show()                # doctest: +SKIP
 
     >>> # more ripples (equivalent to increasing the size of the
     >>> # Gaussian spread)
     >>> gk = gabor_kernel(frequency=0.2, bandwidth=0.1)
-    >>> plt.figure()        # doctest: +SKIP
-    >>> io.imshow(gk.real)  # doctest: +SKIP
-    >>> io.show()           # doctest: +SKIP
+    >>> fig, ax = plt.suplots()  # doctest: +SKIP
+    >>> ax.imshow(gk.real)       # doctest: +SKIP
+    >>> plt.show()               # doctest: +SKIP
     """
     if sigma_x is None:
         sigma_x = _sigma_prefactor(bandwidth) / frequency
@@ -179,21 +178,21 @@ def gabor(
     Examples
     --------
     >>> from skimage.filters import gabor
-    >>> from skimage import data, io
+    >>> from skimage import data
     >>> from matplotlib import pyplot as plt  # doctest: +SKIP
 
     >>> image = data.coins()
     >>> # detecting edges in a coin image
     >>> filt_real, filt_imag = gabor(image, frequency=0.6)
-    >>> plt.figure()            # doctest: +SKIP
-    >>> io.imshow(filt_real)    # doctest: +SKIP
-    >>> io.show()               # doctest: +SKIP
+    >>> fix, ax = plt.subplots()  # doctest: +SKIP
+    >>> ax.imshow(filt_real)      # doctest: +SKIP
+    >>> plt.show()                # doctest: +SKIP
 
     >>> # less sensitivity to finer details with the lower frequency kernel
     >>> filt_real, filt_imag = gabor(image, frequency=0.1)
-    >>> plt.figure()            # doctest: +SKIP
-    >>> io.imshow(filt_real)    # doctest: +SKIP
-    >>> io.show()               # doctest: +SKIP
+    >>> fig, ax = plt.subplots()  # doctest: +SKIP
+    >>> ax.imshow(filt_real)      # doctest: +SKIP
+    >>> plt.show()                # doctest: +SKIP
     """
     check_nD(image, 2)
     # do not cast integer types to float!

--- a/skimage/future/manual_segmentation.py
+++ b/skimage/future/manual_segmentation.py
@@ -60,11 +60,13 @@ def manual_polygon_segmentation(image, alpha=0.4, return_all=False):
 
     Examples
     --------
-    >>> from skimage import data, future, io
+    >>> from skimage import data, future
+    >>> import matplotlib.pyplot as plt  # doctest: +SKIP
     >>> camera = data.camera()
     >>> mask = future.manual_polygon_segmentation(camera)  # doctest: +SKIP
-    >>> io.imshow(mask)  # doctest: +SKIP
-    >>> io.show()  # doctest: +SKIP
+    >>> fig, ax = plt.subplots()  # doctest: +SKIP
+    >>> ax.imshow(mask)           # doctest: +SKIP
+    >>> plt.show()                # doctest: +SKIP
     """
     import matplotlib
     import matplotlib.pyplot as plt
@@ -176,11 +178,13 @@ def manual_lasso_segmentation(image, alpha=0.4, return_all=False):
 
     Examples
     --------
-    >>> from skimage import data, future, io
+    >>> from skimage import data, future
+    >>> import matplotlib.pyplot as plt  # doctest: +SKIP
     >>> camera = data.camera()
     >>> mask = future.manual_lasso_segmentation(camera)  # doctest: +SKIP
-    >>> io.imshow(mask)  # doctest: +SKIP
-    >>> io.show()  # doctest: +SKIP
+    >>> fig, ax = plt.subplots()  # doctest: +SKIP
+    >>> ax.imshow(mask)           # doctest: +SKIP
+    >>> plt.show()                # doctest: +SKIP
     """
     import matplotlib
     import matplotlib.pyplot as plt


### PR DESCRIPTION
## Description

These were deprecated in https://github.com/scikit-image/scikit-image/pull/7508 / https://github.com/scikit-image/scikit-image/commit/765577ce288c44dcefdcf10712e6352a2632cade.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
