### PR TITLE
Crop arrays by a spatial bounding box

### DIFF
--- a/doc/examples/numpy_operations/plot_bounding_box_crop.py
+++ b/doc/examples/numpy_operations/plot_bounding_box_crop.py
@@ -117,7 +117,6 @@ ax3[0].set_axis_off()
 ax3[1].imshow(roi_clipped, cmap='gray')
 ax3[1].set_title('Result with clip=True')
 ax3[1].set_axis_off()
-ax3[1].set_anchor('C')  # ensure the ROI is centered within the right subplot
 
 r0o_i, c0o_i = np.floor([r0o, c0o]).astype(int)
 r1o_i, c1o_i = np.ceil([r1o, c1o]).astype(int)

--- a/doc/examples/numpy_operations/plot_bounding_box_crop.py
+++ b/doc/examples/numpy_operations/plot_bounding_box_crop.py
@@ -1,0 +1,135 @@
+"""
+=================================
+Crop arrays by bounding boxes
+=================================
+
+This example demonstrates :py:func:`skimage.util.bounding_box_crop` to extract
+regions of interest from images using spatial min/max bounds. The bounding box
+values may be floats (mins are floored; maxes are ceiled; the stop is
+exclusive, per Python slicing). Optionally, a ``channel_axis`` can be
+specified and is not cropped.
+
+In the figures below, the requested bbox is drawn in red (even if partially
+outside the image) while the effective integer bbox actually used for slicing
+is drawn in green.
+
+See also
+--------
+- :py:func:`skimage.util.crop` for cropping by explicit widths on each axis.
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.patches import Rectangle
+
+import skimage as ski
+
+
+# Example 1: Grayscale image (no channel axis)
+image = ski.data.camera()
+bbox = ((60.3, 70.7), (280.2, 360.1))
+roi = ski.util.bounding_box_crop(image, bbox)
+
+fig, axes = plt.subplots(1, 2, figsize=(10, 7), sharex=False, sharey=False)
+ax = axes.ravel()
+
+r0, c0 = bbox[0]
+r1, c1 = bbox[1]
+rect_req = Rectangle(
+    (c0, r0), c1 - c0, r1 - r0, edgecolor='red', facecolor='none', linewidth=2
+)
+r0_i, c0_i = np.floor([r0, c0]).astype(int)
+r1_i, c1_i = np.ceil([r1, c1]).astype(int)
+rect = Rectangle(
+    (c0_i, r0_i),
+    c1_i - c0_i,
+    r1_i - r0_i,
+    edgecolor='lime',
+    facecolor='none',
+    linewidth=2,
+)
+ax[0].imshow(image, cmap='gray')
+ax[0].add_patch(rect_req)
+ax[0].add_patch(rect)
+ax[0].set_title('Original with bounding box')
+ax[0].set_axis_off()
+
+ax[1].imshow(roi, cmap='gray')
+ax[1].set_title('Cropped ROI (floored/ceiled bounds)')
+ax[1].set_axis_off()
+
+fig.tight_layout()
+
+
+# Example 2: Color image with a channel axis
+color = ski.data.astronaut()  # (M, N, 3)
+bbox_color = ((120.5, 180.2), (330.0, 420.8))
+roi_color = ski.util.bounding_box_crop(color, bbox_color, channel_axis=-1)
+
+fig2, axes2 = plt.subplots(1, 2, figsize=(8, 4), sharex=False, sharey=False)
+ax2 = axes2.ravel()
+
+r0c, c0c = bbox_color[0]
+r1c, c1c = bbox_color[1]
+r0c_i, c0c_i = np.floor([r0c, c0c]).astype(int)
+r1c_i, c1c_i = np.ceil([r1c, c1c]).astype(int)
+rect2 = Rectangle(
+    (c0c_i, r0c_i),
+    c1c_i - c0c_i,
+    r1c_i - r0c_i,
+    edgecolor='lime',
+    facecolor='none',
+    linewidth=2,
+)
+ax2[0].imshow(color)
+rect2_req = Rectangle(
+    (c0c, r0c), c1c - c0c, r1c - r0c, edgecolor='red', facecolor='none', linewidth=2
+)
+ax2[0].add_patch(rect2_req)
+ax2[0].add_patch(rect2)
+ax2[0].set_title('Original RGB with bounding box')
+ax2[0].set_axis_off()
+
+ax2[1].imshow(roi_color)
+ax2[1].set_title('Cropped RGB ROI (channel_axis=-1)')
+ax2[1].set_axis_off()
+
+fig2.tight_layout()
+
+
+# Example 3: Clipping behavior
+out_of_bounds_bbox = ((-40.0, 400.0), (220.0, 700.0))
+roi_clipped = ski.util.bounding_box_crop(image, out_of_bounds_bbox, clip=True)
+
+fig3, axes3 = plt.subplots(1, 2, figsize=(8, 4), sharex=False, sharey=False)
+ax3 = axes3.ravel()
+
+r0o, c0o = out_of_bounds_bbox[0]
+r1o, c1o = out_of_bounds_bbox[1]
+rect3 = Rectangle(
+    (c0o, r0o), c1o - c0o, r1o - r0o, edgecolor='red', facecolor='none', linewidth=2
+)
+ax3[0].imshow(image, cmap='gray')
+ax3[0].add_patch(rect3)
+ax3[0].set_title('Requested bbox (partially outside)')
+ax3[0].set_axis_off()
+
+ax3[1].imshow(roi_clipped, cmap='gray')
+ax3[1].set_title('Result with clip=True')
+ax3[1].set_axis_off()
+ax3[1].set_anchor('C')  # ensure the ROI is centered within the right subplot
+
+r0o_i, c0o_i = np.floor([r0o, c0o]).astype(int)
+r1o_i, c1o_i = np.ceil([r1o, c1o]).astype(int)
+rr0 = np.clip(r0o_i, 0, image.shape[0])
+rr1 = np.clip(r1o_i, 0, image.shape[0])
+cc0 = np.clip(c0o_i, 0, image.shape[1])
+cc1 = np.clip(c1o_i, 0, image.shape[1])
+rect3b = Rectangle(
+    (cc0, rr0), cc1 - cc0, rr1 - rr0, edgecolor='lime', facecolor='none', linewidth=2
+)
+ax3[0].add_patch(rect3b)
+
+fig3.tight_layout()
+
+plt.show()

--- a/src/skimage/util/__init__.py
+++ b/src/skimage/util/__init__.py
@@ -26,7 +26,7 @@ from ._montage import montage
 from ._map_array import map_array
 from ._regular_grid import regular_grid, regular_seeds
 from .apply_parallel import apply_parallel
-from .arraycrop import crop
+from .arraycrop import crop, bounding_box_crop
 from .compare import compare_images
 from .noise import random_noise
 from .shape import view_as_blocks, view_as_windows
@@ -48,6 +48,7 @@ __all__ = [
     'view_as_windows',
     'slice_along_axes',
     'crop',
+    'bounding_box_crop',
     'compare_images',
     'map_array',
     'montage',

--- a/src/skimage/util/arraycrop.py
+++ b/src/skimage/util/arraycrop.py
@@ -130,10 +130,6 @@ def bounding_box_crop(
     skimage.util.crop
         Crop by explicit widths on each axis.
 
-    .. versionadded:: 0.26
-       Added ``bounding_box_crop`` to crop N-D arrays using a spatial bounding box
-       with optional ``channel_axis`` support.
-
     Notes
     -----
     Mins are floored to the slice start; maxes are ceiled and used as the

--- a/src/skimage/util/arraycrop.py
+++ b/src/skimage/util/arraycrop.py
@@ -6,7 +6,7 @@ n-dimensional array.
 import numpy as np
 from numbers import Integral
 
-__all__ = ['crop']
+__all__ = ['crop', 'bounding_box_crop']
 
 
 def crop(ar, crop_width, copy=False, order='K'):
@@ -70,3 +70,119 @@ def crop(ar, crop_width, copy=False, order='K'):
     else:
         cropped = ar[slices]
     return cropped
+
+
+def _bbox_min_max(bbox):
+    """Normalize bbox=((mins...), (maxs...)) -> integer (lo, hi)."""
+    try:
+        lo, hi = bbox
+    except Exception as e:
+        raise ValueError(
+            "bbox must be ((min0,...,min(D-1)), (max0,...,max(D-1)))"
+        ) from e
+
+    lo = np.asarray(lo, dtype=float)
+    hi = np.asarray(hi, dtype=float)
+    if lo.ndim != 1 or hi.ndim != 1 or lo.size != hi.size:
+        raise ValueError("bbox must provide equal-length 1D min and max vectors")
+
+    lo_i = np.floor(lo).astype(int)
+    hi_i = np.ceil(hi).astype(int)
+    if np.any(hi_i < lo_i):
+        raise ValueError("bbox has max < min along at least one axis")
+    return lo_i, hi_i
+
+
+def bounding_box_crop(
+    image, bbox, *, channel_axis=None, clip=True, copy=False, order='K'
+):
+    """
+    Crop ``image`` to a bounding box along spatial axes.
+
+    Parameters
+    ----------
+    image : ndarray
+        Input array of shape (S0, S1, ..., [C]) where [C] is an optional
+        channel axis (see ``channel_axis``). Returns a *view* when possible.
+    bbox : ((min0, ..., min(D-1)), (max0, ..., max(D-1)))
+        Bounding box over the spatial axes only (do not include the channel axis).
+        Float values are allowed; mins are floored, maxes are ceiled.
+        D must equal the number of spatial axes.
+    channel_axis : int or None, optional
+        Index of the channel axis, or None if there is no channel axis (default : None).
+        The channel axis is not cropped.
+    clip : bool, optional
+        If True (default), clamp bbox to array bounds. If False, raise on out-of-bounds.
+    copy : bool, optional
+        If True, return a contiguous copy with the selected crop.
+        If False (default), return a view when possible.
+    order : {'C', 'F', 'A', 'K'}, optional
+        Memory layout of the copy when ``copy=True``. Default is 'K'. See ``np.copy``.
+
+    Returns
+    -------
+    view : ndarray
+        A sliced view of ``image`` cropped to the bbox. If ``copy=True``, a contiguous
+        copy is returned using the specified ``order``.
+
+    See Also
+    --------
+    skimage.util.crop
+        Crop by explicit widths on each axis.
+
+    .. versionadded:: 0.26
+       Added ``bounding_box_crop`` to crop N-D arrays using a spatial bounding box
+       with optional ``channel_axis`` support.
+
+    Notes
+    -----
+    Mins are floored to the slice start; maxes are ceiled and used as the
+    exclusive slice stop (Python slicing).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skimage.util import bounding_box_crop
+    >>> im = np.arange(6*7).reshape(6, 7)
+    >>> bounding_box_crop(im, ((1, 2), (5, 6))).shape
+    (4, 4)
+    >>> rgb = np.zeros((32, 48, 3), np.uint8)  # H, W, C
+    >>> bounding_box_crop(rgb, ((4, 5), (10, 12)), channel_axis=-1).shape
+    (6, 7, 3)
+    >>> im = np.arange(6*7).reshape(6, 7)
+    >>> bounding_box_crop(im, ((1.2, 2.1), (4.0, 5.9))).shape
+    (3, 4)
+    >>> chw = np.zeros((3, 32, 48), np.uint8)
+    >>> bounding_box_crop(chw, ((4, 5), (10, 12)), channel_axis=0).shape
+    (3, 6, 7)
+    """
+    arr = np.asarray(image)
+    nd = arr.ndim
+
+    if channel_axis is None:
+        spatial_axes = tuple(range(nd))
+    else:
+        ch = channel_axis % nd
+        spatial_axes = tuple(ax for ax in range(nd) if ax != ch)
+
+    D = len(spatial_axes)
+    lo, hi = _bbox_min_max(bbox)
+    if lo.size != D:
+        raise ValueError(
+            f"bbox dimensionality (got {lo.size}) must match number of spatial axes (got {D})"
+        )
+
+    indexer = [slice(None) for _ in range(nd)]
+    for k, ax in enumerate(spatial_axes):
+        lo_k, hi_k = int(lo[k]), int(hi[k])
+        if clip:
+            lo_k = max(0, min(lo_k, arr.shape[ax]))
+            hi_k = max(0, min(hi_k, arr.shape[ax]))
+        if not (0 <= lo_k <= hi_k <= arr.shape[ax]):
+            raise ValueError(
+                f"bbox out of bounds on axis {ax}: [{lo_k}, {hi_k}] for shape {arr.shape}"
+            )
+        indexer[ax] = slice(lo_k, hi_k)
+
+    result = arr[tuple(indexer)]
+    return np.array(result, copy=True, order=order) if copy else result

--- a/tests/skimage/util/test_arraycrop.py
+++ b/tests/skimage/util/test_arraycrop.py
@@ -1,5 +1,6 @@
 import numpy as np
-from skimage.util import crop
+import pytest
+from skimage.util import crop, bounding_box_crop
 from skimage._shared.testing import assert_array_equal, assert_equal
 
 
@@ -69,3 +70,78 @@ def test_np_int_crop():
     out2 = crop(arr, np.int32(1))
     assert_array_equal(out1, out2)
     assert out1.shape == (7, 3)
+
+
+def test_bounding_box_basic_2d():
+    arr = np.arange(6 * 7).reshape(6, 7)
+    out = bounding_box_crop(arr, ((1, 2), (5, 6)))
+    expected = arr[1:5, 2:6]
+    assert_array_equal(out, expected)
+    assert_equal(out.shape, (4, 4))
+
+
+def test_bounding_box_float_semantics():
+    arr = np.arange(6 * 7).reshape(6, 7)
+    out = bounding_box_crop(arr, ((1.2, 2.1), (4.0, 5.9)))
+    expected = arr[1:4, 2:6]  # floor mins, ceil maxes, stop is exclusive
+    assert_array_equal(out, expected)
+    assert_equal(out.shape, (3, 4))
+
+
+def test_bounding_box_channel_axis_last():
+    rgb = np.arange(32 * 48 * 3).reshape(32, 48, 3)
+    out = bounding_box_crop(rgb, ((4, 5), (10, 12)), channel_axis=-1)
+    assert_equal(out.shape, (6, 7, 3))
+    # Check a couple of values to ensure spatial crop only
+    assert_array_equal(out[0, 0], rgb[4, 5])
+    assert_array_equal(out[-1, -1], rgb[9, 11])
+
+
+def test_bounding_box_channel_axis_first():
+    chw = np.arange(3 * 32 * 48).reshape(3, 32, 48)
+    out = bounding_box_crop(chw, ((4, 5), (10, 12)), channel_axis=0)
+    assert_equal(out.shape, (3, 6, 7))
+    # Check spatial indices unaffected for the channel axis
+    assert_array_equal(out[:, 0, 0], chw[:, 4, 5])
+    assert_array_equal(out[:, -1, -1], chw[:, 9, 11])
+
+
+def test_bounding_box_clip_behavior():
+    arr = np.arange(5 * 5).reshape(5, 5)
+    # Partially out of bounds: clamp to [0:3] x [0:5]
+    out = bounding_box_crop(arr, ((-2, -1), (3, 7)), clip=True)
+    assert_equal(out.shape, (3, 5))
+    assert_array_equal(out, arr[0:3, 0:5])
+
+    # With clip=False, the same bbox should raise
+    with pytest.raises(ValueError):
+        _ = bounding_box_crop(arr, ((-2, -1), (3, 7)), clip=False)
+
+
+def test_bounding_box_degenerate_zero_length():
+    arr = np.arange(6 * 7).reshape(6, 7)
+    out = bounding_box_crop(arr, ((2, 3), (2, 5)))  # zero length on axis 0
+    assert_equal(out.shape, (0, 2))
+    # Zero-length slices compare equal trivially
+    assert_array_equal(out, arr[2:2, 3:5])
+
+
+def test_bounding_box_copy_and_order_semantics():
+    arr = np.arange(10 * 12).reshape(10, 12)
+    out_view = bounding_box_crop(arr, ((1, 2), (9, 11)), copy=False)
+    assert np.may_share_memory(arr, out_view)
+
+    out_c = bounding_box_crop(arr, ((1, 2), (9, 11)), copy=True, order='C')
+    assert not np.may_share_memory(arr, out_c)
+    assert out_c.flags.c_contiguous
+
+    out_f = bounding_box_crop(arr, ((1, 2), (9, 11)), copy=True, order='F')
+    assert not np.may_share_memory(arr, out_f)
+    assert out_f.flags.f_contiguous
+
+
+def test_bounding_box_dimensionality_mismatch():
+    arr = np.zeros((10, 10, 3), dtype=np.uint8)
+    # With channel_axis=-1, spatial D=2 but we provide 3D bbox
+    with pytest.raises(ValueError):
+        _ = bounding_box_crop(arr, ((0, 0, 0), (5, 5, 2)), channel_axis=-1)


### PR DESCRIPTION
## Description

This PR adds `skimage.util.bounding_box_crop(image, bbox, *, channel_axis=None, clip=True, copy=False, order='K')`, a general N‑D utility to crop arrays by a spatial bounding box. It supports float bounding boxes (mins are floored, maxes are ceiled), preserves an optional `channel_axis` (not cropped), returns a view by default, and, with `copy=True`, returns a contiguous copy in the requested memory `order`.

## Motivation & context

Closes #5428. The prior attempt (#5499) addressed a different utility and, while being a solidly devised feature, did not meet the original request; this PR provides a small, public, NumPy‑consistent helper with tests and documentation.

### Why #5499 didn’t resolve #5428

PR #5499 implemented `_slice_along_axes` rather than a user‑facing bounding‑box crop, omitted explicit float‑bbox rounding (floor/ceil with exclusive stop) and `clip` control, and lacked `channel_axis` handling (crop only over spatial axes, preserving channels). Consequently the original request for a clear, documented N‑D bounding‑box crop helper remained unresolved.

## What’s implemented

The function is implemented in `src/skimage/util/arraycrop.py` and exported via `skimage.util.__init__`. The docstring includes examples, a “See also” link to `skimage.util.crop`, and notes on floor/ceil with exclusive stop.

Documentation includes a gallery example at `doc/examples/numpy_operations/plot_bounding_box_crop.py` demonstrating grayscale and RGB crops (with `channel_axis`) and out‑of‑bounds clipping. Overlays use red for the requested bbox and green for the effective integer bbox. Tests in `tests/skimage/util/test_arraycrop.py` cover the main behavior:
- shape/content
- float rounding
- `channel_axis`
- clamping vs error on out‑of‑bounds
- degenerate empty crops
- view vs copy and contiguity
- dimensionality checks.

## API and behavior details

The bbox is `((mins...), (maxs...))` and may contain floats; compute `lo = floor(mins)` and `hi = ceil(maxs)` with the stop exclusive. If `channel_axis` is provided, it is normalized with modulo and not cropped. With `clip=True` (default), clamp to bounds; with `clip=False`, raise `ValueError` on out‑of‑bounds. `copy=False` returns a view when possible, while `copy=True` returns a contiguous copy with the requested memory order. This is a new function only; no existing behavior changes.

## Release note

```release-note
Add `skimage.util.bounding_box_crop` to crop arrays by a spatial bounding box (float floor/ceil, `channel_axis`, optional clipping).
```

## Checklist

- [x] Descriptive PR title
- [x] Appropriately styled docstrings
- [x] Unit tests added and passing locally
- [x] Gallery example in `./doc/examples`
- [x] Release-note block included in PR description