### PR TITLE
Remove np.testing from skimage._shared.utils

### DIFF
--- a/src/skimage/_shared/utils.py
+++ b/src/skimage/_shared/utils.py
@@ -821,9 +821,7 @@ def safe_as_int(val, atol=1e-3):
     else:  # Iterable input, now ndarray
         mod[mod > 0.5] = 1 - mod[mod > 0.5]  # Test on each side of nearest int
 
-    try:
-        np.testing.assert_allclose(mod, 0, atol=atol)
-    except AssertionError:
+    if not np.allclose(mod, 0, atol=atol):
         raise ValueError(f'Integer argument required but received {val}, check inputs.')
 
     return np.round(val).astype(np.int64)


### PR DESCRIPTION
## Description

Following and closing #7890.

This PR rework the helper `safe_as_int` to not depend on `numpy.testing`.

`numpy.testing` is supposed to be used for tests, while `safe_as_int` is now used by part of the `scikit-image` library.

The change looks to be safer than what i though.

The previous assertion error was not exposed to the outside, but instead it was captured and reraised with a full custom exception. As result a change here should not create a huge side effects: this only affect the exception chain.

This PR only replace the condition check by a numpy function from the library (instead of the testing library).

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
