### PR TITLE
Update blur effect tests.

### DIFF
--- a/skimage/measure/tests/test_blur_effect.py
+++ b/skimage/measure/tests/test_blur_effect.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import skimage as ski
 
@@ -53,8 +54,10 @@ def test_blur_effect_3d():
     assert B0 < B1 < B2
 
 
-def test_blur_effect_zerodivision():
-    """Test that the blur effect function errors upon division by zero."""
-    image = np.zeros((100, 100, 3))
-    with np.testing.raises(ZeroDivisionError):
-        ski.measure.blur_effect(image)
+@pytest.mark.parametrize('image', [np.zeros((100, 100, 3)), np.ones((100, 100, 3))])
+def test_blur_effect_uniform_input(image):
+    """Test that the blur metric is 1 for completely uniform images."""
+    image = np.ones((100, 100, 3))
+    with np.testing.assert_warns(UserWarning):
+        B = ski.measure.blur_effect(image)
+        assert B == 1

--- a/skimage/measure/tests/test_blur_effect.py
+++ b/skimage/measure/tests/test_blur_effect.py
@@ -1,3 +1,4 @@
+import numpy as np
 from numpy.testing import assert_array_equal
 
 from skimage.color import rgb2gray
@@ -50,3 +51,10 @@ def test_blur_effect_3d():
     B2 = blur_effect(gaussian(image_3d, sigma=4))
     assert 0 <= B0 < 1
     assert B0 < B1 < B2
+
+
+def test_blur_effect_zerodivision():
+    """Test that the blur effect function errors upon division by zero."""
+    image = np.zeros((100, 100, 3))
+    with np.testing.raises(ZeroDivisionError):
+        blur_effect(image)

--- a/skimage/measure/tests/test_blur_effect.py
+++ b/skimage/measure/tests/test_blur_effect.py
@@ -1,18 +1,18 @@
 import numpy as np
-from numpy.testing import assert_array_equal
 
-from skimage.color import rgb2gray
-from skimage.data import astronaut, cells3d
-from skimage.filters import gaussian
-from skimage.measure import blur_effect
+import skimage as ski
 
 
 def test_blur_effect():
     """Test that the blur metric increases with more blurring."""
-    image = astronaut()
-    B0 = blur_effect(image, channel_axis=-1)
-    B1 = blur_effect(gaussian(image, sigma=1, channel_axis=-1), channel_axis=-1)
-    B2 = blur_effect(gaussian(image, sigma=4, channel_axis=-1), channel_axis=-1)
+    image = ski.data.astronaut()
+    B0 = ski.measure.blur_effect(image, channel_axis=-1)
+    B1 = ski.measure.blur_effect(
+        ski.filters.gaussian(image, sigma=1, channel_axis=-1), channel_axis=-1
+    )
+    B2 = ski.measure.blur_effect(
+        ski.filters.gaussian(image, sigma=4, channel_axis=-1), channel_axis=-1
+    )
     assert 0 <= B0 < 1
     assert B0 < B1 < B2
 
@@ -21,10 +21,10 @@ def test_blur_effect_h_size():
     """Test that the blur metric decreases with increasing size of the
     re-blurring filter.
     """
-    image = astronaut()
-    B0 = blur_effect(image, h_size=3, channel_axis=-1)
-    B1 = blur_effect(image, channel_axis=-1)  # default h_size is 11
-    B2 = blur_effect(image, h_size=30, channel_axis=-1)
+    image = ski.data.astronaut()
+    B0 = ski.measure.blur_effect(image, h_size=3, channel_axis=-1)
+    B1 = ski.measure.blur_effect(image, channel_axis=-1)  # default h_size is 11
+    B2 = ski.measure.blur_effect(image, h_size=30, channel_axis=-1)
     assert 0 <= B0 < 1
     assert B0 > B1 > B2
 
@@ -33,22 +33,22 @@ def test_blur_effect_channel_axis():
     """Test that passing an RGB image is equivalent to passing its grayscale
     version.
     """
-    image = astronaut()
-    B0 = blur_effect(image, channel_axis=-1)
-    B1 = blur_effect(rgb2gray(image))
-    B0_arr = blur_effect(image, channel_axis=-1, reduce_func=None)
-    B1_arr = blur_effect(rgb2gray(image), reduce_func=None)
+    image = ski.data.astronaut()
+    B0 = ski.measure.blur_effect(image, channel_axis=-1)
+    B1 = ski.measure.blur_effect(ski.color.rgb2gray(image))
+    B0_arr = ski.measure.blur_effect(image, channel_axis=-1, reduce_func=None)
+    B1_arr = ski.measure.blur_effect(ski.color.rgb2gray(image), reduce_func=None)
     assert 0 <= B0 < 1
     assert B0 == B1
-    assert_array_equal(B0_arr, B1_arr)
+    np.testing.assert_array_equal(B0_arr, B1_arr)
 
 
 def test_blur_effect_3d():
     """Test that the blur metric works on a 3D image."""
-    image_3d = cells3d()[:, 1, :, :]  # grab just the nuclei
-    B0 = blur_effect(image_3d)
-    B1 = blur_effect(gaussian(image_3d, sigma=1))
-    B2 = blur_effect(gaussian(image_3d, sigma=4))
+    image_3d = ski.data.cells3d()[:, 1, :, :]  # grab just the nuclei
+    B0 = ski.measure.blur_effect(image_3d)
+    B1 = ski.measure.blur_effect(ski.filters.gaussian(image_3d, sigma=1))
+    B2 = ski.measure.blur_effect(ski.filters.gaussian(image_3d, sigma=4))
     assert 0 <= B0 < 1
     assert B0 < B1 < B2
 
@@ -57,4 +57,4 @@ def test_blur_effect_zerodivision():
     """Test that the blur effect function errors upon division by zero."""
     image = np.zeros((100, 100, 3))
     with np.testing.raises(ZeroDivisionError):
-        blur_effect(image)
+        ski.measure.blur_effect(image)


### PR DESCRIPTION
## Description

I don't mean to submit this PR, I only created this branch so I can potentially cherry-pick a0410c3d8959a7fb2665a77 for #7598.

Along the way, I wondered whether we wanted to update (all?) our tests with the new import convention, `import skimage as ski` (that's what I did in b528e4aaf389b6395 but we don't have to keep it). Basically, do we want #7454 also for the test suite? Maybe it doesn't matter too much because the code isn't exposed, but I still think it would improve that code's overall maintainability.

I couldn't find an issue for this; I also searched in the [sprint/skimage2 pad](https://hackmd.io/6YwDSkIdTXWY95px9e326g). Happy to create one if we agree we should go this way! Cc @lagru @stefanv 

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
