### PR TITLE
Fix pyramid `mode` options that have different names in numpy and scipy

### DIFF
--- a/src/skimage/transform/pyramids.py
+++ b/src/skimage/transform/pyramids.py
@@ -3,7 +3,7 @@ import math
 import numpy as np
 
 from .._shared.filters import gaussian
-from .._shared.utils import convert_to_float
+from .._shared.utils import convert_to_float, _to_ndimage_mode
 from ._warps import resize
 
 
@@ -18,11 +18,13 @@ def _smooth(image, sigma, mode, cval, channel_axis):
         sigma = (sigma,) * (image.ndim - 1)
     else:
         channel_axis = None
+
+    ndi_mode = _to_ndimage_mode(mode)
     gaussian(
         image,
         sigma=sigma,
         out=smoothed,
-        mode=mode,
+        mode=ndi_mode,
         cval=cval,
         channel_axis=channel_axis,
     )

--- a/tests/skimage/transform/test_pyramids.py
+++ b/tests/skimage/transform/test_pyramids.py
@@ -51,7 +51,7 @@ def test_pyramid_reduce_modes(mode):
     out1 = pyramids.pyramid_reduce(image_gray, mode=mode)
     assert_array_equal(out1.shape, (rows / 2, cols / 2))
     assert_almost_equal(np.ptp(out1), 1.0, decimal=2)
-    out2 = pyramids.pyramid_reduce(image_gray, preserve_range=True)
+    out2 = pyramids.pyramid_reduce(image_gray, mode=mode, preserve_range=True)
     assert_almost_equal(np.ptp(out2) / np.ptp(image_gray), 1.0, decimal=2)
 
 
@@ -85,6 +85,9 @@ def test_pyramid_expand_modes(mode):
     rows, cols = image_gray.shape
     out1 = pyramids.pyramid_expand(image_gray, mode=mode)
     assert_array_equal(out1.shape, (rows * 2, cols * 2))
+    assert_almost_equal(np.ptp(out1), 1.0, decimal=2)
+    out2 = pyramids.pyramid_expand(image_gray, mode=mode, preserve_range=True)
+    assert_almost_equal(np.ptp(out2) / np.ptp(image_gray), 1.0, decimal=2)
 
 
 def test_pyramid_expand_nd():

--- a/tests/skimage/transform/test_pyramids.py
+++ b/tests/skimage/transform/test_pyramids.py
@@ -67,11 +67,7 @@ def test_pyramid_reduce_nd():
         out1 = pyramids.pyramid_reduce(img, downscale=2, channel_axis=None)
         expected_shape = np.asarray(img.shape) / 2
         assert_array_equal(out1.shape, expected_shape)
-        assert_almost_equal(np.ptp(out1), 1.0, decimal=2)
-        out2 = pyramids.pyramid_reduce(
-            img, downscale=2, channel_axis=None, preserve_range=True
-        )
-        assert_almost_equal(np.ptp(out2) / np.ptp(img), 1.0, decimal=2)
+        # no ptp check because it's a small array of random numbers
 
 
 @pytest.mark.parametrize('channel_axis', [0, 1, 2, -1, -2, -3])
@@ -115,11 +111,7 @@ def test_pyramid_expand_nd():
         out1 = pyramids.pyramid_expand(img, upscale=2, channel_axis=None)
         expected_shape = np.asarray(img.shape) * 2
         assert_array_equal(out1.shape, expected_shape)
-        assert_almost_equal(np.ptp(out1), 1.0, decimal=2)
-        out2 = pyramids.pyramid_expand(
-            img, upscale=2, channel_axis=None, preserve_range=True
-        )
-        assert_almost_equal(np.ptp(out2) / np.ptp(img), 1.0, decimal=2)
+        # no ptp check because it's a small array of random numbers
 
 
 @pytest.mark.parametrize('mode', ['reflect', 'constant', 'edge', 'symmetric', 'wrap'])
@@ -150,8 +142,15 @@ def test_build_gaussian_pyramid_rgb(channel_axis):
         layer_shape = [rows / 2**layer, cols / 2**layer]
         layer_shape.insert(channel_axis % image.ndim, dim)
         assert out1.shape == tuple(layer_shape)
