### PR TITLE
Display actual threshold value in Global Otsu plot

### DIFF
--- a/doc/examples/applications/plot_thresholding_guide.py
+++ b/doc/examples/applications/plot_thresholding_guide.py
@@ -213,7 +213,7 @@ ax[2].set_title('Original >= Local Otsu')
 ax[2].set_axis_off()
 
 ax[3].imshow(global_otsu, cmap=plt.cm.gray)
-ax[3].set_title('Global Otsu (threshold = {threshold_global_otsu})')
+ax[3].set_title(f'Global Otsu (threshold = {threshold_global_otsu})')
 ax[3].set_axis_off()
 
 plt.show()


### PR DESCRIPTION
## Description
This PR fixes an issue in the thresholding guide example where the Global Otsu plot title displayed a literal placeholder (`{threshold_global_otsu}`) instead of the actual computed threshold value. The placeholder was inside a regular string rather than an f-string, preventing the value from rendering correctly. Currently the output image is:

![image](https://github.com/user-attachments/assets/8f63edcf-d38c-4bdd-8b40-5886773b614c)

relevant page can be found [here](https://scikit-image.org/docs/stable/auto_examples/applications/plot_thresholding_guide.html).

## Checklist

## Release note
```release-note
Display actual threshold value in Global Otsu plot
```
