### PR TITLE
Use `intersphinx_registry` to keep intersphinx urls up to date.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -11,6 +11,7 @@ from warnings import filterwarnings
 
 import plotly.io as pio
 import skimage
+from intersphinx_registry import get_intersphinx_mapping
 from packaging.version import parse
 from plotly.io._sg_scraper import plotly_sg_scraper
 from sphinx_gallery.sorting import ExplicitOrder
@@ -245,17 +246,20 @@ numpydoc_show_class_members = False
 numpydoc_class_members_toctree = False
 
 # -- intersphinx --------------------------------------------------------------
-intersphinx_mapping = {
-    "python": ("https://docs.python.org/3/", None),
-    "numpy": ("https://numpy.org/doc/stable/", None),
-    "neps": ("https://numpy.org/neps/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
-    "sklearn": ("https://scikit-learn.org/stable/", None),
-    "matplotlib": ("https://matplotlib.org/stable/", None),
-    "networkx": ("https://networkx.org/documentation/stable/", None),
-    "plotly": ("https://plotly.com/python-api-reference/", None),
-    "seaborn": ("https://seaborn.pydata.org/", None),
-}
+# ...
+intersphinx_mapping = get_intersphinx_mapping(
+    packages={
+        "python",
+        "numpy",
+        "neps",
+        "scipy",
+        "sklearn",
+        "matplotlib",
+        "networkx",
+        "plotly",
+        "seaborn",
+    }
+)
 
 # Do not (yet) use nitpicky mode for checking cross-references
 nitpicky = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ docs = [
     'pooch>=1.6',
     'tifffile>=2022.8.12',
     'myst-parser',
+    'intersphinx-registry>=0.2411.14',
     'ipywidgets',
     'ipykernel',  # needed until https://github.com/jupyter-widgets/ipywidgets/issues/3731 is resolved
     'plotly>=5.20',

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -11,6 +11,7 @@ seaborn>=0.11
 pooch>=1.6
 tifffile>=2022.8.12
 myst-parser
+intersphinx-registry>=0.2411.14
 ipywidgets
 ipykernel
 plotly>=5.20


### PR DESCRIPTION
Plotly was missing from the registry so far, but the version I just published now have it.

(it may take a few hours to be on conda-forge)

This allows to automatically make sure the URLs are updated if a package ever move; And make it easier to add a new package if necessary.

## Description

I think this may be of interest for @stefanv as this is one of the things I tried to push during last scientific-python retreat.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- [x] A descriptive but concise pull request title

I'm not sure the rest of the checklist is relevant.

- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Use `intersphinx_registry` package in `conf.py` to keep intersphinx urls up to date. This means that building docs now requires the `intersphinx-registry` package.
```
