### PR TITLE
Use `divmod` in `montage` index computation

### DIFF
--- a/src/skimage/util/_montage.py
+++ b/src/skimage/util/_montage.py
@@ -148,8 +148,7 @@ def montage(
 
     # Copy the data to the output array
     for idx_image, image in enumerate(arr_in):
-        idx_sr = idx_image // ntiles_col
-        idx_sc = idx_image % ntiles_col
+        idx_sr, idx_sc = divmod(idx_image, ntiles_col)
         arr_out[slices_row[idx_sr], slices_col[idx_sc], :] = image
 
     if channel_axis is not None:


### PR DESCRIPTION
## Description

In the `montage` function, use `divmod` to handle both floor division and modulus in one operation.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
