### PR TITLE
Make ransac in plot_stitching example deterministic

### DIFF
--- a/doc/examples/registration/plot_stitching.py
+++ b/doc/examples/registration/plot_stitching.py
@@ -117,6 +117,13 @@ matching_corners = [
 ############################################################################
 # Once all the points are registered to the reference points, robust
 # relative affine transformations can be estimated using the RANSAC method.
+#
+# .. hint::
+#    :func:`skimage.measure.ransac` uses random sampling to estimate a model's
+#    parameters. Sometimes, the number of trials may not be enough to arrive
+#    at a successful estimation. To make this example deterministic, we pass a
+#    seed ``42`` to the parameter ``rng`` that is known to be successful.
+
 src = np.array(coords0)
 trfm_list = [
     measure.ransac(
@@ -125,6 +132,7 @@ trfm_list = [
         min_samples=3,
         residual_threshold=2,
         max_trials=100,
+        rng=42,
     )[0].params
     for dst in matching_corners
 ]


### PR DESCRIPTION
## Description

Closes #7849.

This avoids random failures when the number of max_trials is not enough to successfully estimate a EuclideanTransform.

This was also the case previously, but recent updates to our Transform API in #7771 made these failures visible in the CI.

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
