### PR TITLE
Mark `test_rag.py::test_reproducibility` as flaky pre SciPy 1.17.0.dev0

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -38,7 +38,7 @@ Other
   see https://github.com/scikit-image/scikit-image/issues/2624
 * Review why test precision needs to be lowered for macOS ARM in
   `test_apply_parallel.py`
-* Once SciPy 1.17.0 is minimal required version and the `rng` parameter of
+* Once SciPy 1.17.0 is minimal required version, so that the `rng` parameter of
   `scipy.linalg.eigsh` is available everywhere, remove the compatibility logic in
   `skimage/graph/_graph_cut.py::_ncut_relabel` and the `xfail` mark in
   `tests/skimage/graph/test_rag.py::test_reproducibility`.

--- a/TODO.txt
+++ b/TODO.txt
@@ -38,6 +38,10 @@ Other
   see https://github.com/scikit-image/scikit-image/issues/2624
 * Review why test precision needs to be lowered for macOS ARM in
   `test_apply_parallel.py`
+* Once SciPy 1.17.0 is minimal required version and the `rng` parameter of
+  `scipy.linalg.eigsh` is available everywhere, remove the compatibility logic in
+  `skimage/graph/_graph_cut.py::_ncut_relabel` and the `xfail` mark in
+  `tests/skimage/graph/test_rag.py::test_reproducibility`.
 
 Post numpy 2
 ------------

--- a/src/skimage/_shared/compat.py
+++ b/src/skimage/_shared/compat.py
@@ -28,3 +28,5 @@ SCIPY_LT_1_12 = parse(sp.__version__) < parse('1.12')
 # Starting in SciPy v1.12, 'scipy.sparse.linalg.cg' keyword argument `tol` is
 # deprecated in favor of `rtol`.
 SCIPY_CG_TOL_PARAM_NAME = "tol" if SCIPY_LT_1_12 else "rtol"
+
+SCIPY_GE_1_17_0_DEV0 = parse('1.17.0.dev0') <= parse(sp.__version__)

--- a/src/skimage/graph/_graph_cut.py
+++ b/src/skimage/graph/_graph_cut.py
@@ -295,7 +295,7 @@ def _ncut_relabel(rag, thresh, num_cuts, random_generator):
         # become deterministic. We `.spawn` a new child generator to avoid
         # influencing existing calls to the generator and breaking backwards
         # compatibility that way
-        kw = {"rng": random_generator.spawn(1)[0]} if SCIPY_GE_1_17_0_DEV0 else {}
+        kw = {"rng": rng} if SCIPY_GE_1_17_0_DEV0 else {}
         vals, vectors = linalg.eigsh(A, which='SM', v0=v0, k=min(100, m - 2), **kw)
 
         # Pick second smallest eigenvector.

--- a/src/skimage/graph/_graph_cut.py
+++ b/src/skimage/graph/_graph_cut.py
@@ -2,6 +2,7 @@ import networkx as nx
 import numpy as np
 from scipy.sparse import linalg
 
+from skimage._shared.compat import SCIPY_GE_1_17_0_DEV0
 from . import _ncut, _ncut_cy
 
 
@@ -289,7 +290,13 @@ def _ncut_relabel(rag, thresh, num_cuts, random_generator):
         A = d2 @ (d - w) @ d2
         # Initialize the vector to ensure reproducibility.
         v0 = random_generator.random(A.shape[0])
-        vals, vectors = linalg.eigsh(A, which='SM', v0=v0, k=min(100, m - 2))
+
+        # SciPy 1.17.0.dev0 adds the new `rng` keyword, allowing `eigsh` to
+        # become deterministic. We `.spawn` a new child generator to avoid
+        # influencing existing calls to the generator and breaking backwards
+        # compatibility that way
+        kw = {"rng": random_generator.spawn(1)[0]} if SCIPY_GE_1_17_0_DEV0 else {}
+        vals, vectors = linalg.eigsh(A, which='SM', v0=v0, k=min(100, m - 2), **kw)
 
         # Pick second smallest eigenvector.
         # Refer Shi & Malik 2001, Section 3.2.3, Page 893

--- a/src/skimage/graph/_graph_cut.py
+++ b/src/skimage/graph/_graph_cut.py
@@ -292,11 +292,9 @@ def _ncut_relabel(rag, thresh, num_cuts, random_generator):
         v0 = random_generator.random(A.shape[0])
 
         # SciPy 1.17.0.dev0 adds the new `rng` keyword, allowing `eigsh` to
