### PR TITLE
No need to download all data on each test run

### DIFF
--- a/tests/skimage/data/test_data.py
+++ b/tests/skimage/data/test_data.py
@@ -1,6 +1,5 @@
 import numpy as np
 import skimage.data as data
-from skimage.data._fetchers import _image_fetcher
 from skimage import io
 from skimage._shared.testing import (
     assert_equal,
@@ -8,31 +7,7 @@ from skimage._shared.testing import (
     fetch,
     assert_stacklevel,
 )
-import os
 import pytest
-
-
-def test_download_all_with_pooch():
-    # jni first wrote this test with the intention of
-    # fully deleting the files in the data_dir,
-    # then ensure that the data gets downloaded accordingly.
-    # hmaarrfk raised the concern that this test wouldn't
-    # play well with parallel testing since we
-    # may be breaking the global state that certain other
-    # tests require, especially in parallel testing
-
-    # The second concern is that this test essentially uses
-    # a lot of bandwidth, which is not fun for developers on
-    # lower speed connections.
-    # https://github.com/scikit-image/scikit-image/pull/4666/files/26d5138b25b958da6e97ebf979e9bc36f32c3568#r422604863
-    data_dir = data.data_dir
-    if _image_fetcher is not None:
-        data.download_all()
-        assert 'astronaut.png' in os.listdir(data_dir)
-        assert len(os.listdir(data_dir)) > 50
-    else:
-        with pytest.raises(ModuleNotFoundError):
-            data.download_all()
 
 
 def test_astronaut():


### PR DESCRIPTION

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
