### PR TITLE
Fix/random seed unwrap

### DIFF
--- a/src/skimage/restoration/_unwrap_2d.pyx
+++ b/src/skimage/restoration/_unwrap_2d.pyx
@@ -29,7 +29,7 @@ def unwrap_2d(cnp.float64_t[:, ::1] image,
         int wrap_around_y
 
     # convert from python types to C types so we can release the GIL
-    use_seed = seed is None
+    use_seed = seed is not None
     cseed = 0 if seed is None else seed
     wrap_around_y, wrap_around_x = wrap_around
     with nogil:

--- a/src/skimage/restoration/_unwrap_3d.pyx
+++ b/src/skimage/restoration/_unwrap_3d.pyx
@@ -31,7 +31,7 @@ def unwrap_3d(cnp.float64_t[:, :, ::1] image,
         int wrap_around_z
 
     # convert from python types to C types so we can release the GIL
-    use_seed = seed is None
+    use_seed = seed is not None
     cseed = 0 if seed is None else seed
     wrap_around_z, wrap_around_y, wrap_around_x = wrap_around
 

--- a/src/skimage/restoration/unwrap.py
+++ b/src/skimage/restoration/unwrap.py
@@ -28,12 +28,11 @@ def unwrap_phase(image, wrap_around=False, rng=None):
         process. If only a single boolean is given, it will apply to all axes.
         Wrap around is not supported for 1D arrays.
     rng : {`numpy.random.Generator`, int}, optional
-        Pseudo-random number generator.
-        By default, a PCG64 generator is used (see :func:`numpy.random.default_rng`).
-        If `rng` is an int, it is used to seed the generator.
-
-        Unwrapping relies on a random initialization. This sets the
-        PRNG to use to achieve deterministic behavior.
+        Seed for the random number generator used during unwrapping.
+        If an int, it is used directly as the seed. If a
+        `numpy.random.Generator`, a seed is drawn from it. If `None`,
+        unwrapping relies on a random initialization and results may vary
+        between runs.
 
     Returns
     -------
@@ -95,6 +94,13 @@ def unwrap_phase(image, wrap_around=False, rng=None):
             'algorithm'
         )
 
+    if isinstance(rng, np.random.Generator):
+        seed = int(rng.integers(np.iinfo(np.uint32).max))
+    elif rng is None:
+        seed = None
+    else:
+        seed = int(rng)
+
     if np.ma.isMaskedArray(image):
         mask = np.require(np.ma.getmaskarray(image), np.uint8, ['C'])
     else:
@@ -106,9 +112,9 @@ def unwrap_phase(image, wrap_around=False, rng=None):
     if image.ndim == 1:
         unwrap_1d(image_not_masked, image_unwrapped)
     elif image.ndim == 2:
-        unwrap_2d(image_not_masked, mask, image_unwrapped, wrap_around, rng)
+        unwrap_2d(image_not_masked, mask, image_unwrapped, wrap_around, seed)
     elif image.ndim == 3:
-        unwrap_3d(image_not_masked, mask, image_unwrapped, wrap_around, rng)
+        unwrap_3d(image_not_masked, mask, image_unwrapped, wrap_around, seed)
 
     if np.ma.isMaskedArray(image):
         return np.ma.array(image_unwrapped, mask=mask, fill_value=image.fill_value)

--- a/src/skimage/restoration/unwrap.py
+++ b/src/skimage/restoration/unwrap.py
@@ -95,7 +95,7 @@ def unwrap_phase(image, wrap_around=False, rng=None):
         )
 
     if isinstance(rng, np.random.Generator):
-        seed = int(rng.integers(np.iinfo(np.uint32).max))
+        seed = int(rng.integers(np.iinfo(np.uint32).max, endpoint=True))
     elif rng is None:
         seed = None
     else:

--- a/tests/skimage/restoration/test_unwrap.py
+++ b/tests/skimage/restoration/test_unwrap.py
@@ -1,8 +1,4 @@
-import sys
-from datetime import date
-
 import numpy as np
-import pytest
 
 from skimage.restoration import unwrap_phase
 
@@ -132,12 +128,6 @@ def check_wrap_around(ndim, axis):
 dim_axis = [(ndim, axis) for ndim in (2, 3) for axis in range(ndim)]
 
 
-@pytest.mark.xfail(
-    condition=sys.platform == "darwin" and date.today() < date(2026, 2, 1),
-    reason="Flakiness on macOS (gh-7964, xfail expires 2026-02-01)",
-    raises=AssertionError,
-    strict=False,
-)
 @testing.parametrize("ndim, axis", dim_axis)
 def test_wrap_around(ndim, axis):
     check_wrap_around(ndim, axis)

--- a/tests/skimage/restoration/test_unwrap.py
+++ b/tests/skimage/restoration/test_unwrap.py
@@ -166,6 +166,29 @@ def test_mask():
         assert_array_almost_equal_nulp(image_unwrapped_3d[:, :, -1], image[i, -1])
 
 
+def test_rng():
+    # Use a (100, 1) image with wrap_around: all pixel reliabilities come from
+    # rand() (no interior pixels), so the result is sensitive to the seed.
+    ramp = np.linspace(0, 12 * np.pi, 100)
+    ramp[-1] = ramp[0]
+    image_wrapped = np.angle(np.exp(1j * ramp.reshape(100, 1)))
+
+    def unwrap(rng):
+        with expected_warnings(['length 1 dimension']):
+            return unwrap_phase(image_wrapped, wrap_around=[True, False], rng=rng)
+
+    for seed in range(50):
+        assert_(np.allclose(unwrap(seed), unwrap(seed)))
+        assert_(
+            np.allclose(
+                unwrap(np.random.default_rng(seed)), unwrap(np.random.default_rng(seed))
+            )
+        )
+    # For `None` the behavior is not deterministic, so it does not make sense to check
+    # for equality. At least call it to see that `None` is an accepted value.
+    unwrap(None)
+
+
 def test_invalid_input():
     with testing.raises(ValueError):
         unwrap_phase(np.zeros([]))


### PR DESCRIPTION
## Description

* Fix seed initialization in `unwrap`
* Fix support `np.random.Generator` in `unwrap`

Relates to: https://github.com/scikit-image/scikit-image/issues/7964

## Release note

For maintainers and optionally contributors, please refer to the [instructions](https://scikit-image.org/docs/stable/development/contribute.html#documenting-changes) on how to document this PR for the release notes.

```release-note
Fix seed initialization in `unwrap`
```
