### PR TITLE
Test if recent stuck CI jobs are caused by PR 7922

### DIFF
--- a/tests/skimage/draw/test_random_shapes.py
+++ b/tests/skimage/draw/test_random_shapes.py
@@ -7,20 +7,20 @@ from skimage.draw import random_shapes
 
 
 def test_generates_color_images_with_correct_shape():
-    image, _ = random_shapes((128, 128), max_shapes=10, rng=1234)
+    image, _ = random_shapes((128, 128), max_shapes=10)
     assert image.shape == (128, 128, 3)
 
 
 def test_generates_gray_images_with_correct_shape():
     image, _ = random_shapes(
-        (4567, 123), min_shapes=3, max_shapes=20, channel_axis=None, rng=1234
+        (4567, 123), min_shapes=3, max_shapes=20, channel_axis=None
     )
     assert image.shape == (4567, 123)
 
 
 def test_generates_gray_images_with_correct_shape_deprecated_multichannel():
     image, _ = random_shapes(
-        (4567, 123), min_shapes=3, max_shapes=20, channel_axis=None, rng=1234
+        (4567, 123), min_shapes=3, max_shapes=20, channel_axis=None
     )
     assert image.shape == (4567, 123)
 
@@ -36,7 +36,6 @@ def test_generated_shape_for_channel_axis(channel_axis):
         min_shapes=3,
         max_shapes=10,
         channel_axis=channel_axis,
-        rng=1234,
     )
 
     if channel_axis is None:

--- a/tests/skimage/graph/test_rag.py
+++ b/tests/skimage/graph/test_rag.py
@@ -8,9 +8,6 @@ from skimage import graph
 from skimage import segmentation, data
 from skimage._shared import testing
 
-# Version is less than 1.17.0.dev0
-SCIPY_LT_1_17_DEV0 = parse(sp.__version__) < parse("1.17.0.dev0")
-
 
 def max_edge(g, src, dst, n):
     default = {'weight': -np.inf}
@@ -210,6 +207,10 @@ def test_ncut_stable_subgraph():
     new_labels, _, _ = segmentation.relabel_sequential(new_labels)
 
     assert new_labels.max() == 0
