### PR TITLE
Display code blocks with a caption and extra indentation.

### DIFF
--- a/doc/examples/applications/plot_3d_structure_tensor.py
+++ b/doc/examples/applications/plot_3d_structure_tensor.py
@@ -76,24 +76,26 @@ for it, (ax, image) in enumerate(zip(axes.flatten(), sample[::step])):
 #####################################################################
 # To view the sample data in 3D, run the following code:
 #
-# .. code-block:: python
+#   .. code-block:: python
+#      :caption: We import the `plotly.graph_objects` module, upon which
+#                `plotly.express` is built.
 #
-#     import plotly.graph_objects as go
+#       import plotly.graph_objects as go
 #
-#     (n_Z, n_Y, n_X) = sample.shape
-#     Z, Y, X = np.mgrid[:n_Z, :n_Y, :n_X]
+#       (n_Z, n_Y, n_X) = sample.shape
+#       Z, Y, X = np.mgrid[:n_Z, :n_Y, :n_X]
 #
-#     fig = go.Figure(
-#         data=go.Volume(
-#             x=X.flatten(),
-#             y=Y.flatten(),
-#             z=Z.flatten(),
-#             value=sample.flatten(),
-#             opacity=0.5,
-#             slices_z=dict(show=True, locations=[4])
-#         )
-#     )
-#     fig.show()
+#       fig = go.Figure(
+#           data=go.Volume(
+#               x=X.flatten(),
+#               y=Y.flatten(),
+#               z=Z.flatten(),
+#               value=sample.flatten(),
+#               opacity=0.5,
+#               slices_z=dict(show=True, locations=[4])
+#           )
+#       )
+#       fig.show()
 
 #####################################################################
 # Compute structure tensor

--- a/doc/examples/applications/plot_fluorescence_nuclear_envelope.py
+++ b/doc/examples/applications/plot_fluorescence_nuclear_envelope.py
@@ -203,11 +203,13 @@ thresh_seq = [smooth_seq[k, ...] > val for k, val in enumerate(thresh_values)]
 # dimension now contains all pixel values), and applying the thresholding
 # function on the image sequence along its second axis:
 #
-# .. code-block:: python
+#   .. code-block:: python
+#      :caption: NumPy's `apply_along_axis` applies a function to 1D slices of
+#                `arr` along `axis`.
 #
-#     thresh_values = np.apply_along_axis(filters.threshold_otsu,
-#                                         axis=1,
-#                                         arr=smooth_seq.reshape(n_z, -1))
+#       thresh_values = np.apply_along_axis(filters.threshold_otsu,
+#                                           axis=1,
+#                                           arr=smooth_seq.reshape(n_z, -1))
 #
 # We use the following flat structuring element for morphological
 # computations (``np.newaxis`` is used to prepend an axis of size 1 for time):

--- a/doc/examples/applications/plot_fluorescence_nuclear_envelope.py
+++ b/doc/examples/applications/plot_fluorescence_nuclear_envelope.py
@@ -227,25 +227,27 @@ fill_seq = ndi.binary_fill_holes(thresh_seq, structure=footprint)
 # In this case, the only relevant border is the edge at the greatest (x, y)
 # values. This can be seen in 3D by running the following code:
 #
-# .. code-block:: python
+#   .. code-block:: python
+#      :caption: We import the `plotly.graph_objects` module, upon which
+#                `plotly.express` is built.
 #
-#     import plotly.graph_objects as go
+#       import plotly.graph_objects as go
 #
-#     sample = fill_seq
-#     (n_Z, n_Y, n_X) = sample.shape
-#     Z, Y, X = np.mgrid[:n_Z, :n_Y, :n_X]
+#       sample = fill_seq
+#       (n_Z, n_Y, n_X) = sample.shape
+#       Z, Y, X = np.mgrid[:n_Z, :n_Y, :n_X]
 #
-#     fig = go.Figure(
-#         data=go.Volume(
-#             x=X.flatten(),
-#             y=Y.flatten(),
-#             z=Z.flatten(),
-#             value=sample.flatten(),
-#             opacity=0.5,
-#             slices_z=dict(show=True, locations=[n_z // 2])
-#         )
-#     )
-#     fig.show()
+#       fig = go.Figure(
+#           data=go.Volume(
+#               x=X.flatten(),
+#               y=Y.flatten(),
+#               z=Z.flatten(),
+#               value=sample.flatten(),
+#               opacity=0.5,
+#               slices_z=dict(show=True, locations=[n_z // 2])
+#           )
+#       )
+#       fig.show()
 
 border_mask = np.ones_like(fill_seq)
 border_mask[n_z // 2, -1, -1] = False


### PR DESCRIPTION
## Description

With the new web theme, the `code-block` directive doesn't actually render the code block as a 'snapshot' (it looks just like regular code, as if the `code-block` directive wasn't even in there). See, this [example](https://scikit-image.org/docs/stable/auto_examples/applications/plot_3d_structure_tensor.html#sphx-glr-auto-examples-applications-plot-3d-structure-tensor-py):

![commented_out](https://github.com/user-attachments/assets/97c30b7f-7485-42d0-a615-da8e5686144c)

This issue was originally noted by @lagru at https://github.com/scikit-image/scikit-image/pull/7309#discussion_r1597646214. I applied the same 'fix' to the various (3) instances of `code-block` found in the gallery. The above code block now renders like this:

![cation_commented_out](https://github.com/user-attachments/assets/9633071c-039e-4a9d-aa03-6d09a5d4a6c4)

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
