### PR TITLE
Fix incorrect raise syntax in _clear_border Fixes: #8018

### DIFF
--- a/src/skimage/segmentation/_clear_border.py
+++ b/src/skimage/segmentation/_clear_border.py
@@ -68,12 +68,12 @@ def clear_border(labels, buffer_size=0, bgval=0, mask=None, *, out=None):
         out = labels.copy()
 
     if mask is not None:
-        err_msg = (
-            f'labels and mask should have the same shape but '
-            f'are {out.shape} and {mask.shape}'
-        )
         if out.shape != mask.shape:
-            raise (ValueError, err_msg)
+            err_msg = (
+                f'labels and mask should have the same shape but '
+                f'are {out.shape} and {mask.shape}'
+            )
+            raise ValueError(err_msg)
         if mask.dtype != bool:
             raise TypeError("mask should be of type bool.")
         borders = ~mask

--- a/tests/skimage/segmentation/test_clear_border.py
+++ b/tests/skimage/segmentation/test_clear_border.py
@@ -179,11 +179,12 @@ def test_clear_border_non_binary_out_3d():
     assert_array_equal(result, expected)
     assert_array_equal(out, result)
 
+
 def test_clear_border_mask_shape_mismatch():
     import pytest
-    
+
     labels = np.zeros((10, 10), dtype=int)
-    mask = np.ones((5, 5), dtype=bool) 
-    
+    mask = np.ones((5, 5), dtype=bool)
+
     with pytest.raises(ValueError, match="labels and mask should have the same shape"):
         clear_border(labels, mask=mask)

--- a/tests/skimage/segmentation/test_clear_border.py
+++ b/tests/skimage/segmentation/test_clear_border.py
@@ -181,7 +181,6 @@ def test_clear_border_non_binary_out_3d():
 
 
 def test_clear_border_mask_shape_mismatch():
-
     labels = np.zeros((10, 10), dtype=int)
     mask = np.ones((5, 5), dtype=bool)
 

--- a/tests/skimage/segmentation/test_clear_border.py
+++ b/tests/skimage/segmentation/test_clear_border.py
@@ -1,6 +1,6 @@
 import numpy as np
 from skimage.segmentation import clear_border
-
+import pytest
 from skimage._shared.testing import assert_array_equal, assert_
 
 
@@ -181,7 +181,6 @@ def test_clear_border_non_binary_out_3d():
 
 
 def test_clear_border_mask_shape_mismatch():
-    import pytest
 
     labels = np.zeros((10, 10), dtype=int)
     mask = np.ones((5, 5), dtype=bool)

--- a/tests/skimage/segmentation/test_clear_border.py
+++ b/tests/skimage/segmentation/test_clear_border.py
@@ -178,3 +178,12 @@ def test_clear_border_non_binary_out_3d():
 
     assert_array_equal(result, expected)
     assert_array_equal(out, result)
+
+def test_clear_border_mask_shape_mismatch():
+    import pytest
+    
+    labels = np.zeros((10, 10), dtype=int)
+    mask = np.ones((5, 5), dtype=bool) 
+    
+    with pytest.raises(ValueError, match="labels and mask should have same shape"):
+        clear_border(labels, mask=mask)

--- a/tests/skimage/segmentation/test_clear_border.py
+++ b/tests/skimage/segmentation/test_clear_border.py
@@ -185,5 +185,5 @@ def test_clear_border_mask_shape_mismatch():
     labels = np.zeros((10, 10), dtype=int)
     mask = np.ones((5, 5), dtype=bool) 
     
-    with pytest.raises(ValueError, match="labels and mask should have same shape"):
+    with pytest.raises(ValueError, match="labels and mask should have the same shape"):
         clear_border(labels, mask=mask)


### PR DESCRIPTION
## Description
Fixed incorrect `raise` syntax in the `_clear_border` function that was creating a tuple instead of properly raising a ValueError.

## Changes
- `raise (ValueError, err_msg)` to `raise ValueError(err_msg)`
- file : src/skimage/segmentation/_clear_border.py

## Issue
Fixes #8018

<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

<!-- ## Checklist -->

<!-- Before pull requests can be merged, they should provide: 

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
...
```
-->