### PR TITLE
Temporarily disable parallel building of gallery

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -128,7 +128,9 @@ sphinx_gallery_conf = {
     # Remove sphinx_gallery_thumbnail_number from generated files
     "remove_config_comments": True,
     # `True` defaults to the number of jobs used by Sphinx (see its flag `-j`)
-    "parallel": True,
+    #   Temporarily disabled because plotly scraper isn't parallel-safe
+    #   (see https://github.com/plotly/plotly.py/issues/4959)!
+    # "parallel": True,
 }
 
 


### PR DESCRIPTION
## Description

plotly's scraper for sphinx-gallery isn't parallel-safe, see https://github.com/plotly/plotly.py/issues/4959. To get rid of frequent failures like [this one](https://github.com/scikit-image/scikit-image/actions/runs/12680820918/job/35343335107#step:6:2332) we can temporarily prevent the gallery from building in parallel.  

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
