### PR TITLE
Discourage contributors from force-pushing.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -111,7 +111,8 @@ For a more detailed discussion, read these :doc:`detailed documents
 
    * To update your pull request, make your changes on your local repository
      and commit. As soon as those changes are pushed up (to the same branch as
-     before) the pull request will update automatically.
+     before) the pull request will update automatically. Please do *not*
+     force-push any commit once the review process has started.
 
    * Continuous integration (CI) services are triggered after each pull request
      submission to build the package, run unit tests, measure code coverage,


### PR DESCRIPTION
## Description

This small addition follows from the conversation at https://discuss.scientific-python.org/t/force-pushing-in-big-prs/1999, assuming lazy consensus. I haven't mentioned *draft* PRs to avoid bloating this general 'How to contribute' (possibly greater details would belong here https://scikit-image.org/docs/stable/gitwash/index.html -- do people still make patches though?).

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
