### PR TITLE
Create 'skimage.segmentation.set_segment_mask_numbers(ax, imgSegmentMask, **kwargs)'

### DIFF
--- a/quickshift_numbering.py
+++ b/quickshift_numbering.py
@@ -1,0 +1,68 @@
+# Created as test harness for
+# 'skimage.segmentation.set_segment_mask_numbers(ax, imgSegmentMask, **kwargs)'
+"""
+Algorithm used in populating the segment mid-point with the segment number
+created by 'skimage.segmentation.quickshift(...)':
+--------------------------------------------------
+
+xLeft = 0.14
+xRight = 0.8
+yTop = 0.95
+yBottom = 0.06
+
+for num in sortedSegmentNums:
+    (midX, midY) = self.getSegmentMidpoint(imgSegmentMask, num)
+
+    xFigText = ((xRight - xLeft) * (midX / endX)) + xLeft
+    yFigText = (-(yTop - yBottom) * (midY / endY)) + yTop
+
+    if (num not in manual_segments):
+        plt.figtext(xFigText, yFigText, num)
+"""
+
+import matplotlib
+import matplotlib.pyplot as plt
+import skimage.segmentation
+
+
+def displayImgSegments(imgSegmentMask):
+    fig, ax = plt.subplots()
+
+    # Add awkward shaped segments manually
+    kwargs = {
+        'segment_values': [
+            {'num': 10, 'x': 0.25, 'y': 0.88},
+            {'num': 5, 'x': 0.68, 'y': 0.84},
+        ]
+    }
+
+    skimage.segmentation.set_segment_mask_numbers(ax, imgSegmentMask, **kwargs)
+
+    # Get around 'plt.figtext' not being scalable with the image
+    fig.savefig('numbered_segments.png')
+
+    plt.show()
+
+
+def getSegmentedImg():
+    url = "https://arteagac.github.io/blog/lime_image/img/cat-and-dog.jpg"
+    img = skimage.io.imread(url)
+
+    img = skimage.transform.resize(img, (299, 299))
+    img = (img - 0.5) * 2  # Inception pre-processing
+
+    imgSegmentMask = skimage.segmentation.quickshift(
+        img, kernel_size=6, max_dist=200, ratio=0.2
+    )
+
+    return imgSegmentMask
+
+
+if __name__ == '__main__':
+    print()
+    print(f"matplotlib version: {matplotlib.__version__}")
+    print(f"skimage version: {skimage.__version__}")
+    print()
+
+    imgSegmentMask = getSegmentedImg()
+    displayImgSegments(imgSegmentMask)

--- a/skimage/segmentation/__init__.py
+++ b/skimage/segmentation/__init__.py
@@ -5,7 +5,7 @@ from .random_walker_segmentation import random_walker
 from .active_contour_model import active_contour
 from ._felzenszwalb import felzenszwalb
 from .slic_superpixels import slic
-from ._quickshift import quickshift
+from ._quickshift import quickshift, set_segment_mask_numbers
 from .boundaries import find_boundaries, mark_boundaries
 from ._clear_border import clear_border
 from ._join import join_segmentations, relabel_sequential
@@ -28,6 +28,7 @@ __all__ = [
     'felzenszwalb',
     'slic',
     'quickshift',
+    'set_segment_mask_numbers',
     'find_boundaries',
     'mark_boundaries',
     'clear_border',


### PR DESCRIPTION
Addition of algorithm to populate the segment mid-point with the segment number created by 'skimage.segmentation.quickshift(...)': 

```
xLeft = 0.14
xRight = 0.8
yTop = 0.95
yBottom = 0.06

for num in sortedSegmentNums:
    (midX, midY) = get_segment_midpoint(imgSegmentMask, num)

    xFigText = ((xRight - xLeft) * (midX / endX)) + xLeft
    yFigText = (-(yTop - yBottom) * (midY / endY)) + yTop

    if (num not in manual_segments):
        plt.figtext(xFigText, yFigText, num)
```

**System:** MacOS 10.15.7

Python 3.9.15
```
Running '$ spin run python quickshift_numbering.py' resulted in:
  ImportError: cannot import name 'geometry' from 'skimage._shared'

NEED TO RUN FROM PARENT DIRECTORY TO PREVENT ImportError

(skimage-dev) scikit-image$ cp quickshift_numbering.py ..; spin run python ../quickshift_numbering.py
```
Python 3.11.10, 3.12.7
```
(skimage-dev) scikit-image$ spin build
  skimage/_shared/fast_exp.cpython-39-darwin.so.p/fast_exp.c:1227:10: fatal error: 'numpy/arrayobject.h' file not found
  ...
  skimage/_shared/transform.cpython-39-darwin.so.p/transform.c:1227:10: fatal error: 'numpy/arrayobject.h' file not found
  ...
  skimage/_shared/geometry.cpython-39-darwin.so.p/geometry.c:1227:10: fatal error: 'numpy/arrayobject.h' file not found
  ...
  skimage/_shared/interpolation.cpython-39-darwin.so.p/interpolation.c:1228:10: fatal error: 'numpy/arrayobject.h' file not found
  ...
  skimage/feature/corner_cy.cpython-39-darwin.so.p/corner_cy.c:1227:10: fatal error: 'numpy/arrayobject.h' file not found
  ...
  skimage/draw/_draw.cpython-39-darwin.so.p/_draw.c:1227:10: fatal error: 'numpy/arrayobject.h' file not found
```

### Update on build/run
The above issue is a MacOS 10.15.7 issue with meson/ninja since Python 3.12.7 builds OK on Ubuntu 20 and runs as expected with:
```
(skimage-dev) scikit-image$ pip install -r requirements.txt
(skimage-dev) scikit-image$ pip install -r requirements/build.txt
(skimage-dev) scikit-image$ spin build

(skimage-dev) scikit-image$ pip install matplotlib
(skimage-dev) scikit-image$ pip install PyQt5
(skimage-dev) scikit-image$ spin python quickshift_numbering.py
  ...
  INFO: calculating backend command to run: /home/doug/envs/skimage-dev/bin/ninja -C /home/doug/src/ai/scikit-image/build
  ninja: Entering directory `/home/doug/src/ai/scikit-image/build'
  ninja: no work to do.
  $ meson install --only-changed -C build --destdir ../build-install
  $ export PYTHONPATH="/home/doug/src/ai/scikit-image/build-install/usr/lib/python3.12/site-packages"
  🐍 Launching Python with PYTHONPATH="/home/doug/src/ai/scikit-image/build-install/usr/lib/python3.12/site-packages"
  $ /home/doug/envs/skimage-dev/bin/python -P quickshift_numbering.py
```

## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
