### PR TITLE
Add greedy optimization to einsum in moments

### DIFF
--- a/src/skimage/measure/_moments.py
+++ b/src/skimage/measure/_moments.py
@@ -272,6 +272,7 @@ def moments_central(image, center=None, order=3, *, spacing=None, **kwargs):
             powers_of_delta,
             [sum_label, order_label],  # Coord, order axis labels.
             L[:dim] + [order_label] + L[dim + 1 :],  # Output axis labels.
+            optimize='greedy',
         )
     return calc
 


### PR DESCRIPTION
Checking with a larger image, the original np.dot implementation was
about twice as fast as the new einsum implementation:

```python
[nav] In [2]: timeit my_moments_central(image, ctr)
248 μs ± 1.53 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

[nav] In [3]: timeit moments_central(image, ctr)
467 μs ± 292 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

Adding `greedy` optimization puts them in the same ballpark:

```python
[ins] In [2]: timeit my_moments_central(image, ctr)
243 μs ± 244 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

[ins] In [3]: timeit moments_central(image, ctr)
294 μs ± 335 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Use greedy einsum optimization in `skimage.measure.moments_central`.
``` 
