### PR TITLE
Add a warning when importing experimental skimage2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,7 @@ xfail_strict = true
 testpaths = ["tests"]
 filterwarnings = [
     "error",
+    "ignore:Importing from the `skimage2` namespace is experimental:UserWarning",
     "ignore:.*use `imageio` or other I/O packages directly.*:FutureWarning",
     "ignore:Implicit conversion of A to CSR:scipy.sparse.SparseEfficiencyWarning"  # warn by pyamg in ruge_stuben_solver
 ]

--- a/src/skimage2/__init__.py
+++ b/src/skimage2/__init__.py
@@ -1,1 +1,19 @@
 """skimage2 namespace"""
+
+import warnings
+
+import lazy_loader as _lazy
+
+
+class ExperimentalAPIWarning(UserWarning):
+    pass
+
+
+warnings.warn(
+    "Importing from the `skimage2` namespace is experimental. "
+    "It's API is under development and considered unstable!",
+    category=ExperimentalAPIWarning,
+    stacklevel=2,
+)
+
+__getattr__, _, __all__ = _lazy.attach_stub(__name__, __file__)

--- a/src/skimage2/__init__.pyi
+++ b/src/skimage2/__init__.pyi
@@ -1,0 +1,3 @@
+_submodules = []
+
+__all__ = _submodules + ["__version__", "ExperimentalAPIWarning"]  # noqa: F822

--- a/src/skimage2/meson.build
+++ b/src/skimage2/meson.build
@@ -1,5 +1,6 @@
 py3.install_sources(
   '__init__.py',
+  '__init__.pyi',
   pure: false,
   subdir: 'skimage2'
 )

--- a/tests/skimage2/test_skimage2.py
+++ b/tests/skimage2/test_skimage2.py
@@ -1,0 +1,15 @@
+import pytest
+import importlib
+
+import skimage2
+
+
+def test_import_skimage2_warning():
+    regex = "Importing from the `skimage2` namespace is experimental"
+    with pytest.warns(UserWarning, match=regex) as record:
+        importlib.reload(skimage2)
+    assert len(record) == 1
+    assert record[0].category == skimage2.ExperimentalAPIWarning
+    # `importlib.reload` adds a stacklevel, so we actually want the warning to
+    # be raised in importlib and not in this file
+    assert record[0].filename.endswith("importlib/__init__.py")


### PR DESCRIPTION
## Description

Also test for it and setup basic lazy loading.


## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
