### PR TITLE
Hide traceback inside `assert_stacklevel`

### DIFF
--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -260,7 +260,7 @@ def assert_stacklevel(warnings, *, offset=-1):
     When scikit-image raises warnings, the stacklevel should ideally be set
     so that the origin of the warnings will point to the public function
     that was called by the user and not necessarily the very place where the
-    warnings were emitted (which may be inside of some internal function).
+    warnings were emitted (which may be inside some internal function).
     This utility function helps with checking that
     the stacklevel was set correctly on warnings captured by `pytest.warns`.
 
@@ -294,10 +294,18 @@ def assert_stacklevel(warnings, *, offset=-1):
     ...         )
     ...     assert_stacklevel(record, offset=-3)
     """
+    __tracebackhide__ = True  # Hide traceback for py.test
+
     frame = inspect.stack()[1].frame  # 0 is current frame, 1 is outer frame
     line_number = frame.f_lineno + offset
     filename = frame.f_code.co_filename
     expected = f"{filename}:{line_number}"
     for warning in warnings:
         actual = f"{warning.filename}:{warning.lineno}"
-        assert actual == expected, f"{actual} != {expected}"
+        msg = (
+            "Warning with wrong stacklevel:\n"
+            f"  Expected: {expected}\n"
+            f"  Actual: {actual}\n"
+            f"  {warning.category.__name__}: {warning.message}"
+        )
+        assert actual == expected, msg

--- a/skimage/_shared/tests/test_testing.py
+++ b/skimage/_shared/tests/test_testing.py
@@ -150,6 +150,6 @@ class Test_assert_stacklevel:
             self.raise_warning("wrong", UserWarning, stacklevel=level)
         # Check that message contains expected line on right side
         line_number = inspect.currentframe().f_lineno - 2
-        regex = ".*" + re.escape(f"!= {__file__}:{line_number}")
+        regex = ".*" + re.escape(f"Expected: {__file__}:{line_number}")
         with pytest.raises(AssertionError, match=regex):
             assert_stacklevel(record, offset=-5)


### PR DESCRIPTION
## Description

and include the actual warning text in the error message. This helps debug cases where unexpected and unrelated warnings trigger `assert_stacklevel`.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
