### PR TITLE
DOC: transform.resize: document output dtype

### DIFF
--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -100,6 +100,10 @@ def resize(
     -------
     resized : ndarray
         Resized version of the input.
+        The dtype is ``float64`` with the following exceptions:
+
+        - ``order==0``: resized dtype is ``image.dtype``.
+        - ``image.dtype`` is ``float16`` or ``float32``: resized dtype is``float32``.
 
     Other parameters
     ----------------

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -147,7 +147,7 @@ def resize(
     would be [0, 1, 2, 1, 0, 1, 2].
 
     `resize` uses interpolation. Unless the interpolation method is nearest-neighbor
-    (``order==0``), the algorithm will generate output values as a weighted average
+    (``order==0``), the algorithm will generate output values as weighted averages
     of input values. Accordingly, the output dtype is ``float64`` with the following
     exceptions:
 

--- a/skimage/transform/_warps.py
+++ b/skimage/transform/_warps.py
@@ -99,11 +99,7 @@ def resize(
     Returns
     -------
     resized : ndarray
-        Resized version of the input.
-        The dtype is ``float64`` with the following exceptions:
-
-        - ``order==0``: resized dtype is ``image.dtype``.
-        - ``image.dtype`` is ``float16`` or ``float32``: resized dtype is``float32``.
+        Resized version of the input. See Notes regarding dtype.
 
     Other parameters
     ----------------
@@ -138,6 +134,10 @@ def resize(
         downsampling factor, where s > 1. For the up-size case, s < 1, no
         anti-aliasing is performed prior to rescaling.
 
+    See Also
+    --------
+    scipy.ndimage.zoom
+
     Notes
     -----
     Modes 'reflect' and 'symmetric' are similar, but differ in whether the edge
@@ -145,6 +145,18 @@ def resize(
     has values [0, 1, 2] and was padded to the right by four values using
     symmetric, the result would be [0, 1, 2, 2, 1, 0, 0], while for reflect it
     would be [0, 1, 2, 1, 0, 1, 2].
+
+    `resize` uses interpolation. Unless the interpolation method is nearest-neighbor
+    (``order==0``), the algorithm will generate output values as a weighted average
+    of input values. Accordingly, the output dtype is ``float64`` with the following
+    exceptions:
+
+    - When ``order==0``, the output dtype is ``image.dtype``.
+    - When ``image.dtype`` is ``float16`` or ``float32``, the output dtype is
+      ``float32``.
+
+    For a similar function that preserves the dtype of the input, consider
+    `scipy.ndimage.zoom`.
 
     Examples
     --------


### PR DESCRIPTION
## Description

Closes gh-7524

gh-7524 noted that the output dtype of `transform.resize` is not the same as the input dtype. This appears to be an intended feature, so perhaps the issue can be closed by documenting the output dtype. (Feel free to close if there is standard dtype behavior documented elsewhere.)

---

I traced the code a bit, but ultimately determined the relationship between input and output dtype using this script. I varied some of the other parameters manually rather than looping over all possibilities. If you know of another exception, I'd be happy to add it, but I think the consequences of missing an obscure one are rather low. 

```python3
import numpy as np
from skimage.transform import resize

for order in [0, 3, 5]:
    for size in [(41, 41), (50, 50), (57, 57)]:
        for dtype in [np.uint8, np.uint16, np.uint32, np.uint64, 
                    np.int8, np.int16, np.int32, np.int64, 
                    np.float16, np.float32, np.float64]:
            image = np.ones((50, 50), dtype=dtype)
            out = resize(image, size, order=order)
            if out.dtype != np.float64:
                print(order, size, dtype, out.dtype)
```

