### PR TITLE
Don't assign `-inf` to watershed markers

### DIFF
--- a/skimage/segmentation/_watershed.py
+++ b/skimage/segmentation/_watershed.py
@@ -172,7 +172,7 @@ def watershed(
 
     .. [2] https://en.wikipedia.org/wiki/Watershed_%28image_processing%29
 
-    .. [3] http://cmm.ensmp.fr/~beucher/wtshed.html
+    .. [3] https://web.archive.org/web/20180702213110/http://cmm.ensmp.fr/~beucher/wtshed.html
 
     .. [4] P. J. Soille and M. M. Ansoult, "Automated basin delineation from
            digital elevation models using mathematical morphology," Signal

--- a/skimage/segmentation/_watershed_cy.pyx
+++ b/skimage/segmentation/_watershed_cy.pyx
@@ -2,7 +2,6 @@
 """
 from libc.math cimport sqrt
 from .._shared.fused_numerics cimport np_anyint
-import numpy as np
 
 cimport numpy as cnp
 cimport cython
@@ -116,14 +115,13 @@ def watershed_raveled(cnp.float64_t[::1] image,
     cdef Py_ssize_t index = 0
     cdef Py_ssize_t neighbor_index = 0
     cdef DTYPE_BOOL_t compact = (compactness > 0)
-    cdef cnp.float64_t neg_inf = -np.inf
 
     cdef Heap *hp = <Heap *> heap_from_numpy2()
 
     with nogil:
         for i in range(marker_locations.shape[0]):
             index = marker_locations[i]
-            elem.value = neg_inf
+            elem.value = image[index]
             elem.age = 0
             elem.index = index
             elem.source = index

--- a/skimage/segmentation/_watershed_cy.pyx
+++ b/skimage/segmentation/_watershed_cy.pyx
@@ -180,8 +180,12 @@ def watershed_raveled(cnp.float64_t[::1] image,
                 new_elem.index = neighbor_index
                 new_elem.source = elem.source
 
-                # watershed cost of moving to neighbor is at least the cost of
-                # its own neighboring pixel
+                # The cost adding a neighbor should be at least the cost of its
+                # originating pixel, effectively its marker. This leads to "fairer"
+                # outcomes in edge cases. It prevents one marker from conquering a basin
+                # against other markers with a similar claim, just because it spills
+                # into the basin one step earlier. Instead `age` will distribute the
+                # basin more evenly between contesting markers with the same cost.
                 if new_elem.value < elem.value:
                     new_elem.value = elem.value
 

--- a/skimage/segmentation/tests/test_watershed.py
+++ b/skimage/segmentation/tests/test_watershed.py
@@ -892,6 +892,27 @@ def test_watershed_simple_basin_overspill():
     np.testing.assert_array_equal(result, expected)
 
 
+def test_watershed_evenly_distributed_overspill():
+    """Basins should be distributed evenly between contesting markers.
+
+    Markers should be prevented from spilling over into another basin and
+    conquering it against other markers with the same claim, just because they
+    get to the basin one step earlier.
+    """
+    # Scenario 1: markers start with the same value
+    image =    np.array([0, 2, 1, 1, 1, 1, 1, 1, 2, 0])  # fmt: skip
+    markers =  np.array([1, 0, 0, 0, 0, 0, 0, 0, 0, 2])  # fmt: skip
+    expected = np.array([1, 1, 1, 1, 1, 2, 2, 2, 2, 2])  # fmt: skip
+    result = watershed(image, markers=markers)
+    np.testing.assert_equal(result, expected)
+
+    # Scenario 2: markers start with the different values
+    image =    np.array([2, 2, 1, 1, 1, 1, 1, 1, 2, 0])  # fmt: skip
+    expected = np.array([1, 1, 1, 1, 1, 2, 2, 2, 2, 2])  # fmt: skip
+    result = watershed(image, markers=markers)
+    np.testing.assert_equal(result, expected)
+
+
 def test_markers_on_maxima():
     """Check that markers placed at maxima don't conquer other pixels.
 

--- a/skimage/segmentation/tests/test_watershed.py
+++ b/skimage/segmentation/tests/test_watershed.py
@@ -817,7 +817,8 @@ def test_compact_watershed():
 
 
 def test_watershed_with_markers_offset():
-    """Check behavior reported in gh-6632.
+    """
+    Check edge case behavior reported in gh-6632
 
     While we initially viewed the behavior described in gh-6632 [1]_ as a bug,
     we have reverted that decision in gh-7661. See [2]_ for an explanation.
@@ -862,7 +863,7 @@ def test_watershed_with_markers_offset():
 
 def test_watershed_simple_basin_overspill():
     """
-    Test behavior when markers spill over into another basin / compete.
+    Test edge case behavior when markers spill over into another basin / compete.
 
     While we initially viewed the behavior described in gh-6632 [1]_ as a bug,
     we have reverted that decision in gh-7661. See [2]_ for an explanation.
@@ -893,7 +894,8 @@ def test_watershed_simple_basin_overspill():
 
 
 def test_watershed_evenly_distributed_overspill():
-    """Basins should be distributed evenly between contesting markers.
+    """
+    Edge case: Basins should be distributed evenly between contesting markers.
 
     Markers should be prevented from spilling over into another basin and
     conquering it against other markers with the same claim, just because they

--- a/skimage/segmentation/tests/test_watershed.py
+++ b/skimage/segmentation/tests/test_watershed.py
@@ -817,9 +817,15 @@ def test_compact_watershed():
 
 
 def test_watershed_with_markers_offset():
-    """
-    Regression test from https://github.com/scikit-image/scikit-image/issues/6632
-    Generate an initial image with two overlapping circles.
+    """Check behavior reported in gh-6632.
+
+    While we initially viewed the behavior described in gh-6632 [1]_ as a bug,
+    we have reverted that decision in gh-7661. See [2]_ for an explanation.
+    So this test now actually asserts the behavior reported in gh-6632 as
+    correct.
+
+    .. [1] https://github.com/scikit-image/scikit-image/issues/6632.
+    .. [2] https://github.com/scikit-image/scikit-image/issues/7661#issuecomment-2645810807
     """
     # Generate an initial image with two overlapping circles
     x, y = np.indices((80, 80))
@@ -841,27 +847,63 @@ def test_watershed_with_markers_offset():
 
     labels = watershed(-distance, markers, mask=image)
 
+    props = skimage.measure.regionprops(labels, intensity_image=-distance)
+
+    # Generally, assert that the smaller object could only conquer a thin line
+    # in the direction of the positive gradient
+    assert props[0].extent == 1
+    expected_region = np.arange(start=-10, stop=0, dtype=float).reshape(-1, 1)
+    np.testing.assert_equal(props[0].image_intensity, expected_region)
+
     # Assert pixel count from reviewed reproducing example in bug report
-    # Generally, assert both objects have covered their basin
-    props = skimage.measure.regionprops(labels)
-    assert props[0].eccentricity <= 0.5
-    assert props[1].eccentricity <= 0.5
-    assert props[0].num_pixels == 732
-    assert props[1].num_pixels == 1206
+    assert props[0].num_pixels == 10
+    assert props[1].num_pixels == 1928
 
 
 def test_watershed_simple_basin_overspill():
     """
     Test behavior when markers spill over into another basin / compete.
 
-    Regression test for
-    https://github.com/scikit-image/scikit-image/issues/6632.
+    While we initially viewed the behavior described in gh-6632 [1]_ as a bug,
+    we have reverted that decision in gh-7661. See [2]_ for an explanation.
+    So this test now actually asserts the behavior reported in gh-6632 as
+    correct.
+
+    .. [1] https://github.com/scikit-image/scikit-image/issues/6632.
+    .. [2] https://github.com/scikit-image/scikit-image/issues/7661#issuecomment-2645810807
     """
+    # Scenario 1
+    # fmt: off
+    image =    np.array([[6, 5, 4, 3, 0, 3, 0, 1, 2],
+                         [6, 5, 4, 3, 0, 3, 0, 1, 2]])
+    markers =  np.array([[0, 1, 0, 0, 0, 0, 0, 2, 0],
+                         [0, 0, 0, 0, 0, 0, 0, 0, 0]])
+    expected = np.array([[1, 1, 2, 2, 2, 2, 2, 2, 2],
+                         [2, 2, 2, 2, 2, 2, 2, 2, 2]])
+    # fmt: on
+    result = watershed(image, markers=markers)
+    np.testing.assert_equal(result, expected)
+
+    # Scenario 2
     image = -np.array([1, 2, 2, 2, 2, 2, 3])
     markers = np.array([1, 0, 0, 0, 0, 0, 2])
-    expected = np.array([1, 1, 1, 1, 2, 2, 2])
+    expected = np.array([1, 2, 2, 2, 2, 2, 2])
     result = watershed(image, markers=markers, mask=image != 0)
     np.testing.assert_array_equal(result, expected)
+
+
+def test_markers_on_maxima():
+    """Check that markers placed at maxima don't conquer other pixels.
+
+    Regression test for gh-7661 [1]_.
+
+    .. [1] https://github.com/scikit-image/scikit-image/issues/7661
+    """
+    image = np.array([0, 1, 2, 3, 4, 5])
+    markers = np.array([1, 0, 0, 0, 0, 2])
+    expected = np.array([1, 1, 1, 1, 1, 2])
+    result = watershed(image, markers=markers)
+    np.testing.assert_equal(result, expected)
 
 
 def test_numeric_seed_watershed():
@@ -960,8 +1002,8 @@ def test_connectivity():
     assert np.unique(labels_c2).shape[0] == 5
 
     # checking via area of each individual segment.
-    for lab, area in zip(range(6), [61824, 3653, 20467, 11097, 1300, 11279]):
+    for lab, area in zip(range(6), [61824, 3653, 20467, 11097, 1301, 11278]):
         assert np.sum(labels_c1 == lab) == area
 
-    for lab, area in zip(range(5), [61824, 3653, 20466, 12385, 11292]):
+    for lab, area in zip(range(5), [61824, 3653, 20466, 12386, 11291]):
         assert np.sum(labels_c2 == lab) == area

--- a/skimage/segmentation/tests/test_watershed.py
+++ b/skimage/segmentation/tests/test_watershed.py
@@ -922,9 +922,12 @@ def test_markers_on_maxima():
 
     .. [1] https://github.com/scikit-image/scikit-image/issues/7661
     """
-    image = np.array([0, 1, 2, 3, 4, 5])
-    markers = np.array([1, 0, 0, 0, 0, 2])
-    expected = np.array([1, 1, 1, 1, 1, 2])
+    image =    np.array([[0, 1, 2, 3, 4, 5, 4],
+                         [0, 1, 2, 3, 4, 4, 4]])  # fmt: skip
+    markers =  np.array([[1, 0, 0, 0, 0, 2, 0],
+                         [0, 0, 0, 0, 0, 0, 0]])  # fmt: skip
+    expected = np.array([[1, 1, 1, 1, 1, 2, 1],
+                         [1, 1, 1, 1, 1, 1, 1]])  # fmt: skip
     result = watershed(image, markers=markers)
     np.testing.assert_equal(result, expected)
 


### PR DESCRIPTION
## Description

Closes #7661.

While we initially viewed the behavior described in #6632 as a bug, we have reverted that decision in #7661 ([long explanation](https://github.com/scikit-image/scikit-image/issues/7661#issuecomment-2645810807)). So this PR reverts parts of #7071 that address this.

I've also updated and expanded the set of tests covering these and more edge cases.

I hope the comments and commit messages make it somewhat easier to understand this and review it. If not, ask away!


## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Revert a previous fix to `skimage.segmentation.watershed` that
unintentionally changed the algorithm's behavior for markers placed
at maxima in the image. We decided that the behavior originally
reported as a bug (gh-6632), is not actually one.
```
