### PR TITLE
Remove deprecated image2 param

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -22,12 +22,6 @@ Version 0.27
   - Remove `doc/source/user_guide/plugins.rst`
 * Complete deprecation of `square`, `rectangle` and `cube` in `skimage.morphology`.
 
-Version 0.26
-------------
-* In `skimage/util/compare.py`, remove deprecated parameter `image2` as
-  well as `test_compare_images_replaced_param` in `skimage/util/tests/test_compare.py`
-  (and all `pytest.warns(FutureWarning)` context managers there).
-
 Other
 -----
 * Once NumPy 1.25.0 is minimal required version:

--- a/skimage/util/compare.py
+++ b/skimage/util/compare.py
@@ -1,5 +1,4 @@
 import functools
-import warnings
 from itertools import product
 
 import numpy as np
@@ -8,28 +7,12 @@ from .dtype import img_as_float
 
 
 def _rename_image_params(func):
-    wm_images = (
-        "Since version 0.24, the two input images are named `image0` and "
-        "`image1` (instead of `image1` and `image2`, respectively). Please use "
-        "`image0, image1` to avoid this warning for now, and avoid an error "
-        "from version 0.26 onwards."
-    )
-
-    wm_method = (
-        "Starting in version 0.24, all arguments following `image0, image1` "
-        "(including `method`) will be keyword-only. Please pass `method=` "
-        "in the function call to avoid this warning for now, and avoid an error "
-        "from version 0.26 onwards."
-    )
-
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         # Turn all args into kwargs
         for i, (value, param) in enumerate(
             zip(args, ["image0", "image1", "method", "n_tiles"])
         ):
-            if i >= 2:
-                warnings.warn(wm_method, category=FutureWarning, stacklevel=2)
             if param in kwargs:
                 raise ValueError(
                     f"{param} passed both as positional and keyword argument."
@@ -37,21 +20,6 @@ def _rename_image_params(func):
             else:
                 kwargs[param] = value
         args = tuple()
-
-        # Account for `image2` if given
-        if "image2" in kwargs.keys():
-            warnings.warn(wm_images, category=FutureWarning, stacklevel=2)
-
-            # Safely move `image2` to `image1` if that's empty
-            if "image1" in kwargs.keys():
-                # Safely move `image1` to `image0`
-                if "image0" in kwargs.keys():
-                    raise ValueError(
-                        "Three input images given; please use only `image0` "
-                        "and `image1`."
-                    )
-                kwargs["image0"] = kwargs.pop("image1")
-            kwargs["image1"] = kwargs.pop("image2")
 
         return func(*args, **kwargs)
 

--- a/skimage/util/tests/test_compare.py
+++ b/skimage/util/tests/test_compare.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from skimage.util.compare import compare_images
-from skimage._shared.testing import assert_stacklevel
 
 
 def test_compare_images_ValueError_shape():
@@ -27,39 +26,6 @@ def test_compare_images_diff():
     expected_result = np.zeros_like(img1, dtype=np.float64)
     expected_result[3:8, 0:3] = 1
     result = compare_images(img1, img2, method='diff')
-    np.testing.assert_array_equal(result, expected_result)
-
-
-def test_compare_images_replaced_param():
-    img1 = np.zeros((10, 10), dtype=np.uint8)
-    img1[3:8, 3:8] = 255
-    img2 = np.zeros_like(img1)
-    img2[3:8, 0:8] = 255
-    expected_result = np.zeros_like(img1, dtype=np.float64)
-    expected_result[3:8, 0:3] = 1
-
-    regex = ".*Please use `image0, image1`.*"
-    with pytest.warns(FutureWarning, match=regex) as record:
-        result = compare_images(image1=img1, image2=img2)
-    assert_stacklevel(record)
-    np.testing.assert_array_equal(result, expected_result)
-
-    with pytest.warns(FutureWarning, match=regex) as record:
-        result = compare_images(image0=img1, image2=img2)
-    assert_stacklevel(record)
-    np.testing.assert_array_equal(result, expected_result)
-
-    with pytest.warns(FutureWarning, match=regex) as record:
-        result = compare_images(img1, image2=img2)
-    assert_stacklevel(record)
-    np.testing.assert_array_equal(result, expected_result)
-
-    # Test making "method" keyword-only here as well
-    # so whole test can be removed in one go
-    regex = ".*Please pass `method=`.*"
-    with pytest.warns(FutureWarning, match=regex) as record:
-        result = compare_images(img1, img2, "diff")
-    assert_stacklevel(record)
     np.testing.assert_array_equal(result, expected_result)
 
 


### PR DESCRIPTION
## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
