### PR TITLE
Fix missing minigalleries by using full names in directives

### DIFF
--- a/doc/tools/apigen.py
+++ b/doc/tools/apigen.py
@@ -298,7 +298,7 @@ class ApiDocWriter:
             ad += "------------\n\n"
             # must NOT exclude from index to keep cross-refs working
             ad += '\n.. autofunction:: ' + f + '\n\n'
-            ad += f'    .. minigallery:: {f}\n\n'
+            ad += f'    .. minigallery:: {uri}.{f}\n\n'
         for c in classes:
             ad += '\n.. autoclass:: ' + c + '\n'
             # must NOT exclude from index to keep cross-refs working
@@ -310,7 +310,7 @@ class ApiDocWriter:
                 '\n'
                 '  .. automethod:: __init__\n\n'
             )
-            ad += f'    .. minigallery:: {c}\n\n'
+            ad += f'    .. minigallery:: {uri}.{c}\n\n'
         return ad
 
     def _survives_exclude(self, matchstr, match_type):


### PR DESCRIPTION
## Description

Fixes #7543. Apparently, the minigallery directive ignores the currentmodule directive that sets a module context. To reference the appropriate minigallery object and for it to appear, we need the full string.

I believe this was broken (by me) in https://github.com/scikit-image/scikit-image/pull/7486. 

We probably want to include this in the 0.25 release.

cc @jarrodmillman, @stefanv

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
