### PR TITLE
Build Python 3.13 wheels

### DIFF
--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -17,6 +17,8 @@ permissions:
 jobs:
   call-workflow-build-wheels:
     uses: ./.github/workflows/wheels_recipe.yml
+    with:
+      CIBW_SKIP: cp313t-* # until Cython 3.1 is released
 
   deploy:
     name: Release

--- a/.github/workflows/wheel_tests_and_release.yml
+++ b/.github/workflows/wheel_tests_and_release.yml
@@ -17,8 +17,6 @@ permissions:
 jobs:
   call-workflow-build-wheels:
     uses: ./.github/workflows/wheels_recipe.yml
-    with:
-      CIBW_SKIP: cp313t-* # until Cython 3.1 is released
 
   deploy:
     name: Release

--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cibw_python: ["cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp313t-*"]
+        cibw_python: ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]
         cibw_manylinux: [manylinux2014]
         cibw_arch: ["x86_64"]
     steps:

--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cibw_python: ["cp310-*", "cp311-*", "cp312-*", "cp313t-*"]
+        cibw_python: ["cp310-*", "cp311-*", "cp312-*", "cp313-*", "cp313t-*"]
         cibw_manylinux: [manylinux2014]
         cibw_arch: ["x86_64"]
     steps:
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cibw_python: ["cp310-*", "cp311-*", "cp312-*"]
+        cibw_python: ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]
         cibw_manylinux: [manylinux2014]
         cibw_arch: ["aarch64"]
     steps:
@@ -123,7 +123,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-12]
-        cibw_python: ["cp310-*", "cp311-*", "cp312-*"]
+        cibw_python: ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]
         # TODO: add "universal2" once a universal2 libomp is available
         cibw_arch: ["x86_64", "arm64"]
 
@@ -202,7 +202,7 @@ jobs:
       matrix:
         os: [windows-latest]
         cibw_arch: ["AMD64"]
-        cibw_python: ["cp310-*", "cp311-*", "cp312-*"]
+        cibw_python: ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Building cp313t wheels requires Cython 3.1, which hasn't been released. I will make open a new PR after this is merged to build cp313t wheels.