### PR TITLE
Don't trigger "Release wheels" workflow on pyproject.toml change

### DIFF
--- a/.github/workflows/wheels-test-and-release.yaml
+++ b/.github/workflows/wheels-test-and-release.yaml
@@ -11,7 +11,6 @@ on:
     paths:
       - ".github/workflows/wheels-test-and-release.yaml"
       - ".github/workflows/wheels-recipe.yaml"
-      - "pyproject.toml"
 
 concurrency:
   # Cancel previous workflows on the same branch


### PR DESCRIPTION
## Description

I think in practice this file is changed far to often for unrelated reasons. Thus resulting in a significant waste of resources (for example https://github.com/scikit-image/scikit-image/pull/7889 or https://github.com/scikit-image/scikit-image/pull/7976). We are periodically building and testing wheels for our nightlies. So we should still catch stuff early. And if necessary there's always the option to use a `maintenance/*` branch.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
