### PR TITLE
Added "downscale_2D" option to rolling_ball for speed improvements

### DIFF
--- a/src/skimage/restoration/_rolling_ball.py
+++ b/src/skimage/restoration/_rolling_ball.py
@@ -21,7 +21,7 @@ def _downscale_rolling_ball_2D(img, radius, workers, nansafe):
                 kernel=None,
                 nansafe=nansafe,
                 workers=workers,
-                downscale_2D=False,
+                downscale='none',
             )
             for i in down_scale_img
         ]
@@ -43,7 +43,7 @@ def rolling_ball(
     nansafe=False,
     num_threads=DEPRECATED,
     workers=None,
-    downscale_2D=False,
+    downscale='none',
 ):
     """Estimate background intensity using the rolling-ball algorithm.
 
@@ -72,12 +72,12 @@ def rolling_ball(
         default value; typically equal to the maximum number of virtual cores.
         Note: This is an upper limit to the number of threads. The exact number
         is determined by the system's OpenMP library.
-    downscale_2D : bool, optional
-        If ``True``, the input image is converted to 2D slices which are
+    downscale : {'none', '2d'}, optional
+        If ``'2d'``, the input image is converted to 2d slices which are
         downscaled before applying the rolling ball algorithm and then upscaled
-        back to the original shape for increased speed. In this case the kernel
-        parameter is ignored and only the radius parameter is used to generate
-        a ball kernel.
+        back to the original shape for significant speed increases with higher
+        radius. In this case the kernel parameter is ignored and only the radius
+        parameter is used to generate a ball kernel.
 
         .. versionadded:: 0.26
             Replaces deprecated parameter `num_threads`.
@@ -141,7 +141,7 @@ def rolling_ball(
 
     if kernel is None:
         kernel = ball_kernel(radius, image.ndim)
-        if downscale_2D:
+        if downscale == '2d' and image.ndim >= 2:
             background = _downscale_rolling_ball_2D(
                 img, radius, workers, nansafe
             ).astype(image.dtype, copy=False)

--- a/tests/skimage/restoration/test_rolling_ball.py
+++ b/tests/skimage/restoration/test_rolling_ball.py
@@ -24,7 +24,8 @@ def test_ellipsoid_const(dtype):
     assert background.dtype == img.dtype
 
 
-def test_nan_const():
+@pytest.mark.parametrize("downscale_2D", [True, False])
+def test_nan_const(downscale_2D):
     img = 123 * np.ones((100, 100), dtype=float)
     img[20, 20] = np.nan
     img[50, 53] = np.nan
@@ -36,15 +37,29 @@ def test_nan_const():
     expected_img[y + 20, x + 20] = np.nan
     expected_img[y + 50, x + 53] = np.nan
     kernel = ellipsoid_kernel(kernel_shape, 100)
-    background = rolling_ball(img, kernel=kernel, nansafe=True)
+    background = rolling_ball(
+        img, kernel=kernel, nansafe=True, downscale_2D=downscale_2D
+    )
     assert np.allclose(img - background, expected_img, equal_nan=True)
 
 
-@pytest.mark.parametrize("radius", [1, 2.5, 10.346, 50])
-def test_const_image(radius):
+@pytest.mark.parametrize(
+    "radius, downscale_2D",
+    [
+        (1, False),
+        (2.5, False),
+        (10.346, False),
+        (50, False),
+        (1, True),
+        (2.5, True),
+        (10.346, True),
+        (50, True),
+    ],
+)
+def test_const_image(radius, downscale_2D):
     # infinite plane light source at top left corner
     img = 23 * np.ones((100, 100), dtype=np.uint8)
-    background = rolling_ball(img, radius=radius)
+    background = rolling_ball(img, radius=radius, downscale_2D=downscale_2D)
     assert np.allclose(img - background, np.zeros_like(img))
 
 
@@ -70,8 +85,20 @@ def test_linear_gradient():
     assert np.allclose(img - background, expected_img)
 
 
-@pytest.mark.parametrize("radius", [2, 10, 12.5, 50])
-def test_preserve_peaks(radius):
+@pytest.mark.parametrize(
+    "radius, downscale_2D",
+    [
+        (2, False),
+        (10, False),
+        (12.5, False),
+        (50, False),
+        (2, True),
+        (10, True),
+        (12.5, True),
+        (50, True),
+    ],
+)
+def test_preserve_peaks(radius, downscale_2D):
     x, y = np.meshgrid(range(100), range(100))
     img = 0 * x + 0 * y + 10
     img[10, 10] = 20
@@ -79,7 +106,7 @@ def test_preserve_peaks(radius):
     img[45, 26] = 156
 
     expected_img = img - 10
-    background = rolling_ball(img, radius=radius)
+    background = rolling_ball(img, radius=radius, downscale_2D=downscale_2D)
     assert np.allclose(img - background, expected_img)
 
 

--- a/tests/skimage/restoration/test_rolling_ball.py
+++ b/tests/skimage/restoration/test_rolling_ball.py
@@ -24,8 +24,8 @@ def test_ellipsoid_const(dtype):
     assert background.dtype == img.dtype
 
 
-@pytest.mark.parametrize("downscale_2D", [True, False])
-def test_nan_const(downscale_2D):
+@pytest.mark.parametrize("downscale", ['none', '2d'])
+def test_nan_const(downscale):
     img = 123 * np.ones((100, 100), dtype=float)
     img[20, 20] = np.nan
     img[50, 53] = np.nan
@@ -37,29 +37,27 @@ def test_nan_const(downscale_2D):
     expected_img[y + 20, x + 20] = np.nan
     expected_img[y + 50, x + 53] = np.nan
     kernel = ellipsoid_kernel(kernel_shape, 100)
-    background = rolling_ball(
-        img, kernel=kernel, nansafe=True, downscale_2D=downscale_2D
-    )
+    background = rolling_ball(img, kernel=kernel, nansafe=True, downscale=downscale)
     assert np.allclose(img - background, expected_img, equal_nan=True)
 
 
 @pytest.mark.parametrize(
-    "radius, downscale_2D",
+    "radius, downscale",
     [
-        (1, False),
-        (2.5, False),
-        (10.346, False),
-        (50, False),
-        (1, True),
-        (2.5, True),
-        (10.346, True),
-        (50, True),
+        (1, 'none'),
+        (2.5, 'none'),
+        (10.346, 'none'),
+        (50, 'none'),
+        (1, '2d'),
+        (2.5, '2d'),
+        (10.346, '2d'),
+        (50, '2d'),
     ],
 )
-def test_const_image(radius, downscale_2D):
+def test_const_image(radius, downscale):
     # infinite plane light source at top left corner
     img = 23 * np.ones((100, 100), dtype=np.uint8)
-    background = rolling_ball(img, radius=radius, downscale_2D=downscale_2D)
+    background = rolling_ball(img, radius=radius, downscale=downscale)
     assert np.allclose(img - background, np.zeros_like(img))
 
 
@@ -86,19 +84,19 @@ def test_linear_gradient():
 
 
 @pytest.mark.parametrize(
-    "radius, downscale_2D",
+    "radius, downscale",
     [
-        (2, False),
-        (10, False),
-        (12.5, False),
-        (50, False),
-        (2, True),
-        (10, True),
-        (12.5, True),
-        (50, True),
+        (2, 'none'),
+        (10, 'none'),
+        (12.5, 'none'),
+        (50, 'none'),
+        (2, '2d'),
+        (10, '2d'),
+        (12.5, '2d'),
+        (50, '2d'),
     ],
 )
-def test_preserve_peaks(radius, downscale_2D):
+def test_preserve_peaks(radius, downscale):
     x, y = np.meshgrid(range(100), range(100))
     img = 0 * x + 0 * y + 10
     img[10, 10] = 20
@@ -106,7 +104,7 @@ def test_preserve_peaks(radius, downscale_2D):
     img[45, 26] = 156
 
     expected_img = img - 10
-    background = rolling_ball(img, radius=radius, downscale_2D=downscale_2D)
+    background = rolling_ball(img, radius=radius, downscale=downscale)
     assert np.allclose(img - background, expected_img)
 
 


### PR DESCRIPTION
## Description
Added new option to restoration.rolling_ball to allow for approximating the background using 2D slice by slice processing on a radius dependent downscaled image as suggested by @jni in existing issue [7423](https://github.com/scikit-image/scikit-image/issues/7423).  This attempts to more closely match other rolling ball based background subtraction speeds while utilizing the existing rolling_ball algorithm.  Expanded existing test_const_image and test_preserve_peaks tests to include this option when testing.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
