### PR TITLE
Switch back to using Cython wheels from PyPI

### DIFF
--- a/.github/scripts/setup-build-env.sh
+++ b/.github/scripts/setup-build-env.sh
@@ -19,12 +19,6 @@ python -m pip install --upgrade pip
 # Install build time requirements
 python -m pip install $PIP_FLAGS -r requirements/build.txt
 
-# TODO: delete when cython free-threaded wheels are available on PyPi
-FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
-if [[ $FREE_THREADED_BUILD == "True" ]]; then
-    pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
-fi
-
 # Show what's installed
 python -m pip list
 


### PR DESCRIPTION
## Description

There was some mention that a free-threaded Cython wheel was available on PyPI now. We didn't see it in the list https://pypi.org/project/Cython/#files but decided to just try it.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
