### PR TITLE
Report failures on main via issue

### DIFF
--- a/.github/MAIN_FAIL_TEMPLATE.md
+++ b/.github/MAIN_FAIL_TEMPLATE.md
@@ -1,0 +1,6 @@
+---
+title: "⚠ {{ env.BUILD_TYPE }} failed on `main`"
+labels: "CI failure"
+---
+
+Commit {{ sha }} by @{{ payload.sender.login }} did not pass CI.

--- a/.github/workflows/test-docs.yaml
+++ b/.github/workflows/test-docs.yaml
@@ -9,6 +9,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   test_docs_aarch64:
@@ -39,3 +40,12 @@ jobs:
       - name: Build docs / run examples
         run: |
           SPHINXCACHE=${HOME}/.cache/sphinx SPHINXOPTS="-W -j auto" make -C doc html
+
+      - name: "Job has failed: reporting"
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_TYPE: "docs build"
+        with:
+          filename: .github/MAIN_FAIL_TEMPLATE.md

--- a/.github/workflows/test-linux.yaml
+++ b/.github/workflows/test-linux.yaml
@@ -176,3 +176,18 @@ jobs:
           EAGER_IMPORT: ${{ matrix.EAGER_IMPORT }}
         run: |
           (cd .. && $PYTEST --doctest-plus --showlocals --pyargs skimage)
+
+  report-failures:
+    runs-on: ubuntu-latest
+    needs: [test_skimage_linux, test_skimage_linux_free_threaded]
+    if: ${{ always() && github.ref == 'refs/heads/main' && contains(needs.*.result, 'failure') }}
+    permissions:
+      issues: write
+    steps:
+      - name: "Job has failed: reporting"
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_TYPE: "linux tests"
+        with:
+          filename: .github/MAIN_FAIL_TEMPLATE.md

--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -9,6 +9,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
 
 env:
   PYTEST: "pytest --config-file ${{ github.workspace }}/pyproject.toml"
@@ -73,3 +74,12 @@ jobs:
       - name: Check benchmarks
         run: |
           asv check -v -E existing
+
+      - name: "Job has failed: reporting"
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_TYPE: "macos tests"
+        with:
+          filename: .github/MAIN_FAIL_TEMPLATE.md

--- a/.github/workflows/test-nightlies-on-main.yaml
+++ b/.github/workflows/test-nightlies-on-main.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 env:
   PYTHONOPTIMIZE: 0
@@ -62,3 +63,12 @@ jobs:
       - name: Run tests
         run: |
           (cd .. && $PYTEST --doctest-plus --showlocals --pyargs skimage)
+
+      - name: "Job has failed: reporting"
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_TYPE: "nightly test"
+        with:
+          filename: .github/MAIN_FAIL_TEMPLATE.md

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -9,6 +9,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
 
 env:
   CC: clang
@@ -16,7 +17,7 @@ env:
   PYTEST: "pytest --config-file ${{ github.workspace }}/pyproject.toml"
 
 jobs:
-  test_skimage_linux:
+  test_skimage_windows:
     name: windows-cp${{ matrix.python-version }}-${{ matrix.OPTIONS_NAME }}
     runs-on: windows-latest
 
@@ -81,3 +82,12 @@ jobs:
         shell: bash
         run: |
           (cd .. && $PYTEST --doctest-plus --showlocals --pyargs skimage)
+
+      - name: "Job has failed: reporting"
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_TYPE: "windows tests"
+        with:
+          filename: .github/MAIN_FAIL_TEMPLATE.md

--- a/.github/workflows/wheels-recipe.yaml
+++ b/.github/workflows/wheels-recipe.yaml
@@ -253,3 +253,22 @@ jobs:
         with:
           name: wheels-windows-${{ matrix.cibw_arch }}-${{ strategy.job-index }}
           path: ./dist/*.whl
+
+  report-failures:
+    runs-on: ubuntu-latest
+    needs:
+      - build_linux_wheels
+      - build_linux_aarch64_wheels
+      - build_macos_wheels
+      - build_windows_wheels
+    if: ${{ always() && github.ref == 'refs/heads/main' && contains(needs.*.result, 'failure') }}
+    permissions:
+      issues: write
+    steps:
+      - name: "Job has failed: reporting"
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_TYPE: "wheels build"
+        with:
+          filename: .github/MAIN_FAIL_TEMPLATE.md


### PR DESCRIPTION
We currently have no mechanism of reporting when CI fails on `main`.

This PR changes that, by filing issues whenever tests on `main` fail.

I did not add this reporting to every single workflow: `emscripten` and `benchmarks` are currently left out.