### PR TITLE
Restore fast page navigation with in page anchors

### DIFF
--- a/doc/source/_static/theme_overrides.css
+++ b/doc/source/_static/theme_overrides.css
@@ -1,5 +1,10 @@
 /* Additional styling for the PyData Sphinx theme. */
 
+/* Avoid "slow" animated scroll when navigating to anchors */
+html {
+    scroll-behavior: auto;
+}
+
 /* Use hyperlink color for grid-item-cards.
 TODO find a way to only apply this to grid-item-cards that link somewhere */
 .sd-card-title {


### PR DESCRIPTION
## Description

This is a usability suggestion and might be somewhat subjective. Especially for [larger pages in scikit-image's API documentation](https://scikit-image.org/docs/dev/api/skimage.transform.html#skimage.transform.SimilarityTransform), I've perceived the navigation with the right sidebar TOC as annoyingly slow. When I click an anchor link, my browser can take around a second to scroll to the target. This is a small paper cut but it adds up.

I finally figured out how to override this. See https://github.com/pydata/pydata-sphinx-theme/issues/2260 for more background.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
