### PR TITLE
Require at least 5 data points for ellipse estimation

### DIFF
--- a/skimage/measure/fit.py
+++ b/skimage/measure/fit.py
@@ -440,12 +440,20 @@ class EllipseModel(BaseModel):
         # another REFERENCE: [2] http://mathworld.wolfram.com/Ellipse.html
         _check_data_dim(data, dim=2)
 
+        if len(data) < 5:
+            warn(
+                "Need at least 5 data points to estimate an ellipse.",
+                category=RuntimeWarning,
+                stacklevel=2,
+            )
+            return False
+
         # to prevent integer overflow, cast data to float, if it isn't already
         float_type = np.promote_types(data.dtype, np.float32)
         data = data.astype(float_type, copy=False)
 
         # normalize value range to avoid misfitting due to numeric errors if
-        # the relative distanceses are small compared to absolute distances
+        # the relative distances are small compared to absolute distances
         origin = data.mean(axis=0)
         data = data - origin
         scale = data.std()

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -461,6 +461,7 @@ def test_ellipse_model_estimate_from_far_shifted_data():
 def test_ellipse_model_estimate_failers():
     # estimate parameters of real data
     model = EllipseModel()
+
     warning_message = (
         "Standard deviation of data is too small to estimate "
         "ellipse with meaningful precision."
@@ -470,7 +471,11 @@ def test_ellipse_model_estimate_failers():
     assert_stacklevel(_warnings)
     assert len(_warnings) == 1
 
-    assert not model.estimate(np.array([[50, 80], [51, 81], [52, 80]]))
+    warning_message = "Need at least 5 data points to estimate an ellipse."
+    with pytest.warns(RuntimeWarning, match=warning_message) as _warnings:
+        assert not model.estimate(np.array([[50, 80], [51, 81], [52, 80]]))
+    assert_stacklevel(_warnings)
+    assert len(_warnings) == 1
 
 
 def test_ellipse_model_residuals():


### PR DESCRIPTION
## Description

Do not try to estimate an ellipse if there are insufficient data points for unique determination.

Relates to: https://github.com/scikit-image/scikit-image/issues/7497

## Release note

```release-note
Require at least 5 data points for ellipse estimation
```
