### PR TITLE
Fix definition of entropy in NMI docstring

### DIFF
--- a/skimage/metrics/simple_metrics.py
+++ b/skimage/metrics/simple_metrics.py
@@ -211,7 +211,7 @@ def normalized_mutual_information(image0, image1, *, bins=100):
 
     where :math:`H(X) := - \sum_{x \in X}{p(x) \log p(x)}` is the entropy,
     :math:`X` is the set of image values, and :math:`p(x)` is the probability
-    of ocurrence of a specific value :math:`x \in X`.
+    of occurrence of value :math:`x \in X`.
 
     It was proposed to be useful in registering images by Colin Studholme and
     colleagues [1]_. It ranges from 1 (perfectly uncorrelated image values)

--- a/skimage/metrics/simple_metrics.py
+++ b/skimage/metrics/simple_metrics.py
@@ -211,7 +211,7 @@ def normalized_mutual_information(image0, image1, *, bins=100):
 
     where :math:`H(X) := - \sum_{x \in X}{p(x) \log p(x)}` is the entropy,
     :math:`X` is the set of image values, and :math:`p(x)` is the probability
-    of observing a specific value :math:`x \in X`.
+    of ocurrence of a specific value :math:`x \in X`.
 
     It was proposed to be useful in registering images by Colin Studholme and
     colleagues [1]_. It ranges from 1 (perfectly uncorrelated image values)

--- a/skimage/metrics/simple_metrics.py
+++ b/skimage/metrics/simple_metrics.py
@@ -209,7 +209,9 @@ def normalized_mutual_information(image0, image1, *, bins=100):
 
        Y(A, B) = \frac{H(A) + H(B)}{H(A, B)}
 
-    where :math:`H(X) := - \sum_{x \in X}{x \log x}` is the entropy.
+    where :math:`H(X) := - \sum_{x \in X}{p(x) \log p(x)}` is the entropy,
+    :math:`X` is the set of image values, and :math:`p(x)` is the probability 
+    of observing a specific value :math:`x \in X`.
 
     It was proposed to be useful in registering images by Colin Studholme and
     colleagues [1]_. It ranges from 1 (perfectly uncorrelated image values)

--- a/skimage/metrics/simple_metrics.py
+++ b/skimage/metrics/simple_metrics.py
@@ -210,7 +210,7 @@ def normalized_mutual_information(image0, image1, *, bins=100):
        Y(A, B) = \frac{H(A) + H(B)}{H(A, B)}
 
     where :math:`H(X) := - \sum_{x \in X}{p(x) \log p(x)}` is the entropy,
-    :math:`X` is the set of image values, and :math:`p(x)` is the probability 
+    :math:`X` is the set of image values, and :math:`p(x)` is the probability
     of observing a specific value :math:`x \in X`.
 
     It was proposed to be useful in registering images by Colin Studholme and


### PR DESCRIPTION
See discussion at:

https://skimage.zulipchat.com/#narrow/channel/175598-general/topic/entropy.20formula.20.28in.20metrics.2Enormalized_mutual_information.29

## Description

Hi! As commented on the linked topic from [scikit-image's Zulip](https://skimage.zulipchat.com/#narrow/channel/175598-general/topic/entropy.20formula.20.28in.20metrics.2Enormalized_mutual_information.29), I have changed NMI's docstring so that the entropy formula is better specified. This is just a documentation change, so I'm guessing no unit tests are required. However, I would recommend checking I haven't messed up using latex's math inside python, since I'm new to writing proper docs.
