### PR TITLE
Describe custom warning-strategy in migration guide

### DIFF
--- a/doc/source/user_guide/skimage2_migration.md
+++ b/doc/source/user_guide/skimage2_migration.md
@@ -1,4 +1,4 @@
-(skimage2_migration)=
+(skimage2-migration)=
 
 # Migration guide: from skimage to skimage2
 
@@ -8,24 +8,46 @@ This document is a work in progress and still subject to change.
 
 scikit-image is preparing to release version 2.0 as a new package: `skimage2`.
 Alongside skimage2, we will release version 1.0.0. Versions 1.x will be using the current API.
-Versions 1.1.x will throw a FutureWarning upon import, as a means to notify users that
+Versions 1.1.x will throw a `FutureWarning` upon import, as a means to notify users that
 they should either upgrade to skimage2 or pin to version 1.0.x.
 
 We have undertaken this to make some long-outstanding, backward-incomptible changes to the scikit-image API.
 Most changes were difficult or impossible to make using deprecations alone.
-To honor the Hinsen principle—that is, never change results silently, unless to fix a bug—we introduce a new package, which gives users an explicit way of upgrading.
+To honor the Hinsen principle (that is, never change results silently unless to fix a bug), we introduce a new package, which gives users an explicit way of upgrading.
 Users also have the option to use the two versions side-by-side while they do so.
 
 You can find a more detailed description of our motivation and discussion leading up to this in {doc}`SKIP 4 <../skips/4-transition-to-v2>`.
 
-## Changes in skimage2
+(enable-skimage2-warnings)=
 
-_To be defined._
+## Enable skimage2-related warnings
 
-## Changes pre skimage2
+Even before skimage2 is released, you may enable skimage2-related warnings to prepare for code changes early on.
+Run the following [warnings filter](https://docs.python.org/3/library/warnings.html#the-warnings-filter) before you use scikit-image in your code:
+
+```python
+import warnings
+import skimage as ski
+warnings.filterwarnings(action="default", category=ski.util.PendingSkimage2Change)
+```
+
+This will raise a warning in code that needs to be modified to continue functioning with the new, skimage2 API.
+
+## Updating existing code
+
+When switching to the new `skimage2` namespace, some code will need to be updated to continue working the way it did before.
+
+:::{note}
+For a while, you will be able to use `skimage` and `skimage2` (the 2.0 API) side-by-side, to facilitate porting.
+The new API may, for the same function call, return different results—e.g., because of a change in a keyword argument default value.
+By importing functionality from `skimage2`, you explicitly opt in to the new behavior.
+:::
+
+## Deprecations prior to skimage2
 
 We have already introduced a number of changes and deprecations to our API.
-These will only be completed in during the transition to skimage2 and will continue to work in all versions pre-skimage2.
-However, updating your code to the new API will make it easier to transition to the skimage2 API.
+These are part of the API cleanup for skimage2 but are not breaking.
+You will simply notice these as the classical deprecation warnings that you are already used to.
+We list them here, because updating your code to the new API will make it easier to transition to skimage2.
 
 _To be defined._

--- a/skimage/util/__init__.py
+++ b/skimage/util/__init__.py
@@ -60,4 +60,22 @@ __all__ = [
     'label_points',
     'lookfor',
     'FailedEstimationAccessError',
+    'PendingSkimage2Change',
 ]
+
+
+class PendingSkimage2Change(PendingDeprecationWarning):
+    """A warning about API usage that will silently change or break in skimage2.
+
+    As a subclass of :class:`PendingDeprecationWarning`, this warning isn't
+    shown by default. But it can be enabled with a warnings filter to prepare
+    for code changes related to skimage2 early on:
+
+    .. code-block:: python
+
+        import warnings
+        import skimage as ski
+        warnings.filterwarnings(
+            action="default", category=ski.util.PendingSkimage2Change
+        )
+    """


### PR DESCRIPTION
## Description

These changes are extracted from https://github.com/scikit-image/scikit-image/pull/7797 since that PR will probably not be merged. Nevertheless, the machinery and idea around using a custom warning for skimage2 related changes should be useful. Early on we can make it subclass [`PendingDeprecationWarning`](https://docs.python.org/3/library/exceptions.html#PendingDeprecationWarning) which will not be shown by default. However, it can easily be made visible in case we or users want to take an early look and prepare. Later, we can switch the base out to `FutureWarning` to make it visible by default.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
