### PR TITLE
Draft migration guide for skimage2

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -362,4 +362,6 @@ def linkcode_resolve(domain, info):
 myst_enable_extensions = [
     # Enable fieldlist to allow for Field Lists like in rST (e.g., :orphan:)
     "fieldlist",
+    # Enable fencing directives with `:::`
+    "colon_fence",
 ]

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -25,4 +25,5 @@ and more advanced topics.
    :maxdepth: 1
    :caption: Other resources
 
+   skimage2_migration
    glossary

--- a/doc/source/user_guide/skimage2_migration.md
+++ b/doc/source/user_guide/skimage2_migration.md
@@ -1,0 +1,30 @@
+(skimage2_migration)=
+
+# Transition to skimage2
+
+:::{hint}
+This document is a work in progress and still subject to change.
+:::
+
+scikit-image is preparing to release version 2.0 under the new namespace `skimage2`.
+This will affect both its import name and its package name on PyPI and elsewhere.
+Together with skimage2, we will release version 1.0.0 and 1.0.1 with the old API.
+Version 1.0.1 will emit a notification (FutureWarning) on import, telling users to either upgrade to skimage2 or pin to version 1.0.0.
+
+We do this to clean up long-standing issue without our API.
+Some of these issues involve changes to behavior that are difficult to address with conventional deprecations.
+Since we don't want to change behavior silently, we will introduce the new namespace which gives users an explicit way to upgrade to new behavior.
+
+You can find a more detailed description of our motivation and discussion leading up to this in {doc}`SKIP 4 <../skips/4-transition-to-v2>`.
+
+## Changes in skimage2
+
+_To be defined._
+
+## Changes pre skimage2
+
+We have already introduced a number of changes and deprecations to our API.
+These will only be completed in during the transition to skimage2 and will continue to work in all versions pre-skimage2.
+However, updating your code to the new API will make it easier to transition to the skimage2 API.
+
+_To be defined._


### PR DESCRIPTION
## Description

Adds an document with an outline of the planned migration guide. The idea is to compile something like the [NumPy 2 migration guide](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html) while we work on this.

My gut feeling is that we should keep this guide similarly focused and concise and link to motivation, etc elsewhere.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
