### PR TITLE
Fix SSIM example to use the dynamic range

### DIFF
--- a/doc/examples/transform/plot_ssim.py
+++ b/doc/examples/transform/plot_ssim.py
@@ -36,20 +36,20 @@ noise = np.ones_like(img) * 0.2 * (img.max() - img.min())
 rng = np.random.default_rng()
 noise[rng.random(size=noise.shape) > 0.5] *= -1
 
-img_noise = img + noise
-img_const = img + abs(noise)
+img_noise = np.clip(img + noise, 0.0, 1.0)
+img_const = np.clip(img + abs(noise), 0.0, 1.0)
 
 fig, axes = plt.subplots(nrows=1, ncols=3, figsize=(10, 4), sharex=True, sharey=True)
 ax = axes.ravel()
 
 mse_none = mean_squared_error(img, img)
-ssim_none = ssim(img, img, data_range=img.max() - img.min())
+ssim_none = ssim(img, img, data_range=1.0)
 
 mse_noise = mean_squared_error(img, img_noise)
-ssim_noise = ssim(img, img_noise, data_range=img_noise.max() - img_noise.min())
+ssim_noise = ssim(img, img_noise, data_range=1.0)
 
 mse_const = mean_squared_error(img, img_const)
-ssim_const = ssim(img, img_const, data_range=img_const.max() - img_const.min())
+ssim_const = ssim(img, img_const, data_range=1.0)
 
 ax[0].imshow(img, cmap=plt.cm.gray, vmin=0, vmax=1)
 ax[0].set_xlabel(f'MSE: {mse_none:.2f}, SSIM: {ssim_none:.2f}')


### PR DESCRIPTION
## Description

The data range used by SSIM (structural similarity) should be the dynamic range of the pixel values (e.g. 255 for uint8 images). It should not be computed on a per-example basis from the second image.

https://ece.uwaterloo.ca/~z70wang/publications/ssim.pdf

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
