### PR TITLE
Clarify RELEASE.txt after v0.26.0rc2

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -10,7 +10,7 @@ Before you start, make sure you have all the required write
 permissions (if not, you will need to ask an owner to grant you
 access), specifically to:
 
-  - https://github.com/scikit-image/skimage (push new tags, push to `main`).
+  - https://github.com/scikit-image/skimage (push new tags, push to `main`)
   - https://github.com/scikit-image/skimage-web (force-push)
 
 It's a good idea to have somebody standing by who can yank releases on


### PR DESCRIPTION
## Description

As recommended by @stefanv. While preparing the recent release candidate I noticed that write access to PyPI is no longer needed (although still useful). I suggest a clarification here.