### PR TITLE
MAINT: make ellipse fitting forward compatible 

### DIFF
--- a/src/skimage/measure/fit.py
+++ b/src/skimage/measure/fit.py
@@ -906,7 +906,12 @@ class EllipseModel(_BaseModel):
 
         # https://github.com/scikit-image/scikit-image/issues/7013
         if not (np.all(np.isreal(eig_vals)) and np.all(np.isreal(eig_vecs))):
-            raise ValueError("Expected real eigenvalues and -vectors")
+            raise ValueError(
+                "Uh oh! We expected real eigenvalues and -vectors. "
+                "We've had one report of this issue in the past, but couldn't reproduce it. "
+                "Please help us fix it by sharing your input data at\n\n"
+                "  https://github.com/scikit-image/scikit-image/issues/7013\n"
+            )
         eig_vals = eig_vals.real
         eig_vecs = eig_vecs.real
 


### PR DESCRIPTION
## Description

NumPy plans to change it's `linalg.eig` routine to always return complex results, instead of the current _complex or real if eigenvalues happen to be on the real axis_, https://github.com/numpy/numpy/pull/30411

The only effect on scikit-image AFAICS, is in the ellipse estimation routines, which require that eigenvalues are real. In fact, the story seems to be somewhat convoluted: 
- some datasets produce non-zero imaginary parts, which break `EllipseModel.fit`, https://github.com/scikit-image/scikit-image/issues/7013
- the current failure mode is a TypeError from an in-place modulo operation, `phi %= np.pi`, where `phi` is constructed from eigenvalues/eigenvectors
- https://github.com/scikit-image/scikit-image/issues/7013#issuecomment-1583203321 asks for a reproducer, and https://github.com/numpy/numpy/issues/29000#issuecomment-3414690376 has some discussion of potential fixes/enhancements


This PR makes a minimal fix to make `EllipseModel.fit` both backwards and forwards compatible: take the real part of eigenvalues/eigenvectors explicitly, and raise a TypeError if either of them has non-zero imaginary parts.

This is backwards compatible because
- if all eigenvalues are on the real line, we explicitly take the real part---even if numpy does it for us, `.real.real` is a no-op
- if there are non-zero imaginary parts, it raises the same TypeError, with a different error message: instead of implementation details, the new message asks to report the reproducer, per https://github.com/scikit-image/scikit-image/issues/7013#issuecomment-1583203321

It is forwards compatible for the numpy change: the output of `eig` will always be complex with zero imaginary parts, and the fix here takes the real part. 



<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

This is not user-visible.
