### PR TITLE
Remove deprecated gaussian output parameter

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -13,10 +13,6 @@ Version 0.25
 ------------
 * Remove deprecated `skimage.morphology._skeletonize.skeletonize_3d` and
   tests related to that deprecation.
-* Remove traces of deprecated `output` parameter in `skimage.filters.gaussian`
-  and remove `test_gaussian.py::test_deprecated_gaussian_output`.
-  Make arguments after the deprecated `output` parameter, keyword only:
-  `gaussian(image, sigma, *, ...)`.
 * In `skimage/util/compare.py`, remove deprecated parameter `image2` as
   well as `test_compare_images_replaced_param` in `skimage/util/tests/test_compare.py`
   (and all `pytest.warns(FutureWarning)` context managers there).

--- a/skimage/_shared/filters.py
+++ b/skimage/_shared/filters.py
@@ -13,23 +13,17 @@ from scipy import ndimage as ndi
 from .._shared.utils import (
     _supported_float_type,
     convert_to_float,
-    deprecate_parameter,
-    DEPRECATED,
 )
 
 
-@deprecate_parameter(
-    "output", new_name="out", start_version="0.23", stop_version="0.25"
-)
 def gaussian(
     image,
     sigma=1,
-    output=DEPRECATED,
+    *,
     mode='nearest',
     cval=0,
     preserve_range=False,
     truncate=4.0,
-    *,
     channel_axis=None,
     out=None,
 ):

--- a/skimage/filters/tests/test_gaussian.py
+++ b/skimage/filters/tests/test_gaussian.py
@@ -3,7 +3,6 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from skimage._shared.utils import _supported_float_type
-from skimage._shared.testing import assert_stacklevel
 from skimage.filters import difference_of_gaussians, gaussian
 
 
@@ -165,13 +164,3 @@ def test_dog_invalid_sigma2():
         difference_of_gaussians(image, 3, 2)
     with pytest.raises(ValueError):
         difference_of_gaussians(image, (1, 5), (2, 4))
-
-
-def test_deprecated_gaussian_output():
-    image = np.array([0, 1, 0], dtype=float)
-    desired = np.array([0.24197145, 0.39894347, 0.24197145])
-    with pytest.warns(FutureWarning, match="Parameter `output` is") as record:
-        gaussian(image, output=image)
-    assert_stacklevel(record)
-    assert len(record) == 1
-    np.testing.assert_almost_equal(desired, image)


### PR DESCRIPTION
## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
