### PR TITLE
Add forgotten pytest-pretty to Pyodide wheel recipe too

### DIFF
--- a/.github/workflows/wheels-recipe.yaml
+++ b/.github/workflows/wheels-recipe.yaml
@@ -275,7 +275,7 @@ jobs:
           # in favour of Pyodide-related settings.
           CIBW_PLATFORM: pyodide
           CIBW_ENVIRONMENT_PYODIDE: "" # sdists are not present in Pyodide
-          CIBW_TEST_REQUIRES_PYODIDE: "pytest astropy cloudpickle dask[array] matplotlib PyWavelets scikit-learn"
+          CIBW_TEST_REQUIRES_PYODIDE: "pytest astropy cloudpickle dask[array] matplotlib PyWavelets scikit-learn pytest-pretty"
           # Don't use the cache provider plugin, as it doesn't work with Pyodide
           # right now: https://github.com/pypa/cibuildwheel/issues/1966
           CIBW_TEST_COMMAND_PYODIDE: "pytest -svra -p no:cacheprovider --pyargs skimage {project}/tests"


### PR DESCRIPTION
## Description

Partial fix for https://github.com/scikit-image/scikit-image/issues/7893.
This is tripping up our CI because test/conftest.py wants to use it.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
