### PR TITLE
Bare-bones patch: Add band ratio support for hyperspectral preprocessing

### DIFF
--- a/band_ratio.py
+++ b/band_ratio.py
@@ -1,0 +1,19 @@
+"""
+A bare-bones band ratio function for hyperspectral data.
+"""
+
+import numpy as np
+
+def band_ratio(hypercube, band1, band2):
+    """
+    Compute a simple band ratio between two bands.
+
+    Parameters:
+        hypercube (ndarray): 3D hyperspectral cube (rows, cols, bands)
+        band1 (int): Index of numerator band
+        band2 (int): Index of denominator band
+
+    Returns:
+        ndarray: 2D ratio image (rows, cols)
+    """
+    return np.divide(hypercube[:, :, band1], hypercube[:, :, band2] + 1e-6)  # prevent div by zero


### PR DESCRIPTION
## Description
This patch introduces a minimal utility function to compute simple band ratios between hyperspectral image bands. The goal is to enable baseline support for hyperspectral data, which is currently lacking.

Function:
- `band_ratio(hypercube, band1, band2)`: Returns the pixel-wise ratio of two spectral bands.

Thanks in advance to whoever finally reviews this.
<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
