### PR TITLE
Ignore UserWarning for missing pyamg in test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,7 @@ python_functions = ["time_*", "test_*", "peakmem_*"]
 filterwarnings = [
     "error",
     "ignore:.*use `imageio` or other I/O packages directly.*:FutureWarning:skimage",
+    "ignore:.*requires pyamg.*:UserWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Description

pyamg is marked as "optional" (and not available as a Debian package yet).

Otherwise, if pyamg is not installed, tests will fail with
```
[…]
        if mode == 'cg_mg' and not amg_loaded:
>           warn(
                '"cg_mg" not available, it requires pyamg to be installed. '
                'The "cg_j" mode will be used instead.',
                stacklevel=2,
            )
E           UserWarning: "cg_mg" not available, it requires pyamg to be installed. The "cg_j" mode will be used instead.
skimage/segmentation/random_walker_segmentation.py:190: UserWarning
```
## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
