### PR TITLE
Update ruff linter / formatter

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,6 @@
+# Use ruff for formatting
+68633e8c682d47ade07a891f1511a5eefda8dc9a
+
 # Applied codespell to the codebase
 025757f8d5a1ece2687781000560aad79047b6c3
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,10 +24,10 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 75b98813cfb7e663870a28c74366a1e99d7bfe79 # frozen: v0.6.9
-
     hooks:
       - id: ruff
         args: [--fix, --show-fixes, --exit-non-zero-on-fix]
+      - id: ruff-format
 
   - repo: https://github.com/MarcoGorelli/cython-lint
     rev: 9247866fce7128f2c0eaf4a09f437880397d4689 # frozen: v0.16.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c # frozen: v4.6.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # frozen: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -23,7 +23,7 @@ repos:
         args: [--prose-wrap=preserve]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: cc915bbf189077041f55bc59c4c0cf7f30cc921f # frozen: v0.6.8
+    rev: 75b98813cfb7e663870a28c74366a1e99d7bfe79 # frozen: v0.6.9
 
     hooks:
       - id: ruff

--- a/benchmarks/benchmark_morphology.py
+++ b/benchmarks/benchmark_morphology.py
@@ -254,7 +254,6 @@ class LocalMaxima:
 
 
 class RemoveObjectsByDistance:
-
     param_names = ["min_distance"]
     params = [5, 100]
 

--- a/doc/examples/applications/plot_colocalization_metrics.py
+++ b/doc/examples/applications/plot_colocalization_metrics.py
@@ -26,7 +26,6 @@ area?
 # and assume that whatever is not in the nucleus is in the cytoplasm.
 # The protein, "protein A", will be simulated as blobs and segmented.
 
-
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.colors import LinearSegmentedColormap

--- a/doc/examples/filters/plot_nonlocal_means.py
+++ b/doc/examples/filters/plot_nonlocal_means.py
@@ -51,7 +51,9 @@ sigma_est = np.mean(estimate_sigma(noisy, channel_axis=-1))
 print(f'estimated noise standard deviation = {sigma_est}')
 
 patch_kw = dict(
-    patch_size=5, patch_distance=6, channel_axis=-1  # 5x5 patches  # 13x13 search area
+    patch_size=5,
+    patch_distance=6,
+    channel_axis=-1,  # 5x5 patches  # 13x13 search area
 )
 
 # slow algorithm

--- a/doc/ext/doi_role.py
+++ b/doc/ext/doi_role.py
@@ -1,17 +1,17 @@
 """
-    doilinks
-    ~~~~~~~~
-    Extension to add links to DOIs. With this extension you can use e.g.
-    :doi:`10.1016/S0022-2836(05)80360-2` in your documents. This will
-    create a link to a DOI resolver
-    (``https://doi.org/10.1016/S0022-2836(05)80360-2``).
-    The link caption will be the raw DOI.
-    You can also give an explicit caption, e.g.
-    :doi:`Basic local alignment search tool <10.1016/S0022-2836(05)80360-2>`.
+doilinks
+~~~~~~~~
+Extension to add links to DOIs. With this extension you can use e.g.
+:doi:`10.1016/S0022-2836(05)80360-2` in your documents. This will
+create a link to a DOI resolver
+(``https://doi.org/10.1016/S0022-2836(05)80360-2``).
+The link caption will be the raw DOI.
+You can also give an explicit caption, e.g.
+:doi:`Basic local alignment search tool <10.1016/S0022-2836(05)80360-2>`.
 
-    :copyright: Copyright 2015  Jon Lund Steffensen. Based on extlinks by
-        the Sphinx team.
-    :license: BSD.
+:copyright: Copyright 2015  Jon Lund Steffensen. Based on extlinks by
+    the Sphinx team.
+:license: BSD.
 """
 
 from docutils import nodes, utils

--- a/doc/gh-pages.py
+++ b/doc/gh-pages.py
@@ -9,7 +9,7 @@ If no tag is given, the current output of 'git describe' is used.  If given,
 that is how the resulting directory will be named.
 
 In practice, you should use either actual clean tags from a current build or
