### PR TITLE
Use correct CSS selector to override scroll-behavior

### DIFF
--- a/doc/source/_static/theme_overrides.css
+++ b/doc/source/_static/theme_overrides.css
@@ -1,7 +1,10 @@
 /* Additional styling for the PyData Sphinx theme. */
 
-/* Avoid "slow" animated scroll when navigating to anchors */
-html {
+/* Avoid "slow" animated scroll when navigating to anchors
+May be removed if this is addressed upstream
+https://github.com/pydata/pydata-sphinx-theme/issues/2260
+*/
+:root {
     scroll-behavior: auto;
 }
 


### PR DESCRIPTION
## Description

Third attempt to get this in! I think because of https://github.com/scikit-image/scikit-image/pull/7901 not being squash-merged we included the original https://github.com/scikit-image/scikit-image/pull/7902 and its revert at the same time.

Here's a step-by-step of what I think happened:

- https://github.com/scikit-image/scikit-image/pull/7901 wasn't squased before merging. This preserved and included its entire history in `main`.
- In that PRs history I accidentally included https://github.com/scikit-image/scikit-image/commit/8372c7b0704f0472c45b080b43001ad0e1644bfe which I then reverted in https://github.com/scikit-image/scikit-image/commit/3b80724aa3461371dce5330453e634507bd21da7.  
- When that PR including this commit was merged, GitHub took this as https://github.com/scikit-image/scikit-image/pull/7902 being merged too. But because the revert is also included in `main`, the fix is still not present on `main`!



## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
