### PR TITLE
Refactor transform initialization

### DIFF
--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1325,7 +1325,7 @@ class EuclideanTransform(ProjectiveTransform):
     matrix : (D+1, D+1) array_like, optional
         Homogeneous transformation matrix.
     rotation : float or sequence of float, optional
-        Rotation angle, clockwise, as radians. If given as a vector, it is
+        Rotation angle, clockwise, in radians. If given as a vector, it is
         interpreted as Euler rotation angles [1]_. Only 2D (single rotation)
         and 3D (Euler rotations) values are supported. For higher dimensions,
         you must provide or estimate the transformation matrix instead, and

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1256,6 +1256,11 @@ class EuclideanTransform(ProjectiveTransform):
     transformation is only a translation, you may use the implicit parameter
     `translation`; otherwise, you must use `matrix`.
 
+    The implicit parameters are applied in the following order:
+
+    1. Rotation;
+    2. Translation.
+
     Parameters
     ----------
     matrix : (D+1, D+1) array_like, optional
@@ -1394,6 +1399,12 @@ class SimilarityTransform(EuclideanTransform):
     The similarity transformation extends the Euclidean transformation with a
     single scaling factor in addition to the rotation and translation
     parameters.
+
+    The implicit parameters are applied in the following order:
+
+    1. Scale;
+    2. Rotation;
+    3. Translation.
 
     Parameters
     ----------

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -610,6 +610,12 @@ class EssentialMatrixTransform(FundamentalMatrixTransform):
 
     """
 
+    # Threshold for determinant of rotation matrix.
+    _rot_det_tol = 1e-6
+
+    # Threshold for difference of translation vector from unit length.
+    _trans_len_tol = 1e-6
+
     def __init__(
         self, *, rotation=None, translation=None, matrix=None, dimensionality=None
     ):
@@ -632,11 +638,11 @@ class EssentialMatrixTransform(FundamentalMatrixTransform):
         translation = np.asarray(translation)
         if rotation.shape != (3, 3):
             raise ValueError("Invalid shape of rotation matrix")
-        if abs(np.linalg.det(rotation) - 1) > 1e-6:
+        if abs(np.linalg.det(rotation) - 1) > self._rot_det_tol:
             raise ValueError("Rotation matrix must have unit determinant")
         if translation.size != 3:
             raise ValueError("Invalid shape of translation vector")
-        if abs(np.linalg.norm(translation) - 1) > 1e-6:
+        if abs(np.linalg.norm(translation) - 1) > self._trans_len_tol:
             raise ValueError("Translation vector must have unit length")
         # Matrix representation of the cross product for t.
         t0, t1, t2 = translation

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1389,12 +1389,12 @@ class EuclideanTransform(ProjectiveTransform):
             translation = translation = (0,) * n_dims
         if rotation is None:
             rotation = 0 if n_dims == 2 else np.zeros(3)
+        matrix = np.eye(n_dims + 1)
         if n_dims == 2:
             cos_r, sin_r = math.cos(rotation), math.sin(rotation)
-            matrix = np.array([[cos_r, -sin_r, 0], [sin_r, cos_r, 0], [0, 0, 1]])
+            matrix[:2, :2] = [[cos_r, -sin_r], [sin_r, cos_r]]
         elif n_dims == 3:
-            matrix = np.eye(n_dims + 1)
-            matrix[:n_dims, :n_dims] = _euler_rotation_matrix(rotation)
+            matrix[:3, :3] = _euler_rotation_matrix(rotation)
         matrix[0:n_dims, n_dims] = translation
         return matrix
 

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1382,7 +1382,7 @@ class EuclideanTransform(ProjectiveTransform):
 
     def _rt2matrix(self, rotation, translation, n_dims):
         if translation is None:
-            translation = translation = (0,) * n_dims
+            translation = (0,) * n_dims
         if rotation is None:
             rotation = 0 if n_dims == 2 else np.zeros(3)
         matrix = np.eye(n_dims + 1)

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -264,7 +264,7 @@ class _GeometricTransform(ABC):
 
 
 class _HMatrixTransform(_GeometricTransform):
-    """Transform accepting homogenous matrix as input"""
+    """Transform accepting homogeneous matrix as input."""
 
     def __init__(self, matrix=None, *, dimensionality=None):
         if matrix is None:

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1569,8 +1569,6 @@ class PolynomialTransform(_GeometricTransform):
     def __init__(self, params=None, *, dimensionality=None):
         if dimensionality is None:
             dimensionality = 2
-        elif params is not None:
-            raise ValueError('Do not pass dimensionality with not-None parameters')
         elif dimensionality != 2:
             raise NotImplementedError(
                 'Polynomial transforms are only implemented for 2D.'

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1348,9 +1348,9 @@ class EuclideanTransform(ProjectiveTransform):
     translation : (x, y[, z, ...]) sequence of float, length D, optional
         Translation parameters for each axis.
     dimensionality : int, optional
-        Fallback number of dimensions for transform when neither of `matrix` nor
-        `rotation` are specified.  Otherwise ignored, and we infer
-        dimensionality from `matrix` shape, or ``len(translations)``.
+        Fallback number of dimensions for transform when no other paremeters
+        are specified.  Otherwise ignored, and we infer dimensionality from the
+        input parameters.
 
     Attributes
     ----------

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -84,7 +84,7 @@ def _center_and_normalize_points(points):
 
 
 def _apply_homogeneous(matrix, points):
-    """Transform (N, D) `points` array with homogenous (D+1, D+1) `matrix`
+    """Transform (N, D) `points` array with homogeneous (D+1, D+1) `matrix`.
 
     Parameters
     ----------

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -585,7 +585,7 @@ class EssentialMatrixTransform(FundamentalMatrixTransform):
     """
 
     def __init__(
-        self, rotation=None, translation=None, matrix=None, *, dimensionality=None
+        self, *, rotation=None, translation=None, matrix=None, dimensionality=None
     ):
         n_rt_none = sum(p is None for p in (rotation, translation))
         if n_rt_none == 1:
