### PR TITLE
[RFC] Parameterize LLVM OpenMP install

### DIFF
--- a/.github/workflows/wheels-recipe.yaml
+++ b/.github/workflows/wheels-recipe.yaml
@@ -155,23 +155,24 @@ jobs:
 
       - name: Build wheels for CPython Mac OS
         run: |
-          # Make sure to use a libomp version binary compatible with the oldest
-          # supported version of the macos SDK as libomp will be vendored into
-          # the scikit-image wheels for macos. The list of binaries are in
-          # https://packages.macports.org/libomp/
+          # Make sure to use a LLVM OpenMP version binary compatible with the oldest
+          # supported version of the macOS SDK as it will be vendored into
+          # the scikit-image wheels for macos. We use the `llvm-openmp` packages from
+          # https://github.com/conda-forge/openmp-feedstock
           if [[ "$CIBW_ARCHS_MACOS" == arm64 ]]; then
-              export MACOSX_DEPLOYMENT_TARGET=12.3
-              OPENMP_URL="https://anaconda.org/conda-forge/llvm-openmp/19.1.7/download/osx-arm64/llvm-openmp-19.1.7-hdb05f8b_0.conda"
+              export MACOSX_DEPLOYMENT_TARGET="12.3"
+              export CONDA_SUBDIR="osx-arm64"
+              export CONDA_OVERRIDE_OSX="${MACOSX_DEPLOYMENT_TARGET}"
           else
-              export MACOSX_DEPLOYMENT_TARGET=10.14
-              OPENMP_URL="https://anaconda.org/conda-forge/llvm-openmp/19.1.7/download/osx-64/llvm-openmp-19.1.7-ha54dae1_0.conda"
+              export MACOSX_DEPLOYMENT_TARGET="10.14"
+              export CONDA_SUBDIR="osx-arm64"
+              export CONDA_OVERRIDE_OSX="${MACOSX_DEPLOYMENT_TARGET}"
           fi
-          echo MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}
 
           # use conda to install llvm-openmp
           # Note that we do NOT activate the conda environment, we just add the
           # library install path to CFLAGS/CXXFLAGS/LDFLAGS below.
-          conda create -n build $OPENMP_URL
+          conda create -n build llvm-openmp -yq
           PREFIX="/Users/runner/miniconda3/envs/build"
           export CC=/usr/bin/clang
           export CXX=/usr/bin/clang++


### PR DESCRIPTION
## Description

To aid in selecting the right macOS LLVM OpenMP package:

* Specify the OS & architecture with [the `CONDA_SUBDIR` environment variable]( https://conda-forge.org/docs/user/tipsandtricks/#installing-apple-intel-packages-on-apple-silicon )
* Set the macOS version with [the `CONDA_OVERRIDE_OSX` environment variable]( https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html )

Using this we are able to get the same packages listed under the URLs today. Going forward if there are new builds with fixes, we can pick them up. Also if we need to change the macOS minimum version, it is as simple as updating the `MACOSX_DEPLOYMENT_TARGET`

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
