### PR TITLE
Clip perimeter_image before bincount to prevent MemoryError in perimeter() (fixes #7822)

### DIFF
--- a/skimage/measure/_regionprops_utils.py
+++ b/skimage/measure/_regionprops_utils.py
@@ -476,9 +476,9 @@ def perimeter(image, neighborhood=4):
     # return perimeter_weights[perimeter_image].sum()
     # but that was measured as taking much longer than bincount + np.dot (5x
     # as much time)
-    perimeter_histogram = np.bincount(perimeter_image.ravel(), minlength=50)
-    total_perimeter = perimeter_histogram @ perimeter_weights
-    return total_perimeter
+    clipped = np.clip(perimeter_image, 0, 49)
+    perimeter_histogram = np.bincount(clipped.ravel(), minlength=50)
+    return perimeter_histogram @ perimeter_weights
 
 
 def perimeter_crofton(image, directions=4):


### PR DESCRIPTION
A sporadic MemoryError was happening in skimage.measure.perimeter because values in the 3×3 convolution output could exceed 49, causing np.bincount to allocate an array of size max(x)+1 (potentially multi-petabyte). This patch:

1. Clips perimeter_image to the valid range [0, 49] before histogramming
2. Removes the unused steps variable
3. Ensures np.bincount(..., minlength=50) always produces exactly 50 bins and cannot over-allocate

Closes scikit-image#7822