### PR TITLE
CI pre-commit fix

### DIFF
--- a/doc/source/release_notes/release_dev.rst
+++ b/doc/source/release_notes/release_dev.rst
@@ -197,4 +197,3 @@ Contributors
 
 _These lists are automatically generated, and may not be complete or may contain
 duplicates._
-


### PR DESCRIPTION
## Description
fixes the failing pre-commit.ci workflow

log msg:

```
fix end of files.........................................................Failed
- hook id: end-of-file-fixer
- exit code: 1
- files were modified by this hook

Fixing doc/source/release_notes/release_dev.rst

```
<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
