### PR TITLE
Add threshold_elen method based on Elen & Donmez (2024)

### DIFF
--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -24,6 +24,7 @@ from skimage.filters._multiotsu import (
 from skimage.filters.thresholding import (
     _cross_entropy,
     _mean_std,
+    threshold_elen,
     threshold_isodata,
     threshold_li,
     threshold_local,
@@ -821,3 +822,53 @@ def test_multiotsu_hist_parameter():
             thresh_img = threshold_multiotsu(img, classes)
             thresh_sk_hist = threshold_multiotsu(classes=classes, hist=sk_hist)
             assert np.allclose(thresh_img, thresh_sk_hist)
+
+
+def test_elen_camera_image():
+    camera = util.img_as_ubyte(data.camera())
+    thresh = threshold_elen(camera)
+    assert 126 < thresh < 128
+
+
+def test_elen_camera_image_hist():
+    camera = util.img_as_ubyte(data.camera())
+    hist = histogram(camera.ravel(), 256, source_range='image')
+    thresh = threshold_elen(hist=hist)
+    assert 126 < thresh < 128
+
+
+def test_elen_camera_hist_counts_only():
+    camera = util.img_as_ubyte(data.camera())
+    counts, _ = histogram(camera.ravel(), 256, source_range='image')
+    thresh = threshold_elen(hist=counts)
+    assert 126 < thresh < 128
+
+
+def test_elen_coins_image():
+    coins = util.img_as_ubyte(data.coins())
+    thresh = threshold_elen(coins)
+    assert 98 < thresh < 100
+
+
+def test_elen_coins_image_as_float():
+    coins = util.img_as_float(data.coins())
+    thresh = threshold_elen(coins)
+    assert 0.37 < thresh < 0.39
+
+
+def test_elen_one_color_image():
+    img = np.ones((10, 10), dtype=np.uint8) * 42
+    thresh = threshold_elen(img)
+    assert thresh == 42
+
+
+def test_elen_one_color_image_3d():
+    img = np.ones((10, 10, 10), dtype=np.uint8) * 42
+    thresh = threshold_elen(img)
+    assert thresh == 42
+
+
+def test_elen_rgb_warns():
+    img = util.img_as_ubyte(data.astronaut())
+    with expected_warnings(['grayscale']):
+        threshold_elen(img)

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -33,6 +33,7 @@ __all__ = [
     'threshold_triangle',
     'apply_hysteresis_threshold',
     'threshold_multiotsu',
+    'threshold_elen'
 ]
 
 


### PR DESCRIPTION
## Description

This pull request adds a new thresholding method `threshold_elen`, based on the work of Elen & Donmez (2024).  
The method defines a threshold as the midpoint between the average pixel values in the central region (mean ± std) and its complement in the histogram.

- Implementation added to `filters/thresholding.py`
- Unit tests added in `filters/tests/test_thresholding.py`
- Histogram input and grayscale image input both supported
- RGB images raise a warning
- Reference: https://doi.org/10.1016/j.ijleo.2024.171814

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

- A descriptive but concise pull request title ✔️
- [x] Docstrings for all functions
- [x] Unit tests
- [ ] A gallery example in `./doc/examples` for new features *(optional for now)*
- [x] Contribution guide is followed

## Release note

```release-note
Added `threshold_elen` thresholding method based on histogram mean and standard deviation separation,
as proposed by Elen, A. & Donmez, E. (2024).