-        assert_almost_equal(np.ptp(out1), 1.0, decimal=2)
-        assert_almost_equal(np.ptp(out2) / np.ptp(image), 1.0, decimal=2)
+        # smaller layers are too smooth, reducing the PTP
+        if max(layer_shape) >= 128:
+            decimal = 2
+        elif max(layer_shape) >= 16:
+            decimal = 1
+        else:
+            decimal = 0
+        assert_almost_equal(np.ptp(out1), 1.0, decimal=decimal, err_msg=f"layer {layer} shape {out1.shape}")
+        assert_almost_equal(np.ptp(out2) / np.ptp(image), 1.0, decimal=decimal, err_msg=f"layer {layer} shape {out2.shape}")
 
 
 def test_build_gaussian_pyramid_gray():
@@ -167,8 +166,15 @@ def test_build_gaussian_pyramid_gray():
     for layer, (out1, out2) in enumerate(zip(pyramid1, pyramid2, strict=True)):
         layer_shape = (rows / 2**layer, cols / 2**layer)
         assert_array_equal(out1.shape, layer_shape)
-        assert_almost_equal(np.ptp(out1), 1.0, decimal=2)
-        assert_almost_equal(np.ptp(out2) / np.ptp(image_gray), 1.0, decimal=2)
+        # smaller layers are too smooth, reducing the PTP
+        if max(layer_shape) >= 128:
+            decimal = 2
+        elif max(layer_shape) >= 16:
+            decimal = 1
+        else:
+            decimal = 0
+        assert_almost_equal(np.ptp(out1), 1.0, decimal=decimal)
+        assert_almost_equal(np.ptp(out2) / np.ptp(image_gray), 1.0, decimal=decimal)
 
 
 def test_build_gaussian_pyramid_gray_defaults():
@@ -178,8 +184,15 @@ def test_build_gaussian_pyramid_gray_defaults():
     for layer, (out1, out2) in enumerate(zip(pyramid1, pyramid2, strict=True)):
         layer_shape = (rows / 2**layer, cols / 2**layer)
         assert_array_equal(out1.shape, layer_shape)
-        assert_almost_equal(np.ptp(out1), 1.0, decimal=2)
-        assert_almost_equal(np.ptp(out2) / np.ptp(image_gray), 1.0, decimal=2)
+        # smaller layers are too smooth, reducing the PTP
+        if max(layer_shape) >= 128:
+            decimal = 2
+        elif max(layer_shape) >= 16:
+            decimal = 1
+        else:
+            decimal = 0
+        assert_almost_equal(np.ptp(out1), 1.0, decimal=decimal)
+        assert_almost_equal(np.ptp(out2) / np.ptp(image_gray), 1.0, decimal=decimal)
 
 
 @pytest.mark.parametrize('mode', ['reflect', 'constant', 'edge', 'symmetric', 'wrap'])
@@ -192,8 +205,15 @@ def test_build_gaussian_pyramid_gray_modes(mode):
     for layer, (out1, out2) in enumerate(zip(pyramid1, pyramid2, strict=True)):
         layer_shape = (rows / 2**layer, cols / 2**layer)
         assert_array_equal(out1.shape, layer_shape)
-        assert_almost_equal(np.ptp(out1), 1.0, decimal=2)
-        assert_almost_equal(np.ptp(out2) / np.ptp(image_gray), 1.0, decimal=2)
+        # smaller layers are too smooth, reducing the PTP
+        if max(layer_shape) >= 128:
+            decimal = 2
+        elif max(layer_shape) >= 16:
+            decimal = 1
+        else:
+            decimal = 0
+        assert_almost_equal(np.ptp(out1), 1.0, decimal=decimal)
+        assert_almost_equal(np.ptp(out2) / np.ptp(image_gray), 1.0, decimal=decimal)
 
 
 def test_build_gaussian_pyramid_nd():
@@ -209,8 +229,7 @@ def test_build_gaussian_pyramid_nd():
         for layer, (out1, out2) in enumerate(zip(pyramid1, pyramid2, strict=True)):
             layer_shape = original_shape / 2**layer
             assert_array_equal(out1.shape, layer_shape)
