### PR TITLE
Test scikit-image on free-threaded Python using pytest-run-parallel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,21 +116,34 @@ jobs:
     name: linux-cp313t-default
     runs-on: ubuntu-latest
 
+    strategy:
+      # Ensure that a wheel builder finishes even if another fails
+      fail-fast: false
+      matrix:
+        run_parallel: [0, 1]
+    env:
+      RUN_PARALLEL: ${{ matrix.run_parallel }}
+
     steps:
       - name: Checkout scikit-image
         uses: actions/checkout@v4
 
       # TODO: replace with setup-python when there is support
-      - uses: deadsnakes/action@6c8b9b82fe0b4344f4b98f2775fcc395df45e494 # v3.1.0
+      # TODO: replace with setup-python when there is support
+      - uses: Quansight-Labs/setup-python@b9ab292c751a42bcd2bb465b7fa202ea2c3f5796 # v5.3.1
         with:
-          python-version: "3.13"
-          nogil: true
+          python-version: "3.13t"
 
       - name: Install nightly dependencies
         run: |
           set -ex
           source tools/github/before_install.sh
           pip install -vv --no-build-isolation .
+
+      - name: Install pytest-run-parallel
+        if: ${{ matrix.run_parallel == '1' }}
+        run: |
+          pip install pytest-run-parallel
 
       - name: Run tests
         env:

--- a/skimage/_shared/tests/test_testing.py
+++ b/skimage/_shared/tests/test_testing.py
@@ -18,6 +18,7 @@ from skimage._shared._warnings import expected_warnings
 from warnings import warn
 
 
+@pytest.mark.thread_unsafe
 def test_skipper():
     def f():
         pass
@@ -82,6 +83,7 @@ def test_skipper():
         doctest_skip_parser(c)
 
 
+@pytest.mark.thread_unsafe
 @pytest.mark.skipif(is_wasm, reason="Cannot start threads in WASM")
 def test_run_in_parallel():
     state = []
@@ -108,6 +110,7 @@ def test_run_in_parallel():
     assert len(state) == 6
 
 
+@pytest.mark.thread_unsafe
 @pytest.mark.skipif(is_wasm, reason="Cannot run parallel code in WASM")
 def test_parallel_warning():
     @run_in_parallel()
@@ -124,6 +127,7 @@ def test_parallel_warning():
     change_state_warns_passes()
 
 
+@pytest.mark.thread_unsafe
 def test_expected_warnings_noop():
     # This will ensure the line beolow it behaves like a no-op
     with expected_warnings(['Expected warnings test']):

--- a/skimage/color/tests/test_colorconv.py
+++ b/skimage/color/tests/test_colorconv.py
@@ -915,7 +915,7 @@ def test_gray2rgba_dtype():
         assert gray2rgba(img).dtype == img.dtype
 
 
-def test_gray2rgba_alpha():
+def test_gray2rgba_alpha(num_parallel_threads):
     img = np.random.random((5, 5))
     img_u8 = img_as_ubyte(img)
 
@@ -942,9 +942,10 @@ def test_gray2rgba_alpha():
 
     # Warning about alpha cast
     alpha = 0.5
-    with expected_warnings(["alpha cannot be safely cast to image dtype"]):
-        rgba = gray2rgba(img_u8, alpha)
-        assert_equal(rgba[..., :3], gray2rgb(img_u8))
+    if num_parallel_threads == 1:
+        with expected_warnings(["alpha cannot be safely cast to image dtype"]):
+            rgba = gray2rgba(img_u8, alpha)
+            assert_equal(rgba[..., :3], gray2rgb(img_u8))
 
     # Invalid shape
     alpha = np.random.random((5, 5, 1))

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -203,6 +203,7 @@ def test_avg(channel_axis):
     assert_array_equal(out_bg, expected_out_bg)
 
 
+@pytest.mark.thread_unsafe
 def test_negative_intensity():
     labels = np.arange(100).reshape(10, 10)
     image = np.full((10, 10), -1, dtype='float64')
@@ -309,6 +310,7 @@ def test_overlay_custom_saturation():
     assert_array_almost_equal(saturaded_img[:3, :3] * (1 - alpha), rgb[:3, :3])
 
 
+@pytest.mark.thread_unsafe
 def test_saturation_warning():
     rgb_img = np.random.uniform(size=(10, 10, 3))
     labels = np.ones((10, 10), dtype=np.int64)

--- a/skimage/conftest.py
+++ b/skimage/conftest.py
@@ -1,9 +1,34 @@
 import pytest
 