@@ -952,13 +952,13 @@ class AffineTransform(ProjectiveTransform):
 
         .. versionadded:: 0.17
            Added support for supplying a single scalar value.
-    rotation : float, optional
-        Rotation angle, clockwise, as radians. Only available for 2D.
     shear : float or 2-tuple of float, optional
         The x and y shear angles, clockwise, by which these axes are
         rotated around the origin [2].
         If a single value is given, take that to be the x shear angle, with
         the y angle remaining 0. Only available in 2D.
+    rotation : float, optional
+        Rotation angle, clockwise, as radians. Only available for 2D.
     translation : (tx, ty) as array, list or tuple, optional
         Translation parameters. Only available for 2D.
     dimensionality : int, optional
@@ -1013,11 +1013,11 @@ class AffineTransform(ProjectiveTransform):
     def __init__(
         self,
         matrix=None,
-        scale=None,
-        rotation=None,
-        shear=None,
-        translation=None,
         *,
+        scale=None,
+        shear=None,
+        rotation=None,
+        translation=None,
         dimensionality=None,
     ):
         n_srst_none = sum(p is None for p in (scale, rotation, shear, translation))
@@ -1293,7 +1293,7 @@ class EuclideanTransform(ProjectiveTransform):
     _estimate_scale = False
 
     def __init__(
-        self, matrix=None, rotation=None, translation=None, *, dimensionality=None
+        self, matrix=None, *, rotation=None, translation=None, dimensionality=None
     ):
         n_rt_none = sum(p is None for p in (rotation, translation))
         if n_rt_none != 2:
@@ -1436,10 +1436,10 @@ class SimilarityTransform(EuclideanTransform):
     def __init__(
         self,
         matrix=None,
+        *,
         scale=None,
         rotation=None,
         translation=None,
-        *,
         dimensionality=None,
     ):
         n_srt_none = sum(p is None for p in (scale, rotation, translation))

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1348,8 +1348,8 @@ class EuclideanTransform(ProjectiveTransform):
     translation : (x, y[, z, ...]) sequence of float, length D, optional
         Translation parameters for each axis.
     dimensionality : int, optional
-        Fallback number of dimensions for transform when no other paremeters
-        are specified.  Otherwise ignored, and we infer dimensionality from the
+        Fallback number of dimensions for transform when no other parameter
+        is specified.  Otherwise ignored, and we infer dimensionality from the
         input parameters.
 
     Attributes

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -240,9 +240,9 @@ class _GeometricTransform(ABC):
         Parameters
         ----------
         dimensionality : {None, 2}, optional
-            This transform only allows dimensionality of 2, so None or 2 are
-            the only acceptable values.  The parameter exists for compatibility
-            with other transforms.
+            This transform only allows dimensionality of 2, where None
+            corresponds to 2. The parameter exists for compatibility with other
+            transforms.
 
         Returns
         -------
@@ -280,9 +280,9 @@ class _MatrixTransform(_GeometricTransform):
         Parameters
         ----------
         dimensionality : {None, 2}, optional
-            This transform only allows dimensionality of 2, so None or 2 are
-            the only acceptable values.  The parameter exists for compatibility
-            with other transforms.
+            This transform only allows dimensionality of 2, where None
+            corresponds to 2. The parameter exists for compatibility with other
+            transforms.
 
         Returns
         -------
@@ -938,9 +938,8 @@ class ProjectiveTransform(_MatrixTransform):
 
         Parameters
         ----------
-        dimensionality : {None, 2, 3}, optional
-            This transform only allows dimensionality of 2 or 3, so None or 2
-            or 3 are the only acceptable values.
+        dimensionality : {None, int}, optional
+            Dimensionality of identity transform.
 
         Returns
         -------

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -233,6 +233,24 @@ class _GeometricTransform(ABC):
         """
         return np.sqrt(np.sum((self(src) - dst) ** 2, axis=1))
 
+    @classmethod
+    def identity(cls, dimensionality=None):
+        """Identity transform
+
+        Parameters
+        ----------
+        dimensionality : {None, 2}, optional
+            This transform only allows dimensionality of 2, so None or 2 are
+            the only acceptable values.  The parameter exists for compatibility
+            with other transforms.
+
+        Returns
+        -------
+        tform : transform
+            Transform such that ``np.all(tform(pts) == pts)``.
+        """
+        return cls(dimensionality=dimensionality)
+
 
 class _MatrixTransform(_GeometricTransform):
     valid_dims = (2,)
@@ -257,6 +275,20 @@ class _MatrixTransform(_GeometricTransform):
 
     @classmethod
     def identity(cls, dimensionality=None):
+        """Identity transform
+
+        Parameters
+        ----------
+        dimensionality : {None, 2}, optional
+            This transform only allows dimensionality of 2, so None or 2 are
+            the only acceptable values.  The parameter exists for compatibility
+            with other transforms.
+
+        Returns
+        -------
+        tform : transform
+            Transform such that ``np.all(tform(pts) == pts)``.
+        """
         d = cls._default_dim() if dimensionality is None else dimensionality
         return cls(matrix=np.eye(d + 1))
 
@@ -900,6 +932,23 @@ class ProjectiveTransform(_MatrixTransform):
         """The dimensionality of the transformation."""
         return self.params.shape[0] - 1
 
+    @classmethod
+    def identity(cls, dimensionality=None):
+        """Identity transform
+
+        Parameters
+        ----------
+        dimensionality : {None, 2, 3}, optional
+            This transform only allows dimensionality of 2 or 3, so None or 2
+            or 3 are the only acceptable values.
+
+        Returns
+        -------
+        tform : transform
+            Transform such that ``np.all(tform(pts) == pts)``.
+        """
+        return super().identity(dimensionality=dimensionality)
+
 
 class AffineTransform(ProjectiveTransform):
     """Affine transformation.
