### PR TITLE
Reflect deprecation of I/O plugin infrastructure in user guide.

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -11,7 +11,8 @@ Version 0.27
   - Remove `skimage/io/_plugins`
   - Remove `skimage/io/manage_plugins.py`
   - Remove `skimage/io/__init__.py::__getattr__`
-  - Remove related tests, imports, etc...
+  - Remove related tests, imports, etc.
+  - Remove `doc/source/user_guide/plugins.rst`
 * Complete deprecation of `square`, `rectangle` and `cube` in `skimage.morphology`.
 
 Version 0.26

--- a/TODO.txt
+++ b/TODO.txt
@@ -24,9 +24,6 @@ Version 0.26
   well as `test_compare_images_replaced_param` in `skimage/util/tests/test_compare.py`
   (and all `pytest.warns(FutureWarning)` context managers there).
 
-Version 0.25
-------------
-
 Other
 -----
 * Remove warningsfilter for imageio and Pillow once

--- a/doc/source/user_guide/plugins.rst
+++ b/doc/source/user_guide/plugins.rst
@@ -1,5 +1,11 @@
 I/O Plugin Infrastructure
 -------------------------
+
+.. note::
+    The plugin infrastructure of ``skimage.io`` is deprecated since version
+    0.25 and will be removed in version 0.27. Please use ``imageio`` or other
+    I/O packages directly.
+
 A plugin consists of two files, the source and the descriptor ``.ini``.  Let's
 say we'd like to provide a plugin for ``imshow`` using ``matplotlib``.  We'll
 call our plugin ``mpl``::


### PR DESCRIPTION
## Description

This is a minor completion of #7353. I noticed the [I/O Plugin Infrastructure page](https://scikit-image.org/docs/stable/user_guide/plugins.html) (identical in its dev version) was still around, so here's a note specifying we're moving away from this plugin infrastructure.

Prompted by question "read from zip file in URL" in the Zulip chat.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
