### PR TITLE
Fix test to not fetch data already presented in test directory

### DIFF
--- a/tests/skimage/_shared/test_utils.py
+++ b/tests/skimage/_shared/test_utils.py
@@ -474,13 +474,13 @@ class Test_deprecate_parameter:
                 _func_deprecated_params(1, 2, old0=2)
 
     def test_wrong_param_name(self):
-        with pytest.raises(ValueError, match="is not in list"):
+        with pytest.raises(ValueError, match="not in list"):
 
             @deprecate_parameter("old", start_version="0.10", stop_version="0.12")
             def foo(arg0):
                 pass
 
-        with pytest.raises(ValueError, match="is not in list"):
+        with pytest.raises(ValueError, match="not in list"):
 
             @deprecate_parameter(
                 "old", new_name="new", start_version="0.10", stop_version="0.12"

--- a/tests/skimage/_shared/test_utils.py
+++ b/tests/skimage/_shared/test_utils.py
@@ -474,13 +474,13 @@ class Test_deprecate_parameter:
                 _func_deprecated_params(1, 2, old0=2)
 
     def test_wrong_param_name(self):
-        with pytest.raises(ValueError, match="'old' is not in list"):
+        with pytest.raises(ValueError, match="is not in list"):
 
             @deprecate_parameter("old", start_version="0.10", stop_version="0.12")
             def foo(arg0):
                 pass
 
-        with pytest.raises(ValueError, match="'new' is not in list"):
+        with pytest.raises(ValueError, match="is not in list"):
 
             @deprecate_parameter(
                 "old", new_name="new", start_version="0.10", stop_version="0.12"

--- a/tests/skimage/color/test_colorconv.py
+++ b/tests/skimage/color/test_colorconv.py
@@ -15,7 +15,7 @@ from numpy.testing import assert_almost_equal, assert_array_almost_equal, assert
 
 from skimage import data
 from skimage._shared._warnings import expected_warnings
-from skimage._shared.testing import fetch, assert_stacklevel
+from skimage._shared.testing import assert_stacklevel
 from skimage._shared.utils import _supported_float_type, slice_at_axis
 from skimage.color import (
     rgb2hsv,
@@ -455,7 +455,7 @@ class TestColorconv:
         assert xyz2lab(img).dtype == img.dtype
         assert xyz2lab(img32).dtype == img32.dtype
 
-    def test_lab2xyz(self):
+    def test_lab2xyz(self, test_root_dir):
         assert_array_almost_equal(lab2xyz(self.lab_array), self.xyz_array, decimal=3)
 
         # Test the conversion with the rest of the illuminants.
@@ -464,13 +464,13 @@ class TestColorconv:
             for obs in ["2", "10", "R"]:
                 obs = obs.lower()
                 fname = f'color/data/lab_array_{I}_{obs}.npy'
-                lab_array_I_obs = np.load(fetch(fname, prefix="tests"))
+                lab_array_I_obs = np.load(test_root_dir / fname)
                 assert_array_almost_equal(
                     lab2xyz(lab_array_I_obs, I, obs), self.xyz_array, decimal=3
                 )
         for I in ["d75", "e"]:
             fname = f'color/data/lab_array_{I}_2.npy'
-            lab_array_I_obs = np.load(fetch(fname, prefix="tests"))
+            lab_array_I_obs = np.load(test_root_dir / fname)
             assert_array_almost_equal(
                 lab2xyz(lab_array_I_obs, I, "2"), self.xyz_array, decimal=3
             )
@@ -547,7 +547,7 @@ class TestColorconv:
     # test matrices for xyz2luv and luv2xyz generated using
     # http://www.easyrgb.com/index.php?X=CALC
     # Note: easyrgb website displays xyz*100
-    def test_xyz2luv(self):
+    def test_xyz2luv(self, test_root_dir):
         assert_array_almost_equal(xyz2luv(self.xyz_array), self.luv_array, decimal=3)
 
         # Test the conversion with the rest of the illuminants.
@@ -556,13 +556,13 @@ class TestColorconv:
             for obs in ["2", "10", "R"]:
                 obs = obs.lower()
                 fname = f'color/data/luv_array_{I}_{obs}.npy'
-                luv_array_I_obs = np.load(fetch(fname, prefix="tests"))
+                luv_array_I_obs = np.load(test_root_dir / fname)
                 assert_array_almost_equal(
                     luv_array_I_obs, xyz2luv(self.xyz_array, I, obs), decimal=2
                 )
         for I in ["d75", "e"]:
             fname = f'color/data/luv_array_{I}_2.npy'
-            luv_array_I_obs = np.load(fetch(fname, prefix="tests"))
+            luv_array_I_obs = np.load(test_root_dir / fname)
             assert_array_almost_equal(
                 luv_array_I_obs, xyz2luv(self.xyz_array, I, "2"), decimal=2
             )
@@ -582,7 +582,7 @@ class TestColorconv:
         assert xyz2luv(img).dtype == img.dtype
         assert xyz2luv(img32).dtype == img32.dtype
 
-    def test_luv2xyz(self):
+    def test_luv2xyz(self, test_root_dir):
         assert_array_almost_equal(luv2xyz(self.luv_array), self.xyz_array, decimal=3)
 
         # Test the conversion with the rest of the illuminants.
@@ -591,13 +591,13 @@ class TestColorconv:
             for obs in ["2", "10", "R"]:
                 obs = obs.lower()
                 fname = f'color/data/luv_array_{I}_{obs}.npy'
-                luv_array_I_obs = np.load(fetch(fname, prefix="tests"))
+                luv_array_I_obs = np.load(test_root_dir / fname)
                 assert_array_almost_equal(
                     luv2xyz(luv_array_I_obs, I, obs), self.xyz_array, decimal=3
                 )
         for I in ["d75", "e"]:
             fname = f'color/data/luv_array_{I}_2.npy'
-            luv_array_I_obs = np.load(fetch(fname, prefix="tests"))
+            luv_array_I_obs = np.load(test_root_dir / fname)
             assert_array_almost_equal(
                 luv2xyz(luv_array_I_obs, I, "2"), self.xyz_array, decimal=3
             )

--- a/tests/skimage/color/test_colorconv.py
+++ b/tests/skimage/color/test_colorconv.py
@@ -420,7 +420,7 @@ class TestColorconv:
     # test matrices for xyz2lab and lab2xyz generated using
     # http://www.easyrgb.com/index.php?X=CALC
     # Note: easyrgb website displays xyz*100
-    def test_xyz2lab(self):
+    def test_xyz2lab(self, test_root_dir):
         assert_array_almost_equal(xyz2lab(self.xyz_array), self.lab_array, decimal=3)
 
         # Test the conversion with the rest of the illuminants.
@@ -429,13 +429,13 @@ class TestColorconv:
             for obs in ["2", "10", "R"]:
                 obs = obs.lower()
                 fname = f'color/data/lab_array_{I}_{obs}.npy'
-                lab_array_I_obs = np.load(fetch(fname, prefix="tests"))
+                lab_array_I_obs = np.load(test_root_dir / fname)
                 assert_array_almost_equal(
                     lab_array_I_obs, xyz2lab(self.xyz_array, I, obs), decimal=2
                 )
         for I in ["d75", "e"]:
             fname = f'color/data/lab_array_{I}_2.npy'
-            lab_array_I_obs = np.load(fetch(fname, prefix="tests"))
+            lab_array_I_obs = np.load(test_root_dir / fname)
             assert_array_almost_equal(
                 lab_array_I_obs, xyz2lab(self.xyz_array, I, "2"), decimal=2
             )

--- a/tests/skimage/color/test_delta_e.py
+++ b/tests/skimage/color/test_delta_e.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 
-from skimage._shared.testing import fetch
 from skimage._shared.utils import _supported_float_type
 from skimage.color.delta_e import (
     deltaE_cie76,
@@ -16,8 +15,8 @@ from skimage.color.delta_e import (
 
 @pytest.mark.parametrize("channel_axis", [0, 1, -1])
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
-def test_ciede2000_dE(dtype, channel_axis):
-    data = load_ciede2000_data()
+def test_ciede2000_dE(dtype, channel_axis, test_root_dir):
+    data = load_ciede2000_data(test_root_dir)
     N = len(data)
     lab1 = np.zeros((N, 3), dtype=dtype)
     lab1[:, 0] = data['L1']
@@ -37,7 +36,7 @@ def test_ciede2000_dE(dtype, channel_axis):
     assert_allclose(dE2, data['dE'], rtol=1e-2)
 
 
-def load_ciede2000_data():
+def load_ciede2000_data(prefix):
     dtype = [
         ('pair', int),
         ('1', int),
@@ -65,14 +64,13 @@ def load_ciede2000_data():
     ]
 
     # note: ciede_test_data.txt contains several intermediate quantities
-    path = fetch('color/ciede2000_test_data.txt', prefix='tests')
-    return np.loadtxt(path, dtype=dtype)
+    return np.loadtxt(prefix / 'color/ciede2000_test_data.txt', dtype=dtype)
 
 
 @pytest.mark.parametrize("channel_axis", [0, 1, -1])
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
-def test_cie76(dtype, channel_axis):
-    data = load_ciede2000_data()
+def test_cie76(dtype, channel_axis, test_root_dir):
+    data = load_ciede2000_data(test_root_dir)
     N = len(data)
     lab1 = np.zeros((N, 3), dtype=dtype)
     lab1[:, 0] = data['L1']
@@ -132,8 +130,8 @@ def test_cie76(dtype, channel_axis):
 
 @pytest.mark.parametrize("channel_axis", [0, 1, -1])
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
-def test_ciede94(dtype, channel_axis):
-    data = load_ciede2000_data()
+def test_ciede94(dtype, channel_axis, test_root_dir):
+    data = load_ciede2000_data(test_root_dir)
     N = len(data)
     lab1 = np.zeros((N, 3), dtype=dtype)
     lab1[:, 0] = data['L1']
@@ -193,8 +191,8 @@ def test_ciede94(dtype, channel_axis):
 
 @pytest.mark.parametrize("channel_axis", [0, 1, -1])
 @pytest.mark.parametrize('dtype', [np.float32, np.float64])
-def test_cmc(dtype, channel_axis):
-    data = load_ciede2000_data()
+def test_cmc(dtype, channel_axis, test_root_dir):
+    data = load_ciede2000_data(test_root_dir)
     N = len(data)
     lab1 = np.zeros((N, 3), dtype=dtype)
     lab1[:, 0] = data['L1']

--- a/tests/skimage/conftest.py
+++ b/tests/skimage/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from pathlib import Path
+
+
+@pytest.fixture
+def test_root_dir():
+    return Path(__file__).absolute().parent

--- a/tests/skimage/registration/test_masked_phase_cross_correlation.py
+++ b/tests/skimage/registration/test_masked_phase_cross_correlation.py
@@ -10,7 +10,6 @@ from numpy.testing import (
 from scipy.ndimage import fourier_shift, shift as real_shift
 import scipy.fft as fft
 
-from skimage._shared.testing import fetch
 from skimage._shared.utils import _supported_float_type
 from skimage.data import camera, brain
 
@@ -105,7 +104,7 @@ def test_masked_registration_random_masks_non_equal_sizes():
     assert_equal(measured_shift, -np.array(shift))
 
 
-def test_masked_registration_padfield_data():
+def test_masked_registration_padfield_data(test_root_dir):
     """Masked translation registration should behave like in the original
     publication"""
     # Test translated from MATLABimplementation `MaskedFFTRegistrationTest`
@@ -115,9 +114,9 @@ def test_masked_registration_padfield_data():
     shifts = [(75, 75), (-130, 130), (130, 130)]
     for xi, yi in shifts:
         fname = f'registration/data/OriginalX{xi}Y{yi}.png'
-        fixed_image = imread(fetch(fname, prefix='tests'))
+        fixed_image = imread(test_root_dir / fname)
         fname = f'registration/data/TransformedX{xi}Y{yi}.png'
-        moving_image = imread(fetch(fname, prefix='tests'))
+        moving_image = imread(test_root_dir / fname)
 
         # Valid pixels are 1
         fixed_mask = fixed_image != 0

--- a/tests/skimage/restoration/test_restoration.py
+++ b/tests/skimage/restoration/test_restoration.py
@@ -28,7 +28,7 @@ def _get_rtol_atol(dtype):
 
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
 @pytest.mark.parametrize('ndim', [1, 2, 3])
-def test_wiener(dtype, ndim):
+def test_wiener(dtype, ndim, test_root_dir):
     """
     currently only performs pixelwise comparison to
     precomputed result in 2d case.
@@ -51,7 +51,7 @@ def test_wiener(dtype, ndim):
 
     if ndim == 2:
         rtol, atol = _get_rtol_atol(dtype)
-        path = fetch('restoration/camera_wiener.npy', prefix='tests')
+        path = test_root_dir / 'restoration/camera_wiener.npy'
         np.testing.assert_allclose(deconvolved, np.load(path), rtol=rtol, atol=atol)
 
     _, laplacian = uft.laplacian(ndim, data.shape)
@@ -66,7 +66,7 @@ def test_wiener(dtype, ndim):
 
 
 @pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
-def test_unsupervised_wiener(dtype):
+def test_unsupervised_wiener(dtype, test_root_dir):
     psf = np.ones((5, 5), dtype=dtype) / 25
     data = convolve2d(test_img, psf, 'same')
     seed = 16829302
@@ -81,7 +81,7 @@ def test_unsupervised_wiener(dtype):
     assert deconvolved.dtype == float_type
 
     rtol, atol = _get_rtol_atol(dtype)
-    path = fetch('restoration/camera_unsup.npy', prefix='tests')
+    path = test_root_dir / 'restoration/camera_unsup.npy'
     np.testing.assert_allclose(deconvolved, np.load(path), rtol=rtol, atol=atol)
 
     _, laplacian = uft.laplacian(2, data.shape)
@@ -100,7 +100,7 @@ def test_unsupervised_wiener(dtype):
         rng=seed,
     )[0]
     assert deconvolved2.real.dtype == float_type
-    path = fetch('restoration/camera_unsup2.npy', prefix='tests')
+    path = test_root_dir / 'restoration/camera_unsup2.npy'
     np.testing.assert_allclose(
         np.real(deconvolved2), np.load(path), rtol=rtol, atol=atol
     )
@@ -145,7 +145,7 @@ def test_image_shape():
 
 
 @pytest.mark.parametrize('ndim', [1, 2, 3])
-def test_richardson_lucy(ndim):
+def test_richardson_lucy(ndim, test_root_dir):
     psf = np.ones([5] * ndim, dtype=float) / 5**ndim
     if ndim != 2:
         test_img = np.random.randint(0, 100, [30] * ndim)
@@ -158,13 +158,13 @@ def test_richardson_lucy(ndim):
     deconvolved = restoration.richardson_lucy(data, psf, num_iter=5)
 
     if ndim == 2:
-        path = fetch('restoration/camera_rl.npy', prefix='tests')
+        path = test_root_dir / 'restoration/camera_rl.npy'
         np.testing.assert_allclose(deconvolved, np.load(path), rtol=1e-3)
 
 
 @pytest.mark.parametrize('dtype_image', [np.float16, np.float32, np.float64])
 @pytest.mark.parametrize('dtype_psf', [np.float32, np.float64])
-def test_richardson_lucy_filtered(dtype_image, dtype_psf):
+def test_richardson_lucy_filtered(dtype_image, dtype_psf, test_root_dir):
     if dtype_image == np.float64:
         atol = 1e-8
     else:

--- a/tests/skimage/util/test_apply_parallel.py
+++ b/tests/skimage/util/test_apply_parallel.py
@@ -1,4 +1,5 @@
 import numpy as np
+import platform
 
 from skimage._shared.testing import assert_array_almost_equal, assert_equal
 from skimage import color, data, img_as_float
@@ -8,6 +9,13 @@ from skimage.util.apply_parallel import apply_parallel
 import pytest
 
 da = pytest.importorskip('dask.array')
+
+
+IS_MACOS_ARM = platform.system() == 'Darwin' and platform.machine() == 'arm64'
+
+IMG_COMPARE_PRECISION = 4 if IS_MACOS_ARM else 6
+# on macOS arm64 the result is slightly different from other platforms,
+# so we need to lower the decimal precision
 
 
 def test_apply_parallel():
@@ -129,7 +137,9 @@ def test_apply_parallel_rgb(depth, chunks, dtype):
 
     assert_equal(cat_ycbcr.dtype, cat.dtype)
 
-    assert_array_almost_equal(cat_ycbcr_expected, cat_ycbcr)
+    assert_array_almost_equal(
+        cat_ycbcr_expected, cat_ycbcr, decimal=IMG_COMPARE_PRECISION
+    )
 
 
 @pytest.mark.parametrize('chunks', (None, (128, 256), 'ndim'))


### PR DESCRIPTION
## Description

Extracted from #7877 

Currently the tests in building wheels are failing because `pytest` is not called from the root directory of the repository. 

This PR contains fixes for Python 3.14 and loading test data without fetch. 
