### PR TITLE
ENH: note multiple warnings in assert_stacklevel error message

### DIFF
--- a/src/skimage/_shared/testing.py
+++ b/src/skimage/_shared/testing.py
@@ -316,6 +316,14 @@ def assert_stacklevel(warnings, *, offset=-1):
     line_number = frame.f_lineno + offset
     filename = frame.f_code.co_filename
     expected = f"{filename}:{line_number}"
+    warnings = list(warnings)
+    num_warnings = len(warnings)
+    multi_note = (
+        f"\nNote: {num_warnings} warnings were captured in total."
+        " Unexpected extra warnings may cause wrong stacklevel failures."
+        if num_warnings > 1
+        else ""
+    )
     for warning in warnings:
         actual = f"{warning.filename}:{warning.lineno}"
         msg = (

--- a/src/skimage/_shared/testing.py
+++ b/src/skimage/_shared/testing.py
@@ -331,5 +331,6 @@ def assert_stacklevel(warnings, *, offset=-1):
             f"  Expected: {expected}\n"
             f"  Actual: {actual}\n"
             f"  {warning.category.__name__}: {warning.message}"
+            f"{multi_note}"
         )
         assert actual == expected, msg


### PR DESCRIPTION
## Description
Fixes #7799

When multiple warnings are captured, the AssertionError message now 
includes a note about the total number of warnings found. This makes 
it clearer to the developer that unexpected extra warnings may be the 
cause of a wrong stacklevel failure.
<!--
- Reference relevant issues or related pull requests with their URL / #<number>.
- Use `pre-commit` to check and format code.
-->

## Checklist

<!-- Before pull requests can be merged, they should provide: -->

- A descriptive but concise pull request title
- [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- A gallery example in `./doc/examples` for new features
- [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Improved `assert_stacklevel` error message to note when multiple warnings 
were captured, making it easier to diagnose wrong stacklevel failures.
```
