### PR TITLE
Add convergence safeguards to threshold_li with oscillation detection and iteration limit

### DIFF
--- a/skimage/filters/tests/test_thresholding.py
+++ b/skimage/filters/tests/test_thresholding.py
@@ -1,4 +1,5 @@
 import math
+import os
 
 import numpy as np
 import pytest
@@ -412,6 +413,31 @@ def test_li_negative_inital_guess():
     with pytest.raises(ValueError, match=".*initial guess.*must be within the range"):
         threshold_li(coins, initial_guess=-5)
 
+def test_threshold_li_warns_on_oscillating_input():
+    img_path = os.path.abspath(os.path.join(
+        os.path.dirname(__file__), 
+        "..",
+        "..",
+        "data",
+        "threshold_li_oscillation_img.txt.gz"
+    ))
+    oscillating_image = np.loadtxt(img_path, dtype="float32")
+
+    with pytest.warns(UserWarning, match="threshold_li oscillates between two threshold values"):
+        threshold_li(oscillating_image)
+
+def test_threshold_li_breaks_at_max_iteration():
+    img_path = os.path.abspath(os.path.join(
+        os.path.dirname(__file__), 
+        "..",
+        "..",
+        "data",
+        "threshold_li_oscillation_img.txt.gz"
+    ))
+    oscillating_image = np.loadtxt(img_path, dtype="float32")
+    
+    with pytest.warns(UserWarning, match="threshold_li did not converge"):
+        threshold_li(oscillating_image, tolerance=1e-12, max_iter=5)
 
 @pytest.mark.parametrize(
     "image",

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from collections.abc import Iterable
 
 import numpy as np
+import warnings
 from scipy import ndimage as ndi
 
 from .._shared.filters import gaussian
@@ -639,7 +640,7 @@ def _cross_entropy(image, threshold, bins=_DEFAULT_ENTROPY_BINS):
     return nu
 
 
-def threshold_li(image, *, tolerance=None, initial_guess=None, iter_callback=None):
+def threshold_li(image, *, tolerance=None, initial_guess=None, iter_callback=None, max_iter=100):
     """Compute threshold value by Li's iterative Minimum Cross Entropy method.
 
     Parameters
@@ -663,6 +664,12 @@ def threshold_li(image, *, tolerance=None, initial_guess=None, iter_callback=Non
     iter_callback : Callable[[float], Any], optional
         A function that will be called on the threshold at every iteration of
         the algorithm.
+    max_iter : int, optional
+        Maximum number of iterations to perform. If the threshold does not
+        converge within this number of steps, the algorithm stops and issues
+        a warning. This prevents infinite loops in cases where the threshold
+        oscillates between values or convergence is too slow.
+        Default is 100.
 
     Returns
     -------
@@ -753,10 +760,15 @@ def threshold_li(image, *, tolerance=None, initial_guess=None, iter_callback=Non
     # new and old threshold values is less than the tolerance
     # or if the background mode has only one value left,
     # since log(0) is not defined.
+    # Additionally, check for previously seen values to prevent 
+    # threshold oscillation between two values.
+    iteration = 0
+    seen_thresholds = []
 
     if image.dtype.kind in 'iu':
         hist, bin_centers = histogram(image.reshape(-1), source_range='image')
         hist = hist.astype('float32', copy=False)
+
         while abs(t_next - t_curr) > tolerance:
             t_curr = t_next
             foreground = bin_centers > t_curr
@@ -772,6 +784,15 @@ def threshold_li(image, *, tolerance=None, initial_guess=None, iter_callback=Non
 
             if iter_callback is not None:
                 iter_callback(t_next + image_min)
+            
+            if round(float(t_next), 10) in seen_thresholds:
+                break
+            seen_thresholds.append(round(float(t_next), 10))
+            
+            if iteration >= max_iter:
+                warnings.warn("threshold_li did not converge")
+                break
+            iteration += 1
 
     else:
         while abs(t_next - t_curr) > tolerance:
@@ -787,6 +808,15 @@ def threshold_li(image, *, tolerance=None, initial_guess=None, iter_callback=Non
 
             if iter_callback is not None:
                 iter_callback(t_next + image_min)
+
+            if round(float(t_next), 10) in seen_thresholds:
+                break
+            seen_thresholds.append(round(float(t_next), 10))
+            
+            if iteration >= max_iter:
+                warnings.warn("threshold_li did not converge", RuntimeWarning)
+                break
+            iteration += 1
 
     threshold = t_next + image_min
     return threshold

--- a/skimage/filters/thresholding.py
+++ b/skimage/filters/thresholding.py
@@ -785,12 +785,14 @@ def threshold_li(image, *, tolerance=None, initial_guess=None, iter_callback=Non
             if iter_callback is not None:
                 iter_callback(t_next + image_min)
             
-            if round(float(t_next), 10) in seen_thresholds:
+
+            if round(float(t_curr), 10) in seen_thresholds:
+                warnings.warn("threshold_li oscillates between two threshold values", UserWarning)
                 break
-            seen_thresholds.append(round(float(t_next), 10))
+            seen_thresholds.append(round(float(t_curr), 10))
             
             if iteration >= max_iter:
-                warnings.warn("threshold_li did not converge")
+                warnings.warn("threshold_li did not converge", UserWarning)
                 break
             iteration += 1
 
@@ -809,12 +811,13 @@ def threshold_li(image, *, tolerance=None, initial_guess=None, iter_callback=Non
             if iter_callback is not None:
                 iter_callback(t_next + image_min)
 
-            if round(float(t_next), 10) in seen_thresholds:
+            if round(float(t_curr), 10) in seen_thresholds:
+                warnings.warn("threshold_li oscillates between two threshold values", UserWarning)
                 break
-            seen_thresholds.append(round(float(t_next), 10))
+            seen_thresholds.append(round(float(t_curr), 10))
             
             if iteration >= max_iter:
-                warnings.warn("threshold_li did not converge", RuntimeWarning)
+                warnings.warn("threshold_li did not converge", UserWarning)
                 break
             iteration += 1
 


### PR DESCRIPTION
## Description

This PR improves the robustness of threshold_li by adding a mechanism to detect and handle threshold oscillation during iteration. Specifically:

- A warning is now raised if the threshold value oscillates between already-seen values (e.g., two local optima).
- In the event of such oscillation, the iteration is explicitly terminated to avoid infinite loops.
- A maximum iteration limit (max_iter) was added to prevent infinite loops in edge cases.

Two tests were added:

- test_threshold_li_warns_on_oscillating_input to verify that oscillating inputs emit a UserWarning.
- test_threshold_li_breaks_at_max_iteration to check that the method stops after a given number of iterations and warns accordingly.

These additions help ensure graceful failure behavior in pathological cases and improve the method's robustness.

## Release note

```release-note
Improved `threshold_li` to detect oscillations and enforce a maximum number of iterations. Added user warnings in both cases.
```
