### PR TITLE
Test docs & gallery on Windows (Azure) only for `main`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ variables:
   SKIMAGE_DATA_CACHE_FOLDER: C:\Users\VssAdministrator\AppData\Local\scikit-image\scikit-image\Cache
 
 jobs:
-  - job: "Default"
+  - job: "Pytest"
     pool:
       vmImage: "windows-latest"
     strategy:
@@ -15,6 +15,7 @@ jobs:
         Python313-x64:
           PYTHON_VERSION: "3.13"
           ARCH: "x64"
+          DOCS_ON_MAIN: "true"
         Python312-x64:
           PYTHON_VERSION: "3.12"
           ARCH: "x64"
@@ -22,14 +23,9 @@ jobs:
           PYTHON_VERSION: "3.12"
           ARCH: "x64"
           PIP_FLAGS: "--pre"
-        Python311-x64-docs:
+        Python311-x64:
           PYTHON_VERSION: "3.11"
           ARCH: "x64"
-          BUILD_DOCS: "true"
-        Python311-x64-gallery:
-          PYTHON_VERSION: "3.11"
-          ARCH: "x64"
-          TEST_EXAMPLES: "true"
     continueOnError: false
     timeoutInMinutes: 60
 
@@ -190,35 +186,9 @@ jobs:
           export SPHINXCACHE=${AGENT_BUILDDIRECTORY}/.cache/sphinx
           export SPHINXOPTS="-W -j auto"
           make -C doc html
-        condition: eq(variables['BUILD_DOCS'], 'true')
+        condition: |
+          and(
+              eq(variables['DOCS_ON_MAIN'], 'true'),
+              eq(variables['Build.SourceBranch'], 'refs/heads/main')
+          )
         displayName: "Documentation testing"
-
-      - bash: |
-          set -ex
-          PYTHON="$(python.pythonLocation)\\python.exe"
-
-          # Install the doc dependencies
-          $PYTHON -m pip install ${PIP_FLAGS} -r requirements/docs.txt
-          $PYTHON -m pip list
-
-          # Force matplotlib to use the prepared config
-          export MATPLOTLIBRC=${AGENT_BUILDDIRECTORY}
-
-          # Run example applications
-          for f in doc/examples/*/*.py; do
-            # Comment out any plotly.io.show() calls before running the example.
-            # Plotly opens a web browser, which often seemed to cause the CI to
-            # hang and timeout.
-            sed -i 's/plotly.io.show/# plotly.io.show/g' ${f}
-
-            $PYTHON -W ignore:Matplotlib:UserWarning "${f}"
-            if [ $? -ne 0 ]; then
-              exit 1
-            fi
-          done
-        condition: eq(variables['TEST_EXAMPLES'], 'true')
-        displayName: "Gallery testing"
-#  - bash: |
-#      # -- Publish the .whl artifacts
-#      # -- Upload the content of dist/*.whl to a public wheelhouse
-#    displayName: 'Further consideration'


### PR DESCRIPTION
## Description

The Azure jobs testing our documentation are still the longest running jobs in our CI: ~40 min or longer. As a first step, I'd like to exclude them from running for every PR. That should get the iteration time for PRs down to 20 min (building the package will be the biggest contributor to runtime after than). 

@stefanv, suggested to disable them altogether. I'm not sure yet how I feel about that. Since we have contributors on Windows, I do want to ensure that that building the docs locally keeps working for them. 

So for now, I propose this compromise which skips in PRs and keeps building the docs on `main`.


## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