+try:
+    import pytest_run_parallel  # noqa:F401
+
+    PARALLEL_RUN_AVAILABLE = True
+except Exception:
+    PARALLEL_RUN_AVAILABLE = False
+
+
 # List of files that pytest should ignore
 collect_ignore = [
     "io/_plugins",
 ]
+
+
+def pytest_configure(config):
+    if not PARALLEL_RUN_AVAILABLE:
+        config.addinivalue_line(
+            'markers',
+            'parallel_threads(n): run the given test function in parallel '
+            'using `n` threads.',
+        )
+        config.addinivalue_line(
+            "markers",
+            "thread_unsafe: mark the test function as single-threaded",
+        )
+        config.addinivalue_line(
+            "markers",
+            "iterations(n): run the given test function `n` times in each thread",
+        )
 
 
 @pytest.fixture(autouse=True)

--- a/skimage/data/tests/test_data.py
+++ b/skimage/data/tests/test_data.py
@@ -167,6 +167,7 @@ def test_brain_3d():
     assert image.shape == (10, 256, 256)
 
 
+@pytest.mark.thread_unsafe
 @pytest.mark.xfail(
     Version(np.__version__) >= Version('2.0.0.dev0'),
     reason='tifffile uses deprecated attribute `ndarray.newbyteorder`',

--- a/skimage/draw/tests/test_random_shapes.py
+++ b/skimage/draw/tests/test_random_shapes.py
@@ -151,6 +151,7 @@ def test_throws_when_intensity_range_out_of_range():
         random_shapes((2, 2), max_shapes=1, intensity_range=((-1, 255),))
 
 
+@pytest.mark.thread_unsafe
 def test_returns_empty_labels_and_white_image_when_cannot_fit_shape():
     # The circle will never fit this.
     with expected_warnings(['Could not fit']):

--- a/skimage/exposure/tests/test_exposure.py
+++ b/skimage/exposure/tests/test_exposure.py
@@ -357,6 +357,7 @@ def test_rescale_same_values():
     assert_array_almost_equal(out, image)
 
 
+@pytest.mark.thread_unsafe
 @pytest.mark.skipif(
     Version(np.__version__) < Version('1.25'),
     reason="Older NumPy throws a few extra warnings here",

--- a/skimage/feature/tests/test_corner.py
+++ b/skimage/feature/tests/test_corner.py
@@ -162,7 +162,7 @@ def test_structure_tensor_sigma(ndim):
 
 
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
-def test_hessian_matrix(dtype):
+def test_hessian_matrix(dtype, num_parallel_threads):
     square = np.zeros((5, 5), dtype=dtype)
     square[2, 2] = 4
     Hrr, Hrc, Hcc = hessian_matrix(
@@ -210,10 +210,11 @@ def test_hessian_matrix(dtype):
         ),
     )
 
-    with expected_warnings(["use_gaussian_derivatives currently defaults"]):
-        # FutureWarning warning when use_gaussian_derivatives is not
-        # specified.
-        hessian_matrix(square, sigma=0.1, order='rc')
+    if num_parallel_threads == 1:
+        with expected_warnings(["use_gaussian_derivatives currently defaults"]):
+            # FutureWarning warning when use_gaussian_derivatives is not
+            # specified.
+            hessian_matrix(square, sigma=0.1, order='rc')
 
 
 @pytest.mark.parametrize('use_gaussian_derivatives', [False, True])
@@ -698,6 +699,7 @@ def test_corner_fast_image_unsupported_error():
         corner_fast(img)
 
 
+@pytest.mark.thread_unsafe
 @run_in_parallel()
 def test_corner_fast_astronaut():
     img = rgb2gray(data.astronaut())

--- a/skimage/feature/tests/test_haar.py
+++ b/skimage/feature/tests/test_haar.py
@@ -88,6 +88,7 @@ def test_haar_like_feature_precomputed(feature_type):
     img = np.ones((5, 5), dtype=np.int8)
     img_ii = integral_image(img)
     if isinstance(feature_type, list):
+        feature_type = list(feature_type)
         # shuffle the index of the feature to be sure that we are output
         # the features in the same order
         shuffle(feature_type)

--- a/skimage/feature/tests/test_peak.py
+++ b/skimage/feature/tests/test_peak.py
@@ -452,6 +452,7 @@ class TestPeakLocalMax:
             peak.peak_local_max(image, min_distance=5, threshold_rel=0).tolist()
         ) == [[5, 5, 5, 5], [15, 15, 15, 15]]
 
+    @pytest.mark.thread_unsafe
     def test_threshold_rel_default(self):
         image = np.ones((5, 5))
 

