### PR TITLE
Use __doctest_requires__ instead of inline importorskip

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -46,7 +46,7 @@ dependencies:
   - sphinx-design>=0.5
   - pydata-sphinx-theme>=0.16
   - PyWavelets>=1.6
-  - pytest-doctestplus
+  - pytest-doctestplus>=1.6.0
   # optional
   - SimpleITK
   - scikit-learn>=1.2
@@ -66,4 +66,4 @@ dependencies:
   - pytest-pretty
   - pytest-localserver
   - pytest-faulthandler
-  - pytest-doctestplus
+  - pytest-doctestplus>=1.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ docs = [
     'sphinx_design>=0.5',
     'pydata-sphinx-theme>=0.16',
     'PyWavelets>=1.6',
-    'pytest-doctestplus',
+    'pytest-doctestplus>=1.6.0',
 ]
 optional = [
     'SimpleITK; sys_platform != "emscripten"',
@@ -107,7 +107,7 @@ test = [
     'pytest-pretty',
     'pytest-localserver',
     'pytest-faulthandler',
-    'pytest-doctestplus',
+    'pytest-doctestplus>=1.6.0',
 ]
 
 [project.urls]

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -20,4 +20,4 @@ scikit-learn>=1.2
 sphinx_design>=0.5
 pydata-sphinx-theme>=0.16
 PyWavelets>=1.6
-pytest-doctestplus
+pytest-doctestplus>=1.6.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,4 +8,4 @@ pytest-cov>=2.11.0
 pytest-pretty
 pytest-localserver
 pytest-faulthandler
-pytest-doctestplus
+pytest-doctestplus>=1.6.0

--- a/src/skimage/draw/draw.py
+++ b/src/skimage/draw/draw.py
@@ -15,6 +15,9 @@ from ._draw import (
 )
 
 
+__doctest_requires__ = {("polygon_perimeter", "rectangle_perimeter"): ["matplotlib"]}
+
+
 def _ellipse_in_shape(shape, center, radii, rotation=0.0):
     """Generate coordinates of points within ellipse bounded by shape.
 
@@ -243,9 +246,6 @@ def polygon_perimeter(r, c, shape=None, clip=False):
 
     Examples
     --------
-    .. testsetup::
-        >>> import pytest; _ = pytest.importorskip('matplotlib')
-
     >>> from skimage.draw import polygon_perimeter
     >>> img = np.zeros((10, 10), dtype=np.uint8)
     >>> rr, cc = polygon_perimeter([5, -1, 5, 10],
@@ -906,9 +906,6 @@ def rectangle_perimeter(start, end=None, extent=None, shape=None, clip=False):
 
     Examples
     --------
-    .. testsetup::
-        >>> import pytest; _ = pytest.importorskip('matplotlib')
-
     >>> import numpy as np
     >>> from skimage.draw import rectangle_perimeter
     >>> img = np.zeros((5, 6), dtype=np.uint8)

--- a/src/skimage/feature/_fisher_vector.py
+++ b/src/skimage/feature/_fisher_vector.py
@@ -27,6 +27,9 @@ scikit-image (here) by other authors.)
 import numpy as np
 
 
+__doctest_requires__ = {("learn_gmm", "fisher_vector"): ["sklearn"]}
+
+
 class FisherVectorException(Exception):
     pass
 
@@ -80,9 +83,6 @@ def learn_gmm(descriptors, *, n_modes=32, gm_args=None):
 
     Examples
     --------
-    .. testsetup::
-        >>> import pytest; _ = pytest.importorskip('sklearn')
-
     >>> from skimage.feature import fisher_vector
     >>> rng = np.random.Generator(np.random.PCG64())
     >>> sift_for_images = [rng.standard_normal((10, 128)) for _ in range(10)]
@@ -193,9 +193,6 @@ def fisher_vector(descriptors, gmm, *, improved=False, alpha=0.5):
 
     Examples
     --------
-    .. testsetup::
-        >>> import pytest; _ = pytest.importorskip('sklearn')
-
     >>> from skimage.feature import fisher_vector, learn_gmm
     >>> sift_for_images = [np.random.random((10, 128)) for _ in range(10)]
     >>> num_modes = 16

--- a/src/skimage/filters/thresholding.py
+++ b/src/skimage/filters/thresholding.py
@@ -36,6 +36,9 @@ __all__ = [
 ]
 
 
+__doctest_requires__ = {("try_all_threshold",): ["matpotlib"]}
+
+
 def _try_all(image, methods=None, figsize=None, num_cols=2, verbose=True):
     """Returns a figure comparing the outputs of different methods.
 
@@ -137,9 +140,6 @@ def try_all_threshold(image, figsize=(8, 5), verbose=True):
 
     Examples
     --------
-    .. testsetup::
-        >>> import pytest; _ = pytest.importorskip('matplotlib')
-
     >>> from skimage.data import text
     >>> fig, ax = try_all_threshold(text(), figsize=(10, 6), verbose=False)
     """

--- a/src/skimage/graph/_rag.py
+++ b/src/skimage/graph/_rag.py
@@ -8,6 +8,9 @@ from .. import measure, segmentation, util, color
 from .._shared.version_requirements import require
 
 
+__doctest_requires__ = {("show_rag",): ["matplotlib"]}
+
+
 def _edge_generator_from_csr(csr_array):
     """Yield weighted edge triples for use by NetworkX from a CSR matrix.
 
@@ -506,9 +509,6 @@ def show_rag(
 
     Examples
     --------
-    .. testsetup::
-        >>> import pytest; _ = pytest.importorskip('matplotlib')
-
     >>> from skimage import data, segmentation, graph
     >>> import matplotlib.pyplot as plt
     >>>

--- a/src/skimage/restoration/_denoise.py
+++ b/src/skimage/restoration/_denoise.py
@@ -13,6 +13,9 @@ from .. import color
 from ..color.colorconv import ycbcr_from_rgb
 
 
+__doctest_requires__ = {("denoise_wavelet", "estimate_sigma"): ["pywt"]}
+
+
 def _gaussian_weight(array, sigma_squared, *, dtype=float):
     """Helping function. Define a Gaussian weighting from array and
     sigma_square.
@@ -961,9 +964,6 @@ def denoise_wavelet(
 
     Examples
     --------
-    .. testsetup::
-        >>> import pytest; _ = pytest.importorskip('pywt')
-
     >>> from skimage import color, data
     >>> img = img_as_float(data.astronaut())
     >>> img = color.rgb2gray(img)
@@ -1087,9 +1087,6 @@ def estimate_sigma(image, average_sigmas=False, *, channel_axis=None):
 
     Examples
     --------
-    .. testsetup::
-        >>> import pytest; _ = pytest.importorskip('pywt')
-
     >>> import skimage.data
     >>> from skimage import img_as_float
     >>> img = img_as_float(skimage.data.camera())

--- a/src/skimage/util/lookfor.py
+++ b/src/skimage/util/lookfor.py
@@ -3,6 +3,9 @@ import sys
 from .._vendored.numpy_lookfor import lookfor as _lookfor
 
 
+__doctest_requires__ = {("lookfor",): ["SimpleITK"]}
+
+
 def lookfor(what):
     """Do a keyword search on scikit-image docstrings and print results.
 
@@ -18,9 +21,6 @@ def lookfor(what):
 
     Examples
     --------
-    .. testsetup::
-        >>> import pytest; _ = pytest.importorskip('SimpleITK')
-
     >>> import skimage as ski
     >>> ski.util.lookfor('regular_grid')
     Search results for 'regular_grid'


### PR DESCRIPTION
## Description

With [pytest-doctestplus v1.6.0](https://github.com/scientific-python/pytest-doctestplus/releases/tag/v1.6.0), doctests that are skipped via __doctest_requires__ are now visible in PyTests output. This addresses one of the concerns @lagru had in adopting these.

Removing the inlined importorskip from docstring examples makes them a bit less confusing for people taking a peak. I think this was a concern brought up by @stefanv.

Marking this as lower priority, since I'm content with the status quo. The current status quo also has the charm of making it a bit more explicit that a doctest depends on an optional dependency.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