-            assert_almost_equal(np.ptp(out1), 1.0, decimal=2)
-            assert_almost_equal(np.ptp(out2) / np.ptp(img), 1.0, decimal=2)
+            # no ptp check because it's a small array of random numbers
 
 
 @pytest.mark.parametrize('channel_axis', [0, 1, 2, -1, -2, -3])
@@ -230,9 +249,15 @@ def test_build_laplacian_pyramid_rgb(channel_axis):
         layer_shape = [rows / 2**layer, cols / 2**layer]
         layer_shape.insert(channel_axis % image.ndim, dim)
         assert out1.shape == tuple(layer_shape)
-        # PTP for Laplacian is naturally different from Gaussian/Reduce, but consistency checks still apply
-        assert_almost_equal(np.ptp(out1), 1.0, decimal=1)
-        assert_almost_equal(np.ptp(out2) / np.ptp(image), 1.0, decimal=1)
+        # smaller layers are too smooth, reducing the PTP
+        if max(layer_shape) >= 128:
+            decimal = 2
+        elif max(layer_shape) >= 16:
+            decimal = 1
+        else:
+            decimal = 0
+        assert_almost_equal(np.ptp(out1), 1.0, decimal=decimal, err_msg=f"layer {layer} shape {out1.shape}")
+        assert_almost_equal(np.ptp(out2) / np.ptp(image), 1.0, decimal=decimal, err_msg=f"layer {layer} shape {out2.shape}")
 
 
 def test_build_laplacian_pyramid_defaults():

--- a/tests/skimage/transform/test_pyramids.py
+++ b/tests/skimage/transform/test_pyramids.py
@@ -54,7 +54,7 @@ def test_pyramid_reduce_modes(mode):
     assert_almost_equal(np.ptp(out2) / np.ptp(image_gray), 1.0, decimal=2)
 
 
-def test_pyramid_reduce_nd(mode):
+def test_pyramid_reduce_nd():
     for ndim in [1, 2, 3, 4]:
         img = np.random.randn(*((8,) * ndim))
         out = pyramids.pyramid_reduce(img, downscale=2, channel_axis=None)

--- a/tests/skimage/transform/test_pyramids.py
+++ b/tests/skimage/transform/test_pyramids.py
@@ -138,8 +138,14 @@ def test_build_gaussian_pyramid_rgb(channel_axis):
     image = data.astronaut()
     rows, cols, dim = image.shape
     image = np.moveaxis(image, source=-1, destination=channel_axis)
-    pyramid1 = list(pyramids.pyramid_gaussian(image, downscale=2, channel_axis=channel_axis))
-    pyramid2 = list(pyramids.pyramid_gaussian(image, downscale=2, channel_axis=channel_axis, preserve_range=True))
+    pyramid1 = list(
+        pyramids.pyramid_gaussian(image, downscale=2, channel_axis=channel_axis)
+    )
+    pyramid2 = list(
+        pyramids.pyramid_gaussian(
+            image, downscale=2, channel_axis=channel_axis, preserve_range=True
+        )
+    )
     for layer, (out1, out2) in enumerate(zip(pyramid1, pyramid2, strict=True)):
         layer_shape = [rows / 2**layer, cols / 2**layer]
         layer_shape.insert(channel_axis % image.ndim, dim)
@@ -150,8 +156,14 @@ def test_build_gaussian_pyramid_rgb(channel_axis):
 
 def test_build_gaussian_pyramid_gray():
     rows, cols = image_gray.shape
-    pyramid1 = list(pyramids.pyramid_gaussian(image_gray, downscale=2, channel_axis=None))
-    pyramid2 = list(pyramids.pyramid_gaussian(image_gray, downscale=2, channel_axis=None, preserve_range=True))
+    pyramid1 = list(
+        pyramids.pyramid_gaussian(image_gray, downscale=2, channel_axis=None)
+    )
+    pyramid2 = list(
+        pyramids.pyramid_gaussian(
+            image_gray, downscale=2, channel_axis=None, preserve_range=True
+        )
+    )
     for layer, (out1, out2) in enumerate(zip(pyramid1, pyramid2, strict=True)):
         layer_shape = (rows / 2**layer, cols / 2**layer)
         assert_array_equal(out1.shape, layer_shape)
