### PR TITLE
Avoid doctest error for -0 vs 0

### DIFF
--- a/src/skimage/measure/_moments.py
+++ b/src/skimage/measure/_moments.py
@@ -375,7 +375,7 @@ def moments_hu(nu):
     >>> image[10:12, 10:12] = 1
     >>> mu = moments_central(image)
     >>> nu = moments_normalized(mu)
-    >>> np.round(moments_hu(nu), 4)
+    >>> np.round(moments_hu(nu), 4)  # doctest: +FLOAT_CMP
     array([0.7454, 0.3512, 0.104 , 0.0406, 0.0026, 0.0241, 0.    ])
     """
     dtype = np.float32 if nu.dtype == 'float32' else np.float64


### PR DESCRIPTION
Use doctest-plus FLOAT_CMP to allow -0 to equal 0.