### PR TITLE
Avoid uploading unsupported wasm wheels to PyPI

### DIFF
--- a/.github/workflows/wheels-test-and-release.yaml
+++ b/.github/workflows/wheels-test-and-release.yaml
@@ -65,6 +65,8 @@ jobs:
       - name: Remove distributions that PyPI doesn't support
         run: |
           find ./dist -name '*wasm32.whl' -delete -print
+          echo "::notice::Remaining distributions to upload"
+          ls -Al ./dist
 
       # We prefer to release wheels before source because otherwise there is a
       # small window during which users who pip install scikit-image will require compilation.


### PR DESCRIPTION
## Description

Fixes our release workflow. Skipped the CI here because the change is only executed / tested when pushing a release candidate.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
