### PR TITLE
Try and force meson to use clang, instead of gcc

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,6 +126,9 @@ jobs:
 
           which clang || true
 
+          export CC=clang
+          export CXX=clang++
+
           # Compile the package and build the wheel
           $PYTHON -m build --no-isolation --skip-dependency-check --wheel
 

--- a/skimage/graph/tests/test_rag.py
+++ b/skimage/graph/tests/test_rag.py
@@ -4,7 +4,6 @@ import numpy as np
 from skimage import graph
 from skimage import segmentation, data
 from skimage._shared import testing
-import sys
 
 
 def max_edge(g, src, dst, n):
@@ -207,8 +206,6 @@ def test_ncut_stable_subgraph():
     assert new_labels.max() == 0
 
 
-# FIXME: https://github.com/scikit-image/scikit-image/issues/7651
-@pytest.mark.skipif(sys.platform == "win32", reason="test is flaky on azure")
 def test_reproducibility():
     """ensure cut_normalized returns the same output for the same input,
     when specifying random seed


### PR DESCRIPTION
gcc is building a library that has a random reproducibility failure; no one who uses clang has been able to reproduce so far, so let's hope using that compiler helps.