### PR TITLE
Fix invalid syntax (..., C=3, ...) ndarray: docstub fixes (VI).

### DIFF
--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           echo -e "## docstub output\n\`\`\`" >> $GITHUB_STEP_SUMMARY
           (set -o pipefail && \
-           docstub run --verbose --group-errors --allow-errors=947 \
+           docstub run --verbose --group-errors --allow-errors=895 \
                        --workers -1 --out-dir ${MYPYPATH}/skimage src/skimage/ \
            2>&1 | tee -a $GITHUB_STEP_SUMMARY)
            echo -e "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/src/skimage/color/colorconv.py
+++ b/src/skimage/color/colorconv.py
@@ -81,7 +81,7 @@ def convert_colorspace(arr, fromspace, tospace, *, channel_axis=-1):
 
     Parameters
     ----------
-    arr : (..., C=3, ...) array_like
+    arr : array_like of shape (..., C=3, ...)
         The image to convert. By default, the final dimension denotes
         channels.
     fromspace : str
@@ -97,7 +97,7 @@ def convert_colorspace(arr, fromspace, tospace, *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The converted image. Same dimensions as input.
 
     Raises
@@ -1038,13 +1038,13 @@ def gray2rgb(image, *, channel_axis=-1):
 
     Returns
     -------
-    rgb : (..., C=3, ...) ndarray
+    rgb : ndarray of shape (..., C=3, ...)
         RGB image. A new dimension of length 3 is added to input image.
 
     Notes
     -----
     If the input is a 1-dimensional image of shape ``(M,)``, the output
-    will be shape ``(M, C=3)``.
+    will be of shape ``(M, C=3)``.
     """
     return np.stack(3 * (image,), axis=channel_axis)
 
@@ -1055,7 +1055,7 @@ def xyz2lab(xyz, illuminant="D65", observer="2", *, channel_axis=-1):
 
     Parameters
     ----------
-    xyz : (..., C=3, ...) array_like
+    xyz : array_like of shape (..., C=3, ...)
         The image in XYZ format. By default, the final dimension denotes
         channels.
     illuminant : {"A", "B", "C", "D50", "D55", "D65", "D75", "E"}, optional
@@ -1072,7 +1072,7 @@ def xyz2lab(xyz, illuminant="D65", observer="2", *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in CIE-LAB format. Same dimensions as input.
 
     Raises
@@ -1132,7 +1132,7 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
 
     Parameters
     ----------
-    lab : (..., C=3, ...) array_like
+    lab : array_like of shape (..., C=3, ...)
         The input image in CIE-LAB color space.
         Unless `channel_axis` is set, the final dimension denotes the CIE-LAB
         channels.
@@ -1151,7 +1151,7 @@ def lab2xyz(lab, illuminant="D65", observer="2", *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in XYZ color space, of same shape as input.
 
     Raises
@@ -1198,7 +1198,7 @@ def _lab2xyz(lab, illuminant, observer):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in XYZ format. Same dimensions as input.
     n_invalid : int
         Number of invalid pixels in the Z channel after conversion.
@@ -1238,7 +1238,7 @@ def rgb2lab(rgb, illuminant="D65", observer="2", *, channel_axis=-1):
 
     Parameters
     ----------
-    rgb : (..., C=3, ...) array_like
+    rgb : array_like of shape (..., C=3, ...)
         The image in RGB format. By default, the final dimension denotes
         channels.
     illuminant : {"A", "B", "C", "D50", "D55", "D65", "D75", "E"}, optional
@@ -1254,7 +1254,7 @@ def rgb2lab(rgb, illuminant="D65", observer="2", *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in Lab format. Same dimensions as input.
 
     Raises
@@ -1286,7 +1286,7 @@ def lab2rgb(lab, illuminant="D65", observer="2", *, channel_axis=-1):
 
     Parameters
     ----------
-    lab : (..., C=3, ...) array_like
+    lab : array_like of shape (..., C=3, ...)
         The input image in CIE-LAB color space.
         Unless `channel_axis` is set, the final dimension denotes the CIE-LAB
         channels.
@@ -1305,7 +1305,7 @@ def lab2rgb(lab, illuminant="D65", observer="2", *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in sRGB color space, of same shape as input.
 
     Raises
@@ -1345,7 +1345,7 @@ def xyz2luv(xyz, illuminant="D65", observer="2", *, channel_axis=-1):
 
     Parameters
     ----------
-    xyz : (..., C=3, ...) array_like
+    xyz : array_like of shape (..., C=3, ...)
         The image in XYZ format. By default, the final dimension denotes
         channels.
     illuminant : {"A", "B", "C", "D50", "D55", "D65", "D75", "E"}, optional
@@ -1361,7 +1361,7 @@ def xyz2luv(xyz, illuminant="D65", observer="2", *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in CIE-Luv format. Same dimensions as input.
 
     Raises
@@ -1441,7 +1441,7 @@ def luv2xyz(luv, illuminant="D65", observer="2", *, channel_axis=-1):
 
     Parameters
     ----------
-    luv : (..., C=3, ...) array_like
+    luv : array_like of shape (..., C=3, ...)
         The image in CIE-Luv format. By default, the final dimension denotes
         channels.
     illuminant : {"A", "B", "C", "D50", "D55", "D65", "D75", "E"}, optional
@@ -1457,7 +1457,7 @@ def luv2xyz(luv, illuminant="D65", observer="2", *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in XYZ format. Same dimensions as input.
 
     Raises
@@ -1518,7 +1518,7 @@ def rgb2luv(rgb, *, channel_axis=-1):
 
     Parameters
     ----------
-    rgb : (..., C=3, ...) array_like
+    rgb : array_like of shape (..., C=3, ...)
         The image in RGB format. By default, the final dimension denotes
         channels.
     channel_axis : int, optional
@@ -1530,7 +1530,7 @@ def rgb2luv(rgb, *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in CIE Luv format. Same dimensions as input.
 
     Raises
@@ -1556,13 +1556,13 @@ def luv2rgb(luv, *, channel_axis=-1):
 
     Parameters
     ----------
-    luv : (..., C=3, ...) array_like
+    luv : array_like of shape (..., C=3, ...)
         The image in CIE Luv format. By default, the final dimension denotes
         channels.
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in RGB format. Same dimensions as input.
 
     Raises
@@ -1583,7 +1583,7 @@ def rgb2hed(rgb, *, channel_axis=-1):
 
     Parameters
     ----------
-    rgb : (..., C=3, ...) array_like
+    rgb : array_like of shape (..., C=3, ...)
         The image in RGB format. By default, the final dimension denotes
         channels.
     channel_axis : int, optional
@@ -1595,7 +1595,7 @@ def rgb2hed(rgb, *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in HED format. Same dimensions as input.
 
     Raises
@@ -1626,7 +1626,7 @@ def hed2rgb(hed, *, channel_axis=-1):
 
     Parameters
     ----------
-    hed : (..., C=3, ...) array_like
+    hed : array_like of shape (..., C=3, ...)
         The image in the HED color space. By default, the final dimension
         denotes channels.
     channel_axis : int, optional
@@ -1638,7 +1638,7 @@ def hed2rgb(hed, *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in RGB. Same dimensions as input.
 
     Raises
@@ -1670,7 +1670,7 @@ def separate_stains(rgb, conv_matrix, *, channel_axis=-1):
 
     Parameters
     ----------
-    rgb : (..., C=3, ...) array_like
+    rgb : array_like of shape (..., C=3, ...)
         The image in RGB format. By default, the final dimension denotes
         channels.
     conv_matrix : ndarray
@@ -1684,7 +1684,7 @@ def separate_stains(rgb, conv_matrix, *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in stain color space. Same dimensions as input.
 
     Raises
@@ -1746,7 +1746,7 @@ def combine_stains(stains, conv_matrix, *, channel_axis=-1):
 
     Parameters
     ----------
-    stains : (..., C=3, ...) array_like
+    stains : array_like of shape (..., C=3, ...)
         The image in stain color space. By default, the final dimension denotes
         channels.
     conv_matrix : ndarray
@@ -1760,7 +1760,7 @@ def combine_stains(stains, conv_matrix, *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in RGB format. Same dimensions as input.
 
     Raises
@@ -1821,7 +1821,7 @@ def lab2lch(lab, *, channel_axis=-1):
 
     Parameters
     ----------
-    lab : (..., C=3, ...) array_like
+    lab : array_like of shape (..., C=3, ...)
         The input image in CIE-LAB color space.
         Unless `channel_axis` is set, the final dimension denotes the CIE-LAB
         channels.
@@ -1836,7 +1836,7 @@ def lab2lch(lab, *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in CIE-LCh color space, of same shape as input.
 
     Raises
@@ -1892,7 +1892,7 @@ def lch2lab(lch, *, channel_axis=-1):
 
     Parameters
     ----------
-    lch : (..., C=3, ...) array_like
+    lch : array_like of shape (..., C=3, ...)
         The input image in CIE-LCh color space.
         Unless `channel_axis` is set, the final dimension denotes the CIE-LAB
         channels.
@@ -1908,7 +1908,7 @@ def lch2lab(lch, *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in CIE-LAB format, of same shape as input.
 
     Raises
@@ -1970,7 +1970,7 @@ def rgb2yuv(rgb, *, channel_axis=-1):
 
     Parameters
     ----------
-    rgb : (..., C=3, ...) array_like
+    rgb : array_like of shape (..., C=3, ...)
         The image in RGB format. By default, the final dimension denotes
         channels.
     channel_axis : int, optional
@@ -1982,7 +1982,7 @@ def rgb2yuv(rgb, *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in YUV format. Same dimensions as input.
 
     Raises
@@ -2008,7 +2008,7 @@ def rgb2yiq(rgb, *, channel_axis=-1):
 
     Parameters
     ----------
-    rgb : (..., C=3, ...) array_like
+    rgb : array_like of shape (..., C=3, ...)
         The image in RGB format. By default, the final dimension denotes
         channels.
     channel_axis : int, optional
@@ -2020,7 +2020,7 @@ def rgb2yiq(rgb, *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in YIQ format. Same dimensions as input.
 
     Raises
@@ -2037,7 +2037,7 @@ def rgb2ypbpr(rgb, *, channel_axis=-1):
 
     Parameters
     ----------
-    rgb : (..., C=3, ...) array_like
+    rgb : array_like of shape (..., C=3, ...)
         The image in RGB format. By default, the final dimension denotes
         channels.
     channel_axis : int, optional
@@ -2049,7 +2049,7 @@ def rgb2ypbpr(rgb, *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in YPbPr format. Same dimensions as input.
 
     Raises
@@ -2070,7 +2070,7 @@ def rgb2ycbcr(rgb, *, channel_axis=-1):
 
     Parameters
     ----------
-    rgb : (..., C=3, ...) array_like
+    rgb : array_like of shape (..., C=3, ...)
         The image in RGB format. By default, the final dimension denotes
         channels.
     channel_axis : int, optional
@@ -2082,7 +2082,7 @@ def rgb2ycbcr(rgb, *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in YCbCr format. Same dimensions as input.
 
     Raises
@@ -2112,7 +2112,7 @@ def rgb2ydbdr(rgb, *, channel_axis=-1):
 
     Parameters
     ----------
-    rgb : (..., C=3, ...) array_like
+    rgb : array_like of shape (..., C=3, ...)
         The image in RGB format. By default, the final dimension denotes
         channels.
     channel_axis : int, optional
@@ -2124,7 +2124,7 @@ def rgb2ydbdr(rgb, *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in YDbDr format. Same dimensions as input.
 
     Raises
@@ -2151,13 +2151,13 @@ def yuv2rgb(yuv, *, channel_axis=-1):
 
     Parameters
     ----------
-    yuv : (..., C=3, ...) array_like
+    yuv : array_like of shape (..., C=3, ...)
         The image in YUV format. By default, the final dimension denotes
         channels.
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in RGB format. Same dimensions as input.
 
     Raises
@@ -2178,7 +2178,7 @@ def yiq2rgb(yiq, *, channel_axis=-1):
 
     Parameters
     ----------
-    yiq : (..., C=3, ...) array_like
+    yiq : array_like of shape (..., C=3, ...)
         The image in YIQ format. By default, the final dimension denotes
         channels.
     channel_axis : int, optional
@@ -2190,7 +2190,7 @@ def yiq2rgb(yiq, *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in RGB format. Same dimensions as input.
 
     Raises
@@ -2207,7 +2207,7 @@ def ypbpr2rgb(ypbpr, *, channel_axis=-1):
 
     Parameters
     ----------
-    ypbpr : (..., C=3, ...) array_like
+    ypbpr : array_like of shape (..., C=3, ...)
         The image in YPbPr format. By default, the final dimension denotes
         channels.
     channel_axis : int, optional
@@ -2219,7 +2219,7 @@ def ypbpr2rgb(ypbpr, *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in RGB format. Same dimensions as input.
 
     Raises
@@ -2240,7 +2240,7 @@ def ycbcr2rgb(ycbcr, *, channel_axis=-1):
 
     Parameters
     ----------
-    ycbcr : (..., C=3, ...) array_like
+    ycbcr : array_like of shape (..., C=3, ...)
         The image in YCbCr format. By default, the final dimension denotes
         channels.
     channel_axis : int, optional
@@ -2252,7 +2252,7 @@ def ycbcr2rgb(ycbcr, *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in RGB format. Same dimensions as input.
 
     Raises
@@ -2282,7 +2282,7 @@ def ydbdr2rgb(ydbdr, *, channel_axis=-1):
 
     Parameters
     ----------
-    ydbdr : (..., C=3, ...) array_like
+    ydbdr : array_like of shape (..., C=3, ...)
         The image in YDbDr format. By default, the final dimension denotes
         channels.
     channel_axis : int, optional
@@ -2294,7 +2294,7 @@ def ydbdr2rgb(ydbdr, *, channel_axis=-1):
 
     Returns
     -------
-    out : (..., C=3, ...) ndarray
+    out : ndarray of shape (..., C=3, ...)
         The image in RGB format. Same dimensions as input.
 
     Raises


### PR DESCRIPTION
## Description

This PR is orthogonal to all previous docstub-related PRs.

Here I have addressed the second-to-last item in the list of errors that docstub spits out (and a little more, i.e., `(..., C=3, ...) array_like`).

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined docstring formatting in color conversion functions with improved parameter and return value descriptions for enhanced clarity and consistency.

* **Chores**
  * Updated type-checking configuration threshold in continuous integration workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->