### PR TITLE
Infer floating point type for sigma parameter

### DIFF
--- a/skimage/_shared/filters.py
+++ b/skimage/_shared/filters.py
@@ -18,7 +18,7 @@ from .._shared.utils import (
 
 def gaussian(
     image,
-    sigma=1,
+    sigma=1.0,
     *,
     mode='nearest',
     cval=0,


### PR DESCRIPTION
Right now, pyright thinks it has to be an int.