### PR TITLE
Don't check test coverage in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -170,7 +170,7 @@ jobs:
           # We don't test docstring examples (--doctest-plus) on
           # Windows due to inconsistent ndarray formatting in `numpy`.
           # For more details, see https://github.com/numpy/numpy/issues/13468
-          export TEST_ARGS="-v --cov=skimage"
+          export TEST_ARGS="-v"
           $PYTHON -m pytest ${TEST_ARGS} --pyargs skimage
         displayName: "Package testing"
 

--- a/tools/github/script.sh
+++ b/tools/github/script.sh
@@ -2,7 +2,7 @@
 # Fail on non-zero exit and echo the commands
 set -evx
 
-TEST_ARGS="--doctest-plus --cov=skimage --showlocals"
+TEST_ARGS="--doctest-plus --showlocals"
 
 
 # Combine requirement files for a more robust pip solve


### PR DESCRIPTION
## Description

While I'd still like some kind of process to keep an eye on test coverage, the current status isn't really useful. It's slowing down our CI while we suspect that nobody really checks it in the CI. It also creates a big block of "noise" in the middle of pytest's report of failed tests.

Locally, I see a speed difference with and without coverage (with 4m6s vs without 3m14s).

Suggested & discussed in the last community meeting (2024-10-22).

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
