### PR TITLE
Simultaneously resolve all dependencies; add pip caching

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -36,6 +36,8 @@ jobs:
         name: Install Python
         with:
           python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "requirements/*.txt"
 
       - name: Setup some dependencies
         shell: bash -l {0}

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "requirements/*.txt"
       - name: Install dependencies
         run: |
           sudo apt install optipng

--- a/.github/workflows/emscripten.yaml
+++ b/.github/workflows/emscripten.yaml
@@ -39,6 +39,8 @@ jobs:
         uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+          cache: "pip"
+          cache-dependency-path: "requirements/*.txt"
 
       - name: Set up Emscripten toolchain
         uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -23,6 +23,8 @@ jobs:
         with:
           python-version: "3.13"
           allow-prereleases: true
+          cache: "pip"
+          cache-dependency-path: "requirements/*.txt"
 
       - name: Build and install from source
         run: |

--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -110,6 +110,12 @@ jobs:
         run: |
           source .github/scripts/setup-test-env.sh
 
+      - name: Verify non-conflicting dependencies
+        if: ${{ matrix.OPTIONAL_DEPS == 1 && matrix.MINIMUM_REQUIREMENTS == 0}}
+        run: |
+          # Attempt to resolve all requirements simultaneously
+          pip install --dry-run --ignore-installed $(ls requirements/*.txt | sed 's/^/-r /')
+
       - name: Run tests
         env:
           # A lazy loader configuration parameter

--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -81,6 +81,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version}}
           allow-prereleases: true
+          cache: "pip"
+          cache-dependency-path: "requirements/*.txt"
 
       - name: Install build dependencies
         if: ${{ matrix.INSTALL_FROM_SDIST != 1 }}

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -42,6 +42,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version}}
           allow-prereleases: true
+          cache: "pip"
+          cache-dependency-path: "requirements/*.txt"
 
       - name: OSX configuration
         run: |

--- a/.github/workflows/test-nightlies-on-main.yaml
+++ b/.github/workflows/test-nightlies-on-main.yaml
@@ -36,6 +36,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "requirements/*.txt"
 
       - name: Setup build dependencies
         # PIP_FLAGS: exposed via global env

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -50,6 +50,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version}}
           allow-prereleases: true
+          cache-dependency-path: "requirements/*.txt"
+          cache: "pip"
 
       - name: Install build dependencies
         env:

--- a/.github/workflows/wheel-recipe.yaml
+++ b/.github/workflows/wheel-recipe.yaml
@@ -47,6 +47,8 @@ jobs:
         name: Install Python
         with:
           python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "requirements/*.txt"
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
       - name: Setup free-threaded environment
@@ -93,6 +95,8 @@ jobs:
         name: Install Python
         with:
           python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "requirements/*.txt"
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
       - name: Build the wheel
@@ -131,6 +135,8 @@ jobs:
         name: Install Python
         with:
           python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "requirements/*.txt"
 
       - name: Install cibuildwheel
         run: |
@@ -218,6 +224,8 @@ jobs:
         name: Install Python
         with:
           python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "requirements/*.txt"
 
       - name: Install cibuildwheel and add clang-cl to path
         run: |

--- a/.github/workflows/wheel-test-and-release.yaml
+++ b/.github/workflows/wheel-test-and-release.yaml
@@ -36,6 +36,8 @@ jobs:
         name: Install Python
         with:
           python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "requirements/*.txt"
 
       - uses: actions/download-artifact@v4
         id: download


### PR DESCRIPTION
@lagru was concerned that, because of CI simplifications, we no longer simultaneously resolve all dependencies to see if they are compatible. This step aims to bring back that check.