### PR TITLE
MNT: Add filterwarnings to suppress FutureWarnings from deprecated plugin infrastructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,9 @@ testpaths = ["tests"]
 filterwarnings = [
     "error",
     "ignore:.*use `imageio` or other I/O packages directly.*:FutureWarning",
+    "ignore:.*`reset_plugins` is deprecated.*:FutureWarning",
+    "ignore:.*`use_plugin` is deprecated.*:FutureWarning",
+    "ignore:.*plugin infrastructure.*deprecated.*:FutureWarning",
     "ignore:Implicit conversion of A to CSR:scipy.sparse.SparseEfficiencyWarning"  # warn by pyamg in ruge_stuben_solver
 ]
 norecursedirs = ["io/_plugins"]


### PR DESCRIPTION
Added specific pytest filterwarnings to suppress deprecation warnings for reset_plugins, use_plugin, and plugin infrastructure in io tests to reduce noise in test logs.

Closes https://github.com/scikit-image/scikit-image/issues/7896

CC: @bsipocz

- [ ] I Checked that the warnings don't appear in the test suite anymore