--- a/skimage/feature/tests/test_texture.py
+++ b/skimage/feature/tests/test_texture.py
@@ -275,6 +275,7 @@ class TestLBP:
         )
         np.testing.assert_array_equal(lbp, ref)
 
+    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
     def test_float_warning(self, dtype):
         image = self.image.astype(dtype)

--- a/skimage/filters/rank/tests/test_rank.py
+++ b/skimage/filters/rank/tests/test_rank.py
@@ -106,6 +106,7 @@ class TestRank:
         self.refs = ref_data
         self.refs_3d = ref_data_3d
 
+    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('outdt', [None, np.float32, np.float64])
     @pytest.mark.parametrize('filter', all_rank_filters)
     def test_rank_filter(self, filter, outdt):
@@ -156,6 +157,7 @@ class TestRank:
         with pytest.raises(ValueError):
             getattr(rank, filter)(self.image.astype(np.uint8), footprint_sequence)
 
+    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('outdt', [None, np.float32, np.float64])
     @pytest.mark.parametrize('filter', _3d_rank_filters)
     def test_rank_filters_3D(self, filter, outdt):
@@ -307,6 +309,7 @@ class TestRank:
             cm = gray.erosion(image, elem)
             assert_equal(out, cm)
 
+    @pytest.mark.thread_unsafe
     def test_bitdepth(self):
         # test the different bit depth for rank16
 
@@ -389,6 +392,7 @@ class TestRank:
         )
         assert_equal(r, out)
 
+    @pytest.mark.thread_unsafe
     def test_pass_on_bitdepth(self):
         # should pass because data bitdepth is not too high for the function
 
@@ -436,6 +440,7 @@ class TestRank:
 
         assert_equal(loc_autolevel, loc_perc_autolevel)
 
+    @pytest.mark.thread_unsafe
     def test_compare_ubyte_vs_float(self):
         # Create signed int8 image that and convert it to uint8
         image_uint = img_as_ubyte(data.camera()[:50, :50])
@@ -458,6 +463,7 @@ class TestRank:
                 out_f = func(image_float, disk(3))
             assert_equal(out_u, out_f)
 
+    @pytest.mark.thread_unsafe
     def test_compare_ubyte_vs_float_3d(self):
         # Create signed int8 volume that and convert it to uint8
         np.random.seed(0)
@@ -492,6 +498,7 @@ class TestRank:
                 out_f = func(volume_float, ball(3))
             assert_equal(out_u, out_f)
 
+    @pytest.mark.thread_unsafe
     def test_compare_8bit_unsigned_vs_signed(self):
         # filters applied on 8-bit image or 16-bit image (having only real 8-bit
         # of dynamic) should be identical
@@ -526,6 +533,7 @@ class TestRank:
                 out_s = func(image_s, disk(3))
             assert_equal(out_u, out_s)
 
+    @pytest.mark.thread_unsafe
     def test_compare_8bit_unsigned_vs_signed_3d(self):
         # filters applied on 8-bit volume or 16-bit volume (having only real 8-bit
         # of dynamic) should be identical
@@ -787,6 +795,7 @@ class TestRank:
         th = 1 * (test >= rank.otsu(test, footprint))
         assert_equal(th, res)
 
+    @pytest.mark.thread_unsafe
     def test_entropy(self):
         #  verify that entropy is coherent with bitdepth of the input data
 
@@ -860,6 +869,7 @@ class TestRank:
             )
             assert_equal(image, out)
 
+    @pytest.mark.thread_unsafe
     def test_16bit(self):
         image = np.zeros((21, 21), dtype=np.uint16)
         footprint = np.ones((3, 3), dtype=np.uint8)

--- a/skimage/graph/tests/test_rag.py
+++ b/skimage/graph/tests/test_rag.py
@@ -209,6 +209,7 @@ def test_ncut_stable_subgraph():
 
 # FIXME: https://github.com/scikit-image/scikit-image/issues/7651
 @pytest.mark.skipif(sys.platform == "win32", reason="test is flaky on azure")
