### PR TITLE
Upgrade kaleido

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ docs = [
     'ipywidgets',
     'ipykernel',  # needed until https://github.com/jupyter-widgets/ipywidgets/issues/3731 is resolved
     'plotly>=5.20',
-    'kaleido==0.2.1',
+    'kaleido>=1.0.0rc0',
     'scikit-learn>=1.2',
     'sphinx_design>=0.5',
     'pydata-sphinx-theme>=0.16',

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -15,7 +15,7 @@ intersphinx-registry>=0.2411.14
 ipywidgets
 ipykernel
 plotly>=5.20
-kaleido==0.2.1
+kaleido>=1.0.0rc0
 scikit-learn>=1.2
 sphinx_design>=0.5
 pydata-sphinx-theme>=0.16


### PR DESCRIPTION
Try their new version, which no longer pre-packages the browser.

xref: https://github.com/plotly/plotly.py/issues/4959