### PR TITLE
Run docstub on skimage2 namespace too

### DIFF
--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -63,7 +63,7 @@ jobs:
            echo -e "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
       # Not needed yet, since we don't run mypy.stubtest or similar
-      # which wants to import scikit-image
+      # which would require importing scikit-image.
       #
       #      - name: Install build dependencies
       #        env:


### PR DESCRIPTION
## Description

We should eventually also setup type checkers to run `mypy.stubtest skimage2` and `mypy tests/skimage2` so that we can make sure we are typing `skimage2` correctly from the start.

Playing around locally with this suggests, that getting the configuration right will not be trivial. So I'm not making that a priority right now. 

This also disables the step that builds scikit-image for now. Docstub runs on static files, and we don't run type checkers (yet) that need to import scikit-image. So we can save CPU for now.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