+@pytest.mark.thread_unsafe
 def test_reproducibility():
     """ensure cut_normalized returns the same output for the same input,
     when specifying random seed

--- a/skimage/io/tests/test_collection.py
+++ b/skimage/io/tests/test_collection.py
@@ -70,6 +70,7 @@ def test_imagecollection_input():
     assert len(images) == 3
 
 
+@pytest.mark.thread_unsafe
 class TestImageCollection:
     pics = [fetch('data/brick.png'), fetch('data/color.png'), fetch('data/moon.png')]
     pattern = pics[:2]

--- a/skimage/io/tests/test_imageio.py
+++ b/skimage/io/tests/test_imageio.py
@@ -1,6 +1,7 @@
 from tempfile import NamedTemporaryFile
 
 import numpy as np
+import threading
 from skimage.io import imread, imsave, plugin_order
 
 from skimage._shared import testing
@@ -65,7 +66,9 @@ class TestSave:
             min_, max_, endpoint=True, num=np.prod(shape), dtype=dtype
         )
         expected = expected.reshape(shape)
-        file_path = tmp_path / "roundtrip.png"
+        tmp_dir = tmp_path / str(threading.get_native_id())
+        tmp_dir.mkdir()
+        file_path = tmp_dir / "roundtrip.png"
         imsave(file_path, expected)
         actual = imread(file_path)
         np.testing.assert_array_almost_equal(actual, expected)

--- a/skimage/io/tests/test_multi_image.py
+++ b/skimage/io/tests/test_multi_image.py
@@ -7,7 +7,10 @@ from skimage.io.collection import MultiImage
 from skimage._shared import testing
 from skimage._shared.testing import assert_equal, assert_allclose
 
+import pytest
 from pytest import fixture
+
+pytestmark = pytest.mark.thread_unsafe
 
 
 @fixture
@@ -30,6 +33,7 @@ def imgs():
     reset_plugins()
 
 
+@pytest.mark.thread_unsafe
 def test_shapes(imgs):
     imgs = imgs[-1]
     assert imgs[0][0].shape == imgs[0][1].shape
@@ -54,6 +58,7 @@ def test_slicing(imgs):
     assert_allclose(img[0], img[::-1][-1])
 
 
+@pytest.mark.thread_unsafe
 def test_getitem(imgs):
     for img in imgs[0]:
         num = len(img)

--- a/skimage/io/tests/test_pil.py
+++ b/skimage/io/tests/test_pil.py
@@ -26,6 +26,7 @@ from .._plugins.pil_plugin import _palette_is_grayscale, ndarray_to_pil, pil_to_
 
 
 plugin_deprecation_warning = r"use `imageio` or other I/O packages directly|\A\Z"
+pytestmark = pytest.mark.thread_unsafe
 
 
 @pytest.fixture(autouse=True)
@@ -157,6 +158,7 @@ def test_imread_truncated_jpg():
         imread(fetch('data/truncated.jpg'))
 
 
+@pytest.mark.thread_unsafe
 def test_jpg_quality_arg():
     chessboard = np.load(fetch('data/chessboard_GRAY_U8.npy'))
     with temporary_file(suffix='.jpg') as jpg:
@@ -222,6 +224,7 @@ def test_imsave_incorrect_dimension():
                 imsave(fname, np.zeros((2, 3, 2)), check_contrast=False)
 
 
+@pytest.mark.thread_unsafe
 def test_imsave_filelike():
     shape = (2, 2)
     image = np.zeros(shape)
@@ -238,6 +241,7 @@ def test_imsave_filelike():
     assert_allclose(out, image)
 
 
+@pytest.mark.thread_unsafe
 def test_imsave_boolean_input():
     shape = (2, 2)
     image = np.eye(*shape, dtype=bool)
@@ -262,6 +266,7 @@ def test_imexport_imimport():
     assert_equal(out.shape, shape)
 
 
+@pytest.mark.thread_unsafe
 def test_all_color():
     with expected_warnings(['.* is a boolean image', plugin_deprecation_warning]):
         color_check('pil')
@@ -269,6 +274,7 @@ def test_all_color():
         color_check('pil', 'bmp')
 
 
+@pytest.mark.thread_unsafe
 def test_all_mono():
     with expected_warnings(['.* is a boolean image', plugin_deprecation_warning]):
         mono_check('pil')

--- a/skimage/io/tests/test_tifffile.py
+++ b/skimage/io/tests/test_tifffile.py
@@ -8,6 +8,9 @@ from skimage._shared.testing import fetch
 from skimage.io import imread, imsave, reset_plugins, use_plugin
 
 
+pytestmark = pytest.mark.thread_unsafe
+
+
 @pytest.fixture(autouse=True)
 def _use_tifffile_plugin():
     """Ensure that PIL plugin is used in tests here."""
@@ -36,6 +39,7 @@ def test_imread_multipage_rgb_tif():
     assert img.shape == (2, 10, 10, 3), img.shape
 
 
+@pytest.mark.thread_unsafe
 def test_tifffile_kwarg_passthrough():
     img = imread(fetch('data/multipage.tif'), key=[1], is_ome=True)
     assert img.shape == (15, 10), img.shape
@@ -49,6 +53,7 @@ def test_imread_handle():
     assert_array_almost_equal(img, expected)
 
 
+@pytest.mark.thread_unsafe
 class TestSave:
     def roundtrip(self, dtype, x, use_pathlib=False, **kwargs):
         with NamedTemporaryFile(suffix='.tif') as f:

--- a/skimage/measure/tests/test_fit.py
+++ b/skimage/measure/tests/test_fit.py
@@ -532,6 +532,7 @@ def test_ransac_geometric():
     assert np.all(np.nonzero(inliers == False)[0] == outliers)
 
 
+@pytest.mark.thread_unsafe
 def test_ransac_is_data_valid():
     def is_data_valid(data):
         return data.shape[0] > 2
@@ -549,6 +550,7 @@ def test_ransac_is_data_valid():
     assert_equal(inliers, None)
 
 
+@pytest.mark.thread_unsafe
 def test_ransac_is_model_valid():
     def is_model_valid(model, data):
         return False
@@ -661,6 +663,7 @@ def test_ransac_invalid_input():
         ransac(np.zeros((10, 2)), None, min_samples=-1, residual_threshold=0)
 
 
+@pytest.mark.thread_unsafe
 def test_ransac_sample_duplicates():
     class DummyModel:
         """Dummy model to check for duplicates."""
@@ -680,6 +683,7 @@ def test_ransac_sample_duplicates():
         ransac(data, DummyModel, min_samples=3, residual_threshold=0.0, max_trials=10)
 
 
+@pytest.mark.thread_unsafe
 def test_ransac_with_no_final_inliers():
     data = np.random.rand(5, 2)
     with expected_warnings(['No inliers found. Model not fitted']):
@@ -694,6 +698,7 @@ def test_ransac_with_no_final_inliers():
     assert model is None
 
 
+@pytest.mark.thread_unsafe
 def test_ransac_non_valid_best_model():
     """Example from GH issue #5572"""
 

