### PR TITLE
Address ResourceWarning in `_built_utils/version.py`

### DIFF
--- a/src/skimage/_build_utils/version.py
+++ b/src/skimage/_build_utils/version.py
@@ -25,13 +25,13 @@ def version_from_init():
 def append_git_revision_and_date(version):
     """Try to append last commit date and hash to version.
 
-    Apppends nothing if run outside a git repository.
+    Appends nothing if the current working directory is outside a git
+    repository.
     """
     try:
         result = subprocess.run(
             ['git', 'log', '-1', '--format="%H %aI"'],
             capture_output=True,
-            cwd=Path(__file__).parent,
             text=True,
             check=True,
         )


### PR DESCRIPTION
## Description

The opened `skimage/__init__.py` was never properly closed. In certain cases this caused pytest to fail with an `ResourceWarning` – because pytest would filter all warnings as errors.

In the process, clean up the script and move it to tools/ where it is way more appropriate. Should also have way less potential for weird interactions and confusion since it is no longer in our package.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