@@ -174,7 +186,9 @@ def test_build_gaussian_pyramid_gray_defaults():
 def test_build_gaussian_pyramid_gray_modes(mode):
     rows, cols = image_gray.shape
     pyramid1 = list(pyramids.pyramid_gaussian(image_gray, mode=mode))
-    pyramid2 = list(pyramids.pyramid_gaussian(image_gray, mode=mode, preserve_range=True))
+    pyramid2 = list(
+        pyramids.pyramid_gaussian(image_gray, mode=mode, preserve_range=True)
+    )
     for layer, (out1, out2) in enumerate(zip(pyramid1, pyramid2, strict=True)):
         layer_shape = (rows / 2**layer, cols / 2**layer)
         assert_array_equal(out1.shape, layer_shape)
@@ -187,7 +201,11 @@ def test_build_gaussian_pyramid_nd():
         img = np.random.randn(*((8,) * ndim))
         original_shape = np.asarray(img.shape)
         pyramid1 = list(pyramids.pyramid_gaussian(img, downscale=2, channel_axis=None))
-        pyramid2 = list(pyramids.pyramid_gaussian(img, downscale=2, channel_axis=None, preserve_range=True))
+        pyramid2 = list(
+            pyramids.pyramid_gaussian(
+                img, downscale=2, channel_axis=None, preserve_range=True
+            )
+        )
         for layer, (out1, out2) in enumerate(zip(pyramid1, pyramid2, strict=True)):
             layer_shape = original_shape / 2**layer
             assert_array_equal(out1.shape, layer_shape)
@@ -200,8 +218,14 @@ def test_build_laplacian_pyramid_rgb(channel_axis):
     image = data.astronaut()
     rows, cols, dim = image.shape
     image = np.moveaxis(image, source=-1, destination=channel_axis)
-    pyramid1 = list(pyramids.pyramid_laplacian(image, downscale=2, channel_axis=channel_axis))
-    pyramid2 = list(pyramids.pyramid_laplacian(image, downscale=2, channel_axis=channel_axis, preserve_range=True))
+    pyramid1 = list(
+        pyramids.pyramid_laplacian(image, downscale=2, channel_axis=channel_axis)
+    )
+    pyramid2 = list(
+        pyramids.pyramid_laplacian(
+            image, downscale=2, channel_axis=channel_axis, preserve_range=True
+        )
+    )
     for layer, (out1, out2) in enumerate(zip(pyramid1, pyramid2, strict=True)):
         layer_shape = [rows / 2**layer, cols / 2**layer]
         layer_shape.insert(channel_axis % image.ndim, dim)
@@ -226,7 +250,9 @@ def test_build_laplacian_pyramid_defaults():
 def test_build_laplacian_pyramid_modes(mode):
     rows, cols = image_gray.shape
     pyramid1 = list(pyramids.pyramid_laplacian(image_gray, mode=mode))
-    pyramid2 = list(pyramids.pyramid_laplacian(image_gray, mode=mode, preserve_range=True))
+    pyramid2 = list(
+        pyramids.pyramid_laplacian(image_gray, mode=mode, preserve_range=True)
+    )
     for layer, (out1, out2) in enumerate(zip(pyramid1, pyramid2, strict=True)):
         layer_shape = (rows / 2**layer, cols / 2**layer)
         assert_array_equal(out1.shape, layer_shape)
@@ -239,7 +265,11 @@ def test_build_laplacian_pyramid_nd():
         img = np.random.randn(*(16,) * ndim)
         original_shape = np.asarray(img.shape)
         pyramid1 = list(pyramids.pyramid_laplacian(img, downscale=2, channel_axis=None))
-        pyramid2 = list(pyramids.pyramid_laplacian(img, downscale=2, channel_axis=None, preserve_range=True))
+        pyramid2 = list(
+            pyramids.pyramid_laplacian(
+                img, downscale=2, channel_axis=None, preserve_range=True
+            )
+        )
         for layer, (out1, out2) in enumerate(zip(pyramid1, pyramid2, strict=True)):
             layer_shape = original_shape / 2**layer
             assert_array_equal(out1.shape, layer_shape)

