### PR TITLE
Fix typo in morphology doc

### DIFF
--- a/doc/examples/applications/plot_morphology.py
+++ b/doc/examples/applications/plot_morphology.py
@@ -126,7 +126,7 @@ plot_comparison(phantom, closed, 'closing')
 
 ######################################################################
 # Since ``closing`` an image starts with a dilation operation, dark regions
-# that are *smaller* than the structuring element are removed. The dilation
+# that are *smaller* than the structuring element are removed. The erosion
 # operation that follows ensures that dark regions that are *larger* than the
 # structuring element retain their original size. Notice how the white
 # ellipses at the bottom get connected because of dilation, but other dark


### PR DESCRIPTION
## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->
Fixed the morphology doc which erroneously referred to dilation when describing the second step.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- [x] A descriptive but concise pull request title
- [ ] N/A - [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [ ] N/A - [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- [ ] N/A - A gallery example in `./doc/examples` for new features
- [x] [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed
