### PR TITLE
Explicitly setup conda on macos for wheel building

### DIFF
--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -182,7 +182,7 @@ jobs:
           # use conda to install llvm-openmp
           # Note that we do NOT activate the conda environment, we just add the
           # library install path to CFLAGS/CXXFLAGS/LDFLAGS below.
-          sudo conda create -n build $OPENMP_URL
+          conda create -n build $OPENMP_URL
           PREFIX="/Users/runner/miniconda3/envs/build"
           export CC=/usr/bin/clang
           export CXX=/usr/bin/clang++

--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -141,6 +141,16 @@ jobs:
         run: |
           python -m pip install cibuildwheel
 
+      # Needed to install a specific libomp version later
+      - name: Setup Conda
+        uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d # v3.1.0
+        with:
+          python-version: "3.12"
+          channels: conda-forge
+          channel-priority: true
+          miniforge-variant: Miniforge3
+          miniforge-version: latest
+
       - name: Build wheels for CPython Mac OS
         run: |
           # Make sure to use a libomp version binary compatible with the oldest

--- a/.github/workflows/wheels_recipe.yml
+++ b/.github/workflows/wheels_recipe.yml
@@ -183,7 +183,7 @@ jobs:
           # Note that we do NOT activate the conda environment, we just add the
           # library install path to CFLAGS/CXXFLAGS/LDFLAGS below.
           sudo conda create -n build $OPENMP_URL
-          PREFIX="/usr/local/miniconda/envs/build"
+          PREFIX="/Users/runner/miniconda3/envs/build"
           export CC=/usr/bin/clang
           export CXX=/usr/bin/clang++
           export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"


### PR DESCRIPTION
## Description

Close https://github.com/scikit-image/scikit-image/issues/7607.

Apparently the [macos-13 image on GitHub no longer includes conda](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md). We use conda, to make an explicit libomp version available for wheel building on macos. So this is an attempt to restore the wheel building pipeline to a working state again. 

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
