### PR TITLE
Explicitly upcast float16 to float32 in random_walker

### DIFF
--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -8,8 +8,6 @@ Installing pyamg and using the 'cg_mg' mode of random_walker improves
 significantly the performance.
 """
 
-import warnings
-
 import numpy as np
 from scipy import sparse, ndimage as ndi
 
@@ -496,34 +494,21 @@ def random_walker(
     if data.dtype == np.float16:
         # SciPy sparse, which is used later on, doesn't officially support float16
         # This led to failures when testing with NumPy 1.26 (see gh-7635).
-        warnings.warn(
-            message="upcasting `data` with dtype float16 to float32",
-            stacklevel=3,
-        )
         data = data.astype(np.float32, casting="safe")
 
     # Spacing kwarg checks
     if spacing is None:
-        spacing = np.ones(3, dtype=data.dtype)
+        spacing = np.ones(3)
     elif len(spacing) == labels.ndim:
-        if not isinstance(spacing, np.ndarray):
-            spacing = np.asarray(spacing, dtype=data.dtype)
         if len(spacing) == 2:
             # Need a dummy spacing for singleton 3rd dim
             spacing = np.r_[spacing, 1.0]
+        spacing = np.asarray(spacing)
     else:
         raise ValueError(
             'Input argument `spacing` incorrect, should be an '
             'iterable with one number per spatial dimension.'
         )
-    try:
-        spacing = spacing.astype(data.dtype, casting="safe", copy=False)
-    except TypeError as error:
-        msg = (
-            f"Cannot safely cast `spacing` to the same dtype as `data`, got: "
-            f"{data.dtype=}, {spacing.dtype=}"
-        )
-        raise TypeError(msg) from error
 
     # This algorithm expects 4-D arrays of floats, where the first three
     # dimensions are spatial and the final denotes channels. 2-D images have

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -148,6 +148,7 @@ def _build_laplacian(data, spacing, mask, beta, multichannel):
     j_indices = edges[::-1].ravel()
     data = np.hstack((weights, weights))
     lap = sparse.csr_array((data, (i_indices, j_indices)), shape=(pixel_nb, pixel_nb))
+    lap = sparse.lil_array(lap)  # Avoid SparseEfficiencyWarning
     lap.setdiag(-np.ravel(lap.sum(axis=0)))
     return lap
 

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -505,9 +505,9 @@ def random_walker(
     # Spacing kwarg checks
     if spacing is None:
         spacing = np.ones(3, dtype=data.dtype)
-    elif not isinstance(spacing, np.ndarray):
-        spacing = np.asarray(spacing, dtype=data.dtype)
-    if len(spacing) == labels.ndim:
+    elif len(spacing) == labels.ndim:
+        if not isinstance(spacing, np.ndarray):
+            spacing = np.asarray(spacing, dtype=data.dtype)
         if len(spacing) == 2:
             # Need a dummy spacing for singleton 3rd dim
             spacing = np.r_[spacing, 1.0]

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -8,6 +8,8 @@ Installing pyamg and using the 'cg_mg' mode of random_walker improves
 significantly the performance.
 """
 
+import warnings
+
 import numpy as np
 from scipy import sparse, ndimage as ndi
 
@@ -504,6 +506,15 @@ def random_walker(
             'Input argument `spacing` incorrect, should be an '
             'iterable with one number per spatial dimension.'
         )
+
+    if data.dtype == np.float16:
+        # SciPy sparse, which is used later on, doesn't officially support float16
+        # This led to failures when testing with NumPy 1.26 (see gh-7635).
+        warnings.warn(
+            message="upcasting `data` with dtype float16 to float32",
+            stacklevel=3,
+        )
+        data = data.astype(np.float32)
 
     # This algorithm expects 4-D arrays of floats, where the first three
     # dimensions are spatial and the final denotes channels. 2-D images have

--- a/skimage/segmentation/random_walker_segmentation.py
+++ b/skimage/segmentation/random_walker_segmentation.py
@@ -148,7 +148,6 @@ def _build_laplacian(data, spacing, mask, beta, multichannel):
     j_indices = edges[::-1].ravel()
     data = np.hstack((weights, weights))
     lap = sparse.csr_array((data, (i_indices, j_indices)), shape=(pixel_nb, pixel_nb))
