### PR TITLE
Make apigen.py work with editable hooks

### DIFF
--- a/doc/tools/apigen.py
+++ b/doc/tools/apigen.py
@@ -92,6 +92,18 @@ class ApiDocWriter:
         self._package_name = package_name
         root_module = self._import(package_name)
         self.root_path = root_module.__path__[-1]
+
+        if not os.path.isdir(self.root_path):
+            # __path__ might point to editable loader, try falling back to __file__
+            self.root_path = os.path.dirname(root_module.__file__)
+
+        if not os.path.isdir(self.root_path):
+            msg = (
+                f"could not determine a valid directory for {root_module!r}, "
+                f"'{self.root_path}' is not a directory"
+            )
+            raise NotADirectoryError(msg)
+
         self.written_modules = None
 
     package_name = property(

--- a/doc/tools/build_modref_templates.py
+++ b/doc/tools/build_modref_templates.py
@@ -58,4 +58,12 @@ if __name__ == '__main__':
     ]
     docwriter.write_api_docs(outdir)
     docwriter.write_index(outdir, 'api', relative_to='source/api')
-    print(f'{len(docwriter.written_modules)} files written')
+
+    if len(docwriter.written_modules) <= 1:
+        msg = (
+            f"expected more modules, only wrote files for: "
+            f"{docwriter.written_modules!r}"
+        )
+        raise RuntimeWarning(msg)
+    else:
+        print(f'{len(docwriter.written_modules)} files written')


### PR DESCRIPTION
## Description

apigen.py in the previous form wasn't able to deal with skimage if it was installed in editable mode using a _scikit-image_editable_loader hook. In that case `root_module.__path__[-1]` would point to an invalid directory.

This fix aims to (a) account for this by falling back to the __file__ attribute and (b) adds some defensive checks so we are not suprised in the future when something breaks.

Longterm this part of our tooling could probably use some love, it seems a bit brittle.


## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
