### PR TITLE
Test on macOS intel in CI again

### DIFF
--- a/.github/workflows/test-macos.yaml
+++ b/.github/workflows/test-macos.yaml
@@ -24,13 +24,13 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.13"]
-        os: [macos-latest-large]
+        os: [macos-latest]
         OPTIONAL_DEPS: [1]
         OPTIONS_NAME: ["default"]
         include:
           - python-version: "3.13"
-            # Also test on ARM version of MacOS
-            os: macos-15
+            # Also test on Intel version of MacOS
+            os: macos-15-intel
             OPTIONAL_DEPS: 1
             OPTIONS_NAME: "default"
     env:


### PR DESCRIPTION
## Description

According to https://github.com/actions/runner-images, `macos-latest` and `macos-15` are currently aliases of the same arch: macOS-15-arm64. I don't think it was our intention in https://github.com/scikit-image/scikit-image/pull/7949 to stop testing on MacOS Intel?

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
