### PR TITLE
Use correct CSS selector to override scroll-behavior

### DIFF
--- a/doc/source/_static/theme_overrides.css
+++ b/doc/source/_static/theme_overrides.css
@@ -1,7 +1,10 @@
 /* Additional styling for the PyData Sphinx theme. */
 
-/* Avoid "slow" animated scroll when navigating to anchors */
-html {
+/* Avoid "slow" animated scroll when navigating to anchors
+May be removed if this is addressed upstream
+https://github.com/pydata/pydata-sphinx-theme/issues/2260
+*/
+:root {
     scroll-behavior: auto;
 }
 


### PR DESCRIPTION
## Description

Fallow-up that makes #7899 actually work. The upstream theme actually uses
```css
@media (prefers-reduced-motion: no-preference) {
    :root {
        scroll-behavior: smooth;
    }
}
```
which takes precedence over a simple `html` selector. To override, we need to use `:root`. The media query is apparently not necessary.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
