### PR TITLE
Arpack eigenvector for zero A

### DIFF
--- a/skimage/graph/_graph_cut.py
+++ b/skimage/graph/_graph_cut.py
@@ -268,6 +268,17 @@ def _ncut_relabel(rag, thresh, num_cuts, random_generator):
     m = w.shape[0]
 
     if m > 2:
+        if (d != w).nnz == 0:
+            # Degenerate case, usually 3 single pixels.
+            #
+            # We're not sure exactly why this case arises. For SciPy <= 0.14, SciPy continued
+            # to compute an eigenvector, but later versions (correctly) won't.
+            # We refuse to guess, and give up.
+            #
+            # It may make sense to a warning here; on the other hand segmentations
+            # are not a ground truth, so this level of "noise" should be acceptable.
+            return
+
         d2 = d.copy()
         # Since d is diagonal, we can directly operate on its data
         # the inverse of the square root


### PR DESCRIPTION
Potentially closes #7653

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Handle random degenerate case in `skimage.graph.cut_normalized` gracefully. 
``` 