### PR TITLE
Add forgotten TODO about deprecated `square`, `cube` & `rectangle`

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -8,6 +8,7 @@ Version 0.27
   - Remove `skimage/io/manage_plugins.py`
   - Remove `skimage/io/__init__.py::__getattr__`
   - Remove related tests, imports, etc...
+* Complete deprecation of `square`, `rectangle` and `cube` in `skimage.morphology`.
 
 
 Version 0.26


### PR DESCRIPTION
## Description

We forgot to include this in https://github.com/scikit-image/scikit-image/pull/7566.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
