### PR TITLE
Raise a ValueError when M1 = 0

### DIFF
--- a/skimage/measure/_blur_effect.py
+++ b/skimage/measure/_blur_effect.py
@@ -85,6 +85,11 @@ def blur_effect(image, h_size=11, channel_axis=None, reduce_func=np.max):
         T = np.maximum(0, im_sharp - im_blur)
         M1 = np.sum(im_sharp[slices])
         M2 = np.sum(T[slices])
+        if M1 == 0:
+            raise ValueError(
+                'Cannot compute blur for an image with zero values. '
+                'This would result in a NaN value.'
+            )
         B.append(np.abs(M1 - M2) / M1)
 
     return B if reduce_func is None else reduce_func(B)


### PR DESCRIPTION
Fixes #7597

To stop NaN value from further propogating in the pipeline, a ValueError is put in place when the blur effect is applied to an all zero image

## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