@@ -1203,6 +1252,20 @@ class PiecewiseAffineTransform(_GeometricTransform):
 
     @classmethod
     def identity(cls, dimensionality=None):
+        """Identity transform
+
+        Parameters
+        ----------
+        dimensionality : optional
+            This transform does not use the `dimensionality` parameter, so the
+            value is ignored.  The parameter exists for compatibility with
+            other transforms.
+
+        Returns
+        -------
+        tform : transform
+            Transform such that ``np.all(tform(pts) == pts)``.
+        """
         return cls()
 
 
@@ -1647,6 +1710,20 @@ class PolynomialTransform(_GeometricTransform):
 
     @classmethod
     def identity(cls, dimensionality=None):
+        """Identity transform
+
+        Parameters
+        ----------
+        dimensionality : {None, 2}, optional
+            This transform only allows dimensionality of 2, so None or 2 are
+            the only acceptable values.  The parameter exists for compatibility
+            with other transforms.
+
+        Returns
+        -------
+        tform : transform
+            Transform such that ``np.all(tform(pts) == pts)``.
+        """
         if dimensionality not in (2, None):
             raise ValueError('Dimensionality must be None or == 2')
         return cls(params=None)

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -89,7 +89,10 @@ def _apply_homogeneous(matrix, points):
     Parameters
     ----------
     matrix : (D+1, D+1) array_like
-        The transformation matrix to obtain the new points.
+        The transformation matrix to obtain the new points. Note that any
+        object with an `__array__` method [1]_ that returns a matrix with the
+        correct dimensions can be used as input here. This includes all
+        subclasses of :class:`ProjectiveTransform`, for example.
     points : (N, D) array
         The coordinates of the image points.
 
@@ -97,6 +100,11 @@ def _apply_homogeneous(matrix, points):
     -------
     new_points : (N, D) array
         The transformed image points.
+
+    References
+    ----------
+    .. [1]:
+        https://numpy.org/doc/stable/user/basics.interoperability.html#using-arbitrary-objects-in-numpy
     """
     matrix = np.asarray(matrix)
     points = np.array(points, copy=NP_COPY_IF_NEEDED, ndmin=2)

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -260,7 +260,7 @@ class _GeometricTransform(ABC):
         tform : transform
             Transform such that ``np.all(tform(pts) == pts)``.
         """
-        return cls(dimensionality=dimensionality)
+        raise NotImplementedError('identity not implemented for this class')
 
 
 class _HMatrixTransform(_GeometricTransform):

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1533,7 +1533,7 @@ class SimilarityTransform(EuclideanTransform):
                 'to indicate the dimensionality of the transform.\n'
                 'Please indicate dimensionality by passing a vector '
                 'of suitable length to ``scale``.',
-                DeprecationWarning,
+                FutureWarning,
                 stacklevel=2,
             )
 

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1493,7 +1493,7 @@ class SimilarityTransform(EuclideanTransform):
         x, y[, z] translation parameters. Implemented only for 2D and 3D.
     dimensionality : int, optional
         The dimensionality of the transform, corresponding to ``dim`` above.
