### PR TITLE
Feature/improve stability blur effect

### DIFF
--- a/skimage/measure/_blur_effect.py
+++ b/skimage/measure/_blur_effect.py
@@ -16,7 +16,7 @@ except ImportError:
 __all__ = ['blur_effect']
 
 
-_EPSILON = 1e-10
+_EPSILON = 1e-12
 
 
 def blur_effect(image, h_size=11, channel_axis=None, reduce_func=np.max):
@@ -88,7 +88,7 @@ def blur_effect(image, h_size=11, channel_axis=None, reduce_func=np.max):
         T = np.maximum(0, im_sharp - im_blur)
         M1 = np.sum(im_sharp[slices])
         M2 = np.sum(T[slices])
-        M1 = np.clip(M1, a_min=_EPSILON, a_max=None)
+        M1 = np.clip(M1, a_min=_EPSILON * im_sharp.size, a_max=None)
         B.append(np.abs(M1 - M2) / M1)
 
     return B if reduce_func is None else reduce_func(B)

--- a/skimage/measure/_blur_effect.py
+++ b/skimage/measure/_blur_effect.py
@@ -16,7 +16,7 @@ except ImportError:
 __all__ = ['blur_effect']
 
 
-_EPSILON = np.spacing(1e4)
+_EPSILON = np.spacing(1)
 
 
 def blur_effect(image, h_size=11, channel_axis=None, reduce_func=np.max):
@@ -85,10 +85,14 @@ def blur_effect(image, h_size=11, channel_axis=None, reduce_func=np.max):
         filt_im = ndi.uniform_filter1d(image, h_size, axis=ax)
         im_sharp = np.abs(sobel(image, axis=ax))
         im_blur = np.abs(sobel(filt_im, axis=ax))
+
+        # avoid numerical instabilities
+        im_sharp = np.maximum(_EPSILON, im_sharp)
+        im_blur = np.maximum(_EPSILON, im_blur)
+
         T = np.maximum(0, im_sharp - im_blur)
         M1 = np.sum(im_sharp[slices])
         M2 = np.sum(T[slices])
-        M1 = np.clip(M1, a_min=_EPSILON * im_sharp.size, a_max=None)
         B.append(np.abs(M1 - M2) / M1)
 
     return B if reduce_func is None else reduce_func(B)

--- a/skimage/measure/_blur_effect.py
+++ b/skimage/measure/_blur_effect.py
@@ -16,7 +16,7 @@ except ImportError:
 __all__ = ['blur_effect']
 
 
-_EPSILON = np.spacing(1)
+_EPSILON = np.spacing(np.float64(1))
 
 
 def blur_effect(image, h_size=11, channel_axis=None, reduce_func=np.max):

--- a/skimage/measure/_blur_effect.py
+++ b/skimage/measure/_blur_effect.py
@@ -16,6 +16,9 @@ except ImportError:
 __all__ = ['blur_effect']
 
 
