### PR TITLE
CI: Add support for building wheels for WoA

### DIFF
--- a/.github/windows_arm64_steps /action.yml
+++ b/.github/windows_arm64_steps /action.yml
@@ -1,0 +1,17 @@
+name: Build Dependencies(Win-ARM64)
+description: "Common setup steps for Win-ARM64 CI"
+runs:
+  using: "composite"
+  steps:
+    - name: Install LLVM for Win-ARM64
+      shell: pwsh
+      run: |
+        Invoke-WebRequest https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.6/LLVM-20.1.6-woa64.exe -UseBasicParsing -OutFile LLVM-woa64.exe
+        $expectedHash = "92f69a1134e32e54b07d51c6e24d9594852f6476f32c3d70471ae00fffc2d462"
+        $fileHash = (Get-FileHash -Path "LLVM-woa64.exe" -Algorithm SHA256).Hash
+        if ($fileHash -ne $expectedHash) {
+            Write-Error "Checksum verification failed. The downloaded file may be corrupted or tampered with."
+            exit 1
+        }
+        Start-Process -FilePath ".\LLVM-woa64.exe" -ArgumentList "/S" -Wait
+        echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/wheels-recipe.yaml
+++ b/.github/workflows/wheels-recipe.yaml
@@ -199,33 +199,37 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest]
-        cibw_arch: ["AMD64"]
+        os: [windows-latest, windows-11-arm]
+        cibw_arch: ["AMD64", "ARM64"]
         cibw_python: ["cp311-*", "cp312-*", "cp313-*"]
-
+        exclude:
+          - os: windows-latest
+            cibw_arch: AMD64
+          - os: windows-11-arm
+            cibw_arch: ARM64
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
-
+          
       - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: "3.12"
           cache: "pip"
           cache-dependency-path: "requirements/*.txt"
-
+          
       - name: Install cibuildwheel and add clang-cl to path
         run: |
           python -m pip install cibuildwheel
-
+          
+      - name: Set up LLVM for Windows ARM64
+        if: matrix.cibw_arch == 'ARM64'
+        uses: ./.github/windows_arm64_steps
+        
       - name: Build AMD64 Windows wheels for CPython
         if: matrix.cibw_arch == 'AMD64'
-        # To avoid "LINK : fatal error LNK1158: cannot run 'rc.exe'"
-        # we explicitly add rc.exe to path using the method from:
-        # https://github.com/actions/virtual-environments/issues/294#issuecomment-588090582
-        # with additional -arch=x86 flag to vsdevcmd.bat
         run: |
           function Invoke-VSDevEnvironment {
             $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
@@ -241,14 +245,35 @@ jobs:
           Get-Command rc.exe | Format-Table -AutoSize
           python -m cibuildwheel --output-dir dist
         env:
-          # define CC, CXX so meson will use clang-cl instead of MSVC
           CC: clang-cl
           CXX: clang-cl
           CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
-          # -Wl,-S equivalent to gcc's -Wl,--strip-debug
           LDFLAGS: "-Wl,-S"
-
+          
+      - name: Build ARM64 Windows wheels for CPython
+        if: matrix.cibw_arch == 'ARM64'
+        run: |
+          function Invoke-VSDevEnvironment {
+            $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+              $installationPath = & $vswhere -prerelease -legacy -latest -property installationPath
+              $Command = Join-Path $installationPath "Common7\Tools\vsdevcmd.bat"
+            & "${env:COMSPEC}" /s /c "`"$Command`" -arch=arm64 -no_logo && set" | Foreach-Object {
+                  if ($_ -match '^([^=]+)=(.*)') {
+                      [System.Environment]::SetEnvironmentVariable($matches[1], $matches[2])
+                  }
+              }
+          }
+          Invoke-VSDevEnvironment
+          Get-Command rc.exe | Format-Table -AutoSize
+          python -m cibuildwheel --output-dir dist
+        env:
+          CC: clang-cl
+          CXX: clang-cl
+          CIBW_BUILD: ${{ matrix.cibw_python }}
+          CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
+          LDFLAGS: "-Wl,-S"
+          CIBW_TEST_SKIP: "-win_arm64" #Skip testing on Win-ARM64, since SciPy is yet to be supported
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-windows-${{ matrix.cibw_arch }}-${{ strategy.job-index }}

--- a/.github/workflows/wheels-recipe.yaml
+++ b/.github/workflows/wheels-recipe.yaml
@@ -230,6 +230,10 @@ jobs:
         
       - name: Build AMD64 Windows wheels for CPython
         if: matrix.cibw_arch == 'AMD64'
+        # To avoid "LINK : fatal error LNK1158: cannot run 'rc.exe'"
+        # we explicitly add rc.exe to path using the method from:
+        # https://github.com/actions/virtual-environments/issues/294#issuecomment-588090582
+        # with additional -arch=x86 flag to vsdevcmd.bat
         run: |
           function Invoke-VSDevEnvironment {
             $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
@@ -245,10 +249,12 @@ jobs:
           Get-Command rc.exe | Format-Table -AutoSize
           python -m cibuildwheel --output-dir dist
         env:
+          # define CC, CXX so meson will use clang-cl instead of MSVC
           CC: clang-cl
           CXX: clang-cl
           CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
+          # define CC, CXX so meson will use clang-cl instead of MSVC
           LDFLAGS: "-Wl,-S"
           
       - name: Build ARM64 Windows wheels for CPython

--- a/.github/workflows/wheels-recipe.yaml
+++ b/.github/workflows/wheels-recipe.yaml
@@ -254,7 +254,7 @@ jobs:
           CXX: clang-cl
           CIBW_BUILD: ${{ matrix.cibw_python }}
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_arch }}
-          # define CC, CXX so meson will use clang-cl instead of MSVC
+          # -Wl,-S equivalent to gcc's -Wl,--strip-debug
           LDFLAGS: "-Wl,-S"
           
       - name: Build ARM64 Windows wheels for CPython


### PR DESCRIPTION
## Description

- The PR introduces support for building scikit-image wheels on new Windows on ARM GitHub runners
- Current setup relies on LLVM's clang-cl for building wheels from source.
- The test suite for WoA are skipped due to unavailability of SciPy wheels on Windows on ARM