--- a/skimage/metrics/tests/test_set_metrics.py
+++ b/skimage/metrics/tests/test_set_metrics.py
@@ -7,6 +7,7 @@ from skimage._shared._warnings import expected_warnings
 from skimage.metrics import hausdorff_distance, hausdorff_pair
 
 
+@pytest.mark.thread_unsafe
 def test_hausdorff_empty():
     empty = np.zeros((0, 2), dtype=bool)
     non_empty = np.zeros((3, 2), dtype=bool)

--- a/skimage/metrics/tests/test_simple_metrics.py
+++ b/skimage/metrics/tests/test_simple_metrics.py
@@ -42,6 +42,7 @@ def test_PSNR_vs_IPOL():
     assert_almost_equal(p, p_IPOL, decimal=4)
 
 
+@pytest.mark.thread_unsafe
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_PSNR_float(dtype):
     p_uint8 = peak_signal_noise_ratio(cam, cam_noisy)

--- a/skimage/metrics/tests/test_structural_similarity.py
+++ b/skimage/metrics/tests/test_structural_similarity.py
@@ -215,6 +215,7 @@ def test_mssim_vs_legacy(dtype):
     assert_almost_equal(mssim, mssim_skimage_0pt17)
 
 
+@pytest.mark.thread_unsafe
 def test_ssim_warns_about_data_range():
     mssim = structural_similarity(cam, cam_noisy)
     with expected_warnings(['Setting data_range based on im1.dtype']):

--- a/skimage/morphology/tests/test_convex_hull.py
+++ b/skimage/morphology/tests/test_convex_hull.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from skimage.morphology import convex_hull_image, convex_hull_object
 from skimage.morphology._convex_hull import possible_hull
 
@@ -35,6 +36,7 @@ def test_basic():
     assert_array_equal(convex_hull_image(image), expected)
 
 
+@pytest.mark.thread_unsafe
 def test_empty_image():
     image = np.zeros((6, 6), dtype=bool)
     with expected_warnings(['entirely zero']):
@@ -331,6 +333,7 @@ def test_consistent_2d_3d_hulls(images2d3d):
     assert_array_equal(chimage3d[1], chimage)
 
 