-        Ignored if `matrix` is not None, and set to `matrix.shape[0] - 1`.
+        Ignored if `matrix` is not None, and set to ``matrix.shape[0] - 1``.
         Otherwise, must be one of 2 or 3.
 
     Attributes

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1550,11 +1550,11 @@ class SimilarityTransform(EuclideanTransform):
         if all(p is None for p in other_params):
             warnings.warn(
                 'In the future, it will be a ValueError to pass a '
-                'scalar ``scale`` value with a ``dimensionality`` '
+                'scalar `scale` value with a ``dimensionality`` '
                 '> 2\n,and without other implicit parameters '
                 'to indicate the dimensionality of the transform.\n'
                 'Please indicate dimensionality by passing a vector '
-                'of suitable length to ``scale``.',
+                'of suitable length to `scale`.',
                 FutureWarning,
                 stacklevel=2,
             )

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -1370,16 +1370,14 @@ class EuclideanTransform(ProjectiveTransform):
     def _rt2ndims_msg(self, rotation, translation):
         if rotation is not None:
             N = 1 if np.isscalar(rotation) else len(rotation)
-            return (
-                2 if N == 1 else N,
-                (
-                    None
-                    if N in (1, 3)
-                    else '``rotations`` must be scalar (2D) or length 3 (3D)'
-                ),
+            msg = (
+                '``rotations`` must be scalar (3D) or length 3 (3D)'
+                if N not in (1, 3)
+                else None
             )
+            return 2 if N == 1 else N, msg
         if translation is not None:
-            return (len(np.array(translation)), None)
+            return (2 if np.isscalar(translation) else len(translation), None)
         return None, None
 
     def _rt2matrix(self, rotation, translation, n_dims):

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -80,10 +80,10 @@ def _center_and_normalize_points(points):
     matrix = np.eye(d + 1)
     matrix[:d, d] = -centroid
     matrix[:d, :] *= norm_factor
-    return matrix, _apply_homogenous(matrix, points)
+    return matrix, _apply_homogeneous(matrix, points)
 
 
-def _apply_homogenous(matrix, points):
+def _apply_homogeneous(matrix, points):
     """Transform (N, D) `points` array with homogenous (D+1, D+1) `matrix`
 
     Parameters
@@ -756,7 +756,7 @@ class ProjectiveTransform(_HMatrixTransform):
             Destination coordinates.
 
         """
-        return _apply_homogenous(self.params, coords)
+        return _apply_homogeneous(self.params, coords)
 
     @property
     def inverse(self):

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -614,7 +614,8 @@ class EssentialMatrixTransform(FundamentalMatrixTransform):
             raise ValueError("Translation vector must have unit length")
         # Matrix representation of the cross product for t.
         t0, t1, t2 = translation
-        return np.array([[0, -t2, t1], [t2, 0, -t0], [-t1, t0, 0]])
+        t_arr = np.array([[0, -t2, t1], [t2, 0, -t0], [-t1, t0, 0]], dtype=float)
+        return t_arr @ rotation
 
     def estimate(self, src, dst):
         """Estimate essential matrix using 8-point algorithm.

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -260,6 +260,7 @@ class _GeometricTransform(ABC):
         return np.sqrt(np.sum((self(src) - dst) ** 2, axis=1))
 
     @classmethod
+    @abstractmethod
     def identity(cls, dimensionality=None):
         """Identity transform
 
@@ -275,7 +276,6 @@ class _GeometricTransform(ABC):
         tform : transform
             Transform such that ``np.all(tform(pts) == pts)``.
         """
-        raise NotImplementedError('identity not implemented for this class')
 
 
 class _HMatrixTransform(_GeometricTransform):

--- a/skimage/transform/_geometric.py
+++ b/skimage/transform/_geometric.py
@@ -77,22 +77,9 @@ def _center_and_normalize_points(points):
 
     norm_factor = np.sqrt(d) / rms
 
-    part_matrix = norm_factor * np.concatenate(
-        (np.eye(d), -centroid[:, np.newaxis]), axis=1
-    )
-    matrix = np.concatenate(
-        (
-            part_matrix,
-            [
-                [
-                    0,
-                ]
-                * d
-                + [1]
-            ],
-        ),
-        axis=0,
-    )
+    matrix = np.eye(d + 1)
+    matrix[:d, d] = -centroid
+    matrix[:d, :] *= norm_factor
 
     points_h = np.vstack([points.T, np.ones(n)])
 

--- a/skimage/transform/_thin_plate_splines.py
+++ b/skimage/transform/_thin_plate_splines.py
@@ -42,7 +42,7 @@ class ThinPlateSplineTransform:
 
     Appyling the transformation to `src` approximates `dst`:
 
-    >>> np.round(tps(src))
+    >>> np.round(tps(src), 4)  # doctest: +FLOAT_CMP
     array([[5., 0.],
            [0., 0.],
            [0., 5.],

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -1118,7 +1118,7 @@ EG_OPS = dict(scale=(4, 5), shear=(1.4, 1.8), rotation=0.4, translation=(10, 12)
 
 
 @pytest.mark.parametrize(
-    'tform_class,op_order',
+    'tform_class, op_order',
     (
         (AffineTransform, ('scale', 'shear', 'rotation', 'translation')),
         (EuclideanTransform, ('rotation', 'translation')),

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -1260,3 +1260,21 @@ def test_init_contract_dims(tform_class):
     # Test vector matrix input invalid.
     with pytest.raises(ValueError):
         tform_class(np.zeros((2, 3)))
+
+
+def test_broadcasting():
+    # Scalar scale broadcasts.
+    translation = [3, 4, 5]
+    tf = SimilarityTransform(scale=2, translation=translation)
+    assert_equal(tf.params, _from_matvec(np.eye(3) * 2, translation))
+    # Translation does broadcast.
+    # 2D.
+    tf = SimilarityTransform(scale=2, translation=10)
+    assert_equal(tf.params, _from_matvec(np.eye(2) * 2, [10, 10]))
+    # 3D.
+    tf = SimilarityTransform(scale=[2, 3, 4], translation=10)
+    assert_equal(tf.params, _from_matvec(np.diag([2, 3, 4]), [10] * 3))
+    # Scalar rotation does not broadclast
+    for tf_class in SimilarityTransform, EuclideanTransform:
+        with pytest.raises(ValueError):
+            tf_class(rotation=0.2, translation=translation)

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -1094,16 +1094,22 @@ def test_affine_transform_from_linearized_parameters():
         _ = AffineTransform(matrix=v[:-1])
 
 
-def test_affine_transform_order():
+EG_OPS = dict(scale=(4, 5), shear=(1.4, 1.8), rotation=0.4, translation=(10, 12))
+
+
+@pytest.mark.parametrize(
+    'tform_class,op_order',
+    (
+        (AffineTransform, ('scale', 'shear', 'rotation', 'translation')),
+        (EuclideanTransform, ('rotation', 'translation')),
+        (SimilarityTransform, ('scale', 'rotation', 'translation')),
+    ),
+)
+def test_transform_order(tform_class, op_order):
     # Test transforms are applied in order stated.
-    ops = (
-        ('scale', (4, 5)),
-        ('shear', (1.4, 1.8)),
-        ('rotation', 0.4),
-        ('translation', (10, 12)),
-    )
-    part_xforms = [AffineTransform(**{k: v}) for k, v in ops]
-    full_xform = AffineTransform(**dict(ops))
+    ops = [(k, EG_OPS[k]) for k in op_order]
+    part_xforms = [tform_class(**{k: v}) for k, v in ops]
+    full_xform = tform_class(**dict(ops))
     # Assemble affine transform via matrices.
     out = np.eye(3)
     for tf in part_xforms:

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -768,9 +768,6 @@ def test_polynomial_init(array_like_input):
         params = tform.params
     tform2 = PolynomialTransform(params)
     assert_almost_equal(tform2.params, tform.params)
-    # Can't specify parameters and dimensionality.
-    with pytest.raises(ValueError):
-        _ = PolynomialTransform(params, dimensionality=2)
     # Can't specify scalar params.
     with pytest.raises(ValueError):
         _ = PolynomialTransform(0)

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -246,10 +246,10 @@ def test_similarity_init():
     assert_almost_equal(tform.rotation, rotation)
     assert_almost_equal(tform.translation, translation)
 
-    # With scalar scale and 3D, we get a deprecationwarning.  This is to
+    # With scalar scale and 3D, we get a FutureWarning.  This is to
     # generalize the rule that dimensionality should be implied by
     # input parameters, when given.
-    with pytest.deprecated_call():
+    with pytest.warns(FutureWarning):
         tf = SimilarityTransform(scale=4, dimensionality=3)
     assert_equal(tf([[1, 1, 1]]), [[4, 4, 4]])
     # Not so if we specify some other input giving dimensionality.

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -22,7 +22,7 @@ from skimage.transform._geometric import (
     _GeometricTransform,
     _affine_matrix_from_vector,
     _center_and_normalize_points,
-    _apply_homogenous,
+    _apply_homogeneous,
     _euler_rotation_matrix,
     TRANSFORMS,
 )
@@ -52,7 +52,7 @@ DST = np.array(
     ]
 )
 
-# Transforms accepting homogenous matrix as input.
+# Transforms accepting homogeneous matrix as input.
 HMAT_TFORMS = (
     FundamentalMatrixTransform,
     ProjectiveTransform,
@@ -987,7 +987,7 @@ def test_degenerate():
 def test_normalize_points():
     mat, normed = _center_and_normalize_points(SRC)
     assert np.allclose(np.mean(normed, axis=0), 0)
-    assert np.allclose(normed, _apply_homogenous(mat, SRC))
+    assert np.allclose(normed, _apply_homogeneous(mat, SRC))
 
 
 def test_normalize_degenerate_points():

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -496,10 +496,18 @@ def test_fundamental_matrix_epipolar_projection():
 
 
 def test_essential_matrix_init():
-    tform = EssentialMatrixTransform(
-        rotation=np.eye(3), translation=np.array([0, 0, 1])
-    )
+    r = np.eye(3)
+    t = np.array([0, 0, 1])
+    tform = EssentialMatrixTransform(rotation=r, translation=t)
     assert_equal(tform.params, np.array([0, -1, 0, 1, 0, 0, 0, 0, 0]).reshape(3, 3))
+    t2 = np.array([0, 0, 2])
+    with pytest.raises(ValueError, match="Translation vector must have unit length"):
+        EssentialMatrixTransform(rotation=r, translation=t2)
+    with pytest.raises(ValueError, match="Rotation matrix must have unit determinant"):
+        EssentialMatrixTransform(rotation=np.eye(3)[::-1], translation=t)
+    r2 = r[[2, 0, 1]]
+    tform = EssentialMatrixTransform(rotation=r2, translation=t)
+    assert_equal(tform.params, [[-1, 0, 0], [0, 0, 1], [0, 0, 0]])
 
 
 def test_essential_matrix_estimation():

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -868,9 +868,9 @@ def test_inverse_all_transforms(tform):
 
 @pytest.mark.parametrize('tform_class', TRANSFORMS.values())
 def test_identity(tform_class):
-    rng = np.random.default_rng()
     if tform_class is PiecewiseAffineTransform:
         return  # Identity transform unusable.
+    rng = np.random.default_rng()
     allows_nd = tform_class in HMAT_TFORMS_ND
     for ndim in (2, 3, 4, 5) if allows_nd else (2,):
         src = rng.normal(size=(10, ndim))

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -1274,7 +1274,7 @@ def test_broadcasting():
     # 3D.
     tf = SimilarityTransform(scale=[2, 3, 4], translation=10)
     assert_equal(tf.params, _from_matvec(np.diag([2, 3, 4]), [10] * 3))
-    # Scalar rotation does not broadclast
+    # Scalar rotation does not broadcast.
     for tf_class in SimilarityTransform, EuclideanTransform:
         with pytest.raises(ValueError):
             tf_class(rotation=0.2, translation=translation)

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -1222,7 +1222,7 @@ def test_kw_only_params(tform_class):
 
 
 def test_kw_only_emt():
-    # Check all parameters are keyword only for EssentialMatrixTransform.
+    # Check all parameters are keyword-only for EssentialMatrixTransform.
     with pytest.raises(TypeError):
         EssentialMatrixTransform(None)
 

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -1094,6 +1094,23 @@ def test_affine_transform_from_linearized_parameters():
         _ = AffineTransform(matrix=v[:-1])
 
 
+def test_affine_transform_order():
+    # Test transforms are applied in order stated.
+    ops = (
+        ('scale', (4, 5)),
+        ('shear', (1.4, 1.8)),
+        ('rotation', 0.4),
+        ('translation', (10, 12)),
+    )
+    part_xforms = [AffineTransform(**{k: v}) for k, v in ops]
+    full_xform = AffineTransform(**dict(ops))
+    # Assemble affine transform via matrices.
+    out = np.eye(3)
+    for tf in part_xforms:
+        out = tf @ out
+    assert np.allclose(full_xform.params, out)
+
+
 def test_affine_params_nD_error():
     with pytest.raises(ValueError):
         _ = AffineTransform(scale=5, dimensionality=3)

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -21,6 +21,7 @@ from skimage.transform._geometric import (
     _GeometricTransform,
     _affine_matrix_from_vector,
     _center_and_normalize_points,
+    _apply_homogenous,
     _euler_rotation_matrix,
     TRANSFORMS,
 )
@@ -913,6 +914,12 @@ def test_degenerate():
             assert not np.all(np.isnan(affine.params))
     for affine in tform.inverse_affines:
         assert not np.all(np.isnan(affine.params))
+
+
+def test_normalize_points():
+    mat, normed = _center_and_normalize_points(SRC)
+    assert np.allclose(np.mean(normed, axis=0), 0)
+    assert np.allclose(normed, _apply_homogenous(mat, SRC))
 
 
 def test_normalize_degenerate_points():

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -1181,3 +1181,15 @@ def test_2D_only_implementations():
         _ = tf.rotation
     with pytest.raises(NotImplementedError):
         _ = tf.shear
+
+
+@pytest.mark.parametrize(
+    'tform_class',
+    (EssentialMatrixTransform,
+     AffineTransform,
+     EuclideanTransform,
+     SimilarityTransform))
+def test_kw_only_params(tform_class):
+    # Check only matrix can be passed as positional arg.
+    with pytest.raises(TypeError):
+        tform_class(None, None)

--- a/skimage/transform/tests/test_geometric.py
+++ b/skimage/transform/tests/test_geometric.py
@@ -322,7 +322,7 @@ def test_affine_shear():
 
 
 @pytest.mark.parametrize(
-    'pts,params',
+    'pts, params',
     product(
         (SRC, DST),
         (


### PR DESCRIPTION
Standardize and refactor initialization of transform classes, formalize rules for specifying dimensionality.

API break: implicit (scale, shear, rotation, translation) parameters are now all keyword-only, to avoid confusion from differences in previous argument ordering and application order of the transforms.

Add and test `identity` class constructor.

Deprecate use of scalar ``scale`` parameter with dimensionality=3.

In due course, perhaps warn on use of `dimensionality` when calling class constructor with other arguments, to avoid confusion, and prefer ``identity`` class constructor.


## Release note

```release-note
Deprecate use of scalar `scale`, with `dimensionality=3` where this can be passed to a geometric transform contructor.  This allows us to generalize the use of the constructors to the case where the paraters must specify the dimensionality, unless you mean to construct an identity transform.

Add `identity` class constructor to all geometric transforms.

Make all input parameters to Transform constructors, other than `matrix`, keyword only, to work around difference in the order of parameters, from the order of application, in `AffineTransform`.
```
