### PR TITLE
Refactor to `skimage.morphology.footprint_octagon`

### DIFF
--- a/skimage/morphology/__init__.py
+++ b/skimage/morphology/__init__.py
@@ -22,6 +22,7 @@ from .footprints import (
     ellipse,
     footprint_from_sequence,
     footprint_rectangle,
+    footprint_octagon,
     mirror_footprint,
     octagon,
     octahedron,


### PR DESCRIPTION
## Description

The problem here is that the [old API of `octagon`](https://scikit-image.org/docs/stable/api/skimage.morphology.html#skimage.morphology.octagon) and its implementation doesn't map easily to an API using `shape` that allows for varying dimension lengths. If no decomposition is used, I've almost figured it out...

Let's discuss it at the meeting.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
