### PR TITLE
Change type annotation of ball radius from `int` to `float`

### DIFF
--- a/skimage/morphology/footprints.py
+++ b/skimage/morphology/footprints.py
@@ -847,7 +847,7 @@ def ball(radius, dtype=np.uint8, *, strict_radius=True, decomposition=None):
 
     Parameters
     ----------
-    radius : int
+    radius : float
         The radius of the ball-shaped footprint.
 
     Other Parameters


### PR DESCRIPTION
## Description

I belive the correct type annotation for `radius` is `float` and not `int`. Especially since 0.5 is added to the `radius` in the case when `strict_radius` is False. Also `numpy.mgrid` accepts floats. 

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Change type description of parameter `radius` in 
`skimage.morphology.ball` from `int` to `float`.
```
