### PR TITLE
Ensure that `RegionProperties` can be deserialized with pickle

### DIFF
--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -366,6 +366,14 @@ class RegionProperties:
             self._extra_properties = {func.__name__: func for func in extra_properties}
 
     def __getattr__(self, attr):
+        if attr == "__setstate__":
+            # When deserializing this object with pickle, `__setstate__`
+            # is accessed before any other attributes like `self._intensity_image`
+            # are available which leads to a RecursionError when trying to
+            # access them later on in this function. So guard against this by
+            # provoking the default AttributeError (gh-6465).
+            return self.__getattribute__(attr)
+
         if self._intensity_image is None and attr in _require_intensity_image:
             raise AttributeError(
                 f"Attribute '{attr}' unavailable when `intensity_image` "

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -1,4 +1,5 @@
 import math
+import pickle
 
 import re
 import numpy as np
@@ -1534,3 +1535,18 @@ def test_3d_ellipsoid_axis_lengths():
     # verify that the axis length regionprops also agree
     assert abs(rp.axis_major_length - axis_lengths[0]) < 1e-7
     assert abs(rp.axis_minor_length - axis_lengths[-1]) < 1e-7
+
+
+def test_pickling_region_properties():
+    # Check that RegionProperties can be pickled & unpickled (gh-6465)
+
+    # Prepare RegionProperties object
+    label_image = np.zeros((10, 10), dtype=int)
+    label_image[:, 0:5] = 1
+    regions = regionprops(label_image)
+    assert len(regions) == 1
+
+    #pickle and unpickle
+    pickled = pickle.dumps(regions[0])
+    unpickled = pickle.loads(pickled) #RecursionError here
+    assert regions[0] == unpickled


### PR DESCRIPTION
## Description

Fixes #6465. When deserializing a RegionProperties object with pickle, [`__setstate__`](https://docs.python.org/3/library/pickle.html#object.__setstate__) is accessed before any other attributes are available. This leads to a RecursionError in `__getattr__` which doesn't account for this and tries to call attributes such as `self._intensity_image`. We can guard against this in multiple ways. I chose a very specific one in this case which makes sure that the default AttributeError is provoked.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Ensure that `RegionProperties` objects returned by `skimage.measure.regionprops`
can be deserialized with pickle.
```
