### PR TITLE
Pin kaleido to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ docs = [
     'ipywidgets',
     'ipykernel',  # needed until https://github.com/jupyter-widgets/ipywidgets/issues/3731 is resolved
     'plotly>=5.20',
-    'kaleido',
+    'kaleido==0.2.1',
     'scikit-learn>=1.2',
     'sphinx_design>=0.5',
     'pydata-sphinx-theme>=0.16',

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -14,7 +14,7 @@ myst-parser
 ipywidgets
 ipykernel
 plotly>=5.20
-kaleido
+kaleido==0.2.1
 scikit-learn>=1.2
 sphinx_design>=0.5
 pydata-sphinx-theme>=0.16


### PR DESCRIPTION
Trying to figure out why our CI system is timing out now. The CI was okay when using `kaleido==0.2.1` recently `kaleido==0.4.1` came out, which brings in additional dependencies such as `choreographer`.

## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
