### PR TITLE
Clarify non-native support for masked array in the documentation

### DIFF
--- a/doc/source/user_guide/numpy_images.rst
+++ b/doc/source/user_guide/numpy_images.rst
@@ -29,10 +29,9 @@ manipulating arrays::
     `Masked NumPy arrays <https://numpy.org/doc/stable/reference/maskedarray.baseclass.html#numpy.ma.MaskedArray>`_
     are not natively supported either. Please convert images to plain
     ``numpy.ndarray``, and handle masks separately when calling scikit-image
-    functions. Some functions do accept a ``mask`` keyword argument,
-    but in many cases you'll want to post-process the output
-    yourself (for example, by using masks to overwrite pixel values
-    :ref:`Masking <numpy-images-masking>`).
+    functions. Some functions do accept a ``mask`` keyword argument, but in many
+    cases you'll want to handle the masking yourself (for example, by using
+    masks to overwrite pixel values :ref:`Masking <numpy-images-masking>`).
 
 Retrieving the geometry of the image and the number of pixels::
 


### PR DESCRIPTION
## Description

Closes #7300

This PR updates the “A crash course on NumPy for images” user guide to clarify
that NumPy masked arrays (`numpy.ma.MaskedArray`) are not natively supported in
`scikit-image`.
## Release note

```release-note

```
