### PR TITLE
Change type of default `active_contour` argument `w_line` literal to indicate it is a float

### DIFF
--- a/skimage/segmentation/active_contour_model.py
+++ b/skimage/segmentation/active_contour_model.py
@@ -11,7 +11,7 @@ def active_contour(
     snake,
     alpha=0.01,
     beta=0.1,
-    w_line=0,
+    w_line=0.0,
     w_edge=1,
     gamma=0.01,
     max_px_move=1.0,


### PR DESCRIPTION
Change type of default `active_contour` argument `w_line` literal to indicate it is a float

## Description

Minor change to indicate default type of `w_line` argument of the `active_contour` function is a float

## Checklist

 - [x] A descriptive but concise pull request title
- [x] [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [ ] [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- [ ] A gallery example in `./doc/examples` for new features
- [ ] [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

```release-note
Change type of default `active_contour` argument `w_line` literal to indicate it is a float
```
