### PR TITLE
Note how to deal with automatic CI failure notifications / issues

### DIFF
--- a/.github/MAIN_FAIL_TEMPLATE.md
+++ b/.github/MAIN_FAIL_TEMPLATE.md
@@ -11,4 +11,4 @@ Commit {{ sha }} by @{{ payload.sender.login }} did not pass CI.
 > Otherwise, a new identical issue will be opened.
 >
 > Instead, consider opening new issue(s) with a more descriptive title and link
-> them to this issue (for example as a parent for this).
+> them to this issue.


### PR DESCRIPTION
## Description

Suggests a workflow for how to deal with our automated CI failure reports. I hope that that might avoid some confusion (on my part) and spamming of the same issue. 

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
