### PR TITLE
Fix corner case with empty skeleton (#3757)

### DIFF
--- a/skimage/morphology/_skeletonize_lee_cy.pyx.in
+++ b/skimage/morphology/_skeletonize_lee_cy.pyx.in
@@ -78,8 +78,10 @@ def _compute_thin_image(pixel_type[:, :, ::1] img not None):
 
         pixel_type neighb[27]
 
+        int[::1] Euler_LUT = LUT
+
     # loop over the six directions in this order (for consistency with ImageJ)
-    borders[:] = [4, 3, 2, 1, 5, 6]
+    borders[:] = [4, 2, 5, 3, 1, 6]
 
     with nogil:
         # no need to worry about the z direction if the original image is 2D.
@@ -107,7 +109,12 @@ def _compute_thin_image(pixel_type[:, :, ::1] img not None):
                     r = point.r
                     c = point.c
                     get_neighborhood(img, p, r, c, neighb)
-                    if is_simple_point(neighb):
+
+                    if (
+                        is_simple_point(neighb)
+                        and is_Euler_invariant(neighb, Euler_LUT)
+                        and not is_endpoint(neighb)
+                    ):
                         img[p, r, c] = 0
                         no_change = False
 


### PR DESCRIPTION
## Description

Fixes #3757

Fix was made based on comments in the issue and
some ideas from http://dx.doi.org/10.1117/12.2528805

1. Change border order from WESNUP to WSUENB (i.e. avoid processing opposite border as the next one)
2. Remove point only if it is Euler invariant and not endpoint (i.e. has two or more neighbors)

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
