### PR TITLE
DOC: document use of environment.yml in installation guide

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -231,17 +231,11 @@ After installing miniforge:
 
 .. code-block:: sh
 
-  # Create a conda environment named ``skimage-dev``
-  conda create --name skimage-dev
+  # Create a conda environment with required dependencies
+  conda env create -f environment.yml
 
   # Activate it
   conda activate skimage-dev
-
-  # Install development dependencies
-  conda install -c conda-forge --file requirements/default.txt
-  conda install -c conda-forge --file requirements/test.txt
-  conda install -c conda-forge pre-commit ipython
-  conda install -c conda-forge --file requirements/build.txt
 
   # Install scikit-image in editable mode. In editable mode,
   # scikit-image will be recompiled, as necessary, on import.


### PR DESCRIPTION
## Description

Closes gh-6494. 
For convenience, here is a link to the relevant [rendered documentation](https://output.circle-artifacts.com/output/job/17d9a8da-2189-4f8d-a394-d7717cbe2db4/artifacts/0/doc/build/html/user_guide/install.html#id5).

Feel free to push or suggest any adjustments to core-developer documentation about updating `environment.yml`, etc.

## Release note

Does this need one?

To conserve resources until gh-7749 merges, how do I ensure that only doc CI runs?