### PR TITLE
Require pytest >=8.3 which hides tracebacks for xfailures

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -61,7 +61,7 @@ dependencies:
   - asv
   - numpydoc>=1.7
   - pooch>=1.6.0
-  - pytest>=8
+  - pytest>=8.3
   - pytest-cov>=2.11.0
   - pytest-pretty
   - pytest-localserver

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ test = [
     'asv; sys_platform != "emscripten"',
     'numpydoc>=1.7',
     'pooch>=1.6.0; sys_platform != "emscripten"',
-    'pytest>=8',
+    'pytest>=8.3',
     'pytest-cov>=2.11.0',
     'pytest-pretty',
     'pytest-localserver',

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,7 +3,7 @@
 asv; sys_platform != "emscripten"
 numpydoc>=1.7
 pooch>=1.6.0; sys_platform != "emscripten"
-pytest>=8
+pytest>=8.3
 pytest-cov>=2.11.0
 pytest-pretty
 pytest-localserver


### PR DESCRIPTION
## Description

Closes #7936.

This reduces the size of our CI logs significantly for the linux-cp3.11-mini-req-eager-import job that tries to use the oldest possible versions.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
