### PR TITLE
moments_hu doctest should ignore tiny differences

### DIFF
--- a/src/skimage/measure/_moments.py
+++ b/src/skimage/measure/_moments.py
@@ -365,9 +365,8 @@ def moments_hu(nu):
     >>> image[10:12, 10:12] = 1
     >>> mu = moments_central(image)
     >>> nu = moments_normalized(mu)
-    >>> moments_hu(nu)
-    array([0.74537037, 0.35116598, 0.10404918, 0.04064421, 0.00264312,
-           0.02408546, 0.        ])
+    >>> np.round(moments_hu(nu), 4)
+    array([0.7454, 0.3512, 0.104 , 0.0406, 0.0026, 0.0241, 0.    ])
     """
     dtype = np.float32 if nu.dtype == 'float32' else np.float64
     return _moments_cy.moments_hu(nu.astype(dtype, copy=False))


### PR DESCRIPTION
There is a tiny difference in the result of the `moments_hu` calculation for Win ARM64.  

The result we were testing for (in the doctest) - was the following:

```
 [0.74537037 0.35116598 0.10404918 0.04064421 0.00264312 0.02408546
 0.        ]
```

However, Win ARM64 gives this output:

```
 [ 7.45370370e-01  3.51165981e-01  1.04049179e-01  4.06442107e-02
  2.64312299e-03  2.40854582e-02 -8.90690725e-21]
```

This is a a very small difference:

```
array([ 0.00000000e+00,  0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
       -4.33680869e-19,  0.00000000e+00, -8.90690725e-21])
```

It appears that the difference is due to some compiler optimization by `clang`, compared to `gcc`.  See gh-7943 for a more detailed explanation.    This PR changes the doctest to test only to 4 decimal figures.

Closes gh-7943