--- a/tests/skimage/transform/test_pyramids.py
+++ b/tests/skimage/transform/test_pyramids.py
@@ -44,7 +44,17 @@ def test_pyramid_reduce_gray_defaults():
     assert_almost_equal(np.ptp(out2) / np.ptp(image_gray), 1.0, decimal=2)
 
 
-def test_pyramid_reduce_nd():
+@pytest.mark.parametrize('mode', ['reflect', 'constant', 'edge', 'symmetric', 'wrap'])
+def test_pyramid_reduce_modes(mode):
+    rows, cols = image_gray.shape
+    out1 = pyramids.pyramid_reduce(image_gray, mode=mode)
+    assert_array_equal(out1.shape, (rows / 2, cols / 2))
+    assert_almost_equal(np.ptp(out1), 1.0, decimal=2)
+    out2 = pyramids.pyramid_reduce(image_gray, preserve_range=True)
+    assert_almost_equal(np.ptp(out2) / np.ptp(image_gray), 1.0, decimal=2)
+
+
+def test_pyramid_reduce_nd(mode):
     for ndim in [1, 2, 3, 4]:
         img = np.random.randn(*((8,) * ndim))
         out = pyramids.pyramid_reduce(img, downscale=2, channel_axis=None)
@@ -67,6 +77,13 @@ def test_pyramid_expand_gray():
     rows, cols = image_gray.shape
     out = pyramids.pyramid_expand(image_gray, upscale=2)
     assert_array_equal(out.shape, (rows * 2, cols * 2))
+
+
+@pytest.mark.parametrize('mode', ['reflect', 'constant', 'edge', 'symmetric', 'wrap'])
+def test_pyramid_expand_modes(mode):
+    rows, cols = image_gray.shape
+    out1 = pyramids.pyramid_expand(image_gray, mode=mode)
+    assert_array_equal(out1.shape, (rows * 2, cols * 2))
 
 
 def test_pyramid_expand_nd():
@@ -105,6 +122,15 @@ def test_build_gaussian_pyramid_gray_defaults():
         assert_array_equal(out.shape, layer_shape)
 
 
+@pytest.mark.parametrize('mode', ['reflect', 'constant', 'edge', 'symmetric', 'wrap'])
+def test_build_gaussian_pyramid_gray_modes(mode):
+    rows, cols = image_gray.shape
+    pyramid = pyramids.pyramid_gaussian(image_gray, mode=mode)
+    for layer, out in enumerate(pyramid):
+        layer_shape = (rows / 2**layer, cols / 2**layer)
+        assert_array_equal(out.shape, layer_shape)
+
+
 def test_build_gaussian_pyramid_nd():
     for ndim in [1, 2, 3, 4]:
         img = np.random.randn(*((8,) * ndim))
@@ -130,6 +156,15 @@ def test_build_laplacian_pyramid_rgb(channel_axis):
 def test_build_laplacian_pyramid_defaults():
     rows, cols = image_gray.shape
     pyramid = pyramids.pyramid_laplacian(image_gray)
+    for layer, out in enumerate(pyramid):
+        layer_shape = (rows / 2**layer, cols / 2**layer)
+        assert_array_equal(out.shape, layer_shape)
+
+
+@pytest.mark.parametrize('mode', ['reflect', 'constant', 'edge', 'symmetric', 'wrap'])
+def test_build_laplacian_pyramid_modes(mode):
+    rows, cols = image_gray.shape
+    pyramid = pyramids.pyramid_laplacian(image_gray, mode=mode)
     for layer, out in enumerate(pyramid):
         layer_shape = (rows / 2**layer, cols / 2**layer)
         assert_array_equal(out.shape, layer_shape)


### PR DESCRIPTION
## Description

See scikit-image/scikit-image#7986.  The documented modes are in the `numpy.pad` convention, but the function also uses `scipy.ndimage`.  The only modes that worked were the ones that are common to both numpy and scipy.

All modes are now tested.
