### PR TITLE
CI: Update pypa/gh-action-pypi-publish to v1.12.4 for attestations on PyPI

### DIFF
--- a/.github/workflows/wheels-test-and-release.yaml
+++ b/.github/workflows/wheels-test-and-release.yaml
@@ -79,7 +79,7 @@ jobs:
       # We prefer to release wheels before source because otherwise there is a
       # small window during which users who pip install scikit-image will require compilation.
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # v1.8.14
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
 
       - name: Github release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Description

Update to [`pypa/gh-action-pypi-publish` `v1.12.4`](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.4) (https://github.com/pypa/gh-action-pypi-publish/commit/76f52bc884231f62b9a034ebfe128415bbaabdfc).

As of `pypa/gh-action-pypi-publish` `v1.11.0` using Trusted Publishers will produce and publish attestations by default which are visible on PyPI through inspection and through APIs.
   - c.f. https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.11.0
   - c.f. https://docs.pypi.org/api/integrity/
   - Example: https://pypi.org/project/awkward/2.8.2/#awkward-2.8.2-py3-none-any.whl

Big thanks to @mihaimaruseac for pointing this out!

This hasn't been automatically picked up yet as Dependabot isn't active for GitHub Actions in `scikit-image`.

Amends and follows up on:
* https://github.com/scikit-image/scikit-image/pull/7178
* https://github.com/scikit-image/scikit-image/pull/7433

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- [x] A descriptive but concise pull request title
- [N/A] [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [N/A] [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- [N/A] A gallery example in `./doc/examples` for new features
- [x] [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```


I'm assuming this isn't needed for this, but let me know otherwise.