-    lap = sparse.lil_array(lap)  # Avoid SparseEfficiencyWarning
     lap.setdiag(-np.ravel(lap.sum(axis=0)))
     return lap
 

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -89,9 +89,6 @@ def test_2d_bf(dtype):
     assert data.shape == labels.shape
 
 
-@pytest.mark.filterwarnings(
-    "ignore:upcasting `data` with dtype float16 to float32:UserWarning:skimage"
-)
 @pytest.mark.filterwarnings('ignore:"cg" mode may be slow:UserWarning:skimage')
 @testing.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_2d_cg(dtype):

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -578,6 +578,9 @@ def test_empty_labels():
     random_walker(image, labels)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Changing the sparsity structure of a csr_matrix is expensive::scipy"
+)
 def test_float16_upcasting_warning():
     data, labels = make_2d_syntheticdata(lx=70, ly=100)
     data = data.astype(np.float16, copy=False)

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -578,9 +578,6 @@ def test_empty_labels():
     random_walker(image, labels)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:Changing the sparsity structure of a csr_matrix is expensive::scipy"
-)
 def test_float16_upcasting_warning():
     data, labels = make_2d_syntheticdata(lx=70, ly=100)
     data = data.astype(np.float16, copy=False)

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -579,7 +579,7 @@ def test_empty_labels():
 
 
 @pytest.mark.filterwarnings(
-    "ignore:Changing the sparsity structure of a csr_matrix is expensive:scipy"
+    "ignore:Changing the sparsity structure of a csr_matrix is expensive::scipy"
 )
 def test_float16_upcasting_warning():
     data, labels = make_2d_syntheticdata(lx=70, ly=100)

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -588,7 +588,10 @@ def test_float16_upcasting_warning():
     regex = "upcasting `data` with dtype float16 to float32"
     with pytest.warns(UserWarning, match=regex) as record:
         random_walker(data, labels, beta=90, mode='cg_j')
-    testing.assert_stacklevel(record)
+    # For SciPy 1.11.2, an additionional SparseEfficiencyWarning (ignored above)
+    # is raised, we need to drop it so that assert_stacklevel doesn't check it
+    record = [r for r in record if "upcasting" in r.message.args[0]]
+    testing.assert_stacklevel(record, offset=-2)
     assert len(record) == 1
 
 

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from skimage._shared import testing
 from skimage._shared._warnings import expected_warnings
@@ -60,6 +61,9 @@ def make_3d_syntheticdata(lx, ly=None, lz=None):
     return data, seeds
 
 
+@pytest.mark.filterwarnings(
+    "ignore:upcasting `data` with dtype float16 to float32::skimage"
+)
 @testing.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_2d_bf(dtype):
     lx = 70
@@ -88,50 +92,51 @@ def test_2d_bf(dtype):
     assert data.shape == labels.shape
 
 
+@pytest.mark.filterwarnings(
+    "ignore:upcasting `data` with dtype float16 to float32:UserWarning:skimage"
+)
+@pytest.mark.filterwarnings('ignore:"cg" mode may be slow:UserWarning:skimage')
 @testing.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_2d_cg(dtype):
     lx = 70
     ly = 100
     data, labels = make_2d_syntheticdata(lx, ly)
     data = data.astype(dtype, copy=False)
-    with expected_warnings(
-        ['Changing the sparsity structure|"cg" mode|scipy.sparse.linalg.cg']
-    ):
-        labels_cg = random_walker(data, labels, beta=90, mode='cg')
+
+    labels_cg = random_walker(data, labels, beta=90, mode='cg')
     assert (labels_cg[25:45, 40:60] == 2).all()
     assert data.shape == labels.shape
-    with expected_warnings(
-        ['Changing the sparsity structure|"cg" mode|scipy.sparse.linalg.cg']
-    ):
-        full_prob = random_walker(
-            data, labels, beta=90, mode='cg', return_full_prob=True
-        )
+
+    full_prob = random_walker(data, labels, beta=90, mode='cg', return_full_prob=True)
     assert (full_prob[1, 25:45, 40:60] >= full_prob[0, 25:45, 40:60]).all()
     assert data.shape == labels.shape
 
 
