### PR TITLE
Milestone labeler permission not needed

### DIFF
--- a/.github/workflows/milestone-merged-prs.yaml
+++ b/.github/workflows/milestone-merged-prs.yaml
@@ -7,8 +7,7 @@ on:
     branches:
       - "main"
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
   milestone_pr:


### PR DESCRIPTION
I suspect this permission addition wasn't needed.