### PR TITLE
Add mode parameter to skeletonize for border handling

### DIFF
--- a/src/skimage/morphology/_skeletonize.py
+++ b/src/skimage/morphology/_skeletonize.py
@@ -15,7 +15,7 @@ from ._skeletonize_various_cy import (
 )
 
 
-def skeletonize(image, *, method=None):
+def skeletonize(image, *, method=None, mode='constant'):
     """Compute the skeleton of the input image via thinning.
 
     Parameters
@@ -30,6 +30,15 @@ def skeletonize(image, *, method=None):
         Which algorithm to use. Zhang's algorithm [Zha84]_ only works for
         2D images, and is the default for 2D. Lee's algorithm [Lee94]_
         works for 2D or 3D images and is the default for 3D.
+    mode : str, optional
+        The mode parameter determines how the image borders are handled during
+        padding before skeletonization. This is passed to ``numpy.pad``. The
+        default is 'constant', which pads with zeros. Other options include
+        'edge', 'reflect', 'symmetric', 'wrap', etc. See ``numpy.pad`` for
+        more details. This parameter only affects the Lee algorithm
+        (used for 3D images or when explicitly specified).
+
+        .. versionadded:: 0.26
 
     Returns
     -------
@@ -88,7 +97,7 @@ def skeletonize(image, *, method=None):
     elif image.ndim == 3 and method == 'zhang':
         raise ValueError('skeletonize method "zhang" only works for 2D ' 'images.')
     elif image.ndim == 3 or (image.ndim == 2 and method == 'lee'):
-        skeleton = _skeletonize_lee(image)
+        skeleton = _skeletonize_lee(image, mode=mode)
     else:
         raise ValueError(
             f'skeletonize requires a 2D or 3D image as input, ' f'got {image.ndim}D.'
@@ -588,7 +597,7 @@ def _table_lookup(image, table):
     return image
 
 
-def _skeletonize_lee(image):
+def _skeletonize_lee(image, *, mode='constant'):
     """Compute the skeleton of a binary image.
 
     Thinning is used to reduce each connected component in a binary image
@@ -599,6 +608,9 @@ def _skeletonize_lee(image):
     image : ndarray, 2D or 3D
         An image containing the objects to be skeletonized. Zeros or ``False``
         represent background, nonzero values or ``True`` are foreground.
+    mode : str, optional
+        The mode parameter determines how the image borders are handled during
+        padding. This is passed to ``numpy.pad``. The default is 'constant'.
 
     Returns
     -------
@@ -642,7 +654,7 @@ def _skeletonize_lee(image):
     # NB: careful here to not clobber the original *and* minimize copying
     if image.ndim == 2:
         image_o = image_o[np.newaxis, ...]
-    image_o = np.pad(image_o, pad_width=1, mode='constant')  # copies
+    image_o = np.pad(image_o, pad_width=1, mode=mode)  # copies
 
     # do the computation
     image_o = _compute_thin_image(image_o)

--- a/tests/skimage/morphology/test_skeletonize.py
+++ b/tests/skimage/morphology/test_skeletonize.py
@@ -159,6 +159,29 @@ class TestSkeletonize:
         assert result.dtype == bool
         assert_array_equal(image, original)
 
+    @pytest.mark.parametrize("method", ["lee"])
+    @pytest.mark.parametrize("mode", ["constant", "edge", "reflect", "symmetric"])
+    def test_padding_mode(self, method, mode):
+        # Test that different padding modes are accepted and produce valid output
+        image = np.zeros((10, 10), dtype=bool)
+        image[2:8, 2:8] = True
+        result = skeletonize(image, method=method, mode=mode)
+        assert result.dtype == bool
+        assert result.shape == image.shape
+
+    def test_padding_mode_edge_vs_constant(self):
+        # Test that edge mode can give different results at borders than constant
+        # Create an image where the object touches the border
+        image = np.zeros((10, 10), dtype=bool)
+        image[:, 4:6] = True  # vertical bar touching top and bottom
+
+        result_constant = skeletonize(image, method='lee', mode='constant')
+        result_edge = skeletonize(image, method='lee', mode='edge')
+
+        # Both should produce valid skeletons
+        assert result_constant.dtype == bool
+        assert result_edge.dtype == bool
+
     def test_two_hole_image_vs_fiji(self):
         # Test a simple 2D image against FIJI
         image = np.array(


### PR DESCRIPTION
Fixes #7022

## Description

This PR adds a `mode` parameter to the `skeletonize` function to control how image borders are handled during internal padding. This allows users to select different padding modes (e.g., 'edge', 'reflect', 'symmetric') instead of the default 'constant' mode (which pads with zeros).

This is particularly useful for skeletonizing elongated shapes (like vessels) that extend to image borders, where different padding modes can produce more desirable skeleton results.

## Changes

- Added `mode` parameter to `skeletonize()` function with default value `'constant'` (backward compatible)
- Added `mode` parameter to internal `_skeletonize_lee()` function
- Updated docstrings to document the new parameter
- Added unit tests for the new functionality

## Checklist

- [x] A descriptive but concise pull request title
- [x] [Docstrings for all functions](https://github.com/numpy/numpydoc/blob/main/doc/example.py)
- [x] [Unit tests](https://scikit-image.org/docs/dev/development/contribute.html#testing)
- [ ] A gallery example in `./doc/examples` for new features (not needed for parameter addition)
- [x] [Contribution guide](https://scikit-image.org/docs/dev/development/contribute.html) is followed

## Release note

```release-note
Add `mode` parameter to `skeletonize` function to control padding behavior at image borders.
```

---

**Diff stats:**
```
 src/skimage/morphology/_skeletonize.py       | 20 ++++++++++++++++----
 tests/skimage/morphology/test_skeletonize.py | 23 +++++++++++++++++++++++
 2 files changed, 39 insertions(+), 4 deletions(-)
```