### PR TITLE
Fix integer overflow in reconstruction cython code

### DIFF
--- a/src/skimage/morphology/_grayreconstruct.pyx
+++ b/src/skimage/morphology/_grayreconstruct.pyx
@@ -15,16 +15,14 @@ ctypedef fused np_uints:
 @cython.boundscheck(False)
 @cython.nonecheck(False)
 @cython.wraparound(False)
-def reconstruction_loop(cnp.ndarray[dtype=np_uints, ndim=1,
-                                    negative_indices=False, mode='c'] aranks,
-                        cnp.ndarray[dtype=np_ints, ndim=1,
-                                    negative_indices=False, mode='c'] aprev,
-                        cnp.ndarray[dtype=np_ints, ndim=1,
-                                    negative_indices=False, mode='c'] anext,
-                        cnp.ndarray[dtype=np_ints, ndim=1,
-                                    negative_indices=False, mode='c'] astrides,
-                        Py_ssize_t current_idx,
-                        Py_ssize_t image_stride):
+def reconstruction_loop(
+    np_uints[::1] ranks,
+    np_ints[::1] prev,
+    np_ints[::1] next,
+    np_ints[::1] strides,
+    np_ints current_idx,
+    np_ints image_stride
+):
     """The inner loop for reconstruction.
 
     This algorithm uses the rank-order of pixels. If low intensity pixels have
@@ -39,11 +37,11 @@ def reconstruction_loop(cnp.ndarray[dtype=np_uints, ndim=1,
 
     Parameters
     ----------
-    aranks : array
+    ranks : array
         The rank order of the flattened seed and mask images.
-    aprev, anext: arrays
+    prev, next: arrays
         Indices of previous and next pixels in rank sorted order.
-    astrides : array
+    strides : array
         Strides to neighbors of the current pixel.
     current_idx : int
         Index of highest-ranked pixel used as starting point in loop.
@@ -51,12 +49,9 @@ def reconstruction_loop(cnp.ndarray[dtype=np_uints, ndim=1,
         Stride between seed image and mask image in `aranks`.
     """
     cdef np_uints neighbor_rank, current_rank, mask_rank
-    cdef np_ints neighbor_idx, current_link, nprev, nnext
-    cdef int i, nstrides = astrides.shape[0]
-    cdef np_uints *ranks = <np_uints *>(aranks.data)
-    cdef np_ints *prev = <np_ints *>(aprev.data)
-    cdef np_ints *next = <np_ints *>(anext.data)
-    cdef np_ints *strides = <np_ints *>(astrides.data)
+    cdef np_ints i, neighbor_idx, current_link, nprev, nnext, nstrides
+
+    nstrides  = strides.shape[0]
 
     with nogil:
         while current_idx != -1:


### PR DESCRIPTION
## Description
I was experiencing segfaults in the reconstruction_loop cython code when reconstruction was called with very large images, even after #6342 added code to support passing int64 arrays. I discovered that the local variables that hold the values from these arrays are still 32-bit. This change uses the appropriate fused int types instead.

## Checklist
- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Avoid potential integer overflow in `skimage.morphology.reconstruction`.
```
