### PR TITLE
Remove obsolete `doctest_skip_parser`

### DIFF
--- a/skimage/_shared/testing.py
+++ b/skimage/_shared/testing.py
@@ -64,53 +64,6 @@ def assert_greater(a, b, msg=None):
     assert a > b, message
 
 
-def doctest_skip_parser(func):
-    """Decorator replaces custom skip test markup in doctests
-
-    Say a function has a docstring::
-
-        >>> something, HAVE_AMODULE, HAVE_BMODULE = 0, False, False
-        >>> something # skip if not HAVE_AMODULE
-        0
-        >>> something # skip if HAVE_BMODULE
-        0
-
-    This decorator will evaluate the expression after ``skip if``.  If this
-    evaluates to True, then the comment is replaced by ``# doctest: +SKIP``. If
-    False, then the comment is just removed. The expression is evaluated in the
-    ``globals`` scope of `func`.
-
-    For example, if the module global ``HAVE_AMODULE`` is False, and module
-    global ``HAVE_BMODULE`` is False, the returned function will have docstring::
-
-        >>> something # doctest: +SKIP
-        >>> something + else # doctest: +SKIP
-        >>> something # doctest: +SKIP
-
-    """
-    lines = func.__doc__.split('\n')
-    new_lines = []
-    for line in lines:
-        match = SKIP_RE.match(line)
-        if match is None:
-            new_lines.append(line)
-            continue
-        code, space, expr = match.groups()
-
-        try:
-            # Works as a function decorator
-            if eval(expr, func.__globals__):
-                code = code + space + "# doctest: +SKIP"
-        except AttributeError:
-            # Works as a class decorator
-            if eval(expr, func.__init__.__globals__):
-                code = code + space + "# doctest: +SKIP"
-
-        new_lines.append(code)
-    func.__doc__ = "\n".join(new_lines)
-    return func
-
-
 def roundtrip(image, plugin, suffix):
     """Save and read an image using a specified plugin"""
     if '.' not in suffix:

--- a/skimage/_shared/tests/test_testing.py
+++ b/skimage/_shared/tests/test_testing.py
@@ -5,81 +5,14 @@ import re
 import warnings
 
 import pytest
-from numpy.testing import assert_equal
 from skimage._shared.testing import (
-    doctest_skip_parser,
     run_in_parallel,
     assert_stacklevel,
 )
-from skimage._shared import testing
 from skimage._shared._dependency_checks import is_wasm
 
 from skimage._shared._warnings import expected_warnings
 from warnings import warn
-
-
-def test_skipper():
-    def f():
-        pass
-
-    class c:
-        def __init__(self):
-            self.me = "I think, therefore..."
-
-    docstring = """ Header
-
-            >>> something # skip if not HAVE_AMODULE
-            >>> something + else
-            >>> a = 1 # skip if not HAVE_BMODULE
-            >>> something2   # skip if HAVE_AMODULE
-        """
-    f.__doc__ = docstring
-    c.__doc__ = docstring
-
-    global HAVE_AMODULE, HAVE_BMODULE
-    HAVE_AMODULE = False
-    HAVE_BMODULE = True
-
-    f2 = doctest_skip_parser(f)
-    c2 = doctest_skip_parser(c)
-    assert f is f2
-    assert c is c2
-
-    expected = """ Header
-
-            >>> something # doctest: +SKIP
-            >>> something + else
-            >>> a = 1
-            >>> something2
-        """
-    assert_equal(f2.__doc__, expected)
-    assert_equal(c2.__doc__, expected)
-
-    HAVE_AMODULE = True
-    HAVE_BMODULE = False
-    f.__doc__ = docstring
-    c.__doc__ = docstring
-    f2 = doctest_skip_parser(f)
-    c2 = doctest_skip_parser(c)
-
-    assert f is f2
-    expected = """ Header
-
-            >>> something
-            >>> something + else
-            >>> a = 1 # doctest: +SKIP
-            >>> something2   # doctest: +SKIP
-        """
-    assert_equal(f2.__doc__, expected)
-    assert_equal(c2.__doc__, expected)
-
-    del HAVE_AMODULE
-    f.__doc__ = docstring
-    c.__doc__ = docstring
-    with testing.raises(NameError):
-        doctest_skip_parser(f)
-    with testing.raises(NameError):
-        doctest_skip_parser(c)
 
 
 @pytest.mark.skipif(is_wasm, reason="Cannot start threads in WASM")


### PR DESCRIPTION
## Description

Noticed this while reviewing #7678. This decorator isn't used anywhere right now. Since we use docstest-plus an alternative to this exists, e.g. pre-pending

```python
.. testsetup::
    >>> import pytest; _ = pytest.importorskip('matplotlib')
```
to a docstring example.

I can totally see that the above solution has the disadvantage of adding noise to the docstring. It's hidden in HTML and PyCharm's peek feature but might show up in other places, e.g. with `help(func)`. So take this PR as a trigger to discuss whether we want to restart using `doctest_skip_parser` explicitly or remove it. 


## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
