### PR TITLE
Try to pinpoint test during which CI stalls (in main repo)

### DIFF
--- a/.github/workflows/wheels-recipe.yaml
+++ b/.github/workflows/wheels-recipe.yaml
@@ -16,7 +16,7 @@ on:
       CIBW_TEST_COMMAND:
         required: false
         type: string
-        default: "pytest --pyargs skimage {project}/tests"
+        default: "pytest -ra -l -v --strict-markers --pyargs skimage {project}/tests -k morphology"
 
 env:
   CIBW_BUILD_VERBOSITY: 1


### PR DESCRIPTION
## Description

Debugging for https://github.com/scikit-image/scikit-image/issues/7893. Supersedes #7900 because the `maintenance/` branch needs to be in the actual scikit-image repo.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
