### PR TITLE
CI: bump macos image pin from 12 to 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,7 +140,7 @@ jobs:
 
   test_skimage_macos:
     name: macos-cp${{ matrix.python-version }}
-    runs-on: macos-12
+    runs-on: macos-13
 
     strategy:
       # Ensure that a wheel builder finishes even if another fails

--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -122,7 +122,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12]
+        os: [macos-13]
         cibw_python: ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]
         # TODO: add "universal2" once a universal2 libomp is available
         cibw_arch: ["x86_64", "arm64"]


### PR DESCRIPTION
`macos-12` is being deprecated and will soon cause test failures. It was originally pinned while https://github.com/scikit-image/scikit-image/pull/7407 is being sorted out, I hope that this PR can be a fix until that happens.