### PR TITLE
Fix  ResourceWarning in CI

### DIFF
--- a/.github/workflows/wheels-recipe.yaml
+++ b/.github/workflows/wheels-recipe.yaml
@@ -19,7 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-            macos-15-intel,
+            # macos-15-intel,
+            macos-13,
             macos-latest, # ARM-version of MacOS
           ]
         build: ["cp31{1,2}*", "cp313*", "cp314*"]


### PR DESCRIPTION
Trying to work around:

```
2025-11-04T08:44:37.6145489Z E                   Traceback (most recent call last):
2025-11-04T08:44:37.6146396Z E                     File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/imageio/v3.py", line 53, in imread
2025-11-04T08:44:37.6147579Z E                       with imopen(uri, "r", **plugin_kwargs) as img_file:
2025-11-04T08:44:37.6148131Z E                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-11-04T08:44:37.6149345Z E                   ResourceWarning: unclosed file <_io.BufferedReader name='/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/skimage/data/motorcycle_disp.npz'>
```

Seen in [failure on main](https://github.com/scikit-image/scikit-image/actions/runs/19062610728/job/54445551196).
