### PR TITLE
Fix source links in HTML docs after switch to src-layout

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -347,15 +347,15 @@ def linkcode_resolve(domain, info):
     fn = os.path.relpath(fn, start=os.path.dirname(skimage.__file__))
 
     if "dev" in skimage.__version__:
-        return (
-            "https://github.com/scikit-image/scikit-image/blob/"
-            f"main/skimage/{fn}{linespec}"
-        )
+        git_ref = "main"
     else:
-        return (
-            "https://github.com/scikit-image/scikit-image/blob/"
-            f"v{skimage.__version__}/skimage/{fn}{linespec}"
-        )
+        git_ref = f"v{skimage.__version__}"
+    src_url = (
+        f"https://github.com/scikit-image/scikit-image/blob/"
+        f"{git_ref}/src/skimage/{fn}{linespec}"
+    )
+
+    return src_url
 
 
 # -- MyST --------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fixes #8041. This only applies to our development docs. To fix v0.26 we'd need to update https://github.com/scikit-image/docs/tree/gh-pages/0.26.x directly.


## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
