### PR TITLE
Fix CircleCI redirector

### DIFF
--- a/.github/workflows/circleci.yaml
+++ b/.github/workflows/circleci.yaml
@@ -1,3 +1,5 @@
+name: CircleCI
+
 on: [status]
 permissions:
   contents: read


### PR DESCRIPTION
## Description

Our circleci redirector fails a lot of the time:
https://github.com/scikit-image/scikit-image/actions/workflows/circleci.yaml

Here is the error message:
```
 Run CircleCI artifacts redirector
invalid json response body at https://circleci.com/api/v2/project/gh/scikit-image/scikit-image/8411/artifacts reason: Unexpected token 'I', "Invalid to"... is not valid JSON
```

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