+@pytest.mark.thread_unsafe
 def test_few_points():
     image = np.array(
         [

--- a/skimage/morphology/tests/test_extrema.py
+++ b/skimage/morphology/tests/test_extrema.py
@@ -3,6 +3,7 @@ import unittest
 
 import numpy as np
 from numpy.testing import assert_equal
+import pytest
 from pytest import raises, warns
 
 from skimage._shared.testing import expected_warnings
@@ -196,6 +197,7 @@ class TestExtrema:
             error = diff(expected_result, out)
             assert error < eps
 
+    @pytest.mark.thread_unsafe
     def test_h_maxima_float_h(self):
         """specific tests for h-maxima float h parameter"""
         data = np.array(
@@ -275,6 +277,7 @@ class TestExtrema:
             error = diff(expected_result, out)
             assert error < eps
 
+    @pytest.mark.thread_unsafe
     def test_h_minima_float_h(self):
         """specific tests for h-minima float h parameter"""
         data = np.array(

--- a/skimage/morphology/tests/test_misc.py
+++ b/skimage/morphology/tests/test_misc.py
@@ -49,6 +49,7 @@ def test_in_place():
     )
 
 
+@pytest.mark.thread_unsafe
 @pytest.mark.parametrize("in_dtype", [bool, int, np.int32])
 @pytest.mark.parametrize("out_dtype", [bool, int, np.int32])
 def test_out(in_dtype, out_dtype):
@@ -91,6 +92,7 @@ def test_uint_image():
     assert_array_equal(observed, expected)
 
 
+@pytest.mark.thread_unsafe
 def test_single_label_warning():
     image = np.array([[0, 0, 0, 1, 0], [1, 1, 1, 0, 0], [1, 1, 1, 0, 0]], int)
     with expected_warnings(['use a boolean array?']):
@@ -183,6 +185,7 @@ def test_non_bool_out():
         remove_small_holes(image, area_threshold=3, out=expected_out)
 
 
+@pytest.mark.thread_unsafe
 def test_labeled_image_holes():
     labeled_holes_image = np.array(
         [
@@ -215,6 +218,7 @@ def test_labeled_image_holes():
     assert_array_equal(observed, expected)
 
 
+@pytest.mark.thread_unsafe
 def test_uint_image_holes():
     labeled_holes_image = np.array(
         [
@@ -247,6 +251,7 @@ def test_uint_image_holes():
     assert_array_equal(observed, expected)
 
 
+@pytest.mark.thread_unsafe
 def test_label_warning_holes():
     labeled_holes_image = np.array(
         [
@@ -395,6 +400,7 @@ class Test_remove_near_objects:
         desired = np.array([0, 1, 0, 1])
         assert_array_equal(result, desired)
 
+    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize("order", ["C", "F"])
     def test_out(self, order):
         labels_original = np.array([[1, 0, 2], [1, 0, 2]], order=order)

--- a/skimage/restoration/tests/test_denoise.py
+++ b/skimage/restoration/tests/test_denoise.py
@@ -359,6 +359,7 @@ def test_denoise_bilateral_3d_grayscale():
         restoration.denoise_bilateral(img, channel_axis=None)
 
 
+@pytest.mark.thread_unsafe
 def test_denoise_bilateral_3d_multichannel():
     img = np.ones((50, 50, 50))
     with expected_warnings(["grayscale"]):

--- a/skimage/restoration/tests/test_unwrap.py
+++ b/skimage/restoration/tests/test_unwrap.py
@@ -1,6 +1,8 @@
 import numpy as np
 from skimage.restoration import unwrap_phase
 import sys
+import sysconfig
+import pytest
 
 from skimage._shared import testing
 from skimage._shared.testing import (
@@ -133,11 +135,16 @@ dim_axis = [(ndim, axis) for ndim in (2, 3) for axis in range(ndim)]
     sys.version_info[:2] == (3, 4),
     reason="Doesn't work with python 3.4. See issue #3079",
 )
+@skipif(
+    bool(sysconfig.get_config_var("Py_GIL_DISABLED")),
+    reason='This test is failing under free-threaded Python',
+)
 @testing.parametrize("ndim, axis", dim_axis)
 def test_wrap_around(ndim, axis):
     check_wrap_around(ndim, axis)
 
 
+@pytest.mark.thread_unsafe
 def test_mask():
     length = 100
     ramps = [

--- a/skimage/segmentation/tests/test_boundaries.py
+++ b/skimage/segmentation/tests/test_boundaries.py
@@ -128,8 +128,8 @@ def test_mark_boundaries_subpixel(dtype):
         [[0, 0, 0, 0], [0, 0, 5, 0], [0, 1, 5, 0], [0, 0, 5, 0], [0, 0, 0, 0]],
         dtype=np.uint8,
     )
-    np.random.seed(0)
-    image = np.round(np.random.rand(*labels.shape), 2)
+    rng = np.random.RandomState(0)
+    image = np.round(rng.random(labels.shape), 2)
     image = image.astype(dtype, copy=False)
     marked = mark_boundaries(image, labels, color=white, mode='subpixel')
     assert marked.dtype == _supported_float_type(dtype)

--- a/skimage/segmentation/tests/test_felzenszwalb.py
+++ b/skimage/segmentation/tests/test_felzenszwalb.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from skimage import data
 from skimage.segmentation import felzenszwalb
 
@@ -46,6 +47,7 @@ def test_minsize():
         assert_greater(counts.min() + 1, min_size)
 
 
+@pytest.mark.thread_unsafe
 @testing.parametrize('channel_axis', [0, -1])
 def test_3D(channel_axis):
     grey_img = np.zeros((10, 10))

--- a/skimage/segmentation/tests/test_random_walker.py
+++ b/skimage/segmentation/tests/test_random_walker.py
@@ -90,6 +90,7 @@ def test_2d_bf(dtype):
 
 
 @pytest.mark.filterwarnings('ignore:"cg" mode may be slow:UserWarning:skimage')
+@pytest.mark.thread_unsafe
 @testing.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_2d_cg(dtype):
     lx = 70
@@ -188,6 +189,7 @@ def test_2d_laplacian_size():
     np.testing.assert_array_equal(labels, expected_labels)
 
 
+@pytest.mark.thread_unsafe
 @testing.parametrize('dtype', [np.float32, np.float64])
 def test_3d(dtype):
     n = 30
@@ -202,6 +204,7 @@ def test_3d(dtype):
     assert data.shape == labels.shape
 
 
+@pytest.mark.thread_unsafe
 def test_3d_inactive():
     n = 30
     lx, ly, lz = n, n, n
@@ -217,6 +220,7 @@ def test_3d_inactive():
     assert data.shape == labels.shape
 
 
+@pytest.mark.thread_unsafe
 @testing.parametrize('channel_axis', [0, 1, -1])
 @testing.parametrize('dtype', [np.float32, np.float64])
 def test_multispectral_2d(dtype, channel_axis):
@@ -244,6 +248,7 @@ def test_multispectral_2d(dtype, channel_axis):
     assert data[..., 0].shape == labels.shape
 
 
+@pytest.mark.thread_unsafe
 @testing.parametrize('dtype', [np.float32, np.float64])
 def test_multispectral_3d(dtype):
     n = 30
@@ -265,6 +270,7 @@ def test_multispectral_3d(dtype):
     assert data[..., 0].shape == labels.shape
 
 
+@pytest.mark.thread_unsafe
 def test_spacing_0():
     n = 30
     lx, ly, lz = n, n, n
@@ -296,6 +302,7 @@ def test_spacing_0():
     assert (labels_aniso[13:17, 13:17, 7:9] == 2).all()
 
 
+@pytest.mark.thread_unsafe
 # Passing on WASM
 @xfail(
     condition=arch32 and not is_wasm,
@@ -359,6 +366,7 @@ def test_spacing_1():
     assert (labels_aniso2[26:34, 13:17, 13:17] == 2).all()
 
 
+@pytest.mark.thread_unsafe
 def test_trivial_cases():
     # When all voxels are labeled
     img = np.ones((10, 10))
@@ -442,6 +450,7 @@ def test_bad_inputs():
         random_walker(img, labels, mode='bad')
 
 
+@pytest.mark.thread_unsafe
 def test_isolated_seeds():
     np.random.seed(0)
     a = np.random.random((7, 7))
@@ -472,6 +481,7 @@ def test_isolated_seeds():
     assert res[1, 1, 1] == 0
 
 
+@pytest.mark.thread_unsafe
 def test_isolated_area():
     np.random.seed(0)
     a = np.random.random((7, 7))
@@ -502,6 +512,7 @@ def test_isolated_area():
     assert res[1, 1, 1] == 0
 
 
+@pytest.mark.thread_unsafe
 def test_prob_tol():
     np.random.seed(0)
     a = np.random.random((7, 7))

--- a/skimage/segmentation/tests/test_slic.py
+++ b/skimage/segmentation/tests/test_slic.py
@@ -169,6 +169,7 @@ def test_gray_3d():
         assert_equal(seg[s], c)
 
 
+@pytest.mark.thread_unsafe
 def test_list_sigma():
     rng = np.random.default_rng(0)
     img = np.array([[1, 1, 1, 0, 0, 0], [0, 0, 0, 1, 1, 1]], float)

--- a/skimage/transform/tests/test_radon_transform.py
+++ b/skimage/transform/tests/test_radon_transform.py
@@ -268,8 +268,8 @@ def test_reconstruct_with_wrong_angles():
 
 def _random_circle(shape):
     # Synthetic random data, zero outside reconstruction circle
-    np.random.seed(98312871)
-    image = np.random.rand(*shape)
+    rng = np.random.RandomState(98312871)
+    image = rng.rand(*shape)
     c0, c1 = np.ogrid[0 : shape[0], 0 : shape[1]]
     r = np.sqrt((c0 - shape[0] // 2) ** 2 + (c1 - shape[1] // 2) ** 2)
     radius = min(shape) // 2
@@ -277,6 +277,7 @@ def _random_circle(shape):
     return image
 
 
+@pytest.mark.thread_unsafe
 def test_radon_circle():
     a = np.ones((10, 10))
     with expected_warnings(['reconstruction circle']):
@@ -487,6 +488,7 @@ def test_radon_dtype():
     assert radon(img32).dtype == img32.dtype
 
 
+@pytest.mark.thread_unsafe
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 def test_iradon_sart_dtype(dtype):
     sinogram = np.zeros((16, 1), dtype=int)

--- a/skimage/transform/tests/test_warps.py
+++ b/skimage/transform/tests/test_warps.py
@@ -146,6 +146,7 @@ def test_warp_clip_cval_is_nan(order):
     assert_array_almost_equal(np.nanmax(outx), 2)
 
 
+@pytest.mark.thread_unsafe
 @pytest.mark.parametrize('order', range(6))
 def test_warp_clip_cval_outside_input_range(order):
     # Test that clipping behavior considers cval part of the input range
@@ -166,6 +167,7 @@ def test_warp_clip_cval_outside_input_range(order):
         assert np.sum(np.less(1, outx) * np.less(outx, 2)) > 0
 
 
+@pytest.mark.thread_unsafe
 @pytest.mark.parametrize('order', range(6))
 def test_warp_clip_cval_not_used(order):
     # Test that clipping does not consider cval part of the input range if it
@@ -466,6 +468,7 @@ def test_resize_clip(order, preserve_range, anti_aliasing, dtype):
     assert np.nanmax(resized) == expected_max
 
 
+@pytest.mark.thread_unsafe
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
 def test_swirl(dtype):
     image = img_as_float(checkerboard()).astype(dtype, copy=False)
@@ -600,6 +603,7 @@ def test_downsize_anti_aliasing():
         )
 
 
+@pytest.mark.thread_unsafe
 def test_downsize_anti_aliasing_invalid_stddev():
     x = np.zeros((10, 10), dtype=np.float64)
     with pytest.raises(ValueError):

--- a/skimage/util/tests/test_dtype.py
+++ b/skimage/util/tests/test_dtype.py
@@ -1,5 +1,6 @@
 import numpy as np
 import itertools
+import pytest
 from skimage import (
     img_as_float,
     img_as_float32,
@@ -87,6 +88,7 @@ def test_range_extra_dtypes(dtype_in, dt):
     )
 
 
+@pytest.mark.thread_unsafe
 def test_downcast():
     x = np.arange(10).astype(np.uint64)
     with expected_warnings(['Downcasting']):
@@ -187,6 +189,7 @@ def test_float_conversion_dtype():
         assert y.dtype == np.dtype(dtype_out)
 
 
+@pytest.mark.thread_unsafe
 def test_float_conversion_dtype_warns():
     """Test that convert issues a warning when called"""
     from skimage.util.dtype import convert

--- a/tools/github/script.sh
+++ b/tools/github/script.sh
@@ -3,6 +3,9 @@
 set -evx
 
 TEST_ARGS="--doctest-plus --showlocals"
+if [[ $RUN_PARALLEL == "1" ]]; then
+  TEST_ARGS="$TEST_ARGS --parallel-threads=4"
+fi
 
 
 # Combine requirement files for a more robust pip solve


### PR DESCRIPTION
## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

This PR adds an additional CI job on top of the already-existing 3.13 free threaded one, this new CI pipeline runs the scikit-image testsuite using the [pytest-run-parallel](https://github.com/Quansight-Labs/pytest-run-parallel/) plugin, which allows to run individual tests concurrently during a pytest session

Some tests were using the global random number generator, via np.random.seed, which was causing numeric result mismatches when the tests were being run in parallel. Instead, all tests now use np.random.RandomState, which ensures that each thread gets its own independent random generator.

Also, several tests check for warnings, which as 3.13 is not thread-safe, therefore, such tests are marked as thread unsafe and are run in a single thread

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
