### PR TITLE
Deprecate old names & attributes in RegionProperties

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -56,5 +56,7 @@ Version 2.0
 - In `skimage.morphology.remove_small_holes`, complete the deprecation of
   `area_threshold` and re-order the argument `connectivity` after the
   keyword-only parameter `max_size`.
+- In `skimage.measure.regionprops` complete deprecation of old property names.
+  Remove `PROPS` dict, related logic and warnings.
 
 See https://github.com/scikit-image/scikit-image/wiki/API-changes-for-skimage2

--- a/skimage/measure/_regionprops.py
+++ b/skimage/measure/_regionprops.py
@@ -413,10 +413,18 @@ class RegionProperties:
                     f"Attribute '{attr}' unavailable when `intensity_image` "
                     f"has not been specified."
                 )
+            warn(
+                f"`RegionProperties.{attr}` is deprecated starting in "
+                "version 0.26 and will be removed in version 2.0. Use "
+                f"`RegionProperties.{PROPS[attr]}` instead. ",
+                category=FutureWarning,
+                stacklevel=2,
+            )
             # retrieve deprecated property (excluding old CamelCase ones)
             return getattr(self, PROPS[attr])
-        else:
-            raise AttributeError(f"'{type(self)}' object has no attribute '{attr}'")
+
+        # Fallback to default behavior, potentially raising an attribute error
+        return self.__getattribute__(attr)
 
     def __setattr__(self, name, value):
         if name in PROPS:
@@ -772,11 +780,16 @@ class RegionProperties:
         return iter(sorted(props))
 
     def __getitem__(self, key):
-        value = getattr(self, key, None)
-        if value is not None:
-            return value
-        else:  # backwards compatibility
-            return getattr(self, PROPS[key])
+        if key in PROPS:
+            warn(
+                f"`RegionProperties[{key!r}]` is deprecated starting in "
+                "version 0.26 and will be removed in version 2.0. Use "
+                f"`RegionProperties[{PROPS[key]!r}]` instead. ",
+                category=FutureWarning,
+                stacklevel=2,
+            )
+            key = PROPS[key]
+        return getattr(self, key)
 
     def __eq__(self, other):
         if not isinstance(other, RegionProperties):

--- a/skimage/measure/tests/test_regionprops.py
+++ b/skimage/measure/tests/test_regionprops.py
@@ -100,6 +100,9 @@ def get_central_moment_function(img, spacing=(1, 1)):
     return lambda p, q: np.sum((Y - cY) ** p * (X - cX) ** q * img)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:`RegionProperties.* is deprecated:FutureWarning:skimage"
+)
 def test_all_props():
     region = regionprops(SAMPLE, INTENSITY_SAMPLE)[0]
     for prop in PROPS:
@@ -117,6 +120,9 @@ def test_all_props():
             pass
 
 
+@pytest.mark.filterwarnings(
+    "ignore:`RegionProperties.* is deprecated:FutureWarning:skimage"
+)
 def test_all_props_3d():
     region = regionprops(SAMPLE_3D, INTENSITY_SAMPLE_3D)[0]
     for prop in PROPS:
@@ -1478,6 +1484,9 @@ def test_extra_properties_table():
     assert out["bbox_list"][1] == [1] * 1
 
 
+@pytest.mark.filterwarnings(
+    "ignore:`RegionProperties.* is deprecated:FutureWarning:skimage"
+)
 def test_multichannel():
     """Test that computing multichannel properties works."""
     astro = data.astronaut()[::4, ::4]
@@ -1550,3 +1559,31 @@ def test_pickling_region_properties():
     pickled = pickle.dumps(regions[0])
     unpickled = pickle.loads(pickled)  # RecursionError here
     assert regions[0] == unpickled
+
+
+@pytest.mark.parametrize("old_name", list(PROPS))
+def test_deprecated_properties(old_name):
+    regions = regionprops(SAMPLE, intensity_image=INTENSITY_SAMPLE)
+
+    regex = rf"`RegionProperties\['{old_name}'\]` is deprecated"
+    with pytest.warns(FutureWarning, match=regex) as record:
+        result = regions[0][old_name]
+    testing.assert_stacklevel(record)
+
+    current_name = PROPS[old_name]
+    np.testing.assert_equal(result, regions[0][current_name])
+
+    if old_name == old_name.lower():
+        # lower case names in PROPS are still accessible as attributes
+        # Make sure those emit an appropriate warning
+        regex = f"`RegionProperties.{old_name}` is deprecated."
+        with pytest.warns(FutureWarning, match=regex) as record:
+            result = getattr(regions[0], old_name)
+        testing.assert_stacklevel(record)
+        current_name = PROPS[old_name]
+        np.testing.assert_equal(result, regions[0][current_name])
+
+    else:
+        regex = f"'RegionProperties' object has no attribute {old_name!r}"
+        with pytest.raises(AttributeError, match=regex):
+            getattr(regions[0], old_name)


### PR DESCRIPTION
## Description

Closes #7732. 

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Of ficially deprecate old properties in `skimage.measure.regionprops` and
related functions. While we removed the documentation for these some time
ago, they where still accessible as keys (via `__get_item__`) or attributes.
Going forward, using deprecated keys or attributes, will emit an
appropriate warning.
```
