### PR TITLE
Add minimal TIFF stack loading example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,10 @@
-# scikit-image: Image processing in Python
+## Loading TIFF Stacks
 
-[![Image.sc forum](https://img.shields.io/badge/dynamic/json.svg?label=forum&url=https%3A%2F%2Fforum.image.sc%2Ftags%2Fscikit-image.json&query=%24.topic_list.tags.0.topic_count&colorB=brightgreen&suffix=%20topics&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAABPklEQVR42m3SyyqFURTA8Y2BER0TDyExZ+aSPIKUlPIITFzKeQWXwhBlQrmFgUzMMFLKZeguBu5y+//17dP3nc5vuPdee6299gohUYYaDGOyyACq4JmQVoFujOMR77hNfOAGM+hBOQqB9TjHD36xhAa04RCuuXeKOvwHVWIKL9jCK2bRiV284QgL8MwEjAneeo9VNOEaBhzALGtoRy02cIcWhE34jj5YxgW+E5Z4iTPkMYpPLCNY3hdOYEfNbKYdmNngZ1jyEzw7h7AIb3fRTQ95OAZ6yQpGYHMMtOTgouktYwxuXsHgWLLl+4x++Kx1FJrjLTagA77bTPvYgw1rRqY56e+w7GNYsqX6JfPwi7aR+Y5SA+BXtKIRfkfJAYgj14tpOF6+I46c4/cAM3UhM3JxyKsxiOIhH0IO6SH/A1Kb1WBeUjbkAAAAAElFTkSuQmCC)](https://forum.image.sc/tags/scikit-image)
-[![Stackoverflow](https://img.shields.io/badge/stackoverflow-Ask%20questions-blue.svg)](https://stackoverflow.com/questions/tagged/scikit-image)
-[![project chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://skimage.zulipchat.com)
-[![Scientific Python Ecosystem Coordination](https://img.shields.io/badge/SPEC-0,1,4,6,7,8-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/)
+Use `scikit-image` to load multi-page TIFF files for microgravity experiments:
 
-- **Website (including documentation):** [https://scikit-image.org/](https://scikit-image.org)
-- **Documentation:** [https://scikit-image.org/docs/stable/](https://scikit-image.org/docs/stable/)
-- **User forum:** [https://forum.image.sc/tag/scikit-image](https://forum.image.sc/tag/scikit-image)
-- **Developer forum:** [https://discuss.scientific-python.org/c/contributor/skimage](https://discuss.scientific-python.org/c/contributor/skimage)
-- **Source:** [https://github.com/scikit-image/scikit-image](https://github.com/scikit-image/scikit-image)
+```python
+from skimage import io
 
-## Installation
-
-- **pip:** `pip install scikit-image`
-- **conda:** `conda install -c conda-forge scikit-image`
-
-Also see [installing `scikit-image`](https://github.com/scikit-image/scikit-image/blob/main/INSTALL.rst).
-
-## License
-
-See [LICENSE.txt](https://github.com/scikit-image/scikit-image/blob/main/LICENSE.txt).
-
-## Citation
-
-If you find this project useful, please cite:
-
-> Stéfan van der Walt, Johannes L. Schönberger, Juan Nunez-Iglesias,
-> François Boulogne, Joshua D. Warner, Neil Yager, Emmanuelle
-> Gouillart, Tony Yu, and the scikit-image contributors.
-> _scikit-image: Image processing in Python_. PeerJ 2:e453 (2014)
-> https://doi.org/10.7717/peerj.453
+stack = io.imread('microgravity_stack.tif')
+print(stack.shape)
+```


### PR DESCRIPTION
Adds a README>md explaining how to use scikit-image's 1io.imread` to load multi-page TIFFs in scientific contexts such as microgravity image capture.