+@pytest.mark.filterwarnings(
+    "ignore:upcasting `data` with dtype float16 to float32::skimage"
+)
+@pytest.mark.filterwarnings("ignore:Implicit conversion of A to CSR::pyamg")
 @testing.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_2d_cg_mg(dtype):
     lx = 70
     ly = 100
     data, labels = make_2d_syntheticdata(lx, ly)
     data = data.astype(dtype, copy=False)
-    anticipated_warnings = [
-        f'Changing the sparsity structure|conversion of A to CSR|scipy.sparse.sparsetools|'
-        f'{PYAMG_MISSING_WARNING}|scipy.sparse.linalg.cg'
-    ]
-    with expected_warnings(anticipated_warnings):
-        labels_cg_mg = random_walker(data, labels, beta=90, mode='cg_mg')
+
+    labels_cg_mg = random_walker(data, labels, beta=90, mode='cg_mg')
     assert (labels_cg_mg[25:45, 40:60] == 2).all()
     assert data.shape == labels.shape
-    with expected_warnings(anticipated_warnings):
-        full_prob = random_walker(
-            data, labels, beta=90, mode='cg_mg', return_full_prob=True
-        )
+
+    full_prob = random_walker(
+        data, labels, beta=90, mode='cg_mg', return_full_prob=True
+    )
     assert (full_prob[1, 25:45, 40:60] >= full_prob[0, 25:45, 40:60]).all()
     assert data.shape == labels.shape
 
 
+@pytest.mark.filterwarnings(
+    "ignore:upcasting `data` with dtype float16 to float32::skimage"
+)
 @testing.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_2d_cg_j(dtype):
     lx = 70
@@ -571,3 +576,14 @@ def test_empty_labels():
     # Once seeds are provided, it should run without error
     labels[3, 3] = 1
     random_walker(image, labels)
+
+
+def test_float16_upcasting_warning():
+    data, labels = make_2d_syntheticdata(lx=70, ly=100)
+    data = data.astype(np.float16, copy=False)
+
+    regex = "upcasting `data` with dtype float16 to float32"
+    with pytest.warns(UserWarning, match=regex) as record:
+        random_walker(data, labels, beta=90, mode='cg_j')
+    testing.assert_stacklevel(record)
+    assert len(record) == 1

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -578,6 +578,9 @@ def test_empty_labels():
     random_walker(image, labels)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Changing the sparsity structure of a csr_matrix is expensive:scipy"
+)
 def test_float16_upcasting_warning():
     data, labels = make_2d_syntheticdata(lx=70, ly=100)
     data = data.astype(np.float16, copy=False)

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -61,9 +61,6 @@ def make_3d_syntheticdata(lx, ly=None, lz=None):
     return data, seeds
 
 
-@pytest.mark.filterwarnings(
-    "ignore:upcasting `data` with dtype float16 to float32::skimage"
-)
 @testing.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_2d_bf(dtype):
     lx = 70
@@ -112,9 +109,6 @@ def test_2d_cg(dtype):
     assert data.shape == labels.shape
 
 
-@pytest.mark.filterwarnings(
-    "ignore:upcasting `data` with dtype float16 to float32::skimage"
-)
 @pytest.mark.filterwarnings("ignore:Implicit conversion of A to CSR::pyamg")
 @testing.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_2d_cg_mg(dtype):
@@ -134,9 +128,6 @@ def test_2d_cg_mg(dtype):
     assert data.shape == labels.shape
 
 
-@pytest.mark.filterwarnings(
-    "ignore:upcasting `data` with dtype float16 to float32::skimage"
-)
 @testing.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_2d_cg_j(dtype):
     lx = 70


### PR DESCRIPTION
## Description

Fixes https://github.com/scikit-image/scikit-image/issues/7635.

SciPy sparse, which is used in `random_walker`, doesn't officially support float16. This led to failures when testing with NumPy 1.26, and only worked accidentally for other NumPy versions (see GH issue 7635).

This fix handles that situation gracefully and makes the upcasting clear to users, in the hopefully least disruptive way.

Also update related warning plubming from `expected_warnings` to external `pytest.mark.filterwarnings`. The latter is hopefully a step towards less maintenance.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Explicitly upcast `data` with dtype `float16` to `float32` in 
`skimage.segmentation.random_walker`; this fixes passing `float16` on NumPy 1.26.
```
