### PR TITLE
Remove unused & obsolete `legacy_datasets`, `legacy_registry` vars

### DIFF
--- a/skimage/data/_registry.py
+++ b/skimage/data/_registry.py
@@ -1,40 +1,3 @@
-# This minimal dataset was available as part of
-# scikit-image 0.15 and will be retained until
-# further notice.
-# Testing data and additional datasets should only
-# be made available by pooch
-legacy_datasets = [
-    'astronaut.png',
-    'brick.png',
-    'camera.png',
-    'chessboard_GRAY.png',
-    'chessboard_RGB.png',
-    'chelsea.png',
-    'clock_motion.png',
-    'coffee.png',
-    'coins.png',
-    'color.png',
-    'cell.png',
-    'grass.png',
-    'gravel.png',
-    'horse.png',
-    'hubble_deep_field.jpg',
-    'ihc.png',
-    'lbpcascade_frontalface_opencv.xml',
-    'lfw_subset.npy',
-    'logo.png',
-    'microaneurysms.png',
-    'moon.png',
-    'page.png',
-    'text.png',
-    'retina.jpg',
-    'rocket.jpg',
-    'phantom.png',
-    'motorcycle_disp.npz',
-    'motorcycle_left.png',
-    'motorcycle_right.png',
-]
-
 # Registry of datafiles that can be downloaded along with their SHA256 hashes
 # To generate the SHA256 hash, use the command
 # openssl sha256 filename
@@ -177,8 +140,4 @@ registry_urls = {
     "data/solidification.tif": "https://gitlab.com/scikit-image/data/-/raw/2cdc5ce89b334d28f06a58c9f0ca21aa6992a5ba/nickel_solidification.tif",
     "restoration/tests/astronaut_rl.npy": "https://gitlab.com/scikit-image/data/-/raw/2cdc5ce89b334d28f06a58c9f0ca21aa6992a5ba/astronaut_rl.npy",
     "data/gray_morph_output.npz": "https://gitlab.com/scikit-image/data/-/raw/806548e112bcf2b708a9a32275d335cb592480fd/Tests_besides_Equalize_Otsu/gray_morph_output.npz",
-}
-
-legacy_registry = {
-    ('data/' + filename): registry['data/' + filename] for filename in legacy_datasets
 }


### PR DESCRIPTION
## Description

Closes https://github.com/scikit-image/scikit-image/issues/7676. 

It looks like `legacy_datasets` is only ever used to create `legacy_registry`. `legacy_datasets` is also not including all datasets from v0.15 as the comment implies.

So I propose to remove them.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
