### PR TITLE
Revert "Refactor names in Pyodide workflow (#7959)"

### DIFF
--- a/.github/workflows/emscripten.yaml
+++ b/.github/workflows/emscripten.yaml
@@ -2,7 +2,7 @@
 # https://github.com/numpy/numpy/blob/d2d2c25fa81b47810f5cbd85ea6485eb3a3ffec3/.github/workflows/emscripten.yml
 #
 
-name: Test Pyodide
+name: Test Emscripten/Pyodide build
 
 on: [push, pull_request, merge_group]
 
@@ -19,10 +19,7 @@ permissions:
 
 jobs:
   build-wasm-emscripten:
-    name: >-
-      pyodide${{ env.PYODIDE_VERSION }}
-      -py${{ env.PYTHON_VERSION }}
-      -emscr${{ env.EMSCRIPTEN_VERSION }}
+    name: Build scikit-image distribution for Pyodide
     runs-on: ubuntu-24.04
     env:
       PYODIDE_VERSION: 0.29.0
@@ -66,7 +63,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Set up Pyodide test environment
+      - name: Set up Pyodide virtual environment and test scikit-image for Pyodide
         run: |
           # Set up Pyodide virtual environment
           pyodide venv .venv-pyodide
@@ -78,7 +75,4 @@ jobs:
           # Install pytest and optional dependencies that are available
           pip install pytest pytest-pretty
           pip install "astropy" "dask[array]" "matplotlib" "PyWavelets" "scikit-learn"
-
-      - name: Test scikit-image
-        run: |
           $PYTEST -svra --pyargs skimage ./tests


### PR DESCRIPTION
## Description

Edit: @scikit-image/core: Sorry for the confusion. You'll probably want to review and merge https://github.com/scikit-image/scikit-image/pull/7963 instead of this PR. https://github.com/scikit-image/scikit-image/pull/7963 fixes the faulty configuration introduced in https://github.com/scikit-image/scikit-image/pull/7959. But you can also merge this revert (the current PR), in case https://github.com/scikit-image/scikit-image/pull/7963 requires more iteration and isn't resolved fast enough.

This reverts commit 7cb47b6ce811ecee9186cc82a1b9aa478bd287b3 from https://github.com/scikit-image/scikit-image/pull/7959 which accidentally merged broken workflow configuration into `main`.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
