### PR TITLE
Using `label_image` throughout scikit-image and added `rename_parameter`

### DIFF
--- a/doc/source/user_guide/glossary.md
+++ b/doc/source/user_guide/glossary.md
@@ -68,7 +68,7 @@ int values
 iso-valued contour
     See {term}`contour`.
 
-labels
+label image
     An image of labels is of integer type, where pixels with the same
     integer value belong to the same object. For example, the result of a
     segmentation is an image of labels. {func}`skimage.measure.label` labels
@@ -76,9 +76,6 @@ labels
     labels. Labels are usually contiguous integers, and
     {func}`skimage.segmentation.relabel_sequential` can be used to relabel
     arbitrary labels to sequential (contiguous) ones.
-
-label image
-    See {term}`labels`.
 
 pixel
     Smallest element of an image. An image is a grid of pixels, and the
@@ -91,7 +88,7 @@ pixel
 segmentation
     Partitioning an image into multiple objects (segments), for
     example an object of interest and its background. The output of a
-    segmentation is typically an image of {term}`labels`, where
+    segmentation is typically a {term}`label image`, where
     the pixels of different objects have been attributed different
     integer labels. Several segmentation algorithms are available in
     {mod}`skimage.segmentation`.

--- a/skimage/_shared/tests/test_utils.py
+++ b/skimage/_shared/tests/test_utils.py
@@ -13,6 +13,7 @@ from skimage._shared.utils import (
     check_nD,
     deprecate_func,
     deprecate_parameter,
+    rename_parameter,
     DEPRECATED,
 )
 
@@ -514,3 +515,19 @@ class Test_deprecate_parameter:
         with pytest.warns(FutureWarning, match="`old` is deprecated") as records:
             bar(0, 1)
             testing.assert_stacklevel(records)
+
+
+class Test_rename_parameter:
+    def test_warning(self):
+        @rename_parameter(
+            "old", "new", deprecated_version="0.10", removed_version="0.12"
+        )
+        def foo(arg0, old=None):
+            return arg0, old
+
+        with pytest.raises(TypeError, match="Cannot specify both 'old' and 'new' "):
+            foo(arg0=3, new=1, old=1)
+        with pytest.warns(
+            FutureWarning, match="'old' is deprecated since version 0.10 "
+        ):
+            foo(arg0=2, old=3)

--- a/skimage/color/colorlabel.py
+++ b/skimage/color/colorlabel.py
@@ -2,7 +2,7 @@ import itertools
 
 import numpy as np
 
-from .._shared.utils import _supported_float_type, warn
+from .._shared.utils import _supported_float_type, warn, rename_parameter
 from ..util import img_as_float
 from . import rgb_colors
 from .colorconv import gray2rgb, rgb2hsv, hsv2rgb
@@ -82,6 +82,12 @@ def _match_label_with_color(label, colors, bg_label, bg_color):
     return mapped_labels, color_cycle
 
 
+@rename_parameter(
+    new_name="label_image",
+    old_name="label",
+    deprecated_version="0.26",
+    removed_version="0.28",
+)
 def label2rgb(
     label,
     image=None,

--- a/skimage/color/tests/test_colorlabel.py
+++ b/skimage/color/tests/test_colorlabel.py
@@ -316,3 +316,12 @@ def test_saturation_warning():
         label2rgb(labels, image=rgb_img, bg_label=0, saturation=2)
     with expected_warnings(["saturation must be in range"]):
         label2rgb(labels, image=rgb_img, bg_label=0, saturation=-1)
+
+
+def test_label_rename_warning_and_error():
+    with pytest.raises(
+        TypeError, match="Cannot specify both 'label' and 'label_image' "
+    ):
+        label2rgb(label=np.array([0, 1, 0]), label_image=np.array([0, 1, 0]))
+    with pytest.warns(FutureWarning, match="'label' is deprecated since version 0.26 "):
+        label2rgb(label=np.array([0, 1, 0]))


### PR DESCRIPTION
## Description

closes https://github.com/scikit-image/scikit-image/issues/7733

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
