### PR TITLE
Fix unsharp_mask returning black image with negative channel_axis

### DIFF
--- a/src/skimage/filters/_unsharp_mask.py
+++ b/src/skimage/filters/_unsharp_mask.py
@@ -132,8 +132,9 @@ def unsharp_mask(
             vrange = [0.0, 1.0]
 
     if channel_axis is not None:
+        channel_axis = channel_axis % fimg.ndim
         result = np.empty_like(fimg, dtype=float_dtype)
-        for channel in range(image.shape[channel_axis]):
+        for channel in range(fimg.shape[channel_axis]):
             sl = utils.slice_at_axis(channel, channel_axis)
             result[sl] = _unsharp_mask_single_channel(fimg[sl], radius, amount, vrange)
         return result

--- a/tests/skimage/filters/test_unsharp_mask.py
+++ b/tests/skimage/filters/test_unsharp_mask.py
@@ -155,3 +155,30 @@ def test_unsharp_masking_dtypes(shape, channel_axis, preserve, dtype):
             assert np.any(output >= 0)
     assert output.dtype == _supported_float_type(dtype)
     assert output.shape == shape
+
+
+def test_unsharp_mask_channel_axis_negative():
+    """Test that channel_axis=-1 works correctly for RGB images.
+
+    Regression test for https://github.com/scikit-image/scikit-image/issues/7264
+    """
+    # Create a simple RGB image with non-zero values
+    rgb_image = np.random.rand(32, 32, 3).astype(np.float32)
+
+    # Apply unsharp mask with channel_axis=-1
+    result = unsharp_mask(rgb_image, channel_axis=-1)
+
+    # Verify the result is not all zeros (the bug caused black output)
+    assert not np.all(result == 0), "Output should not be all zeros"
+
+    # Verify output has values in expected range
+    assert np.any(result > 0), "Output should have positive values"
+    assert result.min() >= 0, "Output should be non-negative for non-negative input"
+    assert result.max() <= 1, "Output should be at most 1 for normalized input"
+
+    # Also test with uint8 image (the common case from the issue)
+    rgb_uint8 = (rgb_image * 255).astype(np.uint8)
+    result_uint8 = unsharp_mask(rgb_uint8, channel_axis=-1)
+
+    assert not np.all(result_uint8 == 0), "Output should not be all zeros for uint8 input"
+    assert np.any(result_uint8 > 0), "Output should have positive values for uint8 input"


### PR DESCRIPTION
Fixes #7264

## Description

When applying `skimage.filters.unsharp_mask` to an RGB image with `channel_axis=-1`, the resulting image was all zeros (black). This was caused by the `slice_at_axis` utility function not handling negative axis indices correctly.

The fix normalizes `channel_axis` to a positive index using `channel_axis % fimg.ndim` before passing it to `slice_at_axis`. This is the same pattern used in `skimage/restoration/_denoise.py`.

## Changes

- Normalize `channel_axis` to positive index in `_unsharp_mask.py`
- Use `fimg.shape` instead of `image.shape` for consistency (both have the same shape)
- Add regression test that verifies the fix for RGB images with `channel_axis=-1`

## Checklist

- [x] A descriptive but concise pull request title
- [x] Unit tests added
- [x] Contribution guide is followed

## Release note

```release-note
Fix `unsharp_mask` returning black image when `channel_axis` is negative (e.g., -1).
```

## Diff stats

```
 src/skimage/filters/_unsharp_mask.py           |  3 ++-
 tests/skimage/filters/test_unsharp_mask.py     | 27 ++++++++++++++++++++++++++
 2 files changed, 29 insertions(+), 1 deletion(-)
```