### PR TITLE
Ensure pytest configuration in pyproject.toml is picked up

### DIFF
--- a/tools/github/script.sh
+++ b/tools/github/script.sh
@@ -23,7 +23,7 @@ python -m pip list
 
 
 # Run the tests
-(cd .. && pytest $TEST_ARGS --pyargs skimage)
+pytest $TEST_ARGS --pyargs skimage
 
 
 # Optionally, prepare building the docs (and test examples)


### PR DESCRIPTION
## Description

~~Supersedes #7555. Closes https://github.com/scikit-image/scikit-image/issues/7554.~~

Edit: #7555 might actually be the better short-term fix after all.

Stepping out of the directory during tests might have been for the purpose of ensuring that the installed version is tested? Not sure if that is still necessary with the way we build and test. There's only one compiled version so if pytest tries to do the wrong thing, then it should fail and we should notice...

Though I would feel more secure about this if we were using the SRC-layout.


## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
