### PR TITLE
Skip flaky test on azure

### DIFF
--- a/skimage/graph/tests/test_rag.py
+++ b/skimage/graph/tests/test_rag.py
@@ -4,6 +4,7 @@ import numpy as np
 from skimage import graph
 from skimage import segmentation, data
 from skimage._shared import testing
+import sys
 
 
 def max_edge(g, src, dst, n):
@@ -206,6 +207,8 @@ def test_ncut_stable_subgraph():
     assert new_labels.max() == 0
 
 
+# FIXME: https://github.com/scikit-image/scikit-image/issues/7651
+@pytest.mark.skipif(sys.platform == "win32", reason="test is flaky on azure")
 def test_reproducibility():
     """ensure cut_normalized returns the same output for the same input,
     when specifying random seed


### PR DESCRIPTION
See https://github.com/scikit-image/scikit-image/issues/7651

This is a temporary fix until someone can figure out how to make the test reliable. That fix should revert this change.

## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
