### PR TITLE
Remove deprecated shift parameters

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -24,9 +24,6 @@ Version 0.27
 
 Version 0.26
 ------------
-* In ``skimage/morphology/gray.py``, remove deprecated parameters ``shift_x``
-  and ``shift_y`` from ``erosion`` and ``dilation``, along with associated
-  function ``_shift_footprint``.
 * In `skimage/util/compare.py`, remove deprecated parameter `image2` as
   well as `test_compare_images_replaced_param` in `skimage/util/tests/test_compare.py`
   (and all `pytest.warns(FutureWarning)` context managers there).

--- a/skimage/morphology/gray.py
+++ b/skimage/morphology/gray.py
@@ -2,14 +2,11 @@
 Grayscale morphological operations
 """
 
-import warnings
-
 import numpy as np
 from scipy import ndimage as ndi
 
 from .footprints import _footprint_is_sequence, mirror_footprint, pad_footprint
 from .misc import default_footprint
-from .._shared.utils import DEPRECATED
 
 
 __all__ = ['erosion', 'dilation', 'opening', 'closing', 'white_tophat', 'black_tophat']
@@ -30,66 +27,6 @@ def _iterate_gray_func(gray_func, image, footprints, out, mode, cval):
         for _ in range(num_iter):
             gray_func(out.copy(), footprint=fp, output=out, mode=mode, cval=cval)
     return out
-
-
-def _shift_footprint(footprint, shift_x, shift_y):
-    """Shift the binary image `footprint` in the left and/or up.
-
-    This only affects 2D footprints with even number of rows
-    or columns.
-
-    Parameters
-    ----------
-    footprint : 2D array, shape (M, N)
-        The input footprint.
-    shift_x, shift_y : bool or None
-        Whether to move `footprint` along each axis. If ``None``, the
-        array is not modified along that dimension.
-
-    Returns
-    -------
-    out : 2D array, shape (M + int(shift_x), N + int(shift_y))
-        The shifted footprint.
-    """
-    footprint = np.asarray(footprint)
-    if footprint.ndim != 2:
-        # do nothing for 1D or 3D or higher footprints
-        return footprint
-    m, n = footprint.shape
-    if m % 2 == 0:
-        extra_row = np.zeros((1, n), footprint.dtype)
-        if shift_x:
-            footprint = np.vstack((footprint, extra_row))
-        else:
-            footprint = np.vstack((extra_row, footprint))
-        m += 1
-    if n % 2 == 0:
-        extra_col = np.zeros((m, 1), footprint.dtype)
-        if shift_y:
-            footprint = np.hstack((footprint, extra_col))
-        else:
-            footprint = np.hstack((extra_col, footprint))
-    return footprint
-
-
-def _shift_footprints(footprint, shift_x, shift_y):
-    """Shifts the footprints, whether it's a single array or a sequence.
-
-    See `_shift_footprint`, which is called for each array in the sequence.
-    """
-    if shift_x is DEPRECATED and shift_y is DEPRECATED:
-        return footprint
-
-    warning_msg = (
-        "The parameters `shift_x` and `shift_y` are deprecated since v0.23 and "
-        "will be removed in v0.26. Use `pad_footprint` or modify the footprint"
-        "manually instead."
-    )
-    warnings.warn(warning_msg, FutureWarning, stacklevel=4)
-
-    if _footprint_is_sequence(footprint):
-        return tuple((_shift_footprint(fp, shift_x, shift_y), n) for fp, n in footprint)
-    return _shift_footprint(footprint, shift_x, shift_y)
 
 
 def _min_max_to_constant_mode(dtype, mode, cval):
@@ -130,8 +67,6 @@ def erosion(
     image,
     footprint=None,
     out=None,
-    shift_x=DEPRECATED,
-    shift_y=DEPRECATED,
     *,
     mode="reflect",
     cval=0.0,
@@ -172,12 +107,6 @@ def erosion(
     -------
     eroded : array, same shape as `image`
         The result of the morphological erosion.
-
-    Other Parameters
-    ----------------
-    shift_x, shift_y : DEPRECATED
-
-        .. deprecated:: 0.23
 
     Notes
     -----
@@ -227,7 +156,6 @@ def erosion(
         mode = "max"
     mode, cval = _min_max_to_constant_mode(image.dtype, mode, cval)
 
-    footprint = _shift_footprints(footprint, shift_x, shift_y)
     footprint = pad_footprint(footprint, pad_end=False)
     if not _footprint_is_sequence(footprint):
         footprint = [(footprint, 1)]
@@ -248,8 +176,6 @@ def dilation(
     image,
     footprint=None,
     out=None,
-    shift_x=DEPRECATED,
-    shift_y=DEPRECATED,
     *,
     mode="reflect",
     cval=0.0,
@@ -291,12 +217,6 @@ def dilation(
     -------
     dilated : uint8 array, same shape and type as `image`
         The result of the morphological dilation.
-
-    Other Parameters
-    ----------------
-    shift_x, shift_y : DEPRECATED
-
-        .. deprecated:: 0.23
 
     Notes
     -----
@@ -346,7 +266,6 @@ def dilation(
         mode = "min"
     mode, cval = _min_max_to_constant_mode(image.dtype, mode, cval)
 
-    footprint = _shift_footprints(footprint, shift_x, shift_y)
     footprint = pad_footprint(footprint, pad_end=False)
     # Note that `ndi.grey_dilation` mirrors the footprint and this
     # additional inversion should be removed in skimage2, see gh-6676.

--- a/skimage/morphology/tests/test_gray.py
+++ b/skimage/morphology/tests/test_gray.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose, assert_array_equal, assert_equal
 
 from skimage import color, data, transform
 from skimage._shared._warnings import expected_warnings
-from skimage._shared.testing import fetch, assert_stacklevel
+from skimage._shared.testing import fetch
 from skimage.morphology import gray, footprints, footprint_rectangle
 from skimage.util import img_as_uint, img_as_ubyte
 
@@ -485,16 +485,3 @@ def test_octahedron_decomposition(cell3d_image, function, radius, decomposition)
     expected = func(cell3d_image, footprint=footprint_ndarray)
     out = func(cell3d_image, footprint=footprint)
     assert_array_equal(expected, out)
-
-
-@pytest.mark.parametrize("func", [gray.erosion, gray.dilation])
-@pytest.mark.parametrize("name", ["shift_x", "shift_y"])
-@pytest.mark.parametrize("value", [True, False, None])
-def test_deprecated_shift(func, name, value):
-    img = np.ones(10)
-    func(img)  # Shouldn't warn
-
-    regex = "`shift_x` and `shift_y` are deprecated"
-    with pytest.warns(FutureWarning, match=regex) as record:
-        func(img, **{name: value})
-    assert_stacklevel(record)


### PR DESCRIPTION
## Description

See #6695.
<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
