### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
-    commit-message:
-      prefix: "ci(dependabot):"
+      interval: "quarterly"
     labels:
-      - ":wrench: type: Maintenance"
+      - ":robot: type: Infrastructure"
     groups:
       actions:
         patterns:


### PR DESCRIPTION
## Description

This PR add a [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates) configuration to the scikit-image repository. 

The dependabot generates automatic PRs with bumping action versions. 

This reduces maintenance time, as maintainers do not need to check if there is a new version of actions. It is configured to perform monthly checks to not generate too many PRs. 

You may see an example of PR in the napari repository: https://github.com/napari/napari/pull/7572
