### PR TITLE
Add `__repr__` to `RegionProperties` class

### DIFF
--- a/src/skimage/measure/_regionprops.py
+++ b/src/skimage/measure/_regionprops.py
@@ -303,8 +303,21 @@ def _inertia_eigvals_to_axes_lengths_3D(inertia_tensor_eigvals):
 
 
 class RegionProperties:
-    """Please refer to `skimage.measure.regionprops` for more information
+    """Provides properties of a labeled image region.
+
+    Please refer to `skimage.measure.regionprops` for more information
     on the available region properties.
+
+    Examples
+    --------
+    >>> RegionProperties(
+    ...     slice=(slice(0, 2), slice(0, 4)),
+    ...     label=2,
+    ...     label_image=np.array([[0, 1, 1, 2, 0], [2, 2, 2, 2, 0]]),
+    ...     intensity_image=None,
+    ...     cache_active=False,
+    ... )
+    <RegionProperties: label=2, bbox=(0, 0, 2, 4)>
     """
 
     def __init__(
@@ -810,6 +823,11 @@ class RegionProperties:
                 return False
 
         return True
+
+    def __repr__(self):
+        cls_name = type(self).__qualname__
+        out = f"<{cls_name}: label={self.label!r}, bbox={self.bbox}>"
+        return out
 
 
 # For compatibility with code written prior to 0.16


### PR DESCRIPTION
## Description

The representation uses the easily available label value and bbox (bounding box) to describe its region.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
In `skimage.measure`, the `RegionProperties` class that is returned by `regionprops`,
now has a formatted string representation (`__repr__`). This representation includes
the label of the region and its bounding box.
```
