### PR TITLE
Remove superfluous mask argument from _generic_edge_filter

### DIFF
--- a/skimage/filters/edges.py
+++ b/skimage/filters/edges.py
@@ -131,7 +131,6 @@ def _generic_edge_filter(
     axis=None,
     mode='reflect',
     cval=0.0,
-    mask=None,
 ):
     """Apply a generic, n-dimensional edge filter.
 


### PR DESCRIPTION
## Description

The `mask` argument is not used in `_generic_edge_filter`. For masking in the edge filters, the function `mask_filter_result` is already used instead https://github.com/scikit-image/scikit-image/blob/be7ff3442864f8c44236c4cd50c04039a85b3ea8/skimage/filters/edges.py#L253

## Release note

```release-note
Remove superfluous `mask` argument in `_generic_edge_filter`
```
