### PR TITLE
DOC: Include missing gain parameter in adjust_gamma equation

### DIFF
--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -624,9 +624,9 @@ def _adjust_gamma_u8(image, gamma, gain):
 
 
 def adjust_gamma(image, gamma=1, gain=1):
-    """Performs Gamma Correction on the input image.
+    """Perform gamma correction on the input image.
 
-    Gamma correction is a power-law transform. [1]_ This function
+    Gamma correction is a power-law transform [1]_. This function
     transforms the input `image` pixel-wise according to the power law
     ``image**gamma`` after scaling each pixel to the range 0 to 1. Then
     it is rescaled to its original range and muliplied by `gain`.
@@ -664,7 +664,7 @@ def adjust_gamma(image, gamma=1, gain=1):
     Examples
     --------
     >>> import skimage as ski
-    >>> image = ski.img_as_float(ski.data.moon())
+    >>> image = ski.util.img_as_float(ski.data.moon())
     >>> gamma_corrected = ski.exposure.adjust_gamma(image, 2)
     >>> # Output is darker for gamma > 1
     >>> image.mean() > gamma_corrected.mean()

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -680,7 +680,8 @@ def adjust_gamma(image, gamma=1, gain=1):
     else:
         _assert_non_negative(image)
 
-        scale = float(dtype_limits(image, True)[1] - dtype_limits(image, True)[0])
+        limits = dtype_limits(image, clip_negative=True)
+        scale = float(limits[1] - limits[0])
 
         out = (((image / scale) ** gamma) * scale * gain).astype(dtype)
 

--- a/skimage/exposure/exposure.py
+++ b/skimage/exposure/exposure.py
@@ -626,9 +626,10 @@ def _adjust_gamma_u8(image, gamma, gain):
 def adjust_gamma(image, gamma=1, gain=1):
     """Performs Gamma Correction on the input image.
 
-    Also known as Power Law Transform.
-    This function transforms the input image pixelwise according to the
-    equation ``O = I**gamma`` after scaling each pixel to the range 0 to 1.
+    Gamma correction is a power-law transform. [1]_ This function
+    transforms the input `image` pixel-wise according to the power law
+    ``image**gamma`` after scaling each pixel to the range 0 to 1. Then
+    it is rescaled to its original range and muliplied by `gain`.
 
     Parameters
     ----------
@@ -662,9 +663,9 @@ def adjust_gamma(image, gamma=1, gain=1):
 
     Examples
     --------
-    >>> from skimage import data, exposure, img_as_float
-    >>> image = img_as_float(data.moon())
-    >>> gamma_corrected = exposure.adjust_gamma(image, 2)
+    >>> import skimage as ski
+    >>> image = ski.img_as_float(ski.data.moon())
+    >>> gamma_corrected = ski.exposure.adjust_gamma(image, 2)
     >>> # Output is darker for gamma > 1
     >>> image.mean() > gamma_corrected.mean()
     True


### PR DESCRIPTION
## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->
The `adjust_gamma` docstring is missing the `gain` parameter in the equation describing the transformation.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
