### PR TITLE
Remove contributor docs section on pushing to another contributor's branch

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -96,6 +96,11 @@ can be contributed to scikit-image.
      A message will be displayed with a URL to open in your browser to create a
      pull request (PR). Open it and click the green button.
 
+.. tip::
+
+   If you get stuck, reach out to us on
+   `our Zulip chat <https://skimage.zulipchat.com/>`__.
+
 4. Review process:
 
    * Reviewers (the other developers and interested community members) will

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -100,15 +100,24 @@ can be contributed to scikit-image.
    ::
 
      git remote add friend-username git@github.com:friend-username/scikit-image
-     git fetch friend-username
-     git checkout pr-branch-name
+     git fetch friend-username friend-branch-name
+     git switch friend-branch-name
 
-   Make changes, commit them, and then push back to the other person's
-   branch:
+   Create a new branch based on the other person's branch:
 
    ::
 
-     git push friend-username pr-branch-name
+     git switch -c my-branch-name
+
+   Make changes, commit them, and then push this new local branch to your
+   personal fork:
+
+   ::
+
+     git push codemonkey my-branch-name
+
+   This new branch contains the other person's contribution plus your changes.
+   You may create a pull request with it, as described in the previous section.
 
 For a more detailed discussion, read these :doc:`detailed documents
 <../gitwash/index>` on how to use Git with ``scikit-image`` (:ref:`using-git`).

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -96,38 +96,6 @@ can be contributed to scikit-image.
      A message will be displayed with a URL to open in your browser to create a
      pull request (PR). Open it and click the green button.
 
-4. To work on someone else's PR:
-
-   ::
-
-     git remote add friend-username git@github.com:friend-username/scikit-image
-     git fetch friend-username friend-branch-name
-     git switch friend-branch-name
-
-   Create a new branch based on the other person's branch:
-
-   ::
-
-     git switch -c my-branch-name
-
-   Make changes, commit them, and then push this new local branch to your
-   personal fork:
-
-   ::
-
-     git push codemonkey my-branch-name
-
-   This new branch contains the other person's contribution plus your changes.
-   You may create a pull request with it, as described in the previous section.
-
-For a more detailed discussion, read these :doc:`detailed documents
-<../gitwash/index>` on how to use Git with ``scikit-image`` (:ref:`using-git`).
-
-.. tip::
-
-   If you get stuck, reach out to us on
-   `our Zulip chat <https://skimage.zulipchat.com/>`__.
-
 4. Review process:
 
    * Reviewers (the other developers and interested community members) will


### PR DESCRIPTION
## Description

I have re-cloned the repository to follow the latest instructions!

This PR addresses my [comment](https://github.com/scikit-image/scikit-image/pull/7953/files#r2551008313) on #7953.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