-something like 'current' as a stable URL for the mest current version of the """
+something like 'current' as a stable URL for the mest current version of the"""
 
 # -----------------------------------------------------------------------------
 # Imports

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -216,9 +216,7 @@ latex_documents = [
     ),
 ]
 latex_elements = {}
-latex_elements[
-    "preamble"
-] = r"""
+latex_elements["preamble"] = r"""
 \usepackage{enumitem}
 \setlistdepth{100}
 

--- a/doc/tools/build_modref_templates.py
+++ b/doc/tools/build_modref_templates.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-"""Script to auto-generate our API docs.
-"""
+"""Script to auto-generate our API docs."""
 
 import sys
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,9 +148,8 @@ Metrics = [
     '.spin/cmds.py:asv'
 ]
 
-[tool.black]
-target-version = ['py310', 'py311', 'py312']
-skip-string-normalization = 1
+[tool.ruff.format]
+quote-style = "preserve"
 
 [tool.ruff.lint]
 select = [

--- a/skimage/_build_utils/copyfiles.py
+++ b/skimage/_build_utils/copyfiles.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-""" Platform independent file copier script
-"""
+"""Platform independent file copier script"""
 
 import shutil
 import argparse

--- a/skimage/_build_utils/cythoner.py
+++ b/skimage/_build_utils/cythoner.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-""" Scipy variant of Cython command
+"""Scipy variant of Cython command
 
 Cython, as applied to single pyx file.
 

--- a/skimage/_build_utils/gcc_build_bitness.py
+++ b/skimage/_build_utils/gcc_build_bitness.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-""" Detect bitness (32 or 64) of Mingw-w64 gcc build target on Windows.
-"""
+"""Detect bitness (32 or 64) of Mingw-w64 gcc build target on Windows."""
 
 import re
 from subprocess import run

--- a/skimage/_build_utils/version.py
+++ b/skimage/_build_utils/version.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-""" Extract version number from __init__.py
-"""
+"""Extract version number from __init__.py"""
 
 import os
 

--- a/skimage/_shared/tests/test_testing.py
+++ b/skimage/_shared/tests/test_testing.py
@@ -1,5 +1,4 @@
-""" Testing decorators module
-"""
+"""Testing decorators module"""
 
 import inspect
 import re

--- a/skimage/_shared/tests/test_version_requirements.py
+++ b/skimage/_shared/tests/test_version_requirements.py
@@ -1,6 +1,4 @@
-"""Tests for the version requirement functions.
-
-"""
+"""Tests for the version requirement functions."""
 
 import numpy as np
 from numpy.testing import assert_equal

--- a/skimage/_vendored/numpy_lookfor.py
+++ b/skimage/_vendored/numpy_lookfor.py
@@ -132,7 +132,9 @@ def _lookfor_generate_cache(module, import_modules, regenerate):
             for n, v in _getmembers(item):
                 try:
                     item_name = getattr(
-                        v, '__name__', "%s.%s" % (name, n)  # noqa: UP031
+                        v,
+                        '__name__',
+                        "%s.%s" % (name, n),  # noqa: UP031
                     )  # noqa: UP031
                     mod_name = getattr(v, '__module__', None)
                 except NameError:

--- a/skimage/future/manual_segmentation.py
+++ b/skimage/future/manual_segmentation.py
@@ -95,7 +95,7 @@ def manual_polygon_segmentation(image, alpha=0.4, return_all=False):
             fig.canvas.draw_idle()
 
     undo_pos = fig.add_axes([0.85, 0.05, 0.075, 0.075])
-    undo_button = matplotlib.widgets.Button(undo_pos, '\u27F2')
+    undo_button = matplotlib.widgets.Button(undo_pos, '\u27f2')
     undo_button.on_clicked(_undo)
 
     def _extend_polygon(event):
@@ -210,7 +210,7 @@ def manual_lasso_segmentation(image, alpha=0.4, return_all=False):
             fig.canvas.draw_idle()
 
     undo_pos = fig.add_axes([0.85, 0.05, 0.075, 0.075])
-    undo_button = matplotlib.widgets.Button(undo_pos, '\u27F2')
+    undo_button = matplotlib.widgets.Button(undo_pos, '\u27f2')
     undo_button.on_clicked(_undo)
 
     def _on_lasso_selection(vertices):

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -1546,7 +1546,7 @@ def test_pickling_region_properties():
     regions = regionprops(label_image)
     assert len(regions) == 1
 
-    #pickle and unpickle
+    # pickle and unpickle
     pickled = pickle.dumps(regions[0])
-    unpickled = pickle.loads(pickled) #RecursionError here
+    unpickled = pickle.loads(pickled)  # RecursionError here
     assert regions[0] == unpickled

--- a/skimage/morphology/tests/test_misc.py
+++ b/skimage/morphology/tests/test_misc.py
@@ -273,7 +273,6 @@ def test_float_input_holes():
 
 
 class Test_remove_near_objects:
-
     @pytest.mark.parametrize("min_distance", [2.1, 5, 30.99, 49])
     @pytest.mark.parametrize("dtype", supported_dtypes)
     def test_min_distance_1d(self, min_distance, dtype):

--- a/skimage/registration/_optical_flow.py
+++ b/skimage/registration/_optical_flow.py
@@ -1,6 +1,4 @@
-"""TV-L1 optical flow algorithm implementation.
-
-"""
+"""TV-L1 optical flow algorithm implementation."""
 
 from functools import partial
 from itertools import combinations_with_replacement

--- a/skimage/registration/_optical_flow_utils.py
+++ b/skimage/registration/_optical_flow_utils.py
@@ -1,6 +1,4 @@
-"""Common tools to optical flow algorithms.
-
-"""
+"""Common tools to optical flow algorithms."""
 
 import numpy as np
 from scipy import ndimage as ndi

--- a/skimage/restoration/__init__.py
+++ b/skimage/restoration/__init__.py
@@ -1,6 +1,4 @@
-"""Image restoration module.
-
-"""
+"""Image restoration module."""
 
 import lazy_loader as _lazy
 

--- a/skimage/segmentation/__init__.py
+++ b/skimage/segmentation/__init__.py
@@ -1,5 +1,4 @@
-"""Algorithms to partition images into meaningful regions or boundaries.
-"""
+"""Algorithms to partition images into meaningful regions or boundaries."""
 
 from ._expand_labels import expand_labels
 from .random_walker_segmentation import random_walker

--- a/skimage/segmentation/tests/test_watershed.py
+++ b/skimage/segmentation/tests/test_watershed.py
@@ -1,5 +1,4 @@
-"""test_watershed.py - tests the watershed function
-"""
+"""test_watershed.py - tests the watershed function"""
 
 import math
 import unittest

--- a/skimage/util/tests/test_labels.py
+++ b/skimage/util/tests/test_labels.py
@@ -42,9 +42,10 @@ def test_label_points_two_dimensional_output():
 
 
 def test_label_points_multi_dimensional_output():
-    coords, output_shape = np.array(
-        [[0, 0, 0], [1, 1, 1], [2, 2, 2], [3, 3, 0], [4, 4, 1]]
-    ), (5, 5, 3)
+    coords, output_shape = (
+        np.array([[0, 0, 0], [1, 1, 1], [2, 2, 2], [3, 3, 0], [4, 4, 1]]),
+        (5, 5, 3),
+    )
     mask = label_points(coords, output_shape)
     result = np.array(
         [

--- a/tools/precompute/mc_meta/createluts.py
+++ b/tools/precompute/mc_meta/createluts.py
@@ -1,4 +1,4 @@
-""" Create lookup tables for the marching cubes algorithm, by parsing
+"""Create lookup tables for the marching cubes algorithm, by parsing
 the file "LookUpTable.h". This prints a text to the stdout which
 can then be copied to luts.py.
 


### PR DESCRIPTION
## Description

I noticed (using repo-review) a syntax error in pyproject.toml and then noticed we hadn't enabled ruff formatting.  I reviewed the changes and they are all reasonable. I would like to get this merged before he 0.25 release, since we had a syntax error in our pyproject.toml. This should be merged (and not squashed) to preserve the git blame ignore commit hash.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
