### PR TITLE
Mark `test_wrap_around` as xfail on macOS until 2026-02-01

### DIFF
--- a/tests/skimage/restoration/test_unwrap.py
+++ b/tests/skimage/restoration/test_unwrap.py
@@ -134,7 +134,7 @@ dim_axis = [(ndim, axis) for ndim in (2, 3) for axis in range(ndim)]
 
 @pytest.mark.xfail(
     condition=sys.platform == "darwin" and date.today() < date(2026, 2, 1),
-    reason="Flakiness on macOS (marked until 2026-02-01)",
+    reason="Flakiness on macOS (gh-7964, xfail expires 2026-02-01)",
     raises=AssertionError,
     strict=False,
 )


### PR DESCRIPTION
## Description

Mark flaky `test_wrap_around` on MacOS-15-ARM with `xfail`, so we can go ahead with the release. Tracked in https://github.com/scikit-image/scikit-image/issues/7964.

> [!NOTE]
> Still a draft because I'm trying to figure out how to test for running on MacOS-15-ARM.


## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
