### PR TITLE
Temporarily pin to `pyodide-build==0.30.0`, and ensure that the correct xbuildenvs are used

### DIFF
--- a/.github/workflows/emscripten.yaml
+++ b/.github/workflows/emscripten.yaml
@@ -22,7 +22,7 @@ jobs:
     name: Build scikit-image distribution for Pyodide
     runs-on: ubuntu-24.04
     env:
-      PYODIDE_VERSION: 0.27.3
+      PYODIDE_VERSION: 0.27.5
       # PYTHON_VERSION and EMSCRIPTEN_VERSION are determined by PYODIDE_VERSION.
       # The appropriate versions can be found in the Pyodide repodata.json
       # "info" field, or in Makefile.envs:

--- a/.github/workflows/emscripten.yaml
+++ b/.github/workflows/emscripten.yaml
@@ -54,7 +54,9 @@ jobs:
         run: pip install pyodide-build==0.30.0
 
       - name: Build scikit-image for Pyodide
-        run: pyodide build
+        run: |
+          pyodide xbuildenv install ${{ env.PYODIDE_VERSION }}
+          pyodide build
 
       - name: Set up Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
@@ -64,7 +66,6 @@ jobs:
       - name: Set up Pyodide virtual environment and test scikit-image for Pyodide
         run: |
           # Set up Pyodide virtual environment
-          pyodide xbuildenv install ${{ env.PYODIDE_VERSION }}
           pyodide venv .venv-pyodide
 
           # Activate the virtual environment and install the built scikit-image wheel

--- a/.github/workflows/emscripten.yaml
+++ b/.github/workflows/emscripten.yaml
@@ -51,7 +51,7 @@ jobs:
           actions-cache-folder: emsdk-cache
 
       - name: Install pyodide-build
-        run: pip install pyodide-build
+        run: pip install pyodide-build==0.30.0
 
       - name: Build scikit-image for Pyodide
         run: pyodide build


### PR DESCRIPTION
## Description

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

This PR serves as a temporary fix for #7783 to get CI green until we can get to the bottom of the issue. Also, another thing (non-breaking) that I addressed here is that we were using Pyodide 0.27.5 xbuildenvs at build time using `pyodide build`, and `pyodide venv` was downloading its own Pyodide xbuildenv/runtime (pinned via the `PYODIDE_VERSION:` environment variable) for testing packages. While this didn't impact anything, it could have been prone to errors when we would have released a new Pyodide version.

It would be great if #7440 could be merged sometime soon, though – it's ready for review/merging. It uses `cibuildwheel` to build and test the Pyodide/WASM wheels, and `cibuildwheel` pins the `pyodide-build` and Pyodide versions, so while that may make updating the testing configuration a little difficult, it's certainly going to much more stable.

cc: @stefanv

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
