### PR TITLE
Fix: Allow scikit-image to be run with -OO flag

### DIFF
--- a/src/skimage/_shared/utils.py
+++ b/src/skimage/_shared/utils.py
@@ -765,9 +765,12 @@ def _update_from_estimate_docstring(cls):
 
     inherited_class_name = inherited_cmeth.__qualname__.split('.')[-2]
 
-    from_estimate.__doc__ = inherited_cmeth.__doc__.replace(
-        inherited_class_name, cls.__name__
-    )
+    if inherited_cmeth.__doc__ is not None:
+        from_estimate.__doc__ = inherited_cmeth.__doc__.replace(
+            inherited_class_name, cls.__name__
+        )
+    else:
+        from_estimate.__doc__ = None
     from_estimate.__signature__ = inspect.signature(inherited_cmeth)
 
     cls.from_estimate = classmethod(from_estimate)

--- a/tests/skimage/_shared/test_utils.py
+++ b/tests/skimage/_shared/test_utils.py
@@ -7,6 +7,10 @@ import pytest
 
 from skimage._shared import testing
 from skimage._shared.utils import (
+    DEPRECATED,
+    DEPRECATED_GOT_VALUE,
+    FailedEstimation,
+    FailedEstimationAccessError,
     _supported_float_type,
     _validate_interpolation_order,
     change_default_value,
@@ -14,11 +18,8 @@ from skimage._shared.utils import (
     check_nD,
     deprecate_func,
     deprecate_parameter,
-    DEPRECATED,
-    DEPRECATED_GOT_VALUE,
-    FailedEstimationAccessError,
-    FailedEstimation,
 )
+from skimage.transform import ProjectiveTransform
 
 complex_dtypes = [np.complex64, np.complex128]
 if hasattr(np, 'complex256'):
@@ -539,3 +540,18 @@ def test_failed_estimation():
     )
     with pytest.raises(FailedEstimationAccessError, match=regex):
         fe.params
+
+
+def test_from_estimate_docstring_none_branch(monkeypatch):
+    # Simulate `python -OO`
+    monkeypatch.setattr(
+        ProjectiveTransform.from_estimate.__func__,
+        "__doc__",
+        None,
+        raising=False,
+    )
+
+    class Child(ProjectiveTransform):
+        pass
+
+    assert Child.from_estimate.__doc__ is None


### PR DESCRIPTION
## Description

This PR fixes an import-time crash when running scikit-image under `python -OO`.

In optimized mode (`-OO`), Python strips docstrings, setting `__doc__ = None`.
The `_update_from_estimate_docstring` decorator unconditionally calls
`.replace()` on `inherited_cmeth.__doc__`, which raises an `AttributeError`
when docstrings are absent.

This patch adds a minimal guard to skip docstring rewriting when
`inherited_cmeth.__doc__` is `None`, preserving existing behavior when
docstrings are present while preventing import failures under `-OO`.

Reproduction:
```bash
python -OO -c "from skimage.transform import resize"