+
+
+# Version is less than 1.17.0.dev0
+SCIPY_LT_1_17_DEV0 = parse(sp.__version__) < parse("1.17.0.dev0")
 
 
 @pytest.mark.xfail(

--- a/tests/skimage/measure/test_fit.py
+++ b/tests/skimage/measure/test_fit.py
@@ -853,9 +853,9 @@ def test_ransac_is_model_valid():
     def is_model_valid(model, data):
         return False
 
-    with pytest.warns(UserWarning, match="No inliers found"):
+    with expected_warnings(["No inliers found"]):
         model, inliers = ransac(
-            np.zeros((10, 2), dtype=np.float64),
+            np.empty((10, 2)),
             LineModelND,
             2,
             np.inf,
@@ -977,13 +977,13 @@ def test_ransac_sample_duplicates():
     # Create dataset with four unique points. Force 10 iterations
     # and check that there are no duplicated data points.
     data = np.arange(4)
-    with pytest.warns(UserWarning, match="No inliers found"):
+    with expected_warnings(["No inliers found"]):
         ransac(data, DummyModel, min_samples=3, residual_threshold=0.0, max_trials=10)
 
 
 def test_ransac_with_no_final_inliers():
     data = np.random.rand(5, 2)
-    with pytest.warns(UserWarning, match='No inliers found. Model not fitted'):
+    with expected_warnings(['No inliers found. Model not fitted']):
         model, inliers = ransac(
             data,
             model_class=LineModelND,
@@ -1005,7 +1005,7 @@ def test_ransac_non_valid_best_model():
 
     rng = np.random.RandomState(1)
     data = np.linspace([0, 0, 0], [0.3, 0, 1], 1000) + rng.rand(1000, 3) - 0.5
-    with pytest.warns(UserWarning, match="Estimated model is not valid"):
+    with expected_warnings(["Estimated model is not valid"]):
         ransac(
             data,
             LineModelND,

--- a/tests/skimage/metrics/test_set_metrics.py
+++ b/tests/skimage/metrics/test_set_metrics.py
@@ -3,6 +3,7 @@ import pytest
 from numpy.testing import assert_almost_equal, assert_array_equal
 from scipy.spatial import distance
 
+from skimage._shared._warnings import expected_warnings
 from skimage.metrics import hausdorff_distance, hausdorff_pair
 
 
@@ -13,19 +14,19 @@ def test_hausdorff_empty():
     assert (
         hausdorff_distance(empty, non_empty, method="modified") == 0.0
     )  # modified Hausdorff
-    with pytest.warns(UserWarning, match="One or both of the images is empty"):
+    with expected_warnings(["One or both of the images is empty"]):
         assert_array_equal(hausdorff_pair(empty, non_empty), [(), ()])
     assert hausdorff_distance(non_empty, empty) == 0.0  # standard Hausdorff
     assert (
         hausdorff_distance(non_empty, empty, method="modified") == 0.0
     )  # modified Hausdorff
-    with pytest.warns(UserWarning, match="One or both of the images is empty"):
+    with expected_warnings(["One or both of the images is empty"]):
         assert_array_equal(hausdorff_pair(non_empty, empty), [(), ()])
     assert hausdorff_distance(empty, non_empty) == 0.0  # standard Hausdorff
     assert (
         hausdorff_distance(empty, non_empty, method="modified") == 0.0
     )  # modified Hausdorff
-    with pytest.warns(UserWarning, match="One or both of the images is empty"):
+    with expected_warnings(["One or both of the images is empty"]):
         assert_array_equal(hausdorff_pair(empty, non_empty), [(), ()])
 
 

--- a/tests/skimage/metrics/test_simple_metrics.py
+++ b/tests/skimage/metrics/test_simple_metrics.py
@@ -3,6 +3,7 @@ import pytest
 from numpy.testing import assert_equal, assert_almost_equal
 
 from skimage import data
+from skimage._shared._warnings import expected_warnings
 from skimage.metrics import (
     peak_signal_noise_ratio,
     normalized_root_mse,
@@ -59,12 +60,12 @@ def test_PSNR_float(dtype):
     assert_almost_equal(p_mixed, p_float64, decimal=decimal)
 
     # mismatched dtype results in a warning if data_range is unspecified
-    with pytest.warns(UserWarning, match='Inputs have mismatched dtype'):
+    with expected_warnings(['Inputs have mismatched dtype']):
         p_mixed = peak_signal_noise_ratio(cam / 255.0, np.float32(cam_noisy / 255.0))
     assert_almost_equal(p_mixed, p_float64, decimal=decimal)
 
     # mismatched dtype results in a warning if data_range is unspecified
-    with pytest.warns(UserWarning, match='Inputs have mismatched dtype'):
+    with expected_warnings(['Inputs have mismatched dtype']):
         p_mixed = peak_signal_noise_ratio(cam / 255.0, np.float32(cam_noisy / 255.0))
     assert_almost_equal(p_mixed, p_float64, decimal=decimal)
 

--- a/tests/skimage/metrics/test_structural_similarity.py
+++ b/tests/skimage/metrics/test_structural_similarity.py
@@ -3,6 +3,7 @@ import pytest
 from numpy.testing import assert_equal, assert_almost_equal
 
 from skimage import data
+from skimage._shared._warnings import expected_warnings
 from skimage._shared.utils import _supported_float_type
 from skimage.metrics import structural_similarity
 
@@ -216,7 +217,7 @@ def test_mssim_vs_legacy(dtype):
 
 def test_ssim_warns_about_data_range():
     mssim = structural_similarity(cam, cam_noisy)
-    with pytest.warns(UserWarning, match='Setting data_range based on im1.dtype'):
+    with expected_warnings(['Setting data_range based on im1.dtype']):
         mssim_uint16 = structural_similarity(
             cam.astype(np.uint16), cam_noisy.astype(np.uint16)
         )
@@ -225,8 +226,10 @@ def test_ssim_warns_about_data_range():
         # is getting a warning about avoiding mistakes.
         assert mssim_uint16 > 0.99
 
-    with pytest.warns(UserWarning, match='Setting data_range based on im1.dtype'):
-        _ = structural_similarity(cam, cam_noisy.astype(np.int32))
+    with expected_warnings(
+        ['Setting data_range based on im1.dtype', 'Inputs have mismatched dtypes']
+    ):
+        mssim_mixed = structural_similarity(cam, cam_noisy.astype(np.int32))
 
     # no warning when user supplies data_range
     mssim_mixed = structural_similarity(

--- a/tests/skimage/morphology/test_extrema.py
+++ b/tests/skimage/morphology/test_extrema.py
@@ -1,11 +1,11 @@
 import math
 import unittest
 
-import pytest
 import numpy as np
 from numpy.testing import assert_equal
 from pytest import raises, warns
 
+from skimage._shared.testing import expected_warnings
 from skimage.morphology import extrema
 
 
@@ -214,11 +214,11 @@ class TestExtrema:
 
         for h in h_vals:
             if h % 1 != 0:
-                with pytest.warns(
-                    UserWarning, match='possible precision loss converting image'
-                ):
-                    maxima = extrema.h_maxima(data, h)
+                msgs = ['possible precision loss converting image']
             else:
+                msgs = []
+
+            with expected_warnings(msgs):
                 maxima = extrema.h_maxima(data, h)
 
             if maxima[2, 2] == 0:
@@ -292,11 +292,11 @@ class TestExtrema:
         failures = 0
         for h in h_vals:
             if h % 1 != 0:
-                with pytest.warns(
-                    UserWarning, match='possible precision loss converting image'
-                ):
-                    minima = extrema.h_minima(data, h)
+                msgs = ['possible precision loss converting image']
             else:
+                msgs = []
+
+            with expected_warnings(msgs):
                 minima = extrema.h_minima(data, h)
 
             if minima[2, 2] == 0:


### PR DESCRIPTION
## Description

Test if [recent stuck jobs](https://github.com/scikit-image/scikit-image/pull/7877#issuecomment-3432707092) are due to https://github.com/scikit-image/scikit-image/pull/7922 by temporarily reverting commit cdacc792d8cf5ccbe6a174263ba8e0a45c4b4449.


## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
