### PR TITLE
Use `ski` import convention in  `_regionprops_utils` docstring

### DIFF
--- a/skimage/measure/_regionprops_utils.py
+++ b/skimage/measure/_regionprops_utils.py
@@ -340,12 +340,13 @@ def euler_number(image, connectivity=None):
     Examples
     --------
     >>> import numpy as np
+    >>> import skimage as ski
     >>> SAMPLE = np.zeros((100,100,100));
     >>> SAMPLE[40:60, 40:60, 40:60]=1
-    >>> euler_number(SAMPLE) # doctest: +ELLIPSIS
+    >>> ski.measure.euler_number(SAMPLE) # doctest: +ELLIPSIS
     1...
     >>> SAMPLE[45:55,45:55,45:55] = 0;
-    >>> euler_number(SAMPLE) # doctest: +ELLIPSIS
+    >>> ski.measure.euler_number(SAMPLE) # doctest: +ELLIPSIS
     2...
     >>> SAMPLE = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0],
     ...                    [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
@@ -357,9 +358,9 @@ def euler_number(image, connectivity=None):
     ...                    [1, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0],
     ...                    [0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1],
     ...                    [0, 1, 1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1]])
-    >>> euler_number(SAMPLE)  # doctest:
+    >>> ski.measure.euler_number(SAMPLE)
     0
-    >>> euler_number(SAMPLE, connectivity=1)  # doctest:
+    >>> ski.measure.euler_number(SAMPLE, connectivity=1)
     2
     """
 
@@ -438,14 +439,13 @@ def perimeter(image, neighborhood=4):
 
     Examples
     --------
-    >>> from skimage import data, util
-    >>> from skimage.measure import label
+    >>> import skimage as ski
     >>> # coins image (binary)
-    >>> img_coins = data.coins() > 110
+    >>> img_coins = ski.data.coins() > 110
     >>> # total perimeter of all objects in the image
-    >>> perimeter(img_coins, neighborhood=4)  # doctest: +ELLIPSIS
+    >>> ski.measure.perimeter(img_coins, neighborhood=4)  # doctest: +ELLIPSIS
     7796.867...
-    >>> perimeter(img_coins, neighborhood=8)  # doctest: +ELLIPSIS
+    >>> ski.measure.perimeter(img_coins, neighborhood=8)  # doctest: +ELLIPSIS
     8806.268...
 
     """
@@ -521,14 +521,13 @@ def perimeter_crofton(image, directions=4):
 
     Examples
     --------
-    >>> from skimage import data, util
-    >>> from skimage.measure import label
+    >>> import skimage as ski
     >>> # coins image (binary)
-    >>> img_coins = data.coins() > 110
+    >>> img_coins = ski.data.coins() > 110
     >>> # total perimeter of all objects in the image
-    >>> perimeter_crofton(img_coins, directions=2)  # doctest: +ELLIPSIS
+    >>> ski.measure.perimeter_crofton(img_coins, directions=2)  # doctest: +ELLIPSIS
     8144.578...
-    >>> perimeter_crofton(img_coins, directions=4)  # doctest: +ELLIPSIS
+    >>> ski.measure.perimeter_crofton(img_coins, directions=4)  # doctest: +ELLIPSIS
     7837.077...
     """
     if image.ndim != 2:


### PR DESCRIPTION
## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Use the import convention `import skimage as ski` in the docstrings of
`ski.measure.euler_number`, `ski.measure.perimeter` and `ski.measure.perimeter_crofton`.
```
