### PR TITLE
Try to make coderabbit respect exisiting type labels

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,38 +9,38 @@ reviews:
     - label: ":scroll: type: API"
       instructions: >-
         For backward-incompatible changes to the API and deprecations.
-        Only apply this if no other label with "type:" is already assigned.
+        Only apply if no "type:" label is already assigned.
     - label: ":baby: type: New feature"
       instructions: >-
         For new features that previously did not exist.
         New features for tooling, infrastructure and such shouldn't use this label.
-        Only apply this if no other label with "type:" is already assigned.
+        Only apply if no "type:" label is already assigned.
     - label: ":wrench: type: Maintenance"
       instructions: >-
         For internal code changes and cleanups.
-        Only apply this if no other label with "type:" is already assigned.
+        Only apply if no "type:" label is already assigned.
     - label: ":adhesive_bandage: type: Bug fix"
       instructions: >-
         For bug fixes that apply to user facing API.
         Fixes for tooling, infrastructure and such shouldn't use this label.
-        Only apply this if no other label with "type:" is already assigned.
+        Only apply if no "type:" label is already assigned.
     - label: ":page_facing_up: type: Documentation"
       instructions: >-
         For changes dedicated to documentation (i.e., not as part of a new feature).
-        Only apply this if no other label with "type:" is already assigned.
+        Only apply if no "type:" label is already assigned.
     - label: ":robot: type: Infrastructure"
       instructions: >-
         Fixes to CI and other infrastructure.
-        Only apply this if no other label with "type:" is already assigned.
+        Only apply if no "type:" label is already assigned.
     - label: ":fast_forward: type: Enhancement"
       instructions: >-
         Improvements made to an existing feature.
         Improvements for tooling, infrastructure and such shouldn't use this label.
-        Only apply this if no other label with "type:" is already assigned.
+        Only apply if no "type:" label is already assigned.
     - label: ":chart_with_upwards_trend: type: Performance"
       instructions: >-
         For changes intended to improve performance.
-        Only apply this if no other label with "type:" is already assigned.
+        Only apply if no "type:" label is already assigned.
   auto_apply_labels: true
   in_progress_fortune: false
   poem: false


### PR DESCRIPTION
## Description

I was very tempted to just remove the auto-labeling altogether. Attempting a fix since I think @stefanv cares about it labeling new PRs from outside contributors.

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