-        # become deterministic. We `.spawn` a new child generator to avoid
-        # influencing existing calls to the generator and breaking backwards
-        # compatibility that way
-        kw = {"rng": rng} if SCIPY_GE_1_17_0_DEV0 else {}
-        vals, vectors = linalg.eigsh(A, which='SM', v0=v0, k=min(100, m - 2), **kw)
+        # become deterministic
+        rng_kw = {"rng": random_generator} if SCIPY_GE_1_17_0_DEV0 else {}
+        vals, vectors = linalg.eigsh(A, which='SM', v0=v0, k=min(100, m - 2), **rng_kw)
 
         # Pick second smallest eigenvector.
         # Refer Shi & Malik 2001, Section 3.2.3, Page 893

--- a/tests/skimage/graph/test_rag.py
+++ b/tests/skimage/graph/test_rag.py
@@ -209,16 +209,15 @@ def test_ncut_stable_subgraph():
     assert new_labels.max() == 0
 
 
-# Version is 1.16.x or a pre-release like 1.17.0.devX
-IS_SCIPY_1_16_or_1_17dev = parse("1.16.0") <= parse(sp.__version__) < parse("1.17.0")
+# Version is less than 1.17.0.dev0
+SCIPY_LT_1_17_DEV0 = parse(sp.__version__) < parse("1.17.0.dev0")
 
 
 @pytest.mark.xfail(
-    IS_SCIPY_1_16_or_1_17dev,
+    SCIPY_LT_1_17_DEV0,
     strict=False,
-    reason="Flaky with SciPy 1.16.x to 1.17.0.devX",
-    # See https://github.com/scikit-image/scikit-image/issues/7911
-    # and https://github.com/scikit-image/scikit-image/pull/7684
+    reason="Flaky before SciPy 1.17.0.dev0",
+    # See https://github.com/scikit-image/scikit-image/issues/7911#issuecomment-3353082011
 )
 def test_reproducibility():
     """ensure cut_normalized returns the same output for the same input,

--- a/tests/skimage/graph/test_rag.py
+++ b/tests/skimage/graph/test_rag.py
@@ -1,7 +1,9 @@
-import sys
+from packaging.version import parse
 import pytest
 from numpy.testing import assert_array_equal
 import numpy as np
+import scipy as sp
+
 from skimage import graph
 from skimage import segmentation, data
 from skimage._shared import testing
@@ -207,11 +209,16 @@ def test_ncut_stable_subgraph():
     assert new_labels.max() == 0
 
 
+# Version is 1.16.x or a pre-release like 1.17.0.devX
+IS_SCIPY_1_16_or_1_17dev = parse("1.16.0") <= parse(sp.__version__) < parse("1.17.0")
+
+
 @pytest.mark.xfail(
-    sys.platform == "win32",
+    IS_SCIPY_1_16_or_1_17dev,
     strict=False,
-    reason="Flaky for unknown reasons on Windows",
-    # Fixme: details in https://github.com/scikit-image/scikit-image/issues/7911
+    reason="Flaky with SciPy 1.16.x to 1.17.0.devX",
+    # See https://github.com/scikit-image/scikit-image/issues/7911
+    # and https://github.com/scikit-image/scikit-image/pull/7684
 )
 def test_reproducibility():
     """ensure cut_normalized returns the same output for the same input,

--- a/tests/skimage/graph/test_rag.py
+++ b/tests/skimage/graph/test_rag.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 from numpy.testing import assert_array_equal
 import numpy as np
@@ -206,6 +207,12 @@ def test_ncut_stable_subgraph():
     assert new_labels.max() == 0
 
 
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    strict=False,
+    reason="Flaky for unknown reasons on Windows",
+    # Fixme: details in https://github.com/scikit-image/scikit-image/issues/7911
+)
 def test_reproducibility():
     """ensure cut_normalized returns the same output for the same input,
     when specifying random seed


### PR DESCRIPTION
## Description

Temporarily get's our CI green again and closes #7869 while we investigate #7911.

@scikit-image/core Would be good to get this in fast.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Ensure `skimage.graph.cut_normalized` is deterministic when seeded with the 
`rng` parameter and when SciPy 1.17.0.dev0 or newer is installed. With
earlier SciPy versions the internally used function `scipy.linalg.eigsh`
is not deterministic and can lead to different results.
{label="bug fix"}
```

```release-note
Mark `test_rag.py::test_reproducibility` as flaky for current versions of
SciPy (< 1.17.0.dev0).
{label="maintenance"}
```