+_EPSILON = 1e-10
+
+
 def blur_effect(image, h_size=11, channel_axis=None, reduce_func=np.max):
     """Compute a metric that indicates the strength of blur in an image
     (0 for no blur, 1 for maximal blur).
@@ -85,6 +88,7 @@ def blur_effect(image, h_size=11, channel_axis=None, reduce_func=np.max):
         T = np.maximum(0, im_sharp - im_blur)
         M1 = np.sum(im_sharp[slices])
         M2 = np.sum(T[slices])
+        M1 = np.clip(M1, a_min=_EPSILON, a_max=None)
         B.append(np.abs(M1 - M2) / M1)
 
     return B if reduce_func is None else reduce_func(B)

--- a/skimage/measure/_blur_effect.py
+++ b/skimage/measure/_blur_effect.py
@@ -16,7 +16,7 @@ except ImportError:
 __all__ = ['blur_effect']
 
 
-_EPSILON = 1e-12
+_EPSILON = np.spacing(1e4)
 
 
 def blur_effect(image, h_size=11, channel_axis=None, reduce_func=np.max):

--- a/skimage/measure/tests/test_blur_effect.py
+++ b/skimage/measure/tests/test_blur_effect.py
@@ -1,5 +1,5 @@
-from numpy.testing import assert_array_equal, assert_almost_equal, assert_equal
 import numpy as np
+from numpy.testing import assert_array_equal, assert_almost_equal, assert_equal
 
 from skimage.color import rgb2gray
 from skimage.data import astronaut, cells3d
@@ -66,3 +66,10 @@ def test_blur_single_axis_constant_image():
     image = np.array([row for _ in range(1000)])
     B0 = blur_effect(image)
     assert_almost_equal(B0, 1.0, decimal=5)
+
+
+def test_blur_effect_zerodivision():
+    """Test that the blur effect function errors upon division by zero."""
+    image = np.zeros((100, 100, 3))
+    with np.testing.assert_raises(ZeroDivisionError):
+        blur_effect(image)

--- a/skimage/measure/tests/test_blur_effect.py
+++ b/skimage/measure/tests/test_blur_effect.py
@@ -62,14 +62,7 @@ def test_blur_constant_image():
 
 def test_blur_single_axis_constant_image():
     """Test that the blur metric work for an image that is constant in one axis."""
-    image = np.array(
-        [
-            [0, 0.025, 0.05, 0.075, 0.1],
-            [0, 0.025, 0.05, 0.075, 0.1],
-            [0, 0.025, 0.05, 0.075, 0.1],
-            [0, 0.025, 0.05, 0.075, 0.1],
-            [0, 0.025, 0.05, 0.075, 0.1],
-        ]
-    )
+    row = np.linspace(0, 1, 1000)
+    image = np.array([row for _ in range(1000)])
     B0 = blur_effect(image)
     assert_almost_equal(B0, 1.0, decimal=5)

--- a/skimage/measure/tests/test_blur_effect.py
+++ b/skimage/measure/tests/test_blur_effect.py
@@ -1,4 +1,5 @@
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_almost_equal, assert_equal
+import numpy as np
 
 from skimage.color import rgb2gray
 from skimage.data import astronaut, cells3d
@@ -50,3 +51,25 @@ def test_blur_effect_3d():
     B2 = blur_effect(gaussian(image_3d, sigma=4))
     assert 0 <= B0 < 1
     assert B0 < B1 < B2
+
+
+def test_blur_constant_image():
+    """Test that the blur metric works for a constant image."""
+    image = np.zeros((1080, 1920, 3), dtype=int)
+    B0 = blur_effect(image)
+    assert_equal(B0, 1.0)
+
+
+def test_blur_single_axis_constant_image():
+    """Test that the blur metric work for an image that is constant in one axis."""
+    image = np.array(
+        [
+            [0, 0.025, 0.05, 0.075, 0.1],
+            [0, 0.025, 0.05, 0.075, 0.1],
+            [0, 0.025, 0.05, 0.075, 0.1],
+            [0, 0.025, 0.05, 0.075, 0.1],
+            [0, 0.025, 0.05, 0.075, 0.1],
+        ]
+    )
+    B0 = blur_effect(image)
+    assert_almost_equal(B0, 1.0, decimal=5)

--- a/skimage/measure/tests/test_blur_effect.py
+++ b/skimage/measure/tests/test_blur_effect.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import skimage as ski
 
@@ -53,11 +54,11 @@ def test_blur_effect_3d():
     assert B0 < B1 < B2
 
 
-def test_blur_constant_image():
-    """Test that the blur metric works for a constant image."""
-    image = np.zeros((1080, 1920, 3), dtype=int)
-    B0 = ski.measure.blur_effect(image)
-    np.testing.assert_equal(B0, 1.0)
+@pytest.mark.parametrize('image', [np.zeros((100, 100, 3)), np.ones((100, 100, 3))])
+def test_blur_effect_uniform_input(image):
+    """Test that the blur metric is 1 for completely uniform images."""
+    B = ski.measure.blur_effect(image)
+    assert B == 1
 
 
 def test_blur_single_axis_constant_image():
@@ -66,10 +67,3 @@ def test_blur_single_axis_constant_image():
     image = np.array([row for _ in range(1000)])
     B0 = ski.measure.blur_effect(image)
     np.testing.assert_almost_equal(B0, 1.0, decimal=5)
-
-
-def test_blur_effect_zerodivision():
-    """Test that the blur effect function errors upon division by zero."""
-    image = np.zeros((100, 100, 3))
-    with np.testing.assert_raises(ZeroDivisionError):
-        ski.measure.blur_effect(image)

--- a/skimage/measure/tests/test_blur_effect.py
+++ b/skimage/measure/tests/test_blur_effect.py
@@ -61,9 +61,10 @@ def test_blur_effect_uniform_input(image):
     assert B == 1
 
 
-def test_blur_single_axis_constant_image():
+@pytest.mark.parametrize('size', [1, 10, 100, 1000])
+def test_blur_single_axis_constant_image(size):
     """Test that the blur metric work for an image that is constant in one axis."""
-    row = np.linspace(0, 1, 1000)
-    image = np.array([row for _ in range(1000)])
+    row = np.linspace(0, 1, size)
+    image = np.array([row for _ in range(size)])
     B0 = ski.measure.blur_effect(image)
     np.testing.assert_almost_equal(B0, 1.0, decimal=5)

--- a/skimage/measure/tests/test_blur_effect.py
+++ b/skimage/measure/tests/test_blur_effect.py
@@ -1,18 +1,18 @@
 import numpy as np
-from numpy.testing import assert_array_equal, assert_almost_equal, assert_equal
 
-from skimage.color import rgb2gray
-from skimage.data import astronaut, cells3d
-from skimage.filters import gaussian
-from skimage.measure import blur_effect
+import skimage as ski
 
 
 def test_blur_effect():
     """Test that the blur metric increases with more blurring."""
-    image = astronaut()
-    B0 = blur_effect(image, channel_axis=-1)
-    B1 = blur_effect(gaussian(image, sigma=1, channel_axis=-1), channel_axis=-1)
-    B2 = blur_effect(gaussian(image, sigma=4, channel_axis=-1), channel_axis=-1)
+    image = ski.data.astronaut()
+    B0 = ski.measure.blur_effect(image, channel_axis=-1)
+    B1 = ski.measure.blur_effect(
+        ski.filters.gaussian(image, sigma=1, channel_axis=-1), channel_axis=-1
+    )
+    B2 = ski.measure.blur_effect(
+        ski.filters.gaussian(image, sigma=4, channel_axis=-1), channel_axis=-1
+    )
     assert 0 <= B0 < 1
     assert B0 < B1 < B2
 
@@ -21,10 +21,10 @@ def test_blur_effect_h_size():
     """Test that the blur metric decreases with increasing size of the
     re-blurring filter.
     """
-    image = astronaut()
-    B0 = blur_effect(image, h_size=3, channel_axis=-1)
-    B1 = blur_effect(image, channel_axis=-1)  # default h_size is 11
-    B2 = blur_effect(image, h_size=30, channel_axis=-1)
+    image = ski.data.astronaut()
+    B0 = ski.measure.blur_effect(image, h_size=3, channel_axis=-1)
+    B1 = ski.measure.blur_effect(image, channel_axis=-1)  # default h_size is 11
+    B2 = ski.measure.blur_effect(image, h_size=30, channel_axis=-1)
     assert 0 <= B0 < 1
     assert B0 > B1 > B2
 
@@ -33,22 +33,22 @@ def test_blur_effect_channel_axis():
     """Test that passing an RGB image is equivalent to passing its grayscale
     version.
     """
-    image = astronaut()
-    B0 = blur_effect(image, channel_axis=-1)
-    B1 = blur_effect(rgb2gray(image))
-    B0_arr = blur_effect(image, channel_axis=-1, reduce_func=None)
-    B1_arr = blur_effect(rgb2gray(image), reduce_func=None)
+    image = ski.data.astronaut()
+    B0 = ski.measure.blur_effect(image, channel_axis=-1)
+    B1 = ski.measure.blur_effect(ski.color.rgb2gray(image))
+    B0_arr = ski.measure.blur_effect(image, channel_axis=-1, reduce_func=None)
+    B1_arr = ski.measure.blur_effect(ski.color.rgb2gray(image), reduce_func=None)
     assert 0 <= B0 < 1
     assert B0 == B1
-    assert_array_equal(B0_arr, B1_arr)
+    np.testing.assert_array_equal(B0_arr, B1_arr)
 
 
 def test_blur_effect_3d():
     """Test that the blur metric works on a 3D image."""
-    image_3d = cells3d()[:, 1, :, :]  # grab just the nuclei
-    B0 = blur_effect(image_3d)
-    B1 = blur_effect(gaussian(image_3d, sigma=1))
-    B2 = blur_effect(gaussian(image_3d, sigma=4))
+    image_3d = ski.data.cells3d()[:, 1, :, :]  # grab just the nuclei
+    B0 = ski.measure.blur_effect(image_3d)
+    B1 = ski.measure.blur_effect(ski.filters.gaussian(image_3d, sigma=1))
+    B2 = ski.measure.blur_effect(ski.filters.gaussian(image_3d, sigma=4))
     assert 0 <= B0 < 1
     assert B0 < B1 < B2
 
@@ -56,20 +56,20 @@ def test_blur_effect_3d():
 def test_blur_constant_image():
     """Test that the blur metric works for a constant image."""
     image = np.zeros((1080, 1920, 3), dtype=int)
-    B0 = blur_effect(image)
-    assert_equal(B0, 1.0)
+    B0 = ski.measure.blur_effect(image)
+    np.testing.assert_equal(B0, 1.0)
 
 
 def test_blur_single_axis_constant_image():
     """Test that the blur metric work for an image that is constant in one axis."""
     row = np.linspace(0, 1, 1000)
     image = np.array([row for _ in range(1000)])
-    B0 = blur_effect(image)
-    assert_almost_equal(B0, 1.0, decimal=5)
+    B0 = ski.measure.blur_effect(image)
+    np.testing.assert_almost_equal(B0, 1.0, decimal=5)
 
 
 def test_blur_effect_zerodivision():
     """Test that the blur effect function errors upon division by zero."""
     image = np.zeros((100, 100, 3))
     with np.testing.assert_raises(ZeroDivisionError):
-        blur_effect(image)
+        ski.measure.blur_effect(image)

--- a/skimage/measure/tests/test_blur_effect.py
+++ b/skimage/measure/tests/test_blur_effect.py
@@ -54,16 +54,17 @@ def test_blur_effect_3d():
     assert B0 < B1 < B2
 
 
-@pytest.mark.parametrize('image', [np.zeros((100, 100, 3)), np.ones((100, 100, 3))])
-def test_blur_effect_uniform_input(image):
+@pytest.mark.parametrize('factor', [0, 1, 2.5])
+def test_blur_effect_uniform_input(factor):
     """Test that the blur metric is 1 for completely uniform images."""
+    image = np.ones((10, 10, 3)) * factor
     B = ski.measure.blur_effect(image, channel_axis=-1)
     assert B == 1
 
 
 @pytest.mark.parametrize('size', [10, 100, 1000])
 def test_blur_single_axis_constant_image(size):
-    """Test that the blur metric work for an image that is constant in one axis."""
+    """Test that the blur metric is 1 for an image that is uniform along one axis."""
     row = np.linspace(0, 1, size)
     image = np.array([row for _ in range(size)])
     B = ski.measure.blur_effect(image)

--- a/skimage/measure/tests/test_blur_effect.py
+++ b/skimage/measure/tests/test_blur_effect.py
@@ -62,10 +62,10 @@ def test_blur_effect_uniform_input(factor):
     assert B == 1
 
 
-@pytest.mark.parametrize('size', [10, 100, 1000])
-def test_blur_single_axis_constant_image(size):
+@pytest.mark.parametrize('shape', [(10, 11), (4, 5, 6)])
+def test_blur_single_axis_constant_image(shape):
     """Test that the blur metric is 1 for an image that is uniform along one axis."""
-    row = np.linspace(0, 1, size)
-    image = np.array([row for _ in range(size)])
+    row = np.linspace(0, 1, shape[-1])
+    image = np.broadcast_to(row, shape)
     B = ski.measure.blur_effect(image)
     assert B == 1

--- a/skimage/measure/tests/test_blur_effect.py
+++ b/skimage/measure/tests/test_blur_effect.py
@@ -57,14 +57,14 @@ def test_blur_effect_3d():
 @pytest.mark.parametrize('image', [np.zeros((100, 100, 3)), np.ones((100, 100, 3))])
 def test_blur_effect_uniform_input(image):
     """Test that the blur metric is 1 for completely uniform images."""
-    B = ski.measure.blur_effect(image)
+    B = ski.measure.blur_effect(image, channel_axis=-1)
     assert B == 1
 
 
-@pytest.mark.parametrize('size', [1, 10, 100, 1000])
+@pytest.mark.parametrize('size', [10, 100, 1000])
 def test_blur_single_axis_constant_image(size):
     """Test that the blur metric work for an image that is constant in one axis."""
     row = np.linspace(0, 1, size)
     image = np.array([row for _ in range(size)])
-    B0 = ski.measure.blur_effect(image)
-    np.testing.assert_almost_equal(B0, 1.0, decimal=5)
+    B = ski.measure.blur_effect(image)
+    assert B == 1


### PR DESCRIPTION
## Description

As stated in https://github.com/scikit-image/scikit-image/issues/7597, the blur metric returns `np.nan` for constant images. Nevertheless, constant images are a valid use case and perfectly blurred so that `blur_effect` should return 1.0.

To improve numerical stability, the denominator is limited from below to avoid division by zero.

Relates to: https://github.com/scikit-image/scikit-image/pull/7598 and https://github.com/scikit-image/scikit-image/pull/7599

Closes: https://github.com/scikit-image/scikit-image/issues/7597

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Improve numerical stability of `blur_effect`
```
